### PR TITLE
refactor: use tmpfile for subprocess output, remove 100MB output cap

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -390,17 +390,13 @@ tokscale cursor logout --all --purge-cache
 | 変数 | デフォルト | 説明 |
 |----------|---------|-------------|
 | `TOKSCALE_NATIVE_TIMEOUT_MS` | `300000`（5分） | ネイティブサブプロセス処理の最大時間 |
-| `TOKSCALE_MAX_OUTPUT_BYTES` | `104857600`（100MB） | ネイティブサブプロセスからの最大出力サイズ |
 
 ```bash
 # 例：非常に大きなデータセット用にタイムアウトを増加
 TOKSCALE_NATIVE_TIMEOUT_MS=600000 tokscale graph --output data.json
-
-# 例：長年のデータを持つパワーユーザー用に出力制限を増加
-TOKSCALE_MAX_OUTPUT_BYTES=104857600 tokscale --json > report.json
 ```
 
-> **注**: これらの制限はハングやメモリ問題を防ぐための安全対策です。ほとんどのユーザーは変更する必要がありません。
+> **注**: この制限はハングを防ぐための安全対策です。ほとんどのユーザーは変更する必要がありません。
 
 ### ヘッドレスモード
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -389,17 +389,13 @@ tokscale cursor logout --all --purge-cache
 | 변수 | 기본값 | 설명 |
 |----------|---------|-------------|
 | `TOKSCALE_NATIVE_TIMEOUT_MS` | `300000` (5분) | 네이티브 서브프로세스 처리 최대 시간 |
-| `TOKSCALE_MAX_OUTPUT_BYTES` | `104857600` (100MB) | 네이티브 서브프로세스의 최대 출력 크기 |
 
 ```bash
 # 예시: 매우 큰 데이터셋에 대한 타임아웃 증가
 TOKSCALE_NATIVE_TIMEOUT_MS=600000 tokscale graph --output data.json
-
-# 예시: 수년간의 데이터를 가진 파워 유저를 위한 출력 제한 증가
-TOKSCALE_MAX_OUTPUT_BYTES=104857600 tokscale --json > report.json
 ```
 
-> **참고**: 이러한 제한은 중단 및 메모리 문제를 방지하기 위한 안전 조치입니다. 대부분의 사용자는 변경할 필요가 없습니다.
+> **참고**: 이 제한은 중단을 방지하기 위한 안전 조치입니다. 대부분의 사용자는 변경할 필요가 없습니다.
 
 ### Headless 모드
 

--- a/README.md
+++ b/README.md
@@ -421,17 +421,13 @@ For advanced users with large datasets or specific requirements:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `TOKSCALE_NATIVE_TIMEOUT_MS` | `300000` (5 min) | Maximum time for native subprocess processing |
-| `TOKSCALE_MAX_OUTPUT_BYTES` | `104857600` (100MB) | Maximum output size from native subprocess |
 
 ```bash
 # Example: Increase timeout for very large datasets
 TOKSCALE_NATIVE_TIMEOUT_MS=600000 tokscale graph --output data.json
-
-# Example: Increase output limit for power users with years of data
-TOKSCALE_MAX_OUTPUT_BYTES=104857600 tokscale --json > report.json
 ```
 
-> **Note**: These limits are safety measures to prevent hangs and memory issues. Most users won't need to change them.
+> **Note**: This limit is a safety measure to prevent hangs. Most users won't need to change it.
 
 ### Headless Mode
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -390,17 +390,13 @@ tokscale cursor logout --all --purge-cache
 | 变量 | 默认值 | 描述 |
 |----------|---------|-------------|
 | `TOKSCALE_NATIVE_TIMEOUT_MS` | `300000`（5 分钟） | 原生子进程处理的最大时间 |
-| `TOKSCALE_MAX_OUTPUT_BYTES` | `104857600`（100MB） | 原生子进程的最大输出大小 |
 
 ```bash
 # 示例：为非常大的数据集增加超时时间
 TOKSCALE_NATIVE_TIMEOUT_MS=600000 tokscale graph --output data.json
-
-# 示例：为有多年数据的资深用户增加输出限制
-TOKSCALE_MAX_OUTPUT_BYTES=104857600 tokscale --json > report.json
 ```
 
-> **注意**：这些限制是防止卡住和内存问题的安全措施。大多数用户不需要更改它们。
+> **注意**：此限制是防止卡住的安全措施。大多数用户不需要更改。
 
 ### Headless 模式
 


### PR DESCRIPTION
## Summary

- Replaces stdout chunked-streaming (with 100MB hard cap) with tmpfile-based output for native subprocess IPC
- Eliminates `TOKSCALE_MAX_OUTPUT_BYTES` entirely — no more artificial output size limit
- Net **-64 lines** — simpler code, fewer failure modes

Closes #160

## Problem

`runInSubprocess` buffered Rust subprocess stdout into `Uint8Array[]` chunks with a 100MB cap. Power users with years of multi-platform data could easily exceed this, getting zero results instead of a report.

## Solution

The subprocess already receives input via tmpfile. Now output works the same way:

```
Before:  tmpfile (input) → stdout pipe (output, 100MB cap)
After:   tmpfile (input) → tmpfile (output, no cap)
```

### What changed

| File | Change |
|------|--------|
| `native-runner.ts` | `process.stdout.write(result)` → `writeFileSync(outputFile, result)` |
| `native.ts` | Removed `readStream` + chunked buffering + `MAX_OUTPUT_BYTES`. Now: `readFileSync(outputFile)` |
| `README*.md` (×4) | Removed `TOKSCALE_MAX_OUTPUT_BYTES` docs |

### Why this is better

| Aspect | Before (stdout) | After (tmpfile) |
|--------|-----------------|-----------------|
| Size limit | 100MB hard cap | None (filesystem-bound) |
| Memory copies | 3× (chunks → concat → decode → parse) | 2× (read → parse) |
| Code complexity | 30-line `readStream` with abort logic | Single `readFileSync` call |
| Failure mode | Silent crash, zero results | Natural OS/V8 limits |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch subprocess output from stdout streaming to a tmpfile to remove the 100MB cap and support large results without failures. Simplifies IPC and addresses #160.

- **Refactors**
  - Output is written to a tmpfile; no artificial size limit.
  - Runner now takes inputFile and outputFile; parent reads the tmpfile and removes chunked stdout logic and TOKSCALE_MAX_OUTPUT_BYTES.
  - Updated READMEs to drop the removed env var.

<sup>Written for commit 05decac1f4e0deb4cd48f79bed8544a9e16b6dfb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

