### PR TITLE
docs: sync headless mode documentation to README translations

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -381,6 +381,55 @@ TOKSCALE_MAX_OUTPUT_BYTES=104857600 tokscale --json > report.json
 
 > **注**: これらの制限はハングやメモリ問題を防ぐための安全対策です。ほとんどのユーザーは変更する必要がありません。
 
+### ヘッドレスモード
+
+Tokscaleは、自動化、CI/CDパイプライン、バッチ処理のための**ヘッドレス/非対話型CLI出力**からトークン使用量を集計できます。
+
+**ヘッドレスモードとは？**
+
+AIコーディングツールをJSON出力フラグ付きで実行すると（例：\`codex exec --json\`、\`claude --output-format json\`）、通常のセッションディレクトリに保存する代わりに、使用量データをstdoutに出力します。ヘッドレスモードを使用すると、この使用量をキャプチャして追跡できます。
+
+**保存場所:** \`~/.config/tokscale/headless/\`
+
+Tokscaleは次のディレクトリ構造を自動的にスキャンします:
+\`\`\`
+~/.config/tokscale/headless/
+├── claude/      # Claude Code JSON出力
+├── codex/       # Codex CLI JSONL出力
+└── gemini/      # Gemini CLI JSON/JSONL出力
+\`\`\`
+
+**環境変数:** \`TOKSCALE_HEADLESS_DIR\`を設定してヘッドレスログディレクトリをカスタマイズできます:
+\`\`\`bash
+export TOKSCALE_HEADLESS_DIR="$HOME/my-custom-logs"
+\`\`\`
+
+**使用例:**
+
+| ツール | コマンド例 |
+|--------|-----------|
+| **Codex CLI** | \`codex exec --json "implement feature" > ~/.config/tokscale/headless/codex/ci-run.jsonl\` |
+| **Claude Code** | \`claude --output-format json "fix bugs" > ~/.config/tokscale/headless/claude/automation.json\` |
+| **Claude Code (ストリーミング)** | \`claude --output-format stream-json "task" > ~/.config/tokscale/headless/claude/stream.jsonl\` |
+| **Gemini CLI** | *(サポートされている場合)* \`gemini --json "analyze" > ~/.config/tokscale/headless/gemini/batch.json\` |
+
+**CI/CD統合例:**
+
+\`\`\`bash
+# GitHub Actionsワークフローで
+- name: Run AI automation
+  run: |
+    mkdir -p ~/.config/tokscale/headless/claude
+    claude --output-format json "review code changes" \\
+      > ~/.config/tokscale/headless/claude/pr-\${{ github.event.pull_request.number }}.json
+
+# 後で使用量を追跡
+- name: Report token usage
+  run: tokscale --json
+\`\`\`
+
+> **注**: ツールはJSON出力を自動的にファイルに保存しません。上記のようにstdoutをヘッドレスディレクトリにリダイレクトする必要があります。
+
 ## フロントエンド可視化
 
 フロントエンドはGitHubスタイルの貢献グラフ可視化を提供します：

--- a/README.ko.md
+++ b/README.ko.md
@@ -380,6 +380,55 @@ TOKSCALE_MAX_OUTPUT_BYTES=104857600 tokscale --json > report.json
 
 > **참고**: 이러한 제한은 중단 및 메모리 문제를 방지하기 위한 안전 조치입니다. 대부분의 사용자는 변경할 필요가 없습니다.
 
+### Headless 모드
+
+Tokscale은 자동화, CI/CD 파이프라인 및 배치 처리를 위한 **headless/비대화형 CLI 출력**의 토큰 사용량을 집계할 수 있습니다.
+
+**Headless 모드란?**
+
+AI 코딩 도구를 JSON 출력 플래그와 함께 실행할 때(예: \`codex exec --json\`, \`claude --output-format json\`), 일반 세션 디렉토리에 저장하는 대신 사용량 데이터를 stdout으로 출력합니다. Headless 모드를 사용하면 이러한 사용량을 캡처하고 추적할 수 있습니다.
+
+**저장 위치:** \`~/.config/tokscale/headless/\`
+
+Tokscale은 다음 디렉토리 구조를 자동으로 스캔합니다:
+\`\`\`
+~/.config/tokscale/headless/
+├── claude/      # Claude Code JSON 출력
+├── codex/       # Codex CLI JSONL 출력
+└── gemini/      # Gemini CLI JSON/JSONL 출력
+\`\`\`
+
+**환경 변수:** \`TOKSCALE_HEADLESS_DIR\`을 설정하여 headless 로그 디렉토리를 커스터마이징할 수 있습니다:
+\`\`\`bash
+export TOKSCALE_HEADLESS_DIR="$HOME/my-custom-logs"
+\`\`\`
+
+**사용 예시:**
+
+| 도구 | 명령어 예시 |
+|------|-------------|
+| **Codex CLI** | \`codex exec --json "implement feature" > ~/.config/tokscale/headless/codex/ci-run.jsonl\` |
+| **Claude Code** | \`claude --output-format json "fix bugs" > ~/.config/tokscale/headless/claude/automation.json\` |
+| **Claude Code (스트리밍)** | \`claude --output-format stream-json "task" > ~/.config/tokscale/headless/claude/stream.jsonl\` |
+| **Gemini CLI** | *(지원되는 경우)* \`gemini --json "analyze" > ~/.config/tokscale/headless/gemini/batch.json\` |
+
+**CI/CD 통합 예시:**
+
+\`\`\`bash
+# GitHub Actions 워크플로우에서
+- name: Run AI automation
+  run: |
+    mkdir -p ~/.config/tokscale/headless/claude
+    claude --output-format json "review code changes" \\
+      > ~/.config/tokscale/headless/claude/pr-\${{ github.event.pull_request.number }}.json
+
+# 나중에 사용량 추적
+- name: Report token usage
+  run: tokscale --json
+\`\`\`
+
+> **참고**: 도구들은 JSON 출력을 자동으로 파일에 저장하지 않습니다. 위와 같이 stdout을 headless 디렉토리로 리다이렉트해야 합니다.
+
 ## 프론트엔드 시각화
 
 프론트엔드는 GitHub 스타일의 기여 그래프 시각화를 제공합니다:

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -381,6 +381,55 @@ TOKSCALE_MAX_OUTPUT_BYTES=104857600 tokscale --json > report.json
 
 > **注意**：这些限制是防止卡住和内存问题的安全措施。大多数用户不需要更改它们。
 
+### Headless 模式
+
+Tokscale 可以聚合来自**无头/非交互式 CLI 输出**的令牌使用情况，用于自动化、CI/CD 流水线和批处理。
+
+**什么是 Headless 模式？**
+
+当您使用 JSON 输出标志运行 AI 编码工具时（例如 \`codex exec --json\`、\`claude --output-format json\`），它们会将使用数据输出到 stdout，而不是存储在常规会话目录中。Headless 模式允许您捕获和跟踪这些使用情况。
+
+**存储位置：** \`~/.config/tokscale/headless/\`
+
+Tokscale 会自动扫描此目录结构：
+\`\`\`
+~/.config/tokscale/headless/
+├── claude/      # Claude Code JSON 输出
+├── codex/       # Codex CLI JSONL 输出
+└── gemini/      # Gemini CLI JSON/JSONL 输出
+\`\`\`
+
+**环境变量：** 设置 \`TOKSCALE_HEADLESS_DIR\` 以自定义无头日志目录：
+\`\`\`bash
+export TOKSCALE_HEADLESS_DIR="$HOME/my-custom-logs"
+\`\`\`
+
+**使用示例：**
+
+| 工具 | 命令示例 |
+|------|----------|
+| **Codex CLI** | \`codex exec --json "implement feature" > ~/.config/tokscale/headless/codex/ci-run.jsonl\` |
+| **Claude Code** | \`claude --output-format json "fix bugs" > ~/.config/tokscale/headless/claude/automation.json\` |
+| **Claude Code (流式)** | \`claude --output-format stream-json "task" > ~/.config/tokscale/headless/claude/stream.jsonl\` |
+| **Gemini CLI** | *（如果支持）* \`gemini --json "analyze" > ~/.config/tokscale/headless/gemini/batch.json\` |
+
+**CI/CD 集成示例：**
+
+\`\`\`bash
+# 在 GitHub Actions 工作流中
+- name: Run AI automation
+  run: |
+    mkdir -p ~/.config/tokscale/headless/claude
+    claude --output-format json "review code changes" \\
+      > ~/.config/tokscale/headless/claude/pr-\${{ github.event.pull_request.number }}.json
+
+# 稍后跟踪使用情况
+- name: Report token usage
+  run: tokscale --json
+\`\`\`
+
+> **注意**：这些工具不会自动将 JSON 输出保存到文件。您必须如上所示将 stdout 重定向到 headless 目录。
+
 ## 前端可视化
 
 前端提供 GitHub 风格的贡献图可视化：


### PR DESCRIPTION
## Summary

Synchronizes headless mode documentation from English README to all translation files (Korean, Japanese, Simplified Chinese).

## Changes

- ✅ **README.ko.md** - Added Korean translation of headless mode section
- ✅ **README.ja.md** - Added Japanese translation of headless mode section  
- ✅ **README.zh-cn.md** - Added Simplified Chinese translation of headless mode section

All translations include:
- Explanation of headless/non-interactive CLI outputs for automation
- Storage location (`~/.config/tokscale/headless/`) and directory structure
- Environment variable configuration (`TOKSCALE_HEADLESS_DIR`)
- Tool-specific usage examples (Codex CLI, Claude Code, Gemini CLI)
- CI/CD integration examples with GitHub Actions

## Context

Related to PR #120 (headless CLI log aggregation) and commit afabd99 which added headless mode documentation to the English README but didn't update translations.

## Verification

- [x] All 3 translation files updated (+49 lines each, 147 lines total)
- [x] Markdown formatting preserved
- [x] Code examples and technical terms kept in English
- [x] Natural language translation for Korean/Japanese/Chinese readers
- [x] Consistent with English README structure

## Preview

### Korean (README.ko.md)
```markdown
### Headless 모드

Tokscale은 자동화, CI/CD 파이프라인 및 배치 처리를 위한 **headless/비대화형 CLI 출력**의 토큰 사용량을 집계할 수 있습니다.
```

### Japanese (README.ja.md)
```markdown
### ヘッドレスモード

Tokscaleは、自動化、CI/CDパイプライン、バッチ処理のための**ヘッドレス/非対話型CLI出力**からトークン使用量を集計できます。
```

### Chinese (README.zh-cn.md)
```markdown
### Headless 模式

Tokscale 可以聚合来自**无头/非交互式 CLI 输出**的令牌使用情况，用于自动化、CI/CD 流水线和批处理。
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the headless mode docs from the English README to Korean, Japanese, and Simplified Chinese READMEs to keep translations up to date. Adds translated sections covering the default log path (~/.config/tokscale/headless/), TOKSCALE_HEADLESS_DIR, tool examples (Codex, Claude, Gemini), and a GitHub Actions CI/CD example.

<sup>Written for commit 158fbf976dd2b61e43d9592b6a29cbdd99245852. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

