### PR TITLE
fix(ci): keep PR auto-fix commits from skipping validation

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -81,7 +81,7 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add -A
-          git diff --staged --quiet || git commit -m "style: auto-fix lint issues [skip ci]"
+          git diff --staged --quiet || git commit -m "style: auto-fix lint issues"
           git pull --rebase origin "${{ github.head_ref }}"
           git push origin "HEAD:${{ github.head_ref }}"
       - name: Run Clippy (strict)


### PR DESCRIPTION
## Summary
- Removes the CI skip marker from the `pull_request` auto-fix commit message.
- Leaves the coverage badge commit marker unchanged so the main-branch badge update cannot trigger a loop.

## Why
The auto-fix job can push a bot commit back to a PR branch. If that commit message includes a CI skip token, the token can be carried into the eventual squash merge message and suppress the main-branch validation run for the merged change.

## Diff scope
- `.github/workflows/test_coverage.yml`
- One-line workflow change in the `Commit auto-fixes` step.
- No Rust runtime, parser, pricing, database, or CLI behavior changed.

## Branch integrity
- Base branch: `main`
- Validated base: `origin/main` at `3a7297d313e753e100c0489399821eeb9b271874`
- Ahead/behind: `0 1`
- Merge base: `3a7297d313e753e100c0489399821eeb9b271874`
- `origin/main` is an ancestor of this branch.

## Commit integrity
- `c62fd0fb22e7ee768eaffc1c0d644f8f76ffd958 fix(ci): keep PR auto-fix commits from skipping validation`
- One logical workflow commit.

## Ledger/version proof
Not applicable - `scripts/ledger/` does not exist in this repository, and no package versions changed.

## Diff hygiene
- `git diff --name-status origin/main...HEAD`: `M .github/workflows/test_coverage.yml`
- `git diff --check origin/main...HEAD`: PASS, no output
- No secrets, credentials, local environment files, caches, build artifacts, or unrelated generated files are included.

## Validation mode and proof
Selected mode: Mode 4 - CI/workflow change.

Local validation:
- `awk '/name: Commit auto-fixes/ { in_block=1 } in_block && /git commit -m/ && /skip ci/ { found=1 } in_block && /name: Run Clippy/ { in_block=0 } END { exit found ? 1 : 0 }' .github/workflows/test_coverage.yml`: PASS
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test_coverage.yml"); puts "workflow yaml parsed"'`: PASS
- `rg -n "skip ci" .github/workflows/test_coverage.yml`: PASS, only the coverage badge commit retains the marker
- `rg -n --pcre2 "\\p{Cyrillic}" .github/workflows/test_coverage.yml`: PASS, no matches
- `git diff --check origin/main...HEAD`: PASS, no output

Not run - cargo tests are not required for this workflow-only change because no Rust runtime, CLI, parser, pricing, or library code changed.

## Migration notes
Not applicable - no database migration changed.

## CI context confirmation
Pending - required GitHub checks can only run after the PR is opened.
CI workflow context names are unchanged.

## Runtime safety
Not applicable - no runtime path changed.

## Documentation integrity
Not applicable - no docs, runbooks, commands, or user-facing behavior changed.

## Rollback plan
Revert the final merge commit to restore the previous auto-fix commit message. No DB downgrade or data repair is required.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the CI skip token from the PR auto-fix commit message so squash merges don’t inherit it and skip main-branch validation. Kept the skip token on the coverage badge update to avoid a workflow loop.

<sup>Written for commit c62fd0fb22e7ee768eaffc1c0d644f8f76ffd958. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

