### PR TITLE
fix: use daily breakdown for leaderboard periods

### DIFF
--- a/packages/frontend/__tests__/lib/getLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboard.test.ts
@@ -114,9 +114,9 @@ let getLeaderboardData: ModuleExports["getLeaderboardData"];
 let getUserRank: ModuleExports["getUserRank"];
 
 beforeAll(async () => {
-  const module = await import("../../src/lib/leaderboard/getLeaderboard");
-  getLeaderboardData = module.getLeaderboardData;
-  getUserRank = module.getUserRank;
+  const leaderboardModule = await import("../../src/lib/leaderboard/getLeaderboard");
+  getLeaderboardData = leaderboardModule.getLeaderboardData;
+  getUserRank = leaderboardModule.getUserRank;
 });
 
 beforeEach(() => {
@@ -136,7 +136,6 @@ describe("period leaderboard data", () => {
       avatarUrl: null,
       tokens: 100,
       cost: 1.25,
-      submissionCount: 8,
       updatedAt: "2026-03-07T11:00:00.000Z",
     },
     {
@@ -146,7 +145,6 @@ describe("period leaderboard data", () => {
       avatarUrl: null,
       tokens: 150,
       cost: 1.75,
-      submissionCount: 8,
       updatedAt: "2026-03-07T11:00:00.000Z",
     },
     {
@@ -156,7 +154,6 @@ describe("period leaderboard data", () => {
       avatarUrl: null,
       tokens: 1000,
       cost: 9.5,
-      submissionCount: 2,
       updatedAt: "2026-03-07T09:00:00.000Z",
     },
   ];
@@ -189,12 +186,12 @@ describe("period leaderboard data", () => {
       username: "alice",
       totalTokens: 250,
       totalCost: 3,
-      submissionCount: 8,
+      submissionCount: null,
     });
     expect(leaderboard.stats).toMatchObject({
       totalTokens: 1250,
       totalCost: 12.5,
-      totalSubmissions: 2,
+      totalSubmissions: null,
       uniqueUsers: 2,
     });
   });
@@ -229,12 +226,13 @@ describe("period leaderboard data", () => {
 
     const rank = await getUserRank("alice", "week", "tokens");
 
+    expect(mockState.fromCalls[0]).toBe(mockState.tables.dailyBreakdown);
     expect(rank).toMatchObject({
       rank: 2,
       username: "alice",
       totalTokens: 250,
       totalCost: 3,
-      submissionCount: 8,
+      submissionCount: null,
       lastSubmission: "2026-03-07T11:00:00.000Z",
     });
   });

--- a/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
@@ -732,7 +732,7 @@ export interface LeaderboardUser {
   avatarUrl: string | null;
   totalTokens: number;
   totalCost: number;
-  submissionCount: number;
+  submissionCount: number | null;
   lastSubmission: string;
 }
 
@@ -749,7 +749,7 @@ export interface LeaderboardData {
   stats: {
     totalTokens: number;
     totalCost: number;
-    totalSubmissions: number;
+    totalSubmissions: number | null;
     uniqueUsers: number;
   };
   period: Period;
@@ -778,6 +778,7 @@ interface LeaderboardRowProps {
   user: LeaderboardUser;
   isCurrentUser: boolean;
   isLastRow: boolean;
+  showSubmissionCount: boolean;
   onRowClick: (username: string) => void;
 }
 
@@ -785,6 +786,7 @@ const LeaderboardRow = memo(function LeaderboardRow({
   user,
   isCurrentUser,
   isLastRow,
+  showSubmissionCount,
   onRowClick,
 }: LeaderboardRowProps) {
   const formattedTokens = useMemo(() => user.totalTokens.toLocaleString('en-US'), [user.totalTokens]);
@@ -836,9 +838,11 @@ const LeaderboardRow = memo(function LeaderboardRow({
           </CostValue>
         </CombinedValueContainer>
       </TableCell>
-      <TableCell className="text-right hidden-mobile w-24">
-        <SubmitCount>{user.submissionCount}</SubmitCount>
-      </TableCell>
+      {showSubmissionCount && (
+        <TableCell className="text-right hidden-mobile w-24">
+          <SubmitCount>{user.submissionCount ?? "—"}</SubmitCount>
+        </TableCell>
+      )}
     </TableRow>
   );
 });
@@ -955,6 +959,7 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
   }, [data.pagination.totalPages, page]);
 
   const sortedUsers = data.users || [];
+  const showSubmissionCount = period === "all";
 
   const handleCopyCommand = (command: string) => {
     navigator.clipboard.writeText(command);
@@ -1103,7 +1108,9 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
                       <TableHeaderCell>User</TableHeaderCell>
                       <TableHeaderCell className="text-right hidden-cost-mobile">Cost</TableHeaderCell>
                       <TableHeaderCell className="text-right">Tokens</TableHeaderCell>
-                      <TableHeaderCell className="text-right hidden-mobile w-24">Submits</TableHeaderCell>
+                      {showSubmissionCount && (
+                        <TableHeaderCell className="text-right hidden-mobile w-24">Submits</TableHeaderCell>
+                      )}
                     </tr>
                   </TableHead>
                   <TableBody>
@@ -1113,6 +1120,7 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
                         user={user}
                         isCurrentUser={!!(currentUser && user.username === currentUser.username)}
                         isLastRow={index === sortedUsers.length - 1}
+                        showSubmissionCount={showSubmissionCount}
                         onRowClick={handleRowClick}
                       />
                     ))}

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -13,7 +13,7 @@ export interface LeaderboardUser {
   avatarUrl: string | null;
   totalTokens: number;
   totalCost: number;
-  submissionCount: number;
+  submissionCount: number | null;
   lastSubmission: string;
 }
 
@@ -30,7 +30,7 @@ export interface LeaderboardData {
   stats: {
     totalTokens: number;
     totalCost: number;
-    totalSubmissions: number;
+    totalSubmissions: number | null;
     uniqueUsers: number;
   };
   period: Period;
@@ -44,7 +44,6 @@ interface LeaderboardPeriodRow {
   avatarUrl: string | null;
   tokens: number;
   cost: number;
-  submissionCount: number;
   updatedAt: string;
 }
 
@@ -60,7 +59,6 @@ interface PeriodLeaderboardDbRow {
   avatarUrl: string | null;
   tokens: number | string | null;
   cost: number | string | null;
-  submissionCount: number | string | null;
   updatedAt: Date | string;
 }
 
@@ -143,7 +141,6 @@ function aggregatePeriodRows(
     if (existing) {
       existing.totalTokens += row.tokens;
       existing.totalCost += row.cost;
-      existing.submissionCount = Math.max(existing.submissionCount, row.submissionCount);
       if (row.updatedAt > existing.lastSubmission) {
         existing.lastSubmission = row.updatedAt;
       }
@@ -157,7 +154,7 @@ function aggregatePeriodRows(
       avatarUrl: row.avatarUrl,
       totalTokens: row.tokens,
       totalCost: row.cost,
-      submissionCount: row.submissionCount,
+      submissionCount: null,
       lastSubmission: row.updatedAt,
     });
   }
@@ -194,7 +191,8 @@ function buildPeriodLeaderboardData(
     stats: {
       totalTokens: aggregatedUsers.reduce((sum, user) => sum + user.totalTokens, 0),
       totalCost: aggregatedUsers.reduce((sum, user) => sum + user.totalCost, 0),
-      totalSubmissions: aggregatedUsers.length,
+      // submitCount lives on the all-time submission row, so period-scoped submit totals are unavailable here.
+      totalSubmissions: null,
       uniqueUsers: aggregatedUsers.length,
     },
     period,
@@ -237,7 +235,6 @@ async function fetchPeriodLeaderboardRows(
       avatarUrl: users.avatarUrl,
       tokens: dailyBreakdown.tokens,
       cost: dailyBreakdown.cost,
-      submissionCount: submissions.submitCount,
       updatedAt: submissions.updatedAt,
     })
     .from(dailyBreakdown)
@@ -257,7 +254,6 @@ async function fetchPeriodLeaderboardRows(
     avatarUrl: row.avatarUrl,
     tokens: Number(row.tokens) || 0,
     cost: Number(row.cost) || 0,
-    submissionCount: Number(row.submissionCount) || 0,
     updatedAt: row.updatedAt instanceof Date
       ? row.updatedAt.toISOString()
       : new Date(row.updatedAt).toISOString(),


### PR DESCRIPTION
Fix leaderboard period totals so `week` and `month` use in-range daily data.

Previously the leaderboard filtered by `submissions.createdAt`, but submission rows store one aggregate row per user that already contains all-time totals. This meant period views could either exclude users with fresh activity (if their submission row was old) or show their all-time totals in a weekly/monthly view.

This change computes `week` and `month` totals from `daily_breakdown` rows within the selected date range instead. All-time totals continue to use the existing submissions aggregate.

Leaderboard rows and `getUserRank` now share the same aggregation path for each period to keep totals and ranking consistent.

Added regression tests covering week/month ranges and period ranking.


