### PR TITLE
fix(cli): prevent spinner freeze by running native calls in subprocess

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,12 +21,13 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@junhoyeo/blackhole": "^1.0.1",
         "@neondatabase/serverless": "^0.10.4",
         "@primer/primitives": "^11.3.1",
         "@primer/react": "^38.3.0",
         "date-fns": "^4.1.0",
         "drizzle-orm": "^0.38.3",
-        "framer-motion": "^12.23.25",
+        "framer-motion": "^12.23.26",
         "lodash-es": "^4.17.21",
         "lucide-react": "^0.555.0",
         "next": "16.0.7",
@@ -36,6 +37,7 @@
         "react-dom": "19.2.0",
         "react-is": "^19.2.0",
         "styled-components": "^6.1.19",
+        "three": "^0.177.0",
         "zod": "^3.24.1",
       },
       "devDependencies": {
@@ -74,6 +76,7 @@
         "string-width": "^8.1.0",
       },
       "devDependencies": {
+        "@types/bun": "^1.2.16",
         "@types/node": "^20.0.0",
         "@types/react": "^19.2.7",
         "tsx": "^4.0.0",
@@ -434,6 +437,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@junhoyeo/blackhole": ["@junhoyeo/blackhole@1.0.2", "", { "peerDependencies": { "react": ">=18", "react-dom": ">=18", "three": ">=0.150.0" } }, "sha512-ZC5a88cmkk809g6WclvjROehqcvlhfSBqhaTKQarAh411zlZC/O1fXOLCtFursERTHstX8aQ0OPN+Ps5Ped53g=="],
+
     "@lit-labs/react": ["@lit-labs/react@1.2.1", "", {}, "sha512-DiZdJYFU0tBbdQkfwwRSwYyI/mcWkg3sWesKRsHUd4G+NekTmmeq9fzsurvcKTNVa0comNljwtg4Hvi1ds3V+A=="],
 
     "@lit-labs/ssr-dom-shim": ["@lit-labs/ssr-dom-shim@1.4.0", "", {}, "sha512-ficsEARKnmmW5njugNYKipTm4SFnbik7CXtoencDZzmzo/dQ+2Q0bgkzJuoJP20Aj0F+izzJjOqsnkd6F/o1bw=="],
@@ -680,6 +685,8 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/bun": ["@types/bun@1.3.4", "", { "dependencies": { "bun-types": "1.3.4" } }, "sha512-EEPTKXHP+zKGPkhRLv+HI0UEX8/o+65hqARxLy8Ov5rIxMBPNTjeZww00CIihrIQGEQBYg+0roO5qOnS/7boGA=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/hoist-non-react-statics": ["@types/hoist-non-react-statics@3.3.7", "", { "dependencies": { "hoist-non-react-statics": "^3.3.0" } }, "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g=="],
@@ -865,6 +872,8 @@
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
     "bun-ffi-structs": ["bun-ffi-structs@0.1.2", "", {}, "sha512-Lh1oQAYHDcnesJauieA4UNkWGXY9hYck7OA5IaRwE3Bp6K2F2pJSNYqq+hIy7P3uOvo3km3oxS8304g5gDMl/w=="],
+
+    "bun-types": ["bun-types@1.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ=="],
 
     "bun-webgpu": ["bun-webgpu@0.1.4", "", { "dependencies": { "@webgpu/types": "^0.1.60" }, "optionalDependencies": { "bun-webgpu-darwin-arm64": "^0.1.4", "bun-webgpu-darwin-x64": "^0.1.4", "bun-webgpu-linux-x64": "^0.1.4", "bun-webgpu-win32-x64": "^0.1.4" } }, "sha512-Kw+HoXl1PMWJTh9wvh63SSRofTA8vYBFCw0XEP1V1fFdQEDhI8Sgf73sdndE/oDpN/7CMx0Yv/q8FCvO39ROMQ=="],
 
@@ -1122,7 +1131,7 @@
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
-    "framer-motion": ["framer-motion@12.23.25", "", { "dependencies": { "motion-dom": "^12.23.23", "motion-utils": "^12.23.6", "tslib": "^2.4.0" } }, "sha512-gUHGl2e4VG66jOcH0JHhuJQr6ZNwrET9g31ZG0xdXzT0CznP7fHX4P8Bcvuc4MiUB90ysNnWX2ukHRIggkl6hQ=="],
+    "framer-motion": ["framer-motion@12.23.26", "", { "dependencies": { "motion-dom": "^12.23.23", "motion-utils": "^12.23.6", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-cPcIhgR42xBn1Uj+PzOyheMtZ73H927+uWPDVhUMqxy8UHt6Okavb6xIz9J/phFUHUj0OncR6UvMfJTXoc/LKA=="],
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
@@ -1870,6 +1879,8 @@
 
     "babel-plugin-jsx-dom-expressions/@babel/helper-module-imports": ["@babel/helper-module-imports@7.18.6", "", { "dependencies": { "@babel/types": "^7.18.6" } }, "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA=="],
 
+    "bun-types/@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
+
     "cli-table3/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "cli-truncate/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
@@ -2045,6 +2056,8 @@
     "@vercel/nft/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "@vercel/nft/glob/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "cli-table3/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,6 +44,7 @@
     "string-width": "^8.1.0"
   },
   "devDependencies": {
+    "@types/bun": "^1.2.16",
     "@types/node": "^20.0.0",
     "@types/react": "^19.2.7",
     "tsx": "^4.0.0",

--- a/packages/cli/src/native-runner.ts
+++ b/packages/cli/src/native-runner.ts
@@ -1,0 +1,50 @@
+import {
+  parseLocalSourcesNative,
+  finalizeReportNative,
+  finalizeMonthlyReportNative,
+  finalizeGraphNative,
+} from "./native.js";
+
+const outputFile = process.argv[2];
+if (!outputFile) {
+  console.error(JSON.stringify({ error: "Usage: native-runner.ts <output-file>" }));
+  process.exit(1);
+}
+
+try {
+  const input = await Bun.stdin.text();
+  
+  const parsed = JSON.parse(input);
+  if (!parsed.method || !Array.isArray(parsed.args)) {
+    throw new Error("Invalid input: missing method or args");
+  }
+  
+  const { method, args } = parsed;
+  
+  let result: unknown;
+  switch (method) {
+    case "parseLocalSources":
+      result = parseLocalSourcesNative(args[0]);
+      break;
+    case "finalizeReport":
+      result = finalizeReportNative(args[0]);
+      break;
+    case "finalizeMonthlyReport":
+      result = finalizeMonthlyReportNative(args[0]);
+      break;
+    case "finalizeGraph":
+      result = finalizeGraphNative(args[0]);
+      break;
+    default:
+      throw new Error(`Unknown method: ${method}`);
+  }
+  
+  await Bun.write(outputFile, JSON.stringify(result));
+} catch (e) {
+  const error = e as Error;
+  console.error(JSON.stringify({ 
+    error: error.message, 
+    stack: error.stack 
+  }));
+  process.exit(1);
+}

--- a/packages/cli/src/tui/hooks/useData.ts
+++ b/packages/cli/src/tui/hooks/useData.ts
@@ -14,9 +14,9 @@ import type {
 } from "../types/index.js";
 import {
   isNativeAvailable,
-  parseLocalSourcesNative,
-  finalizeReportNative,
-  finalizeGraphNative,
+  parseLocalSourcesAsync,
+  finalizeReportAsync,
+  finalizeGraphAsync,
   type ParsedMessages,
 } from "../../native.js";
 import { PricingFetcher } from "../../pricing.js";
@@ -147,7 +147,7 @@ async function loadData(enabledSources: Set<SourceType>, dateFilters?: DateFilte
     pricingFetcher.fetchPricing(),
     includeCursor && loadCursorCredentials() ? syncCursorCache() : Promise.resolve({ synced: false, rows: 0 }),
     localSources.length > 0
-      ? parseLocalSourcesNative({ sources: localSources as ("opencode" | "claude" | "codex" | "gemini")[], since, until, year })
+      ? parseLocalSourcesAsync({ sources: localSources as ("opencode" | "claude" | "codex" | "gemini")[], since, until, year })
       : Promise.resolve({ messages: [], opencodeCount: 0, claudeCount: 0, codexCount: 0, geminiCount: 0, processingTimeMs: 0 } as ParsedMessages),
   ]);
 
@@ -160,23 +160,24 @@ async function loadData(enabledSources: Set<SourceType>, dateFilters?: DateFilte
     processingTimeMs: 0,
   };
 
-  const report = finalizeReportNative({
-    localMessages: localMessages || emptyMessages,
-    pricing: pricingFetcher.toPricingEntries(),
-    includeCursor: includeCursor && cursorSync.synced,
-    since,
-    until,
-    year,
-  });
-
-  const graph = finalizeGraphNative({
-    localMessages: localMessages || emptyMessages,
-    pricing: pricingFetcher.toPricingEntries(),
-    includeCursor: includeCursor && cursorSync.synced,
-    since,
-    until,
-    year,
-  });
+  const [report, graph] = await Promise.all([
+    finalizeReportAsync({
+      localMessages: localMessages || emptyMessages,
+      pricing: pricingFetcher.toPricingEntries(),
+      includeCursor: includeCursor && cursorSync.synced,
+      since,
+      until,
+      year,
+    }),
+    finalizeGraphAsync({
+      localMessages: localMessages || emptyMessages,
+      pricing: pricingFetcher.toPricingEntries(),
+      includeCursor: includeCursor && cursorSync.synced,
+      since,
+      until,
+      year,
+    }),
+  ]);
 
   const modelEntries: ModelEntry[] = report.entries.map(e => ({
     source: e.source,


### PR DESCRIPTION
## Summary

- Fix spinner animation freezing during native Rust calls by offloading them to a subprocess
- The main event loop now stays free to animate the spinner while heavy computation runs in isolation

## Problem

The CLI spinner would freeze during native module execution because:
1. Native Rust calls (via napi-rs) are synchronous and block the main thread
2. Node.js/Bun only yields between async operations, not during blocking native FFI calls
3. This caused the spinner to appear stuck while parsing files and generating reports

## Solution

Run native calls in a separate Bun subprocess, communicating through temporary JSON files:

```
Main Process                    Subprocess (native-runner.ts)
     │                                    │
     ├─ Write input to temp file ────────►│
     │                                    ├─ Read input
     │  (spinner animates freely)         ├─ Execute native call
     │                                    ├─ Write output to temp file
     │◄─ Read output from temp file ──────┤
     │                                    │
```

## Changes

| File | Description |
|------|-------------|
| `native-runner.ts` | New subprocess script for isolated native execution |
| `native.ts` | Added async variants: `parseLocalSourcesAsync`, `finalizeReportAsync`, `finalizeMonthlyReportAsync`, `finalizeGraphAsync` |
| `cli.ts` | Updated to use async native functions |
| `useData.ts` | Updated TUI to use async native functions with `Promise.all` |

## Testing

- [x] `bun run cli --help` works
- [x] `bun run cli models` displays data correctly
- [x] Spinner animates smoothly during loading