### PR TITLE
fix(claudecode): cache parent lookups, handle aside_question naming, use payload agent_id

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -2412,6 +2412,7 @@ fn run_monthly_report(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_hourly_report(
     json: bool,
     home_dir: Option<String>,

--- a/crates/tokscale-cli/src/tui/ui/hourly_profile.rs
+++ b/crates/tokscale-cli/src/tui/ui/hourly_profile.rs
@@ -39,8 +39,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let overhead = 36; // 34 + small margin
     let bar_width = (inner.width as usize)
         .saturating_sub(overhead)
-        .max(20)
-        .min(80);
+        .clamp(20, 80);
 
     // Get date range
     let min_date = hourly.iter().map(|h| h.datetime.date()).min();

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1633,8 +1633,8 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     let claude_msgs_raw: Vec<(String, ParsedMessage)> = scan_result
         .get(ClientId::Claude)
         .par_iter()
-        .flat_map(|path| {
-            sessions::claudecode::parse_claude_file(path)
+        .map_init(std::collections::HashMap::new, |parent_cache, path| {
+            sessions::claudecode::parse_claude_file_with_cache(path, parent_cache)
                 .into_iter()
                 .map(|msg| {
                     let dedup_key = msg.dedup_key.clone().unwrap_or_default();
@@ -1642,6 +1642,7 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
                 })
                 .collect::<Vec<_>>()
         })
+        .flatten()
         .collect();
 
     let mut seen_keys: HashSet<String> = HashSet::new();

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -15,6 +15,8 @@ use std::collections::HashMap;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
+type ParentSubagentTypeCache = HashMap<PathBuf, HashMap<String, String>>;
+
 /// Claude Code entry structure (from JSONL files)
 #[derive(Debug, Deserialize)]
 pub struct ClaudeEntry {
@@ -65,7 +67,12 @@ pub struct ClaudeUsage {
 /// Tier 1: Read the sibling `.meta.json` sidecar for the `agentType` field.
 /// Tier 2: Scan the parent session JSONL for the tool_use that spawned this agent.
 /// Tier 3: Fall back to a generic "claude-code-subagent" label.
-fn resolve_subagent_name(path: &Path, parent_session_id: Option<&str>) -> String {
+fn resolve_subagent_name(
+    path: &Path,
+    parent_session_id: Option<&str>,
+    entry_agent_id: Option<&str>,
+    parent_cache: &mut ParentSubagentTypeCache,
+) -> String {
     let stem = match path.file_stem().and_then(|s| s.to_str()) {
         Some(s) => s,
         None => return normalize_agent_name("claude-code-subagent"),
@@ -84,9 +91,15 @@ fn resolve_subagent_name(path: &Path, parent_session_id: Option<&str>) -> String
     }
 
     // Tier 2: parent session tool_use inference
-    if let (Some(parent_id), Some(agent_id)) = (parent_session_id, stem.strip_prefix("agent-")) {
+    let lookup_agent_id = entry_agent_id
+        .filter(|agent_id| !agent_id.trim().is_empty())
+        .map(|agent_id| agent_id.to_string())
+        .or_else(|| sidechain_agent_id_from_stem(stem));
+    if let (Some(parent_id), Some(agent_id)) = (parent_session_id, lookup_agent_id.as_deref()) {
         if let Some(parent_path) = find_parent_session_path(path, parent_id) {
-            if let Some(subagent_type) = lookup_subagent_type_in_parent(&parent_path, agent_id) {
+            if let Some(subagent_type) =
+                lookup_subagent_type_in_parent(&parent_path, agent_id, parent_cache)
+            {
                 return normalize_agent_name(&subagent_type);
             }
         }
@@ -135,7 +148,24 @@ fn find_parent_session_path(sidechain_path: &Path, parent_session_id: &str) -> O
 /// - User messages with `tool_result` blocks whose text contains `agentId: <hex>`
 ///
 /// We join on `tool_use_id` to map `agentId → subagent_type`.
-fn lookup_subagent_type_in_parent(parent_path: &Path, target_agent_id: &str) -> Option<String> {
+fn lookup_subagent_type_in_parent(
+    parent_path: &Path,
+    target_agent_id: &str,
+    parent_cache: &mut ParentSubagentTypeCache,
+) -> Option<String> {
+    if !parent_cache.contains_key(parent_path) {
+        parent_cache.insert(
+            parent_path.to_path_buf(),
+            build_parent_subagent_type_lookup(parent_path)?,
+        );
+    }
+
+    parent_cache
+        .get(parent_path)
+        .and_then(|lookup| lookup.get(target_agent_id).cloned())
+}
+
+fn build_parent_subagent_type_lookup(parent_path: &Path) -> Option<HashMap<String, String>> {
     let file = std::fs::File::open(parent_path).ok()?;
     let reader = BufReader::new(file);
 
@@ -214,15 +244,28 @@ fn lookup_subagent_type_in_parent(parent_path: &Path, target_agent_id: &str) -> 
         }
     }
 
-    // Join: find the tool_use_id whose tool_result produced our target agentId,
-    // then look up the subagent_type from the corresponding tool_use.
+    let mut subagent_types = HashMap::new();
     for (tool_use_id, agent_id) in &agent_id_links {
-        if agent_id == target_agent_id {
-            return tool_use_types.get(tool_use_id).cloned();
+        if let Some(subagent_type) = tool_use_types.get(tool_use_id) {
+            subagent_types.insert(agent_id.clone(), subagent_type.clone());
         }
     }
 
-    None
+    Some(subagent_types)
+}
+
+fn sidechain_agent_id_from_stem(stem: &str) -> Option<String> {
+    let agent_stem = stem.strip_prefix("agent-")?;
+    if !agent_stem.contains('-') {
+        return Some(agent_stem.to_string());
+    }
+
+    let trailing_segment = agent_stem.rsplit('-').next()?;
+    if trailing_segment.chars().all(|c| c.is_ascii_hexdigit()) {
+        Some(trailing_segment.to_string())
+    } else {
+        Some(agent_stem.to_string())
+    }
 }
 
 /// Extract the `agentId` hex string from a tool_result text block.
@@ -244,6 +287,14 @@ fn extract_agent_id_from_text(text: &str) -> Option<String> {
 
 /// Parse a Claude Code JSONL file
 pub fn parse_claude_file(path: &Path) -> Vec<UnifiedMessage> {
+    let mut parent_cache = ParentSubagentTypeCache::new();
+    parse_claude_file_with_cache(path, &mut parent_cache)
+}
+
+pub fn parse_claude_file_with_cache(
+    path: &Path,
+    parent_cache: &mut ParentSubagentTypeCache,
+) -> Vec<UnifiedMessage> {
     let (workspace_key, workspace_label) = claude_workspace_from_path(path);
     let mut session_id = path
         .file_stem()
@@ -312,8 +363,12 @@ pub fn parse_claude_file(path: &Path) -> Vec<UnifiedMessage> {
                     if let Some(ref parent_id) = entry.session_id {
                         session_id = parent_id.clone();
                     }
-                    sidechain_agent =
-                        Some(resolve_subagent_name(path, entry.session_id.as_deref()));
+                    sidechain_agent = Some(resolve_subagent_name(
+                        path,
+                        entry.session_id.as_deref(),
+                        entry.agent_id.as_deref(),
+                        parent_cache,
+                    ));
                 }
             }
 
@@ -1407,6 +1462,76 @@ mod tests {
             extract_agent_id_from_text("agentId: "),
             None,
             "Empty agent id should return None"
+        );
+    }
+
+    #[test]
+    fn test_sidechain_agent_id_from_stem_extracts_aside_question_suffix() {
+        assert_eq!(
+            sidechain_agent_id_from_stem("agent-aside_question-0320a3d71bc1d01e"),
+            Some("0320a3d71bc1d01e".to_string())
+        );
+        assert_eq!(
+            sidechain_agent_id_from_stem("agent-flatagent1"),
+            Some("flatagent1".to_string())
+        );
+    }
+
+    #[test]
+    fn test_tier2_uses_entry_agent_id_when_filename_prefix_differs() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let project_dir = temp_dir
+            .path()
+            .join(".claude")
+            .join("projects")
+            .join("myproject");
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        let parent_session_id = "aside-parent-uuid";
+        let parent_content = r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","message":{"id":"msg_aside_parent","model":"claude-3-5-sonnet","role":"assistant","content":[{"type":"tool_use","id":"toolu_aside","name":"Agent","input":{"subagent_type":"writer","prompt":"Summarize findings"}}],"usage":{"input_tokens":50,"output_tokens":30}}}
+{"type":"user","timestamp":"2024-12-01T10:00:01.000Z","message":{"role":"user","content":[{"tool_use_id":"toolu_aside","type":"tool_result","content":[{"type":"text","text":"agentId: 0320a3d71bc1d01e (use SendMessage)"}]}]}}"#;
+        std::fs::write(
+            project_dir.join(format!("{}.jsonl", parent_session_id)),
+            parent_content,
+        )
+        .unwrap();
+
+        let subagents_dir = project_dir.join(parent_session_id).join("subagents");
+        std::fs::create_dir_all(&subagents_dir).unwrap();
+        let sidechain_content = r#"{"type":"user","isSidechain":true,"sessionId":"aside-parent-uuid","agentId":"0320a3d71bc1d01e","timestamp":"2024-12-01T10:00:00.500Z","message":{"content":"task"}}
+{"type":"assistant","isSidechain":true,"sessionId":"aside-parent-uuid","agentId":"0320a3d71bc1d01e","timestamp":"2024-12-01T10:00:01.000Z","requestId":"req_aside","message":{"id":"msg_aside","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50}}}"#;
+        let sidechain_path = subagents_dir.join("agent-aside_question-0320a3d71bc1d01e.jsonl");
+        std::fs::write(&sidechain_path, sidechain_content).unwrap();
+
+        let messages = parse_claude_file(&sidechain_path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].agent, Some("Writer".to_string()));
+    }
+
+    #[test]
+    fn test_parent_subagent_lookup_cache_reuses_parsed_parent_results() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let parent_path = temp_dir.path().join("parent.jsonl");
+        let initial_parent = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_a","name":"Agent","input":{"subagent_type":"explore"}},{"type":"tool_use","id":"toolu_b","name":"Agent","input":{"subagent_type":"executor"}}]}}
+{"type":"user","message":{"content":[{"tool_use_id":"toolu_a","type":"tool_result","content":[{"type":"text","text":"agentId: cacheA"}]},{"tool_use_id":"toolu_b","type":"tool_result","content":[{"type":"text","text":"agentId: cacheB"}]}]}}"#;
+        std::fs::write(&parent_path, initial_parent).unwrap();
+
+        let mut parent_cache = ParentSubagentTypeCache::new();
+        assert_eq!(
+            lookup_subagent_type_in_parent(&parent_path, "cacheA", &mut parent_cache),
+            Some("explore".to_string())
+        );
+
+        std::fs::write(
+            &parent_path,
+            r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_b","name":"Agent","input":{"subagent_type":"writer"}}]}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            lookup_subagent_type_in_parent(&parent_path, "cacheB", &mut parent_cache),
+            Some("executor".to_string())
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes 3 bugs in subagent type resolution for the Agents tab (introduced in #423):

- **Cache parent JSONL lookups** — Parent session is now parsed once per parent path, not once per sibling subagent. On a real session with 110 subagents and a 17MB parent JSONL, this eliminates ~1.7GB redundant I/O.
- **Handle `aside_question` naming** — Files named `agent-aside_question-<hex>` now correctly extract the trailing hex ID for Tier 2 lookup. Previously these 15 subagents were permanently mislabeled as "Claude Code Subagent".
- **Use payload `agent_id` when available** — Tier 2 lookup now prefers the `agent_id` field from the JSONL payload over the filename-derived ID, which is more reliable across layout changes.

## Verified Against Real Data

Tested on `~/.claude/projects/-Users-junhoyeo-nadu/` session:
- 110 subagents (95 with meta.json, 15 `aside_question` without)
- 17MB parent JSONL
- Agent types: executor(26), oh-my-claudecode:executor(22), architect(10), writer(10), etc.
- `cargo test -p tokscale-core` — 511 passed, 0 failed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix subagent type resolution in Claude Code sessions. Caches parent JSONL lookups, handles `aside_question` filenames, and prefers payload `agent_id` to improve accuracy and performance. Also fixes minor clippy warnings in the hourly report and TUI.

- **Bug Fixes**
  - Cache parent subagent-type lookups per parent path; avoids re-parsing for each sibling (e.g., 17MB parent × 110 siblings → ~1.7GB I/O avoided).
  - Extract trailing hex from `agent-aside_question-<hex>.jsonl` for Tier 2 lookup, fixing mislabeled subagents.
  - Prefer `agent_id` from the JSONL payload over filename-derived IDs for more reliable resolution.

- **Refactors**
  - Added `parse_claude_file_with_cache` and used Rayon `map_init` to pass a per-thread parent cache in `parse_local_clients`.
  - Build a parent subagent-type index once per parent file and reuse for all agent IDs.
  - Replace chained `max/min` with `.clamp()` in TUI hourly profile; suppress `clippy::too_many_arguments` for `run_hourly_report`.

<sup>Written for commit 3e42e829e561d238791567e2feb99d63a9ebffa6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

