### PR TITLE
fix(copilot): harden VS Code OTel parser against trace-id collisions

### DIFF
--- a/crates/tokscale-core/src/sessions/copilot.rs
+++ b/crates/tokscale-core/src/sessions/copilot.rs
@@ -288,7 +288,7 @@ fn candidate_contexts(
 ) -> HashSet<String> {
     candidates
         .iter()
-        .filter(|candidate| candidate.source == source)
+        .filter(|candidate| candidate.source == source && candidate.trace_id.is_some())
         .map(|candidate| candidate.context_key().to_string())
         .collect()
 }
@@ -299,6 +299,14 @@ fn should_emit_candidate(
     inference_contexts: &HashSet<String>,
     agent_turn_contexts: &HashSet<String>,
 ) -> bool {
+    // Cross-source priority filtering only applies within a known OTel trace.
+    // Records lacking a trace_id cannot be reliably grouped (their session_id
+    // fallback can collide with unrelated records), so emit them unconditionally
+    // and rely on per-record dedup keys to suppress true duplicates.
+    if candidate.trace_id.is_none() {
+        return true;
+    }
+
     let context_key = candidate.context_key();
 
     match candidate.source {
@@ -377,6 +385,12 @@ fn is_agent_turn_log_record(value: &Value, attributes: &Map<String, Value>) -> b
 }
 
 fn is_span_record(value: &Value) -> bool {
+    // VS Code Copilot Chat exports omit `type: "span"`, so when `type` is absent
+    // we infer span-ness from a top-level `name` plus span identity (spanId or
+    // traceId), span timing, or `kind`. This is intentionally permissive for
+    // VS Code support. Inference-log and agent-turn-log records do NOT carry a
+    // top-level `name` field — that is the property that disambiguates them
+    // here. If a future record shape adds a top-level `name`, revisit this.
     match value.get("type").and_then(Value::as_str) {
         Some("span") => return true,
         Some(_) => return false,
@@ -436,11 +450,19 @@ fn dedup_key_for_record(
             _ => format!("log:{session_id}:{timestamp_ms}:{index}"),
         },
         CopilotUsageSource::AgentTurnLog => {
-            let turn_index = attr_i64_first(attributes, &["turn.index", "copilot_chat.turn.index"]);
+            // When the record actually carries a turn.index, use it so the key
+            // is stable across re-runs. Otherwise fall back to the line index
+            // so two turn-less agent-turn records in the same trace do not
+            // collide on a `0` sentinel.
+            let turn_part = ["turn.index", "copilot_chat.turn.index"]
+                .iter()
+                .find_map(|key| attributes.get(*key).and_then(value_as_i64))
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| format!("idx-{index}"));
             if let Some(trace_id) = trace_id {
-                format!("agent-turn:{trace_id}:{turn_index}")
+                format!("agent-turn:{trace_id}:{turn_part}")
             } else {
-                format!("agent-turn:{session_id}:{turn_index}:{index}")
+                format!("agent-turn:{session_id}:{turn_part}:{index}")
             }
         }
     }
@@ -752,6 +774,81 @@ mod tests {
             messages[0].dedup_key.as_deref(),
             Some("agent-turn:trace-turn:3")
         );
+    }
+
+    #[test]
+    fn test_parse_copilot_prefers_chat_span_over_agent_turn_in_same_trace() {
+        let content = r#"{"type":"span","traceId":"trace-mix","spanId":"chat-mix","name":"chat gpt-5.4-mini","endTime":[1775934264,967317833],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.conversation.id":"conv-mix","gen_ai.usage.input_tokens":50,"gen_ai.usage.output_tokens":8}}
+{"hrTime":[1775934265,0],"spanContext":{"traceId":"trace-mix","spanId":"turn-mix","traceFlags":1},"attributes":{"event.name":"copilot_chat.agent.turn","turn.index":1,"gen_ai.usage.input_tokens":50,"gen_ai.usage.output_tokens":8},"_body":"copilot_chat.agent.turn: 1"}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].dedup_key.as_deref(), Some("trace-mix:chat-mix"));
+        assert_eq!(messages[0].tokens.input, 50);
+        assert_eq!(messages[0].tokens.output, 8);
+    }
+
+    #[test]
+    fn test_parse_copilot_traceless_records_do_not_cross_suppress() {
+        // Two unrelated records that both lack a trace_id must not suppress
+        // each other via session_id collision in the cross-source priority
+        // filter. Here the chat span and inference log share gen_ai.response.id
+        // (used as the session fallback) but are independent records.
+        let content = r#"{"type":"span","spanId":"chat-traceless","name":"chat gpt-5.4-mini","endTime":[1775934260,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.response.id":"shared-resp","gen_ai.usage.input_tokens":11,"gen_ai.usage.output_tokens":3}}
+{"hrTime":[1775934262,0],"attributes":{"event.name":"gen_ai.client.inference.operation.details","gen_ai.request.model":"gpt-5.4-mini","gen_ai.response.model":"gpt-5.4-mini","gen_ai.response.id":"shared-resp","gen_ai.usage.input_tokens":22,"gen_ai.usage.output_tokens":4},"_body":"GenAI inference: gpt-5.4-mini"}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 2);
+        let total_input: i64 = messages.iter().map(|m| m.tokens.input).sum();
+        let total_output: i64 = messages.iter().map(|m| m.tokens.output).sum();
+        assert_eq!(total_input, 33);
+        assert_eq!(total_output, 7);
+    }
+
+    #[test]
+    fn test_parse_copilot_agent_turn_log_without_turn_index_uses_line_index() {
+        // Two agent-turn records in the same trace with no turn.index attribute
+        // must produce distinct dedup keys (no `0` sentinel collision).
+        let content = r#"{"hrTime":[1775934260,0],"spanContext":{"traceId":"trace-noidx","spanId":"turn-a","traceFlags":1},"attributes":{"event.name":"copilot_chat.agent.turn","gen_ai.request.model":"gpt-5.4-mini","gen_ai.usage.input_tokens":10,"gen_ai.usage.output_tokens":2},"_body":"copilot_chat.agent.turn"}
+{"hrTime":[1775934261,0],"spanContext":{"traceId":"trace-noidx","spanId":"turn-b","traceFlags":1},"attributes":{"event.name":"copilot_chat.agent.turn","gen_ai.request.model":"gpt-5.4-mini","gen_ai.usage.input_tokens":11,"gen_ai.usage.output_tokens":3},"_body":"copilot_chat.agent.turn"}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 2);
+        let mut keys: Vec<String> = messages
+            .iter()
+            .filter_map(|m| m.dedup_key.clone())
+            .collect();
+        keys.sort();
+        assert_eq!(keys.len(), 2);
+        assert_ne!(keys[0], keys[1], "dedup keys must be unique: {keys:?}");
+    }
+
+    #[test]
+    fn test_parse_copilot_inference_log_uses_time_unix_nano_timestamp() {
+        let content = r#"{"timeUnixNano":1775934264967317833,"spanContext":{"traceId":"trace-nano","spanId":"span-nano","traceFlags":1},"attributes":{"event.name":"gen_ai.client.inference.operation.details","gen_ai.response.model":"gpt-5.4-mini","gen_ai.response.id":"resp-nano","gen_ai.usage.input_tokens":5,"gen_ai.usage.output_tokens":2},"_body":"GenAI inference: gpt-5.4-mini"}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].timestamp, 1_775_934_264_967);
+    }
+
+    #[test]
+    fn test_parse_copilot_agent_turn_log_uses_scalar_timestamp() {
+        let content = r#"{"timestamp":1775934264967,"spanContext":{"traceId":"trace-ts","spanId":"turn-ts","traceFlags":1},"attributes":{"event.name":"copilot_chat.agent.turn","turn.index":2,"gen_ai.request.model":"gpt-5.4-mini","gen_ai.usage.input_tokens":7,"gen_ai.usage.output_tokens":1},"_body":"copilot_chat.agent.turn: 2"}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].timestamp, 1_775_934_264_967);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/copilot.rs
+++ b/crates/tokscale-core/src/sessions/copilot.rs
@@ -46,18 +46,26 @@ pub fn parse_copilot_file(path: &Path) -> Vec<UnifiedMessage> {
         })
         .collect();
 
