### PR TITLE
fix(tui): use BTreeMap for DailyUsage.models to eliminate all HashMap flickering

### DIFF
--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 
 use anyhow::Result;
@@ -51,7 +51,7 @@ pub struct DailyUsage {
     pub date: NaiveDate,
     pub tokens: TokenBreakdown,
     pub cost: f64,
-    pub models: HashMap<String, DailyModelInfo>,
+    pub models: BTreeMap<String, DailyModelInfo>,
 }
 
 #[derive(Debug, Clone)]
@@ -434,7 +434,7 @@ impl DataLoader {
                     date,
                     tokens: TokenBreakdown::default(),
                     cost: 0.0,
-                    models: HashMap::new(),
+                    models: BTreeMap::new(),
                 });
 
                 daily_entry.tokens.input = daily_entry

--- a/crates/tokscale-cli/src/tui/ui/stats.rs
+++ b/crates/tokscale-cli/src/tui/ui/stats.rs
@@ -457,9 +457,7 @@ fn render_breakdown_panel(frame: &mut Frame, app: &App, area: Rect) {
             String,
             Vec<(String, &crate::tui::data::DailyModelInfo)>,
         > = std::collections::BTreeMap::new();
-        let mut model_entries: Vec<_> = daily.models.iter().collect();
-        model_entries.sort_by_key(|(name, _)| (*name).clone());
-        for (model_name, model_info) in model_entries {
+        for (model_name, model_info) in &daily.models {
             grouped
                 .entry(model_info.client.clone())
                 .or_default()


### PR DESCRIPTION
## Summary
- Structural root fix for HashMap non-deterministic iteration across all TUI views
- Changes `DailyUsage.models` from `HashMap<String, DailyModelInfo>` to `BTreeMap<String, DailyModelInfo>` in `data/mod.rs`
- Removes redundant `sort_by_key` in `stats.rs` since `BTreeMap` iterates in sorted order inherently

## Context
Follow-up to #279 which fixed the stats day breakdown panel specifically. This PR fixes the root cause structurally — all consumers of `DailyUsage.models` (stats breakdown, overview stacked bar chart, cache serialization) now get deterministic iteration order without needing per-site sorting.

## Audit Results
| File | Issue | Fix |
|------|-------|-----|
| `ui/overview.rs:56-64` | `d.models.iter()` for stacked bar chart — unsorted | ✅ Fixed by BTreeMap |
| `ui/stats.rs:460` | `daily.models` for tooltip panel — had manual sort | ✅ Sort removed (inherent) |
| `cache.rs:206` | `.collect()` for deserialization | ✅ Collects into BTreeMap |
| `data/mod.rs:599` | Lookup HashMap (not iterated for display) | ✅ Safe (unchanged) |

## Verification
- `cargo check` — clean compilation
- `cargo test` — 336 tests pass (271 unit + 65 integration), 0 failures
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use BTreeMap for DailyUsage.models to guarantee a stable iteration order and eliminate flickering in TUI views. Removed manual sorting in stats.rs; the day breakdown and overview stacked bar chart now render consistently.

<sup>Written for commit 327f214263cb9cc88fdd86b17c1b75a371134ab3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

