### PR TITLE
fix(core): add SQLite database support for OpenCode 1.2+

### DIFF
--- a/packages/core/Cargo.lock
+++ b/packages/core/Cargo.lock
@@ -346,6 +346,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +545,15 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]
@@ -843,6 +864,17 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags",
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1287,6 +1319,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,6 +1729,7 @@ dependencies = [
  "once_cell",
  "rayon",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "serial_test",

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -41,6 +41,9 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 # For disk caching (XDG paths)
 dirs = "5"
 
+# SQLite database support (bundled for cross-compilation)
+rusqlite = { version = "0.32", features = ["bundled"] }
+
 # Lazy static initialization
 once_cell = "1"
 

--- a/packages/core/src/sessions/opencode.rs
+++ b/packages/core/src/sessions/opencode.rs
@@ -1,19 +1,23 @@
 //! OpenCode session parser
 //!
-//! Parses individual JSON files from ~/.local/share/opencode/storage/message/
+//! Parses messages from:
+//! - SQLite database (OpenCode 1.2+): ~/.local/share/opencode/opencode.db
+//! - Legacy JSON files: ~/.local/share/opencode/storage/message/
 
 use super::{normalize_agent_name, UnifiedMessage};
 use crate::TokenBreakdown;
+use rusqlite::Connection;
 use serde::Deserialize;
 use std::path::Path;
 
-/// OpenCode message structure (from JSON files)
+/// OpenCode message structure (from JSON files and SQLite data column)
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 pub struct OpenCodeMessage {
-    pub id: String,
-    #[serde(rename = "sessionID")]
-    pub session_id: String,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(rename = "sessionID", default)]
+    pub session_id: Option<String>,
     pub role: String,
     #[serde(rename = "modelID")]
     pub model_id: Option<String>,
@@ -62,11 +66,13 @@ pub fn parse_opencode_file(path: &Path) -> Option<UnifiedMessage> {
     let agent_or_mode = msg.mode.or(msg.agent);
     let agent = agent_or_mode.map(|a| normalize_agent_name(&a));
 
+    let session_id = msg.session_id.unwrap_or_else(|| "unknown".to_string());
+
     Some(UnifiedMessage::new_with_agent(
         "opencode",
         model_id,
         msg.provider_id.unwrap_or_else(|| "unknown".to_string()),
-        msg.session_id.clone(),
+        session_id,
         msg.time.created as i64,
         TokenBreakdown {
             input: tokens.input.max(0),
@@ -78,6 +84,88 @@ pub fn parse_opencode_file(path: &Path) -> Option<UnifiedMessage> {
         msg.cost.unwrap_or(0.0).max(0.0),
         agent,
     ))
+}
+
+pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
+    let conn = match Connection::open_with_flags(
+        db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    ) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+
+    let query = r#"
+        SELECT m.session_id, m.data
+        FROM message m
+        WHERE json_extract(m.data, '$.role') = 'assistant'
+          AND json_extract(m.data, '$.tokens') IS NOT NULL
+    "#;
+
+    let mut stmt = match conn.prepare(query) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+
+    let rows = match stmt.query_map([], |row| {
+        let session_id: String = row.get(0)?;
+        let data_json: String = row.get(1)?;
+        Ok((session_id, data_json))
+    }) {
+        Ok(r) => r,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut messages = Vec::new();
+
+    for row_result in rows {
+        let (session_id, data_json) = match row_result {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+
+        let mut bytes = data_json.into_bytes();
+        let msg: OpenCodeMessage = match simd_json::from_slice(&mut bytes) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+
+        if msg.role != "assistant" {
+            continue;
+        }
+
+        let tokens = match msg.tokens {
+            Some(t) => t,
+            None => continue,
+        };
+
+        let model_id = match msg.model_id {
+            Some(m) => m,
+            None => continue,
+        };
+
+        let agent_or_mode = msg.mode.or(msg.agent);
+        let agent = agent_or_mode.map(|a| normalize_agent_name(&a));
+
+        messages.push(UnifiedMessage::new_with_agent(
+            "opencode",
+            model_id,
+            msg.provider_id.unwrap_or_else(|| "unknown".to_string()),
+            session_id,
+            msg.time.created as i64,
+            TokenBreakdown {
+                input: tokens.input.max(0),
+                output: tokens.output.max(0),
+                cache_read: tokens.cache.read.max(0),
+                cache_write: tokens.cache.write.max(0),
+                reasoning: tokens.reasoning.unwrap_or(0).max(0),
+            },
+            msg.cost.unwrap_or(0.0).max(0.0),
+            agent,
+        ));
+    }
+
+    messages
 }
 
 #[cfg(test)]
@@ -184,6 +272,40 @@ mod tests {
             msg.cost >= 0.0,
             "Negative cost should be clamped to 0.0, got {}",
             msg.cost
+        );
+    }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    #[ignore] // Run manually with: cargo test integration -- --ignored
+    fn test_parse_real_sqlite_db() {
+        let home = std::env::var("HOME").unwrap();
+        let db_path = PathBuf::from(format!("{}/.local/share/opencode/opencode.db", home));
+
+        if !db_path.exists() {
+            println!("Skipping: OpenCode database not found at {:?}", db_path);
+            return;
+        }
+
+        let messages = parse_opencode_sqlite(&db_path);
+        println!("Parsed {} messages from SQLite", messages.len());
+
+        if !messages.is_empty() {
+            let first = &messages[0];
+            println!(
+                "First message: model={}, provider={}, tokens={:?}",
+                first.model_id, first.provider_id, first.tokens
+            );
+        }
+
+        assert!(
+            !messages.is_empty(),
+            "Expected to parse some messages from SQLite"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Add SQLite database support for OpenCode 1.2+ which stores sessions in `~/.local/share/opencode/opencode.db`
- SQLite-first, JSON-fallback logic to avoid duplicate counting (all JSON IDs exist in SQLite)
- Made `id`/`session_id` fields optional in `OpenCodeMessage` struct to support both data sources

## Changes
- Added `rusqlite` dependency with `bundled` feature
- Added `opencode_db: Option<PathBuf>` field to `ScanResult` struct
- Created `parse_opencode_sqlite()` function to query the `message` table
- Updated `parse_all_messages_with_pricing()` and `parse_local_sources()` to use SQLite when available

## Testing
- All 150 existing tests pass
- CLI tested manually - correctly reads 230,267 messages from SQLite

Closes #181

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SQLite support for OpenCode 1.2+, reading sessions from ~/.local/share/opencode/opencode.db with SQLite-first, JSON-fallback to avoid double counting. Addresses Linear #181.

- **New Features**
  - Detects opencode.db via ScanResult.opencode_db and prefers SQLite; falls back to legacy JSON files.
  - Adds parse_opencode_sqlite() and updates parse_all_messages_with_pricing() and parse_local_sources() to use it.
  - Makes id and session_id optional in OpenCodeMessage to handle both data sources.

- **Dependencies**
  - Adds rusqlite with bundled feature for cross-compilation.

<sup>Written for commit 11f48d05c2de378986f6b851adbd65903acc9943. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

