### PR TITLE
chore(frontend): add vitest config so @/* aliases resolve in tests

### DIFF
--- a/packages/frontend/__tests__/lib/bearerToken.test.ts
+++ b/packages/frontend/__tests__/lib/bearerToken.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getBearerToken } from "../../src/lib/auth/bearerToken";
+import { getBearerToken } from "@/lib/auth/bearerToken";
 
 describe("getBearerToken", () => {
   it("returns null when the header is missing or malformed", () => {

--- a/packages/frontend/src/app/api/auth/token/route.ts
+++ b/packages/frontend/src/app/api/auth/token/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { authenticatePersonalToken } from "@/lib/auth/personalTokens";
-import { getBearerToken } from "../../../../lib/auth/bearerToken";
+import { getBearerToken } from "@/lib/auth/bearerToken";
 
 export async function GET(request: Request) {
   try {

--- a/packages/frontend/vitest.config.ts
+++ b/packages/frontend/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+import { resolve } from "path";
+
+// Mirrors the `@/*` -> `./src/*` mapping in tsconfig.json so test files (and
+// the production sources they import) can resolve aliased paths under
+// `npx vitest run`. Without this, vitest fails on `import "@/lib/..."`
+// outside of mocked imports because vitest does not honor tsconfig path
+// aliases automatically.
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
Closes the import-style nit deferred from #514.

## Problem
The frontend has no \`vitest.config.ts\`, so vitest cannot resolve tsconfig path aliases. Production code can mix \`@/lib/...\` and relative imports freely (Next.js bundles both), but the moment a test pulls in production code that imports \`@/lib/...\`, vitest fails to resolve the alias unless the symbol is \`vi.mock\`ed first.

Concrete consequence: \`route.ts\` imported \`authenticatePersonalToken\` via \`@/...\` (test mocks it) but \`getBearerToken\` via a four-level relative path (test runs the real implementation, so the alias would fail). #514's audit flagged this as nit N1 and reverted the alias-cleanup attempt because the cleanup broke \`npx vitest run\`.

## Fix
- **\`packages/frontend/vitest.config.ts\` (new, 12 lines)**: mirrors the \`@/* -> ./src/*\` mapping in tsconfig.json. Manual alias config — no \`vite-tsconfig-paths\` dep added.
- **\`src/app/api/auth/token/route.ts\`**: \`getBearerToken\` import switched from \`../../../../lib/auth/bearerToken\` to \`@/lib/auth/bearerToken\`. Now internally consistent with the matching \`personalTokens\` import.
- **\`__tests__/lib/bearerToken.test.ts\`**: \`getBearerToken\` import switched from \`../../src/lib/auth/bearerToken\` to \`@/lib/auth/bearerToken\` for parity.

## Out of scope
Other test files (\`submit.test.ts\`, \`renderProfileBadgeSvg.test.ts\`, \`renderIsometric3DSvg.test.ts\`, \`renderProfileEmbedSvg.test.ts\`) still use \`../../src/lib/...\` paths. Left as-is to keep this PR narrow to the original nit. Convertible in a separate cleanup once the convention is established here.

## Validation
- \`npx vitest run\` from \`packages/frontend\` → **21 test files / 177 tests pass** (0 regressions)

## Scope
- 3 files, +17/-2
- 1 new file (vitest.config.ts), 2 single-line edits
- No production behavior change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `vitest.config.ts` to resolve `@/*` aliases in frontend tests. This lets tests import production code via aliases without mocks and keeps imports consistent; no production changes.

- **Bug Fixes**
  - Add `packages/frontend/vitest.config.ts` mapping `@` -> `./src`.
  - Switch `getBearerToken` imports in `src/app/api/auth/token/route.ts` and `__tests__/lib/bearerToken.test.ts` to `@/lib/bearerToken`.
  - No new deps; `npx vitest run` passes (21 files, 177 tests).

<sup>Written for commit 967d21d405b4b34c992c2e23892c7db4f8d6e5aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

