### PR TITLE
fix(scanner): include OpenClaw auto-archived subagent transcripts in scan

### DIFF
--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -168,7 +168,7 @@ define_clients!(
         id: "openclaw",
         root: PathRoot::Home,
         relative: ".openclaw/agents",
-        pattern: "*.jsonl",
+        pattern: "*.jsonl*",
         headless: false,
         parse_local: true
     },

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -105,6 +105,10 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
             match pattern {
                 "*.json" => file_name.ends_with(".json"),
                 "*.jsonl" => file_name.ends_with(".jsonl"),
+                // OpenClaw: also match deleted transcripts (<uuid>.jsonl.deleted.<ts>)
+                "*.jsonl*" => {
+                    file_name.ends_with(".jsonl") || file_name.contains(".jsonl.deleted.")
+                }
                 "*.csv" => file_name.ends_with(".csv"),
                 "usage*.csv" => {
                     if is_in_archive_dir {

--- a/crates/tokscale-core/src/sessions/openclaw.rs
+++ b/crates/tokscale-core/src/sessions/openclaw.rs
@@ -88,9 +88,13 @@ pub fn parse_openclaw_index(index_path: &Path) -> Vec<UnifiedMessage> {
 
 pub fn parse_openclaw_transcript(transcript_path: &Path) -> Vec<UnifiedMessage> {
     let session_id = match transcript_path
-        .file_stem()
-        .map(|stem| stem.to_string_lossy().to_string())
-        .filter(|stem| !stem.is_empty())
+        .file_name()
+        .and_then(|n| {
+            n.to_string_lossy()
+                .split_once(".jsonl")
+                .map(|(id, _)| id.to_string())
+        })
+        .filter(|id| !id.is_empty())
     {
         Some(id) => id,
         None => return Vec::new(),


### PR DESCRIPTION
## Summary
- match OpenClaw's auto-archived subagent transcripts (`<uuid>.jsonl.deleted.<ts>`) via a dedicated `*.jsonl*` scan pattern

## Why
OpenClaw renames completed subagent transcripts from `<uuid>.jsonl` to `<uuid>.jsonl.deleted.<timestamp>`, which falls outside the `*.jsonl` glob. These files stay on disk with full usage data but are invisible to tokscale's scanner.

Rather than broadening the shared `*.jsonl` arm (which would affect every JSONL-based client), this adds an OpenClaw-specific `*.jsonl*` pattern.

## Diff scope
- add a `*.jsonl*` pattern arm in `scan_directory` that matches both `.jsonl` and `.jsonl.deleted.*`
- set OpenClaw's client pattern to `*.jsonl*` in `clients.rs`
- fix `parse_openclaw_transcript` to use `split_once(".jsonl")` instead of `file_stem()`, which incorrectly extracts `uuid.jsonl.deleted` as the session ID for archived transcripts


## Test proof
- `cargo fmt --all --check`
  - passed
- `cargo test -p tokscale-core`
  - `377 passed, 0 failed, 1 ignored`
- `cargo clippy -p tokscale-core --all-features -- -D warnings`
  - passed

## Verification-pack proof
Not applicable — scanner behavior change only.

## Migration notes
Not applicable — no schema or data migration.

## Rollback plan
- if merged with a merge commit: `git revert <merge_commit_sha>`
- if merged as a squash commit: `git revert <squash_commit_sha>`
- no DB downgrade required

## Known residual risks
- if OpenClaw introduces additional suffixed variants beyond `.deleted`, the `contains(".jsonl.deleted.")` check would need updating

## Related
- fixes #341


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include OpenClaw’s auto-archived subagent transcripts in scans by matching `<uuid>.jsonl.deleted.<ts>` files. Adds an OpenClaw-specific `*.jsonl*` pattern and fixes session ID parsing to attribute archived transcripts correctly.

- **Bug Fixes**
  - Scanner: add `*.jsonl*` arm to match `.jsonl` and `.jsonl.deleted.*`, used only for OpenClaw.
  - Clients: set OpenClaw pattern to `*.jsonl*` under `.openclaw/agents`.
  - Parsing: use `split_once(".jsonl")` in `parse_openclaw_transcript` to extract the UUID instead of `file_stem()`.

<sup>Written for commit 6795d0d4d6bd957d7692c1d12a32ef88e73b46e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

