### PR TITLE
fix(cursor): bound auto-sync latency with HTTP timeout and freshness gate

### DIFF
--- a/crates/tokscale-cli/src/cursor.rs
+++ b/crates/tokscale-cli/src/cursor.rs
@@ -5,6 +5,26 @@ use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+/// Timeout for every Cursor HTTP request. Picked to bound the worst case for
+/// auto-sync (which runs synchronously before local reports and the TUI) while
+/// still tolerating routine API latency. If the network is hung, the report
+/// proceeds against cached data after this timeout instead of stalling forever.
+const CURSOR_HTTP_TIMEOUT: Duration = Duration::from_secs(8);
+
+/// Skip implicit pre-report sync when the active account's `usage.csv` was
+/// modified within this window. Prevents `tokscale models` (and its siblings)
+/// from issuing a Cursor API call on every invocation. The manual `tokscale
+/// cursor sync` command bypasses this — explicit user intent is always honored.
+pub const CURSOR_AUTO_SYNC_FRESHNESS: Duration = Duration::from_secs(5 * 60);
+
+fn build_cursor_http_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(CURSOR_HTTP_TIMEOUT)
+        .build()
+        .context("Failed to build Cursor HTTP client")
+}
 
 fn home_dir() -> Result<PathBuf> {
     dirs::home_dir().context("Could not determine home directory")
@@ -635,6 +655,55 @@ pub fn has_cursor_usage_cache() -> bool {
     }
 }
 
+/// Returns the freshest mtime across all cached `usage*.csv` files in the
+/// given home directory. Returns `None` when the cache dir is missing, no
+/// cache files exist, or all mtime reads fail (callers should treat that as
+/// stale and re-sync).
+fn cursor_usage_cache_mtime_in(home_dir: &Path) -> Option<SystemTime> {
+    let cache_dir = cursor_cache_dir(home_dir);
+    if !cache_dir.exists() {
+        return None;
+    }
+
+    fs::read_dir(&cache_dir)
+        .ok()?
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| {
+            entry
+                .file_name()
+                .into_string()
+                .ok()
+                .is_some_and(|name| is_cursor_usage_csv_filename(&name))
+        })
+        .filter_map(|entry| entry.metadata().ok())
+        .filter_map(|meta| meta.modified().ok())
+        .max()
+}
+
+fn cursor_usage_cache_is_fresh_in(home_dir: &Path, max_age: Duration) -> bool {
+    let Some(mtime) = cursor_usage_cache_mtime_in(home_dir) else {
+        return false;
+    };
+    match SystemTime::now().duration_since(mtime) {
+        Ok(age) => age < max_age,
+        // mtime is in the future (clock skew) — treat as fresh; a clock-skew
+        // cache is no less authoritative than a freshly-fetched one, and we'd
+        // rather not thrash the API while the system clock recovers.
+        Err(_) => true,
+    }
+}
+
+/// True when the cursor usage cache was refreshed within `max_age`. Used by
+/// the implicit pre-report sync path to avoid hitting the Cursor API on every
+/// invocation. The manual `tokscale cursor sync` CLI bypasses this — explicit
+/// user intent is always honored.
+pub fn cursor_usage_cache_is_fresh(max_age: Duration) -> bool {
+    let Ok(home_dir) = home_dir() else {
+        return false;
+    };
+    cursor_usage_cache_is_fresh_in(&home_dir, max_age)
+}
+
 pub fn is_cursor_logged_in() -> bool {
     load_active_credentials().is_some()
 }
