### PR TITLE
fix: resolve truncated PR titles in release notes generation

### DIFF
--- a/scripts/generate-release-notes.ts
+++ b/scripts/generate-release-notes.ts
@@ -103,7 +103,7 @@ function resolveGitHubUsername(email: string, fallbackName: string): string {
 
 function findAssociatedPR(commitHash: string): PRInfo | null {
   const result = runJson<
-    Array<{ number: number; title: string; state: string; user?: { login?: string } }>
+    Array<{ number: number; title: string; state: string; merged_at?: string | null; user?: { login?: string } }>
   >(
     "gh",
     ["api", `repos/${REPO}/commits/${commitHash}/pulls`],
@@ -111,7 +111,7 @@ function findAssociatedPR(commitHash: string): PRInfo | null {
   );
   if (!result?.length) return null;
 
-  const pr = result.find((p) => p.state === "closed") ?? result[0];
+  const pr = result.find((p) => p.merged_at != null) ?? result.find((p) => p.state === "closed") ?? result[0];
   if (!pr?.number || !pr.user?.login) return null;
 
   let title = pr.title;
@@ -128,7 +128,7 @@ function findAssociatedPR(commitHash: string): PRInfo | null {
       const truncatedPrefix = title.slice(0, -1);
       title = lastSubject.startsWith(truncatedPrefix) ? lastSubject
         : firstSubject.startsWith(truncatedPrefix) ? firstSubject
-        : lastSubject;
+        : title;
     }
   }
 


### PR DESCRIPTION
## Summary
- Fixes release notes showing truncated PR titles with `…` (e.g., `feat(tui): add today jump/highlight in daily view while keeping globa…`)
- Two changes to `scripts/generate-release-notes.ts`:
  1. **Use commits API** instead of `gh pr list --search` — `repos/{repo}/commits/{hash}/pulls` reliably finds PRs by git history, not text search
  2. **Recover full titles** — when a PR title contains `…`, fetches the first commit's message from that PR to get the un-truncated text

## Root Cause
Contributors' PRs sometimes have truncated titles because GitHub auto-fills the PR title from the commit subject and truncates long ones with `…`. The old `gh pr list --search <hash>` also used unreliable text search that could miss PRs entirely, falling back to the (also truncated) commit subject.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release notes now show full PR titles and reliably link PRs from commit history. This avoids GitHub’s auto-truncated titles in releases.

- **Bug Fixes**
  - Resolve PRs via repos/{repo}/commits/{hash}/pulls, preferring merged PRs, then closed, otherwise the first result.
  - Recover full titles only when the title ends with "…": check first and last commit subjects for a match; if none, keep the original title.

<sup>Written for commit 03fddf0549d8532a08bffb70d6f9f7a6fce7b4a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

