### PR TITLE
fix(pricing): support GPT-5.5 tiered pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1293,7 +1293,7 @@ Pricing includes:
 - Cache read tokens (discounted)
 - Cache write tokens
 - Reasoning tokens (for models like o1)
-- Tiered pricing (above 200k tokens)
+- Model-specific tiered pricing (for example, above 200k or 272k tokens)
 
 ## Contributing
 

--- a/crates/tokscale-cli/src/antigravity.rs
+++ b/crates/tokscale-cli/src/antigravity.rs
@@ -832,7 +832,7 @@ fn process_executable_path(pid: u32) -> Option<PathBuf> {
                 }
             }
         }
-        return None;
+        None
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {

--- a/crates/tokscale-cli/src/commands/wrapped.rs
+++ b/crates/tokscale-cli/src/commands/wrapped.rs
@@ -1550,6 +1550,10 @@ fn format_model_name(model: &str) -> String {
 
     cleaned = strip_date_suffix(cleaned);
 
+    if let Some(display) = format_gpt_5_series_model_name(&cleaned, &suffix) {
+        return display;
+    }
+
     let normalized = cleaned
         .to_lowercase()
         .chars()
@@ -1702,6 +1706,49 @@ fn format_model_name(model: &str) -> String {
     }
 }
 
+fn format_gpt_5_series_model_name(model: &str, suffix: &str) -> Option<String> {
+    let lower = model.to_lowercase();
+    let model_part = lower
+        .rsplit(['/', ':'])
+        .find(|part| !part.is_empty())
+        .unwrap_or(&lower);
+
+    let mut parts = model_part.split(['-', '_']).filter(|part| !part.is_empty());
+
+    if parts.next()? != "gpt" {
+        return None;
+    }
+
+    let version = parts.next()?;
+    if version != "5" && !version.starts_with("5.") {
+        return None;
+    }
+
+    let mut display = format!("GPT-{}", version);
+    for part in parts {
+        if part.starts_with("20") && part.chars().all(|ch| ch.is_ascii_digit()) {
+            break;
+        }
+
+        match part {
+            "pro" => display.push_str(" Pro"),
+            "mini" => display.push_str(" Mini"),
+            "nano" => display.push_str(" Nano"),
+            "codex" => display.push_str(" Codex"),
+            "max" => display.push_str(" Max"),
+            "spark" => display.push_str(" Spark"),
+            "chat" => display.push_str(" Chat"),
+            "preview" => display.push_str(" Preview"),
+            "latest" => display.push_str(" Latest"),
+            _ if part.chars().all(|ch| ch.is_ascii_digit()) => break,
+            _ => {}
+        }
+    }
+
+    display.push_str(suffix);
+    Some(display)
+}
+
 fn exact_model_display_name(model: &str) -> Option<&'static str> {
     match model {
         "claude-sonnet-4-20250514" => Some("Claude Sonnet 4"),
@@ -1731,6 +1778,8 @@ fn split_quality_suffix(model: &str) -> (String, String) {
     let lower = model.to_lowercase();
 
     for (needle, label) in [
+        ("-xhigh", " XHigh"),
+        ("_xhigh", " XHigh"),
         ("-high", " High"),
         ("_high", " High"),
         ("-medium", " Medium"),
@@ -2025,6 +2074,14 @@ mod tests {
     }
 
     #[test]
+    fn test_split_quality_suffix_xhigh() {
+        assert_eq!(
+            split_quality_suffix("model-xhigh"),
+            ("model".to_string(), " XHigh".to_string())
+        );
+    }
+
+    #[test]
     fn test_split_quality_suffix_medium() {
         assert_eq!(
             split_quality_suffix("model-medium"),
@@ -2104,6 +2161,12 @@ mod tests {
         assert_eq!(format_model_name("gpt-4o"), "GPT-4o");
         assert_eq!(format_model_name("gpt-4o-mini"), "GPT-4o Mini");
         assert_eq!(format_model_name("gpt-5"), "GPT-5");
+        assert_eq!(format_model_name("gpt-5.5"), "GPT-5.5");
+        assert_eq!(
+            format_model_name("openai/gpt-5.5-pro-20260423"),
+            "GPT-5.5 Pro"
+        );
+        assert_eq!(format_model_name("gpt-5.5-xhigh"), "GPT-5.5 XHigh");
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/litellm.rs
+++ b/crates/tokscale-core/src/pricing/litellm.rs
@@ -11,13 +11,20 @@ const INITIAL_BACKOFF_MS: u64 = 200;
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ModelPricing {
     pub input_cost_per_token: Option<f64>,
+    pub input_cost_per_token_above_128k_tokens: Option<f64>,
     pub input_cost_per_token_above_200k_tokens: Option<f64>,
+    pub input_cost_per_token_above_256k_tokens: Option<f64>,
+    pub input_cost_per_token_above_272k_tokens: Option<f64>,
     pub output_cost_per_token: Option<f64>,
+    pub output_cost_per_token_above_128k_tokens: Option<f64>,
     pub output_cost_per_token_above_200k_tokens: Option<f64>,
+    pub output_cost_per_token_above_256k_tokens: Option<f64>,
+    pub output_cost_per_token_above_272k_tokens: Option<f64>,
     pub cache_creation_input_token_cost: Option<f64>,
     pub cache_creation_input_token_cost_above_200k_tokens: Option<f64>,
     pub cache_read_input_token_cost: Option<f64>,
     pub cache_read_input_token_cost_above_200k_tokens: Option<f64>,
+    pub cache_read_input_token_cost_above_272k_tokens: Option<f64>,
 }
 
 pub type PricingDataset = HashMap<String, ModelPricing>;
@@ -172,5 +179,36 @@ mod tests {
         );
         assert_eq!(pricing.cache_read_input_token_cost, Some(0.000000125));
         assert_eq!(pricing.cache_read_input_token_cost_above_200k_tokens, None);
+    }
+
+    #[test]
+    fn test_deserialize_model_pricing_with_above_272k_fields() {
+        let pricing: ModelPricing = serde_json::from_str(
+            r#"{
+                "input_cost_per_token": 0.000005,
+                "input_cost_per_token_above_272k_tokens": 0.000010,
+                "output_cost_per_token": 0.000030,
+                "output_cost_per_token_above_272k_tokens": 0.000045,
+                "cache_read_input_token_cost": 0.0000005,
+                "cache_read_input_token_cost_above_272k_tokens": 0.000001
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(pricing.input_cost_per_token, Some(0.000005));
+        assert_eq!(
+            pricing.input_cost_per_token_above_272k_tokens,
+            Some(0.000010)
+        );
+        assert_eq!(pricing.output_cost_per_token, Some(0.000030));
+        assert_eq!(
+            pricing.output_cost_per_token_above_272k_tokens,
+            Some(0.000045)
+        );
+        assert_eq!(pricing.cache_read_input_token_cost, Some(0.0000005));
+        assert_eq!(
+            pricing.cache_read_input_token_cost_above_272k_tokens,
+            Some(0.000001)
+        );
     }
 }

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -833,6 +833,13 @@ pub fn compute_cost(
             ),
         ],
     );
+    // Cache-read tiers stay limited to the 200k and 272k thresholds
+    // because upstream LiteLLM does not currently declare 128k or 256k
+    // cache-read pricing for any model. If upstream begins emitting
+    // those keys, also add matching fields to `ModelPricing`,
+    // `has_any_usable_pricing`, `has_any_valid_above_tier_value`, and
+    // `has_meaningful_tier_support`; otherwise tier walks will silently
+    // undercost long-context cache reads on those models.
     let cache_read_cost = tiered_cost(
         cache_read_clamped,
         pricing.cache_read_input_token_cost,

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -50,7 +50,10 @@ const RESELLER_PROVIDER_PREFIXES: &[&str] = &[
 const FUZZY_BLOCKLIST: &[&str] = &["auto", "mini", "chat", "base"];
 
 const MAX_LOOKUP_CACHE_ENTRIES: usize = 512;
-const TIERED_PRICING_THRESHOLD_TOKENS: f64 = 200_000.0;
+const TIERED_PRICING_THRESHOLD_128K_TOKENS: f64 = 128_000.0;
+const TIERED_PRICING_THRESHOLD_200K_TOKENS: f64 = 200_000.0;
+const TIERED_PRICING_THRESHOLD_256K_TOKENS: f64 = 256_000.0;
+const TIERED_PRICING_THRESHOLD_272K_TOKENS: f64 = 272_000.0;
 
 const MIN_FUZZY_MATCH_LEN: usize = 5;
 
@@ -754,16 +757,31 @@ pub fn compute_cost(
     reasoning: i64,
 ) -> f64 {
     let safe_price = |opt: Option<f64>| opt.filter(|v| is_valid_price_value(*v)).unwrap_or(0.0);
-    let tiered_cost = |tokens: f64, base: Option<f64>, above_200k: Option<f64>| {
+    let tiered_cost = |tokens: f64, base: Option<f64>, tiers: &[(f64, Option<f64>)]| {
         let base_price = safe_price(base);
-        let above_price = above_200k.filter(|v| is_valid_price_value(*v));
-        if tokens > TIERED_PRICING_THRESHOLD_TOKENS {
-            if let Some(above_price) = above_price {
-                return TIERED_PRICING_THRESHOLD_TOKENS * base_price
-                    + (tokens - TIERED_PRICING_THRESHOLD_TOKENS) * above_price;
+        let mut cost = 0.0;
+        let mut lower_bound = 0.0;
+        let mut active_price = base_price;
+
+        for (threshold, tier_price) in tiers {
+            let Some(tier_price) = tier_price.filter(|v| is_valid_price_value(*v)) else {
+                continue;
+            };
+
+            if !threshold.is_finite() || *threshold <= lower_bound {
+                continue;
             }
+
+            if tokens <= *threshold {
+                return cost + (tokens - lower_bound).max(0.0) * active_price;
+            }
+
+            cost += (*threshold - lower_bound) * active_price;
+            lower_bound = *threshold;
+            active_price = tier_price;
         }
-        tokens * base_price
+
+        cost + (tokens - lower_bound).max(0.0) * active_price
     };
 
     let input_clamped = input.max(0) as f64;
@@ -774,22 +792,68 @@ pub fn compute_cost(
     let input_cost = tiered_cost(
         input_clamped,
         pricing.input_cost_per_token,
-        pricing.input_cost_per_token_above_200k_tokens,
+        &[
+            (
+                TIERED_PRICING_THRESHOLD_128K_TOKENS,
+                pricing.input_cost_per_token_above_128k_tokens,
+            ),
+            (
+                TIERED_PRICING_THRESHOLD_200K_TOKENS,
+                pricing.input_cost_per_token_above_200k_tokens,
+            ),
+            (
+                TIERED_PRICING_THRESHOLD_256K_TOKENS,
+                pricing.input_cost_per_token_above_256k_tokens,
+            ),
+            (
+                TIERED_PRICING_THRESHOLD_272K_TOKENS,
+                pricing.input_cost_per_token_above_272k_tokens,
+            ),
+        ],
     );
     let output_cost = tiered_cost(
         output_clamped,
         pricing.output_cost_per_token,
-        pricing.output_cost_per_token_above_200k_tokens,
+        &[
+            (
+                TIERED_PRICING_THRESHOLD_128K_TOKENS,
+                pricing.output_cost_per_token_above_128k_tokens,
+            ),
+            (
+                TIERED_PRICING_THRESHOLD_200K_TOKENS,
+                pricing.output_cost_per_token_above_200k_tokens,
+            ),
+            (
+                TIERED_PRICING_THRESHOLD_256K_TOKENS,
+                pricing.output_cost_per_token_above_256k_tokens,
+            ),
+            (
+                TIERED_PRICING_THRESHOLD_272K_TOKENS,
+                pricing.output_cost_per_token_above_272k_tokens,
+            ),
+        ],
     );
     let cache_read_cost = tiered_cost(
         cache_read_clamped,
         pricing.cache_read_input_token_cost,
-        pricing.cache_read_input_token_cost_above_200k_tokens,
+        &[
+            (
+                TIERED_PRICING_THRESHOLD_200K_TOKENS,
+                pricing.cache_read_input_token_cost_above_200k_tokens,
+            ),
+            (
+                TIERED_PRICING_THRESHOLD_272K_TOKENS,
+                pricing.cache_read_input_token_cost_above_272k_tokens,
+            ),
+        ],
     );
     let cache_write_cost = tiered_cost(
         cache_write_clamped,
         pricing.cache_creation_input_token_cost,
-        pricing.cache_creation_input_token_cost_above_200k_tokens,
+        &[(
+            TIERED_PRICING_THRESHOLD_200K_TOKENS,
+            pricing.cache_creation_input_token_cost_above_200k_tokens,
+        )],
     );
 
     input_cost + output_cost + cache_read_cost + cache_write_cost
@@ -986,9 +1050,16 @@ fn has_any_usable_pricing(pricing: &ModelPricing) -> bool {
         pricing.output_cost_per_token,
         pricing.cache_read_input_token_cost,
         pricing.cache_creation_input_token_cost,
+        pricing.input_cost_per_token_above_128k_tokens,
         pricing.input_cost_per_token_above_200k_tokens,
+        pricing.input_cost_per_token_above_256k_tokens,
+        pricing.input_cost_per_token_above_272k_tokens,
+        pricing.output_cost_per_token_above_128k_tokens,
         pricing.output_cost_per_token_above_200k_tokens,
+        pricing.output_cost_per_token_above_256k_tokens,
+        pricing.output_cost_per_token_above_272k_tokens,
         pricing.cache_read_input_token_cost_above_200k_tokens,
+        pricing.cache_read_input_token_cost_above_272k_tokens,
         pricing.cache_creation_input_token_cost_above_200k_tokens,
     ]
     .into_iter()
@@ -997,9 +1068,16 @@ fn has_any_usable_pricing(pricing: &ModelPricing) -> bool {
 
 fn has_any_valid_above_tier_value(pricing: &ModelPricing) -> bool {
     [
+        pricing.input_cost_per_token_above_128k_tokens,
         pricing.input_cost_per_token_above_200k_tokens,
+        pricing.input_cost_per_token_above_256k_tokens,
+        pricing.input_cost_per_token_above_272k_tokens,
+        pricing.output_cost_per_token_above_128k_tokens,
         pricing.output_cost_per_token_above_200k_tokens,
+        pricing.output_cost_per_token_above_256k_tokens,
+        pricing.output_cost_per_token_above_272k_tokens,
         pricing.cache_read_input_token_cost_above_200k_tokens,
+        pricing.cache_read_input_token_cost_above_272k_tokens,
         pricing.cache_creation_input_token_cost_above_200k_tokens,
     ]
     .into_iter()
@@ -1011,11 +1089,35 @@ fn has_meaningful_tier_support(pricing: &ModelPricing) -> bool {
     [
         (
             pricing.input_cost_per_token,
+            pricing.input_cost_per_token_above_128k_tokens,
+        ),
+        (
+            pricing.input_cost_per_token,
             pricing.input_cost_per_token_above_200k_tokens,
+        ),
+        (
+            pricing.input_cost_per_token,
+            pricing.input_cost_per_token_above_256k_tokens,
+        ),
+        (
+            pricing.input_cost_per_token,
+            pricing.input_cost_per_token_above_272k_tokens,
+        ),
+        (
+            pricing.output_cost_per_token,
+            pricing.output_cost_per_token_above_128k_tokens,
         ),
         (
             pricing.output_cost_per_token,
             pricing.output_cost_per_token_above_200k_tokens,
+        ),
+        (
+            pricing.output_cost_per_token,
+            pricing.output_cost_per_token_above_256k_tokens,
+        ),
+        (
+            pricing.output_cost_per_token,
+            pricing.output_cost_per_token_above_272k_tokens,
         ),
     ]
     .into_iter()
@@ -1409,6 +1511,19 @@ mod tests {
                 input_cost_per_token: Some(0.00000175),
                 output_cost_per_token: Some(0.000014),
                 cache_read_input_token_cost: Some(1.75e-7),
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "gpt-5.5".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000005),
+                input_cost_per_token_above_272k_tokens: Some(0.000010),
+                output_cost_per_token: Some(0.000030),
+                output_cost_per_token_above_272k_tokens: Some(0.000045),
+                cache_read_input_token_cost: Some(0.0000005),
+                cache_read_input_token_cost_above_272k_tokens: Some(0.000001),
                 cache_creation_input_token_cost: None,
                 ..Default::default()
             },
@@ -2108,6 +2223,14 @@ mod tests {
     }
 
     #[test]
+    fn test_exact_match_gpt_5_5_litellm() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("gpt-5.5").unwrap();
+        assert_eq!(result.matched_key, "gpt-5.5");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
     fn test_exact_match_openrouter() {
         let lookup = create_lookup();
         let result = lookup.lookup("z-ai/glm-4.7").unwrap();
@@ -2152,6 +2275,14 @@ mod tests {
         let lookup = create_lookup();
         let result = lookup.lookup("gpt-5.2-xhigh").unwrap();
         assert_eq!(result.matched_key, "gpt-5.2");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_tier_suffix_xhigh_gpt_5_5() {
+        let lookup = create_lookup();
+        let result = lookup.lookup("gpt-5.5-xhigh").unwrap();
+        assert_eq!(result.matched_key, "gpt-5.5");
         assert_eq!(result.source, "LiteLLM");
     }
 
@@ -2692,6 +2823,49 @@ mod tests {
     }
 
     #[test]
+    fn test_compute_cost_tiered_above_272k_splits_gpt_5_5_tokens() {
+        let pricing: ModelPricing = serde_json::from_str(
+            r#"{
+                "input_cost_per_token": 0.000005,
+                "input_cost_per_token_above_272k_tokens": 0.000010,
+                "output_cost_per_token": 0.000030,
+                "output_cost_per_token_above_272k_tokens": 0.000045,
+                "cache_read_input_token_cost": 0.0000005,
+                "cache_read_input_token_cost_above_272k_tokens": 0.000001
+            }"#,
+        )
+        .unwrap();
+
+        let cost = compute_cost(&pricing, 272_001, 272_001, 272_001, 0, 0);
+        let expected = (272_000.0 * 0.000005 + 1.0 * 0.000010)
+            + (272_000.0 * 0.000030 + 1.0 * 0.000045)
+            + (272_000.0 * 0.0000005 + 1.0 * 0.000001);
+
+        assert!((cost - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_compute_cost_tiered_uses_multiple_thresholds_in_order() {
+        let pricing: ModelPricing = serde_json::from_str(
+            r#"{
+                "input_cost_per_token": 0.000001,
+                "input_cost_per_token_above_128k_tokens": 0.000002,
+                "input_cost_per_token_above_256k_tokens": 0.000003,
+                "input_cost_per_token_above_272k_tokens": 0.000004
+            }"#,
+        )
+        .unwrap();
+
+        let cost = compute_cost(&pricing, 300_000, 0, 0, 0, 0);
+        let expected = (128_000.0 * 0.000001)
+            + (128_000.0 * 0.000002)
+            + (16_000.0 * 0.000003)
+            + (28_000.0 * 0.000004);
+
+        assert!((cost - expected).abs() < 1e-12);
+    }
+
+    #[test]
     fn test_compute_cost_tiered_is_applied_per_bucket() {
         let pricing: ModelPricing = serde_json::from_str(
             r#"{
@@ -3064,6 +3238,7 @@ mod tests {
                 cache_read_input_token_cost_above_200k_tokens: Some(0.000002),
                 cache_creation_input_token_cost: Some(0.000003),
                 cache_creation_input_token_cost_above_200k_tokens: Some(0.000004),
+                ..Default::default()
             },
         );
 
@@ -3165,6 +3340,7 @@ mod tests {
                 cache_read_input_token_cost_above_200k_tokens: Some(0.0000002),
                 cache_creation_input_token_cost: Some(0.0000003),
                 cache_creation_input_token_cost_above_200k_tokens: Some(0.0000004),
+                ..Default::default()
             },
         );
 

--- a/crates/tokscale-core/src/provider_identity.rs
+++ b/crates/tokscale-core/src/provider_identity.rs
@@ -233,6 +233,7 @@ mod tests {
             Some("anthropic")
         );
         assert_eq!(inferred_provider_from_model("gpt-5.2"), Some("openai"));
+        assert_eq!(inferred_provider_from_model("gpt-5.5"), Some("openai"));
         assert_eq!(
             inferred_provider_from_model("gemini-2.5-pro"),
             Some("google")


### PR DESCRIPTION
## Summary

- Add support for GPT-5.5 pricing data that uses model-specific long-context tier fields, including above-272k token prices.
- Preserve GPT-5.x model names in Wrapped output, including GPT-5.5, GPT-5.5 Pro, and GPT-5.5 XHigh variants.
- Add regression coverage for GPT-5.5 lookup, tier suffix matching, tiered cost calculation, LiteLLM field deserialization, and provider inference.

## Why

LiteLLM pricing metadata is not limited to the existing above-200k shape. Newer OpenAI model entries can expose additional above-threshold fields such as above-272k token prices. Without reading those fields, Tokscale can undercount long-context GPT-5.5 usage and display GPT-5.5-family models less precisely in Wrapped summaries.

## Changes

- Extend LiteLLM `ModelPricing` deserialization with 128k, 256k, and 272k input/output tier fields, plus 272k cache-read pricing.
- Generalize tiered cost calculation so each token bucket uses the correct ordered threshold instead of assuming a single 200k breakpoint.
- Keep existing 200k tier behavior while allowing models with different tier thresholds to price correctly.
- Add GPT-5.5 lookup coverage and provider inference coverage.
- Add Wrapped display formatting for GPT-5.x model names without collapsing minor versions.
- Include a narrow clippy cleanup in the Antigravity macOS path lookup so this branch passes the repository's strict lint job on current `main`.

## Validation

- `bash scripts/check-version-coherence.sh`
  - `Version coherence OK: 2.0.27`
- `cargo test --workspace -- --quiet`
  - `1131 passed; 0 failed; 2 ignored`
- `cargo test --workspace --all-features -- --quiet`
  - `1131 passed; 0 failed; 2 ignored`
- `cargo fmt --all --check`
- `/opt/homebrew/Cellar/rust/1.94.0/bin/cargo-clippy clippy --workspace --all-features -- -D warnings`
- `git diff --check origin/main...HEAD`

## Branch Notes

- Base: `junhoyeo/tokscale@main` (`edc8ed1fca49ec4a6936e4d4e15ca45dfd442b8e` at validation time)
- Head: `IvGolovach:codex/gpt-5-5-pricing-support-current-main`
- Branch status at validation time: 2 commits ahead, 0 commits behind `origin/main`

## Risk

Low. The pricing change keeps the existing base-price and above-200k paths intact, adds support for additional LiteLLM fields, and covers the new behavior with focused unit tests.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
