### PR TITLE
fix(copilot): parse VS Code OTel usage records

### DIFF
--- a/crates/tokscale-core/src/sessions/copilot.rs
+++ b/crates/tokscale-core/src/sessions/copilot.rs
@@ -1,14 +1,15 @@
-//! GitHub Copilot CLI OTEL parser
+//! GitHub Copilot OTEL parser
 //!
-//! Parses file-exported OpenTelemetry JSONL emitted by Copilot CLI monitoring.
-//! Phase 1 only turns `chat` spans into token usage rows; tool spans and metrics
-//! are intentionally ignored.
+//! Parses file-exported OpenTelemetry JSONL emitted by Copilot CLI and VS Code
+//! Copilot Chat monitoring. Chat spans and inference log records are preferred;
+//! aggregate agent records are only used as a fallback to avoid double counting.
 
 use super::utils::file_modified_timestamp_ms;
 use super::UnifiedMessage;
 use crate::provider_identity::inferred_provider_from_model;
 use crate::TokenBreakdown;
 use serde_json::{Map, Value};
+use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 
@@ -19,10 +20,8 @@ pub fn parse_copilot_file(path: &Path) -> Vec<UnifiedMessage> {
     };
 
     let fallback_timestamp = file_modified_timestamp_ms(path);
-    let reader = BufReader::new(file);
-    let mut messages = Vec::new();
-
-    for line in reader.lines() {
+    let mut records = Vec::new();
+    for line in BufReader::new(file).lines() {
         let line = match line {
             Ok(line) => line,
             Err(_) => continue,
@@ -33,96 +32,308 @@ pub fn parse_copilot_file(path: &Path) -> Vec<UnifiedMessage> {
             continue;
         }
 
-        let span = match serde_json::from_str::<Value>(trimmed) {
-            Ok(value) => value,
-            Err(_) => continue,
-        };
-
-        if !is_chat_span(&span) {
-            continue;
+        if let Ok(record) = serde_json::from_str::<Value>(trimmed) {
+            records.push(record);
         }
-
-        let attributes = match span.get("attributes").and_then(Value::as_object) {
-            Some(attributes) => attributes,
-            None => continue,
-        };
-
-        let input = attr_i64(attributes, "gen_ai.usage.input_tokens");
-        let output = attr_i64(attributes, "gen_ai.usage.output_tokens");
-        let cache_read = attr_i64(attributes, "gen_ai.usage.cache_read.input_tokens");
-        let cache_write = attr_i64(attributes, "gen_ai.usage.cache_write.input_tokens");
-        let reasoning = attr_i64(attributes, "gen_ai.usage.reasoning.output_tokens");
-
-        let model = first_non_empty_attr(
-            attributes,
-            &["gen_ai.response.model", "gen_ai.request.model"],
-        )
-        .unwrap_or("unknown")
-        .to_string();
-
-        let provider_id = inferred_provider_from_model(&model)
-            .unwrap_or("github-copilot")
-            .to_string();
-
-        let trace_id = span
-            .get("traceId")
-            .and_then(Value::as_str)
-            .unwrap_or("unknown-trace");
-        let span_id = span
-            .get("spanId")
-            .and_then(Value::as_str)
-            .unwrap_or("unknown-span");
-        let dedup_key = format!("{trace_id}:{span_id}");
-
-        let session_id = first_non_empty_attr(
-            attributes,
-            &[
-                "gen_ai.conversation.id",
-                "github.copilot.interaction_id",
-                "gen_ai.response.id",
-            ],
-        )
-        .unwrap_or(trace_id)
-        .to_string();
-
-        let timestamp_ms = span
-            .get("endTime")
-            .and_then(timestamp_ms_from_value)
-            .or_else(|| span.get("startTime").and_then(timestamp_ms_from_value))
-            .unwrap_or(fallback_timestamp);
-
-        let tokens = normalize_input_tokens(input, output, cache_read, cache_write, reasoning);
-        if tokens.total() == 0 {
-            continue;
-        }
-
-        messages.push(UnifiedMessage::new_with_dedup(
-            "copilot",
-            model,
-            provider_id,
-            session_id,
-            timestamp_ms,
-            tokens,
-            0.0,
-            Some(dedup_key),
-        ));
     }
 
-    messages
+    let trace_contexts = collect_trace_contexts(&records);
+    let candidates: Vec<CopilotUsageCandidate> = records
+        .iter()
+        .enumerate()
+        .filter_map(|(index, record)| {
+            usage_candidate_from_record(record, index, fallback_timestamp, &trace_contexts)
+        })
+        .collect();
+
+    let chat_contexts = candidate_contexts(&candidates, CopilotUsageSource::ChatSpan);
+    let inference_contexts = candidate_contexts(&candidates, CopilotUsageSource::InferenceLog);
+    let agent_turn_contexts = candidate_contexts(&candidates, CopilotUsageSource::AgentTurnLog);
+
+    candidates
+        .into_iter()
+        .filter(|candidate| {
+            should_emit_candidate(
+                candidate,
+                &chat_contexts,
+                &inference_contexts,
+                &agent_turn_contexts,
+            )
+        })
+        .map(CopilotUsageCandidate::into_message)
+        .collect()
 }
 
-fn is_chat_span(value: &Value) -> bool {
-    if value.get("type").and_then(Value::as_str) != Some("span") {
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum CopilotUsageSource {
+    ChatSpan,
+    InferenceLog,
+    AgentTurnLog,
+    AgentSummarySpan,
+}
+
+struct TraceContext {
+    model: Option<String>,
+    session_id: Option<String>,
+    session_id_priority: SessionIdPriority,
+}
+
+struct CopilotUsageCandidate {
+    source: CopilotUsageSource,
+    trace_id: Option<String>,
+    model: String,
+    provider_id: String,
+    session_id: String,
+    timestamp_ms: i64,
+    tokens: TokenBreakdown,
+    dedup_key: String,
+}
+
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+enum SessionIdPriority {
+    Missing,
+    Response,
+    Interaction,
+    Session,
+}
+
+impl CopilotUsageCandidate {
+    fn context_key(&self) -> &str {
+        self.trace_id.as_deref().unwrap_or(&self.session_id)
+    }
+
+    fn into_message(self) -> UnifiedMessage {
+        UnifiedMessage::new_with_dedup(
+            "copilot",
+            self.model,
+            self.provider_id,
+            self.session_id,
+            self.timestamp_ms,
+            self.tokens,
+            0.0,
+            Some(self.dedup_key),
+        )
+    }
+}
+
+fn collect_trace_contexts(records: &[Value]) -> HashMap<String, TraceContext> {
+    let mut contexts = HashMap::new();
+
+    for record in records {
+        let Some(trace_id) = trace_id_from_record(record) else {
+            continue;
+        };
+
+        let Some(attributes) = record.get("attributes").and_then(Value::as_object) else {
+            continue;
+        };
+
+        let context = contexts
+            .entry(trace_id.to_string())
+            .or_insert(TraceContext {
+                model: None,
+                session_id: None,
+                session_id_priority: SessionIdPriority::Missing,
+            });
+
+        if context.model.is_none() {
+            context.model = first_non_empty_attr(attributes, MODEL_ATTRS).map(str::to_string);
+        }
+
+        if let Some((session_id, priority)) = best_session_attr(attributes) {
+            if priority > context.session_id_priority {
+                context.session_id = Some(session_id.to_string());
+                context.session_id_priority = priority;
+            }
+        }
+    }
+
+    contexts
+}
+
+fn usage_candidate_from_record(
+    record: &Value,
+    index: usize,
+    fallback_timestamp: i64,
+    trace_contexts: &HashMap<String, TraceContext>,
+) -> Option<CopilotUsageCandidate> {
+    let attributes = record.get("attributes").and_then(Value::as_object)?;
+    let trace_id = trace_id_from_record(record).map(str::to_string);
+    let trace_context = trace_id
+        .as_deref()
+        .and_then(|trace_id| trace_contexts.get(trace_id));
+
+    if is_chat_span_record(record, attributes) {
+        return candidate_from_attributes(
+            CopilotUsageSource::ChatSpan,
+            record,
+            attributes,
+            trace_id,
+            trace_context,
+            index,
+            fallback_timestamp,
+        );
+    }
+
+    if is_inference_log_record(record, attributes) {
+        return candidate_from_attributes(
+            CopilotUsageSource::InferenceLog,
+            record,
+            attributes,
+            trace_id,
+            trace_context,
+            index,
+            fallback_timestamp,
+        );
+    }
+
+    if is_agent_turn_log_record(record, attributes) {
+        return candidate_from_attributes(
+            CopilotUsageSource::AgentTurnLog,
+            record,
+            attributes,
+            trace_id,
+            trace_context,
+            index,
+            fallback_timestamp,
+        );
+    }
+
+    if is_agent_summary_span_record(record, attributes) {
+        return candidate_from_attributes(
+            CopilotUsageSource::AgentSummarySpan,
+            record,
+            attributes,
+            trace_id,
+            trace_context,
+            index,
+            fallback_timestamp,
+        );
+    }
+
+    None
+}
+
+fn candidate_from_attributes(
+    source: CopilotUsageSource,
+    record: &Value,
+    attributes: &Map<String, Value>,
+    trace_id: Option<String>,
+    trace_context: Option<&TraceContext>,
+    index: usize,
+    fallback_timestamp: i64,
+) -> Option<CopilotUsageCandidate> {
+    let input = attr_i64_first(attributes, &["gen_ai.usage.input_tokens"]);
+    let output = attr_i64_first(attributes, &["gen_ai.usage.output_tokens"]);
+    let cache_read = attr_i64_first(attributes, &["gen_ai.usage.cache_read.input_tokens"]);
+    let cache_write = attr_i64_first(
+        attributes,
+        &[
+            "gen_ai.usage.cache_write.input_tokens",
+            "gen_ai.usage.cache_creation.input_tokens",
+        ],
+    );
+    let reasoning = attr_i64_first(
+        attributes,
+        &[
+            "gen_ai.usage.reasoning.output_tokens",
+            "gen_ai.usage.reasoning_tokens",
+        ],
+    );
+
+    let tokens = normalize_input_tokens(input, output, cache_read, cache_write, reasoning);
+    if tokens.total() == 0 {
+        return None;
+    }
+
+    let model = first_non_empty_attr(attributes, MODEL_ATTRS)
+        .or_else(|| trace_context.and_then(|context| context.model.as_deref()))
+        .unwrap_or("unknown")
+        .to_string();
+    let provider_id = inferred_provider_from_model(&model)
+        .unwrap_or("github-copilot")
+        .to_string();
+    let session_id = best_session_attr(attributes)
+        .map(|(session_id, _)| session_id)
+        .or_else(|| trace_context.and_then(|context| context.session_id.as_deref()))
+        .or(trace_id.as_deref())
+        .unwrap_or("unknown-session")
+        .to_string();
+    let timestamp_ms = timestamp_ms_from_record(record).unwrap_or(fallback_timestamp);
+    let dedup_key = dedup_key_for_record(
+        source,
+        record,
+        attributes,
+        trace_id.as_deref(),
+        &session_id,
+        timestamp_ms,
+        index,
+    );
+
+    Some(CopilotUsageCandidate {
+        source,
+        trace_id,
+        model,
+        provider_id,
+        session_id,
+        timestamp_ms,
+        tokens,
+        dedup_key,
+    })
+}
+
+fn candidate_contexts(
+    candidates: &[CopilotUsageCandidate],
+    source: CopilotUsageSource,
+) -> HashSet<String> {
+    candidates
+        .iter()
+        .filter(|candidate| candidate.source == source)
+        .map(|candidate| candidate.context_key().to_string())
+        .collect()
+}
+
+fn should_emit_candidate(
+    candidate: &CopilotUsageCandidate,
+    chat_contexts: &HashSet<String>,
+    inference_contexts: &HashSet<String>,
+    agent_turn_contexts: &HashSet<String>,
+) -> bool {
+    let context_key = candidate.context_key();
+
+    match candidate.source {
+        CopilotUsageSource::ChatSpan => true,
+        CopilotUsageSource::InferenceLog => !chat_contexts.contains(context_key),
+        CopilotUsageSource::AgentTurnLog => {
+            !chat_contexts.contains(context_key) && !inference_contexts.contains(context_key)
+        }
+        CopilotUsageSource::AgentSummarySpan => {
+            !chat_contexts.contains(context_key)
+                && !inference_contexts.contains(context_key)
+                && !agent_turn_contexts.contains(context_key)
+        }
+    }
+}
+
+const MODEL_ATTRS: &[&str] = &["gen_ai.response.model", "gen_ai.request.model"];
+const SESSION_ATTRS: &[(&str, SessionIdPriority)] = &[
+    ("gen_ai.conversation.id", SessionIdPriority::Session),
+    ("copilot_chat.session_id", SessionIdPriority::Session),
+    ("copilot_chat.chat_session_id", SessionIdPriority::Session),
+    ("session.id", SessionIdPriority::Session),
+    (
+        "github.copilot.interaction_id",
+        SessionIdPriority::Interaction,
+    ),
+    ("gen_ai.response.id", SessionIdPriority::Response),
+];
+
+fn is_chat_span_record(value: &Value, attributes: &Map<String, Value>) -> bool {
+    if !is_span_record(value) {
         return false;
     }
 
-    if value
-        .get("attributes")
-        .and_then(Value::as_object)
-        .and_then(|attributes| attributes.get("gen_ai.operation.name"))
-        .and_then(Value::as_str)
-        == Some("chat")
-    {
+    if attr_str(attributes, "gen_ai.operation.name") == Some("chat") {
         return true;
     }
 
@@ -132,12 +343,126 @@ fn is_chat_span(value: &Value) -> bool {
         .is_some_and(|name| name.starts_with("chat "))
 }
 
+fn is_agent_summary_span_record(value: &Value, attributes: &Map<String, Value>) -> bool {
+    if !is_span_record(value) {
+        return false;
+    }
+
+    if attr_str(attributes, "gen_ai.operation.name") == Some("invoke_agent") {
+        return true;
+    }
+
+    value
+        .get("name")
+        .and_then(Value::as_str)
+        .is_some_and(|name| name.starts_with("invoke_agent "))
+}
+
+fn is_inference_log_record(value: &Value, attributes: &Map<String, Value>) -> bool {
+    if is_span_record(value) {
+        return false;
+    }
+
+    attr_str(attributes, "event.name") == Some("gen_ai.client.inference.operation.details")
+        || record_body(value).is_some_and(|body| body.starts_with("GenAI inference:"))
+}
+
+fn is_agent_turn_log_record(value: &Value, attributes: &Map<String, Value>) -> bool {
+    if is_span_record(value) {
+        return false;
+    }
+
+    attr_str(attributes, "event.name") == Some("copilot_chat.agent.turn")
+        || record_body(value).is_some_and(|body| body.starts_with("copilot_chat.agent.turn"))
+}
+
+fn is_span_record(value: &Value) -> bool {
+    match value.get("type").and_then(Value::as_str) {
+        Some("span") => return true,
+        Some(_) => return false,
+        None => {}
+    }
+
+    let has_name = value.get("name").and_then(Value::as_str).is_some();
+    let has_span_identity = value.get("spanId").and_then(Value::as_str).is_some()
+        || value.get("traceId").and_then(Value::as_str).is_some();
+    let has_span_timing = value.get("startTime").is_some()
+        || value.get("endTime").is_some()
+        || value.get("duration").is_some();
+
+    has_name && (has_span_identity || has_span_timing || value.get("kind").is_some())
+}
+
+fn trace_id_from_record(value: &Value) -> Option<&str> {
+    value.get("traceId").and_then(Value::as_str).or_else(|| {
+        value
+            .get("spanContext")
+            .and_then(Value::as_object)
+            .and_then(|context| context.get("traceId"))
+            .and_then(Value::as_str)
+    })
+}
+
+fn span_id_from_record(value: &Value) -> Option<&str> {
+    value.get("spanId").and_then(Value::as_str).or_else(|| {
+        value
+            .get("spanContext")
+            .and_then(Value::as_object)
+            .and_then(|context| context.get("spanId"))
+            .and_then(Value::as_str)
+    })
+}
+
+fn dedup_key_for_record(
+    source: CopilotUsageSource,
+    record: &Value,
+    attributes: &Map<String, Value>,
+    trace_id: Option<&str>,
+    session_id: &str,
+    timestamp_ms: i64,
+    index: usize,
+) -> String {
+    let span_id = span_id_from_record(record);
+
+    match source {
+        CopilotUsageSource::ChatSpan | CopilotUsageSource::AgentSummarySpan => {
+            match (trace_id, span_id) {
+                (Some(trace_id), Some(span_id)) => format!("{trace_id}:{span_id}"),
+                _ => format!("span:{session_id}:{timestamp_ms}:{index}"),
+            }
+        }
+        CopilotUsageSource::InferenceLog => match (trace_id, span_id) {
+            (Some(trace_id), Some(span_id)) => format!("log:{trace_id}:{span_id}"),
+            _ => format!("log:{session_id}:{timestamp_ms}:{index}"),
+        },
+        CopilotUsageSource::AgentTurnLog => {
+            let turn_index = attr_i64_first(attributes, &["turn.index", "copilot_chat.turn.index"]);
+            if let Some(trace_id) = trace_id {
+                format!("agent-turn:{trace_id}:{turn_index}")
+            } else {
+                format!("agent-turn:{session_id}:{turn_index}:{index}")
+            }
+        }
+    }
+}
+
+fn attr_str<'a>(attributes: &'a Map<String, Value>, key: &str) -> Option<&'a str> {
+    attributes.get(key).and_then(Value::as_str)
+}
+
 fn attr_i64(attributes: &Map<String, Value>, key: &str) -> i64 {
     attributes
         .get(key)
         .and_then(value_as_i64)
         .unwrap_or(0)
         .max(0)
+}
+
+fn attr_i64_first(attributes: &Map<String, Value>, keys: &[&str]) -> i64 {
+    keys.iter()
+        .map(|key| attr_i64(attributes, key))
+        .find(|value| *value > 0)
+        .unwrap_or(0)
 }
 
 fn normalize_input_tokens(
@@ -167,6 +492,27 @@ fn first_non_empty_attr<'a>(attributes: &'a Map<String, Value>, keys: &[&str]) -
         .find(|value| !value.trim().is_empty())
 }
 
+fn best_session_attr(attributes: &Map<String, Value>) -> Option<(&str, SessionIdPriority)> {
+    SESSION_ATTRS
+        .iter()
+        .filter_map(|(key, priority)| {
+            let value = attributes.get(*key).and_then(Value::as_str)?;
+            if value.trim().is_empty() {
+                return None;
+            }
+
+            Some((value, *priority))
+        })
+        .max_by_key(|(_, priority)| *priority)
+}
+
+fn record_body(value: &Value) -> Option<&str> {
+    value
+        .get("body")
+        .and_then(Value::as_str)
+        .or_else(|| value.get("_body").and_then(Value::as_str))
+}
+
 fn value_as_i64(value: &Value) -> Option<i64> {
     value
         .as_i64()
@@ -175,11 +521,46 @@ fn value_as_i64(value: &Value) -> Option<i64> {
         .or_else(|| value.as_str().and_then(|value| value.parse::<i64>().ok()))
 }
 
+fn timestamp_ms_from_record(value: &Value) -> Option<i64> {
+    value
+        .get("endTime")
+        .and_then(timestamp_ms_from_value)
+        .or_else(|| value.get("startTime").and_then(timestamp_ms_from_value))
+        .or_else(|| value.get("hrTime").and_then(timestamp_ms_from_value))
+        .or_else(|| value.get("_hrTime").and_then(timestamp_ms_from_value))
+        .or_else(|| value.get("time").and_then(timestamp_ms_from_value))
+        .or_else(|| value.get("timestamp").and_then(timestamp_ms_from_scalar))
+        .or_else(|| {
+            value
+                .get("observedTimestamp")
+                .and_then(timestamp_ms_from_scalar)
+        })
+        .or_else(|| {
+            value
+                .get("timeUnixNano")
+                .and_then(timestamp_ms_from_unix_nanos)
+        })
+}
+
 fn timestamp_ms_from_value(value: &Value) -> Option<i64> {
     let parts = value.as_array()?;
     let seconds = parts.first().and_then(value_as_i64)?;
     let nanos = parts.get(1).and_then(value_as_i64)?;
     Some(seconds.saturating_mul(1000) + nanos / 1_000_000)
+}
+
+fn timestamp_ms_from_scalar(value: &Value) -> Option<i64> {
+    let raw = value_as_i64(value)?;
+    Some(match raw.abs() {
+        100_000_000_000_000_000.. => raw / 1_000_000,
+        100_000_000_000_000.. => raw / 1_000,
+        100_000_000_000.. => raw,
+        _ => raw.saturating_mul(1000),
+    })
+}
+
+fn timestamp_ms_from_unix_nanos(value: &Value) -> Option<i64> {
+    value_as_i64(value).map(|raw| raw / 1_000_000)
 }
 
 #[cfg(test)]
@@ -297,5 +678,99 @@ mod tests {
         assert_eq!(messages[0].tokens.input, 0);
         assert_eq!(messages[0].tokens.cache_read, 50);
         assert_eq!(messages[0].tokens.cache_write, 0);
+    }
+
+    #[test]
+    fn test_parse_copilot_vscode_chat_span_without_type() {
+        let content = r#"{"resource":{"attributes":{"service.name":"copilot-chat"}},"instrumentationScope":{"name":"copilot-chat","version":"0.44.0"},"traceId":"trace-vscode","spanId":"span-vscode","name":"chat claude-sonnet-4.5","kind":2,"endTime":[1775934264,967317833],"attributes":{"gen_ai.operation.name":"chat","gen_ai.provider.name":"github","gen_ai.request.model":"claude-sonnet-4.5","gen_ai.response.model":"claude-sonnet-4.5","gen_ai.conversation.id":"conv-vscode","gen_ai.usage.input_tokens":1000,"gen_ai.usage.output_tokens":50,"gen_ai.usage.cache_read.input_tokens":200,"gen_ai.usage.cache_creation.input_tokens":75,"gen_ai.usage.reasoning_tokens":12}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "claude-sonnet-4.5");
+        assert_eq!(messages[0].provider_id, "anthropic");
+        assert_eq!(messages[0].session_id, "conv-vscode");
+        assert_eq!(messages[0].tokens.input, 800);
+        assert_eq!(messages[0].tokens.output, 50);
+        assert_eq!(messages[0].tokens.cache_read, 200);
+        assert_eq!(messages[0].tokens.cache_write, 75);
+        assert_eq!(messages[0].tokens.reasoning, 12);
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some("trace-vscode:span-vscode")
+        );
+    }
+
+    #[test]
+    fn test_parse_copilot_vscode_inference_log_when_span_is_unavailable() {
+        let content = r#"{"hrTime":[1775934264,967317833],"spanContext":{"traceId":"trace-log","spanId":"span-log","traceFlags":1},"instrumentationScope":{"name":"copilot-chat","version":"0.44.0"},"attributes":{"event.name":"gen_ai.client.inference.operation.details","gen_ai.operation.name":"chat","gen_ai.request.model":"gpt-5.4-mini","gen_ai.response.model":"gpt-5.4-mini","gen_ai.response.id":"response-log","gen_ai.usage.input_tokens":42,"gen_ai.usage.output_tokens":7},"_body":"GenAI inference: gpt-5.4-mini"}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gpt-5.4-mini");
+        assert_eq!(messages[0].session_id, "response-log");
+        assert_eq!(messages[0].tokens.input, 42);
+        assert_eq!(messages[0].tokens.output, 7);
+        assert_eq!(messages[0].timestamp, 1_775_934_264_967);
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some("log:trace-log:span-log")
+        );
+    }
+
+    #[test]
+    fn test_parse_copilot_prefers_chat_spans_over_agent_summary() {
+        let content = r#"{"traceId":"trace-dupe","spanId":"agent-1","name":"invoke_agent GitHub Copilot Chat","endTime":[1775934270,0],"attributes":{"gen_ai.operation.name":"invoke_agent","gen_ai.response.model":"gpt-5.4-mini","gen_ai.conversation.id":"conv-dupe","gen_ai.usage.input_tokens":100,"gen_ai.usage.output_tokens":30}}
+{"traceId":"trace-dupe","spanId":"chat-1","name":"chat gpt-5.4-mini","endTime":[1775934264,967317833],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.conversation.id":"conv-dupe","gen_ai.usage.input_tokens":60,"gen_ai.usage.output_tokens":10}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].dedup_key.as_deref(), Some("trace-dupe:chat-1"));
+        assert_eq!(messages[0].tokens.input, 60);
+        assert_eq!(messages[0].tokens.output, 10);
+    }
+
+    #[test]
+    fn test_parse_copilot_agent_turn_log_uses_trace_context_as_last_resort() {
+        let content = r#"{"hrTime":[1775934260,0],"spanContext":{"traceId":"trace-turn","spanId":"session-log","traceFlags":1},"attributes":{"event.name":"copilot_chat.session.start","session.id":"conv-turn","gen_ai.request.model":"claude-sonnet-4.5"},"_body":"copilot_chat.session.start"}
+{"hrTime":[1775934264,967317833],"spanContext":{"traceId":"trace-turn","spanId":"turn-log","traceFlags":1},"attributes":{"event.name":"copilot_chat.agent.turn","turn.index":3,"gen_ai.usage.input_tokens":120,"gen_ai.usage.output_tokens":9},"_body":"copilot_chat.agent.turn: 3"}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "claude-sonnet-4.5");
+        assert_eq!(messages[0].session_id, "conv-turn");
+        assert_eq!(messages[0].tokens.input, 120);
+        assert_eq!(messages[0].tokens.output, 9);
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some("agent-turn:trace-turn:3")
+        );
+    }
+
+    #[test]
+    fn test_parse_copilot_trace_context_prefers_session_id_over_response_id() {
+        let content = r#"{"hrTime":[1775934260,0],"spanContext":{"traceId":"trace-session-upgrade","spanId":"response-log","traceFlags":1},"attributes":{"event.name":"gen_ai.client.inference.operation.details","gen_ai.response.id":"response-scoped-id","gen_ai.request.model":"claude-sonnet-4.5"},"_body":"GenAI inference: claude-sonnet-4.5"}
+{"hrTime":[1775934261,0],"spanContext":{"traceId":"trace-session-upgrade","spanId":"session-log","traceFlags":1},"attributes":{"event.name":"copilot_chat.session.start","session.id":"durable-session-id"},"_body":"copilot_chat.session.start"}
+{"hrTime":[1775934264,967317833],"spanContext":{"traceId":"trace-session-upgrade","spanId":"turn-log","traceFlags":1},"attributes":{"event.name":"copilot_chat.agent.turn","turn.index":4,"gen_ai.usage.input_tokens":120,"gen_ai.usage.output_tokens":9},"_body":"copilot_chat.agent.turn: 4"}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "claude-sonnet-4.5");
+        assert_eq!(messages[0].session_id, "durable-session-id");
+        assert_eq!(messages[0].tokens.input, 120);
+        assert_eq!(messages[0].tokens.output, 9);
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some("agent-turn:trace-session-upgrade:4")
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Parse GitHub Copilot VS Code OTel exports that do not include `type: "span"` records.
- Add support for VS Code Copilot Chat inference log records and agent-turn fallback records.
- Keep aggregate `invoke_agent` spans as a fallback only, so detailed chat/inference records are not double-counted.

## Why
VS Code-created Copilot OTel JSONL files can contain usage-bearing records without the CLI-style span shape. In that format, the current parser can ignore the entire file even though token usage is present.

Fixes #430.

## Implementation Notes
- Keeps the existing Copilot CLI chat-span path working.
- Infers trace-level model/session context before parsing usage records, so model-less agent-turn records can still be attributed correctly when the surrounding trace contains the context.
- Supports VS Code token aliases such as `gen_ai.usage.cache_creation.input_tokens` and `gen_ai.usage.reasoning_tokens`.
- Uses source-priority filtering to prefer detailed chat spans, then inference logs, then agent-turn logs, and only then aggregate agent summary spans.
- Preserves stable deduplication keys across span, log, and agent-turn record shapes.

## Validation
- `cargo test -p tokscale-core copilot` — PASS, 14 passed.
- `cargo clippy -p tokscale-core --all-features -- -D warnings` — PASS.
- `cargo fmt --all -- --check` — PASS.
- `git diff --check origin/main...HEAD` — PASS, no output.
- `rg -n --pcre2 "\\p{Cyrillic}" crates/tokscale-core/src/sessions/copilot.rs` — PASS, no matches.

## Branch Proof
- Base: `origin/main` at `3a7297d313e753e100c0489399821eeb9b271874`.
- Head: `284be886bedf1a82d6099c48c5cc2edaf0cc6210`.
- Ahead/behind: `0 1` from `git rev-list --left-right --count origin/main...HEAD`.
- Diff scope: `crates/tokscale-core/src/sessions/copilot.rs` only.

## Rollback
Revert the merge commit for this PR. No migration, data repair, or release procedure changes are required.


