### PR TITLE
fix(opencode): canonicalize agent name casing

### DIFF
--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -871,6 +871,55 @@ mod tests {
     }
 
     #[test]
+    fn test_aggregate_messages_merges_opencode_agent_case_variants() {
+        let loader = DataLoader::new(None);
+        let messages = vec![
+            UnifiedMessage::new_with_agent(
+                "opencode",
+                "claude-opus-4-6",
+                "anthropic",
+                "session-1",
+                1_735_689_600_000,
+                tokscale_core::TokenBreakdown {
+                    input: 10,
+                    output: 5,
+                    cache_read: 0,
+                    cache_write: 0,
+                    reasoning: 0,
+                },
+                1.5,
+                Some("Hephaestus".to_string()),
+            ),
+            UnifiedMessage::new_with_agent(
+                "opencode",
+                "claude-opus-4-6",
+                "anthropic",
+                "session-2",
+                1_735_689_700_000,
+                tokscale_core::TokenBreakdown {
+                    input: 20,
+                    output: 10,
+                    cache_read: 0,
+                    cache_write: 0,
+                    reasoning: 0,
+                },
+                2.5,
+                Some("hephaestus".to_string()),
+            ),
+        ];
+
+        let usage = loader
+            .aggregate_messages(messages, &GroupBy::Model)
+            .unwrap();
+
+        assert_eq!(usage.agents.len(), 1);
+        assert_eq!(usage.agents[0].agent, "Hephaestus");
+        assert_eq!(usage.agents[0].clients, "opencode");
+        assert_eq!(usage.agents[0].message_count, 2);
+        assert!((usage.agents[0].cost - 4.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
     fn test_aggregate_messages_does_not_merge_omo_variants_for_non_opencode_clients() {
         let loader = DataLoader::new(None);
         let messages = vec![

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -66,12 +66,14 @@ pub fn normalize_opencode_agent_name(agent: &str) -> String {
 
 fn normalize_oh_my_opencode_agent_name(agent_lower: &str) -> Option<String> {
     let normalized = match agent_lower {
-        "sisyphus (ultraworker)" => "Sisyphus",
-        "hephaestus (deep agent)" => "Hephaestus",
-        "prometheus (plan builder)" | "prometheus (planner)" => "Prometheus",
-        "atlas (plan executor)" => "Atlas",
-        "metis (plan consultant)" => "Metis",
-        "momus (plan critic)" | "momus (plan reviewer)" => "Momus",
+        "sisyphus (ultraworker)" | "sisyphus" => "Sisyphus",
+        "hephaestus (deep agent)" | "hephaestus" => "Hephaestus",
+        "prometheus (plan builder)" | "prometheus (planner)" | "prometheus" => "Prometheus",
+        "atlas (plan executor)" | "atlas" => "Atlas",
+        "metis (plan consultant)" | "metis" => "Metis",
+        "momus (plan critic)" | "momus (plan reviewer)" | "momus" => "Momus",
+        "sisyphus-junior" => "Sisyphus-Junior",
+        "planner-sisyphus" => "Planner-Sisyphus",
         _ => return None,
     };
 
@@ -263,6 +265,19 @@ mod tests {
         assert_eq!(
             normalize_opencode_agent_name("Sisyphus (Ultraworker)"),
             "Sisyphus"
+        );
+        assert_eq!(normalize_opencode_agent_name("hephaestus"), "Hephaestus");
+        assert_eq!(normalize_opencode_agent_name("prometheus"), "Prometheus");
+        assert_eq!(normalize_opencode_agent_name("atlas"), "Atlas");
+        assert_eq!(normalize_opencode_agent_name("metis"), "Metis");
+        assert_eq!(normalize_opencode_agent_name("momus"), "Momus");
+        assert_eq!(
+            normalize_opencode_agent_name("sisyphus-junior"),
+            "Sisyphus-Junior"
+        );
+        assert_eq!(
+            normalize_opencode_agent_name("planner-sisyphus"),
+            "Planner-Sisyphus"
         );
 
         assert_eq!(


### PR DESCRIPTION
## Summary
- normalize lowercase oh-my-opencode/OpenCode agent names to their canonical display casing on the OpenCode path
- keep the casing merge scoped to OpenCode so other clients still preserve their raw agent names
- add focused TUI regression coverage for case-only duplicates in agent aggregation

## Testing
- cargo test -p tokscale-core normalize_agent_name -- --nocapture
- cargo test -p tokscale-cli merges_opencode_agent_case_variants -- --nocapture
- cargo test -p tokscale-cli merges_oh_my_opencode_agent_variants -- --nocapture
- cargo test -p tokscale-cli does_not_merge_omo_variants_for_non_opencode_clients -- --nocapture
- cargo check -p tokscale-core && cargo check -p tokscale-cli
- cargo fmt --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Canonicalize OpenCode agent names to their proper display casing so case-only variants merge in usage views. Normalization is scoped to OpenCode; other clients keep original names.

- **Bug Fixes**
  - In `tokscale-core`, expand OpenCode agent normalization to handle lowercase and bare names (e.g., "hephaestus" -> "Hephaestus"; added "Sisyphus-Junior", "Planner-Sisyphus").
  - In `tokscale-cli` TUI, add tests to verify OpenCode case variants merge with correct counts/costs and that non-OpenCode clients are unchanged.

<sup>Written for commit 8d892b8b5c93c1237f31ade5612e3117f04345b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

