### PR TITLE
fix: add Cursor pricing for Composer 1.5

### DIFF
--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -126,9 +126,8 @@ impl DataLoader {
         let pricing_result = rt.block_on(async { PricingService::get_or_init().await });
         let pricing = pricing_result.as_ref().ok();
 
-        // Always parse only enabled clients. Synthetic re-attribution (Strategy 1)
-        // runs on these messages after parsing — it doesn't need ALL clients, just the
-        // ones the user actually enabled. Octofriend SQLite (Strategy 2) is handled
+        // Always parse only enabled clients. Synthetic gateway detection runs on these
+        // messages after parsing, while Octofriend SQLite (Strategy 2) is handled
         // separately by the scanner when "synthetic" is in the sources list.
         let clients_to_parse: Vec<ClientId> = enabled_clients.to_vec();
 
@@ -295,18 +294,10 @@ impl DataLoader {
             }
 
             for msg in &mut all_messages {
-                if msg.client == "synthetic" {
-                    continue;
-                }
-                if sessions::synthetic::is_synthetic_model(&msg.model_id)
-                    || sessions::synthetic::is_synthetic_provider(&msg.provider_id)
-                {
-                    msg.client = "synthetic".to_string();
-                    msg.model_id = sessions::synthetic::normalize_synthetic_model(&msg.model_id);
-                    if !msg.provider_id.is_empty() {
-                        msg.provider_id = "synthetic".to_string();
-                    }
-                }
+                sessions::synthetic::normalize_synthetic_gateway_fields(
+                    &mut msg.model_id,
+                    &mut msg.provider_id,
+                );
             }
         }
 
