### PR TITLE
fix(copilot): normalize cache tokens in parser to align with others

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-cli"
-version = "2.0.21"
+version = "2.0.22"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-core"
-version = "2.0.21"
+version = "2.0.22"
 dependencies = [
  "bincode",
  "chrono",

--- a/crates/tokscale-core/src/sessions/copilot.rs
+++ b/crates/tokscale-core/src/sessions/copilot.rs
@@ -53,10 +53,6 @@ pub fn parse_copilot_file(path: &Path) -> Vec<UnifiedMessage> {
         let cache_write = attr_i64(attributes, "gen_ai.usage.cache_write.input_tokens");
         let reasoning = attr_i64(attributes, "gen_ai.usage.reasoning.output_tokens");
 
-        if input + output + cache_read + cache_write + reasoning == 0 {
-            continue;
-        }
-
         let model = first_non_empty_attr(
             attributes,
             &["gen_ai.response.model", "gen_ai.request.model"],
@@ -95,13 +91,18 @@ pub fn parse_copilot_file(path: &Path) -> Vec<UnifiedMessage> {
             .or_else(|| span.get("startTime").and_then(timestamp_ms_from_value))
             .unwrap_or(fallback_timestamp);
 
+        let tokens = normalize_input_tokens(input, output, cache_read, cache_write, reasoning);
+        if tokens.total() == 0 {
+            continue;
+        }
+
         messages.push(UnifiedMessage::new_with_dedup(
             "copilot",
             model,
             provider_id,
             session_id,
             timestamp_ms,
-            normalize_input_tokens(input, output, cache_read, cache_write, reasoning),
+            tokens,
             0.0,
             Some(dedup_key),
         ));
@@ -275,5 +276,15 @@ mod tests {
         assert_eq!(messages[0].tokens.input, 0);
         assert_eq!(messages[0].tokens.cache_read, 90);
         assert_eq!(messages[0].tokens.cache_write, 10);
+    }
+
+    #[test]
+    fn test_parse_copilot_skips_zero_token_message_after_normalization() {
+        let content = r#"{"type":"span","traceId":"trace-zero","spanId":"span-zero","name":"chat gpt-5.4-mini","endTime":[1775934264,967317833],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.usage.input_tokens":0,"gen_ai.usage.cache_read.input_tokens":50,"gen_ai.usage.cache_write.input_tokens":20}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert!(messages.is_empty());
     }
 }

--- a/crates/tokscale-core/src/sessions/copilot.rs
+++ b/crates/tokscale-core/src/sessions/copilot.rs
@@ -101,13 +101,7 @@ pub fn parse_copilot_file(path: &Path) -> Vec<UnifiedMessage> {
             provider_id,
             session_id,
             timestamp_ms,
-            TokenBreakdown {
-                input,
-                output,
-                cache_read,
-                cache_write,
-                reasoning,
-            },
+            normalize_input_tokens(input, output, cache_read, cache_write, reasoning),
             0.0,
             Some(dedup_key),
         ));
@@ -143,6 +137,32 @@ fn attr_i64(attributes: &Map<String, Value>, key: &str) -> i64 {
         .and_then(value_as_i64)
         .unwrap_or(0)
         .max(0)
+}
+
+fn normalize_input_tokens(
+    input: i64,
+    output: i64,
+    cache_read: i64,
+    cache_write: i64,
+    reasoning: i64,
+) -> TokenBreakdown {
+    // OTEL reports input_tokens inclusive of cached input. Normalize it so
+    // Tokscale's input bucket remains the non-cached portion, consistent with
+    // cache-aware clients that report cache tokens separately.
+    let clamped_cache_read = cache_read.min(input).max(0);
+    let remaining_input = input.saturating_sub(clamped_cache_read);
+    let clamped_cache_write = cache_write.min(remaining_input).max(0);
+
+    TokenBreakdown {
+        input: input
+            .saturating_sub(clamped_cache_read)
+            .saturating_sub(clamped_cache_write)
+            .max(0),
+        output: output.max(0),
+        cache_read: clamped_cache_read,
+        cache_write: clamped_cache_write,
+        reasoning: reasoning.max(0),
+    }
 }
 
 fn first_non_empty_attr<'a>(attributes: &'a Map<String, Value>, keys: &[&str]) -> Option<&'a str> {
@@ -193,7 +213,7 @@ mod tests {
         assert_eq!(message.model_id, "claude-sonnet-4");
         assert_eq!(message.provider_id, "anthropic");
         assert_eq!(message.session_id, "conv-1");
-        assert_eq!(message.tokens.input, 19_452);
+        assert_eq!(message.tokens.input, 19_329);
         assert_eq!(message.tokens.output, 281);
         assert_eq!(message.tokens.cache_read, 123);
         assert_eq!(message.tokens.reasoning, 128);
@@ -228,5 +248,32 @@ mod tests {
         assert_eq!(messages[0].session_id, "trace-fallback");
         assert_eq!(messages[0].tokens.input, 7);
         assert_eq!(messages[0].tokens.output, 9);
+    }
+
+    #[test]
+    fn test_parse_copilot_normalizes_cache_read_and_write_from_input() {
+        let content = r#"{"type":"span","traceId":"trace-cache","spanId":"span-cache","name":"chat gpt-5.4","endTime":[1775934264,967317833],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4","gen_ai.usage.input_tokens":1000,"gen_ai.usage.output_tokens":20,"gen_ai.usage.cache_read.input_tokens":200,"gen_ai.usage.cache_write.input_tokens":50}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 750);
+        assert_eq!(messages[0].tokens.output, 20);
+        assert_eq!(messages[0].tokens.cache_read, 200);
+        assert_eq!(messages[0].tokens.cache_write, 50);
+    }
+
+    #[test]
+    fn test_parse_copilot_clamps_cache_tokens_to_input() {
+        let content = r#"{"type":"span","traceId":"trace-clamp","spanId":"span-clamp","name":"chat gpt-5.4-mini","endTime":[1775934264,967317833],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.usage.input_tokens":100,"gen_ai.usage.output_tokens":5,"gen_ai.usage.cache_read.input_tokens":90,"gen_ai.usage.cache_write.input_tokens":20}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 0);
+        assert_eq!(messages[0].tokens.cache_read, 90);
+        assert_eq!(messages[0].tokens.cache_write, 10);
     }
 }

--- a/crates/tokscale-core/src/sessions/copilot.rs
+++ b/crates/tokscale-core/src/sessions/copilot.rs
@@ -147,21 +147,16 @@ fn normalize_input_tokens(
     cache_write: i64,
     reasoning: i64,
 ) -> TokenBreakdown {
-    // OTEL reports input_tokens inclusive of cached input. Normalize it so
-    // Tokscale's input bucket remains the non-cached portion, consistent with
-    // cache-aware clients that report cache tokens separately.
+    // OTEL reports input_tokens inclusive of cache reads. Normalize only the
+    // cached-read portion out of input and preserve cache_write as a separate
+    // bucket until Copilot documents stronger semantics for cache creation.
     let clamped_cache_read = cache_read.min(input).max(0);
-    let remaining_input = input.saturating_sub(clamped_cache_read);
-    let clamped_cache_write = cache_write.min(remaining_input).max(0);
 
     TokenBreakdown {
-        input: input
-            .saturating_sub(clamped_cache_read)
-            .saturating_sub(clamped_cache_write)
-            .max(0),
+        input: input.saturating_sub(clamped_cache_read).max(0),
         output: output.max(0),
         cache_read: clamped_cache_read,
-        cache_write: clamped_cache_write,
+        cache_write: cache_write.max(0),
         reasoning: reasoning.max(0),
     }
 }
@@ -252,39 +247,42 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_copilot_normalizes_cache_read_and_write_from_input() {
+    fn test_parse_copilot_normalizes_only_cache_read_from_input() {
         let content = r#"{"type":"span","traceId":"trace-cache","spanId":"span-cache","name":"chat gpt-5.4","endTime":[1775934264,967317833],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4","gen_ai.usage.input_tokens":1000,"gen_ai.usage.output_tokens":20,"gen_ai.usage.cache_read.input_tokens":200,"gen_ai.usage.cache_write.input_tokens":50}}"#;
         let file = create_test_file(content);
 
         let messages = parse_copilot_file(file.path());
 
         assert_eq!(messages.len(), 1);
-        assert_eq!(messages[0].tokens.input, 750);
+        assert_eq!(messages[0].tokens.input, 800);
         assert_eq!(messages[0].tokens.output, 20);
         assert_eq!(messages[0].tokens.cache_read, 200);
         assert_eq!(messages[0].tokens.cache_write, 50);
     }
 
     #[test]
-    fn test_parse_copilot_clamps_cache_tokens_to_input() {
+    fn test_parse_copilot_clamps_only_cache_read_to_input() {
         let content = r#"{"type":"span","traceId":"trace-clamp","spanId":"span-clamp","name":"chat gpt-5.4-mini","endTime":[1775934264,967317833],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.usage.input_tokens":100,"gen_ai.usage.output_tokens":5,"gen_ai.usage.cache_read.input_tokens":90,"gen_ai.usage.cache_write.input_tokens":20}}"#;
         let file = create_test_file(content);
 
         let messages = parse_copilot_file(file.path());
 
         assert_eq!(messages.len(), 1);
-        assert_eq!(messages[0].tokens.input, 0);
+        assert_eq!(messages[0].tokens.input, 10);
         assert_eq!(messages[0].tokens.cache_read, 90);
-        assert_eq!(messages[0].tokens.cache_write, 10);
+        assert_eq!(messages[0].tokens.cache_write, 20);
     }
 
     #[test]
-    fn test_parse_copilot_skips_zero_token_message_after_normalization() {
+    fn test_parse_copilot_keeps_cache_write_only_message() {
         let content = r#"{"type":"span","traceId":"trace-zero","spanId":"span-zero","name":"chat gpt-5.4-mini","endTime":[1775934264,967317833],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.usage.input_tokens":0,"gen_ai.usage.cache_read.input_tokens":50,"gen_ai.usage.cache_write.input_tokens":20}}"#;
         let file = create_test_file(content);
 
         let messages = parse_copilot_file(file.path());
 
-        assert!(messages.is_empty());
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 0);
+        assert_eq!(messages[0].tokens.cache_read, 0);
+        assert_eq!(messages[0].tokens.cache_write, 20);
     }
 }


### PR DESCRIPTION
## Summary

  Align Copilot token accounting with the existing cache-aware parsers by normalizing OTEL `input_tokens` into non-cached input plus separate cache buckets.

  ## What changed

  - Normalize Copilot OTEL usage so `TokenBreakdown.input` excludes cached input
  - Keep `cache_read` and `cache_write` as separate buckets instead of effectively counting them twice
  - Clamp malformed cache totals so cache buckets cannot exceed reported input
  - Update the existing Copilot parser assertion to reflect normalized input
  - Add coverage for:
    - cache read + cache write normalization
    - cache token clamping when cache totals exceed input
  - Bump `tokscale-core` / `tokscale-cli` lockfile entries to `2.0.22`

  ## Why

  Copilot OTEL spans expose `gen_ai.usage.input_tokens` alongside cache-specific usage fields. The previous parser stored raw `input_tokens` and cache buckets together, which inflated Copilot input and total token counts in reports.

  This change makes Copilot reporting consistent with the repo’s normalized cache-aware behavior, especially the Codex parser.

  ## Testing

  - `cargo +1.88.0 test -p tokscale-core copilot --no-fail-fast

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inflated Copilot token counts by normalizing OTEL `input_tokens` to exclude only cache reads while keeping cache reads and writes as separate buckets. Skips zero-token spans after normalization to align Copilot with other cache-aware parsers.

- **Bug Fixes**
  - Subtract only `cache_read` from `input`; keep `cache_write` separate.
  - Clamp `cache_read` to not exceed `input`; do not reallocate `cache_write`.
  - Skip spans where normalized tokens total to zero.
  - Update parser assertion; add tests for read-only normalization, `cache_read` clamping, zero-token skips, and cache_write-only spans.

- **Dependencies**
  - Bump `tokscale-core` and `tokscale-cli` to `2.0.22`.

<sup>Written for commit 399f174f652c131aae5f20f01a80378646f9098f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
