### PR TITLE
fix(cli): unify settings.json + star-cache.json under ~/.config/tokscale on macOS

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -498,6 +498,7 @@ Tokscaleは設定を`~/.config/tokscale/settings.json`に保存します：
 | 変数 | デフォルト | 説明 |
 |----------|---------|-------------|
 | `TOKSCALE_NATIVE_TIMEOUT_MS` | `300000`（5分） | `nativeTimeoutMs` 設定をオーバーライド |
+| `TOKSCALE_CONFIG_DIR` | unset | 設定ディレクトリ（`settings.json` の保存場所）をオーバーライドします。絶対パス。CI サンドボックスや非デフォルトの場所を固定したい場合に便利です。 |
 
 ```bash
 # 例：非常に大きなデータセット用にタイムアウトを増加
@@ -896,9 +897,10 @@ AIコーディングツールはクロスプラットフォームの場所にセ
 #### Windows固有の設定
 
 Tokscaleは以下の場所に設定を保存します：
-- **設定**: `%USERPROFILE%\.config\tokscale\settings.json`
+- **TUI設定**: `%APPDATA%\tokscale\settings.json`（プラットフォームのデフォルト。`TOKSCALE_CONFIG_DIR` でオーバーライド可能）
 - **キャッシュ**: `%USERPROFILE%\.cache\tokscale\`
 - **Cursor認証情報**: `%USERPROFILE%\.config\tokscale\cursor-credentials.json`
+- **Tokscaleアカウント認証情報**: `%USERPROFILE%\.config\tokscale\credentials.json`
 
 ## セッションデータ保持
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -497,6 +497,7 @@ Tokscale은 설정을 `~/.config/tokscale/settings.json`에 저장합니다:
 | 변수 | 기본값 | 설명 |
 |----------|---------|-------------|
 | `TOKSCALE_NATIVE_TIMEOUT_MS` | `300000` (5분) | `nativeTimeoutMs` 설정 오버라이드 |
+| `TOKSCALE_CONFIG_DIR` | unset | 설정 디렉토리(`settings.json` 위치)를 오버라이드합니다. 절대 경로. CI 샌드박스나 비기본 위치를 고정할 때 유용합니다. |
 
 ```bash
 # 예시: 매우 큰 데이터셋에 대한 타임아웃 증가
@@ -895,9 +896,10 @@ AI 코딩 도구들은 크로스 플랫폼 위치에 세션 데이터를 저장�
 #### Windows 전용 설정
 
 Tokscale은 다음 위치에 설정을 저장합니다:
-- **설정**: `%USERPROFILE%\.config\tokscale\settings.json`
+- **TUI 설정**: `%APPDATA%\tokscale\settings.json` (플랫폼 기본값. `TOKSCALE_CONFIG_DIR`로 오버라이드 가능)
 - **캐시**: `%USERPROFILE%\.cache\tokscale\`
 - **Cursor 자격 증명**: `%USERPROFILE%\.config\tokscale\cursor-credentials.json`
+- **Tokscale 계정 자격 증명**: `%USERPROFILE%\.config\tokscale\credentials.json`
 
 ## 세션 데이터 보존
 

--- a/README.md
+++ b/README.md
@@ -515,6 +515,7 @@ Environment variables override config file values. For CI/CD or one-off use:
 |----------|---------|-------------|
 | `TOKSCALE_NATIVE_TIMEOUT_MS` | `300000` (5 min) | Overrides `nativeTimeoutMs` config |
 | `TOKSCALE_EXTRA_DIRS` | unset | One-off extra session roots as `client:/abs/path,client:/abs/path` |
+| `TOKSCALE_CONFIG_DIR` | unset | Overrides the config directory (where `settings.json` lives). Absolute path. Useful for CI sandboxes or pinning a non-default location. |
 
 ```bash
 # Example: Increase timeout for very large datasets
@@ -917,9 +918,10 @@ AI coding tools store their session data in cross-platform locations. Most tools
 #### Windows-Specific Configuration
 
 Tokscale stores its configuration in:
