### PR TITLE
docs: remove outdated OpenTUI/Bun references from READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -124,12 +124,12 @@ AI支援開発の時代において、**トークンは新しいエネルギー*
 
 ## 機能
 
-- **インタラクティブTUIモード** - OpenTUIによる美しいターミナルUI（デフォルトモード）
+- **インタラクティブTUIモード** - Ratatuiによる美しいターミナルUI（デフォルトモード）
   - 4つのインタラクティブビュー：概要、モデル、日別、統計
   - キーボード＆マウスナビゲーション
   - 9色テーマのGitHubスタイル貢献グラフ
   - リアルタイムフィルタリングとソート
-  - ゼロフリッカーレンダリング（ネイティブZigエンジン）
+  - ゼロフリッカーレンダリング
 - **マルチプラットフォームサポート** - OpenCode、Claude Code、Codex CLI、Cursor IDE、Gemini CLI、Amp、Droid、OpenClaw、Pi、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Synthetic全体の使用量追跡
 - **リアルタイム価格** - 1時間ディスクキャッシュ付きでLiteLLMから現在の価格を取得；OpenRouter自動フォールバックと新規モデル向けCursor価格サポート
 - **詳細な内訳** - 入力、出力、キャッシュ読み書き、推論トークン追跡
@@ -144,26 +144,24 @@ AI支援開発の時代において、**トークンは新しいエネルギー*
 ### クイックスタート
 
 ```bash
-# Bunをインストール（まだインストールしていない場合）
-curl -fsSL https://bun.sh/install | bash
+# npxで直接実行
+npx tokscale@latest
 
-# bunxで直接実行
+# またはbunxを使用
 bunx tokscale@latest
 
-# ライトモード（OpenTUIなし、テーブルレンダリングのみ）
-bunx tokscale@latest --light
+# ライトモード（テーブルレンダリングのみ）
+npx tokscale@latest --light
 ```
 
 これだけです！セットアップ不要で完全なインタラクティブTUI体験が得られます。
