### PR TITLE
fix(tui): force dark background for light terminal themes

### DIFF
--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -345,7 +345,7 @@ export function App(props: AppProps) {
   };
 
   return (
-    <box flexDirection="column" width={columns()} height={rows()}>
+    <box flexDirection="column" width={columns()} height={rows()} backgroundColor="black">
       <Header activeTab={activeTab()} onTabClick={handleTabClick} width={columns()} />
 
       <box flexDirection="column" flexGrow={1} paddingX={1}>


### PR DESCRIPTION
## Summary
- Add `backgroundColor="black"` to TUI root container
- Fix text visibility issue on light terminal themes

## Problem
TUI did not specify a background color, inheriting the terminal's default background. On light themes, gray text (`#666666`, `#AAAAAA`, `dim`) becomes invisible.

## Solution
Force black background on the root container so text is visible regardless of terminal theme.