### PR TITLE
chore(ci): add frontend API validation workflow

### DIFF
--- a/.github/workflows/frontend_api_validation.yml
+++ b/.github/workflows/frontend_api_validation.yml
@@ -37,4 +37,5 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Run frontend/API tests
-        run: bun x vitest run packages/frontend/__tests__/api/*.test.ts packages/frontend/__tests__/lib/*.test.ts
+        working-directory: packages/frontend
+        run: bun x vitest run __tests__/api/*.test.ts __tests__/lib/*.test.ts

--- a/.github/workflows/frontend_api_validation.yml
+++ b/.github/workflows/frontend_api_validation.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.10
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/frontend_api_validation.yml
+++ b/.github/workflows/frontend_api_validation.yml
@@ -16,6 +16,9 @@ on:
       - "package.json"
       - "packages/frontend/**"
 
+permissions:
+  contents: read
+
 jobs:
   frontend-api-tests:
     name: Frontend/API Tests
@@ -23,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/frontend_api_validation.yml
+++ b/.github/workflows/frontend_api_validation.yml
@@ -1,0 +1,35 @@
+name: Frontend/API Validation
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - ".github/workflows/frontend_api_validation.yml"
+      - "bun.lock"
+      - "package.json"
+      - "packages/frontend/**"
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - ".github/workflows/frontend_api_validation.yml"
+      - "bun.lock"
+      - "package.json"
+      - "packages/frontend/**"
+
+jobs:
+  frontend-api-tests:
+    name: Frontend/API Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run frontend/API tests
+        run: bun x vitest run packages/frontend/__tests__/api/*.test.ts packages/frontend/__tests__/lib/*.test.ts


### PR DESCRIPTION
## Summary
- add a repo-owned GitHub Actions workflow for frontend and API test coverage
- run the existing frontend Vitest API and lib suites whenever frontend code or its lockfile inputs change

## Why
Right now, the repository's built-in GitHub Actions checks mainly cover Rust paths. That leaves `packages/frontend/**` without a repo-owned validation gate, even though the project already has meaningful frontend API and library test coverage. This change closes that gap with the smallest reliable workflow that fits the current state of `main`.

## Diff scope
- add a new workflow at `.github/workflows/frontend_api_validation.yml`
- trigger that workflow for `push` and `pull_request` events when `packages/frontend/**`, `package.json`, or `bun.lock` change
- set up Bun, install dependencies with `bun install --frozen-lockfile`, and run the existing frontend API and lib Vitest suites
- intentionally leave out frontend typecheck and build steps from this PR because current `main` still has an unrelated typecheck blocker outside this diff

## Test proof
- `bun install --frozen-lockfile`
  - passed
- `bun x vitest run packages/frontend/__tests__/api/*.test.ts packages/frontend/__tests__/lib/*.test.ts`
  - `15 files, 113 tests passed`
- `git diff --check`
  - passed

## Verification-pack proof
Not applicable - this PR adds a small repo-owned workflow but does not change runtime logic, infrastructure, or migration behavior.

## Migration notes
Not applicable - no schema or data migration.

## CI context confirmation
CI context names unchanged.

## Rollback plan
- if merged with a merge commit: `git revert <merge_commit_sha>`
- if merged as a squash commit: `git revert <squash_commit_sha>`
- no DB downgrade required

## Known residual risks
- this workflow covers the existing frontend API and library test surface, not the full Next.js build or typecheck surface
- frontend typecheck is intentionally left out because current `main` still has an unrelated missing-asset error in `BlackholeHero.tsx` that this PR does not introduce or change

