### PR TITLE
fix: preserve multi-machine submissions on the leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,10 +493,17 @@ Environment variables override config file values. For CI/CD or one-off use:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `TOKSCALE_NATIVE_TIMEOUT_MS` | `300000` (5 min) | Overrides `nativeTimeoutMs` config |
+| `TOKSCALE_API_URL` | `https://tokscale.ai` | Overrides the API base URL used by `login` and `submit` |
+| `TOKSCALE_SOURCE_ID` | auto-generated per machine | Overrides the stable source ID attached to `submit` payloads |
+| `TOKSCALE_SOURCE_NAME` | `CLI on <hostname>` | Overrides the human-readable source name attached to `submit` payloads |
 
 ```bash
 # Example: Increase timeout for very large datasets
 TOKSCALE_NATIVE_TIMEOUT_MS=600000 tokscale graph --output data.json
+
+# Example: submit two local test sources without using two machines
+TOKSCALE_SOURCE_ID=machine-a tokscale submit
+TOKSCALE_SOURCE_ID=machine-b TOKSCALE_SOURCE_NAME="Work Laptop" tokscale submit
 ```
 
 > **Note**: For persistent changes, prefer setting `nativeTimeoutMs` in `~/.config/tokscale/settings.json`. Environment variables are best for one-off overrides or CI/CD.

