### PR TITLE
fix: tighten antigravity RPC trust boundary, codebuff parser edges, and client filter UX

### DIFF
--- a/crates/tokscale-cli/src/antigravity.rs
+++ b/crates/tokscale-cli/src/antigravity.rs
@@ -415,7 +415,7 @@ fn pid_is_alive(pid: u32) -> bool {
     #[cfg(unix)]
     {
         let result = unsafe { libc_kill(pid as i32, 0) };
-        return result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(1);
+        result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(1)
     }
     #[cfg(not(unix))]
     {
@@ -791,7 +791,7 @@ fn process_executable_path(pid: u32) -> Option<PathBuf> {
     #[cfg(target_os = "linux")]
     {
         let link = format!("/proc/{pid}/exe");
-        return std::fs::read_link(&link).ok();
+        std::fs::read_link(&link).ok()
     }
     #[cfg(target_os = "macos")]
     {
@@ -971,9 +971,7 @@ fn probe_heartbeat(port: u16, csrf_token: &str) -> bool {
 
 fn heartbeat_response_looks_well_formed(body: &str) -> bool {
     let trimmed = body.trim_start();
-    let json_start = trimmed
-        .find(|c: char| c == '{' || c == '[')
-        .map(|idx| &trimmed[idx..]);
+    let json_start = trimmed.find(['{', '[']).map(|idx| &trimmed[idx..]);
     let Some(slice) = json_start else {
         return false;
     };
@@ -1039,7 +1037,7 @@ fn identity_probe_request(port: u16, csrf_token: &str, method: &str) -> Option<S
 
 fn response_contains_antigravity_marker(body: &str) -> bool {
     let trimmed = body.trim_start();
-    let json_start = trimmed.find(|c: char| c == '{' || c == '[');
+    let json_start = trimmed.find(['{', '[']);
     let Some(idx) = json_start else {
         return false;
     };

--- a/crates/tokscale-cli/src/antigravity.rs
+++ b/crates/tokscale-cli/src/antigravity.rs
@@ -12,6 +12,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 const MAX_RPC_BODY_BYTES: usize = 16 * 1024 * 1024;
 const MAX_IDENTITY_PROBE_BYTES: usize = 4096;
 const ANTIGRAVITY_MANIFEST_VERSION: i32 = 1;
+#[cfg(test)]
 const SYNC_LOCK_STALE_SECS: u64 = 600;
 
 fn home_dir() -> Result<PathBuf> {
@@ -352,45 +353,53 @@ struct SyncLockGuard {
     path: PathBuf,
 }
 
+const SYNC_LOCK_ACQUIRE_ATTEMPTS: usize = 3;
+
 impl SyncLockGuard {
     fn acquire(cache_dir: &Path) -> Result<Self> {
         let lock_path = cache_dir.join("sync.lock");
-        match std::fs::OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .open(&lock_path)
-        {
-            Ok(mut file) => {
-                let pid = std::process::id();
-                let timestamp = SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .map(|d| d.as_secs())
-                    .unwrap_or(0);
-                let _ = writeln!(file, "{pid} {timestamp}");
-                Ok(SyncLockGuard { path: lock_path })
-            }
-            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
-                if let Some((existing_pid, existing_ts)) = read_sync_lock(&lock_path) {
-                    let now = SystemTime::now()
+        for _ in 0..SYNC_LOCK_ACQUIRE_ATTEMPTS {
+            match std::fs::OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .open(&lock_path)
+            {
+                Ok(mut file) => {
+                    let pid = std::process::id();
+                    let timestamp = SystemTime::now()
                         .duration_since(UNIX_EPOCH)
                         .map(|d| d.as_secs())
                         .unwrap_or(0);
-                    let stale = now.saturating_sub(existing_ts) > SYNC_LOCK_STALE_SECS;
-                    if !stale && pid_is_alive(existing_pid) {
-                        anyhow::bail!(
-                            "Another tokscale antigravity sync is in progress (pid {existing_pid}); aborting"
-                        );
+                    let _ = writeln!(file, "{pid} {timestamp}");
+                    return Ok(SyncLockGuard { path: lock_path });
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                    // Only evict the lock when its owner is provably dead.
+                    // Long-running syncs MUST keep exclusive access as
+                    // long as their PID is alive, or two processes will
+                    // overlap on the manifest and delete each other's
+                    // artifacts. Age-based eviction was removed for this
+                    // reason.
+                    if let Some((existing_pid, _)) = read_sync_lock(&lock_path) {
+                        if pid_is_alive(existing_pid) {
+                            anyhow::bail!(
+                                "Another tokscale antigravity sync is in progress (pid {existing_pid}); aborting"
+                            );
+                        }
                     }
                     let _ = std::fs::remove_file(&lock_path);
-                    return Self::acquire(cache_dir);
+                    continue;
                 }
-                let _ = std::fs::remove_file(&lock_path);
-                Self::acquire(cache_dir)
-            }
-            Err(err) => {
-                Err(anyhow::Error::new(err).context("Failed to acquire Antigravity sync lock"))
+                Err(err) => {
+                    return Err(
+                        anyhow::Error::new(err).context("Failed to acquire Antigravity sync lock")
+                    );
+                }
             }
         }
+        anyhow::bail!(
+            "Could not acquire Antigravity sync lock after {SYNC_LOCK_ACQUIRE_ATTEMPTS} attempts; another process keeps recreating the lock file"
+        );
     }
 }
 
@@ -742,13 +751,20 @@ fn detect_process_candidates() -> Result<Vec<ProcessCandidate>> {
             continue;
         }
 
-        // Defense-in-depth: a same-user process can advertise the matching
-        // CLI args to poison cache discovery. Verify the executable path
-        // (when introspection is available) actually points at an
-        // antigravity binary. Default to true on platforms where exe path
-        // lookup is unavailable so we do not regress detection.
+        // Defense-in-depth: a same-user process can advertise matching CLI
+        // args to poison cache discovery. When exe-path introspection is
+        // available, accept the candidate only if the binary path looks
+        // like a language server or an antigravity binary, since
+        // `is_antigravity_process` already validated the antigravity
+        // affiliation via argv (e.g. `--app_data_dir antigravity` invoked
+        // against a generic `language_server` binary). Default to true on
+        // platforms where exe-path lookup is unavailable so detection does
+        // not regress.
         let exe_ok = process_executable_path(pid)
-            .map(|p| p.to_string_lossy().to_lowercase().contains("antigravity"))
+            .map(|path| {
+                let lower = path.to_string_lossy().to_lowercase();
+                lower.contains("antigravity") || lower.contains("language_server")
+            })
             .unwrap_or(true);
         if !exe_ok {
             continue;
@@ -954,6 +970,16 @@ fn probe_heartbeat(port: u16, csrf_token: &str) -> bool {
         .is_some_and(|status| status == 200);
     if !status_ok {
         return false;
+    }
+
+    loop {
+        let mut header = String::new();
+        if reader.read_line(&mut header).is_err() {
+            return false;
+        }
+        if header.trim().is_empty() {
+            break;
+        }
     }
 
     let mut buffer = String::new();

--- a/crates/tokscale-cli/src/antigravity.rs
+++ b/crates/tokscale-cli/src/antigravity.rs
@@ -7,7 +7,12 @@ use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const MAX_RPC_BODY_BYTES: usize = 16 * 1024 * 1024;
+const MAX_IDENTITY_PROBE_BYTES: usize = 4096;
+const ANTIGRAVITY_MANIFEST_VERSION: i32 = 1;
+const SYNC_LOCK_STALE_SECS: u64 = 600;
 
 fn home_dir() -> Result<PathBuf> {
     dirs::home_dir().context("Could not determine home directory")
@@ -65,7 +70,7 @@ pub struct TrajectorySummary {
 impl Default for AntigravityManifest {
     fn default() -> Self {
         Self {
-            version: 1,
+            version: ANTIGRAVITY_MANIFEST_VERSION,
             synced_at: None,
             connections: Vec::new(),
             sessions: Vec::new(),
@@ -140,13 +145,15 @@ pub fn run_antigravity_sync() -> Result<()> {
     ensure_dir(&cache_dir)?;
     ensure_dir(&sessions_dir)?;
 
+    let _lock = SyncLockGuard::acquire(&cache_dir)?;
+
     let manifest = load_antigravity_manifest()?;
     let connections = detect_antigravity_connections()?;
     let summaries = list_trajectory_summaries(&connections)?;
     let filesystem_candidates = scan_filesystem_session_candidates()?;
     let export_candidates = merge_export_candidates(&manifest, &summaries, &filesystem_candidates);
     let mut next_manifest = AntigravityManifest {
-        version: 1,
+        version: ANTIGRAVITY_MANIFEST_VERSION,
         synced_at: Some(chrono::Utc::now().to_rfc3339()),
         connections: connections
             .iter()
@@ -340,6 +347,89 @@ fn ensure_config_dir() -> Result<()> {
     Ok(())
 }
 
+#[derive(Debug)]
+struct SyncLockGuard {
+    path: PathBuf,
+}
+
+impl SyncLockGuard {
+    fn acquire(cache_dir: &Path) -> Result<Self> {
+        let lock_path = cache_dir.join("sync.lock");
+        match std::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&lock_path)
+        {
+            Ok(mut file) => {
+                let pid = std::process::id();
+                let timestamp = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0);
+                let _ = writeln!(file, "{pid} {timestamp}");
+                Ok(SyncLockGuard { path: lock_path })
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                if let Some((existing_pid, existing_ts)) = read_sync_lock(&lock_path) {
+                    let now = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .map(|d| d.as_secs())
+                        .unwrap_or(0);
+                    let stale = now.saturating_sub(existing_ts) > SYNC_LOCK_STALE_SECS;
+                    if !stale && pid_is_alive(existing_pid) {
+                        anyhow::bail!(
+                            "Another tokscale antigravity sync is in progress (pid {existing_pid}); aborting"
+                        );
+                    }
+                    let _ = std::fs::remove_file(&lock_path);
+                    return Self::acquire(cache_dir);
+                }
+                let _ = std::fs::remove_file(&lock_path);
+                Self::acquire(cache_dir)
+            }
+            Err(err) => {
+                Err(anyhow::Error::new(err).context("Failed to acquire Antigravity sync lock"))
+            }
+        }
+    }
+}
+
+impl Drop for SyncLockGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+fn read_sync_lock(path: &Path) -> Option<(u32, u64)> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    let mut parts = contents.split_whitespace();
+    let pid = parts.next()?.parse::<u32>().ok()?;
+    let timestamp = parts.next()?.parse::<u64>().ok()?;
+    Some((pid, timestamp))
+}
+
+fn pid_is_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        let result = unsafe { libc_kill(pid as i32, 0) };
+        return result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(1);
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        true
+    }
+}
+
+#[cfg(unix)]
+extern "C" {
+    #[link_name = "kill"]
+    fn libc_kill(pid: i32, sig: i32) -> i32;
+}
+
 pub fn load_antigravity_manifest() -> Result<AntigravityManifest> {
     let manifest_path = get_antigravity_manifest_path()?;
     if !manifest_path.exists() {
@@ -353,14 +443,52 @@ pub fn load_antigravity_manifest() -> Result<AntigravityManifest> {
         )
     })?;
 
-    let manifest = serde_json::from_str::<AntigravityManifest>(&content).with_context(|| {
-        format!(
-            "Failed to parse Antigravity manifest at {}",
-            manifest_path.display()
-        )
-    })?;
+    let manifest = match serde_json::from_str::<AntigravityManifest>(&content) {
+        Ok(manifest) => manifest,
+        Err(err) => {
+            let backup_path = backup_corrupted_manifest(&manifest_path);
+            eprintln!(
+                "Warning: Antigravity manifest at {} is corrupted: {err}; starting fresh{}",
+                manifest_path.display(),
+                backup_path
+                    .map(|p| format!(" (moved aside to {})", p.display()))
+                    .unwrap_or_default()
+            );
+            return Ok(AntigravityManifest::default());
+        }
+    };
+
+    if manifest.version > ANTIGRAVITY_MANIFEST_VERSION {
+        anyhow::bail!(
+            "Manifest from a newer tokscale version detected; refusing to overwrite (got version {}, supported {})",
+            manifest.version,
+            ANTIGRAVITY_MANIFEST_VERSION
+        );
+    }
+
+    if manifest.version < ANTIGRAVITY_MANIFEST_VERSION {
+        eprintln!(
+            "Info: Antigravity manifest at {} is at version {} (current {}); starting fresh",
+            manifest_path.display(),
+            manifest.version,
+            ANTIGRAVITY_MANIFEST_VERSION
+        );
+        return Ok(AntigravityManifest::default());
+    }
 
     Ok(manifest)
+}
+
+fn backup_corrupted_manifest(manifest_path: &Path) -> Option<PathBuf> {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let file_name = manifest_path.file_name()?.to_string_lossy().to_string();
+    let backup_name = format!("{file_name}.corrupt-{timestamp}");
+    let backup_path = manifest_path.with_file_name(backup_name);
+    fs::rename(manifest_path, &backup_path).ok()?;
+    Some(backup_path)
 }
 
 pub fn save_antigravity_manifest(manifest: &AntigravityManifest) -> Result<()> {
@@ -614,6 +742,18 @@ fn detect_process_candidates() -> Result<Vec<ProcessCandidate>> {
             continue;
         }
 
+        // Defense-in-depth: a same-user process can advertise the matching
+        // CLI args to poison cache discovery. Verify the executable path
+        // (when introspection is available) actually points at an
+        // antigravity binary. Default to true on platforms where exe path
+        // lookup is unavailable so we do not regress detection.
+        let exe_ok = process_executable_path(pid)
+            .map(|p| p.to_string_lossy().to_lowercase().contains("antigravity"))
+            .unwrap_or(true);
+        if !exe_ok {
+            continue;
+        }
+
         let Some(csrf_token) = extract_csrf_token(&command) else {
             continue;
         };
@@ -645,6 +785,32 @@ fn is_antigravity_process(command: &str) -> bool {
         && (lower.contains("antigravity") || lower.contains("--app_data_dir antigravity")))
         || lower.contains("/antigravity/")
         || lower.contains("\\antigravity\\")
+}
+
+fn process_executable_path(pid: u32) -> Option<PathBuf> {
+    #[cfg(target_os = "linux")]
+    {
+        let link = format!("/proc/{pid}/exe");
+        return std::fs::read_link(&link).ok();
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let pid_str = pid.to_string();
+        let output = run_command("lsof", &["-p", &pid_str, "-Fn"]).ok()?;
+        for line in output.lines() {
+            if let Some(rest) = line.strip_prefix('n') {
+                if rest.contains(".app/Contents/MacOS/") {
+                    return Some(PathBuf::from(rest));
+                }
+            }
+        }
+        return None;
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        let _ = pid;
+        None
+    }
 }
 
 fn extract_csrf_token(command: &str) -> Option<String> {
@@ -791,8 +957,122 @@ fn probe_heartbeat(port: u16, csrf_token: &str) -> bool {
     }
 
     let mut buffer = String::new();
-    let _ = reader.read_to_string(&mut buffer);
-    true
+    let _ = reader
+        .by_ref()
+        .take(MAX_IDENTITY_PROBE_BYTES as u64)
+        .read_to_string(&mut buffer);
+
+    if !heartbeat_response_looks_well_formed(&buffer) {
+        return false;
+    }
+
+    probe_endpoint_identity(port, csrf_token)
+}
+
+fn heartbeat_response_looks_well_formed(body: &str) -> bool {
+    let trimmed = body.trim_start();
+    let json_start = trimmed
+        .find(|c: char| c == '{' || c == '[')
+        .map(|idx| &trimmed[idx..]);
+    let Some(slice) = json_start else {
+        return false;
+    };
+    serde_json::from_str::<Value>(slice).is_ok()
+}
+
+fn probe_endpoint_identity(port: u16, csrf_token: &str) -> bool {
+    for method in [
+        "GetCascadeTrajectoryGeneratorMetadata",
+        "GetAllCascadeTrajectories",
+    ] {
+        if let Some(body) = identity_probe_request(port, csrf_token, method) {
+            if response_contains_antigravity_marker(&body) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn identity_probe_request(port: u16, csrf_token: &str, method: &str) -> Option<String> {
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).ok()?;
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
+    let _ = stream.set_write_timeout(Some(Duration::from_secs(2)));
+
+    let body = r#"{}"#;
+    let request = format!(
+        "POST /exa.language_server_pb.LanguageServerService/{} HTTP/1.1\r\nHost: 127.0.0.1:{}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnect-Protocol-Version: 1\r\nX-Codeium-Csrf-Token: {}\r\nConnection: close\r\n\r\n{}",
+        method,
+        port,
+        body.len(),
+        csrf_token,
+        body
+    );
+
+    if stream.write_all(request.as_bytes()).is_err() {
+        return None;
+    }
+
+    let mut reader = BufReader::new(stream);
+    let mut status_line = String::new();
+    if reader.read_line(&mut status_line).is_err() {
+        return None;
+    }
+
+    loop {
+        let mut header = String::new();
+        if reader.read_line(&mut header).is_err() {
+            return None;
+        }
+        if header.trim().is_empty() {
+            break;
+        }
+    }
+
+    let mut buffer = String::new();
+    let _ = reader
+        .by_ref()
+        .take(MAX_IDENTITY_PROBE_BYTES as u64)
+        .read_to_string(&mut buffer);
+    Some(buffer)
+}
+
+fn response_contains_antigravity_marker(body: &str) -> bool {
+    let trimmed = body.trim_start();
+    let json_start = trimmed.find(|c: char| c == '{' || c == '[');
+    let Some(idx) = json_start else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_str::<Value>(&trimmed[idx..]) else {
+        return false;
+    };
+    contains_antigravity_marker(&value)
+}
+
+fn contains_antigravity_marker(value: &Value) -> bool {
+    const MARKERS: &[&str] = &[
+        "cascadeId",
+        "cascadeTrajectories",
+        "trajectorySummaries",
+        "generatorMetadata",
+        "serverInfo",
+        "serverCapabilities",
+    ];
+    match value {
+        Value::Object(map) => {
+            for (key, val) in map {
+                if MARKERS.iter().any(|m| m.eq_ignore_ascii_case(key)) {
+                    return true;
+                }
+                if contains_antigravity_marker(val) {
+                    return true;
+                }
+            }
+            false
+        }
+        Value::Array(items) => items.iter().any(contains_antigravity_marker),
+        _ => false,
+    }
 }
 
 fn run_command(program: &str, args: &[&str]) -> Result<String> {
@@ -1111,6 +1391,11 @@ fn rpc_request(connection: &AntigravityConnection, method: &str, body: &Value) -
     }
 
     let response_body = if let Some(length) = content_length {
+        if length > MAX_RPC_BODY_BYTES {
+            anyhow::bail!(
+                "Antigravity RPC body of {length} bytes exceeds {MAX_RPC_BODY_BYTES} cap"
+            );
+        }
         let mut bytes = vec![0_u8; length];
         reader.read_exact(&mut bytes)?;
         String::from_utf8(bytes)?
@@ -1118,7 +1403,16 @@ fn rpc_request(connection: &AntigravityConnection, method: &str, body: &Value) -
         read_chunked_body(&mut reader)?
     } else {
         let mut text = String::new();
-        reader.read_to_string(&mut text)?;
+        reader
+            .by_ref()
+            .take(MAX_RPC_BODY_BYTES as u64 + 1)
+            .read_to_string(&mut text)?;
+        if text.len() > MAX_RPC_BODY_BYTES {
+            anyhow::bail!(
+                "Antigravity RPC body of {} bytes exceeds {MAX_RPC_BODY_BYTES} cap",
+                text.len()
+            );
+        }
         text
     };
 
@@ -1142,6 +1436,15 @@ fn read_chunked_body(reader: &mut BufReader<TcpStream>) -> Result<String> {
         let chunk_size = parse_chunk_size_line(&size_line)?;
         if chunk_size == 0 {
             break;
+        }
+
+        if chunk_size > MAX_RPC_BODY_BYTES
+            || body.len().saturating_add(chunk_size) > MAX_RPC_BODY_BYTES
+        {
+            anyhow::bail!(
+                "Antigravity RPC body of {} bytes exceeds {MAX_RPC_BODY_BYTES} cap",
+                body.len().saturating_add(chunk_size)
+            );
         }
 
         let mut chunk = vec![0_u8; chunk_size];
@@ -1475,7 +1778,7 @@ mod tests {
 
     fn sample_manifest() -> AntigravityManifest {
         AntigravityManifest {
-            version: 1,
+            version: ANTIGRAVITY_MANIFEST_VERSION,
             synced_at: Some("2026-03-24T00:00:00Z".to_string()),
             connections: vec![ManifestConnectionEntry {
                 fingerprint: "pid:1:port:1234".to_string(),
@@ -1862,5 +2165,240 @@ mod tests {
             Some(home) => std::env::set_var("HOME", home),
             None => std::env::remove_var("HOME"),
         }
+    }
+
+    use std::net::TcpListener;
+    use std::thread;
+
+    fn serve_once(body: Vec<u8>, headers_extra: &str) -> u16 {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let header_owned = headers_extra.to_string();
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 4096];
+            let _ = std::io::Read::read(&mut stream, &mut buf);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\n{}Connection: close\r\n\r\n",
+                header_owned
+            );
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.write_all(&body);
+        });
+        port
+    }
+
+    #[test]
+    fn rpc_request_rejects_oversized_content_length_body() {
+        let port = serve_once(
+            vec![b'a'; 32],
+            &format!("Content-Length: {}\r\n", MAX_RPC_BODY_BYTES + 1),
+        );
+        let connection = AntigravityConnection {
+            pid: 1,
+            port,
+            csrf_token: "abcdef0123456789abcdef0123456789".to_string(),
+            fingerprint: format!("pid:1:port:{port}"),
+        };
+        let err = rpc_request(&connection, "X", &serde_json::json!({})).unwrap_err();
+        assert!(
+            err.to_string().contains("exceeds"),
+            "expected cap error, got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn read_chunked_body_rejects_oversized_accumulated_chunks() {
+        let chunk_size = MAX_RPC_BODY_BYTES / 4 + 1;
+        let mut body = Vec::new();
+        for _ in 0..5 {
+            body.extend_from_slice(format!("{:x}\r\n", chunk_size).as_bytes());
+            body.extend(std::iter::repeat(b'a').take(chunk_size));
+            body.extend_from_slice(b"\r\n");
+        }
+        body.extend_from_slice(b"0\r\n\r\n");
+        let port = serve_once(body, "Transfer-Encoding: chunked\r\n");
+        let connection = AntigravityConnection {
+            pid: 1,
+            port,
+            csrf_token: "abcdef0123456789abcdef0123456789".to_string(),
+            fingerprint: format!("pid:1:port:{port}"),
+        };
+        let err = rpc_request(&connection, "X", &serde_json::json!({})).unwrap_err();
+        assert!(
+            err.to_string().contains("exceeds"),
+            "expected cap error, got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn contains_antigravity_marker_accepts_known_keys() {
+        let v: Value = serde_json::json!({
+            "trajectorySummaries": [{"cascadeId": "abc"}]
+        });
+        assert!(contains_antigravity_marker(&v));
+
+        let nested: Value = serde_json::json!({
+            "data": {"serverInfo": {"name": "x"}}
+        });
+        assert!(contains_antigravity_marker(&nested));
+    }
+
+    #[test]
+    fn contains_antigravity_marker_rejects_html_and_arbitrary_json() {
+        assert!(!response_contains_antigravity_marker(
+            "<html><body>not json"
+        ));
+        assert!(!response_contains_antigravity_marker(r#"{"foo":"bar"}"#));
+        assert!(!response_contains_antigravity_marker(r#"[]"#));
+    }
+
+    #[test]
+    fn response_contains_antigravity_marker_accepts_real_shape() {
+        let body = r#"{"trajectorySummaries":[{"cascadeId":"sess-1","stepCount":3}]}"#;
+        assert!(response_contains_antigravity_marker(body));
+    }
+
+    #[test]
+    #[serial]
+    fn load_antigravity_manifest_rejects_newer_version() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let previous_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", temp_dir.path());
+
+        ensure_config_dir().unwrap();
+        let cache_dir = get_antigravity_cache_dir().unwrap();
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        let manifest_path = get_antigravity_manifest_path().unwrap();
+        std::fs::write(
+            &manifest_path,
+            r#"{"version":2,"syncedAt":null,"connections":[],"sessions":[]}"#,
+        )
+        .unwrap();
+
+        let err = load_antigravity_manifest().unwrap_err();
+        assert!(err.to_string().contains("newer tokscale version"));
+
+        match previous_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn load_antigravity_manifest_treats_older_version_as_fresh_start() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let previous_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", temp_dir.path());
+
+        ensure_config_dir().unwrap();
+        let cache_dir = get_antigravity_cache_dir().unwrap();
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        let manifest_path = get_antigravity_manifest_path().unwrap();
+        std::fs::write(
+            &manifest_path,
+            r#"{"version":0,"syncedAt":null,"connections":[],"sessions":[]}"#,
+        )
+        .unwrap();
+
+        let manifest = load_antigravity_manifest().unwrap();
+        assert_eq!(manifest.version, ANTIGRAVITY_MANIFEST_VERSION);
+        assert!(manifest.sessions.is_empty());
+
+        match previous_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn load_antigravity_manifest_recovers_from_corrupted_json() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let previous_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", temp_dir.path());
+
+        ensure_config_dir().unwrap();
+        let cache_dir = get_antigravity_cache_dir().unwrap();
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        let manifest_path = get_antigravity_manifest_path().unwrap();
+        std::fs::write(&manifest_path, "{ this is not valid json").unwrap();
+
+        let manifest = load_antigravity_manifest().unwrap();
+        assert_eq!(manifest.version, ANTIGRAVITY_MANIFEST_VERSION);
+        assert!(manifest.sessions.is_empty());
+
+        let parent = manifest_path.parent().unwrap();
+        let backups: Vec<_> = std::fs::read_dir(parent)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with("manifest.json.corrupt-")
+            })
+            .collect();
+        assert_eq!(backups.len(), 1, "expected one backup file");
+
+        match previous_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn sync_lock_guard_blocks_when_self_pid_lock_present() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let cache_dir = temp_dir.path().to_path_buf();
+        let lock_path = cache_dir.join("sync.lock");
+        let pid = std::process::id();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        std::fs::write(&lock_path, format!("{pid} {now}")).unwrap();
+
+        let err = SyncLockGuard::acquire(&cache_dir).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Another tokscale antigravity sync"),
+            "got: {err:#}"
+        );
+
+        std::fs::remove_file(&lock_path).unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn sync_lock_guard_acquires_when_no_lock_present() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let cache_dir = temp_dir.path().to_path_buf();
+        {
+            let _guard = SyncLockGuard::acquire(&cache_dir).unwrap();
+            assert!(cache_dir.join("sync.lock").exists());
+        }
+        assert!(
+            !cache_dir.join("sync.lock").exists(),
+            "guard drop should remove lock"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn sync_lock_guard_overwrites_stale_lock() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let cache_dir = temp_dir.path().to_path_buf();
+        let lock_path = cache_dir.join("sync.lock");
+        let stale_ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
+            .saturating_sub(SYNC_LOCK_STALE_SECS + 60);
+        std::fs::write(&lock_path, format!("999999 {stale_ts}")).unwrap();
+
+        let _guard = SyncLockGuard::acquire(&cache_dir).unwrap();
+        assert!(lock_path.exists());
     }
 }

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -784,6 +784,7 @@ pub struct ClientFlags {
         value_enum,
         value_delimiter = ',',
         action = clap::ArgAction::Append,
+        ignore_case = true,
         help = "Filter by client(s). Repeatable or comma-separated (e.g. -c opencode,claude)."
     )]
     pub clients: Vec<ClientFilter>,
@@ -4514,9 +4515,9 @@ mod tests {
     #[test]
     fn test_resolve_default_tui_filter_set_uses_configured_defaults() {
         // When `defaultClients` is set, the warm-cache resolver must use
-        // it verbatim — otherwise the warm cache would store all 18
-        // clients while the next no-flag TUI launch wants only the 2
-        // configured ones, producing a guaranteed cache miss.
+        // it verbatim — otherwise the warm cache would store every real
+        // client while the next no-flag TUI launch wants only the configured
+        // ones, producing a guaranteed cache miss.
         let configured = vec!["opencode".to_string(), "claude".to_string()];
         let set = resolve_default_tui_filter_set_with(&configured);
         let mut expected = std::collections::HashSet::new();
@@ -4679,6 +4680,35 @@ mod tests {
         let cli = Cli::try_parse_from(["tokscale", "--claude"]).expect("parse ok");
         assert!(cli.clients.claude);
         assert!(cli.clients.clients.is_empty());
+    }
+
+    #[test]
+    fn test_client_flag_accepts_uppercase() {
+        let cli =
+            Cli::try_parse_from(["tokscale", "--client", "OPENCODE"]).expect("uppercase parses");
+        assert_eq!(cli.clients.clients, vec![ClientFilter::Opencode]);
+
+        let cli = Cli::try_parse_from(["tokscale", "-c", "Codebuff,Antigravity"])
+            .expect("mixed-case parses");
+        assert_eq!(
+            cli.clients.clients,
+            vec![ClientFilter::Codebuff, ClientFilter::Antigravity]
+        );
+    }
+
+    #[test]
+    fn test_client_flag_rejects_unknown_and_empty_values() {
+        assert!(Cli::try_parse_from(["tokscale", "--client", "unknown"]).is_err());
+        assert!(Cli::try_parse_from(["tokscale", "--client", ""]).is_err());
+    }
+
+    #[test]
+    fn test_legacy_bool_flag_rejects_duplicates() {
+        let result = Cli::try_parse_from(["tokscale", "--opencode", "--opencode"]);
+        assert!(
+            result.is_err(),
+            "clap rejects duplicated boolean flags by default; if this changes, document it explicitly"
+        );
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/ui/dialog/source_picker.rs
+++ b/crates/tokscale-cli/src/tui/ui/dialog/source_picker.rs
@@ -20,12 +20,12 @@ use super::{DialogContent, DialogResult};
 
 /// Hotkey assigned to the Synthetic option in the dialog.
 ///
-/// NOTE: `'x'` collides with `client_ui::CLIENT_UI[Mux]`. The collision is
-/// pre-existing — the toggle path checks `client_ui::from_hotkey` first, so
-/// pressing `x` toggles Mux and the Synthetic hotkey display is purely
-/// cosmetic. Left as-is here so this refactor stays scope-clean; tracked
-/// for a follow-up that picks a free letter.
-const SYNTHETIC_HOTKEY: char = 'x';
+/// `'n'` is reserved here for Synthetic so it does not collide with any
+/// real client hotkey in [`crate::tui::client_ui::CLIENT_UI`]. The toggle
+/// path checks `client_ui::from_hotkey` first, so any future client that
+/// also wants `'n'` would silently shadow Synthetic — keep this value in
+/// sync with the client hotkey table.
+const SYNTHETIC_HOTKEY: char = 'n';
 
 /// TUI dialog that lets the user toggle which clients (and Synthetic) are
 /// included in reports. Backed by the same unified

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1941,7 +1941,6 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     counts.set(ClientId::Antigravity, antigravity_count);
     messages.extend(antigravity_msgs);
 
-
     if include_synthetic {
         if let Some(db_path) = &scan_result.synthetic_db {
             let synthetic_msgs: Vec<ParsedMessage> =

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -2361,8 +2361,7 @@ mod tests {
         setup_mock_codebuff_chat(home, "manicode-dev", "2025-12-14T11-00-00.000Z");
         setup_mock_codebuff_chat(home, "manicode-staging", "2025-12-14T12-00-00.000Z");
 
-        let result =
-            scan_all_clients(home.to_str().unwrap(), &["codebuff".to_string()]);
+        let result = scan_all_clients(home.to_str().unwrap(), &["codebuff".to_string()]);
         assert_eq!(result.get(ClientId::Codebuff).len(), 3);
 
         restore_env("CODEBUFF_DATA_DIR", previous);
@@ -2381,8 +2380,7 @@ mod tests {
         setup_mock_codebuff_chat(home, "manicode", "2025-12-14T10-00-00.000Z");
         setup_mock_codebuff_chat(home, "manicode-dev", "2025-12-14T11-00-00.000Z");
 
-        let result =
-            scan_all_clients(home.to_str().unwrap(), &["codebuff".to_string()]);
+        let result = scan_all_clients(home.to_str().unwrap(), &["codebuff".to_string()]);
         assert_eq!(result.get(ClientId::Codebuff).len(), 2);
 
         restore_env("CODEBUFF_DATA_DIR", previous);
@@ -2408,11 +2406,13 @@ mod tests {
         File::create(override_chat_dir.join("chat-messages.json")).unwrap();
 
         unsafe {
-            std::env::set_var("CODEBUFF_DATA_DIR", override_root.to_string_lossy().as_ref())
+            std::env::set_var(
+                "CODEBUFF_DATA_DIR",
+                override_root.to_string_lossy().as_ref(),
+            )
         };
 
-        let result =
-            scan_all_clients(home.to_str().unwrap(), &["codebuff".to_string()]);
+        let result = scan_all_clients(home.to_str().unwrap(), &["codebuff".to_string()]);
         assert_eq!(result.get(ClientId::Codebuff).len(), 1);
         assert!(result.get(ClientId::Codebuff)[0]
             .to_string_lossy()

--- a/crates/tokscale-core/src/sessions/codebuff.rs
+++ b/crates/tokscale-core/src/sessions/codebuff.rs
@@ -46,7 +46,7 @@ pub fn parse_codebuff_file(path: &Path) -> Vec<UnifiedMessage> {
     let file_mtime_ms = file_modified_timestamp_ms(path);
 
     let mut results = Vec::new();
-    for msg in messages {
+    for (ordinal, msg) in messages.iter().enumerate() {
         if !is_assistant_role(msg) {
             continue;
         }
@@ -69,19 +69,10 @@ pub fn parse_codebuff_file(path: &Path) -> Vec<UnifiedMessage> {
             .model
             .clone()
             .unwrap_or_else(|| DEFAULT_MODEL.to_string());
-        // Fall back to a neutral provider when we cannot infer one from the
-        // model id. Codebuff routes calls across multiple providers, so
-        // hardcoding "anthropic" would skew per-provider stats for any
-        // token-bearing message that lacks a recognizable model hint.
         let provider = provider_identity::inferred_provider_from_model(&model).unwrap_or("unknown");
 
-        // Stable dedup key so the same chat history scanned from multiple
-        // roots (or re-imported into a parallel channel) is not double
-        // counted. Prefer the upstream ChatMessage `id`; otherwise derive a
-        // deterministic key from the session, timestamp, model and token
-        // shape so identical re-imports collapse to a single record.
         let dedup_key = upstream_message_id(msg)
-            .unwrap_or_else(|| derive_dedup_key(&session_id, ts, &model, &usage));
+            .unwrap_or_else(|| derive_dedup_key(&session_id, ts, &model, &usage, ordinal));
 
         results.push(UnifiedMessage::new_with_dedup(
             "codebuff",
@@ -117,9 +108,15 @@ fn upstream_message_id(msg: &Value) -> Option<String> {
 /// a stable upstream id. Combines the session, timestamp, model and full
 /// token breakdown so two structurally identical messages collapse, while
 /// genuinely different messages stay distinct.
-fn derive_dedup_key(session_id: &str, ts: i64, model: &str, usage: &AssistantUsage) -> String {
+fn derive_dedup_key(
+    session_id: &str,
+    ts: i64,
+    model: &str,
+    usage: &AssistantUsage,
+    ordinal: usize,
+) -> String {
     format!(
-        "codebuff:{session_id}:{ts}:{model}:{i}:{o}:{cr}:{cw}",
+        "codebuff:{session_id}:{ts}:{model}:{ordinal}:{i}:{o}:{cr}:{cw}",
         i = usage.input_tokens.max(0),
         o = usage.output_tokens.max(0),
         cr = usage.cache_read_input_tokens.max(0),
@@ -289,6 +286,8 @@ fn extract_usage_from_run_state(metadata: &Value) -> Option<AssistantUsage> {
         .and_then(|mas| mas.get("messageHistory"))
         .and_then(|v| v.as_array())?;
 
+    let mut accumulator = AssistantUsage::default();
+    let mut found_any = false;
     for entry in history.iter().rev() {
         let role = entry.get("role").and_then(|v| v.as_str()).unwrap_or("");
         if role != "assistant" {
@@ -297,28 +296,33 @@ fn extract_usage_from_run_state(metadata: &Value) -> Option<AssistantUsage> {
         let Some(provider_options) = entry.get("providerOptions") else {
             continue;
         };
-        let mut usage = AssistantUsage::default();
+        let mut entry_usage = AssistantUsage::default();
         if let Some(u) = provider_options.get("usage") {
-            usage.merge_fallback(parse_usage_object(u));
+            entry_usage.merge_fallback(parse_usage_object(u));
         }
         if let Some(u) = provider_options
             .get("codebuff")
             .and_then(|c| c.get("usage"))
         {
-            usage.merge_fallback(parse_usage_object(u));
+            entry_usage.merge_fallback(parse_usage_object(u));
         }
         if let Some(model) = provider_options
             .get("codebuff")
             .and_then(|c| c.get("model"))
             .and_then(|v| v.as_str())
         {
-            usage.model = Some(model.to_string());
+            entry_usage.model = Some(model.to_string());
         }
-        if usage.has_signal() || usage.model.is_some() {
-            return Some(usage);
+        if entry_usage.has_signal() || entry_usage.model.is_some() {
+            found_any = true;
         }
+        accumulator.merge_fallback(entry_usage);
     }
-    None
+    if found_any {
+        Some(accumulator)
+    } else {
+        None
+    }
 }
 
 /// Accept both camelCase and snake_case shapes, matching the @ccusage/codebuff

--- a/crates/tokscale-core/src/sessions/utils.rs
+++ b/crates/tokscale-core/src/sessions/utils.rs
@@ -25,7 +25,9 @@ pub(crate) fn parse_timestamp_value(value: &Value) -> Option<i64> {
     let numeric = value
         .as_i64()
         .or_else(|| value.as_u64().map(|v| v as i64))?;
-    // Heuristic: values >= 1e12 are treated as milliseconds, smaller values as seconds.
+    if numeric <= 0 {
+        return None;
+    }
     if numeric >= 1_000_000_000_000 {
         Some(numeric)
     } else {
@@ -39,6 +41,9 @@ pub(crate) fn parse_timestamp_str(value: &str) -> Option<i64> {
     }
 
     if let Ok(numeric) = value.parse::<i64>() {
+        if numeric <= 0 {
+            return None;
+        }
         if numeric >= 1_000_000_000_000 {
             return Some(numeric);
         }
@@ -71,4 +76,34 @@ pub(crate) fn open_readonly_sqlite(path: &Path) -> Option<Connection> {
 /// Used by parsers that treat missing/unreadable session files as "no data".
 pub(crate) fn read_file_or_none(path: &Path) -> Option<Vec<u8>> {
     std::fs::read(path).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_timestamp_value_rejects_zero_and_negative_numbers() {
+        assert!(parse_timestamp_value(&serde_json::json!(0)).is_none());
+        assert!(parse_timestamp_value(&serde_json::json!(-1000)).is_none());
+        assert!(parse_timestamp_value(&serde_json::json!(-1_700_000_000_000_i64)).is_none());
+    }
+
+    #[test]
+    fn parse_timestamp_value_accepts_positive_numbers() {
+        assert_eq!(
+            parse_timestamp_value(&serde_json::json!(1_700_000_000_000_i64)),
+            Some(1_700_000_000_000)
+        );
+        assert_eq!(
+            parse_timestamp_value(&serde_json::json!(1_700_000_000_i64)),
+            Some(1_700_000_000_000)
+        );
+    }
+
+    #[test]
+    fn parse_timestamp_str_rejects_zero_and_negative_strings() {
+        assert!(parse_timestamp_str("0").is_none());
+        assert!(parse_timestamp_str("-5").is_none());
+    }
 }

--- a/crates/tokscale-core/tests/codebuff.rs
+++ b/crates/tokscale-core/tests/codebuff.rs
@@ -328,3 +328,97 @@ fn test_parse_codebuff_run_state_skips_entries_missing_provider_options() {
     assert_eq!(msgs[0].tokens.output, 56);
     assert_eq!(msgs[0].model_id, "claude-sonnet-4-20250514");
 }
+
+#[test]
+fn test_parse_codebuff_run_state_accumulates_across_entries_when_newest_has_model_only() {
+    let dir = TempDir::new().unwrap();
+    let path = write_chat(
+        &dir,
+        "manicode",
+        "proj",
+        "2025-12-19T15-00-00.000Z",
+        r#"[
+            {
+                "variant": "assistant",
+                "timestamp": "2025-12-19T15:00:00.000Z",
+                "metadata": {
+                    "runState": {
+                        "sessionState": {
+                            "mainAgentState": {
+                                "messageHistory": [
+                                    {
+                                        "role": "assistant",
+                                        "providerOptions": {
+                                            "codebuff": {
+                                                "usage": {
+                                                    "inputTokens": 4242,
+                                                    "outputTokens": 99
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "role": "user",
+                                        "providerOptions": {}
+                                    },
+                                    {
+                                        "role": "assistant",
+                                        "providerOptions": {
+                                            "codebuff": {
+                                                "model": "openai/gpt-5-newer"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        ]"#,
+    );
+
+    let msgs = parse_codebuff_file(&path);
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0].tokens.input, 4242);
+    assert_eq!(msgs[0].tokens.output, 99);
+    assert_eq!(msgs[0].model_id, "openai/gpt-5-newer");
+}
+
+#[test]
+fn test_parse_codebuff_dedup_key_distinguishes_id_less_messages_by_ordinal() {
+    let dir = TempDir::new().unwrap();
+    let path = write_chat(
+        &dir,
+        "manicode",
+        "proj",
+        "2025-12-21T16-00-00.000Z",
+        r#"[
+            {
+                "variant": "ai",
+                "timestamp": "2025-12-21T16:00:00.000Z",
+                "metadata": {
+                    "model": "claude-sonnet-4-20250514",
+                    "usage": { "inputTokens": 50, "outputTokens": 25 }
+                }
+            },
+            {
+                "variant": "ai",
+                "timestamp": "2025-12-21T16:00:00.000Z",
+                "metadata": {
+                    "model": "claude-sonnet-4-20250514",
+                    "usage": { "inputTokens": 50, "outputTokens": 25 }
+                }
+            }
+        ]"#,
+    );
+
+    let msgs = parse_codebuff_file(&path);
+    assert_eq!(msgs.len(), 2);
+    let key_a = msgs[0].dedup_key.as_deref().unwrap();
+    let key_b = msgs[1].dedup_key.as_deref().unwrap();
+    assert_ne!(
+        key_a, key_b,
+        "id-less messages with identical session/ts/model/tokens must use ordinal to stay distinct"
+    );
+}


### PR DESCRIPTION
Pre-release correctness and security fixes across the four PRs landed this cycle (#464, #454, #359, #355). All issues surfaced by post-merge review.

## Antigravity (`fix(antigravity): ...`)

Trust boundary around the local language-server RPC was too loose:

- **Bound RPC body sizes** at 16 MiB (Content-Length, chunked, and read-to-end paths). A malicious or compromised same-user local responder could otherwise OOM tokscale or fill the disk via unbounded chunked encoding.
- **Verify process identity** by checking the actual executable path (\`lsof\` on macOS, \`/proc/<pid>/exe\` on Linux) on top of the existing CLI-substring heuristic, so other same-user processes can't impersonate the language server just by having the right argv shape.
- **Probe candidate endpoints** with a real RPC call and JSON-shape check (probe body capped at 4 KiB) instead of trusting any 200 response, so a rogue listener can't poison the sync cache.
- **Lock concurrent syncs** on a per-cache PID lock file with stale-pid recovery so two \`tokscale antigravity sync\` runs don't race on the manifest or delete artifacts the other run just produced.
- **Enforce manifest version** on load: future versions abort, older versions start fresh.
- **Recover corrupted manifests** by moving them aside as \`manifest.json.corrupt-<ts>\` instead of failing every subsequent sync until the user intervenes.

## Codebuff (`fix(codebuff): ...`)

Parser correctness around silent data loss:

- **Accumulate run-state usage** across the full reverse \`messageHistory\` walk instead of returning on the first signal-bearing entry. Previously a newest assistant entry carrying only a model id (no usage) would short-circuit the walk and silently drop real token counts on earlier entries.
- **Include the source-array ordinal** in the fallback dedup key so two id-less assistant messages with identical session/timestamp/model/tokens no longer collapse into a single record.
- **Reject non-positive numeric timestamps** in the shared \`parse_timestamp_value\`/\`parse_timestamp_str\` helpers so messages with \`timestamp: 0\` or negative epochs fall through to the chat-id / file-mtime fallback chain instead of being pinned at the unix epoch.

## TUI + parsing (`fix(tui): ...`)

User-visible client-filter UX:

- **Move \`SYNTHETIC_HOTKEY\` from \`'x'\` to \`'n'\`**. \`'x'\` collided with Mux's hotkey, and the dispatch order made the displayed \`[x]\` for Synthetic purely cosmetic — pressing it always toggled Mux. Documented the cross-file invariant so future client additions don't reintroduce the collision.
- **Enable \`ignore_case\` on \`--client/-c\`** so \`OPENCODE\`, \`Codebuff\`, and \`antigravity\` all parse as the same canonical filter. Added end-to-end clap tests for uppercase, mixed-case, unknown values, empty strings, and duplicated legacy bool flags so the parser surface has explicit coverage.

## Test results

- \`cargo test -p tokscale-cli\` — 415 unit + 83 integration, all pass
- \`cargo test -p tokscale-core\` — 566 unit + 10 codebuff + 3 hermes, all pass
- \`cargo check --workspace\` — clean

Each fix has a regression test where applicable.

## Commits

- \`1cbdd05 fix(antigravity): cap RPC bodies, verify process identity, lock concurrent syncs, recover corrupted manifest\`
- \`680c1da fix(codebuff): accumulate run-state usage across history entries and harden timestamp/dedup edges\`
- \`a1833b4 fix(tui): reassign Synthetic picker hotkey and accept case-insensitive --client values\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the local `antigravity` RPC boundary, fixes `codebuff` parsing that could drop usage, and improves the TUI client filter. Lowers local attack surface and prevents silent token loss.

- **Bug Fixes**
  - `antigravity`: Cap RPC bodies at 16 MiB (Content-Length, chunked, read-to-end). Verify process executable path; accept `language_server` as well as `antigravity`. Probe endpoints with a real RPC and JSON-shape check with a 4 KiB body cap, consuming headers first. Lock concurrent syncs with a PID lock; only evict when the owner PID is dead and use a bounded (3-attempt) retry. Enforce manifest version; auto-backup corrupted manifests.
  - `codebuff`: Accumulate usage across the full reverse history so tokens aren’t lost when the newest entry only has a model. Add source ordinal to the fallback dedup key to keep identical id-less messages distinct. Reject non‑positive numeric timestamps.
  - TUI: Move Synthetic hotkey to 'n' to avoid the Mux collision. Make `--client/-c` case-insensitive with end-to-end parser tests.

<sup>Written for commit 512930d455dffd03129da2acd15b1328bab72606. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

