### PR TITLE
fix(frontend): address top codebase contract issues

### DIFF
--- a/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
@@ -924,7 +924,6 @@ const LeaderboardRow = memo(function LeaderboardRow({
 export default function LeaderboardClient({ initialData, currentUser, initialSortBy, initialUserRank }: LeaderboardClientProps) {
   const router = useRouter();
   const [data, setData] = useState<LeaderboardData>(initialData);
-  const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copiedCommand, setCopiedCommand] = useState<string | null>(null);
   const [period, setPeriod] = useState<Period>(initialData.period);
@@ -933,16 +932,27 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
   const [currentUserRankError, setCurrentUserRankError] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [retryToken, setRetryToken] = useState(0);
+  const [resolvedRequest, setResolvedRequest] = useState({
+    period: initialData.period,
+    page: initialData.pagination.page,
+    sortBy: initialSortBy,
+    search: "",
+    retryToken: 0,
+  });
 
   const { leaderboardSortBy, setLeaderboardSort, mounted } = useSettings();
-  
-  const effectiveSortBy = mounted ? leaderboardSortBy : initialSortBy;
 
-  const isFirstMount = useRef(true);
-  const prevPeriodRef = useRef<Period>(initialData.period);
-  const prevPageRef = useRef(initialData.pagination.page);
-  const prevSortByRef = useRef(initialSortBy);
-  const prevSearchRef = useRef("");
+  const effectiveSortBy = mounted ? leaderboardSortBy : initialSortBy;
+  const requestedPage = data.pagination.totalPages > 0
+    ? Math.min(page, data.pagination.totalPages)
+    : page;
+  const isLoading =
+    period !== resolvedRequest.period
+    || requestedPage !== resolvedRequest.page
+    || effectiveSortBy !== resolvedRequest.sortBy
+    || debouncedSearch !== resolvedRequest.search
+    || retryToken !== resolvedRequest.retryToken;
 
   const isFirstRankFetch = useRef(true);
 
@@ -962,8 +972,6 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
 
   useEffect(() => {
     if (!currentUser) {
-      setCurrentUserRank(null);
-      setCurrentUserRankError(false);
       return;
     }
 
@@ -973,7 +981,6 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
     }
 
     const abortController = new AbortController();
-    setCurrentUserRankError(false);
 
     fetch(`/api/leaderboard/user/${currentUser.username}?period=${period}&sortBy=${effectiveSortBy}`, {
       signal: abortController.signal,
@@ -996,10 +1003,15 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
     return () => abortController.abort();
   }, [currentUser, period, effectiveSortBy]);
 
-  const fetchData = (targetPeriod: Period, targetPage: number, targetSortBy: 'tokens' | 'cost', signal?: AbortSignal) => {
-    setIsLoading(true);
-    setError(null);
-    const searchParam = debouncedSearch ? `&search=${encodeURIComponent(debouncedSearch)}` : '';
+  const fetchData = useCallback((
+    targetPeriod: Period,
+    targetPage: number,
+    targetSortBy: "tokens" | "cost",
+    targetSearch: string,
+    targetRetryToken: number,
+    signal?: AbortSignal,
+  ) => {
+    const searchParam = targetSearch ? `&search=${encodeURIComponent(targetSearch)}` : "";
     fetch(`/api/leaderboard?period=${targetPeriod}&page=${targetPage}&limit=50&sortBy=${targetSortBy}${searchParam}`, { signal })
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -1010,47 +1022,38 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
           throw new Error("Invalid response format");
         }
         setData(result);
-        setIsLoading(false);
+        setError(null);
+        setResolvedRequest({
+          period: targetPeriod,
+          page: targetPage,
+          sortBy: targetSortBy,
+          search: targetSearch,
+          retryToken: targetRetryToken,
+        });
       })
       .catch((err) => {
         if (err.name !== "AbortError") {
           setError(err.message || "Failed to load");
-          setIsLoading(false);
+          setResolvedRequest({
+            period: targetPeriod,
+            page: targetPage,
+            sortBy: targetSortBy,
+            search: targetSearch,
+            retryToken: targetRetryToken,
+          });
         }
       });
-  };
+  }, []);
 
   useEffect(() => {
-    if (isFirstMount.current) {
-      isFirstMount.current = false;
-      prevSortByRef.current = effectiveSortBy;
+    if (!isLoading) {
       return;
     }
-
-    const periodChanged = period !== prevPeriodRef.current;
-    const pageChanged = page !== prevPageRef.current;
-    const sortByChanged = effectiveSortBy !== prevSortByRef.current;
-    const searchChanged = debouncedSearch !== prevSearchRef.current;
-
-    if (!periodChanged && !pageChanged && !sortByChanged && !searchChanged) {
-      return;
-    }
-
-    prevPeriodRef.current = period;
-    prevPageRef.current = page;
-    prevSortByRef.current = effectiveSortBy;
-    prevSearchRef.current = debouncedSearch;
 
     const abortController = new AbortController();
-    fetchData(period, page, effectiveSortBy, abortController.signal);
+    fetchData(period, requestedPage, effectiveSortBy, debouncedSearch, retryToken, abortController.signal);
     return () => abortController.abort();
-  }, [period, page, effectiveSortBy, debouncedSearch]);
-
-  useEffect(() => {
-    if (data.pagination.totalPages > 0 && page > data.pagination.totalPages) {
-      setPage(data.pagination.totalPages);
-    }
-  }, [data.pagination.totalPages, page]);
+  }, [debouncedSearch, effectiveSortBy, fetchData, isLoading, period, requestedPage, retryToken]);
 
   const sortedUsers = data.users || [];
   const showSubmissionCount = period === "all";
