### PR TITLE
refactor(core): remove legacy single-phase report API

### DIFF
--- a/packages/cli/src/graph-types.ts
+++ b/packages/cli/src/graph-types.ts
@@ -158,23 +158,6 @@ export interface TokenContributionData {
 }
 
 /**
- * Options for graph data generation
- */
-export interface GraphOptions {
-  /** Filter to specific sources */
-  sources?: SourceType[];
-
-  /** Start date filter (ISO format) */
-  since?: string;
-
-  /** End date filter (ISO format) */
-  until?: string;
-
-  /** Filter to specific year */
-  year?: string;
-}
-
-/**
  * Unified message format for aggregation
  * Used internally to normalize data from different sources
  */

--- a/packages/cli/src/native.ts
+++ b/packages/cli/src/native.ts
@@ -169,7 +169,6 @@ interface NativeFinalizeReportOptions {
 
 interface NativeCore {
   version(): string;
-  healthCheck(): string;
   parseLocalSources(options: NativeLocalParseOptions): NativeParsedMessages;
   finalizeReport(options: NativeFinalizeReportOptions): NativeModelReport;
   finalizeMonthlyReport(options: NativeFinalizeReportOptions): NativeMonthlyReport;

--- a/packages/core/__test__/index.spec.mjs
+++ b/packages/core/__test__/index.spec.mjs
@@ -22,10 +22,6 @@ testFn("version returns semver string", (t) => {
   t.regex(v, /^\d+\.\d+\.\d+$/);
 });
 
-testFn("healthCheck returns expected message", (t) => {
-  t.is(nativeModule.healthCheck(), "tokscale-core is healthy!");
-});
-
 testFn("parseLocalSources with empty directory returns zeros", (t) => {
   const tmpDir = join(__dirname, "tmp-scan-test-" + Date.now());
   mkdirSync(tmpDir, { recursive: true });

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -90,9 +90,6 @@ export interface GraphResult {
   contributions: Array<DailyContribution>
 }
 
-/** Simple health check to verify the native module is working */
-export declare function healthCheck(): string
-
 /** Options for parsing local sources only (no Cursor) */
 export interface LocalParseOptions {
   homeDir?: string

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -580,7 +580,6 @@ module.exports.finalizeGraph = nativeBinding.finalizeGraph
 module.exports.finalizeMonthlyReport = nativeBinding.finalizeMonthlyReport
 module.exports.finalizeReport = nativeBinding.finalizeReport
 module.exports.finalizeReportAndGraph = nativeBinding.finalizeReportAndGraph
-module.exports.healthCheck = nativeBinding.healthCheck
 module.exports.lookupPricing = nativeBinding.lookupPricing
 module.exports.parseLocalSources = nativeBinding.parseLocalSources
 module.exports.version = nativeBinding.version

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -23,12 +23,6 @@ pub fn version() -> String {
     env!("CARGO_PKG_VERSION").to_string()
 }
 
-/// Simple health check to verify the native module is working
-#[napi]
-pub fn health_check() -> String {
-    "tokscale-core is healthy!".to_string()
-}
-
 /// Token breakdown by type
 #[napi(object)]
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
## Summary

- Remove ~539 lines of dead code from the legacy single-phase report API
- The CLI exclusively uses the two-phase finalize API (`FinalizeReportOptions`) since the cursor parallel processing refactor
- The removed code duplicated parsing, pricing, filtering, and aggregation that the finalize path already handles

## What's Removed

### Rust (`packages/core/src/lib.rs`)
| Item | Type | Lines |
|------|------|-------|
| `ReportOptions` | struct | ~10 |
| `get_model_report` | exported fn | ~90 |
| `get_monthly_report` | exported fn | ~75 |
| `generate_graph_with_pricing` | exported fn | ~35 |
| `filter_messages_for_report` | private fn | ~25 |
| `parse_all_messages_with_pricing` | private fn | ~270 |

### NAPI Exports (`packages/core/index.d.ts`, `index.js`)
- `ReportOptions` interface
- `generateGraphWithPricing()`, `getModelReport()`, `getMonthlyReport()` declarations + bindings

### CLI (`packages/cli/src/native.ts`)
- `NativeReportOptions` interface (declared but never instantiated)

## What's Kept
- `MonthAggregator` (shared with active `finalize_monthly_report`)
- All `ModelUsage`, `MonthlyUsage`, `ModelReport`, `MonthlyReport`, `GraphResult` types (used by finalize functions)
- All finalize functions (`finalize_report`, `finalize_monthly_report`, `finalize_report_and_graph`, `finalize_graph`)

## Verification
- `cargo test`: 160 passed, 0 failed
- LSP diagnostics: clean on all modified TS files
- Repo-wide grep: zero remaining references to removed items

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the legacy single-phase report API and cleaned up unused exports (healthCheck, GraphOptions) to simplify the core surface. No behavior changes; the CLI stays on the two-phase finalize flow.

- **Refactors**
  - Removed ReportOptions and single-phase functions: getModelReport, getMonthlyReport, generateGraphWithPricing (Rust + NAPI bindings).
  - Removed healthCheck from Rust core, NAPI exports (index.d.ts, index.js), CLI NativeCore interface, and its test.
  - Deleted NativeReportOptions and the unused GraphOptions type from the CLI.
  - Kept MonthAggregator, finalize_* functions, and report types.

- **Migration**
  - If you used the removed APIs, switch to FinalizeReportOptions and finalize_report / finalize_monthly_report / finalize_report_and_graph / finalize_graph.
  - Remove any calls to healthCheck; no replacement.
  - No changes needed for the CLI.

<sup>Written for commit cd58183934a50745b33040fcacc0ae91d66c364b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

