### PR TITLE
feat(workspace): attribute Codex and OpenCode workspaces

### DIFF
--- a/crates/tokscale-cli/src/tui/cache.rs
+++ b/crates/tokscale-cli/src/tui/cache.rs
@@ -1397,9 +1397,11 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let previous_home = env::var_os("HOME");
         let previous_override = env::var_os("TOKSCALE_CONFIG_DIR");
+        let previous_xdg_config_home = env::var_os("XDG_CONFIG_HOME");
         unsafe {
             env::set_var("HOME", temp_dir.path());
             env::remove_var("TOKSCALE_CONFIG_DIR");
+            env::set_var("XDG_CONFIG_HOME", temp_dir.path().join(".xdg-config"));
         }
 
         let legacy_path = temp_dir.path().join(".cache/tokscale/tui-data-cache.json");
@@ -1440,6 +1442,10 @@ mod tests {
         match previous_override {
             Some(value) => unsafe { env::set_var("TOKSCALE_CONFIG_DIR", value) },
             None => unsafe { env::remove_var("TOKSCALE_CONFIG_DIR") },
+        }
+        match previous_xdg_config_home {
+            Some(value) => unsafe { env::set_var("XDG_CONFIG_HOME", value) },
+            None => unsafe { env::remove_var("XDG_CONFIG_HOME") },
         }
     }
 

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -217,6 +217,58 @@ fn create_codex_fixture_dir() -> TempDir {
     tmp
 }
 
