### PR TITLE
feat(settings): add personal token creation flow

### DIFF
--- a/packages/frontend/__tests__/api/settingsTokens.test.ts
+++ b/packages/frontend/__tests__/api/settingsTokens.test.ts
@@ -1,0 +1,189 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const getSession = vi.fn();
+  const listPersonalTokens = vi.fn();
+  const issuePersonalToken = vi.fn();
+
+  class PersonalTokenNameConflictError extends Error {
+    constructor(name: string) {
+      super(`A personal token named "${name}" already exists`);
+      this.name = "PersonalTokenNameConflictError";
+    }
+  }
+
+  return {
+    getSession,
+    listPersonalTokens,
+    issuePersonalToken,
+    PersonalTokenNameConflictError,
+    reset() {
+      getSession.mockReset();
+      listPersonalTokens.mockReset();
+      issuePersonalToken.mockReset();
+    },
+  };
+});
+
+vi.mock("@/lib/auth/session", () => ({
+  getSession: mockState.getSession,
+}));
+
+vi.mock("@/lib/auth/personalTokens", () => ({
+  listPersonalTokens: mockState.listPersonalTokens,
+  issuePersonalToken: mockState.issuePersonalToken,
+  PersonalTokenNameConflictError: mockState.PersonalTokenNameConflictError,
+}));
+
+type ModuleExports = typeof import("../../src/app/api/settings/tokens/route");
+
+let GET: ModuleExports["GET"];
+let POST: ModuleExports["POST"];
+
+beforeAll(async () => {
+  const routeModule = await import("../../src/app/api/settings/tokens/route");
+  GET = routeModule.GET;
+  POST = routeModule.POST;
+});
+
+beforeEach(() => {
+  mockState.reset();
+});
+
+describe("/api/settings/tokens", () => {
+  it("lists tokens for the current user and includes expiresAt", async () => {
+    mockState.getSession.mockResolvedValue({ id: "user-1" });
+    mockState.listPersonalTokens.mockResolvedValue([
+      {
+        id: "token-1",
+        userId: "user-1",
+        name: "GitHub Actions CI",
+        createdAt: new Date("2026-03-08T18:00:00.000Z"),
+        lastUsedAt: null,
+        expiresAt: new Date("2026-04-07T18:00:00.000Z"),
+      },
+    ]);
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockState.listPersonalTokens).toHaveBeenCalledWith("user-1");
+    expect(body).toEqual({
+      tokens: [
+        {
+          id: "token-1",
+          name: "GitHub Actions CI",
+          createdAt: new Date("2026-03-08T18:00:00.000Z").toISOString(),
+          lastUsedAt: null,
+          expiresAt: new Date("2026-04-07T18:00:00.000Z").toISOString(),
+        },
+      ],
+    });
+  });
+
+  it("rejects unauthenticated token creation", async () => {
+    mockState.getSession.mockResolvedValue(null);
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/settings/tokens", {
+        method: "POST",
+        body: JSON.stringify({ name: "GitHub Actions CI" }),
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockState.issuePersonalToken).not.toHaveBeenCalled();
+  });
+
+  it("creates a token with the requested expiry", async () => {
+    mockState.getSession.mockResolvedValue({ id: "user-1" });
+    mockState.issuePersonalToken.mockResolvedValue({
+      id: "token-1",
+      userId: "user-1",
+      name: "GitHub Actions CI",
+      token: "tt_created_token",
+      createdAt: new Date("2026-03-08T18:00:00.000Z"),
+      lastUsedAt: null,
+      expiresAt: new Date("2026-04-07T18:00:00.000Z"),
+    });
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/settings/tokens", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: "  GitHub Actions CI  ",
+          expiresAt: "2026-04-07T18:00:00.000Z",
+        }),
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(mockState.issuePersonalToken).toHaveBeenCalledWith({
+      userId: "user-1",
+      name: "GitHub Actions CI",
+      expiresAt: new Date("2026-04-07T18:00:00.000Z"),
+    });
+    expect(body).toEqual({
+      token: {
+        id: "token-1",
+        name: "GitHub Actions CI",
+        createdAt: new Date("2026-03-08T18:00:00.000Z").toISOString(),
+        lastUsedAt: null,
+        expiresAt: new Date("2026-04-07T18:00:00.000Z").toISOString(),
+      },
+      plainTextToken: "tt_created_token",
+    });
+  });
+
+  it("returns a conflict for duplicate token names", async () => {
+    mockState.getSession.mockResolvedValue({ id: "user-1" });
+    mockState.issuePersonalToken.mockRejectedValue(
+      new mockState.PersonalTokenNameConflictError("GitHub Actions CI")
+    );
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/settings/tokens", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ name: "GitHub Actions CI" }),
+      })
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      error: "A token with this name already exists",
+    });
+  });
+
+  it("rejects past expirations before touching the token service", async () => {
+    mockState.getSession.mockResolvedValue({ id: "user-1" });
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/settings/tokens", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: "GitHub Actions CI",
+          expiresAt: "2026-03-01T00:00:00.000Z",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+    expect(await response.json()).toEqual({
+      error: "Expiration must be in the future",
+    });
+    expect(mockState.issuePersonalToken).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/__tests__/api/settingsTokens.test.ts
+++ b/packages/frontend/__tests__/api/settingsTokens.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockState = vi.hoisted(() => {
   const getSession = vi.fn();
@@ -45,6 +45,7 @@ type DeleteModuleExports = typeof import("../../src/app/api/settings/tokens/[tok
 let GET: ModuleExports["GET"];
 let POST: ModuleExports["POST"];
 let DELETE: DeleteModuleExports["DELETE"];
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
 beforeAll(async () => {
   const routeModule = await import("../../src/app/api/settings/tokens/route");
@@ -56,6 +57,11 @@ beforeAll(async () => {
 
 beforeEach(() => {
   mockState.reset();
+  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore();
 });
 
 describe("/api/settings/tokens", () => {
@@ -98,6 +104,17 @@ describe("/api/settings/tokens", () => {
         },
       ],
     });
+  });
+
+  it("returns a server error when token listing fails", async () => {
+    mockState.getSession.mockResolvedValue({ id: "user-1" });
+    mockState.listPersonalTokens.mockRejectedValue(new Error("db is down"));
+
+    const response = await GET();
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "Failed to fetch tokens" });
+    expect(consoleErrorSpy).toHaveBeenCalled();
   });
 
   it("rejects unauthenticated token creation", async () => {
@@ -200,6 +217,25 @@ describe("/api/settings/tokens", () => {
     });
   });
 
+  it("returns a server error when token creation fails unexpectedly", async () => {
+    mockState.getSession.mockResolvedValue({ id: "user-1" });
+    mockState.issuePersonalToken.mockRejectedValue(new Error("db is down"));
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/settings/tokens", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ name: "GitHub Actions CI" }),
+      })
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "Failed to create token" });
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
   it("rejects past expirations before touching the token service", async () => {
     mockState.getSession.mockResolvedValue({ id: "user-1" });
 
@@ -281,5 +317,18 @@ describe("/api/settings/tokens", () => {
 
     expect(response.status).toBe(404);
     expect(await response.json()).toEqual({ error: "Token not found" });
+  });
+
+  it("returns a server error when token revocation fails unexpectedly", async () => {
+    mockState.getSession.mockResolvedValue({ id: "user-1" });
+    mockState.revokePersonalToken.mockRejectedValue(new Error("db is down"));
+
+    const response = await DELETE(new Request("http://localhost:3000/api/settings/tokens/token-1"), {
+      params: Promise.resolve({ tokenId: "token-1" }),
+    });
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "Failed to delete token" });
+    expect(consoleErrorSpy).toHaveBeenCalled();
   });
 });

--- a/packages/frontend/__tests__/api/settingsTokens.test.ts
+++ b/packages/frontend/__tests__/api/settingsTokens.test.ts
@@ -4,6 +4,7 @@ const mockState = vi.hoisted(() => {
   const getSession = vi.fn();
   const listPersonalTokens = vi.fn();
   const issuePersonalToken = vi.fn();
+  const revokePersonalToken = vi.fn();
 
   class PersonalTokenNameConflictError extends Error {
     constructor(name: string) {
@@ -16,11 +17,13 @@ const mockState = vi.hoisted(() => {
     getSession,
     listPersonalTokens,
     issuePersonalToken,
+    revokePersonalToken,
     PersonalTokenNameConflictError,
     reset() {
       getSession.mockReset();
       listPersonalTokens.mockReset();
       issuePersonalToken.mockReset();
+      revokePersonalToken.mockReset();
     },
   };
 });
@@ -32,18 +35,23 @@ vi.mock("@/lib/auth/session", () => ({
 vi.mock("@/lib/auth/personalTokens", () => ({
   listPersonalTokens: mockState.listPersonalTokens,
   issuePersonalToken: mockState.issuePersonalToken,
+  revokePersonalToken: mockState.revokePersonalToken,
   PersonalTokenNameConflictError: mockState.PersonalTokenNameConflictError,
 }));
 
 type ModuleExports = typeof import("../../src/app/api/settings/tokens/route");
+type DeleteModuleExports = typeof import("../../src/app/api/settings/tokens/[tokenId]/route");
 
 let GET: ModuleExports["GET"];
 let POST: ModuleExports["POST"];
+let DELETE: DeleteModuleExports["DELETE"];
 
 beforeAll(async () => {
   const routeModule = await import("../../src/app/api/settings/tokens/route");
+  const deleteRouteModule = await import("../../src/app/api/settings/tokens/[tokenId]/route");
   GET = routeModule.GET;
   POST = routeModule.POST;
+  DELETE = deleteRouteModule.DELETE;
 });
 
 beforeEach(() => {
@@ -185,5 +193,42 @@ describe("/api/settings/tokens", () => {
       error: "Expiration must be in the future",
     });
     expect(mockState.issuePersonalToken).not.toHaveBeenCalled();
+  });
+
+  it("rejects unauthenticated token revocation", async () => {
+    mockState.getSession.mockResolvedValue(null);
+
+    const response = await DELETE(new Request("http://localhost:3000/api/settings/tokens/token-1"), {
+      params: Promise.resolve({ tokenId: "token-1" }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockState.revokePersonalToken).not.toHaveBeenCalled();
+  });
+
+  it("revokes a token for the current user", async () => {
+    mockState.getSession.mockResolvedValue({ id: "user-1" });
+    mockState.revokePersonalToken.mockResolvedValue(true);
+
+    const response = await DELETE(new Request("http://localhost:3000/api/settings/tokens/token-1"), {
+      params: Promise.resolve({ tokenId: "token-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+    expect(mockState.revokePersonalToken).toHaveBeenCalledWith("user-1", "token-1");
+  });
+
+  it("returns 404 when the token does not exist", async () => {
+    mockState.getSession.mockResolvedValue({ id: "user-1" });
+    mockState.revokePersonalToken.mockResolvedValue(false);
+
+    const response = await DELETE(new Request("http://localhost:3000/api/settings/tokens/token-1"), {
+      params: Promise.resolve({ tokenId: "token-1" }),
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Token not found" });
   });
 });

--- a/packages/frontend/__tests__/api/settingsTokens.test.ts
+++ b/packages/frontend/__tests__/api/settingsTokens.test.ts
@@ -59,6 +59,16 @@ beforeEach(() => {
 });
 
 describe("/api/settings/tokens", () => {
+  it("rejects unauthenticated token listing", async () => {
+    mockState.getSession.mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockState.listPersonalTokens).not.toHaveBeenCalled();
+  });
+
   it("lists tokens for the current user and includes expiresAt", async () => {
     mockState.getSession.mockResolvedValue({ id: "user-1" });
     mockState.listPersonalTokens.mockResolvedValue([
@@ -150,6 +160,24 @@ describe("/api/settings/tokens", () => {
     });
   });
 
+  it("rejects invalid JSON request bodies", async () => {
+    mockState.getSession.mockResolvedValue({ id: "user-1" });
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/settings/tokens", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: "{not valid json",
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid JSON body" });
+    expect(mockState.issuePersonalToken).not.toHaveBeenCalled();
+  });
+
   it("returns a conflict for duplicate token names", async () => {
     mockState.getSession.mockResolvedValue({ id: "user-1" });
     mockState.issuePersonalToken.mockRejectedValue(
@@ -191,6 +219,29 @@ describe("/api/settings/tokens", () => {
     expect(response.status).toBe(422);
     expect(await response.json()).toEqual({
       error: "Expiration must be in the future",
+    });
+    expect(mockState.issuePersonalToken).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-string expirations before touching the token service", async () => {
+    mockState.getSession.mockResolvedValue({ id: "user-1" });
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/settings/tokens", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: "GitHub Actions CI",
+          expiresAt: 12345,
+        }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+    expect(await response.json()).toEqual({
+      error: "Expiration must be an ISO date string",
     });
     expect(mockState.issuePersonalToken).not.toHaveBeenCalled();
   });

--- a/packages/frontend/__tests__/api/settingsTokens.test.ts
+++ b/packages/frontend/__tests__/api/settingsTokens.test.ts
@@ -133,6 +133,9 @@ describe("/api/settings/tokens", () => {
   });
 
   it("creates a token with the requested expiry", async () => {
+    const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+    const expiresAtIso = expiresAt.toISOString();
+
     mockState.getSession.mockResolvedValue({ id: "user-1" });
     mockState.issuePersonalToken.mockResolvedValue({
       id: "token-1",
@@ -141,7 +144,7 @@ describe("/api/settings/tokens", () => {
       token: "tt_created_token",
       createdAt: new Date("2026-03-08T18:00:00.000Z"),
       lastUsedAt: null,
-      expiresAt: new Date("2026-04-07T18:00:00.000Z"),
+      expiresAt,
     });
 
     const response = await POST(
@@ -152,7 +155,7 @@ describe("/api/settings/tokens", () => {
         },
         body: JSON.stringify({
           name: "  GitHub Actions CI  ",
-          expiresAt: "2026-04-07T18:00:00.000Z",
+          expiresAt: expiresAtIso,
         }),
       })
     );
@@ -163,7 +166,7 @@ describe("/api/settings/tokens", () => {
     expect(mockState.issuePersonalToken).toHaveBeenCalledWith({
       userId: "user-1",
       name: "GitHub Actions CI",
-      expiresAt: new Date("2026-04-07T18:00:00.000Z"),
+      expiresAt,
     });
     expect(body).toEqual({
       token: {
@@ -171,7 +174,7 @@ describe("/api/settings/tokens", () => {
         name: "GitHub Actions CI",
         createdAt: new Date("2026-03-08T18:00:00.000Z").toISOString(),
         lastUsedAt: null,
-        expiresAt: new Date("2026-04-07T18:00:00.000Z").toISOString(),
+        expiresAt: expiresAtIso,
       },
       plainTextToken: "tt_created_token",
     });
@@ -271,6 +274,29 @@ describe("/api/settings/tokens", () => {
         body: JSON.stringify({
           name: "GitHub Actions CI",
           expiresAt: 12345,
+        }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+    expect(await response.json()).toEqual({
+      error: "Expiration must be an ISO date string",
+    });
+    expect(mockState.issuePersonalToken).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-ISO expiration strings before touching the token service", async () => {
+    mockState.getSession.mockResolvedValue({ id: "user-1" });
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/settings/tokens", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: "GitHub Actions CI",
+          expiresAt: "04/07/2026",
         }),
       })
     );

--- a/packages/frontend/__tests__/api/settingsTokensList.test.ts
+++ b/packages/frontend/__tests__/api/settingsTokensList.test.ts
@@ -68,7 +68,7 @@ describe("GET /api/settings/tokens", () => {
     expect(await response.json()).toEqual({ tokens: [] });
   });
 
-  it("returns 200 with mapped token list (excluding token, expiresAt, userId fields)", async () => {
+  it("returns 200 with mapped token list (excluding token and userId fields)", async () => {
     mockState.getSession.mockResolvedValue({
       id: "user-1",
       username: "alice",
@@ -109,18 +109,19 @@ describe("GET /api/settings/tokens", () => {
           name: "My Token",
           createdAt: "2024-01-01T00:00:00.000Z",
           lastUsedAt: "2024-01-15T00:00:00.000Z",
+          expiresAt: "2025-01-01T00:00:00.000Z",
         },
         {
           id: "token-2",
           name: "Another Token",
           createdAt: "2024-02-01T00:00:00.000Z",
           lastUsedAt: null,
+          expiresAt: null,
         },
       ],
     });
-    // Verify that token, expiresAt, and userId are not in the response
+    // Verify that token and userId are not in the response
     expect(data.tokens[0]).not.toHaveProperty("token");
-    expect(data.tokens[0]).not.toHaveProperty("expiresAt");
     expect(data.tokens[0]).not.toHaveProperty("userId");
   });
 
@@ -188,20 +189,21 @@ describe("POST /api/settings/tokens", () => {
     expect(mockState.issuePersonalToken).toHaveBeenCalledWith({
       userId: "user-1",
       name: "GitHub Actions",
-      ensureUniqueName: true,
+      expiresAt: null,
     });
     expect(await response.json()).toEqual({
       token: {
         id: "token-1",
         name: "GitHub Actions",
-        token: "tt_raw_token",
         createdAt: "2026-05-01T10:00:00.000Z",
         lastUsedAt: null,
+        expiresAt: null,
       },
+      plainTextToken: "tt_raw_token",
     });
   });
 
-  it("uses a safe default name when the request name is blank", async () => {
+  it("rejects blank token names", async () => {
     mockState.getSession.mockResolvedValue({
       id: "user-1",
       username: "alice",
@@ -209,16 +211,6 @@ describe("POST /api/settings/tokens", () => {
       avatarUrl: null,
       isAdmin: false,
     });
-    mockState.issuePersonalToken.mockResolvedValue({
-      id: "token-1",
-      userId: "user-1",
-      name: "CI token",
-      token: "tt_raw_token",
-      createdAt: new Date("2026-05-01T10:00:00.000Z"),
-      lastUsedAt: null,
-      expiresAt: null,
-    });
-
     const response = await POST(
       new Request("http://localhost:3000/api/settings/tokens", {
         method: "POST",
@@ -226,11 +218,8 @@ describe("POST /api/settings/tokens", () => {
       })
     );
 
-    expect(response.status).toBe(201);
-    expect(mockState.issuePersonalToken).toHaveBeenCalledWith({
-      userId: "user-1",
-      name: "CI token",
-      ensureUniqueName: true,
-    });
+    expect(response.status).toBe(422);
+    expect(await response.json()).toEqual({ error: "Token name is required" });
+    expect(mockState.issuePersonalToken).not.toHaveBeenCalled();
   });
 });

--- a/packages/frontend/__tests__/lib/personalTokens.test.ts
+++ b/packages/frontend/__tests__/lib/personalTokens.test.ts
@@ -2,7 +2,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockState = vi.hoisted(() => {
   const selectResults: Array<Array<Record<string, unknown>>> = [];
-  const insertResults: Array<Array<Record<string, unknown>>> = [];
+  const insertResults: Array<Array<Record<string, unknown>> | Error> = [];
   const updateResults: Array<Array<Record<string, unknown>>> = [];
   const deleteResults: Array<Array<Record<string, unknown>>> = [];
   const insertValues: Array<Record<string, unknown>> = [];
@@ -37,8 +37,13 @@ const mockState = vi.hoisted(() => {
     values,
   }));
 
-  function nextResult<T>(queue: T[][]): T[] {
-    return queue.shift() ?? [];
+  function nextResult<T>(queue: Array<T[] | Error>): T[] {
+    const next = queue.shift();
+    if (next instanceof Error) {
+      throw next;
+    }
+
+    return next ?? [];
   }
 
   const execute = vi.fn(async (statement: unknown) => {
@@ -137,6 +142,9 @@ const mockState = vi.hoisted(() => {
     pushInsertResult(rows: Array<Record<string, unknown>>) {
       insertResults.push(rows);
     },
+    pushInsertError(error: Error) {
+      insertResults.push(error);
+    },
     pushUpdateResult(rows: Array<Record<string, unknown>> = []) {
       updateResults.push(rows);
     },
@@ -174,6 +182,7 @@ let issuePersonalToken: ModuleExports["issuePersonalToken"];
 let authenticatePersonalToken: ModuleExports["authenticatePersonalToken"];
 let listPersonalTokens: ModuleExports["listPersonalTokens"];
 let revokePersonalToken: ModuleExports["revokePersonalToken"];
+let PersonalTokenNameConflictError: ModuleExports["PersonalTokenNameConflictError"];
 
 beforeAll(async () => {
   const personalTokensModule = await import("../../src/lib/auth/personalTokens");
@@ -181,6 +190,7 @@ beforeAll(async () => {
   authenticatePersonalToken = personalTokensModule.authenticatePersonalToken;
   listPersonalTokens = personalTokensModule.listPersonalTokens;
   revokePersonalToken = personalTokensModule.revokePersonalToken;
+  PersonalTokenNameConflictError = personalTokensModule.PersonalTokenNameConflictError;
 });
 
 beforeEach(() => {
@@ -313,6 +323,22 @@ describe("personal token service", () => {
     expect(mockState.insertValues[0]).toMatchObject({
       name: "CLI raw",
     });
+  });
+
+  it("throws a conflict error for duplicate manually named tokens", async () => {
+    mockState.pushInsertError(
+      Object.assign(new Error("duplicate key value violates unique constraint"), {
+        code: "23505",
+        constraint: "api_tokens_user_name_unique",
+      })
+    );
+
+    await expect(
+      issuePersonalToken({
+        userId: "user-1",
+        name: "GitHub Actions CI",
+      })
+    ).rejects.toBeInstanceOf(PersonalTokenNameConflictError);
   });
 
   it("returns invalid for malformed tokens without hitting the database", async () => {

--- a/packages/frontend/src/app/api/settings/tokens/route.ts
+++ b/packages/frontend/src/app/api/settings/tokens/route.ts
@@ -1,21 +1,45 @@
 import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
-import { issuePersonalToken, listPersonalTokens } from "@/lib/auth/personalTokens";
+import {
+  issuePersonalToken,
+  listPersonalTokens,
+  PersonalTokenNameConflictError,
+} from "@/lib/auth/personalTokens";
 
-const DEFAULT_TOKEN_NAME = "CI token";
 const MAX_TOKEN_NAME_LENGTH = 100;
+const ISO_DATE_TIME_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?(?:Z|[+-]\d{2}:\d{2})$/;
 
-function normalizeTokenName(value: unknown): string {
+class TokenRequestValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TokenRequestValidationError";
+  }
+}
+
+function parseExpiresAt(value: unknown): Date | null {
+  if (value == null || value === "") {
+    return null;
+  }
+
   if (typeof value !== "string") {
-    return DEFAULT_TOKEN_NAME;
+    throw new TokenRequestValidationError("Expiration must be an ISO date string");
   }
 
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return DEFAULT_TOKEN_NAME;
+  if (!ISO_DATE_TIME_PATTERN.test(value)) {
+    throw new TokenRequestValidationError("Expiration must be an ISO date string");
   }
 
-  return trimmed.slice(0, MAX_TOKEN_NAME_LENGTH);
+  const expiresAt = new Date(value);
+  if (Number.isNaN(expiresAt.getTime())) {
+    throw new TokenRequestValidationError("Expiration must be a valid date");
+  }
+
+  if (expiresAt <= new Date()) {
+    throw new TokenRequestValidationError("Expiration must be in the future");
+  }
+
+  return expiresAt;
 }
 
 export async function GET() {
@@ -33,6 +57,7 @@ export async function GET() {
         name: token.name,
         createdAt: token.createdAt,
         lastUsedAt: token.lastUsedAt,
+        expiresAt: token.expiresAt,
       })),
     });
   } catch (error) {
@@ -51,13 +76,37 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }
 
-    const body = await request.json().catch(() => ({}));
-    const rawName =
-      body && typeof body === "object" ? (body as { name?: unknown }).name : undefined;
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const input =
+      body && typeof body === "object"
+        ? (body as Record<string, unknown>)
+        : {};
+    const rawName = typeof input.name === "string" ? input.name.trim() : "";
+
+    if (!rawName) {
+      return NextResponse.json(
+        { error: "Token name is required" },
+        { status: 422 }
+      );
+    }
+
+    if (rawName.length > MAX_TOKEN_NAME_LENGTH) {
+      return NextResponse.json(
+        { error: `Token name must be ${MAX_TOKEN_NAME_LENGTH} characters or fewer` },
+        { status: 422 }
+      );
+    }
+
     const issuedToken = await issuePersonalToken({
       userId: session.id,
-      name: normalizeTokenName(rawName),
-      ensureUniqueName: true,
+      name: rawName,
+      expiresAt: parseExpiresAt(input.expiresAt),
     });
 
     return NextResponse.json(
@@ -65,14 +114,31 @@ export async function POST(request: Request) {
         token: {
           id: issuedToken.id,
           name: issuedToken.name,
-          token: issuedToken.token,
           createdAt: issuedToken.createdAt,
           lastUsedAt: issuedToken.lastUsedAt,
+          expiresAt: issuedToken.expiresAt,
         },
+        plainTextToken: issuedToken.token,
       },
-      { status: 201 }
+      {
+        status: 201,
+        headers: {
+          "Cache-Control": "private, no-store",
+        },
+      }
     );
   } catch (error) {
+    if (error instanceof PersonalTokenNameConflictError) {
+      return NextResponse.json(
+        { error: "A token with this name already exists" },
+        { status: 409 }
+      );
+    }
+
+    if (error instanceof TokenRequestValidationError) {
+      return NextResponse.json({ error: error.message }, { status: 422 });
+    }
+
     console.error("Token create error:", error);
     return NextResponse.json(
       { error: "Failed to create token" },

--- a/packages/frontend/src/app/settings/SettingsClient.tsx
+++ b/packages/frontend/src/app/settings/SettingsClient.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import { useRouter } from "nextjs-toploader/app";
 import styled from "styled-components";
-import { KeyIcon } from "@/components/ui/Icons";
+import { CheckIcon, CopyIcon, KeyIcon } from "@/components/ui/Icons";
 import { Navigation } from "@/components/layout/Navigation";
 import { Footer } from "@/components/layout/Footer";
 
@@ -20,10 +20,48 @@ interface ApiToken {
   name: string;
   createdAt: string;
   lastUsedAt: string | null;
+  expiresAt: string | null;
 }
 
-interface CreatedApiToken extends ApiToken {
-  token: string;
+interface RevealedToken {
+  id: string;
+  name: string;
+  plainTextToken: string;
+  expiresAt: string | null;
+}
+
+type ExpiryPreset = "never" | "30d" | "90d";
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+function formatDate(value: string): string {
+  return dateFormatter.format(new Date(value));
+}
+
+function getExpiryText(expiresAt: string | null): string {
+  if (!expiresAt) {
+    return "No expiry";
+  }
+
+  const expiresAtDate = new Date(expiresAt);
+  if (expiresAtDate <= new Date()) {
+    return `Expired ${formatDate(expiresAt)}`;
+  }
+
+  return `Expires ${formatDate(expiresAt)}`;
+}
+
+function getExpiresAtFromPreset(preset: ExpiryPreset): string | null {
+  if (preset === "never") {
+    return null;
+  }
+
+  const days = preset === "30d" ? 30 : 90;
+  return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
 }
 
 const PageWrapper = styled.div`
@@ -91,99 +129,6 @@ const Description = styled.p`
   margin-bottom: 16px;
 `;
 
-const FieldLabel = styled.label`
-  display: block;
-  font-size: 13px;
-  font-weight: 600;
-  margin-bottom: 8px;
-`;
-
-const ActionRow = styled.div`
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 12px;
-  margin-bottom: 16px;
-
-  @media (max-width: 560px) {
-    grid-template-columns: 1fr;
-  }
-`;
-
-const TextInput = styled.input`
-  height: 40px;
-  padding: 0 12px;
-  border-radius: 6px;
-  border: 1px solid var(--color-border-default);
-  background: var(--color-bg-default);
-  color: var(--color-fg-default);
-  font-size: 14px;
-`;
-
-const PrimaryButton = styled.button`
-  height: 40px;
-  padding: 0 14px;
-  border-radius: 6px;
-  border: 1px solid var(--color-accent-fg);
-  background: var(--color-accent-fg);
-  color: #ffffff;
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: opacity 150ms;
-
-  &:disabled {
-    cursor: not-allowed;
-    opacity: 0.6;
-  }
-`;
-
-const TokenReveal = styled.div`
-  padding: 12px;
-  border-radius: 6px;
-  border: 1px solid var(--color-success-fg);
-  background: rgba(63, 185, 80, 0.08);
-  margin-bottom: 16px;
-`;
-
-const TokenCodeRow = styled.div`
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 8px;
-  margin-top: 8px;
-
-  @media (max-width: 560px) {
-    grid-template-columns: 1fr;
-  }
-`;
-
-const TokenCode = styled.code`
-  display: block;
-  overflow-x: auto;
-  white-space: nowrap;
-  padding: 10px 12px;
-  border-radius: 6px;
-  background: var(--color-bg-default);
-  font-size: 13px;
-`;
-
-const SecondaryButton = styled.button`
-  height: 38px;
-  padding: 0 12px;
-  border-radius: 6px;
-  border: 1px solid var(--color-border-default);
-  background: var(--color-bg-default);
-  color: var(--color-fg-default);
-  font-size: 13px;
-  font-weight: 600;
-  cursor: pointer;
-`;
-
-const ErrorText = styled.p`
-  color: #f85149;
-  font-size: 13px;
-  margin: -4px 0 16px;
-`;
-
 const EmptyState = styled.div`
   padding: 32px 0;
   text-align: center;
@@ -211,6 +156,7 @@ const TokenItem = styled.div`
   justify-content: space-between;
   padding: 16px;
   border-radius: 12px;
+  gap: 16px;
 `;
 
 const TokenInfo = styled.div`
@@ -223,18 +169,66 @@ const IconWrapper = styled.div`
   color: #737373;
 `;
 
+const ButtonRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+`;
+
+const TokenActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+`;
 
 const DangerButton = styled.button`
   padding: 4px 12px;
   font-size: 12px;
   font-weight: 500;
   border-radius: 6px;
-  border: 1px solid #F85149;
+  border: 1px solid #f85149;
   background: transparent;
-  color: #F85149;
+  color: #f85149;
   cursor: pointer;
   transition: all 150ms;
-  &:hover { background: #F85149; color: #FFFFFF; }
+
+  &:hover {
+    background: #f85149;
+    color: #ffffff;
+  }
+`;
+
+const PrimaryButton = styled.button`
+  padding: 10px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: #2563eb;
+  color: #ffffff;
+  cursor: pointer;
+  transition: opacity 150ms, transform 150ms;
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+`;
+
+const SecondaryButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-default);
+  color: var(--color-fg-default);
+  cursor: pointer;
 `;
 
 const InfoBanner = styled.div`
@@ -244,6 +238,11 @@ const InfoBanner = styled.div`
   background: var(--color-bg-subtle);
   color: var(--color-fg-muted);
   font-size: 14px;
+`;
+
+const ErrorBanner = styled(InfoBanner)`
+  border-color: rgba(248, 81, 73, 0.5);
+  color: #f85149;
 `;
 
 const AvatarImg = styled.img`
@@ -257,67 +256,151 @@ const TokenName = styled.p`
   font-weight: 500;
 `;
 
-function apiTokenListItem(token: CreatedApiToken): ApiToken {
-  return {
-    id: token.id,
-    name: token.name,
-    createdAt: token.createdAt,
-    lastUsedAt: token.lastUsedAt,
-  };
-}
+const CreateForm = styled.form`
+  display: grid;
+  gap: 16px;
+  margin-bottom: 16px;
+`;
 
-function prependApiToken(tokens: ApiToken[], token: ApiToken): ApiToken[] {
-  return [token, ...tokens.filter((item) => item.id !== token.id)];
-}
+const FormRow = styled.div`
+  display: grid;
+  gap: 12px;
+  grid-template-columns: minmax(0, 2fr) minmax(180px, 1fr) auto;
 
-function mergeApiTokenList(
-  serverTokens: ApiToken[],
-  currentTokens: ApiToken[]
-): ApiToken[] {
-  const serverTokenIds = new Set(serverTokens.map((token) => token.id));
-  const localTokens = currentTokens.filter(
-    (token) => !serverTokenIds.has(token.id)
-  );
-  return [...localTokens, ...serverTokens];
-}
+  @media (max-width: 720px) {
+    grid-template-columns: 1fr;
+  }
+`;
 
-async function fetchApiTokens(): Promise<ApiToken[]> {
-  const tokensResponse = await fetch("/api/settings/tokens");
-  const tokensData = await tokensResponse.json();
-  return Array.isArray(tokensData.tokens) ? tokensData.tokens : [];
-}
+const FormField = styled.label`
+  display: grid;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-fg-default);
+`;
+
+const TextInput = styled.input`
+  width: 100%;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-default);
+  color: var(--color-fg-default);
+  padding: 10px 12px;
+  font-size: 14px;
+`;
+
+const SelectInput = styled.select`
+  width: 100%;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-default);
+  color: var(--color-fg-default);
+  padding: 10px 12px;
+  font-size: 14px;
+`;
+
+const SubmitWrapper = styled.div`
+  display: flex;
+  align-items: end;
+`;
+
+const RevealPanel = styled.div`
+  border-radius: 12px;
+  border: 1px solid rgba(37, 99, 235, 0.4);
+  background: rgba(37, 99, 235, 0.08);
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+  margin-bottom: 16px;
+`;
+
+const RevealTitle = styled.p`
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-fg-default);
+`;
+
+const SecretValue = styled.code`
+  display: block;
+  width: 100%;
+  overflow-x: auto;
+  padding: 12px;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.25);
+  color: var(--color-fg-default);
+  font-size: 13px;
+`;
 
 export default function SettingsClient() {
   const router = useRouter();
   const [user, setUser] = useState<User | null>(null);
   const [tokens, setTokens] = useState<ApiToken[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [tokenName, setTokenName] = useState("CI token");
-  const [createdToken, setCreatedToken] = useState<CreatedApiToken | null>(null);
-  const [isCreatingToken, setIsCreatingToken] = useState(false);
-  const [createTokenError, setCreateTokenError] = useState<string | null>(null);
+  const [tokenName, setTokenName] = useState("");
+  const [expiryPreset, setExpiryPreset] = useState<ExpiryPreset>("never");
+  const [isCreating, setIsCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [revealedToken, setRevealedToken] = useState<RevealedToken | null>(null);
+  const [copiedToken, setCopiedToken] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [revokeCandidateId, setRevokeCandidateId] = useState<string | null>(null);
+  const [revokingTokenId, setRevokingTokenId] = useState<string | null>(null);
+  const [revokeError, setRevokeError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
 
-    async function loadSettings() {
+    async function load() {
       try {
         const sessionResponse = await fetch("/api/auth/session");
         const sessionData = await sessionResponse.json();
-        if (cancelled) return;
 
         if (!sessionData.user) {
+          if (cancelled) {
+            return;
+          }
+
           router.push("/api/auth/github?returnTo=/settings");
           return;
         }
 
-        const loadedTokens = await fetchApiTokens().catch(() => []);
-
-        if (!cancelled) {
-          setUser(sessionData.user);
-          setTokens((current) => mergeApiTokenList(loadedTokens, current));
-          setIsLoading(false);
+        if (cancelled) {
+          return;
         }
+
+        setUser(sessionData.user);
+
+        const tokensResponse = await fetch("/api/settings/tokens");
+        const tokensData = await tokensResponse.json().catch(() => null);
+
+        if (tokensResponse.status === 401) {
+          if (cancelled) {
+            return;
+          }
+
+          router.push("/api/auth/github?returnTo=/settings");
+          return;
+        }
+
+        if (!tokensResponse.ok) {
+          if (cancelled) {
+            return;
+          }
+
+          setTokens([]);
+          setLoadError(tokensData?.error ?? "Failed to load API tokens");
+          setIsLoading(false);
+          return;
+        }
+
+        if (cancelled) {
+          return;
+        }
+
+        setTokens(tokensData.tokens ?? []);
+        setLoadError(null);
+        setIsLoading(false);
       } catch {
         if (!cancelled) {
           router.push("/leaderboard");
@@ -325,64 +408,123 @@ export default function SettingsClient() {
       }
     }
 
-    loadSettings();
+    load();
+
     return () => {
       cancelled = true;
     };
   }, [router]);
 
-  const handleRevokeToken = async (tokenId: string) => {
-    if (!confirm("Are you sure you want to revoke this token?")) return;
+  const handleCreateToken = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
 
-    try {
-      const response = await fetch(`/api/settings/tokens/${tokenId}`, {
-        method: "DELETE",
-      });
-
-      if (response.ok) {
-        setTokens(tokens.filter((t) => t.id !== tokenId));
-      }
-    } catch {
-      alert("Failed to revoke token");
-    }
-  };
-
-  const handleCreateToken = async () => {
-    setIsCreatingToken(true);
-    setCreateTokenError(null);
+    setCreateError(null);
+    setRevealedToken(null);
+    setCopiedToken(false);
+    setRevokeCandidateId(null);
+    setIsCreating(true);
 
     try {
       const response = await fetch("/api/settings/tokens", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: tokenName }),
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: tokenName,
+          expiresAt: getExpiresAtFromPreset(expiryPreset),
+        }),
       });
 
       const data = await response.json();
-      if (!response.ok || !data.token) {
-        throw new Error(data.error || "Failed to create token");
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          router.push("/api/auth/github?returnTo=/settings");
+          return;
+        }
+
+        setCreateError(data.error ?? "Failed to create token");
+        return;
       }
 
-      setCreatedToken(data.token);
-      setTokens((current) =>
-        prependApiToken(current, apiTokenListItem(data.token))
-      );
-    } catch (error) {
-      setCreateTokenError(error instanceof Error ? error.message : "Failed to create token");
+      const createdToken = data.token as ApiToken;
+      const plainTextToken = data.plainTextToken as string;
+
+      setTokens((current) => [createdToken, ...current.filter((token) => token.id !== createdToken.id)]);
+      setRevealedToken({
+        id: createdToken.id,
+        name: createdToken.name,
+        plainTextToken,
+        expiresAt: createdToken.expiresAt,
+      });
+      setLoadError(null);
+      setRevokeError(null);
+      setTokenName("");
+      setExpiryPreset("never");
+      setCopiedToken(false);
+    } catch {
+      setCreateError("Failed to create token");
     } finally {
-      setIsCreatingToken(false);
+      setIsCreating(false);
     }
   };
 
-  const handleCopyCreatedToken = async () => {
-    if (!createdToken) return;
-    await navigator.clipboard.writeText(createdToken.token);
-    // The raw token is shown once and only once. After the user has copied
-    // it we drop it from React state so it no longer lives in the component
-    // tree (and thus no longer in any DevTools / extension snapshot of it).
-    // Users who haven't copied yet still have the value in the reveal panel
-    // until they navigate away.
-    setCreatedToken(null);
+  const handleCopyToken = async () => {
+    if (!revealedToken) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(revealedToken.plainTextToken);
+      setCopiedToken(true);
+      setRevealedToken(null);
+      setTimeout(() => setCopiedToken(false), 2000);
+    } catch {
+      setCreateError("Failed to copy token");
+    }
+  };
+
+  const handleRequestRevoke = (tokenId: string) => {
+    setRevokeError(null);
+    setRevokeCandidateId(tokenId);
+  };
+
+  const handleCancelRevoke = () => {
+    setRevokeCandidateId(null);
+  };
+
+  const handleConfirmRevoke = async (tokenId: string) => {
+    setRevokeError(null);
+    setRevokingTokenId(tokenId);
+    try {
+      const revokesRevealedToken = revealedToken?.id === tokenId;
+      const response = await fetch(`/api/settings/tokens/${tokenId}`, {
+        method: "DELETE",
+      });
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          router.push("/api/auth/github?returnTo=/settings");
+          return;
+        }
+
+        const data = await response.json().catch(() => null);
+        setRevokeError(data?.error ?? "Failed to revoke token");
+        return;
+      }
+
+      setTokens((current) => current.filter((token) => token.id !== tokenId));
+      setRevokeCandidateId((current) => (current === tokenId ? null : current));
+      if (revokesRevealedToken) {
+        setRevealedToken(null);
+        setCopiedToken(false);
+      }
+    } catch {
+      setRevokeError("Failed to revoke token");
+    } finally {
+      setRevokingTokenId(null);
+    }
   };
 
   if (isLoading) {
@@ -449,53 +591,93 @@ export default function SettingsClient() {
             API Tokens
           </SectionTitle>
           <Description style={{ color: "var(--color-fg-muted)" }}>
-            Create a token for CI or use one generated by{" "}
-            <CodeText
-              style={{ backgroundColor: "var(--color-bg-subtle)" }}
-            >
+            Create a token here for CI or other headless flows, or keep using{" "}
+            <CodeText style={{ backgroundColor: "var(--color-bg-subtle)" }}>
               tokscale login
             </CodeText>{" "}
             from the CLI.
           </Description>
 
-          <FieldLabel
-            htmlFor="token-name"
-            style={{ color: "var(--color-fg-default)" }}
-          >
-            Token name
-          </FieldLabel>
-          <ActionRow>
-            <TextInput
-              id="token-name"
-              value={tokenName}
-              onChange={(event) => setTokenName(event.target.value)}
-              maxLength={100}
-            />
-            <PrimaryButton
-              type="button"
-              disabled={isCreatingToken}
-              onClick={handleCreateToken}
-            >
-              {isCreatingToken ? "Creating..." : "Create token"}
-            </PrimaryButton>
-          </ActionRow>
+          <CreateForm onSubmit={handleCreateToken}>
+            <FormRow>
+              <FormField htmlFor="token-name">
+                Token name
+                <TextInput
+                  id="token-name"
+                  value={tokenName}
+                  onChange={(event) => setTokenName(event.target.value)}
+                  placeholder="GitHub Actions CI"
+                  maxLength={100}
+                />
+              </FormField>
 
-          {createTokenError && <ErrorText>{createTokenError}</ErrorText>}
+              <FormField htmlFor="token-expiry">
+                Expiration
+                <SelectInput
+                  id="token-expiry"
+                  value={expiryPreset}
+                  onChange={(event) => setExpiryPreset(event.target.value as ExpiryPreset)}
+                >
+                  <option value="never">No expiry</option>
+                  <option value="30d">30 days</option>
+                  <option value="90d">90 days</option>
+                </SelectInput>
+              </FormField>
 
-          {createdToken && (
-            <TokenReveal>
-              <SmallText style={{ color: "var(--color-fg-default)", fontWeight: 600 }}>
-                Copy this token now. It will not be shown again.
-              </SmallText>
-              <TokenCodeRow>
-                <TokenCode style={{ color: "var(--color-fg-default)" }}>
-                  {createdToken.token}
-                </TokenCode>
-                <SecondaryButton type="button" onClick={handleCopyCreatedToken}>
-                  Copy
+              <SubmitWrapper>
+                <PrimaryButton
+                  type="submit"
+                  disabled={isCreating || tokenName.trim().length === 0}
+                >
+                  {isCreating ? "Creating..." : "Create token"}
+                </PrimaryButton>
+              </SubmitWrapper>
+            </FormRow>
+          </CreateForm>
+
+          {createError && (
+            <ErrorBanner style={{ marginBottom: 16 }}>
+              {createError}
+            </ErrorBanner>
+          )}
+
+          {loadError && (
+            <ErrorBanner style={{ marginBottom: 16 }}>
+              {loadError}
+            </ErrorBanner>
+          )}
+
+          {revokeError && (
+            <ErrorBanner style={{ marginBottom: 16 }}>
+              {revokeError}
+            </ErrorBanner>
+          )}
+
+          {revealedToken && (
+            <RevealPanel>
+              <div>
+                <RevealTitle>
+                  Save this token now
+                </RevealTitle>
+                <SmallText style={{ color: "var(--color-fg-muted)", marginTop: 4 }}>
+                  This is the only time the full token will be shown for{" "}
+                  <CodeText style={{ backgroundColor: "rgba(255, 255, 255, 0.08)" }}>
+                    {revealedToken.name}
+                  </CodeText>
+                  {" - "}
+                  {getExpiryText(revealedToken.expiresAt)}
+                </SmallText>
+              </div>
+
+              <SecretValue>{revealedToken.plainTextToken}</SecretValue>
+
+              <ButtonRow>
+                <SecondaryButton type="button" onClick={handleCopyToken}>
+                  {copiedToken ? <CheckIcon size={16} /> : <CopyIcon size={16} />}
+                  {copiedToken ? "Copied" : "Copy token"}
                 </SecondaryButton>
-              </TokenCodeRow>
-            </TokenReveal>
+              </ButtonRow>
+            </RevealPanel>
           )}
 
           {tokens.length === 0 ? (
@@ -505,13 +687,7 @@ export default function SettingsClient() {
               </EmptyIcon>
               <p>No API tokens yet.</p>
               <EmptyText>
-                Create one here or run{" "}
-                <CodeText
-                  style={{ backgroundColor: "var(--color-bg-subtle)" }}
-                >
-                  tokscale login
-                </CodeText>{" "}
-                from the CLI.
+                Create one above to use tokscale from CI or another headless environment.
               </EmptyText>
             </EmptyState>
           ) : (
@@ -530,25 +706,43 @@ export default function SettingsClient() {
                         {token.name}
                       </TokenName>
                       <SmallText style={{ color: "var(--color-fg-muted)" }}>
-                        Created {new Date(token.createdAt).toLocaleDateString()}
+                        Created {formatDate(token.createdAt)}
                         {token.lastUsedAt && (
-                          <> - Last used {new Date(token.lastUsedAt).toLocaleDateString()}</>
+                          <> - Last used {formatDate(token.lastUsedAt)}</>
                         )}
+                        <> - {getExpiryText(token.expiresAt)}</>
                       </SmallText>
                     </div>
                   </TokenInfo>
-                  <DangerButton
-                    onClick={() => handleRevokeToken(token.id)}
-                  >
-                    Revoke
-                  </DangerButton>
+                  {revokeCandidateId === token.id ? (
+                    <TokenActions>
+                      <DangerButton
+                        onClick={() => handleConfirmRevoke(token.id)}
+                        disabled={revokingTokenId === token.id}
+                      >
+                        {revokingTokenId === token.id ? "Revoking..." : "Confirm revoke"}
+                      </DangerButton>
+                      <SecondaryButton
+                        type="button"
+                        onClick={handleCancelRevoke}
+                        disabled={revokingTokenId === token.id}
+                      >
+                        Cancel
+                      </SecondaryButton>
+                    </TokenActions>
+                  ) : (
+                    <DangerButton
+                      onClick={() => handleRequestRevoke(token.id)}
+                      disabled={revokingTokenId !== null}
+                    >
+                      Revoke
+                    </DangerButton>
+                  )}
                 </TokenItem>
               ))}
             </TokenList>
           )}
         </Section>
-
-
       </MainContent>
 
       <Footer />

--- a/packages/frontend/src/lib/auth/personalTokens.ts
+++ b/packages/frontend/src/lib/auth/personalTokens.ts
@@ -41,7 +41,35 @@ export interface AuthenticatePersonalTokenOptions {
   touchLastUsedAt?: boolean;
 }
 
+export class PersonalTokenNameConflictError extends Error {
+  constructor(name: string) {
+    super(`A personal token named "${name}" already exists`);
+    this.name = "PersonalTokenNameConflictError";
+  }
+}
+
 const TOKEN_NAME_LOCK_NAMESPACE = "personal_token_names";
+
+function isTokenNameConflict(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const databaseError = error as {
+    code?: string;
+    constraint?: string;
+    message?: string;
+  };
+
+  if (databaseError.code !== "23505") {
+    return false;
+  }
+
+  return (
+    databaseError.constraint === "api_tokens_user_name_unique" ||
+    databaseError.message?.includes("api_tokens_user_name_unique") === true
+  );
+}
 
 function getUniqueTokenName(baseName: string, existingNames: Iterable<string>): string {
   const names = new Set(existingNames);
@@ -65,27 +93,36 @@ export async function issuePersonalToken({
   if (!ensureUniqueName) {
     const token = generateApiToken();
     const tokenHashed = hashToken(token);
-    const [createdToken] = await db
-      .insert(apiTokens)
-      .values({
-        userId,
-        token: tokenHashed,
-        name,
-        expiresAt,
-      })
-      .returning({
-        id: apiTokens.id,
-        userId: apiTokens.userId,
-        name: apiTokens.name,
-        createdAt: apiTokens.createdAt,
-        lastUsedAt: apiTokens.lastUsedAt,
-        expiresAt: apiTokens.expiresAt,
-      });
 
-    return {
-      ...createdToken,
-      token,
-    };
+    try {
+      const [createdToken] = await db
+        .insert(apiTokens)
+        .values({
+          userId,
+          token: tokenHashed,
+          name,
+          expiresAt,
+        })
+        .returning({
+          id: apiTokens.id,
+          userId: apiTokens.userId,
+          name: apiTokens.name,
+          createdAt: apiTokens.createdAt,
+          lastUsedAt: apiTokens.lastUsedAt,
+          expiresAt: apiTokens.expiresAt,
+        });
+
+      return {
+        ...createdToken,
+        token,
+      };
+    } catch (error) {
+      if (isTokenNameConflict(error)) {
+        throw new PersonalTokenNameConflictError(name);
+      }
+
+      throw error;
+    }
   }
 
   return db.transaction(async (tx) => {


### PR DESCRIPTION
## Summary
- Add a settings flow for creating personal tokens with optional expiry.
- Reveal the plain-text token once after creation and keep list and revoke actions on the same page.
- Keep duplicate-name handling and token storage rules in the shared personal token service.

## Why
- Provide a direct path for CI and other non-interactive workflows to create personal tokens.
- Keep issuance, expiry validation, duplicate-name handling, and token hashing in one place.

## Diff scope
- Base branch: `main`
- Head branch: `feat-settings-create-personal-tokens`
- Branch integrity: `git rev-list --left-right --count origin/main...HEAD` -> `0 4`
- Ahead count: `4`
- Behind count: `0`
- Fast-forward safety: safe
- Merge-base SHA: `9fe2f2e658389f2000b67ff16ec42c93e452b74a`
- Commits:
  - `51463d94fb6f6a26c8156454509be9a2c9ccac21` `feat(settings): add personal token creation flow`
  - `6c5f74cd8934e568ac8c76cd351a9b9d5d6b5c19` `fix(settings): polish token revoke flow`
  - `9992a37db01b1363249fe2e1d35b1f7591997f40` `fix(settings): harden personal token flow states`
  - `254a4394dbd850b4a7761ed704564d37ee0c5183` `test(settings): cover token route failure states`
- Areas touched:
  - `packages/frontend/src/app/settings/SettingsClient.tsx`
  - `packages/frontend/src/app/api/settings/tokens/route.ts`
  - `packages/frontend/src/lib/auth/personalTokens.ts`
  - `packages/frontend/__tests__/api/settingsTokens.test.ts`
  - `packages/frontend/__tests__/lib/personalTokens.test.ts`

## Test proof
- `npx vitest run __tests__/api/settingsTokens.test.ts __tests__/lib/personalTokens.test.ts __tests__/api/devicePoll.test.ts __tests__/api/submitAuth.test.ts`
  - Result: `4 passed files`, `34 passed tests`
- `npx eslint __tests__/api/settingsTokens.test.ts __tests__/lib/personalTokens.test.ts __tests__/api/devicePoll.test.ts __tests__/api/submitAuth.test.ts src/app/api/settings/tokens/route.ts src/app/settings/SettingsClient.tsx src/lib/auth/personalTokens.ts src/app/api/auth/device/poll/route.ts src/app/api/submit/route.ts`
  - Result: pass
- Coverage: Not applicable - frontend-only change set

## Verification-pack proof
Not applicable - no workflow, infrastructure, governance, replay, or migration changes.

## Migration notes
Not applicable - no schema or migration changes.

## CI context confirmation
CI context names unchanged.

## Rollback plan
`git revert --no-edit 51463d94fb6f6a26c8156454509be9a2c9ccac21^..254a4394dbd850b4a7761ed704564d37ee0c5183`

## Known residual risks
- `npx tsc -p tsconfig.json --noEmit` was not used as merge proof because it did not complete within the local validation window.
- Final browser review of the token reveal panel is still recommended.
