### PR TITLE
fix(wrapper): restore node shebang for Windows compatibility

### DIFF
--- a/.github/workflows/launcher_validation.yml
+++ b/.github/workflows/launcher_validation.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
+        with:
+          bun-version: 1.3.10
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8

--- a/.github/workflows/launcher_validation.yml
+++ b/.github/workflows/launcher_validation.yml
@@ -35,6 +35,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Set up Bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
         with:

--- a/.github/workflows/launcher_validation.yml
+++ b/.github/workflows/launcher_validation.yml
@@ -1,0 +1,48 @@
+name: Launcher Validation
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, develop]
+    paths:
+      - "packages/cli/**"
+      - "packages/tokscale/**"
+      - "packages/cli-*/package.json"
+      - "scripts/test-package-launchers.sh"
+      - "package.json"
+      - "bun.lock"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - "packages/cli/**"
+      - "packages/tokscale/**"
+      - "packages/cli-*/package.json"
+      - "scripts/test-package-launchers.sh"
+      - "package.json"
+      - "bun.lock"
+      - "Cargo.toml"
+      - "Cargo.lock"
+
+jobs:
+  launcher-smoke:
+    name: Launcher Smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+
+      - name: Install workspace dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run launcher smoke tests
+        run: bash scripts/test-package-launchers.sh

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build:core": "cargo build --release -p tokscale-cli",
     "cli": "./scripts/cli.sh",
     "dev:frontend": "bun run --cwd packages/frontend dev",
