### PR TITLE
fix(tui): use fuzzy matching for provider colors

### DIFF
--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -70,16 +70,19 @@ pub fn get_provider_shade(provider: &str, rank: usize) -> Color {
     if let Some(base) = TokscaleConfig::load().get_provider_color(provider) {
         return shade_from_base(base, rank);
     }
-    let palette: &[(u8, u8, u8)] = match provider {
-        "anthropic" => &ANTHROPIC_SHADES,
-        "openai" => &OPENAI_SHADES,
-        "google" => &GOOGLE_SHADES,
-        "deepseek" => &DEEPSEEK_SHADES,
-        "xai" => &XAI_SHADES,
-        "meta" => &META_SHADES,
-        "cursor" => &CURSOR_SHADES,
+
+    let p = provider.to_lowercase();
+    let palette: &[(u8, u8, u8)] = match p.as_str() {
+        s if s.contains("anthropic") => &ANTHROPIC_SHADES,
+        s if s.contains("openai") => &OPENAI_SHADES,
+        s if s.contains("google") || s.contains("gemini") => &GOOGLE_SHADES,
+        s if s.contains("deepseek") => &DEEPSEEK_SHADES,
+        s if s.contains("xai") || s.contains("grok") => &XAI_SHADES,
+        s if s.contains("meta") || s.contains("llama") => &META_SHADES,
+        s if s.contains("cursor") => &CURSOR_SHADES,
         _ => &UNKNOWN_SHADES,
     };
+
     let idx = rank.min(palette.len() - 1);
     let (r, g, b) = palette[idx];
     Color::Rgb(r, g, b)
@@ -349,5 +352,29 @@ mod tests {
         let last = get_provider_shade("anthropic", 6);
         let past_end = get_provider_shade("anthropic", 99);
         assert_eq!(last, past_end);
+    }
+
+    #[test]
+    fn get_provider_shade_fuzzy_matching() {
+        assert_eq!(
+            get_provider_shade("test-anthropic", 0),
+            get_provider_shade("anthropic", 0)
+        );
+        assert_eq!(
+            get_provider_shade("company-google", 0),
+            get_provider_shade("google", 0)
+        );
+        assert_eq!(
+            get_provider_shade("openrouter-gemini-prod", 0),
+            get_provider_shade("google", 0)
+        );
+        assert_eq!(
+            get_provider_shade("deepseek-api", 0),
+            get_provider_shade("deepseek", 0)
+        );
+        assert_eq!(
+            get_provider_shade("meta-llama-endpoint", 0),
+            get_provider_shade("meta", 0)
+        );
     }
 }


### PR DESCRIPTION
## Summary
Custom/namespaced provider IDs (e.g. `api-anthropic-test`, `my-org-google`) now correctly resolve to their brand color palettes instead of falling back to gray

## Problem
`get_provider_shade` used exact string matching (`match provider { "anthropic" => ... }`) to select color palettes. When OpenCode (or other clients) use custom provider IDs that contain the canonical name as a substring (e.g. `api-anthropic-test`, `my-org-google`), none of the known palettes matched and all models rendered in the neutral gray `UNKNOWN_SHADES` ramp.

## Solution
Replace exact `match` arms with guard clauses using `contains()` on the lowercased provider string. This preserves the compact `match` structure while allowing any provider ID containing a known name (like `"anthropic"`, `"google"`, `"gemini"`) to pick up the correct palette. Config overrides via `[colors.providers]` still take priority.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Custom or namespaced provider IDs now map to the correct brand colors in the TUI using fuzzy matching, preventing fallback to gray. This makes provider colors consistent even when IDs include prefixes/suffixes.

- **Bug Fixes**
  - Use lowercase contains matching in `get_provider_shade` to handle namespaced IDs.
  - Support common aliases (e.g., "gemini"→Google, "grok"→XAI, "llama"→Meta).
  - Preserve `[colors.providers]` overrides; added tests for fuzzy matching.

<sup>Written for commit f83c07ab93be14bbe991befddfbd745c5a34e4ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

