### PR TITLE
fix(cursor): sync usage cache before local reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,9 @@ tokscale cursor status
 # List saved Cursor accounts
 tokscale cursor accounts
 
+# Manually refresh cached Cursor usage
+tokscale cursor sync
+
 # Switch active account (controls which account syncs to cursor-cache/usage.csv)
 tokscale cursor switch work
 

--- a/crates/tokscale-cli/src/antigravity.rs
+++ b/crates/tokscale-cli/src/antigravity.rs
@@ -2249,7 +2249,7 @@ mod tests {
         let mut body = Vec::new();
         for _ in 0..5 {
             body.extend_from_slice(format!("{:x}\r\n", chunk_size).as_bytes());
-            body.extend(std::iter::repeat(b'a').take(chunk_size));
+            body.extend(std::iter::repeat_n(b'a', chunk_size));
             body.extend_from_slice(b"\r\n");
         }
         body.extend_from_slice(b"0\r\n\r\n");

--- a/crates/tokscale-cli/src/cursor.rs
+++ b/crates/tokscale-cli/src/cursor.rs
@@ -4,10 +4,26 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 fn home_dir() -> Result<PathBuf> {
     dirs::home_dir().context("Could not determine home directory")
+}
+
+fn cursor_credentials_path(home_dir: &Path) -> PathBuf {
+    home_dir.join(".config/tokscale/cursor-credentials.json")
+}
+
+fn old_cursor_credentials_path(home_dir: &Path) -> PathBuf {
+    home_dir.join(".tokscale/cursor-credentials.json")
+}
+
+fn cursor_cache_dir(home_dir: &Path) -> PathBuf {
+    home_dir.join(".config/tokscale/cursor-cache")
+}
+
+fn old_cursor_cache_dir(home_dir: &Path) -> PathBuf {
+    home_dir.join(".tokscale/cursor-cache")
 }
 
 const USAGE_CSV_ENDPOINT: &str =
@@ -49,7 +65,7 @@ pub struct AccountInfo {
     pub is_active: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct SyncCursorResult {
     pub synced: bool,
     pub rows: usize,
@@ -57,28 +73,16 @@ pub struct SyncCursorResult {
 }
 
 pub fn get_cursor_credentials_path() -> Result<PathBuf> {
-    Ok(home_dir()?.join(".config/tokscale/cursor-credentials.json"))
-}
-
-fn get_old_cursor_credentials_path() -> Result<PathBuf> {
-    Ok(home_dir()?.join(".tokscale/cursor-credentials.json"))
+    Ok(cursor_credentials_path(&home_dir()?))
 }
 
 pub fn get_cursor_cache_dir() -> Result<PathBuf> {
-    Ok(home_dir()?.join(".config/tokscale/cursor-cache"))
+    Ok(cursor_cache_dir(&home_dir()?))
 }
 
-fn get_old_cursor_cache_dir() -> Result<PathBuf> {
-    Ok(home_dir()?.join(".tokscale/cursor-cache"))
-}
-
-fn migrate_cache_dir_from_old_path() {
-    let Ok(old_dir) = get_old_cursor_cache_dir() else {
-        return;
-    };
-    let Ok(new_dir) = get_cursor_cache_dir() else {
-        return;
-    };
+fn migrate_cache_dir_from_old_path_in_home(home_dir: &Path) {
+    let old_dir = old_cursor_cache_dir(home_dir);
+    let new_dir = cursor_cache_dir(home_dir);
     if !new_dir.exists()
         && old_dir.exists()
         && fs::create_dir_all(&new_dir).is_ok()
@@ -193,8 +197,8 @@ fn atomic_write_file(path: &std::path::Path, contents: &str) -> Result<()> {
     Ok(())
 }
 
-fn ensure_config_dir() -> Result<()> {
-    let config_dir = home_dir()?.join(".config/tokscale");
+fn ensure_config_dir_in_home(home_dir: &Path) -> Result<()> {
+    let config_dir = home_dir.join(".config/tokscale");
 
     if !config_dir.exists() {
         fs::create_dir_all(&config_dir)?;
@@ -264,8 +268,13 @@ fn sanitize_account_id_for_filename(account_id: &str) -> String {
 }
 
 pub fn load_credentials_store() -> Option<CursorCredentialsStore> {
-    let path = get_cursor_credentials_path().ok()?;
-    let old_path = get_old_cursor_credentials_path().ok()?;
+    let home_dir = home_dir().ok()?;
+    load_credentials_store_from_home(&home_dir)
+}
+
+fn load_credentials_store_from_home(home_dir: &Path) -> Option<CursorCredentialsStore> {
+    let path = cursor_credentials_path(home_dir);
+    let old_path = old_cursor_credentials_path(home_dir);
     let read_path = if path.exists() {
         path.clone()
     } else if old_path.exists() {
@@ -286,12 +295,10 @@ pub fn load_credentials_store() -> Option<CursorCredentialsStore> {
                 }
             }
             if changed || read_path != path {
-                let _ = save_credentials_store(&store);
+                let _ = save_credentials_store_in_home(home_dir, &store);
             }
             if read_path != path {
-                if let Ok(old) = get_old_cursor_credentials_path() {
-                    let _ = fs::remove_file(old);
-                }
+                let _ = fs::remove_file(old_cursor_credentials_path(home_dir));
             }
             return Some(store);
         }
@@ -307,11 +314,9 @@ pub fn load_credentials_store() -> Option<CursorCredentialsStore> {
             accounts,
         };
 
-        let _ = save_credentials_store(&migrated);
+        let _ = save_credentials_store_in_home(home_dir, &migrated);
         if read_path != path {
-            if let Ok(old) = get_old_cursor_credentials_path() {
-                let _ = fs::remove_file(old);
-            }
+            let _ = fs::remove_file(old_cursor_credentials_path(home_dir));
         }
         return Some(migrated);
     }
@@ -320,8 +325,12 @@ pub fn load_credentials_store() -> Option<CursorCredentialsStore> {
 }
 
 pub fn save_credentials_store(store: &CursorCredentialsStore) -> Result<()> {
-    ensure_config_dir()?;
-    let path = get_cursor_credentials_path()?;
+    save_credentials_store_in_home(&home_dir()?, store)
+}
+
+fn save_credentials_store_in_home(home_dir: &Path, store: &CursorCredentialsStore) -> Result<()> {
+    ensure_config_dir_in_home(home_dir)?;
+    let path = cursor_credentials_path(home_dir);
     let json = serde_json::to_string_pretty(store)?;
     atomic_write_file(&path, &json)?;
 
@@ -607,11 +616,12 @@ fn is_cursor_usage_csv_filename(name: &str) -> bool {
 }
 
 pub fn has_cursor_usage_cache() -> bool {
-    migrate_cache_dir_from_old_path();
-    let cache_dir = match get_cursor_cache_dir() {
-        Ok(d) => d,
+    let home_dir = match home_dir() {
+        Ok(home_dir) => home_dir,
         Err(_) => return false,
     };
+    migrate_cache_dir_from_old_path_in_home(&home_dir);
+    let cache_dir = cursor_cache_dir(&home_dir);
     if !cache_dir.exists() {
         return false;
     }
@@ -746,10 +756,36 @@ pub async fn fetch_cursor_usage_csv(session_token: &str) -> Result<String> {
     Ok(text)
 }
 
-pub async fn sync_cursor_cache() -> SyncCursorResult {
-    migrate_cache_dir_from_old_path();
+async fn sync_cursor_cache_with_fetcher<F, Fut>(fetch_usage_csv: F) -> SyncCursorResult
+where
+    F: Fn(String) -> Fut,
+    Fut: std::future::Future<Output = Result<String>>,
+{
+    let home_dir = match home_dir() {
+        Ok(home_dir) => home_dir,
+        Err(e) => {
+            return SyncCursorResult {
+                synced: false,
+                rows: 0,
+                error: Some(format!("Failed to get home dir: {}", e)),
+            };
+        }
+    };
 
-    let store = match load_credentials_store() {
+    sync_cursor_cache_with_fetcher_in_home(&home_dir, fetch_usage_csv).await
+}
+
+async fn sync_cursor_cache_with_fetcher_in_home<F, Fut>(
+    home_dir: &Path,
+    fetch_usage_csv: F,
+) -> SyncCursorResult
+where
+    F: Fn(String) -> Fut,
+    Fut: std::future::Future<Output = Result<String>>,
+{
+    migrate_cache_dir_from_old_path_in_home(home_dir);
+
+    let store = match load_credentials_store_from_home(home_dir) {
         Some(s) => s,
         None => {
             return SyncCursorResult {
@@ -768,16 +804,7 @@ pub async fn sync_cursor_cache() -> SyncCursorResult {
         };
     }
 
-    let cache_dir = match get_cursor_cache_dir() {
-        Ok(d) => d,
-        Err(e) => {
-            return SyncCursorResult {
-                synced: false,
-                rows: 0,
-                error: Some(format!("Failed to get cache dir: {}", e)),
-            };
-        }
-    };
+    let cache_dir = cursor_cache_dir(home_dir);
     if let Err(e) = fs::create_dir_all(&cache_dir) {
         return SyncCursorResult {
             synced: false,
@@ -806,7 +833,7 @@ pub async fn sync_cursor_cache() -> SyncCursorResult {
     for (account_id, credentials) in &store.accounts {
         let is_active = account_id == &store.active_account_id;
 
-        match fetch_cursor_usage_csv(&credentials.session_token).await {
+        match fetch_usage_csv(credentials.session_token.clone()).await {
             Ok(csv_text) => {
                 let file_path = if is_active {
                     cache_dir.join("usage.csv")
@@ -858,6 +885,13 @@ pub async fn sync_cursor_cache() -> SyncCursorResult {
             ))
         },
     }
+}
+
+pub async fn sync_cursor_cache() -> SyncCursorResult {
+    sync_cursor_cache_with_fetcher(|session_token| async move {
+        fetch_cursor_usage_csv(&session_token).await
+    })
+    .await
 }
 
 fn archive_cache_file(file_path: &std::path::Path, label: &str) -> Result<()> {
@@ -1088,6 +1122,37 @@ pub fn run_cursor_accounts(json: bool) -> Result<()> {
     Ok(())
 }
 
+pub fn run_cursor_sync(json: bool) -> Result<()> {
+    use colored::Colorize;
+    use tokio::runtime::Runtime;
+
+    let rt = Runtime::new()?;
+    let result = rt.block_on(sync_cursor_cache());
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        return Ok(());
+    }
+
+    println!("\n  {}\n", "Cursor IDE - Sync".cyan());
+    if result.synced {
+        println!(
+            "{}",
+            format!("  Synced {} Cursor usage event(s).", result.rows).green()
+        );
+        if let Some(error) = result.error {
+            println!("{}", format!("  Warning: {}", error).yellow());
+        }
+    } else if let Some(error) = result.error {
+        println!("{}", format!("  Sync failed: {}", error).red());
+    } else {
+        println!("{}", "  Sync failed.".red());
+    }
+    println!();
+
+    Ok(())
+}
+
 pub fn run_cursor_switch(name: &str) -> Result<()> {
     use colored::Colorize;
 
@@ -1103,6 +1168,7 @@ pub fn run_cursor_switch(name: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
     use tempfile::TempDir;
 
     #[test]
@@ -1255,6 +1321,74 @@ mod tests {
         // This test verifies the actual behavior: all parseable rows are counted
         let csv = "Date,Model,Tokens\n2024-01-01,gpt-4,100\ninvalid,row\n2024-01-02,gpt-4,200\n";
         assert_eq!(count_cursor_csv_rows(csv), 3);
+    }
+
+    #[test]
+    fn test_sync_cursor_cache_writes_active_and_secondary_account_files() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+
+        let mut accounts = HashMap::new();
+        accounts.insert(
+            "active-account".to_string(),
+            CursorCredentials {
+                session_token: "token-active".to_string(),
+                user_id: Some("active-account".to_string()),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                expires_at: None,
+                label: Some("work".to_string()),
+            },
+        );
+        accounts.insert(
+            "team/account".to_string(),
+            CursorCredentials {
+                session_token: "token-secondary".to_string(),
+                user_id: Some("team/account".to_string()),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                expires_at: None,
+                label: Some("personal".to_string()),
+            },
+        );
+        save_credentials_store_in_home(
+            temp_dir.path(),
+            &CursorCredentialsStore {
+                version: 1,
+                active_account_id: "active-account".to_string(),
+                accounts,
+            },
+        )?;
+
+        let runtime = tokio::runtime::Runtime::new()?;
+        let result = runtime.block_on(sync_cursor_cache_with_fetcher_in_home(
+            temp_dir.path(),
+            |session_token| {
+                let csv = match session_token.as_str() {
+                    "token-active" => "Date,Model,Tokens\n2026-01-01,gpt-5,100\n",
+                    "token-secondary" => {
+                        "Date,Model,Tokens\n2026-01-02,gpt-5,200\n2026-01-03,gpt-5,300\n"
+                    }
+                    _ => "Date,Model,Tokens\n",
+                }
+                .to_string();
+                async move { Ok(csv) }
+            },
+        ));
+
+        assert!(result.synced);
+        assert_eq!(result.rows, 3);
+        assert_eq!(result.error, None);
+
+        let cache_dir = cursor_cache_dir(temp_dir.path());
+        assert_eq!(
+            fs::read_to_string(cache_dir.join("usage.csv"))?,
+            "Date,Model,Tokens\n2026-01-01,gpt-5,100\n"
+        );
+        assert_eq!(
+            fs::read_to_string(cache_dir.join("usage.team-account.csv"))?,
+            "Date,Model,Tokens\n2026-01-02,gpt-5,200\n2026-01-03,gpt-5,300\n"
+        );
+        assert!(!cache_dir.join("usage.active-account.csv").exists());
+
+        Ok(())
     }
 
     #[test]

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -284,6 +284,11 @@ enum CursorSubcommand {
         #[arg(long, help = "Output as JSON")]
         json: bool,
     },
+    #[command(about = "Sync Cursor usage into the local cache")]
+    Sync {
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
+    },
     #[command(about = "Switch active Cursor account")]
     Switch {
         #[arg(help = "Account label or id")]
@@ -357,6 +362,7 @@ fn main() -> Result<()> {
                 )
             } else {
                 ensure_home_supported_for_tui(&cli.home)?;
+                auto_sync_cursor_before_tui(&cli.home, &clients)?;
                 tui::run(
                     &cli.theme,
                     cli.refresh,
@@ -399,6 +405,7 @@ fn main() -> Result<()> {
                 )
             } else {
                 ensure_home_supported_for_tui(&cli.home)?;
+                auto_sync_cursor_before_tui(&cli.home, &clients)?;
                 tui::run(
                     &cli.theme,
                     cli.refresh,
@@ -441,6 +448,7 @@ fn main() -> Result<()> {
                 )
             } else {
                 ensure_home_supported_for_tui(&cli.home)?;
+                auto_sync_cursor_before_tui(&cli.home, &clients)?;
                 tui::run(
                     &cli.theme,
                     cli.refresh,
@@ -510,6 +518,7 @@ fn main() -> Result<()> {
             let (since, until) = build_date_filter(today, week, month, date.since, date.until);
             let year = normalize_year_filter(today, week, month, date.year);
             let clients = build_client_filter(clients);
+            auto_sync_cursor_before_tui(&cli.home, &clients)?;
             tui::run(
                 &cli.theme,
                 cli.refresh,
@@ -634,6 +643,7 @@ fn main() -> Result<()> {
                 )
             } else {
                 ensure_home_supported_for_tui(&cli.home)?;
+                auto_sync_cursor_before_tui(&cli.home, &clients)?;
                 tui::run(
                     &cli.theme,
                     cli.refresh,
@@ -1006,6 +1016,96 @@ fn emit_legacy_client_flag_warning(used: &[&'static str]) {
     );
 }
 
+fn client_filter_includes_cursor(clients: &Option<Vec<String>>) -> bool {
+    clients
+        .as_ref()
+        .is_none_or(|sources| sources.iter().any(|source| source == "cursor"))
+}
+
+fn client_filter_explicitly_requests_cursor(clients: &Option<Vec<String>>) -> bool {
+    clients
+        .as_ref()
+        .is_some_and(|sources| sources.iter().any(|source| source == "cursor"))
+}
+
+fn should_auto_sync_cursor_for_local_report(
+    home_dir: &Option<String>,
+    clients: &Option<Vec<String>>,
+) -> bool {
+    home_dir.is_none() && client_filter_includes_cursor(clients)
+}
+
+fn auto_sync_cursor_for_local_report(
+    home_dir: &Option<String>,
+    clients: &Option<Vec<String>>,
+) -> Option<cursor::SyncCursorResult> {
+    if !should_auto_sync_cursor_for_local_report(home_dir, clients)
+        || !cursor::is_cursor_logged_in()
+    {
+        return None;
+    }
+
+    Some(run_best_effort_cursor_sync_with_runtime_factory(
+        tokio::runtime::Runtime::new,
+    ))
+}
+
+fn run_best_effort_cursor_sync_with_runtime_factory<F>(build_runtime: F) -> cursor::SyncCursorResult
+where
+    F: FnOnce() -> std::io::Result<tokio::runtime::Runtime>,
+{
+    match build_runtime() {
+        Ok(rt) => rt.block_on(async { cursor::sync_cursor_cache().await }),
+        Err(error) => cursor::SyncCursorResult {
+            synced: false,
+            rows: 0,
+            error: Some(format!(
+                "Failed to initialize Cursor sync runtime: {}",
+                error
+            )),
+        },
+    }
+}
+
+fn auto_sync_cursor_before_tui(
+    home_dir: &Option<String>,
+    clients: &Option<Vec<String>>,
+) -> Result<()> {
+    let had_cursor_cache = cursor::has_cursor_usage_cache();
+    let explicit_cursor_filter = client_filter_explicitly_requests_cursor(clients);
+    let cursor_sync_result = auto_sync_cursor_for_local_report(home_dir, clients);
+    emit_cursor_sync_warning(
+        cursor_sync_result.as_ref(),
+        had_cursor_cache,
+        explicit_cursor_filter,
+    );
+    Ok(())
+}
+
+fn emit_cursor_sync_warning(
+    sync: Option<&cursor::SyncCursorResult>,
+    had_cursor_cache: bool,
+    explicit_cursor_filter: bool,
+) {
+    let Some(sync) = sync else {
+        return;
+    };
+    let Some(error) = sync.error.as_ref() else {
+        return;
+    };
+    if sync.synced || had_cursor_cache || explicit_cursor_filter {
+        use colored::Colorize;
+        let prefix = if sync.synced {
+            "Cursor sync warning"
+        } else if had_cursor_cache {
+            "Cursor sync failed; using cached data"
+        } else {
+            "Cursor sync failed"
+        };
+        eprintln!("{}", format!("  {}: {}", prefix, error).yellow());
+    }
+}
+
 fn default_submit_clients() -> Vec<String> {
     let mut clients: Vec<String> = tokscale_core::ClientId::iter()
         .filter(|client| client.submit_default())
@@ -1293,11 +1393,14 @@ fn run_models_report(
 
     let date_range = get_date_range_label(today, week, month_flag, &since, &until, &year);
 
+    let had_cursor_cache = cursor::has_cursor_usage_cache();
+    let explicit_cursor_filter = client_filter_explicitly_requests_cursor(&clients);
     let spinner = if no_spinner {
         None
     } else {
         Some(LightSpinner::start("Scanning session data..."))
     };
+    let cursor_sync_result = auto_sync_cursor_for_local_report(&home_dir, &clients);
     let use_env_roots = use_env_roots(&home_dir);
     let start = Instant::now();
     let rt = Runtime::new()?;
@@ -1320,6 +1423,11 @@ fn run_models_report(
     if let Some(spinner) = spinner {
         spinner.stop();
     }
+    emit_cursor_sync_warning(
+        cursor_sync_result.as_ref(),
+        had_cursor_cache,
+        explicit_cursor_filter,
+    );
 
     let processing_time_ms = start.elapsed().as_millis();
 
@@ -1851,11 +1959,14 @@ fn run_monthly_report(
 
     let date_range = get_date_range_label(today, week, month_flag, &since, &until, &year);
 
+    let had_cursor_cache = cursor::has_cursor_usage_cache();
+    let explicit_cursor_filter = client_filter_explicitly_requests_cursor(&clients);
     let spinner = if no_spinner {
         None
     } else {
         Some(LightSpinner::start("Scanning session data..."))
     };
+    let cursor_sync_result = auto_sync_cursor_for_local_report(&home_dir, &clients);
     let use_env_roots = use_env_roots(&home_dir);
     let start = Instant::now();
     let rt = Runtime::new()?;
@@ -1878,6 +1989,11 @@ fn run_monthly_report(
     if let Some(spinner) = spinner {
         spinner.stop();
     }
+    emit_cursor_sync_warning(
+        cursor_sync_result.as_ref(),
+        had_cursor_cache,
+        explicit_cursor_filter,
+    );
 
     let processing_time_ms = start.elapsed().as_millis();
 
@@ -2137,11 +2253,14 @@ fn run_hourly_report(
 
     let date_range = get_date_range_label(today, week, month_flag, &since, &until, &year);
 
+    let had_cursor_cache = cursor::has_cursor_usage_cache();
+    let explicit_cursor_filter = client_filter_explicitly_requests_cursor(&clients);
     let spinner = if no_spinner {
         None
     } else {
         Some(LightSpinner::start("Scanning session data..."))
     };
+    let cursor_sync_result = auto_sync_cursor_for_local_report(&home_dir, &clients);
     let use_env_roots = use_env_roots(&home_dir);
     let start = Instant::now();
     let rt = Runtime::new()?;
@@ -2164,6 +2283,11 @@ fn run_hourly_report(
     if let Some(spinner) = spinner {
         spinner.stop();
     }
+    emit_cursor_sync_warning(
+        cursor_sync_result.as_ref(),
+        had_cursor_cache,
+        explicit_cursor_filter,
+    );
 
     let processing_time_ms = start.elapsed().as_millis();
 
@@ -4097,6 +4221,7 @@ fn run_cursor_command(subcommand: CursorSubcommand) -> Result<()> {
         } => cursor::run_cursor_logout(name, all, purge_cache),
         CursorSubcommand::Status { name } => cursor::run_cursor_status(name),
         CursorSubcommand::Accounts { json } => cursor::run_cursor_accounts(json),
+        CursorSubcommand::Sync { json } => cursor::run_cursor_sync(json),
         CursorSubcommand::Switch { name } => cursor::run_cursor_switch(&name),
     }
 }
@@ -5518,6 +5643,59 @@ mod tests {
     #[test]
     fn clap_accepts_models_light_write_cache_after_subcommand() {
         assert!(Cli::try_parse_from(["tokscale", "models", "--light", "--write-cache"]).is_ok());
+    }
+
+    #[test]
+    fn clap_accepts_cursor_sync_command() {
+        assert!(Cli::try_parse_from(["tokscale", "cursor", "sync"]).is_ok());
+        assert!(Cli::try_parse_from(["tokscale", "cursor", "sync", "--json"]).is_ok());
+    }
+
+    #[test]
+    fn cursor_auto_sync_enabled_for_default_report() {
+        assert!(should_auto_sync_cursor_for_local_report(&None, &None));
+    }
+
+    #[test]
+    fn cursor_auto_sync_enabled_when_cursor_filter_is_explicit() {
+        assert!(should_auto_sync_cursor_for_local_report(
+            &None,
+            &Some(vec!["cursor".to_string()])
+        ));
+    }
+
+    #[test]
+    fn cursor_auto_sync_disabled_when_filter_excludes_cursor() {
+        assert!(!should_auto_sync_cursor_for_local_report(
+            &None,
+            &Some(vec!["codex".to_string()])
+        ));
+    }
+
+    #[test]
+    fn cursor_auto_sync_disabled_for_home_override() {
+        assert!(!should_auto_sync_cursor_for_local_report(
+            &Some("/tmp/other-home".to_string()),
+            &None
+        ));
+        assert!(!should_auto_sync_cursor_for_local_report(
+            &Some("/tmp/other-home".to_string()),
+            &Some(vec!["cursor".to_string()])
+        ));
+    }
+
+    #[test]
+    fn cursor_auto_sync_runtime_init_failure_is_best_effort() {
+        let result = run_best_effort_cursor_sync_with_runtime_factory(|| {
+            Err(std::io::Error::other("runtime unavailable"))
+        });
+
+        assert!(!result.synced);
+        assert_eq!(result.rows, 0);
+        assert!(result
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("runtime unavailable")));
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/mod.rs
+++ b/crates/tokscale-cli/src/tui/mod.rs
@@ -190,28 +190,6 @@ pub fn run(
     result
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn launches_with_24h_old_cache_renders_immediately() {
-        let (cached_data, needs_background_load) =
-            decide_initial_data(CacheResult::Stale(UsageData::default()));
-
-        assert!(cached_data.is_some());
-        assert!(needs_background_load);
-    }
-
-    #[test]
-    fn miss_renders_empty_until_background_completes() {
-        let (cached_data, needs_background_load) = decide_initial_data(CacheResult::Miss);
-
-        assert!(cached_data.is_none());
-        assert!(needs_background_load);
-    }
-}
-
 fn restore_terminal_best_effort() {
     let _ = execute!(
         io::stdout(),
@@ -372,4 +350,26 @@ pub fn test_data_loading() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn launches_with_24h_old_cache_renders_immediately() {
+        let (cached_data, needs_background_load) =
+            decide_initial_data(CacheResult::Stale(UsageData::default()));
+
+        assert!(cached_data.is_some());
+        assert!(needs_background_load);
+    }
+
+    #[test]
+    fn miss_renders_empty_until_background_completes() {
+        let (cached_data, needs_background_load) = decide_initial_data(CacheResult::Miss);
+
+        assert!(cached_data.is_none());
+        assert!(needs_background_load);
+    }
 }


### PR DESCRIPTION
## Summary
- Refresh Cursor usage before local `models`, `monthly`, `hourly`, and TUI reports when the default home is used and Cursor is included in the selected clients.
- Add `tokscale cursor sync` with optional `--json` output for manual cache refreshes.
- Add tests for auto-sync gating and active/secondary account cache writes.

## Why
Fixes #479. After `tokscale cursor login`, local reports could still omit Cursor usage until another command happened to refresh `cursor-cache`.

## Diff scope
- `crates/tokscale-cli/src/cursor.rs`: testable sync helper, manual sync command, JSON result support.
- `crates/tokscale-cli/src/main.rs`: local-report/TUI auto-sync wiring with client-filter and `--home` guards.
- `README.md`: documents the manual sync command.
- `crates/tokscale-cli/src/antigravity.rs` and `crates/tokscale-cli/src/tui/mod.rs`: minimal clippy hygiene required by the current workspace lint command.

## Safety
- Does not auto-sync when `--home` is set.
- Does not auto-sync when the client filter excludes Cursor.
- Keeps using existing cached data if refresh fails, with warnings only when the user can act on them.
- No migrations or persistent storage format changes.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p tokscale-cli cursor -- --nocapture`
- `cargo test -p tokscale-cli`
- `cargo test --workspace --all-features`
- `/opt/homebrew/bin/cargo-clippy clippy --workspace --all-features -- -D warnings`


