### PR TITLE
fix(cli): detach TUI cache warming after submit to avoid hang

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-cli"
-version = "2.0.24"
+version = "2.0.25"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-core"
-version = "2.0.24"
+version = "2.0.25"
 dependencies = [
  "bincode",
  "chrono",

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -217,6 +217,11 @@ enum Commands {
     },
     #[command(about = "Delete all submitted usage data from the server")]
     DeleteSubmittedData,
+    #[command(
+        about = "Warm TUI cache in background (internal)",
+        hide = true
+    )]
+    WarmTuiCache,
 }
 
 #[derive(Subcommand)]
@@ -505,6 +510,7 @@ fn main() -> Result<()> {
             reject_unsupported_home_override(&cli.home, "delete-submitted-data")?;
             run_delete_data_command()
         }
+        Some(Commands::WarmTuiCache) => run_warm_tui_cache(),
         None => {
             let today = cli.date.today;
             let week = cli.date.week;
@@ -3300,7 +3306,7 @@ fn run_submit_command(
     use colored::Colorize;
     use std::io::IsTerminal;
     use tokio::runtime::Runtime;
-    use tokscale_core::{generate_graph, ClientId, GroupBy, ReportOptions};
+    use tokscale_core::{generate_graph, GroupBy, ReportOptions};
 
     let credentials = match auth::load_credentials() {
         Some(creds) => creds,
@@ -3532,20 +3538,49 @@ fn run_submit_command(
     }
 
     // Warm the TUI cache so the next `tokscale` launch is instant.
-    // We load with all clients and no date filters (default TUI view)
-    // to maximize cache hit rate.
-    {
-        use crate::tui::{save_cached_data, DataLoader};
-        use std::collections::HashSet;
+    // Detached subprocess so submit returns to the shell immediately on large
+    // datasets — a full re-scan would otherwise block for tens of seconds.
+    spawn_warm_tui_cache_detached();
 
-        let all_clients: Vec<ClientId> = ClientId::iter().collect();
-        let enabled_set: HashSet<ClientId> = all_clients.iter().copied().collect();
-        let loader = DataLoader::with_filters(None, None, None, None);
-        if let Ok(data) = loader.load(&all_clients, &GroupBy::default(), false) {
-            save_cached_data(&data, &enabled_set, false, &GroupBy::default());
-        }
+    Ok(())
+}
+
+fn spawn_warm_tui_cache_detached() {
+    use std::process::{Command, Stdio};
+
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    let mut cmd = Command::new(exe);
+    cmd.arg("warm-tui-cache")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // New process group so the child is not killed by Ctrl-C in the
+        // parent's shell and survives after submit exits.
+        cmd.process_group(0);
     }
 
+    let _ = cmd.spawn();
+}
+
+fn run_warm_tui_cache() -> Result<()> {
+    use crate::tui::{save_cached_data, DataLoader};
+    use std::collections::HashSet;
+    use tokscale_core::{ClientId, GroupBy};
+
+    let all_clients: Vec<ClientId> = ClientId::iter().collect();
+    let enabled_set: HashSet<ClientId> = all_clients.iter().copied().collect();
+    let loader = DataLoader::with_filters(None, None, None, None);
+    if let Ok(data) = loader.load(&all_clients, &GroupBy::default(), false) {
+        save_cached_data(&data, &enabled_set, false, &GroupBy::default());
+    }
     Ok(())
 }
 

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -217,10 +217,7 @@ enum Commands {
     },
     #[command(about = "Delete all submitted usage data from the server")]
     DeleteSubmittedData,
-    #[command(
-        about = "Warm TUI cache in background (internal)",
-        hide = true
-    )]
+    #[command(about = "Warm TUI cache in background (internal)", hide = true)]
     WarmTuiCache,
 }
 


### PR DESCRIPTION
## Summary
- `tokscale submit` re-scanned every client with no date filters **inline** after successful submission, blocking the shell for tens of seconds — on large datasets (197 active days, 45B tokens, 78 models) the hang stretches into minutes.
- Move the warm step into a hidden `warm-tui-cache` subcommand and spawn it as a **detached subprocess** (new process group, stdio redirected to /dev/null) just before `submit` returns. Prompt returns immediately; next `tokscale` launch still benefits from a warm cache.

## What changed
- `Commands::WarmTuiCache` (hidden via `hide = true`) runs the existing `DataLoader::load` + `save_cached_data` block.
- `run_submit_command` replaces the inline warm block with `spawn_warm_tui_cache_detached()` — re-execs the current binary, sets `process_group(0)` on Unix so the child isn't bound to the parent's shell, and drops the `Child` handle.

## Why detached subprocess
- A plain `std::thread::spawn` dies when `main()` returns, so the cache would never get written.
- Reusing the submit-time `graph_result` doesn't work cleanly: TUI warms with *all* `ClientId`s (incl. `crush`), while submit defaults exclude some clients — datasets differ.
- Dropping the warm entirely would regress the "instant next TUI launch" UX added in 660f28b.

## Test plan
- [x] `cargo build -p tokscale-cli` clean
- [x] `cargo clippy -p tokscale-cli --all-targets -- -D warnings` clean
- [x] `cargo test -p tokscale-cli --bin tokscale` — 347 passed
- [x] POC: standalone Rust binary using the same `process_group(0)` + `Stdio::null()` + `spawn` pattern returned in 220 µs; the child continued running after parent exit and wrote its marker file 3 s later.
- [x] `./target/debug/tokscale warm-tui-cache --help` shows the subcommand works; it is absent from `tokscale --help` (hidden).
- [ ] Manual e2e: run `tokscale submit` on a real account and confirm shell returns immediately while cache file (`~/Library/Caches/tokscale/tui-data-cache.json` on macOS) updates shortly after.
- [ ] Verify on Linux (`process_group(0)` available) and sanity-check Windows (no `process_group`, but `Stdio::null()` + `spawn` should still detach enough for CI — not tested here).

## Notes
- `WarmTuiCache` is intentionally `hide = true`; please keep it internal.
- Windows detach path is not exercised here; if someone on Windows reports the child hanging with a console window, we'd need `CREATE_NO_WINDOW` via `CommandExt::creation_flags`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the post-submit hang by moving TUI cache warming to a detached background process. `tokscale submit` now returns immediately while the next `tokscale` launch still benefits from a warm cache.

- **Bug Fixes**
  - Added hidden `warm-tui-cache` subcommand to run cache warming (`DataLoader::load` + `save_cached_data`), not shown in `--help`.
  - Replaced inline warm in `submit` with `spawn_warm_tui_cache_detached()` that spawns the current binary, detaches on Unix via `process_group(0)`, and redirects stdio to `/dev/null`.
  - Warms with all clients and no date filters to match the default TUI view and avoid mismatched datasets.
  - Bumped versions: `tokscale-cli` and `tokscale-core` to `2.0.25`.

<sup>Written for commit ecf537d9bff55b56de4cc184e85af7f9b0992cff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

