### PR TITLE
fix(cli): add native-runner.js shim for bunx execution

### DIFF
--- a/packages/cli/src/native-runner.js
+++ b/packages/cli/src/native-runner.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env bun
+// Shim for bunx: when Bun loads src/ directly instead of dist/,
+// this file redirects to the TypeScript source.
+await import("./native-runner.ts");


### PR DESCRIPTION
## Summary

Fixes "Module not found" error when running `bunx tokscale@latest`.

## Problem

When executing via `bunx`, Bun may resolve TypeScript source files directly from `src/` instead of compiled `dist/` files. This causes `__dirname` in `native.ts` to point to `src/`, which then fails to find `native-runner.js` because only `native-runner.ts` exists there.

**Error message:**
```
Error: Subprocess 'finalizeReportAndGraph' failed: error: Module not found "/private/tmp/bunx-501-tokscale@latest/node_modules/@tokscale/cli/src/native-runner.js"
```

## Root Cause

1. The npm package includes both `dist/` (compiled) and `src/` (source) directories
2. Bun's module resolution may load `src/*.ts` files directly instead of `dist/*.js`
3. When this happens, `__dirname` becomes `src/` instead of `dist/`
4. `native.ts` looks for `native-runner.js` in `__dirname`, but only `.ts` exists in `src/`

## Solution

Add a minimal shim file `src/native-runner.js` that redirects to the TypeScript source:

```js
#!/usr/bin/env bun
// Shim for bunx: when Bun loads src/ directly instead of dist/,
// this file redirects to the TypeScript source.
await import("./native-runner.ts");
```

This is a non-invasive fix that:
- Does not modify any existing code
- Does not affect normal execution via `dist/`
- Only activates when Bun resolves from `src/`

## Testing

- Verified shim loads correctly: `bun src/native-runner.js` executes without import errors
- Verified shim is included in npm package: `npm pack --dry-run` shows `src/native-runner.js`