### PR TITLE
refactor(core): clean up OpenCode dedup and add comprehensive tests

### DIFF
--- a/packages/core/src/sessions/opencode.rs
+++ b/packages/core/src/sessions/opencode.rs
@@ -286,6 +286,321 @@ mod tests {
             msg.cost
         );
     }
+
+    /// JSON dedup_key uses msg.id when present
+    #[test]
+    fn test_dedup_key_from_json_message_id() {
+        use std::io::Write;
+
+        let json = r#"{
+            "id": "msg_dedup_001",
+            "sessionID": "ses_001",
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "cost": 0.01,
+            "tokens": {
+                "input": 100,
+                "output": 50,
+                "reasoning": 0,
+                "cache": { "read": 0, "write": 0 }
+            },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        let mut temp_file = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+        temp_file.write_all(json.as_bytes()).unwrap();
+
+        let msg = parse_opencode_file(temp_file.path()).expect("Should parse");
+        assert_eq!(
+            msg.dedup_key,
+            Some("msg_dedup_001".to_string()),
+            "dedup_key should use msg.id from JSON"
+        );
+    }
+
+    /// JSON dedup_key falls back to file stem when msg.id is absent
+    #[test]
+    fn test_dedup_key_falls_back_to_file_stem() {
+        let json = r#"{
+            "sessionID": "ses_001",
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "cost": 0.01,
+            "tokens": {
+                "input": 100,
+                "output": 50,
+                "reasoning": 0,
+                "cache": { "read": 0, "write": 0 }
+            },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("msg_fallback_999.json");
+        std::fs::write(&file_path, json).unwrap();
+
+        let msg = parse_opencode_file(&file_path).expect("Should parse");
+        assert_eq!(
+            msg.dedup_key,
+            Some("msg_fallback_999".to_string()),
+            "dedup_key should fall back to file stem when id is missing"
+        );
+    }
+
+    /// Non-assistant messages are skipped (no dedup_key produced)
+    #[test]
+    fn test_dedup_key_skips_non_assistant() {
+        let json = r#"{
+            "id": "msg_user_001",
+            "sessionID": "ses_001",
+            "role": "user",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "tokens": {
+                "input": 100,
+                "output": 50,
+                "reasoning": 0,
+                "cache": { "read": 0, "write": 0 }
+            },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("msg_user_001.json");
+        std::fs::write(&file_path, json).unwrap();
+
+        let result = parse_opencode_file(&file_path);
+        assert!(result.is_none(), "User messages should be skipped");
+    }
+
+    /// SQLite dedup_key uses m.id from the database row
+    #[test]
+    fn test_sqlite_dedup_key_from_row_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_opencode.db");
+
+        // Create a minimal SQLite DB matching OpenCode's schema
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                data TEXT NOT NULL
+            );",
+        )
+        .unwrap();
+
+        let data_json = r#"{
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "cost": 0.05,
+            "tokens": {
+                "input": 1000,
+                "output": 500,
+                "reasoning": 0,
+                "cache": { "read": 200, "write": 50 }
+            },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["msg_sqlite_001", "ses_001", data_json],
+        )
+        .unwrap();
+        drop(conn);
+
+        let messages = parse_opencode_sqlite(&db_path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].dedup_key,
+            Some("msg_sqlite_001".to_string()),
+            "SQLite dedup_key should come from m.id column"
+        );
+        assert_eq!(messages[0].model_id, "claude-sonnet-4");
+        assert_eq!(messages[0].tokens.input, 1000);
+    }
+
+    /// SQLite skips rows without tokens or with non-assistant role
+    #[test]
+    fn test_sqlite_skips_invalid_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_opencode.db");
+
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                data TEXT NOT NULL
+            );",
+        )
+        .unwrap();
+
+        // Valid assistant message
+        let valid = r#"{
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "tokens": { "input": 100, "output": 50, "reasoning": 0, "cache": { "read": 0, "write": 0 } },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        // User message (should be filtered by SQL WHERE clause)
+        let user_msg = r#"{
+            "role": "user",
+            "modelID": "claude-sonnet-4",
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        // Assistant without tokens (should be filtered by SQL WHERE clause)
+        let no_tokens = r#"{
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["msg_valid", "ses_001", valid],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["msg_user", "ses_001", user_msg],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["msg_no_tokens", "ses_001", no_tokens],
+        )
+        .unwrap();
+        drop(conn);
+
+        let messages = parse_opencode_sqlite(&db_path);
+        assert_eq!(
+            messages.len(),
+            1,
+            "Should only parse valid assistant message"
+        );
+        assert_eq!(messages[0].dedup_key, Some("msg_valid".to_string()));
+    }
+
+    /// Cross-source dedup: matching IDs between SQLite and JSON should deduplicate
+    #[test]
+    fn test_cross_source_dedup_by_message_id() {
+        use std::collections::HashSet;
+
+        let dir = tempfile::tempdir().unwrap();
+
+        // --- SQLite source ---
+        let db_path = dir.path().join("opencode.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                data TEXT NOT NULL
+            );",
+        )
+        .unwrap();
+
+        let data_json = r#"{
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "tokens": { "input": 500, "output": 200, "reasoning": 0, "cache": { "read": 0, "write": 0 } },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        // Insert two messages into SQLite
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["msg_shared_001", "ses_001", data_json],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["msg_sqlite_only", "ses_001", data_json],
+        )
+        .unwrap();
+        drop(conn);
+
+        // --- JSON source ---
+        let json_dir = dir.path().join("json");
+        std::fs::create_dir_all(&json_dir).unwrap();
+
+        // Duplicate of SQLite msg_shared_001
+        let json_shared = r#"{
+            "id": "msg_shared_001",
+            "sessionID": "ses_001",
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "tokens": { "input": 500, "output": 200, "reasoning": 0, "cache": { "read": 0, "write": 0 } },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+        std::fs::write(json_dir.join("msg_shared_001.json"), json_shared).unwrap();
+
+        // JSON-only message (not in SQLite)
+        let json_only = r#"{
+            "id": "msg_json_only",
+            "sessionID": "ses_001",
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "tokens": { "input": 100, "output": 50, "reasoning": 0, "cache": { "read": 0, "write": 0 } },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+        std::fs::write(json_dir.join("msg_json_only.json"), json_only).unwrap();
+
+        // --- Simulate the dedup logic from lib.rs ---
+        let sqlite_messages = parse_opencode_sqlite(&db_path);
+        assert_eq!(sqlite_messages.len(), 2);
+
+        // Build seen set from SQLite (same as lib.rs)
+        let mut seen: HashSet<String> = HashSet::new();
+        for msg in &sqlite_messages {
+            if let Some(ref key) = msg.dedup_key {
+                seen.insert(key.clone());
+            }
+        }
+        assert_eq!(seen.len(), 2);
+
+        // Parse JSON files
+        let json_msg_shared = parse_opencode_file(&json_dir.join("msg_shared_001.json")).unwrap();
+        let json_msg_only = parse_opencode_file(&json_dir.join("msg_json_only.json")).unwrap();
+
+        // Filter JSON through seen set (same logic as lib.rs)
+        let json_messages = vec![json_msg_shared, json_msg_only];
+        let deduped: Vec<UnifiedMessage> = json_messages
+            .into_iter()
+            .filter(|msg| {
+                msg.dedup_key
+                    .as_ref()
+                    .map_or(true, |key| seen.insert(key.clone()))
+            })
+            .collect();
+
+        // msg_shared_001 should be filtered (duplicate), msg_json_only should survive
+        assert_eq!(
+            deduped.len(),
+            1,
+            "Only the JSON-only message should survive dedup"
+        );
+        assert_eq!(
+            deduped[0].dedup_key,
+            Some("msg_json_only".to_string()),
+            "Surviving message should be the JSON-only one"
+        );
+
+        // Total unique messages = 2 from SQLite + 1 from JSON
+        let total = sqlite_messages.len() + deduped.len();
+        assert_eq!(total, 3, "Should have 3 unique messages total");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Follow-up to #188 — addresses the two review notes from the merge:

