### PR TITLE
fix(gemini): avoid double-counting cached input tokens

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1474,22 +1474,11 @@ fn apply_pricing_if_available(
         return;
     };
 
-    let calculated_cost = if message.client.eq_ignore_ascii_case("gemini") {
-        let usage = TokenBreakdown {
-            input: message.tokens.input,
-            output: message.tokens.output + message.tokens.reasoning,
-            cache_read: 0,
-            cache_write: 0,
-            reasoning: 0,
-        };
-        pricing.calculate_cost_with_provider(&message.model_id, Some(&message.provider_id), &usage)
-    } else {
-        pricing.calculate_cost_with_provider(
-            &message.model_id,
-            Some(&message.provider_id),
-            &message.tokens,
-        )
-    };
+    let calculated_cost = pricing.calculate_cost_with_provider(
+        &message.model_id,
+        Some(&message.provider_id),
+        &message.tokens,
+    );
 
     if calculated_cost > 0.0 {
         message.cost = calculated_cost;
@@ -3213,6 +3202,41 @@ mod tests {
         apply_pricing_if_available(&mut msg, Some(&pricing));
 
         assert_eq!(msg.cost, 0.034);
+    }
+
+    #[test]
+    fn test_apply_pricing_if_available_uses_cache_read_pricing_for_gemini() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "gemini-2.5-pro".into(),
+            pricing::ModelPricing {
+                input_cost_per_token: Some(0.001),
+                output_cost_per_token: Some(0.002),
+                cache_read_input_token_cost: Some(0.0001),
+                ..Default::default()
+            },
+        );
+        let pricing = pricing::PricingService::new(litellm, HashMap::new());
+
+        let mut msg = UnifiedMessage::new(
+            "gemini",
+            "gemini-2.5-pro",
+            "google",
+            "session-1",
+            1_733_011_200_000,
+            TokenBreakdown {
+                input: 10,
+                output: 5,
+                cache_read: 7,
+                cache_write: 0,
+                reasoning: 3,
+            },
+            0.0,
+        );
+
+        apply_pricing_if_available(&mut msg, Some(&pricing));
+
+        assert_eq!(msg.cost, 0.0267);
     }
 
     #[test]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1,7 +1,6 @@
 use crate::sessions::codex::CodexParseState;
 use crate::UnifiedMessage;
 use bincode::Options;
-use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
@@ -11,7 +10,7 @@ use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
-const CACHE_SCHEMA_VERSION: u32 = 5;
+const CACHE_SCHEMA_VERSION: u32 = 6;
 const CACHE_FILENAME: &str = "source-message-cache.bin";
 const CACHE_LOCK_FILENAME: &str = "source-message-cache.lock";
 const MAX_CACHE_FILE_BYTES: u64 = 256 * 1024 * 1024;
@@ -282,7 +281,7 @@ impl SourceMessageCache {
             Ok(file) => file,
             Err(_) => return Self::default(),
         };
