### PR TITLE
fix: Windows home directory resolution for parseLocalSources

### DIFF
--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -188,9 +188,10 @@ fn get_home_dir(home_dir_option: &Option<String>) -> napi::Result<String> {
     home_dir_option
         .clone()
         .or_else(|| std::env::var("HOME").ok())
+        .or_else(|| dirs::home_dir().map(|p| p.to_string_lossy().into_owned()))
         .ok_or_else(|| {
             napi::Error::from_reason(
-                "HOME directory not specified and HOME environment variable not set",
+                "HOME directory not specified and could not determine home directory",
             )
         })
 }


### PR DESCRIPTION
## Summary

- Fix Windows compatibility issue where `parseLocalSources` fails with "HOME directory not specified and HOME environment variable not set"
- Add `dirs::home_dir()` as cross-platform fallback for home directory resolution

## Problem

On Windows, the `HOME` environment variable is not set by default. Windows uses `USERPROFILE` instead. The previous implementation only checked for `HOME`:

```rust
fn get_home_dir(home_dir_option: &Option<String>) -> napi::Result<String> {
    home_dir_option
        .clone()
        .or_else(|| std::env::var("HOME").ok())  // ❌ Fails on Windows
        .ok_or_else(|| { ... })
}
```

## Solution

Use the `dirs` crate (already a dependency) which properly handles cross-platform home directory resolution:

```rust
fn get_home_dir(home_dir_option: &Option<String>) -> napi::Result<String> {
    home_dir_option
        .clone()
        .or_else(|| std::env::var("HOME").ok())
        .or_else(|| dirs::home_dir().map(|p| p.to_string_lossy().into_owned()))  // ✅ Works on Windows
        .ok_or_else(|| { ... })
}
```

The `dirs::home_dir()` function:
- On Windows: Uses `USERPROFILE` env var, falls back to `SHGetKnownFolderPath` API
- On Unix: Uses `HOME` env var, falls back to `getpwuid_r` function

## Testing

- ✅ `cargo check` passes
- ✅ All 120 Rust tests pass
- ✅ Maintains backward compatibility (still checks `HOME` first for Unix systems)

## Related Issues

Fixes #93 - "Failed to parse local session files" on Windows
Fixes #95 - "Error generating data: Subprocess 'parseLocalSources' failed: HOME directory not specified"