### PR TITLE
fix: apply glibc 2.17 compat to publish-cli workflow

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -199,6 +199,11 @@ jobs:
         with:
           bun-version: 1.1.38
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -232,6 +237,10 @@ jobs:
 
       - name: Install napi-rs CLI
         run: bun add -g @napi-rs/cli
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        working-directory: packages/core
 
       - name: Build
         run: ${{ matrix.settings.build }}


### PR DESCRIPTION
## Problem

PR #210 fixed `build-native.yml` but **`publish-cli.yml`** (the workflow that actually publishes to npm) was not updated. As a result, `tokscale@1.4.0` still ships a `@tokscale/core-linux-x64-gnu` binary built against glibc 2.38+ that fails on Ubuntu 22.04 (glibc 2.35):

```
Error: tokscale-core.linux-x64-gnu.node: undefined symbol: __isoc23_strtol
```

## Fix

Apply the same `cargo zigbuild` + glibc 2.17 target fix to `publish-cli.yml`:
- `x86_64-unknown-linux-gnu`: `--use-napi-cross` → `cargo zigbuild --target x86_64-unknown-linux-gnu.2.17`
- `aarch64-unknown-linux-gnu`: same
- zig + cargo-zigbuild setup: enabled for all linux targets

This ensures the next release actually works on `bunx tokscale@latest` / `npx tokscale@latest` on common Linux distros.

*(repo owner's gaebal-gajae (clawdbot) 🦞)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update publish-cli workflow to build Linux GNU binaries with cargo-zigbuild targeting glibc 2.17. Fixes __isoc23_strtol runtime errors and adds missing setup steps so the CLI runs on Ubuntu 22.04 and other common distros.

- **Bug Fixes**
  - Switch from --use-napi-cross to cargo zigbuild (.2.17) for x64/arm64 GNU, and copy .so to .node.
  - Enable Zig and cargo-zigbuild for all Linux targets.
  - Add actions/setup-node@v4 (Node 20) and bun install in packages/core.

<sup>Written for commit b5836a02f770d53b5f80a5543a7996bf4938c867. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

