### PR TITLE
test: add route-level tests for settings tokens and device poll edge cases

### DIFF
--- a/packages/frontend/__tests__/api/devicePoll.test.ts
+++ b/packages/frontend/__tests__/api/devicePoll.test.ts
@@ -151,4 +151,77 @@ describe("POST /api/auth/device/poll", () => {
       },
     });
   });
+
+  it("returns 400 when deviceCode is missing", async () => {
+    const response = await POST(
+      new Request("http://localhost:3000/api/auth/device/poll", {
+        method: "POST",
+        body: JSON.stringify({}),
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({ error: "Missing device code" });
+  });
+
+  it("returns expired status when no matching device code found", async () => {
+    mockState.pushSelectResult([]);
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/auth/device/poll", {
+        method: "POST",
+        body: JSON.stringify({ deviceCode: "invalid-code" }),
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ status: "expired" });
+  });
+
+  it("returns pending status when user has not yet authorized", async () => {
+    mockState.pushSelectResult([
+      {
+        id: "device-1",
+        userId: null,
+        deviceName: "CLI on macbook",
+        expiresAt: new Date("2026-03-08T05:00:00.000Z"),
+      },
+    ]);
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/auth/device/poll", {
+        method: "POST",
+        body: JSON.stringify({ deviceCode: "device-code-1" }),
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ status: "pending" });
+  });
+
+  it("returns 500 when authorized user is not found in users table", async () => {
+    mockState.pushSelectResult([
+      {
+        id: "device-1",
+        userId: "user-1",
+        deviceName: "CLI on macbook",
+        expiresAt: new Date("2026-03-08T05:00:00.000Z"),
+      },
+    ]);
+    mockState.pushSelectResult([]);
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/auth/device/poll", {
+        method: "POST",
+        body: JSON.stringify({ deviceCode: "device-code-1" }),
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toEqual({ error: "User not found" });
+  });
 });