-- **Config**: `%USERPROFILE%\.config\tokscale\settings.json`
+- **TUI settings**: `%APPDATA%\tokscale\settings.json` (platform default; override with `TOKSCALE_CONFIG_DIR`)
 - **Cache**: `%USERPROFILE%\.cache\tokscale\`
 - **Cursor credentials**: `%USERPROFILE%\.config\tokscale\cursor-credentials.json`
+- **Tokscale account credentials**: `%USERPROFILE%\.config\tokscale\credentials.json`
 
 ## Session Data Retention
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -498,6 +498,7 @@ Tokscale 将设置存储在 `~/.config/tokscale/settings.json`：
 | 变量 | 默认值 | 描述 |
 |----------|---------|-------------|
 | `TOKSCALE_NATIVE_TIMEOUT_MS` | `300000`（5 分钟） | 覆盖 `nativeTimeoutMs` 配置 |
+| `TOKSCALE_CONFIG_DIR` | unset | 覆盖配置目录（`settings.json` 所在位置）。绝对路径。适用于 CI 沙箱或固定到非默认位置。 |
 
 ```bash
 # 示例：为非常大的数据集增加超时时间
@@ -896,9 +897,10 @@ AI 编程工具将会话数据存储在跨平台位置。大多数工具在所�
 #### Windows 特定配置
 
 Tokscale 将配置存储在：