@@ -317,7 +308,15 @@ impl DataLoader {
         if include_synthetic {
             requested_clients.insert("synthetic".to_string());
         }
-        all_messages.retain(|msg| requested_clients.contains(&msg.client));
+        all_messages.retain(|msg| {
+            requested_clients.contains(&msg.client)
+                || (include_synthetic
+                    && sessions::synthetic::matches_synthetic_filter(
+                        &msg.client,
+                        &msg.model_id,
+                        &msg.provider_id,
+                    ))
+        });
 
         if let Some(svc) = pricing {
             for msg in &mut all_messages {
@@ -956,5 +955,17 @@ mod tests {
         let (current, longest) = calculate_streaks_for_today(&daily, today);
         assert_eq!(current, 2);
         assert_eq!(longest, 2);
+    }
+
+    #[test]
+    fn test_synthetic_filter_match_keeps_gateway_messages_with_original_client() {
+        assert!(sessions::synthetic::matches_synthetic_filter(
+            "opencode",
+            "hf:deepseek-ai/DeepSeek-V3-0324",
+            "unknown"
+        ));
+        assert!(!sessions::synthetic::matches_synthetic_filter(
+            "opencode", "gpt-5.2", "openai"
+        ));
     }
 }

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -51,6 +51,17 @@ pub fn normalize_model_for_grouping(model_id: &str) -> String {
     name
 }
 
+fn retain_for_requested_clients(
+    client: &str,
+    model_id: &str,
+    provider_id: &str,
+    requested: &HashSet<&str>,
+) -> bool {
+    requested.contains(client)
+        || (requested.contains("synthetic")
+            && sessions::synthetic::matches_synthetic_filter(client, model_id, provider_id))
+}
+
 #[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
 pub enum GroupBy {
     Model,
@@ -728,25 +739,18 @@ fn parse_all_messages_with_pricing(
         }
 
         for msg in &mut all_messages {
-            if msg.client == "synthetic" {
-                continue;
-            }
-
-            if sessions::synthetic::is_synthetic_model(&msg.model_id)
-                || sessions::synthetic::is_synthetic_provider(&msg.provider_id)
-            {
-                msg.client = "synthetic".to_string();
-                msg.model_id = sessions::synthetic::normalize_synthetic_model(&msg.model_id);
-                if msg.provider_id.is_empty() || msg.provider_id == "unknown" {
-                    msg.provider_id = "synthetic".to_string();
-                }
-            }
+            sessions::synthetic::normalize_synthetic_gateway_fields(
+                &mut msg.model_id,
+                &mut msg.provider_id,
+            );
         }
     }
 
     if !include_all {
         let requested: HashSet<&str> = clients.iter().map(String::as_str).collect();
-        all_messages.retain(|msg| requested.contains(msg.client.as_str()));
+        all_messages.retain(|msg| {
+            retain_for_requested_clients(&msg.client, &msg.model_id, &msg.provider_id, &requested)
+        });
     }
 
     all_messages
@@ -1255,7 +1259,6 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     counts.set(ClientId::Mux, mux_count);
     messages.extend(mux_msgs);
 
-    let mut synthetic_count: i32 = 0;
     if include_synthetic {
         if let Some(db_path) = &scan_result.synthetic_db {
             let synthetic_msgs: Vec<ParsedMessage> =
@@ -1263,47 +1266,23 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
                     .into_iter()
                     .map(|msg| unified_to_parsed(&msg))
                     .collect();
-            synthetic_count += synthetic_msgs.len() as i32;
             messages.extend(synthetic_msgs);
         }
 
-        let mut deltas = [0_i32; ClientId::COUNT];
         for msg in &mut messages {
-            if msg.client == "synthetic" {
-                continue;
-            }
-
-            if sessions::synthetic::is_synthetic_model(&msg.model_id)
-                || sessions::synthetic::is_synthetic_provider(&msg.provider_id)
-            {
-                if let Some(client_id) = ClientId::from_str(&msg.client) {
-                    deltas[client_id as usize] += 1;
-                }
-
-                msg.client = "synthetic".to_string();
-                msg.model_id = sessions::synthetic::normalize_synthetic_model(&msg.model_id);
-                if msg.provider_id.is_empty() || msg.provider_id == "unknown" {
-                    msg.provider_id = "synthetic".to_string();
-                }
-
-                synthetic_count += 1;
-            }
-        }
-
-        for client_id in ClientId::iter() {
-            let delta = deltas[client_id as usize];
-            if delta > 0 {
-                counts.add(client_id, -delta);
-            }
+            sessions::synthetic::normalize_synthetic_gateway_fields(
+                &mut msg.model_id,
+                &mut msg.provider_id,
+            );
         }
     }
 
     if !include_all {
         let requested: HashSet<&str> = clients.iter().map(String::as_str).collect();
-        messages.retain(|msg| requested.contains(msg.client.as_str()));
+        messages.retain(|msg| {
+            retain_for_requested_clients(&msg.client, &msg.model_id, &msg.provider_id, &requested)
+        });
     }
-
-    let _ = synthetic_count;
 
     let filtered = filter_parsed_messages(messages, &options);
 
@@ -1376,8 +1355,11 @@ pub fn parsed_to_unified(msg: &ParsedMessage, cost: f64) -> UnifiedMessage {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_model_for_grouping, parse_all_messages_with_pricing, pricing, GroupBy};
-    use std::collections::HashMap;
+    use super::{
+        normalize_model_for_grouping, parse_all_messages_with_pricing, pricing,
+        retain_for_requested_clients, GroupBy,
+    };
+    use std::collections::{HashMap, HashSet};
     use std::str::FromStr;
 
     #[test]
@@ -1498,6 +1480,37 @@ mod tests {
             GroupBy::from_str("client , provider , model").unwrap(),
             GroupBy::ClientProviderModel
         );
+    }
+
+    #[test]
+    fn test_retain_for_requested_clients_keeps_original_client_matches() {
+        let requested: HashSet<&str> = HashSet::from(["opencode"]);
+        assert!(retain_for_requested_clients(
+            "opencode", "gpt-5.2", "openai", &requested
+        ));
+        assert!(!retain_for_requested_clients(
+            "claude", "gpt-5.2", "openai", &requested
+        ));
+    }
+
+    #[test]
+    fn test_retain_for_requested_clients_accepts_synthetic_gateway_traffic() {
+        let requested: HashSet<&str> = HashSet::from(["synthetic"]);
+        assert!(retain_for_requested_clients(
+            "opencode",
+            "hf:deepseek-ai/DeepSeek-V3-0324",
+            "unknown",
+            &requested
+        ));
+        assert!(retain_for_requested_clients(
+            "synthetic",
+            "deepseek-v3-0324",
+            "synthetic",
+            &requested
+        ));
+        assert!(!retain_for_requested_clients(
+            "opencode", "gpt-5.2", "openai", &requested
+        ));
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/synthetic.rs
+++ b/crates/tokscale-core/src/sessions/synthetic.rs
@@ -45,6 +45,11 @@ pub fn is_synthetic_provider(provider_id: &str) -> bool {
     )
 }
 
+/// Check if a message appears to have been routed through Synthetic's gateway.
+pub fn is_synthetic_gateway(model_id: &str, provider_id: &str) -> bool {
+    is_synthetic_model(model_id) || is_synthetic_provider(provider_id)
+}
+
 // =============================================================================
 // Model name normalization (strip synthetic.new prefixes for pricing lookup)
 // =============================================================================
@@ -73,6 +78,25 @@ pub fn normalize_synthetic_model(model_id: &str) -> String {
     }
 
     lower
+}
+
+/// Normalize synthetic gateway fields without changing the originating client.
+pub fn normalize_synthetic_gateway_fields(model_id: &mut String, provider_id: &mut String) -> bool {
+    if !is_synthetic_gateway(model_id, provider_id) {
+        return false;
+    }
+
+    *model_id = normalize_synthetic_model(model_id);
+    if provider_id.is_empty() || provider_id.eq_ignore_ascii_case("unknown") {
+        *provider_id = "synthetic".to_string();
+    }
+
+    true
+}
+
+/// Compatibility matcher for `--synthetic` / synthetic source selection.
+pub fn matches_synthetic_filter(client: &str, model_id: &str, provider_id: &str) -> bool {
+    client.eq_ignore_ascii_case("synthetic") || is_synthetic_gateway(model_id, provider_id)
 }
 
 // =============================================================================