-
-> **[Bun](https://bun.sh/)が必要**: インタラクティブTUIはゼロフリッカーレンダリングのためにOpenTUIのネイティブZigモジュールを使用しており、Bunランタイムが必要です。
 
 > **パッケージ構造**: `tokscale`は`@tokscale/cli`をインストールするエイリアスパッケージです（[`swc`](https://www.npmjs.com/package/swc)のように）。どちらもネイティブRustコア（`@tokscale/core`）を含む同じCLIをインストールします。
 
 
 ### 前提条件
 
-- [Bun](https://bun.sh/)（必須）
+- [Node.js](https://nodejs.org/) または [Bun](https://bun.sh/)
 - （オプション）ソースからネイティブモジュールをビルドするためのRustツールチェーン
 
 ### 開発環境セットアップ
@@ -713,7 +711,7 @@ cd packages/cli && bun src/cli.ts --light
 - `packages/cli`: `bun run dev`、`bun run tui`
 - `packages/core`: `bun run build:debug`、`bun run test`、`bun run bench`
 
-**注**: このプロジェクトは**Bun**をパッケージマネージャー兼ランタイムとして使用しています。TUIはOpenTUIのネイティブモジュールのためBunが必要です。
+**注**: このプロジェクトは開発時に**Bun**をパッケージマネージャーとして使用しています。
 
 ### テスト
 
@@ -1145,7 +1143,7 @@ Tokscaleは[LiteLLMの価格データベース](https://github.com/BerriAI/litel
 ## 謝辞
 
 - インスピレーションを与えてくれた[ccusage](https://github.com/ryoppippi/ccusage)、[viberank](https://github.com/sculptdotfun/viberank)、[Isometric Contributions](https://github.com/jasonlong/isometric-contributions)
-- ゼロフリッカーターミナルUIフレームワーク[OpenTUI](https://github.com/sst/opentui)
+- ターミナルUIフレームワーク[Ratatui](https://github.com/ratatui/ratatui)
 - リアクティブレンダリングの[Solid.js](https://www.solidjs.com/)
 - 価格データの[LiteLLM](https://github.com/BerriAI/litellm)
 - Rust/Node.jsバインディングの[napi-rs](https://napi.rs/)

--- a/README.ko.md
+++ b/README.ko.md
@@ -124,12 +124,12 @@ AI 지원 개발 시대에 **토큰은 새로운 에너지**입니다. 토큰은
 
 ## 기능
 
-- **인터랙티브 TUI 모드** - OpenTUI 기반의 터미널 UI (기본 모드)
+- **인터랙티브 TUI 모드** - Ratatui 기반의 터미널 UI (기본 모드)
   - 4개 뷰: 개요, 모델, 일별, 통계
   - 키보드 및 마우스 지원
   - 9가지 테마의 GitHub 스타일 기여 그래프
   - 실시간 필터링 및 정렬
-  - 깜빡임 없는 렌더링 (네이티브 Zig 엔진)
+  - 깜빡임 없는 렌더링
 - **멀티 플랫폼 지원** - OpenCode, Claude Code, Codex CLI, Cursor IDE, Gemini CLI, Amp, Droid, OpenClaw, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Synthetic 사용량 통합 추적
 - **실시간 가격 반영** - LiteLLM에서 최신 가격을 가져와(디스크 캐시 1시간) 비용 계산; OpenRouter 자동 폴백 및 신규 모델용 Cursor 가격 지원
 - **상세 분석** - 입력, 출력, 캐시 읽기/쓰기, 추론 토큰까지 추적
@@ -144,25 +144,23 @@ AI 지원 개발 시대에 **토큰은 새로운 에너지**입니다. 토큰은
 ### 빠른 시작
 
 ```bash
-# Bun 설치 (아직 설치하지 않은 경우)
-curl -fsSL https://bun.sh/install | bash
+# npx로 바로 실행
+npx tokscale@latest
 
-# bunx로 바로 실행
+# 또는 bunx 사용
 bunx tokscale@latest
 
-# 라이트 모드 (OpenTUI 없이, 테이블 렌더링만)
-bunx tokscale@latest --light
+# 라이트 모드 (테이블 렌더링만)
+npx tokscale@latest --light
 ```
 
 이게 전부입니다! 별도 설정 없이 바로 완전한 인터랙티브 TUI 경험을 제공합니다.
-
-> **[Bun](https://bun.sh/) 필요**: 인터랙티브 TUI는 깜빡임 없는 렌더링을 위해 OpenTUI의 네이티브 Zig 모듈을 사용하며, 이는 Bun 런타임이 필요합니다.
 
 > **패키지 구조**: `tokscale`은 `@tokscale/cli`를 설치하는 별칭 패키지입니다 ([`swc`](https://www.npmjs.com/package/swc)처럼). 둘 다 네이티브 Rust 코어 (`@tokscale/core`)가 포함된 동일한 CLI를 설치합니다.
 
 ### 사전 요구사항
 
-- [Bun](https://bun.sh/) (필수)
+- [Node.js](https://nodejs.org/) 또는 [Bun](https://bun.sh/)
 - (선택) 소스에서 네이티브 모듈을 빌드하려면 Rust 툴체인
 
 ### 개발 환경 설정
@@ -712,7 +710,7 @@ cd packages/cli && bun src/cli.ts --light
 - `packages/cli`: `bun run dev`, `bun run tui`
 - `packages/core`: `bun run build:debug`, `bun run test`, `bun run bench`
 
-**참고**: 이 프로젝트는 **Bun**을 패키지 매니저 및 런타임으로 사용합니다. TUI는 OpenTUI의 네이티브 모듈 때문에 Bun이 필요합니다.
+**참고**: 이 프로젝트는 개발 시 **Bun**을 패키지 매니저로 사용합니다.
 
 ### 테스트
 
@@ -1143,7 +1141,7 @@ Tokscale은 [LiteLLM의 가격 데이터베이스](https://github.com/BerriAI/li
 ## 감사의 글
 
 - 영감을 준 [ccusage](https://github.com/ryoppippi/ccusage), [viberank](https://github.com/sculptdotfun/viberank), [Isometric Contributions](https://github.com/jasonlong/isometric-contributions)
-- 깜빡임 없는 터미널 UI 프레임워크 [OpenTUI](https://github.com/sst/opentui)
+- 터미널 UI 프레임워크 [Ratatui](https://github.com/ratatui/ratatui)
 - 반응형 렌더링을 위한 [Solid.js](https://www.solidjs.com/)
 - 가격 데이터를 위한 [LiteLLM](https://github.com/BerriAI/litellm)
 - Rust/Node.js 바인딩을 위한 [napi-rs](https://napi.rs/)

--- a/README.md
+++ b/README.md
@@ -125,12 +125,12 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
 
 ## Features
 
-- **Interactive TUI Mode** - Beautiful terminal UI powered by OpenTUI (default mode)
+- **Interactive TUI Mode** - Beautiful terminal UI powered by Ratatui (default mode)
   - 4 interactive views: Overview, Models, Daily, Stats
   - Keyboard & mouse navigation
   - GitHub-style contribution graph with 9 color themes
   - Real-time filtering and sorting
-  - Zero flicker rendering (native Zig engine)
+  - Zero flicker rendering
 - **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Cursor IDE, Gemini CLI, Amp, Droid, OpenClaw, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, and Synthetic
 - **Real-time pricing** - Fetches current pricing from LiteLLM with 1-hour disk cache; automatic OpenRouter fallback and Cursor model pricing for newly released models
 - **Detailed breakdowns** - Input, output, cache read/write, and reasoning token tracking
@@ -145,26 +145,24 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
 ### Quick Start
 
 ```bash
-# Install Bun (if not already installed)
-curl -fsSL https://bun.sh/install | bash
+# Run directly with npx
+npx tokscale@latest
 
-# Run directly with bunx
+# Or use bunx
 bunx tokscale@latest
 
-# Light mode (no OpenTUI, just table rendering)
-bunx tokscale@latest --light
+# Light mode (table rendering only)
+npx tokscale@latest --light
 ```
 
 That's it! This gives you the full interactive TUI experience with zero setup.
-
-> **Requires [Bun](https://bun.sh/)**: The interactive TUI uses OpenTUI's native Zig modules for zero-flicker rendering, which requires the Bun runtime.
 
 > **Package Structure**: `tokscale` is an alias package (like [`swc`](https://www.npmjs.com/package/swc)) that installs `@tokscale/cli`. Both install the same CLI with the native Rust core (`@tokscale/core`) included.
 
 
 ### Prerequisites
 
-- [Bun](https://bun.sh/) (required)
+- [Node.js](https://nodejs.org/) or [Bun](https://bun.sh/)
 - (Optional) Rust toolchain for building native module from source
 
 ### Development Setup
@@ -714,7 +712,7 @@ cd packages/cli && bun src/cli.ts --light
 - `packages/cli`: `bun run dev`, `bun run tui`
 - `packages/core`: `bun run build:debug`, `bun run test`, `bun run bench`
 
-**Note**: This project uses **Bun** as the package manager and runtime. TUI requires Bun due to OpenTUI's native modules.
+**Note**: This project uses **Bun** as the package manager for development.
 
 ### Testing
 
@@ -1145,7 +1143,7 @@ Contributions are welcome! Please follow these steps:
 ## Acknowledgments
 
 - [ccusage](https://github.com/ryoppippi/ccusage), [viberank](https://github.com/sculptdotfun/viberank), and [Isometric Contributions](https://github.com/jasonlong/isometric-contributions) for inspiration
-- [OpenTUI](https://github.com/sst/opentui) for zero-flicker terminal UI framework
+- [Ratatui](https://github.com/ratatui/ratatui) for terminal UI framework
 - [Solid.js](https://www.solidjs.com/) for reactive rendering
 - [LiteLLM](https://github.com/BerriAI/litellm) for pricing data
 - [napi-rs](https://napi.rs/) for Rust/Node.js bindings

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -124,12 +124,12 @@
 
 ## 功能
 
-- **交互式 TUI 模式** - 由 OpenTUI 驱动的精美终端 UI（默认模式）
+- **交互式 TUI 模式** - 由 Ratatui 驱动的精美终端 UI（默认模式）
   - 4 个交互式视图：概览、模型、每日、统计
   - 键盘和鼠标导航
   - 9 种颜色主题的 GitHub 风格贡献图
   - 实时筛选和排序
-  - 零闪烁渲染（原生 Zig 引擎）
+  - 零闪烁渲染
 - **多平台支持** - 跟踪 OpenCode、Claude Code、Codex CLI、Cursor IDE、Gemini CLI、Amp、Droid、OpenClaw、Pi、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux 和 Synthetic 的使用情况
 - **实时定价** - 从 LiteLLM 获取当前价格，带 1 小时磁盘缓存；OpenRouter 自动回退和新模型的 Cursor 定价支持
 - **详细分解** - 输入、输出、缓存读写和推理 Token 跟踪
@@ -144,26 +144,24 @@
 ### 快速开始
 
 ```bash
-# 安装 Bun（如果尚未安装）
-curl -fsSL https://bun.sh/install | bash
+# 直接用 npx 运行
+npx tokscale@latest
 
-# 直接用 bunx 运行
+# 或使用 bunx
 bunx tokscale@latest
 
-# 轻量模式（无 OpenTUI，仅表格渲染）
-bunx tokscale@latest --light
+# 轻量模式（仅表格渲染）
+npx tokscale@latest --light
 ```
 
 就这样！零配置即可获得完整的交互式 TUI 体验。
-
-> **需要 [Bun](https://bun.sh/)**：交互式 TUI 使用 OpenTUI 的原生 Zig 模块实现零闪烁渲染，这需要 Bun 运行时。
 
 > **包结构**：`tokscale` 是一个别名包（类似 [`swc`](https://www.npmjs.com/package/swc)），它安装 `@tokscale/cli`。两者都安装包含原生 Rust 核心（`@tokscale/core`）的相同 CLI。
 
 
 ### 先决条件
 
-- [Bun](https://bun.sh/)（必需）
+- [Node.js](https://nodejs.org/) 或 [Bun](https://bun.sh/)
 - （可选）从源码构建原生模块的 Rust 工具链
 
 ### 开发环境设置
@@ -713,7 +711,7 @@ cd packages/cli && bun src/cli.ts --light
 - `packages/cli`：`bun run dev`、`bun run tui`
 - `packages/core`：`bun run build:debug`、`bun run test`、`bun run bench`
 
-**注意**：此项目使用 **Bun** 作为包管理器和运行时。TUI 需要 Bun，因为 OpenTUI 的原生模块。
+**注意**：此项目使用 **Bun** 作为开发时的包管理器。
 
 ### 测试
 
@@ -1145,7 +1143,7 @@ Tokscale 从 [LiteLLM 的价格数据库](https://github.com/BerriAI/litellm/blo
 ## 致谢
 
 - 感谢 [ccusage](https://github.com/ryoppippi/ccusage)、[viberank](https://github.com/sculptdotfun/viberank) 和 [Isometric Contributions](https://github.com/jasonlong/isometric-contributions) 提供的灵感
-- [OpenTUI](https://github.com/sst/opentui) 零闪烁终端 UI 框架
+- [Ratatui](https://github.com/ratatui/ratatui) 终端 UI 框架
 - [Solid.js](https://www.solidjs.com/) 响应式渲染
 - [LiteLLM](https://github.com/BerriAI/litellm) 价格数据
 - [napi-rs](https://napi.rs/) Rust/Node.js 绑定


### PR DESCRIPTION
## Summary

The TUI has been rewritten in pure Rust (`ratatui` + `crossterm`) since v2, but the READMEs still reference OpenTUI, Zig modules, and a hard Bun requirement. This PR updates all 4 README translations (EN, KO, JA, ZH-CN) to reflect reality.

## Changes

- **Features section**: Replace "powered by OpenTUI" → "powered by Ratatui", remove "(native Zig engine)"
- **Quick Start**: Remove `curl bun.sh` install step, lead with `npx`, offer `bunx` as alternative
- **Bun requirement callout**: Removed entirely (was: "Requires Bun... OpenTUI's native Zig modules...")
- **Prerequisites**: "Bun (required)" → "Node.js or Bun"
- **Development note**: "TUI requires Bun due to OpenTUI" → "Bun as package manager for development"
- **Acknowledgments**: OpenTUI → Ratatui
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update all four READMEs to reflect the Rust TUI (`ratatui` + `crossterm`) and remove outdated OpenTUI/Zig/Bun requirements. Quick Start now defaults to `npx`, and prerequisites are simplified.

- **Refactors**
  - Replace OpenTUI mentions with Ratatui; remove Zig/native-engine wording.
  - Remove Bun install step; default to `npx`, keep `bunx` as an alternative; update light mode examples.
  - Drop “Requires Bun” callouts; change prerequisites to “Node.js or Bun”.
  - Clarify dev note: Bun is used only as the package manager in development.
  - Update acknowledgments to credit Ratatui.
  - Applied across `README.md`, `README.ko.md`, `README.ja.md`, `README.zh-cn.md`.

<sup>Written for commit c07fade4a4d403c0383008825c8df31fe5e4f9ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

