### PR TITLE
fix(pricing): skip all-None pricing entries in provider-aware match

### DIFF
--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -958,18 +958,23 @@ fn is_valid_price_value(value: f64) -> bool {
     value.is_finite() && value >= 0.0
 }
 
-/// Returns true if the pricing entry has at least one non-None base cost field.
-/// Entries with all-None pricing (e.g. subscription-based providers like Perplexity)
-/// are useless for pay-per-token cost estimation and should be deprioritized.
-fn has_any_base_pricing(pricing: &ModelPricing) -> bool {
+/// Returns true if the pricing entry has at least one usable cost field
+/// (base or above-200k tier). Entries with all-None pricing (e.g.
+/// subscription-based providers like Perplexity) are useless for
+/// pay-per-token cost estimation and should be deprioritized.
+fn has_any_usable_pricing(pricing: &ModelPricing) -> bool {
     [
         pricing.input_cost_per_token,
         pricing.output_cost_per_token,
         pricing.cache_read_input_token_cost,
         pricing.cache_creation_input_token_cost,
+        pricing.input_cost_per_token_above_200k_tokens,
+        pricing.output_cost_per_token_above_200k_tokens,
+        pricing.cache_read_input_token_cost_above_200k_tokens,
+        pricing.cache_creation_input_token_cost_above_200k_tokens,
     ]
     .into_iter()
-    .any(|opt| opt.is_some_and(|v| v.is_finite()))
+    .any(|opt| opt.is_some_and(is_valid_price_value))
 }
 
 fn has_any_valid_above_tier_value(pricing: &ModelPricing) -> bool {
@@ -1141,7 +1146,7 @@ fn select_best_match(
     let with_pricing: Vec<&String> = preferred_matches
         .iter()
         .copied()
-        .filter(|k| dataset.get(k.as_str()).is_some_and(|p| has_any_base_pricing(p)))
+        .filter(|k| dataset.get(k.as_str()).is_some_and(|p| has_any_usable_pricing(p)))
         .collect();
     if with_pricing.is_empty() {
         return None;


### PR DESCRIPTION
## Summary

- Fix provider-aware pricing lookup returning entries with all-None pricing from subscription-based resellers (e.g. Perplexity), shadowing correct per-token pricing entries
- Add `has_any_base_pricing()` helper to detect entries with no usable cost data
- Add regression test for the exact scenario

## Root Cause

`select_best_match` matches LiteLLM keys by provider hint tags extracted from **all** path segments. For keys like `perplexity/anthropic/claude-opus-4-6`, both `"perplexity"` and `"anthropic"` become provider tags. When looking up `claude-opus-4-6` with `provider=anthropic`:

1. `exact_match_litellm_for_provider` finds `perplexity/anthropic/claude-opus-4-6` (model part matches, "anthropic" tag matches)
2. This entry has all-None pricing (Perplexity is subscription-based)
3. The result is returned, short-circuiting before `exact_match_litellm("claude-opus-4-6")` which has the correct pricing
4. `compute_cost` returns `$0.00`

## Fix

In `select_best_match`, filter provider-matched entries to those with at least one non-None base cost field. If no entry has usable pricing, return `None` so the caller falls through to non-provider-specific lookups (exact key match).

## Impact

This affects any model where LiteLLM data contains a subscription-based reseller entry whose key path embeds the original provider name. Currently confirmed: `perplexity/anthropic/claude-*` entries shadow all Claude models when `provider=anthropic`.

Closes #336

## Test plan

- [x] New regression test `test_none_pricing_reseller_does_not_shadow_real_entry`
- [x] All 378 existing tests pass (145 pricing tests, 0 failures)
- [x] Manual verification: `claude-opus-4-6` cost went from `$0.00` to `$1,265`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix provider-aware pricing lookup to ignore entries with no usable per-token pricing (including above-200k tiers), so exact model entries with real costs are used. Prevents $0.00 estimates when reseller keys like `perplexity/anthropic/*` shadow real models.

- **Bug Fixes**
  - Filter provider-hint matches to only entries with at least one valid cost (base or above-200k), validated with `is_valid_price_value`; fall back to non-provider lookup if none.
  - Added `has_any_usable_pricing()` and a regression test for the `claude-opus-4-6` case.

<sup>Written for commit 41864c4f7a28da0f8f945fff115fb317228db163. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

