### PR TITLE
fix(claude): price inline MCP sub-provider usage

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -4537,6 +4537,66 @@ mod tests {
     }
 
     #[test]
+    fn test_apply_pricing_if_available_prices_claude_code_gpt_5_3_codex() {
+        let pricing = pricing::PricingService::new(HashMap::new(), HashMap::new());
+
+        let mut msg = UnifiedMessage::new(
+            "claude",
+            "gpt-5.3-codex",
+            "openai",
+            "session-1",
+            1_776_000_000_000,
+            TokenBreakdown {
+                input: 1_000_000,
+                output: 100_000,
+                cache_read: 50_000,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            0.0,
+        );
+
+        apply_pricing_if_available(&mut msg, Some(&pricing));
+
+        let expected = 1.75 + 1.4 + 0.00875;
+        assert!((msg.cost - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_apply_pricing_if_available_prices_claude_code_minimax_model() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "minimax/minimax-m2.1".into(),
+            pricing::ModelPricing {
+                input_cost_per_token: Some(0.01),
+                output_cost_per_token: Some(0.02),
+                ..Default::default()
+            },
+        );
+        let pricing = pricing::PricingService::new(litellm, HashMap::new());
+
+        let mut msg = UnifiedMessage::new(
+            "claude",
+            "MiniMax-M2.1",
+            "minimax",
+            "session-1",
+            1_776_000_000_000,
+            TokenBreakdown {
+                input: 10,
+                output: 5,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            0.0,
+        );
+
+        apply_pricing_if_available(&mut msg, Some(&pricing));
+
+        assert_eq!(msg.cost, 0.2);
+    }
+
+    #[test]
     fn test_select_local_parse_pricing_prefers_fresh_service_for_new_models() {
         let mut fresh_litellm = HashMap::new();
         fresh_litellm.insert(

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -10,7 +10,7 @@ use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
-const CACHE_SCHEMA_VERSION: u32 = 13;
+const CACHE_SCHEMA_VERSION: u32 = 14;
 const CACHE_FILENAME: &str = "source-message-cache.bin";
 const CACHE_LOCK_FILENAME: &str = "source-message-cache.lock";
 const MAX_CACHE_FILE_BYTES: u64 = 256 * 1024 * 1024;

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -9,6 +9,7 @@ const PROVIDER_PREFIXES: &[&str] = &[
     "google/",
     "meta-llama/",
     "mistralai/",
+    "minimax/",
     "deepseek/",
     "qwen/",
     "cohere/",
@@ -24,6 +25,7 @@ const ORIGINAL_PROVIDER_PREFIXES: &[&str] = &[
     "google/",
     "meta-llama/",
     "mistralai/",
+    "minimax/",
     "deepseek/",
     "z-ai/",
     "qwen/",
@@ -3575,6 +3577,24 @@ mod tests {
             .lookup_with_provider("mistral-large", Some("mistral"))
             .unwrap();
         assert_eq!(result.matched_key, "mistralai/mistral-large");
+    }
+
+    #[test]
+    fn test_provider_hint_minimax_matches_minimax_keys() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "minimax/minimax-m2.1".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.002),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+        let result = lookup
+            .lookup_with_provider("MiniMax-M2.1", Some("minimax"))
+            .unwrap();
+        assert_eq!(result.matched_key, "minimax/minimax-m2.1");
     }
 
     #[test]

--- a/crates/tokscale-core/src/provider_identity.rs
+++ b/crates/tokscale-core/src/provider_identity.rs
@@ -4,6 +4,9 @@ fn canonicalize_provider_segment(segment: &str) -> Option<String> {
         .trim_end_matches('/')
         .to_lowercase()
         .replace('-', "_");
+    if normalized.starts_with('<') && normalized.ends_with('>') {
+        return None;
+    }
 
     let canonical = match normalized.as_str() {
         "" | "unknown" => return None,
@@ -17,6 +20,7 @@ fn canonicalize_provider_segment(segment: &str) -> Option<String> {
         "fireworks" | "fireworks_ai" => "fireworks_ai",
         "google" | "gemini" => "google",
         "openai" | "openai_codex" => "openai",
+        "minimax" | "minimaxai" | "minimax_ai" => "minimax",
         "mistral" | "mistralai" => "mistralai",
         "ai21" => "ai21",
         // For unknown segments, reject if they contain digits — those are
@@ -150,6 +154,10 @@ pub fn inferred_provider_from_model(model: &str) -> Option<&'static str> {
         return Some("deepseek");
     }
 
+    if lower.contains("minimax") {
+        return Some("minimax");
+    }
+
     if lower.contains("mistral") || lower.contains("mixtral") {
         return Some("mistral");
     }
@@ -177,6 +185,7 @@ mod tests {
             ("vertex", vec!["anthropic"]),
             ("azure", vec!["azure_ai"]),
             ("fireworks", vec!["fireworks_ai"]),
+            ("MiniMax", vec!["minimax"]),
             ("openrouter/google", vec!["openrouter", "google"]),
             ("bedrock/anthropic", vec!["bedrock", "anthropic"]),
         ];
@@ -193,6 +202,7 @@ mod tests {
             canonical_provider("openrouter/google"),
             Some("openrouter".into())
         );
+        assert_eq!(canonical_provider("<synthetic>"), None);
         assert_eq!(canonical_provider("unknown"), None);
     }
 
@@ -245,6 +255,10 @@ mod tests {
         assert_eq!(
             inferred_provider_from_model("deepseek-v3"),
             Some("deepseek")
+        );
+        assert_eq!(
+            inferred_provider_from_model("MiniMax-M2.1"),
+            Some("minimax")
         );
         assert_eq!(
             inferred_provider_from_model("mixtral-8x7b"),

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -9,7 +9,7 @@ use super::utils::{
 use super::{
     normalize_agent_name, normalize_workspace_key, workspace_label_from_key, UnifiedMessage,
 };
-use crate::TokenBreakdown;
+use crate::{provider_identity, TokenBreakdown};
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -37,6 +37,9 @@ pub struct ClaudeEntry {
     /// Parent session UUID (present on every sidechain line)
     #[serde(rename = "sessionId")]
     pub session_id: Option<String>,
+    /// Optional billing or routing provider emitted by wrappers around Claude Code.
+    #[serde(rename = "providerId", alias = "provider_id", alias = "provider")]
+    pub provider_id: Option<String>,
 }
 
 /// Meta sidecar written next to nested-layout sidechain transcripts.
@@ -53,6 +56,9 @@ pub struct ClaudeMessage {
     pub usage: Option<ClaudeUsage>,
     /// Message ID for deduplication (used with requestId)
     pub id: Option<String>,
+    /// Optional billing or routing provider emitted by wrappers around Claude Code.
+    #[serde(rename = "providerId", alias = "provider_id", alias = "provider")]
+    pub provider_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -325,6 +331,7 @@ pub fn parse_claude_file_with_cache(
 
     let reader = BufReader::new(file);
     let mut messages: Vec<UnifiedMessage> = Vec::with_capacity(64);
+    let mut provider_confidences: Vec<u8> = Vec::with_capacity(64);
     // Maps dedup_key to the index in `messages` of the first occurrence.
     // CC's streaming API writes the same messageId:requestId multiple times as the
     // response streams in; later entries often carry more complete token counts.
@@ -396,6 +403,14 @@ pub fn parse_claude_file_with_cache(
                     None => continue,
                 };
 
+                let duplicate_provider_choice = claude_provider_choice_from_parts(
+                    message.model.as_deref(),
+                    message
+                        .provider_id
+                        .as_deref()
+                        .or(entry.provider_id.as_deref()),
+                );
+
                 // Build dedup key for global deduplication (messageId:requestId composite).
                 // For streaming responses, merge using per-field max to capture the most
                 // complete token counts across all duplicate entries.
@@ -404,15 +419,24 @@ pub fn parse_claude_file_with_cache(
                         let hash = format!("{}:{}", msg_id, req_id);
                         if let Some(&existing_idx) = processed_hashes.get(&hash) {
                             // Per-field max merge: each token field is updated independently
-                            let t = &mut messages[existing_idx].tokens;
-                            t.input = t.input.max(usage.input_tokens.unwrap_or(0).max(0));
-                            t.output = t.output.max(usage.output_tokens.unwrap_or(0).max(0));
-                            t.cache_read = t
-                                .cache_read
-                                .max(usage.cache_read_input_tokens.unwrap_or(0).max(0));
-                            t.cache_write = t
-                                .cache_write
-                                .max(usage.cache_creation_input_tokens.unwrap_or(0).max(0));
+                            {
+                                let t = &mut messages[existing_idx].tokens;
+                                t.input = t.input.max(usage.input_tokens.unwrap_or(0).max(0));
+                                t.output = t.output.max(usage.output_tokens.unwrap_or(0).max(0));
+                                t.cache_read = t
+                                    .cache_read
+                                    .max(usage.cache_read_input_tokens.unwrap_or(0).max(0));
+                                t.cache_write = t
+                                    .cache_write
+                                    .max(usage.cache_creation_input_tokens.unwrap_or(0).max(0));
+                            }
+                            if let Some(choice) = duplicate_provider_choice {
+                                update_claude_provider_id(
+                                    &mut messages[existing_idx].provider_id,
+                                    &mut provider_confidences[existing_idx],
+                                    choice,
+                                );
+                            }
                             continue;
                         }
                         Some(hash)
@@ -424,6 +448,14 @@ pub fn parse_claude_file_with_cache(
                     Some(m) => m,
                     None => continue,
                 };
+                let provider_choice = claude_provider_choice(
+                    &model,
+                    message
+                        .provider_id
+                        .as_deref()
+                        .or(entry.provider_id.as_deref()),
+                );
+                let provider_confidence = provider_choice.confidence;
 
                 let timestamp = entry
                     .timestamp
@@ -439,7 +471,7 @@ pub fn parse_claude_file_with_cache(
                 let mut unified = UnifiedMessage::new_with_dedup(
                     "claude",
                     model,
-                    "anthropic",
+                    provider_choice.id,
                     session_id.clone(),
                     timestamp,
                     TokenBreakdown {
@@ -460,6 +492,7 @@ pub fn parse_claude_file_with_cache(
                     pending_turn_start = false;
                 }
                 messages.push(unified);
+                provider_confidences.push(provider_confidence);
                 handled = true;
             }
         }
@@ -476,7 +509,9 @@ pub fn parse_claude_file_with_cache(
         ) {
             let mut message = message;
             message.set_workspace(workspace_key.clone(), workspace_label.clone());
+            let provider_confidence = stored_claude_provider_confidence(&message.provider_id);
             messages.push(message);
+            provider_confidences.push(provider_confidence);
         }
     }
 
@@ -485,7 +520,9 @@ pub fn parse_claude_file_with_cache(
     {
         let mut message = message;
         message.set_workspace(workspace_key, workspace_label);
+        let provider_confidence = stored_claude_provider_confidence(&message.provider_id);
         messages.push(message);
+        provider_confidences.push(provider_confidence);
     }
 
     messages
@@ -511,6 +548,7 @@ fn claude_workspace_from_path(path: &Path) -> (Option<String>, Option<String>) {
 #[derive(Default)]
 struct ClaudeHeadlessState {
     model: Option<String>,
+    provider_id: Option<String>,
     input: i64,
     output: i64,
     cache_read: i64,
@@ -562,6 +600,7 @@ fn process_claude_headless_line(
             completed_message = finalize_headless_state(state, session_id, fallback_timestamp);
 
             state.model = extract_claude_model(&value);
+            state.provider_id = extract_claude_provider(&value);
             state.timestamp_ms = extract_claude_timestamp(&value).or(state.timestamp_ms);
             if let Some(usage) = value
                 .get("message")
@@ -603,12 +642,13 @@ fn extract_claude_headless_message(
         .get("usage")
         .or_else(|| value.get("message").and_then(|msg| msg.get("usage")))?;
     let model = extract_claude_model(value)?;
+    let provider_id = claude_provider_id(&model, extract_claude_provider(value).as_deref());
     let timestamp = extract_claude_timestamp(value).unwrap_or(fallback_timestamp);
 
     Some(UnifiedMessage::new(
         "claude",
         model,
-        "anthropic",
+        provider_id,
         session_id.to_string(),
         timestamp,
         TokenBreakdown {
@@ -671,6 +711,126 @@ fn extract_claude_model(value: &Value) -> Option<String> {
     })
 }
 
+fn extract_claude_provider(value: &Value) -> Option<String> {
+    extract_string(value.get("providerId"))
+        .or_else(|| extract_string(value.get("provider_id")))
+        .or_else(|| extract_string(value.get("provider")))
+        .or_else(|| {
+            value.get("message").and_then(|msg| {
+                extract_string(msg.get("providerId"))
+                    .or_else(|| extract_string(msg.get("provider_id")))
+                    .or_else(|| extract_string(msg.get("provider")))
+            })
+        })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ClaudeProviderChoice {
+    id: String,
+    confidence: u8,
+}
+
+impl ClaudeProviderChoice {
+    fn new(id: impl Into<String>, confidence: u8) -> Self {
+        Self {
+            id: id.into(),
+            confidence,
+        }
+    }
+}
+
+const CLAUDE_PROVIDER_DEFAULT_CONFIDENCE: u8 = 1;
+const CLAUDE_PROVIDER_INFERRED_CONFIDENCE: u8 = 2;
+const CLAUDE_PROVIDER_EXPLICIT_CONFIDENCE: u8 = 3;
+
+fn claude_provider_id(model: &str, provider_hint: Option<&str>) -> String {
+    claude_provider_choice(model, provider_hint).id
+}
+
+fn claude_provider_choice_from_parts(
+    model: Option<&str>,
+    provider_hint: Option<&str>,
+) -> Option<ClaudeProviderChoice> {
+    match model {
+        Some(model) => Some(claude_provider_choice(model, provider_hint)),
+        None => claude_provider_choice_from_hint(None, provider_hint),
+    }
+}
+
+fn claude_provider_choice(model: &str, provider_hint: Option<&str>) -> ClaudeProviderChoice {
+    if let Some(choice) = claude_provider_choice_from_hint(Some(model), provider_hint) {
+        return choice;
+    }
+
+    let inferred = provider_identity::inferred_provider_from_model(model);
+
+    if let Some(provider) = provider_from_model_prefix(model) {
+        return ClaudeProviderChoice::new(provider, CLAUDE_PROVIDER_EXPLICIT_CONFIDENCE);
+    }
+
+    if let Some(provider) = inferred {
+        return ClaudeProviderChoice::new(provider, CLAUDE_PROVIDER_INFERRED_CONFIDENCE);
+    }
+
+    ClaudeProviderChoice::new("unknown", 0)
+}
+
+fn claude_provider_choice_from_hint(
+    model: Option<&str>,
+    provider_hint: Option<&str>,
+) -> Option<ClaudeProviderChoice> {
+    let hint = provider_hint.and_then(provider_identity::canonical_provider)?;
+
+    if hint == "anthropic" {
+        if let Some(inferred_provider) =
+            model.and_then(provider_identity::inferred_provider_from_model)
+        {
+            if inferred_provider != "anthropic" {
+                return Some(ClaudeProviderChoice::new(
+                    inferred_provider,
+                    CLAUDE_PROVIDER_INFERRED_CONFIDENCE,
+                ));
+            }
+        }
+        return Some(ClaudeProviderChoice::new(
+            hint,
+            CLAUDE_PROVIDER_DEFAULT_CONFIDENCE,
+        ));
+    }
+
+    Some(ClaudeProviderChoice::new(
+        hint,
+        CLAUDE_PROVIDER_EXPLICIT_CONFIDENCE,
+    ))
+}
+
+fn update_claude_provider_id(
+    existing: &mut String,
+    existing_confidence: &mut u8,
+    candidate: ClaudeProviderChoice,
+) {
+    if candidate.confidence > *existing_confidence {
+        *existing_confidence = candidate.confidence;
+        *existing = candidate.id;
+    }
+}
+
+fn stored_claude_provider_confidence(provider_id: &str) -> u8 {
+    match provider_identity::canonical_provider(provider_id) {
+        None => 0,
+        Some(provider) if provider == "anthropic" => CLAUDE_PROVIDER_DEFAULT_CONFIDENCE,
+        Some(_) => CLAUDE_PROVIDER_INFERRED_CONFIDENCE,
+    }
+}
+
+fn provider_from_model_prefix(model: &str) -> Option<String> {
+    if model.trim().contains('/') {
+        provider_identity::canonical_provider(model)
+    } else {
+        None
+    }
+}
+
 fn extract_claude_timestamp(value: &Value) -> Option<i64> {
     value
         .get("timestamp")
@@ -700,6 +860,7 @@ fn finalize_headless_state(
     fallback_timestamp: i64,
 ) -> Option<UnifiedMessage> {
     let model = state.model.clone()?;
+    let provider_id = claude_provider_id(&model, state.provider_id.as_deref());
     let timestamp = state.timestamp_ms.unwrap_or(fallback_timestamp);
     if state.input == 0 && state.output == 0 && state.cache_read == 0 && state.cache_write == 0 {
         *state = ClaudeHeadlessState::default();
@@ -709,7 +870,7 @@ fn finalize_headless_state(
     let message = UnifiedMessage::new(
         "claude",
         model,
-        "anthropic",
+        provider_id,
         session_id.to_string(),
         timestamp,
         TokenBreakdown {
@@ -877,6 +1038,48 @@ mod tests {
     }
 
     #[test]
+    fn test_deduplication_promotes_provider_hint_from_later_duplicate() {
+        let content = r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50}}}
+{"type":"assistant","timestamp":"2024-12-01T10:00:00.100Z","requestId":"req_001","message":{"id":"msg_001","provider":"openrouter/anthropic","model":"claude-3-5-sonnet","usage":{"input_tokens":120,"output_tokens":75}}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].provider_id, "openrouter");
+        assert_eq!(messages[0].tokens.input, 120);
+        assert_eq!(messages[0].tokens.output, 75);
+    }
+
+    #[test]
+    fn test_deduplication_promotes_provider_hint_without_later_model() {
+        let content = r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50}}}
+{"type":"assistant","provider":"openrouter/anthropic","timestamp":"2024-12-01T10:00:00.100Z","requestId":"req_001","message":{"id":"msg_001","usage":{"input_tokens":120,"output_tokens":75}}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].provider_id, "openrouter");
+        assert_eq!(messages[0].tokens.input, 120);
+        assert_eq!(messages[0].tokens.output, 75);
+    }
+
+    #[test]
+    fn test_deduplication_preserves_explicit_provider_against_later_inference() {
+        let content = r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","requestId":"req_001","message":{"id":"msg_001","provider":"openrouter/anthropic","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50}}}
+{"type":"assistant","timestamp":"2024-12-01T10:00:00.100Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":120,"output_tokens":75}}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].provider_id, "openrouter");
+        assert_eq!(messages[0].tokens.input, 120);
+        assert_eq!(messages[0].tokens.output, 75);
+    }
+
+    #[test]
     fn test_deduplication_skips_model_none_without_stale_index() {
         // First entry has id+requestId+usage but model=null → skipped, no push.
         // Second entry is a valid duplicate. Must not panic on stale index.
@@ -1028,6 +1231,49 @@ mod tests {
     }
 
     #[test]
+    fn test_multi_provider_models_infer_provider_from_model() {
+        let content = r#"{"type":"assistant","timestamp":"2026-02-18T10:00:00.000Z","message":{"model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":10}}}
+{"type":"assistant","timestamp":"2026-02-18T10:00:01.000Z","message":{"model":"gpt-5.3-codex","usage":{"input_tokens":200,"output_tokens":20}}}
+{"type":"assistant","timestamp":"2026-02-18T10:00:02.000Z","message":{"model":"gemini-3-flash-preview","usage":{"input_tokens":300,"output_tokens":30}}}
+{"type":"assistant","timestamp":"2026-02-18T10:00:03.000Z","message":{"model":"MiniMax-M2.1","usage":{"input_tokens":400,"output_tokens":40}}}
+{"type":"assistant","timestamp":"2026-02-18T10:00:04.000Z","message":{"model":"<synthetic>","usage":{"input_tokens":500,"output_tokens":50}}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 5);
+        assert_eq!(messages[0].provider_id, "anthropic");
+        assert_eq!(messages[1].provider_id, "openai");
+        assert_eq!(messages[2].provider_id, "google");
+        assert_eq!(messages[3].provider_id, "minimax");
+        assert_eq!(messages[4].provider_id, "unknown");
+    }
+
+    #[test]
+    fn test_multi_provider_models_prefer_specific_model_over_default_anthropic_hint() {
+        let content = r#"{"type":"assistant","provider":"anthropic","timestamp":"2026-02-18T10:00:00.000Z","message":{"model":"gpt-5.3-codex","usage":{"input_tokens":200,"output_tokens":20}}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gpt-5.3-codex");
+        assert_eq!(messages[0].provider_id, "openai");
+    }
+
+    #[test]
+    fn test_multi_provider_models_preserve_reseller_provider_hint() {
+        let content = r#"{"type":"assistant","timestamp":"2026-02-18T10:00:00.000Z","message":{"provider":"openrouter/anthropic","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":10}}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "claude-opus-4-6");
+        assert_eq!(messages[0].provider_id, "openrouter");
+    }
+
+    #[test]
     fn test_headless_json_output() {
         let content = r#"{"type":"message","message":{"model":"claude-3-5-sonnet","usage":{"input_tokens":120,"output_tokens":60,"cache_read_input_tokens":10}}}"#;
         let file = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
@@ -1040,6 +1286,19 @@ mod tests {
         assert_eq!(messages[0].tokens.input, 120);
         assert_eq!(messages[0].tokens.output, 60);
         assert_eq!(messages[0].tokens.cache_read, 10);
+    }
+
+    #[test]
+    fn test_headless_json_output_infers_subprovider() {
+        let content = r#"{"type":"message","message":{"model":"gpt-5.3-codex","usage":{"input_tokens":120,"output_tokens":60,"cache_read_input_tokens":10}}}"#;
+        let file = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+        std::fs::write(file.path(), content).unwrap();
+
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gpt-5.3-codex");
+        assert_eq!(messages[0].provider_id, "openai");
     }
 
     #[test]
@@ -1068,6 +1327,21 @@ mod tests {
         assert_eq!(messages[0].tokens.output, 80);
         assert_eq!(messages[0].tokens.cache_read, 20);
         assert_eq!(messages[0].tokens.cache_write, 5);
+    }
+
+    #[test]
+    fn test_headless_stream_output_infers_subprovider() {
+        let content = r#"{"type":"message_start","timestamp":"2026-02-18T10:00:00Z","message":{"id":"msg_1","model":"gemini-3-pro-preview","usage":{"input_tokens":200,"cache_read_input_tokens":20}}}
+{"type":"message_delta","usage":{"output_tokens":80}}
+{"type":"message_stop"}"#;
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gemini-3-pro-preview");
+        assert_eq!(messages[0].provider_id, "google");
+        assert_eq!(messages[0].tokens.input, 200);
+        assert_eq!(messages[0].tokens.output, 80);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Infer Claude Code provider IDs for inline MCP sub-provider rows from explicit provider hints or model names.
- Price high-impact inline `gpt-5.3-codex` Claude Code rows through OpenAI pricing instead of leaving them at `$0.00` under Anthropic attribution.
- Add MiniMax provider matching for provider-aware lookup, and keep internal angle-bracket placeholders such as `<synthetic>` as `unknown` instead of inventing billable pricing.
- Bump the source message cache schema so previously cached Claude Code rows are reparsed with corrected provider IDs.

## Why
Claude Code can log oh-my-claudecode MCP calls inline in the Claude JSONL session file, using the actual sub-provider model name. The parser previously hardcoded every Claude Code row as `anthropic`, so provider-aware pricing could miss real OpenAI/Gemini/MiniMax usage and report `$0.00` for billable sub-provider rows.

This addresses the inline MCP provider attribution and pricing path discussed in #173.

## Diff scope
- `crates/tokscale-core/src/sessions/claudecode.rs`: parse optional provider hints and infer per-message providers for normal JSONL, headless JSON, and headless stream paths.
- `crates/tokscale-core/src/provider_identity.rs`: normalize MiniMax provider aliases and reject angle-bracket internal placeholders as provider tags.
- `crates/tokscale-core/src/pricing/lookup.rs`: add MiniMax provider-prefix support and lookup coverage.
- `crates/tokscale-core/src/message_cache.rs`: invalidate the source message cache for corrected Claude Code attribution.
- `crates/tokscale-core/src/lib.rs`: add pricing regressions for Claude Code inline `gpt-5.3-codex` and MiniMax rows.

## Branch integrity
- Base branch: `main`
- Validated `origin/main`: `3a9045bc1b9aa245ca44ffcdca68bdaaa09520eb`
- Branch HEAD: `6dceba199cd3b6de063c17de6b43e225b932c094`
- Ahead/behind from `origin/main...HEAD`: `0` behind, `1` ahead
- Merge base: `3a9045bc1b9aa245ca44ffcdca68bdaaa09520eb`
- Ancestry: `origin/main` is an ancestor of this branch

## Commit integrity
- `6dceba199cd3b6de063c17de6b43e225b932c094 fix(claude): infer providers for inline MCP usage`
- One logical runtime change in one commit.

## Ledger/version proof
Not applicable — `scripts/ledger/` does not exist in this repository.

## Diff hygiene
Changed files:
- `crates/tokscale-core/src/lib.rs`
- `crates/tokscale-core/src/message_cache.rs`
- `crates/tokscale-core/src/pricing/lookup.rs`
- `crates/tokscale-core/src/provider_identity.rs`
- `crates/tokscale-core/src/sessions/claudecode.rs`

`git diff --check origin/main...HEAD`: PASS, no output.

No environment files, secrets, credentials, build artifacts, caches, or unrelated generated files are included.

## Validation mode and proof
Mode 3 — shared core parser and pricing runtime path.

Local validation:
- `cargo test -p tokscale-core`: PASS, `667 passed`, `1 ignored`; `codebuff 10 passed`; `hermes 3 passed`; doc-tests `0 passed`
- `cargo clippy -p tokscale-core --lib -- -D warnings`: PASS
- `cargo fmt --check`: PASS
- `git diff --check`: PASS
- `git diff --cached --check`: PASS

Not run — full workspace validation is not required locally for this scoped `tokscale-core` parser/pricing change; remote CI should provide final SHA proof after PR creation.

## Migration notes
Not applicable — no database migration changed.

## CI context confirmation
Pending — required CI cannot run until the PR is created.

CI/workflow context names unchanged. No workflow files changed.

## Runtime safety
Reviewed runtime paths: Claude Code session parsing, provider identity normalization, provider-aware pricing lookup, and source message cache invalidation.

No new blocking locks, no new unbounded queues, no invariant removal, and no invariant regression introduced.

## Documentation integrity
Not applicable — no docs, runbooks, commands, or release procedures changed.

## Rollback plan
Revert the final merge commit:

```sh
git revert <post_merge_commit_sha>
```

Replace `<post_merge_commit_sha>` with the final squash/merge commit SHA after merge. Rollback does not require a database downgrade or data repair.

## Known residual risks
- MiniMax cost calculation depends on provider pricing data being available in the pricing datasets. This PR enables correct provider-aware resolution when such pricing exists.
- Internal placeholders such as `<synthetic>` are intentionally left unpriced as `unknown` because they do not map to real billable model pricing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix provider attribution and pricing for Claude Code inline MCP sub-providers. OpenAI, Google, and MiniMax usage is now detected and billed correctly across JSONL, headless JSON, and streaming; internal angle-bracket placeholders stay unpriced, and cached sessions are reparsed.

- **Bug Fixes**
  - Read provider hints from `providerId`/`provider` on entries and messages; canonicalize providers and ignore `<...>` placeholders.
  - Infer provider from model names; treat `anthropic` as a default that model inference can override, but never let inference override explicit reseller hints (e.g., `openrouter/anthropic`).
  - Merge streaming duplicates by taking max token counts and resolving provider by confidence so later explicit hints can correct earlier defaults.
  - Price `gpt-5.3-codex` via OpenAI; add `minimax` normalization and provider-aware lookup for pricing.
  - Bump the source message cache schema to reparse existing Claude Code rows with corrected provider IDs.

<sup>Written for commit 787f500eb5bb9bd9c68de0f3b01867c57f57f904. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

