### PR TITLE
fix: backwards compat for source→client rename and SSR profile fetch

### DIFF
--- a/packages/cli/src/submit.ts
+++ b/packages/cli/src/submit.ts
@@ -69,7 +69,7 @@ interface SubmitResponse {
       end: string;
     };
     activeDays: number;
-    sources: string[];
+    clients: string[];
   };
   warnings?: string[];
   error?: string;

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -24,12 +24,16 @@ function normalizeSubmissionData(data: unknown): void {
   for (const contribution of obj.contributions) {
     if (!contribution || typeof contribution !== "object") continue;
     const day = contribution as Record<string, unknown>;
-    if (!Array.isArray(day.sources)) continue;
-
-    for (const source of day.sources) {
-      if (!source || typeof source !== "object") continue;
-      const s = source as Record<string, unknown>;
-
+    // Handle both legacy "sources" and new "clients" formats
+    const items = Array.isArray(day.sources)
+      ? day.sources
+      : Array.isArray(day.clients)
+      ? day.clients
+      : null;
+    if (!items) continue;
+    for (const entry of items) {
+      if (!entry || typeof entry !== "object") continue;
+      const s = entry as Record<string, unknown>;
       if (s.modelId == null || typeof s.modelId !== "string") {
         s.modelId = "unknown";
       } else {

--- a/packages/frontend/src/app/u/[username]/page.tsx
+++ b/packages/frontend/src/app/u/[username]/page.tsx
@@ -5,9 +5,11 @@ import ProfilePageClient from './ProfilePageClient';
 export const revalidate = 60;
 
 async function getProfileData(username: string) {
-  const baseUrl = process.env.NEXT_PUBLIC_URL 
+  // In production: use explicit URL or Vercel auto-URL.
+  // In dev: use 127.0.0.1 to avoid ECONNREFUSED from localhost dual-stack DNS.
+  const baseUrl = process.env.NEXT_PUBLIC_URL
     || (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null)
-    || 'http://localhost:3000';
+    || 'http://127.0.0.1:3000';
   
   const res = await fetch(`${baseUrl}/api/users/${username}`, {
     next: { revalidate: 60 },


### PR DESCRIPTION
- Submit API normalizeSubmissionData now handles both legacy 'sources' and new 'clients' formats
- CLI SubmitResponse type updated to match API response ('clients' instead of 'sources')
- Profile SSR self-fetch uses 127.0.0.1 to avoid ECONNREFUSED from localhost dual-stack DNS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds backwards compatibility for the sources→clients rename in submit data and fixes SSR profile fetching to avoid localhost DNS issues. This keeps older submissions working and prevents profile page errors in dev.

- **Refactors**
  - normalizeSubmissionData now accepts both legacy sources and new clients arrays.
  - CLI SubmitResponse updated to use clients to match the API response.

- **Bug Fixes**
  - SSR profile self-fetch uses 127.0.0.1 instead of localhost to prevent ECONNREFUSED on dual-stack DNS in development.

<sup>Written for commit c76b11a768f2f60ffda49331b9c30c8157a01518. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

