### PR TITLE
fix(cli): recalculate all summary fields after UTC date capping

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -2973,15 +2973,15 @@ fn run_submit_command(
         .contributions
         .retain(|c| c.date.as_str() <= utc_today.as_str());
     if graph_result.contributions.len() < pre_cap_len {
-        // Recalculate date_range_end and summary after capping
-        if let Some(last) = graph_result.contributions.last() {
-            graph_result.meta.date_range_end = last.date.clone();
-        }
-        graph_result.summary.active_days = graph_result
+        graph_result.meta.date_range_end = graph_result
             .contributions
-            .iter()
-            .filter(|c| c.totals.tokens > 0)
-            .count() as i32;
+            .last()
+            .map(|c| c.date.clone())
+            .unwrap_or_default();
+        graph_result.summary =
+            tokscale_core::calculate_summary(&graph_result.contributions);
+        graph_result.years =
+            tokscale_core::calculate_years(&graph_result.contributions);
     }
 
     println!("{}", "  Data to submit:".white());

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -2973,6 +2973,11 @@ fn run_submit_command(
         .contributions
         .retain(|c| c.date.as_str() <= utc_today.as_str());
     if graph_result.contributions.len() < pre_cap_len {
+        graph_result.meta.date_range_start = graph_result
+            .contributions
+            .first()
+            .map(|c| c.date.clone())
+            .unwrap_or_default();
         graph_result.meta.date_range_end = graph_result
             .contributions
             .last()

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -2978,10 +2978,8 @@ fn run_submit_command(
             .last()
             .map(|c| c.date.clone())
             .unwrap_or_default();
-        graph_result.summary =
-            tokscale_core::calculate_summary(&graph_result.contributions);
-        graph_result.years =
-            tokscale_core::calculate_years(&graph_result.contributions);
+        graph_result.summary = tokscale_core::calculate_summary(&graph_result.contributions);
+        graph_result.years = tokscale_core::calculate_years(&graph_result.contributions);
     }
 
     println!("{}", "  Data to submit:".white());

--- a/crates/tokscale-core/src/aggregator.rs
+++ b/crates/tokscale-core/src/aggregator.rs
@@ -88,8 +88,16 @@ pub fn calculate_summary(contributions: &[DailyContribution]) -> DataSummary {
             0.0
         },
         max_cost_in_single_day: max_cost,
-        clients: clients_set.into_iter().collect(),
-        models: models_set.into_iter().collect(),
+        clients: {
+            let mut v: Vec<_> = clients_set.into_iter().collect();
+            v.sort();
+            v
+        },
+        models: {
+            let mut v: Vec<_> = models_set.into_iter().collect();
+            v.sort();
+            v
+        },
     }
 }
 


### PR DESCRIPTION
## Summary

- Fixes stale `summary` and `years` fields after UTC date capping in `submit` (follow-up to #337)
- Uses existing `calculate_summary()` and `calculate_years()` core aggregators instead of hand-updating individual fields

## Problem

PR #337 introduced UTC date capping to prevent future-date rejections for UTC+ timezone users. However, it only recalculated `date_range_end` and `active_days` after filtering contributions, leaving these fields stale:

- `summary.total_tokens`
- `summary.total_cost`
- `summary.total_days`
- `summary.average_per_day`
- `summary.max_cost_in_single_day`
- `summary.clients` — **critical**: server merge uses this as authoritative incoming scope; stale clients can cause unintended deletion of existing server-side client data
- `summary.models`
- `years` vector

(Identified by cubic in #337)

## Fix

Replace the partial field updates with calls to `tokscale_core::calculate_summary()` and `tokscale_core::calculate_years()`, which rebuild all derived fields from the filtered contributions. This also handles edge cases like empty post-cap contributions.

**Before (8 lines, incomplete):**
```rust
if let Some(last) = graph_result.contributions.last() {
    graph_result.meta.date_range_end = last.date.clone();
}
graph_result.summary.active_days = graph_result
    .contributions.iter()
    .filter(|c| c.totals.tokens > 0)
    .count() as i32;
```

**After (8 lines, complete):**
```rust
graph_result.meta.date_range_end = graph_result
    .contributions.last()
    .map(|c| c.date.clone())
    .unwrap_or_default();
graph_result.summary =
    tokscale_core::calculate_summary(&graph_result.contributions);
graph_result.years =
    tokscale_core::calculate_years(&graph_result.contributions);
```

## Test proof

- `cargo check -p tokscale-cli` — passed
- `cargo clippy -p tokscale-cli --all-features -- -D warnings` — passed
- `cargo test -p tokscale-core` — 377 passed, 0 failed, 1 ignored

Follows up on #337.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/343" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recalculates all derived `summary`/`years` fields and resets `meta.date_range_start`/`meta.date_range_end` after UTC date capping in `tokscale-cli` submit. Also sorts `clients` and `models` in `tokscale_core::calculate_summary()` for deterministic payloads.

- **Bug Fixes**
  - After filtering future-dated contributions, rebuild `summary` and `years` via `tokscale_core::calculate_summary()` and `tokscale_core::calculate_years()`.
  - Set `meta.date_range_start` and `meta.date_range_end` from the first/last remaining contribution, or empty when none (avoids disjoint ranges).
  - Sort `clients` and `models` alphabetically in `tokscale_core::calculate_summary()` to avoid non-deterministic payloads.
  - Fixes stale totals, averages, models, and `clients` to prevent unintended server-side deletions during merge.

- **Refactors**
  - Auto-applied lint/style fixes with no behavior changes.

<sup>Written for commit f3a34ffce123bd8cd0b70691333521c4e7cb88de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

