### PR TITLE
fix(core): sort scan paths for deterministic dedup and stable refreshes

### DIFF
--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -150,11 +150,10 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
         })
         .map(|e| e.path().to_path_buf())
         .collect();
-    // Sort to guarantee deterministic ordering across refreshes.
-    // par_bridge() is explicitly non-deterministic, so without sorting the
-    // order-dependent global dedup (seen_keys) would produce different results
-    // each run, causing visible data fluctuations when pressing 'r'.
-    paths.sort();
+    // Sort for deterministic ordering. sort_unstable() is sufficient (no stability
+    // requirement for PathBuf) and avoids allocation. Note: ordering is byte-lexical,
+    // not case-normalized (known Windows/macOS caveat for mixed-case paths).
+    paths.sort_unstable();
     paths
 }
 
@@ -589,6 +588,33 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let files = scan_directory(dir.path().to_str().unwrap(), "*.json");
         assert!(files.is_empty());
+    }
+
+    #[test]
+    fn test_scan_directory_deterministic_order() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path();
+
+        for name in ["zebra.jsonl", "alpha.jsonl", "middle.jsonl", "beta.jsonl"] {
+            File::create(path.join(name)).unwrap();
+        }
+
+        let first = scan_directory(path.to_str().unwrap(), "*.jsonl");
+        let second = scan_directory(path.to_str().unwrap(), "*.jsonl");
+        let third = scan_directory(path.to_str().unwrap(), "*.jsonl");
+
+        assert_eq!(first, second, "Repeated scans must return identical order");
+        assert_eq!(second, third, "Repeated scans must return identical order");
+
+        let names: Vec<_> = first
+            .iter()
+            .map(|p| p.file_name().unwrap().to_str().unwrap())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["alpha.jsonl", "beta.jsonl", "middle.jsonl", "zebra.jsonl"],
+            "Results must be lexically sorted"
+        );
     }
 
     fn setup_mock_opencode_dir(base: &std::path::Path) {


### PR DESCRIPTION
## Problem

`scan_directory` uses `par_bridge()` to parallelize `WalkDir` traversal, which is [explicitly non-deterministic](https://docs.rs/rayon/latest/rayon/iter/trait.ParallelBridge.html) — items may arrive in any order on each call.

The global `seen_keys` dedup in `parse_all_messages_with_pricing` keeps the **first** occurrence of any `messageId:requestId` key. When the same message appears in multiple session files (e.g. original session + `acompact` snapshot), which copy is kept depends on file order. Since that order changes between runs, the deduplicated message set changes too, causing visible data fluctuations every time the user presses `r` to refresh.

## Fix

Sort the collected paths before returning from `scan_directory`. The parallel scan still runs at full speed; we sort only the result.

```
before: par_bridge() → non-deterministic order → different dedup winner each refresh
after:  par_bridge() → collect → sort → stable order → same dedup winner always
```

## Testing

Manually verified on a corpus with ~2,000+ session files: pressing `r` repeatedly in the TUI daily/hourly view now produces stable numbers across refreshes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
