### PR TITLE
docs: update v2 note — v2 is shipped, not upcoming

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -10,7 +10,7 @@
 
 > [!TIP]
 >
-> **v2（ratatui リライト + Windows サポート）近日公開！** <br />
+> **v2 リリース — ネイティブ Rust TUI、クロスプラットフォーム対応など。** <br />
 > 毎週新しいオープンソースプロジェクトを公開しています。お見逃しなく。
 >
 > | [<img alt="GitHub Follow" src="https://img.shields.io/github/followers/junhoyeo?style=flat-square&logo=github&labelColor=black&color=24292f" width="156px" />](https://github.com/junhoyeo) | GitHubで[@junhoyeo](https://github.com/junhoyeo)をフォローして、他のプロジェクトもチェックしてください。AI、インフラ、その他様々な分野で開発しています。 |

--- a/README.ko.md
+++ b/README.ko.md
@@ -10,7 +10,7 @@
 
 > [!TIP]
 >
-> **v2 (ratatui 리라이트 + Windows 지원) 출시 예정!** <br />
+> **v2 출시 — 네이티브 Rust TUI, 크로스 플랫폼 지원 등.** <br />
 > 저는 매주 새로운 오픈소스 프로젝트를 공개합니다. 놓치지 마세요.
 >
 > | [<img alt="GitHub Follow" src="https://img.shields.io/github/followers/junhoyeo?style=flat-square&logo=github&labelColor=black&color=24292f" width="156px" />](https://github.com/junhoyeo) | GitHub에서 [@junhoyeo](https://github.com/junhoyeo)를 팔로우하고 더 많은 프로젝트를 만나보세요. AI, 인프라 등 다양한 분야를 다룹니다. |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 > [!TIP]
 >
-> v2 (ratatui rewrite + windows support) is upcoming! <br />
+> v2 is here — native Rust TUI, cross-platform support, and more. <br />
 > I drop new open-source work every week. Don't miss the next one.
 >
 > | [<img alt="GitHub Follow" src="https://img.shields.io/github/followers/junhoyeo?style=flat-square&logo=github&labelColor=black&color=24292f" width="156px" />](https://github.com/junhoyeo) | Follow [@junhoyeo](https://github.com/junhoyeo) on GitHub for more projects. Hacking on AI, infra, and everything in between. |

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -10,7 +10,7 @@
 
 > [!TIP]
 >
-> **v2（ratatui 重写 + Windows 支持）即将推出！** <br />
+> **v2 已发布 — 原生 Rust TUI、跨平台支持等。** <br />
 > 我每周都会发布新的开源项目。不要错过下一个。
 >
 > | [<img alt="GitHub Follow" src="https://img.shields.io/github/followers/junhoyeo?style=flat-square&logo=github&labelColor=black&color=24292f" width="156px" />](https://github.com/junhoyeo) | 在 GitHub 上关注 [@junhoyeo](https://github.com/junhoyeo) 获取更多项目。涉及 AI、基础设施等各个领域。 |


### PR DESCRIPTION
## Summary
- Update the v2 status note in all 4 READMEs (EN, KO, JA, ZH-CN) from "upcoming" to "shipped"
- v2 was released as v2.0.3 — the old note saying "v2 (ratatui rewrite + windows support) is upcoming!" was outdated

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the v2 status note in all four READMEs (EN, KO, JA, ZH-CN) to reflect that v2 is shipped. Notes v2.0.3 and highlights native Rust TUI and cross-platform support.

<sup>Written for commit dea8ef8f68c044a85ec5e6f56a59387d14661fa5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

