### PR TITLE
fix(tui): filter out key release events to prevent double-action

### DIFF
--- a/crates/tokscale-cli/src/tui/event.rs
+++ b/crates/tokscale-cli/src/tui/event.rs
@@ -3,7 +3,7 @@ use std::thread;
 use std::time::Duration;
 
 use anyhow::Result;
-use crossterm::event::{self, KeyEvent, MouseEvent};
+use crossterm::event::{self, KeyEvent, KeyEventKind, MouseEvent};
 
 pub enum Event {
     Tick,
@@ -16,6 +16,10 @@ pub struct EventHandler {
     rx: mpsc::Receiver<Event>,
 }
 
+fn should_forward_key_event(key: &KeyEvent) -> bool {
+    matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat)
+}
+
 impl EventHandler {
     pub fn new(tick_rate: Duration) -> Self {
         let (tx, rx) = mpsc::channel();
@@ -25,7 +29,8 @@ impl EventHandler {
             if event::poll(tick_rate).unwrap_or(false) {
                 match event::read() {
                     Ok(event::Event::Key(key)) => {
-                        if event_tx.send(Event::Key(key)).is_err() {
+                        if should_forward_key_event(&key) && event_tx.send(Event::Key(key)).is_err()
+                        {
                             break;
                         }
                     }
@@ -57,5 +62,27 @@ impl EventHandler {
 
     pub fn next(&mut self) -> Result<Event> {
         Ok(self.rx.recv()?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_forward_key_event;
+    use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+
+    fn key(kind: KeyEventKind) -> KeyEvent {
+        KeyEvent {
+            code: KeyCode::Tab,
+            modifiers: KeyModifiers::NONE,
+            kind,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    #[test]
+    fn forwards_press_and_repeat_but_not_release() {
+        assert!(should_forward_key_event(&key(KeyEventKind::Press)));
+        assert!(should_forward_key_event(&key(KeyEventKind::Repeat)));
+        assert!(!should_forward_key_event(&key(KeyEventKind::Release)));
     }
 }


### PR DESCRIPTION
## Summary
- Filter key events in the TUI event handler to only forward `Press` and `Repeat` events, ignoring `Release` events
- Prevents duplicate key actions on terminal emulators that emit separate Release events (e.g. Windows Terminal, kitty)
- Adds unit test verifying the filtering behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filter key events in the TUI to forward only `Press` and `Repeat`, ignoring `Release`, preventing double actions on terminals that emit release events (e.g., Windows Terminal, `kitty`). Adds a unit test to verify the filtering behavior.

<sup>Written for commit 5b4c900391151078bb7fa60b07f9a2911c908469. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

