### PR TITLE
fix: add --platform flag to napi build for local development

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "artifacts": "napi artifacts",
-    "build": "napi build --release",
+    "build": "napi build --platform --release",
     "build:platform": "napi build --platform --release",
     "build:debug": "napi build",
     "prepublishOnly": "napi prepublish -t npm",


### PR DESCRIPTION
## Problem

On ARM Mac, running `bun run cli` after `bun run build:core` fails with:

```
Error: Native module required. Run: bun run build:core
```

## Cause

- `napi build --release` only generates `tokscale-core.node`
- `index.js` looks for platform-specific filename (`tokscale-core.darwin-arm64.node`)
- Filename mismatch causes module load failure on local builds

## Fix

Add `--platform` flag to `build` script so it generates platform-specific filenames

```diff
- "build": "napi build --release",
+ "build": "napi build --platform --release",
```