### PR TITLE
fix(core): read both SQLite and legacy JSON for OpenCode, deduplicate by message ID

### DIFF
--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -275,7 +275,9 @@ fn parse_all_messages_with_pricing(
     let scan_result = scanner::scan_all_sources(home_dir, sources);
     let mut all_messages: Vec<UnifiedMessage> = Vec::new();
 
-    // Parse OpenCode: prefer SQLite (1.2+), fall back to legacy JSON
+    // Parse OpenCode: read both SQLite (1.2+) and legacy JSON, deduplicate by message ID
+    let mut opencode_seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
     if let Some(db_path) = &scan_result.opencode_db {
         let sqlite_messages: Vec<UnifiedMessage> = sessions::opencode::parse_opencode_sqlite(db_path)
             .into_iter()
@@ -288,11 +290,16 @@ fn parse_all_messages_with_pricing(
                     msg.tokens.cache_write,
                     msg.tokens.reasoning,
                 );
+                if let Some(ref key) = msg.dedup_key {
+                    opencode_seen.insert(key.clone());
+                }
                 msg
             })
             .collect();
         all_messages.extend(sqlite_messages);
-    } else {
+    }
+
+    {
         let opencode_messages: Vec<UnifiedMessage> = scan_result
             .opencode_files
             .par_iter()
@@ -309,7 +316,13 @@ fn parse_all_messages_with_pricing(
                 Some(msg)
             })
             .collect();
-        all_messages.extend(opencode_messages);
+        all_messages.extend(
+            opencode_messages
+                .into_iter()
+                .filter(|msg| {
+                    msg.dedup_key.as_ref().map_or(true, |key| opencode_seen.insert(key.clone()))
+                }),
+        );
     }
 
     // Parse Claude files in parallel
@@ -808,26 +821,46 @@ pub fn parse_local_sources(options: LocalParseOptions) -> napi::Result<ParsedMes
 
     let mut messages: Vec<ParsedMessage> = Vec::new();
 
-    // Parse OpenCode: prefer SQLite (1.2+), fall back to legacy JSON
-    let opencode_count: i32 = if let Some(db_path) = &scan_result.opencode_db {
-        let sqlite_msgs: Vec<ParsedMessage> = sessions::opencode::parse_opencode_sqlite(db_path)
-            .into_iter()
-            .map(|msg| unified_to_parsed(&msg))
-            .collect();
-        let count = sqlite_msgs.len() as i32;
-        messages.extend(sqlite_msgs);
-        count
-    } else {
-        let opencode_msgs: Vec<ParsedMessage> = scan_result
+    // Parse OpenCode: read both SQLite (1.2+) and legacy JSON, deduplicate by message ID
+    let opencode_count: i32 = {
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut count: i32 = 0;
+
+        if let Some(db_path) = &scan_result.opencode_db {
+            let sqlite_msgs: Vec<(String, ParsedMessage)> =
+                sessions::opencode::parse_opencode_sqlite(db_path)
+                    .into_iter()
+                    .map(|msg| {
+                        let key = msg.dedup_key.clone().unwrap_or_default();
+                        (key, unified_to_parsed(&msg))
+                    })
+                    .collect();
+            count += sqlite_msgs.len() as i32;
+            for (key, parsed) in sqlite_msgs {
+                if !key.is_empty() {
+                    seen.insert(key);
+                }
+                messages.push(parsed);
+            }
+        }
+
+        let json_msgs: Vec<(String, ParsedMessage)> = scan_result
             .opencode_files
             .par_iter()
             .filter_map(|path| {
                 let msg = sessions::opencode::parse_opencode_file(path)?;
-                Some(unified_to_parsed(&msg))
+                let key = msg.dedup_key.clone().unwrap_or_default();
+                Some((key, unified_to_parsed(&msg)))
             })
             .collect();
-        let count = opencode_msgs.len() as i32;
-        messages.extend(opencode_msgs);
+        let deduped: Vec<ParsedMessage> = json_msgs
+            .into_iter()
+            .filter(|(key, _)| key.is_empty() || seen.insert(key.clone()))
+            .map(|(_, msg)| msg)
+            .collect();
+        count += deduped.len() as i32;
+        messages.extend(deduped);
+
         count
     };
 


### PR DESCRIPTION
## Problem

When OpenCode upgrades to v1.2+ and creates `opencode.db`, tokscale switches to SQLite-only mode and **silently drops all legacy JSON data**. If the JSON→SQLite migration was incomplete (or never ran), this causes massive cost underreporting.

**Evidence from a real user:**
| Source | Messages | Date Range |
|--------|----------|------------|
| SQLite | 176 | 1 hour (Feb 14) |
| Legacy JSON | 445,910 | Months of history |

The `if/else` in `lib.rs` meant SQLite's existence caused **100% data loss** of pre-migration history.

## Fix

- Read **both** SQLite and legacy JSON sources (instead of exclusively one)
- Deduplicate by message ID using `dedup_key` (same pattern as existing Claude dedup)
- SQLite messages are inserted into the seen-set first, so duplicates from JSON are filtered out
- JSON messages without a matching SQLite entry are preserved

### Changes

- **`opencode.rs`**: Extract message ID as `dedup_key` from both SQLite (`m.id` column) and JSON (file stem / `msg.id` field)
- **`lib.rs`**: Replace `if/else` with read-both-then-deduplicate in both `parse_all_messages_with_pricing` and `scan_sources_native`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Read both OpenCode SQLite (v1.2+) and legacy JSON, and deduplicate by message ID to preserve historical data and fix cost underreporting after upgrades.

- **Bug Fixes**
  - Always parse both sources; remove SQLite-only branch.
  - Deduplicate by message ID (dedup_key): SQLite uses m.id; JSON uses msg.id or filename.
  - Prioritize SQLite by inserting it first; filter JSON duplicates; keep unmatched JSON.
  - Updated parse_all_messages_with_pricing and parse_local_sources to use a seen set; SQLite query now selects m.id.

<sup>Written for commit ce53bbcdc7a5fa0d07483375100b82d997cb9271. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

