### PR TITLE
fix: allow 1-day timezone buffer in future date validation

### DIFF
--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -170,15 +170,23 @@ export function validateSubmission(data: unknown): ValidationResult {
 
   const submission = parseResult.data;
 
-  // Step 2: No future dates (using UTC since DailyContribution.date is in UTC)
-  const todayStr = new Date().toISOString().split("T")[0];
+  // Step 2: No future dates
+  // The CLI generates dates using the user's local timezone, but the server
+  // runs in UTC. For users in UTC+ timezones (e.g. UTC+8), their local date
+  // can be ahead of UTC — causing valid submissions to be rejected as
+  // "future dates". Adding a 1-day buffer accommodates all timezones (UTC-12
+  // to UTC+14).
+  // See: https://github.com/junhoyeo/tokscale/issues/318
+  const now = new Date();
+  const maxDate = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+  const maxDateStr = maxDate.toISOString().split("T")[0];
 
-  if (submission.meta.dateRange.end > todayStr) {
+  if (submission.meta.dateRange.end > maxDateStr) {
     errors.push(`Date range extends into the future: ${submission.meta.dateRange.end}`);
   }
 
   for (const day of submission.contributions) {
-    if (day.date > todayStr) {
+    if (day.date > maxDateStr) {
       errors.push(`Future date found in contributions: ${day.date}`);
     }
   }


### PR DESCRIPTION
## Problem

The CLI generates contribution dates using the user's local timezone (`chrono::Local`), but the server validates them against UTC (`new Date().toISOString()`). For users in UTC+ timezones (e.g. UTC+8), their local date can be ahead of UTC — causing valid today-submissions to be rejected with:

> Date range extends into the future: 2026-03-14

This happens every day between midnight and ~08:00 local time for UTC+8 users.

## Fix

Add a 1-day buffer to the server-side future date check, accommodating all possible timezone offsets (UTC-12 to UTC+14). This is the minimal server-side fix — no CLI changes needed.

## Changes

- `packages/frontend/src/lib/validation/submission.ts`: Replace `todayStr` (UTC) with `maxDateStr` (UTC + 1 day) for the future date comparison

Fixes #318
Related: #145

---
*Submitted by Omo (Sisyphus)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow a 1-day timezone buffer in server-side future date checks so “today” submissions from UTC+ timezones aren’t rejected. This aligns CLI local-time dates with server validation and covers UTC-12 to UTC+14.

- **Bug Fixes**
  - Use UTC+1 day (`maxDateStr`) instead of UTC “today” when comparing `dateRange.end` and each `day.date`.
  - Change scoped to `packages/frontend/src/lib/validation/submission.ts`; no CLI updates needed.

<sup>Written for commit e0b54614733470bfbc14bc95ba7ce16bd123c4c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

