### PR TITLE
fix(frontend): align 3D graph cube height with color intensity using tokens

### DIFF
--- a/packages/frontend/src/components/GraphContainer.tsx
+++ b/packages/frontend/src/components/GraphContainer.tsx
@@ -94,9 +94,9 @@ export function GraphContainer({ data }: GraphContainerProps) {
 
   useEffect(() => {
     if (!initializedRef.current && yearContributions.length > 0) {
-      const activeDaysWithCost = yearContributions.filter((c) => c.totals.cost > 0);
-      if (activeDaysWithCost.length > 0) {
-        const latestDay = activeDaysWithCost[activeDaysWithCost.length - 1];
+      const activeDaysWithTokens = yearContributions.filter((c) => c.totals.tokens > 0);
+      if (activeDaysWithTokens.length > 0) {
+        const latestDay = activeDaysWithTokens[activeDaysWithTokens.length - 1];
         // Intentional one-time initialization on first data load
         // eslint-disable-next-line react-hooks/set-state-in-effect
         setSelectedDay(latestDay);

--- a/packages/frontend/src/components/TokenGraph3D.tsx
+++ b/packages/frontend/src/components/TokenGraph3D.tsx
@@ -221,7 +221,7 @@ export function TokenGraph3D({
         pixelView.renderObject(cube, p3d);
       }
     }
-  }, [obeliskLoaded, contributions, palette, year, maxTokens, weeksData, isDark]);
+  }, [obeliskLoaded, palette, year, maxTokens, weeksData, isDark]);
 
   const getDayAtPosition = useCallback(
     (clientX: number, clientY: number): { day: DailyContribution | null; position: TooltipPosition } | null => {


### PR DESCRIPTION
## Summary

This PR fixes an important visual consistency bug in the 3D contribution graph where the two visual dimensions (color + height) represented **different metrics**.

## Problem

The 3D contribution graph had an inconsistency:
- **Color intensity** was based on **tokens** ✅ (correct)
- **Cube height** was based on **cost** ❌ (inconsistent)

This caused confusing visualizations where a tall cube (high cost) could have low color intensity (low tokens) and vice versa. For example:
- Using an expensive model with few tokens: tall cube, light color
- Using a cheap model with many tokens: short cube, dark color

## Solution

Changed cube height calculation to use **tokens** instead of **cost**, ensuring both visual dimensions represent the same metric for consistency.

### Changes

| File | Change |
|------|--------|
| `TokenGraph3D.tsx` | Height calculation now uses `day.totals.tokens` instead of `day.totals.cost` |
| `TokenGraph3D.tsx` | Prop renamed from `maxCost` to `maxTokens` for clarity |
| `TokenGraph3D.tsx` | Added `useMemo` for `weeksData` to fix performance issue |
| `TokenGraph3D.tsx` | Added `isDark` to useEffect deps for proper theme toggle re-renders |
| `TokenGraph3D.tsx` | Removed redundant `contributions` from useEffect deps |
| `GraphContainer.tsx` | Updated max calculation and prop passed |
| `GraphContainer.tsx` | Changed `activeDays` filter from `cost > 0` to `tokens > 0` |
| `GraphContainer.tsx` | Changed `dateRange` filter from `cost > 0` to `tokens > 0` |
| `GraphContainer.tsx` | Changed initial day selection from `cost > 0` to `tokens > 0` |

### Before vs After

| Dimension | Before | After |
|-----------|--------|-------|
| Color intensity | tokens | tokens |
| Cube height | ❌ cost | ✅ tokens |
| Active days (graph) | cost > 0 | tokens > 0 |

## Testing

- [x] TypeScript compilation passes
- [x] Next.js build succeeds
- [x] Visual behavior verified - both color and height now correlate to the same token metric

## Future Improvements (Out of Scope)

The following are consistency improvements for future PRs:
- [ ] `utils.ts` streak/summary functions still use `cost > 0` for "active" definition - should align with graph
- [ ] `findBestDay` is still cost-based - may want token-based "best day" for token-focused UI