### PR TITLE
fix(core): handle incomplete upstream session data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,25 @@ When updating AGENTS.md files, follow these principles:
 - **Verify before documenting** — Grep/read the code to confirm claims are accurate
 - **Delete outdated info** — Outdated docs are worse than no docs
 
+## Authoring PR/Issue Content via `gh` CLI
+
+When writing PR bodies, issue bodies, or comments through `gh pr create`, `gh issue comment`, etc.: **prefer `--body-file` with a written-out file over inline `--body` heredocs.**
+
+Why: inline `--body "$(cat <<'EOF' ... EOF)"` patterns lead to recurring mistakes where backticks are written as `` \` `` (incorrectly escaping them inside a single-quoted heredoc where no escaping is needed). The literal `` \` `` then renders in GitHub markdown as backslash + backtick instead of inline code formatting.
+
+**DO:**
+
+- Write the body to `/tmp/pr-body.md` (or similar) with the `Write` tool, then `gh pr create --body-file /tmp/pr-body.md`
+- For comment edits: `gh api -X PATCH repos/<owner>/<repo>/issues/comments/<id> -F body=@/tmp/comment.md`
+
+**DON'T:**
+
+- Use `gh pr create --body "$(cat <<'EOF' ... \` ... \` ... EOF)"` — single-quoted heredoc means backticks are already literal; escaping with `` \` `` is wrong and renders incorrectly.
+- Use double-quoted heredoc for bodies containing backticks unless you intend command substitution.
+- Hard-wrap paragraphs at ~80 columns inside PR/issue/comment bodies. GitHub's markdown collapses single newlines into spaces so the rendered output looks fine, but the **raw markdown view is what reviewers and authors edit in**, and mid-sentence line breaks read as if the prose was chopped. Write each paragraph as one continuous line and let the renderer wrap it. Same rule for blockquotes, list items that span multiple lines, and table cells. Hard wraps are still fine inside fenced code blocks where preserving line layout matters.
+
+This applies to all GitHub-content authoring through the CLI — PR bodies, issue bodies, comments, edits.
+
 ## Commit Message Convention
 
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-cli"
-version = "2.0.27"
+version = "2.1.0"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-core"
-version = "2.0.27"
+version = "2.1.0"
 dependencies = [
  "bincode",
  "chrono",

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -403,6 +403,7 @@ fn parse_all_messages_with_pricing_with_env_strategy(
     struct CachedParseOutcome {
         messages: Vec<UnifiedMessage>,
         cache_entry: Option<message_cache::CachedSourceEntry>,
+        invalidate_cache: bool,
     }
 
     fn apply_pricing_to_messages(
@@ -437,6 +438,7 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         CachedParseOutcome {
             messages,
             cache_entry: None,
+            invalidate_cache: false,
         }
     }
 
@@ -462,6 +464,7 @@ fn parse_all_messages_with_pricing_with_env_strategy(
             return CachedParseOutcome {
                 messages,
                 cache_entry: None,
+                invalidate_cache: false,
             };
         }
 
@@ -469,6 +472,7 @@ fn parse_all_messages_with_pricing_with_env_strategy(
             return CachedParseOutcome {
                 messages,
                 cache_entry: None,
+                invalidate_cache: false,
             };
         }
 
@@ -483,6 +487,7 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         CachedParseOutcome {
             messages,
             cache_entry,
+            invalidate_cache: false,
         }
     }
 
@@ -517,12 +522,15 @@ fn parse_all_messages_with_pricing_with_env_strategy(
             return None;
         }
 
+        let codex_incremental =
+            message_cache::build_codex_incremental_cache(path, consumed_offset, state)?;
+
         Some(message_cache::CachedSourceEntry::new(
             path,
             fingerprint,
             raw_messages,
             fallback_timestamp_indices,
-            message_cache::build_codex_incremental_cache(path, consumed_offset, state),
+            Some(codex_incremental),
         ))
     }
 
@@ -545,6 +553,7 @@ fn parse_all_messages_with_pricing_with_env_strategy(
                 return CachedParseOutcome {
                     messages: cached_messages(cached, pricing),
                     cache_entry: None,
+                    invalidate_cache: false,
                 };
             }
         }
@@ -567,6 +576,7 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         CachedParseOutcome {
             messages,
             cache_entry,
+            invalidate_cache: false,
         }
     }
 
@@ -619,17 +629,28 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         let fallback_timestamp = sessions::utils::file_modified_timestamp_ms(path);
 
         if let Some(cached) = source_cache.get(path) {
+            let reparse_from_start = |invalidate_cache: bool| {
+                let mut outcome = parse_full_log_source(path, pricing, is_headless);
+                outcome.invalidate_cache = invalidate_cache && outcome.cache_entry.is_none();
+                outcome
+            };
+
             if cached.fingerprint == fingerprint {
-                return CachedParseOutcome {
-                    messages: finalize_codex_messages(
-                        cached.messages.clone(),
-                        pricing,
-                        is_headless,
-                        &cached.fallback_timestamp_indices,
-                        fallback_timestamp,
-                    ),
-                    cache_entry: None,
-                };
+                if message_cache::codex_cache_entry_matches_fingerprint(cached, &fingerprint) {
+                    return CachedParseOutcome {
+                        messages: finalize_codex_messages(
+                            cached.messages.clone(),
+                            pricing,
+                            is_headless,
+                            &cached.fallback_timestamp_indices,
+                            fallback_timestamp,
+                        ),
+                        cache_entry: None,
+                        invalidate_cache: false,
+                    };
+                }
+
+                return reparse_from_start(true);
             }
 
             if let Some(codex_incremental) = cached.codex_incremental.as_ref() {
@@ -641,7 +662,7 @@ fn parse_all_messages_with_pricing_with_env_strategy(
                         codex_incremental.consumed_offset,
                         codex_incremental.state.clone(),
                     );
-                    if parsed.parse_succeeded {
+                    if parsed.parse_succeeded && !parsed.unresolved_model_events {
                         let mut raw_messages = cached.messages.clone();
                         let mut fallback_timestamp_indices =
                             cached.fallback_timestamp_indices.clone();
@@ -653,38 +674,33 @@ fn parse_all_messages_with_pricing_with_env_strategy(
                                 .map(|index| existing_len + index),
                         );
                         raw_messages.extend(parsed.messages.clone());
-                        let messages = finalize_codex_messages(
-                            raw_messages.clone(),
-                            pricing,
-                            is_headless,
-                            &fallback_timestamp_indices,
-                            fallback_timestamp,
-                        );
-
-                        if parsed.unresolved_model_events {
-                            return CachedParseOutcome {
-                                messages,
-                                cache_entry: None,
-                            };
-                        }
                         let cache_entry = build_codex_cache_entry(
                             path,
-                            raw_messages,
+                            raw_messages.clone(),
                             parsed.consumed_offset,
                             parsed.state,
-                            fallback_timestamp_indices,
+                            fallback_timestamp_indices.clone(),
                         );
-                        if cache_entry.is_none() {
-                            return parse_full_log_source(path, pricing, is_headless);
-                        }
+                        if let Some(cache_entry) = cache_entry {
+                            let messages = finalize_codex_messages(
+                                raw_messages,
+                                pricing,
+                                is_headless,
+                                &fallback_timestamp_indices,
+                                fallback_timestamp,
+                            );
 
-                        return CachedParseOutcome {
-                            messages,
-                            cache_entry,
-                        };
+                            return CachedParseOutcome {
+                                messages,
+                                cache_entry: Some(cache_entry),
+                                invalidate_cache: false,
+                            };
+                        }
                     }
                 }
             }
+
+            return reparse_from_start(true);
         }
 
         parse_full_log_source(path, pricing, is_headless)
@@ -711,6 +727,7 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         let CachedParseOutcome {
             messages,
             cache_entry,
+            ..
         } = load_or_parse_sqlite_source(db_path, &source_cache, pricing, |path| {
             sessions::opencode::parse_opencode_sqlite(path)
         });
@@ -786,15 +803,22 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         .collect();
     all_messages.extend(claude_messages);
 
-    let codex_outcomes: Vec<CachedParseOutcome> = scan_result
+    let codex_outcomes: Vec<(PathBuf, CachedParseOutcome)> = scan_result
         .get(ClientId::Codex)
         .par_iter()
-        .map(|path| load_or_parse_codex_source(path, &source_cache, pricing, &headless_roots))
+        .map(|path| {
+            (
+                path.clone(),
+                load_or_parse_codex_source(path, &source_cache, pricing, &headless_roots),
+            )
+        })
         .collect();
-    for outcome in codex_outcomes {
+    for (path, outcome) in codex_outcomes {
         all_messages.extend(outcome.messages);
         if let Some(entry) = outcome.cache_entry {
             source_cache.insert(entry);
+        } else if outcome.invalidate_cache {
+            source_cache.remove(&path);
         }
     }
 
@@ -3160,6 +3184,79 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    fn test_codex_cache_reparses_from_zero_when_incremental_prefix_is_stale() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let fresh_cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            let codex_dir = source_home.path().join(".codex/sessions");
+            std::fs::create_dir_all(&codex_dir).unwrap();
+            let path = codex_dir.join("session.jsonl");
+            std::fs::write(
+                &path,
+                concat!(
+                    r#"{"type":"turn_context","payload":{"model":"gpt-5.4"}}"#,
+                    "\n",
+                    r#"{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3}}}}"#,
+                    "\n"
+                ),
+            )
+            .unwrap();
+
+            let initial_messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["codex".to_string()],
+                None,
+            );
+            assert_eq!(initial_messages.len(), 1);
+            assert_eq!(initial_messages[0].model_id, "gpt-5.4");
+            assert!(message_cache::SourceMessageCache::load()
+                .get(&path)
+                .and_then(|entry| entry.codex_incremental.as_ref())
+                .is_some());
+
+            std::thread::sleep(std::time::Duration::from_millis(5));
+            std::fs::write(
+                &path,
+                concat!(
+                    r#"{"type":"turn_context","payload":{"model":"gpt-5.5"}}"#,
+                    "\n",
+                    r#"{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3}}}}"#,
+                    "\n",
+                    r#"{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":15,"cached_input_tokens":3,"output_tokens":5},"last_token_usage":{"input_tokens":5,"cached_input_tokens":1,"output_tokens":2}}}}"#,
+                    "\n"
+                ),
+            )
+            .unwrap();
+
+            let warm_messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["codex".to_string()],
+                None,
+            );
+            std::env::set_var("HOME", fresh_cache_home.path());
+            let fresh_messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["codex".to_string()],
+                None,
+            );
+
+            assert_eq!(warm_messages, fresh_messages);
+            assert_eq!(warm_messages.len(), 2);
+            assert!(warm_messages.iter().all(|message| message.model_id == "gpt-5.5"));
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn test_source_cache_keeps_untimestamped_rows_in_sync_after_append() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let fresh_cache_home = tempfile::TempDir::new().unwrap();
@@ -3209,7 +3306,6 @@ mod tests {
                 &["codex".to_string()],
                 None,
             );
-
             std::env::set_var("HOME", fresh_cache_home.path());
             let fresh_messages = parse_all_messages_with_pricing(
                 source_home.path().to_str().unwrap(),
@@ -3279,6 +3375,7 @@ mod tests {
                 &["codex".to_string()],
                 None,
             );
+            assert!(message_cache::SourceMessageCache::load().get(&path).is_none());
 
             std::env::set_var("HOME", fresh_cache_home.path());
             let fresh_messages = parse_all_messages_with_pricing(
@@ -3354,6 +3451,60 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    fn test_codex_cache_repairs_fallback_timestamps_after_source_mtime_change() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let fresh_cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            let session_dir = source_home.path().join(".codex/sessions");
+            std::fs::create_dir_all(&session_dir).unwrap();
+            let path = session_dir.join("session.jsonl");
+            let contents = concat!(
+                r#"{"type":"turn_context","payload":{"model":"gpt-5.4"}}"#,
+                "\n",
+                r#"{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3}}}}"#,
+                "\n"
+            );
+            std::fs::write(&path, contents).unwrap();
+
+            let initial_messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["codex".to_string()],
+                None,
+            );
+            assert_eq!(initial_messages.len(), 1);
+
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            std::fs::write(&path, contents).unwrap();
+
+            let warm_messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["codex".to_string()],
+                None,
+            );
+
+            std::env::set_var("HOME", fresh_cache_home.path());
+            let fresh_messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["codex".to_string()],
+                None,
+            );
+
+            assert_eq!(warm_messages, fresh_messages);
+            assert_ne!(warm_messages[0].timestamp, initial_messages[0].timestamp);
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn test_full_log_parse_preserves_valid_messages_before_invalid_line_error() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
@@ -3401,6 +3552,7 @@ mod tests {
     #[serial_test::serial]
     fn test_codex_cache_does_not_persist_unknown_before_later_turn_context() {
         let cache_home = tempfile::TempDir::new().unwrap();
+        let fresh_cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
         let original_home = std::env::var("HOME").ok();
         std::env::set_var("HOME", cache_home.path());
@@ -3451,11 +3603,94 @@ mod tests {
                 &["codex".to_string()],
                 None,
             );
+
+            std::env::set_var("HOME", fresh_cache_home.path());
+            let fresh_messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["codex".to_string()],
+                None,
+            );
+
+            assert_eq!(resumed_messages, fresh_messages);
             assert_eq!(resumed_messages.len(), 1);
             assert_eq!(resumed_messages[0].model_id, "gpt-5.5");
+
+            std::env::set_var("HOME", cache_home.path());
             assert!(message_cache::SourceMessageCache::load()
                 .get(&path)
                 .is_some());
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_codex_cache_skips_non_newline_terminated_resume_prefix() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let fresh_cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            let session_dir = source_home.path().join(".codex/sessions");
+            std::fs::create_dir_all(&session_dir).unwrap();
+            let path = session_dir.join("session.jsonl");
+            std::fs::write(
+                &path,
+                concat!(
+                    r#"{"type":"turn_context","payload":{"model":"gpt-5.4"}}"#,
+                    "\n",
+                    r#"{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3}}}}"#
+                ),
+            )
+            .unwrap();
+
+            let initial_messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["codex".to_string()],
+                None,
+            );
+            assert_eq!(initial_messages.len(), 1);
+            assert!(message_cache::SourceMessageCache::load()
+                .get(&path)
+                .is_none());
+
+            std::thread::sleep(std::time::Duration::from_millis(5));
+            let mut file = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&path)
+                .unwrap();
+            file.write_all(
+                concat!(
+                    "\n",
+                    r#"{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":15,"cached_input_tokens":3,"output_tokens":5},"last_token_usage":{"input_tokens":5,"cached_input_tokens":1,"output_tokens":2}}}}"#,
+                    "\n"
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+            file.flush().unwrap();
+
+            let warm_messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["codex".to_string()],
+                None,
+            );
+
+            std::env::set_var("HOME", fresh_cache_home.path());
+            let fresh_messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["codex".to_string()],
+                None,
+            );
+
+            assert_eq!(warm_messages, fresh_messages);
+            assert_eq!(warm_messages.len(), 2);
         }
 
         match original_home {

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -3246,7 +3246,9 @@ mod tests {
 
             assert_eq!(warm_messages, fresh_messages);
             assert_eq!(warm_messages.len(), 2);
-            assert!(warm_messages.iter().all(|message| message.model_id == "gpt-5.5"));
+            assert!(warm_messages
+                .iter()
+                .all(|message| message.model_id == "gpt-5.5"));
         }
 
         match original_home {
@@ -3375,7 +3377,9 @@ mod tests {
                 &["codex".to_string()],
                 None,
             );
-            assert!(message_cache::SourceMessageCache::load().get(&path).is_none());
+            assert!(message_cache::SourceMessageCache::load()
+                .get(&path)
+                .is_none());
 
             std::env::set_var("HOME", fresh_cache_home.path());
             let fresh_messages = parse_all_messages_with_pricing(

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -10,7 +10,7 @@ use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
-const CACHE_SCHEMA_VERSION: u32 = 9;
+const CACHE_SCHEMA_VERSION: u32 = 10;
 const CACHE_FILENAME: &str = "source-message-cache.bin";
 const CACHE_LOCK_FILENAME: &str = "source-message-cache.lock";
 const MAX_CACHE_FILE_BYTES: u64 = 256 * 1024 * 1024;
@@ -347,6 +347,15 @@ impl SourceMessageCache {
         self.entries.get(&key)
     }
 
+    pub(crate) fn remove(&mut self, path: &Path) {
+        let key = CachedPath::from_path(path);
+        if self.entries.remove(&key).is_some() {
+            self.dirty_keys.remove(&key);
+            self.deleted_paths.insert(key);
+            self.dirty = true;
+        }
+    }
+
     pub(crate) fn prune_missing_files(&mut self) {
         let removed_paths: Vec<CachedPath> = self
             .entries
@@ -630,10 +639,15 @@ pub(crate) fn build_codex_incremental_cache(
     consumed_offset: u64,
     state: CodexParseState,
 ) -> Option<CodexIncrementalCache> {
+    let ends_with_newline = consumed_offset == 0 || file_ends_with_newline(path, consumed_offset);
+    if !ends_with_newline {
+        return None;
+    }
+
     Some(CodexIncrementalCache {
         state,
         consumed_offset,
-        ends_with_newline: consumed_offset == 0 || file_ends_with_newline(path, consumed_offset),
+        ends_with_newline,
         prefix_hash: hash_prefix(path, consumed_offset)?,
     })
 }
@@ -664,6 +678,19 @@ pub(crate) fn codex_prefix_matches(path: &Path, cached: &CodexIncrementalCache) 
         Some(prefix_hash) => prefix_hash == cached.prefix_hash,
         None => false,
     }
+}
+
+pub(crate) fn codex_cache_entry_matches_fingerprint(
+    cached: &CachedSourceEntry,
+    fingerprint: &SourceFingerprint,
+) -> bool {
+    let Some(codex_incremental) = cached.codex_incremental.as_ref() else {
+        return false;
+    };
+
+    codex_incremental.consumed_offset == fingerprint.size
+        && codex_incremental.ends_with_newline
+        && codex_incremental.prefix_hash == fingerprint.content_hash
 }
 
 #[cfg(test)]
@@ -831,6 +858,18 @@ mod tests {
             main_fp1, main_fp2,
             "from_claude_code_path always tracks .meta.json if it exists"
         );
+    }
+
+    #[test]
+    fn test_codex_incremental_cache_requires_newline_boundary() {
+        let file = write_temp_file(b"line-1\nline-2");
+
+        assert!(build_codex_incremental_cache(
+            file.path(),
+            file.as_file().metadata().unwrap().len(),
+            CodexParseState::default(),
+        )
+        .is_none());
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/codex.rs
+++ b/crates/tokscale-core/src/sessions/codex.rs
@@ -472,6 +472,13 @@ fn parse_codex_reader<R: BufRead>(
             if used_fallback_timestamp {
                 fallback_timestamp_indices.push(messages.len() - 1);
             }
+            continue;
+        }
+
+        let mut json_probe = trimmed.as_bytes().to_vec();
+        if simd_json::from_slice::<Value>(&mut json_probe).is_err() {
+            parse_succeeded = false;
+            break;
         }
     }
 

--- a/crates/tokscale-core/src/sessions/codex.rs
+++ b/crates/tokscale-core/src/sessions/codex.rs
@@ -176,6 +176,44 @@ fn session_id_from_path(path: &Path) -> String {
         .to_string()
 }
 
+fn codex_workspace_from_cwd(cwd: &str) -> (Option<String>, Option<String>) {
+    let workspace_key = normalize_codex_workspace_key(cwd);
+    let workspace_label = workspace_key
+        .as_deref()
+        .and_then(workspace_label_from_key);
+
+    if workspace_label.is_none() {
+        return (None, None);
+    }
+
+    (workspace_key, workspace_label)
+}
+
+fn normalize_codex_workspace_key(raw: &str) -> Option<String> {
+    let normalized = normalize_workspace_key(raw)?;
+    if normalized.chars().any(char::is_control) {
+        return None;
+    }
+
+    if looks_like_explicit_workspace_path(&normalized) {
+        Some(normalized)
+    } else {
+        None
+    }
+}
+
+fn looks_like_explicit_workspace_path(path: &str) -> bool {
+    if path.starts_with("//") || path.starts_with('/') {
+        return true;
+    }
+
+    let bytes = path.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && bytes[2] == b'/'
+}
+
 fn parse_codex_reader<R: BufRead>(
     mut reader: R,
     session_id: &str,
@@ -225,11 +263,9 @@ fn parse_codex_reader<R: BufRead>(
                         state.session_agent = Some(nickname.clone());
                     }
                     if let Some(ref cwd) = payload.cwd {
-                        state.session_workspace_key = normalize_workspace_key(cwd);
-                        state.session_workspace_label = state
-                            .session_workspace_key
-                            .as_deref()
-                            .and_then(workspace_label_from_key);
+                        let (workspace_key, workspace_label) = codex_workspace_from_cwd(cwd);
+                        state.session_workspace_key = workspace_key;
+                        state.session_workspace_label = workspace_label;
                     }
                 }
                 // Extract model from turn_context
@@ -1272,6 +1308,75 @@ mod tests {
             Some("/Users/alice/demo-repo")
         );
         assert_eq!(messages[0].workspace_label.as_deref(), Some("demo-repo"));
+    }
+
+    #[test]
+    fn test_inaccessible_cwd_still_parses_token_usage() {
+        let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"session_meta","payload":{"source":"interactive","cwd":"/path/that/does/not/exist/demo-repo"}}"#;
+        let line2 = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#;
+        let line3 = r#"{"timestamp":"2026-01-01T00:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1}}}}"#;
+        let content = format!("{}\n{}\n{}", line1, line2, line3);
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 8);
+        assert_eq!(messages[0].tokens.output, 3);
+        assert_eq!(messages[0].tokens.cache_read, 2);
+        assert_eq!(
+            messages[0].workspace_key.as_deref(),
+            Some("/path/that/does/not/exist/demo-repo")
+        );
+        assert_eq!(messages[0].workspace_label.as_deref(), Some("demo-repo"));
+    }
+
+    #[test]
+    fn test_session_meta_empty_cwd_clears_workspace_metadata() {
+        let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"session_meta","payload":{"source":"interactive","cwd":"   "}}"#;
+        let line2 = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#;
+        let line3 = r#"{"timestamp":"2026-01-01T00:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1}}}}"#;
+        let content = format!("{}\n{}\n{}", line1, line2, line3);
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].workspace_key, None);
+        assert_eq!(messages[0].workspace_label, None);
+        assert_eq!(messages[0].tokens.input, 8);
+    }
+
+    #[test]
+    fn test_session_meta_malformed_cwd_clears_workspace_metadata() {
+        let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"session_meta","payload":{"source":"interactive","cwd":"file:///Users/alice/demo-repo"}}"#;
+        let line2 = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#;
+        let line3 = r#"{"timestamp":"2026-01-01T00:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1}}}}"#;
+        let content = format!("{}\n{}\n{}", line1, line2, line3);
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].workspace_key, None);
+        assert_eq!(messages[0].workspace_label, None);
+        assert_eq!(messages[0].tokens.input, 8);
+    }
+
+    #[test]
+    fn test_session_meta_path_like_noncanonical_cwd_normalizes_consistently() {
+        let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"session_meta","payload":{"source":"interactive","cwd":"//server//share///demo-repo/"}}"#;
+        let line2 = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#;
+        let line3 = r#"{"timestamp":"2026-01-01T00:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1}}}}"#;
+        let content = format!("{}\n{}\n{}", line1, line2, line3);
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].workspace_key.as_deref(), Some("//server/share/demo-repo"));
+        assert_eq!(messages[0].workspace_label.as_deref(), Some("demo-repo"));
+        assert_eq!(messages[0].tokens.input, 8);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/codex.rs
+++ b/crates/tokscale-core/src/sessions/codex.rs
@@ -252,6 +252,29 @@ fn parse_codex_reader<R: BufRead>(
         buffer.extend_from_slice(trimmed.as_bytes());
         if let Ok(entry) = simd_json::from_slice::<CodexEntry>(&mut buffer) {
             if let Some(payload) = entry.payload {
+                let payload_model = extract_model(&payload);
+                let is_token_count = entry.entry_type == "event_msg"
+                    && payload.payload_type.as_deref() == Some("token_count");
+                let info_model = if is_token_count {
+                    payload.info.as_ref().and_then(extract_model_from_info)
+                } else {
+                    None
+                };
+                let event_model = payload_model.clone().or(info_model.clone());
+
+                if !pending_model_messages.is_empty()
+                    && event_model.is_none()
+                    && !is_token_count
+                    && entry.entry_type != "session_meta"
+                {
+                    flush_pending_model_messages_as_unknown(
+                        &mut pending_model_messages,
+                        &mut messages,
+                        &mut fallback_timestamp_indices,
+                        &mut unresolved_model_events,
+                    );
+                }
+
                 if entry.entry_type == "session_meta" {
                     if payload.source.as_deref() == Some("exec") {
                         state.session_is_headless = true;
@@ -270,7 +293,7 @@ fn parse_codex_reader<R: BufRead>(
                 }
                 // Extract model from turn_context
                 if entry.entry_type == "turn_context" {
-                    state.current_model = extract_model(&payload);
+                    state.current_model = payload_model.clone();
                     if let Some(model) = state.current_model.clone() {
                         flush_pending_model_messages(
                             &mut pending_model_messages,
@@ -283,37 +306,24 @@ fn parse_codex_reader<R: BufRead>(
                 }
 
                 // Process token_count events
-                if entry.entry_type == "event_msg"
-                    && payload.payload_type.as_deref() == Some("token_count")
-                {
-                    // Try to extract model from payload
-                    if let Some(model) = extract_model(&payload) {
-                        state.current_model = Some(model.clone());
-                        flush_pending_model_messages(
-                            &mut pending_model_messages,
-                            &mut messages,
-                            &mut fallback_timestamp_indices,
-                            &model,
-                        );
-                    }
-
+                if is_token_count {
                     let info = match payload.info {
                         Some(i) => i,
                         None => continue,
                     };
 
-                    // Try to extract model from info
-                    if let Some(model) = info.model.clone().or(info.model_name.clone()) {
+                    let model = payload_model
+                        .or(info_model)
+                        .or_else(|| state.current_model.clone());
+                    if let Some(ref model) = model {
                         state.current_model = Some(model.clone());
                         flush_pending_model_messages(
                             &mut pending_model_messages,
                             &mut messages,
                             &mut fallback_timestamp_indices,
-                            &model,
+                            model,
                         );
                     }
-
-                    let model = state.current_model.clone();
 
                     // Use last_token_usage as the primary increment source.
                     // Upstream totals are mutable snapshots (compaction, context-window
@@ -435,13 +445,22 @@ fn parse_codex_reader<R: BufRead>(
             &state.session_agent,
             state.session_is_headless,
         );
-        if let Some(model) = state.current_model.clone() {
-            flush_pending_model_messages(
-                &mut pending_model_messages,
-                &mut messages,
-                &mut fallback_timestamp_indices,
-                &model,
-            );
+        if !pending_model_messages.is_empty() {
+            if let Some(model) = state.current_model.clone() {
+                flush_pending_model_messages(
+                    &mut pending_model_messages,
+                    &mut messages,
+                    &mut fallback_timestamp_indices,
+                    &model,
+                );
+            } else {
+                flush_pending_model_messages_as_unknown(
+                    &mut pending_model_messages,
+                    &mut messages,
+                    &mut fallback_timestamp_indices,
+                    &mut unresolved_model_events,
+                );
+            }
         }
 
         if let Some((mut msg, used_fallback_timestamp)) = headless_message {
@@ -456,15 +475,12 @@ fn parse_codex_reader<R: BufRead>(
         }
     }
 
-    if !pending_model_messages.is_empty() {
-        unresolved_model_events = true;
-        flush_pending_model_messages(
-            &mut pending_model_messages,
-            &mut messages,
-            &mut fallback_timestamp_indices,
-            "unknown",
-        );
-    }
+    flush_pending_model_messages_as_unknown(
+        &mut pending_model_messages,
+        &mut messages,
+        &mut fallback_timestamp_indices,
+        &mut unresolved_model_events,
+    );
 
     ParsedCodexFile {
         messages,
@@ -489,6 +505,25 @@ fn flush_pending_model_messages(
             fallback_timestamp_indices.push(messages.len() - 1);
         }
     }
+}
+
+fn flush_pending_model_messages_as_unknown(
+    pending_model_messages: &mut Vec<(UnifiedMessage, bool)>,
+    messages: &mut Vec<UnifiedMessage>,
+    fallback_timestamp_indices: &mut Vec<usize>,
+    unresolved_model_events: &mut bool,
+) {
+    if pending_model_messages.is_empty() {
+        return;
+    }
+
+    *unresolved_model_events = true;
+    flush_pending_model_messages(
+        pending_model_messages,
+        messages,
+        fallback_timestamp_indices,
+        "unknown",
+    );
 }
 
 /// Parse a Codex JSONL file with stateful tracking
@@ -558,13 +593,14 @@ fn extract_model(payload: &CodexPayload) -> Option<String> {
         .or(payload
             .info
             .as_ref()
-            .and_then(|i| i.model.clone())
-            .filter(|s| !s.is_empty()))
-        .or(payload
-            .info
-            .as_ref()
-            .and_then(|i| i.model_name.clone())
-            .filter(|s| !s.is_empty()))
+            .and_then(extract_model_from_info))
+}
+
+fn extract_model_from_info(info: &CodexInfo) -> Option<String> {
+    info.model
+        .clone()
+        .filter(|s| !s.is_empty())
+        .or(info.model_name.clone().filter(|s| !s.is_empty()))
 }
 
 struct CodexHeadlessUsage {
@@ -1451,5 +1487,48 @@ mod tests {
 
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].model_id, "gpt-4o");
+    }
+
+    #[test]
+    fn test_pending_model_messages_do_not_bind_across_unrelated_turns() {
+        let file = create_test_file(concat!(
+            r#"{"type":"session_meta","payload":{"source":"interactive","model_provider":"openai"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-04-27T10:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-04-27T10:00:02Z","type":"assistant_message"}"#,
+            "\n",
+            r#"{"timestamp":"2026-04-27T10:00:04Z","type":"turn_context","payload":{"model":"gpt-5.5"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-04-27T10:00:05Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":15,"cached_input_tokens":3,"output_tokens":5},"last_token_usage":{"input_tokens":5,"cached_input_tokens":1,"output_tokens":2}}}}"#,
+            "\n"
+        ));
+
+        let parsed = parse_codex_file_incremental(file.path(), 0, CodexParseState::default());
+
+        assert!(parsed.parse_succeeded);
+        assert!(parsed.unresolved_model_events);
+        assert_eq!(parsed.messages.len(), 2);
+        assert_eq!(parsed.messages[0].model_id, "unknown");
+        assert_eq!(parsed.messages[1].model_id, "gpt-5.5");
+    }
+
+    #[test]
+    fn test_token_count_ignores_empty_info_model_until_later_valid_model() {
+        let file = create_test_file(concat!(
+            r#"{"type":"session_meta","payload":{"source":"interactive","model_provider":"openai"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-04-27T10:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"model":"","model_name":"","total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-04-27T10:00:04Z","type":"turn_context","payload":{"model":"gpt-5.5"}}"#,
+            "\n"
+        ));
+
+        let parsed = parse_codex_file_incremental(file.path(), 0, CodexParseState::default());
+
+        assert!(parsed.parse_succeeded);
+        assert!(!parsed.unresolved_model_events);
+        assert_eq!(parsed.messages.len(), 1);
+        assert_eq!(parsed.messages[0].model_id, "gpt-5.5");
     }
 }

--- a/crates/tokscale-core/src/sessions/codex.rs
+++ b/crates/tokscale-core/src/sessions/codex.rs
@@ -473,7 +473,7 @@ fn parse_codex_reader<R: BufRead>(
         let mut json_probe = trimmed.as_bytes().to_vec();
         if simd_json::from_slice::<Value>(&mut json_probe).is_err() {
             parse_succeeded = false;
-            break;
+            continue;
         }
     }
 

--- a/crates/tokscale-core/src/sessions/codex.rs
+++ b/crates/tokscale-core/src/sessions/codex.rs
@@ -178,9 +178,7 @@ fn session_id_from_path(path: &Path) -> String {
 
 fn codex_workspace_from_cwd(cwd: &str) -> (Option<String>, Option<String>) {
     let workspace_key = normalize_codex_workspace_key(cwd);
-    let workspace_label = workspace_key
-        .as_deref()
-        .and_then(workspace_label_from_key);
+    let workspace_label = workspace_key.as_deref().and_then(workspace_label_from_key);
 
     if workspace_label.is_none() {
         return (None, None);
@@ -208,10 +206,7 @@ fn looks_like_explicit_workspace_path(path: &str) -> bool {
     }
 
     let bytes = path.as_bytes();
-    bytes.len() >= 3
-        && bytes[0].is_ascii_alphabetic()
-        && bytes[1] == b':'
-        && bytes[2] == b'/'
+    bytes.len() >= 3 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' && bytes[2] == b'/'
 }
 
 fn parse_codex_reader<R: BufRead>(
@@ -597,10 +592,7 @@ fn extract_model(payload: &CodexPayload) -> Option<String> {
         .filter(|s| !s.is_empty())
         .or(payload.model.clone().filter(|s| !s.is_empty()))
         .or(payload.model_name.clone().filter(|s| !s.is_empty()))
-        .or(payload
-            .info
-            .as_ref()
-            .and_then(extract_model_from_info))
+        .or(payload.info.as_ref().and_then(extract_model_from_info))
 }
 
 fn extract_model_from_info(info: &CodexInfo) -> Option<String> {
@@ -1417,7 +1409,10 @@ mod tests {
         let messages = parse_codex_file(file.path());
 
         assert_eq!(messages.len(), 1);
-        assert_eq!(messages[0].workspace_key.as_deref(), Some("//server/share/demo-repo"));
+        assert_eq!(
+            messages[0].workspace_key.as_deref(),
+            Some("//server/share/demo-repo")
+        );
         assert_eq!(messages[0].workspace_label.as_deref(), Some("demo-repo"));
         assert_eq!(messages[0].tokens.input, 8);
     }

--- a/crates/tokscale-core/src/sessions/gemini.rs
+++ b/crates/tokscale-core/src/sessions/gemini.rs
@@ -795,7 +795,8 @@ mod tests {
 
     #[test]
     fn test_parse_gemini_stream_jsonl_skips_corrupt_lines() {
-        let content = b"{\"type\":\"init\",\"model\":\"gemini-2.5-pro\",\"session_id\":\"session-1\"}\n\
+        let content =
+            b"{\"type\":\"init\",\"model\":\"gemini-2.5-pro\",\"session_id\":\"session-1\"}\n\
 not-json\n\
 {\"type\":\"result\",\"stats\":{\"input_tokens\":10,\"output_tokens\":20}}\n";
         let dir = TempDir::new().unwrap();
@@ -815,7 +816,8 @@ not-json\n\
 
     #[test]
     fn test_parse_gemini_stream_jsonl_skips_truncated_final_line() {
-        let content = b"{\"type\":\"init\",\"model\":\"gemini-2.5-pro\",\"session_id\":\"session-1\"}\n\
+        let content =
+            b"{\"type\":\"init\",\"model\":\"gemini-2.5-pro\",\"session_id\":\"session-1\"}\n\
 {\"type\":\"result\",\"stats\":{\"input_tokens\":10,\"output_tokens\":20}}\n\
 {\"type\":\"result\",\"stats\":{\"input_tokens\":99";
         let dir = TempDir::new().unwrap();

--- a/crates/tokscale-core/src/sessions/gemini.rs
+++ b/crates/tokscale-core/src/sessions/gemini.rs
@@ -219,25 +219,30 @@ fn parse_gemini_headless_jsonl(path: &Path, fallback_timestamp: i64) -> Vec<Unif
         .unwrap_or("unknown")
         .to_string();
     let mut current_model: Option<String> = None;
-    let reader = BufReader::new(file);
+    let mut reader = BufReader::new(file);
     let mut messages = Vec::with_capacity(64);
     let mut direct_message_indices: HashMap<String, usize> = HashMap::new();
-    let mut buffer = Vec::with_capacity(4096);
+    let mut line_buffer = Vec::with_capacity(4096);
+    let mut json_buffer = Vec::with_capacity(4096);
 
-    for line in reader.lines() {
-        let line = match line {
-            Ok(l) => l,
-            Err(_) => continue,
+    loop {
+        line_buffer.clear();
+        let bytes_read = match reader.read_until(b'\n', &mut line_buffer) {
+            Ok(n) => n,
+            Err(_) => break,
         };
+        if bytes_read == 0 {
+            break;
+        }
 
-        let trimmed = line.trim();
+        let trimmed = trim_ascii_bytes(&line_buffer);
         if trimmed.is_empty() {
             continue;
         }
 
-        buffer.clear();
-        buffer.extend_from_slice(trimmed.as_bytes());
-        let value: Value = match simd_json::from_slice(&mut buffer) {
+        json_buffer.clear();
+        json_buffer.extend_from_slice(trimmed);
+        let value: Value = match simd_json::from_slice(&mut json_buffer) {
             Ok(v) => v,
             Err(_) => continue,
         };
@@ -300,6 +305,21 @@ fn parse_gemini_headless_jsonl(path: &Path, fallback_timestamp: i64) -> Vec<Unif
     }
 
     messages
+}
+
+fn trim_ascii_bytes(bytes: &[u8]) -> &[u8] {
+    let start = bytes.iter().position(|b| !b.is_ascii_whitespace());
+    let Some(start) = start else {
+        return &[];
+    };
+
+    let end = bytes
+        .iter()
+        .rposition(|b| !b.is_ascii_whitespace())
+        .map(|idx| idx + 1)
+        .unwrap_or(start);
+
+    &bytes[start..end]
 }
 
 fn parse_gemini_headless_value(
@@ -758,6 +778,96 @@ mod tests {
         assert_eq!(messages[0].tokens.cache_read, 5);
         assert_eq!(messages[0].tokens.reasoning, 3);
         assert_eq!(messages[0].tokens.total(), 25);
+    }
+
+    #[test]
+    fn test_parse_gemini_stream_jsonl_empty_file_returns_no_messages() {
+        let dir = TempDir::new().unwrap();
+        let chats_dir = dir.path().join(".gemini/tmp/123/chats");
+        std::fs::create_dir_all(&chats_dir).unwrap();
+        let file_path = chats_dir.join("empty.jsonl");
+        std::fs::write(&file_path, b"").unwrap();
+
+        let messages = parse_gemini_file(&file_path);
+
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_parse_gemini_stream_jsonl_skips_corrupt_lines() {
+        let content = b"{\"type\":\"init\",\"model\":\"gemini-2.5-pro\",\"session_id\":\"session-1\"}\n\
+not-json\n\
+{\"type\":\"result\",\"stats\":{\"input_tokens\":10,\"output_tokens\":20}}\n";
+        let dir = TempDir::new().unwrap();
+        let chats_dir = dir.path().join(".gemini/tmp/123/chats");
+        std::fs::create_dir_all(&chats_dir).unwrap();
+        let file_path = chats_dir.join("corrupt.jsonl");
+        std::fs::write(&file_path, content).unwrap();
+
+        let messages = parse_gemini_file(&file_path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].session_id, "session-1");
+        assert_eq!(messages[0].model_id, "gemini-2.5-pro");
+        assert_eq!(messages[0].tokens.input, 10);
+        assert_eq!(messages[0].tokens.output, 20);
+    }
+
+    #[test]
+    fn test_parse_gemini_stream_jsonl_skips_truncated_final_line() {
+        let content = b"{\"type\":\"init\",\"model\":\"gemini-2.5-pro\",\"session_id\":\"session-1\"}\n\
+{\"type\":\"result\",\"stats\":{\"input_tokens\":10,\"output_tokens\":20}}\n\
+{\"type\":\"result\",\"stats\":{\"input_tokens\":99";
+        let dir = TempDir::new().unwrap();
+        let chats_dir = dir.path().join(".gemini/tmp/123/chats");
+        std::fs::create_dir_all(&chats_dir).unwrap();
+        let file_path = chats_dir.join("truncated.jsonl");
+        std::fs::write(&file_path, content).unwrap();
+
+        let messages = parse_gemini_file(&file_path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gemini-2.5-pro");
+        assert_eq!(messages[0].tokens.input, 10);
+        assert_eq!(messages[0].tokens.output, 20);
+    }
+
+    #[test]
+    fn test_parse_gemini_stream_jsonl_mixed_valid_invalid_lines_preserves_duplicate_replacement() {
+        let content = b"{\"type\":\"init\",\"model\":\"gemini-3.1-pro-preview\",\"session_id\":\"session-1\"}\n\
+{\"type\":\"gemini\",\"id\":\"msg-1\",\"model\":\"gemini-3.1-pro-preview\",\"tokens\":{\"input\":10,\"output\":1,\"cached\":0,\"thoughts\":0,\"tool\":0,\"total\":11}}\n\
+\xff\n\
+{\"type\":\"gemini\",\"id\":\"msg-1\",\"model\":\"gemini-3.1-pro-preview\",\"tokens\":{\"input\":20,\"output\":2,\"cached\":5,\"thoughts\":3,\"tool\":0,\"total\":25}}\n\
+{\"type\":\"result\",\"stats\":{\"input_tokens\":7,\"output_tokens\":8}}\n";
+        let dir = TempDir::new().unwrap();
+        let chats_dir = dir.path().join(".gemini/tmp/123/chats");
+        std::fs::create_dir_all(&chats_dir).unwrap();
+        let file_path = chats_dir.join("mixed.jsonl");
+        std::fs::write(&file_path, content).unwrap();
+
+        let messages = parse_gemini_file(&file_path);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].session_id, "session-1");
+        assert_eq!(messages[0].model_id, "gemini-3.1-pro-preview");
+        assert_eq!(messages[0].tokens.input, 15);
+        assert_eq!(messages[0].tokens.output, 2);
+        assert_eq!(messages[0].tokens.cache_read, 5);
+        assert_eq!(messages[0].tokens.reasoning, 3);
+        assert_eq!(messages[1].tokens.input, 7);
+        assert_eq!(messages[1].tokens.output, 8);
+    }
+
+    #[test]
+    fn test_parse_gemini_stream_jsonl_unreadable_file_returns_no_messages() {
+        let dir = TempDir::new().unwrap();
+        let chats_dir = dir.path().join(".gemini/tmp/123/chats");
+        std::fs::create_dir_all(&chats_dir).unwrap();
+        let file_path = chats_dir.join("missing.jsonl");
+
+        let messages = parse_gemini_file(&file_path);
+
+        assert!(messages.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Hardens Tokscale parsing against upstream Codex and Gemini CLI session data issues related to resume, token counting, and model attribution.

## Changes

### fix(gemini): skip corrupt headless JSONL lines
- Parses JSONL as raw byte lines with `read_until` instead of `BufRead::lines()`
- Skips malformed/truncated records without dropping valid earlier lines
- Adds regression tests for empty files, corrupt lines, truncated tails, and mixed validity

### fix(codex): ignore ambiguous cwd metadata
- Treats `cwd` as untrusted metadata — no filesystem access required
- Fails closed to `workspace_key = None` for empty/malformed/URI-style paths
- Preserves token usage parsing even when cwd is unusable

### fix(codex): delay model-less token attribution until context resolves
- Buffers model-less `token_count` events instead of attributing to stale model
- Empty `info.model` strings are ignored until a real model appears
- Falls back to `unknown` only when attribution window becomes ambiguous
- Prevents cross-turn misattribution

### fix(codex): reparse stale resumed history before caching
- Requires stricter freshness gates before persisting incremental cache:
  - newline-terminated prefix, prefix-hash verified, fully consumed
  - parse-successful, model-resolved state
- Evicts stale cache entries instead of trusting them
- Malformed JSON appends mark parse as non-authoritative

### fix(codex): continue parsing after malformed JSON line instead of aborting
- A single corrupt/truncated row no longer breaks the entire parse loop
- `parse_succeeded` is still set to false (blocking cache persistence)
- Subsequent valid lines are still parsed and counted

## Test Results

- `cargo test -p tokscale-core`: **605 passed, 0 failed**
- `cargo test --manifest-path crates/tokscale-cli/Cargo.toml`: **86 passed, 0 failed**
- Total: **691 tests, 0 failures**

## Upstream Issues Addressed

| Upstream Issue | Tokscale Impact | Fix |
|---|---|---|
| Gemini corrupt/empty JSONL breaks discovery | Parse break / missed sessions | Fix 1 |
| Codex inaccessible/malformed cwd | Missed/unreadable sessions | Fix 2 |
| Codex heuristic token counts | Usage drift | Fix 3 (already present, verified) |
| Codex model-less usage events | Weak model attribution | Fix 4 |
| Codex incomplete resumed history | Stale cache / bad attribution | Fix 5 |
| Codex malformed JSON line aborts parse | Undercounting until file rewrite | Fix 6 |