### PR TITLE
fix(release): keep Rust and npm versions in sync

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -91,10 +91,39 @@ jobs:
           # Update packages/tokscale/package.json (version + @tokscale/cli dependency)
           jq --arg v "$NEW_VERSION" '.version = $v | .dependencies["@tokscale/cli"] = $v' packages/tokscale/package.json > tmp.json && mv tmp.json packages/tokscale/package.json
           echo "✅ Updated packages/tokscale/package.json"
+
+          # Update Rust workspace version so the published binary reports the same release version
+          python3 - <<'PY' "$NEW_VERSION"
+          import pathlib
+          import re
+          import sys
+
+          new_version = sys.argv[1]
+          path = pathlib.Path("Cargo.toml")
+          content = path.read_text()
+          updated, count = re.subn(
+              r'(\[workspace\.package\](?:(?!^\[).|\n)*?^version = ")([^"]+)(")',
+              rf"\g<1>{new_version}\g<3>",
+              content,
+              count=1,
+              flags=re.MULTILINE,
+          )
+          if count != 1:
+              raise SystemExit("Failed to update [workspace.package] version in Cargo.toml")
+          path.write_text(updated)
+          PY
+          echo "✅ Updated Cargo.toml workspace version"
           
           # Verify all versions are updated
           echo ""
           echo "📋 Verification:"
+          echo "  Rust workspace:  $(python3 - <<'PY'
+          import pathlib, re
+          content = pathlib.Path('Cargo.toml').read_text()
+          match = re.search(r'\[workspace\.package\](?:(?!^\[).|\n)*?^version = "([^"]+)"', content, re.MULTILINE)
+          print(match.group(1) if match else 'missing')
+          PY
+          )"
           echo "  @tokscale/cli:   $(jq -r '.version' packages/cli/package.json)"
           echo "  tokscale:        $(jq -r '.version' packages/tokscale/package.json)"
           echo "  cli -> darwin arm64: $(jq -r '.optionalDependencies["@tokscale/cli-darwin-arm64"]' packages/cli/package.json)"
@@ -103,15 +132,18 @@ jobs:
           for pkg in cli-darwin-arm64 cli-darwin-x64 cli-linux-x64-gnu cli-linux-x64-musl cli-linux-arm64-gnu cli-linux-arm64-musl cli-win32-x64-msvc cli-win32-arm64-msvc; do
             echo "    $pkg: $(jq -r '.version' "packages/$pkg/package.json")"
           done
+
+          bash scripts/check-version-coherence.sh --expect-version "$NEW_VERSION"
           
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "📝 Version bump prepared (will commit after successful publish)"
 
-      - name: Upload bumped package.json files
+      - name: Upload bumped manifest files
         uses: actions/upload-artifact@v4
         with:
-          name: bumped-packages
+          name: bumped-manifests
           path: |
+            Cargo.toml
             packages/cli/package.json
             packages/cli-darwin-arm64/package.json
             packages/cli-darwin-x64/package.json
@@ -195,8 +227,8 @@ jobs:
       - name: Download bumped package.json files
         uses: actions/download-artifact@v4
         with:
-          name: bumped-packages
-          path: packages/
+          name: bumped-manifests
+          path: .
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -299,8 +331,8 @@ jobs:
       - name: Download bumped package.json files
         uses: actions/download-artifact@v4
         with:
-          name: bumped-packages
-          path: packages/
+          name: bumped-manifests
+          path: .
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -342,8 +374,8 @@ jobs:
       - name: Download bumped package.json files
         uses: actions/download-artifact@v4
         with:
-          name: bumped-packages
-          path: packages/
+          name: bumped-manifests
+          path: .
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -377,8 +409,8 @@ jobs:
       - name: Download bumped package.json files
         uses: actions/download-artifact@v4
         with:
-          name: bumped-packages
-          path: packages/
+          name: bumped-manifests
+          path: .
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -409,8 +441,8 @@ jobs:
       - name: Download bumped package.json files
         uses: actions/download-artifact@v4
         with:
-          name: bumped-packages
-          path: packages/
+          name: bumped-manifests
+          path: .
 
       - name: Configure Git
         run: |
@@ -422,7 +454,7 @@ jobs:
           NEW_VERSION="${{ needs.bump-versions.outputs.version }}"
           echo "📦 Committing version bump to $NEW_VERSION"
           
