### PR TITLE
refactor(frontend): centralize personal token auth paths

### DIFF
--- a/packages/frontend/__tests__/api/devicePoll.test.ts
+++ b/packages/frontend/__tests__/api/devicePoll.test.ts
@@ -1,0 +1,154 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const selectResults: Array<Array<Record<string, unknown>>> = [];
+  const deleteResults: Array<Array<Record<string, unknown>>> = [];
+
+  const tables = {
+    deviceCodes: {
+      id: "deviceCodes.id",
+      deviceCode: "deviceCodes.deviceCode",
+      expiresAt: "deviceCodes.expiresAt",
+    },
+    users: {
+      id: "users.id",
+    },
+  };
+
+  const eq = vi.fn(() => "eq");
+  const and = vi.fn(() => "and");
+  const gt = vi.fn(() => "gt");
+
+  function nextResult<T>(queue: T[][]): T[] {
+    return queue.shift() ?? [];
+  }
+
+  const db = {
+    select: vi.fn(() => {
+      const builder = {
+        from: vi.fn(() => builder),
+        where: vi.fn(() => builder),
+        limit: vi.fn(async () => nextResult(selectResults)),
+      };
+
+      return builder;
+    }),
+    delete: vi.fn(() => {
+      const builder = {
+        where: vi.fn(async () => nextResult(deleteResults)),
+      };
+
+      return builder;
+    }),
+  };
+
+  return {
+    db,
+    tables,
+    eq,
+    and,
+    gt,
+    reset() {
+      selectResults.length = 0;
+      deleteResults.length = 0;
+      db.select.mockClear();
+      db.delete.mockClear();
+      eq.mockClear();
+      and.mockClear();
+      gt.mockClear();
+    },
+    pushSelectResult(rows: Array<Record<string, unknown>>) {
+      selectResults.push(rows);
+    },
+    pushDeleteResult(rows: Array<Record<string, unknown>> = []) {
+      deleteResults.push(rows);
+    },
+  };
+});
+
+const issuePersonalToken = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  db: mockState.db,
+  deviceCodes: mockState.tables.deviceCodes,
+  users: mockState.tables.users,
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: mockState.eq,
+  and: mockState.and,
+  gt: mockState.gt,
+}));
+
+vi.mock("@/lib/auth/personalTokens", () => ({
+  issuePersonalToken,
+}));
+
+type ModuleExports = typeof import("../../src/app/api/auth/device/poll/route");
+
+let POST: ModuleExports["POST"];
+
+beforeAll(async () => {
+  const routeModule = await import("../../src/app/api/auth/device/poll/route");
+  POST = routeModule.POST;
+});
+
+beforeEach(() => {
+  mockState.reset();
+  issuePersonalToken.mockReset();
+});
+
+describe("POST /api/auth/device/poll", () => {
+  it("issues the token through the shared personal token service", async () => {
+    mockState.pushSelectResult([
+      {
+        id: "device-1",
+        userId: "user-1",
+        deviceName: "CLI on macbook",
+        expiresAt: new Date("2026-03-08T05:00:00.000Z"),
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        id: "user-1",
+        username: "alice",
+        avatarUrl: "https://example.com/alice.png",
+      },
+    ]);
+    mockState.pushDeleteResult();
+    issuePersonalToken.mockResolvedValue({
+      id: "token-1",
+      userId: "user-1",
+      name: "CLI on macbook",
+      token: "tt_test_token",
+      createdAt: new Date("2026-03-08T04:00:00.000Z"),
+      lastUsedAt: null,
+      expiresAt: null,
+    });
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/auth/device/poll", {
+        method: "POST",
+        body: JSON.stringify({ deviceCode: "device-code-1" }),
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(issuePersonalToken).toHaveBeenCalledWith({
+      userId: "user-1",
+      name: "CLI on macbook",
+      ensureUniqueName: true,
+    });
+    expect(mockState.db.delete).toHaveBeenCalledTimes(1);
+    expect(mockState.eq).toHaveBeenNthCalledWith(3, mockState.tables.deviceCodes.id, "device-1");
+    expect(body).toEqual({
+      status: "complete",
+      token: "tt_test_token",
+      user: {
+        username: "alice",
+        avatarUrl: "https://example.com/alice.png",
+      },
+    });
+  });
+});

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -1,0 +1,156 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const authenticatePersonalToken = vi.fn();
+  const validateSubmission = vi.fn();
+  const generateSubmissionHash = vi.fn(() => "submission-hash");
+  const revalidateTag = vi.fn();
+
+  const db = {
+    transaction: vi.fn(),
+  };
+
+  return {
+    authenticatePersonalToken,
+    validateSubmission,
+    generateSubmissionHash,
+    revalidateTag,
+    db,
+    reset() {
+      authenticatePersonalToken.mockReset();
+      validateSubmission.mockReset();
+      generateSubmissionHash.mockClear();
+      revalidateTag.mockClear();
+      db.transaction.mockReset();
+    },
+  };
+});
+
+vi.mock("next/cache", () => ({
+  revalidateTag: mockState.revalidateTag,
+}));
+
+vi.mock("@/lib/auth/personalTokens", () => ({
+  authenticatePersonalToken: mockState.authenticatePersonalToken,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockState.db,
+  submissions: {
+    id: "submissions.id",
+    userId: "submissions.userId",
+  },
+  dailyBreakdown: {
+    id: "dailyBreakdown.id",
+    submissionId: "dailyBreakdown.submissionId",
+  },
+}));
+
+vi.mock("@/lib/validation/submission", () => ({
+  validateSubmission: mockState.validateSubmission,
+  generateSubmissionHash: mockState.generateSubmissionHash,
+}));
+
+vi.mock("@/lib/db/helpers", () => ({
+  mergeClientBreakdowns: vi.fn(),
+  recalculateDayTotals: vi.fn(),
+  buildModelBreakdown: vi.fn(),
+  clientContributionToBreakdownData: vi.fn(),
+  mergeTimestampMs: vi.fn(),
+}));
+
+type ModuleExports = typeof import("../../src/app/api/submit/route");
+
+let POST: ModuleExports["POST"];
+
+beforeAll(async () => {
+  const routeModule = await import("../../src/app/api/submit/route");
+  POST = routeModule.POST;
+});
+
+beforeEach(() => {
+  mockState.reset();
+});
+
+describe("POST /api/submit auth path", () => {
+  it("rejects invalid API tokens through the shared auth service", async () => {
+    mockState.authenticatePersonalToken.mockResolvedValue({ status: "invalid" });
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_invalid",
+        },
+        body: JSON.stringify({}),
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockState.authenticatePersonalToken).toHaveBeenCalledWith("tt_invalid", {
+      touchLastUsedAt: false,
+    });
+    expect(await response.json()).toEqual({ error: "Invalid API token" });
+  });
+
+  it("returns the expired-token error without entering the transaction path", async () => {
+    mockState.authenticatePersonalToken.mockResolvedValue({ status: "expired" });
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_expired",
+        },
+        body: JSON.stringify({}),
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockState.authenticatePersonalToken).toHaveBeenCalledWith("tt_expired", {
+      touchLastUsedAt: false,
+    });
+    expect(await response.json()).toEqual({ error: "API token has expired" });
+    expect(mockState.db.transaction).not.toHaveBeenCalled();
+  });
+
+  it("accepts a valid token and continues into submission validation", async () => {
+    mockState.authenticatePersonalToken.mockResolvedValue({
+      status: "valid",
+      tokenId: "token-1",
+      userId: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      isAdmin: false,
+      expiresAt: null,
+    });
+    mockState.validateSubmission.mockReturnValue({
+      valid: false,
+      data: null,
+      errors: ["bad payload"],
+    });
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ meta: {}, contributions: [] }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockState.authenticatePersonalToken).toHaveBeenCalledWith("tt_valid", {
+      touchLastUsedAt: false,
+    });
+    expect(mockState.validateSubmission).toHaveBeenCalledTimes(1);
+    expect(mockState.db.transaction).not.toHaveBeenCalled();
+    expect(await response.json()).toEqual({
+      error: "Validation failed",
+      details: ["bad payload"],
+    });
+  });
+});

