### PR TITLE
test(antigravity): redirect TOKSCALE_CONFIG_DIR for hermetic test isolation

### DIFF
--- a/crates/tokscale-cli/src/antigravity.rs
+++ b/crates/tokscale-cli/src/antigravity.rs
@@ -1811,6 +1811,45 @@ fn parse_timestamp(values: &[Option<&Value>]) -> Option<i64> {
 mod tests {
     use super::*;
     use serial_test::serial;
+    use std::ffi::OsString;
+
+    /// RAII guard that redirects every tokscale config-dir lookup into a
+    /// caller-supplied directory and restores the previous environment on
+    /// drop (including on panic). Setting `HOME` alone is not sufficient on
+    /// Linux CI runners because `dirs::config_dir()` honors
+    /// `$XDG_CONFIG_HOME` first; tokscale's own `paths::get_config_dir()`
+    /// short-circuits on `TOKSCALE_CONFIG_DIR`, which is the canonical
+    /// hermetic override for tests.
+    struct TestEnvGuard {
+        prev_home: Option<OsString>,
+        prev_config_dir: Option<OsString>,
+    }
+
+    impl TestEnvGuard {
+        fn redirect_to(path: &Path) -> Self {
+            let prev_home = std::env::var_os("HOME");
+            let prev_config_dir = std::env::var_os("TOKSCALE_CONFIG_DIR");
+            std::env::set_var("HOME", path);
+            std::env::set_var("TOKSCALE_CONFIG_DIR", path);
+            Self {
+                prev_home,
+                prev_config_dir,
+            }
+        }
+    }
+
+    impl Drop for TestEnvGuard {
+        fn drop(&mut self) {
+            match self.prev_home.take() {
+                Some(home) => std::env::set_var("HOME", home),
+                None => std::env::remove_var("HOME"),
+            }
+            match self.prev_config_dir.take() {
+                Some(dir) => std::env::set_var("TOKSCALE_CONFIG_DIR", dir),
+                None => std::env::remove_var("TOKSCALE_CONFIG_DIR"),
+            }
+        }
+    }
 
     fn sample_manifest() -> AntigravityManifest {
         AntigravityManifest {
@@ -2014,8 +2053,7 @@ mod tests {
     #[serial]
     fn cleanup_stale_session_artifacts_removes_legacy_files_after_migration() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let previous_home = std::env::var_os("HOME");
-        std::env::set_var("HOME", temp_dir.path());
+        let _env = TestEnvGuard::redirect_to(temp_dir.path());
 
         let sessions_dir = get_antigravity_sessions_dir().unwrap();
         std::fs::create_dir_all(&sessions_dir).unwrap();
@@ -2053,19 +2091,13 @@ mod tests {
         cleanup_stale_session_artifacts(&previous, &next).unwrap();
         assert!(!legacy_path.exists());
         assert!(new_path.exists());
-
-        match previous_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
     }
 
     #[test]
     #[serial]
     fn delete_artifact_relative_path_rejects_paths_outside_cache_root() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let previous_home = std::env::var_os("HOME");
-        std::env::set_var("HOME", temp_dir.path());
+        let _env = TestEnvGuard::redirect_to(temp_dir.path());
 
         let err = delete_artifact_relative_path("../outside.jsonl").unwrap_err();
         assert!(err.to_string().contains("cache root"));
@@ -2076,11 +2108,6 @@ mod tests {
 
         let err = delete_artifact_relative_path("manifest.json").unwrap_err();
         assert!(err.to_string().contains("session artifact"));
-
-        match previous_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
     }
 
     #[test]
@@ -2090,8 +2117,7 @@ mod tests {
         use std::os::unix::fs::symlink;
 
         let temp_dir = tempfile::tempdir().unwrap();
-        let previous_home = std::env::var_os("HOME");
-        std::env::set_var("HOME", temp_dir.path());
+        let _env = TestEnvGuard::redirect_to(temp_dir.path());
 
         let cache_dir = get_antigravity_cache_dir().unwrap();
         let sessions_dir = cache_dir.join("sessions");
@@ -2108,19 +2134,13 @@ mod tests {
         let err = delete_artifact_relative_path("sessions/escape.jsonl").unwrap_err();
         assert!(err.to_string().contains("sessions cache root"));
         assert!(outside_file.exists());
-
-        match previous_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
     }
 
     #[test]
     #[serial]
     fn filesystem_scan_finds_brain_and_conversation_candidates() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let previous_home = std::env::var_os("HOME");
-        std::env::set_var("HOME", temp_dir.path());
+        let _env = TestEnvGuard::redirect_to(temp_dir.path());
 
         let root = temp_dir.path().join(".gemini/antigravity");
         std::fs::create_dir_all(root.join("brain/session-a")).unwrap();
@@ -2136,11 +2156,6 @@ mod tests {
         assert!(ids.contains(&"session-a".to_string()));
         assert!(ids.contains(&"session-b".to_string()));
         assert!(ids.contains(&"session-c".to_string()));
-
-        match previous_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
     }
 
     #[test]
@@ -2172,8 +2187,7 @@ mod tests {
     #[serial]
     fn manifest_round_trip_and_artifact_write() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let previous_home = std::env::var_os("HOME");
-        std::env::set_var("HOME", temp_dir.path());
+        let _env = TestEnvGuard::redirect_to(temp_dir.path());
 
         let manifest = sample_manifest();
         save_antigravity_manifest(&manifest).unwrap();
@@ -2196,11 +2210,6 @@ mod tests {
             .to_string();
         assert!(delete_session_artifact(&relative).unwrap());
         assert!(!artifact_path.exists());
-
-        match previous_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
     }
 
     use std::net::TcpListener;
@@ -2299,8 +2308,7 @@ mod tests {
     #[serial]
     fn load_antigravity_manifest_rejects_newer_version() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let previous_home = std::env::var_os("HOME");
-        std::env::set_var("HOME", temp_dir.path());
+        let _env = TestEnvGuard::redirect_to(temp_dir.path());
 
         ensure_config_dir().unwrap();
         let cache_dir = get_antigravity_cache_dir().unwrap();
@@ -2314,19 +2322,13 @@ mod tests {
 
         let err = load_antigravity_manifest().unwrap_err();
         assert!(err.to_string().contains("newer tokscale version"));
-
-        match previous_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
     }
 
     #[test]
     #[serial]
     fn load_antigravity_manifest_treats_older_version_as_fresh_start() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let previous_home = std::env::var_os("HOME");
-        std::env::set_var("HOME", temp_dir.path());
+        let _env = TestEnvGuard::redirect_to(temp_dir.path());
 
         ensure_config_dir().unwrap();
         let cache_dir = get_antigravity_cache_dir().unwrap();
@@ -2341,19 +2343,13 @@ mod tests {
         let manifest = load_antigravity_manifest().unwrap();
         assert_eq!(manifest.version, ANTIGRAVITY_MANIFEST_VERSION);
         assert!(manifest.sessions.is_empty());
-
-        match previous_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
     }
 
     #[test]
     #[serial]
     fn load_antigravity_manifest_recovers_from_corrupted_json() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let previous_home = std::env::var_os("HOME");
-        std::env::set_var("HOME", temp_dir.path());
+        let _env = TestEnvGuard::redirect_to(temp_dir.path());
 
         ensure_config_dir().unwrap();
         let cache_dir = get_antigravity_cache_dir().unwrap();
@@ -2376,11 +2372,6 @@ mod tests {
             })
             .collect();
         assert_eq!(backups.len(), 1, "expected one backup file");
-
-        match previous_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes the two antigravity tests that started failing on main once #502 stopped suppressing main-branch CI:

- `delete_artifact_relative_path_rejects_symlink_escape` — panicked at `symlink()` with `AlreadyExists` (errno 17)
- `load_antigravity_manifest_recovers_from_corrupted_json` — assertion `expected one backup file: left=2 right=1`

## Root cause
Both tests redirect cache lookups by overriding `HOME` only. That works on macOS (`dirs::config_dir()` → `$HOME/Library/Application Support`). It does **not** work on Linux CI: `dirs::config_dir()` honors `$XDG_CONFIG_HOME` first, and the GitHub runner has it set to `/home/runner/.config`. Result: every antigravity test wrote into the shared real `/home/runner/.config/tokscale/antigravity-cache/`, and residue from one test (stray symlinks, extra `manifest.json.corrupt-*` backups) poisoned the next one in the `#[serial]` group.

CI logs showed it explicitly — `manifest.json` was being read at `/home/runner/.config/tokscale/antigravity-cache/manifest.json`, not the tempdir.

`paths::get_config_dir()` already short-circuits on `TOKSCALE_CONFIG_DIR`, and `get_antigravity_cache_dir()` (in `crates/tokscale-cli/src/antigravity.rs:22-31`) routes through it precisely for hermetic test override. The tests simply weren't using the canonical env var.

## Why these surfaced now
PR #502 removed `[skip ci]` from the auto-fix bot's commit message. Previously that token leaked into squash-merge bodies and silently skipped the on-push validation workflow on main. With #502 merged, main CI actually runs — exposing latent test-isolation bugs that had been hidden for an unknown stretch of time. **#502 is doing exactly what it was supposed to do**; this PR fixes one of the genuine bugs it surfaced.

## Implementation
Replace per-test `HOME`-only save/restore boilerplate with a single `TestEnvGuard` RAII helper that:

- Saves and restores both `HOME` and `TOKSCALE_CONFIG_DIR`.
- Restores on `Drop` (including on panic) — so a failing test no longer leaves residue that poisons the next `#[serial]` test.

Net diff: **-9 lines** (the boilerplate removal beats the helper addition).

## Validation
Reproduced the CI failure scenario locally on macOS by setting a host-level override that simulates `XDG_CONFIG_HOME` redirection:

```
TOKSCALE_CONFIG_DIR=/tmp/host-shared-config cargo test -p tokscale-cli antigravity
# ✅ 31 passed; 0 failed (was: 2 failed before this PR under the same condition)
```

- `cargo test -p tokscale-cli antigravity` — **31 passed**
- `cargo clippy -p tokscale-cli --tests --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `/tmp/host-shared-config/` is **never created** by the run, confirming no host-dir leakage

## Scope
- One file: `crates/tokscale-cli/src/antigravity.rs`
- Test-only changes — no production code, no public API, no schema
- 8 test bodies refactored to use the shared guard

## Rollback
Revert the merge commit. No follow-up actions required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes antigravity test isolation on Linux CI by redirecting config/cache lookups via `TOKSCALE_CONFIG_DIR` and restoring env vars with an RAII guard. Prevents cross-test residue; test-only changes in `crates/tokscale-cli/src/antigravity.rs`.

- **Bug Fixes**
  - Added `TestEnvGuard` to set and restore `HOME` and `TOKSCALE_CONFIG_DIR` (restores on panic).
  - Updated tests to use the guard so cache writes stay in the temp dir (avoids `XDG_CONFIG_HOME` leakage).
  - Resolved failures in `delete_artifact_relative_path_rejects_symlink_escape` and `load_antigravity_manifest_recovers_from_corrupted_json`.

<sup>Written for commit 5096737366c8d028d7109c6cf2ea89cfdef70b79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

