### PR TITLE
Fix panic in Stats tab when terminal height is small

### DIFF
--- a/crates/tokscale-cli/src/tui/ui/stats.rs
+++ b/crates/tokscale-cli/src/tui/ui/stats.rs
@@ -176,6 +176,10 @@ fn render_stats_panel(frame: &mut Frame, app: &App, area: Rect) {
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
+    if inner.height == 0 || inner.width == 0 {
+        return;
+    }
+
     let is_narrow = app.is_narrow();
     let graph = &app.data.graph;
 
@@ -243,6 +247,7 @@ fn render_stats_panel(frame: &mut Frame, app: &App, area: Rect) {
 
     let col1_width = if is_narrow { 36u16 } else { 60u16 };
     let col2_x = inner.x + col1_width;
+    let y_max = inner.y + inner.height;
 
     let mut y = inner.y;
 
@@ -280,6 +285,9 @@ fn render_stats_panel(frame: &mut Frame, app: &App, area: Rect) {
     );
 
     y += 1;
+    if y >= y_max {
+        return;
+    }
 
     let row2 = Line::from(vec![
         Span::styled("Sessions:", Style::default().fg(app.theme.muted)),
@@ -300,6 +308,9 @@ fn render_stats_panel(frame: &mut Frame, app: &App, area: Rect) {
     );
 
     y += 1;
+    if y >= y_max {
+        return;
+    }
 
     // Row 3: Current streak / Longest streak
     let streak_label = if is_narrow {
@@ -336,6 +347,9 @@ fn render_stats_panel(frame: &mut Frame, app: &App, area: Rect) {
     );
 
     y += 1;
+    if y >= y_max {
+        return;
+    }
 
     let active_label = if is_narrow { "Active:" } else { "Active days:" };
     let active_days_line = Line::from(vec![
@@ -352,6 +366,9 @@ fn render_stats_panel(frame: &mut Frame, app: &App, area: Rect) {
     );
 
     y += 2;
+    if y >= y_max {
+        return;
+    }
 
     let legend_spans = vec![
         Span::styled("Less ", Style::default().fg(app.theme.muted)),
@@ -372,6 +389,9 @@ fn render_stats_panel(frame: &mut Frame, app: &App, area: Rect) {
     );
 
     y += 2;
+    if y >= y_max {
+        return;
+    }
 
     if !is_narrow {
         let footer = Line::from(Span::styled(


### PR DESCRIPTION
## Summary
- Fixes a buffer overflow panic (`index outside of buffer`) that occurs when navigating to the Stats tab in terminals with limited height (e.g. 22 rows)
- The `render_stats_panel` function manually increments y-coordinates to render rows but never checks bounds. The Stats layout requests `Min(12) + Length(12)` = 24 rows in an area that may only have ~14 rows, so the stats panel gets a tiny allocation and unbounded y increments push rendering past the buffer edge
- Added `y >= y_max` bounds checks before each row render, and an early return when the inner area has zero dimensions

## Reproduction
1. Use a terminal with ~22 rows height
2. Run `tokscale`
3. Press Right arrow to navigate to the Stats tab
4. Panic: `index outside of buffer: the area is Rect { x: 0, y: 0, width: 189, height: 22 } but index is (1, 23)`

## Test plan
- [ ] Run `tokscale` in a small terminal (height ≤ 22) and navigate to Stats tab — no crash
- [ ] Run `tokscale` in a normal-sized terminal — Stats tab renders identically to before
- [ ] Resize terminal while on Stats tab — graceful degradation, no panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a buffer overflow panic in the Stats tab on short terminals by adding y-bound checks and early returns. Rendering now stops when out of vertical space and exits if the inner area is zero-size.

- **Bug Fixes**
  - Add y_max and y >= y_max checks after each y increment; early-return when inner.width/height == 0.
  - No visual changes on normal terminal sizes; graceful degradation on small heights.

<sup>Written for commit 671ddebc4e4af2a3a8111e0056f9f92338f52a91. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

