### PR TITLE
feat(frontend): add Groups with leaderboard, roles, and invite system

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,6 @@
     "": {
       "name": "tokscale-monorepo",
       "devDependencies": {
-        "@napi-rs/cli": "^3.4.1",
         "@resvg/resvg-js": "^2.6.2",
         "@types/node": "^20.0.0",
         "typescript": "^5.0.0",
@@ -68,24 +67,6 @@
       "name": "@tokscale/cli-win32-x64-msvc",
       "version": "1.2.3",
     },
-    "packages/core": {
-      "name": "@tokscale/core",
-      "version": "1.4.3",
-      "devDependencies": {
-        "@napi-rs/cli": "^3.4.1",
-        "ava": "^6.1.0",
-      },
-      "optionalDependencies": {
-        "@tokscale/core-darwin-arm64": "1.4.3",
-        "@tokscale/core-darwin-x64": "1.4.3",
-        "@tokscale/core-linux-arm64-gnu": "1.4.3",
-        "@tokscale/core-linux-arm64-musl": "1.4.3",
-        "@tokscale/core-linux-x64-gnu": "1.4.3",
-        "@tokscale/core-linux-x64-musl": "1.4.3",
-        "@tokscale/core-win32-arm64-msvc": "1.4.3",
-        "@tokscale/core-win32-x64-msvc": "1.4.3",
-      },
-    },
     "packages/frontend": {
       "name": "@tokscale/frontend",
       "version": "0.1.0",
@@ -97,7 +78,7 @@
         "date-fns": "^4.1.0",
         "drizzle-orm": "^0.38.3",
         "figma-squircle": "^1.1.0",
-        "next": "16.0.7",
+        "next": "16.0.10",
         "nextjs-toploader": "^3.9.17",
         "obelisk.js": "^1.2.2",
         "postgres": "^3.4.7",
@@ -319,42 +300,6 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
-    "@inquirer/ansi": ["@inquirer/ansi@2.0.2", "", {}, "sha512-SYLX05PwJVnW+WVegZt1T4Ip1qba1ik+pNJPDiqvk6zS5Y/i8PhRzLpGEtVd7sW0G8cMtkD8t4AZYhQwm8vnww=="],
-
-    "@inquirer/checkbox": ["@inquirer/checkbox@5.0.3", "", { "dependencies": { "@inquirer/ansi": "^2.0.2", "@inquirer/core": "^11.1.0", "@inquirer/figures": "^2.0.2", "@inquirer/type": "^4.0.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-xtQP2eXMFlOcAhZ4ReKP2KZvDIBb1AnCfZ81wWXG3DXLVH0f0g4obE0XDPH+ukAEMRcZT0kdX2AS1jrWGXbpxw=="],
-
-    "@inquirer/confirm": ["@inquirer/confirm@6.0.3", "", { "dependencies": { "@inquirer/core": "^11.1.0", "@inquirer/type": "^4.0.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-lyEvibDFL+NA5R4xl8FUmNhmu81B+LDL9L/MpKkZlQDJZXzG8InxiqYxiAlQYa9cqLLhYqKLQwZqXmSTqCLjyw=="],
-
-    "@inquirer/core": ["@inquirer/core@11.1.0", "", { "dependencies": { "@inquirer/ansi": "^2.0.2", "@inquirer/figures": "^2.0.2", "@inquirer/type": "^4.0.2", "cli-width": "^4.1.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^9.0.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-+jD/34T1pK8M5QmZD/ENhOfXdl9Zr+BrQAUc5h2anWgi7gggRq15ZbiBeLoObj0TLbdgW7TAIQRU2boMc9uOKQ=="],
-
-    "@inquirer/editor": ["@inquirer/editor@5.0.3", "", { "dependencies": { "@inquirer/core": "^11.1.0", "@inquirer/external-editor": "^2.0.2", "@inquirer/type": "^4.0.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-wYyQo96TsAqIciP/r5D3cFeV8h4WqKQ/YOvTg5yOfP2sqEbVVpbxPpfV3LM5D0EP4zUI3EZVHyIUIllnoIa8OQ=="],
-
-    "@inquirer/expand": ["@inquirer/expand@5.0.3", "", { "dependencies": { "@inquirer/core": "^11.1.0", "@inquirer/type": "^4.0.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-2oINvuL27ujjxd95f6K2K909uZOU2x1WiAl7Wb1X/xOtL8CgQ1kSxzykIr7u4xTkXkXOAkCuF45T588/YKee7w=="],
-
-    "@inquirer/external-editor": ["@inquirer/external-editor@2.0.2", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-X/fMXK7vXomRWEex1j8mnj7s1mpnTeP4CO/h2gysJhHLT2WjBnLv4ZQEGpm/kcYI8QfLZ2fgW+9kTKD+jeopLg=="],
-
-    "@inquirer/figures": ["@inquirer/figures@2.0.2", "", {}, "sha512-qXm6EVvQx/FmnSrCWCIGtMHwqeLgxABP8XgcaAoywsL0NFga9gD5kfG0gXiv80GjK9Hsoz4pgGwF/+CjygyV9A=="],
-
-    "@inquirer/input": ["@inquirer/input@5.0.3", "", { "dependencies": { "@inquirer/core": "^11.1.0", "@inquirer/type": "^4.0.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-4R0TdWl53dtp79Vs6Df2OHAtA2FVNqya1hND1f5wjHWxZJxwDMSNB1X5ADZJSsQKYAJ5JHCTO+GpJZ42mK0Otw=="],
-
-    "@inquirer/number": ["@inquirer/number@4.0.3", "", { "dependencies": { "@inquirer/core": "^11.1.0", "@inquirer/type": "^4.0.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-TjQLe93GGo5snRlu83JxE38ZPqj5ZVggL+QqqAF2oBA5JOJoxx25GG3EGH/XN/Os5WOmKfO8iLVdCXQxXRZIMQ=="],
-
-    "@inquirer/password": ["@inquirer/password@5.0.3", "", { "dependencies": { "@inquirer/ansi": "^2.0.2", "@inquirer/core": "^11.1.0", "@inquirer/type": "^4.0.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-rCozGbUMAHedTeYWEN8sgZH4lRCdgG/WinFkit6ZPsp8JaNg2T0g3QslPBS5XbpORyKP/I+xyBO81kFEvhBmjA=="],
-
-    "@inquirer/prompts": ["@inquirer/prompts@8.1.0", "", { "dependencies": { "@inquirer/checkbox": "^5.0.3", "@inquirer/confirm": "^6.0.3", "@inquirer/editor": "^5.0.3", "@inquirer/expand": "^5.0.3", "@inquirer/input": "^5.0.3", "@inquirer/number": "^4.0.3", "@inquirer/password": "^5.0.3", "@inquirer/rawlist": "^5.1.0", "@inquirer/search": "^4.0.3", "@inquirer/select": "^5.0.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-LsZMdKcmRNF5LyTRuZE5nWeOjganzmN3zwbtNfcs6GPh3I2TsTtF1UYZlbxVfhxd+EuUqLGs/Lm3Xt4v6Az1wA=="],
-
-    "@inquirer/rawlist": ["@inquirer/rawlist@5.1.0", "", { "dependencies": { "@inquirer/core": "^11.1.0", "@inquirer/type": "^4.0.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-yUCuVh0jW026Gr2tZlG3kHignxcrLKDR3KBp+eUgNz+BAdSeZk0e18yt2gyBr+giYhj/WSIHCmPDOgp1mT2niQ=="],
-
-    "@inquirer/search": ["@inquirer/search@4.0.3", "", { "dependencies": { "@inquirer/core": "^11.1.0", "@inquirer/figures": "^2.0.2", "@inquirer/type": "^4.0.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-lzqVw0YwuKYetk5VwJ81Ba+dyVlhseHPx9YnRKQgwXdFS0kEavCz2gngnNhnMIxg8+j1N/rUl1t5s1npwa7bqg=="],
-
-    "@inquirer/select": ["@inquirer/select@5.0.3", "", { "dependencies": { "@inquirer/ansi": "^2.0.2", "@inquirer/core": "^11.1.0", "@inquirer/figures": "^2.0.2", "@inquirer/type": "^4.0.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-M+ynbwS0ecQFDYMFrQrybA0qL8DV0snpc4kKevCCNaTpfghsRowRY7SlQBeIYNzHqXtiiz4RG9vTOeb/udew7w=="],
-
-    "@inquirer/type": ["@inquirer/type@4.0.2", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-cae7mzluplsjSdgFA6ACLygb5jC8alO0UUnFPyu0E7tNRPrL+q/f8VcSXp+cjZQ7l5CMpDpi2G1+IQvkOiL1Lw=="],
-
-    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
-
-    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
-
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -365,133 +310,29 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mapbox/node-pre-gyp": ["@mapbox/node-pre-gyp@2.0.3", "", { "dependencies": { "consola": "^3.2.3", "detect-libc": "^2.0.0", "https-proxy-agent": "^7.0.5", "node-fetch": "^2.6.7", "nopt": "^8.0.0", "semver": "^7.5.3", "tar": "^7.4.0" }, "bin": { "node-pre-gyp": "bin/node-pre-gyp" } }, "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg=="],
-
-    "@napi-rs/cli": ["@napi-rs/cli@3.5.0", "", { "dependencies": { "@inquirer/prompts": "^8.0.0", "@napi-rs/cross-toolchain": "^1.0.3", "@napi-rs/wasm-tools": "^1.0.1", "@octokit/rest": "^22.0.1", "clipanion": "^4.0.0-rc.4", "colorette": "^2.0.20", "emnapi": "^1.7.1", "es-toolkit": "^1.41.0", "js-yaml": "^4.1.0", "obug": "^2.0.0", "semver": "^7.7.3", "typanion": "^3.14.0" }, "peerDependencies": { "@emnapi/runtime": "^1.7.1" }, "optionalPeers": ["@emnapi/runtime"], "bin": { "napi": "dist/cli.js", "napi-raw": "cli.mjs" } }, "sha512-bJsDvAa9qK9VMkFhr780XWfQlK+GDlAX8qpK20buSmA0ld6nxCtiZ5a0J45zbd0FWT+VTZE1/u8VPH2vLfnVvw=="],
-
-    "@napi-rs/cross-toolchain": ["@napi-rs/cross-toolchain@1.0.3", "", { "dependencies": { "@napi-rs/lzma": "^1.4.5", "@napi-rs/tar": "^1.1.0", "debug": "^4.4.1" }, "peerDependencies": { "@napi-rs/cross-toolchain-arm64-target-aarch64": "^1.0.3", "@napi-rs/cross-toolchain-arm64-target-armv7": "^1.0.3", "@napi-rs/cross-toolchain-arm64-target-ppc64le": "^1.0.3", "@napi-rs/cross-toolchain-arm64-target-s390x": "^1.0.3", "@napi-rs/cross-toolchain-arm64-target-x86_64": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-aarch64": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-armv7": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-ppc64le": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-s390x": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-x86_64": "^1.0.3" }, "optionalPeers": ["@napi-rs/cross-toolchain-arm64-target-aarch64", "@napi-rs/cross-toolchain-arm64-target-armv7", "@napi-rs/cross-toolchain-arm64-target-ppc64le", "@napi-rs/cross-toolchain-arm64-target-s390x", "@napi-rs/cross-toolchain-arm64-target-x86_64", "@napi-rs/cross-toolchain-x64-target-aarch64", "@napi-rs/cross-toolchain-x64-target-armv7", "@napi-rs/cross-toolchain-x64-target-ppc64le", "@napi-rs/cross-toolchain-x64-target-s390x", "@napi-rs/cross-toolchain-x64-target-x86_64"] }, "sha512-ENPfLe4937bsKVTDA6zdABx4pq9w0tHqRrJHyaGxgaPq03a2Bd1unD5XSKjXJjebsABJ+MjAv1A2OvCgK9yehg=="],
-
-    "@napi-rs/lzma": ["@napi-rs/lzma@1.4.5", "", { "optionalDependencies": { "@napi-rs/lzma-android-arm-eabi": "1.4.5", "@napi-rs/lzma-android-arm64": "1.4.5", "@napi-rs/lzma-darwin-arm64": "1.4.5", "@napi-rs/lzma-darwin-x64": "1.4.5", "@napi-rs/lzma-freebsd-x64": "1.4.5", "@napi-rs/lzma-linux-arm-gnueabihf": "1.4.5", "@napi-rs/lzma-linux-arm64-gnu": "1.4.5", "@napi-rs/lzma-linux-arm64-musl": "1.4.5", "@napi-rs/lzma-linux-ppc64-gnu": "1.4.5", "@napi-rs/lzma-linux-riscv64-gnu": "1.4.5", "@napi-rs/lzma-linux-s390x-gnu": "1.4.5", "@napi-rs/lzma-linux-x64-gnu": "1.4.5", "@napi-rs/lzma-linux-x64-musl": "1.4.5", "@napi-rs/lzma-wasm32-wasi": "1.4.5", "@napi-rs/lzma-win32-arm64-msvc": "1.4.5", "@napi-rs/lzma-win32-ia32-msvc": "1.4.5", "@napi-rs/lzma-win32-x64-msvc": "1.4.5" } }, "sha512-zS5LuN1OBPAyZpda2ZZgYOEDC+xecUdAGnrvbYzjnLXkrq/OBC3B9qcRvlxbDR3k5H/gVfvef1/jyUqPknqjbg=="],
-
-    "@napi-rs/lzma-android-arm-eabi": ["@napi-rs/lzma-android-arm-eabi@1.4.5", "", { "os": "android", "cpu": "arm" }, "sha512-Up4gpyw2SacmyKWWEib06GhiDdF+H+CCU0LAV8pnM4aJIDqKKd5LHSlBht83Jut6frkB0vwEPmAkv4NjQ5u//Q=="],
-
-    "@napi-rs/lzma-android-arm64": ["@napi-rs/lzma-android-arm64@1.4.5", "", { "os": "android", "cpu": "arm64" }, "sha512-uwa8sLlWEzkAM0MWyoZJg0JTD3BkPknvejAFG2acUA1raXM8jLrqujWCdOStisXhqQjZ2nDMp3FV6cs//zjfuQ=="],
-
-    "@napi-rs/lzma-darwin-arm64": ["@napi-rs/lzma-darwin-arm64@1.4.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0Y0TQLQ2xAjVabrMDem1NhIssOZzF/y/dqetc6OT8mD3xMTDtF8u5BqZoX3MyPc9FzpsZw4ksol+w7DsxHrpMA=="],
-
-    "@napi-rs/lzma-darwin-x64": ["@napi-rs/lzma-darwin-x64@1.4.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-vR2IUyJY3En+V1wJkwmbGWcYiT8pHloTAWdW4pG24+51GIq+intst6Uf6D/r46citObGZrlX0QvMarOkQeHWpw=="],
-
-    "@napi-rs/lzma-freebsd-x64": ["@napi-rs/lzma-freebsd-x64@1.4.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-XpnYQC5SVovO35tF0xGkbHYjsS6kqyNCjuaLQ2dbEblFRr5cAZVvsJ/9h7zj/5FluJPJRDojVNxGyRhTp4z2lw=="],
-
-    "@napi-rs/lzma-linux-arm-gnueabihf": ["@napi-rs/lzma-linux-arm-gnueabihf@1.4.5", "", { "os": "linux", "cpu": "arm" }, "sha512-ic1ZZMoRfRMwtSwxkyw4zIlbDZGC6davC9r+2oX6x9QiF247BRqqT94qGeL5ZP4Vtz0Hyy7TEViWhx5j6Bpzvw=="],
-
-    "@napi-rs/lzma-linux-arm64-gnu": ["@napi-rs/lzma-linux-arm64-gnu@1.4.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-asEp7FPd7C1Yi6DQb45a3KPHKOFBSfGuJWXcAd4/bL2Fjetb2n/KK2z14yfW8YC/Fv6x3rBM0VAZKmJuz4tysg=="],
-
-    "@napi-rs/lzma-linux-arm64-musl": ["@napi-rs/lzma-linux-arm64-musl@1.4.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-yWjcPDgJ2nIL3KNvi4536dlT/CcCWO0DUyEOlBs/SacG7BeD6IjGh6yYzd3/X1Y3JItCbZoDoLUH8iB1lTXo3w=="],
-
-    "@napi-rs/lzma-linux-ppc64-gnu": ["@napi-rs/lzma-linux-ppc64-gnu@1.4.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-0XRhKuIU/9ZjT4WDIG/qnX7Xz7mSQHYZo9Gb3MP2gcvBgr6BA4zywQ9k3gmQaPn9ECE+CZg2V7DV7kT+x2pUMQ=="],
-
-    "@napi-rs/lzma-linux-riscv64-gnu": ["@napi-rs/lzma-linux-riscv64-gnu@1.4.5", "", { "os": "linux", "cpu": "none" }, "sha512-QrqDIPEUUB23GCpyQj/QFyMlr8SGxxyExeZz9OWFnHfb70kXdTLWrHS/hEI1Ru+lSbQ/6xRqeoGyQ4Aqdg+/RA=="],
-
-    "@napi-rs/lzma-linux-s390x-gnu": ["@napi-rs/lzma-linux-s390x-gnu@1.4.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-k8RVM5aMhW86E9H0QXdquwojew4H3SwPxbRVbl49/COJQWCUjGi79X6mYruMnMPEznZinUiT1jgKbFo2A00NdA=="],
-
-    "@napi-rs/lzma-linux-x64-gnu": ["@napi-rs/lzma-linux-x64-gnu@1.4.5", "", { "os": "linux", "cpu": "x64" }, "sha512-6rMtBgnIq2Wcl1rQdZsnM+rtCcVCbws1nF8S2NzaUsVaZv8bjrPiAa0lwg4Eqnn1d9lgwqT+cZgm5m+//K08Kw=="],
-
-    "@napi-rs/lzma-linux-x64-musl": ["@napi-rs/lzma-linux-x64-musl@1.4.5", "", { "os": "linux", "cpu": "x64" }, "sha512-eiadGBKi7Vd0bCArBUOO/qqRYPHt/VQVvGyYvDFt6C2ZSIjlD+HuOl+2oS1sjf4CFjK4eDIog6EdXnL0NE6iyQ=="],
-
-    "@napi-rs/lzma-wasm32-wasi": ["@napi-rs/lzma-wasm32-wasi@1.4.5", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.0.3" }, "cpu": "none" }, "sha512-+VyHHlr68dvey6fXc2hehw9gHVFIW3TtGF1XkcbAu65qVXsA9D/T+uuoRVqhE+JCyFHFrO0ixRbZDRK1XJt1sA=="],
-
-    "@napi-rs/lzma-win32-arm64-msvc": ["@napi-rs/lzma-win32-arm64-msvc@1.4.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-eewnqvIyyhHi3KaZtBOJXohLvwwN27gfS2G/YDWdfHlbz1jrmfeHAmzMsP5qv8vGB+T80TMHNkro4kYjeh6Deg=="],
-
-    "@napi-rs/lzma-win32-ia32-msvc": ["@napi-rs/lzma-win32-ia32-msvc@1.4.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-OeacFVRCJOKNU/a0ephUfYZ2Yt+NvaHze/4TgOwJ0J0P4P7X1mHzN+ig9Iyd74aQDXYqc7kaCXA2dpAOcH87Cg=="],
-
-    "@napi-rs/lzma-win32-x64-msvc": ["@napi-rs/lzma-win32-x64-msvc@1.4.5", "", { "os": "win32", "cpu": "x64" }, "sha512-T4I1SamdSmtyZgDXGAGP+y5LEK5vxHUFwe8mz6D4R7Sa5/WCxTcCIgPJ9BD7RkpO17lzhlaM2vmVvMy96Lvk9Q=="],
-
-    "@napi-rs/tar": ["@napi-rs/tar@1.1.0", "", { "optionalDependencies": { "@napi-rs/tar-android-arm-eabi": "1.1.0", "@napi-rs/tar-android-arm64": "1.1.0", "@napi-rs/tar-darwin-arm64": "1.1.0", "@napi-rs/tar-darwin-x64": "1.1.0", "@napi-rs/tar-freebsd-x64": "1.1.0", "@napi-rs/tar-linux-arm-gnueabihf": "1.1.0", "@napi-rs/tar-linux-arm64-gnu": "1.1.0", "@napi-rs/tar-linux-arm64-musl": "1.1.0", "@napi-rs/tar-linux-ppc64-gnu": "1.1.0", "@napi-rs/tar-linux-s390x-gnu": "1.1.0", "@napi-rs/tar-linux-x64-gnu": "1.1.0", "@napi-rs/tar-linux-x64-musl": "1.1.0", "@napi-rs/tar-wasm32-wasi": "1.1.0", "@napi-rs/tar-win32-arm64-msvc": "1.1.0", "@napi-rs/tar-win32-ia32-msvc": "1.1.0", "@napi-rs/tar-win32-x64-msvc": "1.1.0" } }, "sha512-7cmzIu+Vbupriudo7UudoMRH2OA3cTw67vva8MxeoAe5S7vPFI7z0vp0pMXiA25S8IUJefImQ90FeJjl8fjEaQ=="],
-
-    "@napi-rs/tar-android-arm-eabi": ["@napi-rs/tar-android-arm-eabi@1.1.0", "", { "os": "android", "cpu": "arm" }, "sha512-h2Ryndraj/YiKgMV/r5by1cDusluYIRT0CaE0/PekQ4u+Wpy2iUVqvzVU98ZPnhXaNeYxEvVJHNGafpOfaD0TA=="],
-
-    "@napi-rs/tar-android-arm64": ["@napi-rs/tar-android-arm64@1.1.0", "", { "os": "android", "cpu": "arm64" }, "sha512-DJFyQHr1ZxNZorm/gzc1qBNLF/FcKzcH0V0Vwan5P+o0aE2keQIGEjJ09FudkF9v6uOuJjHCVDdK6S6uHtShAw=="],
-
-    "@napi-rs/tar-darwin-arm64": ["@napi-rs/tar-darwin-arm64@1.1.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Zz2sXRzjIX4e532zD6xm2SjXEym6MkvfCvL2RMpG2+UwNVDVscHNcz3d47Pf3sysP2e2af7fBB3TIoK2f6trPw=="],
-
-    "@napi-rs/tar-darwin-x64": ["@napi-rs/tar-darwin-x64@1.1.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-EI+CptIMNweT0ms9S3mkP/q+J6FNZ1Q6pvpJOEcWglRfyfQpLqjlC0O+dptruTPE8VamKYuqdjxfqD8hifZDOA=="],
-
-    "@napi-rs/tar-freebsd-x64": ["@napi-rs/tar-freebsd-x64@1.1.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J0PIqX+pl6lBIAckL/c87gpodLbjZB1OtIK+RDscKC9NLdpVv6VGOxzUV/fYev/hctcE8EfkLbgFOfpmVQPg2g=="],
-
-    "@napi-rs/tar-linux-arm-gnueabihf": ["@napi-rs/tar-linux-arm-gnueabihf@1.1.0", "", { "os": "linux", "cpu": "arm" }, "sha512-SLgIQo3f3EjkZ82ZwvrEgFvMdDAhsxCYjyoSuWfHCz0U16qx3SuGCp8+FYOPYCECHN3ZlGjXnoAIt9ERd0dEUg=="],
-
-    "@napi-rs/tar-linux-arm64-gnu": ["@napi-rs/tar-linux-arm64-gnu@1.1.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-d014cdle52EGaH6GpYTQOP9Py7glMO1zz/+ynJPjjzYFSxvdYx0byrjumZk2UQdIyGZiJO2MEFpCkEEKFSgPYA=="],
-
-    "@napi-rs/tar-linux-arm64-musl": ["@napi-rs/tar-linux-arm64-musl@1.1.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-L/y1/26q9L/uBqiW/JdOb/Dc94egFvNALUZV2WCGKQXc6UByPBMgdiEyW2dtoYxYYYYc+AKD+jr+wQPcvX2vrQ=="],
-
-    "@napi-rs/tar-linux-ppc64-gnu": ["@napi-rs/tar-linux-ppc64-gnu@1.1.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-EPE1K/80RQvPbLRJDJs1QmCIcH+7WRi0F73+oTe1582y9RtfGRuzAkzeBuAGRXAQEjRQw/RjtNqr6UTJ+8UuWQ=="],
-
-    "@napi-rs/tar-linux-s390x-gnu": ["@napi-rs/tar-linux-s390x-gnu@1.1.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-B2jhWiB1ffw1nQBqLUP1h4+J1ovAxBOoe5N2IqDMOc63fsPZKNqF1PvO/dIem8z7LL4U4bsfmhy3gBfu547oNQ=="],
-
-    "@napi-rs/tar-linux-x64-gnu": ["@napi-rs/tar-linux-x64-gnu@1.1.0", "", { "os": "linux", "cpu": "x64" }, "sha512-tbZDHnb9617lTnsDMGo/eAMZxnsQFnaRe+MszRqHguKfMwkisc9CCJnks/r1o84u5fECI+J/HOrKXgczq/3Oww=="],
-
-    "@napi-rs/tar-linux-x64-musl": ["@napi-rs/tar-linux-x64-musl@1.1.0", "", { "os": "linux", "cpu": "x64" }, "sha512-dV6cODlzbO8u6Anmv2N/ilQHq/AWz0xyltuXoLU3yUyXbZcnWYZuB2rL8OBGPmqNcD+x9NdScBNXh7vWN0naSQ=="],
-
-    "@napi-rs/tar-wasm32-wasi": ["@napi-rs/tar-wasm32-wasi@1.1.0", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.0.3" }, "cpu": "none" }, "sha512-jIa9nb2HzOrfH0F8QQ9g3WE4aMH5vSI5/1NYVNm9ysCmNjCCtMXCAhlI3WKCdm/DwHf0zLqdrrtDFXODcNaqMw=="],
-
-    "@napi-rs/tar-win32-arm64-msvc": ["@napi-rs/tar-win32-arm64-msvc@1.1.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-vfpG71OB0ijtjemp3WTdmBKJm9R70KM8vsSExMsIQtV0lVzP07oM1CW6JbNRPXNLhRoue9ofYLiUDk8bE0Hckg=="],
-
-    "@napi-rs/tar-win32-ia32-msvc": ["@napi-rs/tar-win32-ia32-msvc@1.1.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-hGPyPW60YSpOSgzfy68DLBHgi6HxkAM+L59ZZZPMQ0TOXjQg+p2EW87+TjZfJOkSpbYiEkULwa/f4a2hcVjsqQ=="],
-
-    "@napi-rs/tar-win32-x64-msvc": ["@napi-rs/tar-win32-x64-msvc@1.1.0", "", { "os": "win32", "cpu": "x64" }, "sha512-L6Ed1DxXK9YSCMyvpR8MiNAyKNkQLjsHsHK9E0qnHa8NzLFqzDKhvs5LfnWxM2kJ+F7m/e5n9zPm24kHb3LsVw=="],
-
-    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.0", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-Fq6DJW+Bb5jaWE69/qOE0D1TUN9+6uWhCeZpdnSBk14pjLcCWR7Q8n49PTSPHazM37JqrsdpEthXy2xn6jWWiA=="],
-
-    "@napi-rs/wasm-tools": ["@napi-rs/wasm-tools@1.0.1", "", { "optionalDependencies": { "@napi-rs/wasm-tools-android-arm-eabi": "1.0.1", "@napi-rs/wasm-tools-android-arm64": "1.0.1", "@napi-rs/wasm-tools-darwin-arm64": "1.0.1", "@napi-rs/wasm-tools-darwin-x64": "1.0.1", "@napi-rs/wasm-tools-freebsd-x64": "1.0.1", "@napi-rs/wasm-tools-linux-arm64-gnu": "1.0.1", "@napi-rs/wasm-tools-linux-arm64-musl": "1.0.1", "@napi-rs/wasm-tools-linux-x64-gnu": "1.0.1", "@napi-rs/wasm-tools-linux-x64-musl": "1.0.1", "@napi-rs/wasm-tools-wasm32-wasi": "1.0.1", "@napi-rs/wasm-tools-win32-arm64-msvc": "1.0.1", "@napi-rs/wasm-tools-win32-ia32-msvc": "1.0.1", "@napi-rs/wasm-tools-win32-x64-msvc": "1.0.1" } }, "sha512-enkZYyuCdo+9jneCPE/0fjIta4wWnvVN9hBo2HuiMpRF0q3lzv1J6b/cl7i0mxZUKhBrV3aCKDBQnCOhwKbPmQ=="],
-
-    "@napi-rs/wasm-tools-android-arm-eabi": ["@napi-rs/wasm-tools-android-arm-eabi@1.0.1", "", { "os": "android", "cpu": "arm" }, "sha512-lr07E/l571Gft5v4aA1dI8koJEmF1F0UigBbsqg9OWNzg80H3lDPO+auv85y3T/NHE3GirDk7x/D3sLO57vayw=="],
-
-    "@napi-rs/wasm-tools-android-arm64": ["@napi-rs/wasm-tools-android-arm64@1.0.1", "", { "os": "android", "cpu": "arm64" }, "sha512-WDR7S+aRLV6LtBJAg5fmjKkTZIdrEnnQxgdsb7Cf8pYiMWBHLU+LC49OUVppQ2YSPY0+GeYm9yuZWW3kLjJ7Bg=="],
-
-    "@napi-rs/wasm-tools-darwin-arm64": ["@napi-rs/wasm-tools-darwin-arm64@1.0.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-qWTI+EEkiN0oIn/N2gQo7+TVYil+AJ20jjuzD2vATS6uIjVz+Updeqmszi7zq7rdFTLp6Ea3/z4kDKIfZwmR9g=="],
-
-    "@napi-rs/wasm-tools-darwin-x64": ["@napi-rs/wasm-tools-darwin-x64@1.0.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-bA6hubqtHROR5UI3tToAF/c6TDmaAgF0SWgo4rADHtQ4wdn0JeogvOk50gs2TYVhKPE2ZD2+qqt7oBKB+sxW3A=="],
-
-    "@napi-rs/wasm-tools-freebsd-x64": ["@napi-rs/wasm-tools-freebsd-x64@1.0.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-90+KLBkD9hZEjPQW1MDfwSt5J1L46EUKacpCZWyRuL6iIEO5CgWU0V/JnEgFsDOGyyYtiTvHc5bUdUTWd4I9Vg=="],
-
-    "@napi-rs/wasm-tools-linux-arm64-gnu": ["@napi-rs/wasm-tools-linux-arm64-gnu@1.0.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-rG0QlS65x9K/u3HrKafDf8cFKj5wV2JHGfl8abWgKew0GVPyp6vfsDweOwHbWAjcHtp2LHi6JHoW80/MTHm52Q=="],
-
-    "@napi-rs/wasm-tools-linux-arm64-musl": ["@napi-rs/wasm-tools-linux-arm64-musl@1.0.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-jAasbIvjZXCgX0TCuEFQr+4D6Lla/3AAVx2LmDuMjgG4xoIXzjKWl7c4chuaD+TI+prWT0X6LJcdzFT+ROKGHQ=="],
-
-    "@napi-rs/wasm-tools-linux-x64-gnu": ["@napi-rs/wasm-tools-linux-x64-gnu@1.0.1", "", { "os": "linux", "cpu": "x64" }, "sha512-Plgk5rPqqK2nocBGajkMVbGm010Z7dnUgq0wtnYRZbzWWxwWcXfZMPa8EYxrK4eE8SzpI7VlZP1tdVsdjgGwMw=="],
-
-    "@napi-rs/wasm-tools-linux-x64-musl": ["@napi-rs/wasm-tools-linux-x64-musl@1.0.1", "", { "os": "linux", "cpu": "x64" }, "sha512-GW7AzGuWxtQkyHknHWYFdR0CHmW6is8rG2Rf4V6GNmMpmwtXt/ItWYWtBe4zqJWycMNazpfZKSw/BpT7/MVCXQ=="],
-
-    "@napi-rs/wasm-tools-wasm32-wasi": ["@napi-rs/wasm-tools-wasm32-wasi@1.0.1", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.0.3" }, "cpu": "none" }, "sha512-/nQVSTrqSsn7YdAc2R7Ips/tnw5SPUcl3D7QrXCNGPqjbatIspnaexvaOYNyKMU6xPu+pc0BTnKVmqhlJJCPLA=="],
-
-    "@napi-rs/wasm-tools-win32-arm64-msvc": ["@napi-rs/wasm-tools-win32-arm64-msvc@1.0.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-PFi7oJIBu5w7Qzh3dwFea3sHRO3pojMsaEnUIy22QvsW+UJfNQwJCryVrpoUt8m4QyZXI+saEq/0r4GwdoHYFQ=="],
-
-    "@napi-rs/wasm-tools-win32-ia32-msvc": ["@napi-rs/wasm-tools-win32-ia32-msvc@1.0.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-gXkuYzxQsgkj05Zaq+KQTkHIN83dFAwMcTKa2aQcpYPRImFm2AQzEyLtpXmyCWzJ0F9ZYAOmbSyrNew8/us6bw=="],
-
-    "@napi-rs/wasm-tools-win32-x64-msvc": ["@napi-rs/wasm-tools-win32-x64-msvc@1.0.1", "", { "os": "win32", "cpu": "x64" }, "sha512-rEAf05nol3e3eei2sRButmgXP+6ATgm0/38MKhz9Isne82T4rPIMYsCIFj0kOisaGeVwoi2fnm7O9oWp5YVnYQ=="],
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
     "@neondatabase/serverless": ["@neondatabase/serverless@0.10.4", "", { "dependencies": { "@types/pg": "8.11.6" } }, "sha512-2nZuh3VUO9voBauuh+IGYRhGU/MskWHt1IuZvHcJw6GLjDgtqj/KViKo7SIrLdGLdot7vFbiRRw+BgEy3wT9HA=="],
 
-    "@next/env": ["@next/env@16.0.7", "", {}, "sha512-gpaNgUh5nftFKRkRQGnVi5dpcYSKGcZZkQffZ172OrG/XkrnS7UBTQ648YY+8ME92cC4IojpI2LqTC8sTDhAaw=="],
+    "@next/env": ["@next/env@16.0.10", "", {}, "sha512-8tuaQkyDVgeONQ1MeT9Mkk8pQmZapMKFh5B+OrFUlG3rVmYTXcXlBetBgTurKXGaIZvkoqRT9JL5K3phXcgang=="],
 
     "@next/eslint-plugin-next": ["@next/eslint-plugin-next@16.0.6", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-9INsBF3/4XL0/tON8AGsh0svnTtDMLwv3iREGWnWkewGdOnd790tguzq9rX8xwrVthPyvaBHhw1ww0GZz0jO5Q=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.0.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LlDtCYOEj/rfSnEn/Idi+j1QKHxY9BJFmxx7108A6D8K0SB+bNgfYQATPk/4LqOl4C0Wo3LACg2ie6s7xqMpJg=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.0.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4XgdKtdVsaflErz+B5XeG0T5PeXKDdruDf3CRpnhN+8UebNa5N2H58+3GDgpn/9GBurrQ1uWW768FfscwYkJRg=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.0.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rtZ7BhnVvO1ICf3QzfW9H3aPz7GhBrnSIMZyr4Qy6boXF0b5E3QLs+cvJmg3PsTCG2M1PBoC+DANUi4wCOKXpA=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.0.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-spbEObMvRKkQ3CkYVOME+ocPDFo5UqHb8EMTS78/0mQ+O1nqE8toHJVioZo4TvebATxgA8XMTHHrScPrn68OGw=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.0.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-mloD5WcPIeIeeZqAIP5c2kdaTa6StwP4/2EGy1mUw8HiexSHGK/jcM7lFuS3u3i2zn+xH9+wXJs6njO7VrAqww=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.0.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-uQtWE3X0iGB8apTIskOMi2w/MKONrPOUCi5yLO+v3O8Mb5c7K4Q5KD1jvTpTF5gJKa3VH/ijKjKUq9O9UhwOYw=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.0.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-+ksWNrZrthisXuo9gd1XnjHRowCbMtl/YgMpbRvFeDEqEBd523YHPWpBuDjomod88U8Xliw5DHhekBC3EOOd9g=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.0.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-llA+hiDTrYvyWI21Z0L1GiXwjQaanPVQQwru5peOgtooeJ8qx3tlqRV2P7uH2pKQaUfHxI/WVarvI5oYgGxaTw=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.0.7", "", { "os": "linux", "cpu": "x64" }, "sha512-4WtJU5cRDxpEE44Ana2Xro1284hnyVpBb62lIpU5k85D8xXxatT+rXxBgPkc7C1XwkZMWpK5rXLXTh9PFipWsA=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.0.10", "", { "os": "linux", "cpu": "x64" }, "sha512-AK2q5H0+a9nsXbeZ3FZdMtbtu9jxW4R/NgzZ6+lrTm3d6Zb7jYrWcgjcpM1k8uuqlSy4xIyPR2YiuUr+wXsavA=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.0.7", "", { "os": "linux", "cpu": "x64" }, "sha512-HYlhqIP6kBPXalW2dbMTSuB4+8fe+j9juyxwfMwCe9kQPPeiyFn7NMjNfoFOfJ2eXkeQsoUGXg+O2SE3m4Qg2w=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.0.10", "", { "os": "linux", "cpu": "x64" }, "sha512-1TDG9PDKivNw5550S111gsO4RGennLVl9cipPhtkXIFVwo31YZ73nEbLjNC8qG3SgTz/QZyYyaFYMeY4BKZR/g=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.0.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-EviG+43iOoBRZg9deGauXExjRphhuYmIOJ12b9sAPy0eQ6iwcPxfED2asb/s2/yiLYOdm37kPaiZu8uXSYPs0Q=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.0.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-aEZIS4Hh32xdJQbHz121pyuVZniSNoqDVx1yIr2hy+ZwJGipeqnMZBJHyMxv2tiuAXGx6/xpTcQJ6btIiBjgmg=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.0.7", "", { "os": "win32", "cpu": "x64" }, "sha512-gniPjy55zp5Eg0896qSrf3yB1dw4F/3s8VK1ephdsZZ129j2n6e1WqCbE2YgcKhW9hPB9TVZENugquWJD5x0ug=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.0.10", "", { "os": "win32", "cpu": "x64" }, "sha512-E+njfCoFLb01RAFEnGZn6ERoOqhK1Gl3Lfz1Kjnj0Ulfu7oJbuMyvBKNj/bw8XZnenHDASlygTjZICQW+rYW1Q=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -501,33 +342,7 @@
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
 
-    "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
-
-    "@octokit/core": ["@octokit/core@7.0.6", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.3", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q=="],
-
-    "@octokit/endpoint": ["@octokit/endpoint@11.0.2", "", { "dependencies": { "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-4zCpzP1fWc7QlqunZ5bSEjxc6yLAlRTnDwKtgXfcI/FxxGoqedDG8V2+xJ60bV2kODqcGB+nATdtap/XYq2NZQ=="],
-
-    "@octokit/graphql": ["@octokit/graphql@9.0.3", "", { "dependencies": { "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA=="],
-
-    "@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
-
-    "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@14.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw=="],
-
-    "@octokit/plugin-request-log": ["@octokit/plugin-request-log@6.0.0", "", { "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q=="],
-
-    "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@17.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw=="],
-
-    "@octokit/request": ["@octokit/request@10.0.7", "", { "dependencies": { "@octokit/endpoint": "^11.0.2", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "fast-content-type-parse": "^3.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-v93h0i1yu4idj8qFPZwjehoJx4j3Ntn+JhXsdJrG9pYaX6j/XRz2RmasMUHtNgQD39nrv/VwTWSqK0RNXR8upA=="],
-
-    "@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
-
-    "@octokit/rest": ["@octokit/rest@22.0.1", "", { "dependencies": { "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-request-log": "^6.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0" } }, "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw=="],
-
-    "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
-
     "@petamoriken/float16": ["@petamoriken/float16@3.9.3", "", {}, "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g=="],
-
-    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
 
@@ -597,8 +412,6 @@
 
     "@resvg/resvg-js-win32-x64-msvc": ["@resvg/resvg-js-win32-x64-msvc@2.6.2", "", { "os": "win32", "cpu": "x64" }, "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ=="],
 
-    "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
-
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.54.0", "", { "os": "android", "cpu": "arm" }, "sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng=="],
 
     "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.54.0", "", { "os": "android", "cpu": "arm64" }, "sha512-Skx39Uv+u7H224Af+bDgNinitlmHyQX1K/atIA32JP3JQw6hVODX5tkbi2zof/E69M1qH2UoN3Xdxgs90mmNYw=="],
@@ -645,8 +458,6 @@
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
-    "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@2.3.0", "", {}, "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg=="],
-
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
@@ -674,24 +485,6 @@
     "@tokscale/cli-win32-arm64-msvc": ["@tokscale/cli-win32-arm64-msvc@workspace:packages/cli-win32-arm64-msvc"],
 
     "@tokscale/cli-win32-x64-msvc": ["@tokscale/cli-win32-x64-msvc@workspace:packages/cli-win32-x64-msvc"],
-
-    "@tokscale/core": ["@tokscale/core@workspace:packages/core"],
-
-    "@tokscale/core-darwin-arm64": ["@tokscale/core-darwin-arm64@1.4.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-hDeInXnnJpkg8ZDR0W7rxoBpACYoLaFao2HUjIF4E+g+C54ynM4cHuUQ3/HUsNpMDP3PzMOoTmz2Y5FXOfdiFg=="],
-
-    "@tokscale/core-darwin-x64": ["@tokscale/core-darwin-x64@1.4.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-SwxKsTFACDu5uP9IFOUQ20+Yt838jY1Y2tas7uVkK61s6u+COJSCUq0Fq4FA9bK6X5js0xPjLd1fkzJBId9asQ=="],
-
-    "@tokscale/core-linux-arm64-gnu": ["@tokscale/core-linux-arm64-gnu@1.4.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-Pp0q20ug5Zs24CTuPcJuzJ+I2t9ryN7+VDafIQrAXQuzy+a7ySihQSmbJfC78h15yuV+LAQgBqeTZ/cJ+bFBqg=="],
-
-    "@tokscale/core-linux-arm64-musl": ["@tokscale/core-linux-arm64-musl@1.4.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-e1cHOLuz0q4YMrBjLP/Qdy3233fMV4EtNub86a1YwNVI57eojwCGIG0LTmGXIsMG1Qpji1G0EDEKx6fcAUvXKw=="],
-
-    "@tokscale/core-linux-x64-gnu": ["@tokscale/core-linux-x64-gnu@1.4.3", "", { "os": "linux", "cpu": "x64" }, "sha512-3tj8xI0YqHuX6Z+EpsmeDtRhP1xH5brnsWVBpYj8MPHPqDSDq7Do6WfPGq9vRylG4kYpvKYyLB6+v6/qJMpJVg=="],
-
-    "@tokscale/core-linux-x64-musl": ["@tokscale/core-linux-x64-musl@1.4.3", "", { "os": "linux", "cpu": "x64" }, "sha512-VYg+tuMu72qOIztBqhbkxw8DAKJ/MGfiHETs1pxcAaFMKH3qWJZ/vo/0f4hhuMR3ITO9J0I1P1AZf+wAyGC0Ew=="],
-
-    "@tokscale/core-win32-arm64-msvc": ["@tokscale/core-win32-arm64-msvc@1.4.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-hlKPePOMadws4mGffBA7ZLzA6T/9q5XuWXRs3mPNbymgYI+PQEil9Ub+arYKXvqfr6MpejQ5oKlbkerzci5Oxg=="],
-
-    "@tokscale/core-win32-x64-msvc": ["@tokscale/core-win32-x64-msvc@1.4.3", "", { "os": "win32", "cpu": "x64" }, "sha512-XkWa5FSWBgkwaQABxmm++KHMbmNEPmEU3EVnluCW78TxJMXG3Q3Pm3CIqm6zcQbF0JXAzH7A2giRjp3VoFlGig=="],
 
     "@tokscale/frontend": ["@tokscale/frontend@workspace:packages/frontend"],
 
@@ -781,8 +574,6 @@
 
     "@vercel/analytics": ["@vercel/analytics@1.6.1", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "react", "svelte", "vue", "vue-router"] }, "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg=="],
 
-    "@vercel/nft": ["@vercel/nft@0.29.4", "", { "dependencies": { "@mapbox/node-pre-gyp": "^2.0.0", "@rollup/pluginutils": "^5.1.3", "acorn": "^8.6.0", "acorn-import-attributes": "^1.9.5", "async-sema": "^3.1.1", "bindings": "^1.4.0", "estree-walker": "2.0.2", "glob": "^10.4.5", "graceful-fs": "^4.2.9", "node-gyp-build": "^4.2.2", "picomatch": "^4.0.2", "resolve-from": "^5.0.0" }, "bin": { "nft": "out/cli.js" } }, "sha512-6lLqMNX3TuycBPABycx7A9F1bHQR7kiQln6abjFbPrf5C/05qHM9M5E4PeTE59c7z8g6vHnx1Ioihb2AQl7BTA=="],
-
     "@vitest/expect": ["@vitest/expect@4.0.16", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.16", "@vitest/utils": "4.0.16", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA=="],
 
     "@vitest/mocker": ["@vitest/mocker@4.0.16", "", { "dependencies": { "@vitest/spy": "4.0.16", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg=="],
@@ -797,31 +588,19 @@
 
     "@vitest/utils": ["@vitest/utils@4.0.16", "", { "dependencies": { "@vitest/pretty-format": "4.0.16", "tinyrainbow": "^3.0.3" } }, "sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA=="],
 
-    "abbrev": ["abbrev@3.0.1", "", {}, "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg=="],
-
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
-
-    "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
-    "acorn-walk": ["acorn-walk@8.3.4", "", { "dependencies": { "acorn": "^8.11.0" } }, "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g=="],
-
-    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
-
     "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
     "array-buffer-byte-length": ["array-buffer-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "is-array-buffer": "^3.0.5" } }, "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw=="],
-
-    "array-find-index": ["array-find-index@1.0.2", "", {}, "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw=="],
 
     "array-includes": ["array-includes@3.1.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-abstract": "^1.24.0", "es-object-atoms": "^1.1.1", "get-intrinsic": "^1.3.0", "is-string": "^1.1.1", "math-intrinsics": "^1.1.0" } }, "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ=="],
 
@@ -837,19 +616,11 @@
 
     "arraybuffer.prototype.slice": ["arraybuffer.prototype.slice@1.0.4", "", { "dependencies": { "array-buffer-byte-length": "^1.0.1", "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "is-array-buffer": "^3.0.4" } }, "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ=="],
 
-    "arrgv": ["arrgv@1.0.2", "", {}, "sha512-a4eg4yhp7mmruZDQFqVMlxNRFGi/i1r87pt8SDHy0/I8PqSXoUTlWZRdAZo0VXgvEARcujbtTk8kiZRi1uDGRw=="],
-
-    "arrify": ["arrify@3.0.0", "", {}, "sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw=="],
-
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "ast-types-flow": ["ast-types-flow@0.0.8", "", {}, "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ=="],
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
-
-    "async-sema": ["async-sema@3.1.1", "", {}, "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg=="],
-
-    "ava": ["ava@6.4.1", "", { "dependencies": { "@vercel/nft": "^0.29.4", "acorn": "^8.15.0", "acorn-walk": "^8.3.4", "ansi-styles": "^6.2.1", "arrgv": "^1.0.2", "arrify": "^3.0.0", "callsites": "^4.2.0", "cbor": "^10.0.9", "chalk": "^5.4.1", "chunkd": "^2.0.1", "ci-info": "^4.3.0", "ci-parallel-vars": "^1.0.1", "cli-truncate": "^4.0.0", "code-excerpt": "^4.0.0", "common-path-prefix": "^3.0.0", "concordance": "^5.0.4", "currently-unhandled": "^0.4.1", "debug": "^4.4.1", "emittery": "^1.2.0", "figures": "^6.1.0", "globby": "^14.1.0", "ignore-by-default": "^2.1.0", "indent-string": "^5.0.0", "is-plain-object": "^5.0.0", "is-promise": "^4.0.0", "matcher": "^5.0.0", "memoize": "^10.1.0", "ms": "^2.1.3", "p-map": "^7.0.3", "package-config": "^5.0.0", "picomatch": "^4.0.2", "plur": "^5.1.0", "pretty-ms": "^9.2.0", "resolve-cwd": "^3.0.0", "stack-utils": "^2.0.6", "strip-ansi": "^7.1.0", "supertap": "^3.0.1", "temp-dir": "^3.0.0", "write-file-atomic": "^6.0.0", "yargs": "^17.7.2" }, "peerDependencies": { "@ava/typescript": "*" }, "optionalPeers": ["@ava/typescript"], "bin": { "ava": "entrypoints/cli.mjs" } }, "sha512-vxmPbi1gZx9zhAjHBgw81w/iEDKcrokeRk/fqDTyA2DQygZ0o+dUGRHFOtX8RA5N0heGJTTsIk7+xYxitDb61Q=="],
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
@@ -860,12 +631,6 @@
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.10", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-2VIKvDx8Z1a9rTB2eCkdPE5nSe28XnA+qivGnWHoB40hMMt/h1hSz0960Zqsn6ZyxWXUie0EBdElKv8may20AA=="],
-
-    "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
-
-    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
-
-    "blueimp-md5": ["blueimp-md5@2.19.0", "", {}, "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w=="],
 
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
@@ -881,59 +646,27 @@
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
-    "callsites": ["callsites@4.2.0", "", {}, "sha512-kfzR4zzQtAE9PC7CzZsjl3aBNbXWuXiSeOCdLcPpBfGW8YuCqQHcRPFDbr/BPVmd3EEPVpuFzLyuT/cUhPr4OQ=="],
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "camelize": ["camelize@1.0.1", "", {}, "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001761", "", {}, "sha512-JF9ptu1vP2coz98+5051jZ4PwQgd2ni8A+gYSN7EA7dPKIMf0pDlSUxhdmVOaV3/fYK5uWBkgSXJaRLr4+3A6g=="],
 
-    "cbor": ["cbor@10.0.11", "", { "dependencies": { "nofilter": "^3.0.2" } }, "sha512-vIwORDd/WyB8Nc23o2zNN5RrtFGlR6Fca61TtjkUXueI3Jf2DOZDl1zsshvBntZ3wZHBM9ztjnkXSmzQDaq3WA=="],
-
     "chai": ["chai@6.2.1", "", {}, "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg=="],
 
-    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
-
-    "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
-
-    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
-
-    "chunkd": ["chunkd@2.0.1", "", {}, "sha512-7d58XsFmOq0j6el67Ug9mHf9ELUXsQXYJBkyxhH/k+6Ke0qXRnv0kbemx+Twc6fRJ07C49lcbdgm9FL1Ei/6SQ=="],
-
-    "ci-info": ["ci-info@4.3.1", "", {}, "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA=="],
-
-    "ci-parallel-vars": ["ci-parallel-vars@1.0.1", "", {}, "sha512-uvzpYrpmidaoxvIQHM+rKSrigjOe9feHYbw4uOI2gdfe1C3xIlxO+kVXq83WQWNniTf8bAxVpy+cQeFQsMERKg=="],
-
-    "cli-truncate": ["cli-truncate@4.0.0", "", { "dependencies": { "slice-ansi": "^5.0.0", "string-width": "^7.0.0" } }, "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA=="],
-
-    "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
-    "clipanion": ["clipanion@4.0.0-rc.4", "", { "dependencies": { "typanion": "^3.8.0" } }, "sha512-CXkMQxU6s9GklO/1f714dkKBMu1lopS1WFF0B8o4AxPykR1hpozxSiUZ5ZUeBjfPgCWqbcNOtZVFhB8Lkfp1+Q=="],
-
-    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
-
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
-
-    "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
-    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
-
-    "common-path-prefix": ["common-path-prefix@3.0.0", "", {}, "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w=="],
-
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
-    "concordance": ["concordance@5.0.4", "", { "dependencies": { "date-time": "^3.1.0", "esutils": "^2.0.3", "fast-diff": "^1.2.0", "js-string-escape": "^1.0.1", "lodash": "^4.17.15", "md5-hex": "^3.0.1", "semver": "^7.3.2", "well-known-symbols": "^2.0.0" } }, "sha512-OAcsnTEYu1ARJqWVGwf4zh4JDfHZEaSNlNccFmt8YjB2l/n19/PF2viLINHc57vO4FKIAFl2FWASIGZZWZ2Kxw=="],
-
-    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
-
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
-
-    "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -942,8 +675,6 @@
     "css-to-react-native": ["css-to-react-native@3.2.0", "", { "dependencies": { "camelize": "^1.0.0", "css-color-keywords": "^1.0.0", "postcss-value-parser": "^4.0.2" } }, "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
-
-    "currently-unhandled": ["currently-unhandled@0.4.1", "", { "dependencies": { "array-find-index": "^1.0.1" } }, "sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng=="],
 
     "damerau-levenshtein": ["damerau-levenshtein@1.0.8", "", {}, "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="],
 
@@ -954,8 +685,6 @@
     "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
 
     "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
-
-    "date-time": ["date-time@3.1.0", "", { "dependencies": { "time-zone": "^1.0.0" } }, "sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -975,13 +704,7 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
-    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
-
     "electron-to-chromium": ["electron-to-chromium@1.5.267", "", {}, "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="],
-
-    "emittery": ["emittery@1.2.0", "", {}, "sha512-KxdRyyFcS85pH3dnU8Y5yFUm2YJdaHwcBZWrfG8o89ZY9a13/f9itbN+YG3ELbBo9Pg5zvIozstmuV8bX13q6g=="],
-
-    "emnapi": ["emnapi@1.7.1", "", { "peerDependencies": { "node-addon-api": ">= 6.1.0" }, "optionalPeers": ["node-addon-api"] }, "sha512-wlLK2xFq+T+rCBlY6+lPlFVDEyE93b7hSn9dMrfWBIcPf4ArwUvymvvMnN9M5WWuiryYQe9M+UJrkqw4trdyRA=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
@@ -1004,8 +727,6 @@
     "es-shim-unscopables": ["es-shim-unscopables@1.1.0", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw=="],
 
     "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
-
-    "es-toolkit": ["es-toolkit@1.43.0", "", {}, "sha512-SKCT8AsWvYzBBuUqMk4NPwFlSdqLpJwmy6AP322ERn8W2YLIB6JBXnwMI2Qsh2gfphT3q7EKAxKb23cvFHFwKA=="],
 
     "esbuild": ["esbuild@0.19.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.19.12", "@esbuild/android-arm": "0.19.12", "@esbuild/android-arm64": "0.19.12", "@esbuild/android-x64": "0.19.12", "@esbuild/darwin-arm64": "0.19.12", "@esbuild/darwin-x64": "0.19.12", "@esbuild/freebsd-arm64": "0.19.12", "@esbuild/freebsd-x64": "0.19.12", "@esbuild/linux-arm": "0.19.12", "@esbuild/linux-arm64": "0.19.12", "@esbuild/linux-ia32": "0.19.12", "@esbuild/linux-loong64": "0.19.12", "@esbuild/linux-mips64el": "0.19.12", "@esbuild/linux-ppc64": "0.19.12", "@esbuild/linux-riscv64": "0.19.12", "@esbuild/linux-s390x": "0.19.12", "@esbuild/linux-x64": "0.19.12", "@esbuild/netbsd-x64": "0.19.12", "@esbuild/openbsd-x64": "0.19.12", "@esbuild/sunos-x64": "0.19.12", "@esbuild/win32-arm64": "0.19.12", "@esbuild/win32-ia32": "0.19.12", "@esbuild/win32-x64": "0.19.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg=="],
 
@@ -1039,27 +760,21 @@
 
     "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
 
-    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
-
     "esquery": ["esquery@1.6.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg=="],
 
     "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
-    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
-    "fast-content-type-parse": ["fast-content-type-parse@3.0.0", "", {}, "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="],
-
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-diff": ["fast-diff@1.3.0", "", {}, "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw=="],
-
-    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+    "fast-glob": ["fast-glob@3.3.1", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.4" } }, "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg=="],
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
@@ -1071,25 +786,17 @@
 
     "figma-squircle": ["figma-squircle@1.1.0", "", {}, "sha512-3aa6bOurrsybsuYo1TMRuasBpXgVjgnmOUtZ40il6e1dJF2lhTRq89z7oy1uzKDspbH3630rLZD2UvJqXDiktA=="],
 
-    "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
-
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
-
-    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
-
-    "find-up-simple": ["find-up-simple@1.0.1", "", {}, "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ=="],
 
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
     "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
-
-    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -1105,10 +812,6 @@
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
-    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
-
-    "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
-
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
@@ -1117,19 +820,13 @@
 
     "get-tsconfig": ["get-tsconfig@4.13.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ=="],
 
-    "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
-
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "globals": ["globals@16.4.0", "", {}, "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw=="],
 
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
 
-    "globby": ["globby@14.1.0", "", { "dependencies": { "@sindresorhus/merge-streams": "^2.1.0", "fast-glob": "^3.3.3", "ignore": "^7.0.3", "path-type": "^6.0.0", "slash": "^5.1.0", "unicorn-magic": "^0.3.0" } }, "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA=="],
-
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
-
-    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -1151,23 +848,13 @@
 
     "hoist-non-react-statics": ["hoist-non-react-statics@3.3.2", "", { "dependencies": { "react-is": "^16.7.0" } }, "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw=="],
 
-    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "iconv-lite": ["iconv-lite@0.7.1", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw=="],
-
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
-
-    "ignore-by-default": ["ignore-by-default@2.1.0", "", {}, "sha512-yiWd4GVmJp0Q6ghmM2B/V3oZGRmjrKLXvHR3TE1nfoXsmoggllfZUQe74EN0fJdPFZu2NIvNdrMMLm3OsV7Ohw=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
-    "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
-
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
-
-    "irregular-plurals": ["irregular-plurals@3.5.0", "", {}, "sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ=="],
 
     "is-array-buffer": ["is-array-buffer@3.0.5", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A=="],
 
@@ -1191,8 +878,6 @@
 
     "is-finalizationregistry": ["is-finalizationregistry@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg=="],
 
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
-
     "is-generator-function": ["is-generator-function@1.1.2", "", { "dependencies": { "call-bound": "^1.0.4", "generator-function": "^2.0.0", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
@@ -1204,10 +889,6 @@
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-number-object": ["is-number-object@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw=="],
-
-    "is-plain-object": ["is-plain-object@5.0.0", "", {}, "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="],
-
-    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
 
@@ -1221,8 +902,6 @@
 
     "is-typed-array": ["is-typed-array@1.1.15", "", { "dependencies": { "which-typed-array": "^1.1.16" } }, "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ=="],
 
-    "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
-
     "is-weakmap": ["is-weakmap@2.0.2", "", {}, "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w=="],
 
     "is-weakref": ["is-weakref@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew=="],
@@ -1235,11 +914,7 @@
 
     "iterator.prototype": ["iterator.prototype@1.1.5", "", { "dependencies": { "define-data-property": "^1.1.4", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "get-proto": "^1.0.0", "has-symbols": "^1.1.0", "set-function-name": "^2.0.2" } }, "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g=="],
 
-    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
-
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
-
-    "js-string-escape": ["js-string-escape@1.0.1", "", {}, "sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -1289,45 +964,27 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.30.2", "", { "os": "win32", "cpu": "x64" }, "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw=="],
 
-    "load-json-file": ["load-json-file@7.0.1", "", {}, "sha512-Gnxj3ev3mB5TkVBGad0JM6dmLiQL+o0t23JPBZ9sd+yvSLk05mFoqKBw5N8gbbkU4TNXyqCgIrl/VM17OgUIgQ=="],
-
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
-
-    "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
-    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
-    "matcher": ["matcher@5.0.0", "", { "dependencies": { "escape-string-regexp": "^5.0.0" } }, "sha512-s2EMBOWtXFc8dgqvoAzKJXxNHibcdJMV0gwqKUaw9E2JBJuGUK7DrNKrA6g/i+v72TT16+6sVm5mS3thaMLQUw=="],
-
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
-
-    "md5-hex": ["md5-hex@3.0.1", "", { "dependencies": { "blueimp-md5": "^2.10.0" } }, "sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw=="],
-
-    "memoize": ["memoize@10.2.0", "", { "dependencies": { "mimic-function": "^5.0.1" } }, "sha512-DeC6b7QBrZsRs3Y02A6A7lQyzFbsQbqgjI6UW0GigGWV+u1s25TycMr0XHZE4cJce7rY/vyw2ctMQqfDkIhUEA=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
-    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
-
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
-    "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
-
-    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
-
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
-    "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
@@ -1335,19 +992,11 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
-    "next": ["next@16.0.7", "", { "dependencies": { "@next/env": "16.0.7", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.0.7", "@next/swc-darwin-x64": "16.0.7", "@next/swc-linux-arm64-gnu": "16.0.7", "@next/swc-linux-arm64-musl": "16.0.7", "@next/swc-linux-x64-gnu": "16.0.7", "@next/swc-linux-x64-musl": "16.0.7", "@next/swc-win32-arm64-msvc": "16.0.7", "@next/swc-win32-x64-msvc": "16.0.7", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-3mBRJyPxT4LOxAJI6IsXeFtKfiJUbjCLgvXO02fV8Wy/lIhPvP94Fe7dGhUgHXcQy4sSuYwQNcOLhIfOm0rL0A=="],
+    "next": ["next@16.0.10", "", { "dependencies": { "@next/env": "16.0.10", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.0.10", "@next/swc-darwin-x64": "16.0.10", "@next/swc-linux-arm64-gnu": "16.0.10", "@next/swc-linux-arm64-musl": "16.0.10", "@next/swc-linux-x64-gnu": "16.0.10", "@next/swc-linux-x64-musl": "16.0.10", "@next/swc-win32-arm64-msvc": "16.0.10", "@next/swc-win32-x64-msvc": "16.0.10", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-RtWh5PUgI+vxlV3HdR+IfWA1UUHu0+Ram/JBO4vWB54cVPentCD0e+lxyAYEsDTqGGMg7qpjhKh6dc6aW7W/sA=="],
 
     "nextjs-toploader": ["nextjs-toploader@3.9.17", "", { "dependencies": { "nprogress": "^0.2.0", "prop-types": "^15.8.1" }, "peerDependencies": { "next": ">= 6.0.0", "react": ">= 16.0.0", "react-dom": ">= 16.0.0" } }, "sha512-9OF0KSSLtoSAuNg2LZ3aTl4hR9mBDj5L9s9DZiFCbMlXehyICGjkIz5dVGzuATU2bheJZoBdFgq9w07AKSuQQw=="],
 
-    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
-
-    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
-
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
-
-    "nofilter": ["nofilter@3.1.0", "", {}, "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g=="],
-
-    "nopt": ["nopt@8.1.0", "", { "dependencies": { "abbrev": "^3.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A=="],
 
     "nprogress": ["nprogress@0.2.0", "", {}, "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA=="],
 
@@ -1381,25 +1030,13 @@
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
-    "p-map": ["p-map@7.0.4", "", {}, "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ=="],
-
-    "package-config": ["package-config@5.0.0", "", { "dependencies": { "find-up-simple": "^1.0.0", "load-json-file": "^7.0.1" } }, "sha512-GYTTew2slBcYdvRHqjhwaaydVMvn/qrGC323+nKclYioNSLTDUM/lGgtGTgyHVtYcozb+XkE8CNhwcraOmZ9Mg=="],
-
-    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
-
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
-
-    "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
-
-    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
-
-    "path-type": ["path-type@6.0.0", "", {}, "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -1414,8 +1051,6 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
-
-    "plur": ["plur@5.1.0", "", { "dependencies": { "irregular-plurals": "^3.3.0" } }, "sha512-VP/72JeXqak2KiOzjgKtQen5y3IZHn+9GOuLDafPv0eXa47xq0At93XahYBs26MsifCQ4enGKwbjBTKgb9QJXg=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -1437,8 +1072,6 @@
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
-    "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
-
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
@@ -1457,13 +1090,9 @@
 
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
 
-    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
-
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
-    "resolve-cwd": ["resolve-cwd@3.0.0", "", { "dependencies": { "resolve-from": "^5.0.0" } }, "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg=="],
-
-    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
@@ -1479,13 +1108,9 @@
 
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
 
-    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
-
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
-
-    "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
@@ -1513,33 +1138,19 @@
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
-    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
-
-    "slash": ["slash@5.1.0", "", {}, "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="],
-
-    "slice-ansi": ["slice-ansi@5.0.0", "", { "dependencies": { "ansi-styles": "^6.0.0", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ=="],
-
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
-    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
-
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
-
-    "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
-
-    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
-
-    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string.prototype.includes": ["string.prototype.includes@2.0.1", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.3" } }, "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg=="],
 
@@ -1553,10 +1164,6 @@
 
     "string.prototype.trimstart": ["string.prototype.trimstart@1.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg=="],
 
-    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
-    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
@@ -1569,17 +1176,9 @@
 
     "stylis": ["stylis@4.3.2", "", {}, "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg=="],
 
-    "supertap": ["supertap@3.0.1", "", { "dependencies": { "indent-string": "^5.0.0", "js-yaml": "^3.14.1", "serialize-error": "^7.0.1", "strip-ansi": "^7.0.1" } }, "sha512-u1ZpIBCawJnO+0QePsEiOknOfCRq0yERxiAchT0i4li0WHNUJbf0evXXSXOcCAR4M8iMDoajXYmstm/qO81Isw=="],
-
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
-
-    "tar": ["tar@7.5.2", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg=="],
-
-    "temp-dir": ["temp-dir@3.0.0", "", {}, "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw=="],
-
-    "time-zone": ["time-zone@1.0.0", "", {}, "sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
@@ -1593,19 +1192,13 @@
 
     "tokscale": ["tokscale@workspace:packages/tokscale"],
 
-    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
-
     "ts-api-utils": ["ts-api-utils@2.1.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ=="],
 
     "tsconfig-paths": ["tsconfig-paths@3.15.0", "", { "dependencies": { "@types/json5": "^0.0.29", "json5": "^1.0.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg=="],
 
     "tslib": ["tslib@2.6.2", "", {}, "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="],
 
-    "typanion": ["typanion@3.14.0", "", {}, "sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug=="],
-
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
-
-    "type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
     "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
 
@@ -1623,10 +1216,6 @@
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
-    "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
-
-    "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
-
     "unrs-resolver": ["unrs-resolver@1.11.1", "", { "dependencies": { "napi-postinstall": "^0.3.0" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.11.1", "@unrs/resolver-binding-android-arm64": "1.11.1", "@unrs/resolver-binding-darwin-arm64": "1.11.1", "@unrs/resolver-binding-darwin-x64": "1.11.1", "@unrs/resolver-binding-freebsd-x64": "1.11.1", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1", "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1", "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1", "@unrs/resolver-binding-linux-arm64-musl": "1.11.1", "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1", "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-musl": "1.11.1", "@unrs/resolver-binding-wasm32-wasi": "1.11.1", "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1", "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1", "@unrs/resolver-binding-win32-x64-msvc": "1.11.1" } }, "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
@@ -1636,12 +1225,6 @@
     "vite": ["vite@7.3.0", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg=="],
 
     "vitest": ["vitest@4.0.16", "", { "dependencies": { "@vitest/expect": "4.0.16", "@vitest/mocker": "4.0.16", "@vitest/pretty-format": "4.0.16", "@vitest/runner": "4.0.16", "@vitest/snapshot": "4.0.16", "@vitest/spy": "4.0.16", "@vitest/utils": "4.0.16", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.16", "@vitest/browser-preview": "4.0.16", "@vitest/browser-webdriverio": "4.0.16", "@vitest/ui": "4.0.16", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q=="],
-
-    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
-
-    "well-known-symbols": ["well-known-symbols@2.0.0", "", {}, "sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q=="],
-
-    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
@@ -1657,21 +1240,9 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
-    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "write-file-atomic": ["write-file-atomic@6.0.0", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^4.0.1" } }, "sha512-GmqrO8WJ1NuzJ2DrziEI2o57jKAVIQNf8a18W3nCYU3H7PNWqCCVTeH6/NQE93CIllIgQS98rrmVkYgTX9fFJQ=="],
-
-    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
-
-    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "yaml": ["yaml@1.10.2", "", {}, "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="],
-
-    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
-
-    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
@@ -1682,8 +1253,6 @@
     "@babel/core/json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -1699,14 +1268,6 @@
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
-    "@inquirer/core/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
-
-    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
-
-    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
-
-    "@next/eslint-plugin-next/fast-glob": ["fast-glob@3.3.1", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.4" } }, "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg=="],
-
     "@swc/helpers/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@tybys/wasm-util/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
@@ -1715,17 +1276,7 @@
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
-    "@unrs/resolver-binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
-
-    "@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
-
-    "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
-
-    "eslint/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
@@ -1741,59 +1292,19 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
-    "glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "globby/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
     "hoist-non-react-statics/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
-
-    "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
-
-    "matcher/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
-    "parent-module/callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
-
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
-
-    "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
-
-    "string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
-
-    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "string-width-cjs/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "styled-components/csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 
     "styled-components/postcss": ["postcss@8.4.49", "", { "dependencies": { "nanoid": "^3.3.7", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA=="],
 
-    "supertap/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
-
     "vite/esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
 
     "vite/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
-
-    "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 
@@ -1839,25 +1350,9 @@
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
 
-    "@next/eslint-plugin-next/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
-    "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "cliui/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
-
-    "eslint/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
-
-    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "supertap/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw=="],
 
@@ -1904,25 +1399,5 @@
     "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ=="],
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
-
-    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "wrap-ansi-cjs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "wrap-ansi/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/packages/frontend/src/app/(main)/groups/GroupsClient.tsx
+++ b/packages/frontend/src/app/(main)/groups/GroupsClient.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useRouter } from "nextjs-toploader/app";
+import styled from "styled-components";
+import { TabBar } from "@/components/TabBar";
+import { LeaderboardSkeleton } from "@/components/Skeleton";
+
+const Section = styled.div`
+  margin-bottom: 40px;
+`;
+
+const HeaderRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  gap: 16px;
+
+  @media (max-width: 480px) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+`;
+
+const Title = styled.h1`
+  font-size: 30px;
+  font-weight: bold;
+  color: var(--color-fg-default);
+`;
+
+const Description = styled.p`
+  margin-bottom: 24px;
+  color: var(--color-fg-muted);
+`;
+
+const CreateButton = styled.a`
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  background-color: #0073ff;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background-color 0.15s;
+  white-space: nowrap;
+
+  &:hover {
+    background-color: #005fcc;
+  }
+`;
+
+const TabSection = styled.div`
+  margin-bottom: 24px;
+`;
+
+const GroupGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+
+  @media (min-width: 640px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media (min-width: 1024px) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+`;
+
+const GroupCard = styled.div`
+  padding: 20px;
+  border-radius: 12px;
+  border: 1px solid var(--color-border-default);
+  background-color: var(--color-bg-default);
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    border-color: #0073ff;
+    background-color: rgba(0, 115, 255, 0.03);
+  }
+`;
+
+const GroupName = styled.h3`
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-fg-default);
+  margin-bottom: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const GroupDescription = styled.p`
+  font-size: 14px;
+  color: var(--color-fg-muted);
+  margin-bottom: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const GroupMeta = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 12px;
+  color: var(--color-fg-subtle);
+`;
+
+const Badge = styled.span<{ $variant?: "public" | "private" | "role" }>`
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 500;
+
+  ${({ $variant }) =>
+    $variant === "public"
+      ? `background: rgba(63, 185, 80, 0.1); color: #3FB950;`
+      : $variant === "private"
+        ? `background: rgba(248, 81, 73, 0.1); color: #F85149;`
+        : `background: rgba(0, 115, 255, 0.1); color: #0073FF;`}
+`;
+
+const EmptyState = styled.div`
+  padding: 48px;
+  text-align: center;
+  border-radius: 16px;
+  border: 1px solid var(--color-border-default);
+  background-color: var(--color-bg-default);
+`;
+
+const EmptyMessage = styled.p`
+  margin-bottom: 8px;
+  color: var(--color-fg-muted);
+  font-size: 16px;
+`;
+
+const EmptyHint = styled.p`
+  font-size: 14px;
+  color: var(--color-fg-subtle);
+`;
+
+type Tab = "my" | "discover";
+
+interface GroupItem {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  isPublic: boolean;
+  memberCount?: number;
+  role?: string;
+}
+
+interface GroupsResponse {
+  groups: GroupItem[];
+  pagination: {
+    page: number;
+    total: number;
+    totalPages: number;
+    hasNext: boolean;
+  };
+}
+
+interface GroupsClientProps {
+  currentUser: { id: string; username: string } | null;
+}
+
+export default function GroupsClient({ currentUser }: GroupsClientProps) {
+  const router = useRouter();
+  const [tab, setTab] = useState<Tab>(currentUser ? "my" : "discover");
+  const [data, setData] = useState<GroupsResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchGroups = useCallback(
+    async (activeTab: Tab) => {
+      setIsLoading(true);
+      try {
+        const url =
+          activeTab === "my"
+            ? "/api/groups?my=true&limit=50"
+            : "/api/groups?limit=50";
+        const res = await fetch(url);
+        if (res.ok) {
+          const result = await res.json();
+          setData(result);
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    fetchGroups(tab);
+  }, [tab, fetchGroups]);
+
+  const tabs = currentUser
+    ? [
+        { id: "my" as Tab, label: "My Groups" },
+        { id: "discover" as Tab, label: "Discover" },
+      ]
+    : [{ id: "discover" as Tab, label: "Public Groups" }];
+
+  return (
+    <>
+      <Section>
+        <HeaderRow>
+          <Title>Groups</Title>
+          {currentUser && (
+            <CreateButton href="/groups/new">+ Create Group</CreateButton>
+          )}
+        </HeaderRow>
+        <Description>
+          Create or join groups to compete on team leaderboards
+        </Description>
+      </Section>
+
+      <TabSection>
+        <TabBar tabs={tabs} activeTab={tab} onTabChange={(t) => setTab(t)} />
+      </TabSection>
+
+      {isLoading ? (
+        <LeaderboardSkeleton />
+      ) : !data?.groups.length ? (
+        <EmptyState>
+          <EmptyMessage>
+            {tab === "my" ? "You haven't joined any groups yet" : "No public groups found"}
+          </EmptyMessage>
+          <EmptyHint>
+            {tab === "my"
+              ? "Create a group or ask someone to invite you"
+              : "Be the first to create a public group!"}
+          </EmptyHint>
+        </EmptyState>
+      ) : (
+        <GroupGrid>
+          {data.groups.map((group) => (
+            <GroupCard
+              key={group.id}
+              onClick={() => router.push(`/groups/${group.slug}`)}
+            >
+              <GroupName>{group.name}</GroupName>
+              <GroupDescription>
+                {group.description || "No description"}
+              </GroupDescription>
+              <GroupMeta>
+                <span>{group.memberCount ?? "–"} members</span>
+                <Badge $variant={group.isPublic ? "public" : "private"}>
+                  {group.isPublic ? "Public" : "Private"}
+                </Badge>
+                {group.role && <Badge $variant="role">{group.role}</Badge>}
+              </GroupMeta>
+            </GroupCard>
+          ))}
+        </GroupGrid>
+      )}
+    </>
+  );
+}

--- a/packages/frontend/src/app/(main)/groups/GroupsClient.tsx
+++ b/packages/frontend/src/app/(main)/groups/GroupsClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
+import Link from "next/link";
 import { useRouter } from "nextjs-toploader/app";
 import styled from "styled-components";
 import { TabBar } from "@/components/TabBar";
@@ -34,7 +35,7 @@ const Description = styled.p`
   color: var(--color-fg-muted);
 `;
 
-const CreateButton = styled.a`
+const CreateButton = styled(Link)`
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -181,29 +182,32 @@ export default function GroupsClient({ currentUser }: GroupsClientProps) {
   const [data, setData] = useState<GroupsResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  const fetchGroups = useCallback(
-    async (activeTab: Tab) => {
-      setIsLoading(true);
-      try {
-        const url =
-          activeTab === "my"
-            ? "/api/groups?my=true&limit=50"
-            : "/api/groups?limit=50";
-        const res = await fetch(url);
-        if (res.ok) {
-          const result = await res.json();
-          setData(result);
-        }
-      } finally {
-        setIsLoading(false);
-      }
-    },
-    []
-  );
-
   useEffect(() => {
-    fetchGroups(tab);
-  }, [tab, fetchGroups]);
+    const abortController = new AbortController();
+    setIsLoading(true);
+
+    const url = tab === "my" ? "/api/groups?my=true&limit=50" : "/api/groups?limit=50";
+    fetch(url, { signal: abortController.signal })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((result) => {
+        setData(result);
+      })
+      .catch((err) => {
+        if (err.name !== "AbortError") {
+          setData(null);
+        }
+      })
+      .finally(() => {
+        if (!abortController.signal.aborted) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => abortController.abort();
+  }, [tab]);
 
   const tabs = currentUser
     ? [

--- a/packages/frontend/src/app/(main)/groups/GroupsClient.tsx
+++ b/packages/frontend/src/app/(main)/groups/GroupsClient.tsx
@@ -193,10 +193,12 @@ export default function GroupsClient({ currentUser }: GroupsClientProps) {
         return res.json();
       })
       .then((result) => {
-        setData(result);
+        if (!abortController.signal.aborted) {
+          setData(result);
+        }
       })
       .catch((err) => {
-        if (err.name !== "AbortError") {
+        if (err.name !== "AbortError" && !abortController.signal.aborted) {
           setData(null);
         }
       })

--- a/packages/frontend/src/app/(main)/groups/[slug]/GroupDetailClient.tsx
+++ b/packages/frontend/src/app/(main)/groups/[slug]/GroupDetailClient.tsx
@@ -1,0 +1,585 @@
+"use client";
+
+import { useState, useEffect, useCallback, memo, useMemo } from "react";
+import { useRouter } from "nextjs-toploader/app";
+import styled from "styled-components";
+import { TabBar } from "@/components/TabBar";
+import { LeaderboardSkeleton } from "@/components/Skeleton";
+import { formatCurrency, formatNumber } from "@/lib/utils";
+import { Switch } from "@/components/Switch";
+import { useSettings } from "@/lib/useSettings";
+import type { GroupLeaderboardData } from "@/lib/groups/getGroupLeaderboard";
+
+// ============================================================================
+// STYLED COMPONENTS (matching LeaderboardClient patterns)
+// ============================================================================
+
+const Section = styled.div`
+  margin-bottom: 40px;
+`;
+
+const GroupHeader = styled.div`
+  margin-bottom: 32px;
+`;
+
+const GroupTitleRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 8px;
+
+  @media (max-width: 640px) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+`;
+
+const GroupName = styled.h1`
+  font-size: 30px;
+  font-weight: bold;
+  color: var(--color-fg-default);
+`;
+
+const GroupActions = styled.div`
+  display: flex;
+  gap: 8px;
+`;
+
+const ActionButton = styled.a`
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-default);
+  background: transparent;
+  color: var(--color-fg-muted);
+  font-size: 13px;
+  cursor: pointer;
+  text-decoration: none;
+  transition: all 0.15s;
+
+  &:hover {
+    border-color: #0073ff;
+    color: var(--color-fg-default);
+  }
+`;
+
+const PrimaryActionButton = styled(ActionButton)`
+  background-color: #0073ff;
+  border-color: #0073ff;
+  color: #fff;
+
+  &:hover {
+    background-color: #005fcc;
+    border-color: #005fcc;
+    color: #fff;
+  }
+`;
+
+const GroupDescription = styled.p`
+  color: var(--color-fg-muted);
+  margin-bottom: 16px;
+`;
+
+const StatsGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+
+  @media (min-width: 480px) {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+  }
+
+  @media (min-width: 768px) {
+    display: flex;
+  }
+`;
+
+const StatCard = styled.div`
+  flex: 1;
+  border-radius: 12px;
+  border: 1px solid var(--color-border-default);
+  padding: 12px;
+  background-color: var(--color-bg-default);
+`;
+
+const StatLabel = styled.p`
+  font-size: 12px;
+  color: var(--color-fg-muted);
+`;
+
+const StatValue = styled.p`
+  font-size: 16px;
+  font-weight: bold;
+  color: var(--color-fg-default);
+`;
+
+const StatValuePrimary = styled(StatValue)`
+  color: var(--color-primary);
+`;
+
+const TabSection = styled.div`
+  margin-bottom: 24px;
+`;
+
+const SortToggleContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-bottom: 16px;
+`;
+
+const SortLabel = styled.span`
+  font-size: 12px;
+  color: var(--color-fg-muted);
+  font-weight: 500;
+`;
+
+const TableContainer = styled.div`
+  border-radius: 16px;
+  border: 1px solid var(--color-border-default);
+  overflow: hidden;
+  background-color: var(--color-bg-default);
+`;
+
+const TableWrapper = styled.div`
+  overflow-x: auto;
+`;
+
+const Table = styled.table`
+  width: 100%;
+  min-width: 500px;
+
+  @media (max-width: 560px) {
+    min-width: unset;
+  }
+`;
+
+const TableHead = styled.thead`
+  border-bottom: 1px solid var(--color-border-default);
+  background-color: var(--color-bg-elevated);
+`;
+
+const TableHeaderCell = styled.th`
+  padding: 12px;
+  text-align: left;
+  font-size: 12px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-fg-muted);
+
+  @media (min-width: 640px) {
+    padding: 12px 24px;
+  }
+
+  &.text-right {
+    text-align: right;
+  }
+
+  &.hidden-mobile {
+    display: none;
+    @media (min-width: 768px) {
+      display: table-cell;
+    }
+  }
+`;
+
+const TableBody = styled.tbody``;
+
+const TableRow = styled.tr`
+  cursor: pointer;
+  transition: all 0.2s;
+  border-bottom: 1px solid var(--color-border-default);
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:hover {
+    background-color: rgba(20, 26, 33, 0.6);
+  }
+`;
+
+const TableCell = styled.td`
+  padding: 10px 12px;
+  white-space: nowrap;
+  vertical-align: middle;
+
+  @media (min-width: 640px) {
+    padding: 10px 24px;
+  }
+
+  &.text-right {
+    text-align: right;
+  }
+
+  &.hidden-mobile {
+    display: none;
+    @media (min-width: 768px) {
+      display: table-cell;
+    }
+  }
+`;
+
+const RankBadge = styled.span`
+  font-size: 16px;
+  font-weight: bold;
+  color: var(--color-fg-muted);
+
+  &[data-rank="1"] {
+    color: #eab308;
+  }
+  &[data-rank="2"] {
+    color: #9ca3af;
+  }
+  &[data-rank="3"] {
+    color: #d97706;
+  }
+`;
+
+const UserContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  @media (min-width: 640px) {
+    gap: 12px;
+  }
+`;
+
+const UserInfo = styled.div`
+  min-width: 0;
+`;
+
+const UserDisplayName = styled.p`
+  font-weight: 500;
+  font-size: 14px;
+  color: var(--color-fg-default);
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  @media (min-width: 640px) {
+    font-size: 16px;
+  }
+`;
+
+const Username = styled.p`
+  font-size: 12px;
+  color: var(--color-fg-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  @media (min-width: 640px) {
+    font-size: 14px;
+  }
+`;
+
+const RoleBadge = styled.span<{ $role: string }>`
+  font-size: 11px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  font-weight: 500;
+  margin-left: 6px;
+
+  ${({ $role }) =>
+    $role === "owner"
+      ? `background: rgba(234, 179, 8, 0.15); color: #EAB308;`
+      : $role === "admin"
+        ? `background: rgba(0, 115, 255, 0.1); color: #0073FF;`
+        : `background: transparent; color: transparent;`}
+`;
+
+const TokenValue = styled.span`
+  font-weight: 500;
+  font-size: 14px;
+  color: var(--color-primary);
+
+  @media (min-width: 640px) {
+    font-size: 16px;
+  }
+`;
+
+const CostValue = styled.span`
+  font-weight: 500;
+  font-size: 14px;
+  color: var(--color-fg-default);
+
+  @media (min-width: 640px) {
+    font-size: 16px;
+  }
+`;
+
+const EmptyState = styled.div`
+  padding: 32px;
+  text-align: center;
+`;
+
+const EmptyMessage = styled.p`
+  color: var(--color-fg-muted);
+`;
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+type Period = "all" | "month" | "week";
+
+interface GroupInfo {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  isPublic: boolean;
+  memberCount: number;
+}
+
+interface GroupDetailClientProps {
+  group: GroupInfo;
+  userRole: string | null;
+  currentUser: { id: string; username: string } | null;
+  initialLeaderboard: GroupLeaderboardData;
+}
+
+// ============================================================================
+// COMPONENT
+// ============================================================================
+
+const LeaderboardRow = memo(function LeaderboardRow({
+  user,
+  isCurrentUser,
+  onRowClick,
+}: {
+  user: GroupLeaderboardData["users"][0];
+  isCurrentUser: boolean;
+  onRowClick: (username: string) => void;
+}) {
+  return (
+    <TableRow
+      onClick={() => onRowClick(user.username)}
+      style={
+        isCurrentUser
+          ? {
+              background: "rgba(0, 115, 255, 0.05)",
+              boxShadow: "inset 4px 0 0 #0073FF",
+            }
+          : undefined
+      }
+    >
+      <TableCell>
+        <RankBadge data-rank={user.rank <= 3 ? user.rank : undefined}>
+          #{user.rank}
+        </RankBadge>
+      </TableCell>
+      <TableCell>
+        <UserContainer>
+          <img
+            src={
+              user.avatarUrl ||
+              `https://github.com/${user.username}.png`
+            }
+            alt={user.username}
+            width={36}
+            height={36}
+            style={{
+              borderRadius: "50%",
+              objectFit: "cover",
+              flexShrink: 0,
+            }}
+          />
+          <UserInfo>
+            <UserDisplayName>
+              {user.displayName || user.username}
+              <RoleBadge $role={user.role}>{user.role}</RoleBadge>
+            </UserDisplayName>
+            <Username>@{user.username}</Username>
+          </UserInfo>
+        </UserContainer>
+      </TableCell>
+      <TableCell className="text-right hidden-mobile">
+        <CostValue>{formatCurrency(user.totalCost)}</CostValue>
+      </TableCell>
+      <TableCell className="text-right">
+        <TokenValue>{formatNumber(user.totalTokens)}</TokenValue>
+      </TableCell>
+    </TableRow>
+  );
+});
+
+export default function GroupDetailClient({
+  group,
+  userRole,
+  currentUser,
+  initialLeaderboard,
+}: GroupDetailClientProps) {
+  const router = useRouter();
+  const [data, setData] = useState<GroupLeaderboardData>(initialLeaderboard);
+  const [period, setPeriod] = useState<Period>("all");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const { leaderboardSortBy, setLeaderboardSort, mounted } = useSettings();
+  const effectiveSortBy = mounted ? leaderboardSortBy : "tokens";
+
+  const isAdmin = userRole === "owner" || userRole === "admin";
+
+  const fetchLeaderboard = useCallback(
+    async (p: Period, sortBy: string) => {
+      setIsLoading(true);
+      try {
+        const res = await fetch(
+          `/api/groups/${group.slug}/leaderboard?period=${p}&sortBy=${sortBy}&limit=50`
+        );
+        if (res.ok) {
+          setData(await res.json());
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [group.slug]
+  );
+
+  useEffect(() => {
+    // Skip initial load since we have SSR data
+    if (period === "all" && effectiveSortBy === "tokens") return;
+    fetchLeaderboard(period, effectiveSortBy);
+  }, [period, effectiveSortBy, fetchLeaderboard]);
+
+  const handleRowClick = useCallback(
+    (username: string) => {
+      router.push(`/u/${username}`);
+    },
+    [router]
+  );
+
+  return (
+    <>
+      <GroupHeader>
+        <GroupTitleRow>
+          <GroupName>{group.name}</GroupName>
+          <GroupActions>
+            {isAdmin && (
+              <>
+                <ActionButton href={`/groups/${group.slug}/members`}>
+                  Members
+                </ActionButton>
+                <ActionButton href={`/groups/${group.slug}/settings`}>
+                  Settings
+                </ActionButton>
+              </>
+            )}
+            {userRole && userRole !== "owner" && (
+              <ActionButton
+                as="button"
+                onClick={async () => {
+                  if (!confirm("Leave this group?")) return;
+                  const res = await fetch(`/api/groups/${group.slug}/leave`, {
+                    method: "POST",
+                  });
+                  if (res.ok) router.push("/groups");
+                }}
+              >
+                Leave
+              </ActionButton>
+            )}
+          </GroupActions>
+        </GroupTitleRow>
+        {group.description && (
+          <GroupDescription>{group.description}</GroupDescription>
+        )}
+      </GroupHeader>
+
+      <Section>
+        <StatsGrid>
+          <StatCard>
+            <StatLabel>Members</StatLabel>
+            <StatValue>{data.stats.totalMembers}</StatValue>
+          </StatCard>
+          <StatCard>
+            <StatLabel>Total Tokens</StatLabel>
+            <StatValuePrimary>
+              {formatNumber(data.stats.totalTokens)}
+            </StatValuePrimary>
+          </StatCard>
+          <StatCard>
+            <StatLabel>Total Cost</StatLabel>
+            <StatValue>{formatCurrency(data.stats.totalCost)}</StatValue>
+          </StatCard>
+        </StatsGrid>
+      </Section>
+
+      <TabSection>
+        <TabBar
+          tabs={[
+            { id: "all" as Period, label: "All Time" },
+            { id: "month" as Period, label: "This Month" },
+            { id: "week" as Period, label: "This Week" },
+          ]}
+          activeTab={period}
+          onTabChange={(tab) => setPeriod(tab)}
+        />
+      </TabSection>
+
+      <SortToggleContainer>
+        <SortLabel>Sort by:</SortLabel>
+        <Switch
+          checked={effectiveSortBy === "cost"}
+          onChange={(checked) =>
+            setLeaderboardSort(checked ? "cost" : "tokens")
+          }
+          leftLabel="Tokens"
+          rightLabel="Cost"
+        />
+      </SortToggleContainer>
+
+      {isLoading ? (
+        <LeaderboardSkeleton />
+      ) : (
+        <TableContainer>
+          {data.users.length === 0 ? (
+            <EmptyState>
+              <EmptyMessage>
+                No submissions from group members yet
+              </EmptyMessage>
+            </EmptyState>
+          ) : (
+            <TableWrapper>
+              <Table>
+                <TableHead>
+                  <tr>
+                    <TableHeaderCell>Rank</TableHeaderCell>
+                    <TableHeaderCell>User</TableHeaderCell>
+                    <TableHeaderCell className="text-right hidden-mobile">
+                      Cost
+                    </TableHeaderCell>
+                    <TableHeaderCell className="text-right">
+                      Tokens
+                    </TableHeaderCell>
+                  </tr>
+                </TableHead>
+                <TableBody>
+                  {data.users.map((user) => (
+                    <LeaderboardRow
+                      key={user.userId}
+                      user={user}
+                      isCurrentUser={
+                        !!(
+                          currentUser &&
+                          user.username === currentUser.username
+                        )
+                      }
+                      onRowClick={handleRowClick}
+                    />
+                  ))}
+                </TableBody>
+              </Table>
+            </TableWrapper>
+          )}
+        </TableContainer>
+      )}
+    </>
+  );
+}

--- a/packages/frontend/src/app/(main)/groups/[slug]/GroupDetailClient.tsx
+++ b/packages/frontend/src/app/(main)/groups/[slug]/GroupDetailClient.tsx
@@ -66,24 +66,7 @@ const ActionButton = styled.a`
   }
 `;
 
-const ActionLink = styled(Link)`
-  display: inline-flex;
-  align-items: center;
-  padding: 6px 12px;
-  border-radius: 8px;
-  border: 1px solid var(--color-border-default);
-  background: transparent;
-  color: var(--color-fg-muted);
-  font-size: 13px;
-  cursor: pointer;
-  text-decoration: none;
-  transition: all 0.15s;
-
-  &:hover {
-    border-color: #0073ff;
-    color: var(--color-fg-default);
-  }
-`;
+const ActionLink = styled(ActionButton).attrs({ as: Link })``;
 
 const PrimaryActionButton = styled(ActionButton)`
   background-color: #0073ff;

--- a/packages/frontend/src/app/(main)/groups/[slug]/GroupDetailClient.tsx
+++ b/packages/frontend/src/app/(main)/groups/[slug]/GroupDetailClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect, useCallback, memo, useMemo } from "react";
+import { useState, useEffect, useCallback, memo, useMemo, useRef } from "react";
+import Link from "next/link";
 import { useRouter } from "nextjs-toploader/app";
 import styled from "styled-components";
 import { TabBar } from "@/components/TabBar";
@@ -47,6 +48,25 @@ const GroupActions = styled.div`
 `;
 
 const ActionButton = styled.a`
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-default);
+  background: transparent;
+  color: var(--color-fg-muted);
+  font-size: 13px;
+  cursor: pointer;
+  text-decoration: none;
+  transition: all 0.15s;
+
+  &:hover {
+    border-color: #0073ff;
+    color: var(--color-fg-default);
+  }
+`;
+
+const ActionLink = styled(Link)`
   display: inline-flex;
   align-items: center;
   padding: 6px 12px;
@@ -290,7 +310,7 @@ const RoleBadge = styled.span<{ $role: string }>`
       ? `background: rgba(234, 179, 8, 0.15); color: #EAB308;`
       : $role === "admin"
         ? `background: rgba(0, 115, 255, 0.1); color: #0073FF;`
-        : `background: transparent; color: transparent;`}
+        : `display: none;`}
 `;
 
 const TokenValue = styled.span`
@@ -424,6 +444,7 @@ export default function GroupDetailClient({
   const effectiveSortBy = mounted ? leaderboardSortBy : "tokens";
 
   const isAdmin = userRole === "owner" || userRole === "admin";
+  const hasEverFetched = useRef(false);
 
   const fetchLeaderboard = useCallback(
     async (p: Period, sortBy: string) => {
@@ -443,8 +464,11 @@ export default function GroupDetailClient({
   );
 
   useEffect(() => {
-    // Skip initial load since we have SSR data
-    if (period === "all" && effectiveSortBy === "tokens") return;
+    if (!hasEverFetched.current && period === "all" && effectiveSortBy === "tokens") {
+      hasEverFetched.current = true;
+      return;
+    }
+    hasEverFetched.current = true;
     fetchLeaderboard(period, effectiveSortBy);
   }, [period, effectiveSortBy, fetchLeaderboard]);
 
@@ -463,12 +487,8 @@ export default function GroupDetailClient({
           <GroupActions>
             {isAdmin && (
               <>
-                <ActionButton href={`/groups/${group.slug}/members`}>
-                  Members
-                </ActionButton>
-                <ActionButton href={`/groups/${group.slug}/settings`}>
-                  Settings
-                </ActionButton>
+                <ActionLink href={`/groups/${group.slug}/members`}>Members</ActionLink>
+                <ActionLink href={`/groups/${group.slug}/settings`}>Settings</ActionLink>
               </>
             )}
             {userRole && userRole !== "owner" && (

--- a/packages/frontend/src/app/(main)/groups/[slug]/members/GroupMembersClient.tsx
+++ b/packages/frontend/src/app/(main)/groups/[slug]/members/GroupMembersClient.tsx
@@ -1,0 +1,461 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import styled from "styled-components";
+
+const Container = styled.div`
+  max-width: 720px;
+  margin: 0 auto;
+  padding-top: 24px;
+`;
+
+const BackLink = styled.a`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 14px;
+  color: var(--color-fg-muted);
+  text-decoration: none;
+  margin-bottom: 24px;
+
+  &:hover {
+    color: var(--color-fg-default);
+  }
+`;
+
+const Title = styled.h1`
+  font-size: 30px;
+  font-weight: bold;
+  margin-bottom: 32px;
+  color: var(--color-fg-default);
+`;
+
+const SectionTitle = styled.h2`
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 16px;
+  color: var(--color-fg-default);
+`;
+
+const InviteForm = styled.div`
+  display: flex;
+  gap: 8px;
+  margin-bottom: 32px;
+
+  @media (max-width: 640px) {
+    flex-direction: column;
+  }
+`;
+
+const Input = styled.input`
+  flex: 1;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-default);
+  background-color: var(--color-bg-subtle);
+  color: var(--color-fg-default);
+  font-size: 14px;
+
+  &:focus {
+    outline: none;
+    border-color: #0073ff;
+    box-shadow: 0 0 0 2px rgba(0, 115, 255, 0.2);
+  }
+`;
+
+const Select = styled.select`
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-default);
+  background-color: var(--color-bg-subtle);
+  color: var(--color-fg-default);
+  font-size: 14px;
+`;
+
+const InviteButton = styled.button`
+  padding: 10px 16px;
+  background-color: #0073ff;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover:not(:disabled) {
+    background-color: #005fcc;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+const MemberList = styled.div`
+  border-radius: 12px;
+  border: 1px solid var(--color-border-default);
+  overflow: hidden;
+  margin-bottom: 32px;
+`;
+
+const MemberRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--color-border-default);
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+const MemberInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+`;
+
+const MemberDetails = styled.div``;
+
+const MemberName = styled.p`
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-fg-default);
+`;
+
+const MemberUsername = styled.p`
+  font-size: 12px;
+  color: var(--color-fg-muted);
+`;
+
+const MemberActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const RoleBadge = styled.span<{ $role: string }>`
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 8px;
+  font-weight: 500;
+
+  ${({ $role }) =>
+    $role === "owner"
+      ? `background: rgba(234, 179, 8, 0.15); color: #EAB308;`
+      : $role === "admin"
+        ? `background: rgba(0, 115, 255, 0.1); color: #0073FF;`
+        : `background: rgba(139, 148, 158, 0.1); color: var(--color-fg-muted);`}
+`;
+
+const SmallButton = styled.button`
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--color-border-default);
+  background: transparent;
+  color: var(--color-fg-muted);
+  font-size: 12px;
+  cursor: pointer;
+
+  &:hover {
+    border-color: #0073ff;
+    color: var(--color-fg-default);
+  }
+`;
+
+const DangerSmallButton = styled(SmallButton)`
+  &:hover {
+    border-color: #f85149;
+    color: #f85149;
+  }
+`;
+
+const ErrorMessage = styled.p`
+  color: #f85149;
+  font-size: 14px;
+  margin-bottom: 16px;
+`;
+
+const SuccessMessage = styled.p`
+  color: #3fb950;
+  font-size: 14px;
+  margin-bottom: 16px;
+`;
+
+const PendingInviteRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--color-border-default);
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+const InviteInfo = styled.div`
+  font-size: 14px;
+  color: var(--color-fg-default);
+`;
+
+const InviteRole = styled.span`
+  font-size: 12px;
+  color: var(--color-fg-muted);
+  margin-left: 8px;
+`;
+
+interface Member {
+  id: string;
+  userId: string;
+  role: string;
+  joinedAt: string;
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+}
+
+interface PendingInvite {
+  id: string;
+  invitedUsername: string | null;
+  role: string;
+  status: string;
+  createdAt: string;
+}
+
+interface GroupMembersClientProps {
+  group: { id: string; name: string; slug: string };
+  userRole: string;
+  currentUserId: string;
+}
+
+export default function GroupMembersClient({
+  group,
+  userRole,
+  currentUserId,
+}: GroupMembersClientProps) {
+  const [members, setMembers] = useState<Member[]>([]);
+  const [invites, setInvites] = useState<PendingInvite[]>([]);
+  const [inviteUsername, setInviteUsername] = useState("");
+  const [inviteRole, setInviteRole] = useState("member");
+  const [isInviting, setIsInviting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const isOwner = userRole === "owner";
+
+  const fetchMembers = useCallback(async () => {
+    const res = await fetch(`/api/groups/${group.slug}/members`);
+    if (res.ok) {
+      const data = await res.json();
+      setMembers(data.members);
+    }
+  }, [group.slug]);
+
+  const fetchInvites = useCallback(async () => {
+    const res = await fetch(`/api/groups/${group.slug}/invite`);
+    if (res.ok) {
+      const data = await res.json();
+      setInvites(data.invites);
+    }
+  }, [group.slug]);
+
+  useEffect(() => {
+    fetchMembers();
+    fetchInvites();
+  }, [fetchMembers, fetchInvites]);
+
+  const handleInvite = async () => {
+    if (!inviteUsername.trim()) return;
+    setIsInviting(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const res = await fetch(`/api/groups/${group.slug}/invite`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username: inviteUsername.trim(),
+          role: inviteRole,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Failed to invite");
+      }
+
+      setSuccess(`Invited @${inviteUsername.trim()} as ${inviteRole}`);
+      setInviteUsername("");
+      fetchInvites();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setIsInviting(false);
+    }
+  };
+
+  const handleRemoveMember = async (userId: string, username: string) => {
+    if (!confirm(`Remove @${username} from the group?`)) return;
+
+    try {
+      const res = await fetch(`/api/groups/${group.slug}/members`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId }),
+      });
+
+      if (res.ok) {
+        fetchMembers();
+      } else {
+        const data = await res.json();
+        setError(data.error || "Failed to remove member");
+      }
+    } catch {
+      setError("Failed to remove member");
+    }
+  };
+
+  const handleChangeRole = async (userId: string, newRole: string) => {
+    try {
+      const res = await fetch(
+        `/api/groups/${group.slug}/members/${userId}/role`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ role: newRole }),
+        }
+      );
+
+      if (res.ok) {
+        fetchMembers();
+      } else {
+        const data = await res.json();
+        setError(data.error || "Failed to change role");
+      }
+    } catch {
+      setError("Failed to change role");
+    }
+  };
+
+  return (
+    <Container>
+      <BackLink href={`/groups/${group.slug}`}>← Back to group</BackLink>
+      <Title>Members — {group.name}</Title>
+
+      <SectionTitle>Invite Member</SectionTitle>
+      <InviteForm>
+        <Input
+          value={inviteUsername}
+          onChange={(e) => setInviteUsername(e.target.value)}
+          placeholder="GitHub username"
+        />
+        <Select
+          value={inviteRole}
+          onChange={(e) => setInviteRole(e.target.value)}
+        >
+          <option value="member">Member</option>
+          <option value="admin">Admin</option>
+        </Select>
+        <InviteButton
+          onClick={handleInvite}
+          disabled={isInviting || !inviteUsername.trim()}
+        >
+          {isInviting ? "Inviting..." : "Invite"}
+        </InviteButton>
+      </InviteForm>
+
+      {error && <ErrorMessage>{error}</ErrorMessage>}
+      {success && <SuccessMessage>{success}</SuccessMessage>}
+
+      <SectionTitle>
+        Members ({members.length})
+      </SectionTitle>
+      <MemberList>
+        {members.map((member) => (
+          <MemberRow key={member.id}>
+            <MemberInfo>
+              <img
+                src={
+                  member.avatarUrl ||
+                  `https://github.com/${member.username}.png`
+                }
+                alt={member.username}
+                width={36}
+                height={36}
+                style={{ borderRadius: "50%", objectFit: "cover" }}
+              />
+              <MemberDetails>
+                <MemberName>
+                  {member.displayName || member.username}
+                </MemberName>
+                <MemberUsername>@{member.username}</MemberUsername>
+              </MemberDetails>
+            </MemberInfo>
+            <MemberActions>
+              <RoleBadge $role={member.role}>{member.role}</RoleBadge>
+              {isOwner &&
+                member.userId !== currentUserId &&
+                member.role !== "owner" && (
+                  <>
+                    <SmallButton
+                      onClick={() =>
+                        handleChangeRole(
+                          member.userId,
+                          member.role === "admin" ? "member" : "admin"
+                        )
+                      }
+                    >
+                      {member.role === "admin"
+                        ? "Demote"
+                        : "Promote"}
+                    </SmallButton>
+                    <DangerSmallButton
+                      onClick={() =>
+                        handleRemoveMember(member.userId, member.username)
+                      }
+                    >
+                      Remove
+                    </DangerSmallButton>
+                  </>
+                )}
+              {!isOwner &&
+                member.userId !== currentUserId &&
+                member.role === "member" && (
+                  <DangerSmallButton
+                    onClick={() =>
+                      handleRemoveMember(member.userId, member.username)
+                    }
+                  >
+                    Remove
+                  </DangerSmallButton>
+                )}
+            </MemberActions>
+          </MemberRow>
+        ))}
+      </MemberList>
+
+      {invites.length > 0 && (
+        <>
+          <SectionTitle>
+            Pending Invites ({invites.length})
+          </SectionTitle>
+          <MemberList>
+            {invites.map((invite) => (
+              <PendingInviteRow key={invite.id}>
+                <InviteInfo>
+                  @{invite.invitedUsername}
+                  <InviteRole>as {invite.role}</InviteRole>
+                </InviteInfo>
+              </PendingInviteRow>
+            ))}
+          </MemberList>
+        </>
+      )}
+    </Container>
+  );
+}

--- a/packages/frontend/src/app/(main)/groups/[slug]/members/page.tsx
+++ b/packages/frontend/src/app/(main)/groups/[slug]/members/page.tsx
@@ -1,0 +1,50 @@
+import { redirect, notFound } from "next/navigation";
+import { Navigation } from "@/components/layout/Navigation";
+import { Footer } from "@/components/layout/Footer";
+import { db, groups } from "@/lib/db";
+import { eq } from "drizzle-orm";
+import { getSession } from "@/lib/auth/session";
+import { requireGroupRole } from "@/lib/groups/permissions";
+import GroupMembersClient from "./GroupMembersClient";
+
+export default async function GroupMembersPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const session = await getSession();
+  if (!session) redirect("/");
+
+  const { slug } = await params;
+  const groupResult = await db
+    .select()
+    .from(groups)
+    .where(eq(groups.slug, slug))
+    .limit(1);
+  if (!groupResult[0]) notFound();
+
+  const group = groupResult[0];
+  const membership = await requireGroupRole(group.id, session.id, "admin");
+  if (!membership) notFound();
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        backgroundColor: "var(--color-bg-default)",
+      }}
+    >
+      <Navigation />
+      <main className="main-container">
+        <GroupMembersClient
+          group={{ id: group.id, name: group.name, slug: group.slug }}
+          userRole={membership.role}
+          currentUserId={session.id}
+        />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/packages/frontend/src/app/(main)/groups/[slug]/page.tsx
+++ b/packages/frontend/src/app/(main)/groups/[slug]/page.tsx
@@ -1,0 +1,90 @@
+import { Suspense } from "react";
+import { notFound } from "next/navigation";
+import { Navigation } from "@/components/layout/Navigation";
+import { Footer } from "@/components/layout/Footer";
+import { LeaderboardSkeleton } from "@/components/Skeleton";
+import { db, groups } from "@/lib/db";
+import { eq, sql } from "drizzle-orm";
+import { groupMembers } from "@/lib/db/schema";
+import { getSession } from "@/lib/auth/session";
+import { getGroupMembership } from "@/lib/groups/permissions";
+import { getGroupLeaderboardData } from "@/lib/groups/getGroupLeaderboard";
+import GroupDetailClient from "./GroupDetailClient";
+
+async function getGroupData(slug: string) {
+  const result = await db
+    .select({
+      id: groups.id,
+      name: groups.name,
+      slug: groups.slug,
+      description: groups.description,
+      avatarUrl: groups.avatarUrl,
+      isPublic: groups.isPublic,
+      createdBy: groups.createdBy,
+      createdAt: groups.createdAt,
+      memberCount: sql<number>`(SELECT COUNT(*) FROM group_members WHERE group_id = ${groups.id})`.as(
+        "member_count"
+      ),
+    })
+    .from(groups)
+    .where(eq(groups.slug, slug))
+    .limit(1);
+
+  return result[0] ?? null;
+}
+
+export default async function GroupDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const group = await getGroupData(slug);
+  if (!group) notFound();
+
+  const session = await getSession();
+
+  // Check membership
+  let userRole: string | null = null;
+  if (session) {
+    const membership = await getGroupMembership(group.id, session.id);
+    userRole = membership?.role ?? null;
+  }
+
+  // If private and not a member, deny
+  if (!group.isPublic && !userRole) {
+    notFound();
+  }
+
+  const initialLeaderboard = await getGroupLeaderboardData(
+    group.id,
+    "all",
+    1,
+    50,
+    "tokens"
+  );
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        backgroundColor: "var(--color-bg-default)",
+      }}
+    >
+      <Navigation />
+      <main className="main-container">
+        <Suspense fallback={<LeaderboardSkeleton />}>
+          <GroupDetailClient
+            group={group}
+            userRole={userRole}
+            currentUser={session}
+            initialLeaderboard={initialLeaderboard}
+          />
+        </Suspense>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/packages/frontend/src/app/(main)/groups/[slug]/settings/GroupSettingsClient.tsx
+++ b/packages/frontend/src/app/(main)/groups/[slug]/settings/GroupSettingsClient.tsx
@@ -1,0 +1,400 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "nextjs-toploader/app";
+import styled from "styled-components";
+import { Switch } from "@/components/Switch";
+import { CopyIcon, CheckIcon } from "@/components/ui/Icons";
+
+const Container = styled.div`
+  max-width: 560px;
+  margin: 0 auto;
+  padding-top: 24px;
+`;
+
+const BackLink = styled.a`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 14px;
+  color: var(--color-fg-muted);
+  text-decoration: none;
+  margin-bottom: 24px;
+
+  &:hover {
+    color: var(--color-fg-default);
+  }
+`;
+
+const Title = styled.h1`
+  font-size: 30px;
+  font-weight: bold;
+  margin-bottom: 32px;
+  color: var(--color-fg-default);
+`;
+
+const SectionTitle = styled.h2`
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 16px;
+  color: var(--color-fg-default);
+`;
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-bottom: 40px;
+`;
+
+const FieldGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+`;
+
+const Label = styled.label`
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-fg-default);
+`;
+
+const Input = styled.input`
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-default);
+  background-color: var(--color-bg-subtle);
+  color: var(--color-fg-default);
+  font-size: 14px;
+
+  &:focus {
+    outline: none;
+    border-color: #0073ff;
+    box-shadow: 0 0 0 2px rgba(0, 115, 255, 0.2);
+  }
+`;
+
+const TextArea = styled.textarea`
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-default);
+  background-color: var(--color-bg-subtle);
+  color: var(--color-fg-default);
+  font-size: 14px;
+  resize: vertical;
+  min-height: 80px;
+  font-family: inherit;
+
+  &:focus {
+    outline: none;
+    border-color: #0073ff;
+    box-shadow: 0 0 0 2px rgba(0, 115, 255, 0.2);
+  }
+`;
+
+const ToggleRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const ToggleLabel = styled.div``;
+
+const ToggleTitle = styled.p`
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-fg-default);
+`;
+
+const ToggleDescription = styled.p`
+  font-size: 12px;
+  color: var(--color-fg-muted);
+`;
+
+const SaveButton = styled.button`
+  padding: 10px 20px;
+  background-color: #0073ff;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s;
+  align-self: flex-start;
+
+  &:hover:not(:disabled) {
+    background-color: #005fcc;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+const InviteCodeSection = styled.div`
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid var(--color-border-default);
+  background-color: var(--color-bg-default);
+  margin-bottom: 40px;
+`;
+
+const InviteCodeRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const InviteCodeValue = styled.code`
+  flex: 1;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background-color: var(--color-bg-subtle);
+  font-size: 13px;
+  color: var(--color-fg-default);
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const IconButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  border: 1px solid var(--color-border-default);
+  background: transparent;
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  border-radius: 8px;
+  transition: all 150ms;
+
+  &:hover {
+    border-color: #0073ff;
+    color: var(--color-fg-default);
+  }
+`;
+
+const DangerZone = styled.div`
+  padding: 20px;
+  border-radius: 12px;
+  border: 1px solid #f85149;
+  background: rgba(248, 81, 73, 0.05);
+`;
+
+const DangerTitle = styled.h3`
+  font-size: 16px;
+  font-weight: 600;
+  color: #f85149;
+  margin-bottom: 8px;
+`;
+
+const DangerDescription = styled.p`
+  font-size: 14px;
+  color: var(--color-fg-muted);
+  margin-bottom: 16px;
+`;
+
+const DangerButton = styled.button`
+  padding: 8px 16px;
+  background-color: #f85149;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #da3633;
+  }
+`;
+
+const ErrorMessage = styled.p`
+  color: #f85149;
+  font-size: 14px;
+`;
+
+const SuccessMessage = styled.p`
+  color: #3fb950;
+  font-size: 14px;
+`;
+
+interface GroupSettingsClientProps {
+  group: {
+    id: string;
+    name: string;
+    slug: string;
+    description: string | null;
+    isPublic: boolean;
+    avatarUrl: string | null;
+    inviteCode: string | null;
+  };
+  userRole: string;
+}
+
+export default function GroupSettingsClient({
+  group,
+  userRole,
+}: GroupSettingsClientProps) {
+  const router = useRouter();
+  const [name, setName] = useState(group.name);
+  const [description, setDescription] = useState(group.description || "");
+  const [isPublic, setIsPublic] = useState(group.isPublic);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const isOwner = userRole === "owner";
+  const inviteUrl = group.inviteCode
+    ? `${typeof window !== "undefined" ? window.location.origin : ""}/groups/join/${group.inviteCode}`
+    : null;
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSaving(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const res = await fetch(`/api/groups/${group.slug}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          description: description.trim() || null,
+          isPublic,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Failed to save");
+      }
+
+      const updated = await res.json();
+      setSuccess("Settings saved");
+
+      // If slug changed, redirect
+      if (updated.slug !== group.slug) {
+        router.push(`/groups/${updated.slug}/settings`);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    const confirmed = prompt(
+      `Type "${group.name}" to confirm deletion:`
+    );
+    if (confirmed !== group.name) return;
+
+    try {
+      const res = await fetch(`/api/groups/${group.slug}`, {
+        method: "DELETE",
+      });
+      if (res.ok) {
+        router.push("/groups");
+      } else {
+        const data = await res.json();
+        setError(data.error || "Failed to delete");
+      }
+    } catch {
+      setError("Failed to delete group");
+    }
+  };
+
+  const handleCopyInvite = () => {
+    if (inviteUrl) {
+      navigator.clipboard.writeText(inviteUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  return (
+    <Container>
+      <BackLink href={`/groups/${group.slug}`}>← Back to group</BackLink>
+      <Title>Group Settings</Title>
+
+      <SectionTitle>General</SectionTitle>
+      <Form onSubmit={handleSave}>
+        <FieldGroup>
+          <Label>Group Name</Label>
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            maxLength={100}
+            required
+          />
+        </FieldGroup>
+
+        <FieldGroup>
+          <Label>Description</Label>
+          <TextArea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            maxLength={500}
+          />
+        </FieldGroup>
+
+        <ToggleRow>
+          <ToggleLabel>
+            <ToggleTitle>Public Group</ToggleTitle>
+            <ToggleDescription>
+              {isPublic
+                ? "Anyone can see this group and its leaderboard"
+                : "Only members can see this group"}
+            </ToggleDescription>
+          </ToggleLabel>
+          <Switch
+            checked={isPublic}
+            onChange={setIsPublic}
+            leftLabel=""
+            rightLabel=""
+          />
+        </ToggleRow>
+
+        {error && <ErrorMessage>{error}</ErrorMessage>}
+        {success && <SuccessMessage>{success}</SuccessMessage>}
+
+        <SaveButton type="submit" disabled={isSaving || !name.trim()}>
+          {isSaving ? "Saving..." : "Save Changes"}
+        </SaveButton>
+      </Form>
+
+      {inviteUrl && (
+        <>
+          <SectionTitle>Invite Link</SectionTitle>
+          <InviteCodeSection>
+            <InviteCodeRow>
+              <InviteCodeValue>{inviteUrl}</InviteCodeValue>
+              <IconButton onClick={handleCopyInvite} title="Copy invite link">
+                {copied ? <CheckIcon size={16} /> : <CopyIcon size={16} />}
+              </IconButton>
+            </InviteCodeRow>
+          </InviteCodeSection>
+        </>
+      )}
+
+      {isOwner && (
+        <>
+          <SectionTitle>Danger Zone</SectionTitle>
+          <DangerZone>
+            <DangerTitle>Delete Group</DangerTitle>
+            <DangerDescription>
+              This action is irreversible. All members will be removed and group
+              data will be permanently deleted.
+            </DangerDescription>
+            <DangerButton onClick={handleDelete}>Delete Group</DangerButton>
+          </DangerZone>
+        </>
+      )}
+    </Container>
+  );
+}

--- a/packages/frontend/src/app/(main)/groups/[slug]/settings/GroupSettingsClient.tsx
+++ b/packages/frontend/src/app/(main)/groups/[slug]/settings/GroupSettingsClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "nextjs-toploader/app";
 import styled from "styled-components";
 import { Switch } from "@/components/Switch";
@@ -246,10 +246,15 @@ export default function GroupSettingsClient({
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [origin, setOrigin] = useState("");
+
+  useEffect(() => {
+    setOrigin(window.location.origin);
+  }, []);
 
   const isOwner = userRole === "owner";
   const inviteUrl = group.inviteCode
-    ? `${typeof window !== "undefined" ? window.location.origin : ""}/groups/join/${group.inviteCode}`
+    ? `${origin}/groups/join/${group.inviteCode}`
     : null;
 
   const handleSave = async (e: React.FormEvent) => {

--- a/packages/frontend/src/app/(main)/groups/[slug]/settings/page.tsx
+++ b/packages/frontend/src/app/(main)/groups/[slug]/settings/page.tsx
@@ -1,0 +1,57 @@
+import { redirect, notFound } from "next/navigation";
+import { Navigation } from "@/components/layout/Navigation";
+import { Footer } from "@/components/layout/Footer";
+import { db, groups } from "@/lib/db";
+import { eq } from "drizzle-orm";
+import { getSession } from "@/lib/auth/session";
+import { requireGroupRole } from "@/lib/groups/permissions";
+import GroupSettingsClient from "./GroupSettingsClient";
+
+export default async function GroupSettingsPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const session = await getSession();
+  if (!session) redirect("/");
+
+  const { slug } = await params;
+  const groupResult = await db
+    .select()
+    .from(groups)
+    .where(eq(groups.slug, slug))
+    .limit(1);
+  if (!groupResult[0]) notFound();
+
+  const group = groupResult[0];
+  const membership = await requireGroupRole(group.id, session.id, "admin");
+  if (!membership) notFound();
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        backgroundColor: "var(--color-bg-default)",
+      }}
+    >
+      <Navigation />
+      <main className="main-container">
+        <GroupSettingsClient
+          group={{
+            id: group.id,
+            name: group.name,
+            slug: group.slug,
+            description: group.description,
+            isPublic: group.isPublic,
+            avatarUrl: group.avatarUrl,
+            inviteCode: group.inviteCode,
+          }}
+          userRole={membership.role}
+        />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/packages/frontend/src/app/(main)/groups/join/[token]/page.tsx
+++ b/packages/frontend/src/app/(main)/groups/join/[token]/page.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter, useParams } from "next/navigation";
+import styled from "styled-components";
+
+const Container = styled.div`
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--color-bg-default);
+  padding: 24px;
+`;
+
+const Card = styled.div`
+  max-width: 400px;
+  width: 100%;
+  padding: 32px;
+  border-radius: 16px;
+  border: 1px solid var(--color-border-default);
+  background-color: var(--color-bg-default);
+  text-align: center;
+`;
+
+const Title = styled.h1`
+  font-size: 24px;
+  font-weight: bold;
+  margin-bottom: 8px;
+  color: var(--color-fg-default);
+`;
+
+const Description = styled.p`
+  font-size: 14px;
+  color: var(--color-fg-muted);
+  margin-bottom: 24px;
+`;
+
+const JoinButton = styled.button`
+  width: 100%;
+  padding: 12px 20px;
+  background-color: #0073ff;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s;
+
+  &:hover:not(:disabled) {
+    background-color: #005fcc;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+const ErrorMessage = styled.p`
+  color: #f85149;
+  font-size: 14px;
+  margin-bottom: 16px;
+`;
+
+const SuccessMessage = styled.p`
+  color: #3fb950;
+  font-size: 16px;
+  font-weight: 500;
+  margin-bottom: 16px;
+`;
+
+const Link = styled.a`
+  display: inline-block;
+  margin-top: 16px;
+  font-size: 14px;
+  color: #0073ff;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+export default function JoinGroupPage() {
+  const router = useRouter();
+  const params = useParams<{ token: string }>();
+  const [isJoining, setIsJoining] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<{
+    groupName: string;
+    groupSlug: string;
+  } | null>(null);
+
+  const handleJoin = async () => {
+    setIsJoining(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/groups/join/${params.token}`, {
+        method: "POST",
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        throw new Error(data.error || "Failed to join group");
+      }
+
+      setSuccess({
+        groupName: data.group.name,
+        groupSlug: data.group.slug,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setIsJoining(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <Container>
+        <Card>
+          <SuccessMessage>
+            You&apos;ve joined {success.groupName}!
+          </SuccessMessage>
+          <Link href={`/groups/${success.groupSlug}`}>
+            Go to group →
+          </Link>
+        </Card>
+      </Container>
+    );
+  }
+
+  return (
+    <Container>
+      <Card>
+        <Title>Join Group</Title>
+        <Description>
+          You&apos;ve been invited to join a group on Tokscale
+        </Description>
+
+        {error && <ErrorMessage>{error}</ErrorMessage>}
+
+        <JoinButton onClick={handleJoin} disabled={isJoining}>
+          {isJoining ? "Joining..." : "Accept Invite"}
+        </JoinButton>
+
+        <Link href="/groups">← Back to groups</Link>
+      </Card>
+    </Container>
+  );
+}

--- a/packages/frontend/src/app/(main)/groups/join/[token]/page.tsx
+++ b/packages/frontend/src/app/(main)/groups/join/[token]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import NextLink from "next/link";
 import { useRouter, useParams } from "next/navigation";
 import styled from "styled-components";
 
@@ -71,7 +72,7 @@ const SuccessMessage = styled.p`
   margin-bottom: 16px;
 `;
 
-const Link = styled.a`
+const StyledLink = styled(NextLink)`
   display: inline-block;
   margin-top: 16px;
   font-size: 14px;
@@ -126,9 +127,9 @@ export default function JoinGroupPage() {
           <SuccessMessage>
             You&apos;ve joined {success.groupName}!
           </SuccessMessage>
-          <Link href={`/groups/${success.groupSlug}`}>
+          <StyledLink href={`/groups/${success.groupSlug}`}>
             Go to group →
-          </Link>
+          </StyledLink>
         </Card>
       </Container>
     );
@@ -148,7 +149,7 @@ export default function JoinGroupPage() {
           {isJoining ? "Joining..." : "Accept Invite"}
         </JoinButton>
 
-        <Link href="/groups">← Back to groups</Link>
+        <StyledLink href="/groups">← Back to groups</StyledLink>
       </Card>
     </Container>
   );

--- a/packages/frontend/src/app/(main)/groups/new/CreateGroupClient.tsx
+++ b/packages/frontend/src/app/(main)/groups/new/CreateGroupClient.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "nextjs-toploader/app";
+import styled from "styled-components";
+import { Switch } from "@/components/Switch";
+
+const Container = styled.div`
+  max-width: 560px;
+  margin: 0 auto;
+  padding-top: 24px;
+`;
+
+const Title = styled.h1`
+  font-size: 30px;
+  font-weight: bold;
+  margin-bottom: 8px;
+  color: var(--color-fg-default);
+`;
+
+const Description = styled.p`
+  margin-bottom: 32px;
+  color: var(--color-fg-muted);
+`;
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;
+
+const FieldGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+`;
+
+const Label = styled.label`
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-fg-default);
+`;
+
+const Input = styled.input`
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-default);
+  background-color: var(--color-bg-subtle);
+  color: var(--color-fg-default);
+  font-size: 14px;
+
+  &:focus {
+    outline: none;
+    border-color: #0073ff;
+    box-shadow: 0 0 0 2px rgba(0, 115, 255, 0.2);
+  }
+`;
+
+const TextArea = styled.textarea`
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-default);
+  background-color: var(--color-bg-subtle);
+  color: var(--color-fg-default);
+  font-size: 14px;
+  resize: vertical;
+  min-height: 80px;
+  font-family: inherit;
+
+  &:focus {
+    outline: none;
+    border-color: #0073ff;
+    box-shadow: 0 0 0 2px rgba(0, 115, 255, 0.2);
+  }
+`;
+
+const ToggleRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const ToggleLabel = styled.div``;
+
+const ToggleTitle = styled.p`
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-fg-default);
+`;
+
+const ToggleDescription = styled.p`
+  font-size: 12px;
+  color: var(--color-fg-muted);
+`;
+
+const SubmitButton = styled.button`
+  padding: 10px 20px;
+  background-color: #0073ff;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s;
+
+  &:hover:not(:disabled) {
+    background-color: #005fcc;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+const ErrorMessage = styled.p`
+  color: #f85149;
+  font-size: 14px;
+`;
+
+export default function CreateGroupClient() {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [isPublic, setIsPublic] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/groups", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          description: description.trim() || undefined,
+          isPublic,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Failed to create group");
+      }
+
+      const group = await res.json();
+      router.push(`/groups/${group.slug}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Container>
+      <Title>Create a Group</Title>
+      <Description>
+        Set up a group to track and compare token usage with your team
+      </Description>
+
+      <Form onSubmit={handleSubmit}>
+        <FieldGroup>
+          <Label htmlFor="name">Group Name *</Label>
+          <Input
+            id="name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="My Team"
+            maxLength={100}
+            required
+          />
+        </FieldGroup>
+
+        <FieldGroup>
+          <Label htmlFor="description">Description</Label>
+          <TextArea
+            id="description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="What is this group for?"
+            maxLength={500}
+          />
+        </FieldGroup>
+
+        <ToggleRow>
+          <ToggleLabel>
+            <ToggleTitle>Public Group</ToggleTitle>
+            <ToggleDescription>
+              {isPublic
+                ? "Anyone can see this group and its leaderboard"
+                : "Only members can see this group"}
+            </ToggleDescription>
+          </ToggleLabel>
+          <Switch
+            checked={isPublic}
+            onChange={setIsPublic}
+            leftLabel=""
+            rightLabel=""
+          />
+        </ToggleRow>
+
+        {error && <ErrorMessage>{error}</ErrorMessage>}
+
+        <SubmitButton type="submit" disabled={isSubmitting || !name.trim()}>
+          {isSubmitting ? "Creating..." : "Create Group"}
+        </SubmitButton>
+      </Form>
+    </Container>
+  );
+}

--- a/packages/frontend/src/app/(main)/groups/new/page.tsx
+++ b/packages/frontend/src/app/(main)/groups/new/page.tsx
@@ -1,0 +1,29 @@
+import { redirect } from "next/navigation";
+import { Navigation } from "@/components/layout/Navigation";
+import { Footer } from "@/components/layout/Footer";
+import { getSession } from "@/lib/auth/session";
+import CreateGroupClient from "./CreateGroupClient";
+
+export default async function CreateGroupPage() {
+  const session = await getSession();
+  if (!session) {
+    redirect("/");
+  }
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        backgroundColor: "var(--color-bg-default)",
+      }}
+    >
+      <Navigation />
+      <main className="main-container">
+        <CreateGroupClient />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/packages/frontend/src/app/(main)/groups/page.tsx
+++ b/packages/frontend/src/app/(main)/groups/page.tsx
@@ -1,0 +1,36 @@
+import { Suspense } from "react";
+import { Navigation } from "@/components/layout/Navigation";
+import { Footer } from "@/components/layout/Footer";
+import { BlackholeHero } from "@/components/BlackholeHero";
+import { LeaderboardSkeleton } from "@/components/Skeleton";
+import { getSession } from "@/lib/auth/session";
+import GroupsClient from "./GroupsClient";
+
+export default function GroupsPage() {
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        backgroundColor: "var(--color-bg-default)",
+      }}
+    >
+      <Navigation />
+
+      <main className="main-container">
+        <BlackholeHero />
+        <Suspense fallback={<LeaderboardSkeleton />}>
+          <GroupsContent />
+        </Suspense>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}
+
+async function GroupsContent() {
+  const session = await getSession();
+  return <GroupsClient currentUser={session} />;
+}

--- a/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useMemo, memo, useCallback } from "react";
+import Link from "next/link";
 import { useRouter } from "nextjs-toploader/app";
 import styled from "styled-components";
 import { CopyIcon, CheckIcon } from "@/components/ui/Icons";
@@ -499,7 +500,7 @@ const GroupCTASection = styled.div`
   justify-content: flex-end;
 `;
 
-const GroupCTAButton = styled.a`
+const GroupCTAButton = styled(Link)`
   display: inline-flex;
   align-items: center;
   gap: 8px;

--- a/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
@@ -68,6 +68,32 @@ const TabSection = styled.div`
   margin-bottom: 24px;
 `;
 
+const ViewToggleContainer = styled.div`
+  display: inline-flex;
+  gap: 4px;
+  padding: 4px;
+  margin-bottom: 16px;
+  border-radius: 10px;
+  border: 1px solid var(--color-border-default);
+  background-color: var(--color-bg-elevated);
+`;
+
+const ViewToggleButton = styled.button<{ $active: boolean }>`
+  border: none;
+  border-radius: 8px;
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+  color: ${({ $active }) => ($active ? "#fff" : "var(--color-fg-muted)")};
+  background-color: ${({ $active }) => ($active ? "#0073FF" : "transparent")};
+
+  &:hover {
+    color: ${({ $active }) => ($active ? "#fff" : "var(--color-fg-default)")};
+  }
+`;
+
 const TableContainer = styled.div`
   border-radius: 16px;
   border: 1px solid var(--color-border-default);
@@ -337,6 +363,26 @@ const Username = styled.p`
   }
 `;
 
+const GroupAvatar = styled.div`
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--color-bg-subtle);
+  color: var(--color-fg-default);
+  font-size: 14px;
+  font-weight: 600;
+  flex-shrink: 0;
+  overflow: hidden;
+`;
+
+const GroupMembersText = styled.span`
+  color: var(--color-fg-muted);
+  font-size: 14px;
+`;
+
 const StatSpan = styled.span`
   font-weight: 500;
   font-size: 14px;
@@ -445,6 +491,30 @@ const CTASection = styled.div`
   border-radius: 16px;
   border: 1px solid var(--color-border-default);
   background-color: var(--color-bg-default);
+`;
+
+const GroupCTASection = styled.div`
+  margin-top: 16px;
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const GroupCTAButton = styled.a`
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-radius: 8px;
+  background-color: #0073FF;
+  color: #fff;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+  transition: all 0.15s;
+
+  &:hover {
+    background-color: #005fcc;
+  }
 `;
 
 const CTATitle = styled.h2`
@@ -756,6 +826,37 @@ export interface LeaderboardData {
   sortBy?: 'tokens' | 'cost';
 }
 
+interface GroupLeaderboardItem {
+  rank: number;
+  groupId: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  avatarUrl: string | null;
+  memberCount: number;
+  totalTokens: number;
+  totalCost: number;
+}
+
+interface GroupLeaderboardResponse {
+  groups: GroupLeaderboardItem[];
+  pagination: {
+    page: number;
+    limit: number;
+    totalGroups: number;
+    totalPages: number;
+    hasNext: boolean;
+    hasPrev: boolean;
+  };
+  stats: {
+    totalGroups: number;
+    totalTokens: number;
+    totalCost: number;
+  };
+  period: Period;
+  sortBy: 'tokens' | 'cost';
+}
+
 interface LeaderboardClientProps {
   initialData: LeaderboardData;
   currentUser: { id: string; username: string; displayName: string | null; avatarUrl: string | null } | null;
@@ -771,6 +872,17 @@ function isValidLeaderboardData(data: unknown): data is LeaderboardData {
     "pagination" in data &&
     "stats" in data &&
     Array.isArray((data as LeaderboardData).users)
+  );
+}
+
+function isValidGroupLeaderboardData(data: unknown): data is GroupLeaderboardResponse {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "groups" in data &&
+    "pagination" in data &&
+    "stats" in data &&
+    Array.isArray((data as GroupLeaderboardResponse).groups)
   );
 }
 
@@ -845,7 +957,9 @@ const LeaderboardRow = memo(function LeaderboardRow({
 
 export default function LeaderboardClient({ initialData, currentUser, initialSortBy, initialUserRank }: LeaderboardClientProps) {
   const router = useRouter();
+  const [view, setView] = useState<'users' | 'groups'>('users');
   const [data, setData] = useState<LeaderboardData>(initialData);
+  const [groupData, setGroupData] = useState<GroupLeaderboardResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copiedCommand, setCopiedCommand] = useState<string | null>(null);
@@ -862,6 +976,7 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
   const prevPeriodRef = useRef<Period>(initialData.period);
   const prevPageRef = useRef(initialData.pagination.page);
   const prevSortByRef = useRef(initialSortBy);
+  const prevViewRef = useRef<'users' | 'groups'>('users');
 
   const isFirstRankFetch = useRef(true);
 
@@ -924,6 +1039,33 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
       });
   };
 
+  const fetchGroupData = (
+    targetPeriod: Period,
+    targetSortBy: 'tokens' | 'cost',
+    signal?: AbortSignal
+  ) => {
+    setIsLoading(true);
+    setError(null);
+    fetch(`/api/leaderboard/groups?period=${targetPeriod}&sortBy=${targetSortBy}&page=1&limit=20`, { signal })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((result) => {
+        if (!isValidGroupLeaderboardData(result)) {
+          throw new Error("Invalid response format");
+        }
+        setGroupData(result);
+        setIsLoading(false);
+      })
+      .catch((err) => {
+        if (err.name !== "AbortError") {
+          setError(err.message || "Failed to load");
+          setIsLoading(false);
+        }
+      });
+  };
+
   useEffect(() => {
     if (isFirstMount.current) {
       isFirstMount.current = false;
@@ -934,19 +1076,25 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
     const periodChanged = period !== prevPeriodRef.current;
     const pageChanged = page !== prevPageRef.current;
     const sortByChanged = effectiveSortBy !== prevSortByRef.current;
+    const viewChanged = view !== prevViewRef.current;
 
-    if (!periodChanged && !pageChanged && !sortByChanged) {
+    if (!periodChanged && !pageChanged && !sortByChanged && !viewChanged) {
       return;
     }
 
     prevPeriodRef.current = period;
     prevPageRef.current = page;
     prevSortByRef.current = effectiveSortBy;
+    prevViewRef.current = view;
 
     const abortController = new AbortController();
-    fetchData(period, page, effectiveSortBy, abortController.signal);
+    if (view === 'groups') {
+      fetchGroupData(period, effectiveSortBy, abortController.signal);
+    } else {
+      fetchData(period, page, effectiveSortBy, abortController.signal);
+    }
     return () => abortController.abort();
-  }, [period, page, effectiveSortBy]);
+  }, [period, page, effectiveSortBy, view]);
 
   useEffect(() => {
     if (data.pagination.totalPages > 0 && page > data.pagination.totalPages) {
@@ -955,6 +1103,7 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
   }, [data.pagination.totalPages, page]);
 
   const sortedUsers = data.users || [];
+  const sortedGroups = groupData?.groups || [];
 
   const handleCopyCommand = (command: string) => {
     navigator.clipboard.writeText(command);
@@ -966,6 +1115,10 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
     router.push(`/u/${username}`);
   }, [router]);
 
+  const handleGroupRowClick = useCallback((slug: string) => {
+    router.push(`/groups/${slug}`);
+  }, [router]);
+
   return (
     <>
       <Section>
@@ -974,36 +1127,36 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
 
         <StatsGrid>
           <StatCard>
-            <StatLabel>Users</StatLabel>
-            <StatValue>{data.stats.uniqueUsers}</StatValue>
+            <StatLabel>{view === 'users' ? 'Users' : 'Groups'}</StatLabel>
+            <StatValue>{view === 'users' ? data.stats.uniqueUsers : (groupData?.stats.totalGroups ?? 0)}</StatValue>
           </StatCard>
           <StatCard>
             <StatLabel>Total Tokens</StatLabel>
             <StatValuePrimary>
-              <HoverTooltip data-tooltip={data.stats.totalTokens.toLocaleString('en-US')}>
-                {formatNumber(data.stats.totalTokens)}
+              <HoverTooltip data-tooltip={(view === 'users' ? data.stats.totalTokens : (groupData?.stats.totalTokens ?? 0)).toLocaleString('en-US')}>
+                {formatNumber(view === 'users' ? data.stats.totalTokens : (groupData?.stats.totalTokens ?? 0))}
               </HoverTooltip>
             </StatValuePrimary>
           </StatCard>
           <StatCard>
             <StatLabel>Total Cost</StatLabel>
             <StatValue>
-              <HoverTooltip data-tooltip={data.stats.totalCost.toLocaleString('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 2 })}>
-                {formatCurrency(data.stats.totalCost)}
+              <HoverTooltip data-tooltip={(view === 'users' ? data.stats.totalCost : (groupData?.stats.totalCost ?? 0)).toLocaleString('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 2 })}>
+                {formatCurrency(view === 'users' ? data.stats.totalCost : (groupData?.stats.totalCost ?? 0))}
               </HoverTooltip>
             </StatValue>
           </StatCard>
         </StatsGrid>
       </Section>
 
-      {currentUser && currentUserRankError && (
+      {view === 'users' && currentUser && currentUserRankError && (
         <ErrorBanner>
           <span>⚠️</span>
           <span>Unable to load your ranking. Please refresh the page.</span>
         </ErrorBanner>
       )}
 
-      {currentUser && currentUserRank && (
+      {view === 'users' && currentUser && currentUserRank && (
         <CurrentUserCard>
           <CurrentUserInfo>
             <img
@@ -1047,6 +1200,15 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
         </CurrentUserCard>
       )}
 
+      <ViewToggleContainer>
+        <ViewToggleButton $active={view === 'users'} onClick={() => setView('users')}>
+          Users
+        </ViewToggleButton>
+        <ViewToggleButton $active={view === 'groups'} onClick={() => setView('groups')}>
+          Groups
+        </ViewToggleButton>
+      </ViewToggleContainer>
+
       <TabSection>
         <TabBar
           tabs={[
@@ -1079,104 +1241,178 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
           <EmptyState>
             <EmptyMessage>Failed to load leaderboard</EmptyMessage>
             <EmptyHint>{error}</EmptyHint>
-            <RetryButton onClick={() => fetchData(period, page, effectiveSortBy)}>
+            <RetryButton onClick={() => view === 'groups' ? fetchGroupData(period, effectiveSortBy) : fetchData(period, page, effectiveSortBy)}>
               Retry
             </RetryButton>
           </EmptyState>
         </TableContainer>
       ) : (
         <TableContainer>
-          {data.users.length === 0 ? (
-            <EmptyState>
-              <EmptyMessage>No submissions yet. Be the first!</EmptyMessage>
-              <EmptyHint>
-                Run <CodeSnippet>tokscale login && tokscale submit</CodeSnippet>
-              </EmptyHint>
-            </EmptyState>
+          {view === 'users' ? (
+            data.users.length === 0 ? (
+              <EmptyState>
+                <EmptyMessage>No submissions yet. Be the first!</EmptyMessage>
+                <EmptyHint>
+                  Run <CodeSnippet>tokscale login && tokscale submit</CodeSnippet>
+                </EmptyHint>
+              </EmptyState>
+            ) : (
+              <>
+                <TableWrapper>
+                  <Table>
+                    <TableHead>
+                      <tr>
+                        <TableHeaderCell className="rank-cell">Rank</TableHeaderCell>
+                        <TableHeaderCell>User</TableHeaderCell>
+                        <TableHeaderCell className="text-right hidden-cost-mobile">Cost</TableHeaderCell>
+                        <TableHeaderCell className="text-right">Tokens</TableHeaderCell>
+                        <TableHeaderCell className="text-right hidden-mobile w-24">Submits</TableHeaderCell>
+                      </tr>
+                    </TableHead>
+                    <TableBody>
+                      {sortedUsers.map((user: LeaderboardUser, index: number) => (
+                        <LeaderboardRow
+                          key={user.userId}
+                          user={user}
+                          isCurrentUser={!!(currentUser && user.username === currentUser.username)}
+                          isLastRow={index === sortedUsers.length - 1}
+                          onRowClick={handleRowClick}
+                        />
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableWrapper>
+
+                {data.pagination.totalPages > 1 && (
+                  <PaginationContainer>
+                    <PaginationText>
+                      Showing {(data.pagination.page - 1) * data.pagination.limit + 1}-
+                      {Math.min(data.pagination.page * data.pagination.limit, data.pagination.totalUsers)} of{" "}
+                      {data.pagination.totalUsers}
+                    </PaginationText>
+                    <PaginationNav>
+                      <PageButton
+                        disabled={data.pagination.page <= 1}
+                        onClick={() => setPage(data.pagination.page - 1)}
+                        aria-label="Previous page"
+                      >
+                        ←
+                      </PageButton>
+                      <PaginationPages>
+                        {(() => {
+                          const pages: unknown[] = [];
+                          const total = data.pagination.totalPages;
+                          const current = data.pagination.page;
+                          const delta = 2;
+                          const visible = new Set<number>();
+                          visible.add(1);
+                          visible.add(total);
+                          for (let i = Math.max(2, current - delta); i <= Math.min(total - 1, current + delta); i++) {
+                            visible.add(i);
+                          }
+
+                          const sorted = Array.from(visible).sort((a, b) => a - b);
+                          let last = 0;
+                          for (const p of sorted) {
+                            if (last && p - last > 1) {
+                              pages.push(<PageEllipsis key={`e${p}`}>…</PageEllipsis>);
+                            }
+                            pages.push(
+                              <PageButton key={p} $active={p === current} onClick={() => setPage(p)}>
+                                {p}
+                              </PageButton>
+                            );
+                            last = p;
+                          }
+                          return pages;
+                        })()}
+                      </PaginationPages>
+                      <PageButton
+                        disabled={data.pagination.page >= data.pagination.totalPages}
+                        onClick={() => setPage(data.pagination.page + 1)}
+                        aria-label="Next page"
+                      >
+                        →
+                      </PageButton>
+                    </PaginationNav>
+                  </PaginationContainer>
+                )}
+              </>
+            )
           ) : (
             <>
-              <TableWrapper>
-                <Table>
-                  <TableHead>
-                    <tr>
-                      <TableHeaderCell className="rank-cell">Rank</TableHeaderCell>
-                      <TableHeaderCell>User</TableHeaderCell>
-                      <TableHeaderCell className="text-right hidden-cost-mobile">Cost</TableHeaderCell>
-                      <TableHeaderCell className="text-right">Tokens</TableHeaderCell>
-                      <TableHeaderCell className="text-right hidden-mobile w-24">Submits</TableHeaderCell>
-                    </tr>
-                  </TableHead>
-                  <TableBody>
-                    {sortedUsers.map((user, index) => (
-                      <LeaderboardRow
-                        key={user.userId}
-                        user={user}
-                        isCurrentUser={!!(currentUser && user.username === currentUser.username)}
-                        isLastRow={index === sortedUsers.length - 1}
-                        onRowClick={handleRowClick}
-                      />
-                    ))}
-                  </TableBody>
-                </Table>
-              </TableWrapper>
-
-              {data.pagination.totalPages > 1 && (
-                <PaginationContainer>
-                  <PaginationText>
-                    Showing {(data.pagination.page - 1) * data.pagination.limit + 1}-
-                    {Math.min(data.pagination.page * data.pagination.limit, data.pagination.totalUsers)} of{" "}
-                    {data.pagination.totalUsers}
-                  </PaginationText>
-                  <PaginationNav>
-                    <PageButton
-                      disabled={data.pagination.page <= 1}
-                      onClick={() => setPage(data.pagination.page - 1)}
-                      aria-label="Previous page"
-                    >
-                      ←
-                    </PageButton>
-                    <PaginationPages>
-                      {(() => {
-                        const pages: React.ReactNode[] = [];
-                        const total = data.pagination.totalPages;
-                        const current = data.pagination.page;
-                        const delta = 2;
-                        const visible = new Set<number>();
-                        visible.add(1);
-                        visible.add(total);
-                        for (let i = Math.max(2, current - delta); i <= Math.min(total - 1, current + delta); i++) {
-                          visible.add(i);
-                        }
-
-                        const sorted = Array.from(visible).sort((a, b) => a - b);
-                        let last = 0;
-                        for (const p of sorted) {
-                          if (last && p - last > 1) {
-                            pages.push(<PageEllipsis key={`e${p}`}>…</PageEllipsis>);
-                          }
-                          pages.push(
-                            <PageButton key={p} $active={p === current} onClick={() => setPage(p)}>
-                              {p}
-                            </PageButton>
-                          );
-                          last = p;
-                        }
-                        return pages;
-                      })()}
-                    </PaginationPages>
-                    <PageButton
-                      disabled={data.pagination.page >= data.pagination.totalPages}
-                      onClick={() => setPage(data.pagination.page + 1)}
-                      aria-label="Next page"
-                    >
-                      →
-                    </PageButton>
-                  </PaginationNav>
-                </PaginationContainer>
+              {sortedGroups.length === 0 ? (
+                <EmptyState>
+                  <EmptyMessage>No groups ranked yet</EmptyMessage>
+                  <EmptyHint>Create a group and submit data to start ranking.</EmptyHint>
+                </EmptyState>
+              ) : (
+                <TableWrapper>
+                  <Table>
+                    <TableHead>
+                      <tr>
+                        <TableHeaderCell className="rank-cell">Rank</TableHeaderCell>
+                        <TableHeaderCell>Group</TableHeaderCell>
+                        <TableHeaderCell className="text-right hidden-cost-mobile">Members</TableHeaderCell>
+                        <TableHeaderCell className="text-right hidden-cost-mobile">Cost</TableHeaderCell>
+                        <TableHeaderCell className="text-right">Tokens</TableHeaderCell>
+                      </tr>
+                    </TableHead>
+                    <TableBody>
+                      {sortedGroups.map((group: GroupLeaderboardItem, index: number) => (
+                        <TableRow
+                          key={group.groupId}
+                          onClick={() => handleGroupRowClick(group.slug)}
+                          style={index === sortedGroups.length - 1 ? undefined : { borderBottom: "1px solid var(--color-border-default)" }}
+                        >
+                          <TableCell className="rank-cell">
+                            <RankBadge data-rank={group.rank <= 3 ? group.rank : undefined}>#{group.rank}</RankBadge>
+                          </TableCell>
+                          <TableCell>
+                            <UserContainer>
+                              <GroupAvatar>
+                                {group.avatarUrl ? (
+                                  <img
+                                    src={group.avatarUrl}
+                                    alt={group.name}
+                                    width={40}
+                                    height={40}
+                                    style={{ borderRadius: "50%", objectFit: "cover", width: "40px", height: "40px" }}
+                                  />
+                                ) : (
+                                  group.name.slice(0, 2).toUpperCase()
+                                )}
+                              </GroupAvatar>
+                              <UserInfo>
+                                <UserDisplayName>{group.name}</UserDisplayName>
+                                <Username>@{group.slug}</Username>
+                              </UserInfo>
+                            </UserContainer>
+                          </TableCell>
+                          <TableCell className="text-right hidden-cost-mobile">
+                            <GroupMembersText>{formatNumber(group.memberCount)}</GroupMembersText>
+                          </TableCell>
+                          <TableCell className="text-right hidden-cost-mobile">
+                            <StatSpan>{formatCurrency(group.totalCost)}</StatSpan>
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <TokenValue>{formatNumber(group.totalTokens)}</TokenValue>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableWrapper>
               )}
             </>
           )}
         </TableContainer>
+      )}
+
+      {view === 'groups' && (
+        <GroupCTASection>
+          <GroupCTAButton href="/groups/new">+ Create Group</GroupCTAButton>
+        </GroupCTASection>
       )}
 
       <CTASection>

--- a/packages/frontend/src/app/api/groups/[slug]/invite/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/invite/route.ts
@@ -1,0 +1,158 @@
+import { NextResponse } from "next/server";
+import { db, groups, groupMembers, groupInvites, users } from "@/lib/db";
+import { eq, and } from "drizzle-orm";
+import { getSessionFromHeader } from "@/lib/auth/session";
+import { requireGroupRole } from "@/lib/groups/permissions";
+import { generateRandomString } from "@/lib/auth/utils";
+import type { GroupRole } from "@/lib/db/schema";
+
+const INVITE_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const VALID_INVITE_ROLES: GroupRole[] = ["admin", "member"];
+
+interface RouteParams {
+  params: Promise<{ slug: string }>;
+}
+
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const session = await getSessionFromHeader(request);
+    if (!session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const { slug } = await params;
+    const groupResult = await db.select().from(groups).where(eq(groups.slug, slug)).limit(1);
+    if (!groupResult[0]) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    const group = groupResult[0];
+    const membership = await requireGroupRole(group.id, session.id, "admin");
+    if (!membership) {
+      return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+    }
+
+    let body: { username?: string; role?: string };
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    if (!body.username?.trim()) {
+      return NextResponse.json({ error: "Username is required" }, { status: 400 });
+    }
+
+    const inviteRole = (body.role as GroupRole) || "member";
+    if (!VALID_INVITE_ROLES.includes(inviteRole)) {
+      return NextResponse.json({ error: "Invalid role. Must be 'admin' or 'member'" }, { status: 400 });
+    }
+
+    // Look up the user
+    const userResult = await db
+      .select({ id: users.id, username: users.username })
+      .from(users)
+      .where(eq(users.username, body.username.trim()))
+      .limit(1);
+
+    if (!userResult[0]) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const targetUser = userResult[0];
+
+    // Check if already a member
+    const existingMember = await db
+      .select({ id: groupMembers.id })
+      .from(groupMembers)
+      .where(and(eq(groupMembers.groupId, group.id), eq(groupMembers.userId, targetUser.id)))
+      .limit(1);
+
+    if (existingMember[0]) {
+      return NextResponse.json({ error: "User is already a member" }, { status: 409 });
+    }
+
+    // Check if there's already a pending invite
+    const existingInvite = await db
+      .select({ id: groupInvites.id })
+      .from(groupInvites)
+      .where(
+        and(
+          eq(groupInvites.groupId, group.id),
+          eq(groupInvites.invitedUserId, targetUser.id),
+          eq(groupInvites.status, "pending")
+        )
+      )
+      .limit(1);
+
+    if (existingInvite[0]) {
+      return NextResponse.json({ error: "Invite already pending for this user" }, { status: 409 });
+    }
+
+    const token = generateRandomString(64);
+    const expiresAt = new Date(Date.now() + INVITE_EXPIRY_MS);
+
+    const [invite] = await db
+      .insert(groupInvites)
+      .values({
+        groupId: group.id,
+        invitedUsername: targetUser.username,
+        invitedUserId: targetUser.id,
+        invitedBy: session.id,
+        role: inviteRole,
+        token,
+        expiresAt,
+      })
+      .returning();
+
+    return NextResponse.json(invite);
+  } catch (error) {
+    console.error("Create invite error:", error);
+    return NextResponse.json({ error: "Failed to create invite" }, { status: 500 });
+  }
+}
+
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const session = await getSessionFromHeader(request);
+    if (!session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const { slug } = await params;
+    const groupResult = await db.select().from(groups).where(eq(groups.slug, slug)).limit(1);
+    if (!groupResult[0]) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    const group = groupResult[0];
+    const membership = await requireGroupRole(group.id, session.id, "admin");
+    if (!membership) {
+      return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+    }
+
+    const invites = await db
+      .select({
+        id: groupInvites.id,
+        invitedUsername: groupInvites.invitedUsername,
+        invitedUserId: groupInvites.invitedUserId,
+        role: groupInvites.role,
+        status: groupInvites.status,
+        token: groupInvites.token,
+        expiresAt: groupInvites.expiresAt,
+        createdAt: groupInvites.createdAt,
+        inviterUsername: users.username,
+      })
+      .from(groupInvites)
+      .innerJoin(users, eq(groupInvites.invitedBy, users.id))
+      .where(
+        and(eq(groupInvites.groupId, group.id), eq(groupInvites.status, "pending"))
+      )
+      .orderBy(groupInvites.createdAt);
+
+    return NextResponse.json({ invites });
+  } catch (error) {
+    console.error("List invites error:", error);
+    return NextResponse.json({ error: "Failed to fetch invites" }, { status: 500 });
+  }
+}

--- a/packages/frontend/src/app/api/groups/[slug]/leaderboard/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/leaderboard/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { db, groups } from "@/lib/db";
+import { eq } from "drizzle-orm";
+import { getSessionFromHeader } from "@/lib/auth/session";
+import { getGroupMembership } from "@/lib/groups/permissions";
+import { getGroupLeaderboardData } from "@/lib/groups/getGroupLeaderboard";
+import type { Period, SortBy } from "@/lib/leaderboard/getLeaderboard";
+
+const VALID_PERIODS: Period[] = ["all", "month", "week"];
+const VALID_SORT_BY: SortBy[] = ["tokens", "cost"];
+
+function parseIntSafe(value: string | null, defaultValue: number): number {
+  if (!value) return defaultValue;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.floor(parsed) : defaultValue;
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  try {
+    const { slug } = await params;
+    const groupResult = await db.select().from(groups).where(eq(groups.slug, slug)).limit(1);
+    if (!groupResult[0]) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    const group = groupResult[0];
+
+    // If private, require membership
+    if (!group.isPublic) {
+      const session = await getSessionFromHeader(request);
+      if (!session) {
+        return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+      }
+      const membership = await getGroupMembership(group.id, session.id);
+      if (!membership) {
+        return NextResponse.json({ error: "Not a member of this group" }, { status: 403 });
+      }
+    }
+
+    const { searchParams } = new URL(request.url);
+
+    const periodParam = searchParams.get("period") || "all";
+    const period: Period = VALID_PERIODS.includes(periodParam as Period)
+      ? (periodParam as Period)
+      : "all";
+
+    const sortByParam = searchParams.get("sortBy") || "tokens";
+    const sortBy: SortBy = VALID_SORT_BY.includes(sortByParam as SortBy)
+      ? (sortByParam as SortBy)
+      : "tokens";
+
+    const page = Math.max(1, parseIntSafe(searchParams.get("page"), 1));
+    const limit = Math.min(100, Math.max(1, parseIntSafe(searchParams.get("limit"), 50)));
+
+    const data = await getGroupLeaderboardData(group.id, period, page, limit, sortBy);
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Group leaderboard error:", error);
+    return NextResponse.json({ error: "Failed to fetch group leaderboard" }, { status: 500 });
+  }
+}

--- a/packages/frontend/src/app/api/groups/[slug]/leaderboard/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/leaderboard/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { db, groups } from "@/lib/db";
 import { eq } from "drizzle-orm";
-import { getSession, getSessionFromHeader } from "@/lib/auth/session";
+import { getSessionFromHeader } from "@/lib/auth/session";
 import { getGroupMembership } from "@/lib/groups/permissions";
 import { getGroupLeaderboardData } from "@/lib/groups/getGroupLeaderboard";
 import type { Period, SortBy } from "@/lib/leaderboard/getLeaderboard";
@@ -30,10 +30,7 @@ export async function GET(
 
     // If private, require membership
     if (!group.isPublic) {
-      let session = await getSessionFromHeader(request);
-      if (!session) {
-        session = await getSession();
-      }
+      const session = await getSessionFromHeader(request);
       if (!session) {
         return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
       }

--- a/packages/frontend/src/app/api/groups/[slug]/leaderboard/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/leaderboard/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { db, groups } from "@/lib/db";
 import { eq } from "drizzle-orm";
-import { getSessionFromHeader } from "@/lib/auth/session";
+import { getSession, getSessionFromHeader } from "@/lib/auth/session";
 import { getGroupMembership } from "@/lib/groups/permissions";
 import { getGroupLeaderboardData } from "@/lib/groups/getGroupLeaderboard";
 import type { Period, SortBy } from "@/lib/leaderboard/getLeaderboard";
@@ -30,7 +30,10 @@ export async function GET(
 
     // If private, require membership
     if (!group.isPublic) {
-      const session = await getSessionFromHeader(request);
+      let session = await getSessionFromHeader(request);
+      if (!session) {
+        session = await getSession();
+      }
       if (!session) {
         return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
       }

--- a/packages/frontend/src/app/api/groups/[slug]/leave/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/leave/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { db, groups, groupMembers } from "@/lib/db";
+import { eq, and } from "drizzle-orm";
+import { getSessionFromHeader } from "@/lib/auth/session";
+import { getGroupMembership } from "@/lib/groups/permissions";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  try {
+    const session = await getSessionFromHeader(request);
+    if (!session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const { slug } = await params;
+    const groupResult = await db.select().from(groups).where(eq(groups.slug, slug)).limit(1);
+    if (!groupResult[0]) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    const group = groupResult[0];
+    const membership = await getGroupMembership(group.id, session.id);
+    if (!membership) {
+      return NextResponse.json({ error: "Not a member of this group" }, { status: 403 });
+    }
+
+    if (membership.role === "owner") {
+      return NextResponse.json(
+        { error: "Owner cannot leave the group. Transfer ownership or delete the group." },
+        { status: 400 }
+      );
+    }
+
+    await db
+      .delete(groupMembers)
+      .where(and(eq(groupMembers.groupId, group.id), eq(groupMembers.userId, session.id)));
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Leave group error:", error);
+    return NextResponse.json({ error: "Failed to leave group" }, { status: 500 });
+  }
+}

--- a/packages/frontend/src/app/api/groups/[slug]/members/[userId]/role/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/members/[userId]/role/route.ts
@@ -68,6 +68,10 @@ export async function PATCH(
       .where(and(eq(groupMembers.groupId, group.id), eq(groupMembers.userId, userId)))
       .returning();
 
+    if (!updated) {
+      return NextResponse.json({ error: "User is no longer a member" }, { status: 404 });
+    }
+
     return NextResponse.json(updated);
   } catch (error) {
     console.error("Change role error:", error);

--- a/packages/frontend/src/app/api/groups/[slug]/members/[userId]/role/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/members/[userId]/role/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+import { db, groups, groupMembers } from "@/lib/db";
+import { eq, and } from "drizzle-orm";
+import { getSessionFromHeader } from "@/lib/auth/session";
+import { requireGroupRole } from "@/lib/groups/permissions";
+import type { GroupRole } from "@/lib/db/schema";
+
+const ASSIGNABLE_ROLES: GroupRole[] = ["admin", "member"];
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ slug: string; userId: string }> }
+) {
+  try {
+    const session = await getSessionFromHeader(request);
+    if (!session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const { slug, userId } = await params;
+    const groupResult = await db.select().from(groups).where(eq(groups.slug, slug)).limit(1);
+    if (!groupResult[0]) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    const group = groupResult[0];
+    const membership = await requireGroupRole(group.id, session.id, "owner");
+    if (!membership) {
+      return NextResponse.json({ error: "Owner access required" }, { status: 403 });
+    }
+
+    if (userId === session.id) {
+      return NextResponse.json({ error: "Cannot change your own role" }, { status: 400 });
+    }
+
+    let body: { role?: string };
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    if (!body.role || !ASSIGNABLE_ROLES.includes(body.role as GroupRole)) {
+      return NextResponse.json(
+        { error: "Invalid role. Must be 'admin' or 'member'" },
+        { status: 400 }
+      );
+    }
+
+    // Verify target is a member
+    const targetMember = await db
+      .select({ role: groupMembers.role })
+      .from(groupMembers)
+      .where(and(eq(groupMembers.groupId, group.id), eq(groupMembers.userId, userId)))
+      .limit(1);
+
+    if (!targetMember[0]) {
+      return NextResponse.json({ error: "User is not a member" }, { status: 404 });
+    }
+
+    if (targetMember[0].role === "owner") {
+      return NextResponse.json({ error: "Cannot change the owner's role" }, { status: 403 });
+    }
+
+    const [updated] = await db
+      .update(groupMembers)
+      .set({ role: body.role as GroupRole })
+      .where(and(eq(groupMembers.groupId, group.id), eq(groupMembers.userId, userId)))
+      .returning();
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error("Change role error:", error);
+    return NextResponse.json({ error: "Failed to change role" }, { status: 500 });
+  }
+}

--- a/packages/frontend/src/app/api/groups/[slug]/members/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/members/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from "next/server";
+import { db, groups, groupMembers, users } from "@/lib/db";
+import { eq, and } from "drizzle-orm";
+import { getSessionFromHeader } from "@/lib/auth/session";
+import { requireGroupRole } from "@/lib/groups/permissions";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  try {
+    const session = await getSessionFromHeader(request);
+    if (!session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const { slug } = await params;
+    const groupResult = await db.select().from(groups).where(eq(groups.slug, slug)).limit(1);
+    if (!groupResult[0]) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    const group = groupResult[0];
+    const membership = await requireGroupRole(group.id, session.id, "member");
+    if (!membership) {
+      return NextResponse.json({ error: "Must be a group member" }, { status: 403 });
+    }
+
+    const members = await db
+      .select({
+        id: groupMembers.id,
+        userId: groupMembers.userId,
+        role: groupMembers.role,
+        joinedAt: groupMembers.joinedAt,
+        username: users.username,
+        displayName: users.displayName,
+        avatarUrl: users.avatarUrl,
+      })
+      .from(groupMembers)
+      .innerJoin(users, eq(groupMembers.userId, users.id))
+      .where(eq(groupMembers.groupId, group.id))
+      .orderBy(groupMembers.joinedAt);
+
+    return NextResponse.json({ members });
+  } catch (error) {
+    console.error("List members error:", error);
+    return NextResponse.json({ error: "Failed to fetch members" }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  try {
+    const session = await getSessionFromHeader(request);
+    if (!session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const { slug } = await params;
+    const groupResult = await db.select().from(groups).where(eq(groups.slug, slug)).limit(1);
+    if (!groupResult[0]) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    const group = groupResult[0];
+    const membership = await requireGroupRole(group.id, session.id, "admin");
+    if (!membership) {
+      return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+    }
+
+    let body: { userId?: string };
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    if (!body.userId) {
+      return NextResponse.json({ error: "userId is required" }, { status: 400 });
+    }
+
+    if (body.userId === session.id) {
+      return NextResponse.json({ error: "Cannot remove yourself. Use leave instead." }, { status: 400 });
+    }
+
+    // Check target member exists and is not owner
+    const targetMember = await db
+      .select({ role: groupMembers.role })
+      .from(groupMembers)
+      .where(and(eq(groupMembers.groupId, group.id), eq(groupMembers.userId, body.userId)))
+      .limit(1);
+
+    if (!targetMember[0]) {
+      return NextResponse.json({ error: "User is not a member" }, { status: 404 });
+    }
+
+    if (targetMember[0].role === "owner") {
+      return NextResponse.json({ error: "Cannot remove the group owner" }, { status: 403 });
+    }
+
+    await db
+      .delete(groupMembers)
+      .where(and(eq(groupMembers.groupId, group.id), eq(groupMembers.userId, body.userId)));
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Remove member error:", error);
+    return NextResponse.json({ error: "Failed to remove member" }, { status: 500 });
+  }
+}

--- a/packages/frontend/src/app/api/groups/[slug]/members/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/members/route.ts
@@ -100,6 +100,10 @@ export async function DELETE(
       return NextResponse.json({ error: "Cannot remove the group owner" }, { status: 403 });
     }
 
+    if (targetMember[0].role === "admin" && membership.role === "admin") {
+      return NextResponse.json({ error: "Only the owner can remove admins" }, { status: 403 });
+    }
+
     await db
       .delete(groupMembers)
       .where(and(eq(groupMembers.groupId, group.id), eq(groupMembers.userId, body.userId)));

--- a/packages/frontend/src/app/api/groups/[slug]/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { db, groups, groupMembers } from "@/lib/db";
-import { and, eq, sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { getSessionFromHeader } from "@/lib/auth/session";
 import { generateUniqueSlug } from "@/lib/groups/slug";
 import { getGroupMembership, requireGroupRole } from "@/lib/groups/permissions";
@@ -147,7 +147,7 @@ export async function DELETE(request: Request, { params }: RouteParams) {
       return NextResponse.json({ error: "Only the owner can delete this group" }, { status: 403 });
     }
 
-    await db.delete(groups).where(and(eq(groups.id, targetGroup.id), eq(groups.createdBy, session.id)));
+    await db.delete(groups).where(eq(groups.id, targetGroup.id));
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/packages/frontend/src/app/api/groups/[slug]/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/route.ts
@@ -1,0 +1,157 @@
+import { NextResponse } from "next/server";
+import { db, groups, groupMembers } from "@/lib/db";
+import { and, eq, sql } from "drizzle-orm";
+import { getSessionFromHeader } from "@/lib/auth/session";
+import { generateUniqueSlug } from "@/lib/groups/slug";
+import { getGroupMembership, requireGroupRole } from "@/lib/groups/permissions";
+
+interface RouteParams {
+  params: Promise<{ slug: string }>;
+}
+
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { slug } = await params;
+
+    const group = await db.select().from(groups).where(eq(groups.slug, slug)).limit(1);
+    if (!group[0]) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    const targetGroup = group[0];
+    const session = await getSessionFromHeader(request);
+
+    let membership: { role: "owner" | "admin" | "member" } | null = null;
+    if (session) {
+      membership = await getGroupMembership(targetGroup.id, session.id);
+    }
+
+    if (!targetGroup.isPublic && !membership) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const [memberCountResult] = await db
+      .select({ count: sql<number>`COUNT(*)`.as("count") })
+      .from(groupMembers)
+      .where(eq(groupMembers.groupId, targetGroup.id));
+
+    return NextResponse.json({
+      ...targetGroup,
+      memberCount: Number(memberCountResult?.count) || 0,
+      membership,
+    });
+  } catch (error) {
+    console.error("Get group error:", error);
+    return NextResponse.json({ error: "Failed to fetch group" }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: Request, { params }: RouteParams) {
+  try {
+    const session = await getSessionFromHeader(request);
+    if (!session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const { slug } = await params;
+    const group = await db.select().from(groups).where(eq(groups.slug, slug)).limit(1);
+    if (!group[0]) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    const targetGroup = group[0];
+    const allowed = await requireGroupRole(targetGroup.id, session.id, "admin");
+    if (!allowed) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    let body: {
+      name?: string;
+      description?: string | null;
+      isPublic?: boolean;
+      avatarUrl?: string | null;
+    };
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const updateData: {
+      name?: string;
+      slug?: string;
+      description?: string | null;
+      isPublic?: boolean;
+      avatarUrl?: string | null;
+      updatedAt: Date;
+    } = {
+      updatedAt: new Date(),
+    };
+
+    if (typeof body.name === "string") {
+      const nextName = body.name.trim();
+      if (!nextName) {
+        return NextResponse.json({ error: "Group name cannot be empty" }, { status: 400 });
+      }
+      if (nextName.length > 100) {
+        return NextResponse.json({ error: "Group name must be 100 characters or less" }, { status: 400 });
+      }
+
+      updateData.name = nextName;
+      if (nextName !== targetGroup.name) {
+        updateData.slug = await generateUniqueSlug(nextName);
+      }
+    }
+
+    if (body.description !== undefined) {
+      updateData.description = body.description?.trim() || null;
+    }
+
+    if (body.avatarUrl !== undefined) {
+      updateData.avatarUrl = body.avatarUrl?.trim() || null;
+    }
+
+    if (typeof body.isPublic === "boolean") {
+      updateData.isPublic = body.isPublic;
+    }
+
+    const [updated] = await db
+      .update(groups)
+      .set(updateData)
+      .where(eq(groups.id, targetGroup.id))
+      .returning();
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error("Update group error:", error);
+    return NextResponse.json({ error: "Failed to update group" }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request, { params }: RouteParams) {
+  try {
+    const session = await getSessionFromHeader(request);
+    if (!session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const { slug } = await params;
+    const group = await db.select().from(groups).where(eq(groups.slug, slug)).limit(1);
+    if (!group[0]) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    const targetGroup = group[0];
+    const membership = await getGroupMembership(targetGroup.id, session.id);
+    if (!membership || membership.role !== "owner") {
+      return NextResponse.json({ error: "Only the owner can delete this group" }, { status: 403 });
+    }
+
+    await db.delete(groups).where(and(eq(groups.id, targetGroup.id), eq(groups.createdBy, session.id)));
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Delete group error:", error);
+    return NextResponse.json({ error: "Failed to delete group" }, { status: 500 });
+  }
+}

--- a/packages/frontend/src/app/api/groups/join/[token]/route.ts
+++ b/packages/frontend/src/app/api/groups/join/[token]/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from "next/server";
+import { db, groups, groupMembers, groupInvites } from "@/lib/db";
+import { eq, and, gt } from "drizzle-orm";
+import { getSessionFromHeader } from "@/lib/auth/session";
+import type { GroupRole } from "@/lib/db/schema";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ token: string }> }
+) {
+  try {
+    const session = await getSessionFromHeader(request);
+    if (!session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const { token } = await params;
+
+    // Find the invite
+    const inviteResult = await db
+      .select({
+        invite: groupInvites,
+        group: groups,
+      })
+      .from(groupInvites)
+      .innerJoin(groups, eq(groupInvites.groupId, groups.id))
+      .where(
+        and(
+          eq(groupInvites.token, token),
+          eq(groupInvites.status, "pending"),
+          gt(groupInvites.expiresAt, new Date())
+        )
+      )
+      .limit(1);
+
+    if (!inviteResult[0]) {
+      return NextResponse.json(
+        { error: "Invalid, expired, or already used invite" },
+        { status: 404 }
+      );
+    }
+
+    const { invite, group } = inviteResult[0];
+
+    // Check if already a member
+    const existingMember = await db
+      .select({ id: groupMembers.id })
+      .from(groupMembers)
+      .where(
+        and(
+          eq(groupMembers.groupId, group.id),
+          eq(groupMembers.userId, session.id)
+        )
+      )
+      .limit(1);
+
+    if (existingMember[0]) {
+      return NextResponse.json({ error: "Already a member of this group" }, { status: 409 });
+    }
+
+    // Accept the invite in a transaction
+    await db.transaction(async (tx) => {
+      // Add as member
+      await tx.insert(groupMembers).values({
+        groupId: group.id,
+        userId: session.id,
+        role: invite.role as GroupRole,
+        invitedBy: invite.invitedBy,
+      });
+
+      // Mark invite as accepted
+      await tx
+        .update(groupInvites)
+        .set({ status: "accepted" })
+        .where(eq(groupInvites.id, invite.id));
+    });
+
+    return NextResponse.json({
+      success: true,
+      group: {
+        id: group.id,
+        name: group.name,
+        slug: group.slug,
+      },
+    });
+  } catch (error) {
+    console.error("Join group error:", error);
+    return NextResponse.json({ error: "Failed to join group" }, { status: 500 });
+  }
+}

--- a/packages/frontend/src/app/api/groups/join/[token]/route.ts
+++ b/packages/frontend/src/app/api/groups/join/[token]/route.ts
@@ -42,6 +42,10 @@ export async function POST(
 
     const { invite, group } = inviteResult[0];
 
+    if (invite.invitedUserId && invite.invitedUserId !== session.id) {
+      return NextResponse.json({ error: "This invite is not for you" }, { status: 403 });
+    }
+
     // Check if already a member
     const existingMember = await db
       .select({ id: groupMembers.id })

--- a/packages/frontend/src/app/api/groups/route.ts
+++ b/packages/frontend/src/app/api/groups/route.ts
@@ -1,0 +1,163 @@
+import { NextResponse } from "next/server";
+import { db, groups, groupMembers } from "@/lib/db";
+import { and, desc, eq, sql } from "drizzle-orm";
+import { getSessionFromHeader } from "@/lib/auth/session";
+import { generateUniqueSlug } from "@/lib/groups/slug";
+
+function parseIntSafe(value: string | null, defaultValue: number): number {
+  if (!value) return defaultValue;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.floor(parsed) : defaultValue;
+}
+
+export async function POST(request: Request) {
+  try {
+    const session = await getSessionFromHeader(request);
+    if (!session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    let body: { name?: string; description?: string; isPublic?: boolean };
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const name = body.name?.trim();
+    if (!name) {
+      return NextResponse.json({ error: "Group name is required" }, { status: 400 });
+    }
+
+    if (name.length > 100) {
+      return NextResponse.json({ error: "Group name must be 100 characters or less" }, { status: 400 });
+    }
+
+    const slug = await generateUniqueSlug(name);
+
+    const [createdGroup] = await db.transaction(async (tx) => {
+      const [newGroup] = await tx
+        .insert(groups)
+        .values({
+          name,
+          slug,
+          description: body.description?.trim() || null,
+          isPublic: body.isPublic ?? true,
+          createdBy: session.id,
+        })
+        .returning();
+
+      await tx.insert(groupMembers).values({
+        groupId: newGroup.id,
+        userId: session.id,
+        role: "owner",
+      });
+
+      return [newGroup];
+    });
+
+    return NextResponse.json(createdGroup);
+  } catch (error) {
+    console.error("Create group error:", error);
+    return NextResponse.json({ error: "Failed to create group" }, { status: 500 });
+  }
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const myOnly = searchParams.get("my") === "true";
+    const page = Math.max(1, parseIntSafe(searchParams.get("page"), 1));
+    const limit = Math.min(100, Math.max(1, parseIntSafe(searchParams.get("limit"), 20)));
+    const offset = (page - 1) * limit;
+
+    const session = await getSessionFromHeader(request);
+
+    if (myOnly && session) {
+      const [items, totalResult] = await Promise.all([
+        db
+          .select({
+            id: groups.id,
+            name: groups.name,
+            slug: groups.slug,
+            description: groups.description,
+            avatarUrl: groups.avatarUrl,
+            isPublic: groups.isPublic,
+            createdBy: groups.createdBy,
+            createdAt: groups.createdAt,
+            updatedAt: groups.updatedAt,
+            role: groupMembers.role,
+            memberCount: sql<number>`COUNT(${groupMembers.id}) OVER (PARTITION BY ${groups.id})`.as(
+              "member_count"
+            ),
+          })
+          .from(groupMembers)
+          .innerJoin(groups, eq(groupMembers.groupId, groups.id))
+          .where(eq(groupMembers.userId, session.id))
+          .orderBy(desc(groups.updatedAt))
+          .limit(limit)
+          .offset(offset),
+        db
+          .select({ count: sql<number>`COUNT(*)`.as("count") })
+          .from(groupMembers)
+          .where(eq(groupMembers.userId, session.id)),
+      ]);
+
+      const total = Number(totalResult[0]?.count) || 0;
+      return NextResponse.json({
+        groups: items,
+        pagination: {
+          page,
+          limit,
+          total,
+          totalPages: Math.ceil(total / limit),
+          hasNext: offset + items.length < total,
+          hasPrev: page > 1,
+        },
+      });
+    }
+
+    const [items, totalResult] = await Promise.all([
+      db
+        .select({
+          id: groups.id,
+          name: groups.name,
+          slug: groups.slug,
+          description: groups.description,
+          avatarUrl: groups.avatarUrl,
+          isPublic: groups.isPublic,
+          createdBy: groups.createdBy,
+          createdAt: groups.createdAt,
+          updatedAt: groups.updatedAt,
+          memberCount: sql<number>`COUNT(${groupMembers.id})`.as("member_count"),
+        })
+        .from(groups)
+        .leftJoin(groupMembers, eq(groupMembers.groupId, groups.id))
+        .where(eq(groups.isPublic, true))
+        .groupBy(groups.id)
+        .orderBy(desc(groups.updatedAt))
+        .limit(limit)
+        .offset(offset),
+      db
+        .select({ count: sql<number>`COUNT(*)`.as("count") })
+        .from(groups)
+        .where(eq(groups.isPublic, true)),
+    ]);
+
+    const total = Number(totalResult[0]?.count) || 0;
+    return NextResponse.json({
+      groups: items,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+        hasNext: offset + items.length < total,
+        hasPrev: page > 1,
+      },
+    });
+  } catch (error) {
+    console.error("List groups error:", error);
+    return NextResponse.json({ error: "Failed to fetch groups" }, { status: 500 });
+  }
+}

--- a/packages/frontend/src/app/api/groups/route.ts
+++ b/packages/frontend/src/app/api/groups/route.ts
@@ -91,7 +91,7 @@ export async function GET(request: Request) {
             createdAt: groups.createdAt,
             updatedAt: groups.updatedAt,
             role: groupMembers.role,
-            memberCount: sql<number>`(SELECT COUNT(*) FROM "group_members" WHERE "group_members"."group_id" = ${groups.id})`.as(
+            memberCount: sql<number>`CAST((SELECT COUNT(*) FROM "group_members" WHERE "group_members"."group_id" = ${groups.id}) AS integer)`.as(
               "member_count"
             ),
           })

--- a/packages/frontend/src/app/api/groups/route.ts
+++ b/packages/frontend/src/app/api/groups/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { db, groups, groupMembers } from "@/lib/db";
-import { and, desc, eq, sql } from "drizzle-orm";
+import { desc, eq, sql } from "drizzle-orm";
 import { getSessionFromHeader } from "@/lib/auth/session";
 import { generateUniqueSlug } from "@/lib/groups/slug";
 
@@ -73,6 +73,10 @@ export async function GET(request: Request) {
 
     const session = await getSessionFromHeader(request);
 
+    if (myOnly && !session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
     if (myOnly && session) {
       const [items, totalResult] = await Promise.all([
         db
@@ -87,7 +91,7 @@ export async function GET(request: Request) {
             createdAt: groups.createdAt,
             updatedAt: groups.updatedAt,
             role: groupMembers.role,
-            memberCount: sql<number>`COUNT(${groupMembers.id}) OVER (PARTITION BY ${groups.id})`.as(
+            memberCount: sql<number>`(SELECT COUNT(*) FROM "group_members" WHERE "group_members"."group_id" = ${groups.id})`.as(
               "member_count"
             ),
           })
@@ -129,7 +133,7 @@ export async function GET(request: Request) {
           createdBy: groups.createdBy,
           createdAt: groups.createdAt,
           updatedAt: groups.updatedAt,
-          memberCount: sql<number>`COUNT(${groupMembers.id})`.as("member_count"),
+          memberCount: sql<number>`CAST(COUNT(${groupMembers.id}) AS integer)`.as("member_count"),
         })
         .from(groups)
         .leftJoin(groupMembers, eq(groupMembers.groupId, groups.id))

--- a/packages/frontend/src/app/api/leaderboard/groups/route.ts
+++ b/packages/frontend/src/app/api/leaderboard/groups/route.ts
@@ -1,0 +1,192 @@
+import { NextResponse } from "next/server";
+import { unstable_cache } from "next/cache";
+import { db, groups, groupMembers, submissions, users } from "@/lib/db";
+import type { Period, SortBy } from "@/lib/leaderboard/getLeaderboard";
+import { and, desc, eq, gte, lte, sql } from "drizzle-orm";
+
+const VALID_PERIODS: Period[] = ["all", "month", "week"];
+const VALID_SORT_BY: SortBy[] = ["tokens", "cost"];
+
+function parseIntSafe(value: string | null, defaultValue: number): number {
+  if (!value) return defaultValue;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.floor(parsed) : defaultValue;
+}
+
+function getDateFilter(period: Period) {
+  const now = new Date();
+
+  if (period === "week") {
+    const weekAgo = new Date(now);
+    weekAgo.setDate(weekAgo.getDate() - 7);
+    return { start: weekAgo, end: now };
+  }
+
+  if (period === "month") {
+    const monthAgo = new Date(now);
+    monthAgo.setMonth(monthAgo.getMonth() - 1);
+    return { start: monthAgo, end: now };
+  }
+
+  return null;
+}
+
+async function fetchGroupLeaderboardData(
+  period: Period,
+  sortBy: SortBy,
+  page: number,
+  limit: number
+) {
+  const offset = (page - 1) * limit;
+  const dateFilter = getDateFilter(period);
+
+  const submissionJoinCondition = dateFilter
+    ? and(
+        eq(submissions.userId, groupMembers.userId),
+        gte(submissions.createdAt, dateFilter.start),
+        lte(submissions.createdAt, dateFilter.end)
+      )
+    : eq(submissions.userId, groupMembers.userId);
+
+  const orderByColumn =
+    sortBy === "cost"
+      ? sql`COALESCE(SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4))), 0)`
+      : sql`COALESCE(SUM(${submissions.totalTokens}), 0)`;
+
+  const [items, totalResult, statsResult] = await Promise.all([
+    db
+      .select({
+        rank: sql<number>`ROW_NUMBER() OVER (ORDER BY ${orderByColumn} DESC)`.as("rank"),
+        groupId: groups.id,
+        name: groups.name,
+        slug: groups.slug,
+        description: groups.description,
+        avatarUrl: groups.avatarUrl,
+        memberCount: sql<number>`COUNT(DISTINCT ${users.id})`.as("member_count"),
+        totalTokens: sql<number>`COALESCE(SUM(${submissions.totalTokens}), 0)`.as("total_tokens"),
+        totalCost: sql<number>`COALESCE(SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4))), 0)`.as("total_cost"),
+      })
+      .from(groups)
+      .innerJoin(groupMembers, eq(groupMembers.groupId, groups.id))
+      .innerJoin(users, eq(users.id, groupMembers.userId))
+      .leftJoin(submissions, submissionJoinCondition)
+      .where(eq(groups.isPublic, true))
+      .groupBy(groups.id, groups.name, groups.slug, groups.description, groups.avatarUrl)
+      .orderBy(desc(orderByColumn))
+      .limit(limit)
+      .offset(offset),
+    db
+      .select({ count: sql<number>`COUNT(*)`.as("count") })
+      .from(groups)
+      .where(eq(groups.isPublic, true)),
+    db
+      .select({
+        totalTokens: sql<number>`COALESCE(SUM(group_totals.total_tokens), 0)`.as("total_tokens"),
+        totalCost: sql<number>`COALESCE(SUM(group_totals.total_cost), 0)`.as("total_cost"),
+      })
+      .from(
+        db
+          .select({
+            groupId: groups.id,
+            totalTokens: sql<number>`COALESCE(SUM(${submissions.totalTokens}), 0)`.as("total_tokens"),
+            totalCost: sql<number>`COALESCE(SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4))), 0)`.as(
+              "total_cost"
+            ),
+          })
+          .from(groups)
+          .innerJoin(groupMembers, eq(groupMembers.groupId, groups.id))
+          .innerJoin(users, eq(users.id, groupMembers.userId))
+          .leftJoin(submissions, submissionJoinCondition)
+          .where(eq(groups.isPublic, true))
+          .groupBy(groups.id)
+          .as("group_totals")
+      ),
+  ]);
+
+  const totalGroups = Number(totalResult[0]?.count) || 0;
+  const totalPages = Math.ceil(totalGroups / limit);
+
+  return {
+    groups: items.map((
+      group: {
+        rank: number;
+        groupId: string;
+        name: string;
+        slug: string;
+        description: string | null;
+        avatarUrl: string | null;
+        memberCount: number;
+        totalTokens: number;
+        totalCost: number;
+      },
+      index: number
+    ) => ({
+      rank: Number(group.rank) || offset + index + 1,
+      groupId: group.groupId,
+      name: group.name,
+      slug: group.slug,
+      description: group.description,
+      avatarUrl: group.avatarUrl,
+      memberCount: Number(group.memberCount) || 0,
+      totalTokens: Number(group.totalTokens) || 0,
+      totalCost: Number(group.totalCost) || 0,
+    })),
+    pagination: {
+      page,
+      limit,
+      totalGroups,
+      totalPages,
+      hasNext: page < totalPages,
+      hasPrev: page > 1,
+    },
+    stats: {
+      totalGroups,
+      totalTokens: Number(statsResult[0]?.totalTokens) || 0,
+      totalCost: Number(statsResult[0]?.totalCost) || 0,
+    },
+    period,
+    sortBy,
+  };
+}
+
+function getGroupLeaderboardData(
+  period: Period,
+  sortBy: SortBy,
+  page: number,
+  limit: number
+) {
+  return unstable_cache(
+    () => fetchGroupLeaderboardData(period, sortBy, page, limit),
+    [`group-leaderboard:${period}:${sortBy}:${page}:${limit}`],
+    {
+      tags: ["group-leaderboard", `group-leaderboard:${period}`],
+      revalidate: 60,
+    }
+  )();
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+
+    const periodParam = searchParams.get("period") || "all";
+    const period: Period = VALID_PERIODS.includes(periodParam as Period)
+      ? (periodParam as Period)
+      : "all";
+
+    const sortByParam = searchParams.get("sortBy") || "tokens";
+    const sortBy: SortBy = VALID_SORT_BY.includes(sortByParam as SortBy)
+      ? (sortByParam as SortBy)
+      : "tokens";
+
+    const page = Math.max(1, parseIntSafe(searchParams.get("page"), 1));
+    const limit = Math.min(100, Math.max(1, parseIntSafe(searchParams.get("limit"), 20)));
+
+    const data = await getGroupLeaderboardData(period, sortBy, page, limit);
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Group leaderboard error:", error);
+    return NextResponse.json({ error: "Failed to fetch group leaderboard" }, { status: 500 });
+  }
+}

--- a/packages/frontend/src/app/api/leaderboard/groups/route.ts
+++ b/packages/frontend/src/app/api/leaderboard/groups/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { unstable_cache } from "next/cache";
 import { db, groups, groupMembers, submissions, users } from "@/lib/db";
 import type { Period, SortBy } from "@/lib/leaderboard/getLeaderboard";
-import { and, desc, eq, gte, lte, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gte, lte, sql } from "drizzle-orm";
 
 const VALID_PERIODS: Period[] = ["all", "month", "week"];
 const VALID_SORT_BY: SortBy[] = ["tokens", "cost"];
@@ -24,7 +24,7 @@ function getDateFilter(period: Period) {
 
   if (period === "month") {
     const monthAgo = new Date(now);
-    monthAgo.setMonth(monthAgo.getMonth() - 1);
+    monthAgo.setDate(monthAgo.getDate() - 30);
     return { start: monthAgo, end: now };
   }
 
@@ -56,7 +56,7 @@ async function fetchGroupLeaderboardData(
   const [items, totalResult, statsResult] = await Promise.all([
     db
       .select({
-        rank: sql<number>`ROW_NUMBER() OVER (ORDER BY ${orderByColumn} DESC)`.as("rank"),
+        rank: sql<number>`ROW_NUMBER() OVER (ORDER BY ${orderByColumn} DESC, ${groups.id} ASC)`.as("rank"),
         groupId: groups.id,
         name: groups.name,
         slug: groups.slug,
@@ -72,12 +72,14 @@ async function fetchGroupLeaderboardData(
       .leftJoin(submissions, submissionJoinCondition)
       .where(eq(groups.isPublic, true))
       .groupBy(groups.id, groups.name, groups.slug, groups.description, groups.avatarUrl)
-      .orderBy(desc(orderByColumn))
+      .orderBy(desc(orderByColumn), asc(groups.id))
       .limit(limit)
       .offset(offset),
     db
-      .select({ count: sql<number>`COUNT(*)`.as("count") })
+      .select({ count: sql<number>`COUNT(DISTINCT ${groups.id})`.as("count") })
       .from(groups)
+      .innerJoin(groupMembers, eq(groupMembers.groupId, groups.id))
+      .innerJoin(users, eq(users.id, groupMembers.userId))
       .where(eq(groups.isPublic, true)),
     db
       .select({

--- a/packages/frontend/src/app/api/users/[username]/groups/route.ts
+++ b/packages/frontend/src/app/api/users/[username]/groups/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { db, users, groups, groupMembers } from "@/lib/db";
+import { and, eq, sql } from "drizzle-orm";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ username: string }> }
+) {
+  try {
+    const { username } = await params;
+
+    const [user] = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.username, username))
+      .limit(1);
+
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const userGroups = await db
+      .select({
+        id: groups.id,
+        name: groups.name,
+        slug: groups.slug,
+        description: groups.description,
+        avatarUrl: groups.avatarUrl,
+        isPublic: groups.isPublic,
+        role: groupMembers.role,
+        memberCount: sql<number>`(
+          SELECT COUNT(${groupMembers.id})
+          FROM ${groupMembers}
+          WHERE ${groupMembers.groupId} = ${groups.id}
+        )`.as("member_count"),
+      })
+      .from(groupMembers)
+      .innerJoin(groups, eq(groupMembers.groupId, groups.id))
+      .where(and(eq(groupMembers.userId, user.id), eq(groups.isPublic, true)));
+
+    return NextResponse.json({
+      groups: userGroups,
+    });
+  } catch (error) {
+    console.error("Fetch user groups error:", error);
+    return NextResponse.json({ error: "Failed to fetch user groups" }, { status: 500 });
+  }
+}

--- a/packages/frontend/src/app/api/users/[username]/groups/route.ts
+++ b/packages/frontend/src/app/api/users/[username]/groups/route.ts
@@ -29,7 +29,7 @@ export async function GET(
         isPublic: groups.isPublic,
         role: groupMembers.role,
         memberCount: sql<number>`(
-          SELECT COUNT(${groupMembers.id})
+          SELECT CAST(COUNT(${groupMembers.id}) AS integer)
           FROM ${groupMembers}
           WHERE ${groupMembers.groupId} = ${groups.id}
         )`.as("member_count"),

--- a/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
+++ b/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
@@ -95,7 +95,9 @@ export default function ProfilePageClient({ initialData, username }: ProfilePage
           setUserGroups([]);
         }
       } finally {
-        setIsGroupsLoading(false);
+        if (!abortController.signal.aborted) {
+          setIsGroupsLoading(false);
+        }
       }
     };
 

--- a/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
+++ b/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
+import { useRouter } from "nextjs-toploader/app";
 import styled from "styled-components";
 import { Navigation } from "@/components/layout/Navigation";
 import { Footer } from "@/components/layout/Footer";
@@ -54,9 +55,53 @@ interface ProfilePageClientProps {
   username: string;
 }
 
+interface UserGroupItem {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  avatarUrl: string | null;
+  isPublic: boolean;
+  role: "owner" | "admin" | "member";
+  memberCount: number;
+}
+
 export default function ProfilePageClient({ initialData, username }: ProfilePageClientProps) {
+  const router = useRouter();
   const [activeTab, setActiveTab] = useState<ProfileTab>("activity");
+  const [userGroups, setUserGroups] = useState<UserGroupItem[]>([]);
+  const [isGroupsLoading, setIsGroupsLoading] = useState(true);
   const data = initialData;
+
+  useEffect(() => {
+    const abortController = new AbortController();
+
+    const fetchGroups = async () => {
+      setIsGroupsLoading(true);
+      try {
+        const response = await fetch(`/api/users/${username}/groups`, {
+          signal: abortController.signal,
+        });
+
+        if (!response.ok) {
+          setUserGroups([]);
+          return;
+        }
+
+        const result = (await response.json()) as { groups?: UserGroupItem[] };
+        setUserGroups(result.groups ?? []);
+      } catch (error) {
+        if ((error as Error).name !== "AbortError") {
+          setUserGroups([]);
+        }
+      } finally {
+        setIsGroupsLoading(false);
+      }
+    };
+
+    fetchGroups();
+    return () => abortController.abort();
+  }, [username]);
 
   const graphData: TokenContributionData | null = useMemo(() => {
     if (!data || data.contributions.length === 0) return null;
@@ -181,6 +226,34 @@ const EARLY_ADOPTERS = ["code-yeongyu", "gtg7784", "qodot"];
           )}
           {activeTab === "breakdown" && <TokenBreakdown stats={stats} />}
           {activeTab === "models" && <ProfileModels models={data.models} modelUsage={data.modelUsage} />}
+
+          <GroupsSection>
+            <GroupsSectionHeader>Groups</GroupsSectionHeader>
+            {isGroupsLoading ? (
+              <GroupsLoadingText>Loading groups...</GroupsLoadingText>
+            ) : userGroups.length > 0 ? (
+              <GroupsList>
+                {userGroups.map((group: UserGroupItem) => (
+                  <GroupCard
+                    key={group.id}
+                    onClick={() => router.push(`/groups/${group.slug}`)}
+                  >
+                    <GroupCardTop>
+                      <GroupName>{group.name}</GroupName>
+                      <RoleBadge>{group.role}</RoleBadge>
+                    </GroupCardTop>
+                    {group.description && <GroupDescription>{group.description}</GroupDescription>}
+                    <GroupMeta>{group.memberCount} members</GroupMeta>
+                  </GroupCard>
+                ))}
+              </GroupsList>
+            ) : (
+              <NoGroupsCard>
+                <NoGroupsText>No groups yet</NoGroupsText>
+                <CreateGroupLink href="/groups/new">Create Group</CreateGroupLink>
+              </NoGroupsCard>
+            )}
+          </GroupsSection>
         </ContentWrapper>
       </MainContent>
 
@@ -266,4 +339,122 @@ const ActivitySection = styled.div`
   display: flex;
   flex-direction: column;
   gap: 24px;
+`;
+
+const GroupsSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+const GroupsSectionHeader = styled.h2`
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-fg-default);
+`;
+
+const GroupsLoadingText = styled.p`
+  font-size: 14px;
+  color: var(--color-fg-muted);
+`;
+
+const GroupsList = styled.div`
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+
+  &::-webkit-scrollbar {
+    height: 6px;
+  }
+`;
+
+const GroupCard = styled.button`
+  min-width: 220px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 12px;
+  background-color: var(--color-bg-default);
+  padding: 14px;
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.2s;
+
+  &:hover {
+    border-color: var(--color-primary);
+    background-color: rgba(0, 115, 255, 0.04);
+  }
+`;
+
+const GroupCardTop = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+`;
+
+const GroupName = styled.p`
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-fg-default);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const RoleBadge = styled.span`
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #0073ff;
+  background-color: rgba(0, 115, 255, 0.1);
+  text-transform: capitalize;
+`;
+
+const GroupDescription = styled.p`
+  margin-bottom: 8px;
+  font-size: 12px;
+  color: var(--color-fg-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const GroupMeta = styled.p`
+  font-size: 12px;
+  color: var(--color-fg-subtle);
+`;
+
+const NoGroupsCard = styled.div`
+  border: 1px solid var(--color-border-default);
+  border-radius: 12px;
+  background-color: var(--color-bg-default);
+  padding: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+`;
+
+const NoGroupsText = styled.p`
+  font-size: 14px;
+  color: var(--color-fg-muted);
+`;
+
+const CreateGroupLink = styled.a`
+  border-radius: 8px;
+  border: 1px solid var(--color-border-default);
+  background-color: var(--color-bg-elevated);
+  color: var(--color-fg-default);
+  font-size: 12px;
+  font-weight: 500;
+  text-decoration: none;
+  padding: 6px 10px;
+  transition: all 0.15s;
+
+  &:hover {
+    border-color: var(--color-primary);
+    color: #0073ff;
+  }
 `;

--- a/packages/frontend/src/lib/auth/session.ts
+++ b/packages/frontend/src/lib/auth/session.ts
@@ -150,48 +150,44 @@ export async function validateApiToken(
 
 /**
  * Get session from Authorization header (for API routes).
+ * Falls back to cookie-based session when no Authorization header is present,
+ * so web UI fetches (which send cookies, not headers) work automatically.
  */
 export async function getSessionFromHeader(
   request: Request
 ): Promise<SessionUser | null> {
   const authHeader = request.headers.get("Authorization");
-
-  if (!authHeader) {
-    return null;
-  }
-
-  // Support "Bearer <token>" format
-  const token = authHeader.startsWith("Bearer ")
-    ? authHeader.slice(7)
+  if (authHeader) {
+    // Support "Bearer <token>" format
+    const token = authHeader.startsWith("Bearer ")
+      ? authHeader.slice(7)
     : authHeader;
+    if (token.startsWith("tt_")) {
+      return validateApiToken(token);
+    }
 
-  // Check if it's an API token (CLI)
-  if (token.startsWith("tt_")) {
-    return validateApiToken(token);
-  }
-
-  // Otherwise treat as session token (web)
-  const result = await db
-    .select({
-      session: sessions,
-      user: users,
-    })
-    .from(sessions)
-    .innerJoin(users, eq(sessions.userId, users.id))
-    .where(and(eq(sessions.token, token), gt(sessions.expiresAt, new Date())))
+    // Otherwise treat as session token
+    const result = await db
+      .select({
+        session: sessions,
+        user: users,
+      })
+      .from(sessions)
+      .innerJoin(users, eq(sessions.userId, users.id))
+      .where(and(eq(sessions.token, token), gt(sessions.expiresAt, new Date())))
     .limit(1);
-
-  if (result.length === 0) {
-    return null;
+    if (result.length > 0) {
+      const { user } = result[0];
+      return {
+        id: user.id,
+        username: user.username,
+        displayName: user.displayName,
+        avatarUrl: user.avatarUrl,
+        isAdmin: user.isAdmin,
+      };
+    }
   }
 
-  const { user } = result[0];
-
-  return {
-    id: user.id,
-    username: user.username,
-    displayName: user.displayName,
-    avatarUrl: user.avatarUrl,
-    isAdmin: user.isAdmin,
-  };
+  // Fallback: check cookie session (web UI flow)
+  return getSession();
 }

--- a/packages/frontend/src/lib/db/migrations/0005_add_groups.sql
+++ b/packages/frontend/src/lib/db/migrations/0005_add_groups.sql
@@ -1,0 +1,72 @@
+-- Groups feature: groups, group_members, group_invites
+
+CREATE TABLE IF NOT EXISTS "groups" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "name" varchar(100) NOT NULL,
+  "slug" varchar(100) NOT NULL,
+  "description" text,
+  "avatar_url" text,
+  "is_public" boolean DEFAULT true NOT NULL,
+  "invite_code" varchar(32),
+  "created_by" uuid NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "groups_slug_unique" UNIQUE("slug"),
+  CONSTRAINT "groups_invite_code_unique" UNIQUE("invite_code")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "group_members" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "group_id" uuid NOT NULL,
+  "user_id" uuid NOT NULL,
+  "role" varchar(10) DEFAULT 'member' NOT NULL,
+  "invited_by" uuid,
+  "joined_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "group_members_group_user_unique" UNIQUE("group_id", "user_id")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "group_invites" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "group_id" uuid NOT NULL,
+  "invited_username" varchar(39),
+  "invited_user_id" uuid,
+  "invited_by" uuid NOT NULL,
+  "role" varchar(10) DEFAULT 'member' NOT NULL,
+  "status" varchar(10) DEFAULT 'pending' NOT NULL,
+  "token" varchar(64) NOT NULL,
+  "expires_at" timestamp with time zone NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "group_invites_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+ALTER TABLE "groups" ADD CONSTRAINT "groups_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "group_members" ADD CONSTRAINT "group_members_group_id_groups_id_fk" FOREIGN KEY ("group_id") REFERENCES "public"."groups"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "group_members" ADD CONSTRAINT "group_members_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "group_members" ADD CONSTRAINT "group_members_invited_by_users_id_fk" FOREIGN KEY ("invited_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "group_invites" ADD CONSTRAINT "group_invites_group_id_groups_id_fk" FOREIGN KEY ("group_id") REFERENCES "public"."groups"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "group_invites" ADD CONSTRAINT "group_invites_invited_user_id_users_id_fk" FOREIGN KEY ("invited_user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "group_invites" ADD CONSTRAINT "group_invites_invited_by_users_id_fk" FOREIGN KEY ("invited_by") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_groups_slug" ON "groups" USING btree ("slug");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_groups_created_by" ON "groups" USING btree ("created_by");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_groups_is_public" ON "groups" USING btree ("is_public");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_group_members_group_id" ON "group_members" USING btree ("group_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_group_members_user_id" ON "group_members" USING btree ("user_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_group_invites_group_id" ON "group_invites" USING btree ("group_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_group_invites_invited_user_id" ON "group_invites" USING btree ("invited_user_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_group_invites_token" ON "group_invites" USING btree ("token");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_group_invites_status" ON "group_invites" USING btree ("status");

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1771322400000,
       "tag": "0004_add_timestamp_and_schema_version",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1772150400000,
+      "tag": "0005_add_groups",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -45,6 +45,8 @@ export const usersRelations = relations(users, ({ many }) => ({
   sessions: many(sessions),
   apiTokens: many(apiTokens),
   submissions: many(submissions),
+  groupMemberships: many(groupMembers),
+  createdGroups: many(groups),
 }));
 
 // ============================================================================
@@ -268,6 +270,138 @@ export const dailyBreakdownRelations = relations(dailyBreakdown, ({ one }) => ({
 }));
 
 // ============================================================================
+// GROUPS
+// ============================================================================
+export const groupRole = ["owner", "admin", "member"] as const;
+export type GroupRole = (typeof groupRole)[number];
+
+export const groups = pgTable(
+  "groups",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    name: varchar("name", { length: 100 }).notNull(),
+    slug: varchar("slug", { length: 100 }).notNull().unique(),
+    description: text("description"),
+    avatarUrl: text("avatar_url"),
+    isPublic: boolean("is_public").notNull().default(true),
+    inviteCode: varchar("invite_code", { length: 32 }).unique(),
+    createdBy: uuid("created_by")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_groups_slug").on(table.slug),
+    index("idx_groups_created_by").on(table.createdBy),
+    index("idx_groups_is_public").on(table.isPublic),
+  ]
+);
+
+export const groupsRelations = relations(groups, ({ one, many }) => ({
+  creator: one(users, {
+    fields: [groups.createdBy],
+    references: [users.id],
+  }),
+  members: many(groupMembers),
+  invites: many(groupInvites),
+}));
+
+// ============================================================================
+// GROUP MEMBERS
+// ============================================================================
+export const groupMembers = pgTable(
+  "group_members",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    groupId: uuid("group_id")
+      .notNull()
+      .references(() => groups.id, { onDelete: "cascade" }),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    role: varchar("role", { length: 10 }).notNull().default("member").$type<GroupRole>(),
+    invitedBy: uuid("invited_by").references(() => users.id, { onDelete: "set null" }),
+    joinedAt: timestamp("joined_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_group_members_group_id").on(table.groupId),
+    index("idx_group_members_user_id").on(table.userId),
+    unique("group_members_group_user_unique").on(table.groupId, table.userId),
+  ]
+);
+
+export const groupMembersRelations = relations(groupMembers, ({ one }) => ({
+  group: one(groups, {
+    fields: [groupMembers.groupId],
+    references: [groups.id],
+  }),
+  user: one(users, {
+    fields: [groupMembers.userId],
+    references: [users.id],
+  }),
+  inviter: one(users, {
+    fields: [groupMembers.invitedBy],
+    references: [users.id],
+  }),
+}));
+
+// ============================================================================
+// GROUP INVITES
+// ============================================================================
+export const groupInviteStatus = ["pending", "accepted", "declined", "expired"] as const;
+export type GroupInviteStatus = (typeof groupInviteStatus)[number];
+
+export const groupInvites = pgTable(
+  "group_invites",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    groupId: uuid("group_id")
+      .notNull()
+      .references(() => groups.id, { onDelete: "cascade" }),
+    invitedUsername: varchar("invited_username", { length: 39 }),
+    invitedUserId: uuid("invited_user_id").references(() => users.id, { onDelete: "cascade" }),
+    invitedBy: uuid("invited_by")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    role: varchar("role", { length: 10 }).notNull().default("member").$type<GroupRole>(),
+    status: varchar("status", { length: 10 }).notNull().default("pending").$type<GroupInviteStatus>(),
+    token: varchar("token", { length: 64 }).notNull().unique(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_group_invites_group_id").on(table.groupId),
+    index("idx_group_invites_invited_user_id").on(table.invitedUserId),
+    index("idx_group_invites_token").on(table.token),
+    index("idx_group_invites_status").on(table.status),
+  ]
+);
+
+export const groupInvitesRelations = relations(groupInvites, ({ one }) => ({
+  group: one(groups, {
+    fields: [groupInvites.groupId],
+    references: [groups.id],
+  }),
+  invitedUser: one(users, {
+    fields: [groupInvites.invitedUserId],
+    references: [users.id],
+  }),
+  inviter: one(users, {
+    fields: [groupInvites.invitedBy],
+    references: [users.id],
+  }),
+}));
+
+// ============================================================================
 // TYPE EXPORTS
 // ============================================================================
 export type User = typeof users.$inferSelect;
@@ -282,3 +416,9 @@ export type Submission = typeof submissions.$inferSelect;
 export type NewSubmission = typeof submissions.$inferInsert;
 export type DailyBreakdown = typeof dailyBreakdown.$inferSelect;
 export type NewDailyBreakdown = typeof dailyBreakdown.$inferInsert;
+export type Group = typeof groups.$inferSelect;
+export type NewGroup = typeof groups.$inferInsert;
+export type GroupMember = typeof groupMembers.$inferSelect;
+export type NewGroupMember = typeof groupMembers.$inferInsert;
+export type GroupInvite = typeof groupInvites.$inferSelect;
+export type NewGroupInvite = typeof groupInvites.$inferInsert;

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -296,7 +296,7 @@ export const groups = pgTable(
       .defaultNow(),
   },
   (table) => [
-    index("idx_groups_slug").on(table.slug),
+    // slug index omitted: UNIQUE constraint on slug already creates one
     index("idx_groups_created_by").on(table.createdBy),
     index("idx_groups_is_public").on(table.isPublic),
   ]
@@ -331,7 +331,7 @@ export const groupMembers = pgTable(
       .defaultNow(),
   },
   (table) => [
-    index("idx_group_members_group_id").on(table.groupId),
+    // group_id index omitted: composite unique on (group_id, user_id) already indexes group_id
     index("idx_group_members_user_id").on(table.userId),
     unique("group_members_group_user_unique").on(table.groupId, table.userId),
   ]
@@ -383,7 +383,7 @@ export const groupInvites = pgTable(
   (table) => [
     index("idx_group_invites_group_id").on(table.groupId),
     index("idx_group_invites_invited_user_id").on(table.invitedUserId),
-    index("idx_group_invites_token").on(table.token),
+    // token index omitted: UNIQUE constraint on token already creates one
     index("idx_group_invites_status").on(table.status),
   ]
 );

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -45,7 +45,7 @@ export const usersRelations = relations(users, ({ many }) => ({
   sessions: many(sessions),
   apiTokens: many(apiTokens),
   submissions: many(submissions),
-  groupMemberships: many(groupMembers),
+  groupMemberships: many(groupMembers, { relationName: "memberUser" }),
   createdGroups: many(groups),
 }));
 
@@ -345,10 +345,12 @@ export const groupMembersRelations = relations(groupMembers, ({ one }) => ({
   user: one(users, {
     fields: [groupMembers.userId],
     references: [users.id],
+    relationName: "memberUser",
   }),
   inviter: one(users, {
     fields: [groupMembers.invitedBy],
     references: [users.id],
+    relationName: "memberInviter",
   }),
 }));
 
@@ -394,10 +396,12 @@ export const groupInvitesRelations = relations(groupInvites, ({ one }) => ({
   invitedUser: one(users, {
     fields: [groupInvites.invitedUserId],
     references: [users.id],
+    relationName: "inviteTarget",
   }),
   inviter: one(users, {
     fields: [groupInvites.invitedBy],
     references: [users.id],
+    relationName: "inviteCreator",
   }),
 }));
 

--- a/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
+++ b/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
@@ -1,0 +1,198 @@
+import { unstable_cache } from "next/cache";
+import { db, users, submissions, groupMembers } from "@/lib/db";
+import { eq, desc, sql, and, gte, lte } from "drizzle-orm";
+import type { Period, SortBy } from "@/lib/leaderboard/getLeaderboard";
+
+export interface GroupLeaderboardUser {
+  rank: number;
+  userId: string;
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  totalTokens: number;
+  totalCost: number;
+  submissionCount: number;
+  lastSubmission: string;
+  role: string;
+}
+
+export interface GroupLeaderboardData {
+  users: GroupLeaderboardUser[];
+  pagination: {
+    page: number;
+    limit: number;
+    totalUsers: number;
+    totalPages: number;
+    hasNext: boolean;
+    hasPrev: boolean;
+  };
+  stats: {
+    totalTokens: number;
+    totalCost: number;
+    totalMembers: number;
+  };
+  period: Period;
+  sortBy: SortBy;
+}
+
+function getDateFilter(period: Period) {
+  const now = new Date();
+
+  if (period === "week") {
+    const weekAgo = new Date(now);
+    weekAgo.setDate(weekAgo.getDate() - 7);
+    return and(
+      gte(submissions.createdAt, weekAgo),
+      lte(submissions.createdAt, now)
+    );
+  }
+
+  if (period === "month") {
+    const monthAgo = new Date(now);
+    monthAgo.setMonth(monthAgo.getMonth() - 1);
+    return and(
+      gte(submissions.createdAt, monthAgo),
+      lte(submissions.createdAt, now)
+    );
+  }
+
+  return undefined;
+}
+
+async function fetchGroupLeaderboardData(
+  groupId: string,
+  period: Period,
+  page: number,
+  limit: number,
+  sortBy: SortBy = "tokens"
+): Promise<GroupLeaderboardData> {
+  const offset = (page - 1) * limit;
+  const dateFilter = getDateFilter(period);
+
+  const orderByColumn =
+    sortBy === "cost"
+      ? sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`
+      : sql`SUM(${submissions.totalTokens})`;
+
+  // Main query: join submissions with group_members to scope to group
+  const leaderboardQuery = db
+    .select({
+      rank: sql<number>`ROW_NUMBER() OVER (ORDER BY ${orderByColumn} DESC)`.as(
+        "rank"
+      ),
+      userId: users.id,
+      username: users.username,
+      displayName: users.displayName,
+      avatarUrl: users.avatarUrl,
+      totalTokens: sql<number>`SUM(${submissions.totalTokens})`.as(
+        "total_tokens"
+      ),
+      totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`.as(
+        "total_cost"
+      ),
+      submissionCount: sql<number>`COALESCE(SUM(${submissions.submitCount}), 0)`.as(
+        "submission_count"
+      ),
+      lastSubmission: sql<string>`MAX(${submissions.createdAt})`.as(
+        "last_submission"
+      ),
+      role: groupMembers.role,
+    })
+    .from(submissions)
+    .innerJoin(users, eq(submissions.userId, users.id))
+    .innerJoin(
+      groupMembers,
+      and(
+        eq(groupMembers.userId, submissions.userId),
+        eq(groupMembers.groupId, groupId)
+      )
+    )
+    .where(dateFilter)
+    .groupBy(
+      users.id,
+      users.username,
+      users.displayName,
+      users.avatarUrl,
+      groupMembers.role
+    )
+    .orderBy(desc(orderByColumn))
+    .limit(limit)
+    .offset(offset);
+
+  // Member count + total stats for this group
+  const [results, memberCount, groupStats] = await Promise.all([
+    leaderboardQuery,
+    db
+      .select({ count: sql<number>`COUNT(*)`.as("count") })
+      .from(groupMembers)
+      .where(eq(groupMembers.groupId, groupId)),
+    db
+      .select({
+        totalTokens: sql<number>`SUM(${submissions.totalTokens})`,
+        totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`,
+      })
+      .from(submissions)
+      .innerJoin(
+        groupMembers,
+        and(
+          eq(groupMembers.userId, submissions.userId),
+          eq(groupMembers.groupId, groupId)
+        )
+      )
+      .where(dateFilter),
+  ]);
+
+  const totalMembers = Number(memberCount[0]?.count) || 0;
+  const totalPages = Math.ceil(totalMembers / limit);
+
+  return {
+    users: results.map((row, index) => ({
+      rank: offset + index + 1,
+      userId: row.userId,
+      username: row.username,
+      displayName: row.displayName,
+      avatarUrl: row.avatarUrl,
+      totalTokens: Number(row.totalTokens) || 0,
+      totalCost: Number(row.totalCost) || 0,
+      submissionCount: Number(row.submissionCount) || 0,
+      lastSubmission: row.lastSubmission,
+      role: row.role,
+    })),
+    pagination: {
+      page,
+      limit,
+      totalUsers: totalMembers,
+      totalPages,
+      hasNext: page < totalPages,
+      hasPrev: page > 1,
+    },
+    stats: {
+      totalTokens: Number(groupStats[0]?.totalTokens) || 0,
+      totalCost: Number(groupStats[0]?.totalCost) || 0,
+      totalMembers,
+    },
+    period,
+    sortBy,
+  };
+}
+
+export function getGroupLeaderboardData(
+  groupId: string,
+  period: Period = "all",
+  page: number = 1,
+  limit: number = 50,
+  sortBy: SortBy = "tokens"
+): Promise<GroupLeaderboardData> {
+  return unstable_cache(
+    () => fetchGroupLeaderboardData(groupId, period, page, limit, sortBy),
+    [`group-leaderboard:${groupId}:${period}:${page}:${limit}:${sortBy}`],
+    {
+      tags: [
+        "group-leaderboard",
+        `group-leaderboard:${groupId}`,
+        `group-leaderboard:${groupId}:${period}`,
+      ],
+      revalidate: 60,
+    }
+  )();
+}

--- a/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
+++ b/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
@@ -77,9 +77,6 @@ async function fetchGroupLeaderboardData(
   // Main query: join submissions with group_members to scope to group
   const leaderboardQuery = db
     .select({
-      rank: sql<number>`ROW_NUMBER() OVER (ORDER BY ${orderByColumn} DESC)`.as(
-        "rank"
-      ),
       userId: users.id,
       username: users.username,
       displayName: users.displayName,
@@ -120,12 +117,23 @@ async function fetchGroupLeaderboardData(
     .offset(offset);
 
   // Member count + total stats for this group
-  const [results, memberCount, groupStats] = await Promise.all([
+  const [results, memberCount, submittedUserCount, groupStats] = await Promise.all([
     leaderboardQuery,
     db
       .select({ count: sql<number>`COUNT(*)`.as("count") })
       .from(groupMembers)
       .where(eq(groupMembers.groupId, groupId)),
+    db
+      .select({ count: sql<number>`COUNT(DISTINCT ${submissions.userId})`.as("count") })
+      .from(submissions)
+      .innerJoin(
+        groupMembers,
+        and(
+          eq(groupMembers.userId, submissions.userId),
+          eq(groupMembers.groupId, groupId)
+        )
+      )
+      .where(dateFilter),
     db
       .select({
         totalTokens: sql<number>`SUM(${submissions.totalTokens})`,
@@ -143,7 +151,8 @@ async function fetchGroupLeaderboardData(
   ]);
 
   const totalMembers = Number(memberCount[0]?.count) || 0;
-  const totalPages = Math.ceil(totalMembers / limit);
+  const totalSubmittedUsers = Number(submittedUserCount[0]?.count) || 0;
+  const totalPages = Math.ceil(totalSubmittedUsers / limit);
 
   return {
     users: results.map((row, index) => ({
@@ -161,7 +170,7 @@ async function fetchGroupLeaderboardData(
     pagination: {
       page,
       limit,
-      totalUsers: totalMembers,
+      totalUsers: totalSubmittedUsers,
       totalPages,
       hasNext: page < totalPages,
       hasPrev: page > 1,

--- a/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
+++ b/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
@@ -117,27 +117,17 @@ async function fetchGroupLeaderboardData(
     .offset(offset);
 
   // Member count + total stats for this group
-  const [results, memberCount, submittedUserCount, groupStats] = await Promise.all([
+  const [results, memberCount, groupStats] = await Promise.all([
     leaderboardQuery,
     db
       .select({ count: sql<number>`COUNT(*)`.as("count") })
       .from(groupMembers)
       .where(eq(groupMembers.groupId, groupId)),
     db
-      .select({ count: sql<number>`COUNT(DISTINCT ${submissions.userId})`.as("count") })
-      .from(submissions)
-      .innerJoin(
-        groupMembers,
-        and(
-          eq(groupMembers.userId, submissions.userId),
-          eq(groupMembers.groupId, groupId)
-        )
-      )
-      .where(dateFilter),
-    db
       .select({
         totalTokens: sql<number>`SUM(${submissions.totalTokens})`,
         totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`,
+        submittedUserCount: sql<number>`COUNT(DISTINCT ${submissions.userId})`,
       })
       .from(submissions)
       .innerJoin(
@@ -149,9 +139,8 @@ async function fetchGroupLeaderboardData(
       )
       .where(dateFilter),
   ]);
-
   const totalMembers = Number(memberCount[0]?.count) || 0;
-  const totalSubmittedUsers = Number(submittedUserCount[0]?.count) || 0;
+  const totalSubmittedUsers = Number(groupStats[0]?.submittedUserCount) || 0;
   const totalPages = Math.ceil(totalSubmittedUsers / limit);
 
   return {

--- a/packages/frontend/src/lib/groups/permissions.ts
+++ b/packages/frontend/src/lib/groups/permissions.ts
@@ -1,0 +1,53 @@
+import { db, groupMembers } from "@/lib/db";
+import { eq, and } from "drizzle-orm";
+import type { GroupRole } from "@/lib/db/schema";
+
+/**
+ * Role hierarchy: owner > admin > member
+ */
+const ROLE_LEVEL: Record<GroupRole, number> = {
+  owner: 3,
+  admin: 2,
+  member: 1,
+};
+
+export function hasRoleLevel(
+  userRole: GroupRole,
+  requiredRole: GroupRole
+): boolean {
+  return ROLE_LEVEL[userRole] >= ROLE_LEVEL[requiredRole];
+}
+
+/**
+ * Get a user's membership + role in a group.
+ * Returns null if not a member.
+ */
+export async function getGroupMembership(
+  groupId: string,
+  userId: string
+): Promise<{ role: GroupRole } | null> {
+  const result = await db
+    .select({ role: groupMembers.role })
+    .from(groupMembers)
+    .where(
+      and(eq(groupMembers.groupId, groupId), eq(groupMembers.userId, userId))
+    )
+    .limit(1);
+
+  if (result.length === 0) return null;
+  return { role: result[0].role as GroupRole };
+}
+
+/**
+ * Check if user has at least the required role in a group.
+ */
+export async function requireGroupRole(
+  groupId: string,
+  userId: string,
+  requiredRole: GroupRole
+): Promise<{ role: GroupRole } | null> {
+  const membership = await getGroupMembership(groupId, userId);
+  if (!membership) return null;
+  if (!hasRoleLevel(membership.role, requiredRole)) return null;
+  return membership;
+}

--- a/packages/frontend/src/lib/groups/slug.ts
+++ b/packages/frontend/src/lib/groups/slug.ts
@@ -1,0 +1,43 @@
+import { db, groups } from "@/lib/db";
+import { eq } from "drizzle-orm";
+
+/**
+ * Convert a group name to a URL-friendly slug.
+ */
+export function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/[\s_]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 100);
+}
+
+/**
+ * Generate a unique slug, appending a suffix if needed.
+ */
+export async function generateUniqueSlug(name: string): Promise<string> {
+  const base = slugify(name);
+  if (!base) {
+    // Fallback for names that slugify to empty string
+    return `group-${Date.now().toString(36)}`;
+  }
+
+  let candidate = base;
+  let attempt = 0;
+
+  while (true) {
+    const existing = await db
+      .select({ id: groups.id })
+      .from(groups)
+      .where(eq(groups.slug, candidate))
+      .limit(1);
+
+    if (existing.length === 0) return candidate;
+
+    attempt++;
+    candidate = `${base}-${attempt}`;
+  }
+}

--- a/packages/frontend/src/lib/groups/slug.ts
+++ b/packages/frontend/src/lib/groups/slug.ts
@@ -11,18 +11,18 @@ export function slugify(name: string): string {
     .replace(/[^\w\s-]/g, "")
     .replace(/[\s_]+/g, "-")
     .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "")
-    .slice(0, 100);
+    .slice(0, 80)
+    .replace(/^-|-$/g, "");
 }
 
 /**
  * Generate a unique slug, appending a suffix if needed.
  */
 export async function generateUniqueSlug(name: string): Promise<string> {
-  const base = slugify(name);
+  let base = slugify(name);
   if (!base) {
     // Fallback for names that slugify to empty string
-    return `group-${Date.now().toString(36)}`;
+    base = `group-${Date.now().toString(36)}`;
   }
 
   let candidate = base;


### PR DESCRIPTION
## Summary

Adds a complete **Groups** feature to the Tokscale frontend:

- **Group CRUD** — Create, view, edit, and delete groups with public/private visibility
- **Role system** — Owner → Admin → Member hierarchy with scoped permissions
- **Invite system** — Generate invite links, invite as member or admin, accept/decline
- **Group leaderboard** — Per-group member rankings by tokens/cost with period filtering
- **Global group rankings** — Users/Groups toggle on the main leaderboard page
- **Profile integration** — User profile shows groups they belong to (or "Create Group" CTA)
- **No nav clutter** — Groups are surfaced through profile + leaderboard, not the main nav

### Database
- 3 new tables: `groups`, `group_members`, `group_invites`
- Migration `0005_add_groups.sql` with indexes, FKs, cascades, unique constraints
- Drizzle schema + relations + type exports

### API (15 endpoints)
| Route | Methods |
|-------|---------|
| `/api/groups` | GET (list), POST (create) |
| `/api/groups/[slug]` | GET, PATCH, DELETE |
| `/api/groups/[slug]/members` | GET, DELETE |
| `/api/groups/[slug]/members/[userId]/role` | PATCH |
| `/api/groups/[slug]/invite` | GET, POST |
| `/api/groups/[slug]/leave` | POST |
| `/api/groups/[slug]/leaderboard` | GET |
| `/api/groups/join/[token]` | POST |
| `/api/users/[username]/groups` | GET |
| `/api/leaderboard/groups` | GET |

### Frontend (11 pages/components)
- Groups list, create, detail, settings, members, join invite
- Leaderboard: Users/Groups segmented toggle with full group ranking table
- Profile: horizontal scrollable group cards with role badges

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Groups with roles, invites, and leaderboards so teams can track and compare token usage together. Integrated into profiles and the main leaderboard; run migration 0005_add_groups.sql. Includes auth fallback and query cleanup.

- **New Features**
  - Create, edit, and delete public/private groups with unique slugs.
  - Role hierarchy (owner/admin/member); manage members and roles; leave group.
  - Invite links with role + expiry; join flow with accept/decline.
  - Leaderboards: per‑group (period/sort) and global Users/Groups toggle.
  - Profiles show the user’s groups with role badges; API for groups, members, invites, join/leave, and group rankings.

- **Bug Fixes**
  - API auth now falls back to cookie sessions in getSessionFromHeader; added TOCTOU guards across group APIs.
  - Fixed member count casting and corrected SQL aggregation/pagination in group and global leaderboards.
  - Prevented race conditions with an abort‑signal guard in GroupsClient; cleaned up client-side routing.
  - Slug uniqueness and index cleanup (removed redundant indexes); consolidated queries to reduce DB round‑trips.

<sup>Written for commit 8494ab2d36bc2dac4389428f176548bc042534bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
