### PR TITLE
chore(ci): upgrade GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -63,7 +63,7 @@ jobs:
             bin_name: tokscale.exe
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -71,7 +71,7 @@ jobs:
           targets: ${{ matrix.settings.target }}
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -104,7 +104,7 @@ jobs:
         run: ${{ matrix.settings.strip }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: cli-binary-${{ matrix.settings.target }}
           path: target/${{ matrix.settings.target }}/release/${{ matrix.settings.bin_name }}

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -104,7 +104,7 @@ jobs:
         run: ${{ matrix.settings.strip }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: cli-binary-${{ matrix.settings.target }}
           path: target/${{ matrix.settings.target }}/release/${{ matrix.settings.bin_name }}

--- a/.github/workflows/launcher_validation.yml
+++ b/.github/workflows/launcher_validation.yml
@@ -43,10 +43,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
 

--- a/.github/workflows/launcher_validation.yml
+++ b/.github/workflows/launcher_validation.yml
@@ -51,7 +51,7 @@ jobs:
           node-version: '20'
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.10
 

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -139,7 +139,7 @@ jobs:
           echo "📝 Version bump prepared (will commit after successful publish)"
 
       - name: Upload bumped manifest files
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: bumped-manifests
           path: |
@@ -225,7 +225,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Download bumped package.json files
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: bumped-manifests
           path: .
@@ -278,7 +278,7 @@ jobs:
         run: ${{ matrix.settings.strip }}
 
       - name: Upload CLI binary artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.settings.artifact_name }}
           path: target/${{ matrix.settings.target }}/release/${{ matrix.settings.bin_name }}
@@ -329,7 +329,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Download bumped package.json files
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: bumped-manifests
           path: .
@@ -340,7 +340,7 @@ jobs:
           bun-version: 1.1.38
 
       - name: Download CLI binary artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: ${{ matrix.settings.artifact_name }}
           path: artifacts/${{ matrix.settings.package_dir }}
@@ -372,7 +372,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Download bumped package.json files
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: bumped-manifests
           path: .
@@ -407,7 +407,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Download bumped package.json files
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: bumped-manifests
           path: .
@@ -439,7 +439,7 @@ jobs:
           fetch-tags: true
 
       - name: Download bumped package.json files
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: bumped-manifests
           path: .

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       version: ${{ steps.bump.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Calculate version
         id: bump
@@ -139,7 +139,7 @@ jobs:
           echo "📝 Version bump prepared (will commit after successful publish)"
 
       - name: Upload bumped manifest files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: bumped-manifests
           path: |
@@ -222,16 +222,16 @@ jobs:
             strip: ""
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download bumped package.json files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: bumped-manifests
           path: .
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
 
@@ -241,7 +241,7 @@ jobs:
           targets: ${{ matrix.settings.target }}
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -278,7 +278,7 @@ jobs:
         run: ${{ matrix.settings.strip }}
 
       - name: Upload CLI binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.settings.artifact_name }}
           path: target/${{ matrix.settings.target }}/release/${{ matrix.settings.bin_name }}
@@ -326,10 +326,10 @@ jobs:
             binary_name: tokscale.exe
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download bumped package.json files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: bumped-manifests
           path: .
@@ -340,7 +340,7 @@ jobs:
           bun-version: 1.1.38
 
       - name: Download CLI binary artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ${{ matrix.settings.artifact_name }}
           path: artifacts/${{ matrix.settings.package_dir }}
@@ -369,10 +369,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download bumped package.json files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: bumped-manifests
           path: .
@@ -404,10 +404,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download bumped package.json files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: bumped-manifests
           path: .
@@ -431,7 +431,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: true
@@ -439,7 +439,7 @@ jobs:
           fetch-tags: true
 
       - name: Download bumped package.json files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: bumped-manifests
           path: .

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -185,7 +185,7 @@ jobs:
           git diff --staged --quiet || (git commit -m "ci: update coverage badge [skip ci]" && git push)
 
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         if: "!cancelled() && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')"
         with:
           name: coverage-report

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -38,7 +38,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Check out the PR branch for same-repo PRs so we can push auto-fixes back
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || '' }}
@@ -50,7 +50,7 @@ jobs:
       - name: Verify version coherence
         run: bash scripts/check-version-coherence.sh
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -97,13 +97,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -169,7 +169,7 @@ jobs:
 
       - name: Generate coverage badge
         if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-        uses: emibcn/badge-action@v2.0.3
+        uses: emibcn/badge-action@v2.0.4
         with:
           label: 'coverage'
           status: ${{ steps.coverage.outputs.percentage_int }}%
@@ -185,7 +185,7 @@ jobs:
           git diff --staged --quiet || (git commit -m "ci: update coverage badge [skip ci]" && git push)
 
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: "!cancelled() && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')"
         with:
           name: coverage-report

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-cli"
-version = "2.0.26"
+version = "2.0.27"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-core"
-version = "2.0.26"
+version = "2.0.27"
 dependencies = [
  "bincode",
  "chrono",


### PR DESCRIPTION
## Summary
- Upgrades all GitHub Actions from v4 (Node.js 20) to v5 (Node.js 24-compatible)
- Updates `emibcn/badge-action` from v2.0.3 to v2.0.4
- Fixes deprecation warnings: "Node.js 20 actions are deprecated" starting June 2, 2026

## Changes
| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v4 | v5 |
| `actions/cache` | v4 | v5 |
| `actions/upload-artifact` | v4 | v5 |
| `actions/download-artifact` | v4 | v5 |
| `actions/setup-node` | v4 | v5 |
| `emibcn/badge-action` | v2.0.3 | v2.0.4 |

## Test plan
- [ ] Test & Coverage workflow passes
- [ ] Build Native workflow passes
- [ ] Launcher Validation workflow passes
- [ ] No Node.js 20 deprecation warnings in annotations
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade GitHub Actions to Node.js 24-compatible versions across all workflows to remove Node.js 20 deprecation warnings. Bump artifact actions to v6 (first Node 24 release), pin `oven-sh/setup-bun` to `v2`, and sync `Cargo.lock` crate versions to 2.0.27.

- **Dependencies**
  - `actions/checkout` v4 → v5
  - `actions/cache` v4 → v5
  - `actions/upload-artifact` v4 → v6
  - `actions/download-artifact` v4 → v6
  - `actions/setup-node` v4 → v5
  - `emibcn/badge-action` v2.0.3 → v2.0.4
  - `oven-sh/setup-bun` pinned SHA → `v2`

<sup>Written for commit 9d06f67baa50184b682fbfecb48b3067cd0d3023. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

