### PR TITLE
feat(scanner): support persistent extra scan paths in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,15 @@ Tokscale stores settings in `~/.config/tokscale/settings.json`:
 ```json
 {
   "colorPalette": "blue",
-  "includeUnusedModels": false
+  "includeUnusedModels": false,
+  "scanner": {
+    "extraScanPaths": {
+      "codex": [
+        "/Users/me/workspace/project-a/.codex/sessions",
+        "/Users/me/workspace/project-b/.codex/archived_sessions"
+      ]
+    }
+  }
 }
 ```
 
@@ -498,6 +506,9 @@ Tokscale stores settings in `~/.config/tokscale/settings.json`:
 | `autoRefreshEnabled` | boolean | `false` | Enable auto-refresh in TUI |
 | `autoRefreshMs` | number | `60000` | Auto-refresh interval (30000-3600000ms) |
 | `nativeTimeoutMs` | number | `300000` | Maximum time for native subprocess processing (5000-3600000ms) |
+| `scanner.extraScanPaths` | object | `{}` | Additional per-client scan roots for sessions outside Tokscale's default home-root locations |
+
+Use `scanner.extraScanPaths` for persistent extra roots such as project-level `.codex` directories or imported Gemini/OpenClaw histories. Tokscale merges these paths with the default scan roots on every run and deduplicates overlapping roots by canonical path.
 
 ### Environment Variables
 
@@ -506,13 +517,17 @@ Environment variables override config file values. For CI/CD or one-off use:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `TOKSCALE_NATIVE_TIMEOUT_MS` | `300000` (5 min) | Overrides `nativeTimeoutMs` config |
+| `TOKSCALE_EXTRA_DIRS` | unset | One-off extra session roots as `client:/abs/path,client:/abs/path` |
 
 ```bash
 # Example: Increase timeout for very large datasets
 TOKSCALE_NATIVE_TIMEOUT_MS=600000 tokscale graph --output data.json
+
+# Example: one-off extra scan roots
+TOKSCALE_EXTRA_DIRS='codex:/Users/me/workspace/project-a/.codex/sessions,gemini:/Users/me/imports/imac/gemini/tmp' tokscale
 ```
 
-> **Note**: For persistent changes, prefer setting `nativeTimeoutMs` in `~/.config/tokscale/settings.json`. Environment variables are best for one-off overrides or CI/CD.
+> **Note**: For persistent extra roots, prefer `scanner.extraScanPaths` in `~/.config/tokscale/settings.json`. `TOKSCALE_EXTRA_DIRS` is best for one-off overrides or CI/CD.
 
 ### Headless Mode
 
@@ -998,6 +1013,25 @@ If you launched opencode with `OPENCODE_DB` pointing at a file outside `~/.local
 ```
 
 Paths are merged with auto-discovery, deduped by canonical path, and non-existent entries are silently skipped (so stale config never breaks a scan). `opencode.db-wal`, `opencode.db-shm`, and other SQLite sidecars are rejected.
