### PR TITLE
fix(frontend): refetch leaderboard data when switching period tabs

### DIFF
--- a/packages/frontend/src/app/(main)/LeaderboardClient.tsx
+++ b/packages/frontend/src/app/(main)/LeaderboardClient.tsx
@@ -774,6 +774,8 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
   const effectiveSortBy = mounted ? leaderboardSortBy : initialSortBy;
 
   const isFirstMount = useRef(true);
+  const prevPeriodRef = useRef<Period>(initialData.period);
+  const prevPageRef = useRef(initialData.pagination.page);
   const prevSortByRef = useRef(initialSortBy);
 
   useEffect(() => {
@@ -837,15 +839,22 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
       return;
     }
 
-    if (effectiveSortBy === prevSortByRef.current && period === initialData.period && page === initialData.pagination.page) {
+    const periodChanged = period !== prevPeriodRef.current;
+    const pageChanged = page !== prevPageRef.current;
+    const sortByChanged = effectiveSortBy !== prevSortByRef.current;
+
+    if (!periodChanged && !pageChanged && !sortByChanged) {
       return;
     }
+
+    prevPeriodRef.current = period;
+    prevPageRef.current = page;
     prevSortByRef.current = effectiveSortBy;
 
     const abortController = new AbortController();
     fetchData(period, page, effectiveSortBy, abortController.signal);
     return () => abortController.abort();
-  }, [period, page, effectiveSortBy, initialData.period, initialData.pagination.page]);
+  }, [period, page, effectiveSortBy]);
 
   useEffect(() => {
     if (data.pagination.totalPages > 0 && page > data.pagination.totalPages) {


### PR DESCRIPTION
## Summary

- Fix stale data when switching between period tabs (All Time / This Month / This Week) on the leaderboard
- Replace static `initialData` comparisons with proper previous-value refs (`prevPeriodRef`, `prevPageRef`) so every tab change triggers a fresh API call

Closes #155

## Problem

The `useEffect` in `LeaderboardClient.tsx` that fetches leaderboard data was comparing the current `period` and `page` against static `initialData` values from the server-side render. This caused the fetch to be skipped when:

1. Navigating back to the initial period (e.g., All Time → This Month → All Time)
2. Only the period changed but `sortBy` remained the same

Users had to manually refresh the page to see correct data after switching tabs.

## Fix

Replaced the flawed comparison:

```typescript
// Before (broken): compares against static server values
if (effectiveSortBy === prevSortByRef.current && period === initialData.period && page === initialData.pagination.page) {
  return;
}
```

With proper previous-value tracking:

```typescript
// After (fixed): tracks actual previous values via refs
const periodChanged = period !== prevPeriodRef.current;
const pageChanged = page !== prevPageRef.current;
const sortByChanged = effectiveSortBy !== prevSortByRef.current;

if (!periodChanged && !pageChanged && !sortByChanged) {
  return;
}

prevPeriodRef.current = period;
prevPageRef.current = page;
prevSortByRef.current = effectiveSortBy;
```

Also removed `initialData.period` and `initialData.pagination.page` from the `useEffect` dependency array since they are no longer referenced.

## Test plan

- [ ] Switch between All Time → This Month → This Week tabs and verify fresh data loads each time
- [ ] Switch back to a previously visited tab and verify it refetches
- [ ] Change sort (Tokens ↔ Cost) while on a non-default tab and verify correct data
- [ ] Paginate within a tab and verify correct page loads
- [ ] Verify initial page load still uses server-side data without an extra fetch


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refetch leaderboard data when switching period tabs to prevent stale results. Now every tab, page, or sort change triggers a fresh API call.

- **Bug Fixes**
  - Replaced comparisons against static initialData with previous-value refs (period, page, sort).
  - Removed initialData.period and initialData.pagination.page from the fetch effect dependencies.

<sup>Written for commit 9bf4708b189244455f2162da54b27908dc527860. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