+fn create_codex_workspace_fixture_dir() -> TempDir {
+    let tmp = TempDir::new().expect("failed to create temp dir");
+    let base = tmp.path();
+    prime_pricing_cache(base);
+
+    let sessions_dir = base.join(".codex/sessions");
+    fs::create_dir_all(&sessions_dir).unwrap();
+    fs::write(
+        sessions_dir.join("workspace-session.jsonl"),
+        concat!(
+            r#"{"type":"session_meta","payload":{"source":"chat","cwd":"/Users/alice/codex-workspace"}}"#,
+            "\n",
+            r#"{"type":"turn_context","payload":{"model":"gpt-5.4"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-01-01T00:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":120,"cached_input_tokens":20,"output_tokens":30}}}}"#,
+            "\n"
+        ),
+    )
+    .unwrap();
+
+    tmp
+}
+
+fn create_opencode_workspace_fixture_dir() -> TempDir {
+    let tmp = TempDir::new().expect("failed to create temp dir");
+    let base = tmp.path();
+    prime_pricing_cache(base);
+
+    let session = base.join(".local/share/opencode/storage/message/workspace-session");
+    fs::create_dir_all(&session).unwrap();
+
+    let msg = r#"{
+        "id": "workspace_msg",
+        "sessionID": "workspace-session",
+        "role": "assistant",
+        "modelID": "claude-sonnet-4-20250514",
+        "providerID": "anthropic",
+        "cost": 0.05,
+        "tokens": {
+            "input": 1000,
+            "output": 500,
+            "reasoning": 0,
+            "cache": { "read": 200, "write": 50 }
+        },
+        "time": { "created": 1718452800000.0 },
+        "path": { "root": "/Users/alice/opencode-workspace" }
+    }"#;
+    fs::write(session.join("workspace_msg.json"), msg).unwrap();
+
+    tmp
+}
+
 fn create_conflicting_opencode_fixture_dir() -> TempDir {
     let tmp = TempDir::new().expect("failed to create temp dir");
     let base = tmp.path();
@@ -1369,6 +1421,56 @@ fn test_models_group_by_workspace_model_surfaces_workspace_fields_for_qwen() {
         "demo-workspace"
     );
     assert_eq!(entries[0]["model"].as_str().unwrap(), "qwen3.5-plus");
+}
+
+#[test]
+fn test_models_group_by_workspace_model_surfaces_workspace_fields_for_codex() {
+    let tmp = create_codex_workspace_fixture_dir();
+    let output = cmd_with_home(tmp.path())
+        .args(["models", "--json", "--codex", "--no-spinner"])
+        .args(["--group-by", "workspace,model"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["groupBy"].as_str().unwrap(), "workspace,model");
+
+    let entries = json["entries"].as_array().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(
+        entries[0]["workspaceKey"].as_str().unwrap(),
+        "/Users/alice/codex-workspace"
+    );
+    assert_eq!(
+        entries[0]["workspaceLabel"].as_str().unwrap(),
+        "codex-workspace"
+    );
+    assert_eq!(entries[0]["model"].as_str().unwrap(), "gpt-5.4");
+}
+
+#[test]
+fn test_models_group_by_workspace_model_surfaces_workspace_fields_for_opencode() {
+    let tmp = create_opencode_workspace_fixture_dir();
+    let output = cmd_with_home(tmp.path())
+        .args(["models", "--json", "--opencode", "--no-spinner"])
+        .args(["--group-by", "workspace,model"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["groupBy"].as_str().unwrap(), "workspace,model");
+
+    let entries = json["entries"].as_array().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(
+        entries[0]["workspaceKey"].as_str().unwrap(),
+        "/Users/alice/opencode-workspace"
+    );
+    assert_eq!(
+        entries[0]["workspaceLabel"].as_str().unwrap(),
+        "opencode-workspace"
+    );
+    assert_eq!(entries[0]["model"].as_str().unwrap(), "claude-sonnet-4");
 }
 
 // ── Pricing command tests ──────────────────────────────────────────────────

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -10,7 +10,7 @@ use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
-const CACHE_SCHEMA_VERSION: u32 = 7;
+const CACHE_SCHEMA_VERSION: u32 = 8;
 const CACHE_FILENAME: &str = "source-message-cache.bin";
 const CACHE_LOCK_FILENAME: &str = "source-message-cache.lock";
 const MAX_CACHE_FILE_BYTES: u64 = 256 * 1024 * 1024;

--- a/crates/tokscale-core/src/sessions/codex.rs
+++ b/crates/tokscale-core/src/sessions/codex.rs
@@ -6,7 +6,7 @@
 use super::utils::{
     extract_i64, extract_string, file_modified_timestamp_ms, parse_timestamp_value,
 };
-use super::UnifiedMessage;
+use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
 use serde::Deserialize;
 use serde_json::Value;
@@ -31,6 +31,8 @@ pub struct CodexPayload {
     pub model_info: Option<CodexModelInfo>,
     pub info: Option<CodexInfo>,
     pub source: Option<String>,
+    /// Current working directory from session_meta.
+    pub cwd: Option<String>,
     /// Provider identity from session_meta (e.g. "openai", "azure")
     pub model_provider: Option<String>,
     /// Agent name from session_meta
@@ -152,6 +154,8 @@ pub(crate) struct CodexParseState {
     pub session_is_headless: bool,
     pub session_provider: Option<String>,
     pub session_agent: Option<String>,
+    pub session_workspace_key: Option<String>,
+    pub session_workspace_label: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -215,6 +219,13 @@ fn parse_codex_reader<R: BufRead>(
                     }
                     if let Some(ref nickname) = payload.agent_nickname {
                         state.session_agent = Some(nickname.clone());
+                    }
+                    if let Some(ref cwd) = payload.cwd {
+                        state.session_workspace_key = normalize_workspace_key(cwd);
+                        state.session_workspace_label = state
+                            .session_workspace_key
+                            .as_deref()
+                            .and_then(workspace_label_from_key);
                     }
                 }
                 // Extract model from turn_context
@@ -322,7 +333,7 @@ fn parse_codex_reader<R: BufRead>(
 
                     let provider = state.session_provider.as_deref().unwrap_or("openai");
 
-                    messages.push(UnifiedMessage::new_with_agent(
+                    let mut message = UnifiedMessage::new_with_agent(
                         "codex",
                         model,
                         provider,
@@ -331,7 +342,12 @@ fn parse_codex_reader<R: BufRead>(
                         tokens,
                         0.0,
                         agent,
-                    ));
+                    );
+                    message.set_workspace(
+                        state.session_workspace_key.clone(),
+                        state.session_workspace_label.clone(),
+                    );
+                    messages.push(message);
                     if parsed_timestamp.is_none() {
                         fallback_timestamp_indices.push(messages.len() - 1);
                     }
@@ -349,7 +365,7 @@ fn parse_codex_reader<R: BufRead>(
             continue;
         }
 
-        if let Some((msg, used_fallback_timestamp)) = parse_codex_headless_line(
+        if let Some((mut msg, used_fallback_timestamp)) = parse_codex_headless_line(
             trimmed,
             session_id,
             &mut state.current_model,
@@ -358,6 +374,10 @@ fn parse_codex_reader<R: BufRead>(
             &state.session_agent,
             state.session_is_headless,
         ) {
+            msg.set_workspace(
+                state.session_workspace_key.clone(),
+                state.session_workspace_label.clone(),
+            );
             messages.push(msg);
             if used_fallback_timestamp {
                 fallback_timestamp_indices.push(messages.len() - 1);
@@ -661,7 +681,7 @@ mod tests {
     #[test]
     fn test_incremental_parse_matches_full_parse_for_appended_lines() {
         let file = create_test_file(concat!(
-            r#"{"type":"session_meta","payload":{"source":"chat","model_provider":"openai","agent_nickname":"builder"}}"#,
+            r#"{"type":"session_meta","payload":{"source":"chat","model_provider":"openai","agent_nickname":"builder","cwd":"/Users/alice/codex-demo"}}"#,
             "\n",
             r#"{"type":"turn_context","payload":{"model":"gpt-5.4"}}"#,
             "\n",
@@ -673,6 +693,14 @@ mod tests {
         let initial = parse_codex_file_incremental(file.path(), 0, CodexParseState::default());
         assert_eq!(initial.messages.len(), 1);
         assert_eq!(initial.consumed_offset, initial_size);
+        assert_eq!(
+            initial.messages[0].workspace_key.as_deref(),
+            Some("/Users/alice/codex-demo")
+        );
+        assert_eq!(
+            initial.messages[0].workspace_label.as_deref(),
+            Some("codex-demo")
+        );
 
         let appended = concat!(
             r#"{"timestamp":"2026-01-01T00:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":15,"cached_input_tokens":3,"output_tokens":5},"last_token_usage":{"input_tokens":5,"cached_input_tokens":1,"output_tokens":2}}}}"#,
@@ -697,6 +725,17 @@ mod tests {
 
         let full = parse_codex_file(file.path());
         assert_eq!(combined, full);
+        assert_eq!(
+            combined
+                .iter()
+                .map(|msg| msg.workspace_key.as_deref())
+                .collect::<Vec<_>>(),
+            vec![
+                Some("/Users/alice/codex-demo"),
+                Some("/Users/alice/codex-demo"),
+                Some("/Users/alice/codex-demo")
+            ]
+        );
     }
 
     #[test]
@@ -1063,6 +1102,24 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].provider_id, "azure");
         assert_eq!(messages[0].agent.as_deref(), Some("my-agent"));
+    }
+
+    #[test]
+    fn test_session_meta_cwd_sets_workspace_metadata() {
+        let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"session_meta","payload":{"source":"interactive","cwd":"/Users/alice/demo-repo"}}"#;
+        let line2 = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#;
+        let line3 = r#"{"timestamp":"2026-01-01T00:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1}}}}"#;
+        let content = format!("{}\n{}\n{}", line1, line2, line3);
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].workspace_key.as_deref(),
+            Some("/Users/alice/demo-repo")
+        );
+        assert_eq!(messages[0].workspace_label.as_deref(), Some("demo-repo"));
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -816,6 +816,48 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_opencode_sqlite_legacy_fallback_uses_path_root_when_session_table_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_opencode.db");
+
+        let conn = create_opencode_sqlite_db(&db_path);
+
+        let data_json = r#"{
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "cost": 0.05,
+            "tokens": {
+                "input": 1000,
+                "output": 500,
+                "reasoning": 0,
+                "cache": { "read": 200, "write": 50 }
+            },
+            "time": { "created": 1700000000000.0 },
+            "path": { "root": "/Users/alice/legacy-fallback-repo" }
+        }"#;
+
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["msg_sqlite_legacy_workspace", "ses_001", data_json],
+        )
+        .unwrap();
+        drop(conn);
+
+        let messages = parse_opencode_sqlite(&db_path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].workspace_key.as_deref(),
+            Some("/Users/alice/legacy-fallback-repo")
+        );
+        assert_eq!(
+            messages[0].workspace_label.as_deref(),
+            Some("legacy-fallback-repo")
+        );
+        assert_eq!(messages[0].tokens.input, 1000);
+    }
+
+    #[test]
     fn test_parse_opencode_sqlite_duplicate_workspace_conflict_is_unknown() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("test_opencode.db");

--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -92,6 +92,12 @@ struct OpenCodeSqliteFingerprint {
     agent: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+struct OpenCodeSqliteDedupState {
+    has_embedded_message_id: bool,
+    has_workspace_conflict: bool,
+}
+
 fn workspace_from_root(root: Option<&str>) -> (Option<String>, Option<String>) {
     let workspace_key = root.and_then(normalize_workspace_key);
     let workspace_label = workspace_key.as_deref().and_then(workspace_label_from_key);
@@ -101,6 +107,26 @@ fn workspace_from_root(root: Option<&str>) -> (Option<String>, Option<String>) {
 fn set_workspace_from_root(message: &mut UnifiedMessage, root: Option<&str>) {
     let (workspace_key, workspace_label) = workspace_from_root(root);
     message.set_workspace(workspace_key, workspace_label);
+}
+
+fn merge_duplicate_workspace(
+    message: &mut UnifiedMessage,
+    state: &mut OpenCodeSqliteDedupState,
+    root: Option<&str>,
+) {
+    if state.has_workspace_conflict {
+        return;
+    }
+
+    let (candidate_key, candidate_label) = workspace_from_root(root);
+    match (message.workspace_key.as_deref(), candidate_key) {
+        (None, Some(key)) => message.set_workspace(Some(key), candidate_label),
+        (Some(existing), Some(candidate)) if existing != candidate => {
+            state.has_workspace_conflict = true;
+            message.set_workspace(None, None);
+        }
+        _ => {}
+    }
 }
 
 pub fn parse_opencode_file(path: &Path) -> Option<UnifiedMessage> {
@@ -164,6 +190,7 @@ pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
         LEFT JOIN session s ON s.id = m.session_id
         WHERE json_extract(m.data, '$.role') = 'assistant'
           AND json_extract(m.data, '$.tokens') IS NOT NULL
+        ORDER BY m.id, m.session_id
     "#;
 
     let legacy_query = r#"
@@ -171,6 +198,7 @@ pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
         FROM message m
         WHERE json_extract(m.data, '$.role') = 'assistant'
           AND json_extract(m.data, '$.tokens') IS NOT NULL
+        ORDER BY m.id, m.session_id
     "#;
 
     let mut stmt = match conn
@@ -194,7 +222,7 @@ pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
 
     let mut messages: Vec<UnifiedMessage> = Vec::new();
     let mut fingerprint_indices: HashMap<OpenCodeSqliteFingerprint, usize> = HashMap::new();
-    let mut dedup_key_has_embedded_message_id: Vec<bool> = Vec::new();
+    let mut dedup_states: Vec<OpenCodeSqliteDedupState> = Vec::new();
 
     for row_result in rows {
         let (row_id, session_id, data_json, row_workspace_root) = match row_result {
@@ -276,14 +304,19 @@ pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
         set_workspace_from_root(&mut unified, workspace_root);
 
         if let Some(index) = fingerprint_indices.get(&fingerprint).copied() {
-            if message_id.is_some() && !dedup_key_has_embedded_message_id[index] {
-                dedup_key_has_embedded_message_id[index] = true;
+            let dedup_state = &mut dedup_states[index];
+            if message_id.is_some() && !dedup_state.has_embedded_message_id {
+                dedup_state.has_embedded_message_id = true;
                 messages[index].dedup_key = unified.dedup_key;
             }
+            merge_duplicate_workspace(&mut messages[index], dedup_state, workspace_root);
             continue;
         }
 
-        dedup_key_has_embedded_message_id.push(message_id.is_some());
+        dedup_states.push(OpenCodeSqliteDedupState {
+            has_embedded_message_id: message_id.is_some(),
+            has_workspace_conflict: false,
+        });
         fingerprint_indices.insert(fingerprint, messages.len());
         messages.push(unified);
     }
@@ -780,6 +813,64 @@ mod tests {
             messages[0].workspace_label.as_deref(),
             Some("opencode-sqlite-repo")
         );
+    }
+
+    #[test]
+    fn test_parse_opencode_sqlite_duplicate_workspace_conflict_is_unknown() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_opencode.db");
+
+        let conn = create_opencode_sqlite_db(&db_path);
+        conn.execute_batch(
+            "CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                directory TEXT NOT NULL
+            );",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session (id, directory) VALUES (?1, ?2)",
+            rusqlite::params!["ses_root", "/Users/alice/root-workspace"],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session (id, directory) VALUES (?1, ?2)",
+            rusqlite::params!["ses_fork", "/Users/alice/fork-workspace"],
+        )
+        .unwrap();
+
+        let data_json = r#"{
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "cost": 0.05,
+            "tokens": {
+                "input": 1000,
+                "output": 500,
+                "reasoning": 0,
+                "cache": { "read": 200, "write": 50 }
+            },
+            "time": { "created": 1700000000000.0, "completed": 1700000000500.0 },
+            "mode": "build"
+        }"#;
+
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["z_root_copy", "ses_root", data_json],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["a_fork_copy", "ses_fork", data_json],
+        )
+        .unwrap();
+        drop(conn);
+
+        let messages = parse_opencode_sqlite(&db_path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].workspace_key, None);
+        assert_eq!(messages[0].workspace_label, None);
+        assert_eq!(messages[0].tokens.input, 1000);
     }
 
     /// SQLite prefers the embedded message id when present so JSON/SQLite overlap keeps deduplicating.

--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -5,7 +5,10 @@
 //! - Legacy JSON files: ~/.local/share/opencode/storage/message/
 
 use super::utils::{open_readonly_sqlite, read_file_or_none};
-use super::{normalize_opencode_agent_name, UnifiedMessage};
+use super::{
+    normalize_opencode_agent_name, normalize_workspace_key, workspace_label_from_key,
+    UnifiedMessage,
+};
 use crate::TokenBreakdown;
 #[cfg(test)]
 use rusqlite::Connection;
@@ -31,6 +34,26 @@ pub struct OpenCodeMessage {
     pub time: OpenCodeTime,
     pub agent: Option<String>,
     pub mode: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_opencode_path")]
+    pub path: Option<OpenCodePath>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OpenCodePath {
+    pub root: Option<String>,
+}
+
+fn deserialize_opencode_path<'de, D>(deserializer: D) -> Result<Option<OpenCodePath>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    let root = value
+        .get("root")
+        .and_then(|root| root.as_str())
+        .map(str::to_string);
+
+    Ok(Some(OpenCodePath { root }))
 }
 
 #[derive(Debug, Deserialize)]
@@ -69,6 +92,17 @@ struct OpenCodeSqliteFingerprint {
     agent: Option<String>,
 }
 
+fn workspace_from_root(root: Option<&str>) -> (Option<String>, Option<String>) {
+    let workspace_key = root.and_then(normalize_workspace_key);
+    let workspace_label = workspace_key.as_deref().and_then(workspace_label_from_key);
+    (workspace_key, workspace_label)
+}
+
+fn set_workspace_from_root(message: &mut UnifiedMessage, root: Option<&str>) {
+    let (workspace_key, workspace_label) = workspace_from_root(root);
+    message.set_workspace(workspace_key, workspace_label);
+}
+
 pub fn parse_opencode_file(path: &Path) -> Option<UnifiedMessage> {
     let data = read_file_or_none(path)?;
     let mut bytes = data;
@@ -79,6 +113,11 @@ pub fn parse_opencode_file(path: &Path) -> Option<UnifiedMessage> {
         return None;
     }
 
+    let workspace_root = msg
+        .path
+        .as_ref()
+        .and_then(|path| path.root.as_deref())
+        .map(str::to_string);
     let tokens = msg.tokens?;
     let model_id = msg.model_id?;
     let agent_or_mode = msg.mode.or(msg.agent);
@@ -110,6 +149,7 @@ pub fn parse_opencode_file(path: &Path) -> Option<UnifiedMessage> {
         agent,
     );
     unified.dedup_key = dedup_key;
+    set_workspace_from_root(&mut unified, workspace_root.as_deref());
     Some(unified)
 }
 
@@ -118,14 +158,25 @@ pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
         return Vec::new();
     };
 
-    let query = r#"
-        SELECT m.id, m.session_id, m.data
+    let modern_query = r#"
+        SELECT m.id, m.session_id, m.data, NULLIF(s.directory, '') AS workspace_root
+        FROM message m
+        LEFT JOIN session s ON s.id = m.session_id
+        WHERE json_extract(m.data, '$.role') = 'assistant'
+          AND json_extract(m.data, '$.tokens') IS NOT NULL
+    "#;
+
+    let legacy_query = r#"
+        SELECT m.id, m.session_id, m.data, NULL AS workspace_root
         FROM message m
         WHERE json_extract(m.data, '$.role') = 'assistant'
           AND json_extract(m.data, '$.tokens') IS NOT NULL
     "#;
 
-    let mut stmt = match conn.prepare(query) {
+    let mut stmt = match conn
+        .prepare(modern_query)
+        .or_else(|_| conn.prepare(legacy_query))
+    {
         Ok(s) => s,
         Err(_) => return Vec::new(),
     };
@@ -134,7 +185,8 @@ pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
         let id: String = row.get(0)?;
         let session_id: String = row.get(1)?;
         let data_json: String = row.get(2)?;
-        Ok((id, session_id, data_json))
+        let workspace_root: Option<String> = row.get(3)?;
+        Ok((id, session_id, data_json, workspace_root))
     }) {
         Ok(r) => r,
         Err(_) => return Vec::new(),
@@ -145,7 +197,7 @@ pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
     let mut dedup_key_has_embedded_message_id: Vec<bool> = Vec::new();
 
     for row_result in rows {
-        let (row_id, session_id, data_json) = match row_result {
+        let (row_id, session_id, data_json, row_workspace_root) = match row_result {
             Ok(r) => r,
             Err(_) => continue,
         };
@@ -161,6 +213,11 @@ pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
         }
 
         let message_id = msg.id.clone();
+        let embedded_workspace_root = msg
+            .path
+            .as_ref()
+            .and_then(|path| path.root.as_deref())
+            .map(str::to_string);
 
         let tokens = match msg.tokens {
             Some(t) => t,
@@ -213,6 +270,10 @@ pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             agent,
         );
         unified.dedup_key = Some(dedup_key);
+        let workspace_root = row_workspace_root
+            .as_deref()
+            .or(embedded_workspace_root.as_deref());
+        set_workspace_from_root(&mut unified, workspace_root);
 
         if let Some(index) = fingerprint_indices.get(&fingerprint).copied() {
             if message_id.is_some() && !dedup_key_has_embedded_message_id[index] {
@@ -608,6 +669,117 @@ mod tests {
         );
         assert_eq!(messages[0].model_id, "claude-sonnet-4");
         assert_eq!(messages[0].tokens.input, 1000);
+    }
+
+    #[test]
+    fn test_parse_opencode_file_uses_explicit_path_root_as_workspace() {
+        let json = r#"{
+            "id": "msg_workspace_001",
+            "sessionID": "ses_001",
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "cost": 0.01,
+            "tokens": {
+                "input": 100,
+                "output": 50,
+                "reasoning": 0,
+                "cache": { "read": 0, "write": 0 }
+            },
+            "time": { "created": 1700000000000.0 },
+            "path": { "root": "/Users/alice/opencode-json-repo" }
+        }"#;
+
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("msg_workspace_001.json");
+        std::fs::write(&file_path, json).unwrap();
+
+        let msg = parse_opencode_file(&file_path).expect("Should parse");
+        assert_eq!(
+            msg.workspace_key.as_deref(),
+            Some("/Users/alice/opencode-json-repo")
+        );
+        assert_eq!(msg.workspace_label.as_deref(), Some("opencode-json-repo"));
+    }
+
+    #[test]
+    fn test_parse_opencode_file_ignores_non_object_path_without_rejecting_message() {
+        let json = r#"{
+            "id": "msg_path_string_001",
+            "sessionID": "ses_001",
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "cost": 0.01,
+            "tokens": {
+                "input": 100,
+                "output": 50,
+                "reasoning": 0,
+                "cache": { "read": 0, "write": 0 }
+            },
+            "time": { "created": 1700000000000.0 },
+            "path": "/Users/alice/not-object"
+        }"#;
+
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("msg_path_string_001.json");
+        std::fs::write(&file_path, json).unwrap();
+
+        let msg = parse_opencode_file(&file_path).expect("Should parse");
+        assert_eq!(msg.workspace_key, None);
+        assert_eq!(msg.workspace_label, None);
+    }
+
+    #[test]
+    fn test_parse_opencode_sqlite_uses_session_directory_as_workspace() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_opencode.db");
+
+        let conn = create_opencode_sqlite_db(&db_path);
+        conn.execute_batch(
+            "CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                directory TEXT NOT NULL
+            );",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session (id, directory) VALUES (?1, ?2)",
+            rusqlite::params!["ses_001", "/Users/alice/opencode-sqlite-repo"],
+        )
+        .unwrap();
+
+        let data_json = r#"{
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "cost": 0.05,
+            "tokens": {
+                "input": 1000,
+                "output": 500,
+                "reasoning": 0,
+                "cache": { "read": 200, "write": 50 }
+            },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["msg_sqlite_workspace", "ses_001", data_json],
+        )
+        .unwrap();
+        drop(conn);
+
+        let messages = parse_opencode_sqlite(&db_path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].workspace_key.as_deref(),
+            Some("/Users/alice/opencode-sqlite-repo")
+        );
+        assert_eq!(
+            messages[0].workspace_label.as_deref(),
+            Some("opencode-sqlite-repo")
+        );
     }
 
     /// SQLite prefers the embedded message id when present so JSON/SQLite overlap keeps deduplicating.


### PR DESCRIPTION
## Summary

Adds workspace attribution for Codex and OpenCode usage so `--group-by workspace,model` can show real workspace buckets for both clients when reliable source metadata is available.

## Why

Codex and OpenCode were falling into the `Unknown workspace` bucket even when their session data already contained explicit workspace context. This change uses only reliable sources: Codex `session_meta.cwd`, OpenCode SQLite `session.directory`, and OpenCode JSON `path.root`.

## Diff scope

**Touched areas**

- `crates/tokscale-core/src/sessions/codex.rs`: reads `cwd` from Codex `session_meta`, persists it in incremental parse state, and applies it to structured and headless usage rows.
- `crates/tokscale-core/src/sessions/opencode.rs`: reads workspace metadata from OpenCode SQLite sessions and explicit JSON `path.root`, with legacy SQLite fallback kept intact.
- `crates/tokscale-core/src/message_cache.rs`: bumps the source cache schema so stale cached rows without workspace metadata are not reused.
- `crates/tokscale-cli/tests/cli_tests.rs`: adds CLI coverage for Codex and OpenCode workspace/model grouping output.

## Branch integrity

- **Base branch:** `main`
- **origin/main SHA:** `edc8ed1fca49ec4a6936e4d4e15ca45dfd442b8e`
- **Ahead/behind:** `1` ahead, `0` behind
- **Merge-base SHA:** `edc8ed1fca49ec4a6936e4d4e15ca45dfd442b8e`
- **Fast-forward safety:** `git merge-base --is-ancestor origin/main HEAD` returned exit code `0`; `origin/main` is an ancestor of this branch.

## Commit integrity

- `8fc78149ccb9a4369bb4da76809eaee6cf116c09 feat(workspace): attribute Codex and OpenCode workspaces`
- One logical change per commit: yes.
- Ledger-Id trailer validation: Not applicable - `scripts/ledger/` does not exist in this repository.
- Unique Ledger-Id for squash merge: Not applicable - `scripts/ledger/` does not exist in this repository.

## Ledger proof

Not applicable - `scripts/ledger/` does not exist in this repository.

## Diff hygiene

**`git diff --name-status origin/main...HEAD`**

```text
M  crates/tokscale-cli/tests/cli_tests.rs
M  crates/tokscale-core/src/message_cache.rs
M  crates/tokscale-core/src/sessions/codex.rs
M  crates/tokscale-core/src/sessions/opencode.rs
```

**`git diff --check origin/main...HEAD`**

PASS, no output.

**Forbidden-file confirmation**

No `.env` files, local environment files, secrets, tokens, credentials, `ops/reports/**`, `__pycache__/`, `*.pyc`, `.DS_Store`, `.coverage`, `htmlcov/`, `coverage.xml`, build artifacts, cache files, unrelated generated files, or unrelated source changes are included.

## Test proof

- `bash scripts/check-version-coherence.sh`: PASS, `Version coherence OK: 2.0.27`
- `cargo test --workspace --all-features`: PASS, `1131 passed`, `2 ignored`
- `cargo fmt --all -- --check`: PASS, no output
- `cargo clippy -p tokscale-core --all-features -- -D warnings`: PASS

## Verification-pack proof

Not applicable - no infra, governance, replay, invariant, runbook, release, or verification-pack files changed.

## Migration notes

Not applicable - no DB migration changed.

## CI context confirmation

- Required generic contexts `backend`, `frontend`, and `simulated-correctness-core`: Not applicable - this Rust CLI repository does not define those contexts for this PR.
- Repository workflow context names unchanged.
- CI context names unchanged.
- Not applicable - no CI/workflow context changes.

## Runtime safety

Reviewed runtime modules: `crates/tokscale-core/src/sessions/codex.rs`, `crates/tokscale-core/src/sessions/opencode.rs`, and `crates/tokscale-core/src/message_cache.rs`.

- No new blocking locks: parsing only attaches workspace metadata to already parsed messages.
- No new unbounded queues: no queueing or buffering model changed.
- No invariant removal: existing token parsing, deduplication, legacy OpenCode SQLite fallback, and unknown-workspace grouping remain intact.
- No invariant regression introduced.

## Documentation integrity

Not applicable - no docs, runbooks, commands, or user-facing CLI syntax changed.

## Rollback plan

- **Squash merge rollback:** `git revert <post_merge_commit_sha>`
- Replace `<post_merge_commit_sha>` with the final squash or merge commit SHA after merge.
- DB downgrade required: no.
- Data repair required: no.
- Operational caveats: source message cache schema is bumped; rollback may cause cache entries written by this branch to be ignored by older code and regenerated.

## Known residual risks

- Local macOS full-workspace clippy could not be used as final proof because a transitive image dependency fails before project-code linting under the local clippy/dependency combination. Core clippy, full workspace tests, formatting, and diff hygiene all passed locally; GitHub CI remains the source of truth for the repository's full `cargo clippy --workspace --all-features -- -D warnings` job.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/tokscale/pull/486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