+
+If you keep sessions outside Tokscale's default home-root locations, you can also persist extra scan roots per client:
+
+```json
+{
+  "scanner": {
+    "extraScanPaths": {
+      "codex": [
+        "/Users/me/workspace/project-a/.codex/sessions",
+        "/Users/me/workspace/project-b/.codex/archived_sessions"
+      ],
+      "gemini": ["/Users/me/imports/imac/gemini/tmp"],
+      "openclaw": ["/Users/me/imports/imac/openclaw/agents"]
+    }
+  }
+}
+```
+
+This is useful for project-level `.codex` directories and imported histories. Tokscale still scans its default roots, then merges `scanner.extraScanPaths` and `TOKSCALE_EXTRA_DIRS` on top with canonical-path deduplication. It does not auto-discover your whole workspace.
 
 Each message contains:
 ```json

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -2484,10 +2484,11 @@ fn capitalize_client(client: &str) -> String {
 }
 
 fn run_clients_command(json: bool) -> Result<()> {
-    use tokscale_core::{parse_local_clients, ClientId, LocalParseOptions};
+    use tokscale_core::{extra_scan_paths_for, parse_local_clients, ClientId, LocalParseOptions};
 
     let home_dir =
         dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+    let scanner_settings = tui::settings::load_scanner_settings();
 
     let parsed = parse_local_clients(LocalParseOptions {
         home_dir: Some(home_dir.to_string_lossy().to_string()),
@@ -2501,7 +2502,7 @@ fn run_clients_command(json: bool) -> Result<()> {
         since: None,
         until: None,
         year: None,
-        scanner_settings: tui::settings::load_scanner_settings(),
+        scanner_settings: scanner_settings.clone(),
     })
     .map_err(|e| anyhow::anyhow!(e))?;
 
@@ -2549,6 +2550,7 @@ fn run_clients_command(json: bool) -> Result<()> {
     struct ExtraPath {
         path: String,
         exists: bool,
+        source: String,
     }
 
     // Collect extra dirs from TOKSCALE_EXTRA_DIRS for display (reuse core parser)
@@ -2556,91 +2558,101 @@ fn run_clients_command(json: bool) -> Result<()> {
     let all_clients: std::collections::HashSet<ClientId> = ClientId::iter().collect();
     let extra_dirs: Vec<(ClientId, String)> =
         tokscale_core::parse_extra_dirs(&extra_dirs_val, &all_clients);
+    let settings_extra_dirs = extra_scan_paths_for(&scanner_settings, &all_clients);
 
-    let clients: Vec<ClientRow> = ClientId::iter()
-        .map(|client| {
-            let sessions_path = client.data().resolve_path(&home_dir.to_string_lossy());
-            let sessions_path_exists = Path::new(&sessions_path).exists();
-            let legacy_paths = if client == ClientId::OpenClaw {
-                vec![
-                    LegacyPath {
-                        path: home_dir
-                            .join(".clawdbot/agents")
-                            .to_string_lossy()
-                            .to_string(),
-                        exists: home_dir.join(".clawdbot/agents").exists(),
-                    },
-                    LegacyPath {
-                        path: home_dir
-                            .join(".moltbot/agents")
-                            .to_string_lossy()
-                            .to_string(),
-                        exists: home_dir.join(".moltbot/agents").exists(),
-                    },
-                    LegacyPath {
-                        path: home_dir
-                            .join(".moldbot/agents")
-                            .to_string_lossy()
-                            .to_string(),
-                        exists: home_dir.join(".moldbot/agents").exists(),
-                    },
-                ]
-            } else {
-                vec![]
-            };
-            let (headless_supported, headless_paths, headless_message_count) =
-                if client == ClientId::Codex {
-                    (
-                        true,
-                        headless_roots
-                            .iter()
-                            .map(|root| {
-                                let path = root.join(client.as_str());
-                                HeadlessPath {
-                                    path: path.to_string_lossy().to_string(),
-                                    exists: path.exists(),
-                                }
-                            })
-                            .collect(),
-                        headless_codex_count,
-                    )
+    let clients: Vec<ClientRow> =
+        ClientId::iter()
+            .map(|client| {
+                let sessions_path = client.data().resolve_path(&home_dir.to_string_lossy());
+                let sessions_path_exists = Path::new(&sessions_path).exists();
+                let legacy_paths = if client == ClientId::OpenClaw {
+                    vec![
+                        LegacyPath {
+                            path: home_dir
+                                .join(".clawdbot/agents")
+                                .to_string_lossy()
+                                .to_string(),
+                            exists: home_dir.join(".clawdbot/agents").exists(),
+                        },
+                        LegacyPath {
+                            path: home_dir
+                                .join(".moltbot/agents")
+                                .to_string_lossy()
+                                .to_string(),
+                            exists: home_dir.join(".moltbot/agents").exists(),
+                        },
+                        LegacyPath {
+                            path: home_dir
+                                .join(".moldbot/agents")
+                                .to_string_lossy()
+                                .to_string(),
+                            exists: home_dir.join(".moldbot/agents").exists(),
+                        },
+                    ]
                 } else {
-                    (false, vec![], 0)
+                    vec![]
                 };
+                let (headless_supported, headless_paths, headless_message_count) =
+                    if client == ClientId::Codex {
+                        (
+                            true,
+                            headless_roots
+                                .iter()
+                                .map(|root| {
+                                    let path = root.join(client.as_str());
+                                    HeadlessPath {
+                                        path: path.to_string_lossy().to_string(),
+                                        exists: path.exists(),
+                                    }
+                                })
+                                .collect(),
+                            headless_codex_count,
+                        )
+                    } else {
+                        (false, vec![], 0)
+                    };
 
-            let label = match client {
-                ClientId::Claude => "Claude Code",
-                ClientId::Codex => "Codex CLI",
-                ClientId::Gemini => "Gemini CLI",
-                ClientId::Cursor => "Cursor IDE",
-                ClientId::Kimi => "Kimi CLI",
-                _ => client_ui::display_name(client),
-            }
-            .to_string();
+                let label = match client {
+                    ClientId::Claude => "Claude Code",
+                    ClientId::Codex => "Codex CLI",
+                    ClientId::Gemini => "Gemini CLI",
+                    ClientId::Cursor => "Cursor IDE",
+                    ClientId::Kimi => "Kimi CLI",
+                    _ => client_ui::display_name(client),
+                }
+                .to_string();
 
-            let extra_paths: Vec<ExtraPath> = extra_dirs
-                .iter()
-                .filter(|(c, _)| *c == client)
-                .map(|(_, path)| ExtraPath {
-                    path: path.clone(),
-                    exists: Path::new(path).exists(),
-                })
-                .collect();
+                let mut extra_paths: Vec<ExtraPath> = settings_extra_dirs
+                    .iter()
+                    .filter(|(c, _)| *c == client)
+                    .map(|(_, path)| ExtraPath {
+                        path: path.to_string_lossy().to_string(),
+                        exists: path.exists(),
+                        source: "settings".to_string(),
+                    })
+                    .collect();
+                extra_paths.extend(extra_dirs.iter().filter(|(c, _)| *c == client).map(
+                    |(_, path)| ExtraPath {
+                        path: path.clone(),
+                        exists: Path::new(path).exists(),
+                        source: "env".to_string(),
+                    },
+                ));
 
-            ClientRow {
-                client: client.as_str().to_string(),
-                label,
-                sessions_path,
-                sessions_path_exists,
-                legacy_paths,
-                message_count: parsed.counts.get(client),
-                headless_supported,
-                headless_paths,
-                headless_message_count,
-                extra_paths,
-            }
-        })
-        .collect();
+                ClientRow {
+                    client: client.as_str().to_string(),
+                    label,
+                    sessions_path,
+                    sessions_path_exists,
+                    legacy_paths,
+                    message_count: parsed.counts.get(client),
+                    headless_supported,
+                    headless_paths,
+                    headless_message_count,
+                    extra_paths,
+                }
+            })
+            .collect();
 
     if json {
         #[derive(serde::Serialize)]
@@ -2703,15 +2715,31 @@ fn run_clients_command(json: bool) -> Result<()> {
             }
 
             if !row.extra_paths.is_empty() {
-                let extra_desc: Vec<String> = row
+                let settings_desc: Vec<String> = row
                     .extra_paths
                     .iter()
+                    .filter(|ep| ep.source == "settings")
                     .map(|ep| describe_path(&ep.path, ep.exists))
                     .collect();
-                println!(
-                    "  {}",
-                    format!("extra: {}", extra_desc.join(", ")).bright_black()
-                );
+                if !settings_desc.is_empty() {
+                    println!(
+                        "  {}",
+                        format!("extra (settings): {}", settings_desc.join(", ")).bright_black()
+                    );
+                }
+
+                let env_desc: Vec<String> = row
+                    .extra_paths
+                    .iter()
+                    .filter(|ep| ep.source == "env")
+                    .map(|ep| describe_path(&ep.path, ep.exists))
+                    .collect();
+                if !env_desc.is_empty() {
+                    println!(
+                        "  {}",
+                        format!("extra (env): {}", env_desc.join(", ")).bright_black()
+                    );
+                }
             }
 
             if row.headless_supported {

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -216,6 +216,34 @@ mod tests {
     }
 
     #[test]
+    fn settings_load_reads_scanner_extra_scan_paths() {
+        let json = r#"{
+            "colorPalette": "blue",
+            "autoRefreshEnabled": false,
+            "autoRefreshMs": 60000,
+            "includeUnusedModels": false,
+            "nativeTimeoutMs": 300000,
+            "scanner": {
+                "extraScanPaths": {
+                    "codex": ["/tmp/project-a/.codex/sessions"],
+                    "openclaw": ["/tmp/imports/openclaw/agents"]
+                }
+            }
+        }"#;
+        let parsed: Settings = serde_json::from_str(json).unwrap();
+        let serialized = serde_json::to_value(&parsed).unwrap();
+
+        assert_eq!(
+            serialized["scanner"]["extraScanPaths"]["codex"][0],
+            serde_json::json!("/tmp/project-a/.codex/sessions")
+        );
+        assert_eq!(
+            serialized["scanner"]["extraScanPaths"]["openclaw"][0],
+            serde_json::json!("/tmp/imports/openclaw/agents")
+        );
+    }
+
+    #[test]
     fn settings_accepts_empty_scanner_object() {
         // `"scanner": {}` is the documented "no-op" form; must be valid.
         let json = r#"{
@@ -241,6 +269,31 @@ mod tests {
         assert_eq!(
             parsed.scanner.opencode_db_paths,
             vec![PathBuf::from("/a/b/opencode.db")]
+        );
+    }
+
+    #[test]
+    fn settings_round_trips_scanner_extra_scan_paths_through_json() {
+        let json = r#"{
+            "colorPalette": "blue",
+            "autoRefreshEnabled": false,
+            "autoRefreshMs": 60000,
+            "includeUnusedModels": false,
+            "nativeTimeoutMs": 300000,
+            "scanner": {
+                "extraScanPaths": {
+                    "gemini": ["/tmp/imports/gemini/tmp"]
+                }
+            }
+        }"#;
+
+        let parsed: Settings = serde_json::from_str(json).unwrap();
+        let serialized = serde_json::to_string(&parsed).unwrap();
+        let round_trip: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(
+            round_trip["scanner"]["extraScanPaths"]["gemini"][0],
+            serde_json::json!("/tmp/imports/gemini/tmp")
         );
     }
 }

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -308,6 +308,16 @@ fn write_fake_credentials(base: &Path) {
     .unwrap();
 }
 
+fn write_settings_json(base: &Path, body: &str) {
+    for dir in [
+        base.join(".config/tokscale"),
+        base.join("Library/Application Support/tokscale"),
+    ] {
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("settings.json"), body).unwrap();
+    }
+}
+
 // ── Existing tests ─────────────────────────────────────────────────────────
 
 #[test]
@@ -1441,6 +1451,67 @@ fn test_clients_json() {
         first.get("messageCount").is_some(),
         "Client entry should have 'messageCount' field"
     );
+}
+
+#[test]
+fn test_clients_json_includes_settings_extra_paths() {
+    let tmp = create_empty_fixture_dir();
+    write_settings_json(
+        tmp.path(),
+        r#"{
+            "scanner": {
+                "extraScanPaths": {
+                    "codex": ["/tmp/project-a/.codex/sessions"]
+                }
+            }
+        }"#,
+    );
+
+    let output = cmd_with_home(tmp.path())
+        .args(["clients", "--json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let codex = json["clients"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["client"] == "codex")
+        .unwrap();
+
+    assert_eq!(
+        codex["extraPaths"][0]["path"],
+        serde_json::json!("/tmp/project-a/.codex/sessions")
+    );
+    assert_eq!(
+        codex["extraPaths"][0]["source"],
+        serde_json::json!("settings")
+    );
+}
+
+#[test]
+fn test_clients_command_includes_settings_extra_paths_text() {
+    let tmp = create_empty_fixture_dir();
+    write_settings_json(
+        tmp.path(),
+        r#"{
+            "scanner": {
+                "extraScanPaths": {
+                    "codex": ["/tmp/project-a/.codex/sessions"]
+                }
+            }
+        }"#,
+    );
+
+    cmd_with_home(tmp.path())
+        .arg("clients")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "extra (settings): /tmp/project-a/.codex/sessions ✗",
+        ));
 }
 
 // ── Light mode tests ───────────────────────────────────────────────────────

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -3516,6 +3516,7 @@ mod tests {
             year: None,
             scanner_settings: scanner::ScannerSettings {
                 opencode_db_paths: vec![external_db.clone()],
+                ..Default::default()
             },
         })
         .unwrap();
@@ -3594,6 +3595,7 @@ mod tests {
             year: None,
             scanner_settings: scanner::ScannerSettings {
                 opencode_db_paths: vec![external_db.clone()],
+                ..Default::default()
             },
         })
         .unwrap();

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -3,7 +3,7 @@
 //! Uses walkdir with rayon for parallel directory traversal.
 
 use rayon::prelude::*;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
@@ -39,6 +39,12 @@ pub struct ScannerSettings {
     /// auto-discovery.
     #[serde(default)]
     pub opencode_db_paths: Vec<PathBuf>,
+    /// Additional per-client scan roots loaded from settings.json.
+    ///
+    /// Keys use public client ids like `codex`, `gemini`, and `openclaw`
+    /// so the JSON stays stable and human-editable.
+    #[serde(default)]
+    pub extra_scan_paths: BTreeMap<String, Vec<PathBuf>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -244,6 +250,30 @@ pub fn parse_extra_dirs(value: &str, enabled: &HashSet<ClientId>) -> Vec<(Client
         .collect()
 }
 
+pub fn extra_scan_paths_for(
+    settings: &ScannerSettings,
+    enabled: &HashSet<ClientId>,
+) -> Vec<(ClientId, PathBuf)> {
+    settings
+        .extra_scan_paths
+        .iter()
+        .filter_map(|(client_str, paths)| {
+            let client_id = ClientId::from_str(client_str)?;
+            if !enabled.contains(&client_id) || !supports_extra_dir_scanning(client_id) {
+                return None;
+            }
+            Some(
+                paths
+                    .iter()
+                    .filter(|path| !path.as_os_str().is_empty())
+                    .cloned()
+                    .map(move |path| (client_id, path)),
+            )
+        })
+        .flatten()
+        .collect()
+}
+
 #[derive(Debug, Deserialize, Default)]
 struct CrushProjectList {
     #[serde(default)]
@@ -390,6 +420,24 @@ fn supports_extra_dir_scanning(client_id: ClientId) -> bool {
     )
 }
 
+fn push_unique_scan_task(
+    tasks: &mut Vec<(ClientId, String, &'static str)>,
+    seen: &mut HashSet<(ClientId, PathBuf)>,
+    client_id: ClientId,
+    raw_path: impl Into<PathBuf>,
+) {
+    let raw_path = raw_path.into();
+    if raw_path.as_os_str().is_empty() {
+        return;
+    }
+
+    let key = std::fs::canonicalize(&raw_path).unwrap_or_else(|_| raw_path.clone());
+    if seen.insert((client_id, key)) {
+        let pattern = client_id.data().pattern;
+        tasks.push((client_id, raw_path.to_string_lossy().to_string(), pattern));
+    }
+}
+
 /// Merge user-configured OpenCode db paths from [`ScannerSettings`] into the
 /// auto-discovered list, in-place.
 ///
@@ -493,6 +541,7 @@ fn scan_all_clients_with_env_strategy_inner(
 
     // Define scan tasks
     let mut tasks: Vec<(ClientId, String, &str)> = Vec::new();
+    let mut seen_scan_roots: HashSet<(ClientId, PathBuf)> = HashSet::new();
 
     for client_id in &enabled {
         if matches!(
@@ -511,7 +560,11 @@ fn scan_all_clients_with_env_strategy_inner(
 
         let def = client_id.data();
         let path = def.resolve_path_with_env_strategy(home_dir, use_env_roots);
-        tasks.push((*client_id, path, def.pattern));
+        push_unique_scan_task(&mut tasks, &mut seen_scan_roots, *client_id, path);
+    }
+
+    for (client_id, path) in extra_scan_paths_for(scanner_settings, &enabled) {
+        push_unique_scan_task(&mut tasks, &mut seen_scan_roots, client_id, path);
     }
 
     // Extra scan directories are part of the caller's environment, so they are
@@ -519,8 +572,7 @@ fn scan_all_clients_with_env_strategy_inner(
     if use_env_roots {
         let extra_dirs_val = std::env::var("TOKSCALE_EXTRA_DIRS").unwrap_or_default();
         for (client_id, path) in parse_extra_dirs(&extra_dirs_val, &enabled) {
-            let pattern = client_id.data().pattern;
-            tasks.push((client_id, path, pattern));
+            push_unique_scan_task(&mut tasks, &mut seen_scan_roots, client_id, path);
         }
     }
 
@@ -561,11 +613,12 @@ fn scan_all_clients_with_env_strategy_inner(
             .data()
             .resolve_path_with_env_strategy(home_dir, use_env_roots);
         result.opencode_json_dir = Some(PathBuf::from(&opencode_path));
-        tasks.push((
+        push_unique_scan_task(
+            &mut tasks,
+            &mut seen_scan_roots,
             ClientId::OpenCode,
             opencode_path,
-            ClientId::OpenCode.data().pattern,
-        ));
+        );
     }
 
     if enabled.contains(&ClientId::Codex) {
@@ -578,21 +631,30 @@ fn scan_all_clients_with_env_strategy_inner(
         let codex_path = ClientId::Codex
             .data()
             .resolve_path_with_env_strategy(home_dir, use_env_roots);
-        tasks.push((ClientId::Codex, codex_path, ClientId::Codex.data().pattern));
+        push_unique_scan_task(
+            &mut tasks,
+            &mut seen_scan_roots,
+            ClientId::Codex,
+            codex_path,
+        );
 
         // Codex archived sessions: ~/.codex/archived_sessions/**/*.jsonl
         let codex_archived_path = format!("{}/archived_sessions", codex_home);
-        tasks.push((
+        push_unique_scan_task(
+            &mut tasks,
+            &mut seen_scan_roots,
             ClientId::Codex,
             codex_archived_path,
-            ClientId::Codex.data().pattern,
-        ));
+        );
 
         // Codex headless: <headless_root>/codex/*.jsonl
         for root in &headless_roots {
-            let codex_headless_path = root.join("codex");
-            let path = codex_headless_path.to_string_lossy().to_string();
-            tasks.push((ClientId::Codex, path, ClientId::Codex.data().pattern));
+            push_unique_scan_task(
+                &mut tasks,
+                &mut seen_scan_roots,
+                ClientId::Codex,
+                root.join("codex"),
+            );
         }
     }
 
@@ -601,39 +663,43 @@ fn scan_all_clients_with_env_strategy_inner(
         let openclaw_path = ClientId::OpenClaw
             .data()
             .resolve_path_with_env_strategy(home_dir, use_env_roots);
-        tasks.push((
+        push_unique_scan_task(
+            &mut tasks,
+            &mut seen_scan_roots,
             ClientId::OpenClaw,
             openclaw_path,
-            ClientId::OpenClaw.data().pattern,
-        ));
+        );
 
         // Legacy paths (Clawd -> Moltbot -> OpenClaw rebrand history)
         let clawdbot_path = format!("{}/.clawdbot/agents", home_dir);
-        tasks.push((
+        push_unique_scan_task(
+            &mut tasks,
+            &mut seen_scan_roots,
             ClientId::OpenClaw,
             clawdbot_path,
-            ClientId::OpenClaw.data().pattern,
-        ));
+        );
 
         let moltbot_path = format!("{}/.moltbot/agents", home_dir);
-        tasks.push((
+        push_unique_scan_task(
+            &mut tasks,
+            &mut seen_scan_roots,
             ClientId::OpenClaw,
             moltbot_path,
-            ClientId::OpenClaw.data().pattern,
-        ));
+        );
 
         let moldbot_path = format!("{}/.moldbot/agents", home_dir);
-        tasks.push((
+        push_unique_scan_task(
+            &mut tasks,
+            &mut seen_scan_roots,
             ClientId::OpenClaw,
             moldbot_path,
-            ClientId::OpenClaw.data().pattern,
-        ));
+        );
     }
 
     // Oh My Pi fork (https://github.com/can1357/oh-my-pi) — same JSONL format, different root
     if enabled.contains(&ClientId::Pi) {
         let omp_path = format!("{}/.omp/agent/sessions", home_dir);
-        tasks.push((ClientId::Pi, omp_path, ClientId::Pi.data().pattern));
+        push_unique_scan_task(&mut tasks, &mut seen_scan_roots, ClientId::Pi, omp_path);
     }
 
     if include_synthetic {
@@ -652,42 +718,46 @@ fn scan_all_clients_with_env_strategy_inner(
         let local_path = ClientId::RooCode
             .data()
             .resolve_path_with_env_strategy(home_dir, use_env_roots);
-        tasks.push((
+        push_unique_scan_task(
+            &mut tasks,
+            &mut seen_scan_roots,
             ClientId::RooCode,
             local_path,
-            ClientId::RooCode.data().pattern,
-        ));
+        );
 
         let server_path = format!(
             "{}/.vscode-server/data/User/globalStorage/rooveterinaryinc.roo-cline/tasks",
             home_dir
         );
-        tasks.push((
+        push_unique_scan_task(
+            &mut tasks,
+            &mut seen_scan_roots,
             ClientId::RooCode,
             server_path,
-            ClientId::RooCode.data().pattern,
-        ));
+        );
     }
 
     if enabled.contains(&ClientId::KiloCode) {
         let local_path = ClientId::KiloCode
             .data()
             .resolve_path_with_env_strategy(home_dir, use_env_roots);
-        tasks.push((
+        push_unique_scan_task(
+            &mut tasks,
+            &mut seen_scan_roots,
             ClientId::KiloCode,
             local_path,
-            ClientId::KiloCode.data().pattern,
-        ));
+        );
 
         let server_path = format!(
             "{}/.vscode-server/data/User/globalStorage/kilocode.kilo-code/tasks",
             home_dir
         );
-        tasks.push((
+        push_unique_scan_task(
+            &mut tasks,
+            &mut seen_scan_roots,
             ClientId::KiloCode,
             server_path,
-            ClientId::KiloCode.data().pattern,
-        ));
+        );
     }
 
     if enabled.contains(&ClientId::Kilo) {
@@ -1310,6 +1380,35 @@ mod tests {
     }
 
     #[test]
+    fn test_scanner_settings_deserialize_extra_scan_paths_camel_case() {
+        let json = r#"{
+            "extraScanPaths": {
+                "codex": [
+                    "/tmp/project-a/.codex/sessions",
+                    "/tmp/project-b/.codex/archived_sessions"
+                ],
+                "gemini": ["/tmp/imports/gemini/tmp"]
+            }
+        }"#;
+
+        let parsed: ScannerSettings = serde_json::from_str(json).unwrap();
+        let serialized = serde_json::to_value(&parsed).unwrap();
+
+        assert_eq!(
+            serialized["extraScanPaths"]["codex"][0],
+            serde_json::json!("/tmp/project-a/.codex/sessions")
+        );
+        assert_eq!(
+            serialized["extraScanPaths"]["codex"][1],
+            serde_json::json!("/tmp/project-b/.codex/archived_sessions")
+        );
+        assert_eq!(
+            serialized["extraScanPaths"]["gemini"][0],
+            serde_json::json!("/tmp/imports/gemini/tmp")
+        );
+    }
+
+    #[test]
     #[serial]
     fn test_scan_all_clients_with_scanner_settings_merges_user_path() {
         let previous_xdg = std::env::var("XDG_DATA_HOME").ok();
@@ -1332,6 +1431,7 @@ mod tests {
 
         let settings = ScannerSettings {
             opencode_db_paths: vec![outside_db.clone()],
+            ..Default::default()
         };
         let result = scan_all_clients_with_scanner_settings(
             home.to_str().unwrap(),
@@ -1359,6 +1459,77 @@ mod tests {
         );
 
         restore_env("XDG_DATA_HOME", previous_xdg);
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_with_scanner_settings_merges_settings_extra_paths() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+
+        let default_root = home.join(".codex/sessions");
+        fs::create_dir_all(&default_root).unwrap();
+        File::create(default_root.join("default.jsonl")).unwrap();
+
+        let extra_root = home.join("workspace/project-a/.codex/sessions");
+        fs::create_dir_all(&extra_root).unwrap();
+        File::create(extra_root.join("extra.jsonl")).unwrap();
+
+        let settings: ScannerSettings = serde_json::from_value(serde_json::json!({
+            "extraScanPaths": {
+                "codex": [extra_root]
+            }
+        }))
+        .unwrap();
+
+        let result = scan_all_clients_with_scanner_settings(
+            home.to_str().unwrap(),
+            &["codex".to_string()],
+            true,
+            &settings,
+        );
+
+        assert_eq!(result.get(ClientId::Codex).len(), 2);
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_with_scanner_settings_dedups_settings_and_env_extra_paths() {
+        let previous = std::env::var("TOKSCALE_EXTRA_DIRS").ok();
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+
+        let default_root = home.join(".codex/sessions");
+        fs::create_dir_all(&default_root).unwrap();
+        File::create(default_root.join("default.jsonl")).unwrap();
+
+        let extra_root = home.join("workspace/project-a/.codex/sessions");
+        fs::create_dir_all(&extra_root).unwrap();
+        File::create(extra_root.join("extra.jsonl")).unwrap();
+
+        unsafe {
+            std::env::set_var(
+                "TOKSCALE_EXTRA_DIRS",
+                format!("codex:{}", extra_root.join("..").join("sessions").display()),
+            )
+        };
+
+        let settings: ScannerSettings = serde_json::from_value(serde_json::json!({
+            "extraScanPaths": {
+                "codex": [extra_root]
+            }
+        }))
+        .unwrap();
+
+        let result = scan_all_clients_with_scanner_settings(
+            home.to_str().unwrap(),
+            &["codex".to_string()],
+            true,
+            &settings,
+        );
+
+        assert_eq!(result.get(ClientId::Codex).len(), 2);
+        restore_env("TOKSCALE_EXTRA_DIRS", previous);
     }
 
     #[test]
@@ -1399,6 +1570,7 @@ mod tests {
 
         let settings = ScannerSettings {
             opencode_db_paths: vec![outside_db.clone()],
+            ..Default::default()
         };
 
         let scan = |clients: &[&str]| {


### PR DESCRIPTION
## Summary
- add `scanner.extraScanPaths` to persistent settings
- merge settings extra roots with default scan roots and `TOKSCALE_EXTRA_DIRS` using canonical-path deduplication
- show settings and env extra roots in `tokscale clients` text and JSON output

## Motivation
Tokscale's local scanner currently works best when sessions live under the default home-root locations such as `~/.codex/sessions`. In practice, many users also keep project-level `.codex` directories or imported Gemini/OpenClaw histories outside those defaults.

`TOKSCALE_EXTRA_DIRS` already proves the multi-root model is useful, but it is still an ephemeral shell-level override. This PR promotes that existing direction into a persistent scanner setting so users do not need wrappers or repeated env injection just to include non-default roots.

## Scope
- does **not** auto-discover workspaces or scan arbitrary directories
- does **not** change parsing, pricing, or submit logic
- keeps `TOKSCALE_EXTRA_DIRS` for one-off shells and CI/CD

## Testing
- scanner serde coverage for `extraScanPaths`
- scanner merge coverage for settings-provided extra roots
- canonical-path dedup coverage across settings + env extra roots
- settings round-trip coverage in `settings.json`
- `tokscale clients` JSON and text output coverage
- `cargo test -p tokscale-core -p tokscale-cli`

Closes the gap for project-level `.codex` and other explicit non-default session roots without introducing automatic workspace discovery.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add persistent `scanner.extraScanPaths` to settings so you can include non‑default session roots without env overrides. The scanner merges these with default roots and `TOKSCALE_EXTRA_DIRS`, deduped by canonical path; `tokscale clients` now shows extra roots and their source in text and JSON.

- New Features
  - Add `scanner.extraScanPaths` in `settings.json` (per client).
  - Merge settings paths with defaults and `TOKSCALE_EXTRA_DIRS`, with canonical-path dedup and silent skip of missing paths.
  - Update `tokscale clients` to display extra roots from settings vs env in both text and JSON.
  - Add `extra_scan_paths` to `ScannerSettings` and helper to collect paths; update docs and tests.

<sup>Written for commit 459f84b22e683a6c6b0712f909b35cdaab6bc505. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

