### PR TITLE
fix(sessions/claudecode): keep final streaming token count for duplicate entries

### DIFF
--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -104,7 +104,7 @@ pub fn parse_claude_file(path: &Path) -> Vec<UnifiedMessage> {
                 // Build dedup key for global deduplication (messageId:requestId composite).
                 // For streaming responses, merge using per-field max to capture the most
                 // complete token counts across all duplicate entries.
-                let dedup_key = match (&message.id, &entry.request_id) {
+                let pending_hash = match (&message.id, &entry.request_id) {
                     (Some(msg_id), Some(req_id)) => {
                         let hash = format!("{}:{}", msg_id, req_id);
                         if let Some(&existing_idx) = processed_hashes.get(&hash) {
@@ -120,7 +120,6 @@ pub fn parse_claude_file(path: &Path) -> Vec<UnifiedMessage> {
                                 .max(usage.cache_creation_input_tokens.unwrap_or(0).max(0));
                             continue;
                         }
-                        processed_hashes.insert(hash.clone(), messages.len());
                         Some(hash)
                     }
                     _ => None,
@@ -136,6 +135,11 @@ pub fn parse_claude_file(path: &Path) -> Vec<UnifiedMessage> {
                     .and_then(|ts| chrono::DateTime::parse_from_rfc3339(&ts).ok())
                     .map(|dt| dt.timestamp_millis())
                     .unwrap_or(fallback_timestamp);
+
+                // Insert dedup index only after all checks pass, right before push
+                let dedup_key = pending_hash.inspect(|hash| {
+                    processed_hashes.insert(hash.clone(), messages.len());
+                });
 
                 messages.push(UnifiedMessage::new_with_dedup(
                     "claude",
@@ -453,6 +457,24 @@ mod tests {
             messages[0].tokens.input, 100,
             "Should keep max input (first entry)"
         );
+    }
+
+    #[test]
+    fn test_deduplication_skips_model_none_without_stale_index() {
+        // First entry has id+requestId+usage but model=null → skipped, no push.
+        // Second entry is a valid duplicate. Must not panic on stale index.
+        let content = r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","requestId":"req_001","message":{"id":"msg_001","usage":{"input_tokens":10,"output_tokens":50}}}
+{"type":"assistant","timestamp":"2024-12-01T10:00:00.100Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":10,"output_tokens":100}}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(
+            messages.len(),
+            1,
+            "Only the entry with model should be kept"
+        );
+        assert_eq!(messages[0].tokens.output, 100);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Claude Code's streaming API writes the same `messageId:requestId` pair to the JSONL log multiple times while a response is being generated:
- Early writes contain **partial** `output_tokens` (e.g. 31)
- The final write contains the **complete** `output_tokens` count (e.g. 300)

The previous `HashSet`-based dedup kept the **first-seen** entry, causing systematic token undercounts for every streaming response.

## Solution

Replace `processed_hashes: HashSet<String>` with `HashMap<String, usize>` that maps each dedup key to its **index** in the `messages` vec. When a duplicate key is encountered, compare `output_tokens` and update the existing entry in-place if the new value is larger.

## Changes

- `sessions/claudecode.rs`: `HashSet` → `HashMap<String, usize>` for `processed_hashes`; dedup logic updated to keep max `output_tokens`
- Added `test_deduplication_keeps_max_output_for_streaming_duplicates`: three streaming writes for the same `messageId:requestId` collapse to one entry with the final token count

## Test

```
running 3 tests
test sessions::claudecode::tests::test_deduplication_allows_same_message_different_request ... ok
test sessions::claudecode::tests::test_deduplication_keeps_max_output_for_streaming_duplicates ... ok
test sessions::claudecode::tests::test_deduplication_skips_duplicate_entries ... ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