--- a/README.md
+++ b/README.md
@@ -506,6 +506,8 @@ TOKSCALE_SOURCE_ID=machine-a tokscale submit
 TOKSCALE_SOURCE_ID=machine-b TOKSCALE_SOURCE_NAME="Work Laptop" tokscale submit
 ```
 
+> `TOKSCALE_SOURCE_NAME` is stored per `sourceId`. A later submit with the same `sourceId` and a new non-empty `TOKSCALE_SOURCE_NAME` updates the stored display name for that source.
+
 > **Note**: For persistent changes, prefer setting `nativeTimeoutMs` in `~/.config/tokscale/settings.json`. Environment variables are best for one-off overrides or CI/CD.
 
 ### Headless Mode

--- a/crates/tokscale-cli/src/auth.rs
+++ b/crates/tokscale-cli/src/auth.rs
@@ -206,14 +206,14 @@ fn lock_age(path: &Path, state: Option<SourceIdLockState>) -> Duration {
         .unwrap_or_default()
 }
 
-fn lock_owner_is_alive(pid: u32) -> bool {
+fn lock_owner_is_alive(pid: u32) -> Option<bool> {
     #[cfg(unix)]
     {
         std::process::Command::new("kill")
             .args(["-0", &pid.to_string()])
             .status()
+            .ok()
             .map(|status| status.success())
-            .unwrap_or(false)
     }
 
     #[cfg(windows)]
@@ -225,16 +225,19 @@ fn lock_owner_is_alive(pid: u32) -> bool {
         match output {
             Ok(output) if output.status.success() => {
                 let stdout = String::from_utf8_lossy(&output.stdout);
-                stdout.contains(&pid.to_string())
-                    && !stdout.contains("No tasks are running")
+                Some(
+                    stdout.contains(&pid.to_string())
+                        && !stdout.contains("No tasks are running")
+                )
             }
-            _ => false,
+            Ok(_) => None,
+            Err(_) => None,
         }
     }
 
     #[cfg(not(any(unix, windows)))]
     {
-        false
+        None
     }
 }
 
@@ -302,11 +305,12 @@ fn acquire_source_id_lock() -> Result<SourceIdLock> {
             Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
                 let state = read_source_id_lock_state(&lock_path);
                 let age = lock_age(&lock_path, state);
-                let owner_is_alive = state
-                    .map(|lock_state| lock_owner_is_alive(lock_state.pid))
-                    .unwrap_or(false);
+                let owner_is_dead = match state {
+                    Some(lock_state) => matches!(lock_owner_is_alive(lock_state.pid), Some(false)),
+                    None => true,
+                };
 
-                if !owner_is_alive && age >= SOURCE_ID_LOCK_STALE_AFTER {
+                if owner_is_dead && age >= SOURCE_ID_LOCK_STALE_AFTER {
                     let _ = remove_source_id_lock_if_matches(&lock_path, state);
                     continue;
                 }
@@ -352,11 +356,11 @@ fn write_source_id(path: &Path, source_id: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn get_submit_source_id() -> Result<String> {
+pub fn get_submit_source_id() -> Result<Option<String>> {
     if let Some(source_id) = std::env::var_os("TOKSCALE_SOURCE_ID") {
         let trimmed = source_id.to_string_lossy().trim().to_string();
         if !trimmed.is_empty() {
-            return Ok(trimmed);
+            return Ok(Some(trimmed));
         }
     }
 
@@ -364,18 +368,18 @@ pub fn get_submit_source_id() -> Result<String> {
     let path = get_source_id_path()?;
 
     if let Some(existing) = read_source_id(&path) {
-        return Ok(existing);
+        return Ok(Some(existing));
     }
 
     let _lock = acquire_source_id_lock()?;
 
     if let Some(existing) = read_source_id(&path) {
-        return Ok(existing);
+        return Ok(Some(existing));
     }
 
     let source_id = uuid::Uuid::new_v4().to_string();
     write_source_id(&path, &source_id)?;
-    Ok(source_id)
+    Ok(Some(source_id))
 }
 
 pub fn get_submit_source_name() -> Option<String> {

--- a/crates/tokscale-cli/src/auth.rs
+++ b/crates/tokscale-cli/src/auth.rs
@@ -4,8 +4,8 @@ use std::fs;
 use std::io::IsTerminal;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use std::thread;
-use std::time::Duration;
 
 fn home_dir() -> Result<PathBuf> {
     dirs::home_dir().context("Could not determine home directory")
@@ -62,6 +62,10 @@ fn get_source_id_path() -> Result<PathBuf> {
 fn get_source_id_lock_path() -> Result<PathBuf> {
     Ok(home_dir()?.join(".config/tokscale/source-id.lock"))
 }
+
+const SOURCE_ID_LOCK_RETRY_DELAY: Duration = Duration::from_millis(25);
+const SOURCE_ID_LOCK_STALE_AFTER: Duration = Duration::from_secs(2);
+const SOURCE_ID_LOCK_MAX_WAIT: Duration = Duration::from_secs(10);
 
 fn ensure_config_dir() -> Result<()> {
     let config_dir = home_dir()?.join(".config/tokscale");
@@ -144,44 +148,181 @@ fn read_source_id(path: &Path) -> Option<String> {
     Some(trimmed.to_string())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SourceIdLockState {
+    pid: u32,
+    created_at_ms: u128,
+}
+
+fn current_unix_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
+fn serialize_source_id_lock_state(state: SourceIdLockState) -> String {
+    format!(
+        "pid={}\ncreated_at_ms={}\n",
+        state.pid, state.created_at_ms
+    )
+}
+
+fn parse_source_id_lock_state(content: &str) -> Option<SourceIdLockState> {
+    let mut pid = None;
+    let mut created_at_ms = None;
+
+    for line in content.lines() {
+        let (key, value) = line.split_once('=')?;
+        match key.trim() {
+            "pid" => pid = value.trim().parse::<u32>().ok(),
+            "created_at_ms" => created_at_ms = value.trim().parse::<u128>().ok(),
+            _ => {}
+        }
+    }
+
+    Some(SourceIdLockState {
+        pid: pid?,
+        created_at_ms: created_at_ms?,
+    })
+}
+
+fn read_source_id_lock_state(path: &Path) -> Option<SourceIdLockState> {
+    let content = fs::read_to_string(path).ok()?;
+    parse_source_id_lock_state(&content)
+}
+
+fn lock_age(path: &Path, state: Option<SourceIdLockState>) -> Duration {
+    if let Some(state) = state {
+        let now_ms = current_unix_ms();
+        let age_ms = now_ms.saturating_sub(state.created_at_ms);
+        return Duration::from_millis(age_ms.min(u64::MAX as u128) as u64);
+    }
+
+    fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| modified.elapsed().ok())
+        .unwrap_or_default()
+}
+
+fn lock_owner_is_alive(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        std::process::Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    }
+
+    #[cfg(windows)]
+    {
+        let output = std::process::Command::new("tasklist")
+            .args(["/FI", &format!("PID eq {}", pid)])
+            .output();
+
+        match output {
+            Ok(output) if output.status.success() => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                stdout.contains(&pid.to_string())
+                    && !stdout.contains("No tasks are running")
+            }
+            _ => false,
+        }
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        false
+    }
+}
+
+fn write_source_id_lock_state(
+    mut file: fs::File,
+    state: SourceIdLockState,
+) -> Result<()> {
+    let payload = serialize_source_id_lock_state(state);
+    file.write_all(payload.as_bytes())?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn remove_source_id_lock_if_matches(path: &Path, expected: Option<SourceIdLockState>) -> bool {
+    let current_state = read_source_id_lock_state(path);
+    if current_state != expected {
+        return false;
+    }
+
+    match fs::remove_file(path) {
+        Ok(()) => true,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => false,
+        Err(_) => false,
+    }
+}
+
 struct SourceIdLock {
     path: PathBuf,
+    state: SourceIdLockState,
 }
 
 impl Drop for SourceIdLock {
     fn drop(&mut self) {
-        let _ = fs::remove_file(&self.path);
+        let _ = remove_source_id_lock_if_matches(&self.path, Some(self.state));
     }
 }
 
 fn acquire_source_id_lock() -> Result<SourceIdLock> {
     ensure_config_dir()?;
     let lock_path = get_source_id_lock_path()?;
+    let deadline = Instant::now() + SOURCE_ID_LOCK_MAX_WAIT;
 
-    for _ in 0..100 {
+    loop {
         match fs::OpenOptions::new()
             .write(true)
             .create_new(true)
             .open(&lock_path)
         {
-            Ok(_) => return Ok(SourceIdLock { path: lock_path }),
-            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
-                if let Ok(metadata) = fs::metadata(&lock_path) {
-                    if let Ok(modified_at) = metadata.modified() {
-                        if modified_at.elapsed().unwrap_or_default() > Duration::from_secs(10) {
-                            let _ = fs::remove_file(&lock_path);
-                            continue;
-                        }
-                    }
+            Ok(file) => {
+                let state = SourceIdLockState {
+                    pid: std::process::id(),
+                    created_at_ms: current_unix_ms(),
+                };
+
+                if let Err(err) = write_source_id_lock_state(file, state) {
+                    let _ = fs::remove_file(&lock_path);
+                    return Err(err);
                 }
-                thread::sleep(Duration::from_millis(25));
+
+                return Ok(SourceIdLock {
+                    path: lock_path,
+                    state,
+                });
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                let state = read_source_id_lock_state(&lock_path);
+                let age = lock_age(&lock_path, state);
+                let owner_is_alive = state
+                    .map(|lock_state| lock_owner_is_alive(lock_state.pid))
+                    .unwrap_or(false);
+
+                if !owner_is_alive && age >= SOURCE_ID_LOCK_STALE_AFTER {
+                    let _ = remove_source_id_lock_if_matches(&lock_path, state);
+                    continue;
+                }
+
+                if Instant::now() >= deadline {
+                    break;
+                }
+
+                thread::sleep(SOURCE_ID_LOCK_RETRY_DELAY);
             }
             Err(err) => return Err(err.into()),
         }
     }
 
     anyhow::bail!(
-        "Could not acquire source ID lock after 100 retries (~2500ms)"
+        "Could not acquire source ID lock after waiting for stale lock cleanup"
     );
 }
 
@@ -540,6 +681,52 @@ mod tests {
         unsafe {
             env::remove_var("TOKSCALE_API_URL");
         }
+    }
+
+    #[test]
+    fn test_source_id_lock_state_round_trip() {
+        let state = SourceIdLockState {
+            pid: 12345,
+            created_at_ms: 1_717_000_000_000,
+        };
+
+        let encoded = serialize_source_id_lock_state(state);
+        let decoded = parse_source_id_lock_state(&encoded);
+
+        assert_eq!(decoded, Some(state));
+    }
+
+    #[test]
+    fn test_source_id_lock_state_rejects_malformed_input() {
+        assert!(parse_source_id_lock_state("pid=abc\ncreated_at_ms=123\n").is_none());
+        assert!(parse_source_id_lock_state("just some text").is_none());
+    }
+
+    #[test]
+    fn test_source_id_lock_guard_only_removes_owned_lock_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let lock_path = temp_dir.path().join("source-id.lock");
+        let owned_state = SourceIdLockState {
+            pid: 12345,
+            created_at_ms: 1_717_000_000_000,
+        };
+        let newer_state = SourceIdLockState {
+            pid: 54321,
+            created_at_ms: 1_717_000_000_500,
+        };
+
+        fs::write(&lock_path, serialize_source_id_lock_state(owned_state)).unwrap();
+
+        let guard = SourceIdLock {
+            path: lock_path.clone(),
+            state: owned_state,
+        };
+
+        fs::write(&lock_path, serialize_source_id_lock_state(newer_state)).unwrap();
+        drop(guard);
+
+        let persisted = fs::read_to_string(&lock_path).unwrap();
+        assert_eq!(persisted, serialize_source_id_lock_state(newer_state));
     }
 
     #[test]

--- a/crates/tokscale-cli/src/auth.rs
+++ b/crates/tokscale-cli/src/auth.rs
@@ -306,7 +306,10 @@ fn acquire_source_id_lock() -> Result<SourceIdLock> {
                 let state = read_source_id_lock_state(&lock_path);
                 let age = lock_age(&lock_path, state);
                 let owner_is_dead = match state {
-                    Some(lock_state) => matches!(lock_owner_is_alive(lock_state.pid), Some(false)),
+                    Some(lock_state) => match lock_owner_is_alive(lock_state.pid) {
+                        Some(is_alive) => !is_alive,
+                        None => age >= SOURCE_ID_LOCK_STALE_AFTER,
+                    },
                     None => true,
                 };
 

--- a/crates/tokscale-cli/src/auth.rs
+++ b/crates/tokscale-cli/src/auth.rs
@@ -3,7 +3,9 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::IsTerminal;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
 
 fn home_dir() -> Result<PathBuf> {
     dirs::home_dir().context("Could not determine home directory")
@@ -51,6 +53,14 @@ struct UserInfo {
 
 fn get_credentials_path() -> Result<PathBuf> {
     Ok(home_dir()?.join(".config/tokscale/credentials.json"))
+}
+
+fn get_source_id_path() -> Result<PathBuf> {
+    Ok(home_dir()?.join(".config/tokscale/source-id"))
+}
+
+fn get_source_id_lock_path() -> Result<PathBuf> {
+    Ok(home_dir()?.join(".config/tokscale/source-id.lock"))
 }
 
 fn ensure_config_dir() -> Result<()> {
@@ -123,6 +133,114 @@ fn get_device_name() -> String {
         .and_then(|h| h.into_string().ok())
         .unwrap_or_else(|| "unknown".to_string());
     format!("CLI on {}", hostname)
+}
+
+fn read_source_id(path: &Path) -> Option<String> {
+    let content = fs::read_to_string(path).ok()?;
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+struct SourceIdLock {
+    path: PathBuf,
+}
+
+impl Drop for SourceIdLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn acquire_source_id_lock() -> Result<SourceIdLock> {
+    ensure_config_dir()?;
+    let lock_path = get_source_id_lock_path()?;
+
+    for _ in 0..100 {
+        match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&lock_path)
+        {
+            Ok(_) => return Ok(SourceIdLock { path: lock_path }),
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                if let Ok(metadata) = fs::metadata(&lock_path) {
+                    if let Ok(modified_at) = metadata.modified() {
+                        if modified_at.elapsed().unwrap_or_default() > Duration::from_secs(10) {
+                            let _ = fs::remove_file(&lock_path);
+                            continue;
+                        }
+                    }
+                }
+                thread::sleep(Duration::from_millis(25));
+            }
+            Err(err) => return Err(err.into()),
+        }
+    }
+
+    anyhow::bail!("Timed out waiting for source ID lock");
+}
+
+fn write_source_id(path: &Path, source_id: &str) -> Result<()> {
+    let temp_path = path.with_extension(format!("tmp-{}", std::process::id()));
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&temp_path)?;
+        file.write_all(source_id.as_bytes())?;
+        file.write_all(b"\n")?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        fs::write(&temp_path, format!("{source_id}\n"))?;
+    }
+
+    fs::rename(&temp_path, path)?;
+    Ok(())
+}
+
+pub fn get_submit_source_id() -> Result<String> {
+    if let Some(source_id) = std::env::var_os("TOKSCALE_SOURCE_ID") {
+        let trimmed = source_id.to_string_lossy().trim().to_string();
+        if !trimmed.is_empty() {
+            return Ok(trimmed);
+        }
+    }
+
+    ensure_config_dir()?;
+    let path = get_source_id_path()?;
+
+    if let Some(existing) = read_source_id(&path) {
+        return Ok(existing);
+    }
+
+    let _lock = acquire_source_id_lock()?;
+
+    if let Some(existing) = read_source_id(&path) {
+        return Ok(existing);
+    }
+
+    let source_id = uuid::Uuid::new_v4().to_string();
+    write_source_id(&path, &source_id)?;
+    Ok(source_id)
+}
+
+pub fn get_submit_source_name() -> Option<String> {
+    std::env::var("TOKSCALE_SOURCE_NAME")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| Some(get_device_name()))
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/tokscale-cli/src/auth.rs
+++ b/crates/tokscale-cli/src/auth.rs
@@ -180,7 +180,9 @@ fn acquire_source_id_lock() -> Result<SourceIdLock> {
         }
     }
 
-    anyhow::bail!("Timed out waiting for source ID lock");
+    anyhow::bail!(
+        "Could not acquire source ID lock after 100 retries (~2500ms)"
+    );
 }
 
 fn write_source_id(path: &Path, source_id: &str) -> Result<()> {

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -3128,9 +3128,28 @@ fn run_submit_command(
 
     let api_url = auth::get_api_base_url();
 
-    let source_id = auth::get_submit_source_id()?;
-    let source_name = auth::get_submit_source_name();
-    let submit_payload = to_ts_token_contribution_data(&graph_result, Some(source_id), source_name);
+    let (source_id, source_name) = match auth::get_submit_source_id() {
+        Ok(source_id) => {
+            let source_name = if source_id.is_some() {
+                auth::get_submit_source_name()
+            } else {
+                None
+            };
+            (source_id, source_name)
+        }
+        Err(err) => {
+            eprintln!(
+                "{}",
+                format!(
+                    "  Warning: could not determine a stable source ID; continuing without source metadata: {}",
+                    err
+                )
+                .yellow()
+            );
+            (None, None)
+        }
+    };
+    let submit_payload = to_ts_token_contribution_data(&graph_result, source_id, source_name);
 
     let response = rt.block_on(async {
         reqwest::Client::new()

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -2580,6 +2580,10 @@ struct TsDataSummary {
 struct TsExportMeta {
     generated_at: String,
     version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_name: Option<String>,
     date_range: DateRange,
 }
 
@@ -2592,11 +2596,17 @@ struct TsTokenContributionData {
     contributions: Vec<TsDailyContribution>,
 }
 
-fn to_ts_token_contribution_data(graph: &tokscale_core::GraphResult) -> TsTokenContributionData {
+fn to_ts_token_contribution_data(
+    graph: &tokscale_core::GraphResult,
+    source_id: Option<String>,
+    source_name: Option<String>,
+) -> TsTokenContributionData {
     TsTokenContributionData {
         meta: TsExportMeta {
             generated_at: graph.meta.generated_at.clone(),
             version: graph.meta.version.clone(),
+            source_id,
+            source_name,
             date_range: DateRange {
                 start: graph.meta.date_range_start.clone(),
                 end: graph.meta.date_range_end.clone(),
@@ -2874,7 +2884,7 @@ fn run_graph_command(
         .map_err(|e| anyhow::anyhow!(e))?;
 
     let processing_time_ms = start.elapsed().as_millis() as u32;
-    let output_data = to_ts_token_contribution_data(&graph_result);
+    let output_data = to_ts_token_contribution_data(&graph_result, None, None);
     let json_output = serde_json::to_string_pretty(&output_data)?;
 
     if let Some(output_path) = output {
@@ -3118,7 +3128,9 @@ fn run_submit_command(
 
     let api_url = auth::get_api_base_url();
 
-    let submit_payload = to_ts_token_contribution_data(&graph_result);
+    let source_id = auth::get_submit_source_id()?;
+    let source_name = auth::get_submit_source_name();
+    let submit_payload = to_ts_token_contribution_data(&graph_result, Some(source_id), source_name);
 
     let response = rt.block_on(async {
         reqwest::Client::new()

--- a/packages/frontend/__tests__/api/submitSourceScope.test.ts
+++ b/packages/frontend/__tests__/api/submitSourceScope.test.ts
@@ -257,6 +257,16 @@ type ModuleExports = typeof import("../../src/app/api/submit/route");
 
 let POST: ModuleExports["POST"];
 
+function serializeSqlCalls(): string[] {
+  return mockState.sql.mock.calls.map((call) => {
+    const [strings, ...values] = call as [TemplateStringsArray, ...unknown[]];
+    return Array.from(strings).reduce((text, part, index) => {
+      const nextValue = index < values.length ? String(values[index]) : "";
+      return `${text}${part}${nextValue}`;
+    }, "");
+  });
+}
+
 function createSubmissionData(metaOverrides: Partial<{ sourceId: string; sourceName: string }> = {}) {
   return {
     meta: {
@@ -617,5 +627,36 @@ describe("POST /api/submit source scoping", () => {
         sourceName: null,
       }),
     });
+  });
+
+  it("counts only token-bearing dates in response active-day metrics", async () => {
+    mockState.validateSubmission.mockReturnValue({
+      valid: true,
+      data: createSubmissionData({
+        sourceId: "machine-a",
+        sourceName: "MacBook Air",
+      }),
+      errors: [],
+      warnings: [],
+    });
+    queueSuccessfulTransaction();
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(
+      serializeSqlCalls().some((text) =>
+        text.includes("COUNT(DISTINCT CASE WHEN dailyBreakdown.tokens > 0 THEN dailyBreakdown.date END)::int")
+      )
+    ).toBe(true);
   });
 });

--- a/packages/frontend/__tests__/api/submitSourceScope.test.ts
+++ b/packages/frontend/__tests__/api/submitSourceScope.test.ts
@@ -1,0 +1,449 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  type Row = Record<string, unknown>;
+
+  const selectResults: Row[][] = [];
+  const insertReturningResults: Row[][] = [];
+  const whereCalls: Array<{ table: unknown; condition: unknown }> = [];
+  const insertCalls: Array<{ table: unknown; values: unknown }> = [];
+  const updateCalls: Array<{ table: unknown; values: unknown; condition: unknown }> = [];
+
+  const tables = {
+    apiTokens: {
+      id: "apiTokens.id",
+    },
+    submissions: {
+      id: "submissions.id",
+      userId: "submissions.userId",
+      sourceId: "submissions.sourceId",
+      sourceName: "submissions.sourceName",
+      totalTokens: "submissions.totalTokens",
+      totalCost: "submissions.totalCost",
+      inputTokens: "submissions.inputTokens",
+      outputTokens: "submissions.outputTokens",
+      cacheCreationTokens: "submissions.cacheCreationTokens",
+      cacheReadTokens: "submissions.cacheReadTokens",
+      reasoningTokens: "submissions.reasoningTokens",
+      dateStart: "submissions.dateStart",
+      dateEnd: "submissions.dateEnd",
+      sourcesUsed: "submissions.sourcesUsed",
+      modelsUsed: "submissions.modelsUsed",
+      submitCount: "submissions.submitCount",
+      schemaVersion: "submissions.schemaVersion",
+      updatedAt: "submissions.updatedAt",
+    },
+    dailyBreakdown: {
+      id: "dailyBreakdown.id",
+      submissionId: "dailyBreakdown.submissionId",
+      date: "dailyBreakdown.date",
+      tokens: "dailyBreakdown.tokens",
+      cost: "dailyBreakdown.cost",
+      inputTokens: "dailyBreakdown.inputTokens",
+      outputTokens: "dailyBreakdown.outputTokens",
+      timestampMs: "dailyBreakdown.timestampMs",
+      sourceBreakdown: "dailyBreakdown.sourceBreakdown",
+      modelBreakdown: "dailyBreakdown.modelBreakdown",
+    },
+  };
+
+  const eq = vi.fn((left: unknown, right: unknown) => ({ type: "eq", left, right }));
+  const and = vi.fn((...conditions: unknown[]) => ({ type: "and", conditions }));
+  const isNull = vi.fn((value: unknown) => ({ type: "isNull", value }));
+  const sql = Object.assign(
+    vi.fn(() => ({ kind: "sql" })),
+    {
+      join: vi.fn(() => ({ kind: "sql.join" })),
+    }
+  );
+
+  function nextSelectResult() {
+    return selectResults.shift() ?? [];
+  }
+
+  function nextInsertReturningResult() {
+    return insertReturningResults.shift() ?? [];
+  }
+
+  function createSelectBuilder() {
+    let table: unknown;
+    const builder = {
+      from: vi.fn((nextTable: unknown) => {
+        table = nextTable;
+        return builder;
+      }),
+      innerJoin: vi.fn(() => builder),
+      where: vi.fn((condition: unknown) => {
+        whereCalls.push({ table, condition });
+        return builder;
+      }),
+      for: vi.fn(() => builder),
+      limit: vi.fn(() => builder),
+      then: (resolve: (value: unknown) => unknown) => resolve(nextSelectResult()),
+    };
+    return builder;
+  }
+
+  function createInsertBuilder(table: unknown) {
+    return {
+      values: vi.fn((values: unknown) => {
+        insertCalls.push({ table, values });
+        return {
+          returning: vi.fn(async () => nextInsertReturningResult()),
+          then: (resolve: (value: unknown) => unknown) => resolve([]),
+        };
+      }),
+    };
+  }
+
+  function createUpdateBuilder(table: unknown) {
+    return {
+      set: vi.fn((values: unknown) => ({
+        where: vi.fn(async (condition: unknown) => {
+          updateCalls.push({ table, values, condition });
+          return [];
+        }),
+      })),
+    };
+  }
+
+  const transaction = vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => {
+    const tx = {
+      select: vi.fn(() => createSelectBuilder()),
+      insert: vi.fn((table: unknown) => createInsertBuilder(table)),
+      update: vi.fn((table: unknown) => createUpdateBuilder(table)),
+      execute: vi.fn(async () => []),
+    };
+    return callback(tx);
+  });
+
+  return {
+    authenticatePersonalToken: vi.fn(),
+    validateSubmission: vi.fn(),
+    generateSubmissionHash: vi.fn(() => "submission-hash"),
+    revalidateTag: vi.fn(),
+    db: {
+      transaction,
+    },
+    tables,
+    eq,
+    and,
+    isNull,
+    sql,
+    whereCalls,
+    insertCalls,
+    updateCalls,
+    reset() {
+      selectResults.length = 0;
+      insertReturningResults.length = 0;
+      whereCalls.length = 0;
+      insertCalls.length = 0;
+      updateCalls.length = 0;
+      this.authenticatePersonalToken.mockReset();
+      this.validateSubmission.mockReset();
+      this.generateSubmissionHash.mockClear();
+      this.revalidateTag.mockClear();
+      transaction.mockClear();
+      eq.mockClear();
+      and.mockClear();
+      isNull.mockClear();
+      sql.mockClear();
+      sql.join.mockClear();
+    },
+    pushSelectResult(rows: Row[]) {
+      selectResults.push(rows);
+    },
+    pushInsertReturningResult(rows: Row[]) {
+      insertReturningResults.push(rows);
+    },
+  };
+});
+
+vi.mock("next/cache", () => ({
+  revalidateTag: mockState.revalidateTag,
+}));
+
+vi.mock("@/lib/auth/personalTokens", () => ({
+  authenticatePersonalToken: mockState.authenticatePersonalToken,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockState.db,
+  apiTokens: mockState.tables.apiTokens,
+  submissions: mockState.tables.submissions,
+  dailyBreakdown: mockState.tables.dailyBreakdown,
+}));
+
+vi.mock("@/lib/validation/submission", () => ({
+  validateSubmission: mockState.validateSubmission,
+  generateSubmissionHash: mockState.generateSubmissionHash,
+}));
+
+vi.mock("@/lib/db/helpers", () => ({
+  mergeClientBreakdowns: vi.fn((_existing, incoming) => incoming),
+  recalculateDayTotals: vi.fn((clientBreakdown) => {
+    let tokens = 0;
+    let cost = 0;
+    let inputTokens = 0;
+    let outputTokens = 0;
+    for (const client of Object.values(clientBreakdown as Record<string, {
+      tokens: number;
+      cost: number;
+      input: number;
+      output: number;
+    }>)) {
+      tokens += client.tokens;
+      cost += client.cost;
+      inputTokens += client.input;
+      outputTokens += client.output;
+    }
+    return {
+      tokens,
+      cost,
+      inputTokens,
+      outputTokens,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      reasoningTokens: 0,
+    };
+  }),
+  buildModelBreakdown: vi.fn(() => ({})),
+  clientContributionToBreakdownData: vi.fn((client) => ({
+    tokens: client.tokens.input + client.tokens.output + client.tokens.cacheRead + client.tokens.cacheWrite + (client.tokens.reasoning || 0),
+    cost: client.cost,
+    input: client.tokens.input,
+    output: client.tokens.output,
+    cacheRead: client.tokens.cacheRead,
+    cacheWrite: client.tokens.cacheWrite,
+    reasoning: client.tokens.reasoning || 0,
+    messages: client.messages,
+  })),
+  mergeTimestampMs: vi.fn((existing, incoming) => incoming ?? existing ?? null),
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: mockState.eq,
+  and: mockState.and,
+  isNull: mockState.isNull,
+  sql: mockState.sql,
+}));
+
+type ModuleExports = typeof import("../../src/app/api/submit/route");
+
+let POST: ModuleExports["POST"];
+
+function createSubmissionData(metaOverrides: Partial<{ sourceId: string; sourceName: string }> = {}) {
+  return {
+    meta: {
+      generatedAt: "2026-03-29T00:00:00.000Z",
+      version: "2.0.14",
+      dateRange: {
+        start: "2026-03-01",
+        end: "2026-03-01",
+      },
+      ...metaOverrides,
+    },
+    summary: {
+      totalTokens: 150,
+      totalCost: 1.5,
+      totalDays: 1,
+      activeDays: 1,
+      averagePerDay: 1.5,
+      maxCostInSingleDay: 1.5,
+      clients: ["claude"],
+      models: ["claude-sonnet-4-20250514"],
+    },
+    years: [],
+    contributions: [
+      {
+        date: "2026-03-01",
+        totals: {
+          tokens: 150,
+          cost: 1.5,
+          messages: 2,
+        },
+        intensity: 1,
+        tokenBreakdown: {
+          input: 100,
+          output: 50,
+          cacheRead: 0,
+          cacheWrite: 0,
+          reasoning: 0,
+        },
+        clients: [
+          {
+            client: "claude",
+            modelId: "claude-sonnet-4-20250514",
+            tokens: {
+              input: 100,
+              output: 50,
+              cacheRead: 0,
+              cacheWrite: 0,
+              reasoning: 0,
+            },
+            cost: 1.5,
+            messages: 2,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+beforeAll(async () => {
+  const routeModule = await import("../../src/app/api/submit/route");
+  POST = routeModule.POST;
+});
+
+beforeEach(() => {
+  mockState.reset();
+  mockState.authenticatePersonalToken.mockResolvedValue({
+    status: "valid",
+    tokenId: "token-1",
+    userId: "user-1",
+    username: "alice",
+  });
+});
+
+function queueSuccessfulTransaction(existingSubmissionRows: Array<Record<string, unknown>> = []) {
+  mockState.pushSelectResult(existingSubmissionRows);
+  mockState.pushInsertReturningResult([{ id: "submission-1" }]);
+  mockState.pushSelectResult([]);
+  mockState.pushSelectResult([
+    {
+      totalTokens: 150,
+      totalCost: "1.5000",
+      inputTokens: 100,
+      outputTokens: 50,
+      dateStart: "2026-03-01",
+      dateEnd: "2026-03-01",
+      activeDays: 1,
+      rowCount: 1,
+    },
+  ]);
+  mockState.pushSelectResult([
+    {
+      sourceBreakdown: {
+        claude: {
+          tokens: 150,
+          cost: 1.5,
+          input: 100,
+          output: 50,
+          cacheRead: 0,
+          cacheWrite: 0,
+          reasoning: 0,
+          messages: 2,
+          models: {
+            "claude-sonnet-4-20250514": {
+              tokens: 150,
+              cost: 1.5,
+              input: 100,
+              output: 50,
+              cacheRead: 0,
+              cacheWrite: 0,
+              reasoning: 0,
+              messages: 2,
+            },
+          },
+        },
+      },
+    },
+  ]);
+  mockState.pushSelectResult([
+    {
+      totalTokens: 150,
+      totalCost: "1.5000",
+      dateStart: "2026-03-01",
+      dateEnd: "2026-03-01",
+    },
+  ]);
+  mockState.pushSelectResult([{ activeDays: 1 }]);
+  mockState.pushSelectResult([{ sourcesUsed: ["claude"] }]);
+}
+
+describe("POST /api/submit source scoping", () => {
+  it("looks up and creates a source-scoped submission when sourceId is present", async () => {
+    mockState.validateSubmission.mockReturnValue({
+      valid: true,
+      data: createSubmissionData({
+        sourceId: "machine-a",
+        sourceName: "MacBook Air",
+      }),
+      errors: [],
+      warnings: [],
+    });
+    queueSuccessfulTransaction();
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockState.whereCalls[0]).toEqual({
+      table: mockState.tables.submissions,
+      condition: {
+        type: "and",
+        conditions: [
+          { type: "eq", left: "submissions.userId", right: "user-1" },
+          { type: "eq", left: "submissions.sourceId", right: "machine-a" },
+        ],
+      },
+    });
+    expect(mockState.insertCalls[0]).toEqual({
+      table: mockState.tables.submissions,
+      values: expect.objectContaining({
+        userId: "user-1",
+        sourceId: "machine-a",
+        sourceName: "MacBook Air",
+      }),
+    });
+  });
+
+  it("uses the unsourced submission row when sourceId is absent", async () => {
+    mockState.validateSubmission.mockReturnValue({
+      valid: true,
+      data: createSubmissionData(),
+      errors: [],
+      warnings: [],
+    });
+    queueSuccessfulTransaction();
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockState.whereCalls[0]).toEqual({
+      table: mockState.tables.submissions,
+      condition: {
+        type: "and",
+        conditions: [
+          { type: "eq", left: "submissions.userId", right: "user-1" },
+          { type: "isNull", value: "submissions.sourceId" },
+        ],
+      },
+    });
+    expect(mockState.insertCalls[0]).toEqual({
+      table: mockState.tables.submissions,
+      values: expect.objectContaining({
+        userId: "user-1",
+        sourceId: null,
+        sourceName: null,
+      }),
+    });
+  });
+});

--- a/packages/frontend/__tests__/api/submitSourceScope.test.ts
+++ b/packages/frontend/__tests__/api/submitSourceScope.test.ts
@@ -3,7 +3,8 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 const mockState = vi.hoisted(() => {
   type Row = Record<string, unknown>;
 
-  const selectResults: Row[][] = [];
+  const txSelectResults: Row[][] = [];
+  const dbSelectResults: Row[][] = [];
   const insertReturningResults: Row[][] = [];
   const whereCalls: Array<{ table: unknown; condition: unknown }> = [];
   const insertCalls: Array<{ table: unknown; values: unknown }> = [];
@@ -57,8 +58,12 @@ const mockState = vi.hoisted(() => {
     }
   );
 
-  function nextSelectResult() {
-    return selectResults.shift() ?? [];
+  function nextTxSelectResult() {
+    return txSelectResults.shift() ?? [];
+  }
+
+  function nextDbSelectResult() {
+    return dbSelectResults.shift() ?? [];
   }
 
   function nextInsertReturningResult() {
@@ -79,7 +84,17 @@ const mockState = vi.hoisted(() => {
       }),
       for: vi.fn(() => builder),
       limit: vi.fn(() => builder),
-      then: (resolve: (value: unknown) => unknown) => resolve(nextSelectResult()),
+      then: (resolve: (value: unknown) => unknown) => resolve(nextTxSelectResult()),
+    };
+    return builder;
+  }
+
+  function createDbSelectBuilder() {
+    const builder = {
+      from: vi.fn(() => builder),
+      innerJoin: vi.fn(() => builder),
+      where: vi.fn(() => builder),
+      then: (resolve: (value: unknown) => unknown) => resolve(nextDbSelectResult()),
     };
     return builder;
   }
@@ -123,6 +138,7 @@ const mockState = vi.hoisted(() => {
     generateSubmissionHash: vi.fn(() => "submission-hash"),
     revalidateTag: vi.fn(),
     db: {
+      select: vi.fn(() => createDbSelectBuilder()),
       transaction,
     },
     tables,
@@ -134,7 +150,8 @@ const mockState = vi.hoisted(() => {
     insertCalls,
     updateCalls,
     reset() {
-      selectResults.length = 0;
+      txSelectResults.length = 0;
+      dbSelectResults.length = 0;
       insertReturningResults.length = 0;
       whereCalls.length = 0;
       insertCalls.length = 0;
@@ -143,6 +160,7 @@ const mockState = vi.hoisted(() => {
       this.validateSubmission.mockReset();
       this.generateSubmissionHash.mockClear();
       this.revalidateTag.mockClear();
+      this.db.select.mockClear();
       transaction.mockClear();
       eq.mockClear();
       and.mockClear();
@@ -150,8 +168,11 @@ const mockState = vi.hoisted(() => {
       sql.mockClear();
       sql.join.mockClear();
     },
-    pushSelectResult(rows: Row[]) {
-      selectResults.push(rows);
+    pushTxSelectResult(rows: Row[]) {
+      txSelectResults.push(rows);
+    },
+    pushDbSelectResult(rows: Row[]) {
+      dbSelectResults.push(rows);
     },
     pushInsertReturningResult(rows: Row[]) {
       insertReturningResults.push(rows);
@@ -306,10 +327,10 @@ beforeEach(() => {
 });
 
 function queueSuccessfulTransaction(existingSubmissionRows: Array<Record<string, unknown>> = []) {
-  mockState.pushSelectResult(existingSubmissionRows);
+  mockState.pushTxSelectResult(existingSubmissionRows);
   mockState.pushInsertReturningResult([{ id: "submission-1" }]);
-  mockState.pushSelectResult([]);
-  mockState.pushSelectResult([
+  mockState.pushTxSelectResult([]);
+  mockState.pushTxSelectResult([
     {
       totalTokens: 150,
       totalCost: "1.5000",
@@ -321,7 +342,7 @@ function queueSuccessfulTransaction(existingSubmissionRows: Array<Record<string,
       rowCount: 1,
     },
   ]);
-  mockState.pushSelectResult([
+  mockState.pushTxSelectResult([
     {
       sourceBreakdown: {
         claude: {
@@ -349,7 +370,7 @@ function queueSuccessfulTransaction(existingSubmissionRows: Array<Record<string,
       },
     },
   ]);
-  mockState.pushSelectResult([
+  mockState.pushDbSelectResult([
     {
       totalTokens: 150,
       totalCost: "1.5000",
@@ -357,8 +378,8 @@ function queueSuccessfulTransaction(existingSubmissionRows: Array<Record<string,
       dateEnd: "2026-03-01",
     },
   ]);
-  mockState.pushSelectResult([{ activeDays: 1 }]);
-  mockState.pushSelectResult([{ sourcesUsed: ["claude"] }]);
+  mockState.pushDbSelectResult([{ activeDays: 1 }]);
+  mockState.pushDbSelectResult([{ sourcesUsed: ["claude"] }]);
 }
 
 describe("POST /api/submit source scoping", () => {

--- a/packages/frontend/__tests__/api/submitSourceScope.test.ts
+++ b/packages/frontend/__tests__/api/submitSourceScope.test.ts
@@ -100,13 +100,17 @@ const mockState = vi.hoisted(() => {
   }
 
   function createInsertBuilder(table: unknown) {
+    const returning = vi.fn(async () => nextInsertReturningResult());
+    const insertStatement = {
+      onConflictDoNothing: vi.fn(() => insertStatement),
+      returning,
+      then: (resolve: (value: unknown) => unknown) => resolve([]),
+    };
+
     return {
       values: vi.fn((values: unknown) => {
         insertCalls.push({ table, values });
-        return {
-          returning: vi.fn(async () => nextInsertReturningResult()),
-          then: (resolve: (value: unknown) => unknown) => resolve([]),
-        };
+        return insertStatement;
       }),
     };
   }
@@ -382,6 +386,25 @@ function queueSuccessfulTransaction(existingSubmissionRows: Array<Record<string,
   mockState.pushDbSelectResult([{ sourcesUsed: ["claude"] }]);
 }
 
+function expectSubmissionLookup(condition: unknown) {
+  expect(mockState.whereCalls).toContainEqual({
+    table: mockState.tables.submissions,
+    condition,
+  });
+}
+
+function expectSubmissionInsertCount(count: number) {
+  expect(
+    mockState.insertCalls.filter((call) => call.table === mockState.tables.submissions)
+  ).toHaveLength(count);
+}
+
+function expectSubmissionUpdateCount(count: number) {
+  expect(
+    mockState.updateCalls.filter((call) => call.table === mockState.tables.submissions)
+  ).toHaveLength(count);
+}
+
 describe("POST /api/submit source scoping", () => {
   it("looks up and creates a source-scoped submission when sourceId is present", async () => {
     mockState.validateSubmission.mockReturnValue({
@@ -407,16 +430,14 @@ describe("POST /api/submit source scoping", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(mockState.whereCalls[0]).toEqual({
-      table: mockState.tables.submissions,
-      condition: {
-        type: "and",
-        conditions: [
-          { type: "eq", left: "submissions.userId", right: "user-1" },
-          { type: "eq", left: "submissions.sourceId", right: "machine-a" },
-        ],
-      },
+    expectSubmissionLookup({
+      type: "and",
+      conditions: [
+        { type: "eq", left: "submissions.userId", right: "user-1" },
+        { type: "eq", left: "submissions.sourceId", right: "machine-a" },
+      ],
     });
+    expectSubmissionInsertCount(1);
     expect(mockState.insertCalls[0]).toEqual({
       table: mockState.tables.submissions,
       values: expect.objectContaining({
@@ -425,6 +446,139 @@ describe("POST /api/submit source scoping", () => {
         sourceName: "MacBook Air",
       }),
     });
+  });
+
+  it("reuses an existing source-scoped submission on re-submit", async () => {
+    mockState.validateSubmission.mockReturnValue({
+      valid: true,
+      data: createSubmissionData({
+        sourceId: "machine-a",
+        sourceName: "MacBook Air",
+      }),
+      errors: [],
+      warnings: [],
+    });
+    queueSuccessfulTransaction([
+      {
+        id: "submission-existing",
+        sourceName: "MacBook Air",
+      },
+    ]);
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expectSubmissionLookup({
+      type: "and",
+      conditions: [
+        { type: "eq", left: "submissions.userId", right: "user-1" },
+        { type: "eq", left: "submissions.sourceId", right: "machine-a" },
+      ],
+    });
+    expectSubmissionInsertCount(0);
+    expectSubmissionUpdateCount(1);
+  });
+
+  it("recovers when the first insert loses a race for the same source", async () => {
+    mockState.validateSubmission.mockReturnValue({
+      valid: true,
+      data: createSubmissionData({
+        sourceId: "machine-a",
+        sourceName: "MacBook Air",
+      }),
+      errors: [],
+      warnings: [],
+    });
+    mockState.pushTxSelectResult([]);
+    mockState.pushInsertReturningResult([]);
+    mockState.pushTxSelectResult([
+      {
+        id: "submission-raced",
+      },
+    ]);
+    mockState.pushTxSelectResult([
+      {
+        totalTokens: 150,
+        totalCost: "1.5000",
+        inputTokens: 100,
+        outputTokens: 50,
+        dateStart: "2026-03-01",
+        dateEnd: "2026-03-01",
+        activeDays: 1,
+        rowCount: 1,
+      },
+    ]);
+    mockState.pushTxSelectResult([
+      {
+        sourceBreakdown: {
+          claude: {
+            tokens: 150,
+            cost: 1.5,
+            input: 100,
+            output: 50,
+            cacheRead: 0,
+            cacheWrite: 0,
+            reasoning: 0,
+            messages: 2,
+            models: {
+              "claude-sonnet-4-20250514": {
+                tokens: 150,
+                cost: 1.5,
+                input: 100,
+                output: 50,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+                messages: 2,
+              },
+            },
+          },
+        },
+      },
+    ]);
+    mockState.pushDbSelectResult([
+      {
+        totalTokens: 150,
+        totalCost: "1.5000",
+        dateStart: "2026-03-01",
+        dateEnd: "2026-03-01",
+      },
+    ]);
+    mockState.pushDbSelectResult([{ activeDays: 1 }]);
+    mockState.pushDbSelectResult([{ sourcesUsed: ["claude"] }]);
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expectSubmissionInsertCount(1);
+    expectSubmissionLookup({
+      type: "and",
+      conditions: [
+        { type: "eq", left: "submissions.userId", right: "user-1" },
+        { type: "eq", left: "submissions.sourceId", right: "machine-a" },
+      ],
+    });
+    expect(
+      mockState.whereCalls.filter((call) => call.table === mockState.tables.submissions)
+    ).toHaveLength(2);
   });
 
   it("uses the unsourced submission row when sourceId is absent", async () => {
@@ -448,15 +602,12 @@ describe("POST /api/submit source scoping", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(mockState.whereCalls[0]).toEqual({
-      table: mockState.tables.submissions,
-      condition: {
-        type: "and",
-        conditions: [
-          { type: "eq", left: "submissions.userId", right: "user-1" },
-          { type: "isNull", value: "submissions.sourceId" },
-        ],
-      },
+    expectSubmissionLookup({
+      type: "and",
+      conditions: [
+        { type: "eq", left: "submissions.userId", right: "user-1" },
+        { type: "isNull", value: "submissions.sourceId" },
+      ],
     });
     expect(mockState.insertCalls[0]).toEqual({
       table: mockState.tables.submissions,

--- a/packages/frontend/__tests__/api/usersProfile.test.ts
+++ b/packages/frontend/__tests__/api/usersProfile.test.ts
@@ -163,7 +163,7 @@ describe("GET /api/users/[username]", () => {
         cacheReadTokens: 100,
         cacheCreationTokens: 50,
         reasoningTokens: 25,
-        submissionCount: 2,
+        submissionCount: 5,
         earliestDate: "2026-01-01",
         latestDate: "2026-03-10",
       },
@@ -174,6 +174,13 @@ describe("GET /api/users/[username]", () => {
         modelsUsed: ["claude-3-7-sonnet"],
         updatedAt: new Date("2026-01-10T10:00:00.000Z"),
         cliVersion: "1.4.2",
+        schemaVersion: 1,
+      },
+      {
+        sourcesUsed: ["claude"],
+        modelsUsed: ["gpt-4.1"],
+        updatedAt: new Date("2026-01-05T08:00:00.000Z"),
+        cliVersion: "1.4.0",
         schemaVersion: 1,
       },
     ]);
@@ -194,8 +201,9 @@ describe("GET /api/users/[username]", () => {
       isStale: true,
     });
     expect(body.updatedAt).toBe("2026-01-10T10:00:00.000Z");
-    expect(body.clients).toEqual(["cursor"]);
-    expect(body.models).toEqual(["claude-3-7-sonnet"]);
+    expect(body.stats.submissionCount).toBe(5);
+    expect(body.clients).toEqual(["claude", "cursor"]);
+    expect(body.models).toEqual(["claude-3-7-sonnet", "gpt-4.1"]);
   });
 
   it("returns null freshness metadata when the user has no submission yet", async () => {

--- a/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
+++ b/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
@@ -1,0 +1,153 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const selectResults: Array<Array<Record<string, unknown>>> = [];
+  const executeResults: Array<Array<Record<string, unknown>>> = [];
+
+  const tables = {
+    users: {
+      id: "users.id",
+      username: "users.username",
+      displayName: "users.displayName",
+      avatarUrl: "users.avatarUrl",
+    },
+    submissions: {
+      userId: "submissions.userId",
+      totalTokens: "submissions.totalTokens",
+      totalCost: "submissions.totalCost",
+      submitCount: "submissions.submitCount",
+      updatedAt: "submissions.updatedAt",
+    },
+  };
+
+  const eq = vi.fn(() => "eq");
+  const sql = vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings: Array.from(strings),
+    values,
+  }));
+
+  const groupBy = vi.fn(() => builder);
+  const limit = vi.fn(() => builder);
+  const where = vi.fn(() => builder);
+  const leftJoin = vi.fn(() => builder);
+  const from = vi.fn(() => builder);
+  const select = vi.fn(() => builder);
+
+  const builder = {
+    from,
+    leftJoin,
+    where,
+    groupBy,
+    limit,
+    then: (resolve: (value: unknown) => unknown) => resolve(selectResults.shift() ?? []),
+  };
+
+  return {
+    db: {
+      select,
+      execute: vi.fn(async () => executeResults.shift() ?? []),
+    },
+    tables,
+    eq,
+    sql,
+    groupBy,
+    reset() {
+      selectResults.length = 0;
+      executeResults.length = 0;
+      select.mockClear();
+      from.mockClear();
+      leftJoin.mockClear();
+      where.mockClear();
+      groupBy.mockClear();
+      limit.mockClear();
+      this.db.execute.mockClear();
+      eq.mockClear();
+      sql.mockClear();
+    },
+    pushSelectResult(rows: Array<Record<string, unknown>>) {
+      selectResults.push(rows);
+    },
+    pushExecuteResult(rows: Array<Record<string, unknown>>) {
+      executeResults.push(rows);
+    },
+  };
+});
+
+vi.mock("next/cache", () => ({
+  unstable_cache: (fn: () => unknown) => fn,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockState.db,
+  users: mockState.tables.users,
+  submissions: mockState.tables.submissions,
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: mockState.eq,
+  sql: mockState.sql,
+}));
+
+type ModuleExports = typeof import("../../src/lib/embed/getUserEmbedStats");
+
+let getUserEmbedStats: ModuleExports["getUserEmbedStats"];
+
+function serializeSqlCalls(): string[] {
+  return mockState.sql.mock.calls.map((call) => {
+    const [strings, ...values] = call as [TemplateStringsArray, ...unknown[]];
+    return Array.from(strings).reduce((text, part, index) => {
+      const nextValue = index < values.length ? String(values[index]) : "";
+      return `${text}${part}${nextValue}`;
+    }, "");
+  });
+}
+
+beforeAll(async () => {
+  const module = await import("../../src/lib/embed/getUserEmbedStats");
+  getUserEmbedStats = module.getUserEmbedStats;
+});
+
+beforeEach(() => {
+  mockState.reset();
+});
+
+describe("getUserEmbedStats", () => {
+  it("aggregates totals across multiple submission rows", async () => {
+    mockState.pushSelectResult([
+      {
+        id: "user-1",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        totalTokens: 300,
+        totalCost: 3.5,
+        submissionCount: 5,
+        updatedAt: new Date("2026-03-29T10:00:00.000Z"),
+      },
+    ]);
+    mockState.pushExecuteResult([{ rank: 2 }]);
+
+    const result = await getUserEmbedStats("alice", "tokens");
+    const sqlTexts = serializeSqlCalls();
+
+    expect(mockState.groupBy).toHaveBeenCalled();
+    expect(sqlTexts.some((text) =>
+      text.includes("WITH user_totals AS") && text.includes("GROUP BY user_id")
+    )).toBe(true);
+    expect(result).toEqual({
+      user: {
+        id: "user-1",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+      },
+      stats: {
+        totalTokens: 300,
+        totalCost: 3.5,
+        submissionCount: 5,
+        rank: 2,
+        updatedAt: "2026-03-29T10:00:00.000Z",
+      },
+    });
+  });
+});

--- a/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
+++ b/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
@@ -170,4 +170,24 @@ describe("getUserEmbedStats", () => {
 
     expect(result?.stats.updatedAt).toBe("2026-03-29T10:00:00.000Z");
   });
+
+  it("normalizes aggregate ranks returned as strings", async () => {
+    mockState.pushSelectResult([
+      {
+        id: "user-1",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        totalTokens: 300,
+        totalCost: 3.5,
+        submissionCount: 5,
+        updatedAt: new Date("2026-03-29T10:00:00.000Z"),
+      },
+    ]);
+    mockState.pushExecuteResult([{ rank: "2" }]);
+
+    const result = await getUserEmbedStats("alice", "tokens");
+
+    expect(result?.stats.rank).toBe(2);
+  });
 });

--- a/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
+++ b/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
@@ -150,4 +150,24 @@ describe("getUserEmbedStats", () => {
       },
     });
   });
+
+  it("normalizes aggregate timestamps returned as strings", async () => {
+    mockState.pushSelectResult([
+      {
+        id: "user-1",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        totalTokens: 300,
+        totalCost: 3.5,
+        submissionCount: 5,
+        updatedAt: "2026-03-29T10:00:00.000Z",
+      },
+    ]);
+    mockState.pushExecuteResult([{ rank: 2 }]);
+
+    const result = await getUserEmbedStats("alice", "tokens");
+
+    expect(result?.stats.updatedAt).toBe("2026-03-29T10:00:00.000Z");
+  });
 });

--- a/packages/frontend/__tests__/lib/validateSubmission.test.ts
+++ b/packages/frontend/__tests__/lib/validateSubmission.test.ts
@@ -80,7 +80,8 @@ describe("validateSubmission", () => {
     );
 
     expect(result.valid).toBe(true);
-    expect(result.data?.meta.sourceId).toBeUndefined();
-    expect(result.data?.meta.sourceName).toBeUndefined();
+    expect(result.data).toBeDefined();
+    expect(result.data!.meta.sourceId).toBeUndefined();
+    expect(result.data!.meta.sourceName).toBeUndefined();
   });
 });

--- a/packages/frontend/__tests__/lib/validateSubmission.test.ts
+++ b/packages/frontend/__tests__/lib/validateSubmission.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { validateSubmission } from "../../src/lib/validation/submission";
+
+function createValidSubmission(metaOverrides: Partial<Record<"sourceId" | "sourceName", string>> = {}) {
+  return {
+    meta: {
+      generatedAt: "2026-03-31T00:00:00.000Z",
+      version: "2.0.14",
+      dateRange: {
+        start: "2026-03-01",
+        end: "2026-03-01",
+      },
+      ...metaOverrides,
+    },
+    summary: {
+      totalTokens: 150,
+      totalCost: 1.5,
+      totalDays: 1,
+      activeDays: 1,
+      averagePerDay: 1.5,
+      maxCostInSingleDay: 1.5,
+      clients: ["claude"],
+      models: ["claude-sonnet-4-20250514"],
+    },
+    years: [
+      {
+        year: "2026",
+        totalTokens: 150,
+        totalCost: 1.5,
+        range: {
+          start: "2026-03-01",
+          end: "2026-03-01",
+        },
+      },
+    ],
+    contributions: [
+      {
+        date: "2026-03-01",
+        timestampMs: 1740787200000,
+        totals: {
+          tokens: 150,
+          cost: 1.5,
+          messages: 2,
+        },
+        intensity: 1,
+        tokenBreakdown: {
+          input: 100,
+          output: 50,
+          cacheRead: 0,
+          cacheWrite: 0,
+          reasoning: 0,
+        },
+        clients: [
+          {
+            client: "claude",
+            modelId: "claude-sonnet-4-20250514",
+            tokens: {
+              input: 100,
+              output: 50,
+              cacheRead: 0,
+              cacheWrite: 0,
+              reasoning: 0,
+            },
+            cost: 1.5,
+            messages: 2,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("validateSubmission", () => {
+  it("treats blank optional source metadata as absent", () => {
+    const result = validateSubmission(
+      createValidSubmission({
+        sourceId: "   ",
+        sourceName: "\t",
+      })
+    );
+
+    expect(result.valid).toBe(true);
+    expect(result.data?.meta.sourceId).toBeUndefined();
+    expect(result.data?.meta.sourceName).toBeUndefined();
+  });
+});

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -51,6 +51,51 @@ function normalizeOptionalString(value: string | undefined): string | null {
   return trimmed === "" ? null : trimmed;
 }
 
+async function loadUserSubmitMetrics(userId: string) {
+  const [userAggregates, userDayAggregates, userSubmissions] = await Promise.all([
+    db
+      .select({
+        totalTokens: sql<number>`COALESCE(SUM(${submissions.totalTokens}), 0)::bigint`,
+        totalCost: sql<string>`COALESCE(SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4))), 0)::text`,
+        dateStart: sql<string>`MIN(${submissions.dateStart})`,
+        dateEnd: sql<string>`MAX(${submissions.dateEnd})`,
+      })
+      .from(submissions)
+      .where(eq(submissions.userId, userId)),
+    db
+      .select({
+        activeDays: sql<number>`COUNT(DISTINCT ${dailyBreakdown.date})::int`,
+      })
+      .from(dailyBreakdown)
+      .innerJoin(submissions, eq(dailyBreakdown.submissionId, submissions.id))
+      .where(eq(submissions.userId, userId)),
+    db
+      .select({
+        sourcesUsed: submissions.sourcesUsed,
+      })
+      .from(submissions)
+      .where(eq(submissions.userId, userId)),
+  ]);
+
+  const userClients = new Set<string>();
+  for (const submission of userSubmissions) {
+    for (const client of submission.sourcesUsed || []) {
+      userClients.add(client);
+    }
+  }
+
+  return {
+    totalTokens: userAggregates?.totalTokens ?? 0,
+    totalCost: parseFloat(userAggregates?.totalCost ?? "0"),
+    dateRange: {
+      start: userAggregates?.dateStart ?? null,
+      end: userAggregates?.dateEnd ?? null,
+    },
+    activeDays: userDayAggregates?.activeDays ?? 0,
+    clients: Array.from(userClients).sort(),
+  };
+}
+
 /**
  * POST /api/submit
  * Submit token usage data from CLI
@@ -423,53 +468,13 @@ export async function POST(request: Request) {
         })
         .where(eq(submissions.id, submissionId));
 
-      const [userAggregates] = await tx
-        .select({
-          totalTokens: sql<number>`COALESCE(SUM(${submissions.totalTokens}), 0)::bigint`,
-          totalCost: sql<string>`COALESCE(SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4))), 0)::text`,
-          dateStart: sql<string>`MIN(${submissions.dateStart})`,
-          dateEnd: sql<string>`MAX(${submissions.dateEnd})`,
-        })
-        .from(submissions)
-        .where(eq(submissions.userId, tokenRecord.userId));
-
-      const [userDayAggregates] = await tx
-        .select({
-          activeDays: sql<number>`COUNT(DISTINCT ${dailyBreakdown.date})::int`,
-        })
-        .from(dailyBreakdown)
-        .innerJoin(submissions, eq(dailyBreakdown.submissionId, submissions.id))
-        .where(eq(submissions.userId, tokenRecord.userId));
-
-      const userSubmissions = await tx
-        .select({
-          sourcesUsed: submissions.sourcesUsed,
-        })
-        .from(submissions)
-        .where(eq(submissions.userId, tokenRecord.userId));
-
-      const userClients = new Set<string>();
-      for (const submission of userSubmissions) {
-        for (const client of submission.sourcesUsed || []) {
-          userClients.add(client);
-        }
-      }
-
       return {
         submissionId,
         isNewSubmission,
-        metrics: {
-          totalTokens: userAggregates.totalTokens,
-          totalCost: parseFloat(userAggregates.totalCost),
-          dateRange: {
-            start: userAggregates.dateStart,
-            end: userAggregates.dateEnd,
-          },
-          activeDays: userDayAggregates.activeDays,
-          clients: Array.from(userClients).sort(),
-        },
       };
     });
+
+    const metrics = await loadUserSubmitMetrics(tokenRecord.userId);
 
     try {
       revalidateTag("leaderboard", "max");
@@ -484,7 +489,7 @@ export async function POST(request: Request) {
       success: true,
       submissionId: result.submissionId,
       username: tokenRecord.username,
-      metrics: result.metrics,
+      metrics,
       mode: result.isNewSubmission ? "create" : "merge",
       warnings: validation.warnings.length > 0 ? validation.warnings : undefined,
     });

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { db, apiTokens, submissions, dailyBreakdown } from "@/lib/db";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import {
   validateSubmission,
   generateSubmissionHash,
@@ -43,6 +43,12 @@ function normalizeSubmissionData(data: unknown): void {
       }
     }
   }
+}
+
+function normalizeOptionalString(value: string | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
 }
 
 /**
@@ -130,6 +136,8 @@ export async function POST(request: Request) {
         clients: Array.from(submittedClients).sort(),
       },
     };
+    const sourceId = normalizeOptionalString(data.meta.sourceId);
+    const sourceName = normalizeOptionalString(data.meta.sourceName);
 
     // ========================================
     // STEP 3: DATABASE OPERATIONS IN TRANSACTION
@@ -144,9 +152,19 @@ export async function POST(request: Request) {
       // STEP 3a: Get or create user's submission
       // ------------------------------------------
       const [existingSubmission] = await tx
-        .select({ id: submissions.id })
+        .select({ id: submissions.id, sourceName: submissions.sourceName })
         .from(submissions)
-        .where(eq(submissions.userId, tokenRecord.userId))
+        .where(
+          sourceId
+            ? and(
+                eq(submissions.userId, tokenRecord.userId),
+                eq(submissions.sourceId, sourceId)
+              )
+            : and(
+                eq(submissions.userId, tokenRecord.userId),
+                isNull(submissions.sourceId)
+              )
+        )
         .for('update')
         .limit(1);
 
@@ -161,6 +179,8 @@ export async function POST(request: Request) {
           .insert(submissions)
           .values({
             userId: tokenRecord.userId,
+            sourceId,
+            sourceName,
             totalTokens: 0,
             totalCost: "0",
             inputTokens: 0,
@@ -392,8 +412,9 @@ export async function POST(request: Request) {
           reasoningTokens: totalReasoning,
           dateStart: aggregates.dateStart,
           dateEnd: aggregates.dateEnd,
-           sourcesUsed: Array.from(allClients),
-           modelsUsed: Array.from(allModels),
+          sourceName: sourceName ?? existingSubmission?.sourceName ?? null,
+          sourcesUsed: Array.from(allClients),
+          modelsUsed: Array.from(allModels),
           cliVersion: data.meta.version,
           submissionHash: generateSubmissionHash(hashData),
           submitCount: sql`COALESCE(submit_count, 0) + 1`,
@@ -402,18 +423,50 @@ export async function POST(request: Request) {
         })
         .where(eq(submissions.id, submissionId));
 
+      const [userAggregates] = await tx
+        .select({
+          totalTokens: sql<number>`COALESCE(SUM(${submissions.totalTokens}), 0)::bigint`,
+          totalCost: sql<string>`COALESCE(SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4))), 0)::text`,
+          dateStart: sql<string>`MIN(${submissions.dateStart})`,
+          dateEnd: sql<string>`MAX(${submissions.dateEnd})`,
+        })
+        .from(submissions)
+        .where(eq(submissions.userId, tokenRecord.userId));
+
+      const [userDayAggregates] = await tx
+        .select({
+          activeDays: sql<number>`COUNT(DISTINCT ${dailyBreakdown.date})::int`,
+        })
+        .from(dailyBreakdown)
+        .innerJoin(submissions, eq(dailyBreakdown.submissionId, submissions.id))
+        .where(eq(submissions.userId, tokenRecord.userId));
+
+      const userSubmissions = await tx
+        .select({
+          sourcesUsed: submissions.sourcesUsed,
+        })
+        .from(submissions)
+        .where(eq(submissions.userId, tokenRecord.userId));
+
+      const userClients = new Set<string>();
+      for (const submission of userSubmissions) {
+        for (const client of submission.sourcesUsed || []) {
+          userClients.add(client);
+        }
+      }
+
       return {
         submissionId,
         isNewSubmission,
         metrics: {
-          totalTokens: aggregates.totalTokens,
-          totalCost: parseFloat(aggregates.totalCost),
+          totalTokens: userAggregates.totalTokens,
+          totalCost: parseFloat(userAggregates.totalCost),
           dateRange: {
-            start: aggregates.dateStart,
-            end: aggregates.dateEnd,
+            start: userAggregates.dateStart,
+            end: userAggregates.dateEnd,
           },
-          activeDays: aggregates.activeDays,
-          clients: Array.from(allClients),
+          activeDays: userDayAggregates.activeDays,
+          clients: Array.from(userClients).sort(),
         },
       };
     });

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -64,7 +64,7 @@ async function loadUserSubmitMetrics(userId: string) {
       .where(eq(submissions.userId, userId)),
     db
       .select({
-        activeDays: sql<number>`COUNT(DISTINCT ${dailyBreakdown.date})::int`,
+        activeDays: sql<number>`COUNT(DISTINCT CASE WHEN ${dailyBreakdown.tokens} > 0 THEN ${dailyBreakdown.date} END)::int`,
       })
       .from(dailyBreakdown)
       .innerJoin(submissions, eq(dailyBreakdown.submissionId, submissions.id))

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -52,7 +52,7 @@ function normalizeOptionalString(value: string | undefined): string | null {
 }
 
 async function loadUserSubmitMetrics(userId: string) {
-  const [userAggregates, userDayAggregates, userSubmissions] = await Promise.all([
+  const [userAggregatesRows, userDayAggregatesRows, userSubmissionsRows] = await Promise.all([
     db
       .select({
         totalTokens: sql<number>`COALESCE(SUM(${submissions.totalTokens}), 0)::bigint`,
@@ -76,6 +76,10 @@ async function loadUserSubmitMetrics(userId: string) {
       .from(submissions)
       .where(eq(submissions.userId, userId)),
   ]);
+
+  const [userAggregates] = userAggregatesRows;
+  const [userDayAggregates] = userDayAggregatesRows;
+  const userSubmissions = userSubmissionsRows;
 
   const userClients = new Set<string>();
   for (const submission of userSubmissions) {
@@ -240,9 +244,34 @@ export async function POST(request: Request) {
             cliVersion: data.meta.version,
             submissionHash: generateSubmissionHash(hashData),
           })
+          .onConflictDoNothing()
           .returning({ id: submissions.id });
 
-        submissionId = newSubmission.id;
+        if (newSubmission) {
+          submissionId = newSubmission.id;
+        } else {
+          const [conflictedSubmission] = await tx
+            .select({ id: submissions.id })
+            .from(submissions)
+            .where(
+              sourceId
+                ? and(
+                    eq(submissions.userId, tokenRecord.userId),
+                    eq(submissions.sourceId, sourceId)
+                  )
+                : and(
+                    eq(submissions.userId, tokenRecord.userId),
+                    isNull(submissions.sourceId)
+                  )
+            )
+            .limit(1);
+
+          if (!conflictedSubmission) {
+            throw new Error("Submission row was not found after insert conflict");
+          }
+
+          submissionId = conflictedSubmission.id;
+        }
       }
 
       // ------------------------------------------

--- a/packages/frontend/src/app/api/users/[username]/route.ts
+++ b/packages/frontend/src/app/api/users/[username]/route.ts
@@ -43,7 +43,7 @@ export async function GET(_request: Request, { params }: RouteParams) {
           cacheReadTokens: sql<number>`COALESCE(SUM(${submissions.cacheReadTokens}), 0)`,
           cacheCreationTokens: sql<number>`COALESCE(SUM(${submissions.cacheCreationTokens}), 0)`,
           reasoningTokens: sql<number>`COALESCE(SUM(${submissions.reasoningTokens}), 0)`,
-          submissionCount: sql<number>`COALESCE(MAX(${submissions.submitCount}), 0)`,
+          submissionCount: sql<number>`COALESCE(SUM(${submissions.submitCount}), 0)`,
           earliestDate: sql<string>`MIN(${submissions.dateStart})`,
           latestDate: sql<string>`MAX(${submissions.dateEnd})`,
         })
@@ -60,8 +60,7 @@ export async function GET(_request: Request, { params }: RouteParams) {
         })
         .from(submissions)
         .where(eq(submissions.userId, user.id))
-        .orderBy(desc(submissions.updatedAt))
-        .limit(1),
+        .orderBy(desc(submissions.updatedAt)),
 
       db.execute<{ rank: number }>(sql`
         WITH user_totals AS (
@@ -105,6 +104,17 @@ export async function GET(_request: Request, { params }: RouteParams) {
     const [stats] = statsResult;
     const [latestSubmission] = latestSubmissionResult;
     const rank = (rankResult as unknown as { rank: number }[])[0]?.rank || null;
+    const clients = new Set<string>();
+    const models = new Set<string>();
+
+    for (const submission of latestSubmissionResult) {
+      for (const client of submission.sourcesUsed || []) {
+        clients.add(client);
+      }
+      for (const model of submission.modelsUsed || []) {
+        models.add(model);
+      }
+    }
 
     type ModelData = {
       tokens: number;
@@ -392,8 +402,8 @@ export async function GET(_request: Request, { params }: RouteParams) {
         cliVersion: latestSubmission?.cliVersion,
         schemaVersion: latestSubmission?.schemaVersion,
       }),
-      clients: latestSubmission?.sourcesUsed || [],
-      models: latestSubmission?.modelsUsed || [],
+      clients: Array.from(clients).sort(),
+      models: Array.from(models).sort(),
       modelUsage,
       contributions: graphContributions,
     });

