### PR TITLE
refactor(tui): make date sort case explicit in DailyView

### DIFF
--- a/packages/cli/src/tui/components/DailyView.tsx
+++ b/packages/cli/src/tui/components/DailyView.tsx
@@ -50,7 +50,7 @@ export function DailyView(props: DailyViewProps) {
       let cmp = 0;
       if (sortBy === "cost") cmp = a.cost - b.cost;
       else if (sortBy === "tokens") cmp = a.total - b.total;
-      else cmp = a.date.localeCompare(b.date);
+      else if (sortBy === "date") cmp = a.date.localeCompare(b.date);
       return sortDesc ? -cmp : cmp;
     });
   });


### PR DESCRIPTION
## Summary
- Makes the date sort case explicit in DailyView sort logic instead of relying on implicit else fallback

## Changes
Changed from:
```typescript
if (sortBy === "cost") cmp = a.cost - b.cost;
else if (sortBy === "tokens") cmp = a.total - b.total;
else cmp = a.date.localeCompare(b.date);  // implicit fallback
```

To:
```typescript
if (sortBy === "cost") cmp = a.cost - b.cost;
else if (sortBy === "tokens") cmp = a.total - b.total;
else if (sortBy === "date") cmp = a.date.localeCompare(b.date);  // explicit
```

## Motivation
Follow-up to #103. While the previous implementation worked correctly (date sorting fell through to the else branch), this change makes the code intent clearer and treats date sorting as a first-class option alongside cost and tokens.