### PR TITLE
feat(scanner): add scanner.opencodeDbPaths to settings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -984,6 +984,21 @@ OpenCode 1.2+ stores sessions in SQLite. Tokscale reads from SQLite first and fa
 
 OpenCode picks the db filename from the release channel the binary was built against: the `latest` and `beta` channels use `opencode.db`, while other channels use `opencode-<channel>.db` (e.g. `opencode-stable.db`, `opencode-nightly.db`). Tokscale scans all of them, so users running multiple channels side by side get a unified view.
 
+If you launched opencode with `OPENCODE_DB` pointing at a file outside `~/.local/share/opencode`, add the absolute path to `~/.config/tokscale/settings.json` so tokscale can find it on every run:
+
+```json
+{
+  "scanner": {
+    "opencodeDbPaths": [
+      "/custom/location/opencode.db",
+      "/another/location/opencode-stable.db"
+    ]
+  }
+}
+```
+
+Paths are merged with auto-discovery, deduped by canonical path, and non-existent entries are silently skipped (so stale config never breaks a scan). `opencode.db-wal`, `opencode.db-shm`, and other SQLite sidecars are rejected.
+
 Each message contains:
 ```json
 {

--- a/crates/tokscale-cli/src/commands/wrapped.rs
+++ b/crates/tokscale-cli/src/commands/wrapped.rs
@@ -222,6 +222,7 @@ async fn load_wrapped_data(options: &WrappedOptions) -> Result<WrappedData> {
                 since: Some(since.clone()),
                 until: Some(until.clone()),
                 year: Some(year.clone()),
+                scanner_settings: crate::tui::settings::load_scanner_settings(),
             })
             .map_err(anyhow::Error::msg)?,
         )
@@ -237,6 +238,7 @@ async fn load_wrapped_data(options: &WrappedOptions) -> Result<WrappedData> {
         until: Some(until),
         year: Some(year.clone()),
         group_by: GroupBy::default(),
+        scanner_settings: crate::tui::settings::load_scanner_settings(),
     })
     .await
     .map_err(anyhow::Error::msg)?;

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1454,6 +1454,7 @@ fn run_models_report(
                 until,
                 year,
                 group_by: group_by.clone(),
+                scanner_settings: tui::settings::load_scanner_settings(),
             })
             .await
         })
@@ -1968,6 +1969,7 @@ fn run_monthly_report(
                 until,
                 year,
                 group_by: GroupBy::default(),
+                scanner_settings: tui::settings::load_scanner_settings(),
             })
             .await
         })
@@ -2499,6 +2501,7 @@ fn run_clients_command(json: bool) -> Result<()> {
         since: None,
         until: None,
         year: None,
+        scanner_settings: tui::settings::load_scanner_settings(),
     })
     .map_err(|e| anyhow::anyhow!(e))?;
 
@@ -3285,6 +3288,7 @@ fn run_graph_command(
                 until,
                 year,
                 group_by: GroupBy::default(),
+                scanner_settings: tui::settings::load_scanner_settings(),
             })
             .await
         })
@@ -3469,6 +3473,7 @@ fn run_submit_command(
                 until,
                 year,
                 group_by: GroupBy::default(),
+                scanner_settings: tui::settings::load_scanner_settings(),
             })
             .await
         })

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -224,6 +224,7 @@ impl DataLoader {
             since: self.since.clone(),
             until: self.until.clone(),
             year: self.year.clone(),
+            scanner_settings: crate::tui::settings::load_scanner_settings(),
         };
 
         let messages = if Handle::try_current().is_ok() {
@@ -272,6 +273,7 @@ impl DataLoader {
             until: self.until.clone(),
             year: self.year.clone(),
             use_env_roots: false,
+            scanner_settings: crate::tui::settings::load_scanner_settings(),
         };
 
         let messages = if Handle::try_current().is_ok() {
@@ -792,6 +794,7 @@ mod tests {
             since: loader.since.clone(),
             until: loader.until.clone(),
             year: loader.year.clone(),
+            scanner_settings: crate::tui::settings::load_scanner_settings(),
         };
 
         let messages = if Handle::try_current().is_ok() {

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -11,6 +11,21 @@ use tokscale_core::{
     LocalParseOptions,
 };
 
+/// Returns the scanner settings that `DataLoader` should use when building
+/// `LocalParseOptions`. Under `#[cfg(test)]` this intentionally ignores
+/// `~/.config/tokscale/settings.json` so data-loader unit tests stay
+/// hermetic across developer machines; production builds still honor
+/// user-configured paths.
+#[cfg(not(test))]
+fn data_loader_scanner_settings() -> tokscale_core::scanner::ScannerSettings {
+    crate::tui::settings::load_scanner_settings()
+}
+
+#[cfg(test)]
+fn data_loader_scanner_settings() -> tokscale_core::scanner::ScannerSettings {
+    tokscale_core::scanner::ScannerSettings::default()
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct TokenBreakdown {
     pub input: u64,
@@ -224,7 +239,7 @@ impl DataLoader {
             since: self.since.clone(),
             until: self.until.clone(),
             year: self.year.clone(),
-            scanner_settings: crate::tui::settings::load_scanner_settings(),
+            scanner_settings: data_loader_scanner_settings(),
         };
 
         let messages = if Handle::try_current().is_ok() {
@@ -273,7 +288,7 @@ impl DataLoader {
             until: self.until.clone(),
             year: self.year.clone(),
             use_env_roots: false,
-            scanner_settings: crate::tui::settings::load_scanner_settings(),
+            scanner_settings: data_loader_scanner_settings(),
         };
 
         let messages = if Handle::try_current().is_ok() {
@@ -794,7 +809,7 @@ mod tests {
             since: loader.since.clone(),
             until: loader.until.clone(),
             year: loader.year.clone(),
-            scanner_settings: crate::tui::settings::load_scanner_settings(),
+            scanner_settings: data_loader_scanner_settings(),
         };
 
         let messages = if Handle::try_current().is_ok() {
@@ -1069,6 +1084,29 @@ mod tests {
         assert!(loader.since.is_none());
         assert!(loader.until.is_none());
         assert!(loader.year.is_none());
+    }
+
+    #[test]
+    fn test_data_loader_scanner_settings_is_hermetic_under_cfg_test() {
+        // Regression guard: the `#[cfg(test)]` branch of
+        // `data_loader_scanner_settings` must not read
+        // `~/.config/tokscale/settings.json`. Otherwise every DataLoader
+        // unit test becomes machine-dependent as soon as a developer
+        // pins extra OpenCode dbs in their real settings.json.
+        //
+        // This test cannot sandbox HOME (many of the sibling tests in
+        // this module would race against each other if it did), so
+        // instead it asserts the cfg(test) helper returns a default
+        // ScannerSettings regardless of what the real settings file
+        // contains on the developer's machine.
+        let settings = super::data_loader_scanner_settings();
+        assert!(
+            settings.opencode_db_paths.is_empty(),
+            "under #[cfg(test)] data_loader_scanner_settings must return \
+             ScannerSettings::default() so unit tests stay hermetic, but \
+             got {:?}",
+            settings.opencode_db_paths
+        );
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use tokscale_core::scanner::ScannerSettings;
 
 use super::themes::ThemeName;
 
@@ -28,6 +29,15 @@ pub struct Settings {
     pub include_unused_models: bool,
     #[serde(default = "default_native_timeout_ms")]
     pub native_timeout_ms: u64,
+    /// Persistent scanner configuration. Allows users to pin additional
+    /// OpenCode SQLite paths (and, in future, other scanner overrides)
+    /// without having to set env vars on every invocation.
+    ///
+    /// `#[serde(default)]` makes this a drop-in addition — settings.json
+    /// files written before the field existed still load cleanly, and an
+    /// empty `"scanner": {}` is equivalent to not setting it at all.
+    #[serde(default)]
+    pub scanner: ScannerSettings,
 }
 
 fn default_color_palette() -> String {
@@ -50,8 +60,20 @@ impl Default for Settings {
             auto_refresh_ms: DEFAULT_AUTO_REFRESH_MS,
             include_unused_models: false,
             native_timeout_ms: DEFAULT_NATIVE_TIMEOUT_MS,
+            scanner: ScannerSettings::default(),
         }
     }
+}
+
+/// Thin helper that loads settings and returns just the scanner portion.
+///
+/// Every CLI entry point that builds `LocalParseOptions`/`ReportOptions`
+/// calls this so user-configured scanner paths are honored on every
+/// invocation. Errors during load fall through to
+/// [`ScannerSettings::default`] — a missing or malformed settings.json
+/// should never break `tokscale` runs.
+pub fn load_scanner_settings() -> ScannerSettings {
+    Settings::load().scanner
 }
 
 impl Settings {
@@ -145,5 +167,80 @@ impl Settings {
 
         let clamped = timeout_ms.clamp(MIN_NATIVE_TIMEOUT_MS, MAX_NATIVE_TIMEOUT_MS);
         Duration::from_millis(clamped)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn settings_load_backfills_scanner_when_missing_from_json() {
+        // Older settings.json files predate the `scanner` key. They must
+        // still deserialize cleanly and fall through to ScannerSettings::default.
+        let json = r#"{
+            "colorPalette": "blue",
+            "autoRefreshEnabled": false,
+            "autoRefreshMs": 60000,
+            "includeUnusedModels": false,
+            "nativeTimeoutMs": 300000
+        }"#;
+        let parsed: Settings = serde_json::from_str(json).unwrap();
+        assert!(parsed.scanner.opencode_db_paths.is_empty());
+    }
+
+    #[test]
+    fn settings_load_reads_scanner_opencode_db_paths() {
+        let json = r#"{
+            "colorPalette": "blue",
+            "autoRefreshEnabled": false,
+            "autoRefreshMs": 60000,
+            "includeUnusedModels": false,
+            "nativeTimeoutMs": 300000,
+            "scanner": {
+                "opencodeDbPaths": [
+                    "/custom/one.db",
+                    "/custom/opencode-stable.db"
+                ]
+            }
+        }"#;
+        let parsed: Settings = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            parsed.scanner.opencode_db_paths,
+            vec![
+                PathBuf::from("/custom/one.db"),
+                PathBuf::from("/custom/opencode-stable.db"),
+            ]
+        );
+    }
+
+    #[test]
+    fn settings_accepts_empty_scanner_object() {
+        // `"scanner": {}` is the documented "no-op" form; must be valid.
+        let json = r#"{
+            "colorPalette": "blue",
+            "autoRefreshEnabled": false,
+            "autoRefreshMs": 60000,
+            "includeUnusedModels": false,
+            "nativeTimeoutMs": 300000,
+            "scanner": {}
+        }"#;
+        let parsed: Settings = serde_json::from_str(json).unwrap();
+        assert!(parsed.scanner.opencode_db_paths.is_empty());
+    }
+
+    #[test]
+    fn settings_round_trips_scanner_section_through_json() {
+        // Saving and loading must preserve scanner paths verbatim so that
+        // the TUI settings save flow never drops the key silently.
+        let mut settings = Settings::default();
+        settings.scanner.opencode_db_paths = vec![PathBuf::from("/a/b/opencode.db")];
+        let serialized = serde_json::to_string(&settings).unwrap();
+        let parsed: Settings = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(
+            parsed.scanner.opencode_db_paths,
+            vec![PathBuf::from("/a/b/opencode.db")]
+        );
     }
 }

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1419,8 +1419,12 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     let include_all = clients.is_empty();
     let include_synthetic = include_all || clients.iter().any(|c| c == "synthetic");
 
-    let scan_result =
-        scanner::scan_all_clients_with_env_strategy(&home_dir, &clients, options.use_env_roots);
+    let scan_result = scanner::scan_all_clients_with_scanner_settings(
+        &home_dir,
+        &clients,
+        options.use_env_roots,
+        &options.scanner_settings,
+    );
     let headless_roots =
         scanner::headless_roots_with_env_strategy(&home_dir, options.use_env_roots);
 
@@ -3441,5 +3445,87 @@ mod tests {
         assert_eq!(parsed.messages[0].client, "opencode");
         assert_eq!(parsed.messages[0].model_id, "deepseek-v3-0324");
         assert_eq!(parsed.messages[0].provider_id, "fireworks");
+    }
+
+    #[test]
+    fn test_parse_local_clients_honors_scanner_settings_opencode_db_paths() {
+        // Regression guard: `parse_local_clients` used to call
+        // `scan_all_clients_with_env_strategy`, which silently dropped
+        // `options.scanner_settings`. Users with
+        // `scanner.opencodeDbPaths` pointing at an OPENCODE_DB outside the
+        // XDG data dir would see no rows through the clients/wrapped
+        // command paths even though model/monthly/graph reports honored
+        // the same config.
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        // Deliberately do not create ~/.local/share/opencode so nothing
+        // is auto-discoverable; the only db the scanner can find must
+        // come from `scanner_settings`.
+        let outside_dir = temp_dir.path().join("elsewhere");
+        std::fs::create_dir_all(&outside_dir).unwrap();
+        let external_db = outside_dir.join("opencode.db");
+
+        let conn = rusqlite::Connection::open(&external_db).unwrap();
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             CREATE TABLE message (
+                 id TEXT PRIMARY KEY,
+                 session_id TEXT NOT NULL,
+                 data TEXT NOT NULL
+             );",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params![
+                "ext-msg-1",
+                "ext-session",
+                r#"{
+                    "role": "assistant",
+                    "modelID": "claude-sonnet-4",
+                    "providerID": "anthropic",
+                    "tokens": { "input": 42, "output": 7, "reasoning": 0, "cache": { "read": 0, "write": 0 } },
+                    "time": { "created": 1700000000000.0 }
+                }"#
+            ],
+        )
+        .unwrap();
+        drop(conn);
+
+        // Without scanner_settings: no rows (nothing auto-discoverable).
+        let parsed_default = parse_local_clients(LocalParseOptions {
+            home_dir: Some(temp_dir.path().to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(vec!["opencode".to_string()]),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner::ScannerSettings::default(),
+        })
+        .unwrap();
+        assert_eq!(parsed_default.counts.get(ClientId::OpenCode), 0);
+        assert!(parsed_default.messages.is_empty());
+
+        // With scanner_settings pointing at the external db: the user
+        // row must show up.
+        let parsed_with_settings = parse_local_clients(LocalParseOptions {
+            home_dir: Some(temp_dir.path().to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(vec!["opencode".to_string()]),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner::ScannerSettings {
+                opencode_db_paths: vec![external_db.clone()],
+            },
+        })
+        .unwrap();
+        assert_eq!(
+            parsed_with_settings.counts.get(ClientId::OpenCode),
+            1,
+            "scanner.opencodeDbPaths must reach the parse_local_clients path"
+        );
+        assert_eq!(parsed_with_settings.messages.len(), 1);
+        assert_eq!(parsed_with_settings.messages[0].client, "opencode");
+        assert_eq!(parsed_with_settings.messages[0].model_id, "claude-sonnet-4");
     }
 }

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -170,7 +170,7 @@ impl std::fmt::Debug for ParsedMessages {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct LocalParseOptions {
     pub home_dir: Option<String>,
     pub use_env_roots: bool,
@@ -178,6 +178,9 @@ pub struct LocalParseOptions {
     pub since: Option<String>,
     pub until: Option<String>,
     pub year: Option<String>,
+    /// Persistent scanner config loaded from `~/.config/tokscale/settings.json`.
+    /// Defaults to empty when callers don't care about user-configured paths.
+    pub scanner_settings: scanner::ScannerSettings,
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize)]
@@ -244,7 +247,7 @@ pub struct GraphResult {
     pub contributions: Vec<DailyContribution>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ReportOptions {
     pub home_dir: Option<String>,
     pub use_env_roots: bool,
@@ -253,6 +256,9 @@ pub struct ReportOptions {
     pub until: Option<String>,
     pub year: Option<String>,
     pub group_by: GroupBy,
+    /// Persistent scanner config loaded from `~/.config/tokscale/settings.json`.
+    /// Defaults to empty when callers don't care about user-configured paths.
+    pub scanner_settings: scanner::ScannerSettings,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -322,7 +328,13 @@ fn parse_all_messages_with_pricing(
     clients: &[String],
     pricing: Option<&pricing::PricingService>,
 ) -> Vec<UnifiedMessage> {
-    parse_all_messages_with_pricing_with_env_strategy(home_dir, clients, pricing, true)
+    parse_all_messages_with_pricing_with_env_strategy(
+        home_dir,
+        clients,
+        pricing,
+        true,
+        &scanner::ScannerSettings::default(),
+    )
 }
 
 fn parse_all_messages_with_pricing_with_env_strategy(
@@ -330,6 +342,7 @@ fn parse_all_messages_with_pricing_with_env_strategy(
     clients: &[String],
     pricing: Option<&pricing::PricingService>,
     use_env_roots: bool,
+    scanner_settings: &scanner::ScannerSettings,
 ) -> Vec<UnifiedMessage> {
     #[derive(Debug)]
     struct CachedParseOutcome {
@@ -609,7 +622,12 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         parse_full_log_source(path, pricing, is_headless)
     }
 
-    let scan_result = scanner::scan_all_clients_with_env_strategy(home_dir, clients, use_env_roots);
+    let scan_result = scanner::scan_all_clients_with_scanner_settings(
+        home_dir,
+        clients,
+        use_env_roots,
+        scanner_settings,
+    );
     let headless_roots = scanner::headless_roots_with_env_strategy(home_dir, use_env_roots);
     let mut source_cache = message_cache::SourceMessageCache::load();
     source_cache.prune_missing_files();
@@ -1113,6 +1131,7 @@ pub async fn get_model_report(options: ReportOptions) -> Result<ModelReport, Str
         &clients,
         pricing.as_deref(),
         options.use_env_roots,
+        &options.scanner_settings,
     );
 
     let filtered = filter_messages_for_report(all_messages, &options);
@@ -1168,6 +1187,7 @@ pub async fn get_monthly_report(options: ReportOptions) -> Result<MonthlyReport,
         &clients,
         pricing.as_deref(),
         options.use_env_roots,
+        &options.scanner_settings,
     );
 
     let filtered = filter_messages_for_report(all_messages, &options);
@@ -1241,6 +1261,7 @@ async fn generate_graph_with_loaded_pricing(
         &clients,
         pricing,
         options.use_env_roots,
+        &options.scanner_settings,
     );
 
     let filtered = filter_messages_for_report(all_messages, &options);
@@ -1378,6 +1399,7 @@ fn parse_local_unified_messages_resolved(
         clients,
         pricing,
         options.use_env_roots,
+        &options.scanner_settings,
     );
     Ok(filter_unified_messages(messages, &options))
 }
@@ -1811,9 +1833,9 @@ mod tests {
     use super::{
         aggregate_model_usage_entries, apply_pricing_if_available, message_cache,
         normalize_model_for_grouping, parse_all_messages_with_pricing, parse_local_clients,
-        parsed_to_unified, pricing, retain_for_requested_clients, select_local_parse_pricing,
-        unified_to_parsed, ClientId, GroupBy, LocalParseOptions, TokenBreakdown, UnifiedMessage,
-        UNKNOWN_WORKSPACE_LABEL,
+        parsed_to_unified, pricing, retain_for_requested_clients, scanner,
+        select_local_parse_pricing, unified_to_parsed, ClientId, GroupBy, LocalParseOptions,
+        TokenBreakdown, UnifiedMessage, UNKNOWN_WORKSPACE_LABEL,
     };
     use std::collections::{HashMap, HashSet};
     use std::io::Write;
@@ -3346,6 +3368,7 @@ mod tests {
             since: None,
             until: None,
             year: None,
+            scanner_settings: scanner::ScannerSettings::default(),
         })
         .unwrap();
 
@@ -3406,6 +3429,7 @@ mod tests {
             since: None,
             until: None,
             year: None,
+            scanner_settings: scanner::ScannerSettings::default(),
         })
         .unwrap();
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -3528,4 +3528,93 @@ mod tests {
         assert_eq!(parsed_with_settings.messages[0].client, "opencode");
         assert_eq!(parsed_with_settings.messages[0].model_id, "claude-sonnet-4");
     }
+
+    #[test]
+    fn test_parse_local_clients_claude_filter_ignores_scanner_settings_opencode_db_paths() {
+        // Regression guard for the scanner client-filter bypass: even
+        // when `scanner.opencodeDbPaths` pins an external opencode db,
+        // a `--clients claude` request must NOT pull in OpenCode rows.
+        // Before the fix, the merge ran outside the OpenCode-enabled
+        // guard so user-pinned dbs leaked through both `messages` and
+        // `counts` (the latter is computed before the message-level
+        // client filter, so even the post-filter pipeline could not
+        // hide a leaked count).
+        let temp_dir = tempfile::TempDir::new().unwrap();
+
+        // Claude session: one assistant message, the only thing the
+        // filter should accept.
+        let claude_dir = temp_dir.path().join(".claude/projects/myproject");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        std::fs::write(
+            claude_dir.join("conversation.jsonl"),
+            r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50}}}
+"#,
+        )
+        .unwrap();
+
+        // External opencode.db that the user has pinned via
+        // scanner.opencodeDbPaths. Without the fix, this would leak
+        // into the Claude-only result.
+        let outside_dir = temp_dir.path().join("elsewhere");
+        std::fs::create_dir_all(&outside_dir).unwrap();
+        let external_db = outside_dir.join("opencode.db");
+        let conn = rusqlite::Connection::open(&external_db).unwrap();
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             CREATE TABLE message (
+                 id TEXT PRIMARY KEY,
+                 session_id TEXT NOT NULL,
+                 data TEXT NOT NULL
+             );",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params![
+                "leaked-opencode",
+                "should-not-show-up",
+                r#"{
+                    "role": "assistant",
+                    "modelID": "claude-sonnet-4",
+                    "providerID": "anthropic",
+                    "tokens": { "input": 9999, "output": 9999, "reasoning": 0, "cache": { "read": 0, "write": 0 } },
+                    "time": { "created": 1700000000000.0 }
+                }"#
+            ],
+        )
+        .unwrap();
+        drop(conn);
+
+        let parsed = parse_local_clients(LocalParseOptions {
+            home_dir: Some(temp_dir.path().to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(vec!["claude".to_string()]),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner::ScannerSettings {
+                opencode_db_paths: vec![external_db.clone()],
+            },
+        })
+        .unwrap();
+
+        assert_eq!(
+            parsed.counts.get(ClientId::OpenCode),
+            0,
+            "OpenCode count must stay zero under a Claude-only filter even \
+             when scanner.opencodeDbPaths is set"
+        );
+        assert_eq!(
+            parsed.counts.get(ClientId::Claude),
+            1,
+            "Claude message must still be counted"
+        );
+        assert_eq!(parsed.messages.len(), 1);
+        assert_eq!(parsed.messages[0].client, "claude");
+        assert!(
+            parsed.messages.iter().all(|m| m.client != "opencode"),
+            "no OpenCode messages may leak into a Claude-only result, got {:?}",
+            parsed.messages
+        );
+    }
 }

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -9,8 +9,37 @@ use walkdir::WalkDir;
 
 use crate::clients::ClientId;
 use crate::sessions::{normalize_workspace_key, workspace_label_from_key};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
