### PR TITLE
fix(pricing): use author provider pricing from OpenRouter endpoints API

### DIFF
--- a/packages/core/src/pricing/openrouter.rs
+++ b/packages/core/src/pricing/openrouter.rs
@@ -11,9 +11,7 @@ const MAX_RETRIES: u32 = 3;
 const INITIAL_BACKOFF_MS: u64 = 200;
 const MAX_CONCURRENT_REQUESTS: usize = 10;
 
-// =============================================================================
-// Structs for /api/v1/models endpoint (list all models)
-// =============================================================================
+/// Structs for `/api/v1/models` endpoint (list all models).
 
 #[derive(Deserialize)]
 struct ModelListItem {
@@ -25,9 +23,7 @@ struct ModelsListResponse {
     data: Vec<ModelListItem>,
 }
 
-// =============================================================================
-// Structs for /api/v1/models/{id}/endpoints endpoint (author pricing)
-// =============================================================================
+/// Structs for `/api/v1/models/{id}/endpoints` endpoint (author pricing).
 
 #[derive(Deserialize)]
 struct EndpointPricing {
@@ -57,11 +53,10 @@ struct EndpointsResponse {
     data: EndpointData,
 }
 
-// =============================================================================
-// Mapping from model ID prefix to author provider name
-// =============================================================================
-
-/// Maps the model ID prefix (e.g., "z-ai") to the provider_name in endpoints API (e.g., "Z.AI")
+/// Model ID prefix to provider name mapping.
+///
+/// Translates model ID prefixes like `z-ai` to their corresponding
+/// provider names in the endpoints API, such as `Z.AI`.
 fn get_author_provider_name(model_id: &str) -> Option<&'static str> {
     let prefix = model_id.split('/').next()?;
     
@@ -77,7 +72,7 @@ fn get_author_provider_name(model_id: &str) -> Option<&'static str> {
         "qwen" => Some("Alibaba"),
         "cohere" => Some("Cohere"),
         "perplexity" => Some("Perplexity"),
-        "moonshotai" => Some("Moonshot"),
+        "moonshotai" => Some("Moonshot AI"),
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary
- Fix OpenRouter pricing to use author provider prices instead of cheapest aggregated prices
- Fetch `/api/v1/models/{id}/endpoints` API and filter by `provider_name` matching the model author
- Extract complete pricing including `cache_read` from author endpoint

## Problem
The previous implementation used `/api/v1/models` which returns aggregated pricing (cheapest provider). This caused incorrect pricing for models like `glm-4.7` where the cheapest provider (Chutes) has different rates than the author provider (Z.AI).

### Before (using cheapest provider - Chutes)
| Field | Value |
|-------|-------|
| Input | $0.40/M |
| Output | $1.50/M |
| Cache Read | ❌ Not available |

### After (using author provider - Z.AI)
| Field | Value |
|-------|-------|
| Input | $0.60/M |
| Output | $2.20/M |
| Cache Read | $0.11/M ✅ |

## Changes
- Fetch model list from `/api/v1/models`
- For each model with known author, fetch `/api/v1/models/{id}/endpoints`
- Filter endpoints by `provider_name` matching author (e.g., Z.AI, xAI, Google, Anthropic)
- Extract pricing including `input_cache_read` from author endpoint
- Parallel fetching with semaphore (10 concurrent requests)

## Related
Continues the work from #56 (original TypeScript implementation) that was migrated to Rust in #64.