### PR TITLE
feat: support extra scan directories via `TOKSCALE_EXTRA_DIRS`

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -2235,17 +2235,11 @@ fn run_clients_command(json: bool) -> Result<()> {
         exists: bool,
     }
 
-    // Collect extra dirs from TOKSCALE_EXTRA_DIRS for display
-    let extra_dirs: Vec<(String, String)> = std::env::var("TOKSCALE_EXTRA_DIRS")
-        .unwrap_or_default()
-        .split(',')
-        .filter_map(|entry| {
-            let entry = entry.trim();
-            let (client_str, path) = entry.split_once(':')?;
-            Some((client_str.trim().to_string(), path.trim().to_string()))
-        })
-        .filter(|(_, path)| !path.is_empty())
-        .collect();
+    // Collect extra dirs from TOKSCALE_EXTRA_DIRS for display (reuse core parser)
+    let extra_dirs_val = std::env::var("TOKSCALE_EXTRA_DIRS").unwrap_or_default();
+    let all_clients: std::collections::HashSet<ClientId> = ClientId::iter().collect();
+    let extra_dirs: Vec<(ClientId, String)> =
+        tokscale_core::parse_extra_dirs(&extra_dirs_val, &all_clients);
 
     let clients: Vec<ClientRow> = ClientId::iter()
         .map(|client| {
@@ -2310,7 +2304,7 @@ fn run_clients_command(json: bool) -> Result<()> {
 
             let extra_paths: Vec<ExtraPath> = extra_dirs
                 .iter()
-                .filter(|(c, _)| c == client.as_str())
+                .filter(|(c, _)| *c == client)
                 .map(|(_, path)| ExtraPath {
                     path: path.clone(),
                     exists: Path::new(path).exists(),

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -147,20 +147,21 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
         .collect()
 }
 
-/// Parse the TOKSCALE_EXTRA_DIRS environment variable.
+/// Parse a `TOKSCALE_EXTRA_DIRS`-formatted string into (ClientId, path) pairs.
 ///
 /// Format: comma-separated `client:path` pairs.
-/// Example: `claude:/path/to/mac/sessions,openclaw:/other/path`
+/// Example: `"claude:/path/to/mac/sessions,openclaw:/other/path"`
 ///
-/// Returns a list of (ClientId, path) pairs for clients that are in the
-/// enabled set.
-fn parse_extra_dirs(enabled: &HashSet<ClientId>) -> Vec<(ClientId, String)> {
-    let val = match std::env::var("TOKSCALE_EXTRA_DIRS") {
-        Ok(v) if !v.is_empty() => v,
-        _ => return Vec::new(),
-    };
+/// Only returns entries whose client is present in `enabled`.
+/// This is a pure function — the caller is responsible for reading the
+/// environment variable and passing its value here.
+pub fn parse_extra_dirs(value: &str, enabled: &HashSet<ClientId>) -> Vec<(ClientId, String)> {
+    if value.is_empty() {
+        return Vec::new();
+    }
 
-    val.split(',')
+    value
+        .split(',')
         .filter_map(|entry| {
             let entry = entry.trim();
             let (client_str, path) = entry.split_once(':')?;
@@ -216,7 +217,8 @@ pub fn scan_all_clients(home_dir: &str, clients: &[String]) -> ScanResult {
     }
 
     // Extra scan directories from TOKSCALE_EXTRA_DIRS env var
-    for (client_id, path) in parse_extra_dirs(&enabled) {
+    let extra_dirs_val = std::env::var("TOKSCALE_EXTRA_DIRS").unwrap_or_default();
+    for (client_id, path) in parse_extra_dirs(&extra_dirs_val, &enabled) {
         let pattern = client_id.data().pattern;
         tasks.push((client_id, path, pattern));
     }
@@ -352,9 +354,14 @@ pub fn scan_all_clients(home_dir: &str, clients: &[String]) -> ScanResult {
         })
         .collect();
 
-    // Aggregate results
+    // Aggregate results, deduplicating file paths across overlapping directories
+    let mut seen: HashSet<PathBuf> = HashSet::new();
     for (client_id, files) in scan_results {
-        result.get_mut(client_id).extend(files);
+        for file in files {
+            if seen.insert(file.clone()) {
+                result.get_mut(client_id).push(file);
+            }
+        }
     }
 
     result
@@ -891,73 +898,43 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_parse_extra_dirs_basic() {
-        let previous = std::env::var("TOKSCALE_EXTRA_DIRS").ok();
-        unsafe {
-            std::env::set_var(
-                "TOKSCALE_EXTRA_DIRS",
-                "claude:/tmp/mac-sessions,openclaw:/tmp/oc-extra",
-            )
-        };
-
         let enabled: HashSet<ClientId> = [ClientId::Claude, ClientId::OpenClaw]
             .iter()
             .copied()
             .collect();
-        let dirs = parse_extra_dirs(&enabled);
+        let dirs =
+            parse_extra_dirs("claude:/tmp/mac-sessions,openclaw:/tmp/oc-extra", &enabled);
         assert_eq!(dirs.len(), 2);
         assert_eq!(dirs[0].0, ClientId::Claude);
         assert_eq!(dirs[0].1, "/tmp/mac-sessions");
         assert_eq!(dirs[1].0, ClientId::OpenClaw);
         assert_eq!(dirs[1].1, "/tmp/oc-extra");
-
-        restore_env("TOKSCALE_EXTRA_DIRS", previous);
     }
 
     #[test]
-    #[serial]
     fn test_parse_extra_dirs_filters_disabled_clients() {
-        let previous = std::env::var("TOKSCALE_EXTRA_DIRS").ok();
-        unsafe {
-            std::env::set_var(
-                "TOKSCALE_EXTRA_DIRS",
-                "claude:/tmp/mac-sessions,gemini:/tmp/gemini-extra",
-            )
-        };
-
         let enabled: HashSet<ClientId> = [ClientId::Claude].iter().copied().collect();
-        let dirs = parse_extra_dirs(&enabled);
+        let dirs = parse_extra_dirs(
+            "claude:/tmp/mac-sessions,gemini:/tmp/gemini-extra",
+            &enabled,
+        );
         assert_eq!(dirs.len(), 1);
         assert_eq!(dirs[0].0, ClientId::Claude);
-
-        restore_env("TOKSCALE_EXTRA_DIRS", previous);
     }
 
     #[test]
-    #[serial]
-    fn test_parse_extra_dirs_empty_env() {
-        let previous = std::env::var("TOKSCALE_EXTRA_DIRS").ok();
-        unsafe { std::env::remove_var("TOKSCALE_EXTRA_DIRS") };
-
+    fn test_parse_extra_dirs_empty_string() {
         let enabled: HashSet<ClientId> = ClientId::iter().collect();
-        let dirs = parse_extra_dirs(&enabled);
+        let dirs = parse_extra_dirs("", &enabled);
         assert!(dirs.is_empty());
-
-        restore_env("TOKSCALE_EXTRA_DIRS", previous);
     }
 
     #[test]
-    #[serial]
     fn test_parse_extra_dirs_invalid_client() {
-        let previous = std::env::var("TOKSCALE_EXTRA_DIRS").ok();
-        unsafe { std::env::set_var("TOKSCALE_EXTRA_DIRS", "nonexistent:/tmp/foo") };
-
         let enabled: HashSet<ClientId> = ClientId::iter().collect();
-        let dirs = parse_extra_dirs(&enabled);
+        let dirs = parse_extra_dirs("nonexistent:/tmp/foo", &enabled);
         assert!(dirs.is_empty());
-
-        restore_env("TOKSCALE_EXTRA_DIRS", previous);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `TOKSCALE_EXTRA_DIRS` environment variable for scanning session files from additional directories
- Format: comma-separated `client:path` pairs (e.g., `claude:/path/to/mac/sessions,openclaw:/other/path`)
- Extra paths are scanned in parallel alongside default paths, results merged seamlessly
- `tokscale clients` now shows extra paths with existence indicators

## Motivation

Users who sync sessions across machines (e.g., Mac → Linux via rsync) can't have tokscale scan those sessions without copying them into the default path (`~/.claude/projects/`), which may conflict with other tooling that reads from the same directory.

This follows the existing pattern of `TOKSCALE_HEADLESS_DIR` and `CODEX_HOME` env vars.

## Example

```bash
export TOKSCALE_EXTRA_DIRS="claude:/home/user/reports/mac-data/claude-sessions/projects"
tokscale --claude
```

```
Claude Code
sessions: ~/.claude/projects ✓
extra: ~/reports/mac-data/claude-sessions/projects ✓
messages: 25.8K
```

## Changes

- `crates/tokscale-core/src/scanner.rs`: Add `parse_extra_dirs()` + integrate into `scan_all_clients()`
- `crates/tokscale-cli/src/main.rs`: Show extra paths in `clients` command output (text + JSON)
- 5 new unit tests for parsing and scanning with extra dirs

## Test plan

- [x] All 32 scanner tests pass (including 5 new tests)
- [x] `cargo build` compiles with zero warnings
- [x] Manual verification: `TOKSCALE_EXTRA_DIRS=claude:/path` correctly merges Mac sessions (4.9K → 25.8K messages)
- [x] `tokscale clients` shows extra paths with ✓/✗ indicators
- [x] Invalid client names and empty paths are silently ignored

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for scanning extra session directories via `TOKSCALE_EXTRA_DIRS`. Extra paths are scanned in parallel and merged with defaults with de-duplication.

- **New Features**
  - `TOKSCALE_EXTRA_DIRS` accepts comma-separated `client:path` pairs (e.g., `claude:/path/to/sessions`).
  - `tokscale clients` displays extra paths with ✓/✗ in text and JSON.
  - Only enabled clients are considered; invalid client names and empty paths are ignored.

- **Bug Fixes**
  - Deduplicate file paths across overlapping directories to prevent double counting.
  - Introduced a pure `parse_extra_dirs(&str, &HashSet<ClientId>)` in core and reused it in the CLI for consistent parsing.

<sup>Written for commit 0af40647ca3819a06b3982a3b086b3796620a4fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

