### PR TITLE
feat(tui): set terminal tab title to 'Tokscale' on launch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-cli"
-version = "2.0.24"
+version = "2.0.25"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-core"
-version = "2.0.24"
+version = "2.0.25"
 dependencies = [
  "bincode",
  "chrono",

--- a/crates/tokscale-cli/src/tui/mod.rs
+++ b/crates/tokscale-cli/src/tui/mod.rs
@@ -33,7 +33,9 @@ use anyhow::Result;
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture},
     execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    terminal::{
+        disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen, SetTitle,
+    },
 };
 use ratatui::prelude::*;
 use tokscale_core::ClientId;
@@ -101,8 +103,11 @@ pub fn run(
     enable_raw_mode()?;
     let mut stdout = io::stdout();
 
+    let _ = execute!(stdout, SetTitle("Tokscale"));
+
     if let Err(e) = execute!(stdout, EnterAlternateScreen, EnableMouseCapture) {
         let _ = disable_raw_mode();
+        let _ = execute!(stdout, SetTitle(""));
         return Err(e.into());
     }
 
@@ -181,7 +186,12 @@ pub fn run(
 }
 
 fn restore_terminal_best_effort() {
-    let _ = execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture);
+    let _ = execute!(
+        io::stdout(),
+        LeaveAlternateScreen,
+        DisableMouseCapture,
+        SetTitle("")
+    );
     let _ = disable_raw_mode();
 }
 
@@ -190,7 +200,8 @@ fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) {
     let _ = execute!(
         terminal.backend_mut(),
         LeaveAlternateScreen,
-        DisableMouseCapture
+        DisableMouseCapture,
+        SetTitle("")
     );
     let _ = terminal.show_cursor();
 }


### PR DESCRIPTION
## Summary
When running tokscale in TUI mode, the terminal tab title stays as the current working directory path. This PR sets the tab title to `Tokscale` when the TUI starts, and restores it to empty (shell default) on exit — including on panic.

<img width="478" height="108" alt="image" src="https://github.com/user-attachments/assets/6d16fc96-72fe-4663-9e1f-ed24d243a5ba" />

## Changes
- Added `SetTitle` to the `crossterm::terminal` import in `tui/mod.rs`
- Emit `SetTitle("Tokscale")` immediately after `enable_raw_mode()` on TUI start
- Emit `SetTitle("")` in both `restore_terminal` and `restore_terminal_best_effort` (covers normal exit and panics)

## Notes
- Uses `crossterm`'s built-in `SetTitle` command (no new dependencies)
- Works on Windows Terminal, iTerm2, xterm, and any OSC-compatible terminal

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the terminal tab title to "Tokscale" when the TUI starts, and clear it on exit to restore the shell default. Uses `crossterm`’s `SetTitle` and applies on both normal exits and panic paths.

<sup>Written for commit 4a15c4fab9eec732b3199361395cd093f5b38bb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

