### PR TITLE
fix(codex): suppress inherited forked subagent usage

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -10,7 +10,7 @@ use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
-const CACHE_SCHEMA_VERSION: u32 = 11;
+const CACHE_SCHEMA_VERSION: u32 = 12;
 const CACHE_FILENAME: &str = "source-message-cache.bin";
 const CACHE_LOCK_FILENAME: &str = "source-message-cache.lock";
 const MAX_CACHE_FILE_BYTES: u64 = 256 * 1024 * 1024;

--- a/crates/tokscale-core/src/sessions/codex.rs
+++ b/crates/tokscale-core/src/sessions/codex.rs
@@ -61,6 +61,7 @@ pub struct CodexTokenUsage {
     pub cached_input_tokens: Option<i64>,
     pub cache_read_input_tokens: Option<i64>,
     pub reasoning_output_tokens: Option<i64>,
+    pub total_tokens: Option<i64>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -160,6 +161,9 @@ pub(crate) struct CodexParseState {
     pub session_agent: Option<String>,
     pub session_workspace_key: Option<String>,
     pub session_workspace_label: Option<String>,
+    pub forked_child_waiting_for_turn_context: bool,
+    pub forked_child_inherited_baseline: Option<CodexTotals>,
+    pub forked_child_inherited_reported_total: Option<i64>,
 }
 
 #[derive(Debug, Clone)]
@@ -261,6 +265,21 @@ fn parse_codex_reader<R: BufRead>(
                 };
                 let event_model = payload_model.clone().or(info_model.clone());
 
+                if state.forked_child_waiting_for_turn_context {
+                    if entry.entry_type == "turn_context" {
+                        state.forked_child_waiting_for_turn_context = false;
+                        state.current_model = payload_model.clone();
+                        handled = true;
+                    } else {
+                        if is_token_count {
+                            if let Some(info) = payload.info.as_ref() {
+                                remember_forked_child_inherited_baseline(&mut state, info);
+                            }
+                        }
+                        continue;
+                    }
+                }
+
                 if !pending_model_messages.is_empty()
                     && event_model.is_none()
                     && !is_token_count
@@ -283,6 +302,9 @@ fn parse_codex_reader<R: BufRead>(
                     }
                     if let Some(ref forked_from_id) = payload.forked_from_id {
                         state.session_forked_from_id = Some(forked_from_id.clone());
+                        state.forked_child_waiting_for_turn_context = true;
+                        state.forked_child_inherited_baseline = None;
+                        state.forked_child_inherited_reported_total = None;
                     }
                     if let Some(ref provider) = payload.model_provider {
                         state.session_provider = Some(provider.clone());
@@ -336,6 +358,21 @@ fn parse_codex_reader<R: BufRead>(
                     // dedup and monotonicity checks — never as a direct delta source.
                     let total_usage = info.total_token_usage.as_ref().map(CodexTotals::from_usage);
                     let last_usage = info.last_token_usage.as_ref().map(CodexTotals::from_usage);
+
+                    if forked_child_matches_inherited_baseline(
+                        &state,
+                        info.total_token_usage.as_ref(),
+                        total_usage,
+                    ) {
+                        if let Some(total) = total_usage {
+                            state.previous_totals = Some(total);
+                        }
+                        state.forked_child_inherited_baseline = None;
+                        state.forked_child_inherited_reported_total = None;
+                        continue;
+                    }
+                    state.forked_child_inherited_baseline = None;
+                    state.forked_child_inherited_reported_total = None;
 
                     let (tokens, next_totals) =
                         match (total_usage, last_usage, state.previous_totals) {
@@ -444,6 +481,13 @@ fn parse_codex_reader<R: BufRead>(
 
         if handled {
             continue;
+        }
+
+        if state.forked_child_waiting_for_turn_context {
+            let mut json_probe = trimmed.as_bytes().to_vec();
+            if simd_json::from_slice::<Value>(&mut json_probe).is_ok() {
+                continue;
+            }
         }
 
         let headless_message = parse_codex_headless_line(
@@ -588,6 +632,41 @@ pub fn parse_codex_file(path: &Path) -> Vec<UnifiedMessage> {
         CodexParseState::default(),
     );
     parsed.messages
+}
+
+fn reported_total_tokens(usage: &CodexTokenUsage) -> Option<i64> {
+    usage.total_tokens.filter(|total| *total >= 0)
+}
+
+fn remember_forked_child_inherited_baseline(state: &mut CodexParseState, info: &CodexInfo) {
+    let Some(total_usage) = info.total_token_usage.as_ref() else {
+        return;
+    };
+
+    let totals = CodexTotals::from_usage(total_usage);
+    state.previous_totals = Some(totals);
+    state.forked_child_inherited_baseline = Some(totals);
+    state.forked_child_inherited_reported_total = reported_total_tokens(total_usage);
+}
+
+fn forked_child_matches_inherited_baseline(
+    state: &CodexParseState,
+    total_usage: Option<&CodexTokenUsage>,
+    totals: Option<CodexTotals>,
+) -> bool {
+    if let (Some(usage), Some(baseline)) =
+        (total_usage, state.forked_child_inherited_reported_total)
+    {
+        if reported_total_tokens(usage) == Some(baseline) {
+            return true;
+        }
+    }
+
+    if let (Some(totals), Some(baseline)) = (totals, state.forked_child_inherited_baseline) {
+        return totals == baseline;
+    }
+
+    false
 }
 
 pub(crate) fn parse_codex_file_incremental(
@@ -1393,6 +1472,80 @@ mod tests {
     }
 
     #[test]
+    fn test_forked_child_ignores_inherited_records_before_turn_context() {
+        let file = create_test_file(concat!(
+            r#"{"timestamp":"2026-05-05T21:51:57.991Z","type":"session_meta","payload":{"id":"child-session","forked_from_id":"parent-session","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent-session","depth":1}}},"model_provider":"openai","agent_nickname":"worker","cwd":"/repo-child"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:57.992Z","type":"session_meta","payload":{"id":"parent-session","source":"interactive","model_provider":"azure","agent_nickname":"parent","cwd":"/repo-parent"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:57.993Z","type":"event_msg","payload":{"type":"user_message","message":"parent prompt copied into child log"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:57.994Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":116000,"cached_input_tokens":114000,"output_tokens":1000,"total_tokens":117000},"last_token_usage":{"input_tokens":73000,"cached_input_tokens":72000,"output_tokens":500,"total_tokens":73500}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:58.947Z","type":"turn_context","payload":{"model":"gpt-5.5","cwd":"/repo-child"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:58.948Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":116000,"cached_input_tokens":114000,"output_tokens":1000,"total_tokens":117000},"last_token_usage":{"input_tokens":73000,"cached_input_tokens":72000,"output_tokens":500,"total_tokens":73500}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:59.253Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":117500,"cached_input_tokens":115000,"output_tokens":1200,"reasoning_output_tokens":50,"total_tokens":118700},"last_token_usage":{"input_tokens":1500,"cached_input_tokens":1000,"output_tokens":200,"reasoning_output_tokens":50,"total_tokens":1700}}}}"#,
+            "\n"
+        ));
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gpt-5.5");
+        assert_eq!(messages[0].provider_id, "openai");
+        assert_eq!(messages[0].agent.as_deref(), Some("worker"));
+        assert_eq!(messages[0].workspace_key.as_deref(), Some("/repo-child"));
+        assert_eq!(messages[0].tokens.input, 500);
+        assert_eq!(messages[0].tokens.cache_read, 1000);
+        assert_eq!(messages[0].tokens.output, 200);
+        assert_eq!(messages[0].tokens.reasoning, 50);
+    }
+
+    #[test]
+    fn test_forked_child_incremental_state_skips_inherited_prefix() {
+        let file = create_test_file(concat!(
+            r#"{"timestamp":"2026-05-05T21:51:57.991Z","type":"session_meta","payload":{"id":"child-session","forked_from_id":"parent-session","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent-session","depth":1}}},"model_provider":"openai","agent_nickname":"worker","cwd":"/repo-child"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:57.992Z","type":"session_meta","payload":{"id":"parent-session","source":"interactive","model_provider":"azure","agent_nickname":"parent","cwd":"/repo-parent"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:57.994Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":116000,"cached_input_tokens":114000,"output_tokens":1000,"total_tokens":117000},"last_token_usage":{"input_tokens":73000,"cached_input_tokens":72000,"output_tokens":500,"total_tokens":73500}}}}"#,
+            "\n"
+        ));
+        let prefix_size = file.as_file().metadata().unwrap().len();
+        let prefix = parse_codex_file_incremental(file.path(), 0, CodexParseState::default());
+
+        assert!(prefix.parse_succeeded);
+        assert!(!prefix.unresolved_model_events);
+        assert!(prefix.messages.is_empty());
+
+        let appended = concat!(
+            r#"{"timestamp":"2026-05-05T21:51:58.947Z","type":"turn_context","payload":{"model":"gpt-5.5","cwd":"/repo-child"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:58.948Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":116000,"cached_input_tokens":114000,"output_tokens":1000,"total_tokens":117000},"last_token_usage":{"input_tokens":73000,"cached_input_tokens":72000,"output_tokens":500,"total_tokens":73500}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:59.253Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":117500,"cached_input_tokens":115000,"output_tokens":1200,"reasoning_output_tokens":50,"total_tokens":118700},"last_token_usage":{"input_tokens":1500,"cached_input_tokens":1000,"output_tokens":200,"reasoning_output_tokens":50,"total_tokens":1700}}}}"#,
+            "\n"
+        );
+        let mut reopened = file.reopen().unwrap();
+        reopened.seek(SeekFrom::End(0)).unwrap();
+        reopened.write_all(appended.as_bytes()).unwrap();
+        reopened.flush().unwrap();
+
+        let incremental =
+            parse_codex_file_incremental(file.path(), prefix_size, prefix.state.clone());
+        let full = parse_codex_file(file.path());
+
+        assert_eq!(incremental.messages, full);
+        assert_eq!(incremental.messages.len(), 1);
+        assert_eq!(incremental.messages[0].tokens.input, 500);
+        assert_eq!(incremental.messages[0].tokens.cache_read, 1000);
+        assert_eq!(incremental.messages[0].tokens.output, 200);
+        assert_eq!(incremental.messages[0].tokens.reasoning, 50);
+    }
+
+    #[test]
     fn test_session_meta_cwd_sets_workspace_metadata() {
         let line1 = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"session_meta","payload":{"source":"interactive","cwd":"/Users/alice/demo-repo"}}"#;
         let line2 = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#;
@@ -1490,6 +1643,7 @@ mod tests {
             cached_input_tokens: Some(10),
             cache_read_input_tokens: Some(20),
             reasoning_output_tokens: Some(5),
+            total_tokens: None,
         };
         let totals = CodexTotals::from_usage(&usage);
         assert_eq!(totals.cached, 20);


### PR DESCRIPTION
## Summary
- Suppresses inherited parent records in Codex forked child JSONL files until the child's first `turn_context`.
- Tracks the skipped inherited token baseline so the repeated post-`turn_context` snapshot is not counted as child-local usage.
- Preserves forked child provider, agent, and workspace metadata, and bumps the source-message cache schema for the updated Codex incremental state.

## Why
Codex native subagent logs can include copied parent session history before the child session records its own `turn_context`. Those inherited `token_count` rows are parent work, not child-local work. Counting them inside every forked child can multiply the parent usage and produce large artificial spikes.

Fixes #520.

## Test plan
- `cargo test -p tokscale-core sessions::codex::tests::test_forked_child` (2 passed)
- `cargo test -p tokscale-core codex` (61 passed)
- `cargo test -p tokscale-core` (661 passed, 1 ignored)
- `cargo test --workspace --all-features` (passed)
- `cargo clippy -p tokscale-core --all-features -- -D warnings` (passed)
- `cargo fmt --all --check` (passed)
- `git diff --check` (passed)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress inherited parent records in Codex forked child logs until the child’s first `turn_context` so token usage reflects only child-local work. This prevents double-counting by tracking the inherited baseline and keeps provider/agent/workspace metadata intact (fixes #520).

- **Bug Fixes**
  - Ignore copied parent `token_count` rows before the child’s first `turn_context`.
  - Compare the first post-`turn_context` snapshot to the inherited baseline to avoid recounting.
  - Parse `total_tokens` in usage payloads and preserve child provider/agent/workspace attribution.

- **Migration**
  - Bump source-message cache schema to v12 to store the forked-child suppression baseline in incremental state.

<sup>Written for commit e0f728ef59ba2fee27bca243f7ecf760d3f60696. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