+
+/// User-controlled scanner settings loaded from a config file.
+///
+/// This is the persistent, declarative counterpart to environment variables
+/// like `TOKSCALE_EXTRA_DIRS` — it lives on the `scanner` key inside
+/// `~/.config/tokscale/settings.json` and is threaded down into
+/// [`scan_all_clients_with_scanner_settings`].
+///
+/// `#[serde(default)]` at both the struct and field level guarantees that
+/// older settings.json files (which have no `scanner` key at all, or an
+/// empty `{}`) deserialize cleanly without errors.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct ScannerSettings {
+    /// Absolute paths to additional OpenCode SQLite databases to scan.
+    ///
+    /// Use this when the opencode binary was launched with `OPENCODE_DB`
+    /// pointing at a location outside the default `~/.local/share/opencode`
+    /// data directory, so tokscale's auto-discovery can't find it.
+    ///
+    /// Paths are merged into the auto-discovered
+    /// [`ScanResult::opencode_dbs`] list; duplicates (by canonical path)
+    /// are removed and non-existent entries are silently skipped so stale
+    /// config does not break the scan. WAL/SHM sidecar files are rejected
+    /// with the same [`is_opencode_db_filename`] check used for
+    /// auto-discovery.
+    #[serde(default)]
+    pub opencode_db_paths: Vec<PathBuf>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CrushDbSource {
@@ -361,8 +390,94 @@ fn supports_extra_dir_scanning(client_id: ClientId) -> bool {
     )
 }
 
