### PR TITLE
fix: center CloseButton icon in BreakdownPanel

### DIFF
--- a/packages/frontend/src/components/BreakdownPanel.tsx
+++ b/packages/frontend/src/components/BreakdownPanel.tsx
@@ -62,6 +62,9 @@ const CloseButton = styled.button`
   flex: 0 0 auto;
   min-height: 44px;
   min-width: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
   &:hover {
     background-color: var(--color-btn-hover-bg);


### PR DESCRIPTION
## Summary
- Add `display: flex`, `align-items: center`, and `justify-content: center` to `CloseButton` in `BreakdownPanel`
- The button had `min-height`/`min-width` of 44px but no flexbox centering, so the SVG icon was not centered within the button

## Test plan
- [ ] Open the breakdown panel and verify the close button icon is centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Center the BreakdownPanel CloseButton icon by applying flexbox so the SVG sits correctly within the 44px button.

<sup>Written for commit 80c5aa9d094b831b9e47768ecf1f0ac357744e61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

