### PR TITLE
fix(hourly): polish cache schema, dispatch, sort defaults, and float guards

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -359,7 +359,7 @@ fn main() -> Result<()> {
         }
         Some(Commands::Hourly {
             json,
-            light: _,
+            light,
             clients,
             date,
             benchmark,
@@ -371,19 +371,33 @@ fn main() -> Result<()> {
             let (since, until) = build_date_filter(today, week, month, date.since, date.until);
             let year = normalize_year_filter(today, week, month, date.year);
             let clients = build_client_filter(clients);
-            run_hourly_report(
-                json,
-                cli.home.clone(),
-                clients,
-                since,
-                until,
-                year,
-                benchmark,
-                no_spinner || !can_use_tui,
-                today,
-                week,
-                month,
-            )
+            if json || light || !can_use_tui {
+                run_hourly_report(
+                    json,
+                    cli.home.clone(),
+                    clients,
+                    since,
+                    until,
+                    year,
+                    benchmark,
+                    no_spinner || !can_use_tui,
+                    today,
+                    week,
+                    month,
+                )
+            } else {
+                ensure_home_supported_for_tui(&cli.home)?;
+                tui::run(
+                    &cli.theme,
+                    cli.refresh,
+                    cli.debug,
+                    clients,
+                    since,
+                    until,
+                    year,
+                    Some(Tab::Hourly),
+                )
+            }
         }
         Some(Commands::Pricing {
             model_id,
@@ -2512,10 +2526,13 @@ fn format_currency(n: f64) -> String {
 }
 
 fn format_cost_per_million(cost: f64, total_tokens: i64) -> String {
-    if total_tokens == 0 {
+    if total_tokens <= 0 || !cost.is_finite() {
+        return "—".to_string();
+    }
+    let cost_per_m = cost * 1_000_000.0 / total_tokens as f64;
+    if !cost_per_m.is_finite() {
         "—".to_string()
     } else {
-        let cost_per_m = cost * 1_000_000.0 / total_tokens as f64;
         format!("${:.2}/M", cost_per_m)
     }
 }

--- a/crates/tokscale-cli/src/tui/cache.rs
+++ b/crates/tokscale-cli/src/tui/cache.rs
@@ -21,7 +21,7 @@ use super::data::{
 
 /// Cache staleness threshold: 5 minutes (matches TS implementation)
 const CACHE_STALE_THRESHOLD_MS: u64 = 5 * 60 * 1000;
-const CACHE_SCHEMA_VERSION: u32 = 5;
+const CACHE_SCHEMA_VERSION: u32 = 6;
 
 /// Get the cache directory path
 /// Uses `~/.cache/tokscale/` to match TypeScript implementation for cache sharing
@@ -1101,7 +1101,7 @@ mod tests {
         fs::write(
             &cache_path,
             r#"{
-  "schemaVersion": 5,
+  "schemaVersion": 6,
   "timestamp": 9999999999999,
   "enabledClients": ["claude", "cursor"],
   "includeSynthetic": false,

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -619,8 +619,10 @@ impl DataLoader {
                     .saturating_add(msg.message_count.max(0) as u64);
             }
 
-            // Hourly aggregation: derive hour from timestamp (Unix ms)
-            if let Some(hour_dt) = timestamp_to_hour(msg.timestamp) {
+            // Hourly aggregation: derive hour from timestamp (Unix ms),
+            // falling back to msg.date 00:00 when timestamp is missing/zero
+            // so we don't silently drop messages (matches CLI bucketing).
+            if let Some(hour_dt) = hour_bucket_with_fallback(msg.timestamp, &msg.date) {
                 let hourly_entry = hourly_map.entry(hour_dt).or_insert_with(|| HourlyUsage {
                     datetime: hour_dt,
                     tokens: TokenBreakdown::default(),
@@ -779,6 +781,17 @@ fn timestamp_to_hour(timestamp_ms: i64) -> Option<NaiveDateTime> {
         }
         _ => None,
     }
+}
+
+/// Derive an hour-truncated NaiveDateTime from `msg.timestamp` when present,
+/// otherwise fall back to `msg.date`'s 00:00 bucket so messages with missing
+/// timestamps are not silently dropped from hourly aggregation. Mirrors the
+/// CLI hourly bucketing behavior in `tokscale-core::lib::get_hourly_report`.
+fn hour_bucket_with_fallback(timestamp_ms: i64, date_str: &str) -> Option<NaiveDateTime> {
+    if let Some(dt) = timestamp_to_hour(timestamp_ms) {
+        return Some(dt);
+    }
+    parse_date(date_str).and_then(|d| d.and_hms_opt(0, 0, 0))
 }
 
 fn build_contribution_graph(daily: &[DailyUsage]) -> GraphData {

--- a/crates/tokscale-cli/src/tui/ui/overview.rs
+++ b/crates/tokscale-cli/src/tui/ui/overview.rs
@@ -77,74 +77,67 @@ fn render_chart(frame: &mut Frame, app: &App, area: Rect) {
     let group_by = app.group_by.borrow().clone();
 
     let data: Vec<StackedBarData> = match app.chart_granularity {
-        ChartGranularity::Daily => {
-            let daily = &app.data.daily;
-            let mut sorted_daily: Vec<_> = daily.iter().collect();
-            sorted_daily.sort_by_key(|a| a.date);
-
-            sorted_daily
-                .iter()
-                .rev()
-                .take(60)
-                .rev()
-                .map(|d| {
-                    let mut models_by_key =
-                        std::collections::BTreeMap::<String, ModelSegment>::new();
-                    for source_info in d.source_breakdown.values() {
-                        for (key, info) in &source_info.models {
-                            let entry =
-                                models_by_key
-                                    .entry(key.clone())
-                                    .or_insert_with(|| ModelSegment {
-                                        model_id: info.display_name.clone(),
-                                        tokens: 0,
-                                        color: app.model_color_for(
-                                            &info.provider,
-                                            overview_color_key(&group_by, &info.color_key),
-                                        ),
-                                    });
-                            entry.tokens = entry.tokens.saturating_add(info.tokens.total());
-                        }
+        ChartGranularity::Daily => app
+            .data
+            .daily
+            .iter()
+            .take(60)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .map(|d| {
+                let mut models_by_key = std::collections::BTreeMap::<String, ModelSegment>::new();
+                for source_info in d.source_breakdown.values() {
+                    for (key, info) in &source_info.models {
+                        let entry =
+                            models_by_key
+                                .entry(key.clone())
+                                .or_insert_with(|| ModelSegment {
+                                    model_id: info.display_name.clone(),
+                                    tokens: 0,
+                                    color: app.model_color_for(
+                                        &info.provider,
+                                        overview_color_key(&group_by, &info.color_key),
+                                    ),
+                                });
+                        entry.tokens = entry.tokens.saturating_add(info.tokens.total());
                     }
-                    let models: Vec<ModelSegment> = models_by_key.into_values().collect();
+                }
+                let models: Vec<ModelSegment> = models_by_key.into_values().collect();
 
-                    StackedBarData {
-                        date: d.date.format("%m/%d").to_string(),
-                        models,
-                        total: d.tokens.total(),
-                    }
-                })
-                .collect()
-        }
-        ChartGranularity::Hourly => {
-            let hourly = &app.data.hourly;
-            let mut sorted: Vec<_> = hourly.iter().collect();
-            sorted.sort_by_key(|a| a.datetime);
+                StackedBarData {
+                    date: d.date.format("%m/%d").to_string(),
+                    models,
+                    total: d.tokens.total(),
+                }
+            })
+            .collect(),
+        ChartGranularity::Hourly => app
+            .data
+            .hourly
+            .iter()
+            .take(60)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .map(|h| {
+                let models: Vec<ModelSegment> = h
+                    .models
+                    .values()
+                    .map(|info| ModelSegment {
+                        model_id: info.display_name.clone(),
+                        tokens: info.tokens.total(),
+                        color: app.model_color_for(&info.provider, &info.color_key),
+                    })
+                    .collect();
 
-            sorted
-                .iter()
-                .rev()
-                .take(60)
-                .rev()
-                .map(|h| {
-                    let models: Vec<ModelSegment> = h
-                        .models
-                        .values()
-                        .map(|info| ModelSegment {
-                            model_id: info.display_name.clone(),
-                            tokens: info.tokens.total(),
-                            color: app.model_color_for(&info.provider, &info.color_key),
-                        })
-                        .collect();
-
-                    StackedBarData {
-                        date: h.datetime.format("%d %H:%M").to_string(),
-                        models,
-                        total: h.tokens.total(),
-                    }
-                })
-                .collect()
-        }
+                StackedBarData {
+                    date: h.datetime.format("%d %H:%M").to_string(),
+                    models,
+                    total: h.tokens.total(),
+                }
+            })
+            .collect(),
     };
 
     render_stacked_bar_chart(frame, app, area, &data);

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -10,7 +10,7 @@ use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
-const CACHE_SCHEMA_VERSION: u32 = 6;
+const CACHE_SCHEMA_VERSION: u32 = 7;
 const CACHE_FILENAME: &str = "source-message-cache.bin";
 const CACHE_LOCK_FILENAME: &str = "source-message-cache.lock";
 const MAX_CACHE_FILE_BYTES: u64 = 256 * 1024 * 1024;

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -626,6 +626,20 @@ fn extract_claude_headless_message(
     ))
 }
 
+/// Internal Claude Code system/tool tags that should NOT be counted as human turns.
+/// User prompts containing arbitrary HTML/XML (e.g. `<div>hello</div>`) are still
+/// counted, only this narrow allowlist is excluded.
+const CLAUDECODE_INTERNAL_USER_TAGS: &[&str] = &[
+    "<local-command-stdout>",
+    "<local-command-stderr>",
+    "<command-name>",
+    "<command-message>",
+    "<system-reminder>",
+    "<bash-input>",
+    "<bash-stdout>",
+    "<bash-stderr>",
+];
+
 /// Returns true if a `type: "user"` JSONL entry is genuine human input (not tool results or system messages).
 fn is_human_turn(raw_line: &str) -> bool {
     if let Some(pos) = raw_line.find("\"content\":") {
@@ -635,8 +649,13 @@ fn is_human_turn(raw_line: &str) -> bool {
             return false;
         }
         if let Some(content_start) = after_trimmed.strip_prefix('"') {
-            if after_trimmed.len() > 1 && content_start.starts_with('<') {
-                return false;
+            // Only filter out content that begins with a known internal tag.
+            // Anything else (including `<div>`, `<table>`, etc. in genuine prompts)
+            // is treated as a real human turn.
+            for tag in CLAUDECODE_INTERNAL_USER_TAGS {
+                if content_start.starts_with(tag) {
+                    return false;
+                }
             }
             return true;
         }
@@ -712,6 +731,30 @@ mod tests {
     use super::*;
     use std::io::Write;
     use tempfile::{NamedTempFile, TempDir};
+
+    #[test]
+    fn is_human_turn_counts_html_user_prompt() {
+        let line = r#"{"type":"user","message":{"content":"<div>hello</div>"}}"#;
+        assert!(is_human_turn(line));
+    }
+
+    #[test]
+    fn is_human_turn_skips_internal_tool_tags() {
+        for tag in CLAUDECODE_INTERNAL_USER_TAGS {
+            let line =
+                format!(r#"{{"type":"user","message":{{"content":"{tag}some output</...>"}}}}"#);
+            assert!(
+                !is_human_turn(&line),
+                "expected tag {tag} to be filtered as non-human"
+            );
+        }
+    }
+
+    #[test]
+    fn is_human_turn_skips_array_content() {
+        let line = r#"{"type":"user","message":{"content":[{"type":"tool_result"}]}}"#;
+        assert!(!is_human_turn(line));
+    }
 
     fn create_test_file(content: &str) -> NamedTempFile {
         let mut file = NamedTempFile::new().unwrap();


### PR DESCRIPTION
## Summary

- Adds `tokscale hourly` CLI subcommand with `--json`, `--light`, date filters, and all client flags (including the newly added `--kilo`)
- Adds a **Hourly** TUI tab (between Daily and Stats) with the same keyboard navigation
- Overview page gains a toggle (`h`) to switch between daily and hourly breakdown
- **Cache×** column: cache hit multiplier (cache_read / input_tokens), renamed from `Cache%` to clarify it's a multiplier not a percentage
- **Turn** column: counts distinct user-turn timestamps per hour/day — shows actual interaction turns, not just assistant messages
- **Msgs** column in TUI hourly and daily views: raw message count per period

## Details

The hourly report aggregates token usage, cost, turn count, and message count by hour. The Turn count uses a 10-second dedup window to collapse rapid consecutive user messages into a single logical turn (matching CC's session behavior).

Cache× is defined as `cache_read_tokens / input_tokens` — a value > 1 means more tokens were served from cache than paid for as fresh input, indicating good cache utilization.

## Test notes

Three pre-existing scanner tests (`test_scan_all_clients_claude`, `test_scan_all_clients_multiple`, `test_scan_all_clients_headless_paths`) fail on upstream `main` as well — they scan the developer's real `~/.claude/projects` instead of the temp dir due to an unrelated env/path issue. Not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/359" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