-    "dev:benchmarks": "bun run --cwd packages/benchmarks run"
+    "dev:benchmarks": "bun run --cwd packages/benchmarks run",
+    "test:launchers": "bash scripts/test-package-launchers.sh"
   },
   "devDependencies": {
     "@resvg/resvg-js": "^2.6.2",

--- a/packages/cli/bin.js
+++ b/packages/cli/bin.js
@@ -1,4 +1,2 @@
-#!/bin/sh
-':' //; launcher="$(command -v node 2>/dev/null || command -v bun 2>/dev/null)"; [ -n "$launcher" ] || { echo "Error: tokscale requires Node.js or Bun in PATH" >&2; exit 127; }; exec "$launcher" "$0" "$@"
-
+#!/usr/bin/env node
 await import("./dist/index.js");

--- a/packages/cli/bin.js
+++ b/packages/cli/bin.js
@@ -1,4 +1,4 @@
 #!/bin/sh
 ':' //; launcher="$(command -v node 2>/dev/null || command -v bun 2>/dev/null)"; [ -n "$launcher" ] || { echo "Error: tokscale requires Node.js or Bun in PATH" >&2; exit 127; }; exec "$launcher" "$0" "$@"
 
-await import("@tokscale/cli");
+await import("./dist/index.js");

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,9 +6,10 @@
   "type": "module",
   "main": "./dist/index.js",
   "bin": {
-    "tokscale": "./dist/index.js"
+    "tokscale": "./bin.js"
   },
   "files": [
+    "bin.js",
     "dist/**/*"
   ],
   "publishConfig": {

--- a/packages/tokscale/bin.js
+++ b/packages/tokscale/bin.js
@@ -1,4 +1,2 @@
-#!/bin/sh
-':' //; launcher="$(command -v node 2>/dev/null || command -v bun 2>/dev/null)"; [ -n "$launcher" ] || { echo "Error: tokscale requires Node.js or Bun in PATH" >&2; exit 127; }; exec "$launcher" "$0" "$@"
-
+#!/usr/bin/env node
 await import("@tokscale/cli");

--- a/scripts/test-package-launchers.sh
+++ b/scripts/test-package-launchers.sh
@@ -16,12 +16,7 @@ fi
 
 BUN_BIN="${BUN_BIN:-$(command -v bun)}"
 NODE_BIN="${NODE_BIN:-$(command -v node)}"
-BUN_DIR="$(cd "$(dirname "${BUN_BIN}")" && pwd)"
-NODE_DIR="$(cd "$(dirname "${NODE_BIN}")" && pwd)"
-
-SYSTEM_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
-BUN_ONLY_PATH="${BUN_DIR}:${SYSTEM_PATH}"
-NODE_ONLY_PATH="${NODE_DIR}:${SYSTEM_PATH}"
+LDD_BIN="${LDD_BIN:-$(command -v ldd || true)}"
 
 PLATFORM_PACKAGE="$(node --input-type=module <<'NODE'
 import { execSync } from "node:child_process";
@@ -31,6 +26,18 @@ function detectLibcKind() {
     return null;
   }
 
+  const report = process.report?.getReport?.();
+  if (report?.header?.glibcVersionRuntime) {
+    return "gnu";
+  }
+
+  if (
+    Array.isArray(report?.sharedObjects) &&
+    report.sharedObjects.some((obj) => obj.toLowerCase().includes("musl"))
+  ) {
+    return "musl";
+  }
+
   try {
     const output = execSync("ldd --version", {
       encoding: "utf-8",
@@ -38,7 +45,7 @@ function detectLibcKind() {
     }).toLowerCase();
     return output.includes("musl") ? "musl" : "gnu";
   } catch {
-    return "gnu";
+    throw new Error("Unable to determine Linux libc kind for launcher smoke tests");
   }
 }
 
@@ -80,14 +87,32 @@ PLATFORM_STAGE="${TMP_ROOT}/${PLATFORM_PACKAGE}"
 INSTALL_DIR="${TMP_ROOT}/install"
 NPM_CACHE="${TMP_ROOT}/npm-cache"
 EMPTY_PATH_DIR="${TMP_ROOT}/empty-path"
+BUN_ONLY_DIR="${TMP_ROOT}/bun-only-path"
+NODE_ONLY_DIR="${TMP_ROOT}/node-only-path"
 
 cp -R packages/cli "${CLI_STAGE}"
 cp -R packages/tokscale "${WRAPPER_STAGE}"
 cp -R "packages/${PLATFORM_PACKAGE}" "${PLATFORM_STAGE}"
-mkdir -p "${PLATFORM_STAGE}/bin" "${INSTALL_DIR}" "${NPM_CACHE}" "${EMPTY_PATH_DIR}"
+mkdir -p \
+  "${PLATFORM_STAGE}/bin" \
+  "${INSTALL_DIR}" \
+  "${NPM_CACHE}" \
+  "${EMPTY_PATH_DIR}" \
+  "${BUN_ONLY_DIR}" \
+  "${NODE_ONLY_DIR}"
 cp target/release/tokscale "${PLATFORM_STAGE}/bin/tokscale"
 
 chmod +x "${CLI_STAGE}/bin.js" "${WRAPPER_STAGE}/bin.js" "${PLATFORM_STAGE}/bin/tokscale"
+
+ln -s "${BUN_BIN}" "${BUN_ONLY_DIR}/bun"
+ln -s "${NODE_BIN}" "${NODE_ONLY_DIR}/node"
+if [[ -n "${LDD_BIN}" ]]; then
+  ln -s "${LDD_BIN}" "${BUN_ONLY_DIR}/ldd"
+  ln -s "${LDD_BIN}" "${NODE_ONLY_DIR}/ldd"
+fi
+
+BUN_ONLY_PATH="${BUN_ONLY_DIR}"
+NODE_ONLY_PATH="${NODE_ONLY_DIR}"
 
 CLI_TGZ="$(cd "${CLI_STAGE}" && NPM_CONFIG_CACHE="${NPM_CACHE}" npm pack --silent)"
 WRAPPER_TGZ="$(cd "${WRAPPER_STAGE}" && NPM_CONFIG_CACHE="${NPM_CACHE}" npm pack --silent)"

--- a/scripts/test-package-launchers.sh
+++ b/scripts/test-package-launchers.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "bun is required for launcher smoke tests" >&2
+  exit 1
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "node is required for launcher smoke tests" >&2
+  exit 1
+fi
+
+BUN_BIN="${BUN_BIN:-$(command -v bun)}"
+NODE_BIN="${NODE_BIN:-$(command -v node)}"
+BUN_DIR="$(cd "$(dirname "${BUN_BIN}")" && pwd)"
+NODE_DIR="$(cd "$(dirname "${NODE_BIN}")" && pwd)"
+
+SYSTEM_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+BUN_ONLY_PATH="${BUN_DIR}:${SYSTEM_PATH}"
+NODE_ONLY_PATH="${NODE_DIR}:${SYSTEM_PATH}"
+
+PLATFORM_PACKAGE="$(node --input-type=module <<'NODE'
+import { execSync } from "node:child_process";
+
+function detectLibcKind() {
+  if (process.platform !== "linux") {
+    return null;
+  }
+
+  try {
+    const output = execSync("ldd --version", {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).toLowerCase();
+    return output.includes("musl") ? "musl" : "gnu";
+  } catch {
+    return "gnu";
+  }
+}
+
+const arch = process.arch;
+
+if (process.platform === "darwin") {
+  if (arch === "arm64") console.log("cli-darwin-arm64");
+  else if (arch === "x64") console.log("cli-darwin-x64");
+  else process.exit(1);
+} else if (process.platform === "linux") {
+  const libc = detectLibcKind();
+  if (arch === "arm64") console.log(libc === "musl" ? "cli-linux-arm64-musl" : "cli-linux-arm64-gnu");
+  else if (arch === "x64") console.log(libc === "musl" ? "cli-linux-x64-musl" : "cli-linux-x64-gnu");
+  else process.exit(1);
+} else {
+  process.exit(1);
+}
+NODE
+)"
+
+if [[ -z "${PLATFORM_PACKAGE}" ]]; then
+  echo "Unsupported platform for launcher smoke tests: $(uname -s) / $(uname -m)" >&2
+  exit 1
+fi
+
+echo "Building CLI wrapper and native binary..."
+bun run --cwd packages/cli build >/dev/null
+cargo build --release -p tokscale-cli >/dev/null
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/tokscale-launcher-smoke.XXXXXX")"
+cleanup() {
+  rm -rf "${TMP_ROOT}"
+}
+trap cleanup EXIT
+
+CLI_STAGE="${TMP_ROOT}/cli"
+WRAPPER_STAGE="${TMP_ROOT}/tokscale"
+PLATFORM_STAGE="${TMP_ROOT}/${PLATFORM_PACKAGE}"
+INSTALL_DIR="${TMP_ROOT}/install"
+NPM_CACHE="${TMP_ROOT}/npm-cache"
+EMPTY_PATH_DIR="${TMP_ROOT}/empty-path"
+
+cp -R packages/cli "${CLI_STAGE}"
+cp -R packages/tokscale "${WRAPPER_STAGE}"
+cp -R "packages/${PLATFORM_PACKAGE}" "${PLATFORM_STAGE}"
+mkdir -p "${PLATFORM_STAGE}/bin" "${INSTALL_DIR}" "${NPM_CACHE}" "${EMPTY_PATH_DIR}"
+cp target/release/tokscale "${PLATFORM_STAGE}/bin/tokscale"
+
+chmod +x "${CLI_STAGE}/bin.js" "${WRAPPER_STAGE}/bin.js" "${PLATFORM_STAGE}/bin/tokscale"
+
+CLI_TGZ="$(cd "${CLI_STAGE}" && NPM_CONFIG_CACHE="${NPM_CACHE}" npm pack --silent)"
+WRAPPER_TGZ="$(cd "${WRAPPER_STAGE}" && NPM_CONFIG_CACHE="${NPM_CACHE}" npm pack --silent)"
+PLATFORM_TGZ="$(cd "${PLATFORM_STAGE}" && NPM_CONFIG_CACHE="${NPM_CACHE}" npm pack --silent)"
+
+echo "Installing local tarballs with Bun..."
+(
+  cd "${INSTALL_DIR}"
+  env PATH="${BUN_ONLY_PATH}" bun add \
+    "${CLI_STAGE}/${CLI_TGZ}" \
+    "${WRAPPER_STAGE}/${WRAPPER_TGZ}" \
+    "${PLATFORM_STAGE}/${PLATFORM_TGZ}" >/dev/null
+)
+
+INSTALLED_BIN="${INSTALL_DIR}/node_modules/.bin/tokscale"
+if [[ ! -e "${INSTALLED_BIN}" ]]; then
+  echo "Installed tokscale launcher not found at ${INSTALLED_BIN}" >&2
+  exit 1
+fi
+
+echo "Checking source-tree wrapper with Bun-only PATH..."
+env PATH="${BUN_ONLY_PATH}" "${ROOT_DIR}/packages/tokscale/bin.js" --version >/dev/null
+
+echo "Checking source-tree wrapper with Node-only PATH..."
+env PATH="${NODE_ONLY_PATH}" "${ROOT_DIR}/packages/tokscale/bin.js" --version >/dev/null
+
+echo "Checking installed launcher with Bun-only PATH..."
+INSTALLED_VERSION_BUN="$(env PATH="${BUN_ONLY_PATH}" "${INSTALLED_BIN}" --version)"
+[[ "${INSTALLED_VERSION_BUN}" == tokscale* ]] || {
+  echo "Unexpected Bun-only launcher output: ${INSTALLED_VERSION_BUN}" >&2
+  exit 1
+}
+
+echo "Checking installed launcher with Node-only PATH..."
+INSTALLED_VERSION_NODE="$(env PATH="${NODE_ONLY_PATH}" "${INSTALLED_BIN}" --version)"
+[[ "${INSTALLED_VERSION_NODE}" == tokscale* ]] || {
+  echo "Unexpected Node-only launcher output: ${INSTALLED_VERSION_NODE}" >&2
+  exit 1
+}
+
+echo "Checking error path with no Node/Bun in PATH..."
+set +e
+ERROR_OUTPUT="$(env PATH="${EMPTY_PATH_DIR}" "${INSTALLED_BIN}" --version 2>&1)"
+ERROR_CODE=$?
+set -e
+if [[ ${ERROR_CODE} -eq 0 ]]; then
+  echo "Expected launcher to fail when neither Node nor Bun is available" >&2
+  exit 1
+fi
+[[ "${ERROR_OUTPUT}" == *"Node.js or Bun"* ]] || {
+  echo "Unexpected launcher error output: ${ERROR_OUTPUT}" >&2
+  exit 1
+}
+
+echo "Launcher smoke tests passed."


### PR DESCRIPTION
## Summary

This PR fixes a Windows regression identified in #413's Oracle review. Should be merged **after** #413 lands.

## Problem

The polyglot shell/JS launcher pattern (`#!/bin/sh` + JS comment trick) **breaks on Windows**:

1. When npm installs a package with a `bin` entry, it generates platform-specific wrappers
2. On Windows, npm creates `.cmd` files that wrap the shebang'd script
3. Windows cmd.exe cannot execute shell scripts - it doesn't understand `#!/bin/sh`
4. The npm shim generator only knows how to handle `node` shebangs, not shell scripts

**Result:** `npx tokscale` fails on Windows with "command not found" or script interpretation errors.

## Solution

Revert to the original `#!/usr/bin/env node` shebang which:
- Works on all Unix systems via env lookup
- Works on Windows because npm knows how to generate proper `.cmd` wrappers for node scripts

Also adds `actions/setup-node@v4` to the launcher validation workflow since the tests now require Node.js (not just Bun).

## Changes

- `packages/cli/bin.js` - Restore `#!/usr/bin/env node` shebang
- `packages/tokscale/bin.js` - Restore `#!/usr/bin/env node` shebang  
- `.github/workflows/launcher_validation.yml` - Add Node.js setup step

## Trade-off

This means Bun-only systems won't be able to run tokscale via npx. However:
- Windows compatibility is more important (larger user base)
- Bun users can use `bunx` directly which doesn't rely on npm shims
- The native Rust binary works regardless of JS runtime

**Depends on:** #413 (merge first)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore a Node.js shebang in the CLI launchers so npm creates proper Windows shims and `npx tokscale` works on Windows again. Adds CI smoke tests and Node setup to validate launchers with both Node and Bun.

- **Bug Fixes**
  - Replaced the polyglot shell/JS header with `#!/usr/bin/env node` in `packages/cli/bin.js` and `packages/tokscale/bin.js`.
  - Updated `packages/cli/package.json` to point `bin` to `bin.js`, and included `bin.js` in published files.
  - Added a launcher validation workflow with `actions/setup-node@v4` and a smoke test script (`scripts/test-package-launchers.sh`); new npm script `test:launchers`.

<sup>Written for commit 3819accdee2a96044533e916d445b2dd562e7a2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