-          git add packages/cli/package.json packages/cli-darwin-arm64/package.json packages/cli-darwin-x64/package.json packages/cli-linux-x64-gnu/package.json packages/cli-linux-x64-musl/package.json packages/cli-linux-arm64-gnu/package.json packages/cli-linux-arm64-musl/package.json packages/cli-win32-x64-msvc/package.json packages/cli-win32-arm64-msvc/package.json packages/tokscale/package.json
+          git add Cargo.toml packages/cli/package.json packages/cli-darwin-arm64/package.json packages/cli-darwin-x64/package.json packages/cli-linux-x64-gnu/package.json packages/cli-linux-x64-musl/package.json packages/cli-linux-arm64-gnu/package.json packages/cli-linux-arm64-musl/package.json packages/cli-win32-x64-msvc/package.json packages/cli-win32-arm64-msvc/package.json packages/tokscale/package.json
           git commit -m "chore: bump version to $NEW_VERSION"
           git push
           

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -8,12 +8,22 @@ on:
       - 'crates/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'packages/cli/package.json'
+      - 'packages/tokscale/package.json'
+      - 'packages/cli-*/package.json'
+      - 'scripts/check-version-coherence.sh'
+      - '.github/workflows/publish-cli.yml'
   pull_request:
     branches: [main, develop]
     paths:
       - 'crates/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'packages/cli/package.json'
+      - 'packages/tokscale/package.json'
+      - 'packages/cli-*/package.json'
+      - 'scripts/check-version-coherence.sh'
+      - '.github/workflows/publish-cli.yml'
 
 env:
   CARGO_TERM_COLOR: always
@@ -35,6 +45,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
+      - name: Verify version coherence
+        run: bash scripts/check-version-coherence.sh
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,12 +96,12 @@ Releases are published to npm via a GitHub Actions `workflow_dispatch` pipeline,
 
 | # | Job | Description |
 |---|-----|-------------|
-| 1 | `bump-versions` | Reads current version from `packages/cli/package.json`, calculates new version, updates all platform package.json files + CLI + wrapper, uploads as artifact |
+| 1 | `bump-versions` | Reads current version from `packages/cli/package.json`, calculates new version, updates the Rust workspace version plus the CLI, wrapper, and platform package manifests, then uploads the bumped manifests as an artifact |
 | 2 | `build-cli-binary` | 8-target parallel native Rust builds (macOS x86/arm64, Linux glibc/musl x86/arm64, Windows x86/arm64) |
 | 3 | `publish-platform-packages` | Publishes platform-specific packages (`@tokscale/cli-darwin-arm64`, etc.) containing native binaries to npm |
 | 4 | `publish-cli` | Publishes `@tokscale/cli` to npm (binary dispatcher + optionalDependencies) |
 | 5 | `publish-alias` | Publishes `tokscale` wrapper package to npm |
-| 6 | `finalize` | Commits bumped `package.json` files back to repo as `chore: bump version to X.Y.Z` (authored by `github-actions[bot]`) |
+| 6 | `finalize` | Commits the bumped release manifests back to repo as `chore: bump version to X.Y.Z` (authored by `github-actions[bot]`) |
 
 **Duration:** ~15-20 minutes end-to-end.
 
@@ -127,10 +127,11 @@ The CI pipeline does **NOT** create the git tag or GitHub Release. After the wor
 | `minor` | New client support, significant features, UI overhauls | `1.1.2` → `1.2.0` |
 | `major` | Breaking changes (never used so far) | `1.2.1` → `2.0.0` |
 
-Version is stored in 3 places (all updated by CI):
-- `packages/cli/package.json` — source of truth
-- Platform packages (`packages/cli-*/package.json`) — version synced
-- `packages/tokscale/package.json` — version + `@tokscale/cli` dependency version
+Release version is stored in the Rust workspace and the npm package manifests, and CI updates them together:
+- `Cargo.toml` (`[workspace.package].version`) — Rust binary and exported metadata version
+- `packages/cli/package.json` — CLI package version and platform optional dependency versions
+- Platform packages (`packages/cli-*/package.json`) — native package versions
+- `packages/tokscale/package.json` — wrapper version plus `@tokscale/cli` dependency version
 
 ### CI-Only Workflow
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-cli"
-version = "2.0.0"
+version = "2.0.20"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-core"
-version = "2.0.0"
+version = "2.0.20"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.0"
+version = "2.0.20"
 edition = "2021"
 authors = ["Junho Yeo <hello@junho.io>"]
 license = "MIT"

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -334,7 +334,10 @@ fn test_version_flag() {
     cmd.arg("--version")
         .assert()
         .success()
-        .stdout(predicate::str::contains("tokscale"));
+        .stdout(predicate::str::contains(format!(
+            "tokscale {}",
+            env!("CARGO_PKG_VERSION")
+        )));
 }
 
 #[test]

