### PR TITLE
feat: manage native subprocess timeout via config file

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -385,18 +385,18 @@ tokscale cursor logout --all --purge-cache
 
 ### 環境変数
 
-大規模データセットや特別な要件を持つ上級ユーザー向け：
+環境変数は設定ファイルの値をオーバーライドします。CI/CDや一時的な使用向け：
 
 | 変数 | デフォルト | 説明 |
 |----------|---------|-------------|
-| `TOKSCALE_NATIVE_TIMEOUT_MS` | `300000`（5分） | ネイティブサブプロセス処理の最大時間 |
+| `TOKSCALE_NATIVE_TIMEOUT_MS` | `300000`（5分） | `nativeTimeoutMs` 設定をオーバーライド |
 
 ```bash
 # 例：非常に大きなデータセット用にタイムアウトを増加
 TOKSCALE_NATIVE_TIMEOUT_MS=600000 tokscale graph --output data.json
 ```
 
-> **注**: この制限はハングを防ぐための安全対策です。ほとんどのユーザーは変更する必要がありません。
+> **注**: 恒久的な変更には、`~/.config/tokscale/settings.json`で`nativeTimeoutMs`を設定することをお勧めします。環境変数は一時的なオーバーライドやCI/CDに適しています。
 
 ### ヘッドレスモード
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -384,18 +384,18 @@ tokscale cursor logout --all --purge-cache
 
 ### 환경 변수
 
-대용량 데이터셋이나 특수 요구사항이 있는 고급 사용자용:
+환경 변수는 설정 파일 값을 오버라이드합니다. CI/CD 또는 일회성 사용:
 
 | 변수 | 기본값 | 설명 |
 |----------|---------|-------------|
-| `TOKSCALE_NATIVE_TIMEOUT_MS` | `300000` (5분) | 네이티브 서브프로세스 처리 최대 시간 |
+| `TOKSCALE_NATIVE_TIMEOUT_MS` | `300000` (5분) | `nativeTimeoutMs` 설정 오버라이드 |
 
 ```bash
 # 예시: 매우 큰 데이터셋에 대한 타임아웃 증가
 TOKSCALE_NATIVE_TIMEOUT_MS=600000 tokscale graph --output data.json
 ```
 
-> **참고**: 이 제한은 중단을 방지하기 위한 안전 조치입니다. 대부분의 사용자는 변경할 필요가 없습니다.
+> **참고**: 영구적인 변경은 `~/.config/tokscale/settings.json`에서 `nativeTimeoutMs`를 설정하는 것을 권장합니다. 환경 변수는 일회성 오버라이드나 CI/CD에 적합합니다.
 
 ### Headless 모드
 

--- a/README.md
+++ b/README.md
@@ -413,21 +413,22 @@ Tokscale stores settings in `~/.config/tokscale/settings.json`:
 | `includeUnusedModels` | boolean | `false` | Show models with zero tokens in reports |
 | `autoRefreshEnabled` | boolean | `false` | Enable auto-refresh in TUI |
 | `autoRefreshMs` | number | `60000` | Auto-refresh interval (30000-3600000ms) |
+| `nativeTimeoutMs` | number | `300000` | Maximum time for native subprocess processing (5000-3600000ms) |
 
 ### Environment Variables
 
-For advanced users with large datasets or specific requirements:
+Environment variables override config file values. For CI/CD or one-off use:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `TOKSCALE_NATIVE_TIMEOUT_MS` | `300000` (5 min) | Maximum time for native subprocess processing |
+| `TOKSCALE_NATIVE_TIMEOUT_MS` | `300000` (5 min) | Overrides `nativeTimeoutMs` config |
 
 ```bash
 # Example: Increase timeout for very large datasets
 TOKSCALE_NATIVE_TIMEOUT_MS=600000 tokscale graph --output data.json
 ```
 
-> **Note**: This limit is a safety measure to prevent hangs. Most users won't need to change it.
+> **Note**: For persistent changes, prefer setting `nativeTimeoutMs` in `~/.config/tokscale/settings.json`. Environment variables are best for one-off overrides or CI/CD.
 
 ### Headless Mode
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -385,18 +385,18 @@ tokscale cursor logout --all --purge-cache
 
 ### 环境变量
 
-适用于大数据集或特殊需求的高级用户：
+环境变量会覆盖配置文件中的值。适用于 CI/CD 或一次性使用：
 
 | 变量 | 默认值 | 描述 |
 |----------|---------|-------------|
