### PR TITLE
feat(frontend): add mobile navigation for ≤520px viewports

### DIFF
--- a/packages/frontend/src/components/layout/Navigation.tsx
+++ b/packages/frontend/src/components/layout/Navigation.tsx
@@ -56,6 +56,8 @@ const NavContainer = styled.nav`
     align-items: stretch;
     border-radius: 20px;
     overflow: hidden;
+    border: 1px solid #10233E;
+    background: rgba(0, 0, 0, 0.5);
   }
 `;
 
@@ -275,6 +277,7 @@ const NavLogoLink = styled(Link)`
   flex-shrink: 0;
 
   @media (max-width: ${MOBILE_BREAKPOINT}) {
+    padding-left: 8px;
     display: flex;
   }
 `;


### PR DESCRIPTION
## Summary

- Adds a mobile navigation for viewports ≤520px, inspired by [sisyphuslabs-landing](https://github.com/nicepkg/sisyphuslabs-landing) expanding dropdown pattern
- Desktop navigation is completely unchanged — all mobile components use `display: none` above 520px
- Zero new dependencies — pure CSS `max-height` transition for expand/collapse animation

## What's included

- **Expanding dropdown menu**: Hamburger toggles an inline dropdown that expands downward from the navbar pill (not a sidebar)
- **Smaller mobile logo**: Tokscale wordmark at 100×21 with 8px left padding, hidden on desktop
- **Hamburger toggle**: Switches between ☰ and ✕ icons in the same button position
- **NavHeaderRow wrapper**: `display: contents` on desktop (transparent), flex row on mobile
- **Dropdown nav links**: About, Leaderboard, Profile, GitHub ↗ — rounded 12px items with active state
- **Dropdown auth section**: Sign-in button when logged out; user card + profile/settings/sign-out when logged in
- **Mobile navbar styling**: `border: 1px solid #10233E`, darker blurred background `rgba(0, 0, 0, 0.5)`, `border-radius: 20px`
- **Auto-close** on route change or link click
- **No body scroll lock** — not needed for inline dropdown
- SVG icons use `aria-hidden="true"` for accessibility