--- a/scripts/check-version-coherence.sh
+++ b/scripts/check-version-coherence.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXPECTED_VERSION="${1:-}"
+if [[ "${EXPECTED_VERSION}" == "--expect-version" ]]; then
+  EXPECTED_VERSION="${2:-}"
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+python3 - <<'PY' "${EXPECTED_VERSION}"
+import json
+import pathlib
+import re
+import sys
+
+expected_version = sys.argv[1] or None
+root = pathlib.Path(".")
+cargo_toml = (root / "Cargo.toml").read_text()
+match = re.search(r"\[workspace\.package\](?:(?!^\[).|\n)*?^version = \"([^\"]+)\"", cargo_toml, re.MULTILINE)
+if not match:
+    raise SystemExit("Could not find [workspace.package] version in Cargo.toml")
+
+workspace_version = match.group(1)
+if expected_version and workspace_version != expected_version:
+    raise SystemExit(
+        f"Cargo workspace version mismatch: expected {expected_version}, found {workspace_version}"
+    )
+
+def load_json(path: str) -> dict:
+    return json.loads((root / path).read_text())
+
+cli_package = load_json("packages/cli/package.json")
+wrapper_package = load_json("packages/tokscale/package.json")
+
+platform_packages = sorted((root / "packages").glob("cli-*/package.json"))
+if not platform_packages:
+    raise SystemExit("No platform package manifests found under packages/cli-*")
+
+errors: list[str] = []
+
+def expect_equal(label: str, actual: str, expected: str) -> None:
+    if actual != expected:
+        errors.append(f"{label}: expected {expected}, found {actual}")
+
+expect_equal("packages/cli/package.json version", cli_package["version"], workspace_version)
+expect_equal("packages/tokscale/package.json version", wrapper_package["version"], workspace_version)
+expect_equal(
+    "packages/tokscale dependency on @tokscale/cli",
+    wrapper_package["dependencies"]["@tokscale/cli"],
+    workspace_version,
+)
+
+for path in platform_packages:
+    manifest = json.loads(path.read_text())
+    expect_equal(f"{path} version", manifest["version"], workspace_version)
+
+expected_optional = {
+    "@tokscale/cli-darwin-arm64",
+    "@tokscale/cli-darwin-x64",
+    "@tokscale/cli-linux-x64-gnu",
+    "@tokscale/cli-linux-x64-musl",
+    "@tokscale/cli-linux-arm64-gnu",
+    "@tokscale/cli-linux-arm64-musl",
+    "@tokscale/cli-win32-x64-msvc",
+    "@tokscale/cli-win32-arm64-msvc",
+}
+actual_optional = set(cli_package["optionalDependencies"].keys())
+if actual_optional != expected_optional:
+    errors.append(
+        "packages/cli optionalDependencies keys mismatch: "
+        f"expected {sorted(expected_optional)}, found {sorted(actual_optional)}"
+    )
+
+for name, version in cli_package["optionalDependencies"].items():
+    expect_equal(f"packages/cli optional dependency {name}", version, workspace_version)
+
+if expected_version and cli_package["version"] != expected_version:
+    errors.append(
+        f"packages/cli/package.json version mismatch: expected {expected_version}, found {cli_package['version']}"
+    )
+
+if errors:
+    raise SystemExit("Version coherence check failed:\n- " + "\n- ".join(errors))
+
+print(f"Version coherence OK: {workspace_version}")
+PY

--- a/scripts/check-version-coherence.sh
+++ b/scripts/check-version-coherence.sh
@@ -3,7 +3,11 @@ set -euo pipefail
 
 EXPECTED_VERSION="${1:-}"
 if [[ "${EXPECTED_VERSION}" == "--expect-version" ]]; then
-  EXPECTED_VERSION="${2:-}"
+  if [[ -z "${2:-}" ]]; then
+    echo "--expect-version requires a value" >&2
+    exit 2
+  fi
+  EXPECTED_VERSION="${2}"
 fi
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -12,17 +16,26 @@ cd "${ROOT_DIR}"
 python3 - <<'PY' "${EXPECTED_VERSION}"
 import json
 import pathlib
-import re
 import sys
 
 expected_version = sys.argv[1] or None
 root = pathlib.Path(".")
