### PR TITLE
feat: add Goose (aaif-goose/goose) session scanner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-cli"
-version = "2.0.26"
+version = "2.0.27"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-core"
-version = "2.0.26"
+version = "2.0.27"
 dependencies = [
  "bincode",
  "chrono",

--- a/crates/tokscale-cli/src/commands/wrapped.rs
+++ b/crates/tokscale-cli/src/commands/wrapped.rs
@@ -1369,6 +1369,7 @@ fn client_display_name(client: &str) -> Option<&'static str> {
         "kilo" => Some("Kilo CLI"),
         "mux" => Some("Mux"),
         "crush" => Some("Crush"),
+        "goose" => Some("Goose"),
         "synthetic" => Some("Synthetic"),
         _ => None,
     }

--- a/crates/tokscale-cli/src/commands/wrapped.rs
+++ b/crates/tokscale-cli/src/commands/wrapped.rs
@@ -1399,6 +1399,7 @@ fn client_logo_url(client_name: &str) -> Option<&'static str> {
         "Crush" => Some(
             "https://raw.githubusercontent.com/junhoyeo/tokscale/6b483d0f2de3717266dec8faed13acd067f90ff3/.github/assets/client-crush.png",
         ),
+        "Goose" => Some("https://tokscale.ai/assets/logos/goose.png"),
         "Synthetic" => Some("https://tokscale.ai/assets/logos/synthetic.png"),
         _ => None,
     }

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -606,6 +606,8 @@ pub struct ClientFlags {
     pub mux: bool,
     #[arg(long, help = "Show only Crush usage")]
     pub crush: bool,
+    #[arg(long, help = "Show only Goose usage")]
+    pub goose: bool,
     #[arg(long, help = "Show only Synthetic usage")]
     pub synthetic: bool,
 }
@@ -648,6 +650,7 @@ fn build_client_filter(flags: ClientFlags) -> Option<Vec<String>> {
         (ClientId::Kilo, flags.kilo),
         (ClientId::Mux, flags.mux),
         (ClientId::Crush, flags.crush),
+        (ClientId::Goose, flags.goose),
     ]
     .into_iter()
     .filter(|(_, enabled)| *enabled)
@@ -2324,6 +2327,7 @@ fn capitalize_client(client: &str) -> String {
         "crush" => "Crush".to_string(),
         "openclaw" => "openclaw".to_string(),
         "hermes" => "Hermes Agent".to_string(),
+        "goose" => "Goose".to_string(),
         "pi" => "Pi".to_string(),
         other => other.to_string(),
     }
@@ -3883,6 +3887,7 @@ mod tests {
             kilo: false,
             mux: false,
             crush: false,
+            goose: false,
             synthetic: false,
         };
         assert_eq!(build_client_filter(flags), None);
