### PR TITLE
fix(cli): cap submit contributions to UTC today to prevent future-date rejections

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -2959,6 +2959,31 @@ fn run_submit_command(
         })
         .map_err(|e| anyhow::anyhow!(e))?;
 
+    // Cap contributions to UTC today to prevent timezone-related future-date
+    // rejections. The CLI generates dates using chrono::Local, but the server
+    // validates against UTC. In UTC+ timezones the local date can be ahead of
+    // UTC around midnight, causing valid same-day data to be flagged as
+    // "future dates". Capped contributions will be included in the next
+    // submission once the UTC date catches up.
+    // See: https://github.com/junhoyeo/tokscale/issues/318
+    let utc_today = chrono::Utc::now().format("%Y-%m-%d").to_string();
+    let mut graph_result = graph_result;
+    let pre_cap_len = graph_result.contributions.len();
+    graph_result
+        .contributions
+        .retain(|c| c.date.as_str() <= utc_today.as_str());
+    if graph_result.contributions.len() < pre_cap_len {
+        // Recalculate date_range_end and summary after capping
+        if let Some(last) = graph_result.contributions.last() {
+            graph_result.meta.date_range_end = last.date.clone();
+        }
+        graph_result.summary.active_days = graph_result
+            .contributions
+            .iter()
+            .filter(|c| c.totals.tokens > 0)
+            .count() as i32;
+    }
+
     println!("{}", "  Data to submit:".white());
     println!(
         "{}",


### PR DESCRIPTION
## Summary

- Adds client-side date capping in `run_submit_command()` to filter out contributions with dates beyond UTC today before submitting
- Prevents timezone-related "Date range extends into the future" errors for users in UTC+ timezones

## Problem

The CLI generates contribution dates using `chrono::Local`, but the server validates against UTC. In UTC+ timezones (e.g. UTC+8), the local date can be one day ahead of UTC around midnight, causing the server to reject valid same-day contributions as "future dates".

**Reproduction**: Run `tokscale submit` in a UTC+8 timezone shortly after local midnight (when UTC is still the previous day).

```
WSL (UTC+8):  date_range_end = "2026-03-18" (local date)
Server (UTC): maxDate = "2026-03-17" → rejects as future
```

## Fix

Before submitting, cap `graph_result.contributions` to `<= UTC today`. Capped contributions are not lost — they will be included in the next submission once the UTC date catches up.

This complements the server-side +1 day buffer from #319 with a defensive client-side fix that works regardless of server deployment state.

Fixes #318

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps CLI submission to UTC today to prevent timezone-based “future date” rejections. Users in UTC+ timezones no longer get errors when submitting around local midnight.

- **Bug Fixes**
  - Filters out contributions dated after UTC today during `submit`.
  - Recalculates `date_range_end` and `summary.active_days` after capping.
  - Deferred contributions are included automatically on the next submission once UTC catches up.

<sup>Written for commit b24f5efd1ce332e53bd67ff423b508eb17cf46f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

