### PR TITLE
feat: cross-machine usage aggregation with device-level dedup

### DIFF
--- a/packages/frontend/__tests__/api/submit.test.ts
+++ b/packages/frontend/__tests__/api/submit.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  mergeClientBreakdowns,
+  type ClientBreakdownData,
+} from '../../src/lib/db/helpers';
 
 /**
  * Test suite for POST /api/submit - Client-Level Merge
@@ -405,6 +409,183 @@ describe('POST /api/submit - Client-Level Merge', () => {
       expect(modelBreakdown['claude-sonnet-4']).toBe(950);
       expect(modelBreakdown['claude-opus-4']).toBe(1600);
       expect(modelBreakdown['gpt-4o']).toBe(375);
+    });
+  });
+
+  describe('Device-Level Deduplication', () => {
+    const makeClientData = (tokens: number, cost: number, modelId: string): ClientBreakdownData => ({
+      tokens,
+      cost,
+      input: Math.floor(tokens * 0.6),
+      output: Math.floor(tokens * 0.4),
+      cacheRead: 0,
+      cacheWrite: 0,
+      reasoning: 0,
+      messages: 1,
+      models: {
+        [modelId]: {
+          tokens,
+          cost,
+          input: Math.floor(tokens * 0.6),
+          output: Math.floor(tokens * 0.4),
+          cacheRead: 0,
+          cacheWrite: 0,
+          reasoning: 0,
+          messages: 1,
+        },
+      },
+    });
+
+    it('should replace device data on resubmit without double-counting', () => {
+      // First submit from device-A
+      const existing: Record<string, ClientBreakdownData> = {};
+      const incoming1 = { claude: makeClientData(1000, 10, 'claude-sonnet-4') };
+      const after1 = mergeClientBreakdowns(existing, incoming1, new Set(['claude']), 'device-A');
+
+      expect(after1.claude.tokens).toBe(1000);
+      expect(after1.claude.devices!['device-A'].tokens).toBe(1000);
+
+      // Same device resubmits with updated data
+      const incoming2 = { claude: makeClientData(1500, 15, 'claude-sonnet-4') };
+      const after2 = mergeClientBreakdowns(after1, incoming2, new Set(['claude']), 'device-A');
+
+      // Should be 1500, NOT 1000 + 1500 = 2500
+      expect(after2.claude.tokens).toBe(1500);
+      expect(after2.claude.devices!['device-A'].tokens).toBe(1500);
+    });
+
+    it('should aggregate data from multiple devices correctly', () => {
+      const existing: Record<string, ClientBreakdownData> = {};
+
+      // Device A submits
+      const incomingA = { claude: makeClientData(1000, 10, 'claude-sonnet-4') };
+      const afterA = mergeClientBreakdowns(existing, incomingA, new Set(['claude']), 'device-A');
+
+      // Device B submits
+      const incomingB = { claude: makeClientData(500, 5, 'claude-sonnet-4') };
+      const afterBoth = mergeClientBreakdowns(afterA, incomingB, new Set(['claude']), 'device-B');
+
+      // Total should be sum of both devices
+      expect(afterBoth.claude.tokens).toBe(1500);
+      expect(afterBoth.claude.devices!['device-A'].tokens).toBe(1000);
+      expect(afterBoth.claude.devices!['device-B'].tokens).toBe(500);
+    });
+
+    it('should preserve other devices when one device resubmits', () => {
+      const existing: Record<string, ClientBreakdownData> = {};
+
+      // Two devices submit
+      const incomingA = { claude: makeClientData(1000, 10, 'claude-sonnet-4') };
+      const afterA = mergeClientBreakdowns(existing, incomingA, new Set(['claude']), 'device-A');
+      const incomingB = { claude: makeClientData(500, 5, 'claude-sonnet-4') };
+      const afterBoth = mergeClientBreakdowns(afterA, incomingB, new Set(['claude']), 'device-B');
+
+      // Device A resubmits with new data
+      const incomingA2 = { claude: makeClientData(2000, 20, 'claude-sonnet-4') };
+      const afterResubmit = mergeClientBreakdowns(afterBoth, incomingA2, new Set(['claude']), 'device-A');
+
+      // Device B is preserved, device A is replaced
+      expect(afterResubmit.claude.devices!['device-A'].tokens).toBe(2000);
+      expect(afterResubmit.claude.devices!['device-B'].tokens).toBe(500);
+      expect(afterResubmit.claude.tokens).toBe(2500);
+    });
+
+    it('should migrate legacy data (no devices) to __legacy__ key', () => {
+      // Simulate existing data without devices field (pre-device-tracking)
+      const existing: Record<string, ClientBreakdownData> = {
+        claude: {
+          tokens: 800,
+          cost: 8,
+          input: 480,
+          output: 320,
+          cacheRead: 0,
+          cacheWrite: 0,
+          reasoning: 0,
+          messages: 3,
+          models: {
+            'claude-sonnet-4': { tokens: 800, cost: 8, input: 480, output: 320, cacheRead: 0, cacheWrite: 0, reasoning: 0, messages: 3 },
+          },
+        },
+      };
+
+      const incoming = { claude: makeClientData(1000, 10, 'claude-sonnet-4') };
+      const merged = mergeClientBreakdowns(existing, incoming, new Set(['claude']), 'device-A');
+
+      // Legacy data preserved under __legacy__
+      expect(merged.claude.devices!['__legacy__']).toBeDefined();
+      expect(merged.claude.devices!['__legacy__'].tokens).toBe(800);
+      // New device data present
+      expect(merged.claude.devices!['device-A'].tokens).toBe(1000);
+      // Total is sum of legacy + new device
+      expect(merged.claude.tokens).toBe(1800);
+    });
+
+    it('should handle device removal when client declared but no data', () => {
+      const existing: Record<string, ClientBreakdownData> = {};
+
+      // Two devices submit
+      const incomingA = { claude: makeClientData(1000, 10, 'claude-sonnet-4') };
+      const afterA = mergeClientBreakdowns(existing, incomingA, new Set(['claude']), 'device-A');
+      const incomingB = { claude: makeClientData(500, 5, 'claude-sonnet-4') };
+      const afterBoth = mergeClientBreakdowns(afterA, incomingB, new Set(['claude']), 'device-B');
+
+      // Device A submits with claude declared but no claude data
+      const incomingEmpty: Record<string, ClientBreakdownData> = {};
+      const afterRemove = mergeClientBreakdowns(afterBoth, incomingEmpty, new Set(['claude']), 'device-A');
+
+      // Device A removed, device B preserved
+      expect(afterRemove.claude.devices!['device-A']).toBeUndefined();
+      expect(afterRemove.claude.devices!['device-B'].tokens).toBe(500);
+      expect(afterRemove.claude.tokens).toBe(500);
+    });
+
+    it('should delete client entirely when last device is removed', () => {
+      const existing: Record<string, ClientBreakdownData> = {};
+
+      const incomingA = { claude: makeClientData(1000, 10, 'claude-sonnet-4') };
+      const afterA = mergeClientBreakdowns(existing, incomingA, new Set(['claude']), 'device-A');
+
+      // Device A submits with claude declared but no data
+      const incomingEmpty: Record<string, ClientBreakdownData> = {};
+      const afterRemove = mergeClientBreakdowns(afterA, incomingEmpty, new Set(['claude']), 'device-A');
+
+      expect(afterRemove.claude).toBeUndefined();
+    });
+
+    it('should aggregate models across devices correctly', () => {
+      const existing: Record<string, ClientBreakdownData> = {};
+
+      // Device A uses sonnet
+      const incomingA = { claude: makeClientData(1000, 10, 'claude-sonnet-4') };
+      const afterA = mergeClientBreakdowns(existing, incomingA, new Set(['claude']), 'device-A');
+
+      // Device B uses opus
+      const incomingB = { claude: makeClientData(500, 5, 'claude-opus-4') };
+      const afterBoth = mergeClientBreakdowns(afterA, incomingB, new Set(['claude']), 'device-B');
+
+      // Both models present at client level
+      expect(afterBoth.claude.models['claude-sonnet-4'].tokens).toBe(1000);
+      expect(afterBoth.claude.models['claude-opus-4'].tokens).toBe(500);
+      expect(afterBoth.claude.tokens).toBe(1500);
+    });
+
+    it('should handle multiple clients across multiple devices', () => {
+      const existing: Record<string, ClientBreakdownData> = {};
+
+      // Device A: claude + cursor
+      const incomingA = {
+        claude: makeClientData(1000, 10, 'claude-sonnet-4'),
+        cursor: makeClientData(300, 3, 'gpt-4o'),
+      };
+      const afterA = mergeClientBreakdowns(existing, incomingA, new Set(['claude', 'cursor']), 'device-A');
+
+      // Device B: only claude
+      const incomingB = { claude: makeClientData(500, 5, 'claude-sonnet-4') };
+      const afterBoth = mergeClientBreakdowns(afterA, incomingB, new Set(['claude']), 'device-B');
+
+      expect(afterBoth.claude.tokens).toBe(1500);
+      expect(afterBoth.cursor.tokens).toBe(300);
+      expect(afterBoth.cursor.devices!['device-A'].tokens).toBe(300);
     });
   });
 

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -272,7 +272,8 @@ export async function POST(request: Request) {
            const mergedClientBreakdown = mergeClientBreakdowns(
              existingClientBreakdown,
              incomingClientBreakdown,
-             submittedClients
+             submittedClients,
+             tokenRecord.tokenId
            );
           const dayTotals = recalculateDayTotals(mergedClientBreakdown);
           const modelBreakdown = buildModelBreakdown(mergedClientBreakdown);
@@ -288,8 +289,30 @@ export async function POST(request: Request) {
             modelBreakdown,
           });
         } else {
-          const dayTotals = recalculateDayTotals(incomingClientBreakdown);
-          const modelBreakdown = buildModelBreakdown(incomingClientBreakdown);
+          // Initialize with devices[tokenId] from the start to prevent
+          // double-counting on resubmit (avoids __legacy__ migration path)
+          const incomingWithDevices: Record<string, ClientBreakdownData> = {};
+          for (const [clientName, clientData] of Object.entries(incomingClientBreakdown)) {
+            incomingWithDevices[clientName] = {
+              ...clientData,
+              devices: {
+                [tokenRecord.tokenId]: {
+                  tokens: clientData.tokens,
+                  cost: clientData.cost,
+                  input: clientData.input,
+                  output: clientData.output,
+                  cacheRead: clientData.cacheRead,
+                  cacheWrite: clientData.cacheWrite,
+                  reasoning: Number(clientData.reasoning) || 0,
+                  messages: clientData.messages,
+                  models: { ...clientData.models },
+                },
+              },
+            };
+          }
+
+          const dayTotals = recalculateDayTotals(incomingWithDevices);
+          const modelBreakdown = buildModelBreakdown(incomingWithDevices);
 
           toInsert.push({
             submissionId,
@@ -299,7 +322,7 @@ export async function POST(request: Request) {
             inputTokens: dayTotals.inputTokens,
             outputTokens: dayTotals.outputTokens,
             timestampMs: incomingDay.timestampMs ?? null,
-            sourceBreakdown: incomingClientBreakdown,
+            sourceBreakdown: incomingWithDevices,
             modelBreakdown,
           });
         }

--- a/packages/frontend/src/lib/db/helpers.ts
+++ b/packages/frontend/src/lib/db/helpers.ts
@@ -13,6 +13,22 @@ export interface ModelBreakdownData {
   messages: number;
 }
 
+/**
+ * Per-device contribution data for cross-machine aggregation.
+ * Each device (identified by apiTokenId) tracks its own usage.
+ */
+export interface DeviceClientData {
+  tokens: number;
+  cost: number;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  reasoning: number;
+  messages: number;
+  models: Record<string, ModelBreakdownData>;
+}
+
 export interface ClientBreakdownData {
   tokens: number;
   cost: number;
@@ -23,6 +39,8 @@ export interface ClientBreakdownData {
   reasoning: number;
   messages: number;
   models: Record<string, ModelBreakdownData>;
+  /** Per-device contributions for cross-machine aggregation */
+  devices?: Record<string, DeviceClientData>;
   /** @deprecated Legacy field for backward compat - use models instead */
   modelId?: string;
 }
@@ -69,18 +87,152 @@ export function recalculateDayTotals(
   };
 }
 
