### PR TITLE
refactor(tui): toggle sort direction with keyboard shortcuts 'c' and 't'

### DIFF
--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -162,8 +162,12 @@ export function App(props: AppProps) {
   };
 
   const handleSortChange = (sort: SortType) => {
-    setSortBy(sort);
-    setSortDesc(true);
+    if (sortBy() === sort) {
+      setSortDesc(!sortDesc());
+    } else {
+      setSortBy(sort);
+      setSortDesc(true);
+    }
   };
 
   useKeyboard((key) => {
@@ -216,8 +220,7 @@ export function App(props: AppProps) {
     }
 
     if (key.name === "c" && !key.meta && !key.ctrl) {
-      setSortBy("cost");
-      setSortDesc(true);
+      handleSortChange("cost");
       return;
     }
 
@@ -263,8 +266,7 @@ export function App(props: AppProps) {
       return;
     }
     if (key.name === "t") {
-      setSortBy("tokens");
-      setSortDesc(true);
+      handleSortChange("tokens");
       return;
     }
 


### PR DESCRIPTION
## Summary
- Allow keyboard shortcuts 'c' (Cost) and 't' (Total/Tokens) to toggle between ascending/descending order when pressed repeatedly
- Previously, pressing the same key always forced descending order
- Fix DailyView rendering bug that caused visual glitches when changing sort order

## Changes

### `packages/cli/src/tui/App.tsx`
- Updated `handleSortChange` to toggle `sortDesc` when the same sort type is selected
- Modified 'c' and 't' key handlers to use `handleSortChange` instead of directly setting state

### `packages/cli/src/tui/components/DailyView.tsx`
- Added `formattedRows` memo pattern (consistent with ModelView implementation)
- Added `Math.max` protection for negative slice values
- This fixes a rendering bug where rows would appear out of order or duplicated

## Benefits
- Better UX: Users can now alternate between ascending/descending sort by pressing the same key
- Stability: Fixed rendering consistency in DailyView by using memoized row data

## Preview:
![Kooha-2025-12-28-18-08-25](https://github.com/user-attachments/assets/b28c4a48-1b2d-46fc-a6c8-29b5eaddc060)

## Test plan
- [x] Press 'c' to sort by Cost descending
- [x] Press 'c' again to toggle to Cost ascending
- [x] Press 't' to sort by Total descending  
- [x] Press 't' again to toggle to Total ascending
- [x] Switch between Daily and Models tabs while toggling sort
- [x] Verify no visual glitches in DailyView when sorting