@@ -653,7 +722,16 @@ pub struct ValidateSessionResult {
 }
 
 pub async fn validate_cursor_session(token: &str) -> ValidateSessionResult {
-    let client = reqwest::Client::new();
+    let client = match build_cursor_http_client() {
+        Ok(client) => client,
+        Err(e) => {
+            return ValidateSessionResult {
+                valid: false,
+                membership_type: None,
+                error: Some(format!("Failed to build HTTP client: {}", e)),
+            };
+        }
+    };
     let response = match client
         .get(USAGE_SUMMARY_ENDPOINT)
         .headers(build_cursor_headers(token))
@@ -728,7 +806,7 @@ pub async fn validate_cursor_session(token: &str) -> ValidateSessionResult {
 }
 
 pub async fn fetch_cursor_usage_csv(session_token: &str) -> Result<String> {
-    let client = reqwest::Client::new();
+    let client = build_cursor_http_client()?;
     let response = client
         .get(USAGE_CSV_ENDPOINT)
         .headers(build_cursor_headers(session_token))
@@ -1291,6 +1369,101 @@ mod tests {
         let exactly_80 = "b".repeat(80);
         let sanitized = sanitize_account_id_for_filename(&exactly_80);
         assert_eq!(sanitized.len(), 80);
+    }
+
+    #[test]
+    fn test_build_cursor_http_client_applies_timeout() {
+        // Constructing the client must succeed and surface no panics; the
+        // configured timeout is the property the HIGH finding flagged.
+        let client = build_cursor_http_client().expect("client builds");
+        // reqwest::Client doesn't expose its timeout publicly, but we can at
+        // least confirm the const wired into the builder is the documented
+        // 8s value — a future change to the constant must be deliberate.
+        assert_eq!(CURSOR_HTTP_TIMEOUT, std::time::Duration::from_secs(8));
+        // Use the client briefly to ensure it's structurally valid.
+        let _ = client.get("https://example.invalid").build();
+    }
+
+    #[test]
+    fn test_cursor_usage_cache_is_fresh_returns_false_when_cache_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        // No cache dir created yet.
+        assert!(!cursor_usage_cache_is_fresh_in(
+            temp.path(),
+            Duration::from_secs(300)
+        ));
+    }
+
+    #[test]
+    fn test_cursor_usage_cache_is_fresh_returns_false_when_no_csv_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache_dir = cursor_cache_dir(temp.path());
+        fs::create_dir_all(&cache_dir).unwrap();
+        // Unrelated file present, but no usage*.csv.
+        fs::write(cache_dir.join("README.txt"), "noise").unwrap();
+        assert!(!cursor_usage_cache_is_fresh_in(
+            temp.path(),
+            Duration::from_secs(300)
+        ));
+    }
+
+    #[test]
+    fn test_cursor_usage_cache_is_fresh_returns_true_for_recent_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache_dir = cursor_cache_dir(temp.path());
+        fs::create_dir_all(&cache_dir).unwrap();
+        fs::write(cache_dir.join("usage.csv"), "Date,Model\n").unwrap();
+        // Just-written file is fresh under any reasonable window.
+        assert!(cursor_usage_cache_is_fresh_in(
+            temp.path(),
+            Duration::from_secs(300)
+        ));
+    }
+
+    #[test]
+    fn test_cursor_usage_cache_is_fresh_returns_false_for_old_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache_dir = cursor_cache_dir(temp.path());
+        fs::create_dir_all(&cache_dir).unwrap();
+        let path = cache_dir.join("usage.csv");
+        fs::write(&path, "Date,Model\n").unwrap();
+        // Backdate the mtime by an hour. Skip the test if the platform refuses
+        // to set mtime (rare on POSIX/Windows but possible on exotic FS).
+        let f = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
+        let Ok(()) = f.set_modified(SystemTime::now() - Duration::from_secs(3600)) else {
+            return;
+        };
+        drop(f);
+        assert!(!cursor_usage_cache_is_fresh_in(
+            temp.path(),
+            Duration::from_secs(300)
+        ));
+    }
+
+    #[test]
+    fn test_cursor_usage_cache_is_fresh_uses_freshest_csv() {
+        // When multiple usage*.csv files exist the freshest mtime wins, so
+        // a recently-synced secondary account keeps the active stale file
+        // from triggering a refresh.
+        let temp = tempfile::tempdir().unwrap();
+        let cache_dir = cursor_cache_dir(temp.path());
+        fs::create_dir_all(&cache_dir).unwrap();
+        let stale_path = cache_dir.join("usage.csv");
+        fs::write(&stale_path, "Date,Model\n").unwrap();
+        let stale = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&stale_path)
+            .unwrap();
+        let Ok(()) = stale.set_modified(SystemTime::now() - Duration::from_secs(3600)) else {
+            return;
+        };
+        drop(stale);
+        // Secondary account written just now.
+        fs::write(cache_dir.join("usage.team-a.csv"), "Date,Model\n").unwrap();
+        assert!(cursor_usage_cache_is_fresh_in(
+            temp.path(),
+            Duration::from_secs(300)
+        ));
     }
 
     #[test]

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1045,6 +1045,13 @@ fn auto_sync_cursor_for_local_report(
         return None;
     }
 
+    // Skip the implicit refresh when the cache is recent enough — running
+    // `tokscale models` 30× in a script must not produce 30 Cursor API
+    // calls. The manual `tokscale cursor sync` command bypasses this gate.
+    if cursor::cursor_usage_cache_is_fresh(cursor::CURSOR_AUTO_SYNC_FRESHNESS) {
+        return None;
+    }
+
     Some(run_best_effort_cursor_sync_with_runtime_factory(
         tokio::runtime::Runtime::new,
     ))