--- a/packages/frontend/__tests__/api/settingsTokensDelete.test.ts
+++ b/packages/frontend/__tests__/api/settingsTokensDelete.test.ts
@@ -1,0 +1,96 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const getSession = vi.fn();
+  const revokePersonalToken = vi.fn();
+
+  return {
+    getSession,
+    revokePersonalToken,
+    reset() {
+      getSession.mockReset();
+      revokePersonalToken.mockReset();
+    },
+  };
+});
+
+vi.mock("@/lib/auth/session", () => ({
+  getSession: mockState.getSession,
+}));
+
+vi.mock("@/lib/auth/personalTokens", () => ({
+  revokePersonalToken: mockState.revokePersonalToken,
+}));
+
+type ModuleExports = typeof import("../../src/app/api/settings/tokens/[tokenId]/route");
+
+let DELETE: ModuleExports["DELETE"];
+
+beforeAll(async () => {
+  const routeModule = await import("../../src/app/api/settings/tokens/[tokenId]/route");
+  DELETE = routeModule.DELETE;
+});
+
+beforeEach(() => {
+  mockState.reset();
+});
+
+describe("DELETE /api/settings/tokens/[tokenId]", () => {
+  it("returns 401 with 'Not authenticated' when session is null", async () => {
+    mockState.getSession.mockResolvedValue(null);
+
+    const response = await DELETE(
+      new Request("http://localhost:3000/api/settings/tokens/token-1", {
+        method: "DELETE",
+      }),
+      { params: Promise.resolve({ tokenId: "token-1" }) }
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+  });
+
+  it("returns 200 with 'success: true' when token is successfully revoked", async () => {
+    mockState.getSession.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      isAdmin: false,
+    });
+    mockState.revokePersonalToken.mockResolvedValue(true);
+
+    const response = await DELETE(
+      new Request("http://localhost:3000/api/settings/tokens/token-1", {
+        method: "DELETE",
+      }),
+      { params: Promise.resolve({ tokenId: "token-1" }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+    expect(mockState.revokePersonalToken).toHaveBeenCalledWith("user-1", "token-1");
+  });
+
+  it("returns 404 with 'Token not found' when token does not exist or belongs to another user", async () => {
+    mockState.getSession.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      isAdmin: false,
+    });
+    mockState.revokePersonalToken.mockResolvedValue(false);
+
+    const response = await DELETE(
+      new Request("http://localhost:3000/api/settings/tokens/token-999", {
+        method: "DELETE",
+      }),
+      { params: Promise.resolve({ tokenId: "token-999" }) }
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Token not found" });
+    expect(mockState.revokePersonalToken).toHaveBeenCalledWith("user-1", "token-999");
+  });
+});

--- a/packages/frontend/__tests__/api/settingsTokensList.test.ts
+++ b/packages/frontend/__tests__/api/settingsTokensList.test.ts
@@ -1,0 +1,138 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const getSession = vi.fn();
+  const listPersonalTokens = vi.fn();
+
+  return {
+    getSession,
+    listPersonalTokens,
+    reset() {
+      getSession.mockReset();
+      listPersonalTokens.mockReset();
+    },
+  };
+});
+
+vi.mock("@/lib/auth/session", () => ({
+  getSession: mockState.getSession,
+}));
+
+vi.mock("@/lib/auth/personalTokens", () => ({
+  listPersonalTokens: mockState.listPersonalTokens,
+}));
+
+type ModuleExports = typeof import("../../src/app/api/settings/tokens/route");
+
+let GET: ModuleExports["GET"];
+
+beforeAll(async () => {
+  const routeModule = await import("../../src/app/api/settings/tokens/route");
+  GET = routeModule.GET;
+});
+
+beforeEach(() => {
+  mockState.reset();
+});
+
+describe("GET /api/settings/tokens", () => {
+  it("returns 401 when user is not authenticated", async () => {
+    mockState.getSession.mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+  });
+
+  it("returns 200 with empty token list when user has no tokens", async () => {
+    mockState.getSession.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      isAdmin: false,
+    });
+    mockState.listPersonalTokens.mockResolvedValue([]);
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(mockState.listPersonalTokens).toHaveBeenCalledWith("user-1");
+    expect(await response.json()).toEqual({ tokens: [] });
+  });
+
+  it("returns 200 with mapped token list (excluding token, expiresAt, userId fields)", async () => {
+    mockState.getSession.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      isAdmin: false,
+    });
+    mockState.listPersonalTokens.mockResolvedValue([
+      {
+        id: "token-1",
+        name: "My Token",
+        token: "tt_secret_value",
+        createdAt: new Date("2024-01-01"),
+        lastUsedAt: new Date("2024-01-15"),
+        expiresAt: new Date("2025-01-01"),
+        userId: "user-1",
+      },
+      {
+        id: "token-2",
+        name: "Another Token",
+        token: "tt_another_secret",
+        createdAt: new Date("2024-02-01"),
+        lastUsedAt: null,
+        expiresAt: null,
+        userId: "user-1",
+      },
+    ]);
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(mockState.listPersonalTokens).toHaveBeenCalledWith("user-1");
+    const data = await response.json();
+    expect(data).toEqual({
+      tokens: [
+        {
+          id: "token-1",
+          name: "My Token",
+          createdAt: "2024-01-01T00:00:00.000Z",
+          lastUsedAt: "2024-01-15T00:00:00.000Z",
+        },
+        {
+          id: "token-2",
+          name: "Another Token",
+          createdAt: "2024-02-01T00:00:00.000Z",
+          lastUsedAt: null,
+        },
+      ],
+    });
+    // Verify that token, expiresAt, and userId are not in the response
+    expect(data.tokens[0]).not.toHaveProperty("token");
+    expect(data.tokens[0]).not.toHaveProperty("expiresAt");
+    expect(data.tokens[0]).not.toHaveProperty("userId");
+  });
+
+  it("returns 500 when listPersonalTokens throws an error", async () => {
+    mockState.getSession.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      isAdmin: false,
+    });
+    mockState.listPersonalTokens.mockRejectedValue(
+      new Error("Database error")
+    );
+
+    const response = await GET();
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "Failed to fetch tokens" });
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #294 (centralize personal token auth) — addresses P2 test gaps identified during Oracle review.

### New test files
- `__tests__/api/settingsTokensList.test.ts` — GET `/api/settings/tokens` route tests (4 cases: 401 unauth, 200 empty list, 200 mapped fields, 500 error)
- `__tests__/api/settingsTokensDelete.test.ts` — DELETE `/api/settings/tokens/[tokenId]` route tests (3 cases: 401 unauth, 200 success, 404 not found)

### Extended tests
- `__tests__/api/devicePoll.test.ts` — 4 new non-happy-path tests (400 missing code, expired status, pending status, 500 user not found)

### Test coverage before/after
| Route | Before | After |
|---|---|---|
| `GET /api/settings/tokens` | ❌ None | ✅ 4 tests |
| `DELETE /api/settings/tokens/[tokenId]` | ❌ None | ✅ 3 tests |
| `POST /api/auth/device/poll` | 1 test (happy path only) | ✅ 5 tests (all branches) |

All 63 tests pass across 9 test files.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add route-level tests for personal token settings and device auth poll to cover unauthenticated, success, not-found, and error paths. New cases: `GET /api/settings/tokens` (401, empty 200, mapped 200, 500), `DELETE /api/settings/tokens/[tokenId]` (401, 200, 404), and `POST /api/auth/device/poll` (400 missing code, 200 expired, 200 pending, 500 user not found); all 63 tests pass.

<sup>Written for commit 71650d4d5c73b10f496bea06a2ae6e0e982069fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

