### PR TITLE
fix(tui): let Overview scroll through all models

### DIFF
--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -529,8 +529,10 @@ impl App {
     pub fn handle_resize(&mut self, width: u16, height: u16) {
         self.terminal_width = width;
         self.terminal_height = height;
-        // Ensure at least 1 visible item to prevent division/slice issues
-        self.max_visible_items = (height.saturating_sub(10) as usize).max(1);
+    }
+
+    pub(crate) fn set_max_visible_items(&mut self, max_visible_items: usize) {
+        self.max_visible_items = max_visible_items.max(1);
         self.clamp_selection();
     }
 
@@ -1731,6 +1733,22 @@ mod tests {
         assert_eq!(app.scroll_offset, 0);
     }
 
+    #[test]
+    fn test_overview_scroll_keeps_rendered_capacity_after_resize() {
+        let mut app = make_app_with_models(33);
+        app.current_tab = Tab::Overview;
+        app.set_max_visible_items(9);
+
+        for _ in 0..32 {
+            app.move_selection_down();
+            app.handle_resize(120, 40);
+            app.set_max_visible_items(9);
+        }
+
+        assert_eq!(app.selected_index, 32);
+        assert_eq!(app.scroll_offset, 24);
+    }
+
     // ── handle_key_event: theme ─────────────────────────────────────
 
     #[test]
@@ -1943,7 +1961,7 @@ mod tests {
         app.handle_resize(120, 40);
         assert_eq!(app.terminal_width, 120);
         assert_eq!(app.terminal_height, 40);
-        assert_eq!(app.max_visible_items, 30);
+        assert_eq!(app.max_visible_items, 20);
     }
 
     #[test]
@@ -1952,18 +1970,34 @@ mod tests {
         app.handle_resize(40, 12);
         assert_eq!(app.terminal_width, 40);
         assert_eq!(app.terminal_height, 12);
-        assert_eq!(app.max_visible_items, 2);
+        assert_eq!(app.max_visible_items, 20);
     }
 
     #[test]
-    fn test_handle_resize_clamps_selection() {
+    fn test_handle_resize_preserves_rendered_capacity() {
         let mut app = make_app_with_models(5);
         app.selected_index = 4;
-        app.scroll_offset = 3;
-        app.max_visible_items = 20;
+        app.scroll_offset = 2;
+        app.max_visible_items = 3;
 
         app.handle_resize(80, 24);
-        assert!(app.selected_index <= 4);
+
+        assert_eq!(app.max_visible_items, 3);
+        assert_eq!(app.selected_index, 4);
+        assert_eq!(app.scroll_offset, 2);
+    }
+
+    #[test]
+    fn test_set_max_visible_items_clamps_scroll_offset() {
+        let mut app = make_app_with_models(10);
+        app.selected_index = 9;
+        app.scroll_offset = 9;
+
+        app.set_max_visible_items(3);
+
+        assert_eq!(app.max_visible_items, 3);
+        assert_eq!(app.selected_index, 9);
+        assert_eq!(app.scroll_offset, 7);
     }
 
     // ── on_tick ─────────────────────────────────────────────────────

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -526,6 +526,12 @@ impl App {
         }
     }
 
+    /// Cache the latest terminal dimensions. `max_visible_items` is
+    /// intentionally not updated here: each tab's renderer owns its own
+    /// visible-item capacity and pushes the rendered count via
+    /// [`Self::set_max_visible_items`] (which clamps selection and scroll
+    /// state). Between resize and the next render, scroll math runs
+    /// against the previous tab's capacity for one frame and self-corrects.
     pub fn handle_resize(&mut self, width: u16, height: u16) {
         self.terminal_width = width;
         self.terminal_height = height;

--- a/crates/tokscale-cli/src/tui/ui/agents.rs
+++ b/crates/tokscale-cli/src/tui/ui/agents.rs
@@ -23,7 +23,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_widget(block, area);
 
     let visible_height = inner.height.saturating_sub(1) as usize;
-    app.max_visible_items = visible_height;
+    app.set_max_visible_items(visible_height);
 
     let is_narrow = app.is_narrow();
     let is_very_narrow = app.is_very_narrow();

--- a/crates/tokscale-cli/src/tui/ui/daily.rs
+++ b/crates/tokscale-cli/src/tui/ui/daily.rs
@@ -23,7 +23,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_widget(block, area);
 
     let visible_height = inner.height.saturating_sub(1) as usize;
-    app.max_visible_items = visible_height;
+    app.set_max_visible_items(visible_height);
 
     let daily = app.get_sorted_daily();
     if daily.is_empty() {

--- a/crates/tokscale-cli/src/tui/ui/hourly.rs
+++ b/crates/tokscale-cli/src/tui/ui/hourly.rs
@@ -31,7 +31,7 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_widget(block, area);
 
     let visible_height = inner.height.saturating_sub(1) as usize;
-    app.max_visible_items = visible_height;
+    app.set_max_visible_items(visible_height);
 
     let hourly = app.get_sorted_hourly();
     if hourly.is_empty() {

--- a/crates/tokscale-cli/src/tui/ui/models.rs
+++ b/crates/tokscale-cli/src/tui/ui/models.rs
@@ -41,7 +41,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_widget(block, area);
 
     let visible_height = inner.height.saturating_sub(1) as usize;
-    app.max_visible_items = visible_height;
+    app.set_max_visible_items(visible_height);
 
     let is_narrow = app.is_narrow();
     let is_very_narrow = app.is_very_narrow();

--- a/crates/tokscale-cli/src/tui/ui/overview.rs
+++ b/crates/tokscale-cli/src/tui/ui/overview.rs
@@ -66,7 +66,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
 
     let list_area_height = chunks[2].height.saturating_sub(2);
     let items_per_page = ((list_area_height / 2) as usize).max(1);
-    app.max_visible_items = items_per_page;
+    app.set_max_visible_items(items_per_page);
 
     render_chart(frame, app, chunks[0]);
     render_legend(frame, app, chunks[1]);


### PR DESCRIPTION
## 1. Summary

Fixes the Overview tab scroll range so large model lists can scroll all the way to the final rows after redraws or resize events.

Closes #481.

## 2. Why

The Overview tab renders each model as a two-line row, but the shared resize path was clamping `scroll_offset` against a full-terminal item estimate before Overview recalculated its real page size. That made lists with many models stop after only the first few scroll ranges.

## 3. Diff scope

Touched TUI scroll-capacity ownership only:

- `crates/tokscale-cli/src/tui/app.rs`
- `crates/tokscale-cli/src/tui/ui/overview.rs`
- `crates/tokscale-cli/src/tui/ui/models.rs`
- `crates/tokscale-cli/src/tui/ui/daily.rs`
- `crates/tokscale-cli/src/tui/ui/hourly.rs`
- `crates/tokscale-cli/src/tui/ui/agents.rs`

The active renderer now sets the actual visible item capacity through `App::set_max_visible_items()`, which clamps selection and scroll state using the rendered panel height rather than a generic terminal-height estimate.

## 4. Branch integrity

- Base branch: `main`
- `origin/main` SHA: `edc8ed1fca49ec4a6936e4d4e15ca45dfd442b8e`
- Ahead/behind: ahead `1`, behind `0`
- Merge-base SHA: `edc8ed1fca49ec4a6936e4d4e15ca45dfd442b8e`
- Fast-forward safety: `origin/main` is an ancestor of this branch; no divergence detected.

```text
git rev-list --left-right --count origin/main...HEAD
0       1

git merge-base origin/main HEAD
edc8ed1fca49ec4a6936e4d4e15ca45dfd442b8e
```

## 5. Commit integrity

Commit introduced by this PR:

```text
d01497d987340d7c2ff6d95ecafb0769937dbda6 fix(tui): preserve rendered scroll capacity after resize
```

- One logical change per commit: yes.
- Ledger-Id trailer confirmation: Not applicable — `scripts/ledger/` does not exist in this repository.
- Unique Ledger-Id confirmation for squash-merge repositories: Not applicable — `scripts/ledger/` does not exist in this repository.

## 6. Ledger proof

Not applicable — `scripts/ledger/` does not exist in this repository.

## 7. Diff hygiene

```text
git diff --name-status origin/main...HEAD
M       crates/tokscale-cli/src/tui/app.rs
M       crates/tokscale-cli/src/tui/ui/agents.rs
M       crates/tokscale-cli/src/tui/ui/daily.rs
M       crates/tokscale-cli/src/tui/ui/hourly.rs
M       crates/tokscale-cli/src/tui/ui/models.rs
M       crates/tokscale-cli/src/tui/ui/overview.rs
```

`git diff --check origin/main...HEAD`: PASS, no output.

Forbidden-file confirmation:

- No `.env` files.
- No local environment files.
- No secrets, tokens, or credentials.
- No `ops/reports/**` artifacts.
- No `__pycache__/`, `*.pyc`, `.DS_Store`, `.coverage`, `htmlcov/`, or `coverage.xml`.
- No build artifacts or cache files.
- No unrelated generated files.
- No unrelated source changes.
- No Cyrillic text added in touched files.

## 8. Test proof

Regression test added:

- `test_overview_scroll_keeps_rendered_capacity_after_resize`

Validation run:

```text
cargo fmt --all -- --check
PASS

bash scripts/check-version-coherence.sh
Version coherence OK: 2.0.27

cargo test -p tokscale-cli tui::app::tests
test result: ok. 70 passed; 0 failed; 1 ignored; 0 measured; 378 filtered out

docker run --rm -v "$PWD":/work:ro -w /work rust:1.95 bash -c 'rustc --version && rustup component add clippy && cargo clippy --workspace --all-features -- -D warnings'
rustc 1.95.0 (59807616e 2026-04-14)
Finished `dev` profile [unoptimized + debuginfo]

cargo test --workspace --all-features -- --format terse
test result: ok. 448 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
test result: ok. 84 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 582 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Total: 1,127 passed, 2 ignored.

## 9. Verification-pack proof

Not applicable — no infra/governance/replay/invariant/verification files changed.

## 10. Migration notes

Not applicable — no DB migration changed.

## 11. CI context confirmation

CI context names unchanged.

Not applicable — no CI/workflow context changes.

## 12. Runtime safety

Reviewed runtime files/modules:

- TUI state and navigation: `crates/tokscale-cli/src/tui/app.rs`
- TUI render capacity call sites: `overview.rs`, `models.rs`, `daily.rs`, `hourly.rs`, `agents.rs`

Runtime reasoning:

- No new blocking locks: the change only moves scroll-capacity clamping from resize to renderer-owned capacity updates.
- No new unbounded queues: no async, channel, queue, or buffering behavior changed.
- No invariant removal: list navigation still clamps selection and scroll state through the existing `clamp_selection()` path.
- No invariant regression introduced.

## 13. Documentation integrity

Not applicable — no docs/runbooks/commands changed.

## 14. Rollback plan

Use the final merged commit SHA after merge:

```text
git revert <post_merge_commit_sha>
```

Replace `<post_merge_commit_sha>` with the final squash/merge commit SHA after merge.

- DB downgrade required: no.
- Data repair required: no.
- Operational caveats: rollback only restores the previous TUI scroll-capacity behavior.

## 15. Known residual risks

No known residual risks.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
