### PR TITLE
feat: add Codebuff local session support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 | <img width="48px" src=".github/assets/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `~/.gemini/tmp/*/chats/*.json` | ✅ Yes |
 | <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | API sync via `~/.config/tokscale/cursor-cache/` | ✅ Yes |
 | <img width="48px" src=".github/assets/client-amp.png" alt="Amp" /> | [Amp (AmpCode)](https://ampcode.com/) | `~/.local/share/amp/threads/` | ✅ Yes |
+| <img width="48px" src="https://avatars.githubusercontent.com/u/189203002?s=200&v=4" alt="Codebuff" /> | [Codebuff](https://codebuff.com/) | `~/.config/manicode/` (+ `manicode-dev`, `manicode-staging`; override via `CODEBUFF_DATA_DIR`) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-droid.png" alt="Droid" /> | [Droid (Factory Droid)](https://factory.ai/) | `~/.factory/sessions/` | ✅ Yes |
 | <img width="48px" src=".github/assets/client-pi.png" alt="Pi" /> | [Pi](https://github.com/badlogic/pi-mono) | `~/.pi/agent/sessions/` and `~/.omp/agent/sessions/` ([Oh My Pi](https://github.com/can1357/oh-my-pi)) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-kimi.png" alt="Kimi" /> | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) | `~/.kimi/sessions/` | ✅ Yes |
@@ -138,7 +139,7 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
   - GitHub-style contribution graph with 9 color themes
   - Real-time filtering and sorting
   - Zero flicker rendering
-- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, and Synthetic
+- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, and Synthetic
 - **Real-time pricing** - Fetches current pricing from LiteLLM with 1-hour disk cache; automatic OpenRouter fallback and Cursor model pricing for newly released models
 - **Detailed breakdowns** - Input, output, cache read/write, and reasoning token tracking
 - **Native Rust core** - All parsing and aggregation done in Rust for 10x faster processing
@@ -309,7 +310,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-Possible values: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `synthetic`.
+Possible values: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `synthetic`.
 
 > **Deprecation notice**: The legacy single-client flags (`--opencode`, `--claude`, `--codex`, etc.) still work for backward compatibility but are hidden from `--help` and will be removed in the next major release. Migrate to `--client` whenever possible. Running tokscale in an interactive terminal will print a one-line warning when a legacy flag is used.
 

--- a/crates/tokscale-cli/src/commands/wrapped.rs
+++ b/crates/tokscale-cli/src/commands/wrapped.rs
@@ -1387,7 +1387,7 @@ fn client_logo_url(client_name: &str) -> Option<&'static str> {
         "Gemini CLI" => Some("https://tokscale.ai/assets/logos/gemini.png"),
         "Cursor IDE" => Some("https://tokscale.ai/assets/logos/cursor.jpg"),
         "Amp" => Some("https://tokscale.ai/assets/logos/amp.png"),
-        "Codebuff" => Some("https://tokscale.ai/assets/logos/codebuff.png"),
+        "Codebuff" => Some("https://avatars.githubusercontent.com/u/189203002?s=200&v=4"),
         "Droid" => Some("https://tokscale.ai/assets/logos/droid.png"),
         "OpenClaw" => Some("https://tokscale.ai/assets/logos/openclaw.png"),
         "Hermes Agent" => Some("https://tokscale.ai/assets/logos/hermes.png"),
@@ -2344,7 +2344,7 @@ mod tests {
     fn test_client_logo_url_codebuff() {
         assert_eq!(
             client_logo_url("Codebuff"),
-            Some("https://tokscale.ai/assets/logos/codebuff.png")
+            Some("https://avatars.githubusercontent.com/u/189203002?s=200&v=4")
         );
     }
 

--- a/crates/tokscale-cli/src/commands/wrapped.rs
+++ b/crates/tokscale-cli/src/commands/wrapped.rs
@@ -1358,6 +1358,7 @@ fn client_display_name(client: &str) -> Option<&'static str> {
         "gemini" => Some("Gemini CLI"),
         s if s == ClientId::Cursor.as_str() => Some("Cursor IDE"),
         "amp" => Some("Amp"),
+        "codebuff" => Some("Codebuff"),
         "droid" => Some("Droid"),
         "openclaw" => Some("OpenClaw"),
         "hermes" => Some("Hermes Agent"),
@@ -1386,6 +1387,7 @@ fn client_logo_url(client_name: &str) -> Option<&'static str> {
         "Gemini CLI" => Some("https://tokscale.ai/assets/logos/gemini.png"),
         "Cursor IDE" => Some("https://tokscale.ai/assets/logos/cursor.jpg"),
         "Amp" => Some("https://tokscale.ai/assets/logos/amp.png"),
+        "Codebuff" => Some("https://tokscale.ai/assets/logos/codebuff.png"),
         "Droid" => Some("https://tokscale.ai/assets/logos/droid.png"),
         "OpenClaw" => Some("https://tokscale.ai/assets/logos/openclaw.png"),
         "Hermes Agent" => Some("https://tokscale.ai/assets/logos/hermes.png"),
@@ -1741,6 +1743,7 @@ fn default_clients() -> Vec<String> {
         "gemini".to_string(),
         ClientId::Cursor.as_str().to_string(),
         "amp".to_string(),
+        "codebuff".to_string(),
         "droid".to_string(),
         "openclaw".to_string(),
         "hermes".to_string(),
@@ -2209,6 +2212,11 @@ mod tests {
     }
 
     #[test]
+    fn test_client_display_name_codebuff() {
+        assert_eq!(client_display_name("codebuff"), Some("Codebuff"));
+    }
+
+    #[test]
     fn test_client_display_name_pi() {
         assert_eq!(client_display_name("pi"), Some("Pi"));
     }
@@ -2234,6 +2242,12 @@ mod tests {
     fn test_default_clients_includes_hermes() {
         let clients = default_clients();
         assert!(clients.iter().any(|client| client == "hermes"));
+    }
+
+    #[test]
+    fn test_default_clients_includes_codebuff() {
+        let clients = default_clients();
+        assert!(clients.iter().any(|client| client == "codebuff"));
     }
 
     #[test]
@@ -2323,6 +2337,14 @@ mod tests {
         assert_eq!(
             client_logo_url("Hermes Agent"),
             Some("https://tokscale.ai/assets/logos/hermes.png")
+        );
+    }
+
+    #[test]
+    fn test_client_logo_url_codebuff() {
+        assert_eq!(
+            client_logo_url("Codebuff"),
+            Some("https://tokscale.ai/assets/logos/codebuff.png")
         );
     }
 

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -608,6 +608,7 @@ pub enum ClientFilter {
     Hermes,
     Copilot,
     Goose,
+    Codebuff,
     Synthetic,
 }
 
@@ -636,6 +637,7 @@ impl ClientFilter {
             Self::Hermes => "hermes",
             Self::Copilot => "copilot",
             Self::Goose => "goose",
+            Self::Codebuff => "codebuff",
             Self::Synthetic => "synthetic",
         }
     }
@@ -667,6 +669,7 @@ impl ClientFilter {
             Self::Hermes => Some(ClientId::Hermes),
             Self::Copilot => Some(ClientId::Copilot),
             Self::Goose => Some(ClientId::Goose),
+            Self::Codebuff => Some(ClientId::Codebuff),
             Self::Synthetic => None,
         }
     }
@@ -695,6 +698,7 @@ impl ClientFilter {
             ClientId::Hermes => Self::Hermes,
             ClientId::Copilot => Self::Copilot,
             ClientId::Goose => Self::Goose,
+            ClientId::Codebuff => Self::Codebuff,
         }
     }
 
@@ -760,6 +764,8 @@ pub struct ClientFlags {
     pub cursor: bool,
     #[arg(long, hide = true)]
     pub amp: bool,
+    #[arg(long, hide = true)]
+    pub codebuff: bool,
     #[arg(long, hide = true)]
     pub droid: bool,
     #[arg(long, hide = true)]
@@ -838,13 +844,14 @@ fn build_client_filter_with_defaults(
         }
     }
 
-    let legacy: [(bool, ClientFilter); 20] = [
+    let legacy: [(bool, ClientFilter); 21] = [
         (flags.opencode, ClientFilter::Opencode),
         (flags.claude, ClientFilter::Claude),
         (flags.codex, ClientFilter::Codex),
         (flags.cursor, ClientFilter::Cursor),
         (flags.gemini, ClientFilter::Gemini),
         (flags.amp, ClientFilter::Amp),
+        (flags.codebuff, ClientFilter::Codebuff),
         (flags.droid, ClientFilter::Droid),
         (flags.openclaw, ClientFilter::Openclaw),
         (flags.pi, ClientFilter::Pi),
@@ -2570,6 +2577,7 @@ fn capitalize_client(client: &str) -> String {
         "cursor" => "Cursor".to_string(),
         "gemini" => "Gemini".to_string(),
         "amp" => "Amp".to_string(),
+        "codebuff" => "Codebuff".to_string(),
         "droid" => "Droid".to_string(),
         "crush" => "Crush".to_string(),
         "openclaw" => "openclaw".to_string(),
@@ -4228,6 +4236,7 @@ mod tests {
             gemini: true,
             cursor: true,
             amp: true,
+            codebuff: true,
             droid: true,
             openclaw: true,
             hermes: true,
@@ -4257,6 +4266,7 @@ mod tests {
             "gemini",
             "cursor",
             "amp",
+            "codebuff",
             "droid",
             "openclaw",
             "hermes",
@@ -4868,6 +4878,11 @@ mod tests {
     #[test]
     fn test_capitalize_client_hermes() {
         assert_eq!(capitalize_client("hermes"), "Hermes Agent");
+    }
+
+    #[test]
+    fn test_capitalize_client_codebuff() {
+        assert_eq!(capitalize_client("codebuff"), "Codebuff");
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/client_ui.rs
+++ b/crates/tokscale-cli/src/tui/client_ui.rs
@@ -82,6 +82,10 @@ pub const CLIENT_UI: [ClientUi; ClientId::COUNT] = [
         display_name: "Goose",
         hotkey: 'o',
     },
+    ClientUi {
+        display_name: "Codebuff",
+        hotkey: 'b',
+    },
 ];
 
 pub fn display_name(client: ClientId) -> &'static str {

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -1150,6 +1150,7 @@ mod tests {
         assert_eq!(clients[15], ClientId::Crush);
         assert_eq!(clients[16], ClientId::Hermes);
         assert_eq!(clients[17], ClientId::Copilot);
+        assert_eq!(clients[18], ClientId::Codebuff);
     }
 
     #[test]
@@ -1211,6 +1212,10 @@ mod tests {
             crate::tui::client_ui::display_name(ClientId::Hermes),
             "Hermes Agent"
         );
+        assert_eq!(
+            crate::tui::client_ui::display_name(ClientId::Codebuff),
+            "Codebuff"
+        );
     }
 
     #[test]
@@ -1233,6 +1238,7 @@ mod tests {
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Kilo), 'l');
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Crush), 'h');
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Hermes), 'e');
+        assert_eq!(crate::tui::client_ui::hotkey(ClientId::Codebuff), 'b');
     }
 
     #[test]
@@ -1299,6 +1305,10 @@ mod tests {
         assert_eq!(
             crate::tui::client_ui::from_hotkey('e'),
             Some(ClientId::Hermes)
+        );
+        assert_eq!(
+            crate::tui::client_ui::from_hotkey('b'),
+            Some(ClientId::Codebuff)
         );
         assert_eq!(crate::tui::client_ui::from_hotkey('a'), None);
     }

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -1131,7 +1131,7 @@ mod tests {
     #[test]
     fn test_client_all() {
         let clients = ClientId::ALL;
-        assert_eq!(clients.len(), 19);
+        assert_eq!(clients.len(), 20);
         assert_eq!(clients[0], ClientId::OpenCode);
         assert_eq!(clients[1], ClientId::Claude);
         assert_eq!(clients[2], ClientId::Codex);
@@ -1150,7 +1150,8 @@ mod tests {
         assert_eq!(clients[15], ClientId::Crush);
         assert_eq!(clients[16], ClientId::Hermes);
         assert_eq!(clients[17], ClientId::Copilot);
-        assert_eq!(clients[18], ClientId::Codebuff);
+        assert_eq!(clients[18], ClientId::Goose);
+        assert_eq!(clients[19], ClientId::Codebuff);
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/mod.rs
+++ b/crates/tokscale-cli/src/tui/mod.rs
@@ -323,6 +323,7 @@ pub fn test_data_loading() -> Result<()> {
         ClientId::Mux,
         ClientId::Crush,
         ClientId::Hermes,
+        ClientId::Codebuff,
     ];
 
     let data = loader.load(&all_clients, &tokscale_core::GroupBy::default(), false)?;

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -229,17 +229,18 @@ pub fn get_client_color(client: &str) -> Color {
         return color;
     }
     match client.to_lowercase().as_str() {
-        "opencode" => Color::Rgb(34, 197, 94), // #22c55e
-        "claude" => Color::Rgb(218, 119, 86),  // #DA7756 Claude brand coral
-        "codex" => Color::Rgb(59, 130, 246),   // #3b82f6
-        "cursor" => Color::Rgb(168, 85, 247),  // #a855f7
-        "gemini" => Color::Rgb(6, 182, 212),   // #06b6d4
-        "amp" => Color::Rgb(236, 72, 153),     // #EC4899
-        "droid" => Color::Rgb(16, 185, 129),   // #10b981
-        "openclaw" => Color::Rgb(239, 68, 68), // #ef4444
-        "hermes" => Color::Rgb(255, 215, 0),   // #ffd700
-        "goose" => Color::Rgb(100, 180, 220),  // #64b4dc
-        _ => Color::Rgb(136, 136, 136),        // #888888
+        "opencode" => Color::Rgb(34, 197, 94),  // #22c55e
+        "claude" => Color::Rgb(218, 119, 86),   // #DA7756 Claude brand coral
+        "codex" => Color::Rgb(59, 130, 246),    // #3b82f6
+        "cursor" => Color::Rgb(168, 85, 247),   // #a855f7
+        "gemini" => Color::Rgb(6, 182, 212),    // #06b6d4
+        "amp" => Color::Rgb(236, 72, 153),      // #EC4899
+        "droid" => Color::Rgb(16, 185, 129),    // #10b981
+        "openclaw" => Color::Rgb(239, 68, 68),  // #ef4444
+        "hermes" => Color::Rgb(255, 215, 0),    // #ffd700
+        "goose" => Color::Rgb(100, 180, 220),   // #64b4dc
+        "codebuff" => Color::Rgb(124, 58, 237), // #7C3AED Codebuff brand purple
+        _ => Color::Rgb(136, 136, 136),         // #888888
     }
 }
 

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -310,6 +310,18 @@ define_clients!(
         headless: false,
         parse_local: true,
         submit_default: true
+    },
+    Codebuff = 19 => {
+        id: "codebuff",
+        root: PathRoot::EnvVar {
+            var: "CODEBUFF_DATA_DIR",
+            fallback_relative: ".config/manicode",
+        },
+        relative: "projects",
+        pattern: "chat-messages.json",
+        headless: false,
+        parse_local: true,
+        submit_default: true
     }
 );
 
@@ -362,7 +374,7 @@ mod tests {
 
     #[test]
     fn test_client_id_count() {
-        assert_eq!(ClientId::COUNT, 19);
+        assert_eq!(ClientId::COUNT, 20);
     }
 
     #[test]
@@ -534,5 +546,17 @@ mod tests {
             }
         );
         assert_eq!(ClientId::Hermes.data().relative_path, "state.db");
+    }
+
+    #[test]
+    fn test_codebuff_root_uses_codebuff_data_dir_env_var() {
+        assert_eq!(
+            ClientId::Codebuff.data().root,
+            PathRoot::EnvVar {
+                var: "CODEBUFF_DATA_DIR",
+                fallback_relative: ".config/manicode",
+            }
+        );
+        assert_eq!(ClientId::Codebuff.data().pattern, "chat-messages.json");
     }
 }

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -818,6 +818,22 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         }
     }
 
