### PR TITLE
chore(core): remove unused Rust crates

### DIFF
--- a/packages/core/Cargo.lock
+++ b/packages/core/Cargo.lock
@@ -51,12 +51,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
-name = "anyhow"
-version = "1.0.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,16 +73,6 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
-
-[[package]]
-name = "bstr"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "bumpalo"
@@ -518,19 +502,6 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
-]
-
-[[package]]
-name = "globset"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata",
- "regex-syntax",
 ]
 
 [[package]]
@@ -1615,12 +1586,9 @@ dependencies = [
 name = "tokscale-core"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "chrono",
  "criterion",
  "dirs",
- "futures",
- "globset",
  "napi",
  "napi-build",
  "napi-derive",

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -26,14 +26,12 @@ serde_json = "1"
 
 # File system traversal
 walkdir = "2"
-globset = "=0.4.15"  # Pin to version without edition2024 requirement
 
 # Date/time handling
 chrono = { version = "0.4", features = ["serde"] }
 
 # Error handling
 thiserror = "2"
-anyhow = "1"
 
 # HTTP client (async) - for pricing fetching
 # Using native-tls-vendored to compile OpenSSL from source for cross-compilation
@@ -42,9 +40,6 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 
 # For disk caching (XDG paths)
 dirs = "5"
-
-# Async utilities
-futures = "0.3"
 
 # Lazy static initialization
 once_cell = "1"


### PR DESCRIPTION
## Summary

Remove unused Rust dependencies from `packages/core/Cargo.toml`.

## Removed Crates

| Crate | Reason |
|-------|--------|
| `globset` | Pinned at `=0.4.15` but never imported anywhere |
| `anyhow` | Not used - `thiserror` handles all error types |
| `futures` | Not used - `tokio` handles async operations |

## Validation

```
$ rg "use globset\|globset::" src/
(no results)

$ rg "use anyhow\|anyhow::" src/
(no results)

$ rg "use futures\|futures::" src/
(no results)
```

## Verification

- [x] `cargo build --release` passes
- [x] 134 tests pass
- [x] napi module builds successfully
- [x] CLI commands work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed three unused Rust crates from packages/core to reduce the dependency surface and simplify builds. All builds and tests still pass.

- **Dependencies**
  - Removed globset (=0.4.15) — not used.
  - Removed anyhow — thiserror covers error handling.
  - Removed futures — tokio handles async.

<sup>Written for commit 1238e4fcf725937b6bd33ce1b2a2277adf28d9fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

