### PR TITLE
fix(regressions): restore copilot accounting and embed behavior

### DIFF
--- a/crates/tokscale-core/src/sessions/copilot.rs
+++ b/crates/tokscale-core/src/sessions/copilot.rs
@@ -148,14 +148,14 @@ fn normalize_input_tokens(
     reasoning: i64,
 ) -> TokenBreakdown {
     // OTEL reports input_tokens inclusive of cache reads. Normalize only the
-    // cached-read portion out of input and preserve cache_write as a separate
-    // bucket until Copilot documents stronger semantics for cache creation.
-    let clamped_cache_read = cache_read.min(input).max(0);
+    // cached-read portion out of input, but preserve the reported cache buckets
+    // intact because pricing totals account for them separately.
+    let cache_read_for_input = cache_read.max(0).min(input.max(0));
 
     TokenBreakdown {
-        input: input.saturating_sub(clamped_cache_read).max(0),
+        input: input.saturating_sub(cache_read_for_input).max(0),
         output: output.max(0),
-        cache_read: clamped_cache_read,
+        cache_read: cache_read.max(0),
         cache_write: cache_write.max(0),
         reasoning: reasoning.max(0),
     }
@@ -274,7 +274,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_copilot_keeps_cache_write_only_message() {
+    fn test_parse_copilot_keeps_cache_only_message() {
         let content = r#"{"type":"span","traceId":"trace-zero","spanId":"span-zero","name":"chat gpt-5.4-mini","endTime":[1775934264,967317833],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.usage.input_tokens":0,"gen_ai.usage.cache_read.input_tokens":50,"gen_ai.usage.cache_write.input_tokens":20}}"#;
         let file = create_test_file(content);
 
@@ -282,7 +282,20 @@ mod tests {
 
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].tokens.input, 0);
-        assert_eq!(messages[0].tokens.cache_read, 0);
+        assert_eq!(messages[0].tokens.cache_read, 50);
         assert_eq!(messages[0].tokens.cache_write, 20);
+    }
+
+    #[test]
+    fn test_parse_copilot_keeps_cache_read_when_input_is_missing() {
+        let content = r#"{"type":"span","traceId":"trace-cache-read","spanId":"span-cache-read","name":"chat gpt-5.4-mini","endTime":[1775934264,967317833],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.usage.cache_read.input_tokens":50}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 0);
+        assert_eq!(messages[0].tokens.cache_read, 50);
+        assert_eq!(messages[0].tokens.cache_write, 0);
     }
 }

--- a/packages/frontend/__tests__/lib/renderIsometric3DSvg.test.ts
+++ b/packages/frontend/__tests__/lib/renderIsometric3DSvg.test.ts
@@ -169,6 +169,17 @@ describe("renderIsometric3DEmbedSvg", () => {
     expect(svg).toContain("fill:#79b8ff");
     expect(svg).toContain("fill:#1A212A");
   });
