### PR TITLE
fix(tui): stabilize day breakdown render order to prevent flickering

### DIFF
--- a/crates/tokscale-cli/src/tui/ui/stats.rs
+++ b/crates/tokscale-cli/src/tui/ui/stats.rs
@@ -453,17 +453,18 @@ fn render_breakdown_panel(frame: &mut Frame, app: &App, area: Rect) {
     ];
 
     if let Some(daily) = daily_usage {
-        let mut grouped: std::collections::HashMap<
+        let mut grouped: std::collections::BTreeMap<
             String,
             Vec<(String, &crate::tui::data::DailyModelInfo)>,
-        > = std::collections::HashMap::new();
-        for (model_name, model_info) in &daily.models {
+        > = std::collections::BTreeMap::new();
+        let mut model_entries: Vec<_> = daily.models.iter().collect();
+        model_entries.sort_by_key(|(name, _)| (*name).clone());
+        for (model_name, model_info) in model_entries {
             grouped
                 .entry(model_info.client.clone())
                 .or_default()
                 .push((model_name.clone(), model_info));
         }
-
         for (client, mut models) in grouped {
             models.sort_by(|a, b| b.1.tokens.total().cmp(&a.1.tokens.total()));
 


### PR DESCRIPTION
## Summary

- Fix flickering in the Stats view "Day Breakdown" panel caused by `HashMap`'s non-deterministic iteration order
- Replace `HashMap` with `BTreeMap` for client grouping so client sections render in stable alphabetical order
- Sort model entries before grouping to ensure deterministic input order into the `BTreeMap`

## Root Cause

`render_breakdown_panel` in `stats.rs` had two levels of non-determinism:

1. **`daily.models`** (`HashMap<String, DailyModelInfo>`) — iterating this HashMap yielded models in random order each frame
2. **`grouped`** (local `HashMap<String, Vec<...>>`) — client groups appeared in random order each frame

The inner `models.sort_by()` correctly sorted models *within* a client group by token count, but the **client group order itself** was unstable.

## Fix

- Changed `grouped` from `HashMap` to `BTreeMap` → client sections now render in stable alphabetical order
- Added `model_entries.sort_by_key()` before grouping → models enter each group in deterministic order
- Inner `sort_by` (descending token count) preserved — models within a group still sort by usage
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix flickering in the Stats view Day Breakdown by making the render order deterministic. Client groups now render in stable alphabetical order, and models display consistently.

- **Bug Fixes**
  - Use BTreeMap for client grouping to stabilize section order.
  - Sort model entries by name before grouping for deterministic input.
  - Keep within-group sort by tokens (descending) intact.

<sup>Written for commit ba1702da5be59bef3ca8ca45a7dc6f6f96b52506. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