--- a/packages/frontend/src/lib/db/migrations/0005_narrow_thena.sql
+++ b/packages/frontend/src/lib/db/migrations/0005_narrow_thena.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "submissions" DROP CONSTRAINT "submissions_user_id_unique";--> statement-breakpoint
+ALTER TABLE "submissions" DROP CONSTRAINT "submissions_user_hash_unique";--> statement-breakpoint
+ALTER TABLE "submissions" ADD COLUMN "source_id" varchar(255);--> statement-breakpoint
+ALTER TABLE "submissions" ADD COLUMN "source_name" varchar(255);--> statement-breakpoint
+CREATE INDEX "idx_submissions_user_source" ON "submissions" USING btree ("user_id","source_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "submissions_user_unsourced_unique" ON "submissions" USING btree ("user_id") WHERE "submissions"."source_id" is null;--> statement-breakpoint
+CREATE UNIQUE INDEX "submissions_user_source_unique" ON "submissions" USING btree ("user_id","source_id") WHERE "submissions"."source_id" is not null;--> statement-breakpoint
+CREATE UNIQUE INDEX "submissions_user_unsourced_hash_unique" ON "submissions" USING btree ("user_id","submission_hash") WHERE "submissions"."submission_hash" is not null and "submissions"."source_id" is null;--> statement-breakpoint
+CREATE UNIQUE INDEX "submissions_user_source_hash_unique" ON "submissions" USING btree ("user_id","source_id","submission_hash") WHERE "submissions"."submission_hash" is not null and "submissions"."source_id" is not null;

--- a/packages/frontend/src/lib/db/migrations/meta/0004_snapshot.json
+++ b/packages/frontend/src/lib/db/migrations/meta/0004_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "a96b05cf-d394-4a02-9739-42af220811aa",
-  "prevId": "f8e4e377-2f3e-4dd5-b49c-f602048761b5",
+  "id": "f8e4e377-2f3e-4dd5-b49c-f602048761b5",
+  "prevId": "4342d7b5-5562-431f-afd1-0dd773563dff",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -531,18 +531,6 @@
           "primaryKey": false,
           "notNull": true
         },
