### PR TITLE
docs: add deno dx examples

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -161,6 +161,9 @@ npx tokscale@latest
 # またはbunxを使用
 bunx tokscale@latest
 
+# たはdeno dxを使用
+dx tokscale@latest
+
 # ライトモード（テーブルレンダリングのみ）
 npx tokscale@latest --light
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -161,6 +161,9 @@ npx tokscale@latest
 # 또는 bunx 사용
 bunx tokscale@latest
 
+# 또는 deno dx 사용
+dx tokscale@latest
+
 # 라이트 모드 (테이블 렌더링만)
 npx tokscale@latest --light
 ```

--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ npx tokscale@latest
 # Or use bunx
 bunx tokscale@latest
 
+# Or use deno dx
+dx tokscale@latest
+
 # Light mode (table rendering only)
 npx tokscale@latest --light
 ```

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -161,6 +161,9 @@ npx tokscale@latest
 # 或使用 bunx
 bunx tokscale@latest
 
+# 或使用 deno dx
+dx tokscale@latest
+
 # 轻量模式（仅表格渲染）
 npx tokscale@latest --light
 ```


### PR DESCRIPTION
Hello,

This PR introduces Deno DX running method that's got introduced in Deno v2.6

https://deno.com/blog/v2.6

Can confirm it works nicely, so I simply wanted to add a tiny note about this on README.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Deno v2.6 DX run option to the docs, showing `dx tokscale@latest` as an alternative to `npx` and `bunx` across README files (EN, JA, KO, ZH-CN).

<sup>Written for commit f4779eb7a90113d4a968df7887c015b51906580c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

