### PR TITLE
fix(cli): restore star prompt caching from v1 and fix gh API command

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -2474,7 +2474,9 @@ fn save_star_cache(username: &str, has_starred: bool) {
     if !has_starred {
         return;
     }
-    let Some(path) = star_cache_path() else { return };
+    let Some(path) = star_cache_path() else {
+        return;
+    };
     let now = chrono::Utc::now().to_rfc3339();
     let cache = StarCache {
         username: username.to_string(),
@@ -2531,7 +2533,10 @@ fn prompt_star_repo(username: &str) -> Result<()> {
         "{}",
         "  Starring bunx tokscale@latest helps others discover the project.\n".bright_black()
     );
-    print!("{}", "  \u{2b50} Would you like to star tokscale? (Y/n): ".white());
+    print!(
+        "{}",
+        "  \u{2b50} Would you like to star tokscale? (Y/n): ".white()
+    );
     io::stdout().flush()?;
 
     let mut input = String::new();
@@ -2557,7 +2562,10 @@ fn prompt_star_repo(username: &str) -> Result<()> {
         .status();
     match status {
         Ok(s) if s.success() => {
-            println!("{}", "  \u{2713} Starred! Thank you for your support.\n".green());
+            println!(
+                "{}",
+                "  \u{2713} Starred! Thank you for your support.\n".green()
+            );
             save_star_cache(username, true);
         }
         _ => {


### PR DESCRIPTION
## Summary
- Restores v1-compatible star prompt caching that was lost in the v2 Rust rewrite
- Fixes broken `gh repo star` command (replaced with correct `gh api --method PUT`)
- Updates prompt text to reference `bunx tokscale@latest`

## What's Changed

### Star prompt caching (v1 parity)
- Cache file: `~/.config/tokscale/star-cache.json` (same path + schema as v1)
- Per-username caching — different GitHub users on same machine get separate state
- Only `hasStarred=true` is cached; declines are never cached (re-prompts next time)
- Users who already starred in v1 will be recognized without re-prompting

### Flow
1. Check local `star-cache.json` — if starred, skip entirely (no network call)
2. Check `gh` CLI availability
3. Query `gh api /user/starred/junhoyeo/tokscale` — if already starred, cache and skip
4. Prompt user with `(Y/n)` default-yes (matching v1 UX)
5. Star via `gh api --silent --method PUT /user/starred/junhoyeo/tokscale`

### Bug fixes
- `gh repo star junhoyeo/tokscale` → `gh api --method PUT /user/starred/junhoyeo/tokscale` (the former is not a valid gh command; this was fixed in v1 via cad45ee)

### Text update
- `"Please consider starring tokscale on GitHub!"` → `"Starring bunx tokscale@latest helps others discover the project."`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores v1-style star prompt caching and fixes the GitHub CLI star command, reducing unnecessary prompts and making starring reliable. Users who starred in v1 are recognized automatically.

- **New Features**
  - Restore cache at ~/.config/tokscale/star-cache.json (v1 schema), per-username; only cache hasStarred=true.
  - Skip network when cache says starred; default-yes (Y/n) prompt.
  - Updated prompt copy to reference bunx tokscale@latest.

- **Bug Fixes**
  - Replace invalid gh repo star with gh api --method PUT /user/starred/junhoyeo/tokscale.
  - Check existing stars via gh api /user/starred/junhoyeo/tokscale and cache on success.

<sup>Written for commit 514393bc147967942f911e7fcf245ca29c0b9591. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