-        "source_id": {
-          "name": "source_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "source_name": {
-          "name": "source_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
         "total_tokens": {
           "name": "total_tokens",
           "type": "bigint",
@@ -676,27 +664,6 @@
           "method": "btree",
           "with": {}
         },
-        "idx_submissions_user_source": {
-          "name": "idx_submissions_user_source",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "source_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
         "idx_submissions_status": {
           "name": "idx_submissions_status",
           "columns": [
@@ -795,94 +762,6 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
-        },
-        "submissions_user_unsourced_unique": {
-          "name": "submissions_user_unsourced_unique",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"submissions\".\"source_id\" is null",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "submissions_user_source_unique": {
-          "name": "submissions_user_source_unique",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "source_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"submissions\".\"source_id\" is not null",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "submissions_user_unsourced_hash_unique": {
-          "name": "submissions_user_unsourced_hash_unique",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "submission_hash",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"submissions\".\"submission_hash\" is not null and \"submissions\".\"source_id\" is null",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "submissions_user_source_hash_unique": {
-          "name": "submissions_user_source_hash_unique",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "source_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "submission_hash",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"submissions\".\"submission_hash\" is not null and \"submissions\".\"source_id\" is not null",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
         }
       },
       "foreignKeys": {
@@ -901,7 +780,23 @@
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
+      "uniqueConstraints": {
+        "submissions_user_id_unique": {
+          "name": "submissions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "submissions_user_hash_unique": {
+          "name": "submissions_user_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "submission_hash"
+          ]
+        }
+      },
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false

--- a/packages/frontend/src/lib/db/migrations/meta/0005_snapshot.json
+++ b/packages/frontend/src/lib/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,1038 @@
+{
+  "id": "a96b05cf-d394-4a02-9739-42af220811aa",
+  "prevId": "4342d7b5-5562-431f-afd1-0dd773563dff",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_api_tokens_token": {
+          "name": "idx_api_tokens_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_tokens_user_id": {
+          "name": "idx_api_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_unique": {
+          "name": "api_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        },
+        "api_tokens_user_name_unique": {
+          "name": "api_tokens_user_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_breakdown": {
+      "name": "daily_breakdown",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_breakdown": {
+          "name": "provider_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_breakdown": {
+          "name": "source_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_breakdown": {
+          "name": "model_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_daily_breakdown_submission_id": {
+          "name": "idx_daily_breakdown_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_date": {
+          "name": "idx_daily_breakdown_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_breakdown_submission_id_submissions_id_fk": {
+          "name": "daily_breakdown_submission_id_submissions_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_breakdown_submission_date_unique": {
+          "name": "daily_breakdown_submission_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "submission_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_codes_device_code": {
+          "name": "idx_device_codes_device_code",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_code": {
+          "name": "idx_device_codes_user_code",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_expires_at": {
+          "name": "idx_device_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_codes_user_id_users_id_fk": {
+          "name": "device_codes_user_id_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_token": {
+          "name": "idx_sessions_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sources_used": {
+          "name": "sources_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "models_used": {
+          "name": "models_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verified'"
+        },
+        "cli_version": {
+          "name": "cli_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_hash": {
+          "name": "submission_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submit_count": {
+          "name": "submit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_submissions_user_id": {
+          "name": "idx_submissions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_user_source": {
+          "name": "idx_submissions_user_source",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_status": {
+          "name": "idx_submissions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_total_tokens": {
+          "name": "idx_submissions_total_tokens",
+          "columns": [
+            {
+              "expression": "total_tokens",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_created_at": {
+          "name": "idx_submissions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_date_range": {
+          "name": "idx_submissions_date_range",
+          "columns": [
+            {
+              "expression": "date_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_leaderboard": {
+          "name": "idx_submissions_leaderboard",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_tokens",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_cost",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_user_unsourced_unique": {
+          "name": "submissions_user_unsourced_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"submissions\".\"source_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_user_source_unique": {
+          "name": "submissions_user_source_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"submissions\".\"source_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_user_unsourced_hash_unique": {
+          "name": "submissions_user_unsourced_hash_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submission_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"submissions\".\"submission_hash\" is not null and \"submissions\".\"source_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_user_source_hash_unique": {
+          "name": "submissions_user_source_hash_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submission_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"submissions\".\"submission_hash\" is not null and \"submissions\".\"source_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_github_id": {
+          "name": "idx_users_github_id",
+          "columns": [
+            {
+              "expression": "github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1771322400000,
       "tag": "0004_add_timestamp_and_schema_version",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1774777575214,
+      "tag": "0005_narrow_thena",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -12,8 +12,9 @@ import {
   integer,
   index,
   unique,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
-import { relations } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
 
 // ============================================================================
 // USERS
@@ -144,6 +145,8 @@ export const submissions = pgTable(
     userId: uuid("user_id")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
+    sourceId: varchar("source_id", { length: 255 }),
+    sourceName: varchar("source_name", { length: 255 }),
 
     totalTokens: bigint("total_tokens", { mode: "number" }).notNull(),
     totalCost: decimal("total_cost", { precision: 12, scale: 4 }).notNull(),
@@ -182,13 +185,24 @@ export const submissions = pgTable(
   },
   (table) => [
     index("idx_submissions_user_id").on(table.userId),
+    index("idx_submissions_user_source").on(table.userId, table.sourceId),
     index("idx_submissions_status").on(table.status),
     index("idx_submissions_total_tokens").on(table.totalTokens),
     index("idx_submissions_created_at").on(table.createdAt),
     index("idx_submissions_date_range").on(table.dateStart, table.dateEnd),
     index("idx_submissions_leaderboard").on(table.userId, table.totalTokens, table.totalCost, table.createdAt),
-    unique("submissions_user_id_unique").on(table.userId),
-    unique("submissions_user_hash_unique").on(table.userId, table.submissionHash),
+    uniqueIndex("submissions_user_unsourced_unique")
+      .on(table.userId)
+      .where(sql`${table.sourceId} is null`),
+    uniqueIndex("submissions_user_source_unique")
+      .on(table.userId, table.sourceId)
+      .where(sql`${table.sourceId} is not null`),
+    uniqueIndex("submissions_user_unsourced_hash_unique")
+      .on(table.userId, table.submissionHash)
+      .where(sql`${table.submissionHash} is not null and ${table.sourceId} is null`),
+    uniqueIndex("submissions_user_source_hash_unique")
+      .on(table.userId, table.sourceId, table.submissionHash)
+      .where(sql`${table.submissionHash} is not null and ${table.sourceId} is not null`),
   ]
 );
 

--- a/packages/frontend/src/lib/embed/getUserEmbedStats.ts
+++ b/packages/frontend/src/lib/embed/getUserEmbedStats.ts
@@ -70,7 +70,9 @@ async function fetchUserEmbedStats(username: string, sortBy: EmbedSortBy): Promi
       SELECT rank FROM ranked WHERE user_id = ${result.id}
     `);
 
-    rank = (rankResult as unknown as { rank: number }[])[0]?.rank || null;
+    const rawRank = (rankResult as unknown as Array<{ rank: number | string | null }>)[0]?.rank;
+    const normalizedRank = rawRank == null ? null : Number(rawRank);
+    rank = normalizedRank !== null && Number.isFinite(normalizedRank) ? normalizedRank : null;
   }
 
   return {

--- a/packages/frontend/src/lib/embed/getUserEmbedStats.ts
+++ b/packages/frontend/src/lib/embed/getUserEmbedStats.ts
@@ -85,7 +85,11 @@ async function fetchUserEmbedStats(username: string, sortBy: EmbedSortBy): Promi
       totalCost: Number(result.totalCost) || 0,
       submissionCount: Number(result.submissionCount) || 0,
       rank,
-      updatedAt: result.updatedAt?.toISOString() || null,
+      updatedAt: result.updatedAt instanceof Date
+        ? result.updatedAt.toISOString()
+        : result.updatedAt
+        ? new Date(result.updatedAt).toISOString()
+        : null,
     },
   };
 }

--- a/packages/frontend/src/lib/embed/getUserEmbedStats.ts
+++ b/packages/frontend/src/lib/embed/getUserEmbedStats.ts
@@ -27,14 +27,15 @@ async function fetchUserEmbedStats(username: string, sortBy: EmbedSortBy): Promi
       username: users.username,
       displayName: users.displayName,
       avatarUrl: users.avatarUrl,
-      totalTokens: sql<number>`COALESCE(${submissions.totalTokens}, 0)`,
-      totalCost: sql<number>`COALESCE(CAST(${submissions.totalCost} AS DECIMAL(12,4)), 0)`,
-      submissionCount: sql<number>`COALESCE(${submissions.submitCount}, 0)`,
-      updatedAt: submissions.updatedAt,
+      totalTokens: sql<number>`COALESCE(SUM(${submissions.totalTokens}), 0)`,
+      totalCost: sql<number>`COALESCE(SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4))), 0)`,
+      submissionCount: sql<number>`COALESCE(SUM(${submissions.submitCount}), 0)`,
+      updatedAt: sql<Date | null>`MAX(${submissions.updatedAt})`,
     })
     .from(users)
     .leftJoin(submissions, eq(submissions.userId, users.id))
     .where(eq(users.username, username))
+    .groupBy(users.id, users.username, users.displayName, users.avatarUrl)
     .limit(1);
 
   if (!result) {
@@ -47,16 +48,24 @@ async function fetchUserEmbedStats(username: string, sortBy: EmbedSortBy): Promi
 
   if (rankingValue > 0) {
     const rankResult = await db.execute<{ rank: number }>(sql`
-      WITH ranked AS (
+      WITH user_totals AS (
+        SELECT
+          user_id,
+          SUM(total_tokens) AS total_tokens,
+          SUM(CAST(total_cost AS DECIMAL(12,4))) AS total_cost
+        FROM submissions
+        GROUP BY user_id
+      ),
+      ranked AS (
         SELECT
           user_id,
           RANK() OVER (
             ORDER BY
               ${sortBy === "cost"
-                ? sql`CAST(total_cost AS DECIMAL(12,4)) DESC, total_tokens DESC`
-                : sql`total_tokens DESC, CAST(total_cost AS DECIMAL(12,4)) DESC`}
+                ? sql`total_cost DESC, total_tokens DESC`
+                : sql`total_tokens DESC, total_cost DESC`}
           ) AS rank
-        FROM submissions
+        FROM user_totals
       )
       SELECT rank FROM ranked WHERE user_id = ${result.id}
     `);

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -301,7 +301,7 @@ async function fetchLeaderboardData(
       .select({
         totalTokens: sql<number>`SUM(${submissions.totalTokens})`,
         totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`,
-        totalSubmissions: sql<number>`COUNT(${submissions.id})`,
+        totalSubmissions: sql<number>`COALESCE(SUM(${submissions.submitCount}), 0)`,
         uniqueUsers: sql<number>`COUNT(DISTINCT ${submissions.userId})`,
       })
       .from(submissions),

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -78,6 +78,8 @@ export interface DataSummary {
 export interface ExportMeta {
   generatedAt: string;
   version: string;
+  sourceId?: string;
+  sourceName?: string;
   dateRange: {
     start: string;
     end: string;

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -81,11 +81,21 @@ const DataSummarySchema = z.object({
   models: z.array(z.string()),
 });
 
+const OptionalSourceMetadataSchema = z.preprocess(
+  (value) => {
+    if (typeof value === "string" && value.trim() === "") {
+      return undefined;
+    }
+    return value;
+  },
+  z.string().trim().min(1).max(255).optional()
+);
+
 const ExportMetaSchema = z.object({
   generatedAt: z.string(),
   version: z.string(),
-  sourceId: z.string().trim().min(1).max(255).optional(),
-  sourceName: z.string().trim().min(1).max(255).optional(),
+  sourceId: OptionalSourceMetadataSchema,
+  sourceName: OptionalSourceMetadataSchema,
   dateRange: z.object({
     start: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
     end: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -84,6 +84,8 @@ const DataSummarySchema = z.object({
 const ExportMetaSchema = z.object({
   generatedAt: z.string(),
   version: z.string(),
+  sourceId: z.string().trim().min(1).max(255).optional(),
+  sourceName: z.string().trim().min(1).max(255).optional(),
   dateRange: z.object({
     start: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
     end: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),


### PR DESCRIPTION
## Summary

This fixes the leaderboard overwrite case for users who submit from more than one machine.

Instead of merging every submit into a single `submissions` row per user, submissions can now be optionally source-scoped:
- submits with `meta.sourceId` write to a `(user_id, source_id)` row
- submits without `sourceId` keep the existing unsourced behavior
- leaderboard/profile/embed reads continue to aggregate across all of a user's submission rows

This keeps the fix modest and aligned with the existing schema and aggregation patterns, without introducing nested per-source instances into `daily_breakdown.source_breakdown`.

## Repro

Before this patch:
1. Submit usage for user `X` from machine A with `claude` activity.
2. Submit usage for the same user `X` from machine B with `claude` activity.
3. Observe that the later submission overwrites the earlier machine's contribution for overlapping days.

Expected behavior:
- both machines contribute to the user total
- re-submitting from one machine replaces only that source's prior contribution
- unsourced/older submissions keep current behavior

## What changed

- added optional `source_id` and `source_name` to `submissions`
- replaced single-row-per-user uniqueness with:
  - one unsourced row per user
  - many sourced rows per user
- updated `/api/submit` to target the correct submission row by source when provided
- updated profile, leaderboard, and embed queries to aggregate across a user's submission rows
- added CLI source metadata for `submit` payloads only
- documented `TOKSCALE_SOURCE_ID` and `TOKSCALE_SOURCE_NAME`
- added focused regression tests for source-scoped submit behavior and embed/profile aggregation

## Validation

Automated:
- `DATABASE_URL=postgres://localhost:5432/tokscale bun run db:generate`
- `bunx vitest run __tests__/api/submitSourceScope.test.ts __tests__/lib/getUserEmbedStats.test.ts __tests__/api/usersProfile.test.ts __tests__/api/submitAuth.test.ts __tests__/lib/getLeaderboardAllTime.test.ts __tests__/lib/getLeaderboard.test.ts`

Both passed.

## Notes

- `TOKSCALE_SOURCE_NAME` is stored per `sourceId`; a later submit with the same `sourceId` and a new non-empty name updates that source's display name.
- I did not build the Rust CLI in this environment because `cargo` was unavailable here.
- `bunx tsc --noEmit` still fails on an unrelated existing import in `packages/frontend/src/components/BlackholeHero.tsx`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves multi‑machine submissions by scoping per source and aggregating totals across a user’s sources. Adds robust CLI source ID persistence with a stale‑lock cleanup fallback and normalizes profile/leaderboard/embed aggregates.

- **Bug Fixes**
  - `submissions` are source‑scoped: rows keyed by `(user_id, source_id)`; unsourced rows remain; empty/whitespace `sourceId`/`sourceName` are ignored; optional source metadata failures are tolerated.
  - `/api/submit` targets the correct per‑source row, updates `sourceName` only when provided, handles missing/invalid source metadata, and computes response metrics after commit.
  - Profile, leaderboard, and embed aggregate by summing across all a user’s rows; `submissionCount` uses sums; `updatedAt` uses the latest submit; embed ranks are normalized from string results.
  - `crates/tokscale-cli` includes `sourceId`/`sourceName` in submit meta, persists a stable per‑machine source ID with a small file lock, and cleans up stale locks by age if needed; supports `TOKSCALE_SOURCE_ID`, `TOKSCALE_SOURCE_NAME`, and `TOKSCALE_API_URL`.

- **Migration**
  - Run DB migration 0005 to add `source_id`/`source_name` and replace single‑row uniqueness with per‑source partial unique indexes.
  - No changes needed for existing unsourced submits; reads aggregate across rows.

<sup>Written for commit 9eda26d6302e1acc30ace7620b00ce3e2265a4cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

