### PR TITLE
fix(core): port missing SQLite+dedup and OpenClaw fixes to rewrite branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,6 +859,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,6 +1146,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -1641,6 +1662,17 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2648,6 +2680,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.10.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3352,6 +3398,7 @@ dependencies = [
  "once_cell",
  "rayon",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync"
 # For disk caching (XDG paths)
 dirs = "5"
 
+# SQLite database support (bundled for cross-compilation)
+rusqlite = { version = "0.32", features = ["bundled"] }
+
 # Lazy static initialization
 once_cell = "1"
 

--- a/crates/tokscale-core/Cargo.toml
+++ b/crates/tokscale-core/Cargo.toml
@@ -22,6 +22,7 @@ reqwest = { workspace = true }
 tokio = { workspace = true }
 dirs = { workspace = true }
 once_cell = { workspace = true }
+rusqlite = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -568,6 +568,18 @@ mod tests {
     }
 
     #[test]
+    fn test_scan_all_sources_pi() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_pi_dir(home);
+
+        let result = scan_all_sources(home.to_str().unwrap(), &["pi".to_string()]);
+        assert_eq!(result.pi_files.len(), 1);
+        assert!(result.opencode_files.is_empty());
+        assert!(result.claude_files.is_empty());
+    }
+
+    #[test]
     fn test_scan_all_sources_claude() {
         let dir = TempDir::new().unwrap();
         let home = dir.path();

--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -235,6 +235,7 @@ mod tests {
         assert_eq!(msg.agent, Some("OmO".to_string()));
     }
 
+    /// Verify negative token values are clamped to 0 (defense-in-depth for PR #147)
     #[test]
     fn test_negative_values_clamped_to_zero() {
         use std::io::Write;


### PR DESCRIPTION
## Summary

Fixes 3 critical and 2 minor issues found during line-by-line merge validation of PRs #183, #185, #188, #190, #191 against the `feat/ratatui-rewrite` branch.

### 🔴 Critical Fixes

1. **Missing `rusqlite` dependency** — Added to workspace `Cargo.toml` and `crates/tokscale-core/Cargo.toml`. Without this, the crate failed to compile (7 build errors).

2. **SQLite+dedup logic missing from both parse functions** — `parse_all_messages_with_pricing` and `parse_local_sources` in `lib.rs` only read legacy JSON files. Ported the SQLite-first → JSON-fallback → dedup-by-message-ID pipeline from main (#183, #188, #190).

3. **Wrong OpenClaw parser called at 2 sites** — Both `parse_all_messages_with_pricing` and `parse_local_sources` called `parse_openclaw_index` (expects JSON index files) instead of `parse_openclaw_transcript` (expects JSONL transcript files). Since the scanner passes `*.jsonl` files, this caused silent 0-message results for all OpenClaw sessions.

### 🟡 Minor Fixes

4. **Restored `test_scan_all_sources_pi` test** in `scanner.rs` — helper function existed but the `#[test]` was dropped during rewrite.

5. **Restored doc comment** on `test_negative_values_clamped_to_zero` in `opencode.rs`.

## Verification

- `cargo check -p tokscale-core` ✅
- `cargo check -p tokscale-cli` ✅  
- `cargo test -p tokscale-core` ✅ **187 passed, 0 failed, 1 ignored**

## Changed Files

| File | Change |
|------|--------|
| `Cargo.toml` | Add `rusqlite` to `[workspace.dependencies]` |
| `Cargo.lock` | Auto-updated |
| `crates/tokscale-core/Cargo.toml` | Add `rusqlite = { workspace = true }` |
| `crates/tokscale-core/src/lib.rs` | SQLite+dedup in 2 functions + OpenClaw parser fix at 2 call sites |
| `crates/tokscale-core/src/scanner.rs` | Add `test_scan_all_sources_pi` test |
| `crates/tokscale-core/src/sessions/opencode.rs` | Restore doc comment |

## Related PRs (on main)

- #183 — SQLite database support for OpenCode 1.2+
- #185 — Fix OpenClaw session detection  
- #188 — Read both SQLite + legacy JSON, dedup by message ID
- #190 — Clean up OpenCode dedup + comprehensive tests
- #191 — Rewrite release notes generation (CI-only, no core changes needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports the OpenCode SQLite-first + JSON-fallback pipeline and fixes OpenClaw transcript parsing in the ratatui rewrite. Builds now succeed and OpenCode/OpenClaw sessions parse and dedupe correctly.

- **Bug Fixes**
  - Add rusqlite (bundled) to workspace and tokscale-core to fix compile and enable SQLite.
  - Read OpenCode from SQLite when available with JSON fallback; dedupe by message ID in both parse paths.
  - Use parse_openclaw_transcript (JSONL) at two call sites to prevent 0-message results.

- **Tests**
  - Restore test_scan_all_sources_pi; restore doc comment for test_negative_values_clamped_to_zero.

<sup>Written for commit 62a1be684bffe4ca5e6c6ff8b5d6cf5a51e28fc7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