-    let chat_contexts = candidate_contexts(&candidates, CopilotUsageSource::ChatSpan);
-    let inference_contexts = candidate_contexts(&candidates, CopilotUsageSource::InferenceLog);
-    let agent_turn_contexts = candidate_contexts(&candidates, CopilotUsageSource::AgentTurnLog);
+    let chat_traces = candidate_trace_contexts(&candidates, CopilotUsageSource::ChatSpan);
+    let inference_traces = candidate_trace_contexts(&candidates, CopilotUsageSource::InferenceLog);
+    let agent_turn_traces = candidate_trace_contexts(&candidates, CopilotUsageSource::AgentTurnLog);
+    let chat_response_ids = candidate_response_ids(&candidates, CopilotUsageSource::ChatSpan);
+    let inference_response_ids =
+        candidate_response_ids(&candidates, CopilotUsageSource::InferenceLog);
+    let agent_turn_response_ids =
+        candidate_response_ids(&candidates, CopilotUsageSource::AgentTurnLog);
 
     candidates
         .into_iter()
         .filter(|candidate| {
             should_emit_candidate(
                 candidate,
-                &chat_contexts,
-                &inference_contexts,
-                &agent_turn_contexts,
+                &chat_traces,
+                &inference_traces,
+                &agent_turn_traces,
+                &chat_response_ids,
+                &inference_response_ids,
+                &agent_turn_response_ids,
             )
         })
         .map(CopilotUsageCandidate::into_message)
