### PR TITLE
docs: add Windows support documentation with data locations

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -576,14 +576,50 @@ cd packages/core && bun run bench
 
 | プラットフォーム | アーキテクチャ | ステータス |
 |----------|--------------|--------|
-| macOS | x86_64 | サポート |
-| macOS | aarch64（Apple Silicon） | サポート |
-| Linux | x86_64（glibc） | サポート |
-| Linux | aarch64（glibc） | サポート |
-| Linux | x86_64（musl） | サポート |
-| Linux | aarch64（musl） | サポート |
-| Windows | x86_64 | サポート |
-| Windows | aarch64 | サポート |
+| macOS | x86_64 | ✅ サポート |
+| macOS | aarch64（Apple Silicon） | ✅ サポート |
+| Linux | x86_64（glibc） | ✅ サポート |
+| Linux | aarch64（glibc） | ✅ サポート |
+| Linux | x86_64（musl） | ✅ サポート |
+| Linux | aarch64（musl） | ✅ サポート |
+| Windows | x86_64 | ✅ サポート |
+| Windows | aarch64 | ✅ サポート |
+
+### Windowsサポート
+
+TokscaleはWindowsを完全にサポートしています。TUIとCLIはmacOS/Linuxと同様に動作します。
+
+**Windowsでのインストール：**
+```powershell
+# Bunのインストール（PowerShell）
+powershell -c "irm bun.sh/install.ps1 | iex"
+
+# tokscaleの実行
+bunx tokscale@latest
+```
+
+#### Windowsでのデータ保存場所
+
+AIコーディングツールはクロスプラットフォームの場所にセッションデータを保存します。ほとんどのツールはすべてのプラットフォームで同じ相対パスを使用します：
+
+| ツール | Unixパス | Windowsパス | ソース |
+|------|-----------|--------------|--------|
+| OpenCode | `~/.local/share/opencode/` | `%USERPROFILE%\.local\share\opencode\` | クロスプラットフォームの一貫性のため[`xdg-basedir`](https://github.com/sindresorhus/xdg-basedir)を使用（[ソース](https://github.com/sst/opencode/blob/main/packages/opencode/src/global/index.ts)） |
+| Claude Code | `~/.claude/` | `%USERPROFILE%\.claude\` | すべてのプラットフォームで同じパス |
+| Codex CLI | `~/.codex/` | `%USERPROFILE%\.codex\` | `CODEX_HOME`環境変数で設定可能（[ソース](https://github.com/openai/codex)） |
+| Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | すべてのプラットフォームで同じパス |
+| Amp | `~/.local/share/amp/` | `%USERPROFILE%\.local\share\amp\` | OpenCodeと同様に`xdg-basedir`を使用 |
+| Cursor | API同期 | API同期 | APIでデータを取得、`%USERPROFILE%\.config\tokscale\cursor-cache\`にキャッシュ |
+| Droid | `~/.factory/` | `%USERPROFILE%\.factory\` | すべてのプラットフォームで同じパス |
+
+> **注**: Windowsでは`~`は`%USERPROFILE%`に展開されます（例：`C:\Users\ユーザー名`）。これらのツールは`%APPDATA%`のようなWindowsネイティブパスではなく、クロスプラットフォームの一貫性のためにUnixスタイルのパス（`.local/share`など）を意図的に使用しています。
+
+#### Windows固有の設定
+
+Tokscaleは以下の場所に設定を保存します：
+- **設定**: `%USERPROFILE%\.config\tokscale\settings.json`
+- **キャッシュ**: `%USERPROFILE%\.cache\tokscale\`
+- **Cursor認証情報**: `%USERPROFILE%\.config\tokscale\cursor-credentials.json`
 
 ## セッションデータ保持
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -575,14 +575,50 @@ cd packages/core && bun run bench
 
 | 플랫폼 | 아키텍처 | 상태 |
 |----------|--------------|--------|
-| macOS | x86_64 | 지원 |
-| macOS | aarch64 (Apple Silicon) | 지원 |
-| Linux | x86_64 (glibc) | 지원 |
-| Linux | aarch64 (glibc) | 지원 |
-| Linux | x86_64 (musl) | 지원 |
-| Linux | aarch64 (musl) | 지원 |
-| Windows | x86_64 | 지원 |
-| Windows | aarch64 | 지원 |
+| macOS | x86_64 | ✅ 지원 |
+| macOS | aarch64 (Apple Silicon) | ✅ 지원 |
+| Linux | x86_64 (glibc) | ✅ 지원 |
+| Linux | aarch64 (glibc) | ✅ 지원 |
+| Linux | x86_64 (musl) | ✅ 지원 |
+| Linux | aarch64 (musl) | ✅ 지원 |
+| Windows | x86_64 | ✅ 지원 |
+| Windows | aarch64 | ✅ 지원 |
+
+### Windows 지원
+
+Tokscale은 Windows를 완벽하게 지원합니다. TUI와 CLI는 macOS/Linux와 동일하게 작동합니다.
+
+**Windows 설치:**
+```powershell
+# Bun 설치 (PowerShell)
+powershell -c "irm bun.sh/install.ps1 | iex"
+
+# tokscale 실행
+bunx tokscale@latest
+```
+
+#### Windows에서의 데이터 위치
+
+AI 코딩 도구들은 크로스 플랫폼 위치에 세션 데이터를 저장합니다. 대부분의 도구는 모든 플랫폼에서 동일한 상대 경로를 사용합니다:
+
+| 도구 | Unix 경로 | Windows 경로 | 출처 |
+|------|-----------|--------------|--------|
+| OpenCode | `~/.local/share/opencode/` | `%USERPROFILE%\.local\share\opencode\` | 크로스 플랫폼 일관성을 위해 [`xdg-basedir`](https://github.com/sindresorhus/xdg-basedir) 사용 ([소스](https://github.com/sst/opencode/blob/main/packages/opencode/src/global/index.ts)) |
+| Claude Code | `~/.claude/` | `%USERPROFILE%\.claude\` | 모든 플랫폼에서 동일한 경로 |
+| Codex CLI | `~/.codex/` | `%USERPROFILE%\.codex\` | `CODEX_HOME` 환경변수로 설정 가능 ([소스](https://github.com/openai/codex)) |
+| Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | 모든 플랫폼에서 동일한 경로 |
+| Amp | `~/.local/share/amp/` | `%USERPROFILE%\.local\share\amp\` | OpenCode와 동일하게 `xdg-basedir` 사용 |
+| Cursor | API 동기화 | API 동기화 | API를 통해 데이터 가져오기, `%USERPROFILE%\.config\tokscale\cursor-cache\`에 캐시 |
+| Droid | `~/.factory/` | `%USERPROFILE%\.factory\` | 모든 플랫폼에서 동일한 경로 |
+
+> **참고**: Windows에서 `~`는 `%USERPROFILE%`로 확장됩니다 (예: `C:\Users\사용자이름`). 이러한 도구들은 `%APPDATA%`와 같은 Windows 기본 경로 대신 크로스 플랫폼 일관성을 위해 의도적으로 Unix 스타일 경로(`.local/share` 등)를 사용합니다.
+
+#### Windows 전용 설정
+
+Tokscale은 다음 위치에 설정을 저장합니다:
+- **설정**: `%USERPROFILE%\.config\tokscale\settings.json`
+- **캐시**: `%USERPROFILE%\.cache\tokscale\`
+- **Cursor 자격 증명**: `%USERPROFILE%\.config\tokscale\cursor-credentials.json`
 
 ## 세션 데이터 보존
 

--- a/README.md
+++ b/README.md
@@ -633,14 +633,50 @@ cd packages/core && bun run bench
 
 | Platform | Architecture | Status |
 |----------|--------------|--------|
-| macOS | x86_64 | Supported |
-| macOS | aarch64 (Apple Silicon) | Supported |
-| Linux | x86_64 (glibc) | Supported |
-| Linux | aarch64 (glibc) | Supported |
-| Linux | x86_64 (musl) | Supported |
-| Linux | aarch64 (musl) | Supported |
-| Windows | x86_64 | Supported |
-| Windows | aarch64 | Supported |
+| macOS | x86_64 | ✅ Supported |
+| macOS | aarch64 (Apple Silicon) | ✅ Supported |
+| Linux | x86_64 (glibc) | ✅ Supported |
+| Linux | aarch64 (glibc) | ✅ Supported |
+| Linux | x86_64 (musl) | ✅ Supported |
+| Linux | aarch64 (musl) | ✅ Supported |
+| Windows | x86_64 | ✅ Supported |
+| Windows | aarch64 | ✅ Supported |
+
+### Windows Support
+
+Tokscale fully supports Windows. The TUI and CLI work the same as on macOS/Linux.
+
+**Installation on Windows:**
+```powershell
+# Install Bun (PowerShell)
+powershell -c "irm bun.sh/install.ps1 | iex"
+
+# Run tokscale
+bunx tokscale@latest
+```
+
+#### Data Locations on Windows
+
+AI coding tools store their session data in cross-platform locations. Most tools use the same relative paths on all platforms:
+
+| Tool | Unix Path | Windows Path | Source |
+|------|-----------|--------------|--------|
+| OpenCode | `~/.local/share/opencode/` | `%USERPROFILE%\.local\share\opencode\` | Uses [`xdg-basedir`](https://github.com/sindresorhus/xdg-basedir) for cross-platform consistency ([source](https://github.com/sst/opencode/blob/main/packages/opencode/src/global/index.ts)) |
+| Claude Code | `~/.claude/` | `%USERPROFILE%\.claude\` | Same path on all platforms |
+| Codex CLI | `~/.codex/` | `%USERPROFILE%\.codex\` | Configurable via `CODEX_HOME` env var ([source](https://github.com/openai/codex)) |
+| Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | Same path on all platforms |
+| Amp | `~/.local/share/amp/` | `%USERPROFILE%\.local\share\amp\` | Uses `xdg-basedir` like OpenCode |
+| Cursor | API sync | API sync | Data fetched via API, cached in `%USERPROFILE%\.config\tokscale\cursor-cache\` |
+| Droid | `~/.factory/` | `%USERPROFILE%\.factory\` | Same path on all platforms |
+
+> **Note**: On Windows, `~` expands to `%USERPROFILE%` (e.g., `C:\Users\YourName`). These tools intentionally use Unix-style paths (like `.local/share`) even on Windows for cross-platform consistency, rather than Windows-native paths like `%APPDATA%`.
+
+#### Windows-Specific Configuration
+
+Tokscale stores its configuration in:
+- **Config**: `%USERPROFILE%\.config\tokscale\settings.json`
+- **Cache**: `%USERPROFILE%\.cache\tokscale\`
+- **Cursor credentials**: `%USERPROFILE%\.config\tokscale\cursor-credentials.json`
 
 ## Session Data Retention
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -576,14 +576,50 @@ cd packages/core && bun run bench
 
 | 平台 | 架构 | 状态 |
 |----------|--------------|--------|
-| macOS | x86_64 | 支持 |
-| macOS | aarch64（Apple Silicon） | 支持 |
-| Linux | x86_64（glibc） | 支持 |
-| Linux | aarch64（glibc） | 支持 |
-| Linux | x86_64（musl） | 支持 |
-| Linux | aarch64（musl） | 支持 |
-| Windows | x86_64 | 支持 |
-| Windows | aarch64 | 支持 |
+| macOS | x86_64 | ✅ 支持 |
+| macOS | aarch64（Apple Silicon） | ✅ 支持 |
+| Linux | x86_64（glibc） | ✅ 支持 |
+| Linux | aarch64（glibc） | ✅ 支持 |
+| Linux | x86_64（musl） | ✅ 支持 |
+| Linux | aarch64（musl） | ✅ 支持 |
+| Windows | x86_64 | ✅ 支持 |
+| Windows | aarch64 | ✅ 支持 |
+
+### Windows 支持
+
+Tokscale 完全支持 Windows。TUI 和 CLI 的工作方式与 macOS/Linux 相同。
+
+**Windows 安装：**
+```powershell
+# 安装 Bun（PowerShell）
+powershell -c "irm bun.sh/install.ps1 | iex"
+
+# 运行 tokscale
+bunx tokscale@latest
+```
+
+#### Windows 上的数据位置
+
+AI 编程工具将会话数据存储在跨平台位置。大多数工具在所有平台上使用相同的相对路径：
+
+| 工具 | Unix 路径 | Windows 路径 | 来源 |
+|------|-----------|--------------|--------|
+| OpenCode | `~/.local/share/opencode/` | `%USERPROFILE%\.local\share\opencode\` | 使用 [`xdg-basedir`](https://github.com/sindresorhus/xdg-basedir) 实现跨平台一致性（[源码](https://github.com/sst/opencode/blob/main/packages/opencode/src/global/index.ts)） |
+| Claude Code | `~/.claude/` | `%USERPROFILE%\.claude\` | 所有平台使用相同路径 |
+| Codex CLI | `~/.codex/` | `%USERPROFILE%\.codex\` | 可通过 `CODEX_HOME` 环境变量配置（[源码](https://github.com/openai/codex)） |
+| Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | 所有平台使用相同路径 |
+| Amp | `~/.local/share/amp/` | `%USERPROFILE%\.local\share\amp\` | 与 OpenCode 一样使用 `xdg-basedir` |
+| Cursor | API 同步 | API 同步 | 通过 API 获取数据，缓存在 `%USERPROFILE%\.config\tokscale\cursor-cache\` |
+| Droid | `~/.factory/` | `%USERPROFILE%\.factory\` | 所有平台使用相同路径 |
+
+> **注意**：在 Windows 上，`~` 扩展为 `%USERPROFILE%`（例如 `C:\Users\用户名`）。这些工具故意使用 Unix 风格的路径（如 `.local/share`）而不是 Windows 原生路径（如 `%APPDATA%`），以实现跨平台一致性。
+
+#### Windows 特定配置
+
+Tokscale 将配置存储在：
+- **配置**: `%USERPROFILE%\.config\tokscale\settings.json`
+- **缓存**: `%USERPROFILE%\.cache\tokscale\`
+- **Cursor 凭据**: `%USERPROFILE%\.config\tokscale\cursor-credentials.json`
 
 ## 会话数据保留
 


### PR DESCRIPTION
## Summary

- Add comprehensive Windows support section to all README files (EN, KO, JA, ZH-CN)
- Document where each AI tool stores data on Windows vs Unix
- Include source links to official repositories

## Research Findings

Based on source code analysis of each AI coding tool:

| Tool | Windows Path | How it works | Source |
|------|--------------|--------------|--------|
| **OpenCode** | `%USERPROFILE%\.local\share\opencode\` | Uses [`xdg-basedir`](https://github.com/sindresorhus/xdg-basedir) npm package | [source](https://github.com/sst/opencode/blob/main/packages/opencode/src/global/index.ts) |
| **Claude Code** | `%USERPROFILE%\.claude\` | Same relative path on all platforms | - |
| **Codex CLI** | `%USERPROFILE%\.codex\` | Configurable via `CODEX_HOME` | [source](https://github.com/openai/codex) |
| **Gemini CLI** | `%USERPROFILE%\.gemini\` | Same relative path on all platforms | - |
| **Amp** | `%USERPROFILE%\.local\share\amp\` | Uses `xdg-basedir` like OpenCode | - |
| **Droid** | `%USERPROFILE%\.factory\` | Same relative path on all platforms | - |

### Key Insight

These AI tools **intentionally use Unix-style paths** (like `~/.local/share`) even on Windows for cross-platform consistency, rather than Windows-native paths like `%APPDATA%`. This means tokscale's existing path handling already works correctly on Windows.

## Changes

### README.md (English)
- Added "Windows Support" subsection under "Supported Platforms"
- Added PowerShell installation instructions
- Added data location comparison table with sources
- Added Windows-specific configuration paths

### README.ko.md (Korean)
- Same content translated to Korean

### README.ja.md (Japanese)  
- Same content translated to Japanese

### README.zh-cn.md (Chinese)
- Same content translated to Simplified Chinese

## Related

This PR complements the Windows bug fixes in:
- #98 - Windows home directory resolution
- #99 - Windows TUI SolidJS conditions