### PR TITLE
fix(submit): make usage merges device-aware

### DIFF
--- a/crates/tokscale-cli/src/device.rs
+++ b/crates/tokscale-cli/src/device.rs
@@ -1,0 +1,223 @@
+use anyhow::{anyhow, Context, Result};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use uuid::Uuid;
+
+const DEVICE_FILE_NAME: &str = "device.json";
+const DEVICE_ID_ENV: &str = "TOKSCALE_DEVICE_ID";
+const DEVICE_NAME_ENV: &str = "TOKSCALE_DEVICE_NAME";
+const MAX_DEVICE_ID_LEN: usize = 96;
+const MAX_DEVICE_NAME_LEN: usize = 120;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SubmitDevice {
+    pub id: String,
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StoredDevice {
+    id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    created_at: String,
+}
+
+pub fn resolve_submit_device() -> Result<SubmitDevice> {
+    if let Some(id) = env_value(DEVICE_ID_ENV) {
+        return Ok(SubmitDevice {
+            id: validate_device_id(&id)?,
+            name: env_value(DEVICE_NAME_ENV)
+                .map(|name| validate_device_name(&name))
+                .transpose()?,
+        });
+    }
+
+    let path = device_file_path();
+    let name_override = env_value(DEVICE_NAME_ENV)
+        .map(|name| validate_device_name(&name))
+        .transpose()?;
+
+    if path.exists() {
+        let content = std::fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let stored: StoredDevice = serde_json::from_str(&content)
+            .with_context(|| format!("failed to parse {}", path.display()))?;
+        return Ok(SubmitDevice {
+            id: validate_device_id(&stored.id)?,
+            name: name_override.or(stored.name),
+        });
+    }
+
+    let stored = StoredDevice {
+        id: format!("dev_{}", Uuid::new_v4().simple()),
+        name: name_override,
+        created_at: Utc::now().to_rfc3339(),
+    };
+    write_stored_device(&path, &stored)?;
+
+    Ok(SubmitDevice {
+        id: stored.id,
+        name: stored.name,
+    })
+}
+
+fn env_value(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn device_file_path() -> PathBuf {
+    crate::paths::get_config_dir().join(DEVICE_FILE_NAME)
+}
+
+fn validate_device_id(id: &str) -> Result<String> {
+    let trimmed = id.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("{} must not be empty", DEVICE_ID_ENV));
+    }
+    if trimmed.len() > MAX_DEVICE_ID_LEN {
+        return Err(anyhow!(
+            "{} must be at most {} characters",
+            DEVICE_ID_ENV,
+            MAX_DEVICE_ID_LEN
+        ));
+    }
+    if !trimmed
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | ':'))
+    {
+        return Err(anyhow!(
+            "{} may only contain ASCII letters, numbers, '.', '_', '-', or ':'",
+            DEVICE_ID_ENV
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn validate_device_name(name: &str) -> Result<String> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("{} must not be empty", DEVICE_NAME_ENV));
+    }
+    if trimmed.len() > MAX_DEVICE_NAME_LEN {
+        return Err(anyhow!(
+            "{} must be at most {} characters",
+            DEVICE_NAME_ENV,
+            MAX_DEVICE_NAME_LEN
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn write_stored_device(path: &Path, device: &StoredDevice) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+
+    let tmp_path = path.with_extension("json.tmp");
+    let content = serde_json::to_string_pretty(device)?;
+    std::fs::write(&tmp_path, content)
+        .with_context(|| format!("failed to write {}", tmp_path.display()))?;
+    tokscale_core::fs_atomic::replace_file(&tmp_path, path)
+        .with_context(|| format!("failed to replace {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::env;
+
+    fn save_env() -> (
+        Option<std::ffi::OsString>,
+        Option<std::ffi::OsString>,
+        Option<std::ffi::OsString>,
+    ) {
+        (
+            env::var_os("TOKSCALE_CONFIG_DIR"),
+            env::var_os("TOKSCALE_DEVICE_ID"),
+            env::var_os("TOKSCALE_DEVICE_NAME"),
+        )
+    }
+
+    struct EnvRestore(
+        Option<std::ffi::OsString>,
+        Option<std::ffi::OsString>,
+        Option<std::ffi::OsString>,
+    );
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            restore_env((self.0.clone(), self.1.clone(), self.2.clone()));
+        }
+    }
+
+    fn restore_env(
+        prev: (
+            Option<std::ffi::OsString>,
+            Option<std::ffi::OsString>,
+            Option<std::ffi::OsString>,
+        ),
+    ) {
+        unsafe {
+            match prev.0 {
+                Some(v) => env::set_var("TOKSCALE_CONFIG_DIR", v),
+                None => env::remove_var("TOKSCALE_CONFIG_DIR"),
+            }
+            match prev.1 {
+                Some(v) => env::set_var("TOKSCALE_DEVICE_ID", v),
+                None => env::remove_var("TOKSCALE_DEVICE_ID"),
+            }
+            match prev.2 {
+                Some(v) => env::set_var("TOKSCALE_DEVICE_NAME", v),
+                None => env::remove_var("TOKSCALE_DEVICE_NAME"),
+            }
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn env_device_id_is_used_without_touching_config_file() {
+        let prev = save_env();
+        let _restore = EnvRestore(prev.0, prev.1, prev.2);
+        let dir = tempfile::tempdir().unwrap();
+        unsafe {
+            env::set_var("TOKSCALE_CONFIG_DIR", dir.path());
+            env::set_var("TOKSCALE_DEVICE_ID", "dev_ci");
+            env::set_var("TOKSCALE_DEVICE_NAME", "CI runner");
+        }
+
+        let device = resolve_submit_device().unwrap();
+
+        assert_eq!(device.id, "dev_ci");
+        assert_eq!(device.name.as_deref(), Some("CI runner"));
+        assert!(!dir.path().join("device.json").exists());
+    }
+
+    #[test]
+    #[serial]
+    fn generated_device_id_is_stable_in_config_dir() {
+        let prev = save_env();
+        let _restore = EnvRestore(prev.0, prev.1, prev.2);
+        let dir = tempfile::tempdir().unwrap();
+        unsafe {
+            env::set_var("TOKSCALE_CONFIG_DIR", dir.path());
+            env::remove_var("TOKSCALE_DEVICE_ID");
+            env::remove_var("TOKSCALE_DEVICE_NAME");
+        }
+
+        let first = resolve_submit_device().unwrap();
+        let second = resolve_submit_device().unwrap();
+
+        assert!(first.id.starts_with("dev_"));
+        assert_eq!(first, second);
+        assert!(dir.path().join("device.json").exists());
+    }
+}

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -2,6 +2,7 @@ mod antigravity;
 mod auth;
 mod commands;
 mod cursor;
+mod device;
 mod paths;
 mod trae;
 mod tui;
@@ -3621,14 +3622,27 @@ struct TsExportMeta {
 
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
+struct TsSubmitDevice {
+    id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 struct TsTokenContributionData {
     meta: TsExportMeta,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    device: Option<TsSubmitDevice>,
     summary: TsDataSummary,
     years: Vec<TsYearSummary>,
     contributions: Vec<TsDailyContribution>,
 }
 
-fn to_ts_token_contribution_data(graph: &tokscale_core::GraphResult) -> TsTokenContributionData {
+fn to_ts_token_contribution_data(
+    graph: &tokscale_core::GraphResult,
+    device: Option<&device::SubmitDevice>,
+) -> TsTokenContributionData {
     TsTokenContributionData {
         meta: TsExportMeta {
             generated_at: graph.meta.generated_at.clone(),
@@ -3638,6 +3652,10 @@ fn to_ts_token_contribution_data(graph: &tokscale_core::GraphResult) -> TsTokenC
                 end: graph.meta.date_range_end.clone(),
             },
         },
+        device: device.map(|d| TsSubmitDevice {
+            id: d.id.clone(),
+            name: d.name.clone(),
+        }),
         summary: TsDataSummary {
             total_tokens: graph.summary.total_tokens,
             total_cost: graph.summary.total_cost,
@@ -4082,7 +4100,7 @@ fn run_graph_command(
         .map_err(|e| anyhow::anyhow!(e))?;
 
     let processing_time_ms = start.elapsed().as_millis() as u32;
-    let output_data = to_ts_token_contribution_data(&graph_result);
+    let output_data = to_ts_token_contribution_data(&graph_result, None);
     let json_output = serde_json::to_string_pretty(&output_data)?;
 
     if let Some(output_path) = output {
@@ -4335,7 +4353,8 @@ fn run_submit_command(
 
     let api_url = auth::get_api_base_url();
 
-    let submit_payload = to_ts_token_contribution_data(&graph_result);
+    let submit_device = device::resolve_submit_device()?;
+    let submit_payload = to_ts_token_contribution_data(&graph_result, Some(&submit_device));
 
     let response = rt.block_on(async {
         reqwest::Client::new()
@@ -6139,6 +6158,29 @@ mod tests {
         assert_eq!(graph.summary.clients, original_summary.clients);
         assert_eq!(graph.summary.models, original_summary.models);
         assert_eq!(graph.years.len(), original_years.len());
+    }
+
+    #[test]
+    fn test_submit_payload_includes_device_when_provided() {
+        let graph = graph_result_with_contributions(vec![daily_contribution(
+            "2026-12-31",
+            20,
+            2.50,
+            "codex",
+            "model-b",
+        )]);
+        let device = device::SubmitDevice {
+            id: "dev_test".to_string(),
+            name: Some("Test device".to_string()),
+        };
+
+        let payload = to_ts_token_contribution_data(&graph, Some(&device));
+
+        assert_eq!(payload.device.as_ref().unwrap().id, "dev_test");
+        assert_eq!(
+            payload.device.as_ref().unwrap().name.as_deref(),
+            Some("Test device")
+        );
     }
 
     #[test]

--- a/packages/frontend/__tests__/api/settingsSubmittedDataDelete.test.ts
+++ b/packages/frontend/__tests__/api/settingsSubmittedDataDelete.test.ts
@@ -31,10 +31,24 @@ const mockState = vi.hoisted(() => {
   let deletedRows: Array<{ id: string }> = [];
   let deleteError: Error | null = null;
 
+  const deleteFromTable = vi.fn(() => ({
+    where,
+  }));
   const db = {
-    delete: vi.fn(() => ({
-      where,
-    })),
+    delete: deleteFromTable,
+    transaction: vi.fn(async (callback: (tx: { delete: typeof deleteFromTable }) => Promise<unknown>) =>
+      callback(db)
+    ),
+  };
+
+  const tables = {
+    submissions: {
+      id: "submissions.id",
+      userId: "submissions.userId",
+    },
+    submittedDevices: {
+      userId: "submittedDevices.userId",
+    },
   };
 
   return {
@@ -45,6 +59,7 @@ const mockState = vi.hoisted(() => {
     revalidateUsernamePaths,
     eq,
     db,
+    tables,
     where,
     reset() {
       getSession.mockReset();
@@ -54,6 +69,7 @@ const mockState = vi.hoisted(() => {
       revalidateUsernamePaths.mockReset();
       eq.mockClear();
       db.delete.mockClear();
+      db.transaction.mockClear();
       where.mockClear();
       returning.mockClear();
       deletedRows = [];
@@ -87,10 +103,8 @@ vi.mock("@/lib/auth/personalTokens", () => ({
 
 vi.mock("@/lib/db", () => ({
   db: mockState.db,
-  submissions: {
-    id: "submissions.id",
-    userId: "submissions.userId",
-  },
+  submissions: mockState.tables.submissions,
+  submittedDevices: mockState.tables.submittedDevices,
 }));
 
 vi.mock("@/lib/db/usernameLookup", () => ({
@@ -131,6 +145,7 @@ describe("DELETE /api/settings/submitted-data", () => {
     expect(response.status).toBe(401);
     expect(await response.json()).toEqual({ error: "Not authenticated" });
     expect(mockState.db.delete).not.toHaveBeenCalled();
+    expect(mockState.db.transaction).not.toHaveBeenCalled();
   });
 
   it("deletes submitted data and revalidates public caches", async () => {
@@ -151,8 +166,12 @@ describe("DELETE /api/settings/submitted-data", () => {
       deleted: true,
       deletedSubmissions: 1,
     });
-    expect(mockState.db.delete).toHaveBeenCalledTimes(1);
-    expect(mockState.eq).toHaveBeenCalledWith("submissions.userId", "user-1");
+    expect(mockState.db.delete).toHaveBeenCalledTimes(2);
+    expect(mockState.db.transaction).toHaveBeenCalledTimes(1);
+    expect(mockState.db.delete).toHaveBeenNthCalledWith(1, mockState.tables.submissions);
+    expect(mockState.db.delete).toHaveBeenNthCalledWith(2, mockState.tables.submittedDevices);
+    expect(mockState.eq).toHaveBeenNthCalledWith(1, "submissions.userId", "user-1");
+    expect(mockState.eq).toHaveBeenNthCalledWith(2, "submittedDevices.userId", "user-1");
     expect(mockState.where).toHaveBeenCalledWith({
       kind: "eq",
       left: "submissions.userId",

--- a/packages/frontend/__tests__/api/submit.test.ts
+++ b/packages/frontend/__tests__/api/submit.test.ts
@@ -44,6 +44,9 @@ function createMockSubmissionData(overrides: Partial<{
     },
   ];
 
+  const contributionTokenTotal = (client: { tokens: { input: number; output: number; cacheRead: number; cacheWrite: number } }) =>
+    client.tokens.input + client.tokens.output + client.tokens.cacheRead + client.tokens.cacheWrite;
+
   return {
     meta: {
       generatedAt: new Date().toISOString(),
@@ -55,7 +58,7 @@ function createMockSubmissionData(overrides: Partial<{
     },
     summary: {
       totalTokens: defaultContributions.reduce((sum, d) => 
-        sum + d.clients.reduce((s, client) => s + client.tokens.input + client.tokens.output, 0), 0
+        sum + d.clients.reduce((s, client) => s + contributionTokenTotal(client), 0), 0
       ),
       totalCost: defaultContributions.reduce((sum, d) => 
         sum + d.clients.reduce((s, client) => s + client.cost, 0), 0
@@ -71,7 +74,7 @@ function createMockSubmissionData(overrides: Partial<{
     contributions: defaultContributions.map(d => ({
       date: d.date,
       totals: {
-        tokens: d.clients.reduce((s, client) => s + client.tokens.input + client.tokens.output, 0),
+        tokens: d.clients.reduce((s, client) => s + contributionTokenTotal(client), 0),
         cost: d.clients.reduce((s, client) => s + client.cost, 0),
         messages: d.clients.reduce((s, client) => s + client.messages, 0),
       },
@@ -86,7 +89,7 @@ function createMockSubmissionData(overrides: Partial<{
       clients: d.clients.map(client => ({
         client: client.client as ClientType,
         modelId: client.modelId,
-        tokens: client.tokens,
+        tokens: { ...client.tokens, reasoning: 0 },
         cost: client.cost,
         messages: client.messages,
       })),
@@ -168,6 +171,58 @@ function createValidationPayload(overrides: Partial<{
 }
 
 describe('POST /api/submit - Client-Level Merge', () => {
+  describe('Device-Aware Payloads', () => {
+    it('accepts a stable random submit device id', () => {
+      const payload = {
+        ...createMockSubmissionData({ clients: ['claude'] }),
+        device: {
+          id: 'dev_018f4b6f9c2d4f2d8a2f4b6f9c2d4f2d',
+          name: 'Work laptop',
+        },
+      };
+
+      const result = validateSubmission(payload);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      expect(result.data?.device).toEqual({
+        id: 'dev_018f4b6f9c2d4f2d8a2f4b6f9c2d4f2d',
+        name: 'Work laptop',
+      });
+    });
+
+    it('keeps no-device legacy payloads valid', () => {
+      const result = validateSubmission(createMockSubmissionData({ clients: ['claude'] }));
+
+      expect(result.valid).toBe(true);
+      expect(result.data?.device).toBeUndefined();
+    });
+
+    it('includes the submit device id in the submission hash', () => {
+      const base = createMockSubmissionData({ clients: ['claude'] });
+      const laptop = validateSubmission({
+        ...base,
+        device: { id: 'dev_laptop' },
+      }).data!;
+      const desktop = validateSubmission({
+        ...base,
+        device: { id: 'dev_desktop' },
+      }).data!;
+
+      expect(generateSubmissionHash(laptop)).not.toBe(generateSubmissionHash(desktop));
+    });
+
+    it('rejects blank submit device ids', () => {
+      const result = validateSubmission({
+        ...createMockSubmissionData({ clients: ['claude'] }),
+        device: { id: '   ' },
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((error) => error.includes('device.id'))).toBe(true);
+    });
+  });
+
   describe('First Submission (Create Mode)', () => {
     it('should create new submission with all clients', () => {
       const data = createMockSubmissionData({ clients: ['claude', 'cursor'] });

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -75,9 +75,18 @@ vi.mock("@/lib/db", () => ({
     submissionHash: "submissions.submissionHash",
     schemaVersion: "submissions.schemaVersion",
   },
+  submittedDevices: {
+    id: "submittedDevices.id",
+    userId: "submittedDevices.userId",
+    deviceKey: "submittedDevices.deviceKey",
+    displayName: "submittedDevices.displayName",
+    lastSubmittedAt: "submittedDevices.lastSubmittedAt",
+    updatedAt: "submittedDevices.updatedAt",
+  },
   dailyBreakdown: {
     id: "dailyBreakdown.id",
     submissionId: "dailyBreakdown.submissionId",
+    submittedDeviceId: "dailyBreakdown.submittedDeviceId",
     date: "dailyBreakdown.date",
     timestampMs: "dailyBreakdown.timestampMs",
     sourceBreakdown: "dailyBreakdown.sourceBreakdown",
@@ -118,6 +127,17 @@ beforeAll(async () => {
 beforeEach(() => {
   mockState.reset();
 });
+
+function makeAwaitableBuilder(result: unknown) {
+  const builder = {
+    from: vi.fn(() => builder),
+    where: vi.fn(() => builder),
+    for: vi.fn(() => builder),
+    limit: vi.fn(() => builder),
+    then: (resolve: (value: unknown) => unknown) => Promise.resolve(resolve(result)),
+  };
+  return builder;
+}
 
 describe("POST /api/submit auth path", () => {
   it("rejects invalid API tokens through the shared auth service", async () => {
@@ -252,6 +272,10 @@ describe("POST /api/submit auth path", () => {
     mockState.validateSubmission.mockReturnValue({
       valid: true,
       data: {
+        device: {
+          id: "dev_test",
+          name: "Test device",
+        },
         meta: {
           version: "2.0.0",
           dateRange: { start: "2026-04-30", end: "2026-04-30" },
@@ -329,18 +353,9 @@ describe("POST /api/submit auth path", () => {
       }],
     ];
 
-    function makeAwaitableBuilder(result: unknown) {
-      const builder = {
-        from: vi.fn(() => builder),
-        where: vi.fn(() => builder),
-        for: vi.fn(() => builder),
-        limit: vi.fn(() => builder),
-        then: (resolve: (value: unknown) => unknown) => Promise.resolve(resolve(result)),
-      };
-      return builder;
-    }
-
     let insertCall = 0;
+    let submittedDeviceValues: unknown;
+    let dailyInsertValues: unknown;
     const tx = {
       update: vi.fn(() => {
         const builder = {
@@ -360,8 +375,23 @@ describe("POST /api/submit auth path", () => {
           return builder;
         }
 
+        if (insertCall === 2) {
+          const builder = {
+            values: vi.fn((values: unknown) => {
+              submittedDeviceValues = values;
+              return builder;
+            }),
+            onConflictDoUpdate: vi.fn(() => builder),
+            returning: vi.fn(() => Promise.resolve([{ id: "submitted-device-1" }])),
+          };
+          return builder;
+        }
+
         return {
-          values: vi.fn(() => Promise.resolve()),
+          values: vi.fn((values: unknown) => {
+            dailyInsertValues = values;
+            return Promise.resolve();
+          }),
         };
       }),
       execute: vi.fn(() => Promise.resolve()),
@@ -384,10 +414,194 @@ describe("POST /api/submit auth path", () => {
     );
 
     expect(response.status).toBe(200);
+    expect(tx.insert).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      id: "submittedDevices.id",
+    }));
+    expect(submittedDeviceValues).toEqual(expect.objectContaining({
+      userId: "user-1",
+      deviceKey: "dev_test",
+      displayName: "Test device",
+    }));
+    expect(dailyInsertValues).toEqual([
+      expect.objectContaining({
+        submissionId: "submission-1",
+        submittedDeviceId: "submitted-device-1",
+        date: "2026-04-30",
+      }),
+    ]);
     expect(mockState.revalidateTag).toHaveBeenNthCalledWith(1, "leaderboard", "max");
     expect(mockState.revalidateTag).toHaveBeenNthCalledWith(2, "user:alice", "max");
     expect(mockState.revalidateTag).toHaveBeenNthCalledWith(3, "user-rank", "max");
     expect(mockState.revalidateTag).toHaveBeenNthCalledWith(4, "user-rank:alice", "max");
     expect(mockState.revalidateUsernamePaths).toHaveBeenCalledWith("Alice");
+  });
+
+  it("replaces same-device daily rows without inserting duplicate dates", async () => {
+    mockState.authenticatePersonalToken.mockResolvedValue({
+      status: "valid",
+      tokenId: "token-1",
+      userId: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      isAdmin: false,
+      expiresAt: null,
+    });
+
+    mockState.validateSubmission.mockReturnValue({
+      valid: true,
+      data: {
+        device: {
+          id: "dev_laptop",
+        },
+        meta: {
+          version: "2.0.0",
+          dateRange: { start: "2026-04-30", end: "2026-04-30" },
+        },
+        summary: {
+          clients: ["codex"],
+        },
+        contributions: [
+          {
+            date: "2026-04-30",
+            timestampMs: 456,
+            clients: [
+              {
+                client: "codex",
+                modelId: "gpt-5.5",
+                tokens: 15,
+                cost: 0.75,
+                input: 10,
+                output: 5,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+                messages: 1,
+              },
+            ],
+          },
+        ],
+      },
+      errors: [],
+      warnings: [],
+    });
+
+    const incomingBreakdown = {
+      tokens: 15,
+      cost: 0.75,
+      input: 10,
+      output: 5,
+      cacheRead: 0,
+      cacheWrite: 0,
+      reasoning: 0,
+      messages: 1,
+    };
+    const existingBreakdown = {
+      codex: {
+        tokens: 12,
+        cost: 0.5,
+        input: 7,
+        output: 5,
+        cacheRead: 0,
+        cacheWrite: 0,
+        reasoning: 0,
+        messages: 1,
+        models: { "gpt-5.5": { tokens: 12 } },
+      },
+    };
+    const mergedBreakdown = {
+      codex: {
+        ...incomingBreakdown,
+        models: { "gpt-5.5": incomingBreakdown },
+      },
+    };
+
+    mockState.clientContributionToBreakdownData.mockReturnValue(incomingBreakdown);
+    mockState.mergeClientBreakdowns.mockReturnValue(mergedBreakdown);
+    mockState.recalculateDayTotals.mockReturnValue({
+      tokens: 15,
+      cost: 0.75,
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+    mockState.buildModelBreakdown.mockReturnValue({ "gpt-5.5": 15 });
+    mockState.mergeTimestampMs.mockReturnValue(456);
+
+    const selectResults = [
+      [{ id: "submission-1" }],
+      [{
+        id: "daily-1",
+        date: "2026-04-30",
+        timestampMs: 123,
+        sourceBreakdown: existingBreakdown,
+      }],
+      [{
+        totalTokens: 15,
+        totalCost: "0.7500",
+        inputTokens: 10,
+        outputTokens: 5,
+        dateStart: "2026-04-30",
+        dateEnd: "2026-04-30",
+        activeDays: 1,
+        rowCount: 1,
+      }],
+      [{ sourceBreakdown: mergedBreakdown }],
+    ];
+
+    const tx = {
+      update: vi.fn(() => {
+        const builder = {
+          set: vi.fn(() => builder),
+          where: vi.fn(() => Promise.resolve()),
+        };
+        return builder;
+      }),
+      select: vi.fn(() => makeAwaitableBuilder(selectResults.shift() ?? [])),
+      insert: vi.fn(() => {
+        const builder = {
+          values: vi.fn(() => builder),
+          onConflictDoUpdate: vi.fn(() => builder),
+          returning: vi.fn(() => Promise.resolve([{ id: "submitted-device-1" }])),
+        };
+        return builder;
+      }),
+      execute: vi.fn(() => Promise.resolve()),
+    };
+    type MockTransaction = typeof tx;
+
+    mockState.db.transaction.mockImplementation(async (callback: (tx: MockTransaction) => Promise<unknown>) =>
+      callback(tx)
+    );
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ meta: {}, contributions: [] }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(tx.insert).toHaveBeenCalledTimes(1);
+    expect(tx.insert).toHaveBeenCalledWith(expect.objectContaining({
+      id: "submittedDevices.id",
+    }));
+    expect(tx.execute).toHaveBeenCalledTimes(1);
+    expect(mockState.mergeClientBreakdowns).toHaveBeenCalledWith(
+      existingBreakdown,
+      { codex: mergedBreakdown.codex },
+      expect.any(Set)
+    );
+    expect(await response.json()).toEqual(expect.objectContaining({
+      success: true,
+      metrics: expect.objectContaining({
+        totalTokens: 15,
+        activeDays: 1,
+      }),
+      mode: "merge",
+    }));
   });
 });

--- a/packages/frontend/src/app/api/settings/submitted-data/route.ts
+++ b/packages/frontend/src/app/api/settings/submitted-data/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { getSession } from "@/lib/auth/session";
 import { authenticatePersonalToken } from "@/lib/auth/personalTokens";
-import { db, submissions } from "@/lib/db";
+import { db, submissions, submittedDevices } from "@/lib/db";
 import { normalizeUsernameCacheKey, revalidateUsernamePaths } from "@/lib/db/usernameLookup";
 import { getBearerToken } from "../../../../lib/auth/bearerToken";
 
@@ -31,10 +31,18 @@ export async function DELETE(request: Request) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }
 
-    const deletedRows = await db
-      .delete(submissions)
-      .where(eq(submissions.userId, user.id))
-      .returning({ id: submissions.id });
+    const deletedRows = await db.transaction(async (tx) => {
+      const deleted = await tx
+        .delete(submissions)
+        .where(eq(submissions.userId, user.id))
+        .returning({ id: submissions.id });
+
+      await tx
+        .delete(submittedDevices)
+        .where(eq(submittedDevices.userId, user.id));
+
+      return deleted;
+    });
 
     try {
       const usernameCacheKey = normalizeUsernameCacheKey(user.username);

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
-import { db, apiTokens, submissions, dailyBreakdown } from "@/lib/db";
-import { eq, sql } from "drizzle-orm";
+import { db, apiTokens, submissions, submittedDevices, dailyBreakdown } from "@/lib/db";
+import { and, eq, sql } from "drizzle-orm";
 import {
   validateSubmission,
   generateSubmissionHash,
@@ -18,6 +18,9 @@ import {
   type ClientBreakdownData,
 } from "@/lib/db/helpers";
 import { normalizeUsernameCacheKey, revalidateUsernamePaths } from "@/lib/db/usernameLookup";
+
+const LEGACY_SUBMIT_DEVICE_KEY = "legacy-default";
+const LEGACY_SUBMIT_DEVICE_NAME = "Legacy submissions";
 
 function normalizeSubmissionData(data: unknown): void {
   if (!data || typeof data !== "object") return;
@@ -45,6 +48,22 @@ function normalizeSubmissionData(data: unknown): void {
       }
     }
   }
+}
+
+function getSubmitDevice(data: SubmissionData): { key: string; name: string | null; schemaVersion: number } {
+  if (data.device) {
+    return {
+      key: data.device.id,
+      name: data.device.name ?? null,
+      schemaVersion: 2,
+    };
+  }
+
+  return {
+    key: LEGACY_SUBMIT_DEVICE_KEY,
+    name: LEGACY_SUBMIT_DEVICE_NAME,
+    schemaVersion: data.contributions.some((c) => c.timestampMs != null) ? 1 : 0,
+  };
 }
 
 /**
@@ -184,6 +203,27 @@ export async function POST(request: Request) {
         submissionId = newSubmission.id;
       }
 
+      const submitDevice = getSubmitDevice(data);
+      const submittedAt = new Date();
+      const [submittedDevice] = await tx
+        .insert(submittedDevices)
+        .values({
+          userId: tokenRecord.userId,
+          deviceKey: submitDevice.key,
+          displayName: submitDevice.name,
+          lastSubmittedAt: submittedAt,
+          updatedAt: submittedAt,
+        })
+        .onConflictDoUpdate({
+          target: [submittedDevices.userId, submittedDevices.deviceKey],
+          set: {
+            displayName: sql`COALESCE(EXCLUDED.display_name, ${submittedDevices.displayName})`,
+            lastSubmittedAt: submittedAt,
+            updatedAt: submittedAt,
+          },
+        })
+        .returning({ id: submittedDevices.id });
+
       // ------------------------------------------
       // STEP 3b: Fetch existing daily breakdown for merge
       // ------------------------------------------
@@ -195,7 +235,12 @@ export async function POST(request: Request) {
           sourceBreakdown: dailyBreakdown.sourceBreakdown,
         })
         .from(dailyBreakdown)
-        .where(eq(dailyBreakdown.submissionId, submissionId))
+        .where(
+          and(
+            eq(dailyBreakdown.submissionId, submissionId),
+            eq(dailyBreakdown.submittedDeviceId, submittedDevice.id)
+          )
+        )
         .for('update');
 
       const existingDaysMap = new Map(
@@ -207,6 +252,7 @@ export async function POST(request: Request) {
       // ------------------------------------------
       const toInsert: Array<{
         submissionId: string;
+        submittedDeviceId: string;
         date: string;
         tokens: number;
         cost: string;
@@ -291,6 +337,7 @@ export async function POST(request: Request) {
 
           toInsert.push({
             submissionId,
+            submittedDeviceId: submittedDevice.id,
             date: incomingDay.date,
             tokens: dayTotals.tokens,
             cost: dayTotals.cost.toFixed(4),
@@ -343,7 +390,7 @@ export async function POST(request: Request) {
           outputTokens: sql<number>`COALESCE(SUM(${dailyBreakdown.outputTokens}), 0)::bigint`,
           dateStart: sql<string>`MIN(${dailyBreakdown.date})`,
           dateEnd: sql<string>`MAX(${dailyBreakdown.date})`,
-          activeDays: sql<number>`COUNT(CASE WHEN ${dailyBreakdown.tokens} > 0 THEN 1 END)::int`,
+          activeDays: sql<number>`COUNT(DISTINCT CASE WHEN ${dailyBreakdown.tokens} > 0 THEN ${dailyBreakdown.date} END)::int`,
           rowCount: sql<number>`COUNT(*)::int`,
         })
         .from(dailyBreakdown)
@@ -402,7 +449,7 @@ export async function POST(request: Request) {
           cliVersion: data.meta.version,
           submissionHash: generateSubmissionHash(hashData),
           submitCount: sql`COALESCE(submit_count, 0) + 1`,
-          schemaVersion: sql`GREATEST(COALESCE(${submissions.schemaVersion}, 0), ${data.contributions.some((c) => c.timestampMs != null) ? 1 : 0})`,
+          schemaVersion: sql`GREATEST(COALESCE(${submissions.schemaVersion}, 0), ${submitDevice.schemaVersion})`,
           updatedAt: new Date(),
         })
         .where(eq(submissions.id, submissionId));

--- a/packages/frontend/src/lib/db/migrations/0007_add_submitted_devices.sql
+++ b/packages/frontend/src/lib/db/migrations/0007_add_submitted_devices.sql
@@ -1,0 +1,52 @@
+CREATE TABLE "submitted_devices" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"device_key" varchar(96) NOT NULL,
+	"display_name" varchar(120),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_submitted_at" timestamp with time zone,
+	CONSTRAINT "submitted_devices_user_device_key_unique" UNIQUE("user_id","device_key")
+);
+--> statement-breakpoint
+ALTER TABLE "submitted_devices" ADD CONSTRAINT "submitted_devices_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "idx_submitted_devices_user_id" ON "submitted_devices" USING btree ("user_id");
+--> statement-breakpoint
+ALTER TABLE "daily_breakdown" ADD COLUMN "submitted_device_id" uuid;
+--> statement-breakpoint
+INSERT INTO "submitted_devices" (
+	"user_id",
+	"device_key",
+	"display_name",
+	"last_submitted_at",
+	"updated_at"
+)
+SELECT
+	"user_id",
+	'legacy-default',
+	'Legacy submissions',
+	MAX("updated_at"),
+	MAX("updated_at")
+FROM "submissions"
+GROUP BY "user_id"
+ON CONFLICT ("user_id", "device_key") DO NOTHING;
+--> statement-breakpoint
+UPDATE "daily_breakdown" AS db
+SET "submitted_device_id" = sd."id"
+FROM "submissions" AS s
+INNER JOIN "submitted_devices" AS sd
+	ON sd."user_id" = s."user_id"
+	AND sd."device_key" = 'legacy-default'
+WHERE db."submission_id" = s."id"
+	AND db."submitted_device_id" IS NULL;
+--> statement-breakpoint
+ALTER TABLE "daily_breakdown" ALTER COLUMN "submitted_device_id" SET NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "daily_breakdown" ADD CONSTRAINT "daily_breakdown_submitted_device_id_submitted_devices_id_fk" FOREIGN KEY ("submitted_device_id") REFERENCES "public"."submitted_devices"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "idx_daily_breakdown_submitted_device_id" ON "daily_breakdown" USING btree ("submitted_device_id");
+--> statement-breakpoint
+ALTER TABLE "daily_breakdown" DROP CONSTRAINT "daily_breakdown_submission_date_unique";
+--> statement-breakpoint
+ALTER TABLE "daily_breakdown" ADD CONSTRAINT "daily_breakdown_submission_device_date_unique" UNIQUE("submission_id","submitted_device_id","date");

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1778025600000,
       "tag": "0006_rehash_plaintext_personal_tokens",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1778025601000,
+      "tag": "0007_add_submitted_devices",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -53,6 +53,7 @@ export const usersRelations = relations(users, ({ many }) => ({
   sessions: many(sessions),
   apiTokens: many(apiTokens),
   submissions: many(submissions),
+  submittedDevices: many(submittedDevices),
 }));
 
 // ============================================================================
@@ -209,6 +210,40 @@ export const submissionsRelations = relations(submissions, ({ one, many }) => ({
 }));
 
 // ============================================================================
+// SUBMITTED DEVICES
+// ============================================================================
+export const submittedDevices = pgTable(
+  "submitted_devices",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    deviceKey: varchar("device_key", { length: 96 }).notNull(),
+    displayName: varchar("display_name", { length: 120 }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    lastSubmittedAt: timestamp("last_submitted_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("idx_submitted_devices_user_id").on(table.userId),
+    unique("submitted_devices_user_device_key_unique").on(table.userId, table.deviceKey),
+  ]
+);
+
+export const submittedDevicesRelations = relations(submittedDevices, ({ one, many }) => ({
+  user: one(users, {
+    fields: [submittedDevices.userId],
+    references: [users.id],
+  }),
+  dailyBreakdown: many(dailyBreakdown),
+}));
+
+// ============================================================================
 // DAILY BREAKDOWN
 // ============================================================================
 export const dailyBreakdown = pgTable(
@@ -218,6 +253,9 @@ export const dailyBreakdown = pgTable(
     submissionId: uuid("submission_id")
       .notNull()
       .references(() => submissions.id, { onDelete: "cascade" }),
+    submittedDeviceId: uuid("submitted_device_id")
+      .notNull()
+      .references(() => submittedDevices.id, { onDelete: "cascade" }),
 
     date: date("date").notNull(),
     tokens: bigint("tokens", { mode: "number" }).notNull(),
@@ -260,9 +298,11 @@ export const dailyBreakdown = pgTable(
   },
   (table) => [
     index("idx_daily_breakdown_submission_id").on(table.submissionId),
+    index("idx_daily_breakdown_submitted_device_id").on(table.submittedDeviceId),
     index("idx_daily_breakdown_date").on(table.date),
-    unique("daily_breakdown_submission_date_unique").on(
+    unique("daily_breakdown_submission_device_date_unique").on(
       table.submissionId,
+      table.submittedDeviceId,
       table.date
     ),
   ]
@@ -272,6 +312,10 @@ export const dailyBreakdownRelations = relations(dailyBreakdown, ({ one }) => ({
   submission: one(submissions, {
     fields: [dailyBreakdown.submissionId],
     references: [submissions.id],
+  }),
+  submittedDevice: one(submittedDevices, {
+    fields: [dailyBreakdown.submittedDeviceId],
+    references: [submittedDevices.id],
   }),
 }));
 
@@ -288,5 +332,7 @@ export type DeviceCode = typeof deviceCodes.$inferSelect;
 export type NewDeviceCode = typeof deviceCodes.$inferInsert;
 export type Submission = typeof submissions.$inferSelect;
 export type NewSubmission = typeof submissions.$inferInsert;
+export type SubmittedDevice = typeof submittedDevices.$inferSelect;
+export type NewSubmittedDevice = typeof submittedDevices.$inferInsert;
 export type DailyBreakdown = typeof dailyBreakdown.$inferSelect;
 export type NewDailyBreakdown = typeof dailyBreakdown.$inferInsert;

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -111,6 +111,11 @@ const ExportMetaSchema = z.object({
   }),
 });
 
+const SubmitDeviceSchema = z.object({
+  id: z.string().trim().min(1).max(96).regex(/^[A-Za-z0-9._:-]+$/),
+  name: z.string().trim().min(1).max(120).optional(),
+});
+
 const LEGACY_CLIENT_ALIASES: Record<string, string> = {
   kilocode: "kilo",
 };
@@ -176,6 +181,7 @@ function normalizeLegacySources(data: unknown): unknown {
 
 const SubmissionDataSchema = z.preprocess(normalizeLegacySources, z.object({
   meta: ExportMetaSchema,
+  device: SubmitDeviceSchema.optional(),
   summary: DataSummarySchema,
   years: z.array(YearSummarySchema),
   contributions: z.array(DailyContributionSchema),
@@ -474,6 +480,10 @@ export function generateSubmissionHash(data: SubmissionData): string {
     meta: {
       dateRange: data.meta.dateRange,
     },
+    // Which durable device bucket is being replaced. Legacy no-device payloads
+    // omit this key entirely (JSON.stringify skips undefined), preserving prior
+    // hash behavior for clients that don't send device metadata.
+    deviceId: data.device?.id,
     summary: {
       totalTokens: data.summary.totalTokens,
       totalCost: data.summary.totalCost,


### PR DESCRIPTION
## Summary
- Attach a stable CLI submit device id to `tokscale submit` payloads.
- Store submitted devices per user and merge daily rows by `(submission, device, date)` instead of only `(submission, date)`.
- Recalculate submission totals across all device rows while counting active days by distinct date to avoid multi-device regressions.

## Why
Submitting from multiple machines currently shares one daily row per user submission. A later submit for the same date can replace another device's client breakdown because the merge cannot distinguish which local dataset is being refreshed.

## Diff scope
- `crates/tokscale-cli/src/device.rs`: resolves stable submit device identity from env/config, with `TOKSCALE_DEVICE_ID` and `TOKSCALE_DEVICE_NAME` overrides.
- `crates/tokscale-cli/src/main.rs`: includes the device only in submit payloads, not graph JSON output.
- `packages/frontend/src/lib/validation/submission.ts`: validates optional device metadata and folds the device id into the submission hash.
- `packages/frontend/src/lib/db/schema.ts` and `packages/frontend/src/lib/db/migrations/0006_add_submitted_devices.sql`: add `submitted_devices`, backfill legacy rows, and change the daily uniqueness boundary.
- `packages/frontend/src/app/api/submit/route.ts`: upserts submit devices, locks/merges rows for the current device, and recalculates aggregate totals across all devices.
- `packages/frontend/src/app/api/settings/submitted-data/route.ts`: deletes submit device metadata together with submitted usage data.

## Migration notes
- Adds `submitted_devices` with a per-user unique `device_key`.
- Backfills existing daily rows into a `legacy-default` device before making `daily_breakdown.submitted_device_id` required.
- Replaces the old `(submission_id, date)` uniqueness constraint with `(submission_id, submitted_device_id, date)`.
- No submitted usage rows are deleted by the migration.

## Safety
- Legacy payloads without `device` remain valid and use the `legacy-default` bucket.
- Same-device resubmits still replace that device's daily data; different devices on the same date retain separate rows.
- Submission totals continue to sum all daily rows, while `activeDays` counts distinct active dates so it does not inflate across devices.
- Device identity is generated locally for submit only; graph/report JSON output remains unchanged unless submitting.

## Validation
- `cargo fmt --all -- --check` — **PASS**.
- `cargo test -p tokscale-cli` — **PASS**: `473 passed`, `1 ignored`; `cli_tests`: `88 passed`.
- `/opt/homebrew/bin/cargo-clippy --package=tokscale-cli --all-features -- -D warnings` — **PASS**.
- `bunx vitest run packages/frontend/__tests__` — **PASS**: `21 files`, `182 tests`.
- `bun run lint` in `packages/frontend` — **PASS**, 0 errors; 7 existing warnings in untouched files.
- `git diff --check origin/main...HEAD` — **PASS**, no output.

## Rollback
Revert the merge commit. If the database migration has already been applied, rollback also needs to remove `daily_breakdown.submitted_device_id`, drop `submitted_devices`, and restore the previous `(submission_id, date)` uniqueness constraint.

