### PR TITLE
fix(qwen): use per-test TempDir for cleanup and change hotkey to avoid quit conflict

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -3068,6 +3068,7 @@ mod tests {
             openclaw: false,
             pi: false,
             kimi: false,
+            qwen: false,
         };
         assert_eq!(build_client_filter(flags), None);
     }
@@ -3085,6 +3086,7 @@ mod tests {
             openclaw: false,
             pi: false,
             kimi: false,
+            qwen: false,
         };
         assert_eq!(
             build_client_filter(flags),
@@ -3105,6 +3107,7 @@ mod tests {
             openclaw: false,
             pi: true,
             kimi: false,
+            qwen: false,
         };
         assert_eq!(
             build_client_filter(flags),
@@ -3129,11 +3132,12 @@ mod tests {
             openclaw: true,
             pi: true,
             kimi: true,
+            qwen: true,
         };
         let result = build_client_filter(flags);
         assert!(result.is_some());
         let sources = result.unwrap();
-        assert_eq!(sources.len(), 10);
+        assert_eq!(sources.len(), 11);
         assert!(sources.contains(&"opencode".to_string()));
         assert!(sources.contains(&"claude".to_string()));
         assert!(sources.contains(&"codex".to_string()));
@@ -3144,6 +3148,7 @@ mod tests {
         assert!(sources.contains(&"openclaw".to_string()));
         assert!(sources.contains(&"pi".to_string()));
         assert!(sources.contains(&"kimi".to_string()));
+        assert!(sources.contains(&"qwen".to_string()));
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/client_ui.rs
+++ b/crates/tokscale-cli/src/tui/client_ui.rs
@@ -48,7 +48,7 @@ pub const CLIENT_UI: [ClientUi; ClientId::COUNT] = [
     },
     ClientUi {
         display_name: "Qwen",
-        hotkey: 'q',
+        hotkey: 'w',
     },
 ];
 

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -633,7 +633,7 @@ mod tests {
     #[test]
     fn test_client_all() {
         let clients = ClientId::ALL;
-        assert_eq!(clients.len(), 10);
+        assert_eq!(clients.len(), 11);
         assert_eq!(clients[0], ClientId::OpenCode);
         assert_eq!(clients[1], ClientId::Claude);
         assert_eq!(clients[2], ClientId::Codex);

--- a/crates/tokscale-core/src/sessions/qwen.rs
+++ b/crates/tokscale-core/src/sessions/qwen.rs
@@ -43,7 +43,7 @@ const DEFAULT_PROVIDER: &str = "qwen";
 /// Extract session ID with fallback logic:
 /// 1. Use JSON session_id if present and non-empty
 /// 2. Otherwise derive from path including project name to avoid collisions
-/// 
+///
 /// Path format: ~/.qwen/projects/{project}/chats/{filename}.jsonl
 pub fn extract_session_id_with_fallback(path: &Path, json_session_id: Option<&str>) -> String {
     // Priority 1: Use JSON sessionId if present and non-empty
@@ -52,14 +52,14 @@ pub fn extract_session_id_with_fallback(path: &Path, json_session_id: Option<&st
             return id.to_string();
         }
     }
-    
+
     // Priority 2: Derive from path with project context
     // Extract project name from path structure: .../projects/{project}/chats/{file}.jsonl
     let filename = path
         .file_stem()
         .and_then(|n| n.to_str())
         .unwrap_or("unknown");
-    
+
     // Try to extract project name from the path
     let project_name = path
         .parent() // .../chats
@@ -67,7 +67,7 @@ pub fn extract_session_id_with_fallback(path: &Path, json_session_id: Option<&st
         .and_then(|p| p.file_name())
         .and_then(|n| n.to_str())
         .unwrap_or("unknown");
-    
+
     // Combine project and filename for unique session ID
     format!("{}-{}", project_name, filename)
 }
@@ -133,10 +133,8 @@ pub fn parse_qwen_file(path: &Path) -> Vec<UnifiedMessage> {
         let model = qwen_line.model.unwrap_or_else(|| DEFAULT_MODEL.to_string());
 
         // Resolve session ID: prefer JSON sessionId, fallback to path-derived
-        let line_session_id = extract_session_id_with_fallback(
-            path,
-            qwen_line.session_id.as_deref()
-        );
+        let line_session_id =
+            extract_session_id_with_fallback(path, qwen_line.session_id.as_deref());
 
         messages.push(UnifiedMessage::new(
             "qwen",

--- a/crates/tokscale-core/src/sessions/qwen/qwen_session_id_tests.rs
+++ b/crates/tokscale-core/src/sessions/qwen/qwen_session_id_tests.rs
@@ -5,17 +5,19 @@
 //! 2. Fallback to path-derived ID when sessionId is missing/empty
 //! 3. Path-derived ID includes project path to prevent cross-project collisions
 
-use super::{parse_qwen_file, extract_session_id_with_fallback};
+use super::{extract_session_id_with_fallback, parse_qwen_file};
 use std::io::Write;
-use tempfile::TempDir;
 use std::path::Path;
+use tempfile::TempDir;
 
 fn create_test_file_with_name(content: &str, filename: &str) -> (TempDir, std::path::PathBuf) {
     let temp_dir = tempfile::tempdir().unwrap();
 
     // Create a path that simulates the real Qwen structure
     // ~/.qwen/projects/{project}/chats/{filename}.jsonl
-    let path = temp_dir.path().join(format!("test_project/chats/{}.jsonl", filename));
+    let path = temp_dir
+        .path()
+        .join(format!("test_project/chats/{}.jsonl", filename));
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
 
     let mut file = std::fs::File::create(&path).unwrap();
@@ -29,9 +31,9 @@ fn create_test_file_with_name(content: &str, filename: &str) -> (TempDir, std::p
 fn test_session_id_from_json_when_present() {
     let content = r#"{"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:24:56.857Z", "sessionId": "abc123def456", "usageMetadata": {"promptTokenCount": 100, "candidatesTokenCount": 200, "thoughtsTokenCount": 10, "cachedContentTokenCount": 5}}"#;
     let (_dir, path) = create_test_file_with_name(content, "json_present");
-    
+
     let messages = parse_qwen_file(&path);
-    
+
     assert_eq!(messages.len(), 1);
     // Should use the sessionId from JSON, not the filename
     assert_eq!(messages[0].session_id, "abc123def456");
@@ -42,9 +44,9 @@ fn test_session_id_from_json_when_present() {
 fn test_session_id_fallback_when_empty_string() {
     let content = r#"{"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:24:56.857Z", "sessionId": "", "usageMetadata": {"promptTokenCount": 100, "candidatesTokenCount": 200, "thoughtsTokenCount": 10, "cachedContentTokenCount": 5}}"#;
     let (_dir, path) = create_test_file_with_name(content, "json_empty");
-    
+
     let messages = parse_qwen_file(&path);
-    
+
     assert_eq!(messages.len(), 1);
     // Should fallback to path-derived ID (not empty string)
     assert!(!messages[0].session_id.is_empty());
@@ -58,9 +60,9 @@ fn test_session_id_fallback_when_empty_string() {
 fn test_session_id_fallback_when_missing() {
     let content = r#"{"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:24:56.857Z", "usageMetadata": {"promptTokenCount": 100, "candidatesTokenCount": 200, "thoughtsTokenCount": 10, "cachedContentTokenCount": 5}}"#;
     let (_dir, path) = create_test_file_with_name(content, "json_missing");
-    
+
     let messages = parse_qwen_file(&path);
-    
+
     assert_eq!(messages.len(), 1);
     // Should fallback to path-derived ID
     assert!(!messages[0].session_id.is_empty());
@@ -71,9 +73,9 @@ fn test_session_id_fallback_when_missing() {
 fn test_session_id_fallback_when_null() {
     let content = r#"{"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:24:56.857Z", "sessionId": null, "usageMetadata": {"promptTokenCount": 100, "candidatesTokenCount": 200, "thoughtsTokenCount": 10, "cachedContentTokenCount": 5}}"#;
     let (_dir, path) = create_test_file_with_name(content, "json_null");
-    
+
     let messages = parse_qwen_file(&path);
-    
+
     assert_eq!(messages.len(), 1);
     // Should fallback to path-derived ID
     assert!(!messages[0].session_id.is_empty());
@@ -84,23 +86,23 @@ fn test_session_id_fallback_when_null() {
 #[test]
 fn test_cross_project_session_id_uniqueness() {
     let content = r#"{"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:24:56.857Z", "usageMetadata": {"promptTokenCount": 100, "candidatesTokenCount": 200, "thoughtsTokenCount": 10, "cachedContentTokenCount": 5}}"#;
-    
+
     // Create two files with same name in different projects
     let (_dir1, path1) = create_test_file_with_name(content, "session");
-    
+
     // Manually create a second file in a different project
     let temp_dir = tempfile::tempdir().unwrap();
     let path2 = temp_dir.path().join("other_project/chats/session.jsonl");
     std::fs::create_dir_all(path2.parent().unwrap()).unwrap();
     let mut file2 = std::fs::File::create(&path2).unwrap();
     file2.write_all(content.as_bytes()).unwrap();
-    
+
     let messages1 = parse_qwen_file(&path1);
     let messages2 = parse_qwen_file(&path2);
-    
+
     assert_eq!(messages1.len(), 1);
     assert_eq!(messages2.len(), 1);
-    
+
     // Session IDs should be different despite same filename
     assert_ne!(messages1[0].session_id, messages2[0].session_id);
 }
@@ -110,9 +112,9 @@ fn test_cross_project_session_id_uniqueness() {
 fn test_extract_session_id_with_fallback_uses_json_value() {
     let path = Path::new("/home/user/.qwen/projects/myapp/chats/abc123.jsonl");
     let json_session_id = Some("json_session_456");
-    
+
     let result = extract_session_id_with_fallback(path, json_session_id);
-    
+
     assert_eq!(result, "json_session_456");
 }
 
@@ -121,9 +123,9 @@ fn test_extract_session_id_with_fallback_uses_json_value() {
 fn test_extract_session_id_with_fallback_empty_uses_path() {
     let path = Path::new("/home/user/.qwen/projects/myapp/chats/abc123.jsonl");
     let json_session_id = Some("");
-    
+
     let result = extract_session_id_with_fallback(path, json_session_id);
-    
+
     // Should use path-derived ID containing project and filename
     assert!(result.contains("myapp") || result.contains("abc123"));
 }
@@ -133,9 +135,9 @@ fn test_extract_session_id_with_fallback_empty_uses_path() {
 fn test_extract_session_id_with_fallback_none_uses_path() {
     let path = Path::new("/home/user/.qwen/projects/myapp/chats/abc123.jsonl");
     let json_session_id: Option<&str> = None;
-    
+
     let result = extract_session_id_with_fallback(path, json_session_id);
-    
+
     // Should use path-derived ID containing project and filename
     assert!(result.contains("myapp") || result.contains("abc123"));
 }
@@ -145,10 +147,16 @@ fn test_extract_session_id_with_fallback_none_uses_path() {
 fn test_path_derived_session_id_includes_project() {
     let path = Path::new("/home/user/.qwen/projects/some-project/chats/chat-session.jsonl");
     let result = extract_session_id_with_fallback(path, None);
-    
+
     // Should include both project name and filename stem
-    assert!(result.contains("some-project"), "Session ID should contain project name");
-    assert!(result.contains("chat-session"), "Session ID should contain filename");
+    assert!(
+        result.contains("some-project"),
+        "Session ID should contain project name"
+    );
+    assert!(
+        result.contains("chat-session"),
+        "Session ID should contain filename"
+    );
 }
 
 /// Test 10: Multi-turn messages within same file share the same session ID
@@ -157,9 +165,9 @@ fn test_multi_turn_same_session_id() {
     let content = r#"{"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:24:56.857Z", "sessionId": "shared_session", "usageMetadata": {"promptTokenCount": 100, "candidatesTokenCount": 200, "thoughtsTokenCount": 10, "cachedContentTokenCount": 5}}
 {"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:25:00.000Z", "sessionId": "shared_session", "usageMetadata": {"promptTokenCount": 300, "candidatesTokenCount": 400, "thoughtsTokenCount": 20, "cachedContentTokenCount": 10}}"#;
     let (_dir, path) = create_test_file_with_name(content, "multi");
-    
+
     let messages = parse_qwen_file(&path);
-    
+
     assert_eq!(messages.len(), 2);
     // Both messages should have the same session ID from JSON
     assert_eq!(messages[0].session_id, "shared_session");
@@ -173,14 +181,18 @@ fn test_mixed_session_id_in_file() {
 {"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:25:00.000Z", "usageMetadata": {"promptTokenCount": 300, "candidatesTokenCount": 400, "thoughtsTokenCount": 20, "cachedContentTokenCount": 10}}
 {"type": "assistant", "model": "qwen3.5-plus", "timestamp": "2026-02-23T14:26:00.000Z", "sessionId": "", "usageMetadata": {"promptTokenCount": 500, "candidatesTokenCount": 600, "thoughtsTokenCount": 30, "cachedContentTokenCount": 15}}"#;
     let (_dir, path) = create_test_file_with_name(content, "mixed");
-    
+
     let messages = parse_qwen_file(&path);
-    
+
     assert_eq!(messages.len(), 3);
     // First message uses JSON sessionId
     assert_eq!(messages[0].session_id, "valid_id");
     // Second message (no sessionId) uses fallback
-    assert!(messages[1].session_id.contains("mixed") || messages[1].session_id.contains("test_project"));
+    assert!(
+        messages[1].session_id.contains("mixed") || messages[1].session_id.contains("test_project")
+    );
     // Third message (empty sessionId) uses fallback
-    assert!(messages[2].session_id.contains("mixed") || messages[2].session_id.contains("test_project"));
+    assert!(
+        messages[2].session_id.contains("mixed") || messages[2].session_id.contains("test_project")
+    );
 }


### PR DESCRIPTION
## Summary

Follow-up to #236 — fixes two issues flagged during review:

- **Test temp directory leak**: The `create_test_file_with_name` helper in `qwen_session_id_tests.rs` used `NamedTempFile` + `fs::copy` into a shared `test_project/` directory under the system temp root. Only the `NamedTempFile` was cleaned up on drop — the copied files and directory tree were leaked. Replaced with a per-test `TempDir` that owns the entire directory structure and auto-cleans on drop. This matches the established pattern used by other session tests (`opencode.rs`, `openclaw.rs`, `kimi.rs`).

- **Hotkey `'q'` conflicts with quit**: Pressing `q` outside the source picker dialog quits the TUI (`app.rs` line 275), making Qwen's toggle unreachable as a standalone key — unlike digits `1-9, 0` which are inert outside the dialog. Changed to `'w'` (mnemonic: Q**w**en).

Also adds the missing `qwen` field to `ClientFlags` test constructors and updates count assertions from 10 → 11.

## Test Results
- `tokscale-core`: 246 passed
- `tokscale-cli`: 65 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes leaked temp files in Qwen session tests and switches the Qwen hotkey to avoid accidentally quitting the TUI.

- **Bug Fixes**
  - Use a per-test TempDir in qwen_session_id_tests to fully clean up test files and directories.
  - Change Qwen toggle hotkey from 'q' to 'w' to avoid conflict with the global quit key outside the source picker.
  - Include the qwen flag in client test constructors and update client lists/assertions from 10 to 11.

<sup>Written for commit 97d028a9c45c49e392a4bfae8efd4a38c0eb904f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