-cargo_toml = (root / "Cargo.toml").read_text()
-match = re.search(r"\[workspace\.package\](?:(?!^\[).|\n)*?^version = \"([^\"]+)\"", cargo_toml, re.MULTILINE)
-if not match:
-    raise SystemExit("Could not find [workspace.package] version in Cargo.toml")
 
-workspace_version = match.group(1)
+try:
+    import tomllib
+except ModuleNotFoundError:
+    tomllib = None
+
+if tomllib is None:
+    raise SystemExit("Python tomllib is required (Python 3.11+)")
+
+with (root / "Cargo.toml").open("rb") as cargo_file:
+    cargo_data = tomllib.load(cargo_file)
+
+workspace_section = cargo_data.get("workspace", {}).get("package", {})
+workspace_version = workspace_section.get("version")
+if not workspace_version:
+    raise SystemExit("Could not find [workspace.package] version in Cargo.toml")
 if expected_version and workspace_version != expected_version:
     raise SystemExit(
         f"Cargo workspace version mismatch: expected {expected_version}, found {workspace_version}"
@@ -52,8 +65,14 @@ expect_equal(
     workspace_version,
 )
 
+platform_names = set()
 for path in platform_packages:
     manifest = json.loads(path.read_text())
+    name = manifest.get("name")
+    if not name:
+        errors.append(f"{path} missing package name")
+        continue
+    platform_names.add(name)
     expect_equal(f"{path} version", manifest["version"], workspace_version)
 
 expected_optional = {
@@ -75,6 +94,19 @@ if actual_optional != expected_optional:
 
 for name, version in cli_package["optionalDependencies"].items():
     expect_equal(f"packages/cli optional dependency {name}", version, workspace_version)
+
+missing_manifests = actual_optional - platform_names
+extra_manifests = platform_names - actual_optional
+if missing_manifests:
+    errors.append(
+        "Missing platform manifests for optional dependencies: "
+        f"{sorted(missing_manifests)}"
+    )
+if extra_manifests:
+    errors.append(
+        "Platform manifests not listed in optionalDependencies: "
+        f"{sorted(extra_manifests)}"
+    )
 
 if expected_version and cli_package["version"] != expected_version:
     errors.append(


### PR DESCRIPTION
## Summary
- align the Rust workspace version with the published npm version so `tokscale --version` matches the release users installed
- add a repo-owned version coherence guard to prevent future drift between Cargo and npm manifests
- update the publish workflow to bump and verify Cargo version alongside npm packages

## Why
Recent npm releases report `tokscale --version` as `2.0.0` even though the published CLI packages are `v2.0.x`. This is user-facing and makes support, debugging, and release validation harder than it should be. This change synchronizes the source of truth and adds a guardrail so the versions cannot drift again.

## Diff scope
- update `Cargo.toml` workspace version to match the current npm release version
- add `scripts/check-version-coherence.sh` to validate Cargo and npm manifest versions including platform packages and optionalDependencies
- run the version coherence check from CI without adding new contexts
- update the publish workflow to bump and verify Cargo version together with npm manifests
- strengthen the CLI version test to assert the full `tokscale <version>` string
- document the version source of truth in AGENTS.md

## Test proof
- `bash scripts/check-version-coherence.sh`
  - passed
- `cargo run -q -p tokscale-cli -- --version`
  - tokscale 2.0.20
- `cargo test --workspace --all-features`
  - tokscale-core: 484 passed, 0 failed, 1 ignored
  - tokscale-cli: 323 passed, 0 failed, 1 ignored
  - cli_tests: 81 passed, 0 failed
- `cargo clippy --workspace --all-features -- -D warnings`
  - passed
- `cargo fmt --all --check`
  - passed
- `bun install --frozen-lockfile`
  - passed
- `bun run --cwd packages/cli build`
  - passed
- `npm pack --dry-run` (in packages/cli)
  - @tokscale/cli@2.0.20
- `npm pack --dry-run` (in packages/tokscale)
  - tokscale@2.0.20
- `git diff --check`
  - passed

## Verification-pack proof
Not applicable - no infra tooling or runbook verification changes.

## Migration notes
Not applicable - no schema or data migration.

## CI context confirmation
CI context names unchanged.

## Rollback plan
- if merged with a merge commit: `git revert <merge_commit_sha>`
- if merged as a squash commit: `git revert <squash_commit_sha>`
- no DB downgrade required

## Known residual risks
- this adds a version coherence guard but does not change the manual nature of the release workflow
- release notes are still written manually after the publish workflow completes

## Related
- #393