+
+  it("scales cube heights by usage within the same intensity bucket", () => {
+    const svg = renderIsometric3DEmbedSvg(mockStats, [
+      { date: "2026-02-10", intensity: 4, totalTokens: 1, totalCost: 1 },
+      { date: "2026-02-11", intensity: 4, totalTokens: 1000, totalCost: 10 },
+    ]);
+
+    expect(svg).toContain('height="7"');
+    expect(svg).toContain('height="30.4"');
+  });
+
 });
 
 describe("renderIsometric3DErrorSvg", () => {

--- a/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
+++ b/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
@@ -167,20 +167,42 @@ const EARLY_ADOPTERS = ["code-yeongyu", "gtg7784", "qodot"];
           <ProfileTabBar activeTab={activeTab} onTabChange={setActiveTab} />
 
           {activeTab === "activity" && (
-            graphData ? (
-              <ActivitySection>
-                <ProfileActivity data={graphData} />
-                <ProfileStats
-                  stats={stats}
-                  favoriteModel={
-                    data.modelUsage?.reduce((max, current) => current.cost > max.cost ? current : max, data.modelUsage[0])?.model
-                  }
-                />
-              </ActivitySection>
-            ) : <ProfileEmptyActivity />
+            <div
+              role="tabpanel"
+              id="tabpanel-activity"
+              aria-labelledby="tab-activity"
+            >
+              {graphData ? (
+                <ActivitySection>
+                  <ProfileActivity data={graphData} />
+                  <ProfileStats
+                    stats={stats}
+                    favoriteModel={
+                      data.modelUsage?.reduce((max, current) => current.cost > max.cost ? current : max, data.modelUsage[0])?.model
+                    }
+                  />
+                </ActivitySection>
+              ) : <ProfileEmptyActivity />}
+            </div>
           )}
-          {activeTab === "breakdown" && <TokenBreakdown stats={stats} />}
-          {activeTab === "models" && <ProfileModels models={data.models} modelUsage={data.modelUsage} />}
+          {activeTab === "breakdown" && (
+            <div
+              role="tabpanel"
+              id="tabpanel-breakdown"
+              aria-labelledby="tab-breakdown"
+            >
+              <TokenBreakdown stats={stats} />
+            </div>
+          )}
+          {activeTab === "models" && (
+            <div
+              role="tabpanel"
+              id="tabpanel-models"
+              aria-labelledby="tab-models"
+            >
+              <ProfileModels models={data.models} modelUsage={data.modelUsage} />
+            </div>
+          )}
         </ContentWrapper>
       </MainContent>
 

--- a/packages/frontend/src/components/TabBar.tsx
+++ b/packages/frontend/src/components/TabBar.tsx
@@ -104,7 +104,6 @@ export function TabBar<T extends string>({
             key={tab.id}
             role="tab"
             aria-selected={isActive}
-            aria-controls={`tabpanel-${tab.id}`}
             tabIndex={isActive ? 0 : -1}
             onClick={() => onTabChange(tab.id)}
             onKeyDown={(e) => handleKeyDown(e, index)}

--- a/packages/frontend/src/components/profile/ProfileEmbedDialog.tsx
+++ b/packages/frontend/src/components/profile/ProfileEmbedDialog.tsx
@@ -50,7 +50,6 @@ export function ProfileEmbedDialog({
 
   const {
     embedUrl,
-    previewUrl,
     markdownSnippet,
     htmlSnippet,
     profileUrl,
@@ -69,7 +68,6 @@ export function ProfileEmbedDialog({
 
     return {
       embedUrl: resolvedEmbedUrl,
-      previewUrl: `${resolvedEmbedUrl}${query ? "&" : "?"}preview=1`,
       markdownSnippet: `[![Tokscale Stats](${resolvedEmbedUrl})](${resolvedProfileUrl})`,
       htmlSnippet: `<a href="${resolvedProfileUrl}"><img alt="Tokscale Stats for @${username}" src="${resolvedEmbedUrl}" /></a>`,
       profileUrl: resolvedProfileUrl,
@@ -120,7 +118,7 @@ export function ProfileEmbedDialog({
               <PreviewLabel>Live preview</PreviewLabel>
               <PreviewFrame>
                 <PreviewImage
-                  src={previewUrl}
+                  src={embedUrl}
                   alt={`Tokscale README embed preview for ${displayName || username}`}
                 />
               </PreviewFrame>

--- a/packages/frontend/src/components/profile/index.tsx
+++ b/packages/frontend/src/components/profile/index.tsx
@@ -327,6 +327,16 @@ const ActionButton = styled.button`
   ${actionButtonStyles}
 `;
 
+const PrimaryActionButton = styled(ActionButton)`
+  background: linear-gradient(135deg, #169AFF 0%, #0A84FF 100%);
+  border-color: color-mix(in srgb, #9FD4FB 45%, var(--color-border-default));
+  color: #F8FBFF;
+
+  &:focus-visible {
+    box-shadow: 0 0 0 2px var(--color-bg-default), 0 0 0 4px #169AFF;
+  }
+`;
+
 const ActionLink = styled.a`
   ${actionButtonStyles}
   text-decoration: none;
@@ -448,13 +458,13 @@ export function ProfileHeader({ user, stats, lastUpdated }: ProfileHeaderProps) 
         )}
 
         <ActionButtons>
-          <ActionButton
+          <PrimaryActionButton
             onClick={() => setIsEmbedDialogOpen(true)}
             aria-label={`Open GitHub README embed options for ${user.displayName || user.username}`}
           >
             <EmbedIcon />
             <ActionText>Embed</ActionText>
-          </ActionButton>
+          </PrimaryActionButton>
 
           <ActionButton
             onClick={handleShareClick}
@@ -639,6 +649,7 @@ export function ProfileTabBar({ activeTab, onTabChange }: ProfileTabBarProps) {
         return (
           <TabButton
             key={tab.id}
+            id={`tab-${tab.id}`}
             role="tab"
             aria-selected={isActive}
             aria-controls={`tabpanel-${tab.id}`}

--- a/packages/frontend/src/lib/embed/renderIsometric3DSvg.ts
+++ b/packages/frontend/src/lib/embed/renderIsometric3DSvg.ts
@@ -87,7 +87,7 @@ const DY = +(CELL * TAN30).toFixed(2);
 const RIGHT_DY = +(W * TAN30).toFixed(2);
 const MAX_HEIGHT = 35;
 const MIN_HEIGHT = 2;
-const INTENSITY_HEIGHTS: readonly number[] = [MIN_HEIGHT, 8, 16, 26, MAX_HEIGHT];
+const MIN_NON_ZERO_HEIGHT = 8;
 const ANIM_DUR = "2s";
 
 /**
@@ -154,7 +154,20 @@ function formatShortDate(dateStr: string): string {
   return `${mm}/${dd}`;
 }
 
-function computeStreaks(contributions: EmbedContributionDay[]): { longest: number; current: number } {
+function previousUtcDate(dateStr: string): string {
+  const date = new Date(dateStr + "T00:00:00Z");
+  date.setUTCDate(date.getUTCDate() - 1);
+  return date.toISOString().split("T")[0];
+}
+
+function getContributionHeightValue(contribution: EmbedContributionDay): number {
+  return contribution.totalTokens > 0 ? contribution.totalTokens : contribution.totalCost;
+}
+
+function computeStreaks(
+  contributions: EmbedContributionDay[],
+  referenceDate: Date = new Date(),
+): { longest: number; current: number } {
   const activeSet = new Set<string>();
   for (const c of contributions) {
     if (c.intensity > 0) activeSet.add(c.date);
@@ -176,20 +189,21 @@ function computeStreaks(contributions: EmbedContributionDay[]): { longest: numbe
   }
 
   let current = 0;
-  const now = new Date();
-  let cursor = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
+  const todayStr = new Date(
+    Date.UTC(referenceDate.getUTCFullYear(), referenceDate.getUTCMonth(), referenceDate.getUTCDate()),
+  )
     .toISOString()
     .split("T")[0];
-  if (!activeSet.has(cursor)) {
-    const yesterday = new Date(cursor + "T00:00:00Z");
-    yesterday.setUTCDate(yesterday.getUTCDate() - 1);
-    cursor = yesterday.toISOString().split("T")[0];
-  }
-  while (activeSet.has(cursor)) {
+  const yesterdayStr = previousUtcDate(todayStr);
+  let cursor = activeSet.has(todayStr)
+    ? todayStr
+    : activeSet.has(yesterdayStr)
+      ? yesterdayStr
+      : null;
+
+  while (cursor && activeSet.has(cursor)) {
     current++;
-    const d = new Date(cursor + "T00:00:00Z");
-    d.setUTCDate(d.getUTCDate() - 1);
-    cursor = d.toISOString().split("T")[0];
+    cursor = previousUtcDate(cursor);
   }
 
   return { longest, current };
@@ -246,8 +260,8 @@ export function renderIsometric3DEmbedSvg(
   const palette = THEMES[theme];
   const cls = theme === "dark" ? "d" : "l";
 
-  const intensityMap = new Map<string, number>();
-  for (const c of contributions) intensityMap.set(c.date, c.intensity);
+  const contributionMap = new Map<string, EmbedContributionDay>();
+  for (const contribution of contributions) contributionMap.set(contribution.date, contribution);
 
   const now = new Date();
   const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
@@ -271,6 +285,10 @@ export function renderIsometric3DEmbedSvg(
   const gridXExtent = gridRows * CELL + W + W;
   const gridOriginX = +(px + 7 * CELL + Math.max(0, (width - 2 * px - gridXExtent) / 2)).toFixed(1);
   const gridOriginY = +(headerH + MAX_HEIGHT + 4).toFixed(1);
+  const maxContributionHeightValue = contributions.reduce((max, contribution) => {
+    const value = getContributionHeightValue(contribution);
+    return value > max ? value : max;
+  }, 0);
 
   let cubes = "";
   for (let w = 0; w < numWeeks; w++) {
@@ -280,8 +298,18 @@ export function renderIsometric3DEmbedSvg(
       if (date > today) continue;
 
       const dateStr = date.toISOString().split("T")[0];
-      const intensity = (intensityMap.get(dateStr) ?? 0) as 0 | 1 | 2 | 3 | 4;
-      const h = INTENSITY_HEIGHTS[intensity];
+      const contribution = contributionMap.get(dateStr);
+      const intensity = (contribution?.intensity ?? 0) as 0 | 1 | 2 | 3 | 4;
+      const heightValue = contribution ? getContributionHeightValue(contribution) : 0;
+      const h = heightValue > 0 && maxContributionHeightValue > 0
+        ? Math.max(
+            MIN_NON_ZERO_HEIGHT,
+            Math.round(
+              (heightValue / maxContributionHeightValue) * (MAX_HEIGHT - MIN_NON_ZERO_HEIGHT)
+                + MIN_NON_ZERO_HEIGHT,
+            ),
+          )
+        : MIN_HEIGHT;
 
       const cubeX = gridOriginX + (w - d) * CELL;
       const cubeY = gridOriginY + (w + d) * DY - h;
@@ -325,10 +353,6 @@ export function renderIsometric3DEmbedSvg(
   ];
 
   const faceCss = buildFaceCSS(cls, [...palette.graphGrade]);
-  const classCss = palette.graphGrade
-    .map((_, i) => `.${cls}${i}-t{${""}} .${cls}${i}-l{${""}} .${cls}${i}-r{${""}}`)
-    .join("");
-  void classCss;
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Tokscale 3D contribution graph for ${escapeXml(username)}">


### PR DESCRIPTION
## Summary
- preserve reported Copilot cache-read tokens while still normalizing cache reads out of input for pricing
- restore usage-based 3D embed heights and add regression coverage for the renderer path
- remove the dead embed preview param, restore the primary Embed CTA, and wire real profile tabpanels while relaxing the shared TabBar contract for non-tabpanel consumers

## Validation
- cargo +1.88.0 test -p tokscale-core copilot --no-fail-fast
- bun test __tests__/lib/renderIsometric3DSvg.test.ts __tests__/api/embedSvgRoute.test.ts
- bun -e render probe for 3D SVG face heights (verified scaled output)
- bun -e render probe for ProfileTabBar / shared TabBar markup (verified tabpanel linkage and removed stray aria-controls)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores accurate Copilot token accounting and usage‑scaled 3D embed heights. Fixes profile tabs and brings back the primary Embed CTA for a working README embed and accessible navigation.

- **Bug Fixes**
  - Copilot usage: preserve `cache_read`/`cache_write` buckets and subtract `cache_read` from input; handle spans without input; tests added in `tokscale-core`.
  - 3D embed: scale cube heights by usage within intensity buckets and restore face heights; regression tests added for the renderer and SVG route.
  - Profile: wire real tabpanels with proper ids; relax shared `TabBar` (no global `aria-controls`) while `ProfileTabBar` links tabs to panels; remove dead `preview=1` param and use live `embedUrl`; restore primary-styled Embed button.

<sup>Written for commit 73e782ac293c265963f6f4aae26b711ef15d4bc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

