### PR TITLE
fix(frontend): batch daily_breakdown writes to fix ~170s submit on serverless Postgres

### DIFF
--- a/packages/cli/src/submit.ts
+++ b/packages/cli/src/submit.ts
@@ -179,6 +179,9 @@ async function handleStarPrompt(username: string): Promise<void> {
 }
 
 export async function submit(options: SubmitOptions = {}): Promise<void> {
+  const submitStart = performance.now();
+  const timing: Record<string, number> = {};
+
   const credentials = loadCredentials();
   if (!credentials) {
     console.log(pc.yellow("\n  Not logged in."));
@@ -186,7 +189,9 @@ export async function submit(options: SubmitOptions = {}): Promise<void> {
     process.exit(1);
   }
 
+  let t0 = performance.now();
   await handleStarPrompt(credentials.username);
+  timing["star-prompt"] = performance.now() - t0;
 
   console.log(pc.cyan("\n  Tokscale - Submit Usage Data\n"));
 
@@ -214,6 +219,7 @@ export async function submit(options: SubmitOptions = {}): Promise<void> {
   try {
     // Two-phase processing (same as TUI) for consistency:
     // Phase 1: Parse local sources + sync cursor in parallel
+    t0 = performance.now();
     const [localMessages, cursorSync] = await Promise.all([
       parseLocalSourcesAsync({
         sources: localSources,
@@ -225,6 +231,7 @@ export async function submit(options: SubmitOptions = {}): Promise<void> {
         ? syncCursorCache()
         : Promise.resolve({ synced: false, rows: 0, error: undefined }),
     ]);
+    timing["parse-local+cursor-sync"] = performance.now() - t0;
 
     if (includeCursor && cursorSync.error && (cursorSync.synced || hasCursorUsageCache())) {
       const prefix = cursorSync.synced ? "Cursor sync warning" : "Cursor sync failed; using cached data";
@@ -233,6 +240,7 @@ export async function submit(options: SubmitOptions = {}): Promise<void> {
 
     // Phase 2: Finalize with pricing (combines local + cursor)
     // Single subprocess call ensures consistent pricing for both report and graph
+    t0 = performance.now();
     const { report, graph } = await finalizeReportAndGraphAsync({
       localMessages,
       includeCursor: includeCursor && (cursorSync.synced || hasCursorUsageCache()),
@@ -240,6 +248,7 @@ export async function submit(options: SubmitOptions = {}): Promise<void> {
       until: options.until,
       year: options.year,
     });
+    timing["finalize-report+graph"] = performance.now() - t0;
 
     // Use graph structure for submission, report's cost for display
     data = graph;
@@ -257,6 +266,8 @@ export async function submit(options: SubmitOptions = {}): Promise<void> {
   console.log(pc.gray(`    Total cost: ${formatCurrency(data.summary.totalCost)}`));
   console.log(pc.gray(`    Sources: ${data.summary.sources.join(", ")}`));
   console.log(pc.gray(`    Models: ${data.summary.models.length} models`));
+  console.log(pc.gray(`    Contributions: ${data.contributions.length} days`));
+  console.log(pc.gray(`    Payload size: ${(JSON.stringify(data).length / 1024).toFixed(1)} KB`));
   console.log();
 
   if (data.summary.totalTokens === 0) {
@@ -276,16 +287,22 @@ export async function submit(options: SubmitOptions = {}): Promise<void> {
   const baseUrl = getApiBaseUrl();
 
   try {
+    t0 = performance.now();
+    const body = JSON.stringify(data);
+    timing["json-serialize"] = performance.now() - t0;
+
+    t0 = performance.now();
     const response = await fetch(`${baseUrl}/api/submit`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${credentials.token}`,
       },
-      body: JSON.stringify(data),
+      body,
     });
 
     const result: SubmitResponse = await response.json();
+    timing["server-roundtrip"] = performance.now() - t0;
 
     if (!response.ok) {
       console.error(pc.red(`\n  Error: ${result.error || "Submission failed"}`));
@@ -322,4 +339,14 @@ export async function submit(options: SubmitOptions = {}): Promise<void> {
     console.error(pc.gray(`  ${(error as Error).message}\n`));
     process.exit(1);
   }
+
+  // Timing summary
+  timing["total"] = performance.now() - submitStart;
+  console.log(pc.gray("  ⏱ Timing breakdown:"));
+  for (const [label, ms] of Object.entries(timing)) {
+    const formatted = ms < 1000 ? `${ms.toFixed(0)}ms` : `${(ms / 1000).toFixed(2)}s`;
+    const bar = "█".repeat(Math.max(1, Math.round(ms / timing["total"] * 20)));
+    console.log(pc.gray(`    ${label.padEnd(24)} ${formatted.padStart(8)}  ${bar}`));
+  }
+  console.log();
 }


### PR DESCRIPTION
## Summary

Fixes #128 — `POST /api/submit` took **~170 seconds** on production (Neon serverless Postgres) for 332 days of contribution data, because each day was written as a separate `INSERT`/`UPDATE` inside the transaction loop.

This PR batches all day writes into **2 queries** (1 batch INSERT + 1 batch UPDATE) instead of 332 sequential ones.

## Changes

- **`route.ts`**: Refactored Step 3c to compute all merge results in memory first, then execute a single `INSERT ... VALUES` for new days and a single `UPDATE ... FROM (VALUES ...)` for existing days. Source-level merge logic is unchanged.
- **`submit.ts`**: Added per-step timing instrumentation to CLI output so users can see where time is spent.
- Both files include `performance.now()` timing logs for ongoing observability.

## Before / After (local Docker Postgres, 332 days)

| Metric | Before (per-day loop) | After (batched) |
|--------|----------------------|-----------------|
| **1st submit** (332 INSERTs) | `tx:upsert-days=198ms` (332 queries) | `tx:batch-insert=41ms` (1 query) |
| **2nd submit** (332 UPDATEs) | `tx:upsert-days=168ms` (332 queries) | `tx:batch-update=58ms` (1 query) |
| **Total tx time** | ~200ms | ~72–264ms |

On local Postgres the difference is small, but on **serverless Postgres with ~500ms network latency per query**, this is the difference between `332 × 500ms = 166s` and `2 × 500ms = 1s`.

## Testing

- ✅ Local Docker Postgres: 1st submit (332 INSERTs) — success, data verified
- ✅ Local Docker Postgres: 2nd submit (332 UPDATEs) — success, data verified  
- ✅ Data integrity: `daily_breakdown` row count, `submissions` totals all match
- ✅ All 17 existing unit tests pass (`vitest run __tests__/api/submit.test.ts`)

**I'd appreciate thorough testing on production** since I don't have visibility into the Neon setup (connection pooling, region, etc.). The batch UPDATE uses a raw SQL `VALUES` list pattern — standard Postgres, but worth verifying on the actual deployment.

If it helps, I can send my full submit payload (~216 KB JSON) via email so you can use it as test data.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch writes for daily_breakdown in POST /api/submit, replacing 332 per-day queries with 2 bulk queries to cut submit time on serverless Postgres from ~170s to ~1s. Adds timing instrumentation in the CLI and API for clear visibility.

- **Refactors**
  - Compute merges in memory; write all days via one INSERT VALUES and one UPDATE FROM (VALUES).
  - Recalculate submission totals once; existing merge logic stays the same.

- **New Features**
  - CLI timing breakdown (parse, finalize, serialize, server roundtrip) plus days and payload size.
  - Server logs per-step timing (auth, parse/validate, tx stages, cache revalidate) in a compact summary.

<sup>Written for commit fbbd32fdf802f3b6b285cfc673b8ac6f0bc7b021. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

