### PR TITLE
fix(core): add Kimi K2.5 aliases, keep Codex fallback as unknown

### DIFF
--- a/packages/core/src/sessions/codex.rs
+++ b/packages/core/src/sessions/codex.rs
@@ -119,7 +119,7 @@ pub fn parse_codex_file(path: &Path) -> Vec<UnifiedMessage> {
 
                     let model = current_model
                         .clone()
-                        .unwrap_or_else(|| "gpt-5.2-codex".to_string());
+                        .unwrap_or_else(|| "unknown".to_string());
 
                     // Calculate delta tokens
                     // Note: OpenAI's input_tokens INCLUDES cached tokens (they are a subset).
@@ -264,7 +264,7 @@ fn parse_codex_headless_line(
     let model = usage
         .model
         .or_else(|| current_model.clone())
-        .unwrap_or_else(|| "gpt-5.2-codex".to_string());
+        .unwrap_or_else(|| "unknown".to_string());
     let timestamp = usage.timestamp_ms.unwrap_or(fallback_timestamp);
 
     if usage.input == 0 && usage.output == 0 && usage.cached == 0 {


### PR DESCRIPTION
## Summary

Imports the relevant upstream alias improvement, while intentionally **not** forcing unknown Codex records to `gpt-5.2-codex`. (Original imported commit authored by @code-yeongyu)

## Included

- Add alias mappings in `packages/core/src/pricing/aliases.rs`:
  - `k2p5` -> `kimi-k2-thinking`
  - `k2-p5` -> `kimi-k2-thinking`
  - `kimi-k2.5-thinking` -> `kimi-k2-thinking`

## Intentionally excluded

- `unknown` -> `gpt-5.2-codex` fallback in Codex session parsing

Reason: Codex sessions can run non-default models. If model metadata is missing in a record, forcing `gpt-5.2-codex` can misprice usage. Keeping `unknown` is safer and avoids false attribution.

## Verification

- `cargo test --features noop` in `packages/core` passed (150 tests).