+/**
+ * Recalculate a client's aggregate totals and models from its device-level data.
+ * Called after device contributions are added/removed to keep client totals consistent.
+ */
+function recalculateClientAggregate(client: ClientBreakdownData): void {
+  client.tokens = 0;
+  client.cost = 0;
+  client.input = 0;
+  client.output = 0;
+  client.cacheRead = 0;
+  client.cacheWrite = 0;
+  client.reasoning = 0;
+  client.messages = 0;
+  client.models = {};
+
+  if (!client.devices || Object.keys(client.devices).length === 0) return;
+
+  for (const deviceData of Object.values(client.devices)) {
+    client.tokens += Number(deviceData.tokens) || 0;
+    client.cost += Number(deviceData.cost) || 0;
+    client.input += Number(deviceData.input) || 0;
+    client.output += Number(deviceData.output) || 0;
+    client.cacheRead += Number(deviceData.cacheRead) || 0;
+    client.cacheWrite += Number(deviceData.cacheWrite) || 0;
+    client.reasoning += Number(deviceData.reasoning) || 0;
+    client.messages += Number(deviceData.messages) || 0;
+
+    for (const [modelId, modelData] of Object.entries(deviceData.models ?? {})) {
+      if (!client.models[modelId]) {
+        client.models[modelId] = {
+          tokens: Number(modelData.tokens) || 0,
+          cost: Number(modelData.cost) || 0,
+          input: Number(modelData.input) || 0,
+          output: Number(modelData.output) || 0,
+          cacheRead: Number(modelData.cacheRead) || 0,
+          cacheWrite: Number(modelData.cacheWrite) || 0,
+          reasoning: Number(modelData.reasoning) || 0,
+          messages: Number(modelData.messages) || 0,
+        };
+      } else {
+        const m = client.models[modelId];
+        m.tokens += Number(modelData.tokens) || 0;
+        m.cost += Number(modelData.cost) || 0;
+        m.input += Number(modelData.input) || 0;
+        m.output += Number(modelData.output) || 0;
+        m.cacheRead += Number(modelData.cacheRead) || 0;
+        m.cacheWrite += Number(modelData.cacheWrite) || 0;
+        m.reasoning += Number(modelData.reasoning) || 0;
+        m.messages += Number(modelData.messages) || 0;
+      }
+    }
+  }
+}
+
 export function mergeClientBreakdowns(
   existing: Record<string, ClientBreakdownData> | null | undefined,
   incoming: Record<string, ClientBreakdownData>,
-  incomingClients: Set<string>
+  incomingClients: Set<string>,
+  deviceId: string
 ): Record<string, ClientBreakdownData> {
-  const merged: Record<string, ClientBreakdownData> = { ...(existing || {}) };
+  const merged: Record<string, ClientBreakdownData> = JSON.parse(
+    JSON.stringify(existing || {})
+  );
 
   for (const clientName of incomingClients) {
     if (incoming[clientName]) {
-      merged[clientName] = { ...incoming[clientName] };
+      const incomingClient = incoming[clientName];
+
+      if (!merged[clientName]) {
+        merged[clientName] = {
+          tokens: 0,
+          cost: 0,
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          reasoning: 0,
+          messages: 0,
+          models: {},
+          devices: {},
+        };
+      }
+
+      // MIGRATION: If existing client has NO devices field (legacy data),
+      // preserve historical data under "__legacy__" device key
+      if (!merged[clientName].devices) {
+        const hasModels = merged[clientName].models &&
+                          Object.keys(merged[clientName].models).length > 0;
+
+        const legacyModels: Record<string, ModelBreakdownData> = hasModels
+          ? { ...merged[clientName].models }
+          : merged[clientName].modelId?.trim()
+            ? {
+                [merged[clientName].modelId!]: {
+                  tokens: merged[clientName].tokens,
+                  cost: merged[clientName].cost,
+                  input: merged[clientName].input,
+                  output: merged[clientName].output,
+                  cacheRead: merged[clientName].cacheRead,
+                  cacheWrite: merged[clientName].cacheWrite,
+                  reasoning: merged[clientName].reasoning || 0,
+                  messages: merged[clientName].messages,
+                },
+              }
+            : {};
+
+        merged[clientName].devices = {
+          "__legacy__": {
+            tokens: merged[clientName].tokens,
+            cost: merged[clientName].cost,
+            input: merged[clientName].input,
+            output: merged[clientName].output,
+            cacheRead: merged[clientName].cacheRead,
+            cacheWrite: merged[clientName].cacheWrite,
+            reasoning: merged[clientName].reasoning || 0,
+            messages: merged[clientName].messages,
+            models: legacyModels,
+          },
+        };
+      }
+
+      // REPLACE this device's contribution (handles resubmits correctly).
+      // Other devices' contributions are preserved.
+      merged[clientName].devices![deviceId] = {
+        tokens: incomingClient.tokens,
+        cost: incomingClient.cost,
+        input: incomingClient.input,
+        output: incomingClient.output,
+        cacheRead: incomingClient.cacheRead,
+        cacheWrite: incomingClient.cacheWrite,
+        reasoning: Number(incomingClient.reasoning) || 0,
+        messages: incomingClient.messages,
+        models: { ...(incomingClient.models ?? {}) },
+      };
+
+      recalculateClientAggregate(merged[clientName]);
     } else {
-      delete merged[clientName];
+      // Client declared in submission but has no data: remove this device's contribution
+      if (merged[clientName]?.devices?.[deviceId]) {
+        delete merged[clientName].devices![deviceId];
+        if (Object.keys(merged[clientName].devices!).length === 0) {
+          delete merged[clientName];
+        } else {
+          recalculateClientAggregate(merged[clientName]);
+        }
+      }
     }
   }
 

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -244,6 +244,26 @@ export const dailyBreakdown = pgTable(
             reasoning: number;
             messages: number;
           }>;
+          devices?: Record<string, {
+            tokens: number;
+            cost: number;
+            input: number;
+            output: number;
+            cacheRead: number;
+            cacheWrite: number;
+            reasoning: number;
+            messages: number;
+            models: Record<string, {
+              tokens: number;
+              cost: number;
+              input: number;
+              output: number;
+              cacheRead: number;
+              cacheWrite: number;
+              reasoning: number;
+              messages: number;
+            }>;
+          }>;
           modelId?: string;
         }
       >


