### PR TITLE
fix(core): use tokens instead of cost for active days calculation

### DIFF
--- a/packages/core/src/aggregator.rs
+++ b/packages/core/src/aggregator.rs
@@ -42,7 +42,11 @@ pub fn aggregate_by_date(messages: Vec<UnifiedMessage>) -> Vec<DailyContribution
 
     // Convert to sorted vector with pre-allocated capacity
     let mut contributions: Vec<DailyContribution> = Vec::with_capacity(daily_map.len());
-    contributions.extend(daily_map.into_iter().map(|(date, acc)| acc.into_contribution(date)));
+    contributions.extend(
+        daily_map
+            .into_iter()
+            .map(|(date, acc)| acc.into_contribution(date)),
+    );
 
     // Sort by date
     contributions.sort_by(|a, b| a.date.cmp(&b.date));
@@ -57,7 +61,7 @@ pub fn aggregate_by_date(messages: Vec<UnifiedMessage>) -> Vec<DailyContribution
 pub fn calculate_summary(contributions: &[DailyContribution]) -> DataSummary {
     let total_tokens: i64 = contributions.iter().map(|c| c.totals.tokens).sum();
     let total_cost: f64 = contributions.iter().map(|c| c.totals.cost).sum();
-    let active_days = contributions.iter().filter(|c| c.totals.cost > 0.0).count() as i32;
+    let active_days = contributions.iter().filter(|c| c.totals.tokens > 0).count() as i32;
     let max_cost = contributions
         .iter()
         .map(|c| c.totals.cost)
@@ -173,7 +177,9 @@ impl Default for DayAccumulator {
 
 impl DayAccumulator {
     fn add_message(&mut self, msg: &UnifiedMessage) {
-        let total_tokens = msg.tokens.input
+        let total_tokens = msg
+            .tokens
+            .input
             .saturating_add(msg.tokens.output)
             .saturating_add(msg.tokens.cache_read)
             .saturating_add(msg.tokens.cache_write)
@@ -184,10 +190,22 @@ impl DayAccumulator {
         self.totals.messages = self.totals.messages.saturating_add(1);
 
         self.token_breakdown.input = self.token_breakdown.input.saturating_add(msg.tokens.input);
-        self.token_breakdown.output = self.token_breakdown.output.saturating_add(msg.tokens.output);
-        self.token_breakdown.cache_read = self.token_breakdown.cache_read.saturating_add(msg.tokens.cache_read);
-        self.token_breakdown.cache_write = self.token_breakdown.cache_write.saturating_add(msg.tokens.cache_write);
-        self.token_breakdown.reasoning = self.token_breakdown.reasoning.saturating_add(msg.tokens.reasoning);
+        self.token_breakdown.output = self
+            .token_breakdown
+            .output
+            .saturating_add(msg.tokens.output);
+        self.token_breakdown.cache_read = self
+            .token_breakdown
+            .cache_read
+            .saturating_add(msg.tokens.cache_read);
+        self.token_breakdown.cache_write = self
+            .token_breakdown
+            .cache_write
+            .saturating_add(msg.tokens.cache_write);
+        self.token_breakdown.reasoning = self
+            .token_breakdown
+            .reasoning
+            .saturating_add(msg.tokens.reasoning);
 
         // Update source contribution
         let key = format!("{}:{}", msg.source, msg.model_id);
@@ -205,8 +223,14 @@ impl DayAccumulator {
 
         source.tokens.input = source.tokens.input.saturating_add(msg.tokens.input);
         source.tokens.output = source.tokens.output.saturating_add(msg.tokens.output);
-        source.tokens.cache_read = source.tokens.cache_read.saturating_add(msg.tokens.cache_read);
-        source.tokens.cache_write = source.tokens.cache_write.saturating_add(msg.tokens.cache_write);
+        source.tokens.cache_read = source
+            .tokens
+            .cache_read
+            .saturating_add(msg.tokens.cache_read);
+        source.tokens.cache_write = source
+            .tokens
+            .cache_write
+            .saturating_add(msg.tokens.cache_write);
         source.tokens.reasoning = source.tokens.reasoning.saturating_add(msg.tokens.reasoning);
         source.cost += msg.cost;
         source.messages = source.messages.saturating_add(1);
@@ -217,11 +241,26 @@ impl DayAccumulator {
         self.totals.cost += other.totals.cost;
         self.totals.messages = self.totals.messages.saturating_add(other.totals.messages);
 
-        self.token_breakdown.input = self.token_breakdown.input.saturating_add(other.token_breakdown.input);
-        self.token_breakdown.output = self.token_breakdown.output.saturating_add(other.token_breakdown.output);
-        self.token_breakdown.cache_read = self.token_breakdown.cache_read.saturating_add(other.token_breakdown.cache_read);
-        self.token_breakdown.cache_write = self.token_breakdown.cache_write.saturating_add(other.token_breakdown.cache_write);
-        self.token_breakdown.reasoning = self.token_breakdown.reasoning.saturating_add(other.token_breakdown.reasoning);
+        self.token_breakdown.input = self
+            .token_breakdown
+            .input
+            .saturating_add(other.token_breakdown.input);
+        self.token_breakdown.output = self
+            .token_breakdown
+            .output
+            .saturating_add(other.token_breakdown.output);
+        self.token_breakdown.cache_read = self
+            .token_breakdown
+            .cache_read
+            .saturating_add(other.token_breakdown.cache_read);
+        self.token_breakdown.cache_write = self
+            .token_breakdown
+            .cache_write
+            .saturating_add(other.token_breakdown.cache_write);
+        self.token_breakdown.reasoning = self
+            .token_breakdown
+            .reasoning
+            .saturating_add(other.token_breakdown.reasoning);
 
         for (key, source) in other.sources {
             let entry = self
@@ -238,9 +277,18 @@ impl DayAccumulator {
 
             entry.tokens.input = entry.tokens.input.saturating_add(source.tokens.input);
             entry.tokens.output = entry.tokens.output.saturating_add(source.tokens.output);
-            entry.tokens.cache_read = entry.tokens.cache_read.saturating_add(source.tokens.cache_read);
-            entry.tokens.cache_write = entry.tokens.cache_write.saturating_add(source.tokens.cache_write);
-            entry.tokens.reasoning = entry.tokens.reasoning.saturating_add(source.tokens.reasoning);
+            entry.tokens.cache_read = entry
+                .tokens
+                .cache_read
+                .saturating_add(source.tokens.cache_read);
+            entry.tokens.cache_write = entry
+                .tokens
+                .cache_write
+                .saturating_add(source.tokens.cache_write);
+            entry.tokens.reasoning = entry
+                .tokens
+                .reasoning
+                .saturating_add(source.tokens.reasoning);
             entry.cost += source.cost;
             entry.messages = entry.messages.saturating_add(source.messages);
         }


### PR DESCRIPTION
## Summary

- Fixed inconsistent active days calculation between Rust core and TypeScript validation
- Changed `calculate_summary()` to count days with `tokens > 0` instead of `cost > 0.0`

## Problem

When running `tokscale submit`, users would see a warning:
```
Active days mismatch: summary=147, calculated=148
```

This happened because:
- **Rust core** (`aggregator.rs:60`): counted days where `cost > 0.0`
- **TypeScript validation** (`submission.ts:158`): counted days where `tokens > 0`

This mismatch occurs when a day has tokens but zero cost (e.g., pricing lookup failure for an unknown model).

## Solution

Aligned Rust core with TypeScript validation by using `tokens > 0` as the criterion for active days.

```rust
// Before
let active_days = contributions.iter().filter(|c| c.totals.cost > 0.0).count() as i32;

// After
let active_days = contributions.iter().filter(|c| c.totals.tokens > 0).count() as i32;
```

## Testing

- All 143 existing tests pass
- No new tests needed as this is a simple criteria change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistent active-days count by using tokens > 0 in the Rust core. This now matches the TypeScript validator and removes the submit warning during tokscale submit.

- **Bug Fixes**
  - Count active days by tokens > 0 in calculate_summary().
  - Prevent mismatch when a day has tokens but zero cost (e.g., unknown model pricing).

<sup>Written for commit 282025554e627ab538d6351b769689fceae844ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

