### PR TITLE
fix: distribute native binaries via platform-specific npm packages

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -67,9 +67,20 @@ jobs:
           fi
           echo "🚀 New version: $NEW_VERSION"
           
-          # Update packages/core/package.json
-          jq --arg v "$NEW_VERSION" '.version = $v' packages/core/package.json > tmp.json && mv tmp.json packages/core/package.json
+          # Update packages/core/package.json (version + optionalDependencies versions)
+          jq --arg v "$NEW_VERSION" '
+            .version = $v |
+            .optionalDependencies = (.optionalDependencies | to_entries | map(.value = $v) | from_entries)
+          ' packages/core/package.json > tmp.json && mv tmp.json packages/core/package.json
           echo "✅ Updated packages/core/package.json"
+          
+          # Update all platform package.json files in npm/
+          for dir in packages/core/npm/*/; do
+            if [ -f "${dir}package.json" ]; then
+              jq --arg v "$NEW_VERSION" '.version = $v' "${dir}package.json" > tmp.json && mv tmp.json "${dir}package.json"
+              echo "✅ Updated ${dir}package.json"
+            fi
+          done
           
           # Update packages/cli/package.json (version + @tokscale/core dependency)
           jq --arg v "$NEW_VERSION" '.version = $v | .dependencies["@tokscale/core"] = $v' packages/cli/package.json > tmp.json && mv tmp.json packages/cli/package.json
@@ -87,6 +98,12 @@ jobs:
           echo "  tokscale:        $(jq -r '.version' packages/tokscale/package.json)"
           echo "  cli -> core dep: $(jq -r '.dependencies["@tokscale/core"]' packages/cli/package.json)"
           echo "  tokscale -> cli: $(jq -r '.dependencies["@tokscale/cli"]' packages/tokscale/package.json)"
+          echo "  Platform packages:"
+          for dir in packages/core/npm/*/; do
+            if [ -f "${dir}package.json" ]; then
+              echo "    $(basename $dir): $(jq -r '.version' "${dir}package.json")"
+            fi
+          done
           
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "📝 Version bump prepared (will commit after successful publish)"
@@ -97,6 +114,7 @@ jobs:
           name: bumped-packages
           path: |
             packages/core/package.json
+            packages/core/npm/*/package.json
             packages/cli/package.json
             packages/tokscale/package.json
           retention-days: 1
@@ -164,10 +182,15 @@ jobs:
       - name: Restore package.json structure
         shell: bash
         run: |
-          mv packages/core/package.json packages/core/package.json 2>/dev/null || true
-          mv packages/cli/package.json packages/cli/package.json 2>/dev/null || true
-          mv packages/tokscale/package.json packages/tokscale/package.json 2>/dev/null || true
+          # Restore main package.json files (already in correct location from download)
           echo "📦 Using version: $(jq -r '.version' packages/core/package.json)"
+          
+          # Restore platform package.json files
+          for dir in packages/core/npm/*/; do
+            if [ -f "${dir}package.json" ]; then
+              echo "  Platform $(basename $dir): $(jq -r '.version' "${dir}package.json")"
+            fi
+          done
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -230,9 +253,66 @@ jobs:
             packages/core/index.d.ts
           if-no-files-found: error
 
+  publish-platform-packages:
+    name: Publish platform packages
+    needs: [bump-versions, build]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - target: x86_64-apple-darwin
+            npm-dir: darwin-x64
+          - target: aarch64-apple-darwin
+            npm-dir: darwin-arm64
+          - target: x86_64-unknown-linux-gnu
+            npm-dir: linux-x64-gnu
+          - target: aarch64-unknown-linux-gnu
+            npm-dir: linux-arm64-gnu
+          - target: x86_64-unknown-linux-musl
+            npm-dir: linux-x64-musl
+          - target: aarch64-unknown-linux-musl
+            npm-dir: linux-arm64-musl
+          - target: x86_64-pc-windows-msvc
+            npm-dir: win32-x64-msvc
+          - target: aarch64-pc-windows-msvc
+            npm-dir: win32-arm64-msvc
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download bumped package.json files
+        uses: actions/download-artifact@v4
+        with:
+          name: bumped-packages
+          path: packages/
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.1.38
+
+      - name: Download platform binary
+        uses: actions/download-artifact@v4
+        with:
+          name: bindings-${{ matrix.platform.target }}
+          path: packages/core/npm/${{ matrix.platform.npm-dir }}/
+
+      - name: Verify binary exists
+        working-directory: packages/core/npm/${{ matrix.platform.npm-dir }}
+        run: |
+          ls -la *.node
+          echo "📦 Publishing $(jq -r '.name' package.json)@$(jq -r '.version' package.json)"
+
+      - name: Publish platform package
+        working-directory: packages/core/npm/${{ matrix.platform.npm-dir }}
+        run: bun publish --access public
+        env:
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   publish-core:
     name: Publish @tokscale/core
