### PR TITLE
fix: use fallback pricing from OpenRouter models list for Kimi

### DIFF
--- a/packages/core/src/pricing/lookup.rs
+++ b/packages/core/src/pricing/lookup.rs
@@ -1026,12 +1026,20 @@ mod tests {
             },
         );
 
-        // === OpenCode Zen: Kimi family ===
         m.insert(
             "moonshotai/kimi-k2".into(),
             ModelPricing {
                 input_cost_per_token: Some(4.56e-7),
                 output_cost_per_token: Some(0.00000184),
+                cache_read_input_token_cost: None,
+                cache_creation_input_token_cost: None,
+            },
+        );
+        m.insert(
+            "moonshotai/kimi-k2.5".into(),
+            ModelPricing {
+                input_cost_per_token: Some(4.5e-7),
+                output_cost_per_token: Some(0.0000025),
                 cache_read_input_token_cost: None,
                 cache_creation_input_token_cost: None,
             },
@@ -1266,6 +1274,22 @@ mod tests {
         let lookup = create_lookup();
         let result = lookup.lookup("kimi-k2-thinking").unwrap();
         assert_eq!(result.matched_key, "moonshotai/kimi-k2-thinking");
+        assert_eq!(result.source, "OpenRouter");
+    }
+
+    #[test]
+    fn test_opencode_zen_kimi_k2_5() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("kimi-k2.5").unwrap();
+        assert_eq!(result.matched_key, "moonshotai/kimi-k2.5");
+        assert_eq!(result.source, "OpenRouter");
+    }
+
+    #[test]
+    fn test_opencode_zen_kimi_k2_5_free() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("kimi-k2.5-free").unwrap();
+        assert_eq!(result.matched_key, "moonshotai/kimi-k2.5");
         assert_eq!(result.source, "OpenRouter");
     }
 
@@ -1795,14 +1819,18 @@ mod tests {
     #[test]
     fn test_prefix_and_suffix_combined() {
         let lookup = create_lookup();
-        let result = lookup.lookup("antigravity-claude-opus-4-5-thinking").unwrap();
+        let result = lookup
+            .lookup("antigravity-claude-opus-4-5-thinking")
+            .unwrap();
         assert_eq!(result.matched_key, "claude-opus-4-5");
     }
 
     #[test]
     fn test_prefix_and_suffix_with_tier() {
         let lookup = create_lookup();
-        let result = lookup.lookup("antigravity-claude-opus-4-5-thinking-high").unwrap();
+        let result = lookup
+            .lookup("antigravity-claude-opus-4-5-thinking-high")
+            .unwrap();
         assert_eq!(result.matched_key, "claude-opus-4-5");
     }
 


### PR DESCRIPTION
Closes #148

## Problem

Kimi models (kimi-k2.5, kimi-k2.5-free, kimi-k2-thinking) from OpenCode Zen showed $0 cost in Tokscale reports because the OpenRouter `/endpoints` API returns 404 for Moonshot models.

## Solution

Use pricing data from the main `/api/v1/models` response as fallback when the `/endpoints` API fails.

### How it works

1. **Before**: Fetch model list → For each model, call `/endpoints` API → If 404, skip (no pricing)
2. **After**: Fetch model list with pricing → For each model, call `/endpoints` API → If 404, use fallback pricing from step 1

### Changes

**`packages/core/src/pricing/openrouter.rs`**
- Added `ModelListPricing` struct to parse pricing from `/api/v1/models` response
- Modified `fetch_author_pricing()` to accept optional `fallback_pricing` parameter
- When `/endpoints` API fails (404, parse error, author not found), return fallback pricing instead of `None`
- Removed noisy `eprintln!` error logs for expected failures

**`packages/core/src/pricing/lookup.rs`**
- Added `moonshotai/kimi-k2.5` to mock OpenRouter data for tests
- Added tests for `kimi-k2.5` and `kimi-k2.5-free` model ID matching

## Verification

### Pricing lookup works
```
$ tokscale pricing "kimi-k2.5-free"

  Pricing for: kimi-k2.5-free
  Matched key: moonshotai/kimi-k2.5
  Source: OpenRouter

  Input:  $0.60 / 1M tokens
  Output: $3.00 / 1M tokens
  Cache Read:  $0.10 / 1M tokens
```

### Cost calculation correct
```json
{
  "model": "kimi-k2.5-free",
  "input": 1643223,
  "output": 42464,
  "cacheRead": 7379453,
  "cost": 1.85  // Previously $0
}
```

Manual verification:
- Input: 1,643,223 × $0.60/M = $0.986
- Output: 42,464 × $3.00/M = $0.127
- Cache Read: 7,379,453 × $0.10/M = $0.738
- **Total: $1.85** ✅

### All tests pass
```
test result: ok. 144 passed; 0 failed; 0 ignored
```

## Backward Compatibility

- Models that work with `/endpoints` API continue to use author-specific pricing (unchanged)
- Only models where `/endpoints` fails now get fallback pricing instead of nothing
- Cache read/write costs from `/endpoints` are still preferred when available

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes $0 cost for Kimi models by falling back to pricing from OpenRouter /api/v1/models when /endpoints returns 404. Tokscale now reports correct costs for kimi-k2.5, kimi-k2.5-free, and kimi-k2-thinking.

- **Bug Fixes**
  - Parse pricing from the main models list and use it as a fallback in fetch_author_pricing().
  - Apply fallback when /endpoints fails, JSON parse errors occur, or the author provider is missing.
  - Add mocked data and tests for Kimi model ID matching; remove noisy error logs.
  - Preserve author-specific pricing and cache costs when /endpoints succeeds.

<sup>Written for commit fdb2469b20a339a983496bd6d64af372ac79965f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