+    let codebuff_outcomes: Vec<CachedParseOutcome> = scan_result
+        .get(ClientId::Codebuff)
+        .par_iter()
+        .map(|path| {
+            load_or_parse_source(path, &source_cache, pricing, |path| {
+                sessions::codebuff::parse_codebuff_file(path)
+            })
+        })
+        .collect();
+    for outcome in codebuff_outcomes {
+        all_messages.extend(outcome.messages);
+        if let Some(entry) = outcome.cache_entry {
+            source_cache.insert(entry);
+        }
+    }
+
     let droid_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::Droid)
         .par_iter()
@@ -1716,6 +1732,20 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     let amp_count = amp_msgs.len() as i32;
     counts.set(ClientId::Amp, amp_count);
     messages.extend(amp_msgs);
+
+    let codebuff_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::Codebuff)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::codebuff::parse_codebuff_file(path)
+                .into_iter()
+                .map(|msg| unified_to_parsed(&msg))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let codebuff_count = codebuff_msgs.len() as i32;
+    counts.set(ClientId::Codebuff, codebuff_count);
+    messages.extend(codebuff_msgs);
 
     let droid_msgs: Vec<ParsedMessage> = scan_result
         .get(ClientId::Droid)

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -227,6 +227,7 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
                 "wire.jsonl" => file_name == "wire.jsonl",
                 "ui_messages.json" => file_name == "ui_messages.json",
                 "session-usage.json" => file_name == "session-usage.json",
