### PR TITLE
fix(tui): prevent OpenTUI orphan text crash in Legend

### DIFF
--- a/packages/cli/src/tui/components/Legend.tsx
+++ b/packages/cli/src/tui/components/Legend.tsx
@@ -28,8 +28,9 @@ export function Legend(props: LegendProps) {
               <text fg={getModelColor(modelId)}>●</text>
               <text>{` ${truncateModelName(modelId)}`}</text>
               <Show when={i() < models().length - 1}>
-                <text dim>{isVeryNarrowTerminal() ? " " : "  ·"}</text>
+                {() => <text dim>{isVeryNarrowTerminal() ? " " : "  ·"}</text>}
               </Show>
+
             </box>
           )}
         </For>


### PR DESCRIPTION
## Summary
- Fixes a crash in TUI rendering caused by OpenTUI throwing `Orphan text error` when a stray/empty text node is rendered under a `<box>`.
- Wraps the conditional separator rendering in `Legend` with a function child to avoid creating an orphan text node in some terminals (observed on Windows Terminal).

## Reproduction
1. On Windows, install Bun.
2. Run `bunx tokscale@latest`.
3. TUI crashes with:
   - `Orphan text error: \"\" must have a <text> as a parent`
   - stack pointing to `src/tui/components/Legend.tsx`.

## Fix
Use a function child inside `<Show>` so the renderer doesn't create an orphan text node.

## Notes
- No behavior change intended; only prevents the crash.
- `--light` mode already works; this makes default TUI usable.