-| `TOKSCALE_NATIVE_TIMEOUT_MS` | `300000`（5 分钟） | 原生子进程处理的最大时间 |
+| `TOKSCALE_NATIVE_TIMEOUT_MS` | `300000`（5 分钟） | 覆盖 `nativeTimeoutMs` 配置 |
 
 ```bash
 # 示例：为非常大的数据集增加超时时间
 TOKSCALE_NATIVE_TIMEOUT_MS=600000 tokscale graph --output data.json
 ```
 
-> **注意**：此限制是防止卡住的安全措施。大多数用户不需要更改。
+> **注意**：如需永久更改，建议在 `~/.config/tokscale/settings.json` 中设置 `nativeTimeoutMs`。环境变量适用于一次性覆盖或 CI/CD。
 
 ### Headless 模式
 

--- a/packages/cli/src/tui/config/settings.ts
+++ b/packages/cli/src/tui/config/settings.ts
@@ -14,11 +14,16 @@ const MIN_AUTO_REFRESH_MS = 30000;
 const MAX_AUTO_REFRESH_MS = 3600000;
 const DEFAULT_AUTO_REFRESH_MS = 60000;
 
+const DEFAULT_NATIVE_TIMEOUT_MS = 300_000; // 5 minutes
+const MIN_NATIVE_TIMEOUT_MS = 5_000; // 5 seconds
+const MAX_NATIVE_TIMEOUT_MS = 3_600_000; // 1 hour
+
 export interface TokscaleSettings {
   colorPalette: string;
   autoRefreshEnabled?: boolean;
   autoRefreshMs?: number;
   includeUnusedModels?: boolean;
+  nativeTimeoutMs?: number;
 }
 
 function validateSettings(raw: unknown): TokscaleSettings {
@@ -27,6 +32,7 @@ function validateSettings(raw: unknown): TokscaleSettings {
     autoRefreshEnabled: false, 
     autoRefreshMs: DEFAULT_AUTO_REFRESH_MS,
     includeUnusedModels: false,
+    nativeTimeoutMs: DEFAULT_NATIVE_TIMEOUT_MS,
   };
   
   if (!raw || typeof raw !== "object") return defaults;
@@ -43,7 +49,12 @@ function validateSettings(raw: unknown): TokscaleSettings {
   
   const includeUnusedModels = typeof obj.includeUnusedModels === "boolean" ? obj.includeUnusedModels : defaults.includeUnusedModels;
   
-  return { colorPalette, autoRefreshEnabled, autoRefreshMs, includeUnusedModels };
+  let nativeTimeoutMs = defaults.nativeTimeoutMs;
+  if (typeof obj.nativeTimeoutMs === "number" && Number.isFinite(obj.nativeTimeoutMs)) {
+    nativeTimeoutMs = Math.min(MAX_NATIVE_TIMEOUT_MS, Math.max(MIN_NATIVE_TIMEOUT_MS, obj.nativeTimeoutMs));
+  }
+  
+  return { colorPalette, autoRefreshEnabled, autoRefreshMs, includeUnusedModels, nativeTimeoutMs };
 }
 
 interface CachedTUIData {
@@ -66,7 +77,7 @@ export function loadSettings(): TokscaleSettings {
     }
   } catch {
   }
-  return { colorPalette: "blue", autoRefreshEnabled: false, autoRefreshMs: DEFAULT_AUTO_REFRESH_MS, includeUnusedModels: false };
+  return { colorPalette: "blue", autoRefreshEnabled: false, autoRefreshMs: DEFAULT_AUTO_REFRESH_MS, includeUnusedModels: false, nativeTimeoutMs: DEFAULT_NATIVE_TIMEOUT_MS };
 }
 
 export function saveSettings(updates: Partial<TokscaleSettings>): void {


### PR DESCRIPTION
## Summary

- Adds `nativeTimeoutMs` to `~/.config/tokscale/settings.json` so users can persistently configure the native subprocess timeout without env vars
- `TOKSCALE_NATIVE_TIMEOUT_MS` env var still works as an override for CI/CD or one-off use
- Includes input validation with min/max clamping (5s–1h)

## Changes

| File | Change |
|------|--------|
| `packages/cli/src/tui/config/settings.ts` | Added `nativeTimeoutMs` to `TokscaleSettings` interface + validation |
| `packages/cli/src/native.ts` | Reads timeout from config via `loadSettings()`, env var overrides config |
| `README.md` | Added `nativeTimeoutMs` to config table, updated env var docs |
| `README.ko.md`, `README.ja.md`, `README.zh-cn.md` | Updated env var section docs |

## Config example

```json
{
  "colorPalette": "blue",
  "nativeTimeoutMs": 600000
}
```

**Priority:** config file ← env var override (env var wins if set)

> `maxOutputBytes` was removed from this PR — it's no longer needed after #161 switches to tmpfile-based output.