### PR TITLE
feat(frontend): add client logos to filter badges and fix padding

### DIFF
--- a/packages/frontend/src/components/GraphControls.tsx
+++ b/packages/frontend/src/components/GraphControls.tsx
@@ -3,7 +3,7 @@
 import styled from "styled-components";
 import type { ViewMode, ColorPaletteName, SourceType, GraphColorPalette } from "@/lib/types";
 import { getPaletteNames, colorPalettes } from "@/lib/themes";
-import { SOURCE_DISPLAY_NAMES } from "@/lib/constants";
+import { SOURCE_DISPLAY_NAMES, SOURCE_LOGOS } from "@/lib/constants";
 import { formatTokenCount } from "@/lib/utils";
 
 interface GraphControlsProps {
@@ -157,7 +157,10 @@ const FilterLabel = styled.span`
 `;
 
 const SourceFilterButton = styled.button<{ $isSelected: boolean }>`
-  padding: 4px 12px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px 4px 6px;
   font-size: 12px;
   border-radius: 9999px;
   transition: all 200ms;
@@ -165,7 +168,6 @@ const SourceFilterButton = styled.button<{ $isSelected: boolean }>`
   opacity: ${({ $isSelected }) => $isSelected ? '1' : '0.5'};
   border: 1.5px solid;
   flex: 0 0 auto;
-  min-height: 44px;
   touch-action: manipulation;
   
   &:hover {
@@ -178,8 +180,16 @@ const SourceFilterButton = styled.button<{ $isSelected: boolean }>`
   }
 
   @media (max-width: 400px) {
-    padding: 8px 10px;
+    padding: 4px 10px 4px 4px;
   }
+`;
+
+const SourceLogo = styled.img`
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
 `;
 
 const ActionButton = styled.button`
@@ -356,6 +366,12 @@ export function GraphControls({
                     borderColor: isSelected ? palette.grade3 : "var(--color-border-default)",
                   }}
                 >
+                  {SOURCE_LOGOS[source] && (
+                    <SourceLogo
+                      src={SOURCE_LOGOS[source]}
+                      alt={`${SOURCE_DISPLAY_NAMES[source] || source} logo`}
+                    />
+                  )}
                   {SOURCE_DISPLAY_NAMES[source] || source}
                 </SourceFilterButton>
               );

--- a/packages/frontend/src/lib/constants.ts
+++ b/packages/frontend/src/lib/constants.ts
@@ -32,6 +32,20 @@ export const SOURCE_DISPLAY_NAMES: Record<string, string> = {
   cursor: "Cursor",
   amp: "Amp",
   droid: "Droid",
+  openclaw: "OpenClaw",
+};
+
+// Client logos from GitHub CDN (public repo)
+const GITHUB_CDN_BASE = "https://raw.githubusercontent.com/junhoyeo/tokscale/main/.github/assets";
+export const SOURCE_LOGOS: Record<string, string> = {
+  opencode: `${GITHUB_CDN_BASE}/client-opencode.png`,
+  claude: `${GITHUB_CDN_BASE}/client-claude.jpg`,
+  codex: `${GITHUB_CDN_BASE}/client-openai.jpg`,
+  gemini: `${GITHUB_CDN_BASE}/client-gemini.png`,
+  cursor: `${GITHUB_CDN_BASE}/client-cursor.jpg`,
+  amp: `${GITHUB_CDN_BASE}/client-amp.png`,
+  droid: `${GITHUB_CDN_BASE}/client-droid.png`,
+  openclaw: `${GITHUB_CDN_BASE}/client-openclaw.jpg`,
 };
 
 export const SOURCE_COLORS: Record<string, string> = {
@@ -42,6 +56,7 @@ export const SOURCE_COLORS: Record<string, string> = {
   cursor: "#22c55e",
   amp: "#EC4899",
   droid: "#1F1D1C",
+  openclaw: "#EF4444",
 };
 
 export const SOURCE_TEXT_COLORS: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Fix awkward top/bottom padding on client filter badges by removing `min-height: 44px`
- Add client logos (circular 20px) to each filter badge using GitHub CDN URLs
- Add missing OpenClaw configuration (`SOURCE_DISPLAY_NAMES`, `SOURCE_COLORS`)

## Before/After
The badges now display compact with logos like `[🔵] OpenCode` instead of tall awkward pills.

## Changes
- `GraphControls.tsx`: Flexbox layout with logo images, removed min-height
- `constants.ts`: Added `SOURCE_LOGOS` mapping + OpenClaw support

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds client logos to source filter badges and fixes padding to make badges compact and easier to scan. Also adds OpenClaw to source display names and colors.

- **New Features**
  - Show 20px circular client logos in filter badges (via SOURCE_LOGOS using GitHub CDN).
  - Add OpenClaw to SOURCE_DISPLAY_NAMES and SOURCE_COLORS.

- **Bug Fixes**
  - Remove min-height and adjust padding/alignment on filter badges to eliminate tall pills.

<sup>Written for commit b7e9d9e6d44fb1833519c56e4f0e854b90699ac5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

