### PR TITLE
feat(tui): add today jump/highlight in daily view while keeping globa…

### DIFF
--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -312,6 +312,9 @@ impl App {
             KeyCode::Char('d') => {
                 self.set_sort(SortField::Date);
             }
+            KeyCode::Char('j') => {
+                self.jump_to_today();
+            }
             KeyCode::Char('p') => {
                 self.cycle_theme();
             }
@@ -477,6 +480,39 @@ impl App {
             "Sorted by {:?} {:?}",
             self.sort_field, self.sort_direction
         ));
+    }
+
+    fn jump_to_today(&mut self) {
+        if self.current_tab != Tab::Daily {
+            return;
+        }
+
+        let today = chrono::Local::now().date_naive();
+        let (today_index, total_len) = {
+            let sorted_daily = self.get_sorted_daily();
+            (
+                sorted_daily.iter().position(|d| d.date == today),
+                sorted_daily.len(),
+            )
+        };
+
+        if let Some(index) = today_index {
+            self.selected_index = index;
+
+            if self.max_visible_items > 0 {
+                let max_scroll = total_len.saturating_sub(self.max_visible_items);
+                self.scroll_offset = index
+                    .saturating_sub(self.max_visible_items / 2)
+                    .min(max_scroll);
+            } else {
+                self.scroll_offset = 0;
+            }
+
+            self.selected_graph_cell = None;
+            self.set_status("Jumped to today's usage");
+        } else {
+            self.set_status("No usage recorded for today");
+        }
     }
 
     fn cycle_theme(&mut self) {

--- a/crates/tokscale-cli/src/tui/ui/daily.rs
+++ b/crates/tokscale-cli/src/tui/ui/daily.rs
@@ -1,3 +1,4 @@
+use chrono::Local;
 use ratatui::prelude::*;
 use ratatui::widgets::{
     Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, ScrollbarState, Table,
@@ -41,6 +42,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let selected_index = app.selected_index;
     let theme_accent = app.theme.accent;
     let theme_selection = app.theme.selection;
+    let today = Local::now().date_naive();
 
     let header_cells = if is_very_narrow {
         vec!["Date", "Cost"]
@@ -109,22 +111,41 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             let idx = i + start;
             let is_selected = idx == selected_index;
             let is_striped = idx % 2 == 1;
+            let is_today = day.date == today;
 
             let cells: Vec<Cell> = if is_very_narrow {
                 vec![
-                    Cell::from(day.date.format("%m/%d").to_string()),
+                    Cell::from(day.date.format("%m/%d").to_string()).style(if is_today {
+                        Style::default()
+                            .fg(Color::Yellow)
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default()
+                    }),
                     Cell::from(format_cost(day.cost)).style(Style::default().fg(Color::Green)),
                 ]
             } else if is_narrow {
                 vec![
-                    Cell::from(day.date.format("%Y-%m-%d").to_string()),
+                    Cell::from(day.date.format("%Y-%m-%d").to_string()).style(if is_today {
+                        Style::default()
+                            .fg(Color::Yellow)
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default()
+                    }),
                     Cell::from(format_tokens(day.tokens.total())),
                     Cell::from(format_cost(day.cost)).style(Style::default().fg(Color::Green)),
                 ]
             } else {
                 vec![
                     Cell::from(day.date.format("%Y-%m-%d").to_string())
-                        .style(Style::default().add_modifier(Modifier::BOLD)),
+                        .style(if is_today {
+                            Style::default()
+                                .fg(Color::Yellow)
+                                .add_modifier(Modifier::BOLD)
+                        } else {
+                            Style::default().add_modifier(Modifier::BOLD)
+                        }),
                     Cell::from(format_tokens(day.tokens.input))
                         .style(Style::default().fg(Color::Rgb(100, 200, 100))),
                     Cell::from(format_tokens(day.tokens.output))
@@ -140,6 +161,8 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
 
             let row_style = if is_selected {
                 Style::default().bg(theme_selection)
+            } else if is_today {
+                Style::default().bg(Color::Rgb(28, 42, 34))
             } else if is_striped {
                 Style::default().bg(Color::Rgb(20, 24, 30))
             } else {

--- a/crates/tokscale-cli/src/tui/ui/footer.rs
+++ b/crates/tokscale-cli/src/tui/ui/footer.rs
@@ -151,10 +151,12 @@ fn render_help_row(frame: &mut Frame, app: &App, area: Rect) {
     let is_very_narrow = app.is_very_narrow();
 
     let spans = if is_very_narrow {
-        vec![
+        let mut spans = vec![
             Span::styled("↑↓", Style::default().fg(app.theme.muted)),
             Span::styled("·", Style::default().fg(app.theme.muted)),
             Span::styled("←→", Style::default().fg(app.theme.muted)),
+            Span::styled("·", Style::default().fg(app.theme.muted)),
+            Span::styled("d/t/c", Style::default().fg(Color::Blue)),
             Span::styled("·", Style::default().fg(app.theme.muted)),
             Span::styled("[s]", Style::default().fg(Color::Cyan)),
             Span::styled("·", Style::default().fg(app.theme.muted)),
@@ -165,41 +167,53 @@ fn render_help_row(frame: &mut Frame, app: &App, area: Rect) {
             Span::styled("[r]", Style::default().fg(Color::Yellow)),
             Span::styled("·", Style::default().fg(app.theme.muted)),
             Span::styled("q", Style::default().fg(app.theme.muted)),
-        ]
+        ];
+        if app.current_tab == Tab::Daily {
+            spans.push(Span::styled("·", Style::default().fg(app.theme.muted)));
+            spans.push(Span::styled("j", Style::default().fg(Color::Yellow)));
+        }
+        spans
     } else {
-        vec![
+        let mut spans = vec![
             Span::styled(
                 "↑↓ scroll • ←→/tab view • ",
                 Style::default().fg(app.theme.muted),
             ),
-            Span::styled("[s:sources]", Style::default().fg(Color::Cyan)),
-            Span::styled(" ", Style::default()),
-            Span::styled(
-                format!("[g:{}]", app.group_by.borrow()),
-                Style::default().fg(Color::Cyan),
-            ),
+            Span::styled("[d/t/c:sort]", Style::default().fg(Color::Blue)),
             Span::styled(" • ", Style::default().fg(app.theme.muted)),
-            Span::styled(
-                format!("[p:{}]", app.theme.name.as_str()),
-                Style::default().fg(Color::Magenta),
-            ),
-            Span::styled(" ", Style::default()),
-            Span::styled(
-                if app.auto_refresh {
-                    format!("[R:auto {}s]", app.auto_refresh_interval.as_secs())
-                } else {
-                    "[R:auto off]".to_string()
-                },
-                Style::default().fg(if app.auto_refresh {
-                    Color::Green
-                } else {
-                    app.theme.muted
-                }),
-            ),
-            Span::styled(" • ", Style::default().fg(app.theme.muted)),
-            Span::styled("[r:refresh]", Style::default().fg(Color::Yellow)),
-            Span::styled(" • e • q", Style::default().fg(app.theme.muted)),
-        ]
+        ];
+        if app.current_tab == Tab::Daily {
+            spans.push(Span::styled("[j:today]", Style::default().fg(Color::Yellow)));
+            spans.push(Span::styled(" • ", Style::default().fg(app.theme.muted)));
+        }
+        spans.push(Span::styled("[s:sources]", Style::default().fg(Color::Cyan)));
+        spans.push(Span::styled(" ", Style::default()));
+        spans.push(Span::styled(
+            format!("[g:{}]", app.group_by.borrow()),
+            Style::default().fg(Color::Cyan),
+        ));
+        spans.push(Span::styled(" • ", Style::default().fg(app.theme.muted)));
+        spans.push(Span::styled(
+            format!("[p:{}]", app.theme.name.as_str()),
+            Style::default().fg(Color::Magenta),
+        ));
+        spans.push(Span::styled(" ", Style::default()));
+        spans.push(Span::styled(
+            if app.auto_refresh {
+                format!("[R:auto {}s]", app.auto_refresh_interval.as_secs())
+            } else {
+                "[R:auto off]".to_string()
+            },
+            Style::default().fg(if app.auto_refresh {
+                Color::Green
+            } else {
+                app.theme.muted
+            }),
+        ));
+        spans.push(Span::styled(" • ", Style::default().fg(app.theme.muted)));
+        spans.push(Span::styled("[r:refresh]", Style::default().fg(Color::Yellow)));
+        spans.push(Span::styled(" • e • q", Style::default().fg(app.theme.muted)));
+        spans
     };
 
     let line = Line::from(spans);


### PR DESCRIPTION
## Summary

  Improve Daily view discoverability without changing existing global sort behavior.

 ## What changed

  - Added j shortcut in TUI to jump directly to today's entry when on the Daily tab.
  - Highlighted today's row in Daily view (row background + bold yellow date) so it stands out immediately.
  - Updated footer help text to show sorting shortcuts (d/t/c) and j:today hint on Daily.

  ## Behavior notes

  - Sorting behavior remains unchanged and global across tabs (same as before).
  - Repeated d/t/c still toggles ascending/descending.
  - If no usage exists for today, pressing j shows No usage recorded for today.

  ## Testing

  - cargo test -p tokscale-cli tui::app::tests -- --nocapture
  - Result: passed (52 passed, 0 failed, 1 ignored)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a “j” shortcut to jump to today and highlighted today’s row in the Daily view for faster navigation, without changing global sort behavior.

- **New Features**
  - “j” on the Daily tab jumps to today’s usage.
  - Today’s row is highlighted (background + bold yellow date).
  - Footer help shows “d/t/c” sort and a “j:today” hint on Daily.

- **Behavior**
  - Sorting stays global across tabs; “d/t/c” still toggle direction.
  - If there’s no usage today, “j” shows a status message.

<sup>Written for commit eb6986c69a7f334ecee9cad7680b8c6a17da5fd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
