### PR TITLE
fix(wrapped): aggregate models by display name to prevent duplicates

### DIFF
--- a/packages/cli/src/wrapped.ts
+++ b/packages/cli/src/wrapped.ts
@@ -252,8 +252,9 @@ async function loadWrappedData(options: WrappedOptions): Promise<WrappedData> {
 
   const modelMap = new Map<string, { cost: number; tokens: number }>();
   for (const entry of report.entries) {
-    const existing = modelMap.get(entry.model) || { cost: 0, tokens: 0 };
-    modelMap.set(entry.model, {
+    const displayName = formatModelName(entry.model);
+    const existing = modelMap.get(displayName) || { cost: 0, tokens: 0 };
+    modelMap.set(displayName, {
       cost: existing.cost + entry.cost,
       tokens: existing.tokens + entry.input + entry.output + entry.cacheRead + entry.cacheWrite,
     });
@@ -681,7 +682,7 @@ async function generateWrappedImage(data: WrappedData, options: { short?: boolea
 
     ctx.fillStyle = COLORS.textPrimary;
     ctx.font = `${32 * SCALE}px Figtree, sans-serif`;
-    ctx.fillText(formatModelName(model.name), textX, yPos);
+    ctx.fillText(model.name, textX, yPos);
     yPos += 50 * SCALE;
   }
   yPos += 40 * SCALE;


### PR DESCRIPTION
## Summary

- Fix duplicate model entries in Wrapped image's "Top Models" section
- Models with different IDs but same display name are now properly consolidated

## Problem

When generating the Wrapped image, models with different raw IDs (e.g., `claude-opus-4-20250514` vs `claude-4-opus`) were being counted separately even though they represent the same model. This caused duplicate entries like "Claude Opus 4" appearing twice in the Top Models list.

## Solution

Apply `formatModelName()` during the aggregation phase instead of only at display time:

1. **Before**: Aggregate by raw model ID → Format name when rendering
2. **After**: Format name first → Aggregate by formatted display name

This ensures that all variations of the same model (with different ID formats) are consolidated into a single entry.

## Changes

- `loadWrappedData()`: Use `formatModelName(entry.model)` as the aggregation key
- `generateWrappedImage()`: Remove redundant `formatModelName()` call since names are already formatted