### PR TITLE
fix: align core tests with native API and harden runner stdio

### DIFF
--- a/packages/cli/src/native.ts
+++ b/packages/cli/src/native.ts
@@ -408,8 +408,8 @@ interface BunSubprocess {
 }
 
 interface BunSpawnOptions {
-  stdout: string;
-  stderr: string;
+  stdout: "pipe" | "ignore";
+  stderr: "pipe" | "ignore";
 }
 
 interface BunGlobalType {
@@ -440,7 +440,7 @@ async function runInSubprocess<T>(method: string, args: unknown[]): Promise<T> {
   let proc: BunSubprocess;
   try {
     proc = BunGlobal.spawn([process.execPath, runnerPath, inputFile, outputFile], {
-      stdout: "pipe",
+      stdout: "ignore",
       stderr: "pipe",
     });
   } catch (e) {


### PR DESCRIPTION
## Summary
- update `packages/core` integration tests to use the current two-phase native API (`parseLocalSources` + `finalizeGraph`) instead of removed `scanSessions`/`generateGraph`
- replace brittle Claude fixture dependency with a deterministic mock Claude session in tests
- harden CLI native subprocess execution by setting child `stdout` to `ignore` to eliminate pipe-backpressure risk now that output is file-based

## Verification
- `bun run --cwd packages/core test` (11 passed)
- `bun run --cwd packages/cli build` (pass)
- `lsp_diagnostics` clean for modified files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates core tests to the native two-phase API and replaces the Claude fixture with a deterministic mock. Hardens the CLI runner by ignoring stdout to eliminate pipe backpressure since output is file-based.

- **Refactors**
  - Use parseLocalSources + finalizeGraph in core integration tests.
  - Add mock Claude session; remove dependency on fixtures.
  - Update graph/filter/token tests to the new API.

- **Bug Fixes**
  - Set CLI native subprocess stdout to "ignore" (stderr stays "pipe") to prevent backpressure and potential hangs.

<sup>Written for commit 91ffe37ad2849545f6f0ae3a150fbd6044ba5ecd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

