### PR TITLE
fix: prefer cumulative token deltas for repeated snapshots

### DIFF
--- a/crates/tokscale-core/src/sessions/codex.rs
+++ b/crates/tokscale-core/src/sessions/codex.rs
@@ -198,13 +198,11 @@ pub fn parse_codex_file(path: &Path) -> Vec<UnifiedMessage> {
                     if let Some(total) = total_usage {
                         previous_totals = Some(total);
                     } else if let Some(last) = last_usage {
-                        previous_totals = previous_totals.map(|previous| {
-                            CodexTotals {
-                                input: previous.input.saturating_add(last.input),
-                                output: previous.output.saturating_add(last.output),
-                                cached: previous.cached.saturating_add(last.cached),
-                                reasoning: previous.reasoning.saturating_add(last.reasoning),
-                            }
+                        previous_totals = previous_totals.map(|previous| CodexTotals {
+                            input: previous.input.saturating_add(last.input),
+                            output: previous.output.saturating_add(last.output),
+                            cached: previous.cached.saturating_add(last.cached),
+                            reasoning: previous.reasoning.saturating_add(last.reasoning),
                         });
                     }
 


### PR DESCRIPTION
Fix repeated `token_count` snapshots that reuse the same cumulative totals.

When `total_token_usage` is present, the parser was still preferring `last_token_usage`, which can double count repeated snapshot rows that do not advance cumulative totals.

This changes the parser to prefer deltas from `total_token_usage`, skip rows when cumulative totals do not advance, and fall back to `last_token_usage` only when totals are missing or appear to reset.

Added regression tests for repeated cumulative snapshots and for the reset fallback path.

Fixes #297

