### PR TITLE
feat: allow grouping models in report output via flag/toggle

### DIFF
--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -484,7 +484,7 @@ pub async fn get_model_report(options: ReportOptions) -> napi::Result<ModelRepor
         std::collections::HashMap::new();
 
     for msg in filtered {
-        let key = format!("{}:{}:{}", msg.source, msg.provider_id, msg.model_id);
+        let key = format!("{}:{}", msg.source, msg.model_id);
         let entry = model_map.entry(key).or_insert_with(|| ModelUsage {
             source: msg.source.clone(),
             model: msg.model_id.clone(),
@@ -974,7 +974,7 @@ pub async fn finalize_report(options: FinalizeReportOptions) -> napi::Result<Mod
         std::collections::HashMap::new();
 
     for msg in all_messages {
-        let key = format!("{}:{}:{}", msg.source, msg.provider_id, msg.model_id);
+        let key = format!("{}:{}", msg.source, msg.model_id);
         let entry = model_map.entry(key).or_insert_with(|| ModelUsage {
             source: msg.source.clone(),
             model: msg.model_id.clone(),
@@ -1348,7 +1348,7 @@ pub async fn finalize_report_and_graph(options: FinalizeReportOptions) -> napi::
         std::collections::HashMap::new();
 
     for msg in all_messages {
-        let key = format!("{}:{}:{}", msg.source, msg.provider_id, msg.model_id);
+        let key = format!("{}:{}", msg.source, msg.model_id);
         let entry = model_map.entry(key).or_insert_with(|| ModelUsage {
             source: msg.source.clone(),
             model: msg.model_id.clone(),


### PR DESCRIPTION
## Summary

- Remove `provider_id` from model aggregation key to prevent duplicate entries when the same model appears with different provider names

## Problem

When a provider changes its name (e.g., `zai-coding-plan` → `zhipuai-coding-plan` for Zhipu AI), the same model (GLM-4.7) appears as two separate entries in the report because the aggregation key included the provider_id.

**Before (duplicated):**
| Model | Provider | Cost |
|-------|----------|------|
| glm-4.7 | zai-coding-plan | $8.92 |
| glm-4.7 | zhipuai-coding-plan | $0.15 |

**After (consolidated):**
| Model | Cost |
|-------|------|
| glm-4.7 | $9.07 |

## Changes

Changed aggregation key from `source:provider_id:model_id` to `source:model_id` in 3 locations:
- `get_model_report()` 
- `finalize_report()`
- `finalize_report_and_graph()`

This is safe because:
1. Cost calculation happens per-message BEFORE aggregation
2. Pricing always uses the official provider price (not intermediary)
3. The `provider` field is retained in `ModelUsage` struct for reference