### PR TITLE
fix(codex): deduplicate forked token count history

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -813,8 +813,14 @@ fn parse_all_messages_with_pricing_with_env_strategy(
             )
         })
         .collect();
+    let mut codex_seen: HashSet<String> = HashSet::new();
     for (path, outcome) in codex_outcomes {
-        all_messages.extend(outcome.messages);
+        all_messages.extend(
+            outcome
+                .messages
+                .into_iter()
+                .filter(|message| should_keep_deduped_message(&mut codex_seen, message)),
+        );
         if let Some(entry) = outcome.cache_entry {
             source_cache.insert(entry);
         } else if outcome.invalidate_cache {
@@ -1756,7 +1762,7 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     counts.set(ClientId::Claude, claude_count);
     messages.extend(claude_msgs);
 
-    let codex_msgs: Vec<ParsedMessage> = scan_result
+    let codex_msgs_raw: Vec<UnifiedMessage> = scan_result
         .get(ClientId::Codex)
         .par_iter()
         .flat_map(|path| {
@@ -1765,10 +1771,16 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
                 .into_iter()
                 .map(|mut msg| {
                     apply_headless_agent(&mut msg, is_headless);
-                    unified_to_parsed(&msg)
+                    msg
                 })
                 .collect::<Vec<_>>()
         })
+        .collect();
+    let mut codex_seen: HashSet<String> = HashSet::new();
+    let codex_msgs: Vec<ParsedMessage> = codex_msgs_raw
+        .into_iter()
+        .filter(|message| should_keep_deduped_message(&mut codex_seen, message))
+        .map(|message| unified_to_parsed(&message))
         .collect();
     let codex_count = codex_msgs.len() as i32;
     counts.set(ClientId::Codex, codex_count);
@@ -2081,6 +2093,13 @@ fn unified_to_parsed(msg: &UnifiedMessage) -> ParsedMessage {
         message_count: msg.message_count,
         agent: msg.agent.clone(),
     }
+}
+
+fn should_keep_deduped_message(seen_keys: &mut HashSet<String>, message: &UnifiedMessage) -> bool {
+    message
+        .dedup_key
+        .as_ref()
+        .is_none_or(|key| seen_keys.insert(key.clone()))
 }
 
 fn summed_parsed_message_count(messages: &[ParsedMessage]) -> i32 {
@@ -3174,6 +3193,140 @@ mod tests {
             assert_eq!(parsed.messages.len(), 3);
             assert_eq!(parsed.messages.iter().map(|m| m.input).sum::<i64>(), 600);
             assert_eq!(parsed.messages.iter().map(|m| m.output).sum::<i64>(), 250);
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    fn write_codex_forked_history_fixture(source_home: &std::path::Path) {
+        let codex_dir = source_home.join(".codex/sessions");
+        std::fs::create_dir_all(&codex_dir).unwrap();
+        std::fs::write(
+            codex_dir.join("parent.jsonl"),
+            concat!(
+                r#"{"timestamp":"2026-04-30T10:00:00Z","type":"session_meta","payload":{"id":"parent-session","source":"interactive","model_provider":"openai","cwd":"/Users/alice/root"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-04-30T10:00:01Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-04-30T10:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30},"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30}}}}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            codex_dir.join("fork.jsonl"),
+            concat!(
+                r#"{"timestamp":"2026-04-30T10:01:00Z","type":"session_meta","payload":{"id":"fork-session","forked_from_id":"parent-session","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent-session","depth":1}}},"model_provider":"openai","cwd":"/Users/alice/root-worktree"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-04-30T10:01:01Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-04-30T10:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30},"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30}}}}"#,
+                "\n",
+                r#"{"timestamp":"2026-04-30T10:01:03Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":110,"cached_input_tokens":22,"output_tokens":33},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3}}}}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parse_all_messages_with_pricing_codex_deduplicates_forked_history() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            write_codex_forked_history_fixture(source_home.path());
+
+            let messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["codex".to_string()],
+                None,
+            );
+
+            assert_eq!(messages.len(), 2);
+            assert_eq!(
+                messages
+                    .iter()
+                    .map(|message| message.tokens.input)
+                    .sum::<i64>(),
+                88
+            );
+            assert_eq!(
+                messages
+                    .iter()
+                    .map(|message| message.tokens.cache_read)
+                    .sum::<i64>(),
+                22
+            );
+            assert_eq!(
+                messages
+                    .iter()
+                    .map(|message| message.tokens.output)
+                    .sum::<i64>(),
+                33
+            );
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parse_local_clients_codex_counts_deduplicated_forked_history() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            write_codex_forked_history_fixture(source_home.path());
+
+            let parsed = parse_local_clients(LocalParseOptions {
+                home_dir: Some(source_home.path().to_str().unwrap().to_string()),
+                use_env_roots: false,
+                clients: Some(vec!["codex".to_string()]),
+                since: None,
+                until: None,
+                year: None,
+                scanner_settings: scanner::ScannerSettings::default(),
+            })
+            .unwrap();
+
+            assert_eq!(parsed.counts.get(ClientId::Codex), 2);
+            assert_eq!(parsed.messages.len(), 2);
+            assert_eq!(
+                parsed
+                    .messages
+                    .iter()
+                    .map(|message| message.input)
+                    .sum::<i64>(),
+                88
+            );
+            assert_eq!(
+                parsed
+                    .messages
+                    .iter()
+                    .map(|message| message.cache_read)
+                    .sum::<i64>(),
+                22
+            );
+            assert_eq!(
+                parsed
+                    .messages
+                    .iter()
+                    .map(|message| message.output)
+                    .sum::<i64>(),
+                33
+            );
         }
 
         match original_home {

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -10,7 +10,7 @@ use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
-const CACHE_SCHEMA_VERSION: u32 = 10;
+const CACHE_SCHEMA_VERSION: u32 = 11;
 const CACHE_FILENAME: &str = "source-message-cache.bin";
 const CACHE_LOCK_FILENAME: &str = "source-message-cache.lock";
 const MAX_CACHE_FILE_BYTES: u64 = 256 * 1024 * 1024;

--- a/crates/tokscale-core/src/sessions/codex.rs
+++ b/crates/tokscale-core/src/sessions/codex.rs
@@ -24,13 +24,15 @@ pub struct CodexEntry {
 
 #[derive(Debug, Deserialize)]
 pub struct CodexPayload {
+    pub id: Option<String>,
+    pub forked_from_id: Option<String>,
     #[serde(rename = "type")]
     pub payload_type: Option<String>,
     pub model: Option<String>,
     pub model_name: Option<String>,
     pub model_info: Option<CodexModelInfo>,
     pub info: Option<CodexInfo>,
-    pub source: Option<String>,
+    pub source: Option<Value>,
     /// Current working directory from session_meta.
     pub cwd: Option<String>,
     /// Provider identity from session_meta (e.g. "openai", "azure")
@@ -152,6 +154,8 @@ pub(crate) struct CodexParseState {
     pub current_model: Option<String>,
     pub previous_totals: Option<CodexTotals>,
     pub session_is_headless: bool,
+    pub session_id_from_meta: Option<String>,
+    pub session_forked_from_id: Option<String>,
     pub session_provider: Option<String>,
     pub session_agent: Option<String>,
     pub session_workspace_key: Option<String>,
@@ -271,8 +275,14 @@ fn parse_codex_reader<R: BufRead>(
                 }
 
                 if entry.entry_type == "session_meta" {
-                    if payload.source.as_deref() == Some("exec") {
+                    if codex_source_is_exec(payload.source.as_ref()) {
                         state.session_is_headless = true;
+                    }
+                    if let Some(ref id) = payload.id {
+                        state.session_id_from_meta = Some(id.clone());
+                    }
+                    if let Some(ref forked_from_id) = payload.forked_from_id {
+                        state.session_forked_from_id = Some(forked_from_id.clone());
                     }
                     if let Some(ref provider) = payload.model_provider {
                         state.session_provider = Some(provider.clone());
@@ -405,6 +415,11 @@ fn parse_codex_reader<R: BufRead>(
                         0.0,
                         agent,
                     );
+                    if parsed_timestamp.is_some() {
+                        if let Some(model) = model.as_deref() {
+                            set_codex_dedup_key(&mut message, model);
+                        }
+                    }
                     message.set_workspace(
                         state.session_workspace_key.clone(),
                         state.session_workspace_label.clone(),
@@ -494,6 +509,30 @@ fn parse_codex_reader<R: BufRead>(
     }
 }
 
+fn codex_source_is_exec(source: Option<&Value>) -> bool {
+    source.and_then(Value::as_str) == Some("exec")
+}
+
+fn codex_token_count_dedup_key(message: &UnifiedMessage, model: &str) -> String {
+    format!(
+        "codex:token_count:{}:{}:{}:{}:{}:{}:{}:{}",
+        message.timestamp,
+        message.provider_id,
+        model,
+        message.tokens.input,
+        message.tokens.output,
+        message.tokens.cache_read,
+        message.tokens.cache_write,
+        message.tokens.reasoning
+    )
+}
+
+fn set_codex_dedup_key(message: &mut UnifiedMessage, model: &str) {
+    if message.dedup_key.is_none() {
+        message.dedup_key = Some(codex_token_count_dedup_key(message, model));
+    }
+}
+
 fn flush_pending_model_messages(
     pending_model_messages: &mut Vec<(UnifiedMessage, bool)>,
     messages: &mut Vec<UnifiedMessage>,
@@ -501,6 +540,9 @@ fn flush_pending_model_messages(
     model: &str,
 ) {
     for (mut message, used_fallback_timestamp) in pending_model_messages.drain(..) {
+        if !used_fallback_timestamp {
+            set_codex_dedup_key(&mut message, model);
+        }
         message.model_id = model.to_string();
         messages.push(message);
         if used_fallback_timestamp {
@@ -1325,6 +1367,29 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].provider_id, "azure");
         assert_eq!(messages[0].agent.as_deref(), Some("my-agent"));
+    }
+
+    #[test]
+    fn test_session_meta_object_source_keeps_provider_agent_and_workspace() {
+        let file = create_test_file(concat!(
+            r#"{"timestamp":"2026-01-01T00:00:00Z","type":"session_meta","payload":{"id":"fork-session","forked_from_id":"parent-session","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent-session","depth":1}}},"model_provider":"openai","agent_nickname":"worker","cwd":"/Users/alice/codex-fork"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-01-01T00:00:01Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-01-01T00:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3}}}}"#,
+            "\n"
+        ));
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].provider_id, "openai");
+        assert_eq!(messages[0].agent.as_deref(), Some("worker"));
+        assert_eq!(
+            messages[0].workspace_key.as_deref(),
+            Some("/Users/alice/codex-fork")
+        );
+        assert!(messages[0].dedup_key.is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Deduplicates Codex `token_count` rows that are replayed from a parent session into forked or worktree sessions.
- Adds a stable Codex token-count deduplication key and applies it in both parsed message paths.
- Preserves object-valued `session_meta.source` metadata for newer Codex session formats and bumps the source-message cache schema.

## Why
Codex fork/worktree sessions can include token history from the parent session before recording new activity. Without cross-file deduplication, Tokscale can count the same usage once from the parent session and again from the forked session.

Fixes #491.

## Test plan
- `cargo test -p tokscale-core codex` (59 passed)
- `cargo test -p tokscale-core` (639 passed, 1 ignored)
- `/opt/homebrew/bin/cargo test --workspace --all-features` (passed)
- `cargo fmt --all -- --check` (passed)
- `/opt/homebrew/bin/cargo-clippy --workspace --all-features -- -D warnings` (passed)
- `git diff --check` (passed)