@@ -1202,7 +1205,7 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
           <EmptyState>
             <EmptyMessage>Failed to load leaderboard</EmptyMessage>
             <EmptyHint>{error}</EmptyHint>
-            <RetryButton onClick={() => fetchData(period, page, effectiveSortBy)}>
+            <RetryButton onClick={() => setRetryToken((prev) => prev + 1)}>
               Retry
             </RetryButton>
           </EmptyState>

--- a/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
@@ -1025,7 +1025,7 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
         setError(null);
         setResolvedRequest({
           period: targetPeriod,
-          page: targetPage,
+          page: result.pagination.page,
           sortBy: targetSortBy,
           search: targetSearch,
           retryToken: targetRetryToken,

--- a/packages/frontend/src/app/(main)/leaderboard/page.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/page.tsx
@@ -8,6 +8,10 @@ import { getLeaderboardData, getUserRank } from "@/lib/leaderboard/getLeaderboar
 import type { LeaderboardData, SortBy } from "@/lib/leaderboard/types";
 import { getSession } from "@/lib/auth/session";
 import { SORT_BY_COOKIE_NAME, isValidSortBy } from "@/lib/leaderboard/constants";
+
+function isMissingDatabaseUrl(error: unknown): boolean {
+  return error instanceof Error && error.message === "DATABASE_URL environment variable is not set";
+}
 import LeaderboardClient from "./LeaderboardClient";
 
 function createEmptyLeaderboardData(sortBy: SortBy): LeaderboardData {
@@ -62,12 +66,27 @@ async function LeaderboardWithPreferences() {
   const sortBy: SortBy = isValidSortBy(sortByCookie) ? sortByCookie : "tokens";
 
   const [initialData, session] = await Promise.all([
-    getLeaderboardData("all", 1, 50, sortBy).catch(() => createEmptyLeaderboardData(sortBy)),
-    getSession().catch(() => null),
+    getLeaderboardData("all", 1, 50, sortBy).catch((error) => {
+      if (isMissingDatabaseUrl(error)) {
+        return createEmptyLeaderboardData(sortBy);
+      }
+      throw error;
+    }),
+    getSession().catch((error) => {
+      if (isMissingDatabaseUrl(error)) {
+        return null;
+      }
+      throw error;
+    }),
   ]);
 
   const initialUserRank = session
-    ? await getUserRank(session.username, "all", sortBy).catch(() => null)
+    ? await getUserRank(session.username, "all", sortBy).catch((error) => {
+        if (isMissingDatabaseUrl(error)) {
+          return null;
+        }
+        throw error;
+      })
     : null;
 
   return (

--- a/packages/frontend/src/app/(main)/leaderboard/page.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/page.tsx
@@ -5,10 +5,32 @@ import { Footer } from "@/components/layout/Footer";
 import { BlackholeHero } from "@/components/BlackholeHero";
 import { LeaderboardSkeleton } from "@/components/Skeleton";
 import { getLeaderboardData, getUserRank } from "@/lib/leaderboard/getLeaderboard";
-import type { SortBy } from "@/lib/leaderboard/types";
+import type { LeaderboardData, SortBy } from "@/lib/leaderboard/types";
 import { getSession } from "@/lib/auth/session";
 import { SORT_BY_COOKIE_NAME, isValidSortBy } from "@/lib/leaderboard/constants";
 import LeaderboardClient from "./LeaderboardClient";
+
+function createEmptyLeaderboardData(sortBy: SortBy): LeaderboardData {
+  return {
+    users: [],
+    pagination: {
+      page: 1,
+      limit: 50,
+      totalUsers: 0,
+      totalPages: 0,
+      hasNext: false,
+      hasPrev: false,
+    },
+    stats: {
+      totalTokens: 0,
+      totalCost: 0,
+      totalSubmissions: null,
+      uniqueUsers: 0,
+    },
+    period: "all",
+    sortBy,
+  };
+}
 
 export default function LeaderboardPage() {
   return (
@@ -40,12 +62,12 @@ async function LeaderboardWithPreferences() {
   const sortBy: SortBy = isValidSortBy(sortByCookie) ? sortByCookie : "tokens";
 
   const [initialData, session] = await Promise.all([
-    getLeaderboardData("all", 1, 50, sortBy),
-    getSession(),
+    getLeaderboardData("all", 1, 50, sortBy).catch(() => createEmptyLeaderboardData(sortBy)),
+    getSession().catch(() => null),
   ]);
 
   const initialUserRank = session
-    ? await getUserRank(session.username, "all", sortBy)
+    ? await getUserRank(session.username, "all", sortBy).catch(() => null)
     : null;
 
   return (

--- a/packages/frontend/src/app/(main)/page.tsx
+++ b/packages/frontend/src/app/(main)/page.tsx
@@ -1,13 +1,35 @@
 import { Navigation } from "@/components/layout/Navigation";
 import { LandingPage } from "@/components/landing/LandingPage";
 import { getStargazersCount } from "@/lib/github";
-import { getLeaderboardData } from "@/lib/leaderboard/getLeaderboard";
+import { getLeaderboardData, type LeaderboardData } from "@/lib/leaderboard/getLeaderboard";
+
+function createEmptyLeaderboardData(sortBy: "tokens" | "cost"): LeaderboardData {
+  return {
+    users: [],
+    pagination: {
+      page: 1,
+      limit: 5,
+      totalUsers: 0,
+      totalPages: 0,
+      hasNext: false,
+      hasPrev: false,
+    },
+    stats: {
+      totalTokens: 0,
+      totalCost: 0,
+      totalSubmissions: null,
+      uniqueUsers: 0,
+    },
+    period: "all",
+    sortBy,
+  };
+}
 
 export default async function HomePage() {
   const [stargazersCount, topUsersByCost, topUsersByTokens] = await Promise.all([
     getStargazersCount("junhoyeo/tokscale"),
-    getLeaderboardData("all", 1, 5, "cost"),
-    getLeaderboardData("all", 1, 5, "tokens"),
+    getLeaderboardData("all", 1, 5, "cost").catch(() => createEmptyLeaderboardData("cost")),
+    getLeaderboardData("all", 1, 5, "tokens").catch(() => createEmptyLeaderboardData("tokens")),
   ]);
 
   return (

--- a/packages/frontend/src/app/profile/page.tsx
+++ b/packages/frontend/src/app/profile/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 
 export default async function ProfilePage() {
-  const session = await getSession();
+  const session = await getSession().catch(() => null);
 
   if (session) {
     redirect(`/u/${session.username}`);

--- a/packages/frontend/src/app/profile/page.tsx
+++ b/packages/frontend/src/app/profile/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 
 export default async function ProfilePage() {
-  const session = await getSession().catch(() => null);
+  const session = await getSession();
 
   if (session) {
     redirect(`/u/${session.username}`);

--- a/packages/frontend/src/components/SourceLogo.tsx
+++ b/packages/frontend/src/components/SourceLogo.tsx
@@ -59,6 +59,8 @@ export function SourceLogo({ sourceId, height = 14, className = "" }: SourceLogo
         return "/assets/logos/kilocode.png";
       case "mux":
         return "/assets/logos/mux.png";
+      case "crush":
+        return "https://raw.githubusercontent.com/junhoyeo/tokscale/main/.github/assets/client-crush.png";
       case "synthetic":
         return "/assets/logos/synthetic.png";
       default:

--- a/packages/frontend/src/components/landing/hooks/useSquircleClip.ts
+++ b/packages/frontend/src/components/landing/hooks/useSquircleClip.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo, useCallback, useRef } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef, useId } from "react";
 import { getSvgPath } from "figma-squircle";
 
 export interface SquircleBorderDef {
@@ -23,9 +23,8 @@ export function useSquircleClip<T extends HTMLElement = HTMLElement>(
   borderWidth: number = 0
 ) {
   const ref = useRef<T | null>(null);
-  const clipIdRef = useRef(
-    `squircle-clip-${Math.random().toString(36).slice(2, 9)}`
-  );
+  const clipId = useId().replace(/:/g, "");
+  const baseId = `squircle-clip-${clipId}`;
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
 
   const clipResult = useMemo(() => {
@@ -33,7 +32,6 @@ export function useSquircleClip<T extends HTMLElement = HTMLElement>(
     if (width === 0 || height === 0)
       return { clipPath: "", svgDef: null, borderDef: null };
 
-    const baseId = clipIdRef.current;
     let borderDef: SquircleBorderDef | null = null;
 
     if (bottomOnly) {
@@ -97,7 +95,7 @@ export function useSquircleClip<T extends HTMLElement = HTMLElement>(
     }
 
     return { clipPath: `path('${outerPath}')`, svgDef: null, borderDef };
-  }, [dimensions, cornerRadius, cornerSmoothing, bottomOnly, borderWidth]);
+  }, [baseId, borderWidth, bottomOnly, cornerRadius, cornerSmoothing, dimensions]);
 
   useEffect(() => {
     if (!ref.current) return;
@@ -114,7 +112,7 @@ export function useSquircleClip<T extends HTMLElement = HTMLElement>(
     return () => observer.disconnect();
   }, []);
 
-  const setRef = useCallback((node: T | null) => {
+  const setElementRef = useCallback((node: T | null) => {
     ref.current = node;
     if (node) {
       const { width, height } = node.getBoundingClientRect();
@@ -125,7 +123,7 @@ export function useSquircleClip<T extends HTMLElement = HTMLElement>(
   }, []);
 
   return {
-    ref: setRef,
+    setElementRef,
     clipPath: clipResult.clipPath,
     svgDef: clipResult.svgDef,
     borderDef: clipResult.borderDef,

--- a/packages/frontend/src/components/landing/sections/QuickstartSection.tsx
+++ b/packages/frontend/src/components/landing/sections/QuickstartSection.tsx
@@ -8,12 +8,17 @@ import { SquircleBorder } from "../components";
 export function QuickstartSection() {
   const tui = useCopy("bunx tokscale@latest");
   const submit = useCopy("bunx tokscale@latest submit");
-  const cardsRow = useSquircleClip<HTMLDivElement>(32, 0.6, true, 1);
+  const {
+    setElementRef: setCardsRowRef,
+    clipPath: cardsRowClipPath,
+    svgDef: cardsRowSvgDef,
+    borderDef: cardsRowBorderDef,
+  } = useSquircleClip<HTMLDivElement>(32, 0.6, true, 1);
 
   return (
     <>
       {/* SVG clip-path def for cards */}
-      {cardsRow.svgDef && (
+      {cardsRowSvgDef && (
         <svg
           width="0"
           height="0"
@@ -22,10 +27,10 @@ export function QuickstartSection() {
           role="presentation"
         >
           <defs>
-            <clipPath id={cardsRow.svgDef.id}>
+            <clipPath id={cardsRowSvgDef.id}>
               <path
-                d={cardsRow.svgDef.path}
-                transform={`translate(0, -${cardsRow.svgDef.cornerRadius})`}
+                d={cardsRowSvgDef.path}
+                transform={`translate(0, -${cardsRowSvgDef.cornerRadius})`}
               />
             </clipPath>
           </defs>
@@ -43,12 +48,12 @@ export function QuickstartSection() {
       {/* Quickstart Cards */}
       <QuickstartCardsWrapper>
         <QuickstartCardsRow
-          ref={cardsRow.ref}
+          ref={setCardsRowRef}
           style={{
-            clipPath: cardsRow.clipPath || undefined,
+            clipPath: cardsRowClipPath || undefined,
           }}
         >
-          <SquircleBorder def={cardsRow.borderDef} />
+          <SquircleBorder def={cardsRowBorderDef} />
           {/* Left Card */}
           <QuickstartCard $position="left">
             <CardPatternOverlay $position="left" />

--- a/packages/frontend/src/components/landing/sections/WorldwideSection.tsx
+++ b/packages/frontend/src/components/landing/sections/WorldwideSection.tsx
@@ -32,7 +32,12 @@ export function WorldwideSection({
   topUsersByCost = [],
   topUsersByTokens = [],
 }: WorldwideSectionProps) {
-  const worldwideSection = useSquircleClip<HTMLDivElement>(32, 0.6, true, 1);
+  const {
+    setElementRef: setWorldwideSectionClipRef,
+    clipPath: worldwideClipPath,
+    svgDef: worldwideSvgDef,
+    borderDef: worldwideBorderDef,
+  } = useSquircleClip<HTMLDivElement>(32, 0.6, true, 1);
   const [activeTab, setActiveTab] = useState<"tokens" | "cost">("cost");
   const users = activeTab === "cost" ? topUsersByCost : topUsersByTokens;
   // Measure blue header bottom for border gradient transition
@@ -43,9 +48,9 @@ export function WorldwideSection({
   const sectionRef = useCallback(
     (node: HTMLDivElement | null) => {
       sectionElRef.current = node;
-      worldwideSection.ref(node);
+      setWorldwideSectionClipRef(node);
     },
-    [worldwideSection.ref],
+    [setWorldwideSectionClipRef],
   );
 
   useEffect(() => {
@@ -67,7 +72,7 @@ export function WorldwideSection({
   return (
     <>
       {/* SVG clip-path def for globe section */}
-      {worldwideSection.svgDef && (
+      {worldwideSvgDef && (
         <svg
           width="0"
           height="0"
@@ -76,10 +81,10 @@ export function WorldwideSection({
           role="presentation"
         >
           <defs>
-            <clipPath id={worldwideSection.svgDef.id}>
+            <clipPath id={worldwideSvgDef.id}>
               <path
-                d={worldwideSection.svgDef.path}
-                transform={`translate(0, -${worldwideSection.svgDef.cornerRadius})`}
+                d={worldwideSvgDef.path}
+                transform={`translate(0, -${worldwideSvgDef.cornerRadius})`}
               />
             </clipPath>
           </defs>
@@ -90,10 +95,10 @@ export function WorldwideSection({
       <GlobeSectionWrapper
         ref={sectionRef}
         style={{
-          clipPath: worldwideSection.clipPath || undefined,
+          clipPath: worldwideClipPath || undefined,
         }}
       >
-        <SquircleBorder def={worldwideSection.borderDef} color="#0073FF" gradient={gradientTransitionY > 0 ? { colors: ["#0073FF", "#10233E"], transitionY: gradientTransitionY } : undefined} />
+        <SquircleBorder def={worldwideBorderDef} color="#0073FF" gradient={gradientTransitionY > 0 ? { colors: ["#0073FF", "#10233E"], transitionY: gradientTransitionY } : undefined} />
         <GlobeImageWrapper>
           <GlobeBackground />
           <GlobeFadeTop />

--- a/packages/frontend/src/components/layout/Navigation.tsx
+++ b/packages/frontend/src/components/layout/Navigation.tsx
@@ -665,10 +665,6 @@ export function Navigation() {
       });
   }, []);
 
-  useEffect(() => {
-    setIsMobileMenuOpen(false);
-  }, [pathname]); // eslint-disable-line react-hooks/exhaustive-deps
-
   const closeMobileMenu = () => setIsMobileMenuOpen(false);
 
   return (

--- a/packages/frontend/src/lib/constants.ts
+++ b/packages/frontend/src/lib/constants.ts
@@ -42,6 +42,7 @@ export const SOURCE_DISPLAY_NAMES: Record<string, string> = {
   kilocode: "Kilo",
   kilo: "Kilo",
   mux: "Mux",
+  crush: "Crush",
   synthetic: "Synthetic",
 };
 
@@ -65,6 +66,7 @@ export const SOURCE_LOGOS: Record<string, string> = {
   kilocode: `${GITHUB_CDN_BASE}/client-kilocode.png`,
   kilo: `${GITHUB_CDN_BASE}/client-kilocode.png`,
   mux: `${GITHUB_CDN_BASE}/client-mux.png`,
+  crush: `${GITHUB_CDN_BASE}/client-crush.png`,
   synthetic: `${GITHUB_CDN_BASE}/client-synthetic.png`,
 };
 
@@ -86,6 +88,7 @@ export const SOURCE_COLORS: Record<string, string> = {
   kilocode: "#F59E0B",
   kilo: "#F59E0B",
   mux: "#171717",
+  crush: "#DC2626",
   synthetic: "#4ADE80",
 };
 

--- a/packages/frontend/src/lib/db/index.ts
+++ b/packages/frontend/src/lib/db/index.ts
@@ -1,10 +1,14 @@
 import { drizzle } from "drizzle-orm/postgres-js";
 import * as schema from "./schema";
 
-const connectionString = process.env.DATABASE_URL;
+function getConnectionString(): string {
+  const connectionString = process.env.DATABASE_URL;
 
-if (!connectionString) {
-  throw new Error("DATABASE_URL environment variable is not set");
+  if (!connectionString) {
+    throw new Error("DATABASE_URL environment variable is not set");
+  }
+
+  return connectionString;
 }
 
 // Singleton pattern: prevent creating multiple connection pools across
@@ -17,7 +21,7 @@ if (!connectionString) {
 function createDb() {
   return drizzle({
     connection: {
-      url: connectionString!,
+      url: getConnectionString(),
       ssl: process.env.NODE_ENV === "production" ? "require" : false,
 
       // Serverless-optimized pool settings:
@@ -46,14 +50,25 @@ function createDb() {
   });
 }
 
+type DbClient = ReturnType<typeof createDb>;
+
 const globalForDb = globalThis as unknown as {
-  _db: ReturnType<typeof createDb> | undefined;
+  _db: DbClient | undefined;
 };
 
-if (!globalForDb._db) {
-  globalForDb._db = createDb();
+export function getDb(): DbClient {
+  if (!globalForDb._db) {
+    globalForDb._db = createDb();
+  }
+
+  return globalForDb._db;
 }
 
-export const db = globalForDb._db;
+export const db: DbClient = new Proxy({} as DbClient, {
+  get(_target, prop) {
+    const value = Reflect.get(getDb(), prop);
+    return typeof value === "function" ? value.bind(getDb()) : value;
+  },
+});
 
 export * from "./schema";

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type ClientType = "opencode" | "claude" | "codex" | "copilot" | "gemini" | "cursor" | "amp" | "droid" | "openclaw" | "hermes" | "pi" | "kimi" | "qwen" | "roocode" | "kilocode" | "kilo" | "mux" | "synthetic";
+export type ClientType = "opencode" | "claude" | "codex" | "copilot" | "gemini" | "cursor" | "amp" | "droid" | "openclaw" | "hermes" | "pi" | "kimi" | "qwen" | "roocode" | "kilocode" | "kilo" | "mux" | "crush" | "synthetic";
 
 export interface TokenBreakdown {
   input: number;

--- a/packages/frontend/src/lib/useSettings.ts
+++ b/packages/frontend/src/lib/useSettings.ts
@@ -1,12 +1,12 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useCallback, useEffect, useSyncExternalStore } from "react";
 import type { ColorPaletteName } from "./themes";
 import { DEFAULT_PALETTE } from "./themes";
-import { 
+import {
   type LeaderboardSortBy,
   SORT_BY_COOKIE_NAME,
-  isValidSortBy 
+  isValidSortBy,
 } from "./leaderboard/constants";
 
 export type { LeaderboardSortBy };
@@ -18,10 +18,11 @@ export interface Settings {
 
 const DEFAULT_SETTINGS: Settings = {
   paletteName: DEFAULT_PALETTE,
-  leaderboardSortBy: 'tokens',
+  leaderboardSortBy: "tokens",
 };
 
 const STORAGE_KEY = "tokscale-settings";
+const SETTINGS_EVENT = "tokscale-settings-changed";
 
 function setSortByCookie(sortBy: LeaderboardSortBy): void {
   if (typeof document === "undefined") return;
@@ -37,8 +38,8 @@ function getStoredSettings(): Settings {
       const parsed = JSON.parse(stored);
       return {
         paletteName: parsed.paletteName || DEFAULT_SETTINGS.paletteName,
-        leaderboardSortBy: isValidSortBy(parsed.leaderboardSortBy) 
-          ? parsed.leaderboardSortBy 
+        leaderboardSortBy: isValidSortBy(parsed.leaderboardSortBy)
+          ? parsed.leaderboardSortBy
           : DEFAULT_SETTINGS.leaderboardSortBy,
       };
     }
@@ -53,9 +54,33 @@ function saveSettings(settings: Settings): void {
   if (typeof window === "undefined") return;
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+    window.dispatchEvent(new Event(SETTINGS_EVENT));
   } catch {
     // localStorage might be full or disabled
   }
+}
+
+function subscribeToSettings(onStoreChange: () => void): () => void {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+
+  const handleStorage = (event: StorageEvent) => {
+    if (!event.key || event.key === STORAGE_KEY) {
+      onStoreChange();
+    }
+  };
+
+  window.addEventListener("storage", handleStorage);
+  window.addEventListener(SETTINGS_EVENT, onStoreChange);
+  return () => {
+    window.removeEventListener("storage", handleStorage);
+    window.removeEventListener(SETTINGS_EVENT, onStoreChange);
+  };
+}
+
+function subscribeToMounted(): () => void {
+  return () => {};
 }
 
 function applyDarkModeToDocument(): void {
@@ -66,35 +91,30 @@ function applyDarkModeToDocument(): void {
 }
 
 export function useSettings() {
-  const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
-  const mountedRef = useRef(false);
-  const [mounted, setMounted] = useState(false);
+  const settings = useSyncExternalStore(
+    subscribeToSettings,
+    getStoredSettings,
+    () => DEFAULT_SETTINGS,
+  );
+  const mounted = useSyncExternalStore(
+    subscribeToMounted,
+    () => true,
+    () => false,
+  );
 
   useEffect(() => {
     applyDarkModeToDocument();
-    const stored = getStoredSettings();
-    setSettings(stored);
-    setSortByCookie(stored.leaderboardSortBy);
-    mountedRef.current = true;
-    setMounted(true);
-  }, []);
+    setSortByCookie(settings.leaderboardSortBy);
+  }, [settings.leaderboardSortBy]);
 
   const setPalette = useCallback((paletteName: ColorPaletteName) => {
-    setSettings((prev) => {
-      const newSettings = { ...prev, paletteName };
-      saveSettings(newSettings);
-      return newSettings;
-    });
-  }, []);
+    saveSettings({ ...settings, paletteName });
+  }, [settings]);
 
   const setLeaderboardSort = useCallback((sortBy: LeaderboardSortBy) => {
-    setSettings((prev) => {
-      const newSettings = { ...prev, leaderboardSortBy: sortBy };
-      saveSettings(newSettings);
-      setSortByCookie(sortBy);
-      return newSettings;
-    });
-  }, []);
+    setSortByCookie(sortBy);
+    saveSettings({ ...settings, leaderboardSortBy: sortBy });
+  }, [settings]);
 
   return {
     paletteName: settings.paletteName,

--- a/packages/frontend/src/lib/useSettings.ts
+++ b/packages/frontend/src/lib/useSettings.ts
@@ -24,6 +24,9 @@ const DEFAULT_SETTINGS: Settings = {
 const STORAGE_KEY = "tokscale-settings";
 const SETTINGS_EVENT = "tokscale-settings-changed";
 
+let cachedRawSettings: string | null = null;
+let cachedSettings: Settings = DEFAULT_SETTINGS;
+
 function setSortByCookie(sortBy: LeaderboardSortBy): void {
   if (typeof document === "undefined") return;
   document.cookie = `${SORT_BY_COOKIE_NAME}=${sortBy}; path=/; max-age=${60 * 60 * 24 * 365}; SameSite=Lax`;
@@ -34,17 +37,29 @@ function getStoredSettings(): Settings {
 
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) {
-      const parsed = JSON.parse(stored);
-      return {
-        paletteName: parsed.paletteName || DEFAULT_SETTINGS.paletteName,
-        leaderboardSortBy: isValidSortBy(parsed.leaderboardSortBy)
-          ? parsed.leaderboardSortBy
-          : DEFAULT_SETTINGS.leaderboardSortBy,
-      };
+    if (!stored) {
+      cachedRawSettings = null;
+      cachedSettings = DEFAULT_SETTINGS;
+      return DEFAULT_SETTINGS;
     }
+
+    if (stored === cachedRawSettings) {
+      return cachedSettings;
+    }
+
+    const parsed = JSON.parse(stored);
+    cachedRawSettings = stored;
+    cachedSettings = {
+      paletteName: parsed.paletteName || DEFAULT_SETTINGS.paletteName,
+      leaderboardSortBy: isValidSortBy(parsed.leaderboardSortBy)
+        ? parsed.leaderboardSortBy
+        : DEFAULT_SETTINGS.leaderboardSortBy,
+    };
+    return cachedSettings;
   } catch {
     // Invalid JSON or localStorage error
+    cachedRawSettings = null;
+    cachedSettings = DEFAULT_SETTINGS;
   }
 
   return DEFAULT_SETTINGS;
@@ -53,7 +68,10 @@ function getStoredSettings(): Settings {
 function saveSettings(settings: Settings): void {
   if (typeof window === "undefined") return;
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+    const serialized = JSON.stringify(settings);
+    cachedRawSettings = serialized;
+    cachedSettings = settings;
+    localStorage.setItem(STORAGE_KEY, serialized);
     window.dispatchEvent(new Event(SETTINGS_EVENT));
   } catch {
     // localStorage might be full or disabled
@@ -108,13 +126,13 @@ export function useSettings() {
   }, [settings.leaderboardSortBy]);
 
   const setPalette = useCallback((paletteName: ColorPaletteName) => {
-    saveSettings({ ...settings, paletteName });
-  }, [settings]);
+    saveSettings({ ...getStoredSettings(), paletteName });
+  }, []);
 
   const setLeaderboardSort = useCallback((sortBy: LeaderboardSortBy) => {
     setSortByCookie(sortBy);
-    saveSettings({ ...settings, leaderboardSortBy: sortBy });
-  }, [settings]);
+    saveSettings({ ...getStoredSettings(), leaderboardSortBy: sortBy });
+  }, []);
 
   return {
     paletteName: settings.paletteName,

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -36,6 +36,7 @@ const SUPPORTED_SOURCES = [
   "roocode",
   "kilo",
   "mux",
+  "crush",
   "synthetic",
 ] as const;
 const SourceSchema = z.enum(SUPPORTED_SOURCES);


### PR DESCRIPTION
## Summary
- lazy-load the frontend database client and add build-time fallbacks so public pages can build without DATABASE_URL
- add crush to the frontend submission/type/display contract so it matches the core and CLI support surface
- remove the active React effect and hook correctness errors in leaderboard, settings, navigation, and landing squircle hooks

## Validation
- targeted eslint on changed correctness files: 0 errors, 2 existing no-img warnings in LeaderboardClient
- env -u DATABASE_URL bun run build
- crush submission validation probe returned valid: true

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the frontend by lazy-loading the DB client and scoping fail‑soft behavior so public pages build without `DATABASE_URL`. Adds `crush` support and fixes leaderboard paging and settings state churn.

- **New Features**
  - Added `crush` to submission schema, types, display names/colors/logos, and `SourceLogo`.
  - Lazy-loaded frontend DB client via a proxy; the client is created on first use.

- **Bug Fixes**
  - Leaderboard: derived loading state, clamped page to total pages, included debounced search in fetches, and added a reliable retry.
  - Settings: switched to `useSyncExternalStore` with cached snapshots and cross‑tab sync; cookie stays in sync.
  - Landing: stable squircle clip IDs using `useId`; sections updated to the new `useSquircleClip` API with `setElementRef`.
  - Navigation: removed the route-change effect that closed the mobile menu unexpectedly.
  - Fallbacks: when `DATABASE_URL` is missing, leaderboard returns empty data and session/rank resolve to null; landing top‑users lists fall back to empty.

<sup>Written for commit a5a87cf7e561b2a5289e4ed9bb7098ef8de3d46b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

