### PR TITLE
ci(fmt): auto-fix and commit formatting issues on PRs

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -88,8 +88,8 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add -A
           git diff --staged --quiet || git commit -m "style: cargo fmt [skip ci]"
-          git pull --rebase
-          git push
+          git pull --rebase origin "${{ github.head_ref }}"
+          git push origin "HEAD:${{ github.head_ref }}"
 
   coverage:
     name: Code Coverage


### PR DESCRIPTION
## Summary
- When `cargo fmt --check` fails on a PR, the CI now automatically runs `cargo fmt`, commits the fix, and pushes it back — instead of just failing

## How it works

| Step | What happens |
|------|-------------|
| 1. **Check** | `cargo fmt --all -- --check` runs as before |
| 2. **Fix** | If check fails on a PR, runs `cargo fmt --all` |
| 3. **Commit** | Commits as `github-actions[bot]` with message `style: cargo fmt [skip ci]` |
| 4. **Push** | Pushes directly to the PR branch |

## Key details
- **PR-only**: Auto-fix only triggers on `pull_request` events (pushes to `main`/`develop` still just fail — those should already be clean)
- **`[skip ci]`**: The fix commit skips CI to avoid infinite loops
- **`contents: write`**: Added permission so the bot can push
- **`ref: github.head_ref`**: Checks out the actual PR branch (not the merge commit) so the push goes to the right place
- **No-op safe**: `git diff --staged --quiet ||` guard prevents empty commits

## Why
Just had this exact scenario on PR #257 — a `cargo fmt` failure that required a manual `style: cargo fmt` commit. This automates that away.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically fixes Rust formatting on same-repo PRs. If the format check fails, CI runs cargo fmt, commits the fix, and pushes it to the PR branch to avoid manual follow-ups.

- **New Features**
  - Runs cargo fmt --all when --check fails, then commits and pushes as github-actions[bot] with "style: cargo fmt [skip ci]".
  - Limits auto-fix to same-repo PRs; push events and fork PRs fail cleanly.
  - Uses contents: write, checks out the PR branch only when safe, pulls with rebase, pushes to an explicit remote/branch (HEAD:${{ github.head_ref }}), and skips empty commits.

<sup>Written for commit 6a5be3d4f15bcb5c601627038f81554a9d8a7ace. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