### PR DESCRIPTION
## Summary
Follow-up to #504. The auto-sync wired in #504 fixed the underlying bug for #479 but introduced two latency footguns surfaced in post-merge audit:

- **No HTTP timeout** on the Cursor client. With sync running synchronously in front of every `tokscale models`/`monthly`/`hourly`/TUI launch, a hung Cursor API would stall the report indefinitely behind a misleading "Scanning session data…" spinner.
- **No freshness throttle**: `tokscale models × 30` issued 30 Cursor API calls. Issue #479 only required a sync after `cursor login`, not on every report.

## Changes
- `CURSOR_HTTP_TIMEOUT = 8s` const and a `build_cursor_http_client()` helper. Both call sites (`fetch_cursor_usage_csv`, `validate_cursor_session`) now route through it. On timeout, fetch returns an error and the existing "using cached data" fallback handles it.
- `CURSOR_AUTO_SYNC_FRESHNESS = 5min` const and a `cursor_usage_cache_is_fresh(max_age)` helper that reads the freshest mtime across all `usage*.csv` files. The implicit pre-report sync (`auto_sync_cursor_for_local_report` in main.rs) skips the API call inside the freshness window. **The manual `tokscale cursor sync` CLI deliberately bypasses this gate** — explicit user intent is always honored.
- Internal `cursor_usage_cache_is_fresh_in(home_dir, max_age)` mirrors the file's existing `_in_home` test pattern.

## Behavior
| Scenario | Before #504 | After #504 (current main) | After this PR |
|---|---|---|---|
| `tokscale models` immediately after `cursor login` | stale data | refreshed ✓ | refreshed ✓ |
| `tokscale models × 30` in a script | 0 API calls | **30 API calls** | 1 API call |
| Cursor API hangs | n/a (no auto-sync) | **report stalls indefinitely** | report renders cached data after 8s |
| `tokscale cursor sync` (manual) | n/a | hits API | hits API ✓ |

## Tests added
- `test_build_cursor_http_client_applies_timeout` — pins `CURSOR_HTTP_TIMEOUT`
- `test_cursor_usage_cache_is_fresh_returns_false_when_cache_missing`
- `test_cursor_usage_cache_is_fresh_returns_false_when_no_csv_files`
- `test_cursor_usage_cache_is_fresh_returns_true_for_recent_file`
- `test_cursor_usage_cache_is_fresh_returns_false_for_old_file` (uses `File::set_modified` to backdate by 1h)
- `test_cursor_usage_cache_is_fresh_uses_freshest_csv` (multi-account: recent secondary beats stale active)

## Validation
- `cargo test -p tokscale-cli cursor` — **36 passed** (6 new + 30 prior)
- `cargo clippy -p tokscale-cli --tests --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

## Scope
- 2 files: `crates/tokscale-cli/src/cursor.rs`, `crates/tokscale-cli/src/main.rs`
- +182 / -2
- No public API changes outside the new `cursor_usage_cache_is_fresh` and `CURSOR_AUTO_SYNC_FRESHNESS` symbols (additive)
- No persistent storage format changes
- The 5-minute window matches the rough granularity of Cursor usage reporting; tunable via the const if needed

## Rollback
Revert the merge commit. The behavior reverts to #504's "always sync, no timeout."

## Out of scope (Codex audit follow-ups not addressed here)
- Concurrency lock for racing `tokscale` PIDs writing the cache simultaneously (filed as a separate issue).
- Active-account dup-deletion-before-fetch ordering (pre-existing pre-#504 logic, separate fix).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound Cursor auto-sync latency by adding an 8s HTTP timeout and a 5‑minute freshness gate. Reports no longer hang on slow API calls, and repeated runs avoid redundant syncs.

- **Bug Fixes**
  - Added `CURSOR_HTTP_TIMEOUT = 8s` and a shared HTTP client builder; used in `validate_cursor_session` and `fetch_cursor_usage_csv`. On timeout, reports render using cached data.
  - Added `CURSOR_AUTO_SYNC_FRESHNESS = 5min` and `cursor_usage_cache_is_fresh(...)` to skip implicit pre-report sync when `usage*.csv` is recent. Manual `tokscale cursor sync` still hits the API.

<sup>Written for commit 75773f4c56303235b51724c18cb2cc1ab414d3c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

