### PR TITLE
fix: show component missing fallback

### DIFF
--- a/packages/cli/src/tui/components/BarChart.tsx
+++ b/packages/cli/src/tui/components/BarChart.tsx
@@ -191,7 +191,7 @@ export function BarChart(props: BarChartProps) {
           <text dim>{isVeryNarrowTerminal() ? "    0│" : "     0│"}</text>
           <text dim>{getRepeatedString("─", axisWidth())}</text>
         </box>
-        <Show when={dateLabels().length > 0}>
+        <Show when={dateLabels().length > 0} fallback={<></>}>
           <box flexDirection="row">
             <text dim>{isVeryNarrowTerminal() ? "      " : "       "}</text>
             <text dim>

--- a/packages/cli/src/tui/components/Footer.tsx
+++ b/packages/cli/src/tui/components/Footer.tsx
@@ -1,19 +1,8 @@
-import {
-  Show,
-  createSignal,
-  createEffect,
-  onMount,
-  onCleanup,
-} from "solid-js";
-import type {
-  SourceType,
-  SortType,
-  TabType,
-  LoadingPhase,
-} from "../types/index.js";
+import { Show, createEffect, createSignal, onCleanup, onMount } from "solid-js";
 import type { ColorPaletteName } from "../config/themes.js";
-import type { TotalBreakdown } from "../hooks/useData.js";
 import { getPalette } from "../config/themes.js";
+import type { TotalBreakdown } from "../hooks/useData.js";
+import type { LoadingPhase, SortType, SourceType, TabType } from "../types/index.js";
 import { formatTokens } from "../utils/format.js";
 import { isVeryNarrow } from "../utils/responsive.js";
 
@@ -161,7 +150,7 @@ export function Footer(props: FooterProps) {
             enabled={props.enabledSources.has("kimi")}
             onToggle={props.onSourceToggle}
           />
-          <Show when={!isVeryNarrowTerminal()}>
+          <Show when={!isVeryNarrowTerminal()} fallback={<></>}>
             <text dim>|</text>
             <SortButton
               label="Date"
@@ -182,7 +171,7 @@ export function Footer(props: FooterProps) {
               onClick={props.onSortChange}
             />
           </Show>
-          <Show when={showScrollInfo() && !isVeryNarrowTerminal()}>
+          <Show when={showScrollInfo() && !isVeryNarrowTerminal()} fallback={<></>}>
             <text dim>|</text>
             <text
               dim
@@ -194,7 +183,7 @@ export function Footer(props: FooterProps) {
           <text dim>tokens</text>
           <text dim>|</text>
           <text fg="green" bold>{`$${totals().cost.toFixed(2)}`}</text>
-          <Show when={!isVeryNarrowTerminal()}>
+          <Show when={!isVeryNarrowTerminal()} fallback={<></>}>
             <text dim>({props.modelCount} models)</text>
           </Show>
         </box>
@@ -242,18 +231,14 @@ export function Footer(props: FooterProps) {
           </text>
         </Show>
       </box>
-      <Show when={props.isRefreshing}>
+      <Show when={props.isRefreshing} fallback={<></>}>
         <LoadingStatusLine phase={props.loadingPhase} />
       </Show>
-      <Show when={!props.isRefreshing && props.cacheTimestamp}>
+      <Show when={!props.isRefreshing && props.cacheTimestamp} fallback={<></>}>
         <box flexDirection="row" gap={1}>
-          <text
-            dim
-          >{`Last updated: ${formatTimeAgo(props.cacheTimestamp!, now())}`}</text>
-          <Show when={props.autoRefreshEnabled}>
-            <text
-              dim
-            >{`• Auto: ${formatIntervalSeconds(props.autoRefreshMs)}`}</text>
+          <text dim>{`Last updated: ${formatTimeAgo(props.cacheTimestamp!, now())}`}</text>
+          <Show when={props.autoRefreshEnabled} fallback={<></>}>
+            <text dim>{`• Auto: ${formatIntervalSeconds(props.autoRefreshMs)}`}</text>
           </Show>
         </box>
       </Show>
@@ -299,14 +284,7 @@ function SortButton(props: SortButtonProps) {
   );
 }
 
-const SPINNER_COLORS = [
-  "#00FFFF",
-  "#00D7D7",
-  "#00AFAF",
-  "#008787",
-  "#666666",
-  "#666666",
-];
+const SPINNER_COLORS = ["#00FFFF", "#00D7D7", "#00AFAF", "#008787", "#666666", "#666666"];
 const SPINNER_WIDTH = 6;
 const SPINNER_HOLD_START = 20;
 const SPINNER_HOLD_END = 6;
@@ -336,8 +314,7 @@ function LoadingStatusLine(props: LoadingStatusLineProps) {
   const getSpinnerState = () => {
     const forwardFrames = SPINNER_WIDTH;
     const backwardFrames = SPINNER_WIDTH - 1;
-    const totalCycle =
-      forwardFrames + SPINNER_HOLD_END + backwardFrames + SPINNER_HOLD_START;
+    const totalCycle = forwardFrames + SPINNER_HOLD_END + backwardFrames + SPINNER_HOLD_START;
     const normalized = frame() % totalCycle;
 
     if (normalized < forwardFrames) {
@@ -346,8 +323,7 @@ function LoadingStatusLine(props: LoadingStatusLineProps) {
       return { position: SPINNER_WIDTH - 1, forward: true };
     } else if (normalized < forwardFrames + SPINNER_HOLD_END + backwardFrames) {
       return {
-        position:
-          SPINNER_WIDTH - 2 - (normalized - forwardFrames - SPINNER_HOLD_END),
+        position: SPINNER_WIDTH - 2 - (normalized - forwardFrames - SPINNER_HOLD_END),
         forward: false,
       };
     }
@@ -363,8 +339,7 @@ function LoadingStatusLine(props: LoadingStatusLineProps) {
     return { char: "⬝", color: "#444444" };
   };
 
-  const message = () =>
-    props.phase ? PHASE_MESSAGES[props.phase] : "Refreshing...";
+  const message = () => (props.phase ? PHASE_MESSAGES[props.phase] : "Refreshing...");
 
   return (
     <box flexDirection="row" gap={1}>

--- a/packages/cli/src/tui/components/Header.tsx
+++ b/packages/cli/src/tui/components/Header.tsx
@@ -31,7 +31,7 @@ export function Header(props: HeaderProps) {
         <Tab name={getTabName("Daily", "Day")} tabId="daily" active={props.activeTab === "daily"} onClick={props.onTabClick} />
         <Tab name={getTabName("Stats", "Sta")} tabId="stats" active={props.activeTab === "stats"} onClick={props.onTabClick} />
       </box>
-      <Show when={!isNarrowTerminal()}>
+      <Show when={!isNarrowTerminal()} fallback={<></>}>
         <box flexDirection="row" onMouseDown={() => openUrl(REPO_URL)}>
           <text fg="cyan" bold>tokscale</text>
           <text fg="#666666">{" | GitHub"}</text>

--- a/packages/cli/src/tui/components/Legend.tsx
+++ b/packages/cli/src/tui/components/Legend.tsx
@@ -27,7 +27,7 @@ export function Legend(props: LegendProps) {
             <box flexDirection="row" gap={0}>
               <text fg={getModelColor(modelId)}>●</text>
               <text>{` ${truncateModelName(modelId)}`}</text>
-              <Show when={i() < models().length - 1}>
+              <Show when={i() < models().length - 1} fallback={<></>}>
                 <text dim>{isVeryNarrowTerminal() ? " " : "  ·"}</text>
               </Show>
             </box>

--- a/packages/cli/src/tui/components/ModelRow.tsx
+++ b/packages/cli/src/tui/components/ModelRow.tsx
@@ -26,12 +26,12 @@ export function ModelRow(props: ModelRowProps) {
   return (
     <box flexDirection="column">
       <box flexDirection="row" backgroundColor={bgColor()}>
-        <Show when={props.indent}>
+        <Show when={props.indent} fallback={<></>}>
           <text>{indentStr()}</text>
         </Show>
         <text fg={color()} bg={bgColor()}>●</text>
         <text fg={props.isActive ? "white" : undefined} bg={bgColor()}>{` ${truncateName(props.modelId)}`}</text>
-        <Show when={props.percentage !== undefined}>
+        <Show when={props.percentage !== undefined} fallback={<></>}>
           <text dim bg={bgColor()}>{` (${props.percentage!.toFixed(1)}%)`}</text>
         </Show>
       </box>

--- a/packages/cli/src/tui/components/OverviewView.tsx
+++ b/packages/cli/src/tui/components/OverviewView.tsx
@@ -83,7 +83,9 @@ export function OverviewView(props: OverviewViewProps) {
         <box flexDirection="row" justifyContent="space-between" marginBottom={0}>
           <text bold>{isVeryNarrowTerminal() ? "Top Models" : `Models by ${props.sortBy === "tokens" ? "Tokens" : "Cost"}`}</text>
           <box flexDirection="row">
-            <text dim>{isVeryNarrowTerminal() ? "" : "Total: "}</text>
+            <Show when={!isVeryNarrowTerminal()} fallback={<></>}>
+              <text dim>{"Total: "}</text>
+            </Show>
             <text fg="green">{formatCost(props.data.totalCost)}</text>
           </box>
         </box>
@@ -112,7 +114,7 @@ export function OverviewView(props: OverviewViewProps) {
           </For>
         </box>
 
-        <Show when={totalModels() > visibleModels().length}>
+        <Show when={totalModels() > visibleModels().length} fallback={<></>}>
           <text dim>{`↓ ${props.scrollOffset() + 1}-${endIndex()} of ${totalModels()} models (↑↓ to scroll)`}</text>
         </Show>
       </box>

--- a/packages/cli/src/tui/components/StatsView.tsx
+++ b/packages/cli/src/tui/components/StatsView.tsx
@@ -1,8 +1,8 @@
 import { For, Show, createMemo, createSignal } from "solid-js";
-import type { TUIData } from "../hooks/useData.js";
 import type { ColorPaletteName } from "../config/themes.js";
-import type { SortType, GridCell } from "../types/index.js";
-import { getPalette, getGradeColor } from "../config/themes.js";
+import { getGradeColor, getPalette } from "../config/themes.js";
+import type { TUIData } from "../hooks/useData.js";
+import type { GridCell, SortType } from "../types/index.js";
 import { getModelColor } from "../utils/colors.js";
 import { formatTokens } from "../utils/format.js";
 import { isNarrow } from "../utils/responsive.js";
@@ -35,27 +35,27 @@ export function StatsView(props: StatsViewProps) {
   const grid = createMemo((): GridCell[][] => {
     const contributions = props.data.contributions;
     const baseGrid = props.data.contributionGrid;
-    
-    const values = contributions.map(c => metric() === "tokens" ? c.tokens : c.cost);
+
+    const values = contributions.map((c) => (metric() === "tokens" ? c.tokens : c.cost));
     const maxValue = Math.max(1, ...values);
-    
+
     const levelMap = new Map<string, number>();
     for (const c of contributions) {
       const value = metric() === "tokens" ? c.tokens : c.cost;
       const level = value === 0 ? 0 : Math.min(4, Math.ceil((value / maxValue) * 4));
       levelMap.set(c.date, level);
     }
-    
-    return baseGrid.map(row => 
-      row.map(cell => ({
+
+    return baseGrid.map((row) =>
+      row.map((cell) => ({
         date: cell.date,
         level: cell.date ? (levelMap.get(cell.date) ?? 0) : 0,
-      }))
+      })),
     );
   });
-  
+
   const [clickedCell, setClickedCell] = createSignal<string | null>(null);
-  
+
   const selectedBreakdown = createMemo(() => {
     const date = clickedCell();
     if (!date) return null;
@@ -63,15 +63,15 @@ export function StatsView(props: StatsViewProps) {
     if (!(props.data.dailyBreakdowns instanceof Map)) return null;
     return props.data.dailyBreakdowns.get(date) || null;
   });
-  
+
   const monthPositions = createMemo(() => {
     const sundayRow = grid()[0] || [];
     if (sundayRow.length === 0) return [];
-    
+
     const positions: MonthLabel[] = [];
     let lastMonth = -1;
     const monthNames = isNarrowTerminal() ? MONTHS_SHORT : MONTHS;
-    
+
     for (let weekIdx = 0; weekIdx < sundayRow.length; weekIdx++) {
       const cell = sundayRow[weekIdx];
       if (!cell.date) continue;
@@ -90,7 +90,7 @@ export function StatsView(props: StatsViewProps) {
     const weeks = totalWeeks();
     const positions = monthPositions();
     const chars: string[] = new Array(weeks * cellWidth).fill(" ");
-    
+
     for (const pos of positions) {
       const startIdx = pos.weekIndex * cellWidth;
       const monthChars = pos.month.split("");
@@ -98,19 +98,17 @@ export function StatsView(props: StatsViewProps) {
         chars[startIdx + i] = monthChars[i];
       }
     }
-    
+
     return chars.join("");
   });
 
-  const dayLabelWidth = () => isNarrowTerminal() ? 2 : 4;
+  const dayLabelWidth = () => (isNarrowTerminal() ? 2 : 4);
 
-  const isSelected = (cellDate: string | null) => 
+  const isSelected = (cellDate: string | null) =>
     cellDate && (clickedCell() === cellDate || props.selectedDate === cellDate);
-  
-  const getCellColor = (level: number) => 
+
+  const getCellColor = (level: number) =>
     level === 0 ? "#666666" : getGradeColor(palette(), level as 0 | 1 | 2 | 3 | 4);
-
-
 
   return (
     <box flexDirection="column" gap={1}>
@@ -120,43 +118,45 @@ export function StatsView(props: StatsViewProps) {
           <text dim>{monthLabelRow()}</text>
         </box>
 
-        <box onMouseDown={(e: { x: number; y: number }) => {
-          const labelW = dayLabelWidth();
-          const col = Math.floor((e.x - labelW) / cellWidth);
-          const row = e.y - 2;
-          const gridRows = grid().length;
-          
-          if (row < 0 || row >= gridRows) {
-            return;
-          }
-          if (col < 0) {
-            return;
-          }
-          
-          const rowData = grid()[row];
-          if (!rowData || col >= rowData.length) {
-            return;
-          }
-          
-          const cell = rowData[col];
-          if (!cell?.date) {
-            return;
-          }
-          
-          const newDate = clickedCell() === cell.date ? null : cell.date;
-          setClickedCell(newDate);
-        }}>
+        <box
+          onMouseDown={(e: { x: number; y: number }) => {
+            const labelW = dayLabelWidth();
+            const col = Math.floor((e.x - labelW) / cellWidth);
+            const row = e.y - 2;
+            const gridRows = grid().length;
+
+            if (row < 0 || row >= gridRows) {
+              return;
+            }
+            if (col < 0) {
+              return;
+            }
+
+            const rowData = grid()[row];
+            if (!rowData || col >= rowData.length) {
+              return;
+            }
+
+            const cell = rowData[col];
+            if (!cell?.date) {
+              return;
+            }
+
+            const newDate = clickedCell() === cell.date ? null : cell.date;
+            setClickedCell(newDate);
+          }}
+        >
           <For each={DAYS}>
             {(day, dayIndex) => (
               <box flexDirection="row">
                 <text dim>{isNarrowTerminal() ? "  " : day.padStart(3) + " "}</text>
                 <For each={grid()[dayIndex()] || []}>
                   {(cell) => (
-                    <text 
-                      fg={isSelected(cell.date) ? "#ffffff" : getCellColor(cell.level)} 
+                    <text
+                      fg={isSelected(cell.date) ? "#ffffff" : getCellColor(cell.level)}
                       bg={isSelected(cell.date) ? getCellColor(cell.level) : undefined}
                     >
-                      {isSelected(cell.date) ? "▓▓" : (cell.level === 0 ? "· " : "██")}
+                      {isSelected(cell.date) ? "▓▓" : cell.level === 0 ? "· " : "██"}
                     </text>
                   )}
                 </For>
@@ -180,69 +180,74 @@ export function StatsView(props: StatsViewProps) {
           </For>
         </box>
         <text dim>More</text>
-        <Show when={!isNarrowTerminal()}>
+        <Show when={!isNarrowTerminal()} fallback={<></>}>
           <text dim>|</text>
           <text dim>Click on a day to see breakdown</text>
         </Show>
       </box>
 
-      <Show when={selectedBreakdown()}>
+      <Show
+        when={selectedBreakdown()}
+        fallback={
+          <>
+            <box flexDirection="column" marginTop={1}>
+              <box
+                flexDirection={isNarrowTerminal() ? "column" : "row"}
+                gap={isNarrowTerminal() ? 0 : 4}
+              >
+                <box flexDirection="column">
+                  <box flexDirection="row" gap={1}>
+                    <text dim>{isNarrowTerminal() ? "Model:" : "Favorite model:"}</text>
+                    <text fg={getModelColor(props.data.stats.favoriteModel)}>
+                      {props.data.stats.favoriteModel}
+                    </text>
+                  </box>
+                  <box flexDirection="row" gap={1}>
+                    <text dim>Sessions:</text>
+                    <text fg="cyan">{props.data.stats.sessions.toLocaleString()}</text>
+                  </box>
+                  <box flexDirection="row" gap={1}>
+                    <text dim>{isNarrowTerminal() ? "Streak:" : "Current streak:"}</text>
+                    <text fg="cyan">{`${props.data.stats.currentStreak} days`}</text>
+                  </box>
+                  <box flexDirection="row" gap={1}>
+                    <text dim>{isNarrowTerminal() ? "Active:" : "Active days:"}</text>
+                    <text fg="cyan">{`${props.data.stats.activeDays}/${props.data.stats.totalDays}`}</text>
+                  </box>
+                </box>
+
+                <box flexDirection="column">
+                  <box flexDirection="row" gap={1}>
+                    <text dim>{isNarrowTerminal() ? "Tokens:" : "Total tokens:"}</text>
+                    <text fg="cyan">{formatTokens(props.data.stats.totalTokens)}</text>
+                  </box>
+                  <box flexDirection="row" gap={1}>
+                    <text dim>{isNarrowTerminal() ? "Session:" : "Longest session:"}</text>
+                    <text fg="cyan">{props.data.stats.longestSession}</text>
+                  </box>
+                  <box flexDirection="row" gap={1}>
+                    <text dim>{isNarrowTerminal() ? "Max streak:" : "Longest streak:"}</text>
+                    <text fg="cyan">{`${props.data.stats.longestStreak} days`}</text>
+                  </box>
+                  <box flexDirection="row" gap={1}>
+                    <text dim>{isNarrowTerminal() ? "Peak:" : "Peak hour:"}</text>
+                    <text fg="cyan">{props.data.stats.peakHour}</text>
+                  </box>
+                </box>
+              </box>
+            </box>
+
+            <box marginTop={1}>
+              <text fg="yellow" italic>
+                {isNarrowTerminal()
+                  ? `Total: $${props.data.totalCost.toFixed(2)}`
+                  : `Your total spending is $${props.data.totalCost.toFixed(2)} on AI coding assistants!`}
+              </text>
+            </box>
+          </>
+        }
+      >
         <DateBreakdownPanel breakdown={selectedBreakdown()!} isNarrow={isNarrowTerminal()} />
-      </Show>
-
-      <Show when={!selectedBreakdown()}>
-        <box flexDirection="column" marginTop={1}>
-          <box flexDirection={isNarrowTerminal() ? "column" : "row"} gap={isNarrowTerminal() ? 0 : 4}>
-            <box flexDirection="column">
-              <box flexDirection="row" gap={1}>
-                <text dim>{isNarrowTerminal() ? "Model:" : "Favorite model:"}</text>
-                <text fg={getModelColor(props.data.stats.favoriteModel)}>{props.data.stats.favoriteModel}</text>
-              </box>
-              <box flexDirection="row" gap={1}>
-                <text dim>Sessions:</text>
-                <text fg="cyan">{props.data.stats.sessions.toLocaleString()}</text>
-              </box>
-              <box flexDirection="row" gap={1}>
-                <text dim>{isNarrowTerminal() ? "Streak:" : "Current streak:"}</text>
-                <text fg="cyan">{`${props.data.stats.currentStreak} days`}</text>
-              </box>
-              <box flexDirection="row" gap={1}>
-                <text dim>{isNarrowTerminal() ? "Active:" : "Active days:"}</text>
-                <text fg="cyan">{`${props.data.stats.activeDays}/${props.data.stats.totalDays}`}</text>
-              </box>
-            </box>
-
-            <box flexDirection="column">
-              <box flexDirection="row" gap={1}>
-                <text dim>{isNarrowTerminal() ? "Tokens:" : "Total tokens:"}</text>
-                <text fg="cyan">{formatTokens(props.data.stats.totalTokens)}</text>
-              </box>
-              <box flexDirection="row" gap={1}>
-                <text dim>{isNarrowTerminal() ? "Session:" : "Longest session:"}</text>
-                <text fg="cyan">{props.data.stats.longestSession}</text>
-              </box>
-              <box flexDirection="row" gap={1}>
-                <text dim>{isNarrowTerminal() ? "Max streak:" : "Longest streak:"}</text>
-                <text fg="cyan">{`${props.data.stats.longestStreak} days`}</text>
-              </box>
-              <box flexDirection="row" gap={1}>
-                <text dim>{isNarrowTerminal() ? "Peak:" : "Peak hour:"}</text>
-                <text fg="cyan">{props.data.stats.peakHour}</text>
-              </box>
-            </box>
-          </box>
-        </box>
-
-        <Show when={!isNarrowTerminal()}>
-          <box marginTop={1}>
-            <text fg="yellow" italic>{`Your total spending is $${props.data.totalCost.toFixed(2)} on AI coding assistants!`}</text>
-          </box>
-        </Show>
-        <Show when={isNarrowTerminal()}>
-          <box marginTop={1}>
-            <text fg="yellow" italic>{`Total: $${props.data.totalCost.toFixed(2)}`}</text>
-          </box>
-        </Show>
       </Show>
     </box>
   );


### PR DESCRIPTION
On windows running the cli.ts fails. The reason is the Show component default fallback when not specified breaks on windows with:
```
440 |   }
441 |   if (anchor && anchor instanceof SlotRenderable) {
442 |     anchor = anchor.getSlotChild(parent);
443 |   }
444 |   if (isTextNodeRenderable(node)) {
445 |       throw new Error(`Orphan text error: "${node.toChunks().map((c) => c.text).join("")}" must have a <text> as a parent: ${parent.id} above ${node.id}`);
                  ^
error: Orphan text error: "" must have a <text> as a parent: box-31 above text-node-82
      at _insertNode
```

This PR adds fallback to Show components without it.
PS: null fallback does not work as solid.js does `fallback || ''`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows CLI crash by adding explicit empty fallbacks to Solid’s Show components to prevent orphan text errors and blank screen. The CLI now renders correctly on Windows.

- **Bug Fixes**
  - Added fallback={<></>} to Show in Header, Footer, Legend, ModelRow, BarChart, OverviewView, and StatsView to avoid Solid’s default empty-string fallback.
  - Consolidated StatsView conditionals to use Show with fallback, preventing orphan text nodes.
  - Minor import/order tweaks and formatting; no behavior changes.

<sup>Written for commit 72e0e0eee21e81f1b0c4dd8d18b33217c3d5942e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

