### PR TITLE
fix(frontend): prevent rank badge overflow on 3+ digit ranks

### DIFF
--- a/packages/frontend/src/components/profile/index.tsx
+++ b/packages/frontend/src/components/profile/index.tsx
@@ -133,12 +133,15 @@ const UserDetails = styled.div`
 `;
 
 const RankBadge = styled.div`
-  width: 2rem;
+  min-width: 2rem;
   height: 2rem;
+  padding: 0 0.375rem;
   border-radius: 0.5rem;
   display: flex;
   align-items: center;
   justify-content: center;
+  white-space: nowrap;
+  align-self: flex-start;
 `;
 
 const RankText = styled.span`


### PR DESCRIPTION
## Summary

Profile rank badge (`RankBadge`) had a fixed `width: 2rem` (32px), causing text overflow when rank exceeds 2 digits (e.g., `#308`, `#1234`).

## Changes

- `width: 2rem` → `min-width: 2rem` — badge grows with content
- Added `padding: 0 0.375rem` — horizontal breathing room
- Added `white-space: nowrap` — prevents line break
- Added `align-self: flex-start` — prevents flex column stretch

## Before / After

### Before (production)

| `#1` | `#7` | `#99` |
|:---:|:---:|:---:|
| <img width="500" height="120" alt="pr-before-1" src="https://github.com/user-attachments/assets/b83496ae-090d-4418-b740-53e4e0b13cf8" /> | <img width="500" height="120" alt="pr-before-7" src="https://github.com/user-attachments/assets/88c5b7d5-4d61-4471-88b0-e7a1eb04742b" /> | <img width="500" height="120" alt="pr-before-99" src="https://github.com/user-attachments/assets/d06be552-33e8-4e6c-8af3-14ef4874f9fa" /> |

| `#308` | `#1234` | `#99999` |
|:---:|:---:|:---:|
| <img width="500" height="120" alt="pr-before-308" src="https://github.com/user-attachments/assets/04bc1690-1567-474b-b7d2-ed0fea080655" /> | <img width="500" height="120" alt="pr-before-1234" src="https://github.com/user-attachments/assets/b61b00b0-5dfe-4ddd-a24d-604ae899efc9" /> | <img width="500" height="120" alt="pr-before-99999" src="https://github.com/user-attachments/assets/e8a89882-76d0-48eb-aeb3-9578aa2615c4" /> |

### After (with fix)

| `#1` | `#7` | `#99` |
|:---:|:---:|:---:|
| <img width="500" height="120" alt="pr-after-1" src="https://github.com/user-attachments/assets/906e66b6-d251-4e54-a57d-f9f9ac7ee88b" /> | <img width="500" height="120" alt="pr-after-7" src="https://github.com/user-attachments/assets/cfaf46d2-8ec4-42cc-8afc-eb19cb9bc3bc" /> | <img width="500" height="120" alt="pr-after-99" src="https://github.com/user-attachments/assets/addb71d7-75ef-4883-a0d3-9687072753af" /> |

| `#308` | `#1234` | `#99999` |
|:---:|:---:|:---:|
| <img width="500" height="120" alt="pr-after-308" src="https://github.com/user-attachments/assets/22717f26-ee03-44cc-8382-af09056bc987" /> | <img width="500" height="120" alt="pr-after-1234" src="https://github.com/user-attachments/assets/9e0f5b59-8486-46ac-acd1-963d3290e3ec" /> | <img width="500" height="120" alt="pr-after-99999" src="https://github.com/user-attachments/assets/07707002-2bab-4365-b5c0-6b2e987f700c" /> |

> Screenshots taken via Playwright on production (tokscale.ai) with CSS injection for the "After" variant.

## Notes

- 1-2 digit ranks retain the original compact square badge design
- 3+ digit ranks naturally expand to fit content
- No design intent changes for existing users with low ranks