### PR TITLE
fix(kilo): harden SQLite parser row handling

### DIFF
--- a/crates/tokscale-core/src/sessions/kilo.rs
+++ b/crates/tokscale-core/src/sessions/kilo.rs
@@ -64,9 +64,10 @@ pub fn parse_kilo_sqlite_with_fallback(
     };
 
     let query = r#"
-        SELECT m.id, m.data
+        SELECT m.id, m.session_id, m.data
         FROM message m
-        WHERE json_extract(m.data, '$.role') = 'assistant'
+        WHERE json_valid(m.data)
+          AND json_extract(m.data, '$.role') = 'assistant'
           AND json_extract(m.data, '$.tokens') IS NOT NULL
     "#;
 
@@ -77,8 +78,9 @@ pub fn parse_kilo_sqlite_with_fallback(
 
     let rows = match stmt.query_map([], |row| {
         let id: String = row.get(0)?;
-        let data_json: String = row.get(1)?;
-        Ok((id, data_json))
+        let session_id: String = row.get(1)?;
+        let data_json: String = row.get(2)?;
+        Ok((id, session_id, data_json))
     }) {
         Ok(r) => r,
         Err(_) => return Vec::new(),
@@ -87,7 +89,7 @@ pub fn parse_kilo_sqlite_with_fallback(
     let mut messages = Vec::new();
 
     for row_result in rows {
-        let (_id, data_json) = match row_result {
+        let (row_id, row_session_id, data_json) = match row_result {
             Ok(r) => r,
             Err(_) => continue,
         };
@@ -107,13 +109,15 @@ pub fn parse_kilo_sqlite_with_fallback(
             None => continue,
         };
 
+        let dedup_key = msg.id.or(Some(row_id));
+
         let model_id = match msg.model_id {
             Some(m) => m,
             None => continue,
         };
 
         let agent = msg.agent.or(msg.mode);
-        let session_id = msg.session_id.unwrap_or_else(|| "unknown".to_string());
+        let session_id = msg.session_id.unwrap_or(row_session_id);
         let timestamp = msg
             .time
             .map(|t| t.created as i64)
@@ -126,7 +130,7 @@ pub fn parse_kilo_sqlite_with_fallback(
             .unwrap_or("kilo")
             .to_string();
 
-        let unified = UnifiedMessage::new_with_agent(
+        let mut unified = UnifiedMessage::new_with_agent(
             "kilo",
             model_id,
             provider,
@@ -142,6 +146,7 @@ pub fn parse_kilo_sqlite_with_fallback(
             msg.cost.unwrap_or(0.0).max(0.0),
             agent,
         );
+        unified.dedup_key = dedup_key;
 
         messages.push(unified);
     }
@@ -152,6 +157,32 @@ pub fn parse_kilo_sqlite_with_fallback(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rusqlite::{params, Connection};
+    use tempfile::TempDir;
+
+    fn create_kilo_sqlite_db(dir: &TempDir) -> std::path::PathBuf {
+        let db_path = dir.path().join("kilo.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                data TEXT NOT NULL
+            );
+            "#,
+        )
+        .unwrap();
+        db_path
+    }
+
+    fn insert_kilo_message(conn: &Connection, row_id: &str, session_id: &str, data_json: &str) {
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            params![row_id, session_id, data_json],
+        )
+        .unwrap();
+    }
 
     #[test]
     fn test_parse_kilo_message_structure() {
@@ -175,5 +206,130 @@ mod tests {
         assert_eq!(msg.role, "assistant");
         assert_eq!(msg.cost, Some(0.15));
         assert_eq!(msg.model_id, Some("minimax/m2.5".to_string()));
+    }
+
+    #[test]
+    fn test_parse_kilo_sqlite_reads_assistant_rows() {
+        let dir = TempDir::new().unwrap();
+        let db_path = create_kilo_sqlite_db(&dir);
+        let conn = Connection::open(&db_path).unwrap();
+
+        let data_json = r#"{
+            "id": "embedded-msg-1",
+            "session_id": "sess-1",
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "cost": 0.42,
+            "agent": "architect",
+            "tokens": {
+                "input": 1200,
+                "output": 300,
+                "reasoning": 40,
+                "cache": {"read": 75, "write": 25}
+            },
+            "time": {"created": 1700000000123.0}
+        }"#;
+        insert_kilo_message(&conn, "row-msg-1", "sess-1", data_json);
+        drop(conn);
+
+        let messages = parse_kilo_sqlite_with_fallback(&db_path, 42);
+        assert_eq!(messages.len(), 1);
+
+        let msg = &messages[0];
+        assert_eq!(msg.client, "kilo");
+        assert_eq!(msg.session_id, "sess-1");
+        assert_eq!(msg.model_id, "claude-sonnet-4");
+        assert_eq!(msg.provider_id, "anthropic");
+        assert_eq!(msg.timestamp, 1_700_000_000_123);
+        assert_eq!(msg.tokens.input, 1200);
+        assert_eq!(msg.tokens.output, 300);
+        assert_eq!(msg.tokens.reasoning, 40);
+        assert_eq!(msg.tokens.cache_read, 75);
+        assert_eq!(msg.tokens.cache_write, 25);
+        assert_eq!(msg.cost, 0.42);
+        assert_eq!(msg.agent.as_deref(), Some("architect"));
+        assert_eq!(msg.dedup_key.as_deref(), Some("embedded-msg-1"));
+    }
+
+    #[test]
+    fn test_parse_kilo_sqlite_skips_invalid_rows_and_clamps_values() {
+        let dir = TempDir::new().unwrap();
+        let db_path = create_kilo_sqlite_db(&dir);
+        let conn = Connection::open(&db_path).unwrap();
+
+        insert_kilo_message(
+            &conn,
+            "row-user",
+            "sess-user",
+            r#"{
+                "session_id": "sess-user",
+                "role": "user",
+                "modelID": "gpt-5.4",
+                "tokens": {"input": 1, "output": 1, "cache": {"read": 0, "write": 0}}
+            }"#,
+        );
+        insert_kilo_message(
+            &conn,
+            "row-no-tokens",
+            "sess-no-tokens",
+            r#"{
+                "session_id": "sess-no-tokens",
+                "role": "assistant",
+                "modelID": "gpt-5.4"
+            }"#,
+        );
+        insert_kilo_message(
+            &conn,
+            "row-no-model",
+            "sess-no-model",
+            r#"{
+                "session_id": "sess-no-model",
+                "role": "assistant",
+                "tokens": {"input": 1, "output": 1, "cache": {"read": 0, "write": 0}}
+            }"#,
+        );
+        insert_kilo_message(&conn, "row-invalid-json", "sess-invalid", "{not-json");
+        insert_kilo_message(
+            &conn,
+            "row-valid",
+            "sess-valid",
+            r#"{
+                "role": "assistant",
+                "modelID": "gpt-5.4",
+                "cost": -0.75,
+                "mode": "debug",
+                "tokens": {
+                    "input": -100,
+                    "output": -50,
+                    "reasoning": -5,
+                    "cache": {"read": -20, "write": -10}
+                }
+            }"#,
+        );
+        drop(conn);
+
+        let messages = parse_kilo_sqlite_with_fallback(&db_path, 1_800_000_000_000);
+        assert_eq!(messages.len(), 1);
+
+        let msg = &messages[0];
+        assert_eq!(msg.session_id, "sess-valid");
+        assert_eq!(msg.model_id, "gpt-5.4");
+        assert_eq!(msg.provider_id, "openai");
+        assert_eq!(msg.timestamp, 1_800_000_000_000);
+        assert_eq!(msg.tokens.input, 0);
+        assert_eq!(msg.tokens.output, 0);
+        assert_eq!(msg.tokens.reasoning, 0);
+        assert_eq!(msg.tokens.cache_read, 0);
+        assert_eq!(msg.tokens.cache_write, 0);
+        assert_eq!(msg.cost, 0.0);
+        assert_eq!(msg.agent.as_deref(), Some("debug"));
+        assert_eq!(msg.dedup_key.as_deref(), Some("row-valid"));
+    }
+
+    #[test]
+    fn test_parse_kilo_sqlite_returns_empty_for_missing_db() {
+        let messages = parse_kilo_sqlite(std::path::Path::new("/nonexistent/kilo.db"));
+        assert!(messages.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- Add focused Kilo SQLite parser coverage for valid assistant rows, malformed JSON payloads, row-backed session IDs, clamped usage values, provider inference, mode fallback, and missing databases.
- Harden the Kilo SQLite parser so malformed JSON rows are ignored, row `session_id` values are preserved when payloads omit them, and parsed messages get stable deduplication keys.

## Why
Kilo stores assistant messages in SQLite with JSON payloads. The previous parser assumed JSON payloads were valid and self-contained, so one malformed row could prevent usable rows from being parsed, and rows without embedded session IDs fell back to `unknown`. This PR makes the parser more resilient while adding targeted coverage for that behavior.

## Diff scope
- `crates/tokscale-core/src/sessions/kilo.rs`

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `rg -n '\p{Cyrillic}' crates/tokscale-core/src/sessions/kilo.rs` - no output
- [x] `cargo test -p tokscale-core kilo -- --nocapture` - 9 passed
- [x] `cargo test -p tokscale-core` - 639 passed, 1 ignored; integration tests passed; doc tests passed
- [x] `cargo test --workspace --all-features` - workspace tests passed
- [x] `/opt/homebrew/bin/cargo-clippy clippy --workspace --all-features -- -D warnings`
- [x] `git diff --check origin/main...HEAD`

## Notes
- Part of #403.
- No database migration, dependency update, CLI surface change, or release workflow change.
- Rollback: revert the final merge/squash commit; no data repair or DB downgrade required.

