### PR TITLE
fix: correct synthetic provider normalization and remove dead code

### DIFF
--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -294,10 +294,20 @@ impl DataLoader {
             }
 
             for msg in &mut all_messages {
-                sessions::synthetic::normalize_synthetic_gateway_fields(
-                    &mut msg.model_id,
-                    &mut msg.provider_id,
-                );
+                if msg.client == "synthetic" {
+                    continue;
+                }
+                if sessions::synthetic::is_synthetic_model(&msg.model_id)
+                    || sessions::synthetic::is_synthetic_provider(&msg.provider_id)
+                {
+                    msg.client = "synthetic".to_string();
+                    msg.model_id = sessions::synthetic::normalize_synthetic_model(&msg.model_id);
+                    if msg.provider_id.is_empty()
+                        || msg.provider_id.eq_ignore_ascii_case("unknown")
+                    {
+                        msg.provider_id = "synthetic".to_string();
+                    }
+                }
             }
         }
 
@@ -308,15 +318,7 @@ impl DataLoader {
         if include_synthetic {
             requested_clients.insert("synthetic".to_string());
         }
-        all_messages.retain(|msg| {
-            requested_clients.contains(&msg.client)
-                || (include_synthetic
-                    && sessions::synthetic::matches_synthetic_filter(
-                        &msg.client,
-                        &msg.model_id,
-                        &msg.provider_id,
-                    ))
-        });
+        all_messages.retain(|msg| requested_clients.contains(&msg.client));
 
         if let Some(svc) = pricing {
             for msg in &mut all_messages {
@@ -957,15 +959,4 @@ mod tests {
         assert_eq!(longest, 2);
     }
 
-    #[test]
-    fn test_synthetic_filter_match_keeps_gateway_messages_with_original_client() {
-        assert!(sessions::synthetic::matches_synthetic_filter(
-            "opencode",
-            "hf:deepseek-ai/DeepSeek-V3-0324",
-            "unknown"
-        ));
-        assert!(!sessions::synthetic::matches_synthetic_filter(
-            "opencode", "gpt-5.2", "openai"
-        ));
-    }
 }

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -302,8 +302,7 @@ impl DataLoader {
                 {
                     msg.client = "synthetic".to_string();
                     msg.model_id = sessions::synthetic::normalize_synthetic_model(&msg.model_id);
-                    if msg.provider_id.is_empty()
-                        || msg.provider_id.eq_ignore_ascii_case("unknown")
+                    if msg.provider_id.is_empty() || msg.provider_id.eq_ignore_ascii_case("unknown")
                     {
                         msg.provider_id = "synthetic".to_string();
                     }

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -51,17 +51,6 @@ pub fn normalize_model_for_grouping(model_id: &str) -> String {
     name
 }
 
-fn retain_for_requested_clients(
-    client: &str,
-    model_id: &str,
-    provider_id: &str,
-    requested: &HashSet<&str>,
-) -> bool {
-    requested.contains(client)
-        || (requested.contains("synthetic")
-            && sessions::synthetic::matches_synthetic_filter(client, model_id, provider_id))
-}
-
 #[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
 pub enum GroupBy {
     Model,
@@ -739,18 +728,27 @@ fn parse_all_messages_with_pricing(
         }
 
         for msg in &mut all_messages {
-            sessions::synthetic::normalize_synthetic_gateway_fields(
-                &mut msg.model_id,
-                &mut msg.provider_id,
-            );
+            if msg.client == "synthetic" {
+                continue;
+            }
+
+            if sessions::synthetic::is_synthetic_model(&msg.model_id)
+                || sessions::synthetic::is_synthetic_provider(&msg.provider_id)
+            {
+                msg.client = "synthetic".to_string();
+                msg.model_id = sessions::synthetic::normalize_synthetic_model(&msg.model_id);
+                if msg.provider_id.is_empty()
+                    || msg.provider_id.eq_ignore_ascii_case("unknown")
+                {
+                    msg.provider_id = "synthetic".to_string();
+                }
+            }
         }
     }
 
     if !include_all {
         let requested: HashSet<&str> = clients.iter().map(String::as_str).collect();
-        all_messages.retain(|msg| {
-            retain_for_requested_clients(&msg.client, &msg.model_id, &msg.provider_id, &requested)
-        });
+        all_messages.retain(|msg| requested.contains(msg.client.as_str()));
     }
 
     all_messages
@@ -1269,19 +1267,40 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
             messages.extend(synthetic_msgs);
         }
 
+        let mut deltas = [0_i32; ClientId::COUNT];
         for msg in &mut messages {
-            sessions::synthetic::normalize_synthetic_gateway_fields(
-                &mut msg.model_id,
-                &mut msg.provider_id,
-            );
+            if msg.client == "synthetic" {
+                continue;
+            }
+
+            if sessions::synthetic::is_synthetic_model(&msg.model_id)
+                || sessions::synthetic::is_synthetic_provider(&msg.provider_id)
+            {
+                if let Some(client_id) = ClientId::from_str(&msg.client) {
+                    deltas[client_id as usize] += 1;
+                }
+
+                msg.client = "synthetic".to_string();
+                msg.model_id = sessions::synthetic::normalize_synthetic_model(&msg.model_id);
+                if msg.provider_id.is_empty()
+                    || msg.provider_id.eq_ignore_ascii_case("unknown")
+                {
+                    msg.provider_id = "synthetic".to_string();
+                }
+            }
+        }
+
+        for client_id in ClientId::iter() {
+            let delta = deltas[client_id as usize];
+            if delta > 0 {
+                counts.add(client_id, -delta);
+            }
         }
     }
 
     if !include_all {
         let requested: HashSet<&str> = clients.iter().map(String::as_str).collect();
-        messages.retain(|msg| {
-            retain_for_requested_clients(&msg.client, &msg.model_id, &msg.provider_id, &requested)
-        });
+        messages.retain(|msg| requested.contains(msg.client.as_str()));
     }
 
     let filtered = filter_parsed_messages(messages, &options);
@@ -1355,11 +1374,8 @@ pub fn parsed_to_unified(msg: &ParsedMessage, cost: f64) -> UnifiedMessage {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        normalize_model_for_grouping, parse_all_messages_with_pricing, pricing,
-        retain_for_requested_clients, GroupBy,
-    };
-    use std::collections::{HashMap, HashSet};
+    use super::{normalize_model_for_grouping, parse_all_messages_with_pricing, pricing, GroupBy};
+    use std::collections::HashMap;
     use std::str::FromStr;
 
     #[test]
@@ -1480,37 +1496,6 @@ mod tests {
             GroupBy::from_str("client , provider , model").unwrap(),
             GroupBy::ClientProviderModel
         );
-    }
-
-    #[test]
-    fn test_retain_for_requested_clients_keeps_original_client_matches() {
-        let requested: HashSet<&str> = HashSet::from(["opencode"]);
-        assert!(retain_for_requested_clients(
-            "opencode", "gpt-5.2", "openai", &requested
-        ));
-        assert!(!retain_for_requested_clients(
-            "claude", "gpt-5.2", "openai", &requested
-        ));
-    }
-
-    #[test]
-    fn test_retain_for_requested_clients_accepts_synthetic_gateway_traffic() {
-        let requested: HashSet<&str> = HashSet::from(["synthetic"]);
-        assert!(retain_for_requested_clients(
-            "opencode",
-            "hf:deepseek-ai/DeepSeek-V3-0324",
-            "unknown",
-            &requested
-        ));
-        assert!(retain_for_requested_clients(
-            "synthetic",
-            "deepseek-v3-0324",
-            "synthetic",
-            &requested
-        ));
-        assert!(!retain_for_requested_clients(
-            "opencode", "gpt-5.2", "openai", &requested
-        ));
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -737,9 +737,7 @@ fn parse_all_messages_with_pricing(
             {
                 msg.client = "synthetic".to_string();
                 msg.model_id = sessions::synthetic::normalize_synthetic_model(&msg.model_id);
-                if msg.provider_id.is_empty()
-                    || msg.provider_id.eq_ignore_ascii_case("unknown")
-                {
+                if msg.provider_id.is_empty() || msg.provider_id.eq_ignore_ascii_case("unknown") {
                     msg.provider_id = "synthetic".to_string();
                 }
             }
@@ -1282,9 +1280,7 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
 
                 msg.client = "synthetic".to_string();
                 msg.model_id = sessions::synthetic::normalize_synthetic_model(&msg.model_id);
-                if msg.provider_id.is_empty()
-                    || msg.provider_id.eq_ignore_ascii_case("unknown")
-                {
+                if msg.provider_id.is_empty() || msg.provider_id.eq_ignore_ascii_case("unknown") {
                     msg.provider_id = "synthetic".to_string();
                 }
             }

--- a/crates/tokscale-core/src/sessions/synthetic.rs
+++ b/crates/tokscale-core/src/sessions/synthetic.rs
@@ -45,11 +45,6 @@ pub fn is_synthetic_provider(provider_id: &str) -> bool {
     )
 }
 
-/// Check if a message appears to have been routed through Synthetic's gateway.
-pub fn is_synthetic_gateway(model_id: &str, provider_id: &str) -> bool {
-    is_synthetic_model(model_id) || is_synthetic_provider(provider_id)
-}
-
 // =============================================================================
 // Model name normalization (strip synthetic.new prefixes for pricing lookup)
 // =============================================================================
@@ -78,25 +73,6 @@ pub fn normalize_synthetic_model(model_id: &str) -> String {
     }
 
     lower
-}
-
-/// Normalize synthetic gateway fields without changing the originating client.
-pub fn normalize_synthetic_gateway_fields(model_id: &mut String, provider_id: &mut String) -> bool {
-    if !is_synthetic_gateway(model_id, provider_id) {
-        return false;
-    }
-
-    *model_id = normalize_synthetic_model(model_id);
-    if provider_id.is_empty() || provider_id.eq_ignore_ascii_case("unknown") {
-        *provider_id = "synthetic".to_string();
-    }
-
-    true
-}
-
-/// Compatibility matcher for `--synthetic` / synthetic source selection.
-pub fn matches_synthetic_filter(client: &str, model_id: &str, provider_id: &str) -> bool {
-    client.eq_ignore_ascii_case("synthetic") || is_synthetic_gateway(model_id, provider_id)
 }
 
 // =============================================================================
@@ -319,45 +295,6 @@ mod tests {
             "claude-sonnet-4-5"
         );
         assert_eq!(normalize_synthetic_model("gpt-4o"), "gpt-4o");
-    }
-
-    #[test]
-    fn test_normalize_synthetic_gateway_fields_sets_provider_when_unknown() {
-        let mut model_id = "hf:deepseek-ai/DeepSeek-V3-0324".to_string();
-        let mut provider_id = "unknown".to_string();
-
-        let matched = normalize_synthetic_gateway_fields(&mut model_id, &mut provider_id);
-
-        assert!(matched);
-        assert_eq!(model_id, "deepseek-v3-0324");
-        assert_eq!(provider_id, "synthetic");
-    }
-
-    #[test]
-    fn test_normalize_synthetic_gateway_fields_preserves_existing_provider() {
-        let mut model_id = "accounts/fireworks/models/deepseek-v3-0324".to_string();
-        let mut provider_id = "fireworks".to_string();
-
-        let matched = normalize_synthetic_gateway_fields(&mut model_id, &mut provider_id);
-
-        assert!(matched);
-        assert_eq!(model_id, "deepseek-v3-0324");
-        assert_eq!(provider_id, "fireworks");
-    }
-
-    #[test]
-    fn test_matches_synthetic_filter_accepts_gateway_traffic_without_rewriting_client() {
-        assert!(matches_synthetic_filter(
-            "opencode",
-            "hf:deepseek-ai/DeepSeek-V3-0324",
-            "unknown"
-        ));
-        assert!(matches_synthetic_filter(
-            "claude",
-            "claude-sonnet-4-5",
-            "glhf"
-        ));
-        assert!(!matches_synthetic_filter("opencode", "gpt-5.2", "openai"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes 3 bugs found during review of #299:

1. **TUI provider overwrite regression** — `data/mod.rs` had `if !msg.provider_id.is_empty()` which overwrites known providers like `"fireworks"` to `"synthetic"`. Fixed to `if is_empty || eq_ignore_ascii_case("unknown")`, matching the original `normalize_synthetic_gateway_fields` behavior.

2. **Case-insensitive `"unknown"` regression** — All three synthetic reassignment paths (`parse_all_messages_with_pricing`, `parse_local_clients`, TUI data loader) used `== "unknown"` instead of the original `eq_ignore_ascii_case("unknown")`. Fixed to restore case-insensitive matching.

3. **Dead code** — Removed unused `synthetic_count` variable in `parse_local_clients` (computed but suppressed with `let _ =`).

## Files Changed
- `crates/tokscale-core/src/lib.rs` — case-insensitive unknown check + dead code removal
- `crates/tokscale-cli/src/tui/data/mod.rs` — inverted provider condition fix

## Testing
- `cargo check -p tokscale-core -p tokscale-cli` ✅
- `cargo test -p tokscale-core --lib -- synthetic` (10 passed) ✅
- `cargo test -p tokscale-core --lib -- test_cursor` (14 passed) ✅

> **Note**: This branch is based on PR #299's HEAD. Merge #299 first, then this.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes synthetic gateway normalization to avoid overwriting real providers and restores case-insensitive handling of "unknown". Re-attributes gateway traffic to the `synthetic` client across core parsing, local parsing, and the TUI, and removes dead code.

- **Bug Fixes**
  - Only set `provider_id` to `synthetic` when empty or `"unknown"` (case-insensitive) across all paths; no overwriting known providers (e.g. `"fireworks"`).
  - Re-attribute gateway traffic by setting client to `synthetic`, normalizing models, and adjusting per-client counts; skip if already `synthetic`.
  - Keep only requested clients when filtering; removed synthetic gateway helpers and related tests/dead code.

- **New Features**
  - Added Cursor pricing for `Composer 1.5` (and `composer-1.5`), including cache read cost; zero-cost CSV rows now reprice correctly.

<sup>Written for commit 165cf12869b535ffd3080f343014b5045aea9eb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

