### PR TITLE
feat(auth): support non-interactive API token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,11 +390,17 @@ Example: `grok-code` matches `xai/grok-code-fast-1` ($0.20/$1.50) instead of `az
 # Login to Tokscale (opens browser for GitHub auth)
 tokscale login
 
+# Save an existing Tokscale API token without browser auth
+tokscale login --token tt_xxx
+
 # Check who you're logged in as
 tokscale whoami
 
 # Submit your usage data to the leaderboard
 tokscale submit
+
+# Submit in CI/headless environments without writing credentials
+TOKSCALE_API_TOKEN=tt_xxx tokscale submit
 
 # Submit with filters
 tokscale submit --client opencode,claude --since 2024-01-01
@@ -533,6 +539,7 @@ Environment variables override config file values. For CI/CD or one-off use:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `TOKSCALE_NATIVE_TIMEOUT_MS` | `300000` (5 min) | Overrides `nativeTimeoutMs` config |
+| `TOKSCALE_API_TOKEN` | unset | Tokscale personal API token for non-interactive `submit` and `delete-submitted-data` runs. Create one from Settings > API Tokens or save it locally with `tokscale login --token tt_xxx`. |
 | `TOKSCALE_EXTRA_DIRS` | unset | One-off extra session roots as `client:/abs/path,client:/abs/path` |
 | `TOKSCALE_CONFIG_DIR` | unset | Overrides the config directory root (where `settings.json`, `star-cache.json`, `cache/`, and `antigravity-cache/` live). Absolute path recommended; relative paths resolve against the process CWD. Useful for CI sandboxes or pinning a non-default location. When set, tokscale will not fall back to the legacy macOS `~/Library/Application Support/tokscale/` path. |
 
@@ -542,6 +549,9 @@ TOKSCALE_NATIVE_TIMEOUT_MS=600000 tokscale graph --output data.json
 
 # Example: one-off extra scan roots
 TOKSCALE_EXTRA_DIRS='codex:/Users/me/workspace/project-a/.codex/sessions,gemini:/Users/me/imports/imac/gemini/tmp' tokscale
+
+# Example: submit from CI without an interactive browser login
+TOKSCALE_API_TOKEN=tt_xxx tokscale submit
 ```
 
 > **Note**: For persistent extra roots, prefer `scanner.extraScanPaths` in `~/.config/tokscale/settings.json`. `TOKSCALE_EXTRA_DIRS` is best for one-off overrides or CI/CD.
@@ -684,7 +694,7 @@ You can also use a shields.io-style badge for a more compact display:
 
 ### Getting Started
 
-1. **Login** - Run `tokscale login` to authenticate via GitHub
+1. **Login** - Run `tokscale login` to authenticate via GitHub, or create an API token in Settings for CI/headless use
 2. **Submit** - Run `tokscale submit` to upload your usage data
 3. **View** - Visit the web platform to see your profile and the leaderboard
 

--- a/crates/tokscale-cli/src/auth.rs
+++ b/crates/tokscale-cli/src/auth.rs
@@ -5,6 +5,8 @@ use std::io::IsTerminal;
 use std::io::Write;
 use std::path::PathBuf;
 
+const API_TOKEN_ENV_VAR: &str = "TOKSCALE_API_TOKEN";
+
 fn home_dir() -> Result<PathBuf> {
     dirs::home_dir().context("Could not determine home directory")
 }
