### PR TITLE
fix(cache): subset matching for new clients + consolidate lint CI

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -18,19 +18,22 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  clippy:
-    name: Clippy
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
+        with:
+          # Check out the PR branch for same-repo PRs so we can push auto-fixes back
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || '' }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
-
+          components: clippy, rustfmt
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
@@ -40,56 +43,36 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: clippy-${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          key: lint-${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            clippy-${{ runner.os }}-cargo-
+            lint-${{ runner.os }}-cargo-
 
-      - name: Run Clippy
-        run: cargo clippy --workspace --all-features -- -D warnings
-
-  fmt:
-    name: Format Check
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          # Only check out the PR branch for same-repo PRs (forks use default merge ref)
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || '' }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-
-      - name: Check formatting
-        id: fmt-check
+      - name: Auto-fix lint issues
+        id: autofix
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
-          if ! cargo fmt --all -- --check; then
-            # Auto-fix only for same-repo PRs; fail hard for pushes and fork PRs
-            if [ "${{ github.event_name }}" != "pull_request" ] || [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
-              exit 1
-            fi
-            echo "needs_fix=true" >> $GITHUB_OUTPUT
+          # Apply machine-fixable clippy lints
+          cargo clippy --fix --workspace --all-features --allow-dirty --allow-staged 2>&1 || true
+          # Apply formatting
+          cargo fmt --all
+          # Check if anything changed
+          if ! git diff --quiet; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Apply formatting fix
-        if: steps.fmt-check.outputs.needs_fix == 'true'
-        run: cargo fmt --all
-
-      - name: Commit formatting fix
-        if: steps.fmt-check.outputs.needs_fix == 'true'
+      - name: Commit auto-fixes
+        if: steps.autofix.outputs.has_changes == 'true'
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add -A
-          git diff --staged --quiet || git commit -m "style: cargo fmt [skip ci]"
+          git diff --staged --quiet || git commit -m "style: auto-fix lint issues [skip ci]"
           git pull --rebase origin "${{ github.head_ref }}"
           git push origin "HEAD:${{ github.head_ref }}"
+      - name: Run Clippy (strict)
+        run: cargo clippy --workspace --all-features -- -D warnings
+      - name: Check formatting (strict)
+        run: cargo fmt --all -- --check
 
   coverage:
     name: Code Coverage

--- a/crates/tokscale-cli/src/tui/cache.rs
+++ b/crates/tokscale-cli/src/tui/cache.rs
@@ -381,8 +381,8 @@ pub fn load_cache(enabled_clients: &HashSet<ClientId>, include_synthetic: bool) 
 /// Determine how the cached client set relates to the currently enabled set.
 ///
 /// - `Exact`    — same clients, same synthetic flag
-/// - `Subset`   — cached clients ⊆ enabled clients (e.g. update added a new client)
-///                AND cached doesn't carry data the user doesn't want
+/// - `Subset`   — cached clients ⊆ enabled clients (e.g. update added a new client),
+///   and cached doesn't carry data the user doesn't want
 /// - `Mismatch` — anything else (superset, disjoint, unwanted synthetic data)
 fn check_client_match(
     enabled_clients: &HashSet<ClientId>,


### PR DESCRIPTION
## Summary

### Cache subset matching
- When a tokscale update adds new client support (e.g., 12→13 clients), the TUI cache now returns **Stale** instead of **Miss**, showing the old cached data immediately while background refresh fetches the full set
- Replaces strict `clients_match()` equality with `check_client_match()` that returns `ClientMatch::Exact`, `Subset`, or `Mismatch`
- **Subset logic**: if cached clients ⊆ enabled clients (new clients added), treat as Stale; if cached clients ⊄ enabled clients (removed or changed), treat as Miss
- Synthetic flag handling preserved: cached `include_synthetic=true` when user wants `false` → Mismatch (don't show unwanted synthetic data)
- 9 unit tests covering exact match, subset (new client), subset (new synthetic), superset mismatch, disjoint, unwanted synthetic, exact with synthetic, combined new client + synthetic, and empty cache scenarios

### Consolidate lint CI
- Merged separate **Clippy** and **Format Check** jobs into a single **Lint** job
- Auto-fix: on same-repo PRs, runs `cargo clippy --fix` + `cargo fmt`, auto-commits fixes back to the branch
- Strict check: still fails hard on unfixable lint/format issues (pushes and fork PRs fail immediately)
- Fixed `clippy::doc_overindented_list_items` lint in `tui/cache.rs`