### PR TITLE
fix: use local dates for daily usage bucketing

### DIFF
--- a/crates/tokscale-cli/src/commands/wrapped.rs
+++ b/crates/tokscale-cli/src/commands/wrapped.rs
@@ -1,7 +1,7 @@
 use crate::{auth, cursor};
 use ab_glyph::{point, Font, FontArc, GlyphId, PxScale, ScaleFont};
 use anyhow::{Context, Result};
-use chrono::{Datelike, Duration, Local, NaiveDate, Utc};
+use chrono::{Datelike, Duration, Local, NaiveDate};
 use colored::Colorize;
 use image::{imageops::FilterType, Rgba, RgbaImage};
 use imageproc::drawing::draw_filled_circle_mut;
@@ -1254,18 +1254,22 @@ fn calculate_intensity(cost: f64, max_cost: f64) -> u8 {
 }
 
 fn calculate_streaks(sorted_dates: &[String]) -> (i32, i32) {
+    let today = Local::now().date_naive().format("%Y-%m-%d").to_string();
+    calculate_streaks_with_today(sorted_dates, &today)
+}
+
+fn calculate_streaks_with_today(sorted_dates: &[String], today: &str) -> (i32, i32) {
     if sorted_dates.is_empty() {
         return (0, 0);
     }
 
-    let today = Utc::now().date_naive().format("%Y-%m-%d").to_string();
     let mut current_streak = 0;
     let mut longest_streak = 0;
     let mut streak = 1;
 
     for index in (0..sorted_dates.len()).rev() {
         if index == sorted_dates.len() - 1 {
-            let days_diff = date_diff_days(&sorted_dates[index], &today);
+            let days_diff = date_diff_days(&sorted_dates[index], today);
             if days_diff <= 1 {
                 current_streak = 1;
             } else {
@@ -2086,6 +2090,18 @@ mod tests {
         let dates = vec!["2024-01-01".to_string()];
         let (_current, longest) = calculate_streaks(&dates);
         assert_eq!(longest, 1);
+    }
+
+    #[test]
+    fn test_calculate_streaks_current_uses_provided_today() {
+        let dates = vec![
+            "2026-03-01".to_string(),
+            "2026-03-02".to_string(),
+            "2026-03-03".to_string(),
+        ];
+        let (current, longest) = calculate_streaks_with_today(&dates, "2026-03-03");
+        assert_eq!(current, 3);
+        assert_eq!(longest, 3);
     }
 
     // ========== date_diff_days tests ==========

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1009,30 +1009,44 @@ fn build_date_filter(
     since: Option<String>,
     until: Option<String>,
 ) -> (Option<String>, Option<String>) {
-    use chrono::{Datelike, Duration, Utc};
+    build_date_filter_for_date(
+        today,
+        week,
+        month,
+        since,
+        until,
+        chrono::Local::now().date_naive(),
+    )
+}
 
-    // Use UTC for date shortcuts to match TypeScript behavior
-    // TS uses: new Date().toISOString().split("T")[0]
+fn build_date_filter_for_date(
+    today: bool,
+    week: bool,
+    month: bool,
+    since: Option<String>,
+    until: Option<String>,
+    current_date: chrono::NaiveDate,
+) -> (Option<String>, Option<String>) {
+    use chrono::{Datelike, Duration};
+
     if today {
-        let date = Utc::now().format("%Y-%m-%d").to_string();
+        let date = current_date.format("%Y-%m-%d").to_string();
         return (Some(date.clone()), Some(date));
     }
 
     if week {
-        let end = Utc::now();
-        let start = end - Duration::days(6);
+        let start = current_date - Duration::days(6);
         return (
             Some(start.format("%Y-%m-%d").to_string()),
-            Some(end.format("%Y-%m-%d").to_string()),
+            Some(current_date.format("%Y-%m-%d").to_string()),
         );
     }
 
     if month {
-        let now = Utc::now();
-        let start = now.with_day(1).unwrap_or(now);
+        let start = current_date.with_day(1).unwrap_or(current_date);
         return (
             Some(start.format("%Y-%m-%d").to_string()),
-            Some(now.format("%Y-%m-%d").to_string()),
+            Some(current_date.format("%Y-%m-%d").to_string()),
         );
     }
 
@@ -1060,6 +1074,26 @@ fn get_date_range_label(
     until: &Option<String>,
     year: &Option<String>,
 ) -> Option<String> {
+    get_date_range_label_for_date(
+        today,
+        week,
+        month,
+        since,
+        until,
+        year,
+        chrono::Local::now().date_naive(),
+    )
+}
+
+fn get_date_range_label_for_date(
+    today: bool,
+    week: bool,
+    month: bool,
+    since: &Option<String>,
+    until: &Option<String>,
+    year: &Option<String>,
+    current_date: chrono::NaiveDate,
+) -> Option<String> {
     if today {
         return Some("Today".to_string());
     }
@@ -1067,8 +1101,7 @@ fn get_date_range_label(
         return Some("Last 7 days".to_string());
     }
     if month {
-        let now = chrono::Utc::now();
-        return Some(now.format("%B %Y").to_string());
+        return Some(current_date.format("%B %Y").to_string());
     }
     if let Some(y) = year {
         return Some(y.clone());
@@ -3470,6 +3503,30 @@ mod tests {
     }
 
     #[test]
+    fn test_build_date_filter_today_uses_provided_local_date() {
+        let today = chrono::NaiveDate::from_ymd_opt(2026, 3, 8).unwrap();
+        let (since, until) = build_date_filter_for_date(true, false, false, None, None, today);
+        assert_eq!(since, Some("2026-03-08".to_string()));
+        assert_eq!(until, Some("2026-03-08".to_string()));
+    }
+
+    #[test]
+    fn test_build_date_filter_week_uses_provided_local_date() {
+        let today = chrono::NaiveDate::from_ymd_opt(2026, 3, 8).unwrap();
+        let (since, until) = build_date_filter_for_date(false, true, false, None, None, today);
+        assert_eq!(since, Some("2026-03-02".to_string()));
+        assert_eq!(until, Some("2026-03-08".to_string()));
+    }
+
+    #[test]
+    fn test_build_date_filter_month_uses_provided_local_date() {
+        let today = chrono::NaiveDate::from_ymd_opt(2026, 3, 8).unwrap();
+        let (since, until) = build_date_filter_for_date(false, false, true, None, None, today);
+        assert_eq!(since, Some("2026-03-01".to_string()));
+        assert_eq!(until, Some("2026-03-08".to_string()));
+    }
+
+    #[test]
     fn test_normalize_year_filter_with_year() {
         let year = normalize_year_filter(false, false, false, Some("2024".to_string()));
         assert_eq!(year, Some("2024".to_string()));
@@ -3610,6 +3667,13 @@ mod tests {
     fn test_get_date_range_label_week() {
         let label = get_date_range_label(false, true, false, &None, &None, &None);
         assert_eq!(label, Some("Last 7 days".to_string()));
+    }
+
+    #[test]
+    fn test_get_date_range_label_month_uses_provided_local_date() {
+        let today = chrono::NaiveDate::from_ymd_opt(2026, 3, 1).unwrap();
+        let label = get_date_range_label_for_date(false, false, true, &None, &None, &None, today);
+        assert_eq!(label, Some("March 2026".to_string()));
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -549,7 +549,7 @@ impl App {
             return;
         }
 
-        let today = chrono::Utc::now().date_naive();
+        let today = chrono::Local::now().date_naive();
         let (today_index, total_len) = {
             let sorted_daily = self.get_sorted_daily();
             (

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 
 use anyhow::Result;
-use chrono::{Datelike, NaiveDate, Utc};
+use chrono::{Datelike, Local, NaiveDate};
 use rayon::prelude::*;
 use tokio::runtime::Runtime;
 
@@ -587,11 +587,14 @@ fn parse_date(date_str: &str) -> Option<NaiveDate> {
 }
 
 fn build_contribution_graph(daily: &[DailyUsage]) -> GraphData {
+    build_contribution_graph_for_today(daily, Local::now().date_naive())
+}
+
+fn build_contribution_graph_for_today(daily: &[DailyUsage], today: NaiveDate) -> GraphData {
     if daily.is_empty() {
         return GraphData { weeks: vec![] };
     }
 
-    let today = Utc::now().date_naive();
     let days_to_sunday = today.weekday().num_days_from_sunday();
     let end_date = today;
     let start_date = end_date - chrono::Duration::days(364 + days_to_sunday as i64);
@@ -645,11 +648,14 @@ fn build_contribution_graph(daily: &[DailyUsage]) -> GraphData {
 }
 
 fn calculate_streaks(daily: &[DailyUsage]) -> (u32, u32) {
+    calculate_streaks_for_today(daily, Local::now().date_naive())
+}
+
+fn calculate_streaks_for_today(daily: &[DailyUsage], today: NaiveDate) -> (u32, u32) {
     if daily.is_empty() {
         return (0, 0);
     }
 
-    let today = Utc::now().date_naive();
     let dates: HashSet<NaiveDate> = daily.iter().map(|d| d.date).collect();
 
     let mut current_streak = 0u32;
@@ -906,5 +912,49 @@ mod tests {
         assert_eq!(parse_date("invalid"), None);
         assert_eq!(parse_date("2024-13-01"), None);
         assert_eq!(parse_date(""), None);
+    }
+
+    #[test]
+    fn test_build_contribution_graph_uses_provided_today() {
+        let today = NaiveDate::from_ymd_opt(2026, 3, 8).unwrap();
+        let graph = build_contribution_graph_for_today(&[], today);
+        assert!(graph.weeks.is_empty());
+
+        let daily = vec![DailyUsage {
+            date: NaiveDate::from_ymd_opt(2026, 3, 2).unwrap(),
+            tokens: TokenBreakdown::default(),
+            cost: 0.0,
+            models: BTreeMap::new(),
+        }];
+        let graph = build_contribution_graph_for_today(&daily, today);
+        let last_day = graph
+            .weeks
+            .last()
+            .and_then(|week| week.last())
+            .and_then(|day| day.as_ref())
+            .map(|day| day.date);
+        assert_eq!(last_day, Some(today));
+    }
+
+    #[test]
+    fn test_calculate_streaks_uses_provided_today() {
+        let today = NaiveDate::from_ymd_opt(2026, 3, 3).unwrap();
+        let daily = vec![
+            DailyUsage {
+                date: NaiveDate::from_ymd_opt(2026, 3, 2).unwrap(),
+                tokens: TokenBreakdown::default(),
+                cost: 0.0,
+                models: BTreeMap::new(),
+            },
+            DailyUsage {
+                date: NaiveDate::from_ymd_opt(2026, 3, 3).unwrap(),
+                tokens: TokenBreakdown::default(),
+                cost: 0.0,
+                models: BTreeMap::new(),
+            },
+        ];
+        let (current, longest) = calculate_streaks_for_today(&daily, today);
+        assert_eq!(current, 2);
+        assert_eq!(longest, 2);
     }
 }

--- a/crates/tokscale-cli/src/tui/ui/daily.rs
+++ b/crates/tokscale-cli/src/tui/ui/daily.rs
@@ -1,4 +1,4 @@
-use chrono::Utc;
+use chrono::Local;
 use ratatui::prelude::*;
 use ratatui::widgets::{
     Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, ScrollbarState, Table,
@@ -42,7 +42,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let selected_index = app.selected_index;
     let theme_accent = app.theme.accent;
     let theme_selection = app.theme.selection;
-    let today = Utc::now().date_naive();
+    let today = Local::now().date_naive();
 
     let header_cells = if is_very_narrow {
         vec!["Date", "Cost"]

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -3,9 +3,27 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tempfile::TempDir;
 
 // ── Fixture helpers ────────────────────────────────────────────────────────
+
+fn prime_pricing_cache(base: &Path) {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before unix epoch")
+        .as_secs();
+    let payload = format!(r#"{{"timestamp":{},"data":{{}}}}"#, now);
+
+    for dir in [
+        base.join("Library/Caches/tokscale"),
+        base.join(".cache/tokscale"),
+    ] {
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("pricing-litellm.json"), &payload).unwrap();
+        fs::write(dir.join("pricing-openrouter.json"), &payload).unwrap();
+    }
+}
 
 /// Create a temporary directory with minimal OpenCode fixture data.
 ///
@@ -16,6 +34,7 @@ use tempfile::TempDir;
 fn create_temp_fixture_dir() -> TempDir {
     let tmp = TempDir::new().expect("failed to create temp dir");
     let base = tmp.path();
+    prime_pricing_cache(base);
 
     // Session 1: two messages on 2024-06-15 using claude-sonnet-4
     let session1 = base.join(".local/share/opencode/storage/message/session1");
@@ -86,8 +105,56 @@ fn create_temp_fixture_dir() -> TempDir {
 fn create_empty_fixture_dir() -> TempDir {
     let tmp = TempDir::new().expect("failed to create temp dir");
     let base = tmp.path();
+    prime_pricing_cache(base);
     let opencode_dir = base.join(".local/share/opencode/storage/message");
     fs::create_dir_all(opencode_dir).unwrap();
+    tmp
+}
+
+fn create_timezone_boundary_fixture_dir() -> TempDir {
+    let tmp = TempDir::new().expect("failed to create temp dir");
+    let base = tmp.path();
+    prime_pricing_cache(base);
+
+    let session = base.join(".local/share/opencode/storage/message/session1");
+    fs::create_dir_all(&session).unwrap();
+
+    // 2026-03-02 18:00:00 UTC = 2026-03-02 10:00:00 in America/Los_Angeles
+    let msg_a = r#"{
+        "id": "msg_a",
+        "sessionID": "session1",
+        "role": "assistant",
+        "modelID": "claude-sonnet-4-20250514",
+        "providerID": "anthropic",
+        "cost": 0.05,
+        "tokens": {
+            "input": 1000,
+            "output": 500,
+            "reasoning": 0,
+            "cache": { "read": 200, "write": 50 }
+        },
+        "time": { "created": 1772474400000.0 }
+    }"#;
+    fs::write(session.join("msg_a.json"), msg_a).unwrap();
+
+    // 2026-03-03 04:30:00 UTC = 2026-03-02 20:30:00 in America/Los_Angeles
+    let msg_b = r#"{
+        "id": "msg_b",
+        "sessionID": "session1",
+        "role": "assistant",
+        "modelID": "claude-sonnet-4-20250514",
+        "providerID": "anthropic",
+        "cost": 0.03,
+        "tokens": {
+            "input": 800,
+            "output": 300,
+            "reasoning": 0,
+            "cache": { "read": 150, "write": 30 }
+        },
+        "time": { "created": 1772512200000.0 }
+    }"#;
+    fs::write(session.join("msg_b.json"), msg_b).unwrap();
+
     tmp
 }
 
@@ -95,7 +162,8 @@ fn create_empty_fixture_dir() -> TempDir {
 fn cmd_with_home(tmp: &Path) -> Command {
     let mut cmd = cargo_bin_cmd!("tokscale");
     cmd.env("HOME", tmp)
-        .env("XDG_DATA_HOME", tmp.join(".local/share"));
+        .env("XDG_DATA_HOME", tmp.join(".local/share"))
+        .env("XDG_CACHE_HOME", tmp.join(".cache"));
     cmd
 }
 
@@ -376,6 +444,33 @@ fn test_models_with_no_matching_date() {
         entries.is_empty(),
         "No entries expected for future date range"
     );
+}
+
+#[test]
+fn test_graph_single_day_filter_uses_local_timezone_boundaries() {
+    let tmp = create_timezone_boundary_fixture_dir();
+    let output = cmd_with_home(tmp.path())
+        .env("TZ", "America/Los_Angeles")
+        .args(["graph", "--opencode", "--no-spinner"])
+        .args(["--since", "2026-03-02", "--until", "2026-03-02"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let contributions = json["contributions"].as_array().unwrap();
+    assert_eq!(
+        contributions.len(),
+        1,
+        "expected a single local-day bucket, got {:?}",
+        contributions
+    );
+    assert_eq!(contributions[0]["date"].as_str().unwrap(), "2026-03-02");
+    assert_eq!(contributions[0]["totals"]["messages"].as_i64().unwrap(), 2);
 }
 
 #[test]

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -151,12 +151,17 @@ impl UnifiedMessage {
     }
 }
 
-/// Convert Unix milliseconds timestamp to YYYY-MM-DD date string in UTC
+/// Convert Unix milliseconds to a local YYYY-MM-DD date string.
 fn timestamp_to_date(timestamp_ms: i64) -> String {
-    use chrono::{TimeZone, Utc};
+    timestamp_to_date_with_timezone(timestamp_ms, &chrono::Local)
+}
 
-    let datetime = Utc.timestamp_millis_opt(timestamp_ms);
-    match datetime {
+fn timestamp_to_date_with_timezone<Tz>(timestamp_ms: i64, timezone: &Tz) -> String
+where
+    Tz: chrono::TimeZone,
+    Tz::Offset: std::fmt::Display,
+{
+    match timezone.timestamp_millis_opt(timestamp_ms) {
         chrono::LocalResult::Single(dt) => dt.format("%Y-%m-%d").to_string(),
         _ => String::new(),
     }
@@ -165,29 +170,29 @@ fn timestamp_to_date(timestamp_ms: i64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::FixedOffset;
 
     #[test]
-    fn test_timestamp_to_date() {
-        // 2025-06-16 12:00:00 UTC (1750075200 seconds since epoch)
-        let ts = 1750075200000_i64;
-        let date = timestamp_to_date(ts);
-        assert_eq!(date, "2025-06-16");
+    fn test_timestamp_to_date_with_positive_offset() {
+        let kst = FixedOffset::east_opt(9 * 60 * 60).unwrap();
+        let ts = 1772512200000_i64; // 2026-03-03T04:30:00Z
+        let date = timestamp_to_date_with_timezone(ts, &kst);
+        assert_eq!(date, "2026-03-03");
     }
 
     #[test]
-    fn test_timestamp_to_date_epoch() {
-        // Unix epoch: 1970-01-01
-        let ts = 0_i64;
-        let date = timestamp_to_date(ts);
-        assert_eq!(date, "1970-01-01");
+    fn test_timestamp_to_date_with_negative_offset() {
+        let pst = FixedOffset::west_opt(8 * 60 * 60).unwrap();
+        let ts = 1772512200000_i64; // 2026-03-03T04:30:00Z
+        let date = timestamp_to_date_with_timezone(ts, &pst);
+        assert_eq!(date, "2026-03-02");
     }
 
     #[test]
-    fn test_timestamp_to_date_recent() {
-        // 2024-12-01 00:00:00 UTC
-        let ts = 1733011200000_i64;
-        let date = timestamp_to_date(ts);
-        assert_eq!(date, "2024-12-01");
+    fn test_timestamp_to_date_invalid_timestamp() {
+        let utc = FixedOffset::east_opt(0).unwrap();
+        let date = timestamp_to_date_with_timezone(i64::MAX, &utc);
+        assert_eq!(date, "");
     }
 
     #[test]
@@ -213,7 +218,7 @@ mod tests {
         assert_eq!(msg.client, "opencode");
         assert_eq!(msg.model_id, "claude-3-5-sonnet");
         assert_eq!(msg.session_id, "test-session-id");
-        assert_eq!(msg.date, "2024-12-01");
+        assert_eq!(msg.date, timestamp_to_date(1733011200000));
         assert_eq!(msg.cost, 0.05);
         assert_eq!(msg.agent, None);
     }


### PR DESCRIPTION
Fix daily usage bucketing across UTC midnight boundaries.

`UnifiedMessage::date` was being derived in UTC during parsing, and the daily aggregation/filtering code uses that as the day key. That could split a single local day into two buckets when usage crossed UTC midnight.

This switches that date to the system local timezone at parse time, and updates the related local-day behavior for date shortcuts, streaks, contribution ranges, and the TUI `today` state.

Added a regression test for the Los Angeles case where two messages from the same local day were split across 2026-03-02 and 2026-03-03.

Fixes #267 


