### PR TITLE
fix(core): refresh local pricing before stale cache fallback

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -892,11 +892,14 @@ fn apply_pricing_if_available(
     }
 }
 
-fn select_local_parse_pricing(
+fn select_local_parse_pricing<F>(
     fresh: Result<Arc<pricing::PricingService>, String>,
-    stale: Option<pricing::PricingService>,
-) -> Option<Arc<pricing::PricingService>> {
-    fresh.ok().or_else(|| stale.map(Arc::new))
+    stale: F,
+) -> Option<Arc<pricing::PricingService>>
+where
+    F: FnOnce() -> Option<pricing::PricingService>,
+{
+    fresh.ok().or_else(|| stale().map(Arc::new))
 }
 
 async fn load_pricing_for_local_parse() -> Option<Arc<pricing::PricingService>> {
@@ -905,7 +908,7 @@ async fn load_pricing_for_local_parse() -> Option<Arc<pricing::PricingService>> 
     // to any cached dataset when the network path fails.
     select_local_parse_pricing(
         pricing::PricingService::get_or_init().await,
-        pricing::PricingService::load_cached_any_age(),
+        pricing::PricingService::load_cached_any_age,
     )
 }
 
@@ -1783,7 +1786,7 @@ mod tests {
         );
         let fresh = Arc::new(pricing::PricingService::new(fresh_litellm, HashMap::new()));
         let stale = pricing::PricingService::new(HashMap::new(), HashMap::new());
-        let selected = select_local_parse_pricing(Ok(Arc::clone(&fresh)), Some(stale)).unwrap();
+        let selected = select_local_parse_pricing(Ok(Arc::clone(&fresh)), || Some(stale)).unwrap();
 
         let mut msg = UnifiedMessage::new(
             "opencode",
@@ -1820,9 +1823,24 @@ mod tests {
         let stale = pricing::PricingService::new(stale_litellm, HashMap::new());
 
         let selected =
-            select_local_parse_pricing(Err("network failed".to_string()), Some(stale)).unwrap();
+            select_local_parse_pricing(Err("network failed".to_string()), || Some(stale)).unwrap();
 
         assert!(selected.lookup_with_source("gpt-5.2", None).is_some());
+    }
+
+    #[test]
+    fn test_select_local_parse_pricing_does_not_evaluate_stale_fallback_on_fresh_success() {
+        let fresh = Arc::new(pricing::PricingService::new(HashMap::new(), HashMap::new()));
+        let mut stale_called = false;
+
+        let selected = select_local_parse_pricing(Ok(Arc::clone(&fresh)), || {
+            stale_called = true;
+            None
+        })
+        .unwrap();
+
+        assert!(Arc::ptr_eq(&selected, &fresh));
+        assert!(!stale_called);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- refresh pricing before parsing local interactive and unified usage views
- fall back to stale cached pricing only when a fresh pricing fetch fails

## Why
Issue #330 showed a confusing mismatch: `bunx tokscale@latest pricing gpt-5.4` resolves correctly, but plain local usage views can still show missing or stale costs for newly added models. The pricing lookup itself is fine. The problem is that the interactive/local parse path was willing to use any cached pricing dataset without first attempting a normal refresh. That makes new model pricing lag behind until some other command refreshes the cache.

## Diff scope
- add a dedicated local-parse pricing loader that prefers `PricingService::get_or_init()`
- keep offline behavior by falling back to `load_cached_any_age()` when a fresh pricing fetch fails
- add regression coverage for both the fresh-pricing path and the stale-cache fallback path

## Test proof
- `cargo fmt --all --check`
  - passed
- `cargo test -p tokscale-core`
  - `344 passed, 0 failed, 1 ignored`
- `cargo test -p tokscale-cli --no-run`
  - compile passed
- `cargo clippy -p tokscale-core --all-features -- -D warnings`
  - passed

## Verification-pack proof
Not applicable — core library behavior change only.

## Migration notes
Not applicable — no schema or data migration.

## CI context confirmation
CI context names unchanged.

## Rollback plan
- if merged with a merge commit: `git revert <merge_commit_sha>`
- if merged as a squash commit: `git revert <squash_commit_sha>`
- no DB downgrade required

## Known residual risks
- this does not change pricing lookup logic or upstream pricing sources; it only fixes freshness of the local interactive path
- if a machine is offline and only has a stale cache that predates a newly released model, that model can still remain unpriced until connectivity returns
- the original report was on Windows, but the fix is intentionally in the cross-platform local pricing path rather than a Windows-specific special case

## Related
- addresses the stale-cache path discussed in #330


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
