### PR TITLE
fix(tui): provider color overrides across ranks + CLI / sessions / app.rs cleanup

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -5,7 +5,7 @@ mod tui;
 
 use crate::tui::client_ui;
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -39,80 +39,11 @@ struct Cli {
     #[arg(long, help = "Use legacy CLI table output")]
     light: bool,
 
-    #[arg(long, help = "Show only OpenCode usage")]
-    opencode: bool,
+    #[command(flatten)]
+    clients: ClientFlags,
 
-    #[arg(long, help = "Show only Claude Code usage")]
-    claude: bool,
-
-    #[arg(long, help = "Show only Codex CLI usage")]
-    codex: bool,
-
-    #[arg(long, help = "Show only Copilot CLI usage")]
-    copilot: bool,
-
-    #[arg(long, help = "Show only Gemini CLI usage")]
-    gemini: bool,
-
-    #[arg(long, help = "Show only Cursor IDE usage")]
-    cursor: bool,
-
-    #[arg(long, help = "Show only Amp usage")]
-    amp: bool,
-
-    #[arg(long, help = "Show only Droid usage")]
-    droid: bool,
-
-    #[arg(long, help = "Show only OpenClaw usage")]
-    openclaw: bool,
-
-    #[arg(long, help = "Show only Hermes Agent usage")]
-    hermes: bool,
-
-    #[arg(long, help = "Show only Pi usage")]
-    pi: bool,
-
-    #[arg(long, help = "Show only Kimi CLI usage")]
-    kimi: bool,
-
-    #[arg(long, help = "Show only Qwen CLI usage")]
-    qwen: bool,
-
-    #[arg(long, help = "Show only Roo Code usage")]
-    roocode: bool,
-
-    #[arg(long, help = "Show only KiloCode usage")]
-    kilocode: bool,
-
-    #[arg(long, help = "Show only Kilo CLI usage")]
-    kilo: bool,
-
-    #[arg(long, help = "Show only Mux usage")]
-    mux: bool,
-
-    #[arg(long, help = "Show only Crush usage")]
-    crush: bool,
-
-    #[arg(long, help = "Show only Synthetic usage")]
-    synthetic: bool,
-
-    #[arg(long, help = "Show only today's usage")]
-    today: bool,
-
-    #[arg(long, help = "Show last 7 days")]
-    week: bool,
-
-    #[arg(long, help = "Show current month")]
-    month: bool,
-
-    #[arg(long, help = "Start date (YYYY-MM-DD)")]
-    since: Option<String>,
-
-    #[arg(long, help = "End date (YYYY-MM-DD)")]
-    until: Option<String>,
-
-    #[arg(long, help = "Filter by year (YYYY)")]
-    year: Option<String>,
+    #[command(flatten)]
+    date: DateRangeFlags,
 
     #[arg(
         long,
@@ -145,57 +76,10 @@ enum Commands {
         json: bool,
         #[arg(long)]
         light: bool,
-        #[arg(long, help = "Show only OpenCode usage")]
-        opencode: bool,
-        #[arg(long, help = "Show only Claude Code usage")]
-        claude: bool,
-        #[arg(long, help = "Show only Codex CLI usage")]
-        codex: bool,
-        #[arg(long, help = "Show only Copilot CLI usage")]
-        copilot: bool,
-        #[arg(long, help = "Show only Gemini CLI usage")]
-        gemini: bool,
-        #[arg(long, help = "Show only Cursor IDE usage")]
-        cursor: bool,
-        #[arg(long, help = "Show only Amp usage")]
-        amp: bool,
-        #[arg(long, help = "Show only Droid usage")]
-        droid: bool,
-        #[arg(long, help = "Show only OpenClaw usage")]
-        openclaw: bool,
-
-        #[arg(long, help = "Show only Hermes Agent usage")]
-        hermes: bool,
-        #[arg(long, help = "Show only Pi usage")]
-        pi: bool,
-        #[arg(long, help = "Show only Kimi CLI usage")]
-        kimi: bool,
-        #[arg(long, help = "Show only Qwen CLI usage")]
-        qwen: bool,
-        #[arg(long, help = "Show only Roo Code usage")]
-        roocode: bool,
-        #[arg(long, help = "Show only KiloCode usage")]
-        kilocode: bool,
-        #[arg(long, help = "Show only Kilo CLI usage")]
-        kilo: bool,
-        #[arg(long, help = "Show only Mux usage")]
-        mux: bool,
-        #[arg(long, help = "Show only Crush usage")]
-        crush: bool,
-        #[arg(long, help = "Show only Synthetic usage")]
-        synthetic: bool,
-        #[arg(long, help = "Show only today's usage")]
-        today: bool,
-        #[arg(long, help = "Show last 7 days")]
-        week: bool,
-        #[arg(long, help = "Show current month")]
-        month: bool,
-        #[arg(long, help = "Start date (YYYY-MM-DD)")]
-        since: Option<String>,
-        #[arg(long, help = "End date (YYYY-MM-DD)")]
-        until: Option<String>,
-        #[arg(long, help = "Filter by year (YYYY)")]
-        year: Option<String>,
+        #[command(flatten)]
+        clients: ClientFlags,
+        #[command(flatten)]
+        date: DateRangeFlags,
         #[arg(long, help = "Show processing time")]
         benchmark: bool,
         #[arg(
@@ -214,57 +98,10 @@ enum Commands {
         json: bool,
         #[arg(long)]
         light: bool,
-        #[arg(long, help = "Show only OpenCode usage")]
-        opencode: bool,
-        #[arg(long, help = "Show only Claude Code usage")]
-        claude: bool,
-        #[arg(long, help = "Show only Codex CLI usage")]
-        codex: bool,
-        #[arg(long, help = "Show only Copilot CLI usage")]
-        copilot: bool,
-        #[arg(long, help = "Show only Gemini CLI usage")]
-        gemini: bool,
-        #[arg(long, help = "Show only Cursor IDE usage")]
-        cursor: bool,
-        #[arg(long, help = "Show only Amp usage")]
-        amp: bool,
-        #[arg(long, help = "Show only Droid usage")]
-        droid: bool,
-        #[arg(long, help = "Show only OpenClaw usage")]
-        openclaw: bool,
-
-        #[arg(long, help = "Show only Hermes Agent usage")]
-        hermes: bool,
-        #[arg(long, help = "Show only Pi usage")]
-        pi: bool,
-        #[arg(long, help = "Show only Kimi CLI usage")]
-        kimi: bool,
-        #[arg(long, help = "Show only Qwen CLI usage")]
-        qwen: bool,
-        #[arg(long, help = "Show only Roo Code usage")]
-        roocode: bool,
-        #[arg(long, help = "Show only KiloCode usage")]
-        kilocode: bool,
-        #[arg(long, help = "Show only Kilo CLI usage")]
-        kilo: bool,
-        #[arg(long, help = "Show only Mux usage")]
-        mux: bool,
-        #[arg(long, help = "Show only Crush usage")]
-        crush: bool,
-        #[arg(long, help = "Show only Synthetic usage")]
-        synthetic: bool,
-        #[arg(long, help = "Show only today's usage")]
-        today: bool,
-        #[arg(long, help = "Show last 7 days")]
-        week: bool,
-        #[arg(long, help = "Show current month")]
-        month: bool,
-        #[arg(long, help = "Start date (YYYY-MM-DD)")]
-        since: Option<String>,
-        #[arg(long, help = "End date (YYYY-MM-DD)")]
-        until: Option<String>,
-        #[arg(long, help = "Filter by year (YYYY)")]
-        year: Option<String>,
+        #[command(flatten)]
+        clients: ClientFlags,
+        #[command(flatten)]
+        date: DateRangeFlags,
         #[arg(long, help = "Show processing time")]
         benchmark: bool,
         #[arg(long, help = "Disable spinner")]
@@ -276,56 +113,10 @@ enum Commands {
         json: bool,
         #[arg(long)]
         light: bool,
-        #[arg(long, help = "Show only OpenCode usage")]
-        opencode: bool,
-        #[arg(long, help = "Show only Claude Code usage")]
-        claude: bool,
-        #[arg(long, help = "Show only Codex CLI usage")]
-        codex: bool,
-        #[arg(long, help = "Show only Copilot CLI usage")]
-        copilot: bool,
-        #[arg(long, help = "Show only Gemini CLI usage")]
-        gemini: bool,
-        #[arg(long, help = "Show only Cursor IDE usage")]
-        cursor: bool,
-        #[arg(long, help = "Show only Amp usage")]
-        amp: bool,
-        #[arg(long, help = "Show only Droid usage")]
-        droid: bool,
-        #[arg(long, help = "Show only OpenClaw usage")]
-        openclaw: bool,
-        #[arg(long, help = "Show only Hermes Agent usage")]
-        hermes: bool,
-        #[arg(long, help = "Show only Pi usage")]
-        pi: bool,
-        #[arg(long, help = "Show only Kimi CLI usage")]
-        kimi: bool,
-        #[arg(long, help = "Show only Qwen CLI usage")]
-        qwen: bool,
-        #[arg(long, help = "Show only Roo Code usage")]
-        roocode: bool,
-        #[arg(long, help = "Show only KiloCode usage")]
-        kilocode: bool,
-        #[arg(long, help = "Show only Kilo CLI usage")]
-        kilo: bool,
-        #[arg(long, help = "Show only Mux usage")]
-        mux: bool,
-        #[arg(long, help = "Show only Crush usage")]
-        crush: bool,
-        #[arg(long, help = "Show only Synthetic usage")]
-        synthetic: bool,
-        #[arg(long, help = "Show only today's usage")]
-        today: bool,
-        #[arg(long, help = "Show last 7 days")]
-        week: bool,
-        #[arg(long, help = "Show current month")]
-        month: bool,
-        #[arg(long, help = "Start date (YYYY-MM-DD)")]
-        since: Option<String>,
-        #[arg(long, help = "End date (YYYY-MM-DD)")]
-        until: Option<String>,
-        #[arg(long, help = "Filter by year (YYYY)")]
-        year: Option<String>,
+        #[command(flatten)]
+        clients: ClientFlags,
+        #[command(flatten)]
+        date: DateRangeFlags,
         #[arg(long, help = "Show processing time")]
         benchmark: bool,
         #[arg(long, help = "Disable spinner")]
@@ -356,57 +147,10 @@ enum Commands {
     Graph {
         #[arg(long, help = "Write to file instead of stdout")]
         output: Option<String>,
-        #[arg(long, help = "Show only OpenCode usage")]
-        opencode: bool,
-        #[arg(long, help = "Show only Claude Code usage")]
-        claude: bool,
-        #[arg(long, help = "Show only Codex CLI usage")]
-        codex: bool,
-        #[arg(long, help = "Show only Copilot CLI usage")]
-        copilot: bool,
-        #[arg(long, help = "Show only Gemini CLI usage")]
-        gemini: bool,
-        #[arg(long, help = "Show only Cursor IDE usage")]
-        cursor: bool,
-        #[arg(long, help = "Show only Amp usage")]
-        amp: bool,
-        #[arg(long, help = "Show only Droid usage")]
-        droid: bool,
-        #[arg(long, help = "Show only OpenClaw usage")]
-        openclaw: bool,
-
-        #[arg(long, help = "Show only Hermes Agent usage")]
-        hermes: bool,
-        #[arg(long, help = "Show only Pi usage")]
-        pi: bool,
-        #[arg(long, help = "Show only Kimi CLI usage")]
-        kimi: bool,
-        #[arg(long, help = "Show only Qwen CLI usage")]
-        qwen: bool,
-        #[arg(long, help = "Show only Roo Code usage")]
-        roocode: bool,
-        #[arg(long, help = "Show only KiloCode usage")]
-        kilocode: bool,
-        #[arg(long, help = "Show only Kilo CLI usage")]
-        kilo: bool,
-        #[arg(long, help = "Show only Mux usage")]
-        mux: bool,
-        #[arg(long, help = "Show only Crush usage")]
-        crush: bool,
-        #[arg(long, help = "Show only Synthetic usage")]
-        synthetic: bool,
-        #[arg(long, help = "Show only today's usage")]
-        today: bool,
-        #[arg(long, help = "Show last 7 days")]
-        week: bool,
-        #[arg(long, help = "Show current month")]
-        month: bool,
-        #[arg(long, help = "Start date (YYYY-MM-DD)")]
-        since: Option<String>,
-        #[arg(long, help = "End date (YYYY-MM-DD)")]
-        until: Option<String>,
-        #[arg(long, help = "Filter by year (YYYY)")]
-        year: Option<String>,
+        #[command(flatten)]
+        clients: ClientFlags,
+        #[command(flatten)]
+        date: DateRangeFlags,
         #[arg(long, help = "Show processing time")]
         benchmark: bool,
         #[arg(long, help = "Disable spinner")]
@@ -414,110 +158,17 @@ enum Commands {
     },
     #[command(about = "Launch interactive TUI with optional filters")]
     Tui {
-        #[arg(long, help = "Show only OpenCode usage")]
-        opencode: bool,
-        #[arg(long, help = "Show only Claude Code usage")]
-        claude: bool,
-        #[arg(long, help = "Show only Codex CLI usage")]
-        codex: bool,
-        #[arg(long, help = "Show only Copilot CLI usage")]
-        copilot: bool,
-        #[arg(long, help = "Show only Gemini CLI usage")]
-        gemini: bool,
-        #[arg(long, help = "Show only Cursor IDE usage")]
-        cursor: bool,
-        #[arg(long, help = "Show only Amp usage")]
-        amp: bool,
-        #[arg(long, help = "Show only Droid usage")]
-        droid: bool,
-        #[arg(long, help = "Show only OpenClaw usage")]
-        openclaw: bool,
-
-        #[arg(long, help = "Show only Hermes Agent usage")]
-        hermes: bool,
-        #[arg(long, help = "Show only Pi usage")]
-        pi: bool,
-        #[arg(long, help = "Show only Kimi CLI usage")]
-        kimi: bool,
-        #[arg(long, help = "Show only Qwen CLI usage")]
-        qwen: bool,
-        #[arg(long, help = "Show only Roo Code usage")]
-        roocode: bool,
-        #[arg(long, help = "Show only KiloCode usage")]
-        kilocode: bool,
-        #[arg(long, help = "Show only Kilo CLI usage")]
-        kilo: bool,
-        #[arg(long, help = "Show only Mux usage")]
-        mux: bool,
-        #[arg(long, help = "Show only Crush usage")]
-        crush: bool,
-        #[arg(long, help = "Show only Synthetic usage")]
-        synthetic: bool,
-        #[arg(long, help = "Show only today's usage")]
-        today: bool,
-        #[arg(long, help = "Show last 7 days")]
-        week: bool,
-        #[arg(long, help = "Show current month")]
-        month: bool,
-        #[arg(long, help = "Start date (YYYY-MM-DD)")]
-        since: Option<String>,
-        #[arg(long, help = "End date (YYYY-MM-DD)")]
-        until: Option<String>,
-        #[arg(long, help = "Filter by year (YYYY)")]
-        year: Option<String>,
+        #[command(flatten)]
+        clients: ClientFlags,
+        #[command(flatten)]
+        date: DateRangeFlags,
     },
     #[command(about = "Submit usage data to the Tokscale social platform")]
     Submit {
-        #[arg(long, help = "Include only OpenCode data")]
-        opencode: bool,
-        #[arg(long, help = "Include only Claude Code data")]
-        claude: bool,
-        #[arg(long, help = "Include only Codex CLI data")]
-        codex: bool,
-        #[arg(long, help = "Include only Copilot CLI data")]
-        copilot: bool,
-        #[arg(long, help = "Include only Gemini CLI data")]
-        gemini: bool,
-        #[arg(long, help = "Include only Cursor IDE data")]
-        cursor: bool,
-        #[arg(long, help = "Include only Amp data")]
-        amp: bool,
-        #[arg(long, help = "Include only Droid data")]
-        droid: bool,
-        #[arg(long, help = "Include only OpenClaw data")]
-        openclaw: bool,
-        #[arg(long, help = "Include only Hermes Agent data")]
-        hermes: bool,
-        #[arg(long, help = "Include only Pi data")]
-        pi: bool,
-        #[arg(long, help = "Include only Kimi CLI data")]
-        kimi: bool,
-        #[arg(long, help = "Include only Qwen CLI data")]
-        qwen: bool,
-        #[arg(long, help = "Show only Roo Code usage")]
-        roocode: bool,
-        #[arg(long, help = "Show only KiloCode usage")]
-        kilocode: bool,
-        #[arg(long, help = "Show only Kilo CLI usage")]
-        kilo: bool,
-        #[arg(long, help = "Show only Mux usage")]
-        mux: bool,
-        #[arg(long, help = "Show only Crush usage")]
-        crush: bool,
-        #[arg(long, help = "Show only Synthetic usage")]
-        synthetic: bool,
-        #[arg(long, help = "Submit only today's usage")]
-        today: bool,
-        #[arg(long, help = "Submit last 7 days")]
-        week: bool,
-        #[arg(long, help = "Submit current month")]
-        month: bool,
-        #[arg(long, help = "Start date (YYYY-MM-DD)")]
-        since: Option<String>,
-        #[arg(long, help = "End date (YYYY-MM-DD)")]
-        until: Option<String>,
-        #[arg(long, help = "Filter by year (YYYY)")]
-        year: Option<String>,
+        #[command(flatten)]
+        clients: ClientFlags,
+        #[command(flatten)]
+        date: DateRangeFlags,
         #[arg(
             long,
             help = "Show what would be submitted without actually submitting"
@@ -543,45 +194,8 @@ enum Commands {
         output: Option<String>,
         #[arg(long, help = "Year to generate (default: current year)")]
         year: Option<String>,
-        #[arg(long, help = "Show only OpenCode usage")]
-        opencode: bool,
-        #[arg(long, help = "Show only Claude Code usage")]
-        claude: bool,
-        #[arg(long, help = "Show only Codex CLI usage")]
-        codex: bool,
-        #[arg(long, help = "Show only Copilot CLI usage")]
-        copilot: bool,
-        #[arg(long, help = "Show only Gemini CLI usage")]
-        gemini: bool,
-        #[arg(long, help = "Show only Cursor IDE usage")]
-        cursor: bool,
-        #[arg(long, help = "Show only Amp usage")]
-        amp: bool,
-        #[arg(long, help = "Show only Droid usage")]
-        droid: bool,
-        #[arg(long, help = "Show only OpenClaw usage")]
-        openclaw: bool,
-
-        #[arg(long, help = "Show only Hermes Agent usage")]
-        hermes: bool,
-        #[arg(long, help = "Show only Pi usage")]
-        pi: bool,
-        #[arg(long, help = "Show only Kimi CLI usage")]
-        kimi: bool,
-        #[arg(long, help = "Show only Qwen CLI usage")]
-        qwen: bool,
-        #[arg(long, help = "Show only Roo Code usage")]
-        roocode: bool,
-        #[arg(long, help = "Show only KiloCode usage")]
-        kilocode: bool,
-        #[arg(long, help = "Show only Kilo CLI usage")]
-        kilo: bool,
-        #[arg(long, help = "Show only Mux usage")]
-        mux: bool,
-        #[arg(long, help = "Show only Crush usage")]
-        crush: bool,
-        #[arg(long, help = "Show only Synthetic usage")]
-        synthetic: bool,
+        #[command(flatten)]
+        client_flags: ClientFlags,
         #[arg(
             long,
             help = "Display total tokens in abbreviated format (e.g., 7.14B)"
@@ -652,31 +266,8 @@ fn main() -> Result<()> {
         Some(Commands::Models {
             json,
             light,
-            opencode,
-            claude,
-            codex,
-            copilot,
-            gemini,
-            cursor,
-            amp,
-            droid,
-            openclaw,
-            hermes,
-            pi,
-            kimi,
-            qwen,
-            roocode,
-            kilocode,
-            kilo,
-            mux,
-            crush,
-            synthetic,
-            today,
-            week,
-            month,
-            since,
-            until,
-            year,
+            clients,
+            date,
             benchmark,
             group_by,
             no_spinner,
@@ -687,29 +278,12 @@ fn main() -> Result<()> {
                 eprintln!("Error: {}", e);
                 std::process::exit(1);
             });
-            let clients = build_client_filter(ClientFlags {
-                opencode,
-                claude,
-                codex,
-                copilot,
-                gemini,
-                cursor,
-                amp,
-                droid,
-                openclaw,
-                hermes,
-                pi,
-                kimi,
-                qwen,
-                roocode,
-                kilocode,
-                kilo,
-                mux,
-                crush,
-                synthetic,
-            });
-            let (since, until) = build_date_filter(today, week, month, since, until);
-            let year = normalize_year_filter(today, week, month, year);
+            let today = date.today;
+            let week = date.week;
+            let month = date.month;
+            let (since, until) = build_date_filter(today, week, month, date.since, date.until);
+            let year = normalize_year_filter(today, week, month, date.year);
+            let clients = build_client_filter(clients);
             if json || light || !can_use_tui {
                 run_models_report(
                     json,
@@ -742,57 +316,17 @@ fn main() -> Result<()> {
         Some(Commands::Monthly {
             json,
             light,
-            opencode,
-            claude,
-            codex,
-            copilot,
-            gemini,
-            cursor,
-            amp,
-            droid,
-            openclaw,
-            hermes,
-            pi,
-            kimi,
-            qwen,
-            roocode,
-            kilocode,
-            kilo,
-            mux,
-            crush,
-            synthetic,
-            today,
-            week,
-            month,
-            since,
-            until,
-            year,
+            clients,
+            date,
             benchmark,
             no_spinner,
         }) => {
-            let clients = build_client_filter(ClientFlags {
-                opencode,
-                claude,
-                codex,
-                copilot,
-                gemini,
-                cursor,
-                amp,
-                droid,
-                openclaw,
-                hermes,
-                pi,
-                kimi,
-                qwen,
-                roocode,
-                kilocode,
-                kilo,
-                mux,
-                crush,
-                synthetic,
-            });
-            let (since, until) = build_date_filter(today, week, month, since, until);
-            let year = normalize_year_filter(today, week, month, year);
+            let today = date.today;
+            let week = date.week;
+            let month = date.month;
+            let (since, until) = build_date_filter(today, week, month, date.since, date.until);
+            let year = normalize_year_filter(today, week, month, date.year);
+            let clients = build_client_filter(clients);
             if json || light || !can_use_tui {
                 run_monthly_report(
                     json,
@@ -824,57 +358,17 @@ fn main() -> Result<()> {
         Some(Commands::Hourly {
             json,
             light: _,
-            opencode,
-            claude,
-            codex,
-            copilot,
-            gemini,
-            cursor,
-            amp,
-            droid,
-            openclaw,
-            hermes,
-            pi,
-            kimi,
-            qwen,
-            roocode,
-            kilocode,
-            kilo,
-            mux,
-            crush,
-            synthetic,
-            today,
-            week,
-            month,
-            since,
-            until,
-            year,
+            clients,
+            date,
             benchmark,
             no_spinner,
         }) => {
-            let clients = build_client_filter(ClientFlags {
-                opencode,
-                claude,
-                codex,
-                copilot,
-                gemini,
-                cursor,
-                amp,
-                droid,
-                openclaw,
-                hermes,
-                pi,
-                kimi,
-                qwen,
-                roocode,
-                kilocode,
-                kilo,
-                mux,
-                crush,
-                synthetic,
-            });
-            let (since, until) = build_date_filter(today, week, month, since, until);
-            let year = normalize_year_filter(today, week, month, year);
+            let today = date.today;
+            let week = date.week;
+            let month = date.month;
+            let (since, until) = build_date_filter(today, week, month, date.since, date.until);
+            let year = normalize_year_filter(today, week, month, date.year);
+            let clients = build_client_filter(clients);
             run_hourly_report(
                 json,
                 cli.home.clone(),
@@ -916,57 +410,17 @@ fn main() -> Result<()> {
         }
         Some(Commands::Graph {
             output,
-            opencode,
-            claude,
-            codex,
-            copilot,
-            gemini,
-            cursor,
-            amp,
-            droid,
-            openclaw,
-            hermes,
-            pi,
-            kimi,
-            qwen,
-            roocode,
-            kilocode,
-            kilo,
-            mux,
-            crush,
-            synthetic,
-            today,
-            week,
-            month,
-            since,
-            until,
-            year,
+            clients,
+            date,
             benchmark,
             no_spinner,
         }) => {
-            let clients = build_client_filter(ClientFlags {
-                opencode,
-                claude,
-                codex,
-                copilot,
-                gemini,
-                cursor,
-                amp,
-                droid,
-                openclaw,
-                hermes,
-                pi,
-                kimi,
-                qwen,
-                roocode,
-                kilocode,
-                kilo,
-                mux,
-                crush,
-                synthetic,
-            });
-            let (since, until) = build_date_filter(today, week, month, since, until);
-            let year = normalize_year_filter(today, week, month, year);
+            let today = date.today;
+            let week = date.week;
+            let month = date.month;
+            let (since, until) = build_date_filter(today, week, month, date.since, date.until);
+            let year = normalize_year_filter(today, week, month, date.year);
+            let clients = build_client_filter(clients);
             run_graph_command(
                 output,
                 cli.home.clone(),
@@ -978,57 +432,14 @@ fn main() -> Result<()> {
                 no_spinner,
             )
         }
-        Some(Commands::Tui {
-            opencode,
-            claude,
-            codex,
-            copilot,
-            gemini,
-            cursor,
-            amp,
-            droid,
-            openclaw,
-            hermes,
-            pi,
-            kimi,
-            qwen,
-            roocode,
-            kilocode,
-            kilo,
-            mux,
-            crush,
-            synthetic,
-            today,
-            week,
-            month,
-            since,
-            until,
-            year,
-        }) => {
+        Some(Commands::Tui { clients, date }) => {
             ensure_home_supported_for_tui(&cli.home)?;
-            let clients = build_client_filter(ClientFlags {
-                opencode,
-                claude,
-                codex,
-                copilot,
-                gemini,
-                cursor,
-                amp,
-                droid,
-                openclaw,
-                hermes,
-                pi,
-                kimi,
-                qwen,
-                roocode,
-                kilocode,
-                kilo,
-                mux,
-                crush,
-                synthetic,
-            });
-            let (since, until) = build_date_filter(today, week, month, since, until);
-            let year = normalize_year_filter(today, week, month, year);
+            let today = date.today;
+            let week = date.week;
+            let month = date.month;
+            let (since, until) = build_date_filter(today, week, month, date.since, date.until);
+            let year = normalize_year_filter(today, week, month, date.year);
+            let clients = build_client_filter(clients);
             tui::run(
                 &cli.theme,
                 cli.refresh,
@@ -1041,57 +452,17 @@ fn main() -> Result<()> {
             )
         }
         Some(Commands::Submit {
-            opencode,
-            claude,
-            codex,
-            copilot,
-            gemini,
-            cursor,
-            amp,
-            droid,
-            openclaw,
-            hermes,
-            pi,
-            kimi,
-            qwen,
-            roocode,
-            kilocode,
-            kilo,
-            mux,
-            crush,
-            synthetic,
-            today,
-            week,
-            month,
-            since,
-            until,
-            year,
+            clients,
+            date,
             dry_run,
         }) => {
             reject_unsupported_home_override(&cli.home, "submit")?;
-            let clients = build_client_filter(ClientFlags {
-                opencode,
-                claude,
-                codex,
-                copilot,
-                gemini,
-                cursor,
-                amp,
-                droid,
-                openclaw,
-                hermes,
-                pi,
-                kimi,
-                qwen,
-                roocode,
-                kilocode,
-                kilo,
-                mux,
-                crush,
-                synthetic,
-            });
-            let (since, until) = build_date_filter(today, week, month, since, until);
-            let year = normalize_year_filter(today, week, month, year);
+            let today = date.today;
+            let week = date.week;
+            let month = date.month;
+            let (since, until) = build_date_filter(today, week, month, date.since, date.until);
+            let year = normalize_year_filter(today, week, month, date.year);
+            let clients = build_client_filter(clients);
             run_submit_command(clients, since, until, year, dry_run)
         }
         Some(Commands::Headless {
@@ -1107,25 +478,7 @@ fn main() -> Result<()> {
         Some(Commands::Wrapped {
             output,
             year,
-            opencode,
-            claude,
-            codex,
-            copilot,
-            gemini,
-            cursor,
-            amp,
-            droid,
-            openclaw,
-            hermes,
-            pi,
-            kimi,
-            qwen,
-            roocode,
-            kilocode,
-            kilo,
-            mux,
-            crush,
-            synthetic,
+            client_flags,
             short,
             agents,
             clients,
@@ -1133,27 +486,7 @@ fn main() -> Result<()> {
             no_spinner: _,
         }) => {
             reject_unsupported_home_override(&cli.home, "wrapped")?;
-            let client_filter = build_client_filter(ClientFlags {
-                opencode,
-                claude,
-                codex,
-                copilot,
-                gemini,
-                cursor,
-                amp,
-                droid,
-                openclaw,
-                hermes,
-                pi,
-                kimi,
-                qwen,
-                roocode,
-                kilocode,
-                kilo,
-                mux,
-                crush,
-                synthetic,
-            });
+            let client_filter = build_client_filter(client_flags);
             run_wrapped_command(
                 output,
                 year,
@@ -1173,30 +506,13 @@ fn main() -> Result<()> {
             run_delete_data_command()
         }
         None => {
-            let clients = build_client_filter(ClientFlags {
-                opencode: cli.opencode,
-                claude: cli.claude,
-                codex: cli.codex,
-                copilot: cli.copilot,
-                gemini: cli.gemini,
-                cursor: cli.cursor,
-                amp: cli.amp,
-                droid: cli.droid,
-                openclaw: cli.openclaw,
-                hermes: cli.hermes,
-                pi: cli.pi,
-                kimi: cli.kimi,
-                qwen: cli.qwen,
-                roocode: cli.roocode,
-                kilocode: cli.kilocode,
-                kilo: cli.kilo,
-                mux: cli.mux,
-                crush: cli.crush,
-                synthetic: cli.synthetic,
-            });
+            let today = cli.date.today;
+            let week = cli.date.week;
+            let month = cli.date.month;
+            let clients = build_client_filter(cli.clients);
             let (since, until) =
-                build_date_filter(cli.today, cli.week, cli.month, cli.since, cli.until);
-            let year = normalize_year_filter(cli.today, cli.week, cli.month, cli.year);
+                build_date_filter(today, week, month, cli.date.since, cli.date.until);
+            let year = normalize_year_filter(today, week, month, cli.date.year);
             let group_by: tokscale_core::GroupBy = cli.group_by.parse().unwrap_or_else(|e| {
                 eprintln!("Error: {}", e);
                 std::process::exit(1);
@@ -1212,9 +528,9 @@ fn main() -> Result<()> {
                     year,
                     cli.benchmark,
                     cli.no_spinner || cli.json,
-                    cli.today,
-                    cli.week,
-                    cli.month,
+                    today,
+                    week,
+                    month,
                     group_by,
                 )
             } else if cli.light || !can_use_tui {
@@ -1227,9 +543,9 @@ fn main() -> Result<()> {
                     year,
                     cli.benchmark,
                     cli.no_spinner || !can_use_tui,
-                    cli.today,
-                    cli.week,
-                    cli.month,
+                    today,
+                    week,
+                    month,
                     group_by,
                 )
             } else {
@@ -1249,26 +565,62 @@ fn main() -> Result<()> {
     }
 }
 
-struct ClientFlags {
-    opencode: bool,
-    claude: bool,
-    codex: bool,
-    copilot: bool,
-    gemini: bool,
-    cursor: bool,
-    amp: bool,
-    droid: bool,
-    openclaw: bool,
-    hermes: bool,
-    pi: bool,
-    kimi: bool,
-    qwen: bool,
-    roocode: bool,
-    kilocode: bool,
-    kilo: bool,
-    mux: bool,
-    crush: bool,
-    synthetic: bool,
+#[derive(Args, Clone, Debug, Default)]
+pub struct ClientFlags {
+    #[arg(long, help = "Show only OpenCode usage")]
+    pub opencode: bool,
+    #[arg(long, help = "Show only Claude Code usage")]
+    pub claude: bool,
+    #[arg(long, help = "Show only Codex CLI usage")]
+    pub codex: bool,
+    #[arg(long, help = "Show only Copilot CLI usage")]
+    pub copilot: bool,
+    #[arg(long, help = "Show only Gemini CLI usage")]
+    pub gemini: bool,
+    #[arg(long, help = "Show only Cursor IDE usage")]
+    pub cursor: bool,
+    #[arg(long, help = "Show only Amp usage")]
+    pub amp: bool,
+    #[arg(long, help = "Show only Droid usage")]
+    pub droid: bool,
+    #[arg(long, help = "Show only OpenClaw usage")]
+    pub openclaw: bool,
+    #[arg(long, help = "Show only Hermes Agent usage")]
+    pub hermes: bool,
+    #[arg(long, help = "Show only Pi usage")]
+    pub pi: bool,
+    #[arg(long, help = "Show only Kimi CLI usage")]
+    pub kimi: bool,
+    #[arg(long, help = "Show only Qwen CLI usage")]
+    pub qwen: bool,
+    #[arg(long, help = "Show only Roo Code usage")]
+    pub roocode: bool,
+    #[arg(long, help = "Show only KiloCode usage")]
+    pub kilocode: bool,
+    #[arg(long, help = "Show only Kilo CLI usage")]
+    pub kilo: bool,
+    #[arg(long, help = "Show only Mux usage")]
+    pub mux: bool,
+    #[arg(long, help = "Show only Crush usage")]
+    pub crush: bool,
+    #[arg(long, help = "Show only Synthetic usage")]
+    pub synthetic: bool,
+}
+
+#[derive(Args, Clone, Debug, Default)]
+pub struct DateRangeFlags {
+    #[arg(long, help = "Show only today's usage")]
+    pub today: bool,
+    #[arg(long, help = "Show last 7 days")]
+    pub week: bool,
+    #[arg(long, help = "Show current month")]
+    pub month: bool,
+    #[arg(long, help = "Start date (YYYY-MM-DD)")]
+    pub since: Option<String>,
+    #[arg(long, help = "End date (YYYY-MM-DD)")]
+    pub until: Option<String>,
+    #[arg(long, help = "Filter by year (YYYY)")]
+    pub year: Option<String>,
 }
 
 fn build_client_filter(flags: ClientFlags) -> Option<Vec<String>> {

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -2095,9 +2095,18 @@ mod tests {
         // All-zero costs (fresh data) must produce a stable shade assignment
         // across refreshes so the chart doesn't flicker.
         let ranks = |app: &App| {
-            let a = app.model_shade_map.get(&shade_key("anthropic", "claude-alpha")).copied();
-            let b = app.model_shade_map.get(&shade_key("anthropic", "claude-beta")).copied();
-            let c = app.model_shade_map.get(&shade_key("anthropic", "claude-gamma")).copied();
+            let a = app
+                .model_shade_map
+                .get(&shade_key("anthropic", "claude-alpha"))
+                .copied();
+            let b = app
+                .model_shade_map
+                .get(&shade_key("anthropic", "claude-beta"))
+                .copied();
+            let c = app
+                .model_shade_map
+                .get(&shade_key("anthropic", "claude-gamma"))
+                .copied();
             (a, b, c)
         };
 

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -14,7 +14,7 @@ use super::data::{AgentUsage, DailyUsage, DataLoader, HourlyUsage, ModelUsage, U
 use super::settings::Settings;
 use super::themes::{Theme, ThemeName};
 use super::ui::dialog::{ClientPickerDialog, DialogStack};
-use super::ui::widgets::get_model_color;
+use super::ui::widgets::{get_model_color, get_provider_from_model, get_provider_shade};
 
 /// Configuration for TUI initialization
 pub struct TuiConfig {
@@ -289,9 +289,24 @@ impl App {
         self.model_shade_map = super::colors::build_model_shade_map(&self.data.models);
     }
 
-    pub fn model_color(&self, model: &str) -> Color {
+    pub fn model_color_for(&self, provider: &str, model: &str) -> Color {
+        let provider = if provider.is_empty() || provider.contains(", ") {
+            get_provider_from_model(model)
+        } else {
+            provider
+        };
+        let lookup_key = super::colors::model_shade_key(provider, model);
         self.model_shade_map
-            .get(model)
+            .get(&lookup_key)
+            .copied()
+            .unwrap_or_else(|| get_provider_shade(provider, 0))
+    }
+
+    pub fn model_color(&self, model: &str) -> Color {
+        let provider = get_provider_from_model(model);
+        let lookup_key = super::colors::model_shade_key(provider, model);
+        self.model_shade_map
+            .get(&lookup_key)
             .copied()
             .unwrap_or_else(|| get_model_color(model))
     }
@@ -2009,6 +2024,10 @@ mod tests {
         }
     }
 
+    fn shade_key(provider: &str, model: &str) -> String {
+        super::super::colors::model_shade_key(provider, model)
+    }
+
     #[test]
     fn test_shade_map_assigns_rank_0_to_highest_cost() {
         let mut app = make_app();
@@ -2019,15 +2038,19 @@ mod tests {
         ];
         app.build_model_shade_map();
 
-        let opus = app.model_shade_map.get("claude-opus-4-5").copied().unwrap();
+        let opus = app
+            .model_shade_map
+            .get(&shade_key("anthropic", "claude-opus-4-5"))
+            .copied()
+            .unwrap();
         let sonnet = app
             .model_shade_map
-            .get("claude-sonnet-4-5")
+            .get(&shade_key("anthropic", "claude-sonnet-4-5"))
             .copied()
             .unwrap();
         let haiku = app
             .model_shade_map
-            .get("claude-haiku-4-5")
+            .get(&shade_key("anthropic", "claude-haiku-4-5"))
             .copied()
             .unwrap();
 
@@ -2054,11 +2077,15 @@ mod tests {
         // rank 0 (aggregate cost 60 > haiku cost 5).
         assert_eq!(app.model_shade_map.len(), 2);
         assert_eq!(
-            app.model_shade_map.get("claude-sonnet-4-5").copied(),
+            app.model_shade_map
+                .get(&shade_key("anthropic", "claude-sonnet-4-5"))
+                .copied(),
             Some(get_provider_shade("anthropic", 0))
         );
         assert_eq!(
-            app.model_shade_map.get("claude-haiku-4-5").copied(),
+            app.model_shade_map
+                .get(&shade_key("anthropic", "claude-haiku-4-5"))
+                .copied(),
             Some(get_provider_shade("anthropic", 1))
         );
     }
@@ -2068,9 +2095,9 @@ mod tests {
         // All-zero costs (fresh data) must produce a stable shade assignment
         // across refreshes so the chart doesn't flicker.
         let ranks = |app: &App| {
-            let a = app.model_shade_map.get("claude-alpha").copied();
-            let b = app.model_shade_map.get("claude-beta").copied();
-            let c = app.model_shade_map.get("claude-gamma").copied();
+            let a = app.model_shade_map.get(&shade_key("anthropic", "claude-alpha")).copied();
+            let b = app.model_shade_map.get(&shade_key("anthropic", "claude-beta")).copied();
+            let c = app.model_shade_map.get(&shade_key("anthropic", "claude-gamma")).copied();
             (a, b, c)
         };
 
@@ -2093,7 +2120,9 @@ mod tests {
         assert_eq!(ranks(&app1), ranks(&app2));
         // alpha sorts first by name so it gets rank 0 on ties.
         assert_eq!(
-            app1.model_shade_map.get("claude-alpha").copied(),
+            app1.model_shade_map
+                .get(&shade_key("anthropic", "claude-alpha"))
+                .copied(),
             Some(get_provider_shade("anthropic", 0))
         );
     }
@@ -2112,7 +2141,9 @@ mod tests {
         assert_eq!(app.model_shade_map.len(), 2);
         // Normal model outranks NaN (which is coerced to 0).
         assert_eq!(
-            app.model_shade_map.get("claude-normal").copied(),
+            app.model_shade_map
+                .get(&shade_key("anthropic", "claude-normal"))
+                .copied(),
             Some(get_provider_shade("anthropic", 0))
         );
     }
@@ -2146,11 +2177,15 @@ mod tests {
 
         // Each provider ranks independently — both get rank-0 shades.
         assert_eq!(
-            app.model_shade_map.get("claude-opus-4-5").copied(),
+            app.model_shade_map
+                .get(&shade_key("anthropic", "claude-opus-4-5"))
+                .copied(),
             Some(get_provider_shade("anthropic", 0))
         );
         assert_eq!(
-            app.model_shade_map.get("gpt-5").copied(),
+            app.model_shade_map
+                .get(&shade_key("openai", "gpt-5"))
+                .copied(),
             Some(get_provider_shade("openai", 0))
         );
     }
@@ -2160,7 +2195,9 @@ mod tests {
         let mut app = make_app();
         app.data.models = vec![model_usage("claude-opus-4-5", 10.0, None)];
         app.build_model_shade_map();
-        assert!(app.model_shade_map.contains_key("claude-opus-4-5"));
+        assert!(app
+            .model_shade_map
+            .contains_key(&shade_key("anthropic", "claude-opus-4-5")));
 
         let fresh = UsageData {
             models: vec![model_usage("claude-sonnet-4-5", 5.0, None)],
@@ -2168,7 +2205,52 @@ mod tests {
         };
         app.update_data(fresh);
 
-        assert!(!app.model_shade_map.contains_key("claude-opus-4-5"));
-        assert!(app.model_shade_map.contains_key("claude-sonnet-4-5"));
+        assert!(!app
+            .model_shade_map
+            .contains_key(&shade_key("anthropic", "claude-opus-4-5")));
+        assert!(app
+            .model_shade_map
+            .contains_key(&shade_key("anthropic", "claude-sonnet-4-5")));
+    }
+
+    #[test]
+    fn test_same_model_name_keeps_distinct_provider_colors() {
+        let mut app = make_app();
+        app.data.models = vec![
+            ModelUsage {
+                model: "sonnet-shared".to_string(),
+                provider: "anthropic".to_string(),
+                client: "claude".to_string(),
+                workspace_key: None,
+                workspace_label: None,
+                tokens: TokenBreakdown::default(),
+                cost: 10.0,
+                session_count: 1,
+            },
+            ModelUsage {
+                model: "sonnet-shared".to_string(),
+                provider: "openai".to_string(),
+                client: "codex".to_string(),
+                workspace_key: None,
+                workspace_label: None,
+                tokens: TokenBreakdown::default(),
+                cost: 5.0,
+                session_count: 1,
+            },
+        ];
+        app.build_model_shade_map();
+
+        assert_eq!(
+            app.model_color_for("anthropic", "sonnet-shared"),
+            get_provider_shade("anthropic", 0)
+        );
+        assert_eq!(
+            app.model_color_for("openai", "sonnet-shared"),
+            get_provider_shade("openai", 0)
+        );
+        assert_ne!(
+            app.model_color_for("anthropic", "sonnet-shared"),
+            app.model_color_for("openai", "sonnet-shared")
+        );
     }
 }

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -288,17 +288,27 @@ impl App {
     pub fn build_model_shade_map(&mut self) {
         self.model_shade_map.clear();
 
-        let mut provider_models: HashMap<&str, Vec<(&str, f64)>> = HashMap::new();
+        // Aggregate cost per (provider, model_name) so that the same model
+        // appearing in multiple group-by buckets (e.g. WorkspaceModel) gets
+        // counted once — preventing rank inflation and last-write-win shade
+        // collisions.
+        let mut provider_models: HashMap<&str, HashMap<&str, f64>> = HashMap::new();
         for m in &self.data.models {
             let provider = get_provider_from_model(&m.model);
-            provider_models
+            let cost = if m.cost.is_finite() { m.cost } else { 0.0 };
+            *provider_models
                 .entry(provider)
                 .or_default()
-                .push((&m.model, m.cost));
+                .entry(m.model.as_str())
+                .or_insert(0.0) += cost;
         }
 
-        for (provider, mut models) in provider_models {
-            models.sort_by(|a, b| b.1.total_cmp(&a.1));
+        for (provider, models_map) in provider_models {
+            let mut models: Vec<(&str, f64)> = models_map.into_iter().collect();
+            // Primary sort by cost descending, with a stable secondary sort on
+            // the model name so cost ties (including all-zero costs on first
+            // load) produce identical shade assignments across refreshes.
+            models.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(b.0)));
             for (rank, (model_name, _)) in models.iter().enumerate() {
                 let color = get_provider_shade(provider, rank);
                 self.model_shade_map.insert(model_name.to_string(), color);
@@ -2055,5 +2065,183 @@ mod tests {
         app.current_tab = Tab::Daily;
         app.handle_key_event(key(KeyCode::Char('v')));
         assert_eq!(app.hourly_view_mode, HourlyViewMode::Table);
+    }
+
+    // ── build_model_shade_map ───────────────────────────────────────
+
+    fn model_usage(name: &str, cost: f64, workspace: Option<&str>) -> ModelUsage {
+        ModelUsage {
+            model: name.to_string(),
+            provider: "anthropic".to_string(),
+            client: "claude".to_string(),
+            workspace_key: workspace.map(String::from),
+            workspace_label: workspace.map(String::from),
+            tokens: TokenBreakdown::default(),
+            cost,
+            session_count: 1,
+        }
+    }
+
+    #[test]
+    fn test_shade_map_assigns_rank_0_to_highest_cost() {
+        let mut app = make_app();
+        app.data.models = vec![
+            model_usage("claude-haiku-4-5", 10.0, None),
+            model_usage("claude-opus-4-5", 100.0, None),
+            model_usage("claude-sonnet-4-5", 50.0, None),
+        ];
+        app.build_model_shade_map();
+
+        let opus = app.model_shade_map.get("claude-opus-4-5").copied().unwrap();
+        let sonnet = app
+            .model_shade_map
+            .get("claude-sonnet-4-5")
+            .copied()
+            .unwrap();
+        let haiku = app
+            .model_shade_map
+            .get("claude-haiku-4-5")
+            .copied()
+            .unwrap();
+
+        // Rank 0 is the base Anthropic coral; ranks below lighten toward white.
+        assert_eq!(opus, get_provider_shade("anthropic", 0));
+        assert_eq!(sonnet, get_provider_shade("anthropic", 1));
+        assert_eq!(haiku, get_provider_shade("anthropic", 2));
+    }
+
+    #[test]
+    fn test_shade_map_dedupes_same_model_across_workspaces() {
+        // Same model appearing N times in different workspaces (as happens
+        // under GroupBy::WorkspaceModel) must not inflate the rank count.
+        let mut app = make_app();
+        app.data.models = vec![
+            model_usage("claude-sonnet-4-5", 20.0, Some("ws-a")),
+            model_usage("claude-sonnet-4-5", 20.0, Some("ws-b")),
+            model_usage("claude-sonnet-4-5", 20.0, Some("ws-c")),
+            model_usage("claude-haiku-4-5", 5.0, None),
+        ];
+        app.build_model_shade_map();
+
+        // Only two distinct model names should be in the map; sonnet takes
+        // rank 0 (aggregate cost 60 > haiku cost 5).
+        assert_eq!(app.model_shade_map.len(), 2);
+        assert_eq!(
+            app.model_shade_map.get("claude-sonnet-4-5").copied(),
+            Some(get_provider_shade("anthropic", 0))
+        );
+        assert_eq!(
+            app.model_shade_map.get("claude-haiku-4-5").copied(),
+            Some(get_provider_shade("anthropic", 1))
+        );
+    }
+
+    #[test]
+    fn test_shade_map_is_deterministic_on_cost_ties() {
+        // All-zero costs (fresh data) must produce a stable shade assignment
+        // across refreshes so the chart doesn't flicker.
+        let ranks = |app: &App| {
+            let a = app.model_shade_map.get("claude-alpha").copied();
+            let b = app.model_shade_map.get("claude-beta").copied();
+            let c = app.model_shade_map.get("claude-gamma").copied();
+            (a, b, c)
+        };
+
+        let mut app1 = make_app();
+        app1.data.models = vec![
+            model_usage("claude-gamma", 0.0, None),
+            model_usage("claude-alpha", 0.0, None),
+            model_usage("claude-beta", 0.0, None),
+        ];
+        app1.build_model_shade_map();
+
+        let mut app2 = make_app();
+        app2.data.models = vec![
+            model_usage("claude-beta", 0.0, None),
+            model_usage("claude-gamma", 0.0, None),
+            model_usage("claude-alpha", 0.0, None),
+        ];
+        app2.build_model_shade_map();
+
+        assert_eq!(ranks(&app1), ranks(&app2));
+        // alpha sorts first by name so it gets rank 0 on ties.
+        assert_eq!(
+            app1.model_shade_map.get("claude-alpha").copied(),
+            Some(get_provider_shade("anthropic", 0))
+        );
+    }
+
+    #[test]
+    fn test_shade_map_handles_nan_cost() {
+        // NaN costs must not propagate into total_cmp ordering surprises or
+        // crash the builder.
+        let mut app = make_app();
+        app.data.models = vec![
+            model_usage("claude-nan", f64::NAN, None),
+            model_usage("claude-normal", 1.0, None),
+        ];
+        app.build_model_shade_map();
+
+        assert_eq!(app.model_shade_map.len(), 2);
+        // Normal model outranks NaN (which is coerced to 0).
+        assert_eq!(
+            app.model_shade_map.get("claude-normal").copied(),
+            Some(get_provider_shade("anthropic", 0))
+        );
+    }
+
+    #[test]
+    fn test_shade_map_separates_providers() {
+        let mut app = make_app();
+        app.data.models = vec![
+            ModelUsage {
+                model: "claude-opus-4-5".to_string(),
+                provider: "anthropic".to_string(),
+                client: "claude".to_string(),
+                workspace_key: None,
+                workspace_label: None,
+                tokens: TokenBreakdown::default(),
+                cost: 10.0,
+                session_count: 1,
+            },
+            ModelUsage {
+                model: "gpt-5".to_string(),
+                provider: "openai".to_string(),
+                client: "codex".to_string(),
+                workspace_key: None,
+                workspace_label: None,
+                tokens: TokenBreakdown::default(),
+                cost: 1.0,
+                session_count: 1,
+            },
+        ];
+        app.build_model_shade_map();
+
+        // Each provider ranks independently — both get rank-0 shades.
+        assert_eq!(
+            app.model_shade_map.get("claude-opus-4-5").copied(),
+            Some(get_provider_shade("anthropic", 0))
+        );
+        assert_eq!(
+            app.model_shade_map.get("gpt-5").copied(),
+            Some(get_provider_shade("openai", 0))
+        );
+    }
+
+    #[test]
+    fn test_shade_map_rebuilds_on_update_data() {
+        let mut app = make_app();
+        app.data.models = vec![model_usage("claude-opus-4-5", 10.0, None)];
+        app.build_model_shade_map();
+        assert!(app.model_shade_map.contains_key("claude-opus-4-5"));
+
+        let fresh = UsageData {
+            models: vec![model_usage("claude-sonnet-4-5", 5.0, None)],
+            ..UsageData::default()
+        };
+        app.update_data(fresh);
+
+        assert!(!app.model_shade_map.contains_key("claude-opus-4-5"));
+        assert!(app.model_shade_map.contains_key("claude-sonnet-4-5"));
     }
 }

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -14,7 +14,7 @@ use super::data::{AgentUsage, DailyUsage, DataLoader, HourlyUsage, ModelUsage, U
 use super::settings::Settings;
 use super::themes::{Theme, ThemeName};
 use super::ui::dialog::{ClientPickerDialog, DialogStack};
-use super::ui::widgets::{get_model_color, get_provider_from_model, get_provider_shade};
+use super::ui::widgets::get_model_color;
 
 /// Configuration for TUI initialization
 pub struct TuiConfig {
@@ -286,34 +286,7 @@ impl App {
     }
 
     pub fn build_model_shade_map(&mut self) {
-        self.model_shade_map.clear();
-
-        // Aggregate cost per (provider, model_name) so that the same model
-        // appearing in multiple group-by buckets (e.g. WorkspaceModel) gets
-        // counted once — preventing rank inflation and last-write-win shade
-        // collisions.
-        let mut provider_models: HashMap<&str, HashMap<&str, f64>> = HashMap::new();
-        for m in &self.data.models {
-            let provider = get_provider_from_model(&m.model);
-            let cost = if m.cost.is_finite() { m.cost } else { 0.0 };
-            *provider_models
-                .entry(provider)
-                .or_default()
-                .entry(m.model.as_str())
-                .or_insert(0.0) += cost;
-        }
-
-        for (provider, models_map) in provider_models {
-            let mut models: Vec<(&str, f64)> = models_map.into_iter().collect();
-            // Primary sort by cost descending, with a stable secondary sort on
-            // the model name so cost ties (including all-zero costs on first
-            // load) produce identical shade assignments across refreshes.
-            models.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(b.0)));
-            for (rank, (model_name, _)) in models.iter().enumerate() {
-                let color = get_provider_shade(provider, rank);
-                self.model_shade_map.insert(model_name.to_string(), color);
-            }
-        }
+        self.model_shade_map = super::colors::build_model_shade_map(&self.data.models);
     }
 
     pub fn model_color(&self, model: &str) -> Color {
@@ -869,59 +842,12 @@ impl App {
     }
 
     fn export_to_json(&mut self) {
-        let export_data = serde_json::json!({
-            "models": self.data.models.iter().map(|m| serde_json::json!({
-                "model": m.model,
-                "provider": m.provider,
-                "client": m.client,
-                "tokens": {
-                    "input": m.tokens.input,
-                    "output": m.tokens.output,
-                    "cacheRead": m.tokens.cache_read,
-                    "cacheWrite": m.tokens.cache_write,
-                    "total": m.tokens.total()
-                },
-                "cost": m.cost,
-                "sessionCount": m.session_count
-            })).collect::<Vec<_>>(),
-            "agents": self.data.agents.iter().map(|a| serde_json::json!({
-                "agent": a.agent,
-                "clients": a.clients,
-                "tokens": {
-                    "input": a.tokens.input,
-                    "output": a.tokens.output,
-                    "cacheRead": a.tokens.cache_read,
-                    "cacheWrite": a.tokens.cache_write,
-                    "total": a.tokens.total()
-                },
-                "cost": a.cost,
-                "messageCount": a.message_count
-            })).collect::<Vec<_>>(),
-            "daily": self.data.daily.iter().map(|d| serde_json::json!({
-                "date": d.date.to_string(),
-                "tokens": {
-                    "input": d.tokens.input,
-                    "output": d.tokens.output,
-                    "cacheRead": d.tokens.cache_read,
-                    "cacheWrite": d.tokens.cache_write,
-                    "total": d.tokens.total()
-                },
-                "messageCount": d.message_count,
-                "turnCount": d.turn_count,
-                "cost": d.cost
-            })).collect::<Vec<_>>(),
-            "totals": {
-                "tokens": self.data.total_tokens,
-                "cost": self.data.total_cost
-            }
-        });
-
         let filename = format!(
             "tokscale-export-{}.json",
             chrono::Utc::now().format("%Y%m%d-%H%M%S")
         );
 
-        match serde_json::to_string_pretty(&export_data) {
+        match super::export::build_export_json(&self.data) {
             Ok(json) => match std::fs::write(&filename, json) {
                 Ok(_) => self.set_status(&format!("Exported to {}", filename)),
                 Err(e) => self.set_status(&format!("Export failed: {}", e)),
@@ -1093,6 +1019,7 @@ impl App {
 
 #[cfg(test)]
 mod tests {
+    use super::super::ui::widgets::get_provider_shade;
     use super::*;
     use crate::tui::data::{ModelUsage, TokenBreakdown};
 

--- a/crates/tokscale-cli/src/tui/cache.rs
+++ b/crates/tokscale-cli/src/tui/cache.rs
@@ -1235,10 +1235,7 @@ mod tests {
                 assert_eq!(hourly_model.display_name, "claude-sonnet-4-5");
                 assert_eq!(hourly_model.color_key, "claude-sonnet-4-5");
             }
-            other => panic!(
-                "expected cache data, got {:?}",
-                other_variant_name(&other)
-            ),
+            other => panic!("expected cache data, got {:?}", other_variant_name(&other)),
         }
 
         match previous_home {

--- a/crates/tokscale-cli/src/tui/cache.rs
+++ b/crates/tokscale-cli/src/tui/cache.rs
@@ -344,29 +344,27 @@ impl From<&HourlyModelInfo> for CachedHourlyModelInfo {
     }
 }
 
-impl From<CachedHourlyModelInfo> for HourlyModelInfo {
-    fn from(h: CachedHourlyModelInfo) -> Self {
-        let display_name = if h.display_name.is_empty() {
-            h.color_key.clone()
-        } else {
-            h.display_name
-        };
-        let color_key = if h.color_key.is_empty() {
-            display_name
-                .rsplit_once(" / ")
-                .map(|(_, base_model)| base_model.to_string())
-                .unwrap_or_else(|| display_name.clone())
-        } else {
-            h.color_key
-        };
+fn hourly_model_info_from_cached(key: &str, value: CachedHourlyModelInfo) -> HourlyModelInfo {
+    let display_name = if value.display_name.is_empty() {
+        key.to_string()
+    } else {
+        value.display_name
+    };
+    let color_key = if value.color_key.is_empty() {
+        display_name
+            .rsplit_once(" / ")
+            .map(|(_, base_model)| base_model.to_string())
+            .unwrap_or_else(|| display_name.clone())
+    } else {
+        value.color_key
+    };
 
-        Self {
-            provider: h.provider,
-            display_name,
-            color_key,
-            tokens: h.tokens.into(),
-            cost: h.cost,
-        }
+    HourlyModelInfo {
+        provider: value.provider,
+        display_name,
+        color_key,
+        tokens: value.tokens.into(),
+        cost: value.cost,
     }
 }
 
@@ -398,7 +396,14 @@ impl TryFrom<CachedHourlyUsage> for HourlyUsage {
             tokens: h.tokens.into(),
             cost: h.cost,
             clients: h.clients.into_iter().collect(),
-            models: h.models.into_iter().map(|(k, v)| (k, v.into())).collect(),
+            models: h
+                .models
+                .into_iter()
+                .map(|(key, value)| {
+                    let model_info = hourly_model_info_from_cached(&key, value);
+                    (key, model_info)
+                })
+                .collect(),
             message_count: h.message_count,
             turn_count: h.turn_count,
         })
@@ -1153,6 +1158,85 @@ mod tests {
             }
             other => panic!(
                 "expected fresh current-schema cache, got {:?}",
+                other_variant_name(&other)
+            ),
+        }
+
+        match previous_home {
+            Some(home) => unsafe { env::set_var("HOME", home) },
+            None => unsafe { env::remove_var("HOME") },
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_load_cache_stale_legacy_hourly_models_without_display_fields() {
+        let temp_dir = TempDir::new().unwrap();
+        let previous_home = env::var_os("HOME");
+        unsafe {
+            env::set_var("HOME", temp_dir.path());
+        }
+
+        let cache_path = cache_file().unwrap();
+        fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
+        fs::write(
+            &cache_path,
+            r#"{
+  "schemaVersion": 5,
+  "timestamp": 9999999999999,
+  "enabledClients": ["claude"],
+  "includeSynthetic": false,
+  "groupBy": "model",
+  "data": {
+    "models": [],
+    "agents": [],
+    "daily": [],
+    "hourly": [{
+      "datetime": "2026-03-18 10:00:00",
+      "tokens": {
+        "input": 10,
+        "output": 5,
+        "cacheRead": 0,
+        "cacheWrite": 0,
+        "reasoning": 0
+      },
+      "cost": 1.25,
+      "clients": ["claude"],
+      "models": [[
+        "claude-sonnet-4-5",
+        {
+          "tokens": {
+            "input": 10,
+            "output": 5,
+            "cacheRead": 0,
+            "cacheWrite": 0,
+            "reasoning": 0
+          },
+          "cost": 1.25
+        }
+      ]],
+      "messageCount": 1,
+      "turnCount": 1
+    }],
+    "graph": null,
+    "totalTokens": 15,
+    "totalCost": 1.25,
+    "currentStreak": 1,
+    "longestStreak": 1
+  }
+}"#,
+        )
+        .unwrap();
+
+        let clients = make_clients(&[ClientId::Claude]);
+        match load_cache(&clients, false, &GroupBy::Model) {
+            CacheResult::Fresh(data) | CacheResult::Stale(data) => {
+                let hourly_model = data.hourly[0].models.get("claude-sonnet-4-5").unwrap();
+                assert_eq!(hourly_model.display_name, "claude-sonnet-4-5");
+                assert_eq!(hourly_model.color_key, "claude-sonnet-4-5");
+            }
+            other => panic!(
+                "expected cache data, got {:?}",
                 other_variant_name(&other)
             ),
         }

--- a/crates/tokscale-cli/src/tui/cache.rs
+++ b/crates/tokscale-cli/src/tui/cache.rs
@@ -143,6 +143,12 @@ struct CachedDailyUsage {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct CachedHourlyModelInfo {
+    #[serde(default)]
+    provider: String,
+    #[serde(default)]
+    display_name: String,
+    #[serde(default)]
+    color_key: String,
     tokens: CachedTokenBreakdown,
     cost: f64,
 }
@@ -329,6 +335,9 @@ impl From<CachedDailySourceInfo> for DailySourceInfo {
 impl From<&HourlyModelInfo> for CachedHourlyModelInfo {
     fn from(h: &HourlyModelInfo) -> Self {
         Self {
+            provider: h.provider.clone(),
+            display_name: h.display_name.clone(),
+            color_key: h.color_key.clone(),
             tokens: (&h.tokens).into(),
             cost: h.cost,
         }
@@ -337,7 +346,24 @@ impl From<&HourlyModelInfo> for CachedHourlyModelInfo {
 
 impl From<CachedHourlyModelInfo> for HourlyModelInfo {
     fn from(h: CachedHourlyModelInfo) -> Self {
+        let display_name = if h.display_name.is_empty() {
+            h.color_key.clone()
+        } else {
+            h.display_name
+        };
+        let color_key = if h.color_key.is_empty() {
+            display_name
+                .rsplit_once(" / ")
+                .map(|(_, base_model)| base_model.to_string())
+                .unwrap_or_else(|| display_name.clone())
+        } else {
+            h.color_key
+        };
+
         Self {
+            provider: h.provider,
+            display_name,
+            color_key,
             tokens: h.tokens.into(),
             cost: h.cost,
         }

--- a/crates/tokscale-cli/src/tui/colors.rs
+++ b/crates/tokscale-cli/src/tui/colors.rs
@@ -44,7 +44,7 @@ pub fn build_model_shade_map(models: &[ModelUsage]) -> HashMap<String, Color> {
 }
 
 fn provider_color_key<'a>(provider: &'a str, model: &'a str) -> &'a str {
-    if provider.contains(", ") {
+    if provider.is_empty() || provider.contains(", ") {
         get_provider_from_model(model)
     } else {
         provider

--- a/crates/tokscale-cli/src/tui/colors.rs
+++ b/crates/tokscale-cli/src/tui/colors.rs
@@ -5,18 +5,22 @@ use ratatui::style::Color;
 use super::data::ModelUsage;
 use super::ui::widgets::{get_provider_from_model, get_provider_shade};
 
-/// Builds a `model_name -> Color` map where each provider's models are
-/// cost-ranked; rank 0 (highest cost) gets the base provider color and
-/// later ranks get progressively lighter shades.
+pub fn model_shade_key(provider: &str, model: &str) -> String {
+    format!("{provider}\0{model}")
+}
+
+/// Builds a `(provider, model) -> Color` map where each provider's models are
+/// cost-ranked; rank 0 (highest cost) gets the base provider color and later
+/// ranks get progressively lighter shades.
 ///
 /// Aggregates cost per (provider, model) so the same model appearing in
-/// multiple group-by buckets (e.g. `GroupBy::WorkspaceModel`) doesn't
-/// inflate the rank count. Ties on cost are resolved by model name so
-/// shade assignment stays deterministic across refreshes.
+/// multiple group-by buckets (e.g. `GroupBy::WorkspaceModel`) doesn't inflate
+/// the rank count. Ties on cost are resolved by model name so shade assignment
+/// stays deterministic across refreshes.
 pub fn build_model_shade_map(models: &[ModelUsage]) -> HashMap<String, Color> {
     let mut by_provider: HashMap<&str, HashMap<&str, f64>> = HashMap::new();
     for m in models {
-        let provider = get_provider_from_model(&m.model);
+        let provider = provider_color_key(&m.provider, &m.model);
         let cost = if m.cost.is_finite() { m.cost } else { 0.0 };
         *by_provider
             .entry(provider)
@@ -30,8 +34,16 @@ pub fn build_model_shade_map(models: &[ModelUsage]) -> HashMap<String, Color> {
         let mut ranked: Vec<(&str, f64)> = models_map.into_iter().collect();
         ranked.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(b.0)));
         for (rank, (name, _)) in ranked.iter().enumerate() {
-            map.insert(name.to_string(), get_provider_shade(provider, rank));
+            map.insert(model_shade_key(provider, name), get_provider_shade(provider, rank));
         }
     }
     map
+}
+
+fn provider_color_key<'a>(provider: &'a str, model: &'a str) -> &'a str {
+    if provider.contains(", ") {
+        get_provider_from_model(model)
+    } else {
+        provider
+    }
 }

--- a/crates/tokscale-cli/src/tui/colors.rs
+++ b/crates/tokscale-cli/src/tui/colors.rs
@@ -1,0 +1,37 @@
+use std::collections::HashMap;
+
+use ratatui::style::Color;
+
+use super::data::ModelUsage;
+use super::ui::widgets::{get_provider_from_model, get_provider_shade};
+
+/// Builds a `model_name -> Color` map where each provider's models are
+/// cost-ranked; rank 0 (highest cost) gets the base provider color and
+/// later ranks get progressively lighter shades.
+///
+/// Aggregates cost per (provider, model) so the same model appearing in
+/// multiple group-by buckets (e.g. `GroupBy::WorkspaceModel`) doesn't
+/// inflate the rank count. Ties on cost are resolved by model name so
+/// shade assignment stays deterministic across refreshes.
+pub fn build_model_shade_map(models: &[ModelUsage]) -> HashMap<String, Color> {
+    let mut by_provider: HashMap<&str, HashMap<&str, f64>> = HashMap::new();
+    for m in models {
+        let provider = get_provider_from_model(&m.model);
+        let cost = if m.cost.is_finite() { m.cost } else { 0.0 };
+        *by_provider
+            .entry(provider)
+            .or_default()
+            .entry(m.model.as_str())
+            .or_insert(0.0) += cost;
+    }
+
+    let mut map = HashMap::new();
+    for (provider, models_map) in by_provider {
+        let mut ranked: Vec<(&str, f64)> = models_map.into_iter().collect();
+        ranked.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+        for (rank, (name, _)) in ranked.iter().enumerate() {
+            map.insert(name.to_string(), get_provider_shade(provider, rank));
+        }
+    }
+    map
+}

--- a/crates/tokscale-cli/src/tui/colors.rs
+++ b/crates/tokscale-cli/src/tui/colors.rs
@@ -34,7 +34,10 @@ pub fn build_model_shade_map(models: &[ModelUsage]) -> HashMap<String, Color> {
         let mut ranked: Vec<(&str, f64)> = models_map.into_iter().collect();
         ranked.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(b.0)));
         for (rank, (name, _)) in ranked.iter().enumerate() {
-            map.insert(model_shade_key(provider, name), get_provider_shade(provider, rank));
+            map.insert(
+                model_shade_key(provider, name),
+                get_provider_shade(provider, rank),
+            );
         }
     }
     map

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -102,6 +102,9 @@ pub struct DailyUsage {
 
 #[derive(Debug, Clone)]
 pub struct HourlyModelInfo {
+    pub provider: String,
+    pub display_name: String,
+    pub color_key: String,
     pub tokens: TokenBreakdown,
     pub cost: f64,
 }
@@ -206,6 +209,27 @@ fn daily_source_model_display_name(
         GroupBy::WorkspaceModel => workspace_model_display_label(workspace_label, model),
         GroupBy::ClientProviderModel => format!("{provider_id} / {model}"),
         GroupBy::Model | GroupBy::ClientModel => model.to_string(),
+    }
+}
+
+fn model_color_key(group_by: &GroupBy, _provider_id: &str, model: &str) -> String {
+    match group_by {
+        GroupBy::ClientProviderModel => model.to_string(),
+        GroupBy::Model | GroupBy::ClientModel | GroupBy::WorkspaceModel => model.to_string(),
+    }
+}
+
+fn hourly_model_key(group_by: &GroupBy, provider_id: &str, model: &str) -> String {
+    match group_by {
+        GroupBy::ClientProviderModel => format!("{provider_id}:{model}"),
+        GroupBy::Model | GroupBy::ClientModel | GroupBy::WorkspaceModel => model.to_string(),
+    }
+}
+
+fn hourly_model_display_name(group_by: &GroupBy, provider_id: &str, model: &str) -> String {
+    match group_by {
+        GroupBy::ClientProviderModel => format!("{provider_id} / {model}"),
+        GroupBy::Model | GroupBy::ClientModel | GroupBy::WorkspaceModel => model.to_string(),
     }
 }
 
@@ -563,7 +587,7 @@ impl DataLoader {
                             &msg.provider_id,
                             &normalized_model,
                         ),
-                        color_key: normalized_model.clone(),
+                        color_key: model_color_key(group_by, &msg.provider_id, &normalized_model),
                         tokens: TokenBreakdown::default(),
                         cost: 0.0,
                         messages: 0,
@@ -639,10 +663,19 @@ impl DataLoader {
                 }
                 hourly_entry.clients.insert(msg.client.clone());
 
+                let hourly_model_key =
+                    hourly_model_key(group_by, &msg.provider_id, &normalized_model);
                 let h_model = hourly_entry
                     .models
-                    .entry(normalized_model.clone())
+                    .entry(hourly_model_key)
                     .or_insert_with(|| HourlyModelInfo {
+                        provider: msg.provider_id.clone(),
+                        display_name: hourly_model_display_name(
+                            group_by,
+                            &msg.provider_id,
+                            &normalized_model,
+                        ),
+                        color_key: model_color_key(group_by, &msg.provider_id, &normalized_model),
                         tokens: TokenBreakdown::default(),
                         cost: 0.0,
                     });

--- a/crates/tokscale-cli/src/tui/export.rs
+++ b/crates/tokscale-cli/src/tui/export.rs
@@ -1,0 +1,58 @@
+use anyhow::Result;
+use serde_json::json;
+
+use super::data::UsageData;
+
+/// Serializes `UsageData` into the pretty-printed JSON payload used by the
+/// `e` export hotkey. Pure: callers are responsible for file I/O and any
+/// user-facing status messages.
+pub fn build_export_json(data: &UsageData) -> Result<String> {
+    let export_data = json!({
+        "models": data.models.iter().map(|m| json!({
+            "model": m.model,
+            "provider": m.provider,
+            "client": m.client,
+            "tokens": {
+                "input": m.tokens.input,
+                "output": m.tokens.output,
+                "cacheRead": m.tokens.cache_read,
+                "cacheWrite": m.tokens.cache_write,
+                "total": m.tokens.total()
+            },
+            "cost": m.cost,
+            "sessionCount": m.session_count
+        })).collect::<Vec<_>>(),
+        "agents": data.agents.iter().map(|a| json!({
+            "agent": a.agent,
+            "clients": a.clients,
+            "tokens": {
+                "input": a.tokens.input,
+                "output": a.tokens.output,
+                "cacheRead": a.tokens.cache_read,
+                "cacheWrite": a.tokens.cache_write,
+                "total": a.tokens.total()
+            },
+            "cost": a.cost,
+            "messageCount": a.message_count
+        })).collect::<Vec<_>>(),
+        "daily": data.daily.iter().map(|d| json!({
+            "date": d.date.to_string(),
+            "tokens": {
+                "input": d.tokens.input,
+                "output": d.tokens.output,
+                "cacheRead": d.tokens.cache_read,
+                "cacheWrite": d.tokens.cache_write,
+                "total": d.tokens.total()
+            },
+            "messageCount": d.message_count,
+            "turnCount": d.turn_count,
+            "cost": d.cost
+        })).collect::<Vec<_>>(),
+        "totals": {
+            "tokens": data.total_tokens,
+            "cost": data.total_cost
+        }
+    });
+
+    Ok(serde_json::to_string_pretty(&export_data)?)
+}

--- a/crates/tokscale-cli/src/tui/mod.rs
+++ b/crates/tokscale-cli/src/tui/mod.rs
@@ -1,9 +1,11 @@
 mod app;
 mod cache;
 pub mod client_ui;
+mod colors;
 pub mod config;
 pub mod data;
 mod event;
+mod export;
 pub mod settings;
 mod themes;
 mod ui;

--- a/crates/tokscale-cli/src/tui/ui/models.rs
+++ b/crates/tokscale-cli/src/tui/ui/models.rs
@@ -141,7 +141,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             let is_selected = idx == selected_index;
             let is_striped = idx % 2 == 1;
 
-            let model_color = app.model_color(&model.model);
+            let model_color = app.model_color_for(&model.provider, &model.model);
             let display_name = model_display_name(model, &group_by);
 
             let cells: Vec<Cell> = if is_very_narrow {

--- a/crates/tokscale-cli/src/tui/ui/overview.rs
+++ b/crates/tokscale-cli/src/tui/ui/overview.rs
@@ -10,6 +10,7 @@ use tokscale_core::GroupBy;
 
 struct ModelRowData {
     model: String,
+    provider: String,
     workspace_label: Option<String>,
     tokens_input: u64,
     tokens_output: u64,
@@ -97,10 +98,10 @@ fn render_chart(frame: &mut Frame, app: &App, area: Rect) {
                                     .or_insert_with(|| ModelSegment {
                                         model_id: info.display_name.clone(),
                                         tokens: 0,
-                                        color: app.model_color(overview_color_key(
-                                            &group_by,
-                                            &info.color_key,
-                                        )),
+                                        color: app.model_color_for(
+                                            &info.provider,
+                                            overview_color_key(&group_by, &info.color_key),
+                                        ),
                                     });
                             entry.tokens = entry.tokens.saturating_add(info.tokens.total());
                         }
@@ -129,10 +130,10 @@ fn render_chart(frame: &mut Frame, app: &App, area: Rect) {
                     let models: Vec<ModelSegment> = h
                         .models
                         .iter()
-                        .map(|(name, info)| ModelSegment {
-                            model_id: name.clone(),
+                        .map(|(_, info)| ModelSegment {
+                            model_id: info.display_name.clone(),
                             tokens: info.tokens.total(),
-                            color: app.model_color(name),
+                            color: app.model_color_for(&info.provider, &info.color_key),
                         })
                         .collect();
 
@@ -162,7 +163,7 @@ fn render_legend(frame: &mut Frame, app: &App, area: Rect) {
         .map(|m| {
             (
                 overview_model_label(&group_by, &m.model, m.workspace_label.as_deref()),
-                app.model_color(&m.model),
+                app.model_color_for(&m.provider, &m.model),
             )
         })
         .collect();
@@ -211,6 +212,7 @@ fn render_top_models(frame: &mut Frame, app: &mut App, area: Rect, items_per_pag
         .iter()
         .map(|m| ModelRowData {
             model: m.model.clone(),
+            provider: m.provider.clone(),
             workspace_label: m.workspace_label.clone(),
             tokens_input: m.tokens.input,
             tokens_output: m.tokens.output,
@@ -292,7 +294,7 @@ fn render_top_models(frame: &mut Frame, app: &mut App, area: Rect, items_per_pag
             Style::default()
         };
 
-        let model_color = app.model_color(&model.model);
+        let model_color = app.model_color_for(&model.provider, &model.model);
         let display_name =
             overview_model_label(&group_by, &model.model, model.workspace_label.as_deref());
         let name = truncate_string(&display_name, max_name_width);

--- a/crates/tokscale-cli/src/tui/ui/overview.rs
+++ b/crates/tokscale-cli/src/tui/ui/overview.rs
@@ -129,8 +129,8 @@ fn render_chart(frame: &mut Frame, app: &App, area: Rect) {
                 .map(|h| {
                     let models: Vec<ModelSegment> = h
                         .models
-                        .iter()
-                        .map(|(_, info)| ModelSegment {
+                        .values()
+                        .map(|info| ModelSegment {
                             model_id: info.display_name.clone(),
                             tokens: info.tokens.total(),
                             color: app.model_color_for(&info.provider, &info.color_key),

--- a/crates/tokscale-cli/src/tui/ui/stats.rs
+++ b/crates/tokscale-cli/src/tui/ui/stats.rs
@@ -260,19 +260,15 @@ fn render_stats_panel(frame: &mut Frame, app: &App, area: Rect) {
         })
         .unwrap_or(365);
 
-    let favorite_model = app
-        .data
-        .models
-        .iter()
-        .max_by(|a, b| {
-            a.cost
-                .partial_cmp(&b.cost)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        })
-        .map(|m| m.model.as_str())
-        .unwrap_or("N/A");
-
-    let model_color = app.model_color(favorite_model);
+    let favorite_model = app.data.models.iter().max_by(|a, b| {
+        a.cost
+            .partial_cmp(&b.cost)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let favorite_model_name = favorite_model.map(|m| m.model.as_str()).unwrap_or("N/A");
+    let model_color = favorite_model
+        .map(|m| app.model_color_for(&m.provider, &m.model))
+        .unwrap_or_else(|| app.model_color("N/A"));
     let sessions: u32 = app.data.models.iter().map(|m| m.session_count).sum();
 
     let col1_width = if is_narrow { 36u16 } else { 60u16 };
@@ -290,7 +286,7 @@ fn render_stats_panel(frame: &mut Frame, app: &App, area: Rect) {
         Span::styled(row1_label, Style::default().fg(app.theme.muted)),
         Span::raw(" "),
         Span::styled(
-            truncate_model_name(favorite_model, if is_narrow { 15 } else { 30 }),
+            truncate_model_name(favorite_model_name, if is_narrow { 15 } else { 30 }),
             Style::default().fg(model_color),
         ),
     ]);
@@ -550,7 +546,7 @@ fn render_breakdown_panel(frame: &mut Frame, app: &mut App, area: Rect) {
                 ]));
 
                 for model_info in models {
-                    let model_color = app.model_color(&model_info.color_key);
+                    let model_color = app.model_color_for(&model_info.provider, &model_info.color_key);
                     lines.push(Line::from(vec![
                         Span::raw("  "),
                         Span::styled("●", Style::default().fg(model_color)),

--- a/crates/tokscale-cli/src/tui/ui/stats.rs
+++ b/crates/tokscale-cli/src/tui/ui/stats.rs
@@ -546,7 +546,8 @@ fn render_breakdown_panel(frame: &mut Frame, app: &mut App, area: Rect) {
                 ]));
 
                 for model_info in models {
-                    let model_color = app.model_color_for(&model_info.provider, &model_info.color_key);
+                    let model_color =
+                        app.model_color_for(&model_info.provider, &model_info.color_key);
                     lines.push(Line::from(vec![
                         Span::raw("  "),
                         Span::styled("●", Style::default().fg(model_color)),

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -60,15 +60,16 @@ pub fn format_cache_hit_rate(cache_read: u64, input: u64, cache_write: u64) -> S
 }
 
 pub fn get_model_color(model: &str) -> Color {
-    let provider = get_provider_from_model(model);
-    let config = TokscaleConfig::load();
-    if let Some(color) = config.get_provider_color(provider) {
-        return color;
-    }
-    get_provider_shade(provider, 0)
+    get_provider_shade(get_provider_from_model(model), 0)
 }
 
+/// Returns the shade for a given `(provider, rank)` pair.
+/// Honors `[colors.providers]` config overrides at every rank by deriving
+/// a 7-step lighten-to-white palette from the override base color.
 pub fn get_provider_shade(provider: &str, rank: usize) -> Color {
+    if let Some(base) = TokscaleConfig::load().get_provider_color(provider) {
+        return shade_from_base(base, rank);
+    }
     let palette: &[(u8, u8, u8)] = match provider {
         "anthropic" => &ANTHROPIC_SHADES,
         "openai" => &OPENAI_SHADES,
@@ -77,11 +78,28 @@ pub fn get_provider_shade(provider: &str, rank: usize) -> Color {
         "xai" => &XAI_SHADES,
         "meta" => &META_SHADES,
         "cursor" => &CURSOR_SHADES,
-        _ => &[(255, 255, 255)],
+        _ => &UNKNOWN_SHADES,
     };
     let idx = rank.min(palette.len() - 1);
     let (r, g, b) = palette[idx];
     Color::Rgb(r, g, b)
+}
+
+/// Generates a 7-step monochromatic palette from `base` by interpolating
+/// toward white. Factors roughly match the end-of-ramp lightness of the
+/// hardcoded palettes so overrides feel visually consistent.
+fn shade_from_base(base: Color, rank: usize) -> Color {
+    const FACTORS: [f32; 7] = [0.00, 0.11, 0.22, 0.33, 0.44, 0.56, 0.67];
+    let Color::Rgb(r, g, b) = base else {
+        return base;
+    };
+    let idx = rank.min(FACTORS.len() - 1);
+    let f = FACTORS[idx];
+    let lerp = |c: u8| -> u8 {
+        let c = c as f32;
+        (c + (255.0 - c) * f).round().clamp(0.0, 255.0) as u8
+    };
+    Color::Rgb(lerp(r), lerp(g), lerp(b))
 }
 
 const ANTHROPIC_SHADES: [(u8, u8, u8); 7] = [
@@ -144,8 +162,26 @@ const META_SHADES: [(u8, u8, u8); 7] = [
     (225, 226, 252), // #E1E2FC
 ];
 
-const CURSOR_SHADES: [(u8, u8, u8); 1] = [
-    (139, 92, 246), // #8B5CF6
+const CURSOR_SHADES: [(u8, u8, u8); 7] = [
+    (139, 92, 246),  // #8B5CF6
+    (154, 114, 247), // #9A72F7
+    (169, 135, 248), // #A987F8
+    (184, 156, 250), // #B89CFA
+    (199, 177, 251), // #C7B1FB
+    (215, 199, 252), // #D7C7FC
+    (230, 220, 253), // #E6DCFD
+];
+
+/// Neutral gray ramp for providers that don't match any known palette.
+/// Still produces distinct shades per rank instead of collapsing to white.
+const UNKNOWN_SHADES: [(u8, u8, u8); 7] = [
+    (136, 136, 136), // #888888
+    (156, 156, 156), // #9C9C9C
+    (176, 176, 176), // #B0B0B0
+    (196, 196, 196), // #C4C4C4
+    (212, 212, 212), // #D4D4D4
+    (228, 228, 228), // #E4E4E4
+    (244, 244, 244), // #F4F4F4
 ];
 
 pub fn get_provider_from_model(model: &str) -> &'static str {
@@ -244,5 +280,74 @@ fn capitalize_first(s: &str) -> String {
     match chars.next() {
         None => String::new(),
         Some(first) => first.to_uppercase().chain(chars).collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shade_from_base_rank_0_equals_base() {
+        let base = Color::Rgb(255, 0, 0);
+        assert_eq!(shade_from_base(base, 0), base);
+    }
+
+    #[test]
+    fn shade_from_base_lightens_monotonically_toward_white() {
+        let base = Color::Rgb(0, 0, 0);
+        let mut prev_r: u8 = 0;
+        for rank in 0..7 {
+            let Color::Rgb(r, _, _) = shade_from_base(base, rank) else {
+                panic!("expected Rgb")
+            };
+            assert!(
+                r >= prev_r,
+                "shade at rank {} should not be darker than rank {}",
+                rank,
+                rank - 1
+            );
+            prev_r = r;
+        }
+    }
+
+    #[test]
+    fn shade_from_base_clamps_beyond_palette_length() {
+        let base = Color::Rgb(100, 100, 100);
+        // Rank beyond FACTORS.len() saturates to the lightest shade.
+        assert_eq!(shade_from_base(base, 100), shade_from_base(base, 6));
+    }
+
+    #[test]
+    fn shade_from_base_passes_through_non_rgb() {
+        // Indexed terminal colors can't be lightened channel-wise — return as-is.
+        assert_eq!(shade_from_base(Color::Indexed(42), 5), Color::Indexed(42));
+    }
+
+    #[test]
+    fn unknown_provider_returns_gray_ramp_not_pure_white() {
+        // Regression: the old fallback was [(255,255,255)], collapsing all
+        // unknown-provider models to pure white. Now each rank is a distinct
+        // gray so models stay distinguishable.
+        let rank_0 = get_provider_shade("some-new-provider", 0);
+        let rank_3 = get_provider_shade("some-new-provider", 3);
+        assert_ne!(rank_0, rank_3);
+        assert_ne!(rank_0, Color::Rgb(255, 255, 255));
+    }
+
+    #[test]
+    fn cursor_provider_has_distinct_shades_per_rank() {
+        // Regression: CURSOR_SHADES used to be a single-entry palette so all
+        // Cursor models collapsed to one color.
+        let rank_0 = get_provider_shade("cursor", 0);
+        let rank_6 = get_provider_shade("cursor", 6);
+        assert_ne!(rank_0, rank_6);
+    }
+
+    #[test]
+    fn get_provider_shade_saturates_at_palette_end() {
+        let last = get_provider_shade("anthropic", 6);
+        let past_end = get_provider_shade("anthropic", 99);
+        assert_eq!(last, past_end);
     }
 }

--- a/crates/tokscale-core/src/sessions/amp.rs
+++ b/crates/tokscale-core/src/sessions/amp.rs
@@ -2,6 +2,7 @@
 //!
 //! Parses JSON files from ~/.local/share/amp/threads/
 
+use super::utils::read_file_or_none;
 use super::UnifiedMessage;
 use crate::{provider_identity, TokenBreakdown};
 use serde::Deserialize;
@@ -72,9 +73,8 @@ fn get_provider_from_model(model: &str) -> &'static str {
 
 /// Parse an Amp thread JSON file
 pub fn parse_amp_file(path: &Path) -> Vec<UnifiedMessage> {
-    let content = match std::fs::read(path) {
-        Ok(c) => c,
-        Err(_) => return Vec::new(),
+    let Some(content) = read_file_or_none(path) else {
+        return Vec::new();
     };
 
     // Get file mtime as last-resort timestamp fallback

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -4,6 +4,7 @@
 
 use super::utils::{
     extract_i64, extract_string, file_modified_timestamp_ms, parse_timestamp_value,
+    read_file_or_none,
 };
 use super::{
     normalize_agent_name, normalize_workspace_key, workspace_label_from_key, UnifiedMessage,
@@ -524,9 +525,8 @@ fn parse_claude_headless_json(
     workspace_key: Option<String>,
     workspace_label: Option<String>,
 ) -> Vec<UnifiedMessage> {
-    let data = match std::fs::read(path) {
-        Ok(d) => d,
-        Err(_) => return Vec::new(),
+    let Some(data) = read_file_or_none(path) else {
+        return Vec::new();
     };
 
     let mut bytes = data;

--- a/crates/tokscale-core/src/sessions/crush.rs
+++ b/crates/tokscale-core/src/sessions/crush.rs
@@ -4,6 +4,7 @@
 //! The database exposes reliable session-level cost, but not reliable
 //! per-message token accounting for import.
 
+use super::utils::open_readonly_sqlite;
 use super::UnifiedMessage;
 use crate::TokenBreakdown;
 use chrono::{Local, TimeZone};
@@ -37,12 +38,8 @@ struct DayBucket {
 /// - session cost is allocated across those days proportionally
 /// - token fields remain zero
 pub fn parse_crush_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
-    let conn = match Connection::open_with_flags(
-        db_path,
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    ) {
-        Ok(conn) => conn,
-        Err(_) => return Vec::new(),
+    let Some(conn) = open_readonly_sqlite(db_path) else {
+        return Vec::new();
     };
 
     let root_sessions = load_root_sessions(&conn);

--- a/crates/tokscale-core/src/sessions/droid.rs
+++ b/crates/tokscale-core/src/sessions/droid.rs
@@ -2,6 +2,7 @@
 //!
 //! Parses JSON files from ~/.factory/sessions/
 
+use super::utils::read_file_or_none;
 use super::UnifiedMessage;
 use crate::{provider_identity, TokenBreakdown};
 use serde::Deserialize;
@@ -134,9 +135,8 @@ fn extract_model_from_jsonl(jsonl_path: &Path) -> Option<String> {
 
 /// Parse a Droid settings.json file
 pub fn parse_droid_file(path: &Path) -> Vec<UnifiedMessage> {
-    let data = match std::fs::read(path) {
-        Ok(d) => d,
-        Err(_) => return Vec::new(),
+    let Some(data) = read_file_or_none(path) else {
+        return Vec::new();
     };
 
     let mut bytes = data;

--- a/crates/tokscale-core/src/sessions/gemini.rs
+++ b/crates/tokscale-core/src/sessions/gemini.rs
@@ -5,6 +5,7 @@
 
 use super::utils::{
     extract_i64, extract_string, file_modified_timestamp_ms, parse_timestamp_value,
+    read_file_or_none,
 };
 use super::UnifiedMessage;
 use crate::TokenBreakdown;
@@ -95,9 +96,8 @@ pub fn parse_gemini_file(path: &Path) -> Vec<UnifiedMessage> {
         }
     }
 
-    let data = match std::fs::read(path) {
-        Ok(d) => d,
-        Err(_) => return Vec::new(),
+    let Some(data) = read_file_or_none(path) else {
+        return Vec::new();
     };
 
     let mut bytes = data.clone();

--- a/crates/tokscale-core/src/sessions/kilo.rs
+++ b/crates/tokscale-core/src/sessions/kilo.rs
@@ -5,10 +5,9 @@
 //!
 //! Kilo CLI uses a SQLite database similar to OpenCode.
 
-use super::utils::file_modified_timestamp_ms;
+use super::utils::{file_modified_timestamp_ms, open_readonly_sqlite};
 use super::UnifiedMessage;
 use crate::{provider_identity, TokenBreakdown};
-use rusqlite::Connection;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -60,12 +59,8 @@ pub fn parse_kilo_sqlite_with_fallback(
     db_path: &Path,
     fallback_timestamp: i64,
 ) -> Vec<UnifiedMessage> {
-    let conn = match Connection::open_with_flags(
-        db_path,
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    ) {
-        Ok(c) => c,
-        Err(_) => return Vec::new(),
+    let Some(conn) = open_readonly_sqlite(db_path) else {
+        return Vec::new();
     };
 
     let query = r#"

--- a/crates/tokscale-core/src/sessions/mux.rs
+++ b/crates/tokscale-core/src/sessions/mux.rs
@@ -2,7 +2,7 @@
 //!
 //! Parses session-usage.json files from ~/.mux/sessions/<workspaceId>/session-usage.json
 
-use super::utils::file_modified_timestamp_ms;
+use super::utils::{file_modified_timestamp_ms, read_file_or_none};
 use super::UnifiedMessage;
 use crate::TokenBreakdown;
 use serde::Deserialize;
@@ -45,9 +45,8 @@ pub struct MuxLastRequest {
 /// Parse a mux session-usage.json file.
 /// Returns one UnifiedMessage per model entry in byModel.
 pub fn parse_mux_file(path: &Path) -> Vec<UnifiedMessage> {
-    let data = match std::fs::read(path) {
-        Ok(d) => d,
-        Err(_) => return vec![],
+    let Some(data) = read_file_or_none(path) else {
+        return vec![];
     };
 
     let usage: MuxSessionUsage = match serde_json::from_slice(&data) {

--- a/crates/tokscale-core/src/sessions/openclaw.rs
+++ b/crates/tokscale-core/src/sessions/openclaw.rs
@@ -3,6 +3,7 @@
 //! Parses OpenClaw transcript JSONL files from agent directories.
 //! Supports legacy sessions.json index parsing for compatibility.
 
+use super::utils::read_file_or_none;
 use super::UnifiedMessage;
 use crate::TokenBreakdown;
 use serde::Deserialize;
@@ -73,9 +74,8 @@ struct OpenClawCost {
 }
 
 pub fn parse_openclaw_index(index_path: &Path) -> Vec<UnifiedMessage> {
-    let data = match std::fs::read(index_path) {
-        Ok(d) => d,
-        Err(_) => return Vec::new(),
+    let Some(data) = read_file_or_none(index_path) else {
+        return Vec::new();
     };
 
     let mut bytes = data;

--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -4,8 +4,10 @@
 //! - SQLite database (OpenCode 1.2+): ~/.local/share/opencode/opencode.db
 //! - Legacy JSON files: ~/.local/share/opencode/storage/message/
 
+use super::utils::{open_readonly_sqlite, read_file_or_none};
 use super::{normalize_opencode_agent_name, UnifiedMessage};
 use crate::TokenBreakdown;
+#[cfg(test)]
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -52,7 +54,7 @@ pub struct OpenCodeTime {
 }
 
 pub fn parse_opencode_file(path: &Path) -> Option<UnifiedMessage> {
-    let data = std::fs::read(path).ok()?;
+    let data = read_file_or_none(path)?;
     let mut bytes = data;
 
     let msg: OpenCodeMessage = simd_json::from_slice(&mut bytes).ok()?;
@@ -96,12 +98,8 @@ pub fn parse_opencode_file(path: &Path) -> Option<UnifiedMessage> {
 }
 
 pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
-    let conn = match Connection::open_with_flags(
-        db_path,
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    ) {
-        Ok(c) => c,
-        Err(_) => return Vec::new(),
+    let Some(conn) = open_readonly_sqlite(db_path) else {
+        return Vec::new();
     };
 
     let query = r#"

--- a/crates/tokscale-core/src/sessions/roocode.rs
+++ b/crates/tokscale-core/src/sessions/roocode.rs
@@ -4,7 +4,7 @@
 //! - tasks/<taskId>/ui_messages.json
 //! - tasks/<taskId>/api_conversation_history.json
 
-use super::utils::{extract_i64, parse_timestamp_str};
+use super::utils::{extract_i64, parse_timestamp_str, read_file_or_none};
 use super::UnifiedMessage;
 use crate::TokenBreakdown;
 use serde::Deserialize;
@@ -25,9 +25,8 @@ pub fn parse_roocode_file(path: &Path) -> Vec<UnifiedMessage> {
 }
 
 pub(crate) fn parse_roo_kilo_file(path: &Path, source: &str) -> Vec<UnifiedMessage> {
-    let data = match std::fs::read(path) {
-        Ok(d) => d,
-        Err(_) => return Vec::new(),
+    let Some(data) = read_file_or_none(path) else {
+        return Vec::new();
     };
 
     let mut bytes = data;

--- a/crates/tokscale-core/src/sessions/synthetic.rs
+++ b/crates/tokscale-core/src/sessions/synthetic.rs
@@ -3,6 +3,7 @@
 //! Detects synthetic.new API usage across existing agent sessions by model/provider patterns,
 //! and parses Octofriend's SQLite database when token data is available.
 
+use super::utils::open_readonly_sqlite;
 use super::UnifiedMessage;
 use crate::TokenBreakdown;
 use std::path::Path;
@@ -109,12 +110,8 @@ pub fn matches_synthetic_filter(client: &str, model_id: &str, provider_id: &str)
 /// This function checks for token-related tables and parses them when available,
 /// making it future-proof for when Octofriend adds token persistence.
 pub fn parse_octofriend_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
-    let conn = match rusqlite::Connection::open_with_flags(
-        db_path,
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    ) {
-        Ok(conn) => conn,
-        Err(_) => return Vec::new(),
+    let Some(conn) = open_readonly_sqlite(db_path) else {
+        return Vec::new();
     };
 
     // Check if a token-tracking table exists (future-proofing)

--- a/crates/tokscale-core/src/sessions/utils.rs
+++ b/crates/tokscale-core/src/sessions/utils.rs
@@ -1,5 +1,6 @@
 //! Shared parsing helpers for session logs.
 
+use rusqlite::{Connection, OpenFlags};
 use serde_json::Value;
 use std::path::Path;
 use std::time::SystemTime;
@@ -54,4 +55,20 @@ pub(crate) fn file_modified_timestamp_ms(path: &Path) -> i64 {
         .and_then(|time| time.duration_since(SystemTime::UNIX_EPOCH).ok())
         .map(|duration| duration.as_millis() as i64)
         .unwrap_or_else(|| chrono::Utc::now().timestamp_millis())
+}
+
+/// Open a SQLite file for read-only access with no mutex (single-threaded parser use).
+/// Returns `None` if the file cannot be opened — the caller treats that as "no sessions".
+pub(crate) fn open_readonly_sqlite(path: &Path) -> Option<Connection> {
+    Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .ok()
+}
+
+/// Read a file into bytes, returning `None` on any I/O error instead of propagating.
+/// Used by parsers that treat missing/unreadable session files as "no data".
+pub(crate) fn read_file_or_none(path: &Path) -> Option<Vec<u8>> {
+    std::fs::read(path).ok()
 }


### PR DESCRIPTION
## Summary

Follow-ups to #436 (cost-ranked shade palettes) plus adjacent cleanups surfaced during review.

### PR #436 bug fixes (`fix(tui)`)

- **[HIGH]** `[colors.providers]` override was silently disabled for rank ≥ 1. `get_provider_shade()` now consults `TokscaleConfig::get_provider_color()` at every rank and derives a 7-step lighten-to-white palette (`shade_from_base`) from the override base when present. A user setting `anthropic = \"#FF0000\"` now sees red-family shades across *all* their Anthropic models.
- **[MEDIUM]** Shade collisions under `GroupBy::WorkspaceModel`. Same model appearing in N workspaces used to consume N rank slots and then collide on insert. Now aggregated to `(provider, model_name) -> total_cost` before ranking.
- **[MEDIUM]** Non-deterministic order on cost ties caused shade flicker across refreshes. Secondary sort by model name makes assignment stable.
- **[LOW]** `CURSOR_SHADES` expanded from 1 → 7 entries; unknown-provider fallback replaced by a gray ramp (was collapsing every unknown-provider model to pure white).

13 new tests cover: rank-0-to-highest-cost, workspace dedupe, cost-tie determinism, NaN-cost handling, cross-provider independence, rebuild-on-update, plus `shade_from_base` edge cases and unknown/cursor palette regressions.

### CLI refactor (`refactor(cli)`)

19 client-filter bools + 6 date-range options were redeclared across 7 clap structs — ~145 duplicated `#[arg(...)]` lines plus 19-field `ClientFlags { ... }` rebuilds at every call site. The existing `ClientFlags` runtime helper becomes a `#[derive(Args)]` struct; a parallel `DateRangeFlags` captures the date block. Both are `#[command(flatten)]`ed into `Cli`, `Models`, `Monthly`, `Hourly`, `Graph`, `Tui`, and `Submit`.

**main.rs: 5093 → 4445 (-648 lines, -12.7%)**. No CLI surface change — all `--opencode`, `--claude`, `--today`, `--since`, etc. still parse identically. One intentional UX win: Submit's inconsistent \"Include only X data\" help text now matches the uniform \"Show only X usage\" used elsewhere.

### Sessions + TUI cleanup (`refactor(sessions)`, `refactor(tui)`)

An architect review rejected broader refactors (`SessionParser` trait, full app.rs split) as over-engineering, but flagged two narrow wins that landed:

- **11 session parsers** now use shared `open_readonly_sqlite` + `read_file_or_none` helpers in `sessions/utils.rs`. No behavior change — same read-only SQLite flags, same error-to-empty fallback.
- **`build_model_shade_map`** and **`build_export_json`** moved out of `App` into `tui/colors.rs` and `tui/export.rs` as pure functions. app.rs 2247 → 2174.

## Test plan

- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --workspace --all-features` — 950 passing (345 + 83 + 519 + 3), no regressions
- [x] `tokscale models --help` spot-check: all client/date flags preserved
- [x] `tokscale submit --help`: unified \"Show only X usage\" help text
- [ ] Manual TUI verification with a `~/.tokscale` override for `anthropic` (would confirm HIGH bug fix end-to-end)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TUI shade palette bugs, makes model colors provider-aware across all views and reloads, and removes duplicated CLI/session code. No CLI surface changes; TUI colors now respect provider overrides, handle empty providers, and keep labels/colors when loading legacy caches.

- **Bug Fixes**
  - `[colors.providers]` overrides now apply at every rank via a 7-step palette (rank 0 = base).
  - Shade map is keyed and ranked by aggregated (provider, model) cost; ties sort by model name; NaN treated as 0. Duplicate model names across providers no longer collide.
  - Models, Overview, and Stats use provider-aware color lookup. Hourly data and cache retain `provider`/`displayName`/`colorKey` (backward-compatible) so colors persist across reloads.
  - Empty or merged provider IDs are normalized during shade-map build and lookup to prevent mismatches and rank-0 fallbacks.
  - Legacy hourly cache entries missing display fields now fall back to the map key to rebuild `displayName`/`colorKey`, preserving labels and colors.
  - `cursor` palette expanded to 7 shades; unknown providers use a neutral gray ramp. Tests cover ranking, dedupe, ties, NaN handling, provider separation, rebuilds, palette overrides, and legacy cache fallback.

- **Refactors**
  - CLI: Extracted `ClientFlags` and `DateRangeFlags` as `clap` `Args`, flattened into `Cli`, `Models`, `Monthly`, `Hourly`, `Graph`, `Tui`, `Submit`, and `Wrapped`. ~648 lines removed; flags unchanged; help text unified to “Show only X usage”.
  - Sessions (`@tokscale-core`): Added `open_readonly_sqlite` and `read_file_or_none`; applied across 11 parsers. No behavior change.
  - TUI (`@tokscale-cli`): Moved shade-map builder to `tui/colors.rs` and export JSON builder to `tui/export.rs` as pure functions.

<sup>Written for commit 4b2e2a3eccbdaedcb6ded7be29839c59a10284ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

