### PR TITLE
fix(gemini): parse current JSONL session usage

### DIFF
--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -208,7 +208,7 @@ define_clients!(
         id: "gemini",
         root: PathRoot::Home,
         relative: ".gemini/tmp",
-        pattern: "*.json",
+        pattern: "*.json|*.jsonl",
         headless: false,
         parse_local: true,
         submit_default: true

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -188,6 +188,7 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
 
             match pattern {
                 "*.json" => file_name.ends_with(".json"),
+                "*.json|*.jsonl" => file_name.ends_with(".json") || file_name.ends_with(".jsonl"),
                 "*.jsonl" => file_name.ends_with(".jsonl"),
                 // OpenClaw: also match archived transcripts
                 // (<uuid>.jsonl.deleted.<ts>, <uuid>.jsonl.reset.<ts>)
@@ -1031,6 +1032,26 @@ mod tests {
     }
 
     #[test]
+    fn test_scan_directory_json_or_jsonl_pattern() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path();
+
+        File::create(path.join("session.json")).unwrap();
+        File::create(path.join("session.jsonl")).unwrap();
+        File::create(path.join("session.txt")).unwrap();
+
+        let session_files = scan_directory(path.to_str().unwrap(), "*.json|*.jsonl");
+        assert_eq!(session_files.len(), 2);
+        assert_eq!(
+            session_files
+                .iter()
+                .map(|path| path.file_name().unwrap().to_str().unwrap())
+                .collect::<Vec<_>>(),
+            vec!["session.json", "session.jsonl"]
+        );
+    }
+
+    #[test]
     fn test_scan_directory_jsonl_pattern() {
         let dir = TempDir::new().unwrap();
         let path = dir.path();
@@ -1851,6 +1872,19 @@ mod tests {
         let result = scan_all_clients(home.to_str().unwrap(), &["gemini".to_string()]);
         assert_eq!(result.get(ClientId::Gemini).len(), 1);
         assert!(result.get(ClientId::OpenCode).is_empty());
+    }
+
+    #[test]
+    fn test_scan_all_clients_gemini_jsonl_session() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let gemini_path = home.join(".gemini/tmp/123/chats");
+        fs::create_dir_all(&gemini_path).unwrap();
+        File::create(gemini_path.join("session-abc.jsonl")).unwrap();
+
+        let result = scan_all_clients(home.to_str().unwrap(), &["gemini".to_string()]);
+        assert_eq!(result.get(ClientId::Gemini).len(), 1);
+        assert!(result.get(ClientId::Gemini)[0].ends_with("session-abc.jsonl"));
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/gemini.rs
+++ b/crates/tokscale-core/src/sessions/gemini.rs
@@ -1,7 +1,8 @@
 //! Gemini CLI session parser
 //!
-//! Parses JSON session files from ~/.gemini/tmp/* supporting both legacy
-//! `session-*.json` files and new UUID-named files in `chats/` directories.
+//! Parses JSON and JSONL session files from ~/.gemini/tmp/* supporting legacy
+//! `session-*.json` files, UUID-named files in `chats/`, and current
+//! `session-*.jsonl` chat recordings.
 
 use super::utils::{
     extract_i64, extract_string, file_modified_timestamp_ms, parse_timestamp_value,
@@ -11,6 +12,7 @@ use super::UnifiedMessage;
 use crate::TokenBreakdown;
 use serde::Deserialize;
 use serde_json::Value;
+use std::collections::HashMap;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 
@@ -146,33 +148,63 @@ fn parse_gemini_session(session: GeminiSession, fallback_timestamp: i64) -> Vec<
             .and_then(|ts| chrono::DateTime::parse_from_rfc3339(&ts).ok())
             .map(|dt| dt.timestamp_millis())
             .unwrap_or(fallback_timestamp);
-        let (input, cache_read) = normalize_gemini_session_input_and_cache(
-            tokens.input.unwrap_or(0),
-            tokens.cached.unwrap_or(0),
-            tokens.output.unwrap_or(0),
-            tokens.thoughts.unwrap_or(0),
-            tokens.tool.unwrap_or(0),
-            tokens.total,
-        );
-
-        messages.push(UnifiedMessage::new(
-            "gemini",
+        messages.push(build_gemini_token_message(
             model,
-            "google",
-            session_id.clone(),
+            &session_id,
             timestamp,
-            TokenBreakdown {
-                input,
-                output: tokens.output.unwrap_or(0).max(0),
-                cache_read,
-                cache_write: 0,
-                reasoning: tokens.thoughts.unwrap_or(0).max(0),
-            },
-            0.0,
+            tokens,
         ));
     }
 
     messages
+}
+
+fn build_gemini_token_message(
+    model: String,
+    session_id: &str,
+    timestamp: i64,
+    tokens: GeminiTokens,
+) -> UnifiedMessage {
+    let (input, cache_read) = normalize_gemini_session_input_and_cache(
+        tokens.input.unwrap_or(0),
+        tokens.cached.unwrap_or(0),
+        tokens.output.unwrap_or(0),
+        tokens.thoughts.unwrap_or(0),
+        tokens.tool.unwrap_or(0),
+        tokens.total,
+    );
+
+    UnifiedMessage::new(
+        "gemini",
+        model,
+        "google",
+        session_id.to_string(),
+        timestamp,
+        TokenBreakdown {
+            input,
+            output: tokens.output.unwrap_or(0).max(0),
+            cache_read,
+            cache_write: 0,
+            reasoning: tokens.thoughts.unwrap_or(0).max(0),
+        },
+        0.0,
+    )
+}
+
+fn parse_direct_gemini_token_message(
+    value: &Value,
+    model_hint: Option<String>,
+    session_id: &str,
+    fallback_timestamp: i64,
+) -> Option<UnifiedMessage> {
+    let model = extract_string(value.get("model")).or(model_hint)?;
+    let tokens_value = value.get("tokens")?;
+    let tokens: GeminiTokens = serde_json::from_value(tokens_value.clone()).ok()?;
+    let timestamp = extract_timestamp_from_value(value).unwrap_or(fallback_timestamp);
+
+    Some(build_gemini_token_message(
+        model, session_id, timestamp, tokens,
+    ))
 }
 
 fn parse_gemini_headless_jsonl(path: &Path, fallback_timestamp: i64) -> Vec<UnifiedMessage> {
@@ -189,6 +221,7 @@ fn parse_gemini_headless_jsonl(path: &Path, fallback_timestamp: i64) -> Vec<Unif
     let mut current_model: Option<String> = None;
     let reader = BufReader::new(file);
     let mut messages = Vec::with_capacity(64);
+    let mut direct_message_indices: HashMap<String, usize> = HashMap::new();
     let mut buffer = Vec::with_capacity(4096);
 
     for line in reader.lines() {
@@ -222,6 +255,36 @@ fn parse_gemini_headless_jsonl(path: &Path, fallback_timestamp: i64) -> Vec<Unif
             continue;
         }
 
+        if let Some(id) = extract_string(value.get("session_id").or_else(|| value.get("sessionId")))
+        {
+            session_id = id;
+        }
+
+        if event_type == "gemini" {
+            if let Some(model) = extract_string(value.get("model")) {
+                current_model = Some(model);
+            }
+
+            if let Some(message) = parse_direct_gemini_token_message(
+                &value,
+                current_model.clone(),
+                &session_id,
+                fallback_timestamp,
+            ) {
+                if let Some(id) = extract_string(value.get("id")) {
+                    if let Some(index) = direct_message_indices.get(&id).copied() {
+                        messages[index] = message;
+                    } else {
+                        direct_message_indices.insert(id, messages.len());
+                        messages.push(message);
+                    }
+                } else {
+                    messages.push(message);
+                }
+            }
+            continue;
+        }
+
         let stats = value
             .get("stats")
             .or_else(|| value.get("result").and_then(|result| result.get("stats")));
@@ -244,6 +307,14 @@ fn parse_gemini_headless_value(
     session_id: &str,
     fallback_timestamp: i64,
 ) -> Vec<UnifiedMessage> {
+    if value.get("type").and_then(|val| val.as_str()) == Some("gemini") {
+        if let Some(message) =
+            parse_direct_gemini_token_message(value, None, session_id, fallback_timestamp)
+        {
+            return vec![message];
+        }
+    }
+
     let stats = match value
         .get("stats")
         .or_else(|| value.get("result").and_then(|result| result.get("stats")))
@@ -643,6 +714,71 @@ mod tests {
         assert_eq!(messages[0].tokens.cache_read, 5);
         assert_eq!(messages[0].tokens.reasoning, 3);
         assert_eq!(messages[0].tokens.total(), 35);
+    }
+
+    #[test]
+    fn test_parse_gemini_stream_jsonl_direct_tokens() {
+        let content = r#"{"sessionId":"gemini-session-1","projectHash":"abc123","startTime":"2026-05-01T00:00:00.000Z","lastUpdated":"2026-05-01T00:01:00.000Z"}
+{"id":"msg-1","timestamp":"2026-05-01T00:01:00.000Z","type":"gemini","model":"gemini-3.1-pro-preview","tokens":{"input":14918,"output":60,"cached":0,"thoughts":863,"tool":0,"total":15841}}"#;
+        let dir = TempDir::new().unwrap();
+        let chats_dir = dir.path().join(".gemini/tmp/123/chats");
+        std::fs::create_dir_all(&chats_dir).unwrap();
+        let file_path = chats_dir.join("session-abc.jsonl");
+        std::fs::write(&file_path, content).unwrap();
+
+        let messages = parse_gemini_file(&file_path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].session_id, "gemini-session-1");
+        assert_eq!(messages[0].model_id, "gemini-3.1-pro-preview");
+        assert_eq!(messages[0].provider_id, "google");
+        assert_eq!(messages[0].tokens.input, 14918);
+        assert_eq!(messages[0].tokens.output, 60);
+        assert_eq!(messages[0].tokens.cache_read, 0);
+        assert_eq!(messages[0].tokens.reasoning, 863);
+        assert_eq!(messages[0].tokens.total(), 15841);
+    }
+
+    #[test]
+    fn test_parse_gemini_stream_jsonl_replaces_duplicate_message_id() {
+        let content = r#"{"type":"gemini","id":"msg-1","model":"gemini-3.1-pro-preview","tokens":{"input":10,"output":1,"cached":0,"thoughts":0,"tool":0,"total":11}}
+{"type":"gemini","id":"msg-1","model":"gemini-3.1-pro-preview","tokens":{"input":20,"output":2,"cached":5,"thoughts":3,"tool":0,"total":25}}"#;
+        let dir = TempDir::new().unwrap();
+        let chats_dir = dir.path().join(".gemini/tmp/123/chats");
+        std::fs::create_dir_all(&chats_dir).unwrap();
+        let file_path = chats_dir.join("session-abc.jsonl");
+        std::fs::write(&file_path, content).unwrap();
+
+        let messages = parse_gemini_file(&file_path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gemini-3.1-pro-preview");
+        assert_eq!(messages[0].tokens.input, 15);
+        assert_eq!(messages[0].tokens.output, 2);
+        assert_eq!(messages[0].tokens.cache_read, 5);
+        assert_eq!(messages[0].tokens.reasoning, 3);
+        assert_eq!(messages[0].tokens.total(), 25);
+    }
+
+    #[test]
+    fn test_parse_gemini_json_direct_tokens() {
+        let json = r#"{"type":"gemini","model":"gemini-3.1-pro-preview","tokens":{"input":20,"output":2,"cached":5,"thoughts":3,"tool":0,"total":25}}"#;
+        let file = tempfile::Builder::new()
+            .prefix("session-")
+            .suffix(".json")
+            .tempfile()
+            .unwrap();
+        std::fs::write(file.path(), json).unwrap();
+
+        let messages = parse_gemini_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gemini-3.1-pro-preview");
+        assert_eq!(messages[0].tokens.input, 15);
+        assert_eq!(messages[0].tokens.output, 2);
+        assert_eq!(messages[0].tokens.cache_read, 5);
+        assert_eq!(messages[0].tokens.reasoning, 3);
+        assert_eq!(messages[0].tokens.total(), 25);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Detect current Gemini CLI `session-*.jsonl` chat recordings under `.gemini/tmp/**/chats`.
- Parse direct `type: "gemini"` token events into Tokscale's input, output, cache-read, and reasoning buckets.
- Preserve legacy Gemini JSON sessions and existing headless `stats` JSON/JSONL parsing.

Fixes #492. Related to #476 and #463.

## Why

Current Gemini CLI on Windows stores local usage in `%USERPROFILE%\.gemini\tmp\...\chats\session-*.jsonl`. Tokscale only discovered `*.json` for Gemini and its JSONL parser ignored direct Gemini token events, so affected users saw `0 messages, 0 tokens` even though usage data existed locally.

## Diff scope

- **Area touched:** Gemini local-session discovery and parsing in `tokscale-core`.
- **Files changed:**
  - `crates/tokscale-core/src/clients.rs`
  - `crates/tokscale-core/src/scanner.rs`
  - `crates/tokscale-core/src/sessions/gemini.rs`
- **Change type:** Tier 2 narrow runtime parser/scanner change.
- **Metadata files:** Not applicable — no version, changelog, release, generated registry, or governance files changed.

## Branch integrity

- **Base branch:** `main`
- **Validated base SHA:** `97809e755b58b07e21c0eaceb9005f0ba073de0c`
- **Ahead / behind:** `0 behind / 1 ahead`
- **Merge-base SHA:** `97809e755b58b07e21c0eaceb9005f0ba073de0c`
- **Fast-forward safety:** `origin/main` is an ancestor of this branch; the branch contains the current validated base.

## Commit integrity

- `962dcc6e62a97f2dda4561ddec46ece5812aef51 fix(gemini): parse current JSONL session usage`
- One logical change: support current Gemini CLI JSONL session usage.
- Ledger-Id validation: Not applicable — `scripts/ledger/` does not exist in this repository.

## Ledger proof

Not applicable — `scripts/ledger/` does not exist in this repository.

## Diff hygiene

`git diff --name-status origin/main...HEAD`:

```text
M	crates/tokscale-core/src/clients.rs
M	crates/tokscale-core/src/scanner.rs
M	crates/tokscale-core/src/sessions/gemini.rs
```

- `git diff --check origin/main...HEAD`: PASS, no output.
- Forbidden-file check: no `.env`, local environment files, secrets, tokens, credentials, cache files, build artifacts, coverage artifacts, or unrelated generated files are included.
- Required metadata-file explanation: Not applicable — no required metadata files changed.

## Validation tier and test proof

**Validation tier:** Tier 2 — narrow runtime change.

**Reason:** This changes localized Gemini file discovery and parsing behavior in `tokscale-core`. It does not change auth, permissions, payments, database schema, migrations, CI, deployment, or global runtime configuration.

Commands run:

- `cargo test -p tokscale-core jsonl`: PASS — 15 passed, 0 failed.
- `cargo test -p tokscale-core gemini`: PASS — 24 passed, 0 failed.
- `cargo test -p tokscale-core scan_all_clients_gemini`: PASS — 2 passed, 0 failed.
- `cargo test -p tokscale-core`: PASS — 601 passed, 0 failed, 1 ignored; `tests/codebuff.rs`: 10 passed; `tests/hermes.rs`: 3 passed.
- `cargo clippy -p tokscale-core --all-features -- -D warnings`: PASS.
- `cargo fmt --all --check`: PASS.
- `git diff --check`: PASS, no output.
- `git diff --cached --check`: PASS, no output before commit.

Not run:

- Full native release build matrix — not required for this narrow parser/scanner change and covered by GitHub CI after PR creation.
- Windows live Gemini CLI smoke test — not available locally; parser and scanner regressions use the reported Windows JSONL shape and default `.gemini/tmp/**/chats` storage path.

External gates:

- Pending — PR has not been opened yet, so GitHub CI has not run on this branch.

## Verification-pack proof

Not applicable — no infra, governance, replay, invariant, or verification-pack files changed.

## Migration notes

Not applicable — no DB migration changed.

## CI context confirmation

- CI context names unchanged.
- Not applicable — no CI/workflow context changes.
- Required context status: Pending — PR has not been opened yet, so required GitHub checks are not available on this PR.
- Branch-protection status-check API returned 404 for this repository/branch, so no live required-context JSON is included.

## Runtime safety

Reviewed runtime files/modules:

- `crates/tokscale-core/src/clients.rs` — Gemini scan pattern only.
- `crates/tokscale-core/src/scanner.rs` — deterministic file discovery pattern handling and scanner tests.
- `crates/tokscale-core/src/sessions/gemini.rs` — Gemini parser paths and token normalization.

Safety reasoning:

- No new blocking locks are introduced.
- No new unbounded queues are introduced; parser state is limited to the current session file and direct-message ids already present in that file.
- No parser invariant was removed; existing legacy JSON and headless stats tests remain covered.
- Cache/input normalization uses the existing Gemini token normalization path for direct JSONL events.

No invariant regression introduced.

## Documentation integrity

Not applicable — no docs, runbooks, commands, or user-facing CLI flags changed.

## Rollback plan

- Post-merge rollback command: `git revert <post_merge_commit_sha>`
- Replace `<post_merge_commit_sha>` with the final squash or merge commit SHA after merge.
- DB downgrade required: no.
- Data repair required: no.
- Operational caveats: none expected; rollback restores the previous Gemini discovery/parser behavior.

## Known residual risks

- Custom `GEMINI_CLI_HOME` discovery is out of scope for this PR; this fixes the default `.gemini/tmp/**/chats/session-*.jsonl` path reported in #492.

