### PR TITLE
Add date sorting support for Daily tab in TUI

### DIFF
--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -205,7 +205,7 @@ export function App(props: AppProps) {
       return;
     }
 
-    if (key.name === "tab" || key.name === "d" || key.name === "right") {
+    if (key.name === "tab" || key.name === "right") {
       setActiveTab(cycleTabForward(activeTab()));
       setSelectedIndex(0);
       setScrollOffset(0);
@@ -267,6 +267,11 @@ export function App(props: AppProps) {
     }
     if (key.name === "t") {
       handleSortChange("tokens");
+      return;
+    }
+
+    if (key.name === "d") {
+      handleSortChange("date");
       return;
     }
 

--- a/packages/cli/src/tui/components/DailyView.tsx
+++ b/packages/cli/src/tui/components/DailyView.tsx
@@ -77,7 +77,7 @@ export function DailyView(props: DailyViewProps) {
   });
 
   const sortArrow = () => (props.sortDesc ? "▼" : "▲");
-  const dateHeader = () => "Date";
+  const dateHeader = () => (props.sortBy === "date" ? `${sortArrow()} Date` : "Date");
   const totalHeader = () => (props.sortBy === "tokens" ? `${sortArrow()} Total` : "Total");
   const costHeader = () => (props.sortBy === "cost" ? `${sortArrow()} Cost` : "Cost");
 

--- a/packages/cli/src/tui/components/Footer.tsx
+++ b/packages/cli/src/tui/components/Footer.tsx
@@ -140,6 +140,12 @@ export function Footer(props: FooterProps) {
           <Show when={!isVeryNarrowTerminal()}>
             <text dim>|</text>
             <SortButton
+              label="Date"
+              sortType="date"
+              active={props.sortBy === "date"}
+              onClick={props.onSortChange}
+            />
+            <SortButton
               label="Cost"
               sortType="cost"
               active={props.sortBy === "cost"}

--- a/packages/cli/src/tui/types/index.ts
+++ b/packages/cli/src/tui/types/index.ts
@@ -1,7 +1,7 @@
 import type { ColorPaletteName } from "../config/themes.js";
 
 export type TabType = "overview" | "model" | "daily" | "stats";
-export type SortType = "cost" | "tokens";
+export type SortType = "cost" | "tokens" | "date";
 export type SourceType = "opencode" | "claude" | "codex" | "cursor" | "gemini" | "amp" | "droid";
 
 export type { ColorPaletteName };


### PR DESCRIPTION

<img width="1265" height="705" alt="image" src="https://github.com/user-attachments/assets/1b0df44b-09ee-4516-8bd5-575fa4b06baa" />


## Summary
- Add 'date' as a sort option for the Daily tab alongside 'cost' and 'tokens'
- Reassigns the 'd' keyboard shortcut from tab navigation to date sorting (users can still use Tab and → arrow keys)
- Add a Date sort button to the footer UI
- Show a sort arrow indicator (▼/▲) on the Date column header when active

## Changes
- Updated `SortType` type definition to include "date" option
- Removed 'd' key from tab navigation handlers in App.tsx
- Added 'd' key handler for date sorting in App.tsx
- Added Date sort button component to Footer.tsx
- Updated DailyView.tsx to display sort arrow on Date column header

## Testing
To test locally:
```bash
bun run build:core
cd packages/cli && bun src/cli.ts
```

1. Navigate to the Daily tab (Tab or → key)
2. Press `d` to sort by date (with arrow indicator)
3. Press `c` for cost or `t` for tokens sorting
4. Click the Date button in the footer to toggle sort direction
5. Verify the sort arrow changes between ▼ and ▲

## Motivation
Users can already sort daily entries by cost and tokens, but date sorting was missing despite being a primary column. This makes it easier to find usage patterns and chronologically analyze daily token consumption.