-        if lock_file.lock_shared().is_err() {
+        if fs2::FileExt::lock_shared(&lock_file).is_err() {
             return Self::default();
         }
 
@@ -365,7 +364,7 @@ impl SourceMessageCache {
             Ok(file) => file,
             Err(_) => return,
         };
-        if lock_file.lock_exclusive().is_err() {
+        if fs2::FileExt::lock_exclusive(&lock_file).is_err() {
             return;
         }
 

--- a/crates/tokscale-core/src/sessions/gemini.rs
+++ b/crates/tokscale-core/src/sessions/gemini.rs
@@ -146,6 +146,14 @@ fn parse_gemini_session(session: GeminiSession, fallback_timestamp: i64) -> Vec<
             .and_then(|ts| chrono::DateTime::parse_from_rfc3339(&ts).ok())
             .map(|dt| dt.timestamp_millis())
             .unwrap_or(fallback_timestamp);
+        let (input, cache_read) = normalize_gemini_session_input_and_cache(
+            tokens.input.unwrap_or(0),
+            tokens.cached.unwrap_or(0),
+            tokens.output.unwrap_or(0),
+            tokens.thoughts.unwrap_or(0),
+            tokens.tool.unwrap_or(0),
+            tokens.total,
+        );
 
         messages.push(UnifiedMessage::new(
             "gemini",
@@ -154,9 +162,9 @@ fn parse_gemini_session(session: GeminiSession, fallback_timestamp: i64) -> Vec<
             session_id.clone(),
             timestamp,
             TokenBreakdown {
-                input: tokens.input.unwrap_or(0).max(0),
+                input,
                 output: tokens.output.unwrap_or(0).max(0),
-                cache_read: tokens.cached.unwrap_or(0).max(0),
+                cache_read,
                 cache_write: 0,
                 reasoning: tokens.thoughts.unwrap_or(0).max(0),
             },
@@ -260,6 +268,8 @@ fn build_messages_from_stats(
     usages
         .into_iter()
         .map(|usage| {
+            let (input, cache_read) =
+                normalize_gemini_headless_input_and_cache(usage.input, usage.cached);
             UnifiedMessage::new(
                 "gemini",
                 usage.model,
@@ -267,9 +277,9 @@ fn build_messages_from_stats(
                 session_id.to_string(),
                 timestamp,
                 TokenBreakdown {
-                    input: usage.input.max(0),
+                    input,
                     output: usage.output.max(0),
-                    cache_read: usage.cached.max(0),
+                    cache_read,
                     cache_write: 0,
                     reasoning: usage.reasoning.max(0),
                 },
@@ -277,6 +287,47 @@ fn build_messages_from_stats(
             )
         })
         .collect()
+}
+
+fn subtract_cached_overlap(input: i64, cached: i64) -> (i64, i64) {
+    let input = input.max(0);
+    let cached = cached.max(0);
+    let cached_portion = cached.min(input);
+    (input.saturating_sub(cached_portion), cached)
+}
+
+fn normalize_gemini_headless_input_and_cache(input: i64, cached: i64) -> (i64, i64) {
+    // Gemini usage_metadata promptTokenCount is cache-inclusive, while Tokscale
+    // represents non-cached input and cache hits as separate buckets.
+    subtract_cached_overlap(input, cached)
+}
+
+fn normalize_gemini_session_input_and_cache(
+    input: i64,
+    cached: i64,
+    output: i64,
+    reasoning: i64,
+    tool: i64,
+    total: Option<i64>,
+) -> (i64, i64) {
+    let input = input.max(0);
+    let cached = cached.max(0);
+
+    let Some(total) = total.map(|value| value.max(0)) else {
+        return (input, cached);
+    };
+
+    let inclusive_total = input
+        .saturating_add(output.max(0))
+        .saturating_add(reasoning.max(0))
+        .saturating_add(tool.max(0));
+    let exclusive_total = inclusive_total.saturating_add(cached);
+
+    if cached > 0 && total == inclusive_total && total != exclusive_total {
+        return subtract_cached_overlap(input, cached);
+    }
+
+    (input, cached)
 }
 
 struct GeminiHeadlessUsage {
@@ -450,6 +501,88 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_gemini_session_normalizes_cached_input() {
+        let json = r#"{
+            "sessionId": "ses_123",
+            "projectHash": "abc123",
+            "startTime": "2025-06-15T12:00:00Z",
+            "lastUpdated": "2025-06-15T12:30:00Z",
+            "messages": [
+                {
+                    "id": "msg_2",
+                    "timestamp": "2025-06-15T12:01:00Z",
+                    "type": "gemini",
+                    "model": "gemini-2.0-flash",
+                    "tokens": {
+                        "input": 15,
+                        "output": 20,
+                        "cached": 5,
+                        "thoughts": 2,
+                        "total": 37
+                    }
+                }
+            ]
+        }"#;
+
+        let file = tempfile::Builder::new()
+            .prefix("session-")
+            .suffix(".json")
+            .tempfile()
+            .unwrap();
+        std::fs::write(file.path(), json).unwrap();
+
+        let messages = parse_gemini_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 10);
+        assert_eq!(messages[0].tokens.output, 20);
+        assert_eq!(messages[0].tokens.cache_read, 5);
+        assert_eq!(messages[0].tokens.reasoning, 2);
+        assert_eq!(messages[0].tokens.total(), 37);
+    }
+
+    #[test]
+    fn test_parse_gemini_session_preserves_already_net_input_when_total_matches() {
+        let json = r#"{
+            "sessionId": "ses_123",
+            "projectHash": "abc123",
+            "startTime": "2025-06-15T12:00:00Z",
+            "lastUpdated": "2025-06-15T12:30:00Z",
+            "messages": [
+                {
+                    "id": "msg_2",
+                    "timestamp": "2025-06-15T12:01:00Z",
+                    "type": "gemini",
+                    "model": "gemini-2.0-flash",
+                    "tokens": {
+                        "input": 10,
+                        "output": 20,
+                        "cached": 5,
+                        "thoughts": 2,
+                        "total": 37
+                    }
+                }
+            ]
+        }"#;
+
+        let file = tempfile::Builder::new()
+            .prefix("session-")
+            .suffix(".json")
+            .tempfile()
+            .unwrap();
+        std::fs::write(file.path(), json).unwrap();
+
+        let messages = parse_gemini_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 10);
+        assert_eq!(messages[0].tokens.output, 20);
+        assert_eq!(messages[0].tokens.cache_read, 5);
+        assert_eq!(messages[0].tokens.reasoning, 2);
+        assert_eq!(messages[0].tokens.total(), 37);
+    }
+
+    #[test]
     fn test_parse_headless_json() {
         let json = r#"{"response":"Hi","stats":{"models":{"gemini-2.5-pro":{"tokens":{"prompt":12,"candidates":34,"cached":5,"thoughts":2}}}}}"#;
         // Use a legacy prefix to satisfy the path check
@@ -464,10 +597,11 @@ mod tests {
 
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].model_id, "gemini-2.5-pro");
-        assert_eq!(messages[0].tokens.input, 12);
+        assert_eq!(messages[0].tokens.input, 7);
         assert_eq!(messages[0].tokens.output, 34);
         assert_eq!(messages[0].tokens.cache_read, 5);
         assert_eq!(messages[0].tokens.reasoning, 2);
+        assert_eq!(messages[0].tokens.total(), 48);
     }
 
     #[test]
@@ -487,6 +621,47 @@ mod tests {
         assert_eq!(messages[0].model_id, "gemini-2.5-pro");
         assert_eq!(messages[0].tokens.input, 10);
         assert_eq!(messages[0].tokens.output, 20);
+    }
+
+    #[test]
+    fn test_parse_headless_stream_jsonl_normalizes_cached_input() {
+        let content = r#"{"type":"init","model":"gemini-2.5-pro","session_id":"session-1"}
+{"type":"result","stats":{"input_tokens":12,"output_tokens":20,"cached_tokens":5,"thoughts_tokens":3}}"#;
+        let mut file = tempfile::Builder::new()
+            .suffix(".jsonl")
+            .tempfile()
+            .unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        file.flush().unwrap();
+
+        let messages = parse_gemini_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gemini-2.5-pro");
+        assert_eq!(messages[0].tokens.input, 7);
+        assert_eq!(messages[0].tokens.output, 20);
+        assert_eq!(messages[0].tokens.cache_read, 5);
+        assert_eq!(messages[0].tokens.reasoning, 3);
+        assert_eq!(messages[0].tokens.total(), 35);
+    }
+
+    #[test]
+    fn test_parse_headless_json_clamps_cached_input_overlap() {
+        let json = r#"{"response":"Hi","stats":{"models":{"gemini-2.5-pro":{"tokens":{"prompt":5,"candidates":2,"cached":10}}}}}"#;
+        let file = tempfile::Builder::new()
+            .prefix("session-")
+            .suffix(".json")
+            .tempfile()
+            .unwrap();
+        std::fs::write(file.path(), json).unwrap();
+
+        let messages = parse_gemini_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 0);
+        assert_eq!(messages[0].tokens.output, 2);
+        assert_eq!(messages[0].tokens.cache_read, 10);
+        assert_eq!(messages[0].tokens.total(), 12);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- normalize Gemini cached-input accounting so cached tokens are not counted twice in usage or cost
- fix the Gemini pricing path so cache-read tokens use their own pricing bucket instead of being silently folded into paid input
- invalidate stale local source-message cache entries so existing Gemini files pick up the new parser semantics

## Why
Gemini usage metadata reports prompt/input tokens and cached tokens as separate dimensions, but Tokscale currently stores the raw prompt count as `input` and also stores the cached count as `cache_read`. That inflates Gemini token totals and can also inflate costs by treating cached tokens as full-price input. This PR fixes that correctness bug while preserving legacy session files that already store net input counts.

## Diff scope
- add safe Gemini token normalization in `crates/tokscale-core/src/sessions/gemini.rs`
- always normalize headless/API-style Gemini stats where prompt counts are cache-inclusive
- normalize legacy session JSON only when the reported `total` explicitly proves an inclusive-input shape, so already-net session files are not undercounted
- remove the Gemini-specific pricing special-case that discarded `cache_read` during cost calculation
- bump the local source-message cache schema version to invalidate stale Gemini parse results
- add regression tests for inclusive-cache stats, already-net legacy sessions, clamp edge cases, and Gemini cache-read pricing

## Test proof
- `cargo test -p tokscale-core gemini -- --nocapture`
  - `19 passed, 0 failed`
- `cargo test -p tokscale-core`
  - `tokscale-core: 524 passed, 0 failed, 1 ignored`
  - `hermes integration tests: 3 passed, 0 failed`
- `cargo clippy -p tokscale-core --all-features -- -D warnings`
  - passed
- `cargo fmt --all --check`
  - passed
- `git diff --check`
  - passed

## Verification-pack proof
Not applicable - this PR does not change CI, deployment, infrastructure, or verification-pack tooling.

## Migration notes
Not applicable - there is no database or user-data migration. This PR only bumps the local source-message cache schema version to invalidate stale Gemini parse results.

## CI context confirmation
CI context names unchanged.

## Rollback plan
- if merged with a merge commit: `git revert <merge_commit_sha>`
- if merged as a squash commit: `git revert <squash_commit_sha>`
- no DB downgrade required

## Known residual risks
- historical submissions that were already uploaded with inflated Gemini totals do not self-heal server-side; users would need a fresh local parse and resubmit if they want corrected historical submission data
- legacy session JSON without a trustworthy `total` field is left unchanged on purpose to avoid undercounting already-net input records

## Closes
- #439
