### PR TITLE
fix(embed): scale 3d cubes by usage, fix streak counting, handle empty contributions

### DIFF
--- a/packages/frontend/__tests__/api/embedSvgRoute.test.ts
+++ b/packages/frontend/__tests__/api/embedSvgRoute.test.ts
@@ -1,0 +1,86 @@
+import { NextRequest } from "next/server";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getUserEmbedStats = vi.fn();
+const getUserEmbedContributions = vi.fn();
+const renderProfileEmbedErrorSvg = vi.fn();
+const renderProfileEmbedSvg = vi.fn();
+const renderIsometric3DEmbedSvg = vi.fn();
+const renderIsometric3DErrorSvg = vi.fn();
+const isValidGitHubUsername = vi.fn();
+
+vi.mock("@/lib/embed/getUserEmbedStats", () => ({
+  getUserEmbedStats,
+  getUserEmbedContributions,
+}));
+
+vi.mock("@/lib/embed/renderProfileEmbedSvg", () => ({
+  renderProfileEmbedErrorSvg,
+  renderProfileEmbedSvg,
+}));
+
+vi.mock("@/lib/embed/renderIsometric3DSvg", () => ({
+  renderIsometric3DEmbedSvg,
+  renderIsometric3DErrorSvg,
+}));
+
+vi.mock("@/lib/validation/username", () => ({
+  isValidGitHubUsername,
+}));
+
+type ModuleExports = typeof import("../../src/app/api/embed/[username]/svg/route");
+
+let GET: ModuleExports["GET"];
+
+beforeAll(async () => {
+  const routeModule = await import("../../src/app/api/embed/[username]/svg/route");
+  GET = routeModule.GET;
+});
+
+beforeEach(() => {
+  getUserEmbedStats.mockReset();
+  getUserEmbedContributions.mockReset();
+  renderProfileEmbedErrorSvg.mockReset();
+  renderProfileEmbedSvg.mockReset();
+  renderIsometric3DEmbedSvg.mockReset();
+  renderIsometric3DErrorSvg.mockReset();
+  isValidGitHubUsername.mockReset();
+
+  isValidGitHubUsername.mockReturnValue(true);
+  renderIsometric3DEmbedSvg.mockReturnValue("<svg>3d</svg>");
+});
+
+describe("GET /api/embed/[username]/svg", () => {
+  it("renders the 3D embed when contributions are empty", async () => {
+    getUserEmbedStats.mockResolvedValue({
+      user: {
+        id: "user-1",
+        username: "octocat",
+        displayName: "The Octocat",
+        avatarUrl: null,
+      },
+      stats: {
+        totalTokens: 0,
+        totalCost: 0,
+        submissionCount: 0,
+        rank: null,
+        updatedAt: null,
+      },
+    });
+    getUserEmbedContributions.mockResolvedValue([]);
+
+    const response = await GET(
+      new NextRequest("http://localhost:3000/api/embed/octocat/svg?view=3d"),
+      { params: Promise.resolve({ username: "octocat" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(renderIsometric3DEmbedSvg).toHaveBeenCalledWith(
+      expect.objectContaining({ user: expect.objectContaining({ username: "octocat" }) }),
+      [],
+      { theme: "dark" },
+    );
+    expect(renderIsometric3DErrorSvg).not.toHaveBeenCalled();
+    await expect(response.text()).resolves.toBe("<svg>3d</svg>");
+  });
+});

--- a/packages/frontend/__tests__/lib/renderIsometric3DSvg.test.ts
+++ b/packages/frontend/__tests__/lib/renderIsometric3DSvg.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   renderIsometric3DEmbedSvg,
   renderIsometric3DErrorSvg,
@@ -22,14 +22,22 @@ const mockStats: UserEmbedStats = {
 };
 
 const mockContributions: EmbedContributionDay[] = [
-  { date: "2026-01-15", intensity: 0 },
-  { date: "2026-02-10", intensity: 2 },
-  { date: "2026-02-20", intensity: 4 },
-  { date: "2026-03-01", intensity: 1 },
-  { date: "2026-03-10", intensity: 3 },
+  { date: "2026-01-15", totalTokens: 0, totalCost: 0, intensity: 0 },
+  { date: "2026-02-10", totalTokens: 100, totalCost: 1, intensity: 2 },
+  { date: "2026-02-20", totalTokens: 1000, totalCost: 10, intensity: 4 },
+  { date: "2026-03-01", totalTokens: 50, totalCost: 0.5, intensity: 1 },
+  { date: "2026-03-10", totalTokens: 500, totalCost: 5, intensity: 3 },
 ];
 
 describe("renderIsometric3DEmbedSvg", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-11T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
   it("renders a valid SVG with polygon elements", () => {
     const svg = renderIsometric3DEmbedSvg(mockStats, mockContributions);
 
@@ -131,6 +139,31 @@ describe("renderIsometric3DEmbedSvg", () => {
     expect(polygonCount % 3).toBe(0);
     expect(svg).toContain("0 active days");
     expect(svg).toContain("0 days");
+  });
+
+  it("counts the current streak from yesterday when today has no activity", () => {
+    const svg = renderIsometric3DEmbedSvg(mockStats, [
+      { date: "2026-03-08", totalTokens: 200, totalCost: 2, intensity: 2 },
+      { date: "2026-03-09", totalTokens: 300, totalCost: 3, intensity: 3 },
+      { date: "2026-03-10", totalTokens: 400, totalCost: 4, intensity: 4 },
+    ]);
+
+    expect(svg).toContain(">3 days</text>");
+  });
+
+  it("scales cube heights by actual token usage within the same intensity bucket", () => {
+    const svg = renderIsometric3DEmbedSvg(mockStats, [
+      { date: "2026-03-08", totalTokens: 10, totalCost: 1, intensity: 4 },
+      { date: "2026-03-09", totalTokens: 1000, totalCost: 2, intensity: 4 },
+    ]);
+    const topFaceMatches = [...svg.matchAll(/<polygon points="([^"]+)" fill="#0d419d" stroke="#0d419d"/g)];
+    const topFaceYs = topFaceMatches.map((match) => {
+      const firstPoint = match[1].split(" ")[0];
+      return Number(firstPoint.split(",")[1]);
+    }).sort((a, b) => a - b);
+
+    expect(topFaceYs).toHaveLength(2);
+    expect(topFaceYs[0]).toBeLessThan(topFaceYs[1]);
   });
 
   it("renders fixed-width SVG of 680px", () => {

--- a/packages/frontend/src/app/api/embed/[username]/svg/route.ts
+++ b/packages/frontend/src/app/api/embed/[username]/svg/route.ts
@@ -83,7 +83,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     if (view === "3d") {
       const contributions = await getUserEmbedContributions(username).catch(() => null);
 
-      if (!contributions || contributions.length === 0) {
+      if (!contributions) {
         const svg = renderIsometric3DErrorSvg("No contribution data available yet", { theme });
         return createSvgResponse(svg);
       }

--- a/packages/frontend/src/lib/embed/getUserEmbedStats.ts
+++ b/packages/frontend/src/lib/embed/getUserEmbedStats.ts
@@ -6,6 +6,8 @@ export type EmbedSortBy = "tokens" | "cost";
 
 export interface EmbedContributionDay {
   date: string;
+  totalTokens: number;
+  totalCost: number;
   intensity: 0 | 1 | 2 | 3 | 4;
 }
 
@@ -116,6 +118,7 @@ async function fetchUserEmbedContributions(username: string): Promise<EmbedContr
   const rows = await db
     .select({
       date: dailyBreakdown.date,
+      tokens: sql<number>`sum(${dailyBreakdown.tokens})`.as("tokens"),
       cost: sql<number>`sum(${dailyBreakdown.cost})`.as("cost"),
     })
     .from(dailyBreakdown)
@@ -130,9 +133,12 @@ async function fetchUserEmbedContributions(username: string): Promise<EmbedContr
   const maxCost = Math.max(...costs, 0);
 
   return rows.map((row) => {
+    const totalTokens = Number(row.tokens) || 0;
     const cost = Number(row.cost) || 0;
     return {
       date: row.date,
+      totalTokens,
+      totalCost: cost,
       intensity: (
         maxCost === 0 ? 0 : cost === 0 ? 0 : cost <= maxCost * 0.25 ? 1 : cost <= maxCost * 0.5 ? 2 : cost <= maxCost * 0.75 ? 3 : 4
       ) as 0 | 1 | 2 | 3 | 4,

--- a/packages/frontend/src/lib/embed/renderIsometric3DSvg.ts
+++ b/packages/frontend/src/lib/embed/renderIsometric3DSvg.ts
@@ -72,7 +72,8 @@ const FIGTREE_FONT_IMPORT = "https://fonts.googleapis.com/css2?family=Figtree:wg
 
 const CELL = 10;
 const MAX_HEIGHT = 40;
-const INTENSITY_HEIGHTS: readonly number[] = [2, 10, 20, 32, MAX_HEIGHT];
+const BASE_HEIGHT = 2;
+const MIN_NON_ZERO_HEIGHT = 8;
 
 /**
  * 2:1 dimetric projection: col (X) goes screen right-down,
@@ -159,6 +160,16 @@ function formatShortDate(dateStr: string): string {
   return `${mm}/${dd}`;
 }
 
+function previousUtcDate(dateStr: string): string {
+  const d = new Date(dateStr + "T00:00:00Z");
+  d.setUTCDate(d.getUTCDate() - 1);
+  return d.toISOString().split("T")[0];
+}
+
+function getContributionHeightValue(contribution: EmbedContributionDay): number {
+  return contribution.totalTokens > 0 ? contribution.totalTokens : contribution.totalCost;
+}
+
 function computeStreaks(contributions: EmbedContributionDay[]): { longest: number; current: number } {
   const activeSet = new Set<string>();
   for (const c of contributions) {
@@ -186,12 +197,16 @@ function computeStreaks(contributions: EmbedContributionDay[]): { longest: numbe
   const todayStr = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
     .toISOString()
     .split("T")[0];
-  let cursor = todayStr;
-  while (activeSet.has(cursor)) {
+  const yesterdayStr = previousUtcDate(todayStr);
+  let cursor = activeSet.has(todayStr)
+    ? todayStr
+    : activeSet.has(yesterdayStr)
+      ? yesterdayStr
+      : null;
+
+  while (cursor && activeSet.has(cursor)) {
     current++;
-    const d = new Date(cursor + "T00:00:00Z");
-    d.setUTCDate(d.getUTCDate() - 1);
-    cursor = d.toISOString().split("T")[0];
+    cursor = previousUtcDate(cursor);
   }
 
   return { longest, current };
@@ -211,7 +226,6 @@ function renderStatsBox(
   const footerH = footer ? 22 : 0;
   const boxPad = 10;
   const innerH = items.length * itemH;
-  const totalH = titleH + boxPad * 2 + innerH + footerH;
 
   const boxY = y + titleH + 4;
   const boxInnerH = innerH + boxPad * 2 + footerH;
@@ -245,8 +259,8 @@ export function renderIsometric3DEmbedSvg(
   const theme: EmbedTheme = options.theme === "light" ? "light" : "dark";
   const palette = THEMES[theme];
 
-  const intensityMap = new Map<string, number>();
-  for (const c of contributions) intensityMap.set(c.date, c.intensity);
+  const contributionMap = new Map<string, EmbedContributionDay>();
+  for (const c of contributions) contributionMap.set(c.date, c);
 
   const colors = [
     palette.graphGrade0,
@@ -277,6 +291,10 @@ export function renderIsometric3DEmbedSvg(
 
   const gridOriginX = px + 7 * CELL + Math.max(0, (width - 2 * px - gridXExtent) / 2);
   const gridOriginY = headerH + MAX_HEIGHT + 4;
+  const maxContributionHeightValue = contributions.reduce((max, contribution) => {
+    const value = getContributionHeightValue(contribution);
+    return value > max ? value : max;
+  }, 0);
 
   let cubes = "";
   for (let w = 0; w < numWeeks; w++) {
@@ -286,8 +304,15 @@ export function renderIsometric3DEmbedSvg(
       if (date > today) continue;
 
       const dateStr = date.toISOString().split("T")[0];
-      const intensity = (intensityMap.get(dateStr) ?? 0) as 0 | 1 | 2 | 3 | 4;
-      const h = INTENSITY_HEIGHTS[intensity];
+      const contribution = contributionMap.get(dateStr);
+      const intensity = (contribution?.intensity ?? 0) as 0 | 1 | 2 | 3 | 4;
+      const heightValue = contribution ? getContributionHeightValue(contribution) : 0;
+      const h = heightValue > 0 && maxContributionHeightValue > 0
+        ? Math.max(
+            MIN_NON_ZERO_HEIGHT,
+            Math.round((heightValue / maxContributionHeightValue) * (MAX_HEIGHT - MIN_NON_ZERO_HEIGHT) + MIN_NON_ZERO_HEIGHT),
+          )
+        : BASE_HEIGHT;
       const color = colors[intensity];
 
       cubes += renderCube(gridOriginX, gridOriginY, w, d, h, color);


### PR DESCRIPTION
## Summary

Fixes 4 bugs in the isometric 3D contribution graph embed (introduced in #416):

- **Empty contributions no longer error** — Route now passes `[]` to the renderer instead of returning an error SVG. The renderer already handles empty state correctly.
- **Current streak counts yesterday** — If the user was active yesterday but hasn't submitted today, the streak no longer drops to 0. Matches the existing app behavior.
- **Cube height from real usage** — Heights now scale proportionally to actual `totalTokens` (or `totalCost` fallback) instead of the 5-bucket `intensity` value. Very different days no longer render at the same height.
- **Removed dead `totalH`** — Unused computed variable removed.

## Changes
- `route.ts` — Allow empty contributions through for `view=3d`
- `renderIsometric3DSvg.ts` — Fix streak, height scaling, remove dead code
- `getUserEmbedStats.ts` — Include `totalTokens`/`totalCost` in contribution data
- Added tests for yesterday-streak, proportional heights, empty 3D responses

## Verification
- `bunx vitest run` — 148 passed ✅
- `bun run build` — blocked by missing DATABASE_URL (CI will test)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the 3D contribution embed to handle empty data, keep streaks accurate, and scale cube heights by real usage for clearer visuals. Heights now reflect actual tokens/cost while color buckets stay the same.

- Bug Fixes
  - Empty contributions render in 3D; route passes `[]` instead of returning an error.
  - Current streak counts yesterday if today is inactive, matching the app.
  - Cube heights scale with `totalTokens` (fallback `totalCost`) instead of intensity; colors still use intensity buckets.
  - Exposed totals in `getUserEmbedStats` and removed unused code.

<sup>Written for commit 99dcd2d0e7fd0fe6134825283c184742db9f37c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

