### PR TITLE
fix(claude): scan wrapper transcripts with usage metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 | Logo | Client | Data Location | Supported |
 |------|----------|---------------|-----------|
 | <img width="48px" src=".github/assets/client-opencode.png" alt="OpenCode" /> | [OpenCode](https://github.com/sst/opencode) | `~/.local/share/opencode/opencode.db` (1.2+, all channels including `opencode-stable.db`) or/and `~/.local/share/opencode/storage/message/` (legacy/unmigrated) | ✅ Yes |
-| <img width="48px" src=".github/assets/client-claude.jpg" alt="Claude" /> | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `~/.claude/projects/` | ✅ Yes |
+| <img width="48px" src=".github/assets/client-claude.jpg" alt="Claude" /> | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `~/.claude/projects/` and `~/.claude/transcripts/` | ✅ Yes |
 | <img width="48px" src=".github/assets/client-openclaw.jpg" alt="OpenClaw" /> | [OpenClaw](https://openclaw.ai/) | `~/.openclaw/agents/` (+ legacy: `.clawdbot`, `.moltbot`, `.moldbot`) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-openai.jpg" alt="Codex" /> | [Codex CLI](https://github.com/openai/codex) | `~/.codex/sessions/` | ✅ Yes |
 | <img width="48px" src=".github/assets/client-copilot.jpg" alt="Copilot" /> | [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-the-github-copilot-coding-agent-in-cli) | `~/.copilot/otel/*.jsonl` (+ `COPILOT_OTEL_FILE_EXPORTER_PATH`) | ✅ Yes |
@@ -1075,12 +1075,14 @@ Each message contains:
 
 ### Claude Code
 
-Location: `~/.claude/projects/{projectPath}/*.jsonl`
+Location: `~/.claude/projects/{projectPath}/*.jsonl` and `~/.claude/transcripts/*.jsonl`
 
 JSONL format with assistant messages containing usage data:
 ```json
 {"type": "assistant", "message": {"model": "claude-sonnet-4-20250514", "usage": {"input_tokens": 1234, "output_tokens": 567, "cache_read_input_tokens": 890}}, "timestamp": "2024-01-01T00:00:00Z"}
 ```
+
+Wrapper transcript files under `~/.claude/transcripts/` are counted only when they contain real Claude usage metadata. Files with user/tool events but no `usage` block are skipped rather than estimated.
 
 ### Codex CLI
 

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -2809,7 +2809,10 @@ fn capitalize_client(client: &str) -> String {
 }
 
 fn run_clients_command(json: bool) -> Result<()> {
-    use tokscale_core::{extra_scan_paths_for, parse_local_clients, ClientId, LocalParseOptions};
+    use tokscale_core::{
+        built_in_extra_scan_paths_for, extra_scan_paths_for, parse_local_clients, ClientId,
+        LocalParseOptions,
+    };
 
     let home_dir =
         dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
@@ -2846,6 +2849,8 @@ fn run_clients_command(json: bool) -> Result<()> {
         sessions_path: String,
         sessions_path_exists: bool,
         #[serde(skip_serializing_if = "Vec::is_empty")]
+        additional_paths: Vec<AdditionalPath>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
         legacy_paths: Vec<LegacyPath>,
         message_count: i32,
         headless_supported: bool,
@@ -2856,6 +2861,13 @@ fn run_clients_command(json: bool) -> Result<()> {
         exporter_status: Option<String>,
         #[serde(skip_serializing_if = "Vec::is_empty")]
         extra_paths: Vec<ExtraPath>,
+    }
+
+    #[derive(serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct AdditionalPath {
+        path: String,
+        exists: bool,
     }
 
     #[derive(serde::Serialize)]
@@ -2885,6 +2897,8 @@ fn run_clients_command(json: bool) -> Result<()> {
     let all_clients: std::collections::HashSet<ClientId> = ClientId::iter().collect();
     let extra_dirs: Vec<(ClientId, String)> =
         tokscale_core::parse_extra_dirs(&extra_dirs_val, &all_clients);
+    let built_in_extra_paths =
+        built_in_extra_scan_paths_for(&home_dir.to_string_lossy(), &all_clients);
     let settings_extra_dirs = extra_scan_paths_for(&scanner_settings, &all_clients);
     let copilot_exporter_path = tokscale_core::copilot_exporter_path();
 
@@ -2893,6 +2907,14 @@ fn run_clients_command(json: bool) -> Result<()> {
             .map(|client| {
                 let sessions_path = client.data().resolve_path(&home_dir.to_string_lossy());
                 let sessions_path_exists = Path::new(&sessions_path).exists();
+                let additional_paths: Vec<AdditionalPath> = built_in_extra_paths
+                    .iter()
+                    .filter(|(c, _)| *c == client)
+                    .map(|(_, path)| AdditionalPath {
+                        path: path.to_string_lossy().to_string(),
+                        exists: path.exists(),
+                    })
+                    .collect();
                 let legacy_paths = if client == ClientId::OpenClaw {
                     vec![
                         LegacyPath {
@@ -2973,6 +2995,7 @@ fn run_clients_command(json: bool) -> Result<()> {
                     label,
                     sessions_path,
                     sessions_path_exists,
+                    additional_paths,
                     legacy_paths,
                     message_count: parsed.counts.get(client),
                     headless_supported,
@@ -3033,6 +3056,18 @@ fn run_clients_command(json: bool) -> Result<()> {
                 )
                 .bright_black()
             );
+
+            if !row.additional_paths.is_empty() {
+                let additional_desc: Vec<String> = row
+                    .additional_paths
+                    .iter()
+                    .map(|ap| describe_path(&ap.path, ap.exists))
+                    .collect();
+                println!(
+                    "  {}",
+                    format!("additional: {}", additional_desc.join(", ")).bright_black()
+                );
+            }
 
             if !row.legacy_paths.is_empty() {
                 let legacy_desc: Vec<String> = row

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -1590,6 +1590,46 @@ fn test_clients_json() {
 }
 
 #[test]
+fn test_clients_json_includes_claude_transcripts_path() {
+    let tmp = create_empty_fixture_dir();
+    fs::create_dir_all(tmp.path().join(".claude/transcripts")).unwrap();
+
+    let output = cmd_with_home(tmp.path())
+        .args(["clients", "--json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let claude = json["clients"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["client"] == "claude")
+        .unwrap();
+
+    assert_eq!(
+        claude["additionalPaths"][0]["path"],
+        serde_json::json!(tmp.path().join(".claude/transcripts"))
+    );
+    assert_eq!(claude["additionalPaths"][0]["exists"], true);
+}
+
+#[test]
+fn test_clients_command_includes_claude_transcripts_text() {
+    let tmp = create_empty_fixture_dir();
+    fs::create_dir_all(tmp.path().join(".claude/transcripts")).unwrap();
+
+    cmd_with_home(tmp.path())
+        .arg("clients")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "additional: ~/.claude/transcripts ✓",
+        ));
+}
+
+#[test]
 fn test_clients_json_includes_settings_extra_paths() {
     let tmp = create_empty_fixture_dir();
     write_settings_json(

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -4453,6 +4453,52 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_local_clients_claude_transcripts_count_only_usage_metadata() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let transcripts_dir = temp_dir.path().join(".claude/transcripts");
+        std::fs::create_dir_all(&transcripts_dir).unwrap();
+        std::fs::write(
+            transcripts_dir.join("ses_123456789012345678901234567.jsonl"),
+            r#"{"type":"user","timestamp":"2026-04-01T10:00:00.000Z","message":{"content":"Wrapped prompt"}}
+{"type":"assistant","timestamp":"2026-04-01T10:00:01.000Z","requestId":"req_wrapper","message":{"id":"msg_wrapper","model":"claude-sonnet-4","usage":{"input_tokens":123,"output_tokens":45,"cache_read_input_tokens":67,"cache_creation_input_tokens":8}}}
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            transcripts_dir.join("ses_765432109876543210987654321.jsonl"),
+            r#"{"type":"user","timestamp":"2026-04-01T10:00:00.000Z","message":{"content":"Wrapped prompt"}}
+{"type":"tool_use","timestamp":"2026-04-01T10:00:01.000Z","message":{"content":"Run tool"}}
+{"type":"tool_result","timestamp":"2026-04-01T10:00:02.000Z","message":{"content":"Tool result"}}
+"#,
+        )
+        .unwrap();
+
+        let parsed = parse_local_clients(LocalParseOptions {
+            home_dir: Some(temp_dir.path().to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(vec!["claude".to_string()]),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner::ScannerSettings::default(),
+        })
+        .unwrap();
+
+        assert_eq!(parsed.counts.get(ClientId::Claude), 1);
+        assert_eq!(parsed.messages.len(), 1);
+        assert_eq!(parsed.messages[0].client, "claude");
+        assert_eq!(
+            parsed.messages[0].session_id,
+            "ses_123456789012345678901234567"
+        );
+        assert_eq!(parsed.messages[0].model_id, "claude-sonnet-4");
+        assert_eq!(parsed.messages[0].input, 123);
+        assert_eq!(parsed.messages[0].output, 45);
+        assert_eq!(parsed.messages[0].cache_read, 67);
+        assert_eq!(parsed.messages[0].cache_write, 8);
+    }
+
+    #[test]
     fn test_parse_local_clients_amp_partial_ledger_recovers_message_fallback_day() {
         use chrono::TimeZone;
 

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -296,6 +296,22 @@ pub fn extra_scan_paths_for(
         .collect()
 }
 
+pub fn built_in_extra_scan_paths_for(
+    home_dir: &str,
+    enabled: &HashSet<ClientId>,
+) -> Vec<(ClientId, PathBuf)> {
+    let mut paths = Vec::new();
+
+    if enabled.contains(&ClientId::Claude) {
+        paths.push((
+            ClientId::Claude,
+            PathBuf::from(format!("{}/.claude/transcripts", home_dir)),
+        ));
+    }
+
+    paths
+}
+
 #[derive(Debug, Deserialize, Default)]
 struct CrushProjectList {
     #[serde(default)]
@@ -588,6 +604,10 @@ fn scan_all_clients_with_env_strategy_inner(
     }
 
     for (client_id, path) in extra_scan_paths_for(scanner_settings, &enabled) {
+        push_unique_scan_task(&mut tasks, &mut seen_scan_roots, client_id, path);
+    }
+
+    for (client_id, path) in built_in_extra_scan_paths_for(home_dir, &enabled) {
         push_unique_scan_task(&mut tasks, &mut seen_scan_roots, client_id, path);
     }
 
@@ -1194,6 +1214,15 @@ mod tests {
         fs::create_dir_all(&claude_path).unwrap();
         let mut file = File::create(claude_path.join("conversation.jsonl")).unwrap();
         file.write_all(b"").unwrap();
+    }
+
+    fn setup_mock_claude_transcripts_dir(base: &std::path::Path) -> PathBuf {
+        let transcript_path = base.join(".claude/transcripts");
+        fs::create_dir_all(&transcript_path).unwrap();
+        let file_path = transcript_path.join("ses_123456789012345678901234567.jsonl");
+        let mut file = File::create(&file_path).unwrap();
+        file.write_all(b"").unwrap();
+        file_path
     }
 
     fn setup_mock_codex_dir(base: &std::path::Path) {
@@ -1860,6 +1889,40 @@ mod tests {
 
         let result = scan_all_clients(home.to_str().unwrap(), &["claude".to_string()]);
         assert_eq!(result.get(ClientId::Claude).len(), 1);
+        assert!(result.get(ClientId::OpenCode).is_empty());
+    }
+
+    #[test]
+    fn test_scan_all_clients_claude_transcripts() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_claude_dir(home);
+        let transcript = setup_mock_claude_transcripts_dir(home);
+
+        let result = scan_all_clients(home.to_str().unwrap(), &["claude".to_string()]);
+
+        assert_eq!(result.get(ClientId::Claude).len(), 2);
+        assert!(
+            result
+                .get(ClientId::Claude)
+                .iter()
+                .any(|path| path == &transcript),
+            "expected Claude transcript {} in {:?}",
+            transcript.display(),
+            result.get(ClientId::Claude)
+        );
+        assert!(result.get(ClientId::OpenCode).is_empty());
+    }
+
+    #[test]
+    fn test_scan_all_clients_claude_transcripts_without_projects_dir() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let transcript = setup_mock_claude_transcripts_dir(home);
+
+        let result = scan_all_clients(home.to_str().unwrap(), &["claude".to_string()]);
+
+        assert_eq!(result.get(ClientId::Claude), &vec![transcript]);
         assert!(result.get(ClientId::OpenCode).is_empty());
     }
 

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -780,6 +780,18 @@ mod tests {
         (temp_dir, path)
     }
 
+    fn create_transcript_file(content: &str, filename: &str) -> (TempDir, std::path::PathBuf) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir
+            .path()
+            .join(".claude")
+            .join("transcripts")
+            .join(filename);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, content).unwrap();
+        (temp_dir, path)
+    }
+
     #[test]
     fn test_deduplication_skips_duplicate_entries() {
         let content = r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50}}}
@@ -1068,6 +1080,40 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].workspace_key, Some("myproject".to_string()));
         assert_eq!(messages[0].workspace_label, Some("myproject".to_string()));
+    }
+
+    #[test]
+    fn test_wrapper_transcript_with_usage_is_parsed() {
+        let content = r#"{"type":"user","timestamp":"2026-04-01T10:00:00.000Z","message":{"content":"Wrapped prompt"}}
+{"type":"assistant","timestamp":"2026-04-01T10:00:01.000Z","requestId":"req_wrapper","message":{"id":"msg_wrapper","model":"claude-sonnet-4","usage":{"input_tokens":123,"output_tokens":45,"cache_read_input_tokens":67,"cache_creation_input_tokens":8}}}"#;
+        let (_dir, path) = create_transcript_file(content, "ses_123456789012345678901234567.jsonl");
+
+        let messages = parse_claude_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].session_id, "ses_123456789012345678901234567");
+        assert_eq!(messages[0].model_id, "claude-sonnet-4");
+        assert_eq!(messages[0].tokens.input, 123);
+        assert_eq!(messages[0].tokens.output, 45);
+        assert_eq!(messages[0].tokens.cache_read, 67);
+        assert_eq!(messages[0].tokens.cache_write, 8);
+        assert_eq!(messages[0].workspace_key, None);
+        assert_eq!(messages[0].workspace_label, None);
+    }
+
+    #[test]
+    fn test_wrapper_transcript_without_usage_is_skipped() {
+        let content = r#"{"type":"user","timestamp":"2026-04-01T10:00:00.000Z","message":{"content":"Wrapped prompt"}}
+{"type":"tool_use","timestamp":"2026-04-01T10:00:01.000Z","message":{"content":"Run tool"}}
+{"type":"tool_result","timestamp":"2026-04-01T10:00:02.000Z","message":{"content":"Tool result"}}"#;
+        let (_dir, path) = create_transcript_file(content, "ses_765432109876543210987654321.jsonl");
+
+        let messages = parse_claude_file(&path);
+
+        assert!(
+            messages.is_empty(),
+            "wrapper transcripts without usage metadata must not be estimated"
+        );
     }
 
     // --- Sidechain / Agent tracking tests ---


### PR DESCRIPTION
## Summary
- Adds `~/.claude/transcripts/*.jsonl` as a built-in Claude Code scan root alongside `~/.claude/projects/`.
- Counts wrapper transcript files only when they contain real Claude `usage` metadata; user/tool-only transcript files remain ignored instead of estimated.
- Surfaces the additional transcript root in `tokscale clients` text and JSON output and updates the README data-location docs.

## Why
Fixes #487. Wrapper-driven Claude Code sessions can be written under `~/.claude/transcripts/`, so Tokscale previously missed usage-bearing transcript files even though the existing Claude parser already understood Claude usage metadata.

## Diff scope
- `crates/tokscale-core/src/scanner.rs`: adds the built-in Claude transcript root and scanner coverage.
- `crates/tokscale-core/src/sessions/claudecode.rs`: adds parser regression tests for usage-bearing and no-usage wrapper transcripts.
- `crates/tokscale-core/src/lib.rs`: adds an end-to-end `parse_local_clients` regression covering transcript inclusion and no-usage skipping.
- `crates/tokscale-cli/src/main.rs` and `crates/tokscale-cli/tests/cli_tests.rs`: show built-in additional scan roots in `tokscale clients` text and JSON output.
- `README.md`: documents the new Claude Code location and no-estimation behavior.

## Safety
- No token estimation is introduced.
- Existing `~/.claude/projects/` scanning remains unchanged.
- No migrations, cache schema changes, or persistent storage format changes.
- `tokscale clients` adds an optional `additionalPaths` field only when built-in additional roots exist.

## Validation
- `cargo test -p tokscale-core test_parse_local_clients_claude_transcripts_count_only_usage_metadata` — PASS.
- `cargo test -p tokscale-core` — PASS, 641 passed, 1 ignored; codebuff 10 passed; hermes 3 passed; doc-tests 0 passed.
- `cargo test -p tokscale-cli clients` — PASS, 18 passed.
- `cargo fmt --all -- --check` — PASS.
- `/opt/homebrew/bin/cargo-clippy clippy --package tokscale-core --lib --all-features -- -D warnings` — PASS.
- `/opt/homebrew/bin/cargo-clippy clippy --package tokscale-cli --bin tokscale --no-deps -- -D warnings` — PASS.
- `git diff --check origin/main...HEAD` — PASS, no output.

## Branch proof
- Base: `origin/main` at `be259dd6a818e152d8fe6c461aab5cd6388ed138`.
- Head: `e66e9f5466751abee44fa5247fc06951f8e8816c`.
- Ahead/behind: `0 1`.
- Merge base: `be259dd6a818e152d8fe6c461aab5cd6388ed138`.
- `origin/main` is an ancestor of this branch.

## Rollback
Revert the merge commit for this PR. No migration, data repair, or release procedure changes are required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `~/.claude/transcripts` as a built-in Claude Code scan root and count wrapper transcripts only when they include real Claude usage metadata. Surface the new path in `tokscale clients` output and update docs.

- **Bug Fixes**
  - Scan and count usage-bearing wrapper transcripts that were previously missed.
  - Ignore wrapper transcripts without `usage` (no estimation).
  - Existing `~/.claude/projects/` scanning is unchanged.

- **New Features**
  - `tokscale clients` shows an `additionalPaths` entry for built-in paths (text and `--json`).
  - README lists both `~/.claude/projects/` and `~/.claude/transcripts/`.

<sup>Written for commit e66e9f5466751abee44fa5247fc06951f8e8816c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

