### PR TITLE
refactor(pricing): align parenthesized reasoning tiers with CLIProxyAPI

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -23,7 +23,15 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
-pub(crate) fn strip_gpt_parenthesized_reasoning_tier(model_id: &str) -> Option<&str> {
+/// Strip a CLIProxyAPI-style `(level)` reasoning-effort suffix from a model id.
+///
+/// Mirrors <https://help.router-for.me/configuration/thinking>: the proxy
+/// strips the parentheses before routing, so for pricing lookups we treat the
+/// suffix as cosmetic and resolve to the base model. Accepts the level set the
+/// proxy documents (case-insensitive — callers pass the lowercased id):
+/// `minimal`, `low`, `medium`, `high`, `xhigh`, `auto`, `none`. Numeric
+/// thinking budgets are intentionally not handled here.
+pub(crate) fn strip_parenthesized_reasoning_tier(model_id: &str) -> Option<&str> {
     let without_closing_paren = model_id.strip_suffix(')')?;
     let (base_model, tier) = without_closing_paren.rsplit_once('(')?;
 
@@ -31,29 +39,20 @@ pub(crate) fn strip_gpt_parenthesized_reasoning_tier(model_id: &str) -> Option<&
         return None;
     }
 
-    if !matches!(tier, "low" | "medium" | "high" | "xhigh") {
+    if !matches!(
+        tier,
+        "minimal" | "low" | "medium" | "high" | "xhigh" | "auto" | "none"
+    ) {
         return None;
     }
 
-    let model_name = base_model.rsplit('/').next().unwrap_or(base_model);
-    if model_name == "gpt" || model_name.starts_with("gpt-") {
-        Some(base_model)
-    } else {
-        None
-    }
-}
-
-pub(crate) fn has_parenthesized_suffix(model_id: &str) -> bool {
-    model_id
-        .strip_suffix(')')
-        .and_then(|without_closing_paren| without_closing_paren.rsplit_once('('))
-        .is_some()
+    Some(base_model)
 }
 
 pub fn normalize_model_for_grouping(model_id: &str) -> String {
     let mut name = model_id.to_lowercase();
 
-    if let Some(base_model) = strip_gpt_parenthesized_reasoning_tier(&name) {
+    if let Some(base_model) = strip_parenthesized_reasoning_tier(&name) {
         name = base_model.to_string();
     }
     if name.len() > 9 {
@@ -2218,13 +2217,20 @@ mod tests {
         assert_eq!(normalize_model_for_grouping("gpt-5.2"), "gpt-5.2");
         assert_eq!(normalize_model_for_grouping("gpt-5.4(xhigh)"), "gpt-5.4");
         assert_eq!(normalize_model_for_grouping("gpt-5.4(high)"), "gpt-5.4");
+        assert_eq!(normalize_model_for_grouping("gpt-5.4(minimal)"), "gpt-5.4");
+        assert_eq!(normalize_model_for_grouping("gpt-5.4(auto)"), "gpt-5.4");
+        assert_eq!(normalize_model_for_grouping("gpt-5.4(none)"), "gpt-5.4");
         assert_eq!(
-            normalize_model_for_grouping("gpt-5.4(auto)"),
-            "gpt-5.4(auto)"
+            normalize_model_for_grouping("gpt-5.4(weirdgarbage)"),
+            "gpt-5.4(weirdgarbage)"
         );
         assert_eq!(
             normalize_model_for_grouping("claude-sonnet-4.5(high)"),
-            "claude-sonnet-4-5(high)"
+            "claude-sonnet-4-5"
+        );
+        assert_eq!(
+            normalize_model_for_grouping("gemini-3-pro(auto)"),
+            "gemini-3-pro"
         );
         assert_eq!(
             normalize_model_for_grouping("gemini-2.5-pro"),

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -2187,6 +2187,15 @@ mod tests {
         assert!(lookup.lookup("gpt-5.2()").is_none());
         assert!(lookup.lookup("gpt-5.2-codex(invalid)").is_none());
         assert!(lookup.lookup("myproxy-gpt-5.2(invalid)").is_none());
+
+        // The same guard must hold across model families so that the
+        // generalized stripper never misresolves a non-GPT id by peeling
+        // a parenthesized fragment off through the dash-suffix path.
+        assert!(lookup
+            .lookup("antigravity-claude-sonnet-4-5(invalid)")
+            .is_none());
+        assert!(lookup.lookup("claude-sonnet-4-5(garbage)").is_none());
+        assert!(lookup.lookup("gemini-3-pro(weird)").is_none());
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -2151,7 +2151,9 @@ mod tests {
         let prefixed = lookup.lookup("myproxy-gpt-5.2(xhigh)").unwrap();
         assert_eq!(prefixed.matched_key, "gpt-5.2");
 
-        let antigravity = lookup.lookup("antigravity-claude-sonnet-4-5(high)").unwrap();
+        let antigravity = lookup
+            .lookup("antigravity-claude-sonnet-4-5(high)")
+            .unwrap();
         assert_eq!(antigravity.matched_key, "claude-sonnet-4-5");
     }
 

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -235,6 +235,22 @@ impl PricingLookup {
         // Mirrors the dash-suffix path (e.g. `-xhigh`), which is handled by
         // `try_strip_unknown_suffix` below.
         let normalized_owned = strip_parenthesized_reasoning_tier(&lower).map(str::to_owned);
+
+        // Guard against silent misresolution: if the input ends with `(...)`
+        // but the contents are not a recognized CLIProxyAPI level, refuse the
+        // lookup. Falling through to `try_strip_unknown_suffix` would split on
+        // `-` and could match a shorter, unrelated model id by peeling the
+        // parenthesized fragment off (e.g. `gpt-5.2-codex(invalid)` would
+        // strip `-codex(invalid)` and resolve to `gpt-5.2`).
+        if normalized_owned.is_none()
+            && lower
+                .strip_suffix(')')
+                .and_then(|inner| inner.rsplit_once('('))
+                .is_some()
+        {
+            return None;
+        }
+
         let lower_ref: &str = normalized_owned.as_deref().unwrap_or(&lower);
 
         // Helper to perform lookup with the given source constraint
@@ -2161,11 +2177,16 @@ mod tests {
     fn test_parenthesized_reasoning_tier_unknown_value_does_not_strip() {
         let lookup = create_lookup();
 
-        // Values outside the cliproxyapi level set are not stripped, so the
-        // bracketed id stays intact and finds no match.
+        // Values outside the cliproxyapi level set must not silently
+        // misresolve via `try_strip_unknown_suffix`: without an early
+        // return, splitting on `-` would peel the parenthesized fragment
+        // off and match a shorter, unrelated model id (e.g.
+        // `gpt-5.2-codex(invalid)` collapsing to `gpt-5.2`).
         assert!(lookup.lookup("gpt-5.2(weirdgarbage)").is_none());
         assert!(lookup.lookup("gpt-5.2(1024)").is_none());
         assert!(lookup.lookup("gpt-5.2()").is_none());
+        assert!(lookup.lookup("gpt-5.2-codex(invalid)").is_none());
+        assert!(lookup.lookup("myproxy-gpt-5.2(invalid)").is_none());
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -1,8 +1,5 @@
 use super::{aliases, litellm::ModelPricing};
-use crate::{
-    has_parenthesized_suffix, provider_identity, strip_gpt_parenthesized_reasoning_tier,
-    TokenBreakdown,
-};
+use crate::{provider_identity, strip_parenthesized_reasoning_tier, TokenBreakdown};
 use std::collections::HashMap;
 use std::sync::RwLock;
 
@@ -233,6 +230,13 @@ impl PricingLookup {
         let canonical = aliases::resolve_alias(model_id).unwrap_or(model_id);
         let lower = canonical.to_lowercase();
 
+        // CLIProxyAPI strips `(level)` reasoning-effort suffixes before routing,
+        // so for pricing lookup we resolve to the base model regardless of tier.
+        // Mirrors the dash-suffix path (e.g. `-xhigh`), which is handled by
+        // `try_strip_unknown_suffix` below.
+        let normalized_owned = strip_parenthesized_reasoning_tier(&lower).map(str::to_owned);
+        let lower_ref: &str = normalized_owned.as_deref().unwrap_or(&lower);
+
         // Helper to perform lookup with the given source constraint
         let do_lookup = |id: &str| match force_source {
             Some("litellm") => self.lookup_litellm_only(id, provider_id),
@@ -240,34 +244,19 @@ impl PricingLookup {
             _ => self.lookup_auto(id, provider_id),
         };
 
-        if has_parenthesized_suffix(&lower) {
-            if let Some(base_model) = strip_gpt_parenthesized_reasoning_tier(&lower) {
-                if let Some(result) = do_lookup(base_model) {
-                    return Some(result);
-                }
-            }
-
-            if let Some(result) = try_strip_prefixed_parenthesized_reasoning_tier(&lower, do_lookup)
-            {
-                return Some(result);
-            }
-
-            return None;
-        }
-
         // 1. Try direct lookup
-        if let Some(result) = do_lookup(&lower) {
+        if let Some(result) = do_lookup(lower_ref) {
             return Some(result);
         }
 
         // 2. Try stripping unknown suffixes (e.g., -thinking, -high, -codex)
-        if let Some(result) = try_strip_unknown_suffix(&lower, do_lookup) {
+        if let Some(result) = try_strip_unknown_suffix(lower_ref, do_lookup) {
             return Some(result);
         }
 
         // 3. Try stripping unknown prefixes (e.g., antigravity-, myplugin-)
         //    For each prefix candidate, also try suffix stripping
-        if let Some(result) = try_strip_unknown_prefix(&lower, do_lookup) {
+        if let Some(result) = try_strip_unknown_prefix(lower_ref, do_lookup) {
             return Some(result);
         }
 
@@ -1083,36 +1072,6 @@ where
     None
 }
 
-fn try_strip_prefixed_parenthesized_reasoning_tier<F>(
-    model_id: &str,
-    do_lookup: F,
-) -> Option<LookupResult>
-where
-    F: Fn(&str) -> Option<LookupResult>,
-{
-    let parts: Vec<&str> = model_id.split('-').collect();
-
-    if parts.len() < 2 {
-        return None;
-    }
-
-    let max_skip = std::cmp::min(parts.len() - 1, MAX_PREFIX_STRIP_SEGMENTS);
-
-    for skip in 1..=max_skip {
-        let candidate: String = parts[skip..].join("-");
-
-        if candidate.len() >= MIN_MODEL_NAME_LEN {
-            if let Some(base_model) = strip_gpt_parenthesized_reasoning_tier(&candidate) {
-                if let Some(result) = do_lookup(base_model) {
-                    return Some(result);
-                }
-            }
-        }
-    }
-
-    None
-}
-
 /// Attempts to find a model by progressively stripping leading segments.
 /// Handles arbitrary routing prefixes (e.g., "myplugin-claude-3.5-sonnet" → "claude-3.5-sonnet").
 /// This replaces the hardcoded STRIPPED_PREFIXES approach.
@@ -1136,17 +1095,10 @@ where
             if let Some(result) = do_lookup(&candidate) {
                 return Some(result);
             }
-            if let Some(base_model) = strip_gpt_parenthesized_reasoning_tier(&candidate) {
-                if let Some(result) = do_lookup(base_model) {
-                    return Some(result);
-                }
-            }
 
-            if !has_parenthesized_suffix(&candidate) {
-                // Try candidate with suffix stripping
-                if let Some(result) = try_strip_unknown_suffix(&candidate, &do_lookup) {
-                    return Some(result);
-                }
+            // Try candidate with suffix stripping
+            if let Some(result) = try_strip_unknown_suffix(&candidate, &do_lookup) {
+                return Some(result);
             }
         }
     }
@@ -2164,28 +2116,58 @@ mod tests {
     }
 
     #[test]
-    fn test_gpt_parenthesized_reasoning_tier_lookup() {
+    fn test_parenthesized_reasoning_tier_gpt_levels() {
         let lookup = create_lookup();
 
-        let xhigh = lookup.lookup("gpt-5.2(xhigh)").unwrap();
-        assert_eq!(xhigh.matched_key, "gpt-5.2");
-        assert_eq!(xhigh.source, "LiteLLM");
-
-        let high = lookup.lookup("gpt-5.2(high)").unwrap();
-        assert_eq!(high.matched_key, "gpt-5.2");
-        assert_eq!(high.source, "LiteLLM");
+        for tier in ["minimal", "low", "medium", "high", "xhigh", "auto", "none"] {
+            let id = format!("gpt-5.2({tier})");
+            let result = lookup.lookup(&id).unwrap_or_else(|| panic!("{id} miss"));
+            assert_eq!(result.matched_key, "gpt-5.2", "{id}");
+            assert_eq!(result.source, "LiteLLM", "{id}");
+        }
     }
 
     #[test]
-    fn test_gpt_parenthesized_reasoning_tier_scope_is_narrow() {
+    fn test_parenthesized_reasoning_tier_claude_and_gemini() {
         let lookup = create_lookup();
 
-        assert!(lookup.lookup("gpt-5.2(auto)").is_none());
-        assert!(lookup.lookup("claude-sonnet-4-5(high)").is_none());
+        let claude = lookup.lookup("claude-sonnet-4-5(high)").unwrap();
+        assert_eq!(claude.matched_key, "claude-sonnet-4-5");
+        assert_eq!(claude.source, "LiteLLM");
+
+        // Dot-form claude id (cliproxyapi accepts either) routes through
+        // version-separator normalization to the dashed catalog entry.
+        let claude_dot = lookup.lookup("claude-sonnet-4.5(none)").unwrap();
+        assert_eq!(claude_dot.matched_key, "claude-sonnet-4-5");
+
+        let gemini = lookup.lookup("gemini-3-pro(auto)").unwrap();
+        assert_eq!(gemini.matched_key, "openrouter/google/gemini-3-pro-preview");
     }
 
     #[test]
-    fn test_gpt_parenthesized_reasoning_tier_cost_matches_base_model() {
+    fn test_parenthesized_reasoning_tier_with_routing_prefix() {
+        let lookup = create_lookup();
+
+        let prefixed = lookup.lookup("myproxy-gpt-5.2(xhigh)").unwrap();
+        assert_eq!(prefixed.matched_key, "gpt-5.2");
+
+        let antigravity = lookup.lookup("antigravity-claude-sonnet-4-5(high)").unwrap();
+        assert_eq!(antigravity.matched_key, "claude-sonnet-4-5");
+    }
+
+    #[test]
+    fn test_parenthesized_reasoning_tier_unknown_value_does_not_strip() {
+        let lookup = create_lookup();
+
+        // Values outside the cliproxyapi level set are not stripped, so the
+        // bracketed id stays intact and finds no match.
+        assert!(lookup.lookup("gpt-5.2(weirdgarbage)").is_none());
+        assert!(lookup.lookup("gpt-5.2(1024)").is_none());
+        assert!(lookup.lookup("gpt-5.2()").is_none());
+    }
+
+    #[test]
+    fn test_parenthesized_reasoning_tier_cost_matches_base_model() {
         let lookup = create_lookup();
         let base = lookup.calculate_cost("gpt-5.2", 1_000_000, 500_000, 0, 0, 0);
         let tiered = lookup.calculate_cost("gpt-5.2(xhigh)", 1_000_000, 500_000, 0, 0, 0);


### PR DESCRIPTION
## Summary

Follow-up to #478. Generalize the `model(level)` parenthesized reasoning-tier handling so it matches the upstream contract documented at [CLIProxyAPI · Thinking Budgets via Model Name Parentheses](https://help.router-for.me/configuration/thinking). #478 landed a narrow GPT-only / four-level subset; in practice CLIProxyAPI strips the parentheses before routing for **any** model family (Gemini / Claude / OpenAI / Codex / OpenRouter) and accepts a wider level vocabulary, so pricing resolution should mirror that.

## Behavior

- Accept the full CLIProxyAPI level set (case-insensitive): `minimal`, `low`, `medium`, `high`, `xhigh`, `auto`, `none`. Numeric thinking budgets remain out of scope.
- Drop the GPT-family restriction; Claude, Gemini, and any other family routed through CLIProxyAPI now resolve `(level)` suffixes the same way (e.g. `claude-sonnet-4-5(none)` → `claude-sonnet-4-5`, `gemini-3-pro(auto)` → `openrouter/google/gemini-3-pro-preview`).
- Fold the lookup pipeline: the entry point strips a recognized parenthesized tier once and falls through the existing dash-suffix / prefix-strip paths. Routing prefixes compose cleanly: `myproxy-gpt-5.2(xhigh)` → `gpt-5.2`, `antigravity-claude-sonnet-4-5(high)` → `claude-sonnet-4-5`.
- Values outside the level set are not stripped: `gpt-5.2(weirdgarbage)`, `gpt-5.2(1024)`, and `gpt-5.2()` all return `None` instead of silently misresolving.
- Remove the dedicated `try_strip_prefixed_parenthesized_reasoning_tier` helper and the unreachable parenthesis branches inside `try_strip_unknown_prefix` that the previous structure left behind. Net `-92 +80`.

## Caveat / Future Work

`normalize_model_for_grouping` is now **asymmetric** between the two equivalent CLIProxyAPI suffix forms:

| input | grouping output | folded? |
|---|---|---|
| `gpt-5.2(xhigh)` | `gpt-5.2` | yes |
| `gpt-5.2-xhigh` | `gpt-5.2-xhigh` | no |
| `claude-opus-4-5-high` | `claude-opus-4-5-high` | no |

Pricing lookup folds both forms to the same base (and same cost), so reports built on `normalize_model_for_grouping` will fragment cost-equivalent rows when the dash form appears. Aligning the dash path requires introducing a CLIProxyAPI-level whitelist into `normalize_model_for_grouping` (so `-codex` / `-codex-max` / `-nano` — real model variants — are not folded). That is a larger behavior change touching existing grouping assertions and is intentionally **out of scope** for this PR; flagging it here as a follow-up refactor target.

## Test plan

- [x] `cargo test -p tokscale-core` — 599 pass (one pre-existing flaky parallel-test interaction in `test_parse_all_messages_fireworks_provider_kept_under_synthetic_only_filter`; passes single-threaded, unrelated to this change)
- [x] `cargo test --workspace` — 1127 pass
- [x] CLI smoke:
  - `tokscale pricing 'gpt-5.2(xhigh)' --json` → matches `gpt-5.2`
  - `tokscale pricing 'claude-sonnet-4-5(none)' --json` → matches `claude-sonnet-4-5`
  - `tokscale pricing 'myproxy-gpt-5.2(auto)' --json` → matches `gpt-5.2`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align pricing lookup with CLIProxyAPI by stripping `(level)` reasoning suffixes across all model families and rejecting unrecognized `(...)` to avoid misrouting. Prefixed routes and dash variants now resolve cleanly to the base model.

- **New Features**
  - Accept `minimal`, `low`, `medium`, `high`, `xhigh`, `auto`, `none` (case-insensitive); numeric budgets remain out of scope.
  - Strip `(level)` for all families and prefixed IDs (e.g., `myproxy-gpt-5.2(xhigh)` → `gpt-5.2`, `antigravity-claude-sonnet-4-5(high)` → `claude-sonnet-4-5`).
  - Reject unknown/empty tiers, including when paired with other suffixes, with no fallback to generic stripping (e.g., `gpt-5.2(weirdgarbage)`, `gpt-5.2()`, `gpt-5.2-codex(invalid)`).

- **Refactors**
  - Strip recognized `(level)` once at entry, then reuse existing suffix/prefix logic.
  - Remove `try_strip_prefixed_parenthesized_reasoning_tier`, `has_parenthesized_suffix`, and dead parenthesis branches in prefix stripping.
  - Rename `strip_gpt_parenthesized_reasoning_tier` to `strip_parenthesized_reasoning_tier` and use it in `normalize_model_for_grouping`.

<sup>Written for commit afbf2206e523c983018fa28dffd54362f14cf062. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/480?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
