### PR TITLE
feat(pricing): add aliases for GPT-5.x codex OAuth plugin models

### DIFF
--- a/packages/core/src/pricing/aliases.rs
+++ b/packages/core/src/pricing/aliases.rs
@@ -6,6 +6,19 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     m.insert("big-pickle", "glm-4.7");
     m.insert("big pickle", "glm-4.7");
     m.insert("bigpickle", "glm-4.7");
+
+    // OpenAI Codex OAuth plugin models → Azure pricing (LiteLLM has azure/gpt-5.x)
+    m.insert("gpt-5.2-codex-xhigh", "azure/gpt-5.2");
+    m.insert("gpt-5.2-codex-high", "azure/gpt-5.2");
+    m.insert("gpt-5.2-codex-medium", "azure/gpt-5.2");
+    m.insert("gpt-5.2-codex", "azure/gpt-5.2");
+    m.insert("gpt-5.2", "azure/gpt-5.2");
+    m.insert("gpt-5.1-codex-xhigh", "azure/gpt-5.1");
+    m.insert("gpt-5.1-codex-high", "azure/gpt-5.1");
+    m.insert("gpt-5.1-codex-medium", "azure/gpt-5.1");
+    m.insert("gpt-5.1-codex", "azure/gpt-5.1");
+    m.insert("gpt-5.1", "azure/gpt-5.1");
+
     m
 });
 


### PR DESCRIPTION
## Summary
- Add model aliases for GPT-5.x Codex OAuth plugin model names (`gpt-5.2-codex-xhigh`, `gpt-5.2-codex-high`, `gpt-5.2-codex-medium`, etc.)
- Maps these to their Azure equivalents (`azure/gpt-5.2`, `azure/gpt-5.1`) which have pricing data in LiteLLM

## Problem
Models routed through OAuth plugins like `codex-auth` use custom model naming conventions (e.g., `gpt-5.2-codex-xhigh`). These show $0.00 cost in tokscale because the pricing lookup can't find them in LiteLLM.

## Solution
Add explicit aliases in `aliases.rs` to map the custom model names to their Azure equivalents, which have correct pricing data.

## Testing
```bash
bun run --cwd packages/cli ./src/cli.ts pricing "gpt-5.2-codex-xhigh"
# Now correctly shows: azure/gpt-5.2 pricing ($1.75/$14.00 per 1M tokens)
```