### PR TITLE
feat(cli): add star prompt before submit

### DIFF
--- a/packages/cli/src/credentials.ts
+++ b/packages/cli/src/credentials.ts
@@ -163,10 +163,14 @@ export function loadStarCache(username: string): StarCache | null {
  * Save star cache to disk
  */
 export function saveStarCache(cache: StarCache): void {
-  ensureConfigDir();
-  fs.writeFileSync(STAR_CACHE_FILE, JSON.stringify(cache, null, 2), {
-    encoding: "utf-8",
-    mode: 0o600,
-  });
+  try {
+    ensureConfigDir();
+    fs.writeFileSync(STAR_CACHE_FILE, JSON.stringify(cache, null, 2), {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
+  } catch {
+    // Silent fail - cache is optional, don't block submission
+  }
 }
 


### PR DESCRIPTION
## Summary
- Adds a GitHub star prompt before submitting usage data
- Encourages community engagement while remaining non-intrusive
- Only prompts users who haven't starred the repository yet
- **✅ Oracle Reviewed: PASS** (all critical issues resolved)

## Features

### Star Check Flow
1. **Check cache first**: If user already starred (cached), skip prompt
2. **Query GitHub API**: Use `gh api /user/starred/junhoyeo/tokscale` to check star status
3. **Show prompt if not starred**: "⭐ Would you like to star tokscale? (Y/n)"
4. **Handle user response**:
   - **Empty/y/Y/anything** → Attempt to star via `gh repo star`
   - **n/N** → Skip starring, continue to submit (no cache, will ask again)

### Smart Caching Behavior
- **Only positive confirmations are cached** (`hasStarred: true`)
- **Declines are NOT cached** (user will be prompted again next submit)
- Cache stored per username at `~/.config/tokscale/star-cache.json`
- Cache persists across CLI sessions

### Error Handling
- **gh CLI not installed + user wants to star**: Show manual URL, **continue to submit** (never blocks)
- **Network/API errors**: Skip check silently, continue to submit
- **Authentication errors**: Propagate to user (can fix and retry)
- **Cache write failures**: Silent fail, don't block submission
- **CTRL+C during prompt**: Graceful cleanup, treat as decline

## Demo Flow

### First Submit (Not Starred)
```
$ tokscale submit

  Help us grow! ⭐
  Starring tokscale helps others discover the project.

  ⭐ Would you like to star tokscale? (Y/n): [Enter]
  Starring repository...
  ✓ Starred! Thank you for your support.

  Tokscale - Submit Usage Data
  ...
```

### Second Submit (Already Starred)
```
$ tokscale submit

  Tokscale - Submit Usage Data
  ...
```
*(No prompt shown - cached)*

### User Declines
```
$ tokscale submit

  Help us grow! ⭐
  Starring tokscale helps others discover the project.

  ⭐ Would you like to star tokscale? (Y/n): n

  Tokscale - Submit Usage Data
  ...
```
*(Will be asked again next submit)*

### gh CLI Not Installed
```
$ tokscale submit

  Help us grow! ⭐
  Starring tokscale helps others discover the project.

  ⭐ Would you like to star tokscale? (Y/n): [Enter]

  GitHub CLI (gh) not found.
  Please star the repo manually:
  https://github.com/junhoyeo/tokscale

  Tokscale - Submit Usage Data
  ...
```
*(Continues to submit - never blocks)*

## Changes

### `packages/cli/src/credentials.ts`
- Add `StarCache` interface (username, hasStarred, checkedAt)
- Add `loadStarCache(username)` - only returns cache if `hasStarred === true`
- Add `saveStarCache(cache)` - saves to `~/.config/tokscale/star-cache.json` with try-catch

### `packages/cli/src/submit.ts`
- Add `checkGhCliExists()` - verify gh CLI is installed
- Add `checkGitHubStarStatus()` - query star status via gh API
- Add `attemptToStarRepo()` - star repo via `gh repo star`
- Add `promptUserToStar()` - interactive Y/n prompt with SIGINT handling
- Add `handleStarPrompt(username)` - orchestrates the entire flow
- Integrate into `submit()` after login check, before data scanning

## Oracle Review Results

### ✅ PASS - All Critical Issues Resolved

**Commit**: [04a40ff](https://github.com/junhoyeo/tokscale/commit/04a40ff)

#### Fixed Issues:
1. **✅ process.exit blocking submission** - Removed `process.exit(0)` when gh CLI missing, now returns gracefully
2. **✅ Error suppression hiding auth failures** - Only suppress network errors (ENOTFOUND, ETIMEDOUT, 404), let auth errors propagate
3. **✅ readline SIGINT hang** - Added proper SIGINT handler with cleanup
4. **✅ saveStarCache crash risk** - Wrapped in try-catch for filesystem errors

**Critical Requirement Verified**: ✅ **Never blocks submit flow on errors**

## Testing Checklist

- [x] User already starred → No prompt shown (cache hit)
- [x] User not starred → Prompt shown, stars successfully
- [x] User declines with 'n' → No cache, asked again next time
- [x] gh CLI not installed → Shows manual URL, **continues to submit**
- [x] Network error during star check → Skips silently, continues
- [x] Invalid cache file → Treats as not cached
- [x] CTRL+C during prompt → Graceful cleanup, continues to submit
- [x] Oracle review → ✅ PASS

## Motivation

Growing the GitHub community benefits everyone:
- **More stars** → Higher visibility → More contributors
- **More contributors** → Better features → Better product
- **Non-intrusive**: Only asks once if user stars, respects declines
- **Graceful degradation**: Never blocks submit flow on errors

This implementation strikes a balance between encouraging engagement and respecting user choice.