### PR TITLE
Fix navigation bar display on mobile devices

### DIFF
--- a/packages/frontend/src/components/layout/Navigation.tsx
+++ b/packages/frontend/src/components/layout/Navigation.tsx
@@ -37,6 +37,12 @@ const NavContainer = styled.nav`
   align-items: center;
   gap: 4px;
   z-index: 50;
+  
+  @media (max-width: 767px) {
+    width: calc(100% - 24px);
+    max-width: 100%;
+    gap: 2px;
+  }
 `;
 
 const NavItemBase = styled.a<{ $isActive: boolean }>`
@@ -54,6 +60,18 @@ const NavItemBase = styled.a<{ $isActive: boolean }>`
   text-decoration: none;
   cursor: pointer;
   transition: all 0.2s ease;
+  white-space: nowrap;
+  min-width: 0;
+  
+  @media (max-width: 767px) {
+    font-size: 11px;
+    padding: 8px 10px;
+  }
+  
+  @media (max-width: 374px) {
+    font-size: 10px;
+    padding: 8px 6px;
+  }
   
   ${({ $isActive }) =>
     $isActive
@@ -88,6 +106,18 @@ const NavItemLink = styled(Link)<{ $isActive: boolean }>`
   text-decoration: none;
   cursor: pointer;
   transition: all 0.2s ease;
+  white-space: nowrap;
+  min-width: 0;
+  
+  @media (max-width: 767px) {
+    font-size: 11px;
+    padding: 8px 10px;
+  }
+  
+  @media (max-width: 374px) {
+    font-size: 10px;
+    padding: 8px 6px;
+  }
   
   ${({ $isActive }) =>
     $isActive
@@ -150,6 +180,11 @@ const SignInButton = styled.a`
   
   &:hover {
     opacity: 0.9;
+  }
+  
+  @media (max-width: 374px) {
+    padding: 6px;
+    gap: 4px;
   }
 `;
 


### PR DESCRIPTION
## Background

The navigation bar was not displaying correctly on mobile devices. On smaller screens (≤767px), the navigation items would overflow horizontally, causing layout issues and making it difficult for users to access all navigation options.

## Changes

Added responsive media queries to the navigation components:

- **NavContainer**: Set width to `calc(100% - 24px)` on mobile to fit within the viewport with proper margins
- **NavItemBase & NavItemLink**: 
  - Added `white-space: nowrap` and `min-width: 0` to allow proper flex shrinking
  - Reduced font-size from 16px to 11px (10px on very small screens ≤374px)
  - Reduced horizontal padding from 23px to 10px (6px on ≤374px)
- **SignInButton**: Reduced padding and gap on very small screens (≤374px)

### Breakpoints
| Screen Size | Changes Applied |
|-------------|-----------------|
| ≥768px | Desktop (unchanged) |
| ≤767px | Mobile: 11px font, 10px padding |
| ≤374px | Small mobile: 10px font, 6px padding |

## Testing

1. Open the frontend on a mobile device or use browser DevTools responsive mode
2. Test at various widths: 320px, 375px, 414px, 768px
3. Verify all navigation items (LEADERBOARD, PROFILE, GITHUB, Sign In) are visible and tappable
4. Verify no horizontal overflow occurs