--- a/packages/frontend/__tests__/lib/personalTokens.test.ts
+++ b/packages/frontend/__tests__/lib/personalTokens.test.ts
@@ -1,0 +1,441 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const selectResults: Array<Array<Record<string, unknown>>> = [];
+  const insertResults: Array<Array<Record<string, unknown>>> = [];
+  const updateResults: Array<Array<Record<string, unknown>>> = [];
+  const deleteResults: Array<Array<Record<string, unknown>>> = [];
+  const insertValues: Array<Record<string, unknown>> = [];
+  const updateValues: Array<Record<string, unknown>> = [];
+  const executeCalls: unknown[] = [];
+
+  const tables = {
+    apiTokens: {
+      id: "apiTokens.id",
+      userId: "apiTokens.userId",
+      token: "apiTokens.token",
+      name: "apiTokens.name",
+      createdAt: "apiTokens.createdAt",
+      lastUsedAt: "apiTokens.lastUsedAt",
+      expiresAt: "apiTokens.expiresAt",
+    },
+    users: {
+      id: "users.id",
+      username: "users.username",
+      displayName: "users.displayName",
+      avatarUrl: "users.avatarUrl",
+      isAdmin: "users.isAdmin",
+    },
+  };
+
+  const eq = vi.fn(() => "eq");
+  const and = vi.fn(() => "and");
+  const desc = vi.fn(() => "desc");
+  const sql = vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+  }));
+
+  function nextResult<T>(queue: T[][]): T[] {
+    return queue.shift() ?? [];
+  }
+
+  const execute = vi.fn(async (statement: unknown) => {
+    executeCalls.push(statement);
+    return [];
+  });
+
+  const db = {
+    select: vi.fn(() => {
+      const builder = {
+        from: vi.fn(() => builder),
+        innerJoin: vi.fn(() => builder),
+        where: vi.fn(() => builder),
+        limit: vi.fn(async () => nextResult(selectResults)),
+        orderBy: vi.fn(async () => nextResult(selectResults)),
+      };
+
+      return builder;
+    }),
+    insert: vi.fn(() => {
+      const builder = {
+        values: vi.fn((value: Record<string, unknown>) => {
+          insertValues.push(value);
+          return builder;
+        }),
+        returning: vi.fn(async () => nextResult(insertResults)),
+      };
+
+      return builder;
+    }),
+    update: vi.fn(() => {
+      const builder = {
+        set: vi.fn((value: Record<string, unknown>) => {
+          updateValues.push(value);
+          return builder;
+        }),
+        where: vi.fn(async () => nextResult(updateResults)),
+      };
+
+      return builder;
+    }),
+    delete: vi.fn(() => {
+      const builder = {
+        where: vi.fn(() => builder),
+        returning: vi.fn(async () => nextResult(deleteResults)),
+      };
+
+      return builder;
+    }),
+    execute,
+    transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => callback(tx)),
+  };
+
+  const tx = {
+    select: db.select,
+    insert: db.insert,
+    update: db.update,
+    delete: db.delete,
+    execute,
+  };
+
+  return {
+    db,
+    tables,
+    eq,
+    and,
+    desc,
+    sql,
+    insertValues,
+    updateValues,
+    executeCalls,
+    reset() {
+      selectResults.length = 0;
+      insertResults.length = 0;
+      updateResults.length = 0;
+      deleteResults.length = 0;
+      insertValues.length = 0;
+      updateValues.length = 0;
+      executeCalls.length = 0;
+      db.select.mockClear();
+      db.insert.mockClear();
+      db.update.mockClear();
+      db.delete.mockClear();
+      db.execute.mockClear();
+      db.transaction.mockClear();
+      eq.mockClear();
+      and.mockClear();
+      desc.mockClear();
+      sql.mockClear();
+    },
+    pushSelectResult(rows: Array<Record<string, unknown>>) {
+      selectResults.push(rows);
+    },
+    pushInsertResult(rows: Array<Record<string, unknown>>) {
+      insertResults.push(rows);
+    },
+    pushUpdateResult(rows: Array<Record<string, unknown>> = []) {
+      updateResults.push(rows);
+    },
+    pushDeleteResult(rows: Array<Record<string, unknown>>) {
+      deleteResults.push(rows);
+    },
+  };
+});
+
+const generateApiToken = vi.fn(() => "tt_test_token");
+
+vi.mock("@/lib/db", () => ({
+  db: mockState.db,
+  apiTokens: mockState.tables.apiTokens,
+  users: mockState.tables.users,
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: mockState.eq,
+  and: mockState.and,
+  desc: mockState.desc,
+  sql: mockState.sql,
+}));
+
+vi.mock("@/lib/auth/utils", () => ({
+  generateApiToken,
+}));
+
+type ModuleExports = typeof import("../../src/lib/auth/personalTokens");
+
+let issuePersonalToken: ModuleExports["issuePersonalToken"];
+let authenticatePersonalToken: ModuleExports["authenticatePersonalToken"];
+let listPersonalTokens: ModuleExports["listPersonalTokens"];
+let revokePersonalToken: ModuleExports["revokePersonalToken"];
+
+beforeAll(async () => {
+  const personalTokensModule = await import("../../src/lib/auth/personalTokens");
+  issuePersonalToken = personalTokensModule.issuePersonalToken;
+  authenticatePersonalToken = personalTokensModule.authenticatePersonalToken;
+  listPersonalTokens = personalTokensModule.listPersonalTokens;
+  revokePersonalToken = personalTokensModule.revokePersonalToken;
+});
+
+beforeEach(() => {
+  mockState.reset();
+  generateApiToken.mockClear();
+  generateApiToken.mockReturnValue("tt_test_token");
+  vi.useRealTimers();
+});
+
+describe("personal token service", () => {
+  it("issues a token and keeps the requested name when it is available", async () => {
+    mockState.pushSelectResult([]);
+    mockState.pushInsertResult([
+      {
+        id: "token-1",
+        userId: "user-1",
+        name: "CLI",
+        createdAt: new Date("2026-03-08T04:00:00.000Z"),
+        lastUsedAt: null,
+        expiresAt: null,
+      },
+    ]);
+
+    const token = await issuePersonalToken({
+      userId: "user-1",
+      name: "CLI",
+      ensureUniqueName: true,
+    });
+
+    expect(token).toMatchObject({
+      id: "token-1",
+      userId: "user-1",
+      name: "CLI",
+      token: "tt_test_token",
+    });
+    expect(mockState.insertValues[0]).toMatchObject({
+      userId: "user-1",
+      name: "CLI",
+      token: "tt_test_token",
+      expiresAt: null,
+    });
+    expect(mockState.db.transaction).toHaveBeenCalledTimes(1);
+    expect(mockState.executeCalls).toHaveLength(1);
+  });
+
+  it("suffixes duplicate token names when requested", async () => {
+    mockState.pushSelectResult([
+      { name: "CLI" },
+      { name: "CLI (1)" },
+    ]);
+    mockState.pushInsertResult([
+      {
+        id: "token-2",
+        userId: "user-1",
+        name: "CLI (2)",
+        createdAt: new Date("2026-03-08T04:00:00.000Z"),
+        lastUsedAt: null,
+        expiresAt: null,
+      },
+    ]);
+
+    const token = await issuePersonalToken({
+      userId: "user-1",
+      name: "CLI",
+      ensureUniqueName: true,
+    });
+
+    expect(token.name).toBe("CLI (2)");
+    expect(mockState.insertValues[0]).toMatchObject({
+      name: "CLI (2)",
+    });
+    expect(mockState.db.transaction).toHaveBeenCalledTimes(1);
+    expect(mockState.executeCalls).toHaveLength(1);
+  });
+
+  it("keeps incrementing the numeric suffix under the advisory lock", async () => {
+    mockState.pushSelectResult([
+      { name: "CLI" },
+      { name: "CLI (1)" },
+      { name: "CLI (2)" },
+    ]);
+    mockState.pushInsertResult([
+      {
+        id: "token-3",
+        userId: "user-1",
+        name: "CLI (3)",
+        createdAt: new Date("2026-03-08T04:00:00.000Z"),
+        lastUsedAt: null,
+        expiresAt: null,
+      },
+    ]);
+
+    const token = await issuePersonalToken({
+      userId: "user-1",
+      name: "CLI",
+      ensureUniqueName: true,
+    });
+
+    expect(token.name).toBe("CLI (3)");
+    expect(mockState.db.insert).toHaveBeenCalledTimes(1);
+    expect(mockState.db.transaction).toHaveBeenCalledTimes(1);
+    expect(mockState.executeCalls).toHaveLength(1);
+    expect(mockState.insertValues[0]).toMatchObject({
+      name: "CLI (3)",
+    });
+  });
+
+  it("can create a token without taking the advisory lock", async () => {
+    mockState.pushInsertResult([
+      {
+        id: "token-raw",
+        userId: "user-1",
+        name: "CLI raw",
+        createdAt: new Date("2026-03-08T04:00:00.000Z"),
+        lastUsedAt: null,
+        expiresAt: null,
+      },
+    ]);
+
+    const token = await issuePersonalToken({
+      userId: "user-1",
+      name: "CLI raw",
+    });
+
+    expect(token.name).toBe("CLI raw");
+    expect(mockState.db.transaction).not.toHaveBeenCalled();
+    expect(mockState.executeCalls).toHaveLength(0);
+    expect(mockState.insertValues[0]).toMatchObject({
+      name: "CLI raw",
+    });
+  });
+
+  it("returns invalid for malformed tokens without hitting the database", async () => {
+    const result = await authenticatePersonalToken("not-a-token");
+
+    expect(result).toEqual({ status: "invalid" });
+    expect(mockState.db.select).not.toHaveBeenCalled();
+  });
+
+  it("returns expired when the token exists but is past its expiry", async () => {
+    mockState.pushSelectResult([
+      {
+        tokenId: "token-1",
+        userId: "user-1",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        isAdmin: false,
+        expiresAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+    ]);
+
+    const result = await authenticatePersonalToken("tt_test_token");
+
+    expect(result).toEqual({ status: "expired" });
+    expect(mockState.db.update).not.toHaveBeenCalled();
+  });
+
+  it("treats a token expiring right now as expired", async () => {
+    const now = new Date("2026-03-08T04:00:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    mockState.pushSelectResult([
+      {
+        tokenId: "token-1",
+        userId: "user-1",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        isAdmin: false,
+        expiresAt: now,
+      },
+    ]);
+
+    const result = await authenticatePersonalToken("tt_test_token");
+
+    expect(result).toEqual({ status: "expired" });
+    expect(mockState.db.update).not.toHaveBeenCalled();
+  });
+
+  it("returns the user and touches lastUsedAt for a valid token", async () => {
+    mockState.pushSelectResult([
+      {
+        tokenId: "token-1",
+        userId: "user-1",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        isAdmin: false,
+        expiresAt: null,
+      },
+    ]);
+    mockState.pushUpdateResult();
+
+    const result = await authenticatePersonalToken("tt_test_token");
+
+    expect(result).toMatchObject({
+      status: "valid",
+      tokenId: "token-1",
+      userId: "user-1",
+      username: "alice",
+    });
+    expect(mockState.db.update).toHaveBeenCalledTimes(1);
+    expect(mockState.updateValues[0]).toHaveProperty("lastUsedAt");
+  });
+
+  it("can skip touching lastUsedAt when the caller opts out", async () => {
+    mockState.pushSelectResult([
+      {
+        tokenId: "token-1",
+        userId: "user-1",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        isAdmin: false,
+        expiresAt: null,
+      },
+    ]);
+
+    const result = await authenticatePersonalToken("tt_test_token", {
+      touchLastUsedAt: false,
+    });
+
+    expect(result).toMatchObject({
+      status: "valid",
+      tokenId: "token-1",
+    });
+    expect(mockState.db.update).not.toHaveBeenCalled();
+  });
+
+  it("lists tokens for a user", async () => {
+    mockState.pushSelectResult([
+      {
+        id: "token-2",
+        userId: "user-1",
+        name: "CLI",
+        createdAt: new Date("2026-03-08T04:00:00.000Z"),
+        lastUsedAt: null,
+        expiresAt: null,
+      },
+    ]);
+
+    const tokens = await listPersonalTokens("user-1");
+
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]).toMatchObject({
+      id: "token-2",
+      name: "CLI",
+    });
+  });
+
+  it("revokes only matching user tokens", async () => {
+    mockState.pushDeleteResult([{ id: "token-1" }]);
+
+    const revoked = await revokePersonalToken("user-1", "token-1");
+
+    expect(revoked).toBe(true);
+    expect(mockState.db.delete).toHaveBeenCalledTimes(1);
+    expect(mockState.eq).toHaveBeenNthCalledWith(1, mockState.tables.apiTokens.id, "token-1");
+    expect(mockState.eq).toHaveBeenNthCalledWith(2, mockState.tables.apiTokens.userId, "user-1");
+    expect(mockState.and).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/frontend/src/app/api/auth/device/poll/route.ts
+++ b/packages/frontend/src/app/api/auth/device/poll/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
-import { db, deviceCodes, apiTokens, users } from "@/lib/db";
+import { db, deviceCodes, users } from "@/lib/db";
 import { eq, and, gt } from "drizzle-orm";
-import { generateApiToken } from "@/lib/auth/utils";
+import { issuePersonalToken } from "@/lib/auth/personalTokens";
 
 export async function POST(request: Request) {
   try {
@@ -50,28 +50,10 @@ export async function POST(request: Request) {
       );
     }
 
-    // Generate API token
-    const token = generateApiToken();
-    const tokenName = record.deviceName || "CLI";
-
-    // Check if token with same name exists, append number if needed
-    const existingTokens = await db
-      .select()
-      .from(apiTokens)
-      .where(eq(apiTokens.userId, user.id));
-
-    let finalName = tokenName;
-    let counter = 1;
-    while (existingTokens.some((t) => t.name === finalName)) {
-      finalName = `${tokenName} (${counter})`;
-      counter++;
-    }
-
-    // Store API token
-    await db.insert(apiTokens).values({
+    const issuedToken = await issuePersonalToken({
       userId: user.id,
-      token,
-      name: finalName,
+      name: record.deviceName || "CLI",
+      ensureUniqueName: true,
     });
 
     // Delete the device code (one-time use)
@@ -79,7 +61,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({
       status: "complete",
-      token,
+      token: issuedToken.token,
       user: {
         username: user.username,
         avatarUrl: user.avatarUrl,

--- a/packages/frontend/src/app/api/settings/tokens/[tokenId]/route.ts
+++ b/packages/frontend/src/app/api/settings/tokens/[tokenId]/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
-import { db, apiTokens } from "@/lib/db";
-import { eq, and } from "drizzle-orm";
 import { getSession } from "@/lib/auth/session";
+import { revokePersonalToken } from "@/lib/auth/personalTokens";
 
 interface RouteParams {
   params: Promise<{ tokenId: string }>;
@@ -16,13 +15,9 @@ export async function DELETE(_request: Request, { params }: RouteParams) {
 
     const { tokenId } = await params;
 
-    // Delete token only if it belongs to the current user
-    const result = await db
-      .delete(apiTokens)
-      .where(and(eq(apiTokens.id, tokenId), eq(apiTokens.userId, session.id)))
-      .returning({ id: apiTokens.id });
+    const revoked = await revokePersonalToken(session.id, tokenId);
 
-    if (result.length === 0) {
+    if (!revoked) {
       return NextResponse.json({ error: "Token not found" }, { status: 404 });
     }
 

--- a/packages/frontend/src/app/api/settings/tokens/route.ts
+++ b/packages/frontend/src/app/api/settings/tokens/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
-import { db, apiTokens } from "@/lib/db";
-import { eq, desc } from "drizzle-orm";
 import { getSession } from "@/lib/auth/session";
+import { listPersonalTokens } from "@/lib/auth/personalTokens";
 
 export async function GET() {
   try {
@@ -10,18 +9,16 @@ export async function GET() {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }
 
-    const tokens = await db
-      .select({
-        id: apiTokens.id,
-        name: apiTokens.name,
-        createdAt: apiTokens.createdAt,
-        lastUsedAt: apiTokens.lastUsedAt,
-      })
-      .from(apiTokens)
-      .where(eq(apiTokens.userId, session.id))
-      .orderBy(desc(apiTokens.createdAt));
+    const tokens = await listPersonalTokens(session.id);
 
-    return NextResponse.json({ tokens });
+    return NextResponse.json({
+      tokens: tokens.map((token) => ({
+        id: token.id,
+        name: token.name,
+        createdAt: token.createdAt,
+        lastUsedAt: token.lastUsedAt,
+      })),
+    });
   } catch (error) {
     console.error("Tokens list error:", error);
     return NextResponse.json(

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -1,12 +1,13 @@
 import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
-import { db, apiTokens, users, submissions, dailyBreakdown } from "@/lib/db";
+import { db, apiTokens, submissions, dailyBreakdown } from "@/lib/db";
 import { eq, sql } from "drizzle-orm";
 import {
   validateSubmission,
   generateSubmissionHash,
   type SubmissionData,
 } from "@/lib/validation/submission";
+import { authenticatePersonalToken } from "@/lib/auth/personalTokens";
 import {
   mergeClientBreakdowns,
   recalculateDayTotals,
@@ -72,26 +73,19 @@ export async function POST(request: Request) {
     }
 
     const token = authHeader.slice(7);
+    const authResult = await authenticatePersonalToken(token, {
+      touchLastUsedAt: false,
+    });
 
-    const [tokenRecord] = await db
-      .select({
-        tokenId: apiTokens.id,
-        userId: apiTokens.userId,
-        username: users.username,
-        expiresAt: apiTokens.expiresAt,
-      })
-      .from(apiTokens)
-      .innerJoin(users, eq(apiTokens.userId, users.id))
-      .where(eq(apiTokens.token, token))
-      .limit(1);
-
-    if (!tokenRecord) {
+    if (authResult.status === "invalid") {
       return NextResponse.json({ error: "Invalid API token" }, { status: 401 });
     }
 
-    if (tokenRecord.expiresAt && tokenRecord.expiresAt < new Date()) {
+    if (authResult.status === "expired") {
       return NextResponse.json({ error: "API token has expired" }, { status: 401 });
     }
+
+    const tokenRecord = authResult;
 
     // ========================================
     // STEP 2: Parse and Validate
@@ -149,7 +143,7 @@ export async function POST(request: Request) {
       // ------------------------------------------
       // STEP 3a: Get or create user's submission
       // ------------------------------------------
-      let [existingSubmission] = await tx
+      const [existingSubmission] = await tx
         .select({ id: submissions.id })
         .from(submissions)
         .where(eq(submissions.userId, tokenRecord.userId))

--- a/packages/frontend/src/lib/auth/personalTokens.ts
+++ b/packages/frontend/src/lib/auth/personalTokens.ts
@@ -1,0 +1,212 @@
+import { and, desc, eq, sql } from "drizzle-orm";
+import { db, apiTokens, users } from "@/lib/db";
+import { generateApiToken } from "@/lib/auth/utils";
+
+export interface PersonalTokenListItem {
+  id: string;
+  userId: string;
+  name: string;
+  createdAt: Date;
+  lastUsedAt: Date | null;
+  expiresAt: Date | null;
+}
+
+export interface IssuePersonalTokenInput {
+  userId: string;
+  name: string;
+  expiresAt?: Date | null;
+  ensureUniqueName?: boolean;
+}
+
+export interface IssuedPersonalToken extends PersonalTokenListItem {
+  token: string;
+}
+
+export interface AuthenticatedPersonalToken {
+  tokenId: string;
+  userId: string;
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  isAdmin: boolean;
+  expiresAt: Date | null;
+}
+
+export type PersonalTokenAuthResult =
+  | { status: "invalid" }
+  | { status: "expired" }
+  | ({ status: "valid" } & AuthenticatedPersonalToken);
+
+export interface AuthenticatePersonalTokenOptions {
+  touchLastUsedAt?: boolean;
+}
+
+const TOKEN_NAME_LOCK_NAMESPACE = "personal_token_names";
+
+function getUniqueTokenName(baseName: string, existingNames: Iterable<string>): string {
+  const names = new Set(existingNames);
+  let finalName = baseName;
+  let counter = 1;
+
+  while (names.has(finalName)) {
+    finalName = `${baseName} (${counter})`;
+    counter++;
+  }
+
+  return finalName;
+}
+
+export async function issuePersonalToken({
+  userId,
+  name,
+  expiresAt = null,
+  ensureUniqueName = false,
+}: IssuePersonalTokenInput): Promise<IssuedPersonalToken> {
+  if (!ensureUniqueName) {
+    const token = generateApiToken();
+    const [createdToken] = await db
+      .insert(apiTokens)
+      .values({
+        userId,
+        token,
+        name,
+        expiresAt,
+      })
+      .returning({
+        id: apiTokens.id,
+        userId: apiTokens.userId,
+        name: apiTokens.name,
+        createdAt: apiTokens.createdAt,
+        lastUsedAt: apiTokens.lastUsedAt,
+        expiresAt: apiTokens.expiresAt,
+      });
+
+    return {
+      ...createdToken,
+      token,
+    };
+  }
+
+  return db.transaction(async (tx) => {
+    await tx.execute(sql`
+      SELECT pg_advisory_xact_lock(
+        hashtext(${TOKEN_NAME_LOCK_NAMESPACE}),
+        hashtext(${userId})
+      )
+    `);
+
+    const existingTokens = await tx
+      .select({
+        name: apiTokens.name,
+      })
+      .from(apiTokens)
+      .where(eq(apiTokens.userId, userId))
+      .orderBy(desc(apiTokens.createdAt));
+
+    const finalName = getUniqueTokenName(
+      name,
+      existingTokens.map((token) => token.name)
+    );
+    const token = generateApiToken();
+    const [createdToken] = await tx
+      .insert(apiTokens)
+      .values({
+        userId,
+        token,
+        name: finalName,
+        expiresAt,
+      })
+      .returning({
+        id: apiTokens.id,
+        userId: apiTokens.userId,
+        name: apiTokens.name,
+        createdAt: apiTokens.createdAt,
+        lastUsedAt: apiTokens.lastUsedAt,
+        expiresAt: apiTokens.expiresAt,
+      });
+
+    return {
+      ...createdToken,
+      token,
+    };
+  });
+}
+
+export async function listPersonalTokens(userId: string): Promise<PersonalTokenListItem[]> {
+  return db
+    .select({
+      id: apiTokens.id,
+      userId: apiTokens.userId,
+      name: apiTokens.name,
+      createdAt: apiTokens.createdAt,
+      lastUsedAt: apiTokens.lastUsedAt,
+      expiresAt: apiTokens.expiresAt,
+    })
+    .from(apiTokens)
+    .where(eq(apiTokens.userId, userId))
+    .orderBy(desc(apiTokens.createdAt));
+}
+
+export async function revokePersonalToken(
+  userId: string,
+  tokenId: string
+): Promise<boolean> {
+  const result = await db
+    .delete(apiTokens)
+    .where(and(eq(apiTokens.id, tokenId), eq(apiTokens.userId, userId)))
+    .returning({ id: apiTokens.id });
+
+  return result.length > 0;
+}
+
+export async function authenticatePersonalToken(
+  token: string,
+  options: AuthenticatePersonalTokenOptions = {}
+): Promise<PersonalTokenAuthResult> {
+  if (!token.startsWith("tt_")) {
+    return { status: "invalid" };
+  }
+
+  const result = await db
+    .select({
+      tokenId: apiTokens.id,
+      userId: apiTokens.userId,
+      username: users.username,
+      displayName: users.displayName,
+      avatarUrl: users.avatarUrl,
+      isAdmin: users.isAdmin,
+      expiresAt: apiTokens.expiresAt,
+    })
+    .from(apiTokens)
+    .innerJoin(users, eq(apiTokens.userId, users.id))
+    .where(eq(apiTokens.token, token))
+    .limit(1);
+
+  if (result.length === 0) {
+    return { status: "invalid" };
+  }
+
+  const record = result[0];
+
+  if (record.expiresAt && record.expiresAt <= new Date()) {
+    return { status: "expired" };
+  }
+
+  if (options.touchLastUsedAt !== false) {
+    await db
+      .update(apiTokens)
+      .set({ lastUsedAt: new Date() })
+      .where(eq(apiTokens.id, record.tokenId));
+  }
+
+  return {
+    status: "valid",
+    tokenId: record.tokenId,
+    userId: record.userId,
+    username: record.username,
+    displayName: record.displayName,
+    avatarUrl: record.avatarUrl,
+    isAdmin: record.isAdmin,
+    expiresAt: record.expiresAt,
+  };
+}

--- a/packages/frontend/src/lib/auth/session.ts
+++ b/packages/frontend/src/lib/auth/session.ts
@@ -1,7 +1,8 @@
 import { cookies } from "next/headers";
-import { db, sessions, users, apiTokens } from "@/lib/db";
-import { eq, and, gt, or, isNull } from "drizzle-orm";
+import { db, sessions, users } from "@/lib/db";
+import { eq, and, gt } from "drizzle-orm";
 import { generateRandomString } from "./utils";
+import { authenticatePersonalToken } from "./personalTokens";
 
 const SESSION_COOKIE_NAME = "tt_session";
 const SESSION_DURATION_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
@@ -108,43 +109,18 @@ export async function clearSession(): Promise<void> {
 export async function validateApiToken(
   token: string
 ): Promise<SessionUser | null> {
-  if (!token.startsWith("tt_")) {
+  const result = await authenticatePersonalToken(token);
+
+  if (result.status !== "valid") {
     return null;
   }
-
-  const result = await db
-    .select({
-      apiToken: apiTokens,
-      user: users,
-    })
-    .from(apiTokens)
-    .innerJoin(users, eq(apiTokens.userId, users.id))
-    .where(
-      and(
-        eq(apiTokens.token, token),
-        or(isNull(apiTokens.expiresAt), gt(apiTokens.expiresAt, new Date()))
-      )
-    )
-    .limit(1);
-
-  if (result.length === 0) {
-    return null;
-  }
-
-  // Update last_used_at
-  await db
-    .update(apiTokens)
-    .set({ lastUsedAt: new Date() })
-    .where(eq(apiTokens.token, token));
-
-  const { user } = result[0];
 
   return {
-    id: user.id,
-    username: user.username,
-    displayName: user.displayName,
-    avatarUrl: user.avatarUrl,
-    isAdmin: user.isAdmin,
+    id: result.userId,
+    username: result.username,
+    displayName: result.displayName,
+    avatarUrl: result.avatarUrl,
+    isAdmin: result.isAdmin,
   };
 }
 


### PR DESCRIPTION
Refactor personal token authentication to use a single shared implementation.

Previously token validation and issuance logic was duplicated across multiple routes (`/api/submit`, device auth polling, and settings token routes) as well as the `validateApiToken()` session helper. That made it possible for validation rules to drift between paths.

This change centralizes token issuance, validation, and token management helpers in `personalTokens.ts` and updates those routes to use the shared implementation.

There are no schema or client-facing API changes. Existing tokens and clients continue to work as before. The only behavior adjustment is consistent expiry handling (`expiresAt <= now`) across all token auth paths.

Added tests covering token issuance, validation, revocation, device auth flow, and `/api/submit` authentication so the shared logic stays consistent across routes.