@@ -17,6 +19,19 @@ pub struct Credentials {
     pub avatar_url: Option<String>,
     #[serde(rename = "createdAt")]
     pub created_at: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApiTokenSource {
+    Environment,
+    StoredCredentials,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApiTokenAuth {
+    pub token: String,
+    pub username: Option<String>,
+    pub source: ApiTokenSource,
 }
 
 #[derive(Debug, Deserialize)]
@@ -47,6 +62,11 @@ struct UserInfo {
     username: String,
     #[serde(rename = "avatarUrl")]
     avatar_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenValidationResponse {
+    user: UserInfo,
 }
 
 fn get_credentials_path() -> Result<PathBuf> {
@@ -101,6 +121,32 @@ pub fn load_credentials() -> Option<Credentials> {
 
     let content = fs::read_to_string(path).ok()?;
     serde_json::from_str(&content).ok()
+}
+
+pub fn load_api_token_from_env() -> Option<String> {
+    let token = std::env::var(API_TOKEN_ENV_VAR).ok()?;
+    let token = token.trim();
+    if token.is_empty() {
+        None
+    } else {
+        Some(token.to_string())
+    }
+}
+
+pub fn resolve_api_token() -> Option<ApiTokenAuth> {
+    if let Some(token) = load_api_token_from_env() {
+        return Some(ApiTokenAuth {
+            token,
+            username: None,
+            source: ApiTokenSource::Environment,
+        });
+    }
+
+    load_credentials().map(|credentials| ApiTokenAuth {
+        token: credentials.token,
+        username: Some(credentials.username),
+        source: ApiTokenSource::StoredCredentials,
+    })
 }
 
 pub fn clear_credentials() -> Result<bool> {
@@ -300,6 +346,59 @@ pub async fn login() -> Result<()> {
     Ok(())
 }
 
+pub async fn login_with_token(token: &str) -> Result<()> {
+    use colored::Colorize;
+
+    let token = token.trim();
+    if token.is_empty() {
+        anyhow::bail!("API token cannot be empty.");
+    }
+    if !token.starts_with("tt_") {
+        anyhow::bail!("Tokscale API tokens must start with `tt_`.");
+    }
+
+    let base_url = get_api_base_url();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()?;
+
+    let response = client
+        .get(format!("{}/api/auth/token", base_url))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body: serde_json::Value = response.json().await.unwrap_or_default();
+        let error = body
+            .get("error")
+            .and_then(|value| value.as_str())
+            .unwrap_or("API token validation failed");
+        anyhow::bail!("{} ({})", error, status);
+    }
+
+    let data: TokenValidationResponse = response.json().await?;
+    let credentials = Credentials {
+        token: token.to_string(),
+        username: data.user.username.clone(),
+        avatar_url: data.user.avatar_url,
+        created_at: chrono::Utc::now().to_rfc3339(),
+    };
+    save_credentials(&credentials)?;
+
+    println!(
+        "\n  {}",
+        format!("Success! Logged in as {}", credentials.username.bold()).green()
+    );
+    println!(
+        "{}",
+        "  You can now use 'bunx tokscale@latest submit' to share your usage.\n".bright_black()
+    );
+
+    Ok(())
+}
+
 pub fn logout() -> Result<()> {
     use colored::Colorize;
 
@@ -361,6 +460,34 @@ mod tests {
     use serial_test::serial;
     use std::env;
     use tempfile::TempDir;
+
+    struct TestEnvGuard {
+        name: &'static str,
+        original: Option<std::ffi::OsString>,
+    }
+
+    impl TestEnvGuard {
+        fn set(name: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let original = env::var_os(name);
+            unsafe {
+                env::set_var(name, value);
+            }
+            Self { name, original }
+        }
+    }
+
+    impl Drop for TestEnvGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(value) => unsafe {
+                    env::set_var(self.name, value);
+                },
+                None => unsafe {
+                    env::remove_var(self.name);
+                },
+            }
+        }
+    }
 
     #[cfg(target_os = "linux")]
     struct EnvVarGuard {
@@ -689,5 +816,43 @@ mod tests {
         unsafe {
             env::remove_var("HOME");
         }
+    }
+
+    #[test]
+    #[serial]
+    fn test_load_api_token_from_env_trims_value() {
+        let _token = TestEnvGuard::set("TOKSCALE_API_TOKEN", "  tt_ci_token  ");
+
+        assert_eq!(load_api_token_from_env(), Some("tt_ci_token".to_string()));
+    }
+
+    #[test]
+    #[serial]
+    fn test_load_api_token_from_env_ignores_empty_values() {
+        let _token = TestEnvGuard::set("TOKSCALE_API_TOKEN", "   ");
+
+        assert_eq!(load_api_token_from_env(), None);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_api_token_prefers_env_over_saved_credentials() {
+        let temp_dir = TempDir::new().unwrap();
+        let _home = TestEnvGuard::set("HOME", temp_dir.path());
+        let _token = TestEnvGuard::set("TOKSCALE_API_TOKEN", "tt_env_token");
+
+        save_credentials(&Credentials {
+            token: "tt_saved_token".to_string(),
+            username: "saved-user".to_string(),
+            avatar_url: None,
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+        })
+        .unwrap();
+
+        let auth = resolve_api_token().unwrap();
+
+        assert_eq!(auth.token, "tt_env_token");
+        assert_eq!(auth.username.as_deref(), None);
+        assert_eq!(auth.source, ApiTokenSource::Environment);
     }
 }

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -170,7 +170,13 @@ enum Commands {
         json: bool,
     },
     #[command(about = "Login to Tokscale (opens browser for GitHub auth)")]
-    Login,
+    Login {
+        #[arg(
+            long,
+            help = "Save an existing Tokscale API token without browser auth"
+        )]
+        token: Option<String>,
+    },
     #[command(about = "Logout from Tokscale")]
     Logout,
     #[command(about = "Show current logged in user")]
@@ -474,9 +480,9 @@ fn main() -> Result<()> {
             reject_unsupported_home_override(&cli.home, "clients")?;
             run_clients_command(json)
         }
-        Some(Commands::Login) => {
+        Some(Commands::Login { token }) => {
             reject_unsupported_home_override(&cli.home, "login")?;
-            run_login_command()
+            run_login_command(token)
         }
         Some(Commands::Logout) => {
             reject_unsupported_home_override(&cli.home, "logout")?;
@@ -3323,11 +3329,16 @@ fn to_ts_token_contribution_data(graph: &tokscale_core::GraphResult) -> TsTokenC
     }
 }
 
-fn run_login_command() -> Result<()> {
+fn run_login_command(token: Option<String>) -> Result<()> {
     use tokio::runtime::Runtime;
 
     let rt = Runtime::new()?;
-    rt.block_on(async { auth::login().await })
+    rt.block_on(async {
+        match token {
+            Some(token) => auth::login_with_token(&token).await,
+            None => auth::login().await,
+        }
+    })
 }
 
 fn run_logout_command() -> Result<()> {
@@ -3343,8 +3354,9 @@ fn run_delete_data_command() -> Result<()> {
     use std::io::{self, Write};
     use tokio::runtime::Runtime;
 
-    let credentials = auth::load_credentials()
-        .ok_or_else(|| anyhow::anyhow!("Not logged in. Run `tokscale login` first."))?;
+    let auth_token = auth::resolve_api_token().ok_or_else(|| {
+        anyhow::anyhow!("Not logged in. Run `tokscale login` or set TOKSCALE_API_TOKEN.")
+    })?;
 
     println!("\n{}", "  ⚠ Delete all submitted usage data".red().bold());
     println!("{}", "  This will permanently remove:".bright_black());
@@ -3398,7 +3410,7 @@ fn run_delete_data_command() -> Result<()> {
     let response = rt.block_on(async {
         reqwest::Client::new()
             .delete(format!("{}/api/settings/submitted-data", api_url))
-            .header("Authorization", format!("Bearer {}", credentials.token))
+            .header("Authorization", format!("Bearer {}", auth_token.token))
             .send()
             .await
     });
@@ -3815,20 +3827,25 @@ fn run_submit_command(
     use tokio::runtime::Runtime;
     use tokscale_core::{generate_graph, GroupBy, ReportOptions};
 
-    let credentials = match auth::load_credentials() {
-        Some(creds) => creds,
+    let auth_token = match auth::resolve_api_token() {
+        Some(token) => token,
         None => {
             eprintln!("\n  {}", "Not logged in.".yellow());
             eprintln!(
                 "{}",
-                "  Run 'bunx tokscale@latest login' first.\n".bright_black()
+                "  Run 'bunx tokscale@latest login' or set TOKSCALE_API_TOKEN.\n".bright_black()
             );
             std::process::exit(1);
         }
     };
 
-    if std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
-        let _ = prompt_star_repo(&credentials.username);
+    if auth_token.source == auth::ApiTokenSource::StoredCredentials
+        && std::io::stdin().is_terminal()
+        && std::io::stdout().is_terminal()
+    {
+        if let Some(username) = auth_token.username.as_deref() {
+            let _ = prompt_star_repo(username);
+        }
     }
 
     println!("\n  {}\n", "Tokscale - Submit Usage Data".cyan());
@@ -3947,7 +3964,7 @@ fn run_submit_command(
         reqwest::Client::new()
             .post(format!("{}/api/submit", api_url))
             .header("Content-Type", "application/json")
-            .header("Authorization", format!("Bearer {}", credentials.token))
+            .header("Authorization", format!("Bearer {}", auth_token.token))
             .json(&submit_payload)
             .send()
             .await
@@ -4013,19 +4030,22 @@ fn run_submit_command(
                     println!("{}", format!("    Active days: {}", days).bright_black());
                 }
             }
-            println!();
-            println!(
-                "{}",
-                osc8_link_with_text(
-                    &format!("{}/u/{}", api_url, credentials.username),
-                    &format!(
-                        "  View your profile: {}/u/{}",
-                        api_url, credentials.username
-                    ),
-                )
-                .cyan()
-            );
-            println!();
+            if let Some(username) = body
+                .username
+                .clone()
+                .or_else(|| auth_token.username.clone())
+            {
+                println!();
+                println!(
+                    "{}",
+                    osc8_link_with_text(
+                        &format!("{}/u/{}", api_url, username),
+                        &format!("  View your profile: {}/u/{}", api_url, username),
+                    )
+                    .cyan()
+                );
+                println!();
+            }
 
             if let Some(warnings) = body.warnings {
                 if !warnings.is_empty() {
@@ -5042,6 +5062,17 @@ mod tests {
     fn test_delete_submitted_data_command_parses() {
         let cli = Cli::try_parse_from(["tokscale", "delete-submitted-data"]).unwrap();
         assert!(matches!(cli.command, Some(Commands::DeleteSubmittedData)));
+    }
+
+    #[test]
+    fn test_login_token_option_parses() {
+        let cli = Cli::try_parse_from(["tokscale", "login", "--token", "tt_ci_token"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Login {
+                token: Some(token)
+            }) if token == "tt_ci_token"
+        ));
     }
 
     #[test]

--- a/packages/frontend/__tests__/api/authToken.test.ts
+++ b/packages/frontend/__tests__/api/authToken.test.ts
@@ -1,0 +1,111 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const authenticatePersonalToken = vi.fn();
+
+  return {
+    authenticatePersonalToken,
+    reset() {
+      authenticatePersonalToken.mockReset();
+    },
+  };
+});
+
+vi.mock("@/lib/auth/personalTokens", () => ({
+  authenticatePersonalToken: mockState.authenticatePersonalToken,
+}));
+
+type ModuleExports = typeof import("../../src/app/api/auth/token/route");
+
+let GET: ModuleExports["GET"];
+
+beforeAll(async () => {
+  const routeModule = await import("../../src/app/api/auth/token/route");
+  GET = routeModule.GET;
+});
+
+beforeEach(() => {
+  mockState.reset();
+});
+
+describe("GET /api/auth/token", () => {
+  it("returns 401 when the bearer token is missing", async () => {
+    const response = await GET(
+      new Request("http://localhost:3000/api/auth/token")
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      error: "Missing or invalid Authorization header",
+    });
+    expect(mockState.authenticatePersonalToken).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the bearer token is invalid", async () => {
+    mockState.authenticatePersonalToken.mockResolvedValue({ status: "invalid" });
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/auth/token", {
+        headers: { Authorization: "Bearer tt_invalid" },
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockState.authenticatePersonalToken).toHaveBeenCalledWith("tt_invalid", {
+      touchLastUsedAt: false,
+    });
+    expect(await response.json()).toEqual({ error: "Invalid API token" });
+  });
+
+  it("accepts the bearer scheme case-insensitively", async () => {
+    mockState.authenticatePersonalToken.mockResolvedValue({
+      status: "valid",
+      tokenId: "token-1",
+      userId: "user-1",
+      username: "alice",
+      displayName: null,
+      avatarUrl: null,
+      isAdmin: false,
+      expiresAt: null,
+    });
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/auth/token", {
+        headers: { Authorization: "bEaReR tt_valid" },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockState.authenticatePersonalToken).toHaveBeenCalledWith("tt_valid", {
+      touchLastUsedAt: false,
+    });
+  });
+
+  it("returns user metadata for a valid bearer token", async () => {
+    mockState.authenticatePersonalToken.mockResolvedValue({
+      status: "valid",
+      tokenId: "token-1",
+      userId: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: "https://example.com/alice.png",
+      isAdmin: false,
+      expiresAt: null,
+    });
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/auth/token", {
+        headers: { Authorization: "Bearer tt_valid" },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      user: {
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: "https://example.com/alice.png",
+      },
+    });
+  });
+});

--- a/packages/frontend/__tests__/api/settingsTokensList.test.ts
+++ b/packages/frontend/__tests__/api/settingsTokensList.test.ts
@@ -3,13 +3,16 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 const mockState = vi.hoisted(() => {
   const getSession = vi.fn();
   const listPersonalTokens = vi.fn();
+  const issuePersonalToken = vi.fn();
 
   return {
     getSession,
     listPersonalTokens,
+    issuePersonalToken,
     reset() {
       getSession.mockReset();
       listPersonalTokens.mockReset();
+      issuePersonalToken.mockReset();
     },
   };
 });
@@ -20,15 +23,18 @@ vi.mock("@/lib/auth/session", () => ({
 
 vi.mock("@/lib/auth/personalTokens", () => ({
   listPersonalTokens: mockState.listPersonalTokens,
+  issuePersonalToken: mockState.issuePersonalToken,
 }));
 
 type ModuleExports = typeof import("../../src/app/api/settings/tokens/route");
 
 let GET: ModuleExports["GET"];
+let POST: ModuleExports["POST"];
 
 beforeAll(async () => {
   const routeModule = await import("../../src/app/api/settings/tokens/route");
   GET = routeModule.GET;
+  POST = routeModule.POST;
 });
 
 beforeEach(() => {
@@ -134,5 +140,97 @@ describe("GET /api/settings/tokens", () => {
 
     expect(response.status).toBe(500);
     expect(await response.json()).toEqual({ error: "Failed to fetch tokens" });
+  });
+});
+
+describe("POST /api/settings/tokens", () => {
+  it("returns 401 when user is not authenticated", async () => {
+    mockState.getSession.mockResolvedValue(null);
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/settings/tokens", {
+        method: "POST",
+        body: JSON.stringify({ name: "CI" }),
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockState.issuePersonalToken).not.toHaveBeenCalled();
+  });
+
+  it("creates a token and returns the raw token once", async () => {
+    mockState.getSession.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      isAdmin: false,
+    });
+    mockState.issuePersonalToken.mockResolvedValue({
+      id: "token-1",
+      userId: "user-1",
+      name: "GitHub Actions",
+      token: "tt_raw_token",
+      createdAt: new Date("2026-05-01T10:00:00.000Z"),
+      lastUsedAt: null,
+      expiresAt: null,
+    });
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/settings/tokens", {
+        method: "POST",
+        body: JSON.stringify({ name: "  GitHub Actions  " }),
+      })
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockState.issuePersonalToken).toHaveBeenCalledWith({
+      userId: "user-1",
+      name: "GitHub Actions",
+      ensureUniqueName: true,
+    });
+    expect(await response.json()).toEqual({
+      token: {
+        id: "token-1",
+        name: "GitHub Actions",
+        token: "tt_raw_token",
+        createdAt: "2026-05-01T10:00:00.000Z",
+        lastUsedAt: null,
+      },
+    });
+  });
+
+  it("uses a safe default name when the request name is blank", async () => {
+    mockState.getSession.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      isAdmin: false,
+    });
+    mockState.issuePersonalToken.mockResolvedValue({
+      id: "token-1",
+      userId: "user-1",
+      name: "CI token",
+      token: "tt_raw_token",
+      createdAt: new Date("2026-05-01T10:00:00.000Z"),
+      lastUsedAt: null,
+      expiresAt: null,
+    });
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/settings/tokens", {
+        method: "POST",
+        body: JSON.stringify({ name: "   " }),
+      })
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockState.issuePersonalToken).toHaveBeenCalledWith({
+      userId: "user-1",
+      name: "CI token",
+      ensureUniqueName: true,
+    });
   });
 });

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -201,6 +201,40 @@ describe("POST /api/submit auth path", () => {
     });
   });
 
