### PR TITLE
fix(frontend): harden postgres connection pool for serverless

### DIFF
--- a/packages/frontend/src/lib/db/index.ts
+++ b/packages/frontend/src/lib/db/index.ts
@@ -42,9 +42,7 @@ const client =
     prepare: false,
   });
 
-if (process.env.NODE_ENV !== "production") {
-  globalForDb._pgClient = client;
-}
+globalForDb._pgClient = client;
 
 export const db = drizzle(client, { schema });
 


### PR DESCRIPTION
## Summary

Fixes production PostgreSQL connection exhaustion (error `53300: too many clients already`) observed across all API endpoints on tokscale.ai (Feb 18, ~05:55–06:00 KST).

## Root Cause

`packages/frontend/src/lib/db/index.ts` created a `postgres` connection pool with `max: 5` and no timeouts. On Vercel serverless, **each function invocation (cold start) creates its own pool**, so under load: 20+ concurrent invocations × 5 connections = 100+ connections, exceeding Railway PostgreSQL's `max_connections` limit.

## Changes

| Setting | Before | After | Why |
|---------|--------|-------|-----|
| `max` | 5 | **1** | Each serverless instance gets its own pool; 1 × N instances stays within DB limits |
| `idle_timeout` | *(none)* | **20s** | Release idle connections in short-lived serverless functions |
| `max_lifetime` | *(none)* | **5 min** | Recycle connections after deploys / DB restarts |
| `connect_timeout` | *(none)* | **10s** | Fail fast instead of hanging when DB is overwhelmed |
| `prepare` | *(true)* | **false** | Prepared statements are connection-scoped; break across serverless invocations |
| Singleton | *(none)* | **`globalThis` cache** | Reuse pool across requests within the same warm runtime |

## Follow-up (not in this PR)

- `@neondatabase/serverless` in `package.json` is a dead dependency (we use Railway) — can be removed
- The `/api/settings/tokens` 20-request burst pattern (multiple tabs) is a secondary concern; this fix prevents it from cascading into DB exhaustion
- SSR `unstable_cache` thundering herd on leaderboard is mitigated by `max: 1` preventing over-commitment

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents PostgreSQL connection exhaustion on serverless by hardening the pool and persisting a singleton client across warm runs. This stops 53300 “too many clients” errors under load.

- **Bug Fixes**
  - Set pool max to 1 per function instance.
  - Add idle_timeout 20s and max_lifetime 5m.
  - Add connect_timeout 10s to fail fast.
  - Disable prepared statements.
  - Cache and persist the client in globalThis across invocations (including production).

<sup>Written for commit 3cd76bfb08a7de0536297c4a3c35e66b88171e65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

