### PR TITLE
fix(codex): attribute resumed token counts to later model

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -465,6 +465,13 @@ fn parse_all_messages_with_pricing_with_env_strategy(
             };
         }
 
+        if parsed.unresolved_model_events {
+            return CachedParseOutcome {
+                messages,
+                cache_entry: None,
+            };
+        }
+
         let cache_entry = build_codex_cache_entry(
             path,
             parsed.messages,
@@ -654,6 +661,12 @@ fn parse_all_messages_with_pricing_with_env_strategy(
                             fallback_timestamp,
                         );
 
+                        if parsed.unresolved_model_events {
+                            return CachedParseOutcome {
+                                messages,
+                                cache_entry: None,
+                            };
+                        }
                         let cache_entry = build_codex_cache_entry(
                             path,
                             raw_messages,
@@ -3376,6 +3389,73 @@ mod tests {
 
             let cache = message_cache::SourceMessageCache::load();
             assert!(cache.get(&path).is_none());
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_codex_cache_does_not_persist_unknown_before_later_turn_context() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            let session_dir = source_home.path().join(".codex/sessions");
+            std::fs::create_dir_all(&session_dir).unwrap();
+            let path = session_dir.join("session.jsonl");
+            std::fs::write(
+                &path,
+                concat!(
+                    r#"{"type":"session_meta","payload":{"source":"interactive","model_provider":"openai"}}"#,
+                    "\n",
+                    r#"{"timestamp":"2026-04-27T10:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3}}}}"#,
+                    "\n"
+                ),
+            )
+            .unwrap();
+
+            let initial_messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["codex".to_string()],
+                None,
+            );
+            assert_eq!(initial_messages.len(), 1);
+            assert_eq!(initial_messages[0].model_id, "unknown");
+            assert!(message_cache::SourceMessageCache::load()
+                .get(&path)
+                .is_none());
+
+            std::thread::sleep(std::time::Duration::from_millis(5));
+            let mut file = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&path)
+                .unwrap();
+            file.write_all(
+                concat!(
+                    r#"{"timestamp":"2026-04-27T10:00:04Z","type":"turn_context","payload":{"model":"gpt-5.5"}}"#,
+                    "\n"
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+            file.flush().unwrap();
+
+            let resumed_messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["codex".to_string()],
+                None,
+            );
+            assert_eq!(resumed_messages.len(), 1);
+            assert_eq!(resumed_messages[0].model_id, "gpt-5.5");
+            assert!(message_cache::SourceMessageCache::load()
+                .get(&path)
+                .is_some());
         }
 
         match original_home {

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -10,7 +10,7 @@ use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
-const CACHE_SCHEMA_VERSION: u32 = 8;
+const CACHE_SCHEMA_VERSION: u32 = 9;
 const CACHE_FILENAME: &str = "source-message-cache.bin";
 const CACHE_LOCK_FILENAME: &str = "source-message-cache.lock";
 const MAX_CACHE_FILE_BYTES: u64 = 256 * 1024 * 1024;

--- a/crates/tokscale-core/src/sessions/codex.rs
+++ b/crates/tokscale-core/src/sessions/codex.rs
@@ -164,6 +164,8 @@ pub(crate) struct ParsedCodexFile {
     pub fallback_timestamp_indices: Vec<usize>,
     pub consumed_offset: u64,
     pub parse_succeeded: bool,
+    /// True when model-less token_count rows were emitted without a later model.
+    pub unresolved_model_events: bool,
     pub state: CodexParseState,
 }
 
@@ -187,6 +189,8 @@ fn parse_codex_reader<R: BufRead>(
     let mut line = String::with_capacity(4096);
     let mut consumed_offset = start_offset;
     let mut parse_succeeded = true;
+    let mut pending_model_messages = Vec::new();
+    let mut unresolved_model_events = false;
 
     loop {
         line.clear();
@@ -231,6 +235,14 @@ fn parse_codex_reader<R: BufRead>(
                 // Extract model from turn_context
                 if entry.entry_type == "turn_context" {
                     state.current_model = extract_model(&payload);
+                    if let Some(model) = state.current_model.clone() {
+                        flush_pending_model_messages(
+                            &mut pending_model_messages,
+                            &mut messages,
+                            &mut fallback_timestamp_indices,
+                            &model,
+                        );
+                    }
                     handled = true;
                 }
 
@@ -240,7 +252,13 @@ fn parse_codex_reader<R: BufRead>(
                 {
                     // Try to extract model from payload
                     if let Some(model) = extract_model(&payload) {
-                        state.current_model = Some(model);
+                        state.current_model = Some(model.clone());
+                        flush_pending_model_messages(
+                            &mut pending_model_messages,
+                            &mut messages,
+                            &mut fallback_timestamp_indices,
+                            &model,
+                        );
                     }
 
                     let info = match payload.info {
@@ -250,13 +268,16 @@ fn parse_codex_reader<R: BufRead>(
 
                     // Try to extract model from info
                     if let Some(model) = info.model.clone().or(info.model_name.clone()) {
-                        state.current_model = Some(model);
+                        state.current_model = Some(model.clone());
+                        flush_pending_model_messages(
+                            &mut pending_model_messages,
+                            &mut messages,
+                            &mut fallback_timestamp_indices,
+                            &model,
+                        );
                     }
 
-                    let model = state
-                        .current_model
-                        .clone()
-                        .unwrap_or_else(|| "unknown".to_string());
+                    let model = state.current_model.clone();
 
                     // Use last_token_usage as the primary increment source.
                     // Upstream totals are mutable snapshots (compaction, context-window
@@ -335,7 +356,7 @@ fn parse_codex_reader<R: BufRead>(
 
                     let mut message = UnifiedMessage::new_with_agent(
                         "codex",
-                        model,
+                        model.clone().unwrap_or_else(|| "unknown".to_string()),
                         provider,
                         session_id.to_string(),
                         timestamp,
@@ -347,9 +368,13 @@ fn parse_codex_reader<R: BufRead>(
                         state.session_workspace_key.clone(),
                         state.session_workspace_label.clone(),
                     );
-                    messages.push(message);
-                    if parsed_timestamp.is_none() {
-                        fallback_timestamp_indices.push(messages.len() - 1);
+                    if model.is_some() {
+                        messages.push(message);
+                        if parsed_timestamp.is_none() {
+                            fallback_timestamp_indices.push(messages.len() - 1);
+                        }
+                    } else {
+                        pending_model_messages.push((message, parsed_timestamp.is_none()));
                     }
                     handled = true;
                 }
@@ -365,7 +390,7 @@ fn parse_codex_reader<R: BufRead>(
             continue;
         }
 
-        if let Some((mut msg, used_fallback_timestamp)) = parse_codex_headless_line(
+        let headless_message = parse_codex_headless_line(
             trimmed,
             session_id,
             &mut state.current_model,
@@ -373,7 +398,17 @@ fn parse_codex_reader<R: BufRead>(
             state.session_provider.as_deref(),
             &state.session_agent,
             state.session_is_headless,
-        ) {
+        );
+        if let Some(model) = state.current_model.clone() {
+            flush_pending_model_messages(
+                &mut pending_model_messages,
+                &mut messages,
+                &mut fallback_timestamp_indices,
+                &model,
+            );
+        }
+
+        if let Some((mut msg, used_fallback_timestamp)) = headless_message {
             msg.set_workspace(
                 state.session_workspace_key.clone(),
                 state.session_workspace_label.clone(),
@@ -385,12 +420,38 @@ fn parse_codex_reader<R: BufRead>(
         }
     }
 
+    if !pending_model_messages.is_empty() {
+        unresolved_model_events = true;
+        flush_pending_model_messages(
+            &mut pending_model_messages,
+            &mut messages,
+            &mut fallback_timestamp_indices,
+            "unknown",
+        );
+    }
+
     ParsedCodexFile {
         messages,
         fallback_timestamp_indices,
         consumed_offset,
         parse_succeeded,
+        unresolved_model_events,
         state,
+    }
+}
+
+fn flush_pending_model_messages(
+    pending_model_messages: &mut Vec<(UnifiedMessage, bool)>,
+    messages: &mut Vec<UnifiedMessage>,
+    fallback_timestamp_indices: &mut Vec<usize>,
+    model: &str,
+) {
+    for (mut message, used_fallback_timestamp) in pending_model_messages.drain(..) {
+        message.model_id = model.to_string();
+        messages.push(message);
+        if used_fallback_timestamp {
+            fallback_timestamp_indices.push(messages.len() - 1);
+        }
     }
 }
 
@@ -427,6 +488,7 @@ pub(crate) fn parse_codex_file_incremental(
                 fallback_timestamp_indices: Vec::new(),
                 consumed_offset: start_offset,
                 parse_succeeded: false,
+                unresolved_model_events: false,
                 state,
             };
         }
@@ -438,6 +500,7 @@ pub(crate) fn parse_codex_file_incremental(
             fallback_timestamp_indices: Vec::new(),
             consumed_offset: start_offset,
             parse_succeeded: false,
+            unresolved_model_events: false,
             state,
         };
     }
@@ -736,6 +799,95 @@ mod tests {
                 Some("/Users/alice/codex-demo")
             ]
         );
+    }
+
+    #[test]
+    fn test_token_count_before_turn_context_uses_later_model() {
+        let file = create_test_file(concat!(
+            r#"{"type":"session_meta","payload":{"source":"interactive","model_provider":"openai","agent_nickname":"builder","cwd":"/Users/alice/codex-demo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-04-27T10:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-04-27T10:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":15,"cached_input_tokens":3,"output_tokens":5,"reasoning_output_tokens":1},"last_token_usage":{"input_tokens":5,"cached_input_tokens":1,"output_tokens":2,"reasoning_output_tokens":0}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-04-27T10:00:04Z","type":"turn_context","payload":{"model":"gpt-5.5"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-04-27T10:00:05Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":22,"cached_input_tokens":4,"output_tokens":7,"reasoning_output_tokens":2},"last_token_usage":{"input_tokens":7,"cached_input_tokens":1,"output_tokens":2,"reasoning_output_tokens":1}}}}"#,
+            "\n"
+        ));
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 3);
+        assert_eq!(
+            messages
+                .iter()
+                .map(|message| message.model_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["gpt-5.5", "gpt-5.5", "gpt-5.5"]
+        );
+        assert_eq!(
+            messages
+                .iter()
+                .map(|message| message.workspace_key.as_deref())
+                .collect::<Vec<_>>(),
+            vec![
+                Some("/Users/alice/codex-demo"),
+                Some("/Users/alice/codex-demo"),
+                Some("/Users/alice/codex-demo")
+            ]
+        );
+        assert_eq!(messages[0].tokens.input, 8);
+        assert_eq!(messages[0].tokens.output, 3);
+        assert_eq!(messages[0].tokens.cache_read, 2);
+        assert_eq!(messages[0].tokens.reasoning, 1);
+        assert_eq!(messages[1].tokens.input, 4);
+        assert_eq!(messages[1].tokens.output, 2);
+        assert_eq!(messages[1].tokens.cache_read, 1);
+        assert_eq!(messages[1].tokens.reasoning, 0);
+        assert_eq!(messages[2].tokens.input, 6);
+        assert_eq!(messages[2].tokens.output, 2);
+        assert_eq!(messages[2].tokens.cache_read, 1);
+        assert_eq!(messages[2].tokens.reasoning, 1);
+
+        let parsed = parse_codex_file_incremental(file.path(), 0, CodexParseState::default());
+        assert!(!parsed.unresolved_model_events);
+    }
+
+    #[test]
+    fn test_token_count_without_model_stays_unknown_but_is_not_cacheable() {
+        let file = create_test_file(concat!(
+            r#"{"type":"session_meta","payload":{"source":"interactive","model_provider":"openai"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-04-27T10:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1}}}}"#,
+            "\n"
+        ));
+
+        let parsed = parse_codex_file_incremental(file.path(), 0, CodexParseState::default());
+
+        assert!(parsed.parse_succeeded);
+        assert!(parsed.unresolved_model_events);
+        assert_eq!(parsed.messages.len(), 1);
+        assert_eq!(parsed.messages[0].model_id, "unknown");
+    }
+
+    #[test]
+    fn test_model_only_headless_line_flushes_pending_token_counts() {
+        let file = create_test_file(concat!(
+            r#"{"type":"session_meta","payload":{"source":"interactive","model_provider":"openai"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-04-27T10:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1}}}}"#,
+            "\n",
+            r#"{"model":"gpt-5.5","type":"metadata"}"#,
+            "\n"
+        ));
+
+        let parsed = parse_codex_file_incremental(file.path(), 0, CodexParseState::default());
+
+        assert!(parsed.parse_succeeded);
+        assert!(!parsed.unresolved_model_events);
+        assert_eq!(parsed.messages.len(), 1);
+        assert_eq!(parsed.messages[0].model_id, "gpt-5.5");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fix Codex resumed-session attribution so early `token_count` events emitted before `turn_context` inherit the later model instead of staying under `unknown`.

Fixes #490.

## Why
Codex 0.124 resumed sessions can replay `event_msg` / `token_count` rows before the first `turn_context` row that carries `payload.model`. The previous parser emitted those early rows immediately with `modelId = unknown`, which also meant pricing stayed at `0` even after the real model appeared later in the same session file.

## Diff scope
- `crates/tokscale-core/src/sessions/codex.rs`: buffer model-less Codex `token_count` messages until the parser observes a model, then flush them with that model; preserve `unknown` only when no model ever appears.
- `crates/tokscale-core/src/lib.rs`: avoid writing Codex source-cache entries when a file still has unresolved model-less token events.
- `crates/tokscale-core/src/message_cache.rs`: bump the source-message cache schema from `8` to `9` so stale cached `unknown` Codex rows are invalidated.

This is a narrow runtime parser/cache change. No frontend, release, workflow, migration, or CLI command behavior changed.

## Branch integrity
- Base branch: `main`
- `origin/main`: `97809e755b58b07e21c0eaceb9005f0ba073de0c`
- Ahead / behind from `git rev-list --left-right --count origin/main...HEAD`: `0 behind / 1 ahead`
- Merge base: `97809e755b58b07e21c0eaceb9005f0ba073de0c`
- `git merge-base --is-ancestor origin/main HEAD`: PASS
- Fast-forward safety: branch contains the current validated base.

## Commit integrity
- Introduced commit: `c3ca2ce9cfc113bc465dff8965f49da6cb83d865 fix(codex): attribute resumed token counts to later model`
- One logical change per commit: yes.
- Ledger-Id trailers: Not applicable — `scripts/ledger/` does not exist in this repository.
- Duplicate Ledger-Id check: Not applicable — `scripts/ledger/` does not exist in this repository.

## Ledger proof
Not applicable — `scripts/ledger/` does not exist in this repository.

## Diff hygiene
`git diff --name-status origin/main...HEAD`:

```text
M	crates/tokscale-core/src/lib.rs
M	crates/tokscale-core/src/message_cache.rs
M	crates/tokscale-core/src/sessions/codex.rs
```

- `git diff --check origin/main...HEAD`: PASS, no output.
- No `.env` files, local environment files, secrets, tokens, credentials, cache files, build artifacts, or unrelated generated files are included.
- Required metadata note: `CACHE_SCHEMA_VERSION` was bumped because the interpretation of cached Codex source messages changed; invalidating old cache entries prevents previously cached `unknown` rows from surviving the parser fix.

## Validation tier and test proof
Validation tier: Tier 2 — narrow runtime parser/cache change.

Reason: the change is localized to Codex session parsing and source-message cache eligibility. It does not alter migrations, auth, permissions, payment/billing logic, global configuration, CI, release tooling, production infrastructure, or external service contracts.

Run:
- `scripts/ledger/check`: Not applicable — `scripts/ledger/` does not exist in this repository.
- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS.
- `cargo test -p tokscale-core token_count`: PASS, 10 passed.
- `cargo test -p tokscale-core codex_cache`: PASS, 2 passed.
- `cargo test -p tokscale-core`: PASS, 599 passed, 1 ignored; `codebuff` integration tests 10 passed; `hermes` integration tests 3 passed; doc-tests 0 passed.
- `cargo clippy -p tokscale-core --all-features -- -D warnings`: PASS.
- `cargo fmt --all --check`: PASS.
- `git diff --check`: PASS.
- `git diff --cached --check`: PASS.
- Cyrillic scan for touched source files: PASS, no matches.

Not run:
- Full workspace test suite — not required for this Tier 2 parser/cache change because the touched runtime surface is covered by `tokscale-core` tests and clippy.
- Native build matrix — left to GitHub CI; no native build configuration changed.

External gates:
- Pending — required GitHub checks can run only after this PR is opened.

## Verification-pack proof
Not applicable — no infra, governance, replay, invariant, or verification-pack files changed.

## Migration notes
Not applicable — no DB migration changed.

## CI context confirmation
- CI context names unchanged.
- Not applicable — no CI/workflow context changes.
- Required contexts: Pending — PR has not been opened yet, so GitHub has not created check runs for this head branch.
- Live branch-protection status: unavailable from the local check; GitHub API returned 404 for the branch-protection required-status-checks endpoint.

## Runtime safety
Reviewed runtime files/modules:
- `crates/tokscale-core/src/sessions/codex.rs`
- `crates/tokscale-core/src/lib.rs`
- `crates/tokscale-core/src/message_cache.rs`

Safety reasoning:
- No new blocking locks are introduced; parsing still uses the existing sequential reader flow.
- No new unbounded queues are introduced beyond a per-file in-memory buffer for model-less token events before the first model appears; the buffer is drained as soon as a model is observed or at EOF.
- No parser invariants are removed; token delta logic, zero-token filtering, timestamp fallback tracking, workspace attribution, and provider/agent propagation are preserved.
- Cache writes are disabled only for unresolved model-less Codex files, preventing temporary `unknown` attribution from being persisted.

No invariant regression introduced.

## Documentation integrity
Not applicable — no docs, runbooks, public commands, release procedure, deployment procedure, or user-facing documented behavior changed.

## Rollback plan
- Rollback command after merge: `git revert <post_merge_commit_sha>`.
- Replace `<post_merge_commit_sha>` with the final squash or merge commit SHA after merge.
- DB downgrade required: no.
- Data repair required: no.
- Operational caveats: rollback would restore cache schema version `8`; users may keep regenerated cache entries from the fixed parser until the cache naturally refreshes or is removed.

## Known residual risks
No known residual risks.


