### PR TITLE
fix: add `--conditions=browser` for Windows TUI compatibility

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,9 +21,9 @@
   "scripts": {
     "build": "tsc && bun run build:tui",
     "build:tui": "echo 'TUI bundling skipped - OpenTUI requires Bun runtime'",
-    "dev": "bun src/cli.ts",
-    "tui": "bun src/cli.ts tui",
-    "start": "bun dist/cli.js",
+    "dev": "bun run --conditions=browser src/cli.ts",
+    "tui": "bun run --conditions=browser src/cli.ts tui",
+    "start": "bun run --conditions=browser dist/cli.js",
     "prepublishOnly": "bun run build"
   },
   "dependencies": {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -15,7 +15,8 @@
     "resolveJsonModule": true,
     "jsx": "react-jsx",
     "jsxImportSource": "@opentui/solid",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "customConditions": ["browser"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

- Add `--conditions=browser` flag to Bun scripts for Windows TUI compatibility
- Add `customConditions: ["browser"]` to tsconfig.json for consistent type resolution

## Problem

On Windows, the TUI shows a blank screen with no keyboard interactivity. This is because SolidJS uses conditional exports:

| Condition | Build | Features |
|-----------|-------|----------|
| `"browser"` | Client-side reactive runtime | `onMount`, `createEffect`, `useKeyboard` hooks work |
| `"node"` | SSR runtime | Browser lifecycle hooks are missing |

Without `--conditions=browser`, Bun resolves to the SSR build, causing:
- `onMount` lifecycle hooks don't fire
- `useKeyboard` in OpenTUI doesn't register handlers
- Blank screen and loss of keyboard interactivity

## Solution

Following the pattern used by [opencode](https://github.com/sst/opencode/blob/main/packages/opencode/package.json#L9) and [opencode-ralph](https://github.com/Hona/opencode-ralph/blob/main/package.json#L9):

### 1. package.json scripts
```diff
- "dev": "bun src/cli.ts",
- "tui": "bun src/cli.ts tui",
- "start": "bun dist/cli.js",
+ "dev": "bun run --conditions=browser src/cli.ts",
+ "tui": "bun run --conditions=browser src/cli.ts tui",
+ "start": "bun run --conditions=browser dist/cli.js",
```

### 2. tsconfig.json
```diff
  "compilerOptions": {
    ...
+   "customConditions": ["browser"]
  }
```

## References

- Comment suggesting fix: https://github.com/junhoyeo/tokscale/issues/41#issuecomment-3712800466
- OpenCode implementation: https://github.com/sst/opencode
- OpenCode-Ralph implementation: https://github.com/Hona/opencode-ralph

## Related Issues

Fixes #41 - TUI shows blank screen on Windows