+/// Merge user-configured OpenCode db paths from [`ScannerSettings`] into the
+/// auto-discovered list, in-place.
+///
+/// Rules:
+/// - Non-existent paths are silently skipped so stale config never aborts a
+///   scan (the config outlives any single opencode install).
+/// - WAL/SHM/journal sidecars are rejected via [`is_opencode_db_filename`].
+/// - Duplicates are removed by canonicalized path comparison, so a user who
+///   explicitly lists an auto-discovered db in their config does not cause
+///   it to be parsed twice.
+///
+/// Kept as a separate helper so the unit tests can exercise the merge
+/// semantics without spinning up a full `scan_all_clients` run.
+pub(crate) fn merge_user_opencode_db_paths(
+    discovered: &mut Vec<PathBuf>,
+    extra_paths: &[PathBuf],
+) {
+    if extra_paths.is_empty() {
+        return;
+    }
+
+    // Build a canonical-path set of what we already have so we can dedup
+    // against auto-discovered entries. Fall back to the raw path if
+    // canonicalize fails (e.g. on a filesystem that doesn't support it),
+    // which preserves the pre-canonicalization behavior without silently
+    // dropping entries.
+    let mut seen: HashSet<PathBuf> = discovered
+        .iter()
+        .map(|p| std::fs::canonicalize(p).unwrap_or_else(|_| p.clone()))
+        .collect();
+
+    for raw in extra_paths {
+        if !raw.is_file() {
+            // Stale config or wrong path — silently skip.
+            continue;
+        }
+        let Some(name) = raw.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if !is_opencode_db_filename(name) {
+            // Reject sidecars (`.db-wal`, `.db-shm`) and anything that does
+            // not match the upstream channel-db naming rule.
+            continue;
+        }
+        let canonical = std::fs::canonicalize(raw).unwrap_or_else(|_| raw.clone());
+        if seen.insert(canonical) {
+            discovered.push(raw.clone());
+        }
+    }
+}
+
+/// Scan all session client directories in parallel, with user-controlled
+/// [`ScannerSettings`] merged in.
+///
+/// This is the preferred entry point when you have loaded persistent
+/// settings (e.g. from `~/.config/tokscale/settings.json`). Thin wrappers
+/// [`scan_all_clients_with_env_strategy`] and [`scan_all_clients`] call
+/// into this with `ScannerSettings::default()` for callers that don't care
+/// about the persistent config.
+pub fn scan_all_clients_with_scanner_settings(
+    home_dir: &str,
+    clients: &[String],
+    use_env_roots: bool,
+    scanner_settings: &ScannerSettings,
+) -> ScanResult {
+    let mut result =
+        scan_all_clients_with_env_strategy_inner(home_dir, clients, use_env_roots);
+    merge_user_opencode_db_paths(&mut result.opencode_dbs, &scanner_settings.opencode_db_paths);
+    result.opencode_dbs.sort_unstable();
+    result.opencode_dbs.dedup();
+    result
+}
+
 /// Scan all session client directories in parallel
 pub fn scan_all_clients_with_env_strategy(
+    home_dir: &str,
+    clients: &[String],
+    use_env_roots: bool,
+) -> ScanResult {
+    scan_all_clients_with_scanner_settings(
+        home_dir,
+        clients,
+        use_env_roots,
+        &ScannerSettings::default(),
+    )
+}
+
+fn scan_all_clients_with_env_strategy_inner(
     home_dir: &str,
     clients: &[String],
     use_env_roots: bool,
@@ -1112,6 +1227,129 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let missing = dir.path().join("does-not-exist");
         assert!(discover_opencode_dbs(&missing).is_empty());
+    }
+
+    #[test]
+    fn test_merge_user_opencode_db_paths_picks_up_path_outside_xdg() {
+        // Simulate `OPENCODE_DB=/arbitrary/abs/path/custom.db` upstream:
+        // the file is a real opencode db but lives outside
+        // `~/.local/share/opencode`, so auto-discovery never sees it.
+        let dir = TempDir::new().unwrap();
+        let outside = dir.path().join("somewhere-else");
+        fs::create_dir_all(&outside).unwrap();
+        let user_db = outside.join("opencode.db");
+        File::create(&user_db).unwrap();
+
+        let mut discovered: Vec<PathBuf> = Vec::new();
+        merge_user_opencode_db_paths(&mut discovered, std::slice::from_ref(&user_db));
+
+        assert_eq!(discovered, vec![user_db]);
+    }
+
+    #[test]
+    fn test_merge_user_opencode_db_paths_skips_nonexistent_and_sidecars() {
+        let dir = TempDir::new().unwrap();
+        let real = dir.path().join("opencode-stable.db");
+        File::create(&real).unwrap();
+        let wal = dir.path().join("opencode-stable.db-wal");
+        File::create(&wal).unwrap();
+        let missing = dir.path().join("opencode-missing.db"); // never created
+
+        let mut discovered: Vec<PathBuf> = Vec::new();
+        merge_user_opencode_db_paths(
+            &mut discovered,
+            &[real.clone(), wal.clone(), missing.clone()],
+        );
+
+        // Nonexistent path: silently skipped so stale config can't break a scan.
+        // Sidecar path: rejected by is_opencode_db_filename.
+        assert_eq!(discovered, vec![real]);
+    }
+
+    #[test]
+    fn test_merge_user_opencode_db_paths_dedups_against_auto_discovered() {
+        let dir = TempDir::new().unwrap();
+        let shared = dir.path().join("opencode.db");
+        File::create(&shared).unwrap();
+
+        // User explicitly lists a path that auto-discovery also found —
+        // must not double-parse the same sqlite file.
+        let mut discovered: Vec<PathBuf> = vec![shared.clone()];
+        merge_user_opencode_db_paths(&mut discovered, std::slice::from_ref(&shared));
+
+        assert_eq!(discovered, vec![shared]);
+    }
+
+    #[test]
+    fn test_scanner_settings_deserialize_from_json_camel_case() {
+        // This is the contract the CLI's settings.json relies on: the
+        // field is `opencodeDbPaths`, and an empty object or missing key
+        // must round-trip to Default without erroring.
+        let json = r#"{
+            "opencodeDbPaths": ["/one/opencode.db", "/two/opencode-stable.db"]
+        }"#;
+        let parsed: ScannerSettings = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.opencode_db_paths.len(), 2);
+        assert_eq!(parsed.opencode_db_paths[0], PathBuf::from("/one/opencode.db"));
+        assert_eq!(
+            parsed.opencode_db_paths[1],
+            PathBuf::from("/two/opencode-stable.db")
+        );
+
+        let empty: ScannerSettings = serde_json::from_str("{}").unwrap();
+        assert!(empty.opencode_db_paths.is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_with_scanner_settings_merges_user_path() {
+        let previous_xdg = std::env::var("XDG_DATA_HOME").ok();
+
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        // Auto-discoverable channel db inside XDG data dir.
+        let data_dir = home.join(".local/share/opencode");
+        fs::create_dir_all(&data_dir).unwrap();
+        File::create(data_dir.join("opencode-stable.db")).unwrap();
+
+        // User-configured db living outside XDG_DATA_HOME, the way an
+        // `OPENCODE_DB=/abs/path/opencode.db` user would have it.
+        let outside_dir = home.join("elsewhere");
+        fs::create_dir_all(&outside_dir).unwrap();
+        let outside_db = outside_dir.join("opencode.db");
+        File::create(&outside_db).unwrap();
+
+        unsafe { std::env::set_var("XDG_DATA_HOME", home.join(".local/share")) };
+
+        let settings = ScannerSettings {
+            opencode_db_paths: vec![outside_db.clone()],
+        };
+        let result = scan_all_clients_with_scanner_settings(
+            home.to_str().unwrap(),
+            &["opencode".to_string()],
+            true,
+            &settings,
+        );
+
+        // Both paths must appear — the auto-discovered stable db and the
+        // user-configured outside-XDG db.
+        let names: Vec<String> = result
+            .opencode_dbs
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "opencode-stable.db"),
+            "expected auto-discovered opencode-stable.db, got {names:?}"
+        );
+        assert!(
+            result.opencode_dbs.iter().any(|p| p == &outside_db),
+            "expected user-configured {} in {:?}",
+            outside_db.display(),
+            result.opencode_dbs
+        );
+
+        restore_env("XDG_DATA_HOME", previous_xdg);
     }
 
     #[test]

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -403,10 +403,7 @@ fn supports_extra_dir_scanning(client_id: ClientId) -> bool {
 ///
 /// Kept as a separate helper so the unit tests can exercise the merge
 /// semantics without spinning up a full `scan_all_clients` run.
-pub(crate) fn merge_user_opencode_db_paths(
-    discovered: &mut Vec<PathBuf>,
-    extra_paths: &[PathBuf],
-) {
+pub(crate) fn merge_user_opencode_db_paths(discovered: &mut Vec<PathBuf>, extra_paths: &[PathBuf]) {
     if extra_paths.is_empty() {
         return;
     }
@@ -455,12 +452,7 @@ pub fn scan_all_clients_with_scanner_settings(
     use_env_roots: bool,
     scanner_settings: &ScannerSettings,
 ) -> ScanResult {
-    let mut result =
-        scan_all_clients_with_env_strategy_inner(home_dir, clients, use_env_roots);
-    merge_user_opencode_db_paths(&mut result.opencode_dbs, &scanner_settings.opencode_db_paths);
-    result.opencode_dbs.sort_unstable();
-    result.opencode_dbs.dedup();
-    result
+    scan_all_clients_with_env_strategy_inner(home_dir, clients, use_env_roots, scanner_settings)
 }
 
 /// Scan all session client directories in parallel
@@ -481,6 +473,7 @@ fn scan_all_clients_with_env_strategy_inner(
     home_dir: &str,
     clients: &[String],
     use_env_roots: bool,
+    scanner_settings: &ScannerSettings,
 ) -> ScanResult {
     let mut result = ScanResult::default();
 
@@ -549,6 +542,19 @@ fn scan_all_clients_with_env_strategy_inner(
         // the naming rule.
         let opencode_data_dir = PathBuf::from(format!("{}/opencode", xdg_data));
         result.opencode_dbs = discover_opencode_dbs(&opencode_data_dir);
+
+        // Merge user-configured `scanner.opencodeDbPaths` here, INSIDE the
+        // `enabled.contains(&ClientId::OpenCode)` guard, so a request like
+        // `tokscale --claude` does not pull in OpenCode dbs the user pinned
+        // for unrelated reasons. Inflated OpenCode `counts` and wasted
+        // SQLite parsing work otherwise sneak past the message-level
+        // client filter that runs much later in the pipeline.
+        merge_user_opencode_db_paths(
+            &mut result.opencode_dbs,
+            &scanner_settings.opencode_db_paths,
+        );
+        result.opencode_dbs.sort_unstable();
+        result.opencode_dbs.dedup();
 
         // OpenCode legacy: JSON files at ~/.local/share/opencode/storage/message/*/*.json
         let opencode_path = ClientId::OpenCode
@@ -1290,7 +1296,10 @@ mod tests {
         }"#;
         let parsed: ScannerSettings = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.opencode_db_paths.len(), 2);
-        assert_eq!(parsed.opencode_db_paths[0], PathBuf::from("/one/opencode.db"));
+        assert_eq!(
+            parsed.opencode_db_paths[0],
+            PathBuf::from("/one/opencode.db")
+        );
         assert_eq!(
             parsed.opencode_db_paths[1],
             PathBuf::from("/two/opencode-stable.db")
@@ -1347,6 +1356,105 @@ mod tests {
             "expected user-configured {} in {:?}",
             outside_db.display(),
             result.opencode_dbs
+        );
+
+        restore_env("XDG_DATA_HOME", previous_xdg);
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_with_scanner_settings_respects_opencode_client_filter() {
+        // Regression guard: previously the scanner unconditionally
+        // merged `scanner.opencodeDbPaths` after the inner scan, which
+        // bypassed the existing `enabled.contains(&ClientId::OpenCode)`
+        // guard. A request like `tokscale --claude` would still pull in
+        // user-pinned OpenCode dbs and inflate `parse_local_clients`
+        // counts plus waste SQLite parsing work.
+        //
+        // The fix moves the merge inside the OpenCode-enabled block, so
+        // this test exercises the four canonical filter shapes:
+        //   1. ["claude"]    → opencode_dbs must be empty
+        //   2. ["opencode"]  → both auto + user-configured dbs present
+        //   3. ["synthetic"] → both present (synthetic enables all)
+        //   4. []            → both present (empty filter = all clients)
+        let previous_xdg = std::env::var("XDG_DATA_HOME").ok();
+
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+
+        // Auto-discoverable channel db inside XDG data dir.
+        let data_dir = home.join(".local/share/opencode");
+        fs::create_dir_all(&data_dir).unwrap();
+        let auto_db = data_dir.join("opencode.db");
+        File::create(&auto_db).unwrap();
+
+        // User-configured db living outside XDG_DATA_HOME (mirrors the
+        // `OPENCODE_DB=/abs/path/opencode.db` use case).
+        let outside_dir = home.join("elsewhere");
+        fs::create_dir_all(&outside_dir).unwrap();
+        let outside_db = outside_dir.join("opencode.db");
+        File::create(&outside_db).unwrap();
+
+        unsafe { std::env::set_var("XDG_DATA_HOME", home.join(".local/share")) };
+
+        let settings = ScannerSettings {
+            opencode_db_paths: vec![outside_db.clone()],
+        };
+
+        let scan = |clients: &[&str]| {
+            let owned: Vec<String> = clients.iter().map(|s| s.to_string()).collect();
+            scan_all_clients_with_scanner_settings(home.to_str().unwrap(), &owned, true, &settings)
+        };
+
+        // 1. clients=["claude"] — OpenCode disabled, dbs must stay empty.
+        let claude_only = scan(&["claude"]);
+        assert!(
+            claude_only.opencode_dbs.is_empty(),
+            "scanner.opencodeDbPaths must NOT leak into a Claude-only scan, \
+             got {:?}",
+            claude_only.opencode_dbs
+        );
+
+        // 2. clients=["opencode"] — both auto-discovered + user-configured.
+        let opencode_only = scan(&["opencode"]);
+        assert!(
+            opencode_only.opencode_dbs.iter().any(|p| p == &auto_db),
+            "expected auto-discovered {} in {:?}",
+            auto_db.display(),
+            opencode_only.opencode_dbs
+        );
+        assert!(
+            opencode_only.opencode_dbs.iter().any(|p| p == &outside_db),
+            "expected user-configured {} in {:?}",
+            outside_db.display(),
+            opencode_only.opencode_dbs
+        );
+
+        // 3. clients=["synthetic"] — synthetic enables all clients, so
+        //    both dbs must be present.
+        let synthetic_only = scan(&["synthetic"]);
+        assert!(
+            synthetic_only.opencode_dbs.iter().any(|p| p == &auto_db),
+            "synthetic-only filter must enable OpenCode auto-discovery, got {:?}",
+            synthetic_only.opencode_dbs
+        );
+        assert!(
+            synthetic_only.opencode_dbs.iter().any(|p| p == &outside_db),
+            "synthetic-only filter must merge user-configured paths, got {:?}",
+            synthetic_only.opencode_dbs
+        );
+
+        // 4. clients=[] — empty filter = all clients = both dbs present.
+        let all_clients = scan(&[]);
+        assert!(
+            all_clients.opencode_dbs.iter().any(|p| p == &auto_db),
+            "empty client filter must enable OpenCode auto-discovery, got {:?}",
+            all_clients.opencode_dbs
+        );
+        assert!(
+            all_clients.opencode_dbs.iter().any(|p| p == &outside_db),
+            "empty client filter must merge user-configured paths, got {:?}",
+            all_clients.opencode_dbs
         );
 
         restore_env("XDG_DATA_HOME", previous_xdg);


### PR DESCRIPTION
> **Note:** This PR replaces #408 (auto-closed when its base branch `fix/opencode-channel-dbs` was deleted as part of merging #406). All review threads from #408 were resolved before the rebase. The branch is now rebased directly onto `main` (squash commit `7156cac`) with no functional changes.

---

## Summary

Stacked on #406.

Follow-up to the discussion under #387: adds a persistent, declarative counterpart to the `TOKSCALE_EXTRA_DIRS` env var so users who launch opencode with `OPENCODE_DB` pointing at a path outside `~/.local/share/opencode` can pin those dbs in `~/.config/tokscale/settings.json`.

```json
{
  "scanner": {
    "opencodeDbPaths": [
      "/custom/location/opencode.db",
      "/another/location/opencode-stable.db"
    ]
  }
}
```

## Why this shape

Tokscale already has `~/.config/tokscale/settings.json` for TUI preferences, so `scanner` is just another top-level section — no second config file to manage. The struct lives in `tokscale-core` (not just the CLI) so headless consumers of the scanner get the same config surface.

## Changes

**`tokscale-core::scanner`**
- New public `ScannerSettings` struct with `opencode_db_paths: Vec<PathBuf>`, serde camelCase, `#[serde(default)]` at both struct and field level so older/partial settings.json files deserialize cleanly.
- New `scan_all_clients_with_scanner_settings(home_dir, clients, use_env_roots, settings)` entry point. Runs auto-discovery then merges user-configured paths via `merge_user_opencode_db_paths`, which:
  - Canonicalizes for dedup (a user who explicitly lists an auto-discovered db won't get double-parsed).
  - Silently skips non-existent paths (stale config must never break a scan — the config outlives any single opencode install).
  - Rejects WAL/SHM/journal sidecars via the same `is_opencode_db_filename` check introduced in #406.
- `scan_all_clients_with_env_strategy` and `scan_all_clients` become thin wrappers that pass `ScannerSettings::default()`, preserving backward compatibility.

**`tokscale-core::lib`**
- `ReportOptions` and `LocalParseOptions` both grow a `scanner_settings: scanner::ScannerSettings` field and derive `Default`.
- `parse_all_messages_with_pricing_with_env_strategy` takes `&ScannerSettings` and passes it to the new scanner entry point. All four internal call sites (model report, monthly report, graph, local-graph) thread it through from their enclosing options.

**`tokscale-cli::tui::settings`**
- `Settings` struct gets a `scanner: ScannerSettings` field with `#[serde(default)]`.
- New `load_scanner_settings()` helper — the single function every CLI entry point calls to populate `LocalParseOptions`/`ReportOptions`.

**CLI call sites wired** (one-line field addition each):
- `commands/wrapped.rs` (× 2)
- `main.rs` run_models_report / run_monthly_report / run_clients_command / run_graph_command / run_submit_command
- `tui/data/mod.rs` (× 3)

## Test plan

- [x] `cargo test --workspace` — **886 tests pass** (322 + 81 + 480 + 3 + 0 doctest), 2 ignored (unrelated, pre-existing)
- [x] `cargo clippy -p tokscale-core --lib --tests -- -D warnings` — clean
- [x] New `tokscale-core` tests (in `scanner::tests`):
  - `test_merge_user_opencode_db_paths_picks_up_path_outside_xdg` — the flagship OPENCODE_DB=/abs/path use case
  - `test_merge_user_opencode_db_paths_skips_nonexistent_and_sidecars` — graceful degradation for stale config + sidecar rejection
  - `test_merge_user_opencode_db_paths_dedups_against_auto_discovered` — canonicalized dedup
  - `test_scanner_settings_deserialize_from_json_camel_case` — `opencodeDbPaths` field contract + empty-object form
  - `test_scan_all_clients_with_scanner_settings_merges_user_path` — end-to-end through `scan_all_clients_with_scanner_settings` with both an auto-discovered db and a user-configured outside-XDG db
- [x] New `tokscale-cli` tests (in `tui::settings::tests`):
  - `settings_load_backfills_scanner_when_missing_from_json` — older settings.json without the key still loads
  - `settings_load_reads_scanner_opencode_db_paths` — paths deserialize from the expected shape
  - `settings_accepts_empty_scanner_object` — `"scanner": {}` is a valid no-op
  - `settings_round_trips_scanner_section_through_json` — save → load preserves paths verbatim

## Follow-ups (out of scope)

- A TUI pane to edit `scanner.opencodeDbPaths` interactively. Right now users have to hand-edit the JSON file.
- `:memory:` in-process opencode dbs — still no file to scan.
- A broader `ScannerSettings` schema for other clients' override paths (currently only opencode has a use case).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds persistent scanner config via `scanner.opencodeDbPaths` in `~/.config/tokscale/settings.json` so users can pin OpenCode SQLite DBs outside the default data dir; paths merge with auto-discovery, dedupe by canonical path, skip missing, ignore SQLite sidecars, are honored across all report paths (including `parse_local_clients` and the wrapped UI), and are only merged when the OpenCode client is enabled so `--clients claude` doesn’t import OpenCode DBs.

- **New Features**
  - `tokscale-core::scanner::ScannerSettings` (camelCase, `Default`) with `opencodeDbPaths`.
  - `scan_all_clients_with_scanner_settings` merges user paths with discovery; dedupes, skips missing, rejects WAL/SHM/journal via `is_opencode_db_filename`.
  - `ReportOptions` and `LocalParseOptions` carry `scanner_settings` (`Default`); wrappers pass defaults for backward compatibility.
  - CLI `Settings` adds `scanner`; `load_scanner_settings()` threads config into all command entry points; README documents the setting.

- **Bug Fixes**
  - `parse_local_clients` now passes `scanner_settings`, so `tokscale clients` and wrapped views honor `opencodeDbPaths`.
  - Only merge `opencodeDbPaths` when OpenCode is enabled, preventing unrelated scans (e.g. `--clients claude`) from importing OpenCode DBs or inflating counts.
  - `tui::DataLoader` uses a `cfg(test)` helper to ignore real settings in tests, keeping unit tests hermetic.

<sup>Written for commit 0e1a79d2cad88ae3549c6687c4697fb042411bc4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