+                "chat-messages.json" => file_name == "chat-messages.json",
                 _ => false,
             }
         })
@@ -575,6 +576,7 @@ fn scan_all_clients_with_env_strategy_inner(
                 | ClientId::Hermes
                 | ClientId::Goose
                 | ClientId::Crush
+                | ClientId::Codebuff
         ) {
             continue;
         }
@@ -851,6 +853,37 @@ fn scan_all_clients_with_env_strategy_inner(
 
     if enabled.contains(&ClientId::Crush) {
         result.crush_dbs = discover_crush_dbs(home_dir, use_env_roots);
+    }
+
+    if enabled.contains(&ClientId::Codebuff) {
+        // Codebuff persists per-channel chat history under
+        // ~/.config/<channel>/projects/<project>/chats/<chatId>/chat-messages.json.
+        // When CODEBUFF_DATA_DIR is set (via PathRoot::EnvVar), scan only that root;
+        // otherwise walk the three known channel roots:
+        //   - ~/.config/manicode (primary / legacy name — Codebuff was "Manicode")
+        //   - ~/.config/manicode-dev
+        //   - ~/.config/manicode-staging
+        let env_override = if use_env_roots {
+            std::env::var("CODEBUFF_DATA_DIR").ok()
+        } else {
+            None
+        };
+
+        let mut codebuff_roots: Vec<String> = Vec::new();
+        if let Some(root) = env_override {
+            if !root.trim().is_empty() {
+                codebuff_roots.push(format!("{}/projects", root.trim_end_matches('/')));
+            }
+        } else {
+            let config_dir = format!("{}/.config", home_dir);
+            for channel in ["manicode", "manicode-dev", "manicode-staging"] {
+                codebuff_roots.push(format!("{}/{}/projects", config_dir, channel));
+            }
+        }
+
+        for root in codebuff_roots {
+            push_unique_scan_task(&mut tasks, &mut seen_scan_roots, ClientId::Codebuff, root);
+        }
     }
 
     // Execute scans in parallel

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -858,22 +858,25 @@ fn scan_all_clients_with_env_strategy_inner(
     if enabled.contains(&ClientId::Codebuff) {
         // Codebuff persists per-channel chat history under
         // ~/.config/<channel>/projects/<project>/chats/<chatId>/chat-messages.json.
-        // When CODEBUFF_DATA_DIR is set (via PathRoot::EnvVar), scan only that root;
-        // otherwise walk the three known channel roots:
+        // When CODEBUFF_DATA_DIR is set to a non-empty value (via
+        // PathRoot::EnvVar), scan only that root; otherwise — including when
+        // the env var is unset *or* set to an empty/whitespace string — walk
+        // the three known channel roots:
         //   - ~/.config/manicode (primary / legacy name — Codebuff was "Manicode")
         //   - ~/.config/manicode-dev
         //   - ~/.config/manicode-staging
-        let env_override = if use_env_roots {
-            std::env::var("CODEBUFF_DATA_DIR").ok()
+        let trimmed_override = if use_env_roots {
+            std::env::var("CODEBUFF_DATA_DIR")
+                .ok()
+                .map(|v| v.trim().to_string())
+                .filter(|v| !v.is_empty())
         } else {
             None
         };
 
         let mut codebuff_roots: Vec<String> = Vec::new();
-        if let Some(root) = env_override {
-            if !root.trim().is_empty() {
-                codebuff_roots.push(format!("{}/projects", root.trim_end_matches('/')));
-            }
+        if let Some(root) = trimmed_override {
+            codebuff_roots.push(format!("{}/projects", root.trim_end_matches('/')));
         } else {
             let config_dir = format!("{}/.config", home_dir);
             for channel in ["manicode", "manicode-dev", "manicode-staging"] {
@@ -2329,6 +2332,93 @@ mod tests {
         assert_eq!(result.get(ClientId::Claude).len(), 2);
 
         restore_env("TOKSCALE_EXTRA_DIRS", previous);
+    }
+
+    fn setup_mock_codebuff_chat(base: &Path, channel: &str, chat_id: &str) -> PathBuf {
+        let chat_dir = base
+            .join(".config")
+            .join(channel)
+            .join("projects")
+            .join("sandbox")
+            .join("chats")
+            .join(chat_id);
+        fs::create_dir_all(&chat_dir).unwrap();
+        let file_path = chat_dir.join("chat-messages.json");
+        let mut file = File::create(&file_path).unwrap();
+        writeln!(file, "[]").unwrap();
+        file_path
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_codebuff_walks_all_three_channels_by_default() {
+        let previous = std::env::var("CODEBUFF_DATA_DIR").ok();
+        unsafe { std::env::remove_var("CODEBUFF_DATA_DIR") };
+
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_codebuff_chat(home, "manicode", "2025-12-14T10-00-00.000Z");
+        setup_mock_codebuff_chat(home, "manicode-dev", "2025-12-14T11-00-00.000Z");
+        setup_mock_codebuff_chat(home, "manicode-staging", "2025-12-14T12-00-00.000Z");
+
+        let result =
+            scan_all_clients(home.to_str().unwrap(), &["codebuff".to_string()]);
+        assert_eq!(result.get(ClientId::Codebuff).len(), 3);
+
+        restore_env("CODEBUFF_DATA_DIR", previous);
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_codebuff_empty_env_var_falls_back_to_default_channels() {
+        let previous = std::env::var("CODEBUFF_DATA_DIR").ok();
+        // Regression: a whitespace-only override used to produce zero scan
+        // roots because the `Some(_)` branch was taken and then skipped.
+        unsafe { std::env::set_var("CODEBUFF_DATA_DIR", "   ") };
+
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_codebuff_chat(home, "manicode", "2025-12-14T10-00-00.000Z");
+        setup_mock_codebuff_chat(home, "manicode-dev", "2025-12-14T11-00-00.000Z");
+
+        let result =
+            scan_all_clients(home.to_str().unwrap(), &["codebuff".to_string()]);
+        assert_eq!(result.get(ClientId::Codebuff).len(), 2);
+
+        restore_env("CODEBUFF_DATA_DIR", previous);
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_codebuff_honours_explicit_env_override() {
+        let previous = std::env::var("CODEBUFF_DATA_DIR").ok();
+
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        // Default-channel data that should NOT be picked up when the env is set.
+        setup_mock_codebuff_chat(home, "manicode", "2025-12-14T10-00-00.000Z");
+        // Override target (lives OUTSIDE ~/.config to prove the override wins).
+        let override_root = dir.path().join("custom-codebuff");
+        let override_chat_dir = override_root
+            .join("projects")
+            .join("sandbox")
+            .join("chats")
+            .join("2025-12-14T11-00-00.000Z");
+        fs::create_dir_all(&override_chat_dir).unwrap();
+        File::create(override_chat_dir.join("chat-messages.json")).unwrap();
+
+        unsafe {
+            std::env::set_var("CODEBUFF_DATA_DIR", override_root.to_string_lossy().as_ref())
+        };
+
+        let result =
+            scan_all_clients(home.to_str().unwrap(), &["codebuff".to_string()]);
+        assert_eq!(result.get(ClientId::Codebuff).len(), 1);
+        assert!(result.get(ClientId::Codebuff)[0]
+            .to_string_lossy()
+            .contains("custom-codebuff"));
+
+        restore_env("CODEBUFF_DATA_DIR", previous);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/codebuff.rs
+++ b/crates/tokscale-core/src/sessions/codebuff.rs
@@ -69,10 +69,21 @@ pub fn parse_codebuff_file(path: &Path) -> Vec<UnifiedMessage> {
             .model
             .clone()
             .unwrap_or_else(|| DEFAULT_MODEL.to_string());
-        let provider =
-            provider_identity::inferred_provider_from_model(&model).unwrap_or("anthropic");
+        // Fall back to a neutral provider when we cannot infer one from the
+        // model id. Codebuff routes calls across multiple providers, so
+        // hardcoding "anthropic" would skew per-provider stats for any
+        // token-bearing message that lacks a recognizable model hint.
+        let provider = provider_identity::inferred_provider_from_model(&model).unwrap_or("unknown");
 
-        results.push(UnifiedMessage::new(
+        // Stable dedup key so the same chat history scanned from multiple
+        // roots (or re-imported into a parallel channel) is not double
+        // counted. Prefer the upstream ChatMessage `id`; otherwise derive a
+        // deterministic key from the session, timestamp, model and token
+        // shape so identical re-imports collapse to a single record.
+        let dedup_key = upstream_message_id(msg)
+            .unwrap_or_else(|| derive_dedup_key(&session_id, ts, &model, &usage));
+
+        results.push(UnifiedMessage::new_with_dedup(
             "codebuff",
             &model,
             provider,
@@ -86,10 +97,34 @@ pub fn parse_codebuff_file(path: &Path) -> Vec<UnifiedMessage> {
                 reasoning: 0,
             },
             usage.credits.max(0.0),
+            Some(dedup_key),
         ));
     }
 
     results
+}
+
+/// Extract the upstream `ChatMessage.id` if present, so dedup keys remain
+/// stable across re-imports of the same chat history.
+fn upstream_message_id(msg: &Value) -> Option<String> {
+    msg.get("id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+/// Build a deterministic fallback dedup key for messages that don't expose
+/// a stable upstream id. Combines the session, timestamp, model and full
+/// token breakdown so two structurally identical messages collapse, while
+/// genuinely different messages stay distinct.
+fn derive_dedup_key(session_id: &str, ts: i64, model: &str, usage: &AssistantUsage) -> String {
+    format!(
+        "codebuff:{session_id}:{ts}:{model}:{i}:{o}:{cr}:{cw}",
+        i = usage.input_tokens.max(0),
+        o = usage.output_tokens.max(0),
+        cr = usage.cache_read_input_tokens.max(0),
+        cw = usage.cache_creation_input_tokens.max(0),
+    )
 }
 
 /// Convert a filesystem-safe `chatId` back to epoch milliseconds.
@@ -264,7 +299,10 @@ fn extract_usage_from_run_state(metadata: &Value) -> Option<AssistantUsage> {
         if let Some(u) = provider_options.get("usage") {
             usage.merge_fallback(parse_usage_object(u));
         }
-        if let Some(u) = provider_options.get("codebuff").and_then(|c| c.get("usage")) {
+        if let Some(u) = provider_options
+            .get("codebuff")
+            .and_then(|c| c.get("usage"))
+        {
             usage.merge_fallback(parse_usage_object(u));
         }
         if let Some(model) = provider_options
@@ -288,7 +326,12 @@ fn parse_usage_object(value: &Value) -> AssistantUsage {
 
     let input = pick_number(
         value,
-        &["inputTokens", "input_tokens", "promptTokens", "prompt_tokens"],
+        &[
+            "inputTokens",
+            "input_tokens",
+            "promptTokens",
+            "prompt_tokens",
+        ],
     );
     let output = pick_number(
         value,

--- a/crates/tokscale-core/src/sessions/codebuff.rs
+++ b/crates/tokscale-core/src/sessions/codebuff.rs
@@ -42,7 +42,7 @@ pub fn parse_codebuff_file(path: &Path) -> Vec<UnifiedMessage> {
     let (channel, project_basename, chat_id) = derive_context_from_path(path);
     let session_id = format!("{}/{}/{}", channel, project_basename, chat_id);
 
-    let chat_id_ts = parse_timestamp_str(&chat_id.replace('-', ":")).unwrap_or(0);
+    let chat_id_ts = parse_chat_id_to_millis(&chat_id).unwrap_or(0);
     let file_mtime_ms = file_modified_timestamp_ms(path);
 
     let mut results = Vec::new();
@@ -90,6 +90,26 @@ pub fn parse_codebuff_file(path: &Path) -> Vec<UnifiedMessage> {
     }
 
     results
+}
+
+/// Convert a filesystem-safe `chatId` back to epoch milliseconds.
+///
+/// Codebuff's `chatId` is the chat's ISO-8601 timestamp with the three `:`
+/// separators in the time portion (`HH:MM:SS`) replaced by `-` for cross-
+/// platform filesystem safety (e.g. `2025-12-14T10-00-00.000Z`). Only the
+/// separators *after* the `T` need to be flipped back to `:`; the date
+/// portion retains its normal `-` separators. A naive global
+/// `chat_id.replace('-', ":")` corrupts the date to `2025:12:14T...` and
+/// makes RFC3339 parsing fail silently.
+fn parse_chat_id_to_millis(chat_id: &str) -> Option<i64> {
+    let t_index = chat_id.find('T')?;
+    let (date, time_with_separator) = chat_id.split_at(t_index);
+    // `time_with_separator` starts with 'T'; rebuild "<date>T<HH:MM:SS...>".
+    let rebuilt = format!("{}{}", date, time_with_separator.replacen('-', ":", 2));
+    // We only touch the two time separators (`HH:MM` and `MM:SS`); any
+    // leftover `-` afterwards belongs to the millisecond/timezone portion
+    // (e.g. `2025-12-14T10:00:00.000+00:00`) and must stay intact.
+    parse_timestamp_str(&rebuilt)
 }
 
 /// Walks up a `chat-messages.json` file path and returns
@@ -456,6 +476,25 @@ mod tests {
         assert!(is_assistant_role(&ai));
         assert!(is_assistant_role(&assistant));
         assert!(!is_assistant_role(&user));
+    }
+
+    #[test]
+    fn test_parse_chat_id_to_millis_restores_time_separators_without_touching_date() {
+        // 2025-12-14T10:00:00.000Z == 1 765 706 400 000 ms
+        let expected = 1_765_706_400_000_i64;
+        let parsed = parse_chat_id_to_millis("2025-12-14T10-00-00.000Z").unwrap();
+        assert_eq!(parsed, expected);
+
+        // A global `-`→`:` replace would corrupt this to "2025:12:14T..." and
+        // return None. Guarding against that regression here.
+        let broken = "2025-12-14T10-00-00.000Z".replace('-', ":");
+        assert!(parse_timestamp_str(&broken).is_none());
+    }
+
+    #[test]
+    fn test_parse_chat_id_to_millis_returns_none_for_garbage() {
+        assert!(parse_chat_id_to_millis("not-a-chat-id").is_none());
+        assert!(parse_chat_id_to_millis("").is_none());
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/codebuff.rs
+++ b/crates/tokscale-core/src/sessions/codebuff.rs
@@ -294,7 +294,9 @@ fn extract_usage_from_run_state(metadata: &Value) -> Option<AssistantUsage> {
         if role != "assistant" {
             continue;
         }
-        let provider_options = entry.get("providerOptions")?;
+        let Some(provider_options) = entry.get("providerOptions") else {
+            continue;
+        };
         let mut usage = AssistantUsage::default();
         if let Some(u) = provider_options.get("usage") {
             usage.merge_fallback(parse_usage_object(u));

--- a/crates/tokscale-core/src/sessions/codebuff.rs
+++ b/crates/tokscale-core/src/sessions/codebuff.rs
@@ -1,0 +1,505 @@
+//! Codebuff (formerly Manicode) session parser
+//!
+//! Codebuff persists chat history under `~/.config/manicode/projects/<project>/
+//! chats/<chatId>/`:
+//!
+//! - `chat-messages.json` – serialized ChatMessage[]; assistant messages carry
+//!   token usage on `metadata.usage`, `metadata.codebuff.usage`, or (for
+//!   provider-routed calls) `metadata.runState.sessionState.mainAgentState.
+//!   messageHistory[*].providerOptions`.
+//! - `run-state.json` – SDK RunState snapshot (not consumed here).
+//!
+//! Dev and staging channels use the same layout under `manicode-dev` and
+//! `manicode-staging` roots. `chatId` is the chat's ISO-8601 timestamp with
+//! `:` replaced by `-` for filesystem safety (e.g. `2025-12-14T10-00-00.000Z`).
+
+use super::utils::{
+    file_modified_timestamp_ms, parse_timestamp_str, parse_timestamp_value, read_file_or_none,
+};
+use super::UnifiedMessage;
+use crate::{provider_identity, TokenBreakdown};
+use serde_json::Value;
+use std::path::Path;
+
+const DEFAULT_MODEL: &str = "codebuff-unknown";
+
+/// Parse a single `chat-messages.json` file into UnifiedMessages.
+pub fn parse_codebuff_file(path: &Path) -> Vec<UnifiedMessage> {
+    let Some(bytes) = read_file_or_none(path) else {
+        return Vec::new();
+    };
+    let mut bytes = bytes;
+    let root: Value = match simd_json::from_slice(&mut bytes) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+
+    let messages = match root.as_array() {
+        Some(arr) => arr,
+        None => return Vec::new(),
+    };
+
+    let (channel, project_basename, chat_id) = derive_context_from_path(path);
+    let session_id = format!("{}/{}/{}", channel, project_basename, chat_id);
+
+    let chat_id_ts = parse_timestamp_str(&chat_id.replace('-', ":")).unwrap_or(0);
+    let file_mtime_ms = file_modified_timestamp_ms(path);
+
+    let mut results = Vec::new();
+    for msg in messages {
+        if !is_assistant_role(msg) {
+            continue;
+        }
+
+        let usage = extract_assistant_usage(msg);
+        if !usage.has_signal() {
+            continue;
+        }
+
+        let chat_id_fallback = if chat_id_ts > 0 {
+            Some(chat_id_ts)
+        } else {
+            None
+        };
+        let ts = message_timestamp(msg)
+            .or(chat_id_fallback)
+            .unwrap_or(file_mtime_ms);
+
+        let model = usage
+            .model
+            .clone()
+            .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+        let provider =
+            provider_identity::inferred_provider_from_model(&model).unwrap_or("anthropic");
+
+        results.push(UnifiedMessage::new(
+            "codebuff",
+            &model,
+            provider,
+            &session_id,
+            ts,
+            TokenBreakdown {
+                input: usage.input_tokens.max(0),
+                output: usage.output_tokens.max(0),
+                cache_read: usage.cache_read_input_tokens.max(0),
+                cache_write: usage.cache_creation_input_tokens.max(0),
+                reasoning: 0,
+            },
+            usage.credits.max(0.0),
+        ));
+    }
+
+    results
+}
+
+/// Walks up a `chat-messages.json` file path and returns
+/// `(channel, project_basename, chat_id)` by reading the three relevant
+/// ancestor directory names. Missing ancestors fall back to empty strings so
+/// that malformed layouts still produce a deterministic (but lossy) session
+/// identifier instead of panicking.
+fn derive_context_from_path(path: &Path) -> (String, String, String) {
+    let chat_id = path
+        .parent()
+        .and_then(|p| p.file_name())
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    // chats/<chatId>/chat-messages.json → jump up to projects/<project>/chats
+    let chats_dir = path.parent().and_then(|p| p.parent());
+    let project_basename = chats_dir
+        .and_then(|p| p.parent())
+        .and_then(|p| p.file_name())
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    // ../<project>/chats/<chatId>/ → projects dir’s parent is the channel root
+    let channel = chats_dir
+        .and_then(|p| p.parent()) // project dir
+        .and_then(|p| p.parent()) // "projects"
+        .and_then(|p| p.parent()) // channel root (e.g. manicode[-dev])
+        .and_then(|p| p.file_name())
+        .and_then(|s| s.to_str())
+        .unwrap_or("manicode")
+        .to_string();
+
+    (channel, project_basename, chat_id)
+}
+
+fn is_assistant_role(msg: &Value) -> bool {
+    let variant = msg
+        .get("variant")
+        .and_then(|v| v.as_str())
+        .or_else(|| msg.get("role").and_then(|v| v.as_str()))
+        .unwrap_or("");
+    matches!(variant, "ai" | "agent" | "assistant")
+}
+
+fn message_timestamp(msg: &Value) -> Option<i64> {
+    for key in ["timestamp", "createdAt"] {
+        if let Some(v) = msg.get(key) {
+            if let Some(ts) = parse_timestamp_value(v) {
+                return Some(ts);
+            }
+        }
+    }
+    if let Some(meta_ts) = msg.get("metadata").and_then(|m| m.get("timestamp")) {
+        return parse_timestamp_value(meta_ts);
+    }
+    None
+}
+
+#[derive(Default, Debug, Clone)]
+struct AssistantUsage {
+    model: Option<String>,
+    credits: f64,
+    input_tokens: i64,
+    output_tokens: i64,
+    cache_read_input_tokens: i64,
+    cache_creation_input_tokens: i64,
+}
+
+impl AssistantUsage {
+    fn has_signal(&self) -> bool {
+        self.input_tokens > 0
+            || self.output_tokens > 0
+            || self.cache_read_input_tokens > 0
+            || self.cache_creation_input_tokens > 0
+            || self.credits > 0.0
+    }
+
+    fn merge_fallback(&mut self, other: AssistantUsage) {
+        if self.input_tokens <= 0 {
+            self.input_tokens = other.input_tokens;
+        }
+        if self.output_tokens <= 0 {
+            self.output_tokens = other.output_tokens;
+        }
+        if self.cache_read_input_tokens <= 0 {
+            self.cache_read_input_tokens = other.cache_read_input_tokens;
+        }
+        if self.cache_creation_input_tokens <= 0 {
+            self.cache_creation_input_tokens = other.cache_creation_input_tokens;
+        }
+        if self.model.is_none() {
+            self.model = other.model;
+        }
+        if self.credits <= 0.0 {
+            self.credits = other.credits;
+        }
+    }
+}
+
+/// Extract assistant usage trying, in order: `metadata.usage`,
+/// `metadata.codebuff.usage`, and the stashed RunState message history (which
+/// is where OpenRouter-routed calls land their final token counts).
+fn extract_assistant_usage(msg: &Value) -> AssistantUsage {
+    let metadata = msg.get("metadata");
+
+    let mut usage = AssistantUsage::default();
+
+    if let Some(meta) = metadata {
+        if let Some(model) = meta.get("model").and_then(|v| v.as_str()) {
+            usage.model = Some(model.to_string());
+        }
+        if let Some(u) = meta.get("usage") {
+            usage.merge_fallback(parse_usage_object(u));
+        }
+        if let Some(u) = meta.get("codebuff").and_then(|c| c.get("usage")) {
+            usage.merge_fallback(parse_usage_object(u));
+        }
+        if let Some(run_state_usage) = extract_usage_from_run_state(meta) {
+            usage.merge_fallback(run_state_usage);
+        }
+    }
+
+    if let Some(credits) = msg.get("credits").and_then(|v| v.as_f64()) {
+        if credits > 0.0 && usage.credits <= 0.0 {
+            usage.credits = credits;
+        }
+    }
+
+    usage
+}
+
+/// Find the last assistant entry in `metadata.runState.sessionState.
+/// mainAgentState.messageHistory` and pull `providerOptions.usage` (or
+/// `providerOptions.codebuff.usage`) plus any model hint it carries.
+fn extract_usage_from_run_state(metadata: &Value) -> Option<AssistantUsage> {
+    let history = metadata
+        .get("runState")
+        .and_then(|rs| rs.get("sessionState"))
+        .and_then(|ss| ss.get("mainAgentState"))
+        .and_then(|mas| mas.get("messageHistory"))
+        .and_then(|v| v.as_array())?;
+
+    for entry in history.iter().rev() {
+        let role = entry.get("role").and_then(|v| v.as_str()).unwrap_or("");
+        if role != "assistant" {
+            continue;
+        }
+        let provider_options = entry.get("providerOptions")?;
+        let mut usage = AssistantUsage::default();
+        if let Some(u) = provider_options.get("usage") {
+            usage.merge_fallback(parse_usage_object(u));
+        }
+        if let Some(u) = provider_options.get("codebuff").and_then(|c| c.get("usage")) {
+            usage.merge_fallback(parse_usage_object(u));
+        }
+        if let Some(model) = provider_options
+            .get("codebuff")
+            .and_then(|c| c.get("model"))
+            .and_then(|v| v.as_str())
+        {
+            usage.model = Some(model.to_string());
+        }
+        if usage.has_signal() || usage.model.is_some() {
+            return Some(usage);
+        }
+    }
+    None
+}
+
+/// Accept both camelCase and snake_case shapes, matching the @ccusage/codebuff
+/// valibot schema (different upstreams ship different casings).
+fn parse_usage_object(value: &Value) -> AssistantUsage {
+    let mut usage = AssistantUsage::default();
+
+    let input = pick_number(
+        value,
+        &["inputTokens", "input_tokens", "promptTokens", "prompt_tokens"],
+    );
+    let output = pick_number(
+        value,
+        &[
+            "outputTokens",
+            "output_tokens",
+            "completionTokens",
+            "completion_tokens",
+        ],
+    );
+    let cache_read = pick_number(
+        value,
+        &[
+            "cacheReadInputTokens",
+            "cache_read_input_tokens",
+            "cachedTokensCreated",
+            "cached_tokens_created",
+        ],
+    )
+    .or_else(|| {
+        value
+            .get("promptTokensDetails")
+            .or_else(|| value.get("prompt_tokens_details"))
+            .and_then(|d| {
+                d.get("cachedTokens")
+                    .or_else(|| d.get("cached_tokens"))
+                    .and_then(|v| v.as_i64())
+            })
+    });
+    let cache_write = pick_number(
+        value,
+        &[
+            "cacheCreationInputTokens",
+            "cache_creation_input_tokens",
+            "cacheCreationTokens",
+            "cache_creation_tokens",
+        ],
+    );
+
+    usage.input_tokens = input.unwrap_or(0);
+    usage.output_tokens = output.unwrap_or(0);
+    usage.cache_read_input_tokens = cache_read.unwrap_or(0);
+    usage.cache_creation_input_tokens = cache_write.unwrap_or(0);
+
+    if let Some(credits) = value.get("credits").and_then(|v| v.as_f64()) {
+        usage.credits = credits;
+    }
+    if let Some(model) = value.get("model").and_then(|v| v.as_str()) {
+        usage.model = Some(model.to_string());
+    }
+
+    usage
+}
+
+fn pick_number(value: &Value, keys: &[&str]) -> Option<i64> {
+    for key in keys {
+        if let Some(v) = value.get(*key) {
+            if let Some(n) = v
+                .as_i64()
+                .or_else(|| v.as_u64().map(|v| v as i64))
+                .or_else(|| v.as_f64().map(|f| f as i64))
+            {
+                if n > 0 {
+                    return Some(n);
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_derive_context_from_path_extracts_channel_project_and_chat_id() {
+        let p = PathBuf::from(
+            "/tmp/home/.config/manicode-dev/projects/sandbox/chats/2025-12-14T10-00-00.000Z/chat-messages.json",
+        );
+        let (channel, project, chat_id) = derive_context_from_path(&p);
+        assert_eq!(channel, "manicode-dev");
+        assert_eq!(project, "sandbox");
+        assert_eq!(chat_id, "2025-12-14T10-00-00.000Z");
+    }
+
+    #[test]
+    fn test_extract_assistant_usage_from_metadata_usage() {
+        let msg: Value = serde_json::from_str(
+            r#"{
+                "role": "assistant",
+                "metadata": {
+                    "model": "claude-sonnet-4-20250514",
+                    "usage": {
+                        "inputTokens": 1000,
+                        "outputTokens": 400,
+                        "cacheReadInputTokens": 200,
+                        "cacheCreationInputTokens": 50
+                    }
+                },
+                "credits": 1.5
+            }"#,
+        )
+        .unwrap();
+
+        let usage = extract_assistant_usage(&msg);
+        assert_eq!(usage.input_tokens, 1000);
+        assert_eq!(usage.output_tokens, 400);
+        assert_eq!(usage.cache_read_input_tokens, 200);
+        assert_eq!(usage.cache_creation_input_tokens, 50);
+        assert_eq!(usage.credits, 1.5);
+        assert_eq!(usage.model.as_deref(), Some("claude-sonnet-4-20250514"));
+    }
+
+    #[test]
+    fn test_extract_usage_snake_case_shape() {
+        let msg: Value = serde_json::from_str(
+            r#"{
+                "role": "assistant",
+                "metadata": {
+                    "codebuff": {
+                        "usage": {
+                            "prompt_tokens": 750,
+                            "completion_tokens": 120,
+                            "prompt_tokens_details": { "cached_tokens": 100 }
+                        }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let usage = extract_assistant_usage(&msg);
+        assert_eq!(usage.input_tokens, 750);
+        assert_eq!(usage.output_tokens, 120);
+        assert_eq!(usage.cache_read_input_tokens, 100);
+    }
+
+    #[test]
+    fn test_extract_usage_falls_back_to_run_state_message_history() {
+        let msg: Value = serde_json::from_str(
+            r#"{
+                "role": "assistant",
+                "metadata": {
+                    "runState": {
+                        "sessionState": {
+                            "mainAgentState": {
+                                "messageHistory": [
+                                    { "role": "user", "providerOptions": {} },
+                                    {
+                                        "role": "assistant",
+                                        "providerOptions": {
+                                            "codebuff": {
+                                                "model": "openai/gpt-5",
+                                                "usage": {
+                                                    "inputTokens": 2000,
+                                                    "outputTokens": 800,
+                                                    "cacheReadInputTokens": 400
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let usage = extract_assistant_usage(&msg);
+        assert_eq!(usage.input_tokens, 2000);
+        assert_eq!(usage.output_tokens, 800);
+        assert_eq!(usage.cache_read_input_tokens, 400);
+        assert_eq!(usage.model.as_deref(), Some("openai/gpt-5"));
+    }
+
+    #[test]
+    fn test_is_assistant_role_accepts_variant_and_role() {
+        let ai: Value = serde_json::from_str(r#"{"variant":"ai"}"#).unwrap();
+        let assistant: Value = serde_json::from_str(r#"{"role":"assistant"}"#).unwrap();
+        let user: Value = serde_json::from_str(r#"{"role":"user"}"#).unwrap();
+        assert!(is_assistant_role(&ai));
+        assert!(is_assistant_role(&assistant));
+        assert!(!is_assistant_role(&user));
+    }
+
+    #[test]
+    fn test_parse_codebuff_file_skips_messages_without_token_signal() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let chat_dir = dir
+            .path()
+            .join("manicode")
+            .join("projects")
+            .join("proj")
+            .join("chats")
+            .join("2025-12-20T12-00-00.000Z");
+        fs::create_dir_all(&chat_dir).unwrap();
+        let msgs_path = chat_dir.join("chat-messages.json");
+        fs::write(
+            &msgs_path,
+            r#"[
+                { "variant": "user", "content": "hi" },
+                { "variant": "ai",
+                  "timestamp": "2025-12-20T12:00:05.000Z",
+                  "metadata": {
+                    "model": "claude-sonnet-4-20250514",
+                    "usage": { "inputTokens": 10, "outputTokens": 5 }
+                  }
+                },
+                { "variant": "ai",
+                  "timestamp": "2025-12-20T12:00:06.000Z",
+                  "metadata": { "model": "claude-sonnet-4-20250514" }
+                }
+            ]"#,
+        )
+        .unwrap();
+
+        let messages = parse_codebuff_file(&msgs_path);
+        assert_eq!(messages.len(), 1);
+        let only = &messages[0];
+        assert_eq!(only.client, "codebuff");
+        assert_eq!(only.model_id, "claude-sonnet-4-20250514");
+        assert_eq!(only.provider_id, "anthropic");
+        assert!(only.session_id.ends_with("/proj/2025-12-20T12-00-00.000Z"));
+        assert_eq!(only.tokens.input, 10);
+        assert_eq!(only.tokens.output, 5);
+    }
+}

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod amp;
 pub mod claudecode;
+pub mod codebuff;
 pub mod codex;
 pub mod copilot;
 pub mod crush;

--- a/crates/tokscale-core/tests/codebuff.rs
+++ b/crates/tokscale-core/tests/codebuff.rs
@@ -2,7 +2,13 @@ use std::fs;
 use tempfile::TempDir;
 use tokscale_core::sessions::codebuff::parse_codebuff_file;
 
-fn write_chat(dir: &TempDir, channel: &str, project: &str, chat_id: &str, body: &str) -> std::path::PathBuf {
+fn write_chat(
+    dir: &TempDir,
+    channel: &str,
+    project: &str,
+    chat_id: &str,
+    body: &str,
+) -> std::path::PathBuf {
     let chat_dir = dir
         .path()
         .join(channel)
@@ -175,4 +181,97 @@ fn test_parse_codebuff_uses_chat_id_for_timestamp_when_message_has_none() {
     assert_eq!(msgs.len(), 1);
     // 2025-12-14T10:00:00.000Z → epoch ms
     assert_eq!(msgs[0].timestamp, 1_765_706_400_000_i64);
+}
+
+#[test]
+fn test_parse_codebuff_unknown_model_falls_back_to_unknown_provider() {
+    let dir = TempDir::new().unwrap();
+    let path = write_chat(
+        &dir,
+        "manicode",
+        "proj",
+        "2025-12-15T11-00-00.000Z",
+        r#"[
+            {
+                "variant": "ai",
+                "timestamp": "2025-12-15T11:00:01.000Z",
+                "metadata": {
+                    "usage": { "inputTokens": 100, "outputTokens": 50 }
+                }
+            }
+        ]"#,
+    );
+
+    let msgs = parse_codebuff_file(&path);
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0].model_id, "codebuff-unknown");
+    assert_eq!(
+        msgs[0].provider_id, "unknown",
+        "unknown models must not be silently attributed to anthropic"
+    );
+}
+
+#[test]
+fn test_parse_codebuff_dedup_key_is_stable_for_same_history() {
+    let dir = TempDir::new().unwrap();
+    let body = r#"[
+        {
+            "variant": "ai",
+            "id": "msg_abc123",
+            "timestamp": "2025-12-16T12:00:00.000Z",
+            "metadata": {
+                "model": "claude-sonnet-4-20250514",
+                "usage": { "inputTokens": 10, "outputTokens": 5 }
+            }
+        }
+    ]"#;
+    let path_a = write_chat(&dir, "manicode", "proj", "2025-12-16T12-00-00.000Z", body);
+    let path_b = write_chat(
+        &dir,
+        "manicode-dev",
+        "proj",
+        "2025-12-16T12-00-00.000Z",
+        body,
+    );
+
+    let msgs_a = parse_codebuff_file(&path_a);
+    let msgs_b = parse_codebuff_file(&path_b);
+
+    assert_eq!(msgs_a.len(), 1);
+    assert_eq!(msgs_b.len(), 1);
+    assert!(msgs_a[0].dedup_key.is_some());
+    assert_eq!(
+        msgs_a[0].dedup_key, msgs_b[0].dedup_key,
+        "same upstream message id should yield identical dedup keys across channels"
+    );
+    assert_eq!(msgs_a[0].dedup_key.as_deref(), Some("msg_abc123"));
+}
+
+#[test]
+fn test_parse_codebuff_dedup_key_falls_back_when_id_missing() {
+    let dir = TempDir::new().unwrap();
+    let path = write_chat(
+        &dir,
+        "manicode",
+        "proj",
+        "2025-12-17T13-00-00.000Z",
+        r#"[
+            {
+                "variant": "ai",
+                "timestamp": "2025-12-17T13:00:00.000Z",
+                "metadata": {
+                    "model": "claude-sonnet-4-20250514",
+                    "usage": { "inputTokens": 10, "outputTokens": 5 }
+                }
+            }
+        ]"#,
+    );
+
+    let msgs = parse_codebuff_file(&path);
+    assert_eq!(msgs.len(), 1);
+    let key = msgs[0].dedup_key.as_deref().expect("dedup_key required");
+    assert!(
+        key.starts_with("codebuff:"),
+        "fallback dedup key should be namespaced; got {key}"
+    );
 }

--- a/crates/tokscale-core/tests/codebuff.rs
+++ b/crates/tokscale-core/tests/codebuff.rs
@@ -1,0 +1,150 @@
+use std::fs;
+use tempfile::TempDir;
+use tokscale_core::sessions::codebuff::parse_codebuff_file;
+
+fn write_chat(dir: &TempDir, channel: &str, project: &str, chat_id: &str, body: &str) -> std::path::PathBuf {
+    let chat_dir = dir
+        .path()
+        .join(channel)
+        .join("projects")
+        .join(project)
+        .join("chats")
+        .join(chat_id);
+    fs::create_dir_all(&chat_dir).unwrap();
+    let msgs_path = chat_dir.join("chat-messages.json");
+    fs::write(&msgs_path, body).unwrap();
+    msgs_path
+}
+
+#[test]
+fn test_parse_codebuff_emits_one_event_per_assistant_message_with_usage() {
+    let dir = TempDir::new().unwrap();
+    let path = write_chat(
+        &dir,
+        "manicode",
+        "my-project",
+        "2025-12-20T12-00-00.000Z",
+        r#"[
+            { "variant": "user", "content": "hello", "timestamp": "2025-12-20T12:00:00.000Z" },
+            {
+                "variant": "ai",
+                "timestamp": "2025-12-20T12:00:05.000Z",
+                "metadata": {
+                    "model": "claude-sonnet-4-20250514",
+                    "usage": {
+                        "inputTokens": 500,
+                        "outputTokens": 200,
+                        "cacheCreationInputTokens": 300,
+                        "cacheReadInputTokens": 100
+                    }
+                },
+                "credits": 1.25
+            },
+            {
+                "variant": "user",
+                "content": "thanks",
+                "timestamp": "2025-12-20T12:00:10.000Z"
+            },
+            {
+                "variant": "ai",
+                "timestamp": "2025-12-20T12:00:15.000Z",
+                "metadata": {
+                    "model": "openai/gpt-5",
+                    "codebuff": {
+                        "usage": {
+                            "prompt_tokens": 750,
+                            "completion_tokens": 80,
+                            "prompt_tokens_details": { "cached_tokens": 100 }
+                        }
+                    }
+                }
+            }
+        ]"#,
+    );
+
+    let msgs = parse_codebuff_file(&path);
+    assert_eq!(msgs.len(), 2);
+
+    let first = &msgs[0];
+    assert_eq!(first.client, "codebuff");
+    assert_eq!(first.model_id, "claude-sonnet-4-20250514");
+    assert_eq!(first.provider_id, "anthropic");
+    assert_eq!(first.tokens.input, 500);
+    assert_eq!(first.tokens.output, 200);
+    assert_eq!(first.tokens.cache_write, 300);
+    assert_eq!(first.tokens.cache_read, 100);
+    assert_eq!(first.cost, 1.25);
+    assert!(first
+        .session_id
+        .ends_with("/my-project/2025-12-20T12-00-00.000Z"));
+
+    let second = &msgs[1];
+    assert_eq!(second.model_id, "openai/gpt-5");
+    assert_eq!(second.provider_id, "openai");
+    assert_eq!(second.tokens.input, 750);
+    assert_eq!(second.tokens.output, 80);
+    assert_eq!(second.tokens.cache_read, 100);
+}
+
+#[test]
+fn test_parse_codebuff_recovers_usage_from_run_state_history_when_metadata_is_empty() {
+    let dir = TempDir::new().unwrap();
+    let path = write_chat(
+        &dir,
+        "manicode-dev",
+        "sandbox",
+        "2025-12-22T09-30-00.000Z",
+        r#"[
+            { "variant": "user", "content": "run", "timestamp": "2025-12-22T09:30:00.000Z" },
+            {
+                "variant": "assistant",
+                "timestamp": "2025-12-22T09:30:02.500Z",
+                "metadata": {
+                    "runState": {
+                        "sessionState": {
+                            "mainAgentState": {
+                                "messageHistory": [
+                                    { "role": "user", "providerOptions": {} },
+                                    {
+                                        "role": "assistant",
+                                        "providerOptions": {
+                                            "codebuff": {
+                                                "model": "openrouter/anthropic/claude-opus-4-1",
+                                                "usage": {
+                                                    "inputTokens": 2000,
+                                                    "outputTokens": 800,
+                                                    "cacheReadInputTokens": 400
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        ]"#,
+    );
+
+    let msgs = parse_codebuff_file(&path);
+    assert_eq!(msgs.len(), 1);
+    let m = &msgs[0];
+    assert_eq!(m.model_id, "openrouter/anthropic/claude-opus-4-1");
+    assert_eq!(m.provider_id, "anthropic");
+    assert_eq!(m.tokens.input, 2000);
+    assert_eq!(m.tokens.output, 800);
+    assert_eq!(m.tokens.cache_read, 400);
+    assert!(m.session_id.starts_with("manicode-dev/sandbox/"));
+}
+
+#[test]
+fn test_parse_codebuff_returns_empty_for_missing_or_non_array_file() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("chat-messages.json");
+    fs::write(&path, r#"{"not":"an array"}"#).unwrap();
+    assert!(parse_codebuff_file(&path).is_empty());
+
+    let missing = dir.path().join("nope.json");
+    assert!(parse_codebuff_file(&missing).is_empty());
+}

--- a/crates/tokscale-core/tests/codebuff.rs
+++ b/crates/tokscale-core/tests/codebuff.rs
@@ -275,3 +275,56 @@ fn test_parse_codebuff_dedup_key_falls_back_when_id_missing() {
         "fallback dedup key should be namespaced; got {key}"
     );
 }
+
+#[test]
+fn test_parse_codebuff_run_state_skips_entries_missing_provider_options() {
+    // Regression: the run-state recovery walked the message history in
+    // reverse, and the most recent assistant entry can lack providerOptions
+    // while an earlier one carries the real usage payload. The recovery loop
+    // must continue past entries without providerOptions instead of bailing
+    // out of the entire function.
+    let dir = TempDir::new().unwrap();
+    let path = write_chat(
+        &dir,
+        "manicode",
+        "proj",
+        "2025-12-18T14-00-00.000Z",
+        r#"[
+            {
+                "variant": "assistant",
+                "timestamp": "2025-12-18T14:00:00.000Z",
+                "metadata": {
+                    "runState": {
+                        "sessionState": {
+                            "mainAgentState": {
+                                "messageHistory": [
+                                    {
+                                        "role": "assistant",
+                                        "providerOptions": {
+                                            "codebuff": {
+                                                "model": "claude-sonnet-4-20250514",
+                                                "usage": { "inputTokens": 1234, "outputTokens": 56 }
+                                            }
+                                        }
+                                    },
+                                    { "role": "user" },
+                                    { "role": "assistant" }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        ]"#,
+    );
+
+    let msgs = parse_codebuff_file(&path);
+    assert_eq!(
+        msgs.len(),
+        1,
+        "earlier assistant entry's providerOptions must survive missing providerOptions on later entry"
+    );
+    assert_eq!(msgs[0].tokens.input, 1234);
+    assert_eq!(msgs[0].tokens.output, 56);
+    assert_eq!(msgs[0].model_id, "claude-sonnet-4-20250514");
+}

--- a/crates/tokscale-core/tests/codebuff.rs
+++ b/crates/tokscale-core/tests/codebuff.rs
@@ -148,3 +148,31 @@ fn test_parse_codebuff_returns_empty_for_missing_or_non_array_file() {
     let missing = dir.path().join("nope.json");
     assert!(parse_codebuff_file(&missing).is_empty());
 }
+
+#[test]
+fn test_parse_codebuff_uses_chat_id_for_timestamp_when_message_has_none() {
+    // Regression: before fixing the chat-id parser, a global `-`→`:` replace
+    // corrupted the date portion and every message in a chat missing a
+    // per-message timestamp silently fell back to the file mtime.
+    let dir = TempDir::new().unwrap();
+    let path = write_chat(
+        &dir,
+        "manicode",
+        "proj",
+        "2025-12-14T10-00-00.000Z",
+        r#"[
+            {
+                "variant": "ai",
+                "metadata": {
+                    "model": "claude-sonnet-4-20250514",
+                    "usage": { "inputTokens": 10, "outputTokens": 5 }
+                }
+            }
+        ]"#,
+    );
+
+    let msgs = parse_codebuff_file(&path);
+    assert_eq!(msgs.len(), 1);
+    // 2025-12-14T10:00:00.000Z → epoch ms
+    assert_eq!(msgs[0].timestamp, 1_765_706_400_000_i64);
+}


### PR DESCRIPTION
## Summary

Adds [Codebuff](https://codebuff.com) (formerly Manicode) as a new first-class tokscale client, alongside Amp / Droid / Pi / Hermes / Mux / Kimi / Qwen / Kilo / KiloCode / RooCode / Crush.

## Data Source

Codebuff persists per-chat history at:
```
$CODEBUFF_DATA_DIR/                      # default: ~/.config/manicode
  projects/<project>/
    chats/<chatId>/
      chat-messages.json                  # serialized ChatMessage[]
      run-state.json                      # SDK RunState snapshot
```
`chatId` is the chat's ISO-8601 timestamp with `:` replaced by `-` for filesystem safety (e.g. `2025-12-14T10-00-00.000Z`). Dev and staging channels (`manicode-dev`, `manicode-staging`) use the same layout and are walked automatically when present.

## Token / Credit Extraction

Assistant-message usage can land in several places depending on routing. The parser tries, in order:

1. `metadata.usage` — direct provider.
2. `metadata.codebuff.usage` — Codebuff-tagged payload.
3. `metadata.runState.sessionState.mainAgentState.messageHistory[*].providerOptions` — where RunState-stashed OpenRouter calls record totals under `providerOptions.usage` or `providerOptions.codebuff.usage`.

Both camelCase and snake_case shapes are accepted (`inputTokens`/`input_tokens`/`promptTokens`, etc.). Credits are read from `message.credits`.

## Environment

- `CODEBUFF_DATA_DIR` — override the base directory. Point it at a single channel root such as `~/.config/manicode-dev`.

## Changes

**core**
- `sessions/codebuff.rs` — new parser with 7 unit tests
- `clients.rs` — register `ClientId::Codebuff` (id=18)
- `scanner.rs` — `chat-messages.json` pattern + multi-channel scan block
- `lib.rs` — dispatch in both cached-parse and `parse_local_clients` loops

**cli / tui**
- `--codebuff` flag on `ClientFlags`
- Wrapped / display-name / logo URL / default_clients integration
- TUI hotkey `'b'`, brand color `#7C3AED`, per-client tests

**tests**
- `tests/codebuff.rs` — 3 integration tests (3 usage paths, empty/non-array)

**docs**
- New README row + `--codebuff` example + prose list update

## Verification

```
cargo test --workspace   # 968 tests, 0 failures
cargo clippy --workspace --all-targets -- -D warnings   # clean
```

## Notes

- `capitalize_client("codebuff")` → `"Codebuff"`
- Logo referenced via the [CodebuffAI GitHub avatar](https://avatars.githubusercontent.com/u/189203002?s=200&v=4); happy to drop in a local asset under `.github/assets/client-codebuff.png` on request.
- Companion npm package `@ccusage/codebuff` (currently under review in [ryoppippi/ccusage#954](https://github.com/ryoppippi/ccusage/pull/954)) uses the same extraction approach and can serve as a cross-reference for the data shape.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Codebuff (formerly Manicode) as a first-class local client with channel-aware scanning and a resilient parser that extracts token usage from multiple paths. Integrates into CLI/TUI and fixes env handling, timestamps, provider inference, and dedup to avoid double-counting.

- **New Features**
  - Added `ClientId::Codebuff` scanning `~/.config/manicode{,-dev,-staging}` or `CODEBUFF_DATA_DIR`; targets `projects/<project>/chats/<chatId>/chat-messages.json`.
  - Parser reads usage from `metadata.usage`, `metadata.codebuff.usage`, or `metadata.runState...messageHistory[*].providerOptions` (camel/snake); reads `credits`; session id is `channel/project/chatId`; provider inferred from model. Wired into cached and local parsing.
  - CLI/TUI: hidden `--codebuff` flag, default inclusion, display name/logo, hotkey `b`, brand color `#7C3AED`. README and tests updated.

- **Bug Fixes**
  - `CODEBUFF_DATA_DIR` trims/ignores empty values and falls back to default channels; scanner walks all three channels by default.
  - ChatId-to-timestamp restores only time separators to fix missing per-message timestamps; unknown models map to `unknown` provider; added stable dedup keys to prevent double-counting.
  - Run-state history continues when `providerOptions` is missing; logo URL switched to the Codebuff GitHub avatar.

<sup>Written for commit ea19bf72d07666e02a85fda5231e18b67bc421fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