@@ -81,6 +89,7 @@ struct TraceContext {
 struct CopilotUsageCandidate {
     source: CopilotUsageSource,
     trace_id: Option<String>,
+    response_id: Option<String>,
     model: String,
     provider_id: String,
     session_id: String,
@@ -98,10 +107,6 @@ enum SessionIdPriority {
 }
 
 impl CopilotUsageCandidate {
-    fn context_key(&self) -> &str {
-        self.trace_id.as_deref().unwrap_or(&self.session_id)
-    }
-
     fn into_message(self) -> UnifiedMessage {
         UnifiedMessage::new_with_dedup(
             "copilot",
@@ -246,6 +251,13 @@ fn candidate_from_attributes(
         return None;
     }
 
+    let response_id = attributes
+        .get("gen_ai.response.id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+
     let model = first_non_empty_attr(attributes, MODEL_ATTRS)
         .or_else(|| trace_context.and_then(|context| context.model.as_deref()))
         .unwrap_or("unknown")
@@ -273,6 +285,7 @@ fn candidate_from_attributes(
     Some(CopilotUsageCandidate {
         source,
         trace_id,
+        response_id,
         model,
         provider_id,
         session_id,
@@ -282,43 +295,68 @@ fn candidate_from_attributes(
     })
 }
 
-fn candidate_contexts(
+fn candidate_trace_contexts(
     candidates: &[CopilotUsageCandidate],
     source: CopilotUsageSource,
 ) -> HashSet<String> {
     candidates
         .iter()
-        .filter(|candidate| candidate.source == source && candidate.trace_id.is_some())
-        .map(|candidate| candidate.context_key().to_string())
+        .filter(|candidate| candidate.source == source)
+        .filter_map(|candidate| candidate.trace_id.clone())
+        .collect()
+}
+
+fn candidate_response_ids(
+    candidates: &[CopilotUsageCandidate],
+    source: CopilotUsageSource,
+) -> HashSet<String> {
+    candidates
+        .iter()
+        .filter(|candidate| candidate.source == source)
+        .filter_map(|candidate| candidate.response_id.clone())
         .collect()
 }
 
 fn should_emit_candidate(
     candidate: &CopilotUsageCandidate,
-    chat_contexts: &HashSet<String>,
-    inference_contexts: &HashSet<String>,
-    agent_turn_contexts: &HashSet<String>,
+    chat_traces: &HashSet<String>,
+    inference_traces: &HashSet<String>,
+    agent_turn_traces: &HashSet<String>,
+    chat_response_ids: &HashSet<String>,
+    inference_response_ids: &HashSet<String>,
+    agent_turn_response_ids: &HashSet<String>,
 ) -> bool {
-    // Cross-source priority filtering only applies within a known OTel trace.
-    // Records lacking a trace_id cannot be reliably grouped (their session_id
-    // fallback can collide with unrelated records), so emit them unconditionally
-    // and rely on per-record dedup keys to suppress true duplicates.
-    if candidate.trace_id.is_none() {
-        return true;
-    }
+    // Cross-source priority filtering keys off two stable per-event identifiers:
+    // the OTel `trace_id` and `gen_ai.response.id`. Either match is sufficient
+    // to suppress a lower-priority lane, which closes the mixed-trace gap where
+    // one record carries a trace_id and another (describing the same response)
+    // does not. Coarse session attributes such as gen_ai.conversation.id span
+    // multiple turns and are intentionally NOT used here.
+    let trace_id = candidate.trace_id.as_deref();
+    let response_id = candidate.response_id.as_deref();
 
-    let context_key = candidate.context_key();
+    let trace_match = |traces: &HashSet<String>| trace_id.is_some_and(|id| traces.contains(id));
+    let response_match =
+        |response_ids: &HashSet<String>| response_id.is_some_and(|id| response_ids.contains(id));
 
     match candidate.source {
         CopilotUsageSource::ChatSpan => true,
-        CopilotUsageSource::InferenceLog => !chat_contexts.contains(context_key),
+        CopilotUsageSource::InferenceLog => {
+            !trace_match(chat_traces) && !response_match(chat_response_ids)
+        }
         CopilotUsageSource::AgentTurnLog => {
-            !chat_contexts.contains(context_key) && !inference_contexts.contains(context_key)
+            !trace_match(chat_traces)
+                && !trace_match(inference_traces)
+                && !response_match(chat_response_ids)
+                && !response_match(inference_response_ids)
         }
         CopilotUsageSource::AgentSummarySpan => {
-            !chat_contexts.contains(context_key)
-                && !inference_contexts.contains(context_key)
-                && !agent_turn_contexts.contains(context_key)
+            !trace_match(chat_traces)
+                && !trace_match(inference_traces)
+                && !trace_match(agent_turn_traces)
+                && !response_match(chat_response_ids)
+                && !response_match(inference_response_ids)
+                && !response_match(agent_turn_response_ids)
         }
     }
 }
@@ -798,12 +836,13 @@ mod tests {
 
     #[test]
     fn test_parse_copilot_traceless_records_do_not_cross_suppress() {
-        // Two unrelated records that both lack a trace_id must not suppress
-        // each other via session_id collision in the cross-source priority
-        // filter. Here the chat span and inference log share gen_ai.response.id
-        // (used as the session fallback) but are independent records.
-        let content = r#"{"type":"span","spanId":"chat-traceless","name":"chat gpt-5.4-mini","endTime":[1775934260,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.response.id":"shared-resp","gen_ai.usage.input_tokens":11,"gen_ai.usage.output_tokens":3}}
-{"hrTime":[1775934262,0],"attributes":{"event.name":"gen_ai.client.inference.operation.details","gen_ai.request.model":"gpt-5.4-mini","gen_ai.response.model":"gpt-5.4-mini","gen_ai.response.id":"shared-resp","gen_ai.usage.input_tokens":22,"gen_ai.usage.output_tokens":4},"_body":"GenAI inference: gpt-5.4-mini"}"#;
+        // Two traceless records describing distinct OTel responses must both
+        // emit even when they share a coarse session attribute (here
+        // gen_ai.conversation.id, which spans an entire chat). Cross-source
+        // suppression must key on the per-response identifier
+        // (gen_ai.response.id), not on chat-wide session attributes.
+        let content = r#"{"type":"span","spanId":"chat-traceless","name":"chat gpt-5.4-mini","endTime":[1775934260,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.conversation.id":"conv-shared","gen_ai.response.id":"resp-A","gen_ai.usage.input_tokens":11,"gen_ai.usage.output_tokens":3}}
+{"hrTime":[1775934262,0],"attributes":{"event.name":"gen_ai.client.inference.operation.details","gen_ai.request.model":"gpt-5.4-mini","gen_ai.response.model":"gpt-5.4-mini","gen_ai.conversation.id":"conv-shared","gen_ai.response.id":"resp-B","gen_ai.usage.input_tokens":22,"gen_ai.usage.output_tokens":4},"_body":"GenAI inference: gpt-5.4-mini"}"#;
         let file = create_test_file(content);
 
         let messages = parse_copilot_file(file.path());
@@ -861,6 +900,44 @@ mod tests {
 
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].timestamp, 1_775_934_264_967);
+    }
+
+    #[test]
+    fn test_parse_copilot_mixed_trace_double_count_suppressed_via_response_id() {
+        // Mixed-trace gap: a traceless chat span and a traced inference log
+        // describe the same OTel response (same gen_ai.response.id). With no
+        // shared trace_id, the response-id key is what links them; only the
+        // higher-priority chat span should emit.
+        let content = r#"{"type":"span","spanId":"chat-mixed","name":"chat gpt-5.4-mini","endTime":[1775934260,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.conversation.id":"conv-mixed","gen_ai.response.id":"resp-mixed","gen_ai.usage.input_tokens":40,"gen_ai.usage.output_tokens":7}}
+{"hrTime":[1775934261,0],"spanContext":{"traceId":"trace-mixed-inf","spanId":"inf-mixed","traceFlags":1},"attributes":{"event.name":"gen_ai.client.inference.operation.details","gen_ai.request.model":"gpt-5.4-mini","gen_ai.response.model":"gpt-5.4-mini","gen_ai.response.id":"resp-mixed","gen_ai.usage.input_tokens":40,"gen_ai.usage.output_tokens":7},"_body":"GenAI inference: gpt-5.4-mini"}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].session_id, "conv-mixed");
+        assert_eq!(messages[0].tokens.input, 40);
+        assert_eq!(messages[0].tokens.output, 7);
+    }
+
+    #[test]
+    fn test_parse_copilot_traced_chat_suppresses_traceless_inference_via_response_id() {
+        // Inverse of the mixed-trace gap: a traced chat span suppresses a
+        // traceless inference log via shared gen_ai.response.id, even though
+        // the log carries no trace_id to link it through.
+        let content = r#"{"type":"span","traceId":"trace-chat-inv","spanId":"chat-inv","name":"chat gpt-5.4-mini","endTime":[1775934260,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.conversation.id":"conv-inv","gen_ai.response.id":"resp-inv","gen_ai.usage.input_tokens":33,"gen_ai.usage.output_tokens":5}}
+{"hrTime":[1775934261,0],"attributes":{"event.name":"gen_ai.client.inference.operation.details","gen_ai.request.model":"gpt-5.4-mini","gen_ai.response.model":"gpt-5.4-mini","gen_ai.response.id":"resp-inv","gen_ai.usage.input_tokens":33,"gen_ai.usage.output_tokens":5},"_body":"GenAI inference: gpt-5.4-mini"}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some("trace-chat-inv:chat-inv"),
+        );
+        assert_eq!(messages[0].tokens.input, 33);
+        assert_eq!(messages[0].tokens.output, 5);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/copilot.rs
+++ b/crates/tokscale-core/src/sessions/copilot.rs
@@ -582,7 +582,13 @@ fn timestamp_ms_from_scalar(value: &Value) -> Option<i64> {
 }
 
 fn timestamp_ms_from_unix_nanos(value: &Value) -> Option<i64> {
-    value_as_i64(value).map(|raw| raw / 1_000_000)
+    // OTel `timeUnixNano` is unsigned-by-spec; a negative or zero value is
+    // malformed. Refuse it and let the caller fall through to the next
+    // timestamp source (or the file modified time) instead of producing a
+    // pre-1970 timestamp downstream.
+    value_as_i64(value)
+        .filter(|raw| *raw > 0)
+        .map(|raw| raw / 1_000_000)
 }
 
 #[cfg(test)]
@@ -827,6 +833,12 @@ mod tests {
         keys.sort();
         assert_eq!(keys.len(), 2);
         assert_ne!(keys[0], keys[1], "dedup keys must be unique: {keys:?}");
+        for key in &keys {
+            assert!(
+                key.starts_with("agent-turn:trace-noidx:idx-"),
+                "expected line-index fallback shape in {key}",
+            );
+        }
     }
 
     #[test]
@@ -849,6 +861,86 @@ mod tests {
 
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].timestamp, 1_775_934_264_967);
+    }
+
+    #[test]
+    fn test_parse_copilot_inference_log_negative_time_unix_nano_falls_back() {
+        // Malformed `timeUnixNano` must not produce a negative timestamp; the
+        // parser should fall through to the next available timestamp source
+        // (here, the file modified time, which is non-negative).
+        let content = r#"{"timeUnixNano":-1,"spanContext":{"traceId":"trace-bad","spanId":"span-bad","traceFlags":1},"attributes":{"event.name":"gen_ai.client.inference.operation.details","gen_ai.response.model":"gpt-5.4-mini","gen_ai.response.id":"resp-bad","gen_ai.usage.input_tokens":5,"gen_ai.usage.output_tokens":2},"_body":"GenAI inference: gpt-5.4-mini"}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert!(
+            messages[0].timestamp >= 0,
+            "negative timeUnixNano should not leak into output, got {}",
+            messages[0].timestamp,
+        );
+    }
+
+    #[test]
+    fn test_parse_copilot_interleaved_multi_trace_suppression_is_per_trace() {
+        // Two traces interleaved on the wire. Source-priority suppression must
+        // be scoped per-trace; both invoke_agent records should be dropped in
+        // favor of their own trace's chat span, regardless of line order.
+        let content = r#"{"type":"span","traceId":"trace-A","spanId":"agent-A","name":"invoke_agent","endTime":[1775934260,0],"attributes":{"gen_ai.operation.name":"invoke_agent","gen_ai.response.model":"gpt-5.4-mini","gen_ai.conversation.id":"conv-A","gen_ai.usage.input_tokens":100,"gen_ai.usage.output_tokens":30}}
+{"type":"span","traceId":"trace-B","spanId":"chat-B","name":"chat gpt-5.4-mini","endTime":[1775934261,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.conversation.id":"conv-B","gen_ai.usage.input_tokens":50,"gen_ai.usage.output_tokens":8}}
+{"type":"span","traceId":"trace-A","spanId":"chat-A","name":"chat gpt-5.4-mini","endTime":[1775934262,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.conversation.id":"conv-A","gen_ai.usage.input_tokens":40,"gen_ai.usage.output_tokens":6}}
+{"type":"span","traceId":"trace-B","spanId":"agent-B","name":"invoke_agent","endTime":[1775934263,0],"attributes":{"gen_ai.operation.name":"invoke_agent","gen_ai.response.model":"gpt-5.4-mini","gen_ai.conversation.id":"conv-B","gen_ai.usage.input_tokens":80,"gen_ai.usage.output_tokens":20}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 2);
+        let mut keys: Vec<String> = messages
+            .iter()
+            .filter_map(|m| m.dedup_key.clone())
+            .collect();
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec!["trace-A:chat-A".to_string(), "trace-B:chat-B".to_string()],
+        );
+    }
+
+    #[test]
+    fn test_parse_copilot_agent_turn_log_with_top_level_trace_id() {
+        // Some VS Code variants emit `traceId` at the top level rather than
+        // nested inside `spanContext`. The agent-turn classifier should still
+        // resolve the trace and produce a stable per-turn dedup key.
+        let content = r#"{"hrTime":[1775934264,0],"traceId":"trace-toplevel","spanId":"turn-toplevel","attributes":{"event.name":"copilot_chat.agent.turn","turn.index":5,"gen_ai.request.model":"claude-sonnet-4.5","gen_ai.usage.input_tokens":15,"gen_ai.usage.output_tokens":4},"_body":"copilot_chat.agent.turn: 5"}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "claude-sonnet-4.5");
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some("agent-turn:trace-toplevel:5"),
+        );
+    }
+
+    #[test]
+    fn test_parse_copilot_traced_span_does_not_suppress_traceless_record_with_colliding_session() {
+        // A traced chat span has trace_id "T-collide". A separate traceless
+        // inference log uses "T-collide" as its session-fallback (gen_ai.response.id).
+        // The traceless record must NOT be suppressed by the traced chat span's
+        // context_key, because they are unrelated events. Both should emit.
+        let content = r#"{"type":"span","traceId":"T-collide","spanId":"chat-traced","name":"chat gpt-5.4-mini","endTime":[1775934260,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.usage.input_tokens":10,"gen_ai.usage.output_tokens":2}}
+{"hrTime":[1775934261,0],"attributes":{"event.name":"gen_ai.client.inference.operation.details","gen_ai.request.model":"gpt-5.4-mini","gen_ai.response.model":"gpt-5.4-mini","gen_ai.response.id":"T-collide","gen_ai.usage.input_tokens":20,"gen_ai.usage.output_tokens":3},"_body":"GenAI inference: gpt-5.4-mini"}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 2);
+        let total_input: i64 = messages.iter().map(|m| m.tokens.input).sum();
+        let total_output: i64 = messages.iter().map(|m| m.tokens.output).sum();
+        assert_eq!(total_input, 30);
+        assert_eq!(total_output, 5);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Follow-up hardening for #503. Three small correctness fixes plus regression tests, surfaced by a post-merge audit.

- **`should_emit_candidate` now short-circuits when `trace_id` is absent.** Two unrelated records that lack a `trace_id` and happen to share a session-id fallback (e.g. the same `gen_ai.response.id`) could previously suppress one another via the cross-source priority filter. With no trace, there is no reliable grouping signal, so we emit and rely on per-record dedup keys.
- **AgentTurnLog dedup keys disambiguate when `turn.index` is missing.** Two turn-less agent-turn records in the same trace previously collapsed onto an `agent-turn:T:0` sentinel. The fallback now uses the line index, so unique records survive into upstream dedup.
- **Defensive comment on `is_span_record`** documenting the VS Code heuristic (top-level `name` + identity/timing/kind) and the contract that disambiguates it from inference / agent-turn log records (those have no top-level `name`).

## Tests added
1. `chat_span_over_agent_turn_in_same_trace` — locks in source-priority guarantee for the chat-span vs agent-turn pairing (previously only chat vs `invoke_agent` was covered).
2. `traceless_records_do_not_cross_suppress` — exercises the new short-circuit; both records emit even when their session fallback collides.
3. `agent_turn_log_without_turn_index_uses_line_index` — verifies the dedup-key fallback produces distinct keys.
4. `inference_log_uses_time_unix_nano_timestamp` — covers the previously untested `timeUnixNano` path.
5. `agent_turn_log_uses_scalar_timestamp` — covers the previously untested scalar `timestamp` path.

## Why
The VS Code OTel support shipped in #503 introduced a four-lane source-priority filter keyed off `trace_id` (or the session fallback when absent). Both edge cases above are reachable on real exports: VS Code Copilot Chat normally emits `spanContext.traceId`, but exports replayed through a transformer or older VS Code builds can drop it; agent-turn records on session-start spans are sometimes emitted without `turn.index`. This PR closes those gaps without changing behavior on records that have full identity.

## Validation
- `cargo test -p tokscale-core copilot` — **20 passed** (5 new tests, 15 pre-existing including all of #503's).
- `cargo clippy -p tokscale-core --all-features -- -D warnings` — PASS.
- `cargo fmt --all -- --check` — PASS.
- `git diff --check origin/main...HEAD` — PASS.

## Scope
- One file: `crates/tokscale-core/src/sessions/copilot.rs`
- `+101 / -4`. No public API changes; `parse_copilot_file` signature and `TokenBreakdown` semantics unchanged. No fixtures or downstream callers touched.

## Rollback
Revert the merge commit. No migration, data repair, or release procedure changes.

Follow-up to #503 / #430.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the VS Code Copilot OTel parser to prevent trace-id collisions and close mixed-trace double counts by matching records via `trace_id` or `gen_ai.response.id`. Also keeps agent-turn dedup keys unique and rejects bad timestamps. Follow-up to #503; adds additional regression tests; no public API changes.

- Bug Fixes
  - Cross-source suppression now keys off `trace_id` or `gen_ai.response.id`. A match in either suppresses lower-priority lanes; coarse session fields (e.g. `gen_ai.conversation.id`) are ignored. Traceless records emit unless they share a `gen_ai.response.id` with a higher-priority record.
  - AgentTurnLog dedup keys fall back to the line index when `turn.index` is missing, preventing within-trace collisions.
  - `timestamp_ms_from_unix_nanos` rejects non-positive values and falls back to the next timestamp source.
  - Documented the `is_span_record` heuristic (top-level `name` + identity/timing/kind) and how it differs from inference/agent-turn logs.

<sup>Written for commit 27ec55a20756e1666ef58a9c716a8ff7e1e328f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