-- **配置**: `%USERPROFILE%\.config\tokscale\settings.json`
+- **TUI 设置**: `%APPDATA%\tokscale\settings.json`（平台默认值。可用 `TOKSCALE_CONFIG_DIR` 覆盖）
 - **缓存**: `%USERPROFILE%\.cache\tokscale\`
 - **Cursor 凭据**: `%USERPROFILE%\.config\tokscale\cursor-credentials.json`
+- **Tokscale 账号凭据**: `%USERPROFILE%\.config\tokscale\credentials.json`
 
 ## 会话数据保留
 

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -2,6 +2,7 @@ mod antigravity;
 mod auth;
 mod commands;
 mod cursor;
+mod paths;
 mod tui;
 
 use crate::tui::client_ui;
@@ -3307,7 +3308,7 @@ struct StarCache {
 }
 
 fn star_cache_path() -> Option<PathBuf> {
-    dirs::config_dir().map(|d| d.join("tokscale").join("star-cache.json"))
+    Some(crate::paths::get_config_dir().join("star-cache.json"))
 }
 
 fn load_star_cache(username: &str) -> Option<StarCache> {

--- a/crates/tokscale-cli/src/paths.rs
+++ b/crates/tokscale-cli/src/paths.rs
@@ -1,0 +1,106 @@
+//! Cross-platform resolution for tokscale's user config directory.
+//!
+//! macOS users following the docs expect `~/.config/tokscale/` because that
+//! is what `auth.rs`, `cursor.rs`, and `antigravity.rs` already write to.
+//! `dirs::config_dir()` would instead return `~/Library/Application Support/`
+//! on macOS, splitting state across two roots and silently ignoring
+//! settings.json edits the user made via the documented path. This module
+//! enforces the unified `~/.config/tokscale/` location on macOS + Linux,
+//! while keeping the platform default on Windows.
+
+use std::path::PathBuf;
+
+/// Resolve the tokscale config dir, honoring `TOKSCALE_CONFIG_DIR` first.
+///
+/// Resolution order:
+/// 1. `TOKSCALE_CONFIG_DIR` (absolute path, taken verbatim).
+/// 2. macOS / Linux: `$HOME/.config/tokscale`.
+/// 3. Windows (and any other platform): `dirs::config_dir().join("tokscale")`.
+/// 4. Last-ditch fallback: `./.tokscale` so a missing HOME never panics.
+pub fn get_config_dir() -> PathBuf {
+    if let Ok(custom) = std::env::var("TOKSCALE_CONFIG_DIR") {
+        return PathBuf::from(custom);
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(".config").join("tokscale");
+        }
+    }
+
+    dirs::config_dir()
+        .map(|d| d.join("tokscale"))
+        .unwrap_or_else(|| PathBuf::from(".tokscale"))
+}
+
+/// Legacy macOS config dir (`~/Library/Application Support/tokscale`).
+///
+/// Returns `None` off macOS and when HOME cannot be resolved. Used by
+/// `Settings::load()` so users upgrading from a release that wrote
+/// settings.json under `~/Library/Application Support/tokscale/` keep
+/// their preferences on first launch after upgrade.
+#[cfg(target_os = "macos")]
+pub fn legacy_macos_config_dir() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("tokscale"))
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn legacy_macos_config_dir() -> Option<PathBuf> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::env;
+
+    #[test]
+    #[serial]
+    fn env_override_is_returned_verbatim() {
+        let prev = env::var_os("TOKSCALE_CONFIG_DIR");
+        unsafe {
+            env::set_var("TOKSCALE_CONFIG_DIR", "/tmp/tokscale-custom");
+        }
+        assert_eq!(get_config_dir(), PathBuf::from("/tmp/tokscale-custom"));
+        unsafe {
+            match prev {
+                Some(v) => env::set_var("TOKSCALE_CONFIG_DIR", v),
+                None => env::remove_var("TOKSCALE_CONFIG_DIR"),
+            }
+        }
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    fn unix_default_is_dot_config_tokscale_under_home() {
+        let prev_override = env::var_os("TOKSCALE_CONFIG_DIR");
+        let prev_home = env::var_os("HOME");
+        unsafe {
+            env::remove_var("TOKSCALE_CONFIG_DIR");
+            env::set_var("HOME", "/tmp/tokscale-home-test");
+        }
+        assert_eq!(
+            get_config_dir(),
+            PathBuf::from("/tmp/tokscale-home-test/.config/tokscale"),
+        );
+        unsafe {
+            match prev_override {
+                Some(v) => env::set_var("TOKSCALE_CONFIG_DIR", v),
+                None => env::remove_var("TOKSCALE_CONFIG_DIR"),
+            }
+            match prev_home {
+                Some(v) => env::set_var("HOME", v),
+                None => env::remove_var("HOME"),
+            }
+        }
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn legacy_helper_returns_none_off_macos() {
+        assert!(legacy_macos_config_dir().is_none());
+    }
+}

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -119,9 +119,7 @@ pub fn load_default_clients() -> Vec<String> {
 
 impl Settings {
     fn config_path() -> Result<PathBuf> {
-        let config_dir = dirs::config_dir()
-            .ok_or_else(|| anyhow::anyhow!("Could not find config directory"))?
-            .join("tokscale");
+        let config_dir = crate::paths::get_config_dir();
 
         if !config_dir.exists() {
             fs::create_dir_all(&config_dir)?;
@@ -130,11 +128,28 @@ impl Settings {
         Ok(config_dir.join("settings.json"))
     }
 
+    /// Returns the legacy `~/Library/Application Support/tokscale/settings.json`
+    /// path on macOS so `load()` can fall back to it during the transition.
+    /// Returns `None` on other platforms or when HOME cannot be resolved.
+    fn legacy_macos_path() -> Option<PathBuf> {
+        crate::paths::legacy_macos_config_dir().map(|d| d.join("settings.json"))
+    }
+
     pub fn load() -> Self {
-        Self::config_path()
+        let primary = Self::config_path()
             .ok()
-            .and_then(|path| fs::read_to_string(path).ok())
-            .and_then(|content| serde_json::from_str(&content).ok())
+            .and_then(|path| fs::read_to_string(path).ok());
+
+        // Transparent macOS fallback: pre-fix releases wrote settings.json under
+        // `~/Library/Application Support/tokscale/`. Read it once if the new
+        // path is empty so users don't lose theme / scanner / defaultClients
+        // preferences after upgrading. The next `save()` lands at the new
+        // canonical path under `~/.config/tokscale/`.
+        let raw = primary.or_else(|| {
+            Self::legacy_macos_path().and_then(|legacy| fs::read_to_string(legacy).ok())
+        });
+
+        raw.and_then(|content| serde_json::from_str(&content).ok())
             .map(|mut s: Settings| {
                 s.auto_refresh_ms = s
                     .auto_refresh_ms
@@ -215,6 +230,53 @@ impl Settings {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    #[serial_test::serial]
+    fn load_falls_back_to_legacy_macos_path_when_new_path_missing() {
+        // Sandbox HOME so the test never reads or writes a real user's
+        // settings.json. Existing macOS users upgrading to the unified
+        // path must keep the theme + scanner settings they already have
+        // under `~/Library/Application Support/tokscale/`.
+        use std::env;
+        let temp = tempfile::TempDir::new().unwrap();
+        let prev_home = env::var_os("HOME");
+        let prev_override = env::var_os("TOKSCALE_CONFIG_DIR");
+        unsafe {
+            env::set_var("HOME", temp.path());
+            env::remove_var("TOKSCALE_CONFIG_DIR");
+        }
+
+        let legacy_dir = temp
+            .path()
+            .join("Library/Application Support/tokscale");
+        fs::create_dir_all(&legacy_dir).unwrap();
+        fs::write(
+            legacy_dir.join("settings.json"),
+            r#"{"colorPalette":"halloween","defaultClients":["opencode"]}"#,
+        )
+        .unwrap();
+
+        // Sanity: new path must be empty so the fallback is what we exercise.
+        let new_path = temp.path().join(".config/tokscale/settings.json");
+        assert!(!new_path.exists());
+
+        let loaded = Settings::load();
+        assert_eq!(loaded.color_palette, "halloween");
+        assert_eq!(loaded.default_clients, vec!["opencode".to_string()]);
+
+        unsafe {
+            match prev_home {
+                Some(v) => env::set_var("HOME", v),
+                None => env::remove_var("HOME"),
+            }
+            match prev_override {
+                Some(v) => env::set_var("TOKSCALE_CONFIG_DIR", v),
+                None => env::remove_var("TOKSCALE_CONFIG_DIR"),
+            }
+        }
+    }
 
     #[test]
     fn settings_load_backfills_scanner_when_missing_from_json() {


### PR DESCRIPTION
## Summary

`Settings::config_path()` (`tui/settings.rs`) and `star_cache_path()` (`main.rs`) called `dirs::config_dir()`, which returns `~/Library/Application Support/` on macOS. That left two pieces of TUI state stranded under Application Support while `auth.rs`, `cursor.rs`, `antigravity.rs`, and all four README variants documented `~/.config/tokscale/`. macOS users following the docs edited a settings.json that tokscale never read.

This PR unifies the path on macOS + Linux and adds an env override.

- New `crates/tokscale-cli/src/paths.rs::get_config_dir()`: env override → macOS/Linux `$HOME/.config/tokscale` → Windows `dirs::config_dir().join("tokscale")` → `.tokscale` last-ditch fallback.
- Both call sites switched to it.
- `Settings::load()` reads the new path first, then falls back to the legacy `~/Library/Application Support/tokscale/settings.json` on macOS only — so existing macOS users keep their theme / scanner / `defaultClients` after upgrade. `save()` always writes the new path; the next save makes the legacy file irrelevant.
- `TOKSCALE_CONFIG_DIR` env var added (mirrors `TOKSCALE_HEADLESS_DIR` semantics — any `Ok` value wins, no empty-string special case).
- All four README variants: added `TOKSCALE_CONFIG_DIR` row to env-var tables, and corrected the Windows-Specific Configuration section — settings.json lives at `%APPDATA%\tokscale\` (the actual `dirs::config_dir()` default on Windows), not `%USERPROFILE%\.config\tokscale\`. Added the missing `credentials.json` row.

Out of scope (per the originating issue): `auth.rs`, `cursor.rs`, `antigravity.rs` already hardcode `~/.config/tokscale/` correctly and were left alone. Cache dirs and headless paths were also left alone.

## Test plan

- [x] `cargo build -p tokscale-cli` clean
- [x] `cargo clippy -p tokscale-cli --bin tokscale --tests` clean (only pre-existing antigravity warnings)
- [x] `cargo test -p tokscale-cli --bin tokscale paths::tests::` — 2 passed
- [x] `cargo test -p tokscale-cli --bin tokscale tui::settings::` — 10 passed (incl. new macOS-gated `load_falls_back_to_legacy_macos_path_when_new_path_missing`)
- [x] Full `cargo test -p tokscale-cli` — only the pre-existing `test_data_loader_keeps_synthetic_gateway_messages_under_original_client` failure (unrelated, reproduces on `main`)
- [ ] Fresh macOS install: `bunx tokscale@latest tui` creates `~/.config/tokscale/settings.json`, not `~/Library/Application Support/`
- [ ] `TOKSCALE_CONFIG_DIR=/tmp/tk bunx tokscale@latest tui` writes `/tmp/tk/settings.json`
- [ ] Existing macOS user with prior `~/Library/Application Support/tokscale/settings.json` sees their prior settings on first launch after upgrading
- [ ] Windows behavior unchanged (`%APPDATA%\tokscale\settings.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the TUI config and star cache on macOS under `~/.config/tokscale`, matching Linux and the docs. Adds `TOKSCALE_CONFIG_DIR` to override the location and preserves existing macOS settings on upgrade.

- **Bug Fixes**
  - macOS now reads/writes `~/.config/tokscale/settings.json`; no more `~/Library/Application Support/...`.
  - `Settings::load()` falls back to the legacy macOS path once, so existing theme/scanner/defaultClients are kept.
  - `star-cache.json` now lives in the same config dir; Windows behavior is unchanged.

- **New Features**
  - Added `paths::get_config_dir()` to centralize config-dir resolution across platforms.
  - Added `TOKSCALE_CONFIG_DIR` to override where `settings.json` is stored.
  - Updated READMEs: documented `TOKSCALE_CONFIG_DIR`, corrected Windows path to `%APPDATA%\tokscale\`, and added the missing `credentials.json` row.

<sup>Written for commit d8f5b9e1f6289d77217504e1250a6733146ea83a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

