### PR TITLE
fix(core): add dedup_key to Kimi parser and unify colors

### DIFF
--- a/packages/core/src/sessions/kimi.rs
+++ b/packages/core/src/sessions/kimi.rs
@@ -49,7 +49,11 @@ const DEFAULT_PROVIDER: &str = "moonshot";
 fn read_model_from_config(wire_path: &Path) -> String {
     // Navigate from wire.jsonl up to ~/.kimi/config.json
     // wire.jsonl is at ~/.kimi/sessions/GROUP/UUID/wire.jsonl
-    if let Some(sessions_dir) = wire_path.parent().and_then(|p| p.parent()).and_then(|p| p.parent()) {
+    if let Some(sessions_dir) = wire_path
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.parent())
+    {
         if let Some(kimi_dir) = sessions_dir.parent() {
             let config_path = kimi_dir.join("config.json");
             if let Ok(content) = std::fs::read_to_string(&config_path) {
@@ -147,7 +151,9 @@ pub fn parse_kimi_file(path: &Path) -> Vec<UnifiedMessage> {
             continue;
         }
 
-        messages.push(UnifiedMessage::new(
+        let dedup_key = payload.message_id;
+
+        messages.push(UnifiedMessage::new_with_dedup(
             "kimi",
             model.clone(),
             DEFAULT_PROVIDER,
@@ -158,9 +164,11 @@ pub fn parse_kimi_file(path: &Path) -> Vec<UnifiedMessage> {
                 output,
                 cache_read,
                 cache_write,
+                // Kimi wire protocol does not expose reasoning tokens; all reasoning included in output
                 reasoning: 0,
             },
             0.0,
+            dedup_key,
         ));
     }
 

--- a/packages/frontend/src/lib/constants.ts
+++ b/packages/frontend/src/lib/constants.ts
@@ -62,7 +62,7 @@ export const SOURCE_COLORS: Record<string, string> = {
   droid: "#1F1D1C",
   openclaw: "#EF4444",
   pi: "#6366F1",
-  kimi: "#A855F7",
+  kimi: "#8B5CF6",
 };
 
 export const SOURCE_TEXT_COLORS: Record<string, string> = {


### PR DESCRIPTION
- Add dedup_key using message_id from StatusPayload for deduplication
- Update Frontend Kimi color to match CLI (#8B5CF6)
- Document that reasoning tokens are always 0 in Kimi wire protocol

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate Kimi messages by using StatusPayload.message_id as the dedup_key and aligns the frontend Kimi color with the CLI (#8B5CF6). Clarifies that Kimi’s wire protocol always reports 0 reasoning tokens.

<sup>Written for commit 5eea12213a0ba8463515b87fa010aee025d8a022. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

