### PR TITLE
fix(tui): use Utc instead of Local for today comparison in Daily view

### DIFF
--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -487,7 +487,7 @@ impl App {
             return;
         }
 
-        let today = chrono::Local::now().date_naive();
+        let today = chrono::Utc::now().date_naive();
         let (today_index, total_len) = {
             let sorted_daily = self.get_sorted_daily();
             (

--- a/crates/tokscale-cli/src/tui/ui/daily.rs
+++ b/crates/tokscale-cli/src/tui/ui/daily.rs
@@ -1,4 +1,4 @@
-use chrono::Local;
+use chrono::Utc;
 use ratatui::prelude::*;
 use ratatui::widgets::{
     Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, ScrollbarState, Table,
@@ -42,7 +42,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let selected_index = app.selected_index;
     let theme_accent = app.theme.accent;
     let theme_selection = app.theme.selection;
-    let today = Local::now().date_naive();
+    let today = Utc::now().date_naive();
 
     let header_cells = if is_very_narrow {
         vec!["Date", "Cost"]

--- a/crates/tokscale-cli/src/tui/ui/daily.rs
+++ b/crates/tokscale-cli/src/tui/ui/daily.rs
@@ -138,14 +138,13 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                 ]
             } else {
                 vec![
-                    Cell::from(day.date.format("%Y-%m-%d").to_string())
-                        .style(if is_today {
-                            Style::default()
-                                .fg(Color::Yellow)
-                                .add_modifier(Modifier::BOLD)
-                        } else {
-                            Style::default().add_modifier(Modifier::BOLD)
-                        }),
+                    Cell::from(day.date.format("%Y-%m-%d").to_string()).style(if is_today {
+                        Style::default()
+                            .fg(Color::Yellow)
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().add_modifier(Modifier::BOLD)
+                    }),
                     Cell::from(format_tokens(day.tokens.input))
                         .style(Style::default().fg(Color::Rgb(100, 200, 100))),
                     Cell::from(format_tokens(day.tokens.output))

--- a/crates/tokscale-cli/src/tui/ui/footer.rs
+++ b/crates/tokscale-cli/src/tui/ui/footer.rs
@@ -183,10 +183,16 @@ fn render_help_row(frame: &mut Frame, app: &App, area: Rect) {
             Span::styled(" • ", Style::default().fg(app.theme.muted)),
         ];
         if app.current_tab == Tab::Daily {
-            spans.push(Span::styled("[j:today]", Style::default().fg(Color::Yellow)));
+            spans.push(Span::styled(
+                "[j:today]",
+                Style::default().fg(Color::Yellow),
+            ));
             spans.push(Span::styled(" • ", Style::default().fg(app.theme.muted)));
         }
-        spans.push(Span::styled("[s:sources]", Style::default().fg(Color::Cyan)));
+        spans.push(Span::styled(
+            "[s:sources]",
+            Style::default().fg(Color::Cyan),
+        ));
         spans.push(Span::styled(" ", Style::default()));
         spans.push(Span::styled(
             format!("[g:{}]", app.group_by.borrow()),
@@ -211,8 +217,14 @@ fn render_help_row(frame: &mut Frame, app: &App, area: Rect) {
             }),
         ));
         spans.push(Span::styled(" • ", Style::default().fg(app.theme.muted)));
-        spans.push(Span::styled("[r:refresh]", Style::default().fg(Color::Yellow)));
-        spans.push(Span::styled(" • e • q", Style::default().fg(app.theme.muted)));
+        spans.push(Span::styled(
+            "[r:refresh]",
+            Style::default().fg(Color::Yellow),
+        ));
+        spans.push(Span::styled(
+            " • e • q",
+            Style::default().fg(app.theme.muted),
+        ));
         spans
     };
 


### PR DESCRIPTION
## Summary

- Fix timezone mismatch in Daily view's "today" detection — `Local::now()` → `Utc::now()`
- `DailyUsage.date` values are derived from UTC timestamps via `timestamp_to_date()`, but PR #278 introduced `chrono::Local::now()` for the jump-to-today and highlight logic, causing mismatches for users in non-UTC timezones (e.g. after midnight local but still same UTC day, or vice versa)
- The rest of the TUI codebase (`build_contribution_graph`, `calculate_streaks`, `wrapped` command) consistently uses `Utc::now()` — this fix restores that consistency

## Changes

| File | Change |
|------|--------|
| `crates/tokscale-cli/src/tui/app.rs` | `jump_to_today()`: `chrono::Local::now().date_naive()` → `chrono::Utc::now().date_naive()` |
| `crates/tokscale-cli/src/tui/ui/daily.rs` | Import `use chrono::Utc` (was `Local`), today variable uses `Utc::now()` |

## Context

Discovered during review of #278. The underlying data pipeline in `tokscale-core` buckets all timestamps to dates using UTC (`timestamp_to_date()` in `sessions/mod.rs`), so any "is this today?" comparison must also use UTC to match.

## Timezone audit

Ran a full codebase audit to confirm no other instances of this bug:

- **No remaining `Local::now()` date comparisons** against UTC-bucketed data after this fix
- Two benign `Local::now()` calls remain in `wrapped.rs` (lines 164, 780) — these default the current year for wrapped generation, not date comparisons against daily data
- All other "today/streak/graph" logic (`main.rs`, `data/mod.rs`, `wrapped.rs`) already uses `Utc::now()` ✅

## Relation to #267

Issue #267 requests the *opposite* direction — using local timezone throughout the data pipeline so daily usage aligns with the user's wall clock. That's a larger change (est. 1-2 days) requiring:

1. A timezone policy layer at aggregation/filter boundaries (not a direct `timestamp_to_date` flip)
2. Updating all "today/week/month" shortcuts to use the same policy
3. Cache invalidation after policy change
4. Regression tests for timestamps near UTC midnight across multiple offsets

This PR is a **minimal consistency fix** for the current UTC-based system; #267 would be addressed separately as a feature.

## Verification

- `cargo test -p tokscale-cli tui::app::tests` — 52 passed, 0 failed
- LSP diagnostics clean on both changed files