### PR TITLE
fix(cli): restore local runner entrypoints

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -723,10 +723,10 @@ cargo --version
 bun run build:core
 
 # 開発モードで実行（TUIを起動）
-cd packages/cli && bun src/cli.ts
+cd packages/cli && bun src/index.ts
 
 # またはレガシーCLIモードを使用
-cd packages/cli && bun src/cli.ts --light
+cd packages/cli && bun src/index.ts --light
 ```
 
 <details>

--- a/README.ko.md
+++ b/README.ko.md
@@ -722,10 +722,10 @@ cargo --version
 bun run build:core
 
 # 개발 모드로 실행 (TUI 실행)
-cd packages/cli && bun src/cli.ts
+cd packages/cli && bun src/index.ts
 
 # 또는 레거시 CLI 모드 사용
-cd packages/cli && bun src/cli.ts --light
+cd packages/cli && bun src/index.ts --light
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -743,10 +743,10 @@ After following the [Development Setup](#development-setup), you can:
 bun run build:core
 
 # Run in development mode (launches TUI)
-cd packages/cli && bun src/cli.ts
+cd packages/cli && bun src/index.ts
 
 # Or use legacy CLI mode
-cd packages/cli && bun src/cli.ts --light
+cd packages/cli && bun src/index.ts --light
 ```
 
 <details>

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -723,10 +723,10 @@ cargo --version
 bun run build:core
 
 # 以开发模式运行（启动 TUI）
-cd packages/cli && bun src/cli.ts
+cd packages/cli && bun src/index.ts
 
 # 或使用传统 CLI 模式
-cd packages/cli && bun src/cli.ts --light
+cd packages/cli && bun src/index.ts --light
 ```
 
 <details>

--- a/packages/cli/bunfig.toml
+++ b/packages/cli/bunfig.toml
@@ -1,4 +1,1 @@
-# Bun configuration for token-tracker CLI
-# This enables the OpenTUI Solid.js plugin for JSX transformation
-
-preload = ["@opentui/solid/preload"]
+# packages/cli is a plain wrapper entrypoint and does not require Bun preloads.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "dev": "bun run src/index.ts",
+    "dev": "bun src/index.ts",
     "start": "node dist/index.js",
     "prepublishOnly": "bun run build"
   },

--- a/scripts/cli.sh
+++ b/scripts/cli.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 START=$(perl -MTime::HiRes=time -e 'printf "%.0f", time * 1000')
-bun packages/cli/src/cli.ts "$@"
+bun packages/cli/src/index.ts "$@"
 EXIT=$?
 END=$(perl -MTime::HiRes=time -e 'printf "%.0f", time * 1000')
 echo -e "\n⏱  Done in $((END - START))ms"


### PR DESCRIPTION
## Summary
- restore the executable local shell launcher so the root CLI script works again
- align the package-local Bun runner with the real packages/cli/src/index.ts entrypoint and remove the stale preload from the wrapper package
- update all tracked README variants so local development commands no longer reference the deleted src/cli.ts

## Validation
- ./scripts/cli.sh --version
- bun run cli -- --version
- bun run --cwd packages/cli dev -- --version


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the local CLI launcher so the root script works again. Aligns all dev runners to `packages/cli/src/index.ts` and removes a stale Bun preload.

- **Bug Fixes**
  - Root `scripts/cli.sh` now runs `packages/cli/src/index.ts`.
  - `packages/cli` dev script uses `bun src/index.ts` (was `bun run src/index.ts`).
  - Removed `preload = ["@opentui/solid/preload"]` from `packages/cli/bunfig.toml` since the wrapper needs no preloads.
  - Updated all READMEs to use `bun src/index.ts` and `--light` for legacy mode.

<sup>Written for commit 187d9d408d6ad62de56858fa332dd6d4e9c6b4f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

