### PR TITLE
feat: add time period filters and URL sync to leaderboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ ai-todolist.md
 *.tgz
 .sisyphus
 crates/tokscale-cli/tokscale-export-*.json
+self-host/tokscale-key.pem
+self-host/
+.next/

--- a/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useMemo, memo, useCallback } from "react";
 import { useRouter } from "nextjs-toploader/app";
+import { useSearchParams, usePathname } from "next/navigation";
 import styled from "styled-components";
 import { CopyIcon, CheckIcon, SearchIcon, XIcon } from "@/components/ui/Icons";
 import { TabBar } from "@/components/TabBar";
@@ -459,6 +460,25 @@ const CTADescription = styled.p`
   color: var(--color-fg-muted);
 `;
 
+const CTANote = styled.p`
+  margin-top: 16px;
+  margin-bottom: 0;
+  padding: 12px;
+  border-radius: 8px;
+  background-color: var(--color-bg-subtle);
+  color: var(--color-fg-muted);
+  font-size: 13px;
+  line-height: 1.5;
+
+  code {
+    font-family: "Inconsolata", monospace;
+    background: rgba(255, 255, 255, 0.08);
+    padding: 2px 6px;
+    border-radius: 4px;
+    color: var(--color-fg-default);
+  }
+`;
+
 const CodeBlock = styled.div`
   display: flex;
   flex-direction: column;
@@ -714,6 +734,62 @@ const SortToggleInner = styled.div`
   flex-shrink: 0;
 `;
 
+const DateRangeRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+`;
+
+const DateInput = styled.input`
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-default);
+  background-color: var(--color-bg-subtle);
+  color: var(--color-fg-default);
+  font-size: 14px;
+  outline: none;
+  transition: border-color 0.15s ease;
+  min-width: 140px;
+
+  &:focus {
+    border-color: #0073FF;
+    box-shadow: 0 0 0 3px rgba(0, 115, 255, 0.15);
+  }
+
+  &::-webkit-calendar-picker-indicator {
+    filter: invert(0.7);
+    cursor: pointer;
+  }
+`;
+
+const DateSeparator = styled.span`
+  font-size: 14px;
+  color: var(--color-fg-muted);
+`;
+
+const DateApplyButton = styled.button`
+  padding: 8px 16px;
+  border-radius: 8px;
+  border: 1px solid #0073FF;
+  background-color: #0073FF;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 150ms;
+
+  &:hover {
+    opacity: 0.85;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+`;
+
 const HoverTooltip = styled.span`
   position: relative;
   cursor: default;
@@ -796,7 +872,7 @@ const PaginationPages = styled.div`
   }
 `;
 
-export type Period = "all" | "month" | "week";
+export type Period = "all" | "month" | "last-month" | "week" | "custom";
 
 export interface LeaderboardUser {
   rank: number;
@@ -921,40 +997,86 @@ const LeaderboardRow = memo(function LeaderboardRow({
   );
 });
 
+const VALID_PERIODS: Period[] = ["all", "month", "last-month", "week", "custom"];
+
+function parsePeriodParam(value: string | null): Period | null {
+  if (!value) return null;
+  return VALID_PERIODS.includes(value as Period) ? (value as Period) : null;
+}
+
 export default function LeaderboardClient({ initialData, currentUser, initialSortBy, initialUserRank }: LeaderboardClientProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+
+  const urlPeriod = parsePeriodParam(searchParams.get("period"));
+  const urlPage = searchParams.get("page") ? Math.max(1, Number(searchParams.get("page")) || 1) : null;
+  const urlSortBy = searchParams.get("sortBy") === "cost" ? "cost" as const : searchParams.get("sortBy") === "tokens" ? "tokens" as const : null;
+  const urlFrom = searchParams.get("from") || "";
+  const urlTo = searchParams.get("to") || "";
+
   const [data, setData] = useState<LeaderboardData>(initialData);
   const [error, setError] = useState<string | null>(null);
   const [copiedCommand, setCopiedCommand] = useState<string | null>(null);
-  const [period, setPeriod] = useState<Period>(initialData.period);
-  const [page, setPage] = useState(initialData.pagination.page);
+  const [period, setPeriod] = useState<Period>(urlPeriod || initialData.period);
+  const [page, setPage] = useState(urlPage || initialData.pagination.page);
   const [currentUserRank, setCurrentUserRank] = useState<LeaderboardUser | null>(initialUserRank);
   const [currentUserRankError, setCurrentUserRankError] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [retryToken, setRetryToken] = useState(0);
+  const [customFrom, setCustomFrom] = useState(urlFrom);
+  const [customTo, setCustomTo] = useState(urlTo);
+  const [appliedFrom, setAppliedFrom] = useState(urlPeriod === "custom" ? urlFrom : "");
+  const [appliedTo, setAppliedTo] = useState(urlPeriod === "custom" ? urlTo : "");
   const [resolvedRequest, setResolvedRequest] = useState({
     period: initialData.period,
     page: initialData.pagination.page,
     sortBy: initialSortBy,
     search: "",
     retryToken: 0,
+    customFrom: "",
+    customTo: "",
   });
 
   const { leaderboardSortBy, setLeaderboardSort, mounted } = useSettings();
 
-  const effectiveSortBy = mounted ? leaderboardSortBy : initialSortBy;
+  const initialSortByRef = useRef(urlSortBy);
+  const userHasToggledSort = useRef(false);
+  const effectiveSortBy = (!userHasToggledSort.current && initialSortByRef.current)
+    ? initialSortByRef.current
+    : (mounted ? leaderboardSortBy : initialSortBy);
   const requestedPage = data.pagination.totalPages > 0
     ? Math.min(page, data.pagination.totalPages)
     : page;
-  const isLoading =
+  const isCustomWithoutDates = period === "custom" && (!appliedFrom || !appliedTo);
+  const isLoading = !isCustomWithoutDates && (
     period !== resolvedRequest.period
     || requestedPage !== resolvedRequest.page
     || effectiveSortBy !== resolvedRequest.sortBy
     || debouncedSearch !== resolvedRequest.search
-    || retryToken !== resolvedRequest.retryToken;
+    || retryToken !== resolvedRequest.retryToken
+    || (period === "custom" && (appliedFrom !== resolvedRequest.customFrom || appliedTo !== resolvedRequest.customTo))
+  );
 
   const isFirstRankFetch = useRef(true);
+  const isFirstUrlSync = useRef(true);
+
+  useEffect(() => {
+    if (isFirstUrlSync.current) {
+      isFirstUrlSync.current = false;
+      return;
+    }
+    const params = new URLSearchParams();
+    if (period !== "all") params.set("period", period);
+    if (requestedPage > 1) params.set("page", String(requestedPage));
+    if (effectiveSortBy !== "tokens") params.set("sortBy", effectiveSortBy);
+    if (period === "custom" && appliedFrom) params.set("from", appliedFrom);
+    if (period === "custom" && appliedTo) params.set("to", appliedTo);
+    const qs = params.toString();
+    const url = qs ? `${pathname}?${qs}` : pathname;
+    window.history.replaceState(null, "", url);
+  }, [period, requestedPage, effectiveSortBy, appliedFrom, appliedTo, pathname]);
 
   // Debounce search input — skip setPage(1) on initial mount with empty query
   const isSearchMounted = useRef(false);
@@ -982,7 +1104,8 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
 
     const abortController = new AbortController();
 
-    fetch(`/api/leaderboard/user/${currentUser.username}?period=${period}&sortBy=${effectiveSortBy}`, {
+    const customParams = period === "custom" ? `&from=${appliedFrom}&to=${appliedTo}` : "";
+    fetch(`/api/leaderboard/user/${currentUser.username}?period=${period}&sortBy=${effectiveSortBy}${customParams}`, {
       signal: abortController.signal,
     })
       .then((res) => {
@@ -1001,7 +1124,7 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
       });
 
     return () => abortController.abort();
-  }, [currentUser, period, effectiveSortBy]);
+  }, [currentUser, period, effectiveSortBy, appliedFrom, appliedTo]);
 
   const fetchData = useCallback((
     targetPeriod: Period,
@@ -1010,9 +1133,14 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
     targetSearch: string,
     targetRetryToken: number,
     signal?: AbortSignal,
+    targetCustomFrom?: string,
+    targetCustomTo?: string,
   ) => {
     const searchParam = targetSearch ? `&search=${encodeURIComponent(targetSearch)}` : "";
-    fetch(`/api/leaderboard?period=${targetPeriod}&page=${targetPage}&limit=50&sortBy=${targetSortBy}${searchParam}`, { signal })
+    const customParams = targetPeriod === "custom" && targetCustomFrom && targetCustomTo
+      ? `&from=${targetCustomFrom}&to=${targetCustomTo}`
+      : "";
+    fetch(`/api/leaderboard?period=${targetPeriod}&page=${targetPage}&limit=50&sortBy=${targetSortBy}${searchParam}${customParams}`, { signal })
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json();
@@ -1029,6 +1157,8 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
           sortBy: targetSortBy,
           search: targetSearch,
           retryToken: targetRetryToken,
+          customFrom: targetCustomFrom || "",
+          customTo: targetCustomTo || "",
         });
       })
       .catch((err) => {
@@ -1040,6 +1170,8 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
             sortBy: targetSortBy,
             search: targetSearch,
             retryToken: targetRetryToken,
+            customFrom: targetCustomFrom || "",
+            customTo: targetCustomTo || "",
           });
         }
       });
@@ -1050,10 +1182,14 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
       return;
     }
 
+    if (period === "custom" && (!appliedFrom || !appliedTo)) {
+      return;
+    }
+
     const abortController = new AbortController();
-    fetchData(period, requestedPage, effectiveSortBy, debouncedSearch, retryToken, abortController.signal);
+    fetchData(period, requestedPage, effectiveSortBy, debouncedSearch, retryToken, abortController.signal, appliedFrom, appliedTo);
     return () => abortController.abort();
-  }, [debouncedSearch, effectiveSortBy, fetchData, isLoading, period, requestedPage, retryToken]);
+  }, [appliedFrom, appliedTo, debouncedSearch, effectiveSortBy, fetchData, isLoading, period, requestedPage, retryToken]);
 
   const sortedUsers = data.users || [];
   const showSubmissionCount = period === "all";
@@ -1153,8 +1289,10 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
         <TabBar
           tabs={[
             { id: "all" as Period, label: "All Time" },
+            { id: "last-month" as Period, label: "Last Month" },
             { id: "month" as Period, label: "This Month" },
             { id: "week" as Period, label: "This Week" },
+            { id: "custom" as Period, label: "Custom" },
           ]}
           activeTab={period}
           onTabChange={(tab) => {
@@ -1164,9 +1302,41 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
               setSearchQuery("");
               setDebouncedSearch("");
             }
+            if (tab !== "custom") {
+              setAppliedFrom("");
+              setAppliedTo("");
+            }
           }}
         />
       </TabSection>
+
+      {period === "custom" && (
+        <DateRangeRow>
+          <DateInput
+            type="date"
+            value={customFrom}
+            onChange={(e) => setCustomFrom(e.target.value)}
+            max={customTo || undefined}
+          />
+          <DateSeparator>~</DateSeparator>
+          <DateInput
+            type="date"
+            value={customTo}
+            onChange={(e) => setCustomTo(e.target.value)}
+            min={customFrom || undefined}
+          />
+          <DateApplyButton
+            disabled={!customFrom || !customTo}
+            onClick={() => {
+              setAppliedFrom(customFrom);
+              setAppliedTo(customTo);
+              setPage(1);
+            }}
+          >
+            Apply
+          </DateApplyButton>
+        </DateRangeRow>
+      )}
 
       <SearchSortRow>
         {period === "all" && (
@@ -1191,7 +1361,10 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
           <SortLabel>Sort by:</SortLabel>
           <Switch
             checked={effectiveSortBy === 'cost'}
-            onChange={(checked) => setLeaderboardSort(checked ? 'cost' : 'tokens')}
+            onChange={(checked) => {
+              userHasToggledSort.current = true;
+              setLeaderboardSort(checked ? 'cost' : 'tokens');
+            }}
             leftLabel="Tokens"
             rightLabel="Cost"
           />
@@ -1321,6 +1494,21 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
         <CTATitle>Join the Leaderboard</CTATitle>
         <CTADescription>Install Tokscale CLI and submit your usage data:</CTADescription>
         <CodeBlock>
+          {typeof window !== "undefined" && window.location.hostname !== "tokscale.ai" && (
+            <CodeLine>
+              <CommandPrompt>$</CommandPrompt>
+              <CommandPrefix>export</CommandPrefix>
+              <CommandName>TOKSCALE_API_URL</CommandName>
+              <CommandArg>={`${window.location.origin}`}</CommandArg>
+              <CopyIconButton
+                onClick={() => handleCopyCommand(`export TOKSCALE_API_URL=${window.location.origin}`)}
+                className={copiedCommand === `export TOKSCALE_API_URL=${window.location.origin}` ? "copied" : ""}
+                aria-label="Copy command"
+              >
+                {copiedCommand === `export TOKSCALE_API_URL=${window.location.origin}` ? <CheckIcon size={16} /> : <CopyIcon size={16} />}
+              </CopyIconButton>
+            </CodeLine>
+          )}
           <CodeLine>
             <CommandPrompt>$</CommandPrompt>
             <CommandPrefix>bunx</CommandPrefix>

--- a/packages/frontend/src/app/(main)/leaderboard/page.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/page.tsx
@@ -5,7 +5,7 @@ import { Footer } from "@/components/layout/Footer";
 import { BlackholeHero } from "@/components/BlackholeHero";
 import { LeaderboardSkeleton } from "@/components/Skeleton";
 import { getLeaderboardData, getUserRank } from "@/lib/leaderboard/getLeaderboard";
-import type { LeaderboardData, SortBy } from "@/lib/leaderboard/types";
+import type { LeaderboardData, Period, SortBy } from "@/lib/leaderboard/types";
 import { getSession } from "@/lib/auth/session";
 import { SORT_BY_COOKIE_NAME, isValidSortBy } from "@/lib/leaderboard/constants";
 
@@ -13,6 +13,9 @@ function isMissingDatabaseUrl(error: unknown): boolean {
   return error instanceof Error && error.message === "DATABASE_URL environment variable is not set";
 }
 import LeaderboardClient from "./LeaderboardClient";
+
+const VALID_PERIODS: Period[] = ["all", "month", "last-month", "week", "custom"];
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
 function createEmptyLeaderboardData(sortBy: SortBy): LeaderboardData {
   return {
@@ -36,7 +39,11 @@ function createEmptyLeaderboardData(sortBy: SortBy): LeaderboardData {
   };
 }
 
-export default function LeaderboardPage() {
+interface PageProps {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}
+
+export default function LeaderboardPage({ searchParams }: PageProps) {
   return (
     <div
       style={{
@@ -51,7 +58,7 @@ export default function LeaderboardPage() {
       <main className="main-container">
         <BlackholeHero />
         <Suspense fallback={<LeaderboardSkeleton />}>
-          <LeaderboardWithPreferences />
+          <LeaderboardWithPreferences searchParams={searchParams} />
         </Suspense>
       </main>
 
@@ -60,13 +67,37 @@ export default function LeaderboardPage() {
   );
 }
 
-async function LeaderboardWithPreferences() {
-  const cookieStore = await cookies();
+async function LeaderboardWithPreferences({ searchParams: searchParamsPromise }: { searchParams: Promise<{ [key: string]: string | string[] | undefined }> }) {
+  const [cookieStore, searchParams] = await Promise.all([cookies(), searchParamsPromise]);
   const sortByCookie = cookieStore.get(SORT_BY_COOKIE_NAME)?.value;
-  const sortBy: SortBy = isValidSortBy(sortByCookie) ? sortByCookie : "tokens";
+
+  const periodParam = typeof searchParams.period === "string" ? searchParams.period : null;
+  const pageParam = typeof searchParams.page === "string" ? Math.max(1, Number(searchParams.page) || 1) : 1;
+  const sortByParam = typeof searchParams.sortBy === "string" ? searchParams.sortBy : null;
+  const fromParam = typeof searchParams.from === "string" ? searchParams.from : null;
+  const toParam = typeof searchParams.to === "string" ? searchParams.to : null;
+
+  const sortBy: SortBy = sortByParam && (sortByParam === "tokens" || sortByParam === "cost")
+    ? sortByParam
+    : isValidSortBy(sortByCookie) ? sortByCookie : "tokens";
+
+  let period: Period = periodParam && VALID_PERIODS.includes(periodParam as Period)
+    ? (periodParam as Period)
+    : "all";
+
+  let customFrom: string | undefined;
+  let customTo: string | undefined;
+  if (period === "custom") {
+    if (fromParam && DATE_REGEX.test(fromParam) && toParam && DATE_REGEX.test(toParam)) {
+      customFrom = fromParam;
+      customTo = toParam;
+    } else {
+      period = "all";
+    }
+  }
 
   const [initialData, session] = await Promise.all([
-    getLeaderboardData("all", 1, 50, sortBy).catch((error) => {
+    getLeaderboardData(period, pageParam, 50, sortBy, "", customFrom, customTo).catch((error) => {
       if (isMissingDatabaseUrl(error)) {
         return createEmptyLeaderboardData(sortBy);
       }
@@ -81,7 +112,7 @@ async function LeaderboardWithPreferences() {
   ]);
 
   const initialUserRank = session
-    ? await getUserRank(session.username, "all", sortBy).catch((error) => {
+    ? await getUserRank(session.username, period, sortBy, customFrom, customTo).catch((error) => {
         if (isMissingDatabaseUrl(error)) {
           return null;
         }

--- a/packages/frontend/src/app/api/leaderboard/route.ts
+++ b/packages/frontend/src/app/api/leaderboard/route.ts
@@ -4,7 +4,7 @@ import type { Period, SortBy } from "@/lib/leaderboard/types";
 
 export const revalidate = 60;
 
-const VALID_PERIODS: Period[] = ["all", "month", "week"];
+const VALID_PERIODS: Period[] = ["all", "month", "last-month", "week", "custom"];
 const VALID_SORT_BY: SortBy[] = ["tokens", "cost"];
 
 function parseIntSafe(value: string | null, defaultValue: number): number {
@@ -13,12 +13,21 @@ function parseIntSafe(value: string | null, defaultValue: number): number {
   return Number.isFinite(parsed) ? Math.floor(parsed) : defaultValue;
 }
 
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+function isValidDateString(value: string | null): value is string {
+  if (!value || !DATE_REGEX.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(year, month - 1, day);
+  return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;
+}
+
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
 
-    const periodParam = searchParams.get("period") || "all";
-    const period: Period = VALID_PERIODS.includes(periodParam as Period)
+    let periodParam = searchParams.get("period") || "all";
+    let period: Period = VALID_PERIODS.includes(periodParam as Period)
       ? (periodParam as Period)
       : "all";
 
@@ -32,7 +41,22 @@ export async function GET(request: Request) {
 
     const search = (searchParams.get("search") || "").trim();
 
-    const data = await getLeaderboardData(period, page, limit, sortBy, search);
+    const fromParam = searchParams.get("from");
+    const toParam = searchParams.get("to");
+
+    let customFrom: string | undefined;
+    let customTo: string | undefined;
+
+    if (period === "custom") {
+      if (isValidDateString(fromParam) && isValidDateString(toParam)) {
+        customFrom = fromParam;
+        customTo = toParam;
+      } else {
+        period = "all";
+      }
+    }
+
+    const data = await getLeaderboardData(period, page, limit, sortBy, search, customFrom, customTo);
 
     return NextResponse.json(data);
   } catch (error) {

--- a/packages/frontend/src/app/api/leaderboard/user/[username]/route.ts
+++ b/packages/frontend/src/app/api/leaderboard/user/[username]/route.ts
@@ -5,8 +5,17 @@ import { isValidGitHubUsername } from "@/lib/validation/username";
 
 export const revalidate = 60;
 
-const VALID_PERIODS: Period[] = ["all", "month", "week"];
+const VALID_PERIODS: Period[] = ["all", "month", "last-month", "week", "custom"];
 const VALID_SORT_BY: SortBy[] = ["tokens", "cost"];
+
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+function isValidDateString(value: string | null): value is string {
+  if (!value || !DATE_REGEX.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(year, month - 1, day);
+  return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;
+}
 
 export async function GET(
   request: NextRequest,
@@ -24,7 +33,7 @@ export async function GET(
 
     const { searchParams } = new URL(request.url);
     const periodParam = searchParams.get("period") || "all";
-    const period: Period = VALID_PERIODS.includes(periodParam as Period)
+    let period: Period = VALID_PERIODS.includes(periodParam as Period)
       ? (periodParam as Period)
       : "all";
 
@@ -33,7 +42,21 @@ export async function GET(
       ? (sortByParam as SortBy)
       : "tokens";
 
-    const userRank = await getUserRank(username, period, sortBy);
+    const fromParam = searchParams.get("from");
+    const toParam = searchParams.get("to");
+    let customFrom: string | undefined;
+    let customTo: string | undefined;
+
+    if (period === "custom") {
+      if (isValidDateString(fromParam) && isValidDateString(toParam)) {
+        customFrom = fromParam;
+        customTo = toParam;
+      } else {
+        period = "all";
+      }
+    }
+
+    const userRank = await getUserRank(username, period, sortBy, customFrom, customTo);
 
     if (!userRank) {
       return NextResponse.json({ error: "User not found or has no submissions" }, { status: 404 });

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -64,10 +64,19 @@ function toUtcDateString(date: Date): string {
 
 function getPeriodDateRange(
   period: Period,
-  now: Date = new Date()
+  now: Date = new Date(),
+  customFrom?: string,
+  customTo?: string
 ): PeriodDateRange | null {
   if (period === "all") {
     return null;
+  }
+
+  if (period === "custom") {
+    if (!customFrom || !customTo) {
+      return null;
+    }
+    return { start: customFrom, end: customTo };
   }
 
   const end = new Date(
@@ -80,6 +89,15 @@ function getPeriodDateRange(
     return {
       start: toUtcDateString(start),
       end: toUtcDateString(end),
+    };
+  }
+
+  if (period === "last-month") {
+    const lastMonthEnd = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 0));
+    const lastMonthStart = new Date(Date.UTC(lastMonthEnd.getUTCFullYear(), lastMonthEnd.getUTCMonth(), 1));
+    return {
+      start: toUtcDateString(lastMonthStart),
+      end: toUtcDateString(lastMonthEnd),
     };
   }
 
@@ -234,9 +252,11 @@ function buildPeriodUserRank(
 }
 
 async function fetchPeriodLeaderboardRows(
-  period: Exclude<Period, "all">
+  period: Exclude<Period, "all">,
+  customFrom?: string,
+  customTo?: string
 ): Promise<LeaderboardPeriodRow[]> {
-  const dateRange = getPeriodDateRange(period);
+  const dateRange = getPeriodDateRange(period, new Date(), customFrom, customTo);
 
   if (!dateRange) {
     return [];
@@ -284,10 +304,12 @@ async function fetchLeaderboardData(
   page: number,
   limit: number,
   sortBy: SortBy = "tokens",
-  search: string = ""
+  search: string = "",
+  customFrom?: string,
+  customTo?: string
 ): Promise<LeaderboardData> {
   if (period !== "all") {
-    const rows = await fetchPeriodLeaderboardRows(period);
+    const rows = await fetchPeriodLeaderboardRows(period, customFrom, customTo);
     return buildPeriodLeaderboardData(rows, page, limit, period, sortBy, search);
   }
 
@@ -478,11 +500,17 @@ export function getLeaderboardData(
   page: number = 1,
   limit: number = 50,
   sortBy: SortBy = "tokens",
-  search: string = ""
+  search: string = "",
+  customFrom?: string,
+  customTo?: string
 ): Promise<LeaderboardData> {
+  const cacheKey = period === "custom"
+    ? `leaderboard:custom:${customFrom}:${customTo}:${page}:${limit}:${sortBy}:${search}`
+    : `leaderboard:${period}:${page}:${limit}:${sortBy}:${search}`;
+
   return unstable_cache(
-    () => fetchLeaderboardData(period, page, limit, sortBy, search),
-    [`leaderboard:${period}:${page}:${limit}:${sortBy}:${search}`],
+    () => fetchLeaderboardData(period, page, limit, sortBy, search, customFrom, customTo),
+    [cacheKey],
     {
       tags: ["leaderboard", `leaderboard:${period}`],
       revalidate: 60,
@@ -497,10 +525,12 @@ export function getLeaderboardData(
 async function fetchUserRank(
   username: string,
   period: Period,
-  sortBy: SortBy
+  sortBy: SortBy,
+  customFrom?: string,
+  customTo?: string
 ): Promise<LeaderboardUser | null> {
   if (period !== "all") {
-    const rows = await fetchPeriodLeaderboardRows(period);
+    const rows = await fetchPeriodLeaderboardRows(period, customFrom, customTo);
     return buildPeriodUserRank(rows, username, sortBy);
   }
 
@@ -588,13 +618,16 @@ async function fetchUserRank(
 export function getUserRank(
   username: string,
   period: Period = "all",
-  sortBy: SortBy = "tokens"
+  sortBy: SortBy = "tokens",
+  customFrom?: string,
+  customTo?: string
 ): Promise<LeaderboardUser | null> {
   const usernameCacheKey = normalizeUsernameCacheKey(username);
+  const periodKey = period === "custom" ? `custom:${customFrom}:${customTo}` : period;
 
   return unstable_cache(
-    () => fetchUserRank(username, period, sortBy),
-    [`user-rank:${usernameCacheKey}:${period}:${sortBy}`],
+    () => fetchUserRank(username, period, sortBy, customFrom, customTo),
+    [`user-rank:${usernameCacheKey}:${periodKey}:${sortBy}`],
     {
       tags: ["leaderboard", "user-rank", `user-rank:${usernameCacheKey}`],
       revalidate: 60,

--- a/packages/frontend/src/lib/leaderboard/types.ts
+++ b/packages/frontend/src/lib/leaderboard/types.ts
@@ -1,6 +1,6 @@
 import type { SubmissionFreshness } from "@/lib/submissionFreshness";
 
-export type Period = "all" | "month" | "week";
+export type Period = "all" | "month" | "last-month" | "week" | "custom";
 export type SortBy = "tokens" | "cost";
 
 export interface LeaderboardUser {


### PR DESCRIPTION
## Summary

Add time period filter options to the leaderboard and sync filter state to URL params.

### Changes

- **Last Month tab**: View leaderboard for the entire previous month
- **Custom tab**: Select start/end dates to query any date range
- **Tab reorder**: All Time → Last Month → This Month → This Week → Custom
- **URL sync**: `period`, `page`, `sortBy`, `from`, `to` params reflected in URL for deep linking
- **Self-hosted support**: Dynamically show `export TOKSCALE_API_URL=<current origin>` when not on `tokscale.ai`
- Add `from`/`to` query params to API (used with `period=custom`)
- Add `last-month`, `custom` to `Period` type

### UI

When Custom is selected, two date input fields (from, to) and an Apply button are displayed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds "Last Month" and "Custom" date filters to the leaderboard with URL/SSR sync, strict calendar validation, and cache/user‑rank support for ranges. Also shows a copyable `export TOKSCALE_API_URL=<origin>` line when not on `tokscale.ai`.

- **New Features**
  - UI: tabs reordered to All Time → Last Month → This Month → This Week → Custom; "Custom" uses two date pickers with Apply; `period`, `page`, `sortBy`, `from`, `to` sync to the URL and are read on SSR and client init.
  - API/Backend: `period=custom` with `from`/`to`; added `last-month` and `custom` to `Period`; cache keys and user-rank support custom ranges.

- **Bug Fixes**
  - Prevents loading skeleton when "Custom" is selected without applied dates.
  - URL `sortBy` initializes state but no longer overrides the user's toggle.
  - Date validation rejects invalid calendar dates and falls back to All Time (e.g., Feb 31).

<sup>Written for commit eb2b8415ea55f52c4b032718acf3adad754b30f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