@@ -295,6 +319,45 @@ mod tests {
             "claude-sonnet-4-5"
         );
         assert_eq!(normalize_synthetic_model("gpt-4o"), "gpt-4o");
+    }
+
+    #[test]
+    fn test_normalize_synthetic_gateway_fields_sets_provider_when_unknown() {
+        let mut model_id = "hf:deepseek-ai/DeepSeek-V3-0324".to_string();
+        let mut provider_id = "unknown".to_string();
+
+        let matched = normalize_synthetic_gateway_fields(&mut model_id, &mut provider_id);
+
+        assert!(matched);
+        assert_eq!(model_id, "deepseek-v3-0324");
+        assert_eq!(provider_id, "synthetic");
+    }
+
+    #[test]
+    fn test_normalize_synthetic_gateway_fields_preserves_existing_provider() {
+        let mut model_id = "accounts/fireworks/models/deepseek-v3-0324".to_string();
+        let mut provider_id = "fireworks".to_string();
+
+        let matched = normalize_synthetic_gateway_fields(&mut model_id, &mut provider_id);
+
+        assert!(matched);
+        assert_eq!(model_id, "deepseek-v3-0324");
+        assert_eq!(provider_id, "fireworks");
+    }
+
+    #[test]
+    fn test_matches_synthetic_filter_accepts_gateway_traffic_without_rewriting_client() {
+        assert!(matches_synthetic_filter(
+            "opencode",
+            "hf:deepseek-ai/DeepSeek-V3-0324",
+            "unknown"
+        ));
+        assert!(matches_synthetic_filter(
+            "claude",
+            "claude-sonnet-4-5",
+            "glhf"
+        ));
+        assert!(!matches_synthetic_filter("opencode", "gpt-5.2", "openai"));
     }
 
     #[test]


### PR DESCRIPTION
Add a Cursor pricing fallback for `Composer 1.5`.

Cursor usage rows for `Composer 1.5` can arrive with `Cost = 0`, so tokscale needs a local pricing fallback to reprice those rows.

This adds Cursor-sourced pricing for `Composer 1.5` and covers both the lookup path and the real Cursor CSV parse path where a zero-cost row now gets repriced.

Fixes #276


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
