### PR TITLE
sync: merge main into ratatui-rewrite

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -1,0 +1,125 @@
+name: Build Native (Test Only)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "packages/core/**"
+      - "!packages/core/package.json"
+
+env:
+  DEBUG: napi:*
+  APP_NAME: tokscale-core
+  MACOSX_DEPLOYMENT_TARGET: "10.13"
+
+jobs:
+  build:
+    name: Build - ${{ matrix.settings.target }}
+    runs-on: ${{ matrix.settings.host }}
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - host: macos-latest
+            target: x86_64-apple-darwin
+            build: |
+              cd packages/core
+              bun run build:platform --target x86_64-apple-darwin
+              strip -x *.node
+          - host: macos-latest
+            target: aarch64-apple-darwin
+            build: |
+              cd packages/core
+              bun run build:platform --target aarch64-apple-darwin
+              strip -x *.node
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            build: |
+              cd packages/core
+              cargo zigbuild --release --target x86_64-unknown-linux-gnu.2.17
+              cp target/x86_64-unknown-linux-gnu/release/libtokscale_core.so tokscale-core.linux-x64-gnu.node
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            build: |
+              cd packages/core
+              bun run build:platform --target x86_64-unknown-linux-musl -x
+          - host: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            build: |
+              cd packages/core
+              cargo zigbuild --release --target aarch64-unknown-linux-gnu.2.17
+              cp target/aarch64-unknown-linux-gnu/release/libtokscale_core.so tokscale-core.linux-arm64-gnu.node
+          - host: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            build: |
+              cd packages/core
+              bun run build:platform --target aarch64-unknown-linux-musl -x
+          - host: windows-latest
+            target: x86_64-pc-windows-msvc
+            build: |
+              cd packages/core
+              bun run build:platform
+          - host: windows-latest
+            target: aarch64-pc-windows-msvc
+            build: |
+              cd packages/core
+              bun run build:platform --target aarch64-pc-windows-msvc
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.1.38
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.settings.target }}
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ~/.napi-rs
+            .cargo-cache
+            packages/core/target/
+          key: ${{ matrix.settings.target }}-cargo-${{ matrix.settings.host }}-${{ hashFiles('packages/core/Cargo.lock') }}
+
+      - uses: mlugg/setup-zig@v2
+        if: ${{ contains(matrix.settings.target, 'linux') }}
+        with:
+          version: 0.13.0
+
+      - name: Install cargo-zigbuild
+        uses: taiki-e/install-action@v2
+        if: ${{ contains(matrix.settings.target, 'linux') }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          tool: cargo-zigbuild
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        working-directory: packages/core
+
+      - name: Build
+        run: ${{ matrix.settings.build }}
+        shell: bash
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bindings-${{ matrix.settings.target }}
+          path: packages/core/*.node
+          if-no-files-found: error

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -200,6 +200,11 @@ jobs:
           name: bumped-packages
           path: .
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -217,13 +222,13 @@ jobs:
           key: cli-${{ matrix.settings.target }}-cargo-${{ matrix.settings.host }}-${{ hashFiles('Cargo.lock') }}
 
       - uses: mlugg/setup-zig@v2
-        if: ${{ startsWith(matrix.settings.target, 'x86_64-unknown-linux') || startsWith(matrix.settings.target, 'aarch64-unknown-linux') }}
+        if: ${{ contains(matrix.settings.target, 'linux') }}
         with:
           version: 0.13.0
 
       - name: Install cargo-zigbuild
         uses: taiki-e/install-action@v2
-        if: ${{ startsWith(matrix.settings.target, 'x86_64-unknown-linux') || startsWith(matrix.settings.target, 'aarch64-unknown-linux') }}
+        if: ${{ contains(matrix.settings.target, 'linux') }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -504,22 +504,14 @@ impl PricingLookup {
             None => return 0.0,
         };
 
-        let p = &result.pricing;
-        let safe_price =
-            |opt: Option<f64>| opt.filter(|v| v.is_finite() && *v >= 0.0).unwrap_or(0.0);
-
-        // Clamp negative tokens to 0 to prevent negative costs
-        let input_clamped = input.max(0) as f64;
-        let output_clamped = output.max(0).saturating_add(reasoning.max(0)) as f64;
-        let cache_read_clamped = cache_read.max(0) as f64;
-        let cache_write_clamped = cache_write.max(0) as f64;
-
-        let input_cost = input_clamped * safe_price(p.input_cost_per_token);
-        let output_cost = output_clamped * safe_price(p.output_cost_per_token);
-        let cache_read_cost = cache_read_clamped * safe_price(p.cache_read_input_token_cost);
-        let cache_write_cost = cache_write_clamped * safe_price(p.cache_creation_input_token_cost);
-
-        input_cost + output_cost + cache_read_cost + cache_write_cost
+        compute_cost(
+            &result.pricing,
+            input,
+            output,
+            cache_read,
+            cache_write,
+            reasoning,
+        )
     }
 }
 

--- a/crates/tokscale-core/src/sessions/amp.rs
+++ b/crates/tokscale-core/src/sessions/amp.rs
@@ -94,6 +94,14 @@ pub fn parse_amp_file(path: &Path) -> Vec<UnifiedMessage> {
         Err(_) => return Vec::new(),
     };
 
+    // Get file mtime as last-resort timestamp fallback
+    let file_mtime_ms = std::fs::metadata(path)
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+
     let mut bytes = content;
     let thread: AmpThread = match simd_json::from_slice(&mut bytes) {
         Ok(t) => t,
@@ -107,7 +115,10 @@ pub fn parse_amp_file(path: &Path) -> Vec<UnifiedMessage> {
             .to_string()
     });
 
-    let mut messages = Vec::with_capacity(32);
+    // Extract thread created time before consuming usage_ledger, for use as timestamp fallback
+    let thread_created_ms = thread.created.unwrap_or(0);
+
+    let mut messages = Vec::new();
 
     // Prefer usageLedger.events (cleaner aggregated data)
     if let Some(ledger) = thread.usage_ledger {
@@ -124,9 +135,15 @@ pub fn parse_amp_file(path: &Path) -> Vec<UnifiedMessage> {
                     .map(|dt| dt.timestamp_millis())
                     .unwrap_or(0);
 
-                if timestamp == 0 {
-                    continue;
-                }
+                // Use fallbacks when timestamp is missing: thread created time, then file mtime.
+                // Never skip events solely because of a missing timestamp.
+                let timestamp = if timestamp != 0 {
+                    timestamp
+                } else if thread_created_ms != 0 {
+                    thread_created_ms
+                } else {
+                    file_mtime_ms
+                };
 
                 let tokens = event.tokens.unwrap_or(AmpTokens {
                     input: Some(0),
@@ -158,7 +175,7 @@ pub fn parse_amp_file(path: &Path) -> Vec<UnifiedMessage> {
     }
 
     // Fallback: parse from individual message usage
-    let created = thread.created.unwrap_or(0);
+    let created = thread_created_ms;
     if let Some(thread_messages) = thread.messages {
         for msg in thread_messages {
             if msg.role.as_deref() != Some("assistant") {

--- a/crates/tokscale-core/src/sessions/cursor.rs
+++ b/crates/tokscale-core/src/sessions/cursor.rs
@@ -255,8 +255,8 @@ fn parse_date_to_timestamp(date_str: &str) -> i64 {
     }
 
     // Date-only format: "2025-02-05" - use noon UTC (12:00:00Z)
-    // Noon keeps the local date stable for most timezones (UTC-12 to UTC+12).
-    // UTC+13/+14 will roll into the next local day when converting this timestamp.
+    // Noon keeps the local date stable for all timezones from UTC-12 to UTC+14,
+    // so filtering by local day boundaries won't shift the record to an adjacent day.
     if let Ok(date) = NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
         let dt = date.and_hms_opt(12, 0, 0).unwrap();
         return Utc.from_utc_datetime(&dt).timestamp_millis();

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,1 @@
+# glibc compat fix - trigger CI


### PR DESCRIPTION
## Summary

- Merges `origin/main` (v1.2.7–v1.4.1 changes) into `feat/ratatui-rewrite`
- Resolves all conflicts per architecture rules: ratatui-rewrite structure preserved, main bug fixes applied

## Conflict resolutions

**Deleted in ratatui-rewrite (kept deleted):** old TS/TSX CLI and TUI files, napi-rs `packages/core` npm package, `packages/core/src/` Rust sources (moved to `crates/tokscale-core/`)

**Restored from main:** `.github/workflows/build-native.yml`

**Content conflicts:**
- `crates/tokscale-core/src/pricing/lookup.rs` — took main's `compute_cost()` refactor; removed duplicate `exact_match_cursor`
- `crates/tokscale-core/src/sessions/amp.rs` — took main's fix: extract `thread_created_ms` before consuming `usage_ledger`
- `crates/tokscale-core/src/sessions/cursor.rs` — took main's improved timezone comment
- `.github/workflows/publish-cli.yml` — kept ratatui-rewrite Rust CLI build/publish structure; took main's `contains(linux)` zig/zigbuild conditional fix
- `packages/*/package.json` — kept ratatui-rewrite version `1.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merge main into ratatui-rewrite, bringing recent fixes, scanner improvements, and CI updates while preserving the new TUI architecture. Includes Linux glibc 2.17 build support and a native build workflow.

- New Features
  - Scan Codex archived sessions at ~/.codex/archived_sessions in addition to sessions (tests added).
  - Cache OpenCode migration status to skip legacy JSON scanning once fully migrated.

- Bug Fixes
  - AMP: use thread-created/file mtime fallbacks when event timestamps are missing (no events dropped).
  - Pricing: delegate cost calculation to the shared compute_cost helper to keep pricing consistent across sources.

<sup>Written for commit a2dc89434e44256fc25b0e56f7e2dafcdec0d709. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

