### PR TITLE
ci: grant write permissions to coverage job for badge push

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -95,6 +95,8 @@ jobs:
     name: Code Coverage
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- The `coverage` job in `test_coverage.yml` was failing with a 403 when pushing the coverage badge because it lacked write permissions to the repo contents.
- Adds `permissions: contents: write` to the `coverage` job so the badge commit can be pushed.

All 327 tests pass locally (262 unit + 65 integration).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grant write permissions to the coverage job so it can push the coverage badge. Fixes the 403 error that blocked badge updates in .github/workflows/test_coverage.yml.

<sup>Written for commit ae45c8c76eee8faf15081f8f01741c465544a4fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

