### PR TITLE
chore(security): rehash plaintext personal tokens, drop OR-clause

### DIFF
--- a/packages/frontend/src/lib/auth/personalTokens.ts
+++ b/packages/frontend/src/lib/auth/personalTokens.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, or, sql } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
 import { db, apiTokens, users } from "@/lib/db";
 import { generateApiToken, hashToken } from "@/lib/auth/utils";
 
@@ -171,10 +171,13 @@ export async function authenticatePersonalToken(
 
   const tokenHashed = hashToken(token);
 
+  // All rows are SHA-256 hashed at rest. Migration
+  // 0006_rehash_plaintext_personal_tokens.sql rehashed any pre-#512
+  // plaintext rows in place; the prior transitional OR-clause that also
+  // matched the raw token value has been removed.
   const result = await db
     .select({
       tokenId: apiTokens.id,
-      tokenValue: apiTokens.token,
       userId: apiTokens.userId,
       username: users.username,
       displayName: users.displayName,
@@ -184,7 +187,7 @@ export async function authenticatePersonalToken(
     })
     .from(apiTokens)
     .innerJoin(users, eq(apiTokens.userId, users.id))
-    .where(or(eq(apiTokens.token, tokenHashed), eq(apiTokens.token, token)))
+    .where(eq(apiTokens.token, tokenHashed))
     .limit(1);
 
   if (result.length === 0) {
@@ -192,23 +195,15 @@ export async function authenticatePersonalToken(
   }
 
   const record = result[0];
-  const isLegacyPlaintext = record.tokenValue === token;
 
   if (record.expiresAt && record.expiresAt <= new Date()) {
     return { status: "expired" };
   }
 
-  const updates: Record<string, unknown> = {};
   if (options.touchLastUsedAt !== false) {
-    updates.lastUsedAt = new Date();
-  }
-  if (isLegacyPlaintext) {
-    updates.token = tokenHashed;
-  }
-  if (Object.keys(updates).length > 0) {
     await db
       .update(apiTokens)
-      .set(updates)
+      .set({ lastUsedAt: new Date() })
       .where(eq(apiTokens.id, record.tokenId));
   }
 

--- a/packages/frontend/src/lib/db/migrations/0006_rehash_plaintext_personal_tokens.sql
+++ b/packages/frontend/src/lib/db/migrations/0006_rehash_plaintext_personal_tokens.sql
@@ -1,0 +1,30 @@
+-- Migration: rehash any remaining plaintext personal API tokens.
+--
+-- Pre-#512, the api_tokens.token column stored the raw "tt_<hex>" token
+-- as issued. PR #512 introduced SHA-256-at-rest hashing for all NEW
+-- tokens and a transitional OR-clause in `authenticatePersonalToken`
+-- that auto-rehashed legacy plaintext rows on next use. Rows whose
+-- owners never re-authenticated still sit in the DB as plaintext, which
+-- means a DB read leaks usable tokens. This migration finishes the
+-- transition by rehashing every remaining plaintext row in one shot,
+-- so the application code can drop the OR-clause and the
+-- rehash-on-use path entirely (paired commit).
+--
+-- Identification: SHA-256 hex output is `[0-9a-f]{64}` and can never
+-- produce the substring "tt_". Any row whose token still starts with
+-- "tt_" is definitionally plaintext. Hashed rows are skipped.
+--
+-- Idempotent: re-running this migration after every plaintext row has
+-- already been upgraded simply matches zero rows.
+--
+-- Note: pgcrypto is required for `digest(text, 'sha256')`. The
+-- extension is widely available on managed Postgres (Supabase, Neon,
+-- RDS, etc.) and is enabled here defensively. If the deployment lacks
+-- it the migration will fail at the CREATE EXTENSION step rather than
+-- silently leave plaintext rows behind.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+--> statement-breakpoint
+UPDATE "api_tokens"
+SET "token" = encode(digest("token", 'sha256'), 'hex')
+WHERE LEFT("token", 3) = 'tt_';

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1777404000000,
       "tag": "0005_add_case_insensitive_username_index",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1778025600000,
+      "tag": "0006_rehash_plaintext_personal_tokens",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Closes the M2 security finding deferred from #514's audit.

## Background
Pre-#512 the \`api_tokens.token\` column stored personal API tokens in plaintext (\`tt_<48 hex>\`). PR #512 introduced SHA-256-at-rest hashing for all NEW tokens and a transitional OR-clause in \`authenticatePersonalToken\` that matched both the hashed value and the raw value, then auto-rehashed the matched row in place. The upgrade fired only when the token's owner re-authenticated, leaving plaintext rows in the DB indefinitely for users who don't.

The audit flagged this as Medium: any DB read during the migration window leaks directly-usable tokens.

## Change

### 1. Data migration — \`0006_rehash_plaintext_personal_tokens.sql\` (new)
- \`CREATE EXTENSION IF NOT EXISTS pgcrypto\` (idempotent; defensive)
- Single-statement \`UPDATE api_tokens SET token = encode(digest(token, 'sha256'), 'hex') WHERE LEFT(token, 3) = 'tt_'\` rehashes every remaining plaintext row in place.
- **Identification rationale**: SHA-256 hex output is \`[0-9a-f]{64}\` and can never produce the substring \`tt_\`. Any row whose stored token still starts with \`tt_\` is definitionally plaintext. Already-hashed rows are skipped.
- **Idempotent**: re-running after migration matches zero rows.

### 2. Application code — \`src/lib/auth/personalTokens.ts\`
- Drop the \`or(eq(token, hashed), eq(token, raw))\` clause → matches only \`eq(token, hashed)\`.
- Drop the \`isLegacyPlaintext\` detection and the rehash-on-use UPDATE branch — the migration finished that work.
- Drop the \`tokenValue: apiTokens.token\` SELECT column (was only used for plaintext detection).
- Drop the \`or\` import (no longer used).
- Comment now points readers at migration 0006 for historical context.

### 3. Drizzle journal
- Append entry for migration 0006 to \`migrations/meta/_journal.json\`.

## Validation
- \`npx vitest run\` from \`packages/frontend\` → **21 test files / 177 tests pass** (0 regressions). The existing \`personalTokens.test.ts\` fixtures already use pre-hashed \`tokenValue\` strings (\`hashed_tt_test_token\`), so they exercise the new hashed-only path unchanged.

## Deployment notes
- ⚠️ **Order matters**: the migration must run BEFORE the application code change reaches production, OR they must deploy together. Running the app-side change first against a DB that still has plaintext rows would lock those users out (their stored token wouldn't match a SHA-256 hash of itself). The standard \`drizzle-kit migrate\` → deploy-app sequence handles this correctly.
- ⚠️ **pgcrypto required**. Verify on target deployment with \`SELECT * FROM pg_extension WHERE extname = 'pgcrypto';\` before rolling out. The \`CREATE EXTENSION IF NOT EXISTS\` will create it if the role has CREATE privilege; otherwise the migration fails loudly rather than silently leaving plaintext rows behind.

## Out of scope
- Token rotation policy, max-age, automatic expiry, per-user revocation rate limits. This PR only addresses at-rest hashing of EXISTING plaintext rows.

## Scope
- 3 files (1 new SQL migration, 1 modified TS source, 1 journal entry)
- +44 / -12
- No user-visible behavior change beyond DB reads no longer leaking usable tokens.

## Rollback plan
If the migration succeeds but the app-side change introduces a regression, revert just the app-side commit. The hashed rows in the DB will continue to authenticate correctly under the prior OR-clause code.

If the migration itself fails partway, the \`UPDATE\` is a single statement inside a transaction (Drizzle wraps each migration in BEGIN/COMMIT), so it's all-or-nothing per the postgres spec — partial state is not possible.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rehashed all remaining plaintext personal API tokens and switched authentication to hashed-only. This closes the migration window where DB reads could expose usable tokens.

- **Migration**
  - Added `packages/frontend/src/lib/db/migrations/0006_rehash_plaintext_personal_tokens.sql`: single UPDATE hashes rows with `LEFT(token, 3) = 'tt_'` using SHA-256 via `pgcrypto`.
  - Idempotent and transactional.
  - Requires `pgcrypto`. Run the migration before deploying the app code, or deploy together.

- **Refactors**
  - `authenticatePersonalToken` now matches `eq(token, hashed)` only; removed the OR-clause, legacy rehash-on-use path, and the `tokenValue` select.
  - Dropped unused `or` import and added a comment referencing migration `0006`.
  - Updated `migrations/meta/_journal.json` to include the new migration.

<sup>Written for commit bcf230037b710429a59baa51f5e6e86e8170c673. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