### PR DESCRIPTION
## Summary
- Ports the device-level deduplication logic from PR #55 (`feat/cross-machine-aggregation-sync`) into the current `client`-based codebase structure
- Each client (e.g., "claude", "cursor") now tracks per-device contributions via a `devices` field keyed by API token ID
- On resubmit from the same device, only that device's data is replaced — other devices' data is preserved, preventing double-counting
- Legacy data (without device tracking) is gracefully migrated to a `__legacy__` device key on first merge
- Client-level totals and model breakdowns are recalculated from the sum of all devices

## Changes
- **`helpers.ts`**: Added `DeviceClientData` interface, `devices?` field on `ClientBreakdownData`, `recalculateClientAggregate` helper, and updated `mergeClientBreakdowns` to accept `deviceId` and perform device-level merge with legacy migration
- **`route.ts`**: INSERT path now initializes `devices[tokenId]` from the start; UPDATE path passes `tokenRecord.tokenId` to the merge function
- **`schema.ts`**: Added `devices?` to the `sourceBreakdown` JSONB type definition
- **`submit.test.ts`**: Added 8 new tests covering device-level dedup scenarios (resubmit, multi-device aggregation, legacy migration, device removal, cross-device model aggregation, multi-client multi-device)

## Test plan
- [x] All 28 tests pass (20 existing + 8 new device-level dedup tests)
- [x] No TypeScript errors in modified files
- [ ] Manual verification: submit from device A, submit from device B, verify totals = A + B
- [ ] Manual verification: resubmit from device A with updated data, verify totals = A' + B (not A + A' + B)
- [ ] Verify backward compatibility with existing data (no devices field) — should auto-migrate to `__legacy__`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-device usage tracking and dedup to client aggregation to support cross‑machine submissions. Resubmits now replace only that device’s data, preventing double counting and keeping totals accurate.

- **New Features**
  - Track per-device contributions in client breakdowns via devices[tokenId]; mergeClientBreakdowns now replaces only the submitting device and recalculates aggregates.
  - POST /api/submit initializes devices[tokenId] on insert and passes tokenId on update to avoid legacy paths and resubmit inflation.
  - Legacy data auto-migrates to a __legacy__ device on first merge; client totals and model breakdowns are rebuilt from device data.
  - Schema adds devices to sourceBreakdown; 8 tests cover resubmit, multi-device aggregation, legacy migration, device removal, and cross-device model sums.

<sup>Written for commit 556afd9df9abf3dcdf6c4245c85ad3d1f0eea0df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