@@ -3909,6 +3914,7 @@ mod tests {
             kilo: false,
             mux: false,
             crush: false,
+            goose: false,
             synthetic: false,
         };
         assert_eq!(
@@ -3938,6 +3944,7 @@ mod tests {
             kilo: false,
             mux: false,
             crush: false,
+            goose: false,
             synthetic: false,
         };
         assert_eq!(
@@ -3971,6 +3978,7 @@ mod tests {
             kilo: false,
             mux: false,
             crush: false,
+            goose: false,
             synthetic: true,
         };
         assert_eq!(
@@ -4000,6 +4008,7 @@ mod tests {
             kilo: true,
             mux: true,
             crush: true,
+            goose: true,
             synthetic: true,
         };
         let result = build_client_filter(flags);
@@ -4025,6 +4034,7 @@ mod tests {
         assert!(sources.contains(&"kilo".to_string()));
         assert!(sources.contains(&"mux".to_string()));
         assert!(sources.contains(&"crush".to_string()));
+        assert!(sources.contains(&"goose".to_string()));
         assert!(sources.contains(&"synthetic".to_string()));
     }
 

--- a/crates/tokscale-cli/src/tui/client_ui.rs
+++ b/crates/tokscale-cli/src/tui/client_ui.rs
@@ -78,6 +78,10 @@ pub const CLIENT_UI: [ClientUi; ClientId::COUNT] = [
         display_name: "Copilot",
         hotkey: 'c',
     },
+    ClientUi {
+        display_name: "Goose",
+        hotkey: 'o',
+    },
 ];
 
 pub fn display_name(client: ClientId) -> &'static str {

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -1131,7 +1131,7 @@ mod tests {
     #[test]
     fn test_client_all() {
         let clients = ClientId::ALL;
-        assert_eq!(clients.len(), 18);
+        assert_eq!(clients.len(), 19);
         assert_eq!(clients[0], ClientId::OpenCode);
         assert_eq!(clients[1], ClientId::Claude);
         assert_eq!(clients[2], ClientId::Codex);

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -235,6 +235,7 @@ pub fn get_client_color(client: &str) -> Color {
         "droid" => Color::Rgb(16, 185, 129),   // #10b981
         "openclaw" => Color::Rgb(239, 68, 68), // #ef4444
         "hermes" => Color::Rgb(255, 215, 0),   // #ffd700
+        "goose" => Color::Rgb(100, 180, 220),  // #64b4dc
         _ => Color::Rgb(136, 136, 136),        // #888888
     }
 }

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -301,6 +301,15 @@ define_clients!(
         headless: false,
         parse_local: true,
         submit_default: true
+    },
+    Goose = 18 => {
+        id: "goose",
+        root: PathRoot::XdgData,
+        relative: "goose/sessions/sessions.db",
+        pattern: "sessions.db",
+        headless: false,
+        parse_local: true,
+        submit_default: true
     }
 );
 
@@ -353,7 +362,7 @@ mod tests {
 
     #[test]
     fn test_client_id_count() {
-        assert_eq!(ClientId::COUNT, 18);
+        assert_eq!(ClientId::COUNT, 19);
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -972,6 +972,17 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         all_messages.extend(hermes_messages);
     }
 
+    if let Some(db_path) = &scan_result.goose_db {
+        let goose_messages: Vec<UnifiedMessage> = sessions::goose::parse_goose_sqlite(db_path)
+            .into_iter()
+            .map(|mut msg| {
+                apply_pricing_if_available(&mut msg, pricing);
+                msg
+            })
+            .collect();
+        all_messages.extend(goose_messages);
+    }
+
     for source in &scan_result.crush_dbs {
         let crush_messages: Vec<UnifiedMessage> =
             sessions::crush::parse_crush_sqlite(&source.db_path)
@@ -1842,6 +1853,16 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
         let count = summed_parsed_message_count(&hermes_msgs);
         counts.set(ClientId::Hermes, count);
         messages.extend(hermes_msgs);
+    }
+
+    if let Some(db_path) = &scan_result.goose_db {
+        let goose_msgs: Vec<ParsedMessage> = sessions::goose::parse_goose_sqlite(db_path)
+            .into_iter()
+            .map(|msg| unified_to_parsed(&msg))
+            .collect();
+        let count = summed_parsed_message_count(&goose_msgs);
+        counts.set(ClientId::Goose, count);
+        messages.extend(goose_msgs);
     }
 
     let crush_msgs: Vec<ParsedMessage> = scan_result

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -69,6 +69,7 @@ pub struct ScanResult {
     pub synthetic_db: Option<PathBuf>,
     pub kilo_db: Option<PathBuf>,
     pub hermes_db: Option<PathBuf>,
+    pub goose_db: Option<PathBuf>,
     pub crush_dbs: Vec<CrushDbSource>,
     /// Path to the OpenCode legacy JSON directory (for migration cache stat checks)
     pub opencode_json_dir: Option<PathBuf>,
@@ -82,6 +83,7 @@ impl Default for ScanResult {
             synthetic_db: None,
             kilo_db: None,
             hermes_db: None,
+            goose_db: None,
             crush_dbs: Vec::new(),
             opencode_json_dir: None,
         }
@@ -434,7 +436,7 @@ fn supports_extra_dir_scanning(client_id: ClientId) -> bool {
     // registry rather than scanned file paths.
     !matches!(
         client_id,
-        ClientId::Kilo | ClientId::Crush | ClientId::Hermes
+        ClientId::Kilo | ClientId::Crush | ClientId::Hermes | ClientId::Goose
     )
 }
 
@@ -571,6 +573,7 @@ fn scan_all_clients_with_env_strategy_inner(
                 | ClientId::KiloCode
                 | ClientId::Kilo
                 | ClientId::Hermes
+                | ClientId::Goose
                 | ClientId::Crush
         ) {
             continue;
@@ -793,6 +796,52 @@ fn scan_all_clients_with_env_strategy_inner(
             .resolve_path_with_env_strategy(home_dir, use_env_roots);
         if std::path::Path::new(&hermes_db_path).exists() {
             result.hermes_db = Some(PathBuf::from(hermes_db_path));
+        }
+    }
+
+    if enabled.contains(&ClientId::Goose) {
+        if use_env_roots {
+            if let Ok(custom_root) = std::env::var("GOOSE_PATH_ROOT") {
+                let custom_path = PathBuf::from(custom_root).join("data/sessions/sessions.db");
+                if custom_path.exists() {
+                    result.goose_db = Some(custom_path);
+                }
+            }
+        }
+        if result.goose_db.is_none() {
+            let xdg_path = ClientId::Goose
+                .data()
+                .resolve_path_with_env_strategy(home_dir, use_env_roots);
+            if std::path::Path::new(&xdg_path).exists() {
+                result.goose_db = Some(PathBuf::from(xdg_path));
+            }
+        }
+        if result.goose_db.is_none() {
+            let macos_path = PathBuf::from(format!(
+                "{}/Library/Application Support/goose/sessions/sessions.db",
+                home_dir
+            ));
+            if macos_path.exists() {
+                result.goose_db = Some(macos_path);
+            }
+        }
+        if result.goose_db.is_none() {
+            let legacy_macos_path = PathBuf::from(format!(
+                "{}/Library/Application Support/Block/goose/sessions/sessions.db",
+                home_dir
+            ));
+            if legacy_macos_path.exists() {
+                result.goose_db = Some(legacy_macos_path);
+            }
+        }
+        if result.goose_db.is_none() {
+            let legacy_xdg_path = PathBuf::from(format!(
+                "{}/.local/share/Block/goose/sessions/sessions.db",
+                home_dir
+            ));
+            if legacy_xdg_path.exists() {
+                result.goose_db = Some(legacy_xdg_path);
+            }
         }
     }
 

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -802,9 +802,12 @@ fn scan_all_clients_with_env_strategy_inner(
     if enabled.contains(&ClientId::Goose) {
         if use_env_roots {
             if let Ok(custom_root) = std::env::var("GOOSE_PATH_ROOT") {
-                let custom_path = PathBuf::from(custom_root).join("data/sessions/sessions.db");
-                if custom_path.exists() {
-                    result.goose_db = Some(custom_path);
+                let trimmed = custom_root.trim();
+                if !trimmed.is_empty() {
+                    let custom_path = PathBuf::from(trimmed).join("data/sessions/sessions.db");
+                    if custom_path.is_file() {
+                        result.goose_db = Some(custom_path);
+                    }
                 }
             }
         }
@@ -812,8 +815,9 @@ fn scan_all_clients_with_env_strategy_inner(
             let xdg_path = ClientId::Goose
                 .data()
                 .resolve_path_with_env_strategy(home_dir, use_env_roots);
-            if std::path::Path::new(&xdg_path).exists() {
-                result.goose_db = Some(PathBuf::from(xdg_path));
+            let xdg = PathBuf::from(xdg_path);
+            if xdg.is_file() {
+                result.goose_db = Some(xdg);
             }
         }
         if result.goose_db.is_none() {
@@ -821,7 +825,7 @@ fn scan_all_clients_with_env_strategy_inner(
                 "{}/Library/Application Support/goose/sessions/sessions.db",
                 home_dir
             ));
-            if macos_path.exists() {
+            if macos_path.is_file() {
                 result.goose_db = Some(macos_path);
             }
         }
@@ -830,7 +834,7 @@ fn scan_all_clients_with_env_strategy_inner(
                 "{}/Library/Application Support/Block/goose/sessions/sessions.db",
                 home_dir
             ));
-            if legacy_macos_path.exists() {
+            if legacy_macos_path.is_file() {
                 result.goose_db = Some(legacy_macos_path);
             }
         }
@@ -839,7 +843,7 @@ fn scan_all_clients_with_env_strategy_inner(
                 "{}/.local/share/Block/goose/sessions/sessions.db",
                 home_dir
             ));
-            if legacy_xdg_path.exists() {
+            if legacy_xdg_path.is_file() {
                 result.goose_db = Some(legacy_xdg_path);
             }
         }

--- a/crates/tokscale-core/src/sessions/goose.rs
+++ b/crates/tokscale-core/src/sessions/goose.rs
@@ -1,8 +1,9 @@
 //! Goose session parser
 //!
 //! Parses session rows from Goose's SQLite sessions database:
-//! - macOS: `~/Library/Application Support/Block/goose/sessions/sessions.db`
-//! - Linux: `~/.local/share/Block/goose/sessions/sessions.db`
+//! - Primary: `~/.local/share/goose/sessions/sessions.db`
+//! - macOS: `~/Library/Application Support/goose/sessions/sessions.db`
+//! - Legacy Block/goose: `~/.local/share/Block/goose/sessions/sessions.db`
 //! - Custom: `$GOOSE_PATH_ROOT/data/sessions/sessions.db`
 
 use super::UnifiedMessage;
@@ -42,6 +43,23 @@ fn resolved_provider(provider_name: Option<String>, model_id: &str) -> String {
         .and_then(|p| provider_identity::canonical_provider(p.trim()))
         .or_else(|| provider_identity::inferred_provider_from_model(model_id).map(str::to_string))
         .unwrap_or_else(|| "goose".to_string())
+}
+
+fn parse_created_at(s: &str) -> f64 {
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
+        return dt.timestamp_millis() as f64;
+    }
+    if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S") {
+        return dt.and_utc().timestamp_millis() as f64;
+    }
+    if let Ok(date) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+        return date
+            .and_hms_opt(0, 0, 0)
+            .unwrap_or_default()
+            .and_utc()
+            .timestamp_millis() as f64;
+    }
+    0.0
 }
 
 pub fn parse_goose_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
@@ -95,12 +113,12 @@ pub fn parse_goose_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             row.get::<_, Option<String>>(1)?,
             row.get::<_, Option<String>>(2)?,
             row.get::<_, String>(3)?,
-            row.get::<_, Option<i32>>(4)?,
-            row.get::<_, Option<i32>>(5)?,
-            row.get::<_, Option<i32>>(6)?,
-            row.get::<_, Option<i32>>(7)?,
-            row.get::<_, Option<i32>>(8)?,
-            row.get::<_, Option<i32>>(9)?,
+            row.get::<_, Option<i64>>(4)?,
+            row.get::<_, Option<i64>>(5)?,
+            row.get::<_, Option<i64>>(6)?,
+            row.get::<_, Option<i64>>(7)?,
+            row.get::<_, Option<i64>>(8)?,
+            row.get::<_, Option<i64>>(9)?,
         ))
     }) {
         Ok(r) => r,
@@ -141,23 +159,20 @@ pub fn parse_goose_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             let model_config = model_config_json.as_ref()?;
             let model_id = parse_model_config(model_config)?;
 
-            let created_at_ts = chrono::DateTime::parse_from_rfc3339(&created_at)
-                .ok()
-                .map(|dt| dt.timestamp_millis() as f64)
-                .unwrap_or(0.0);
+            let created_at_ts = parse_created_at(&created_at);
 
             let input = accumulated_input_tokens
                 .or(input_tokens)
                 .unwrap_or(0)
-                .max(0) as i64;
+                .max(0);
             let output = accumulated_output_tokens
                 .or(output_tokens)
                 .unwrap_or(0)
-                .max(0) as i64;
+                .max(0);
             let total = accumulated_total_tokens
                 .or(total_tokens)
                 .unwrap_or(0)
-                .max(0) as i64;
+                .max(0);
 
             if input == 0 && output == 0 && total == 0 {
                 return None;
@@ -218,5 +233,33 @@ mod tests {
     fn test_timestamp_secs_to_ms() {
         assert_eq!(timestamp_secs_to_ms(1_700_000_000.0), 1_700_000_000_000);
         assert_eq!(timestamp_secs_to_ms(1_700_000_000_000.0), 1_700_000_000_000);
+    }
+
+    #[test]
+    fn test_parse_created_at_rfc3339() {
+        let ts = parse_created_at("2026-04-14T16:18:53Z");
+        assert!(ts > 0.0);
+    }
+
+    #[test]
+    fn test_parse_created_at_sqlite_timestamp() {
+        let ts = parse_created_at("2026-04-14 16:18:53");
+        assert!(ts > 0.0);
+        let expected = chrono::NaiveDateTime::parse_from_str("2026-04-14 16:18:53", "%Y-%m-%d %H:%M:%S")
+            .unwrap()
+            .and_utc()
+            .timestamp_millis() as f64;
+        assert_eq!(ts, expected);
+    }
+
+    #[test]
+    fn test_parse_created_at_date_only() {
+        let ts = parse_created_at("2026-04-14");
+        assert!(ts > 0.0);
+    }
+
+    #[test]
+    fn test_parse_created_at_invalid() {
+        assert_eq!(parse_created_at("not a date"), 0.0);
     }
 }

--- a/crates/tokscale-core/src/sessions/goose.rs
+++ b/crates/tokscale-core/src/sessions/goose.rs
@@ -1,0 +1,222 @@
+//! Goose session parser
+//!
+//! Parses session rows from Goose's SQLite sessions database:
+//! - macOS: `~/Library/Application Support/Block/goose/sessions/sessions.db`
+//! - Linux: `~/.local/share/Block/goose/sessions/sessions.db`
+//! - Custom: `$GOOSE_PATH_ROOT/data/sessions/sessions.db`
+
+use super::UnifiedMessage;
+use crate::{provider_identity, TokenBreakdown};
+use rusqlite::Connection;
+use serde::Deserialize;
+use std::path::Path;
+use tracing::warn;
+
+#[derive(Debug, Deserialize)]
+struct GooseModelConfig {
+    model_name: String,
+}
+
+fn parse_model_config(json: &str) -> Option<String> {
+    let mut bytes = json.as_bytes().to_vec();
+    let config: GooseModelConfig = simd_json::from_slice(&mut bytes).ok()?;
+    let name = config.model_name.trim().to_string();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name)
+    }
+}
+
+fn timestamp_secs_to_ms(timestamp: f64) -> i64 {
+    if timestamp > 1e12 {
+        timestamp as i64
+    } else {
+        (timestamp * 1000.0) as i64
+    }
+}
+
+fn resolved_provider(provider_name: Option<String>, model_id: &str) -> String {
+    provider_name
+        .filter(|p| !p.trim().is_empty())
+        .and_then(|p| provider_identity::canonical_provider(p.trim()))
+        .or_else(|| provider_identity::inferred_provider_from_model(model_id).map(str::to_string))
+        .unwrap_or_else(|| "goose".to_string())
+}
+
+pub fn parse_goose_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
+    let conn = match Connection::open_with_flags(
+        db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    ) {
+        Ok(c) => c,
+        Err(err) => {
+            warn!(
+                db_path = %db_path.display(),
+                error = %err,
+                "Failed to open Goose sessions database"
+            );
+            return Vec::new();
+        }
+    };
+
+    let query = r#"
+        SELECT
+            id,
+            model_config_json,
+            provider_name,
+            created_at,
+            total_tokens,
+            input_tokens,
+            output_tokens,
+            accumulated_total_tokens,
+            accumulated_input_tokens,
+            accumulated_output_tokens
+        FROM sessions
+        WHERE model_config_json IS NOT NULL
+          AND TRIM(model_config_json) != ''
+    "#;
+
+    let mut stmt = match conn.prepare(query) {
+        Ok(s) => s,
+        Err(err) => {
+            warn!(
+                db_path = %db_path.display(),
+                error = %err,
+                "Failed to prepare Goose session query"
+            );
+            return Vec::new();
+        }
+    };
+
+    let rows = match stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, Option<String>>(1)?,
+            row.get::<_, Option<String>>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, Option<i32>>(4)?,
+            row.get::<_, Option<i32>>(5)?,
+            row.get::<_, Option<i32>>(6)?,
+            row.get::<_, Option<i32>>(7)?,
+            row.get::<_, Option<i32>>(8)?,
+            row.get::<_, Option<i32>>(9)?,
+        ))
+    }) {
+        Ok(r) => r,
+        Err(err) => {
+            warn!(
+                db_path = %db_path.display(),
+                error = %err,
+                "Failed to execute Goose session query"
+            );
+            return Vec::new();
+        }
+    };
+
+    rows.filter_map(|row| match row {
+        Ok(row) => Some(row),
+        Err(err) => {
+            warn!(
+                db_path = %db_path.display(),
+                error = %err,
+                "Failed to decode Goose session row"
+            );
+            None
+        }
+    })
+    .filter_map(
+        |(
+            session_id,
+            model_config_json,
+            provider_name,
+            created_at,
+            total_tokens,
+            input_tokens,
+            output_tokens,
+            accumulated_total_tokens,
+            accumulated_input_tokens,
+            accumulated_output_tokens,
+        )| {
+            let model_config = model_config_json.as_ref()?;
+            let model_id = parse_model_config(model_config)?;
+
+            let created_at_ts = chrono::DateTime::parse_from_rfc3339(&created_at)
+                .ok()
+                .map(|dt| dt.timestamp_millis() as f64)
+                .unwrap_or(0.0);
+
+            let input = accumulated_input_tokens
+                .or(input_tokens)
+                .unwrap_or(0)
+                .max(0) as i64;
+            let output = accumulated_output_tokens
+                .or(output_tokens)
+                .unwrap_or(0)
+                .max(0) as i64;
+            let total = accumulated_total_tokens
+                .or(total_tokens)
+                .unwrap_or(0)
+                .max(0) as i64;
+
+            if input == 0 && output == 0 && total == 0 {
+                return None;
+            }
+
+            let provider = resolved_provider(provider_name, &model_id);
+            let mut msg = UnifiedMessage::new(
+                "goose",
+                model_id,
+                provider,
+                session_id.clone(),
+                timestamp_secs_to_ms(created_at_ts),
+                TokenBreakdown {
+                    input,
+                    output,
+                    cache_read: 0,
+                    cache_write: 0,
+                    reasoning: if total > input + output {
+                        (total - input - output).max(0)
+                    } else {
+                        0
+                    },
+                },
+                0.0,
+            );
+            msg.dedup_key = Some(session_id);
+            Some(msg)
+        },
+    )
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_model_config_valid() {
+        let json = r#"{"model_name":"claude-sonnet-4-20250514","context_limit":200000}"#;
+        assert_eq!(
+            parse_model_config(json),
+            Some("claude-sonnet-4-20250514".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_model_config_empty_name() {
+        let json = r#"{"model_name":"  ","context_limit":200000}"#;
+        assert_eq!(parse_model_config(json), None);
+    }
+
+    #[test]
+    fn test_parse_model_config_invalid_json() {
+        assert_eq!(parse_model_config("not json"), None);
+    }
+
+    #[test]
+    fn test_timestamp_secs_to_ms() {
+        assert_eq!(timestamp_secs_to_ms(1_700_000_000.0), 1_700_000_000_000);
+        assert_eq!(timestamp_secs_to_ms(1_700_000_000_000.0), 1_700_000_000_000);
+    }
+}

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -10,6 +10,7 @@ pub mod crush;
 pub mod cursor;
 pub mod droid;
 pub mod gemini;
+pub mod goose;
 pub mod hermes;
 pub mod kilo;
 pub mod kilocode;


### PR DESCRIPTION
## Summary

- Adds support for [Goose](https://github.com/aaif-goose/goose) (aaif-goose/goose), an open-source AI coding agent with 43k+ stars, now part of the Agentic AI Foundation (AAIF) at the Linux Foundation.
- Parses token usage from Goose's SQLite `sessions.db`, extracting model name from `model_config_json`, provider from `provider_name`, and accumulated token counts per session.

## Data Location

The scanner checks multiple paths in order:
1. `$GOOSE_PATH_ROOT/data/sessions/sessions.db` (env var override)
2. `~/.local/share/goose/sessions/sessions.db` (aaif-goose fork, primary)
3. `~/Library/Application Support/goose/sessions/sessions.db` (macOS)
4. `~/Library/Application Support/Block/goose/sessions/sessions.db` (legacy Block/goose macOS)
5. `~/.local/share/Block/goose/sessions/sessions.db` (legacy Block/goose Linux)

## Files Changed

- `crates/tokscale-core/src/clients.rs` — `Goose = 18` entry in `define_clients!` macro
- `crates/tokscale-core/src/sessions/goose.rs` — **New** SQLite parser
- `crates/tokscale-core/src/sessions/mod.rs` — `pub mod goose`
- `crates/tokscale-core/src/scanner.rs` — DB discovery with multi-path fallback
- `crates/tokscale-core/src/lib.rs` — Parser wiring in both parse paths
- `crates/tokscale-cli/src/main.rs` — `--goose` CLI flag
- `crates/tokscale-cli/src/tui/client_ui.rs` — TUI entry with hotkey `o`
- `crates/tokscale-cli/src/tui/ui/widgets.rs` — Goose color
- `crates/tokscale-cli/src/tui/data/mod.rs` — Client count update
- `crates/tokscale-cli/src/commands/wrapped.rs` — Display name mapping

Closes #456

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Goose session scanner to track token usage from Goose’s SQLite `sessions.db`, with multi-path discovery and pricing. Adds CLI and TUI support for filtering and viewing Goose sessions; closes #456.

- **New Features**
  - Parses model from `model_config_json`, provider from `provider_name`, and accumulated input/output/total tokens per session; infers reasoning tokens when present.
  - DB discovery order: `$GOOSE_PATH_ROOT/data/sessions/sessions.db`, `~/.local/share/goose/sessions/sessions.db`, `~/Library/Application Support/goose/sessions/sessions.db`, plus legacy Block paths.
  - Integrates Goose into `tokscale-core` parsing and pricing; updates client registry and counts.
  - Adds `--goose` filter in `tokscale-cli`, TUI entry with hotkey `o`, display name mapping, color, and logo URL.

- **Bug Fixes**
  - Uses i64 for token counts to prevent overflow.
  - More robust timestamp parsing (RFC3339, SQLite formats) with correct ms conversion.
  - Validates discovered paths with `is_file` to avoid false positives.

<sup>Written for commit d1ab5e569612200111c7ad5476c3a10257522ef5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