+  it("accepts the bearer scheme case-insensitively", async () => {
+    mockState.authenticatePersonalToken.mockResolvedValue({
+      status: "valid",
+      tokenId: "token-1",
+      userId: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      isAdmin: false,
+      expiresAt: null,
+    });
+    mockState.validateSubmission.mockReturnValue({
+      valid: false,
+      data: null,
+      errors: ["bad payload"],
+    });
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ meta: {}, contributions: [] }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockState.authenticatePersonalToken).toHaveBeenCalledWith("tt_valid", {
+      touchLastUsedAt: false,
+    });
+  });
+
   it("revalidates username ISR paths after a successful submit", async () => {
     mockState.authenticatePersonalToken.mockResolvedValue({
       status: "valid",
@@ -330,8 +364,11 @@ describe("POST /api/submit auth path", () => {
       }),
       execute: vi.fn(() => Promise.resolve()),
     };
+    type MockTransaction = typeof tx;
 
-    mockState.db.transaction.mockImplementation(async (callback: (tx: typeof tx) => Promise<unknown>) => callback(tx));
+    mockState.db.transaction.mockImplementation(async (callback: (tx: MockTransaction) => Promise<unknown>) =>
+      callback(tx)
+    );
 
     const response = await POST(
       new Request("http://localhost:3000/api/submit", {

--- a/packages/frontend/__tests__/lib/bearerToken.test.ts
+++ b/packages/frontend/__tests__/lib/bearerToken.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { getBearerToken } from "../../src/lib/auth/bearerToken";
+
+describe("getBearerToken", () => {
+  it("returns null when the header is missing or malformed", () => {
+    expect(getBearerToken(null)).toBeNull();
+    expect(getBearerToken("")).toBeNull();
+    expect(getBearerToken("Basic abc")).toBeNull();
+    expect(getBearerToken("Bearer")).toBeNull();
+  });
+
+  it("accepts the bearer auth scheme case-insensitively", () => {
+    expect(getBearerToken("Bearer tt_token")).toBe("tt_token");
+    expect(getBearerToken("bearer tt_token")).toBe("tt_token");
+    expect(getBearerToken("bEaReR tt_token")).toBe("tt_token");
+  });
+
+  it("trims surrounding token whitespace", () => {
+    expect(getBearerToken("Bearer   tt_token  ")).toBe("tt_token");
+  });
+});

--- a/packages/frontend/src/app/api/auth/token/route.ts
+++ b/packages/frontend/src/app/api/auth/token/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { authenticatePersonalToken } from "@/lib/auth/personalTokens";
+import { getBearerToken } from "../../../../lib/auth/bearerToken";
+
+export async function GET(request: Request) {
+  try {
+    const token = getBearerToken(request.headers.get("Authorization"));
+    if (!token) {
+      return NextResponse.json(
+        { error: "Missing or invalid Authorization header" },
+        { status: 401 }
+      );
+    }
+
+    const authResult = await authenticatePersonalToken(token, {
+      touchLastUsedAt: false,
+    });
+
+    if (authResult.status === "invalid") {
+      return NextResponse.json({ error: "Invalid API token" }, { status: 401 });
+    }
+
+    if (authResult.status === "expired") {
+      return NextResponse.json(
+        { error: "API token has expired" },
+        { status: 401 }
+      );
+    }
+
+    return NextResponse.json({
+      user: {
+        username: authResult.username,
+        displayName: authResult.displayName,
+        avatarUrl: authResult.avatarUrl,
+      },
+    });
+  } catch (error) {
+    console.error("Token auth error:", error);
+    return NextResponse.json(
+      { error: "Failed to validate token" },
+      { status: 500 }
+    );
+  }
+}

--- a/packages/frontend/src/app/api/settings/submitted-data/route.ts
+++ b/packages/frontend/src/app/api/settings/submitted-data/route.ts
@@ -5,11 +5,11 @@ import { getSession } from "@/lib/auth/session";
 import { authenticatePersonalToken } from "@/lib/auth/personalTokens";
 import { db, submissions } from "@/lib/db";
 import { normalizeUsernameCacheKey, revalidateUsernamePaths } from "@/lib/db/usernameLookup";
+import { getBearerToken } from "../../../../lib/auth/bearerToken";
 
 async function resolveUser(request: Request): Promise<{ id: string; username: string } | null> {
-  const authHeader = request.headers.get("Authorization");
-  if (authHeader?.startsWith("Bearer ")) {
-    const token = authHeader.slice(7);
+  const token = getBearerToken(request.headers.get("Authorization"));
+  if (token) {
     const result = await authenticatePersonalToken(token, { touchLastUsedAt: false });
     if (result.status === "valid") {
       return { id: result.userId, username: result.username };

--- a/packages/frontend/src/app/api/settings/tokens/route.ts
+++ b/packages/frontend/src/app/api/settings/tokens/route.ts
@@ -1,6 +1,22 @@
 import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
-import { listPersonalTokens } from "@/lib/auth/personalTokens";
+import { issuePersonalToken, listPersonalTokens } from "@/lib/auth/personalTokens";
+
+const DEFAULT_TOKEN_NAME = "CI token";
+const MAX_TOKEN_NAME_LENGTH = 100;
+
+function normalizeTokenName(value: unknown): string {
+  if (typeof value !== "string") {
+    return DEFAULT_TOKEN_NAME;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return DEFAULT_TOKEN_NAME;
+  }
+
+  return trimmed.slice(0, MAX_TOKEN_NAME_LENGTH);
+}
 
 export async function GET() {
   try {
@@ -23,6 +39,43 @@ export async function GET() {
     console.error("Tokens list error:", error);
     return NextResponse.json(
       { error: "Failed to fetch tokens" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const session = await getSession();
+    if (!session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const rawName =
+      body && typeof body === "object" ? (body as { name?: unknown }).name : undefined;
+    const issuedToken = await issuePersonalToken({
+      userId: session.id,
+      name: normalizeTokenName(rawName),
+      ensureUniqueName: true,
+    });
+
+    return NextResponse.json(
+      {
+        token: {
+          id: issuedToken.id,
+          name: issuedToken.name,
+          token: issuedToken.token,
+          createdAt: issuedToken.createdAt,
+          lastUsedAt: issuedToken.lastUsedAt,
+        },
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("Token create error:", error);
+    return NextResponse.json(
+      { error: "Failed to create token" },
       { status: 500 }
     );
   }

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -8,6 +8,7 @@ import {
   type SubmissionData,
 } from "@/lib/validation/submission";
 import { authenticatePersonalToken } from "@/lib/auth/personalTokens";
+import { getBearerToken } from "../../../lib/auth/bearerToken";
 import {
   mergeClientBreakdowns,
   recalculateDayTotals,
@@ -65,15 +66,14 @@ export async function POST(request: Request) {
     // ========================================
     // STEP 1: Authentication
     // ========================================
-    const authHeader = request.headers.get("Authorization");
-    if (!authHeader?.startsWith("Bearer ")) {
+    const token = getBearerToken(request.headers.get("Authorization"));
+    if (!token) {
       return NextResponse.json(
         { error: "Missing or invalid Authorization header" },
         { status: 401 }
       );
     }
 
-    const token = authHeader.slice(7);
     const authResult = await authenticatePersonalToken(token, {
       touchLastUsedAt: false,
     });

--- a/packages/frontend/src/app/settings/SettingsClient.tsx
+++ b/packages/frontend/src/app/settings/SettingsClient.tsx
@@ -22,6 +22,10 @@ interface ApiToken {
   lastUsedAt: string | null;
 }
 
+interface CreatedApiToken extends ApiToken {
+  token: string;
+}
+
 const PageWrapper = styled.div`
   min-height: 100vh;
   display: flex;
@@ -85,6 +89,99 @@ const CodeText = styled.code`
 const Description = styled.p`
   font-size: 14px;
   margin-bottom: 16px;
+`;
+
+const FieldLabel = styled.label`
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 8px;
+`;
+
+const ActionRow = styled.div`
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  margin-bottom: 16px;
+
+  @media (max-width: 560px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const TextInput = styled.input`
+  height: 40px;
+  padding: 0 12px;
+  border-radius: 6px;
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-default);
+  color: var(--color-fg-default);
+  font-size: 14px;
+`;
+
+const PrimaryButton = styled.button`
+  height: 40px;
+  padding: 0 14px;
+  border-radius: 6px;
+  border: 1px solid var(--color-accent-fg);
+  background: var(--color-accent-fg);
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 150ms;
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+`;
+
+const TokenReveal = styled.div`
+  padding: 12px;
+  border-radius: 6px;
+  border: 1px solid var(--color-success-fg);
+  background: rgba(63, 185, 80, 0.08);
+  margin-bottom: 16px;
+`;
+
+const TokenCodeRow = styled.div`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  margin-top: 8px;
+
+  @media (max-width: 560px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const TokenCode = styled.code`
+  display: block;
+  overflow-x: auto;
+  white-space: nowrap;
+  padding: 10px 12px;
+  border-radius: 6px;
+  background: var(--color-bg-default);
+  font-size: 13px;
+`;
+
+const SecondaryButton = styled.button`
+  height: 38px;
+  padding: 0 12px;
+  border-radius: 6px;
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-default);
+  color: var(--color-fg-default);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+`;
+
+const ErrorText = styled.p`
+  color: #f85149;
+  font-size: 13px;
+  margin: -4px 0 16px;
 `;
 
 const EmptyState = styled.div`
@@ -160,35 +257,78 @@ const TokenName = styled.p`
   font-weight: 500;
 `;
 
+function apiTokenListItem(token: CreatedApiToken): ApiToken {
+  return {
+    id: token.id,
+    name: token.name,
+    createdAt: token.createdAt,
+    lastUsedAt: token.lastUsedAt,
+  };
+}
+
+function prependApiToken(tokens: ApiToken[], token: ApiToken): ApiToken[] {
+  return [token, ...tokens.filter((item) => item.id !== token.id)];
+}
+
+function mergeApiTokenList(
+  serverTokens: ApiToken[],
+  currentTokens: ApiToken[]
+): ApiToken[] {
+  const serverTokenIds = new Set(serverTokens.map((token) => token.id));
+  const localTokens = currentTokens.filter(
+    (token) => !serverTokenIds.has(token.id)
+  );
+  return [...localTokens, ...serverTokens];
+}
+
+async function fetchApiTokens(): Promise<ApiToken[]> {
+  const tokensResponse = await fetch("/api/settings/tokens");
+  const tokensData = await tokensResponse.json();
+  return Array.isArray(tokensData.tokens) ? tokensData.tokens : [];
+}
+
 export default function SettingsClient() {
   const router = useRouter();
   const [user, setUser] = useState<User | null>(null);
   const [tokens, setTokens] = useState<ApiToken[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [tokenName, setTokenName] = useState("CI token");
+  const [createdToken, setCreatedToken] = useState<CreatedApiToken | null>(null);
+  const [isCreatingToken, setIsCreatingToken] = useState(false);
+  const [createTokenError, setCreateTokenError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch("/api/auth/session")
-      .then((res) => res.json())
-      .then((data) => {
-        if (!data.user) {
+    let cancelled = false;
+
+    async function loadSettings() {
+      try {
+        const sessionResponse = await fetch("/api/auth/session");
+        const sessionData = await sessionResponse.json();
+        if (cancelled) return;
+
+        if (!sessionData.user) {
           router.push("/api/auth/github?returnTo=/settings");
           return;
         }
-        setUser(data.user);
-        setIsLoading(false);
-      })
-      .catch(() => {
-        router.push("/leaderboard");
-      });
 
-    fetch("/api/settings/tokens")
-      .then((res) => res.json())
-      .then((data) => {
-        if (data.tokens) {
-          setTokens(data.tokens);
+        const loadedTokens = await fetchApiTokens().catch(() => []);
+
+        if (!cancelled) {
+          setUser(sessionData.user);
+          setTokens((current) => mergeApiTokenList(loadedTokens, current));
+          setIsLoading(false);
         }
-      })
-      .catch(() => {});
+      } catch {
+        if (!cancelled) {
+          router.push("/leaderboard");
+        }
+      }
+    }
+
+    loadSettings();
+    return () => {
+      cancelled = true;
+    };
   }, [router]);
 
   const handleRevokeToken = async (tokenId: string) => {
@@ -205,6 +345,38 @@ export default function SettingsClient() {
     } catch {
       alert("Failed to revoke token");
     }
+  };
+
+  const handleCreateToken = async () => {
+    setIsCreatingToken(true);
+    setCreateTokenError(null);
+
+    try {
+      const response = await fetch("/api/settings/tokens", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: tokenName }),
+      });
+
+      const data = await response.json();
+      if (!response.ok || !data.token) {
+        throw new Error(data.error || "Failed to create token");
+      }
+
+      setCreatedToken(data.token);
+      setTokens((current) =>
+        prependApiToken(current, apiTokenListItem(data.token))
+      );
+    } catch (error) {
+      setCreateTokenError(error instanceof Error ? error.message : "Failed to create token");
+    } finally {
+      setIsCreatingToken(false);
+    }
+  };
+
+  const handleCopyCreatedToken = async () => {
+    if (!createdToken) return;
+    await navigator.clipboard.writeText(createdToken.token);
   };
 
   if (isLoading) {
@@ -271,7 +443,7 @@ export default function SettingsClient() {
             API Tokens
           </SectionTitle>
           <Description style={{ color: "var(--color-fg-muted)" }}>
-            Tokens are created when you run{" "}
+            Create a token for CI or use one generated by{" "}
             <CodeText
               style={{ backgroundColor: "var(--color-bg-subtle)" }}
             >
@@ -280,6 +452,46 @@ export default function SettingsClient() {
             from the CLI.
           </Description>
 
+          <FieldLabel
+            htmlFor="token-name"
+            style={{ color: "var(--color-fg-default)" }}
+          >
+            Token name
+          </FieldLabel>
+          <ActionRow>
+            <TextInput
+              id="token-name"
+              value={tokenName}
+              onChange={(event) => setTokenName(event.target.value)}
+              maxLength={100}
+            />
+            <PrimaryButton
+              type="button"
+              disabled={isCreatingToken}
+              onClick={handleCreateToken}
+            >
+              {isCreatingToken ? "Creating..." : "Create token"}
+            </PrimaryButton>
+          </ActionRow>
+
+          {createTokenError && <ErrorText>{createTokenError}</ErrorText>}
+
+          {createdToken && (
+            <TokenReveal>
+              <SmallText style={{ color: "var(--color-fg-default)", fontWeight: 600 }}>
+                Copy this token now. It will not be shown again.
+              </SmallText>
+              <TokenCodeRow>
+                <TokenCode style={{ color: "var(--color-fg-default)" }}>
+                  {createdToken.token}
+                </TokenCode>
+                <SecondaryButton type="button" onClick={handleCopyCreatedToken}>
+                  Copy
+                </SecondaryButton>
+              </TokenCodeRow>
+            </TokenReveal>
+          )}
+
           {tokens.length === 0 ? (
             <EmptyState style={{ color: "var(--color-fg-muted)" }}>
               <EmptyIcon>
@@ -287,13 +499,13 @@ export default function SettingsClient() {
               </EmptyIcon>
               <p>No API tokens yet.</p>
               <EmptyText>
-                Run{" "}
+                Create one here or run{" "}
                 <CodeText
                   style={{ backgroundColor: "var(--color-bg-subtle)" }}
                 >
                   tokscale login
                 </CodeText>{" "}
-                to create one.
+                from the CLI.
               </EmptyText>
             </EmptyState>
           ) : (

--- a/packages/frontend/src/lib/auth/bearerToken.ts
+++ b/packages/frontend/src/lib/auth/bearerToken.ts
@@ -1,0 +1,13 @@
+export function getBearerToken(authHeader: string | null): string | null {
+  if (!authHeader) {
+    return null;
+  }
+
+  const match = authHeader.match(/^Bearer\s+(.+)$/i);
+  if (!match) {
+    return null;
+  }
+
+  const token = match[1].trim();
+  return token ? token : null;
+}


### PR DESCRIPTION
## Summary
- Add `TOKSCALE_API_TOKEN` as a non-interactive authentication source for `tokscale submit` and `tokscale delete-submitted-data`.
- Add `tokscale login --token tt_xxx` so users can save an existing Tokscale API token without browser/device-flow auth.
- Add Settings UI token creation with one-time token reveal, plus a token validation endpoint for the CLI.

## Why
Fixes #203. Browser-based device login does not work well in CI/CD, headless servers, containers, or ephemeral automation environments. Tokscale already authenticates submissions with personal `tt_...` API tokens server-side, but the CLI and Settings UI did not expose a clean non-interactive workflow.

## Diff scope
- `crates/tokscale-cli/src/auth.rs`: resolves `TOKSCALE_API_TOKEN`, validates `login --token` via the web API, and preserves existing stored credentials behavior.
- `crates/tokscale-cli/src/main.rs`: wires token auth into `submit`, `delete-submitted-data`, and CLI parsing.
- `packages/frontend/src/app/api/auth/token/route.ts`: validates bearer tokens and returns account metadata for CLI token login.
- `packages/frontend/src/app/api/settings/tokens/route.ts`: adds authenticated token creation.
- `packages/frontend/src/app/settings/SettingsClient.tsx`: adds token creation UI with one-time reveal and copy support.
- `README.md`: documents `login --token` and `TOKSCALE_API_TOKEN` for CI/headless usage.

## Safety
- Environment tokens are used only for the current process and are not written to disk.
- Stored browser/device-flow credentials remain the fallback when `TOKSCALE_API_TOKEN` is not set.
- `login --token` validates the token before saving it locally.
- The existing personal-token hashing, expiry, revocation, and submit authentication service remain the source of truth.
- No database migration or token storage format change.

## Validation
- `cargo test -p tokscale-cli auth` — **15 passed**.
- `cargo test -p tokscale-cli` — **461 passed**, **1 ignored**; `cli_tests` **86 passed**.
- `cargo test --workspace --all-features` — **PASS** (`tokscale-cli`: 461 passed, 1 ignored; `cli_tests`: 86 passed; `tokscale-core`: 636 passed, 1 ignored; `codebuff`: 10 passed; `hermes`: 3 passed; doc-tests: 0).
- `bunx vitest run packages/frontend/__tests__` — **20 files passed**, **172 tests passed**.
- `bun run --cwd packages/frontend lint` — **PASS**, 0 errors; 7 pre-existing warnings in untouched files.
- `cargo fmt --all -- --check` — **PASS**.
- `/opt/homebrew/bin/cargo-clippy --package=tokscale-cli --all-features -- -D warnings` — **PASS**.
- `git diff --check origin/main...HEAD` — **PASS**, no output.

## Rollback
Revert the merge commit. No migration, data repair, or release procedure changes are required.

