### PR TITLE
fix(codex): enable gpt-5.4 cost tracking

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -2417,6 +2417,98 @@ fn get_headless_roots(home_dir: &Path) -> Vec<PathBuf> {
     roots
 }
 
+fn build_codex_headless_preamble(args: &[String]) -> String {
+    let timestamp = chrono::Utc::now().to_rfc3339();
+    let mut lines = vec![serde_json::json!({
+        "timestamp": timestamp,
+        "type": "session_meta",
+        "payload": {
+            "originator": "tokscale_headless",
+            "source": "exec",
+        }
+    })
+    .to_string()];
+
+    if let Some(model) = infer_codex_model_from_args(args) {
+        lines.push(
+            serde_json::json!({
+                "timestamp": timestamp,
+                "type": "turn_context",
+                "payload": {
+                    "model": model,
+                }
+            })
+            .to_string(),
+        );
+    }
+
+    format!("{}\n", lines.join("\n"))
+}
+
+fn infer_codex_model_from_args(args: &[String]) -> Option<String> {
+    let mut index = 0;
+
+    while index < args.len() {
+        let arg = args[index].as_str();
+
+        match arg {
+            "-m" | "--model" => {
+                return args
+                    .get(index + 1)
+                    .and_then(|value| normalize_codex_model_arg(value));
+            }
+            "-c" | "--config" => {
+                if let Some(value) = args.get(index + 1) {
+                    if let Some(model) = parse_codex_model_override(value) {
+                        return Some(model);
+                    }
+                }
+                index += 1;
+            }
+            _ => {
+                if let Some(value) = arg.strip_prefix("--model=") {
+                    return normalize_codex_model_arg(value);
+                }
+                if let Some(value) = arg.strip_prefix("-m=") {
+                    return normalize_codex_model_arg(value);
+                }
+                if let Some(value) = arg.strip_prefix("--config=") {
+                    if let Some(model) = parse_codex_model_override(value) {
+                        return Some(model);
+                    }
+                }
+                if let Some(value) = arg.strip_prefix("-c=") {
+                    if let Some(model) = parse_codex_model_override(value) {
+                        return Some(model);
+                    }
+                }
+            }
+        }
+
+        index += 1;
+    }
+
+    None
+}
+
+fn parse_codex_model_override(value: &str) -> Option<String> {
+    let (key, raw_value) = value.split_once('=')?;
+    if key.trim() != "model" {
+        return None;
+    }
+    normalize_codex_model_arg(raw_value)
+}
+
+fn normalize_codex_model_arg(value: &str) -> Option<String> {
+    let normalized = value.trim().trim_matches(|c| c == '"' || c == '\'').trim();
+
+    if normalized.is_empty() {
+        None
+    } else {
+        Some(normalized.to_string())
+    }
+}
+
 fn describe_path(path: &str, exists: bool) -> String {
     let path_display = if let Some(home) = dirs::home_dir() {
         path.replace(&home.to_string_lossy().to_string(), "~")
@@ -3259,6 +3351,12 @@ fn run_headless_command(
     let mut output_file = std::fs::File::create(&output_path)
         .map_err(|e| anyhow::anyhow!("Failed to create output file '{}': {}", output_path, e))?;
 
+    if source_lower == "codex" {
+        output_file
+            .write_all(build_codex_headless_preamble(&args).as_bytes())
+            .map_err(|e| anyhow::anyhow!("Failed to write headless metadata: {}", e))?;
+    }
+
     let timed_out = Arc::new(AtomicBool::new(false));
     let timed_out_clone = Arc::clone(&timed_out);
     let child_id = child.id();
@@ -3805,5 +3903,54 @@ mod tests {
         let (position2, forward2) = LightSpinner::scanner_state(54);
         assert_eq!(position1, position2);
         assert_eq!(forward1, forward2);
+    }
+
+    #[test]
+    fn test_infer_codex_model_from_args_short_flag() {
+        let args = vec![
+            "exec".to_string(),
+            "-m".to_string(),
+            "gpt-5.4".to_string(),
+            "say hi".to_string(),
+        ];
+
+        assert_eq!(
+            infer_codex_model_from_args(&args),
+            Some("gpt-5.4".to_string())
+        );
+    }
+
+    #[test]
+    fn test_infer_codex_model_from_args_config_override() {
+        let args = vec![
+            "exec".to_string(),
+            "--config".to_string(),
+            "model=\"gpt-5.4-codex\"".to_string(),
+        ];
+
+        assert_eq!(
+            infer_codex_model_from_args(&args),
+            Some("gpt-5.4-codex".to_string())
+        );
+    }
+
+    #[test]
+    fn test_build_codex_headless_preamble_includes_headless_metadata_and_model() {
+        let preamble = build_codex_headless_preamble(&[
+            "exec".to_string(),
+            "--model".to_string(),
+            "gpt-5.4".to_string(),
+        ]);
+
+        let lines: Vec<&str> = preamble.lines().collect();
+        assert_eq!(lines.len(), 2);
+
+        let session_meta: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(session_meta["type"], "session_meta");
+        assert_eq!(session_meta["payload"]["source"], "exec");
+
+        let turn_context: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(turn_context["type"], "turn_context");
+        assert_eq!(turn_context["payload"]["model"], "gpt-5.4");
     }
 }

--- a/crates/tokscale-cli/src/tui/cache.rs
+++ b/crates/tokscale-cli/src/tui/cache.rs
@@ -19,7 +19,7 @@ use super::data::{
 
 /// Cache staleness threshold: 5 minutes (matches TS implementation)
 const CACHE_STALE_THRESHOLD_MS: u64 = 5 * 60 * 1000;
-const CACHE_SCHEMA_VERSION: u32 = 2;
+const CACHE_SCHEMA_VERSION: u32 = 3;
 
 /// Get the cache directory path
 /// Uses `~/.cache/tokscale/` to match TypeScript implementation for cache sharing
@@ -387,7 +387,9 @@ pub fn load_cache(enabled_clients: &HashSet<ClientId>, include_synthetic: bool) 
     if cached.schema_version > CACHE_SCHEMA_VERSION {
         return CacheResult::Miss;
     }
-    let schema_outdated = cached.schema_version < CACHE_SCHEMA_VERSION;
+    if cached.schema_version < CACHE_SCHEMA_VERSION {
+        return CacheResult::Miss;
+    }
 
     // Check how cached clients relate to enabled clients
     let client_match = check_client_match(
@@ -406,7 +408,7 @@ pub fn load_cache(enabled_clients: &HashSet<ClientId>, include_synthetic: bool) 
         Err(_) => return CacheResult::Miss,
     };
 
-    if schema_outdated || client_match == ClientMatch::Subset {
+    if client_match == ClientMatch::Subset {
         return CacheResult::Stale(data);
     }
 
@@ -624,7 +626,7 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_load_cache_returns_stale_for_legacy_schema_without_version() {
+    fn test_load_cache_returns_miss_for_legacy_schema_without_version() {
         let temp_dir = TempDir::new().unwrap();
         let previous_home = env::var_os("HOME");
         unsafe {
@@ -653,7 +655,7 @@ mod tests {
         .unwrap();
 
         let clients = make_clients(&[ClientId::Claude]);
-        assert!(matches!(load_cache(&clients, false), CacheResult::Stale(_)));
+        assert!(matches!(load_cache(&clients, false), CacheResult::Miss));
 
         match previous_home {
             Some(home) => unsafe { env::set_var("HOME", home) },

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -925,6 +925,7 @@ mod tests {
     fn test_data_loader_loads_agent_usage_from_roocode_files() {
         let temp_dir = TempDir::new().unwrap();
         let previous_home = env::var_os("HOME");
+        let previous_disable_fresh_pricing = env::var_os("TOKSCALE_DISABLE_FRESH_PRICING_FETCH");
         let task_root = temp_dir
             .path()
             .join(".config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks");
@@ -995,6 +996,7 @@ after"#,
 
         unsafe {
             env::set_var("HOME", temp_dir.path());
+            env::set_var("TOKSCALE_DISABLE_FRESH_PRICING_FETCH", "1");
         }
 
         let loader = DataLoader::new(None);
@@ -1018,6 +1020,10 @@ after"#,
             Some(home) => unsafe { env::set_var("HOME", home) },
             None => unsafe { env::remove_var("HOME") },
         }
+        match previous_disable_fresh_pricing {
+            Some(value) => unsafe { env::set_var("TOKSCALE_DISABLE_FRESH_PRICING_FETCH", value) },
+            None => unsafe { env::remove_var("TOKSCALE_DISABLE_FRESH_PRICING_FETCH") },
+        }
     }
 
     #[test]
@@ -1025,6 +1031,7 @@ after"#,
     fn test_data_loader_keeps_synthetic_gateway_messages_under_original_client() {
         let temp_dir = TempDir::new().unwrap();
         let previous_home = env::var_os("HOME");
+        let previous_disable_fresh_pricing = env::var_os("TOKSCALE_DISABLE_FRESH_PRICING_FETCH");
         let message_dir = temp_dir
             .path()
             .join(".local/share/opencode/storage/message/project-1");
@@ -1037,6 +1044,7 @@ after"#,
 
         unsafe {
             env::set_var("HOME", temp_dir.path());
+            env::set_var("TOKSCALE_DISABLE_FRESH_PRICING_FETCH", "1");
         }
 
         let loader = DataLoader::new(None);
@@ -1054,6 +1062,10 @@ after"#,
         match previous_home {
             Some(home) => unsafe { env::set_var("HOME", home) },
             None => unsafe { env::remove_var("HOME") },
+        }
+        match previous_disable_fresh_pricing {
+            Some(value) => unsafe { env::set_var("TOKSCALE_DISABLE_FRESH_PRICING_FETCH", value) },
+            None => unsafe { env::remove_var("TOKSCALE_DISABLE_FRESH_PRICING_FETCH") },
         }
     }
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -16,6 +16,7 @@ pub use sessions::UnifiedMessage;
 use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Instant;
 
 pub fn normalize_model_for_grouping(model_id: &str) -> String {
@@ -893,6 +894,33 @@ fn apply_pricing_if_available(
     }
 }
 
+async fn resolve_pricing_for_local_parse<F, Fut, G>(
+    fresh_loader: F,
+    cached_loader: G,
+) -> Option<Arc<pricing::PricingService>>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<Arc<pricing::PricingService>, String>>,
+    G: FnOnce() -> Option<pricing::PricingService>,
+{
+    match fresh_loader().await {
+        Ok(pricing) => Some(pricing),
+        Err(_) => cached_loader().map(Arc::new),
+    }
+}
+
+async fn load_pricing_for_local_parse() -> Option<Arc<pricing::PricingService>> {
+    if std::env::var_os("TOKSCALE_DISABLE_FRESH_PRICING_FETCH").is_some() {
+        return pricing::PricingService::load_cached_any_age().map(Arc::new);
+    }
+
+    resolve_pricing_for_local_parse(
+        pricing::PricingService::get_or_init,
+        pricing::PricingService::load_cached_any_age,
+    )
+    .await
+}
+
 pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages, String> {
     let start = Instant::now();
 
@@ -1195,8 +1223,8 @@ pub async fn parse_local_unified_messages(
         clients
     });
 
-    let pricing = pricing::PricingService::load_cached_any_age();
-    let messages = parse_all_messages_with_pricing(&home_dir, &clients, pricing.as_ref());
+    let pricing = load_pricing_for_local_parse().await;
+    let messages = parse_all_messages_with_pricing(&home_dir, &clients, pricing.as_deref());
 
     Ok(filter_unified_messages(messages, &options))
 }
@@ -1265,11 +1293,13 @@ pub fn parsed_to_unified(msg: &ParsedMessage, cost: f64) -> UnifiedMessage {
 mod tests {
     use super::{
         apply_pricing_if_available, normalize_model_for_grouping, parse_all_messages_with_pricing,
-        parse_local_clients, pricing, retain_for_requested_clients, ClientId, GroupBy,
-        LocalParseOptions, TokenBreakdown, UnifiedMessage,
+        parse_local_clients, pricing, resolve_pricing_for_local_parse,
+        retain_for_requested_clients, ClientId, GroupBy, LocalParseOptions, TokenBreakdown,
+        UnifiedMessage,
     };
     use std::collections::{HashMap, HashSet};
     use std::str::FromStr;
+    use std::sync::Arc;
 
     #[test]
     fn test_normalize_model_for_grouping() {
@@ -1455,6 +1485,49 @@ mod tests {
     }
 
     #[test]
+    fn test_codex_headless_preamble_enables_pricing_for_turn_completed_output() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let headless_dir = temp_dir.path().join(".config/tokscale/headless/codex");
+        std::fs::create_dir_all(&headless_dir).unwrap();
+        std::fs::write(
+            headless_dir.join("gpt-5.4.jsonl"),
+            r#"{"timestamp":"2026-03-12T00:00:00Z","type":"session_meta","payload":{"originator":"tokscale_headless","source":"exec"}}
+{"timestamp":"2026-03-12T00:00:00Z","type":"turn_context","payload":{"model":"gpt-5.4"}}
+{"type":"thread.started","thread_id":"019ce3bc-33ed-7990-a38c-88feb5dd0554"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"OK"}}
+{"type":"turn.completed","usage":{"input_tokens":18475,"cached_input_tokens":5504,"output_tokens":25}}"#,
+        )
+        .unwrap();
+
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "gpt-5.4".into(),
+            pricing::ModelPricing {
+                input_cost_per_token: Some(0.0000025),
+                output_cost_per_token: Some(0.000015),
+                cache_read_input_token_cost: Some(0.00000025),
+                ..Default::default()
+            },
+        );
+        let pricing = pricing::PricingService::new(litellm, HashMap::new());
+        let messages = parse_all_messages_with_pricing(
+            temp_dir.path().to_str().unwrap(),
+            &["codex".to_string()],
+            Some(&pricing),
+        );
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, "codex");
+        assert_eq!(messages[0].model_id, "gpt-5.4");
+        assert_eq!(messages[0].agent.as_deref(), Some("headless"));
+        assert_eq!(messages[0].tokens.input, 12971);
+        assert_eq!(messages[0].tokens.output, 25);
+        assert_eq!(messages[0].tokens.cache_read, 5504);
+        assert!((messages[0].cost - 0.0341785).abs() < 1e-9);
+    }
+
+    #[test]
     fn test_apply_pricing_if_available_keeps_existing_cost_without_pricing() {
         let mut msg = UnifiedMessage::new_with_agent(
             "roocode",
@@ -1544,6 +1617,72 @@ mod tests {
         apply_pricing_if_available(&mut msg, Some(&pricing));
 
         assert_eq!(msg.cost, 0.034);
+    }
+
+    #[test]
+    fn test_resolve_pricing_for_local_parse_prefers_fresh_pricing() {
+        let expected = Arc::new(pricing::PricingService::new(HashMap::new(), HashMap::new()));
+        let cached_called = std::cell::Cell::new(false);
+
+        let resolved =
+            tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(resolve_pricing_for_local_parse(
+                    || {
+                        let expected = Arc::clone(&expected);
+                        async move { Ok(expected) }
+                    },
+                    || {
+                        cached_called.set(true);
+                        Some(pricing::PricingService::new(HashMap::new(), HashMap::new()))
+                    },
+                ));
+
+        let resolved = resolved.expect("fresh pricing should be available");
+        assert!(Arc::ptr_eq(&resolved, &expected));
+        assert!(!cached_called.get());
+    }
+
+    #[test]
+    fn test_resolve_pricing_for_local_parse_falls_back_to_cached_pricing() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "gpt-5.4".into(),
+            pricing::ModelPricing {
+                input_cost_per_token: Some(0.001),
+                ..Default::default()
+            },
+        );
+
+        let resolved =
+            tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(resolve_pricing_for_local_parse(
+                    || async { Err("offline".to_string()) },
+                    || {
+                        Some(pricing::PricingService::new(
+                            litellm.clone(),
+                            HashMap::new(),
+                        ))
+                    },
+                ));
+
+        let resolved = resolved.expect("cached pricing should be used");
+        let result = resolved.lookup_with_source("gpt-5.4", None).unwrap();
+        assert_eq!(result.pricing.input_cost_per_token, Some(0.001));
+    }
+
+    #[test]
+    fn test_resolve_pricing_for_local_parse_returns_none_when_unavailable() {
+        let resolved =
+            tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(resolve_pricing_for_local_parse(
+                    || async { Err("offline".to_string()) },
+                    || None,
+                ));
+
+        assert!(resolved.is_none());
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/codex.rs
+++ b/crates/tokscale-core/src/sessions/codex.rs
@@ -524,6 +524,26 @@ mod tests {
     }
 
     #[test]
+    fn test_headless_turn_completed_uses_preamble_turn_context_for_model() {
+        let content = r#"{"timestamp":"2026-03-12T00:00:00Z","type":"session_meta","payload":{"originator":"tokscale_headless","source":"exec"}}
+{"timestamp":"2026-03-12T00:00:00Z","type":"turn_context","payload":{"model":"gpt-5.4"}}
+{"type":"thread.started","thread_id":"019ce3bc-33ed-7990-a38c-88feb5dd0554"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"OK"}}
+{"type":"turn.completed","usage":{"input_tokens":18475,"cached_input_tokens":5504,"output_tokens":25}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gpt-5.4");
+        assert_eq!(messages[0].agent.as_deref(), Some("headless"));
+        assert_eq!(messages[0].tokens.input, 12971);
+        assert_eq!(messages[0].tokens.output, 25);
+        assert_eq!(messages[0].tokens.cache_read, 5504);
+    }
+
+    #[test]
     fn test_session_meta_exec_marks_headless() {
         let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"session_meta","payload":{"originator":"codex_exec","source":"exec"}}"#;
         let line2 = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3}}}}"#;


### PR DESCRIPTION
---
## Summary
Fix tracking of usage and cost for GPT-5.4

- preserve model context for headless Codex captures so gpt-5.4 usage is not recorded as unknown
- prefer fresh local pricing with cached fallback so new models can be repriced without a separate warm-up step
- invalidate legacy TUI cache snapshots and keep fixture-based tests deterministic


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore accurate gpt-5.4 cost tracking for headless Codex by preserving model context and preferring fresh pricing with a cached fallback. Also invalidate legacy TUI cache to prevent zero-cost startup data.

- **Bug Fixes**
  - `tokscale-cli` headless `exec` now prepends a JSONL preamble with `session_meta` and `turn_context` (model), so Codex `gpt-5.4` usage is attributed and costed.
  - `tokscale-core` reads this preamble to set the model for `turn.completed` events.
  - Local parse prefers fresh pricing (`get_or_init`) with cached fallback, allowing new models to be repriced without a warm-up; opt-out via `TOKSCALE_DISABLE_FRESH_PRICING_FETCH`.
  - TUI cache schema bumped to 3; legacy snapshots are treated as a miss to avoid stale zero-cost data.

- **Migration**
  - No action needed; old TUI cache invalidates automatically.
  - Optional for offline/CI: set `TOKSCALE_DISABLE_FRESH_PRICING_FETCH=1` to force cached pricing only.

<sup>Written for commit 8381ddf48f7ab520e7d78188dbf436688359f629. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

