### PR TITLE
fix: preserve client identity for synthetic gateway traffic

### DIFF
--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -965,9 +965,7 @@ mod tests {
             "unknown"
         ));
         assert!(!sessions::synthetic::matches_synthetic_filter(
-            "opencode",
-            "gpt-5.2",
-            "openai"
+            "opencode", "gpt-5.2", "openai"
         ));
     }
 }

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1483,16 +1483,10 @@ mod tests {
     fn test_retain_for_requested_clients_keeps_original_client_matches() {
         let requested: HashSet<&str> = HashSet::from(["opencode"]);
         assert!(retain_for_requested_clients(
-            "opencode",
-            "gpt-5.2",
-            "openai",
-            &requested
+            "opencode", "gpt-5.2", "openai", &requested
         ));
         assert!(!retain_for_requested_clients(
-            "claude",
-            "gpt-5.2",
-            "openai",
-            &requested
+            "claude", "gpt-5.2", "openai", &requested
         ));
     }
 
@@ -1512,10 +1506,7 @@ mod tests {
             &requested
         ));
         assert!(!retain_for_requested_clients(
-            "opencode",
-            "gpt-5.2",
-            "openai",
-            &requested
+            "opencode", "gpt-5.2", "openai", &requested
         ));
     }
 }

--- a/crates/tokscale-core/src/sessions/synthetic.rs
+++ b/crates/tokscale-core/src/sessions/synthetic.rs
@@ -357,11 +357,7 @@ mod tests {
             "claude-sonnet-4-5",
             "glhf"
         ));
-        assert!(!matches_synthetic_filter(
-            "opencode",
-            "gpt-5.2",
-            "openai"
-        ));
+        assert!(!matches_synthetic_filter("opencode", "gpt-5.2", "openai"));
     }
 
     #[test]


### PR DESCRIPTION
Preserve the original client for Synthetic gateway traffic.

When a message matched Synthetic gateway detection, tokscale was rewriting its `client` to `synthetic`. That makes usage disappear from the actual tool the user worked in (for example OpenCode), even though Synthetic is acting as a gateway/provider rather than the client.

This keeps the original client, still normalizes Synthetic gateway model/provider fields, and keeps the existing `--synthetic` filter working as a compatibility view for Synthetic-routed traffic. The same behavior is applied in the TUI data path.

Related to #262.

Checks:
- `cargo test -p tokscale-core --lib`
- `cargo test -p tokscale-cli tui::data -- --nocapture`