### PR TITLE
feat(tui): add PageUp/PageDown/Home/End navigation and three-zone stats layout

### DIFF
--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -305,6 +305,18 @@ impl App {
             KeyCode::Down => {
                 self.move_selection_down();
             }
+            KeyCode::PageUp => {
+                self.move_page_up();
+            }
+            KeyCode::PageDown => {
+                self.move_page_down();
+            }
+            KeyCode::Home => {
+                self.move_to_top();
+            }
+            KeyCode::End => {
+                self.move_to_bottom();
+            }
             KeyCode::Char('c') => {
                 self.set_sort(SortField::Cost);
             }
@@ -511,6 +523,49 @@ impl App {
                 self.scroll_offset = self.selected_index - self.max_visible_items + 1;
             }
         }
+    }
+
+    fn move_page_up(&mut self) {
+        let len = self.get_current_list_len();
+        if len == 0 {
+            return;
+        }
+        let jump = (self.max_visible_items / 2).max(1);
+        self.selected_index = self.selected_index.saturating_sub(jump);
+        if self.selected_index < self.scroll_offset {
+            self.scroll_offset = self.selected_index;
+        }
+    }
+
+    fn move_page_down(&mut self) {
+        let len = self.get_current_list_len();
+        if len == 0 {
+            return;
+        }
+        let jump = (self.max_visible_items / 2).max(1);
+        let max_index = len - 1;
+        self.selected_index = (self.selected_index + jump).min(max_index);
+        if self.selected_index >= self.scroll_offset + self.max_visible_items {
+            self.scroll_offset = self.selected_index - self.max_visible_items + 1;
+        }
+    }
+
+    fn move_to_top(&mut self) {
+        let len = self.get_current_list_len();
+        if len == 0 {
+            return;
+        }
+        self.selected_index = 0;
+        self.scroll_offset = 0;
+    }
+
+    fn move_to_bottom(&mut self) {
+        let len = self.get_current_list_len();
+        if len == 0 {
+            return;
+        }
+        self.selected_index = len - 1;
+        self.scroll_offset = len.saturating_sub(self.max_visible_items);
     }
 
     fn get_current_list_len(&self) -> usize {

--- a/crates/tokscale-cli/src/tui/ui/stats.rs
+++ b/crates/tokscale-cli/src/tui/ui/stats.rs
@@ -15,16 +15,48 @@ const MONTH_LABELS: &[&str] = &[
 const DAY_LABELS: &[&str] = &["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Min(12), Constraint::Length(12)])
-        .split(area);
+    let has_selected_cell = app.selected_graph_cell.is_some();
+    let stats_compact_h: u16 = 8;
+    let min_breakdown_h: u16 = 6;
+    let min_graph_h: u16 = 12;
+    let sufficient_for_both = area.height >= min_graph_h + stats_compact_h + min_breakdown_h;
 
-    render_graph(frame, app, chunks[0]);
+    if has_selected_cell && sufficient_for_both {
+        // Three-zone layout: graph + compact stats + breakdown
+        let non_stats = area.height.saturating_sub(stats_compact_h);
+        let surplus = non_stats.saturating_sub(min_graph_h + min_breakdown_h);
+        let graph_h = min_graph_h + (surplus * 3 / 5); // 60% of surplus to graph
+        let breakdown_h = non_stats.saturating_sub(graph_h); // 40% to breakdown
 
-    if app.selected_graph_cell.is_some() {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(graph_h),
+                Constraint::Length(stats_compact_h),
+                Constraint::Length(breakdown_h),
+            ])
+            .split(area);
+
+        render_graph(frame, app, chunks[0]);
+        render_stats_panel(frame, app, chunks[1]);
+        render_breakdown_panel(frame, app, chunks[2]);
+    } else if has_selected_cell {
+        // Not enough room for both: graph + breakdown only
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(12), Constraint::Length(12)])
+            .split(area);
+
+        render_graph(frame, app, chunks[0]);
         render_breakdown_panel(frame, app, chunks[1]);
     } else {
+        // No cell selected: graph + full stats
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(12), Constraint::Length(12)])
+            .split(area);
+
+        render_graph(frame, app, chunks[0]);
         render_stats_panel(frame, app, chunks[1]);
     }
 }


### PR DESCRIPTION
## Summary

- Add PageUp/PageDown/Home/End keyboard navigation for faster list traversal in all TUI views
- Rework Stats tab to show graph, compact stats, and breakdown panel simultaneously when terminal height permits

## Details

**Keyboard navigation** (`app.rs`):
- `PageUp`/`PageDown`: jump half-page at a time with proper scroll offset
- `Home`/`End`: jump to top/bottom of list

**Stats layout** (`stats.rs`):
- Three-zone layout (graph + compact stats + breakdown) when a cell is selected and there's enough height
- 60/40 surplus split between graph and breakdown
- Falls back to two-zone layout when terminal is too short
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add PageUp/PageDown/Home/End navigation for faster list scrolling in all TUI views. Rework the Stats tab to show graph, compact stats, and breakdown together when the terminal is tall enough, with clean fallbacks.

- **New Features**
  - PageUp/PageDown jump half a page; Home/End go to top/bottom. Scroll offset stays in sync.
  - Stats tab: three-zone layout (graph, compact stats, breakdown) when a cell is selected and height permits. Surplus space split 60% to graph, 40% to breakdown. Falls back to graph+breakdown when short, or graph+full stats when no cell is selected.

<sup>Written for commit 85bd5c83a90fc308f0c06e758274206ea402357c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

