### PR TITLE
fix(cache): backwards-compatible TUI cache for upgrade path

### DIFF
--- a/crates/tokscale-cli/src/tui/cache.rs
+++ b/crates/tokscale-cli/src/tui/cache.rs
@@ -384,7 +384,10 @@ pub fn load_cache(enabled_clients: &HashSet<ClientId>, include_synthetic: bool) 
         Ok(c) => c,
         Err(_) => return CacheResult::Miss,
     };
-    let schema_outdated = cached.schema_version != CACHE_SCHEMA_VERSION;
+    if cached.schema_version > CACHE_SCHEMA_VERSION {
+        return CacheResult::Miss;
+    }
+    let schema_outdated = cached.schema_version < CACHE_SCHEMA_VERSION;
 
     // Check how cached clients relate to enabled clients
     let client_match = check_client_match(


### PR DESCRIPTION
## Summary
- Old cache files (v2.0.9 and earlier) now show cached data instantly on first launch after upgrade instead of a blank screen
- `schema_version` gets `#[serde(default)]` so legacy caches without the field parse as version 0
- Outdated schema returns `Stale` (show cached + background refresh) instead of `Miss` (blank + full reload)
- `agents` field already had `#[serde(default)]` so it deserializes to `[]` — Agents tab is empty until refresh completes

## Before / After

| Cache on disk | Before | After |
|---|---|---|
| v2.0.9 (no `schema_version`) | `Miss` → blank screen | `Stale` → instant display + background refresh |
| Current schema (v2) | Normal | Normal |
| Corrupt | `Miss` | `Miss` |
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the TUI cache backward-compatible so upgrades show cached data immediately. Legacy cache files now load as Stale and refresh in the background, fixing the blank screen on first launch.

- **Bug Fixes**
  - Default `schema_version` with `#[serde(default)]`; legacy caches parse as v0 and return Stale.
  - Reject forward-incompatible schemas (`schema_version` > current) as Miss to avoid parsing newer structures.
  - Updated test to expect Stale for caches without `schema_version`.

<sup>Written for commit 667b9acbc4c3b238373d4a43fe63a29b864f7768. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

