### PR TITLE
feat(embed): add compact mode for 3D view and View toggle in sharing dialog

### DIFF
--- a/packages/frontend/__tests__/api/embedSvgRoute.test.ts
+++ b/packages/frontend/__tests__/api/embedSvgRoute.test.ts
@@ -78,7 +78,7 @@ describe("GET /api/embed/[username]/svg", () => {
     expect(renderIsometric3DEmbedSvg).toHaveBeenCalledWith(
       expect.objectContaining({ user: expect.objectContaining({ username: "octocat" }) }),
       [],
-      { theme: "dark" },
+      { theme: "dark", compact: false },
     );
     expect(renderIsometric3DErrorSvg).not.toHaveBeenCalled();
     await expect(response.text()).resolves.toBe("<svg>3d</svg>");

--- a/packages/frontend/src/app/api/embed/[username]/svg/route.ts
+++ b/packages/frontend/src/app/api/embed/[username]/svg/route.ts
@@ -88,7 +88,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
         return createSvgResponse(svg);
       }
 
-      const svg = renderIsometric3DEmbedSvg(data, contributions, { theme });
+      const svg = renderIsometric3DEmbedSvg(data, contributions, { theme, compact });
 
       console.info("[embed-svg-3d] success", {
         username,
@@ -96,6 +96,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
         durationMs: Date.now() - startedAt,
         sortBy,
         theme,
+        compact,
       });
 
       return createSvgResponse(svg);

--- a/packages/frontend/src/components/profile/ProfileEmbedDialog.tsx
+++ b/packages/frontend/src/components/profile/ProfileEmbedDialog.tsx
@@ -7,6 +7,7 @@ import { toast } from "react-toastify";
 
 type EmbedTheme = "dark" | "light";
 type EmbedSortBy = "tokens" | "cost";
+type EmbedView = "2d" | "3d";
 
 interface ProfileEmbedDialogProps {
   open: boolean;
@@ -26,6 +27,7 @@ export function ProfileEmbedDialog({
   const [theme, setTheme] = useState<EmbedTheme>("dark");
   const [sortBy, setSortBy] = useState<EmbedSortBy>("tokens");
   const [compact, setCompact] = useState(false);
+  const [view, setView] = useState<EmbedView>("2d");
 
   useEffect(() => {
     if (!open) return;
@@ -55,6 +57,7 @@ export function ProfileEmbedDialog({
   } = useMemo(() => {
     const params = new URLSearchParams();
 
+    if (view === "3d") params.set("view", "3d");
     if (theme !== "dark") params.set("theme", theme);
     if (sortBy !== "tokens") params.set("sort", sortBy);
     if (compact) params.set("compact", "1");
@@ -71,7 +74,7 @@ export function ProfileEmbedDialog({
       htmlSnippet: `<a href="${resolvedProfileUrl}"><img alt="Tokscale Stats for @${username}" src="${resolvedEmbedUrl}" /></a>`,
       profileUrl: resolvedProfileUrl,
     };
-  }, [compact, sortBy, theme, username]);
+  }, [compact, sortBy, theme, username, view]);
 
   const copyToClipboard = async (value: string, label: string) => {
     try {
@@ -131,6 +134,26 @@ export function ProfileEmbedDialog({
           </PreviewPanel>
 
           <ControlsPanel>
+            <OptionGroup>
+              <OptionLabel>View</OptionLabel>
+              <SegmentedControl>
+                <SegmentButton
+                  type="button"
+                  $active={view === "2d"}
+                  onClick={() => setView("2d")}
+                >
+                  2D
+                </SegmentButton>
+                <SegmentButton
+                  type="button"
+                  $active={view === "3d"}
+                  onClick={() => setView("3d")}
+                >
+                  3D
+                </SegmentButton>
+              </SegmentedControl>
+            </OptionGroup>
+
             <OptionGroup>
               <OptionLabel>Theme</OptionLabel>
               <SegmentedControl>

--- a/packages/frontend/src/lib/embed/renderIsometric3DSvg.ts
+++ b/packages/frontend/src/lib/embed/renderIsometric3DSvg.ts
@@ -239,9 +239,10 @@ function renderStatsBox(
 export function renderIsometric3DEmbedSvg(
   data: UserEmbedStats,
   contributions: EmbedContributionDay[],
-  options: { theme?: EmbedTheme } = {},
+  options: { theme?: EmbedTheme; compact?: boolean } = {},
 ): string {
   const theme: EmbedTheme = options.theme === "light" ? "light" : "dark";
+  const compactNumbers = options.compact ?? false;
   const palette = THEMES[theme];
   const cls = theme === "dark" ? "d" : "l";
 
@@ -290,8 +291,8 @@ export function renderIsometric3DEmbedSvg(
   }
 
   const username = `@${data.user.username}`;
-  const tokens = formatNumber(data.stats.totalTokens, true);
-  const cost = formatCurrency(data.stats.totalCost, true);
+  const tokens = formatNumber(data.stats.totalTokens, compactNumbers);
+  const cost = formatCurrency(data.stats.totalCost, compactNumbers);
   const rank = data.stats.rank ? `#${data.stats.rank}` : "\u2014";
   const updated = escapeXml(formatDateLabel(data.stats.updatedAt));
   const footerY = height - 14;
@@ -306,7 +307,7 @@ export function renderIsometric3DEmbedSvg(
         : "";
   const streaks = computeStreaks(contributions);
 
-  const statsBoxW = 148;
+  const statsBoxW = compactNumbers ? 148 : 175;
   const tokenUsageX = width - px - statsBoxW;
   const tokenUsageY = headerH + 8;
   const tokenUsageItems: Array<{ value: string; label: string; sub?: string }> = [


### PR DESCRIPTION
## Summary

Follow-up to #416 and #427. Adds compact number formatting for the 3D embed and a View selector in the embed sharing dialog.

## Changes

### 3D embed compact mode (`renderIsometric3DSvg.ts`)
- New `compact` option: when `compact=1`, stats show abbreviated numbers (`4.7B`, `$5.3K`); default shows full numbers (`4,711,240,571`, `$5,320.50`)
- Stats box width auto-adjusts (175px full vs 148px compact) to fit longer numbers

### Embed API route (`route.ts`)
- Passes `compact` flag through to the 3D renderer (previously only used by 2D)

### Embed sharing dialog (`ProfileEmbedDialog.tsx`)
- Adds **View** selector (2D / 3D) as the first option group
- **Layout** (Full / Compact) is now available for both 2D and 3D views
- Live preview and markdown snippet update in real-time

### Usage
```
Full:    https://tokscale.ai/api/embed/<username>/svg?view=3d
Compact: https://tokscale.ai/api/embed/<username>/svg?view=3d&compact=1
```

All 146 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds compact number formatting to the 3D embed and a View toggle (2D/3D) in the embed sharing dialog. Full/Compact layout is now available for both views with a live preview and updated snippet.

- **New Features**
  - 3D embed: `compact=1` shows abbreviated numbers (e.g., 4.7B, $5.3K); default uses full numbers; stats box width adjusts accordingly.
  - Embed API: forwards the `compact` flag to the 3D renderer (defaults to `false`).
  - Sharing dialog: adds View selector (2D/3D); Layout (Full/Compact) applies to both; preview and markdown snippet update in real time.

<sup>Written for commit b8c90817a28bc09729e2247b2e66d797c9a29610. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