-    needs: [bump-versions, build]
+    needs: [bump-versions, build, publish-platform-packages]
     runs-on: ubuntu-latest
 
     steps:
@@ -249,23 +329,6 @@ jobs:
         with:
           bun-version: 1.1.38
 
-      - name: Install napi-rs CLI
-        run: bun add -g @napi-rs/cli
-
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: packages/core/artifacts
-          pattern: bindings-*
-
-      - name: Move artifacts
-        working-directory: packages/core
-        run: |
-          for dir in artifacts/bindings-*/; do
-            cp "$dir"*.node . 2>/dev/null || true
-          done
-          ls -la *.node
-
       - name: Download generated NAPI files
         uses: actions/download-artifact@v4
         with:
@@ -276,6 +339,8 @@ jobs:
         working-directory: packages/core
         run: |
           echo "📦 Publishing version: $(jq -r '.version' package.json)"
+          echo "📋 optionalDependencies:"
+          jq '.optionalDependencies' package.json
           bun publish --access public
         env:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -377,7 +442,7 @@ jobs:
           NEW_VERSION="${{ needs.bump-versions.outputs.version }}"
           echo "📦 Committing version bump to $NEW_VERSION"
           
-          git add packages/core/package.json packages/core/index.js packages/core/index.d.ts packages/cli/package.json packages/tokscale/package.json
+          git add packages/core/package.json packages/core/index.js packages/core/index.d.ts packages/core/npm/*/package.json packages/cli/package.json packages/tokscale/package.json
           git commit -m "chore: bump version to $NEW_VERSION"
           git push
           

--- a/packages/core/npm/darwin-arm64/README.md
+++ b/packages/core/npm/darwin-arm64/README.md
@@ -1,0 +1,3 @@
+# `@tokscale/core-darwin-arm64`
+
+This is the **aarch64-apple-darwin** binary for `@tokscale/core`

--- a/packages/core/npm/darwin-arm64/package.json
+++ b/packages/core/npm/darwin-arm64/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@tokscale/core-darwin-arm64",
+  "version": "1.2.10",
+  "cpu": [
+    "arm64"
+  ],
+  "main": "tokscale-core.darwin-arm64.node",
+  "files": [
+    "tokscale-core.darwin-arm64.node"
+  ],
+  "description": "Native Rust core for tokscale CLI - high-performance session parsing",
+  "keywords": [
+    "napi-rs",
+    "rust",
+    "tokscale",
+    "performance",
+    "native"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">= 16"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/junhoyeo/tokscale.git",
+    "directory": "packages/core"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "darwin"
+  ]
+}

--- a/packages/core/npm/darwin-x64/README.md
+++ b/packages/core/npm/darwin-x64/README.md
@@ -1,0 +1,3 @@
+# `@tokscale/core-darwin-x64`
+
+This is the **x86_64-apple-darwin** binary for `@tokscale/core`

--- a/packages/core/npm/darwin-x64/package.json
+++ b/packages/core/npm/darwin-x64/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@tokscale/core-darwin-x64",
+  "version": "1.2.10",
+  "cpu": [
+    "x64"
+  ],
+  "main": "tokscale-core.darwin-x64.node",
+  "files": [
+    "tokscale-core.darwin-x64.node"
+  ],
+  "description": "Native Rust core for tokscale CLI - high-performance session parsing",
+  "keywords": [
+    "napi-rs",
+    "rust",
+    "tokscale",
+    "performance",
+    "native"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">= 16"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/junhoyeo/tokscale.git",
+    "directory": "packages/core"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "darwin"
+  ]
+}

--- a/packages/core/npm/linux-arm64-gnu/README.md
+++ b/packages/core/npm/linux-arm64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@tokscale/core-linux-arm64-gnu`
+
+This is the **aarch64-unknown-linux-gnu** binary for `@tokscale/core`

--- a/packages/core/npm/linux-arm64-gnu/package.json
+++ b/packages/core/npm/linux-arm64-gnu/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@tokscale/core-linux-arm64-gnu",
+  "version": "1.2.10",
+  "cpu": [
+    "arm64"
+  ],
+  "main": "tokscale-core.linux-arm64-gnu.node",
+  "files": [
+    "tokscale-core.linux-arm64-gnu.node"
+  ],
+  "description": "Native Rust core for tokscale CLI - high-performance session parsing",
+  "keywords": [
+    "napi-rs",
+    "rust",
+    "tokscale",
+    "performance",
+    "native"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">= 16"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/junhoyeo/tokscale.git",
+    "directory": "packages/core"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "glibc"
+  ]
+}

--- a/packages/core/npm/linux-arm64-musl/README.md
+++ b/packages/core/npm/linux-arm64-musl/README.md
@@ -1,0 +1,3 @@
+# `@tokscale/core-linux-arm64-musl`
+
+This is the **aarch64-unknown-linux-musl** binary for `@tokscale/core`

--- a/packages/core/npm/linux-arm64-musl/package.json
+++ b/packages/core/npm/linux-arm64-musl/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@tokscale/core-linux-arm64-musl",
+  "version": "1.2.10",
+  "cpu": [
+    "arm64"
+  ],
+  "main": "tokscale-core.linux-arm64-musl.node",
+  "files": [
+    "tokscale-core.linux-arm64-musl.node"
+  ],
+  "description": "Native Rust core for tokscale CLI - high-performance session parsing",
+  "keywords": [
+    "napi-rs",
+    "rust",
+    "tokscale",
+    "performance",
+    "native"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">= 16"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/junhoyeo/tokscale.git",
+    "directory": "packages/core"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "musl"
+  ]
+}

--- a/packages/core/npm/linux-x64-gnu/README.md
+++ b/packages/core/npm/linux-x64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@tokscale/core-linux-x64-gnu`
+
+This is the **x86_64-unknown-linux-gnu** binary for `@tokscale/core`

--- a/packages/core/npm/linux-x64-gnu/package.json
+++ b/packages/core/npm/linux-x64-gnu/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@tokscale/core-linux-x64-gnu",
+  "version": "1.2.10",
+  "cpu": [
+    "x64"
+  ],
+  "main": "tokscale-core.linux-x64-gnu.node",
+  "files": [
+    "tokscale-core.linux-x64-gnu.node"
+  ],
+  "description": "Native Rust core for tokscale CLI - high-performance session parsing",
+  "keywords": [
+    "napi-rs",
+    "rust",
+    "tokscale",
+    "performance",
+    "native"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">= 16"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/junhoyeo/tokscale.git",
+    "directory": "packages/core"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "glibc"
+  ]
+}

--- a/packages/core/npm/linux-x64-musl/README.md
+++ b/packages/core/npm/linux-x64-musl/README.md
@@ -1,0 +1,3 @@
+# `@tokscale/core-linux-x64-musl`
+
+This is the **x86_64-unknown-linux-musl** binary for `@tokscale/core`

--- a/packages/core/npm/linux-x64-musl/package.json
+++ b/packages/core/npm/linux-x64-musl/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@tokscale/core-linux-x64-musl",
+  "version": "1.2.10",
+  "cpu": [
+    "x64"
+  ],
+  "main": "tokscale-core.linux-x64-musl.node",
+  "files": [
+    "tokscale-core.linux-x64-musl.node"
+  ],
+  "description": "Native Rust core for tokscale CLI - high-performance session parsing",
+  "keywords": [
+    "napi-rs",
+    "rust",
+    "tokscale",
+    "performance",
+    "native"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">= 16"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/junhoyeo/tokscale.git",
+    "directory": "packages/core"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "musl"
+  ]
+}

--- a/packages/core/npm/win32-arm64-msvc/README.md
+++ b/packages/core/npm/win32-arm64-msvc/README.md
@@ -1,0 +1,3 @@
+# `@tokscale/core-win32-arm64-msvc`
+
+This is the **aarch64-pc-windows-msvc** binary for `@tokscale/core`

--- a/packages/core/npm/win32-arm64-msvc/package.json
+++ b/packages/core/npm/win32-arm64-msvc/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@tokscale/core-win32-arm64-msvc",
+  "version": "1.2.10",
+  "cpu": [
+    "arm64"
+  ],
+  "main": "tokscale-core.win32-arm64-msvc.node",
+  "files": [
+    "tokscale-core.win32-arm64-msvc.node"
+  ],
+  "description": "Native Rust core for tokscale CLI - high-performance session parsing",
+  "keywords": [
+    "napi-rs",
+    "rust",
+    "tokscale",
+    "performance",
+    "native"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">= 16"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/junhoyeo/tokscale.git",
+    "directory": "packages/core"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "win32"
+  ]
+}

--- a/packages/core/npm/win32-x64-msvc/README.md
+++ b/packages/core/npm/win32-x64-msvc/README.md
@@ -1,0 +1,3 @@
+# `@tokscale/core-win32-x64-msvc`
+
+This is the **x86_64-pc-windows-msvc** binary for `@tokscale/core`

--- a/packages/core/npm/win32-x64-msvc/package.json
+++ b/packages/core/npm/win32-x64-msvc/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@tokscale/core-win32-x64-msvc",
+  "version": "1.2.10",
+  "cpu": [
+    "x64"
+  ],
+  "main": "tokscale-core.win32-x64-msvc.node",
+  "files": [
+    "tokscale-core.win32-x64-msvc.node"
+  ],
+  "description": "Native Rust core for tokscale CLI - high-performance session parsing",
+  "keywords": [
+    "napi-rs",
+    "rust",
+    "tokscale",
+    "performance",
+    "native"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">= 16"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/junhoyeo/tokscale.git",
+    "directory": "packages/core"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "win32"
+  ]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,7 @@
     "build": "napi build --platform --release",
     "build:platform": "napi build --platform --release",
     "build:debug": "napi build",
-    "prepublishOnly": "napi prepublish -t npm",
+    "create-npm-dirs": "napi create-npm-dirs",
     "test": "ava",
     "test:rust": "cargo test --features noop",
     "test:all": "bun run test:rust && bun run test",
@@ -48,8 +48,7 @@
   },
   "files": [
     "index.js",
-    "index.d.ts",
-    "*.node"
+    "index.d.ts"
   ],
   "engines": {
     "node": ">= 16"
@@ -65,5 +64,15 @@
     "tokscale",
     "performance",
     "native"
-  ]
+  ],
+  "optionalDependencies": {
+    "@tokscale/core-darwin-x64": "1.2.10",
+    "@tokscale/core-darwin-arm64": "1.2.10",
+    "@tokscale/core-linux-x64-gnu": "1.2.10",
+    "@tokscale/core-linux-arm64-gnu": "1.2.10",
+    "@tokscale/core-linux-x64-musl": "1.2.10",
+    "@tokscale/core-linux-arm64-musl": "1.2.10",
+    "@tokscale/core-win32-x64-msvc": "1.2.10",
+    "@tokscale/core-win32-arm64-msvc": "1.2.10"
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #208, Fixes #180 - `bunx tokscale@latest submit` fails on Linux x64 with "Native module required" error.

## Root Cause

The single `@tokscale/core` package bundled all platform `.node` binaries, but bun/npm didn't properly extract the correct binary for the user's platform. Users on Linux only saw `tokscale-core.darwin-arm64.node` in their `node_modules`.

## Solution

Adopt NAPI-RS standard platform package distribution:
- Create separate npm packages per platform (e.g., `@tokscale/core-linux-x64-gnu`)
- Declare them as `optionalDependencies` in `@tokscale/core`
- Package managers install only the platform package matching the user's system

## Changes

- Add `npm/` directory with 8 platform-specific package.json files
- Update publish workflow to publish platform packages before main package
- Update version bumping to include platform package versions
- Remove `*.node` from main package files (binaries in platform packages now)

## Publish Flow (Updated)

```
1. bump-versions  → Updates all package versions including platform packages
2. build         → Builds 8 native binaries (parallel)
3. publish-platform-packages → Publishes @tokscale/core-{platform} (parallel, 8 jobs)
4. publish-core  → Publishes @tokscale/core (with optionalDependencies)
5. publish-cli   → Publishes @tokscale/cli
6. publish-alias → Publishes tokscale wrapper
7. finalize      → Commits version bump, creates tag and release
```

## Testing

After merging and publishing:
```bash
# Should work on all platforms
bunx tokscale@latest
bunx tokscale@latest submit
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Distribute @tokscale/core native binaries via platform-specific npm packages so the right binary is installed per OS/CPU. Fixes the Linux x64 “Native module required” error when running bunx tokscale submit.

- **Bug Fixes**
  - Split native binaries into eight platform npm packages and declare them as optionalDependencies in @tokscale/core.
  - Removed *.node from the main package; binaries live in platform packages.
  - Updated publish workflow to build binaries, publish platform packages first, then @tokscale/core; version bumping now includes platform packages.

<sup>Written for commit 00dded2d5331e08b260fb31e2d9e43e44315e9e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

