### PR TITLE
fix(cli): skip browser auto-open for headless login

### DIFF
--- a/crates/tokscale-cli/src/auth.rs
+++ b/crates/tokscale-cli/src/auth.rs
@@ -125,23 +125,49 @@ fn get_device_name() -> String {
     format!("CLI on {}", hostname)
 }
 
-fn open_browser(url: &str) {
+#[cfg(target_os = "linux")]
+fn has_non_empty_env_var(name: &str) -> bool {
+    std::env::var_os(name).is_some_and(|value| !value.is_empty())
+}
+
+#[cfg(target_os = "linux")]
+fn should_auto_open_browser() -> bool {
+    has_non_empty_env_var("DISPLAY") || has_non_empty_env_var("WAYLAND_DISPLAY")
+}
+
+#[cfg(not(target_os = "linux"))]
+fn should_auto_open_browser() -> bool {
+    true
+}
+
+fn open_browser(url: &str) -> bool {
+    if !should_auto_open_browser() {
+        return false;
+    }
+
     #[cfg(target_os = "macos")]
     {
-        let _ = std::process::Command::new("open").arg(url).spawn();
+        return std::process::Command::new("open").arg(url).spawn().is_ok();
     }
 
     #[cfg(target_os = "windows")]
     {
-        let _ = std::process::Command::new("cmd")
+        return std::process::Command::new("cmd")
             .args(["/C", "start", "", url])
-            .spawn();
+            .spawn()
+            .is_ok();
     }
 
     #[cfg(target_os = "linux")]
     {
-        let _ = std::process::Command::new("xdg-open").arg(url).spawn();
+        return std::process::Command::new("xdg-open")
+            .arg(url)
+            .spawn()
+            .is_ok();
     }
+
+    #[allow(unreachable_code)]
+    false
 }
 
 pub async fn login() -> Result<()> {
@@ -199,7 +225,13 @@ pub async fn login() -> Result<()> {
         format!("  {}", device_data.user_code).green().bold()
     );
 
-    open_browser(&device_data.verification_url);
+    if !open_browser(&device_data.verification_url) {
+        println!(
+            "{}",
+            "  Browser auto-open unavailable in this environment. Continue with the URL above.\n"
+                .bright_black()
+        );
+    }
 
     println!("{}", "  Waiting for authorization...".bright_black());
 
@@ -330,6 +362,45 @@ mod tests {
     use std::env;
     use tempfile::TempDir;
 
+    #[cfg(target_os = "linux")]
+    struct EnvVarGuard {
+        name: &'static str,
+        original: Option<std::ffi::OsString>,
+    }
+
+    #[cfg(target_os = "linux")]
+    impl EnvVarGuard {
+        fn set(name: &'static str, value: &str) -> Self {
+            let original = env::var_os(name);
+            unsafe {
+                env::set_var(name, value);
+            }
+            Self { name, original }
+        }
+
+        fn remove(name: &'static str) -> Self {
+            let original = env::var_os(name);
+            unsafe {
+                env::remove_var(name);
+            }
+            Self { name, original }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(value) => unsafe {
+                    env::set_var(self.name, value);
+                },
+                None => unsafe {
+                    env::remove_var(self.name);
+                },
+            }
+        }
+    }
+
     #[test]
     #[serial]
     fn test_get_api_base_url_default() {
@@ -387,6 +458,36 @@ mod tests {
         assert_eq!(deserialized.created_at, creds.created_at);
 
         assert!(!json.contains("avatarUrl"));
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(target_os = "linux")]
+    fn test_should_not_auto_open_browser_without_desktop_session() {
+        let _display = EnvVarGuard::remove("DISPLAY");
+        let _wayland = EnvVarGuard::remove("WAYLAND_DISPLAY");
+
+        assert!(!should_auto_open_browser());
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(target_os = "linux")]
+    fn test_should_auto_open_browser_with_display() {
+        let _display = EnvVarGuard::set("DISPLAY", ":0");
+        let _wayland = EnvVarGuard::remove("WAYLAND_DISPLAY");
+
+        assert!(should_auto_open_browser());
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(target_os = "linux")]
+    fn test_should_auto_open_browser_with_wayland_display() {
+        let _display = EnvVarGuard::remove("DISPLAY");
+        let _wayland = EnvVarGuard::set("WAYLAND_DISPLAY", "wayland-0");
+
+        assert!(should_auto_open_browser());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- skip browser auto-open during device login when Linux has no desktop session
- keep the manual URL and code flow unchanged and add regression coverage for the decision logic

## Why
On SSH or otherwise headless Linux environments, calling `xdg-open` unconditionally can fall back to a text-mode browser. The device authorization page depends on client-side JavaScript, so that fallback can leave users stuck on a neverending `Loading...` state. The CLI already prints the verification URL and user code, so the safe behavior in headless environments is to skip auto-open entirely.

## Diff scope
- gate Linux browser auto-open on desktop-session availability via `DISPLAY` or `WAYLAND_DISPLAY`
- surface a clear fallback note when browser auto-open is unavailable
- keep macOS and Windows auto-open behavior unchanged
- add Linux-specific regression tests for the auto-open decision path

## Test proof
- `cargo test -p tokscale-cli auth::tests -- --nocapture`
  - 12 passed, 0 failed
- `cargo test -p tokscale-cli --no-run`
  - compile passed
- `cargo clippy -p tokscale-cli --all-features -- -D warnings`
  - passed
- `cargo fmt --all --check`
  - passed

## Verification-pack proof
Not applicable — CLI-only behavior change.

## Migration notes
Not applicable — no schema or data migration.

## CI context confirmation
CI context names unchanged.

## Rollback plan
- if merged with a merge commit: `git revert <merge_commit_sha>`
- if merged as a squash commit: `git revert <squash_commit_sha>`
- no DB downgrade required

## Known residual risks
- the new regression tests are Linux-specific decision-path tests; they compile cleanly here, but they do not execute on this non-Linux machine
- this PR intentionally avoids changing the device authorization page itself and only fixes the CLI runtime behavior that triggered the issue