1. **Remove naked `{ }` scope block** in `parse_all_messages_with_pricing` — the `} else {` → `{` change from #188 left an unconditional scope block that served no purpose. Now the JSON parsing runs at the same indentation level as the rest of the function.

2. **Add comprehensive dedup tests** for OpenCode's `dedup_key` extraction:
   - `test_dedup_key_from_json_message_id` — verifies `msg.id` is used as dedup_key
   - `test_dedup_key_falls_back_to_file_stem` — verifies filename fallback when `id` is absent
   - `test_dedup_key_skips_non_assistant` — verifies user messages produce no output
   - `test_sqlite_dedup_key_from_row_id` — verifies `m.id` column is used from SQLite
   - `test_sqlite_skips_invalid_rows` — verifies SQL WHERE clause filters correctly
   - `test_cross_source_dedup_by_message_id` — end-to-end test: creates both SQLite and JSON sources with overlapping message IDs, simulates the dedup logic from `lib.rs`, and verifies duplicates are filtered while unique messages survive

All 160 tests pass, zero new warnings.

## Related
- #188 — fix(core): read both SQLite and legacy JSON for OpenCode, deduplicate by message ID
- #189 — perf: cache OpenCode migration status to skip redundant legacy JSON scanning

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a dead scope in OpenCode message parsing and added tests to validate dedup_key extraction from JSON and SQLite, including cross-source dedup. This simplifies the code and strengthens dedup behavior.

- **Refactors**
  - Streamlined OpenCode JSON parsing in parse_all_messages_with_pricing; dedup filtering is now inline with other sources.
  - Added tests for dedup_key across JSON and SQLite, covering filename fallback, assistant-only filtering, SQL filtering, and cross-source dedup.

<sup>Written for commit e6fa528e630c79811cc1f14804886920bbe05cd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

