### PR TITLE
fix(tui): handle mouse scroll events for list navigation

### DIFF
--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -368,34 +368,43 @@ impl App {
             return;
         }
 
-        if let MouseEventKind::Down(MouseButton::Left) = event.kind {
-            let x = event.column;
-            let y = event.row;
+        match event.kind {
+            MouseEventKind::Down(MouseButton::Left) => {
+                let x = event.column;
+                let y = event.row;
 
-            for area in &self.click_areas {
-                if x >= area.rect.x
-                    && x < area.rect.x + area.rect.width
-                    && y >= area.rect.y
-                    && y < area.rect.y + area.rect.height
-                {
-                    match &area.action {
-                        ClickAction::Tab(tab) => {
-                            self.current_tab = *tab;
-                            self.reset_selection();
+                for area in &self.click_areas {
+                    if x >= area.rect.x
+                        && x < area.rect.x + area.rect.width
+                        && y >= area.rect.y
+                        && y < area.rect.y + area.rect.height
+                    {
+                        match &area.action {
+                            ClickAction::Tab(tab) => {
+                                self.current_tab = *tab;
+                                self.reset_selection();
+                            }
+                            ClickAction::Sort(field) => {
+                                self.set_sort(*field);
+                            }
+                            ClickAction::GraphCell { week, day } => {
+                                self.selected_graph_cell = Some((*week, *day));
+                                self.stats_breakdown_total_lines = 0;
+                                self.selected_index = 0;
+                                self.scroll_offset = 0;
+                            }
                         }
-                        ClickAction::Sort(field) => {
-                            self.set_sort(*field);
-                        }
-                        ClickAction::GraphCell { week, day } => {
-                            self.selected_graph_cell = Some((*week, *day));
-                            self.stats_breakdown_total_lines = 0;
-                            self.selected_index = 0;
-                            self.scroll_offset = 0;
-                        }
+                        break;
                     }
-                    break;
                 }
             }
+            MouseEventKind::ScrollUp => {
+                self.move_selection_up();
+            }
+            MouseEventKind::ScrollDown => {
+                self.move_selection_down();
+            }
+            _ => {}
         }
     }
 
@@ -1468,7 +1477,7 @@ mod tests {
             modifiers: KeyModifiers::NONE,
         };
         app.handle_mouse_event(event);
-        assert_eq!(app.selected_index, 2);
+        assert_eq!(app.selected_index, 1);
     }
 
     #[test]
@@ -1483,7 +1492,7 @@ mod tests {
             modifiers: KeyModifiers::NONE,
         };
         app.handle_mouse_event(event);
-        assert_eq!(app.selected_index, 2);
+        assert_eq!(app.selected_index, 3);
     }
 
     // ── handle_resize ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Fix mouse wheel scrolling**: `handle_mouse_event()` only matched `MouseButton::Left` clicks, silently dropping `ScrollUp`/`ScrollDown` events. Refactored the `if let` to a `match` that delegates scroll events to `move_selection_up()`/`move_selection_down()`.
- **Fix scroll tests**: Updated `test_handle_mouse_scroll_up` and `test_handle_mouse_scroll_down` to assert the selected index actually changes (previously asserted it stayed the same, confirming the bug as "correct").

## What was broken

Mouse wheel scroll — `ScrollUp`/`ScrollDown` events were completely ignored by `handle_mouse_event()`, which only had an `if let` matching `MouseButton::Left` clicks.

## Changes

Single file: `crates/tokscale-cli/src/tui/app.rs`

```rust
// Before: only handled left clicks
if let MouseEventKind::Down(MouseButton::Left) = event.kind { ... }

// After: handles clicks + scroll
match event.kind {
    MouseEventKind::Down(MouseButton::Left) => { ... }
    MouseEventKind::ScrollUp => { self.move_selection_up(); }
    MouseEventKind::ScrollDown => { self.move_selection_down(); }
    _ => {}
}
```

## Builds on

PR #283 (`fix/stats-breakdown-scroll`) — includes those commits plus this scroll fix.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mouse wheel scrolling in the TUI list. Scrolling now moves the selection up and down as expected.

- **Bug Fixes**
  - Handle ScrollUp/ScrollDown in handle_mouse_event by matching event.kind and calling move_selection_up/down.
  - Update scroll tests to assert the selected index changes.

<sup>Written for commit 06bf497253f5c5b0e704dc603a818ad82615387f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

