### PR TITLE
feat(groups): add scoped leaderboards with invites

### DIFF
--- a/packages/frontend/__tests__/api/groupInviteJoinRoute.test.ts
+++ b/packages/frontend/__tests__/api/groupInviteJoinRoute.test.ts
@@ -1,0 +1,114 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const getSessionFromRequest = vi.fn();
+  const getGroupInvitePreview = vi.fn();
+  const acceptGroupInvite = vi.fn();
+
+  return {
+    getSessionFromRequest,
+    getGroupInvitePreview,
+    acceptGroupInvite,
+    reset() {
+      getSessionFromRequest.mockReset();
+      getGroupInvitePreview.mockReset();
+      acceptGroupInvite.mockReset();
+    },
+  };
+});
+
+vi.mock("@/lib/auth/requestSession", () => ({
+  getSessionFromRequest: mockState.getSessionFromRequest,
+}));
+
+vi.mock("@/lib/groups/invites", () => ({
+  getGroupInvitePreview: mockState.getGroupInvitePreview,
+  acceptGroupInvite: mockState.acceptGroupInvite,
+}));
+
+vi.mock("@/lib/groups/cache", () => ({
+  revalidateGroupCaches: vi.fn(),
+}));
+
+type ModuleExports = typeof import("../../src/app/api/groups/join/[token]/route");
+
+let GET: ModuleExports["GET"];
+let POST: ModuleExports["POST"];
+
+beforeAll(async () => {
+  const routeModule = await import("../../src/app/api/groups/join/[token]/route");
+  GET = routeModule.GET;
+  POST = routeModule.POST;
+});
+
+beforeEach(() => {
+  mockState.reset();
+});
+
+describe("/api/groups/join/[token]", () => {
+  it("shows a safe invite preview without requiring authentication", async () => {
+    mockState.getGroupInvitePreview.mockResolvedValue({
+      group: { name: "Team", slug: "team", isPublic: false },
+      role: "member",
+      invitedUsername: null,
+      expiresAt: "2026-06-01T00:00:00.000Z",
+    });
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/groups/join/tg_token"),
+      { params: Promise.resolve({ token: "tg_token" }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      group: { name: "Team", slug: "team", isPublic: false },
+      role: "member",
+      invitedUsername: null,
+      expiresAt: "2026-06-01T00:00:00.000Z",
+    });
+  });
+
+  it("requires authentication before accepting an invite", async () => {
+    mockState.getSessionFromRequest.mockResolvedValue(null);
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/groups/join/tg_token", { method: "POST" }),
+      { params: Promise.resolve({ token: "tg_token" }) }
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockState.acceptGroupInvite).not.toHaveBeenCalled();
+  });
+
+  it("accepts an invite for the current user", async () => {
+    mockState.getSessionFromRequest.mockResolvedValue({
+      id: "user-1",
+      username: "Alice",
+      displayName: null,
+      avatarUrl: null,
+      isAdmin: false,
+    });
+    mockState.acceptGroupInvite.mockResolvedValue({
+      group: { id: "group-1", name: "Team", slug: "team" },
+      role: "member",
+    });
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/groups/join/tg_token", { method: "POST" }),
+      { params: Promise.resolve({ token: "tg_token" }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockState.acceptGroupInvite).toHaveBeenCalledWith("tg_token", {
+      id: "user-1",
+      username: "Alice",
+      displayName: null,
+      avatarUrl: null,
+      isAdmin: false,
+    });
+    expect(await response.json()).toEqual({
+      group: { id: "group-1", name: "Team", slug: "team" },
+      role: "member",
+    });
+  });
+});

--- a/packages/frontend/__tests__/api/groupLeaderboardRoute.test.ts
+++ b/packages/frontend/__tests__/api/groupLeaderboardRoute.test.ts
@@ -50,7 +50,7 @@ beforeEach(() => {
 });
 
 describe("GET /api/groups/[slug]/leaderboard", () => {
-  it("requires membership before returning private group leaderboard data", async () => {
+  it("hides private group leaderboard data from non-members", async () => {
     mockState.getGroupBySlug.mockResolvedValue({
       id: "group-1",
       slug: "team",
@@ -71,7 +71,7 @@ describe("GET /api/groups/[slug]/leaderboard", () => {
       { params: Promise.resolve({ slug: "team" }) }
     );
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(404);
     expect(mockState.getGroupLeaderboardData).not.toHaveBeenCalled();
   });
 

--- a/packages/frontend/__tests__/api/groupLeaderboardRoute.test.ts
+++ b/packages/frontend/__tests__/api/groupLeaderboardRoute.test.ts
@@ -1,0 +1,116 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const getSessionFromRequest = vi.fn();
+  const getGroupBySlug = vi.fn();
+  const getGroupMembership = vi.fn();
+  const getGroupLeaderboardData = vi.fn();
+
+  return {
+    getSessionFromRequest,
+    getGroupBySlug,
+    getGroupMembership,
+    getGroupLeaderboardData,
+    reset() {
+      getSessionFromRequest.mockReset();
+      getGroupBySlug.mockReset();
+      getGroupMembership.mockReset();
+      getGroupLeaderboardData.mockReset();
+    },
+  };
+});
+
+vi.mock("@/lib/auth/requestSession", () => ({
+  getSessionFromRequest: mockState.getSessionFromRequest,
+}));
+
+vi.mock("@/lib/groups/queries", () => ({
+  getGroupBySlug: mockState.getGroupBySlug,
+}));
+
+vi.mock("@/lib/groups/permissions", () => ({
+  getGroupMembership: mockState.getGroupMembership,
+}));
+
+vi.mock("@/lib/groups/getGroupLeaderboard", () => ({
+  getGroupLeaderboardData: mockState.getGroupLeaderboardData,
+}));
+
+type ModuleExports = typeof import("../../src/app/api/groups/[slug]/leaderboard/route");
+
+let GET: ModuleExports["GET"];
+
+beforeAll(async () => {
+  const routeModule = await import("../../src/app/api/groups/[slug]/leaderboard/route");
+  GET = routeModule.GET;
+});
+
+beforeEach(() => {
+  mockState.reset();
+});
+
+describe("GET /api/groups/[slug]/leaderboard", () => {
+  it("requires membership before returning private group leaderboard data", async () => {
+    mockState.getGroupBySlug.mockResolvedValue({
+      id: "group-1",
+      slug: "team",
+      name: "Team",
+      isPublic: false,
+    });
+    mockState.getSessionFromRequest.mockResolvedValue({
+      id: "user-outsider",
+      username: "outsider",
+      displayName: null,
+      avatarUrl: null,
+      isAdmin: false,
+    });
+    mockState.getGroupMembership.mockResolvedValue(null);
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/groups/team/leaderboard?period=week"),
+      { params: Promise.resolve({ slug: "team" }) }
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockState.getGroupLeaderboardData).not.toHaveBeenCalled();
+  });
+
+  it("passes scoped query options to the group leaderboard service for members", async () => {
+    mockState.getGroupBySlug.mockResolvedValue({
+      id: "group-1",
+      slug: "team",
+      name: "Team",
+      isPublic: false,
+    });
+    mockState.getSessionFromRequest.mockResolvedValue({
+      id: "user-member",
+      username: "member",
+      displayName: null,
+      avatarUrl: null,
+      isAdmin: false,
+    });
+    mockState.getGroupMembership.mockResolvedValue({ role: "member" });
+    mockState.getGroupLeaderboardData.mockResolvedValue({
+      users: [],
+      pagination: { page: 2, limit: 25, totalUsers: 0, totalPages: 0, hasNext: false, hasPrev: true },
+      stats: { totalTokens: 0, totalCost: 0, activeUsers: 0, totalMembers: 1 },
+      period: "month",
+      sortBy: "cost",
+    });
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/groups/team/leaderboard?period=month&page=2&limit=25&sortBy=cost&search=mem"),
+      { params: Promise.resolve({ slug: "team" }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockState.getGroupLeaderboardData).toHaveBeenCalledWith(
+      "group-1",
+      "month",
+      2,
+      25,
+      "cost",
+      "mem"
+    );
+  });
+});

--- a/packages/frontend/__tests__/api/groupLeaveRoute.test.ts
+++ b/packages/frontend/__tests__/api/groupLeaveRoute.test.ts
@@ -1,0 +1,108 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const getSessionFromRequest = vi.fn();
+  const getGroupBySlug = vi.fn();
+  const getGroupMembership = vi.fn();
+  const revalidateGroupCaches = vi.fn();
+  const eq = vi.fn((left: unknown, right: unknown) => ({ kind: "eq", left, right }));
+  const and = vi.fn((...conditions: unknown[]) => ({ kind: "and", conditions }));
+
+  const where = vi.fn(async () => undefined);
+  const db = {
+    delete: vi.fn(() => ({ where })),
+  };
+
+  return {
+    getSessionFromRequest,
+    getGroupBySlug,
+    getGroupMembership,
+    revalidateGroupCaches,
+    eq,
+    and,
+    db,
+    where,
+    reset() {
+      getSessionFromRequest.mockReset();
+      getGroupBySlug.mockReset();
+      getGroupMembership.mockReset();
+      revalidateGroupCaches.mockReset();
+      eq.mockClear();
+      and.mockClear();
+      db.delete.mockClear();
+      where.mockClear();
+    },
+  };
+});
+
+vi.mock("drizzle-orm", () => ({
+  and: mockState.and,
+  eq: mockState.eq,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockState.db,
+  groupMembers: {
+    groupId: "groupMembers.groupId",
+    userId: "groupMembers.userId",
+  },
+}));
+
+vi.mock("@/lib/auth/requestSession", () => ({
+  getSessionFromRequest: mockState.getSessionFromRequest,
+}));
+
+vi.mock("@/lib/groups/cache", () => ({
+  revalidateGroupCaches: mockState.revalidateGroupCaches,
+}));
+
+vi.mock("@/lib/groups/permissions", () => ({
+  getGroupMembership: mockState.getGroupMembership,
+}));
+
+vi.mock("@/lib/groups/queries", () => ({
+  getGroupBySlug: mockState.getGroupBySlug,
+}));
+
+type ModuleExports = typeof import("../../src/app/api/groups/[slug]/leave/route");
+
+let POST: ModuleExports["POST"];
+
+beforeAll(async () => {
+  const routeModule = await import("../../src/app/api/groups/[slug]/leave/route");
+  POST = routeModule.POST;
+});
+
+beforeEach(() => {
+  mockState.reset();
+});
+
+describe("POST /api/groups/[slug]/leave", () => {
+  it("returns success when cache invalidation fails after deleting membership", async () => {
+    mockState.getSessionFromRequest.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+      displayName: null,
+      avatarUrl: null,
+      isAdmin: false,
+    });
+    mockState.getGroupBySlug.mockResolvedValue({
+      id: "group-1",
+      slug: "team",
+      name: "Team",
+      isPublic: false,
+    });
+    mockState.getGroupMembership.mockResolvedValue({ role: "member" });
+    mockState.revalidateGroupCaches.mockRejectedValue(new Error("cache unavailable"));
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/groups/team/leave", { method: "POST" }),
+      { params: Promise.resolve({ slug: "team" }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+    expect(mockState.db.delete).toHaveBeenCalledTimes(1);
+    expect(mockState.revalidateGroupCaches).toHaveBeenCalledWith("group-1", "team");
+  });
+});

--- a/packages/frontend/__tests__/api/groupRoute.test.ts
+++ b/packages/frontend/__tests__/api/groupRoute.test.ts
@@ -1,0 +1,207 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const getSessionFromRequest = vi.fn();
+  const getGroupBySlug = vi.fn();
+  const getGroupMembership = vi.fn();
+  const getGroupMemberCount = vi.fn();
+  const generateUniqueGroupSlug = vi.fn();
+  const revalidateGroupCaches = vi.fn();
+  const revalidatePath = vi.fn();
+  const eq = vi.fn((left: unknown, right: unknown) => ({ left, right }));
+
+  let updatedRows: Array<Record<string, unknown>> = [];
+  const returning = vi.fn(async () => updatedRows);
+  const where = vi.fn(() => ({ returning }));
+  const set = vi.fn(() => ({ where }));
+
+  const db = {
+    update: vi.fn(() => ({ set })),
+    delete: vi.fn(),
+  };
+
+  return {
+    getSessionFromRequest,
+    getGroupBySlug,
+    getGroupMembership,
+    getGroupMemberCount,
+    generateUniqueGroupSlug,
+    revalidateGroupCaches,
+    revalidatePath,
+    eq,
+    db,
+    set,
+    where,
+    returning,
+    reset() {
+      getSessionFromRequest.mockReset();
+      getGroupBySlug.mockReset();
+      getGroupMembership.mockReset();
+      getGroupMemberCount.mockReset();
+      generateUniqueGroupSlug.mockReset();
+      revalidateGroupCaches.mockReset();
+      revalidatePath.mockReset();
+      eq.mockClear();
+      db.update.mockClear();
+      db.delete.mockClear();
+      set.mockClear();
+      where.mockClear();
+      returning.mockClear();
+      updatedRows = [];
+    },
+    setUpdatedRows(rows: Array<Record<string, unknown>>) {
+      updatedRows = rows;
+    },
+  };
+});
+
+vi.mock("next/cache", () => ({
+  revalidatePath: mockState.revalidatePath,
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: mockState.eq,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockState.db,
+  groups: {
+    id: "groups.id",
+  },
+}));
+
+vi.mock("@/lib/auth/requestSession", () => ({
+  getSessionFromRequest: mockState.getSessionFromRequest,
+}));
+
+vi.mock("@/lib/groups/cache", () => ({
+  revalidateGroupCaches: mockState.revalidateGroupCaches,
+}));
+
+vi.mock("@/lib/groups/permissions", () => ({
+  getGroupMembership: mockState.getGroupMembership,
+}));
+
+vi.mock("@/lib/groups/queries", () => ({
+  getGroupBySlug: mockState.getGroupBySlug,
+  getGroupMemberCount: mockState.getGroupMemberCount,
+}));
+
+vi.mock("@/lib/groups/slugs", () => ({
+  generateUniqueGroupSlug: mockState.generateUniqueGroupSlug,
+}));
+
+type ModuleExports = typeof import("../../src/app/api/groups/[slug]/route");
+
+let GET: ModuleExports["GET"];
+let PATCH: ModuleExports["PATCH"];
+
+beforeAll(async () => {
+  const routeModule = await import("../../src/app/api/groups/[slug]/route");
+  GET = routeModule.GET;
+  PATCH = routeModule.PATCH;
+});
+
+beforeEach(() => {
+  mockState.reset();
+});
+
+function group(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "group-1",
+    name: "Team",
+    slug: "team",
+    description: "Current description",
+    avatarUrl: "https://example.com/avatar.png",
+    isPublic: true,
+    createdBy: "owner-1",
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+describe("/api/groups/[slug]", () => {
+  it("returns the same 404 response for missing groups and private groups without membership", async () => {
+    mockState.getGroupBySlug.mockResolvedValueOnce(null);
+
+    const missingResponse = await GET(
+      new Request("http://localhost:3000/api/groups/missing"),
+      { params: Promise.resolve({ slug: "missing" }) }
+    );
+
+    mockState.getGroupBySlug.mockResolvedValueOnce(group({ isPublic: false }));
+    mockState.getSessionFromRequest.mockResolvedValueOnce(null);
+
+    const privateResponse = await GET(
+      new Request("http://localhost:3000/api/groups/team"),
+      { params: Promise.resolve({ slug: "team" }) }
+    );
+
+    expect(missingResponse.status).toBe(404);
+    expect(privateResponse.status).toBe(404);
+    expect(await missingResponse.json()).toEqual(await privateResponse.json());
+    expect(mockState.getGroupMemberCount).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-string nullable PATCH fields without updating the group", async () => {
+    mockState.getSessionFromRequest.mockResolvedValue({
+      id: "admin-1",
+      username: "admin",
+      displayName: null,
+      avatarUrl: null,
+      isAdmin: false,
+    });
+    mockState.getGroupBySlug.mockResolvedValue(group());
+    mockState.getGroupMembership.mockResolvedValue({ role: "admin" });
+
+    const response = await PATCH(
+      new Request("http://localhost:3000/api/groups/team", {
+        method: "PATCH",
+        body: JSON.stringify({ description: 123 }),
+      }),
+      { params: Promise.resolve({ slug: "team" }) }
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "description must be a string or null",
+    });
+    expect(mockState.db.update).not.toHaveBeenCalled();
+  });
+
+  it("allows explicit null PATCH fields to clear optional group metadata", async () => {
+    mockState.getSessionFromRequest.mockResolvedValue({
+      id: "admin-1",
+      username: "admin",
+      displayName: null,
+      avatarUrl: null,
+      isAdmin: false,
+    });
+    mockState.getGroupBySlug.mockResolvedValue(group());
+    mockState.getGroupMembership.mockResolvedValue({ role: "admin" });
+    mockState.setUpdatedRows([
+      group({
+        description: null,
+        avatarUrl: null,
+      }),
+    ]);
+
+    const response = await PATCH(
+      new Request("http://localhost:3000/api/groups/team", {
+        method: "PATCH",
+        body: JSON.stringify({ description: null, avatarUrl: null }),
+      }),
+      { params: Promise.resolve({ slug: "team" }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockState.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: null,
+        avatarUrl: null,
+      })
+    );
+    expect(mockState.revalidateGroupCaches).toHaveBeenCalledWith("group-1", "team");
+  });
+});

--- a/packages/frontend/__tests__/api/groupRoute.test.ts
+++ b/packages/frontend/__tests__/api/groupRoute.test.ts
@@ -138,9 +138,9 @@ describe("/api/groups/[slug]", () => {
       { params: Promise.resolve({ slug: "team" }) }
     );
 
-    expect(missingResponse.status).toBe(404);
-    expect(privateResponse.status).toBe(404);
-    expect(await missingResponse.json()).toEqual(await privateResponse.json());
+    expect(missingResponse!.status).toBe(404);
+    expect(privateResponse!.status).toBe(404);
+    expect(await missingResponse!.json()).toEqual(await privateResponse!.json());
     expect(mockState.getGroupMemberCount).not.toHaveBeenCalled();
   });
 

--- a/packages/frontend/__tests__/api/settingsSubmittedDataDelete.test.ts
+++ b/packages/frontend/__tests__/api/settingsSubmittedDataDelete.test.ts
@@ -164,6 +164,9 @@ describe("DELETE /api/settings/submitted-data", () => {
       isAdmin: false,
     });
     mockState.setDeletedRows([{ id: "submission-1" }]);
+    mockState.revalidateUserGroupLeaderboards.mockRejectedValueOnce(
+      new Error("group cache unavailable")
+    );
 
     const response = await DELETE(createRequest());
 
@@ -185,6 +188,7 @@ describe("DELETE /api/settings/submitted-data", () => {
       right: "user-1",
     });
     expect(mockState.revalidateTag).toHaveBeenCalledTimes(7);
+    expect(mockState.revalidateUserGroupLeaderboards).toHaveBeenCalledWith("user-1");
     expect(mockState.revalidateUsernamePaths).toHaveBeenCalledTimes(1);
     expect(mockState.revalidateUsernamePaths).toHaveBeenCalledWith("Alice");
     expect(mockState.revalidatePath).toHaveBeenCalledTimes(8);

--- a/packages/frontend/__tests__/api/settingsSubmittedDataDelete.test.ts
+++ b/packages/frontend/__tests__/api/settingsSubmittedDataDelete.test.ts
@@ -5,6 +5,7 @@ const mockState = vi.hoisted(() => {
   const authenticatePersonalToken = vi.fn();
   const revalidateTag = vi.fn();
   const revalidatePath = vi.fn();
+  const revalidateUserGroupLeaderboards = vi.fn();
   const revalidateUsernamePaths = vi.fn((username: string) => {
     const lower = username.toLowerCase();
     const variants = username === lower ? [username] : [username, lower];
@@ -56,6 +57,7 @@ const mockState = vi.hoisted(() => {
     authenticatePersonalToken,
     revalidateTag,
     revalidatePath,
+    revalidateUserGroupLeaderboards,
     revalidateUsernamePaths,
     eq,
     db,
@@ -66,6 +68,7 @@ const mockState = vi.hoisted(() => {
       authenticatePersonalToken.mockReset();
       revalidateTag.mockReset();
       revalidatePath.mockReset();
+      revalidateUserGroupLeaderboards.mockReset();
       revalidateUsernamePaths.mockReset();
       eq.mockClear();
       db.delete.mockClear();
@@ -110,6 +113,10 @@ vi.mock("@/lib/db", () => ({
 vi.mock("@/lib/db/usernameLookup", () => ({
   normalizeUsernameCacheKey: (username: string) => username.toLowerCase(),
   revalidateUsernamePaths: mockState.revalidateUsernamePaths,
+}));
+
+vi.mock("@/lib/groups/cache", () => ({
+  revalidateUserGroupLeaderboards: mockState.revalidateUserGroupLeaderboards,
 }));
 
 type ModuleExports = typeof import("../../src/app/api/settings/submitted-data/route");

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -333,6 +333,9 @@ describe("POST /api/submit auth path", () => {
     });
     mockState.buildModelBreakdown.mockReturnValue({ "gpt-5.5": 12 });
     mockState.mergeTimestampMs.mockImplementation((_existing: unknown, incoming: unknown) => incoming);
+    mockState.revalidateUserGroupLeaderboards.mockRejectedValueOnce(
+      new Error("group cache unavailable")
+    );
 
     const selectResults = [
       [],
@@ -440,6 +443,7 @@ describe("POST /api/submit auth path", () => {
     expect(mockState.revalidateTag).toHaveBeenNthCalledWith(2, "user:alice", "max");
     expect(mockState.revalidateTag).toHaveBeenNthCalledWith(3, "user-rank", "max");
     expect(mockState.revalidateTag).toHaveBeenNthCalledWith(4, "user-rank:alice", "max");
+    expect(mockState.revalidateUserGroupLeaderboards).toHaveBeenCalledWith("user-1");
     expect(mockState.revalidateUsernamePaths).toHaveBeenCalledWith("Alice");
   });
 

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -6,6 +6,7 @@ const mockState = vi.hoisted(() => {
   const generateSubmissionHash = vi.fn(() => "submission-hash");
   const revalidateTag = vi.fn();
   const revalidateUsernamePaths = vi.fn();
+  const revalidateUserGroupLeaderboards = vi.fn();
   const mergeClientBreakdowns = vi.fn();
   const recalculateDayTotals = vi.fn();
   const buildModelBreakdown = vi.fn();
@@ -22,6 +23,7 @@ const mockState = vi.hoisted(() => {
     generateSubmissionHash,
     revalidateTag,
     revalidateUsernamePaths,
+    revalidateUserGroupLeaderboards,
     mergeClientBreakdowns,
     recalculateDayTotals,
     buildModelBreakdown,
@@ -34,6 +36,7 @@ const mockState = vi.hoisted(() => {
       generateSubmissionHash.mockClear();
       revalidateTag.mockClear();
       revalidateUsernamePaths.mockReset();
+      revalidateUserGroupLeaderboards.mockReset();
       mergeClientBreakdowns.mockReset();
       recalculateDayTotals.mockReset();
       buildModelBreakdown.mockReset();
@@ -113,6 +116,10 @@ vi.mock("@/lib/db/helpers", () => ({
 vi.mock("@/lib/db/usernameLookup", () => ({
   normalizeUsernameCacheKey: (username: string) => username.toLowerCase(),
   revalidateUsernamePaths: mockState.revalidateUsernamePaths,
+}));
+
+vi.mock("@/lib/groups/cache", () => ({
+  revalidateUserGroupLeaderboards: mockState.revalidateUserGroupLeaderboards,
 }));
 
 type ModuleExports = typeof import("../../src/app/api/submit/route");

--- a/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const periodRows: Array<Record<string, unknown>> = [];
+  const allTimeRows: Array<Record<string, unknown>> = [];
+  const statsRows: Array<Record<string, unknown>> = [];
+  const countRows: Array<Record<string, unknown>> = [];
+  const fromCalls: unknown[] = [];
+
+  const tables = {
+    users: {
+      id: "users.id",
+      username: "users.username",
+      displayName: "users.displayName",
+      avatarUrl: "users.avatarUrl",
+    },
+    submissions: {
+      id: "submissions.id",
+      userId: "submissions.userId",
+      totalTokens: "submissions.totalTokens",
+      totalCost: "submissions.totalCost",
+      submitCount: "submissions.submitCount",
+      updatedAt: "submissions.updatedAt",
+      cliVersion: "submissions.cliVersion",
+      schemaVersion: "submissions.schemaVersion",
+    },
+    dailyBreakdown: {
+      submissionId: "dailyBreakdown.submissionId",
+      date: "dailyBreakdown.date",
+      tokens: "dailyBreakdown.tokens",
+      cost: "dailyBreakdown.cost",
+    },
+    groupMembers: {
+      groupId: "groupMembers.groupId",
+      userId: "groupMembers.userId",
+      role: "groupMembers.role",
+    },
+  };
+
+  const eq = vi.fn(() => "eq");
+  const desc = vi.fn(() => "desc");
+  const asc = vi.fn(() => "asc");
+  const and = vi.fn(() => "and");
+  const gte = vi.fn(() => "gte");
+  const lte = vi.fn(() => "lte");
+  const sql = Object.assign(
+    vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
+      strings: Array.from(strings),
+      values,
+      as: () => ({}),
+    })),
+    {
+      raw: vi.fn(),
+    }
+  );
+
+  function nextRows(table: unknown) {
+    if (table === tables.dailyBreakdown) {
+      return [...periodRows];
+    }
+    if (table === tables.submissions) {
+      return allTimeRows.shift() ? [...allTimeRows] : [];
+    }
+    if (table === tables.groupMembers) {
+      return countRows.shift() ? [...countRows] : [];
+    }
+    return statsRows.shift() ? [...statsRows] : [];
+  }
+
+  const db = {
+    select: vi.fn(() => {
+      let selectedTable: unknown;
+      const builder = {
+        from: vi.fn((table: unknown) => {
+          selectedTable = table;
+          fromCalls.push(table);
+          return builder;
+        }),
+        innerJoin: vi.fn(() => builder),
+        leftJoin: vi.fn(() => builder),
+        where: vi.fn(() => builder),
+        groupBy: vi.fn(() => builder),
+        orderBy: vi.fn(() => builder),
+        limit: vi.fn(() => builder),
+        offset: vi.fn(() => builder),
+        then: (resolve: (value: unknown) => unknown) => resolve(nextRows(selectedTable)),
+      };
+
+      return builder;
+    }),
+  };
+
+  return {
+    db,
+    tables,
+    fromCalls,
+    eq,
+    desc,
+    asc,
+    and,
+    gte,
+    lte,
+    sql,
+    reset() {
+      periodRows.length = 0;
+      allTimeRows.length = 0;
+      statsRows.length = 0;
+      countRows.length = 0;
+      fromCalls.length = 0;
+      db.select.mockClear();
+      eq.mockClear();
+      desc.mockClear();
+      asc.mockClear();
+      and.mockClear();
+      gte.mockClear();
+      lte.mockClear();
+      sql.mockClear();
+      sql.raw.mockClear();
+    },
+    setPeriodRows(rows: Array<Record<string, unknown>>) {
+      periodRows.length = 0;
+      periodRows.push(...rows);
+    },
+  };
+});
+
+vi.mock("next/cache", () => ({
+  unstable_cache: (fn: () => unknown) => fn,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockState.db,
+  users: mockState.tables.users,
+  submissions: mockState.tables.submissions,
+  dailyBreakdown: mockState.tables.dailyBreakdown,
+  groupMembers: mockState.tables.groupMembers,
+}));
+
+vi.mock("@/lib/submissionFreshness", async () =>
+  import("../../src/lib/submissionFreshness")
+);
+
+vi.mock("drizzle-orm", () => ({
+  eq: mockState.eq,
+  desc: mockState.desc,
+  asc: mockState.asc,
+  and: mockState.and,
+  gte: mockState.gte,
+  lte: mockState.lte,
+  sql: mockState.sql,
+}));
+
+type ModuleExports = typeof import("../../src/lib/groups/getGroupLeaderboard");
+
+let getGroupLeaderboardData: ModuleExports["getGroupLeaderboardData"];
+
+beforeAll(async () => {
+  const groupLeaderboardModule = await import("../../src/lib/groups/getGroupLeaderboard");
+  getGroupLeaderboardData = groupLeaderboardModule.getGroupLeaderboardData;
+});
+
+beforeEach(() => {
+  mockState.reset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("group leaderboard data", () => {
+  const rows = [
+    {
+      userId: "user-alice",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      role: "owner",
+      tokens: 200,
+      cost: 2,
+      updatedAt: "2026-03-07T11:00:00.000Z",
+      cliVersion: "1.5.0",
+      schemaVersion: 1,
+    },
+    {
+      userId: "user-bob",
+      username: "bob",
+      displayName: "Bob",
+      avatarUrl: null,
+      role: "member",
+      tokens: 600,
+      cost: 6,
+      updatedAt: "2026-03-06T11:00:00.000Z",
+      cliVersion: "1.5.0",
+      schemaVersion: 1,
+    },
+  ];
+
+  it("builds period rankings from daily rows scoped through group membership", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-07T18:45:00Z"));
+    mockState.setPeriodRows(rows);
+
+    const leaderboard = await getGroupLeaderboardData("group-1", "week", 1, 50, "tokens");
+
+    expect(mockState.fromCalls).toContain(mockState.tables.dailyBreakdown);
+    expect(mockState.gte).toHaveBeenCalledWith(
+      mockState.tables.dailyBreakdown.date,
+      "2026-03-01"
+    );
+    expect(mockState.lte).toHaveBeenCalledWith(
+      mockState.tables.dailyBreakdown.date,
+      "2026-03-07"
+    );
+    expect(mockState.eq).toHaveBeenCalledWith(
+      mockState.tables.groupMembers.groupId,
+      "group-1"
+    );
+    expect(leaderboard.users.map((user) => user.username)).toEqual(["bob", "alice"]);
+    expect(leaderboard.users[0]).toMatchObject({
+      rank: 1,
+      role: "member",
+      totalTokens: 600,
+    });
+    expect(leaderboard.stats).toMatchObject({
+      totalTokens: 800,
+      totalCost: 8,
+      activeUsers: 2,
+    });
+  });
+
+  it("filters search results after computing scoped ranks", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-07T18:45:00Z"));
+    mockState.setPeriodRows(rows);
+
+    const leaderboard = await getGroupLeaderboardData("group-1", "week", 1, 50, "tokens", "ali");
+
+    expect(leaderboard.users).toHaveLength(1);
+    expect(leaderboard.users[0]).toMatchObject({
+      rank: 2,
+      username: "alice",
+    });
+    expect(leaderboard.pagination.totalUsers).toBe(1);
+  });
+});

--- a/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
@@ -6,6 +6,7 @@ const mockState = vi.hoisted(() => {
   const statsRows: Array<Record<string, unknown>> = [];
   const countRows: Array<Record<string, unknown>> = [];
   const fromCalls: unknown[] = [];
+  const orderByCalls: unknown[][] = [];
 
   const tables = {
     users: {
@@ -59,7 +60,7 @@ const mockState = vi.hoisted(() => {
       return [...periodRows];
     }
     if (table === tables.submissions) {
-      return allTimeRows.shift() ? [...allTimeRows] : [];
+      return [...allTimeRows];
     }
     if (table === tables.groupMembers) {
       return countRows.shift() ? [...countRows] : [];
@@ -80,7 +81,10 @@ const mockState = vi.hoisted(() => {
         leftJoin: vi.fn(() => builder),
         where: vi.fn(() => builder),
         groupBy: vi.fn(() => builder),
-        orderBy: vi.fn(() => builder),
+        orderBy: vi.fn((...args: unknown[]) => {
+          orderByCalls.push(args);
+          return builder;
+        }),
         limit: vi.fn(() => builder),
         offset: vi.fn(() => builder),
         then: (resolve: (value: unknown) => unknown) => resolve(nextRows(selectedTable)),
@@ -94,6 +98,7 @@ const mockState = vi.hoisted(() => {
     db,
     tables,
     fromCalls,
+    orderByCalls,
     eq,
     desc,
     asc,
@@ -107,6 +112,7 @@ const mockState = vi.hoisted(() => {
       statsRows.length = 0;
       countRows.length = 0;
       fromCalls.length = 0;
+      orderByCalls.length = 0;
       db.select.mockClear();
       eq.mockClear();
       desc.mockClear();
@@ -120,6 +126,10 @@ const mockState = vi.hoisted(() => {
     setPeriodRows(rows: Array<Record<string, unknown>>) {
       periodRows.length = 0;
       periodRows.push(...rows);
+    },
+    setAllTimeRows(rows: Array<Record<string, unknown>>) {
+      allTimeRows.length = 0;
+      allTimeRows.push(...rows);
     },
   };
 });
@@ -241,5 +251,48 @@ describe("group leaderboard data", () => {
       username: "alice",
     });
     expect(leaderboard.pagination.totalUsers).toBe(1);
+  });
+
+  it("adds deterministic SQL tie-breakers before assigning all-time ranks", async () => {
+    mockState.setAllTimeRows([
+      {
+        userId: "user-alice",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        role: "member",
+        totalTokens: 100,
+        totalCost: "3.0000",
+        submissionCount: 1,
+        lastSubmission: "2026-03-07T11:00:00.000Z",
+        cliVersion: "1.5.0",
+        schemaVersion: 1,
+      },
+      {
+        userId: "user-bob",
+        username: "bob",
+        displayName: "Bob",
+        avatarUrl: null,
+        role: "member",
+        totalTokens: 100,
+        totalCost: "3.0000",
+        submissionCount: 1,
+        lastSubmission: "2026-03-07T11:00:00.000Z",
+        cliVersion: "1.5.0",
+        schemaVersion: 1,
+      },
+    ]);
+
+    const leaderboard = await getGroupLeaderboardData("group-1", "all", 1, 50, "tokens");
+
+    expect(mockState.fromCalls).toContain(mockState.tables.submissions);
+    expect(mockState.orderByCalls[0]).toHaveLength(4);
+    expect(mockState.asc).toHaveBeenCalledWith(mockState.tables.users.username);
+    expect(mockState.asc).toHaveBeenCalledWith(mockState.tables.users.id);
+    expect(mockState.sql).toHaveBeenCalledWith(
+      expect.arrayContaining(["(\n        SELECT s2.cli_version FROM submissions s2\n        WHERE s2.user_id = ", "\n        ORDER BY s2.updated_at DESC, s2.id DESC LIMIT 1\n      )"]),
+      mockState.tables.users.id
+    );
+    expect(leaderboard.users.map((user) => user.username)).toEqual(["alice", "bob"]);
   });
 });

--- a/packages/frontend/__tests__/lib/groupHelpers.test.ts
+++ b/packages/frontend/__tests__/lib/groupHelpers.test.ts
@@ -10,6 +10,8 @@ import {
 describe("group helpers", () => {
   it("creates URL-safe group slugs with reserved fallback handling", () => {
     expect(slugifyGroupName("  AI Usage Team!!  ")).toBe("ai-usage-team");
+    expect(slugifyGroupName("foo_bar")).toBe("foo-bar");
+    expect(slugifyGroupName("foo_bar")).not.toBe(slugifyGroupName("foobar"));
     expect(slugifyGroupName("")).toMatch(/^group-[a-z0-9]+$/);
     expect(slugifyGroupName("join")).toMatch(/^join-[a-z0-9]+$/);
   });

--- a/packages/frontend/__tests__/lib/groupHelpers.test.ts
+++ b/packages/frontend/__tests__/lib/groupHelpers.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canManageGroupRole,
+  createGroupInviteToken,
+  hashGroupInviteToken,
+  slugifyGroupName,
+} from "../../src/lib/groups";
+
+describe("group helpers", () => {
+  it("creates URL-safe group slugs with reserved fallback handling", () => {
+    expect(slugifyGroupName("  AI Usage Team!!  ")).toBe("ai-usage-team");
+    expect(slugifyGroupName("")).toMatch(/^group-[a-z0-9]+$/);
+    expect(slugifyGroupName("join")).toMatch(/^join-[a-z0-9]+$/);
+  });
+
+  it("keeps generated slugs within the database column limit after suffixes", () => {
+    const longName = "A".repeat(140);
+    const slug = slugifyGroupName(longName, { suffix: 12345 });
+
+    expect(slug).toHaveLength(100);
+    expect(slug).toMatch(/-12345$/);
+    expect(slug.endsWith("-")).toBe(false);
+  });
+
+  it("stores invite tokens as hashes and returns raw tokens only for links", () => {
+    const token = createGroupInviteToken();
+    const hashed = hashGroupInviteToken(token);
+
+    expect(token).toMatch(/^tg_[a-f0-9]{48}$/);
+    expect(hashed).toMatch(/^[a-f0-9]{64}$/);
+    expect(hashed).not.toBe(token);
+  });
+
+  it("allows only stronger roles to manage weaker member roles", () => {
+    expect(canManageGroupRole("owner", "admin")).toBe(true);
+    expect(canManageGroupRole("admin", "member")).toBe(true);
+    expect(canManageGroupRole("admin", "owner")).toBe(false);
+    expect(canManageGroupRole("member", "member")).toBe(false);
+  });
+});

--- a/packages/frontend/__tests__/lib/groupInvites.test.ts
+++ b/packages/frontend/__tests__/lib/groupInvites.test.ts
@@ -1,0 +1,209 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const pendingRows: Array<Record<string, unknown>> = [];
+  let claimedRows: Array<Record<string, unknown>> = [];
+
+  const tables = {
+    groupInvites: {
+      id: "groupInvites.id",
+      groupId: "groupInvites.groupId",
+      invitedUsername: "groupInvites.invitedUsername",
+      invitedUsernameNormalized: "groupInvites.invitedUsernameNormalized",
+      invitedUserId: "groupInvites.invitedUserId",
+      invitedBy: "groupInvites.invitedBy",
+      role: "groupInvites.role",
+      status: "groupInvites.status",
+      tokenHash: "groupInvites.tokenHash",
+      expiresAt: "groupInvites.expiresAt",
+      acceptedAt: "groupInvites.acceptedAt",
+    },
+    groupMembers: {
+      groupId: "groupMembers.groupId",
+      userId: "groupMembers.userId",
+    },
+    groups: {
+      id: "groups.id",
+    },
+  };
+
+  const and = vi.fn((...conditions: unknown[]) => ({ kind: "and", conditions }));
+  const eq = vi.fn((left: unknown, right: unknown) => ({ kind: "eq", left, right }));
+  const gt = vi.fn((left: unknown, right: unknown) => ({ kind: "gt", left, right }));
+
+  const limit = vi.fn(async () => pendingRows);
+  const where = vi.fn(() => ({ limit }));
+  const innerJoin = vi.fn(() => ({ where }));
+  const from = vi.fn(() => ({ innerJoin }));
+
+  const claimReturning = vi.fn(async () => claimedRows);
+  const updateWhere = vi.fn(() => ({ returning: claimReturning }));
+  const updateSet = vi.fn(() => ({ where: updateWhere }));
+
+  const onConflictDoNothing = vi.fn(async () => undefined);
+  const insertValues = vi.fn(() => ({ onConflictDoNothing }));
+
+  const tx = {
+    update: vi.fn(() => ({ set: updateSet })),
+    insert: vi.fn(() => ({ values: insertValues })),
+  };
+
+  const db = {
+    select: vi.fn(() => ({ from })),
+    transaction: vi.fn(async (callback: (txArg: typeof tx) => Promise<unknown>) =>
+      callback(tx)
+    ),
+  };
+
+  return {
+    tables,
+    and,
+    eq,
+    gt,
+    db,
+    tx,
+    updateSet,
+    updateWhere,
+    claimReturning,
+    insertValues,
+    onConflictDoNothing,
+    reset() {
+      pendingRows.length = 0;
+      claimedRows = [];
+      and.mockClear();
+      eq.mockClear();
+      gt.mockClear();
+      limit.mockClear();
+      where.mockClear();
+      innerJoin.mockClear();
+      from.mockClear();
+      db.select.mockClear();
+      db.transaction.mockClear();
+      tx.update.mockClear();
+      tx.insert.mockClear();
+      updateSet.mockClear();
+      updateWhere.mockClear();
+      claimReturning.mockClear();
+      insertValues.mockClear();
+      onConflictDoNothing.mockClear();
+    },
+    setPendingRow(row: Record<string, unknown> | null) {
+      pendingRows.length = 0;
+      if (row) {
+        pendingRows.push(row);
+      }
+    },
+    setClaimedRows(rows: Array<Record<string, unknown>>) {
+      claimedRows = rows;
+    },
+  };
+});
+
+vi.mock("drizzle-orm", () => ({
+  and: mockState.and,
+  eq: mockState.eq,
+  gt: mockState.gt,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockState.db,
+  groupInvites: mockState.tables.groupInvites,
+  groupMembers: mockState.tables.groupMembers,
+  groups: mockState.tables.groups,
+}));
+
+vi.mock("../../src/lib/db/schema", () => ({
+  groupRoles: ["owner", "admin", "member"],
+}));
+
+vi.mock("@/lib/validation/username", () => ({
+  isValidGitHubUsername: vi.fn(() => true),
+}));
+
+type ModuleExports = typeof import("../../src/lib/groups/invites");
+
+let acceptGroupInvite: ModuleExports["acceptGroupInvite"];
+
+beforeAll(async () => {
+  const inviteModule = await import("../../src/lib/groups/invites");
+  acceptGroupInvite = inviteModule.acceptGroupInvite;
+});
+
+beforeEach(() => {
+  mockState.reset();
+});
+
+function pendingInvite() {
+  return {
+    invite: {
+      id: "invite-1",
+      groupId: "group-1",
+      invitedUsername: null,
+      invitedUsernameNormalized: null,
+      invitedUserId: null,
+      invitedBy: "owner-1",
+      role: "member",
+      status: "pending",
+      tokenHash: "hash",
+      expiresAt: new Date("2026-06-01T00:00:00Z"),
+      acceptedAt: null,
+      createdAt: new Date("2026-05-01T00:00:00Z"),
+    },
+    group: {
+      id: "group-1",
+      name: "Team",
+      slug: "team",
+      isPublic: false,
+    },
+  };
+}
+
+describe("group invites", () => {
+  it("claims a pending invite inside the transaction before adding membership", async () => {
+    mockState.setPendingRow(pendingInvite());
+    mockState.setClaimedRows([{ id: "invite-1" }]);
+
+    const accepted = await acceptGroupInvite("tg_token", {
+      id: "user-1",
+      username: "alice",
+      displayName: null,
+      avatarUrl: null,
+      isAdmin: false,
+    });
+
+    expect(accepted).toEqual({
+      group: { id: "group-1", name: "Team", slug: "team" },
+      role: "member",
+    });
+    expect(mockState.tx.update).toHaveBeenCalledWith(mockState.tables.groupInvites);
+    expect(mockState.eq).toHaveBeenCalledWith(mockState.tables.groupInvites.status, "pending");
+    expect(mockState.gt).toHaveBeenCalledWith(
+      mockState.tables.groupInvites.expiresAt,
+      expect.any(Date)
+    );
+    expect(mockState.tx.insert).toHaveBeenCalledWith(mockState.tables.groupMembers);
+    expect(mockState.onConflictDoNothing).toHaveBeenCalledWith({
+      target: [mockState.tables.groupMembers.groupId, mockState.tables.groupMembers.userId],
+    });
+  });
+
+  it("rejects the accept when another request already claimed the invite", async () => {
+    mockState.setPendingRow(pendingInvite());
+    mockState.setClaimedRows([]);
+
+    await expect(
+      acceptGroupInvite("tg_token", {
+        id: "user-2",
+        username: "bob",
+        displayName: null,
+        avatarUrl: null,
+        isAdmin: false,
+      })
+    ).rejects.toMatchObject({
+      code: "not_found",
+      message: "Invalid or expired invite",
+    });
+
+    expect(mockState.tx.insert).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/src/app/(main)/groups/GroupsClient.tsx
+++ b/packages/frontend/src/app/(main)/groups/GroupsClient.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useState } from "react";
+import styled from "styled-components";
+
+type GroupRole = "owner" | "admin" | "member";
+
+interface SessionUser {
+  id: string;
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+}
+
+interface GroupCardData {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  avatarUrl: string | null;
+  isPublic: boolean;
+  memberCount: number;
+  role?: GroupRole;
+}
+
+interface GroupsClientProps {
+  currentUser: SessionUser | null;
+  initialPublicGroups: GroupCardData[];
+  initialMyGroups: GroupCardData[];
+}
+
+type ActiveTab = "public" | "mine";
+
+const PageHeader = styled.section`
+  margin: 32px 0 24px;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+
+  @media (max-width: 640px) {
+    flex-direction: column;
+  }
+`;
+
+const Title = styled.h1`
+  margin: 0 0 8px;
+  font-size: 30px;
+  font-weight: 700;
+  color: var(--color-fg-default);
+`;
+
+const Description = styled.p`
+  margin: 0;
+  max-width: 680px;
+  color: var(--color-fg-muted);
+  line-height: 1.6;
+`;
+
+const PrimaryLink = styled(Link)`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  padding: 0 16px;
+  border-radius: 8px;
+  border: 1px solid var(--color-primary);
+  background: var(--color-primary);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+`;
+
+const Tabs = styled.div`
+  display: inline-flex;
+  padding: 4px;
+  margin-bottom: 16px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  background: var(--color-bg-subtle);
+`;
+
+const TabButton = styled.button<{ $active: boolean }>`
+  min-height: 32px;
+  padding: 0 14px;
+  border: 0;
+  border-radius: 6px;
+  background: ${({ $active }) => ($active ? "var(--color-bg-default)" : "transparent")};
+  color: ${({ $active }) => ($active ? "var(--color-fg-default)" : "var(--color-fg-muted)")};
+  font-weight: 600;
+  cursor: pointer;
+`;
+
+const Grid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 12px;
+`;
+
+const Card = styled(Link)`
+  display: flex;
+  flex-direction: column;
+  min-height: 150px;
+  padding: 16px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  background: var(--color-bg-default);
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.15s, background 0.15s;
+
+  &:hover {
+    border-color: var(--color-primary);
+    background: var(--color-bg-subtle);
+  }
+`;
+
+const CardTop = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+`;
+
+const Avatar = styled.div<{ $image?: string | null }>`
+  width: 42px;
+  height: 42px;
+  border-radius: 8px;
+  flex: 0 0 auto;
+  border: 1px solid var(--color-border-default);
+  background:
+    ${({ $image }) => $image ? `url(${$image}) center/cover` : "linear-gradient(135deg, #0073ff, #13a10e)"};
+`;
+
+const CardTitle = styled.h2`
+  margin: 0;
+  font-size: 16px;
+  color: var(--color-fg-default);
+`;
+
+const Meta = styled.div`
+  margin-top: 3px;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  color: var(--color-fg-muted);
+  font-size: 12px;
+`;
+
+const BodyText = styled.p`
+  margin: 0;
+  color: var(--color-fg-muted);
+  line-height: 1.5;
+  font-size: 14px;
+`;
+
+const EmptyState = styled.div`
+  padding: 28px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  background: var(--color-bg-default);
+  color: var(--color-fg-muted);
+`;
+
+const ErrorText = styled.p`
+  color: var(--color-danger-fg, #f85149);
+`;
+
+function GroupCard({ group }: { group: GroupCardData }) {
+  return (
+    <Card href={`/groups/${group.slug}`}>
+      <CardTop>
+        <Avatar $image={group.avatarUrl} />
+        <div>
+          <CardTitle>{group.name}</CardTitle>
+          <Meta>
+            <span>{group.isPublic ? "Public" : "Private"}</span>
+            <span>{group.memberCount} members</span>
+            {group.role && <span>{group.role}</span>}
+          </Meta>
+        </div>
+      </CardTop>
+      <BodyText>{group.description || "A scoped Tokscale leaderboard."}</BodyText>
+    </Card>
+  );
+}
+
+export default function GroupsClient({
+  currentUser,
+  initialPublicGroups,
+  initialMyGroups,
+}: GroupsClientProps) {
+  const [activeTab, setActiveTab] = useState<ActiveTab>(currentUser ? "mine" : "public");
+  const [publicGroups, setPublicGroups] = useState(initialPublicGroups);
+  const [myGroups, setMyGroups] = useState(initialMyGroups);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadGroups = useCallback((tab: ActiveTab, signal?: AbortSignal) => {
+    const url = tab === "mine" ? "/api/groups?my=true" : "/api/groups";
+    setIsLoading(true);
+    setError(null);
+
+    fetch(url, { signal })
+      .then((response) => {
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        return response.json();
+      })
+      .then((payload) => {
+        if (!Array.isArray(payload.groups)) {
+          throw new Error("Invalid response");
+        }
+        if (tab === "mine") {
+          setMyGroups(payload.groups);
+        } else {
+          setPublicGroups(payload.groups);
+        }
+      })
+      .catch((err) => {
+        if (err.name !== "AbortError") {
+          setError(err.message || "Failed to load groups");
+        }
+      })
+      .finally(() => {
+        if (!signal?.aborted) {
+          setIsLoading(false);
+        }
+      });
+  }, []);
+
+  const groups = activeTab === "mine" ? myGroups : publicGroups;
+  const handleTabChange = (tab: ActiveTab) => {
+    setActiveTab(tab);
+    loadGroups(tab);
+  };
+
+  return (
+    <>
+      <PageHeader>
+        <div>
+          <Title>Groups</Title>
+          <Description>
+            Create private or public leaderboards for teams, friends, and workspaces without changing the global Tokscale rankings.
+          </Description>
+        </div>
+        {currentUser ? (
+          <PrimaryLink href="/groups/new">New group</PrimaryLink>
+        ) : (
+          <PrimaryLink href="/api/auth/github?returnTo=/groups">Sign in</PrimaryLink>
+        )}
+      </PageHeader>
+
+      <Tabs aria-label="Group filters">
+        <TabButton $active={activeTab === "public"} onClick={() => handleTabChange("public")}>
+          Public
+        </TabButton>
+        <TabButton $active={activeTab === "mine"} onClick={() => handleTabChange("mine")} disabled={!currentUser}>
+          My groups
+        </TabButton>
+      </Tabs>
+
+      {error && <ErrorText>{error}</ErrorText>}
+      {isLoading ? (
+        <EmptyState>Loading groups...</EmptyState>
+      ) : groups.length === 0 ? (
+        <EmptyState>
+          {activeTab === "mine"
+            ? "You are not in any groups yet."
+            : "No public groups yet."}
+        </EmptyState>
+      ) : (
+        <Grid>
+          {groups.map((group) => (
+            <GroupCard key={group.id} group={group} />
+          ))}
+        </Grid>
+      )}
+    </>
+  );
+}

--- a/packages/frontend/src/app/(main)/groups/[slug]/GroupDetailClient.tsx
+++ b/packages/frontend/src/app/(main)/groups/[slug]/GroupDetailClient.tsx
@@ -488,9 +488,16 @@ export default function GroupDetailClient({
 
   async function copyInvite() {
     if (!inviteUrl) return;
-    await navigator.clipboard.writeText(inviteUrl);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1600);
+
+    try {
+      setInviteError(null);
+      await navigator.clipboard.writeText(inviteUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1600);
+    } catch {
+      setCopied(false);
+      setInviteError("Could not copy invite link.");
+    }
   }
 
   async function leaveGroup() {

--- a/packages/frontend/src/app/(main)/groups/[slug]/GroupDetailClient.tsx
+++ b/packages/frontend/src/app/(main)/groups/[slug]/GroupDetailClient.tsx
@@ -1,0 +1,657 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "nextjs-toploader/app";
+import styled from "styled-components";
+import { CheckIcon, CopyIcon, SearchIcon, XIcon } from "@/components/ui/Icons";
+import { formatCurrency, formatNumber } from "@/lib/utils";
+import type { GroupLeaderboardData, GroupLeaderboardUser } from "@/lib/groups/getGroupLeaderboard";
+import type { Period, SortBy } from "@/lib/leaderboard/types";
+
+type GroupRole = "owner" | "admin" | "member";
+
+interface SessionUser {
+  id: string;
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+}
+
+interface GroupDetail {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  avatarUrl: string | null;
+  isPublic: boolean;
+  memberCount: number;
+  membership: { role: GroupRole } | null;
+}
+
+interface GroupDetailClientProps {
+  group: GroupDetail;
+  currentUser: SessionUser | null;
+  initialData: GroupLeaderboardData;
+}
+
+const Header = styled.section`
+  margin: 32px 0 24px;
+  display: grid;
+  gap: 18px;
+`;
+
+const HeaderTop = styled.div`
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+
+  @media (max-width: 720px) {
+    flex-direction: column;
+  }
+`;
+
+const Identity = styled.div`
+  display: flex;
+  gap: 14px;
+  align-items: center;
+`;
+
+const Avatar = styled.div<{ $image?: string | null }>`
+  width: 58px;
+  height: 58px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-default);
+  background:
+    ${({ $image }) => $image ? `url(${$image}) center/cover` : "linear-gradient(135deg, #0073ff, #13a10e)"};
+  flex: 0 0 auto;
+`;
+
+const Title = styled.h1`
+  margin: 0;
+  color: var(--color-fg-default);
+  font-size: 30px;
+  font-weight: 700;
+`;
+
+const Meta = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 6px;
+  color: var(--color-fg-muted);
+  font-size: 13px;
+`;
+
+const Badge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 8px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 999px;
+  color: var(--color-fg-muted);
+  background: var(--color-bg-subtle);
+`;
+
+const Description = styled.p`
+  margin: 0;
+  color: var(--color-fg-muted);
+  line-height: 1.6;
+`;
+
+const Actions = styled.div`
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+`;
+
+const Button = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 38px;
+  padding: 0 14px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-default);
+  color: var(--color-fg-default);
+  font-weight: 600;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.65;
+    cursor: not-allowed;
+  }
+`;
+
+const PrimaryLink = styled(Link)`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  padding: 0 14px;
+  border-radius: 8px;
+  border: 1px solid var(--color-primary);
+  background: var(--color-primary);
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+`;
+
+const StatsGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+
+  @media (max-width: 760px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+`;
+
+const StatCard = styled.div`
+  padding: 12px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  background: var(--color-bg-default);
+`;
+
+const StatLabel = styled.div`
+  color: var(--color-fg-muted);
+  font-size: 12px;
+`;
+
+const StatValue = styled.div`
+  margin-top: 4px;
+  color: var(--color-fg-default);
+  font-weight: 700;
+  font-size: 18px;
+`;
+
+const InvitePanel = styled.div`
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  background: var(--color-bg-default);
+`;
+
+const InviteForm = styled.div`
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) 140px auto;
+  gap: 10px;
+
+  @media (max-width: 720px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const Input = styled.input`
+  min-height: 38px;
+  padding: 0 12px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  background: var(--color-bg-subtle);
+  color: var(--color-fg-default);
+  font: inherit;
+`;
+
+const Select = styled.select`
+  min-height: 38px;
+  padding: 0 12px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  background: var(--color-bg-subtle);
+  color: var(--color-fg-default);
+  font: inherit;
+`;
+
+const LinkBox = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  background: var(--color-bg-subtle);
+  color: var(--color-fg-default);
+  overflow: hidden;
+`;
+
+const LinkText = styled.code`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const Toolbar = styled.div`
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin: 22px 0 14px;
+`;
+
+const Segmented = styled.div`
+  display: inline-flex;
+  padding: 4px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  background: var(--color-bg-subtle);
+`;
+
+const SegmentButton = styled.button<{ $active: boolean }>`
+  min-height: 32px;
+  padding: 0 12px;
+  border: 0;
+  border-radius: 6px;
+  background: ${({ $active }) => ($active ? "var(--color-bg-default)" : "transparent")};
+  color: ${({ $active }) => ($active ? "var(--color-fg-default)" : "var(--color-fg-muted)")};
+  font-weight: 600;
+  cursor: pointer;
+`;
+
+const SearchWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 38px;
+  padding: 0 10px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  background: var(--color-bg-subtle);
+`;
+
+const SearchInput = styled.input`
+  width: 180px;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--color-fg-default);
+  font: inherit;
+`;
+
+const TableContainer = styled.div`
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--color-bg-default);
+`;
+
+const TableWrapper = styled.div`
+  overflow-x: auto;
+`;
+
+const Table = styled.table`
+  width: 100%;
+  min-width: 680px;
+`;
+
+const Th = styled.th`
+  padding: 12px 16px;
+  text-align: left;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-fg-muted);
+  background: var(--color-bg-elevated);
+  border-bottom: 1px solid var(--color-border-default);
+
+  &.right {
+    text-align: right;
+  }
+`;
+
+const Td = styled.td`
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--color-border-default);
+  color: var(--color-fg-default);
+
+  &.right {
+    text-align: right;
+  }
+`;
+
+const UserCell = styled(Link)`
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: inherit;
+  text-decoration: none;
+`;
+
+const UserAvatar = styled.img`
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  object-fit: cover;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.1);
+`;
+
+const Muted = styled.span`
+  display: block;
+  color: var(--color-fg-muted);
+  font-size: 12px;
+`;
+
+const EmptyState = styled.div`
+  padding: 32px;
+  text-align: center;
+  color: var(--color-fg-muted);
+`;
+
+const ErrorText = styled.p`
+  margin: 0;
+  color: var(--color-danger-fg, #f85149);
+`;
+
+function isAdminRole(role: GroupRole | undefined): boolean {
+  return role === "owner" || role === "admin";
+}
+
+function roleLabel(role: string): string {
+  return role.charAt(0).toUpperCase() + role.slice(1);
+}
+
+function GroupRow({
+  user,
+  showSubmissionCount,
+}: {
+  user: GroupLeaderboardUser;
+  showSubmissionCount: boolean;
+}) {
+  return (
+    <tr>
+      <Td>#{user.rank}</Td>
+      <Td>
+        <UserCell href={`/u/${user.username}`}>
+          <UserAvatar src={user.avatarUrl || `https://github.com/${user.username}.png`} alt={user.username} />
+          <span>
+            {user.displayName || user.username}
+            <Muted>@{user.username}</Muted>
+          </span>
+        </UserCell>
+      </Td>
+      <Td>{roleLabel(user.role)}</Td>
+      <Td className="right">{formatCurrency(user.totalCost)}</Td>
+      <Td className="right">{formatNumber(user.totalTokens)}</Td>
+      {showSubmissionCount && <Td className="right">{user.submissionCount ?? "-"}</Td>}
+    </tr>
+  );
+}
+
+export default function GroupDetailClient({
+  group,
+  initialData,
+}: GroupDetailClientProps) {
+  const router = useRouter();
+  const [data, setData] = useState(initialData);
+  const [period, setPeriod] = useState<Period>(initialData.period);
+  const [sortBy, setSortBy] = useState<SortBy>(initialData.sortBy);
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [inviteRole, setInviteRole] = useState<Exclude<GroupRole, "owner">>("member");
+  const [inviteUsername, setInviteUsername] = useState("");
+  const [inviteUrl, setInviteUrl] = useState<string | null>(null);
+  const [inviteError, setInviteError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const didMountLeaderboard = useRef(false);
+
+  const canInvite = isAdminRole(group.membership?.role);
+  const showSubmissionCount = period === "all";
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(search);
+      setPage(1);
+    }, 250);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  const loadLeaderboard = useCallback((signal?: AbortSignal) => {
+    const params = new URLSearchParams({
+      period,
+      sortBy,
+      page: String(page),
+      limit: "50",
+    });
+    if (debouncedSearch) {
+      params.set("search", debouncedSearch);
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    fetch(`/api/groups/${group.slug}/leaderboard?${params}`, { signal })
+      .then((response) => {
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        return response.json();
+      })
+      .then((payload) => {
+        setData(payload);
+      })
+      .catch((err) => {
+        if (err.name !== "AbortError") {
+          setError(err.message || "Failed to load leaderboard");
+        }
+      })
+      .finally(() => {
+        if (!signal?.aborted) {
+          setIsLoading(false);
+        }
+      });
+  }, [debouncedSearch, group.slug, page, period, sortBy]);
+
+  useEffect(() => {
+    if (!didMountLeaderboard.current) {
+      didMountLeaderboard.current = true;
+      return;
+    }
+
+    const abortController = new AbortController();
+    loadLeaderboard(abortController.signal);
+    return () => abortController.abort();
+  }, [loadLeaderboard]);
+
+  async function createInvite() {
+    setInviteError(null);
+    setInviteUrl(null);
+
+    try {
+      const response = await fetch(`/api/groups/${group.slug}/invite`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          role: inviteRole,
+          invitedUsername: inviteUsername.trim() || null,
+        }),
+      });
+      const payload = await response.json();
+
+      if (!response.ok) {
+        throw new Error(payload.error || "Failed to create invite");
+      }
+
+      const absoluteUrl = `${window.location.origin}${payload.joinUrl}`;
+      setInviteUrl(absoluteUrl);
+      setInviteUsername("");
+    } catch (err) {
+      setInviteError(err instanceof Error ? err.message : "Failed to create invite");
+    }
+  }
+
+  async function copyInvite() {
+    if (!inviteUrl) return;
+    await navigator.clipboard.writeText(inviteUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1600);
+  }
+
+  async function leaveGroup() {
+    const response = await fetch(`/api/groups/${group.slug}/leave`, { method: "POST" });
+    if (response.ok) {
+      router.push("/groups");
+    }
+  }
+
+  const sortedUsers = useMemo(() => data.users || [], [data.users]);
+
+  return (
+    <>
+      <Header>
+        <HeaderTop>
+          <Identity>
+            <Avatar $image={group.avatarUrl} />
+            <div>
+              <Title>{group.name}</Title>
+              <Meta>
+                <Badge>{group.isPublic ? "Public" : "Private"}</Badge>
+                <Badge>{group.memberCount} members</Badge>
+                {group.membership && <Badge>{roleLabel(group.membership.role)}</Badge>}
+              </Meta>
+            </div>
+          </Identity>
+          <Actions>
+            <PrimaryLink href="/groups">All groups</PrimaryLink>
+            {group.membership && group.membership.role !== "owner" && (
+              <Button onClick={leaveGroup}>Leave</Button>
+            )}
+          </Actions>
+        </HeaderTop>
+        {group.description && <Description>{group.description}</Description>}
+
+        <StatsGrid>
+          <StatCard>
+            <StatLabel>Active users</StatLabel>
+            <StatValue>{data.stats.activeUsers}</StatValue>
+          </StatCard>
+          <StatCard>
+            <StatLabel>Members</StatLabel>
+            <StatValue>{data.stats.totalMembers || group.memberCount}</StatValue>
+          </StatCard>
+          <StatCard>
+            <StatLabel>Total tokens</StatLabel>
+            <StatValue>{formatNumber(data.stats.totalTokens)}</StatValue>
+          </StatCard>
+          <StatCard>
+            <StatLabel>Total cost</StatLabel>
+            <StatValue>{formatCurrency(data.stats.totalCost)}</StatValue>
+          </StatCard>
+        </StatsGrid>
+
+        {canInvite && (
+          <InvitePanel>
+            <InviteForm>
+              <Input
+                value={inviteUsername}
+                onChange={(event) => setInviteUsername(event.target.value)}
+                placeholder="GitHub username (optional)"
+              />
+              <Select
+                value={inviteRole}
+                onChange={(event) => setInviteRole(event.target.value as Exclude<GroupRole, "owner">)}
+              >
+                <option value="member">Member</option>
+                <option value="admin">Admin</option>
+              </Select>
+              <Button onClick={createInvite}>Create invite</Button>
+            </InviteForm>
+            {inviteError && <ErrorText>{inviteError}</ErrorText>}
+            {inviteUrl && (
+              <LinkBox>
+                <LinkText>{inviteUrl}</LinkText>
+                <Button onClick={copyInvite} aria-label="Copy invite link">
+                  {copied ? <CheckIcon size={16} /> : <CopyIcon size={16} />}
+                  {copied ? "Copied" : "Copy"}
+                </Button>
+              </LinkBox>
+            )}
+          </InvitePanel>
+        )}
+      </Header>
+
+      <Toolbar>
+        <Segmented aria-label="Period">
+          {(["all", "month", "week"] as Period[]).map((value) => (
+            <SegmentButton
+              key={value}
+              $active={period === value}
+              onClick={() => {
+                setPeriod(value);
+                setPage(1);
+              }}
+            >
+              {value === "all" ? "All time" : value === "month" ? "Month" : "Week"}
+            </SegmentButton>
+          ))}
+        </Segmented>
+
+        <Actions>
+          <SearchWrapper>
+            <SearchIcon size={16} />
+            <SearchInput
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search members"
+            />
+            {search && (
+              <Button onClick={() => setSearch("")} aria-label="Clear search">
+                <XIcon size={16} />
+              </Button>
+            )}
+          </SearchWrapper>
+          <Segmented aria-label="Sort">
+            {(["tokens", "cost"] as SortBy[]).map((value) => (
+              <SegmentButton
+                key={value}
+                $active={sortBy === value}
+                onClick={() => {
+                  setSortBy(value);
+                  setPage(1);
+                }}
+              >
+                {value === "tokens" ? "Tokens" : "Cost"}
+              </SegmentButton>
+            ))}
+          </Segmented>
+        </Actions>
+      </Toolbar>
+
+      <TableContainer>
+        {error ? (
+          <EmptyState>{error}</EmptyState>
+        ) : isLoading ? (
+          <EmptyState>Loading leaderboard...</EmptyState>
+        ) : sortedUsers.length === 0 ? (
+          <EmptyState>No submitted usage for this group yet.</EmptyState>
+        ) : (
+          <TableWrapper>
+            <Table>
+              <thead>
+                <tr>
+                  <Th>Rank</Th>
+                  <Th>User</Th>
+                  <Th>Role</Th>
+                  <Th className="right">Cost</Th>
+                  <Th className="right">Tokens</Th>
+                  {showSubmissionCount && <Th className="right">Submits</Th>}
+                </tr>
+              </thead>
+              <tbody>
+                {sortedUsers.map((user) => (
+                  <GroupRow key={user.userId} user={user} showSubmissionCount={showSubmissionCount} />
+                ))}
+              </tbody>
+            </Table>
+          </TableWrapper>
+        )}
+      </TableContainer>
+    </>
+  );
+}

--- a/packages/frontend/src/app/(main)/groups/[slug]/page.tsx
+++ b/packages/frontend/src/app/(main)/groups/[slug]/page.tsx
@@ -1,0 +1,98 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Navigation } from "@/components/layout/Navigation";
+import { Footer } from "@/components/layout/Footer";
+import { getSession } from "@/lib/auth/session";
+import { getGroupLeaderboardData } from "@/lib/groups/getGroupLeaderboard";
+import { getGroupMembership } from "@/lib/groups/permissions";
+import { getGroupBySlug, getGroupMemberCount } from "@/lib/groups/queries";
+import GroupDetailClient from "./GroupDetailClient";
+
+interface GroupPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+function PageShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        backgroundColor: "var(--color-bg-default)",
+      }}
+    >
+      <Navigation />
+      <main className="main-container">{children}</main>
+      <Footer />
+    </div>
+  );
+}
+
+function AccessMessage({ isSignedIn }: { isSignedIn: boolean }) {
+  return (
+    <PageShell>
+      <section
+        style={{
+          margin: "32px 0",
+          padding: 24,
+          border: "1px solid var(--color-border-default)",
+          borderRadius: 8,
+          background: "var(--color-bg-default)",
+        }}
+      >
+        <h1 style={{ margin: "0 0 8px", color: "var(--color-fg-default)" }}>
+          Private group
+        </h1>
+        <p style={{ margin: "0 0 16px", color: "var(--color-fg-muted)" }}>
+          This group is only visible to members.
+        </p>
+        {!isSignedIn && (
+          <Link href="/api/auth/github" style={{ color: "var(--color-primary)" }}>
+            Sign in with GitHub
+          </Link>
+        )}
+      </section>
+    </PageShell>
+  );
+}
+
+export default async function GroupPage({ params }: GroupPageProps) {
+  const { slug } = await params;
+  const group = await getGroupBySlug(slug);
+
+  if (!group) {
+    notFound();
+  }
+
+  const session = await getSession();
+  const membership = session ? await getGroupMembership(group.id, session.id) : null;
+
+  if (!group.isPublic && !membership) {
+    return <AccessMessage isSignedIn={!!session} />;
+  }
+
+  const [memberCount, initialData] = await Promise.all([
+    getGroupMemberCount(group.id),
+    getGroupLeaderboardData(group.id, "all", 1, 50, "tokens"),
+  ]);
+
+  return (
+    <PageShell>
+      <GroupDetailClient
+        group={{
+          id: group.id,
+          name: group.name,
+          slug: group.slug,
+          description: group.description,
+          avatarUrl: group.avatarUrl,
+          isPublic: group.isPublic,
+          memberCount,
+          membership,
+        }}
+        currentUser={session}
+        initialData={initialData}
+      />
+    </PageShell>
+  );
+}

--- a/packages/frontend/src/app/(main)/groups/[slug]/page.tsx
+++ b/packages/frontend/src/app/(main)/groups/[slug]/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import { Navigation } from "@/components/layout/Navigation";
 import { Footer } from "@/components/layout/Footer";
@@ -29,34 +28,6 @@ function PageShell({ children }: { children: React.ReactNode }) {
   );
 }
 
-function AccessMessage({ isSignedIn }: { isSignedIn: boolean }) {
-  return (
-    <PageShell>
-      <section
-        style={{
-          margin: "32px 0",
-          padding: 24,
-          border: "1px solid var(--color-border-default)",
-          borderRadius: 8,
-          background: "var(--color-bg-default)",
-        }}
-      >
-        <h1 style={{ margin: "0 0 8px", color: "var(--color-fg-default)" }}>
-          Private group
-        </h1>
-        <p style={{ margin: "0 0 16px", color: "var(--color-fg-muted)" }}>
-          This group is only visible to members.
-        </p>
-        {!isSignedIn && (
-          <Link href="/api/auth/github" style={{ color: "var(--color-primary)" }}>
-            Sign in with GitHub
-          </Link>
-        )}
-      </section>
-    </PageShell>
-  );
-}
-
 export default async function GroupPage({ params }: GroupPageProps) {
   const { slug } = await params;
   const group = await getGroupBySlug(slug);
@@ -69,7 +40,7 @@ export default async function GroupPage({ params }: GroupPageProps) {
   const membership = session ? await getGroupMembership(group.id, session.id) : null;
 
   if (!group.isPublic && !membership) {
-    return <AccessMessage isSignedIn={!!session} />;
+    notFound();
   }
 
   const [memberCount, initialData] = await Promise.all([

--- a/packages/frontend/src/app/(main)/groups/join/[token]/JoinGroupClient.tsx
+++ b/packages/frontend/src/app/(main)/groups/join/[token]/JoinGroupClient.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { useRouter } from "nextjs-toploader/app";
+import styled from "styled-components";
+
+interface InvitePreview {
+  group: {
+    name: string;
+    slug: string;
+    isPublic: boolean;
+  };
+  role: "admin" | "member";
+  invitedUsername: string | null;
+  expiresAt: string;
+}
+
+const Shell = styled.section`
+  max-width: 620px;
+  margin: 48px auto;
+  padding: 24px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  background: var(--color-bg-default);
+`;
+
+const Title = styled.h1`
+  margin: 0 0 8px;
+  color: var(--color-fg-default);
+  font-size: 28px;
+  font-weight: 700;
+`;
+
+const Text = styled.p`
+  margin: 0 0 16px;
+  color: var(--color-fg-muted);
+  line-height: 1.6;
+`;
+
+const Meta = styled.div`
+  display: grid;
+  gap: 8px;
+  margin: 18px 0;
+  color: var(--color-fg-muted);
+  font-size: 14px;
+`;
+
+const Actions = styled.div`
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+`;
+
+const Button = styled.button`
+  min-height: 40px;
+  padding: 0 16px;
+  border-radius: 8px;
+  border: 1px solid var(--color-primary);
+  background: var(--color-primary);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.65;
+    cursor: not-allowed;
+  }
+`;
+
+const SecondaryLink = styled(Link)`
+  display: inline-flex;
+  align-items: center;
+  min-height: 40px;
+  padding: 0 16px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-default);
+  color: var(--color-fg-default);
+  text-decoration: none;
+`;
+
+const ErrorText = styled.p`
+  margin: 0;
+  color: var(--color-danger-fg, #f85149);
+`;
+
+function formatRole(role: InvitePreview["role"]): string {
+  return role.charAt(0).toUpperCase() + role.slice(1);
+}
+
+export default function JoinGroupClient({ token }: { token: string }) {
+  const router = useRouter();
+  const [preview, setPreview] = useState<InvitePreview | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isJoining, setIsJoining] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    fetch(`/api/groups/join/${token}`, { signal: abortController.signal })
+      .then((response) => {
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        return response.json();
+      })
+      .then(setPreview)
+      .catch((err) => {
+        if (err.name !== "AbortError") {
+          setError("This invite is invalid or expired.");
+        }
+      })
+      .finally(() => {
+        if (!abortController.signal.aborted) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => abortController.abort();
+  }, [token]);
+
+  async function acceptInvite() {
+    setIsJoining(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/groups/join/${token}`, { method: "POST" });
+      const payload = await response.json();
+
+      if (response.status === 401) {
+        window.location.href = `/api/auth/github?returnTo=/groups/join/${token}`;
+        return;
+      }
+
+      if (!response.ok) {
+        throw new Error(payload.error || "Failed to join group");
+      }
+
+      router.push(`/groups/${payload.group.slug}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to join group");
+      setIsJoining(false);
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <Shell>
+        <Text>Loading invite...</Text>
+      </Shell>
+    );
+  }
+
+  if (!preview) {
+    return (
+      <Shell>
+        <Title>Invite unavailable</Title>
+        <ErrorText>{error || "This invite is invalid or expired."}</ErrorText>
+        <Actions>
+          <SecondaryLink href="/groups">Browse groups</SecondaryLink>
+        </Actions>
+      </Shell>
+    );
+  }
+
+  return (
+    <Shell>
+      <Title>Join {preview.group.name}</Title>
+      <Text>You were invited to join this group leaderboard.</Text>
+      <Meta>
+        <span>Role: {formatRole(preview.role)}</span>
+        <span>Visibility: {preview.group.isPublic ? "Public" : "Private"}</span>
+        {preview.invitedUsername && <span>For: @{preview.invitedUsername}</span>}
+      </Meta>
+      {error && <ErrorText>{error}</ErrorText>}
+      <Actions>
+        <Button onClick={acceptInvite} disabled={isJoining}>
+          {isJoining ? "Joining..." : "Join group"}
+        </Button>
+        <SecondaryLink href="/groups">Cancel</SecondaryLink>
+      </Actions>
+    </Shell>
+  );
+}

--- a/packages/frontend/src/app/(main)/groups/join/[token]/page.tsx
+++ b/packages/frontend/src/app/(main)/groups/join/[token]/page.tsx
@@ -1,0 +1,28 @@
+import { Navigation } from "@/components/layout/Navigation";
+import { Footer } from "@/components/layout/Footer";
+import JoinGroupClient from "./JoinGroupClient";
+
+export default async function JoinGroupPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        backgroundColor: "var(--color-bg-default)",
+      }}
+    >
+      <Navigation />
+      <main className="main-container">
+        <JoinGroupClient token={token} />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/packages/frontend/src/app/(main)/groups/new/CreateGroupClient.tsx
+++ b/packages/frontend/src/app/(main)/groups/new/CreateGroupClient.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "nextjs-toploader/app";
+import styled from "styled-components";
+
+const Shell = styled.section`
+  max-width: 680px;
+  margin: 32px 0;
+`;
+
+const Title = styled.h1`
+  margin: 0 0 8px;
+  color: var(--color-fg-default);
+  font-size: 30px;
+  font-weight: 700;
+`;
+
+const Description = styled.p`
+  margin: 0 0 24px;
+  color: var(--color-fg-muted);
+  line-height: 1.6;
+`;
+
+const Form = styled.form`
+  display: grid;
+  gap: 16px;
+  padding: 20px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  background: var(--color-bg-default);
+`;
+
+const Field = styled.label`
+  display: grid;
+  gap: 8px;
+  color: var(--color-fg-default);
+  font-size: 14px;
+  font-weight: 600;
+`;
+
+const Input = styled.input`
+  min-height: 40px;
+  padding: 0 12px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  background: var(--color-bg-subtle);
+  color: var(--color-fg-default);
+  font: inherit;
+`;
+
+const Textarea = styled.textarea`
+  min-height: 96px;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  background: var(--color-bg-subtle);
+  color: var(--color-fg-default);
+  font: inherit;
+  resize: vertical;
+`;
+
+const CheckboxLabel = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--color-fg-default);
+  font-size: 14px;
+`;
+
+const Actions = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
+`;
+
+const Button = styled.button`
+  min-height: 40px;
+  padding: 0 16px;
+  border-radius: 8px;
+  border: 1px solid var(--color-primary);
+  background: var(--color-primary);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.65;
+  }
+`;
+
+const SecondaryLink = styled(Link)`
+  display: inline-flex;
+  align-items: center;
+  min-height: 40px;
+  padding: 0 16px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-default);
+  color: var(--color-fg-default);
+  text-decoration: none;
+`;
+
+const ErrorText = styled.p`
+  margin: 0;
+  color: var(--color-danger-fg, #f85149);
+`;
+
+export default function CreateGroupClient() {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [isPublic, setIsPublic] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/groups", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name,
+          description,
+          isPublic,
+        }),
+      });
+      const payload = await response.json();
+
+      if (!response.ok) {
+        throw new Error(payload.error || "Failed to create group");
+      }
+
+      router.push(`/groups/${payload.slug}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create group");
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <Shell>
+      <Title>Create group</Title>
+      <Description>
+        Start a scoped leaderboard and invite people by link or GitHub username.
+      </Description>
+
+      <Form onSubmit={handleSubmit}>
+        <Field>
+          Group name
+          <Input
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            maxLength={100}
+            required
+            autoFocus
+          />
+        </Field>
+        <Field>
+          Description
+          <Textarea
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            maxLength={500}
+          />
+        </Field>
+        <CheckboxLabel>
+          <input
+            type="checkbox"
+            checked={isPublic}
+            onChange={(event) => setIsPublic(event.target.checked)}
+          />
+          Make this group public
+        </CheckboxLabel>
+        {error && <ErrorText>{error}</ErrorText>}
+        <Actions>
+          <SecondaryLink href="/groups">Cancel</SecondaryLink>
+          <Button disabled={isSubmitting || !name.trim()} type="submit">
+            {isSubmitting ? "Creating..." : "Create group"}
+          </Button>
+        </Actions>
+      </Form>
+    </Shell>
+  );
+}

--- a/packages/frontend/src/app/(main)/groups/new/page.tsx
+++ b/packages/frontend/src/app/(main)/groups/new/page.tsx
@@ -1,0 +1,30 @@
+import { redirect } from "next/navigation";
+import { Navigation } from "@/components/layout/Navigation";
+import { Footer } from "@/components/layout/Footer";
+import { getSession } from "@/lib/auth/session";
+import CreateGroupClient from "./CreateGroupClient";
+
+export default async function NewGroupPage() {
+  const session = await getSession();
+
+  if (!session) {
+    redirect("/api/auth/github?returnTo=/groups/new");
+  }
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        backgroundColor: "var(--color-bg-default)",
+      }}
+    >
+      <Navigation />
+      <main className="main-container">
+        <CreateGroupClient />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/packages/frontend/src/app/(main)/groups/page.tsx
+++ b/packages/frontend/src/app/(main)/groups/page.tsx
@@ -1,0 +1,62 @@
+import { Suspense } from "react";
+import { Navigation } from "@/components/layout/Navigation";
+import { Footer } from "@/components/layout/Footer";
+import { getSession } from "@/lib/auth/session";
+import { listPublicGroups, listUserGroups } from "@/lib/groups/queries";
+import GroupsClient from "./GroupsClient";
+
+function isMissingDatabaseUrl(error: unknown): boolean {
+  return error instanceof Error && error.message === "DATABASE_URL environment variable is not set";
+}
+
+export default function GroupsPage() {
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        backgroundColor: "var(--color-bg-default)",
+      }}
+    >
+      <Navigation />
+      <main className="main-container">
+        <Suspense fallback={null}>
+          <GroupsContent />
+        </Suspense>
+      </main>
+      <Footer />
+    </div>
+  );
+}
+
+async function GroupsContent() {
+  const session = await getSession().catch((error) => {
+    if (isMissingDatabaseUrl(error)) return null;
+    throw error;
+  });
+  const [publicGroups, myGroups] = await Promise.all([
+    listPublicGroups(1, 20).catch((error) => {
+      if (isMissingDatabaseUrl(error)) {
+        return { groups: [], pagination: { page: 1, limit: 20, total: 0, totalPages: 0, hasNext: false, hasPrev: false } };
+      }
+      throw error;
+    }),
+    session
+      ? listUserGroups(session.id, 1, 20).catch((error) => {
+          if (isMissingDatabaseUrl(error)) {
+            return { groups: [], pagination: { page: 1, limit: 20, total: 0, totalPages: 0, hasNext: false, hasPrev: false } };
+          }
+          throw error;
+        })
+      : Promise.resolve(null),
+  ]);
+
+  return (
+    <GroupsClient
+      currentUser={session}
+      initialPublicGroups={publicGroups.groups}
+      initialMyGroups={myGroups?.groups ?? []}
+    />
+  );
+}

--- a/packages/frontend/src/app/api/groups/[slug]/invite/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/invite/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { getSessionFromRequest } from "@/lib/auth/requestSession";
 import { revalidateGroupCaches } from "@/lib/groups/cache";
 import { createGroupInvite, GroupInviteError } from "@/lib/groups/invites";
-import { requireGroupRole } from "@/lib/groups/permissions";
+import { getGroupMembership } from "@/lib/groups/permissions";
 import { getGroupBySlug } from "@/lib/groups/queries";
 import { isGroupRole } from "@/lib/groups/utils";
 import type { GroupRole } from "@/lib/db";
@@ -23,8 +23,12 @@ export async function POST(
       return NextResponse.json({ error: "Group not found" }, { status: 404 });
     }
 
-    const membership = await requireGroupRole(group.id, session.id, "admin");
-    if (!membership) {
+    const membership = await getGroupMembership(group.id, session.id);
+    if (!group.isPublic && !membership) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    if (!membership || membership.role === "member") {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
@@ -47,7 +51,11 @@ export async function POST(
       invitedUsername,
     });
 
-    await revalidateGroupCaches(group.id, group.slug);
+    try {
+      await revalidateGroupCaches(group.id, group.slug);
+    } catch (cacheError) {
+      console.error("Create group invite cache invalidation failed:", cacheError);
+    }
 
     return NextResponse.json(
       {

--- a/packages/frontend/src/app/api/groups/[slug]/invite/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/invite/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+import { getSessionFromRequest } from "@/lib/auth/requestSession";
+import { revalidateGroupCaches } from "@/lib/groups/cache";
+import { createGroupInvite, GroupInviteError } from "@/lib/groups/invites";
+import { requireGroupRole } from "@/lib/groups/permissions";
+import { getGroupBySlug } from "@/lib/groups/queries";
+import { isGroupRole } from "@/lib/groups/utils";
+import type { GroupRole } from "@/lib/db";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  try {
+    const session = await getSessionFromRequest(request);
+    if (!session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const { slug } = await params;
+    const group = await getGroupBySlug(slug);
+    if (!group) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    const membership = await requireGroupRole(group.id, session.id, "admin");
+    if (!membership) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    let body: Record<string, unknown> = {};
+    try {
+      body = await request.json();
+    } catch {
+      body = {};
+    }
+
+    const role = isGroupRole(body.role) ? body.role : "member";
+    const invitedUsername = typeof body.invitedUsername === "string"
+      ? body.invitedUsername
+      : null;
+
+    const invite = await createGroupInvite({
+      groupId: group.id,
+      invitedBy: session.id,
+      role: role as GroupRole,
+      invitedUsername,
+    });
+
+    await revalidateGroupCaches(group.id, group.slug);
+
+    return NextResponse.json(
+      {
+        invite,
+        joinUrl: `/groups/join/${invite.token}`,
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    if (error instanceof GroupInviteError) {
+      return NextResponse.json({ error: error.message }, { status: error.code === "invalid" ? 400 : 403 });
+    }
+    console.error("Create group invite error:", error);
+    return NextResponse.json({ error: "Failed to create invite" }, { status: 500 });
+  }
+}

--- a/packages/frontend/src/app/api/groups/[slug]/leaderboard/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/leaderboard/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { getSessionFromRequest } from "@/lib/auth/requestSession";
+import { getGroupLeaderboardData } from "@/lib/groups/getGroupLeaderboard";
+import { getGroupMembership } from "@/lib/groups/permissions";
+import { getGroupBySlug } from "@/lib/groups/queries";
+import type { Period, SortBy } from "@/lib/leaderboard/types";
+
+const VALID_PERIODS: Period[] = ["all", "month", "week"];
+const VALID_SORT_BY: SortBy[] = ["tokens", "cost"];
+
+function parseIntSafe(value: string | null, defaultValue: number): number {
+  if (!value) return defaultValue;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.floor(parsed) : defaultValue;
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  try {
+    const { slug } = await params;
+    const group = await getGroupBySlug(slug);
+
+    if (!group) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    if (!group.isPublic) {
+      const session = await getSessionFromRequest(request);
+      if (!session) {
+        return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+      }
+
+      const membership = await getGroupMembership(group.id, session.id);
+      if (!membership) {
+        return NextResponse.json({ error: "Not a member of this group" }, { status: 403 });
+      }
+    }
+
+    const { searchParams } = new URL(request.url);
+    const periodParam = searchParams.get("period") || "all";
+    const sortByParam = searchParams.get("sortBy") || "tokens";
+    const period: Period = VALID_PERIODS.includes(periodParam as Period)
+      ? (periodParam as Period)
+      : "all";
+    const sortBy: SortBy = VALID_SORT_BY.includes(sortByParam as SortBy)
+      ? (sortByParam as SortBy)
+      : "tokens";
+    const page = Math.max(1, parseIntSafe(searchParams.get("page"), 1));
+    const limit = Math.min(100, Math.max(1, parseIntSafe(searchParams.get("limit"), 50)));
+    const search = (searchParams.get("search") || "").trim();
+
+    const data = await getGroupLeaderboardData(
+      group.id,
+      period,
+      page,
+      limit,
+      sortBy,
+      search
+    );
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Group leaderboard error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch group leaderboard" },
+      { status: 500 }
+    );
+  }
+}

--- a/packages/frontend/src/app/api/groups/[slug]/leaderboard/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/leaderboard/route.ts
@@ -29,12 +29,12 @@ export async function GET(
     if (!group.isPublic) {
       const session = await getSessionFromRequest(request);
       if (!session) {
-        return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+        return NextResponse.json({ error: "Group not found" }, { status: 404 });
       }
 
       const membership = await getGroupMembership(group.id, session.id);
       if (!membership) {
-        return NextResponse.json({ error: "Not a member of this group" }, { status: 403 });
+        return NextResponse.json({ error: "Group not found" }, { status: 404 });
       }
     }
 

--- a/packages/frontend/src/app/api/groups/[slug]/leave/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/leave/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { db, groupMembers } from "@/lib/db";
+import { getSessionFromRequest } from "@/lib/auth/requestSession";
+import { revalidateGroupCaches } from "@/lib/groups/cache";
+import { getGroupMembership } from "@/lib/groups/permissions";
+import { getGroupBySlug } from "@/lib/groups/queries";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  try {
+    const session = await getSessionFromRequest(request);
+    if (!session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const { slug } = await params;
+    const group = await getGroupBySlug(slug);
+    if (!group) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    const membership = await getGroupMembership(group.id, session.id);
+    if (!membership) {
+      return NextResponse.json({ error: "Not a member of this group" }, { status: 404 });
+    }
+
+    if (membership.role === "owner") {
+      return NextResponse.json(
+        { error: "Owners must delete the group or transfer ownership before leaving" },
+        { status: 400 }
+      );
+    }
+
+    await db
+      .delete(groupMembers)
+      .where(and(eq(groupMembers.groupId, group.id), eq(groupMembers.userId, session.id)));
+
+    await revalidateGroupCaches(group.id, group.slug);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Leave group error:", error);
+    return NextResponse.json({ error: "Failed to leave group" }, { status: 500 });
+  }
+}

--- a/packages/frontend/src/app/api/groups/[slug]/leave/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/leave/route.ts
@@ -38,7 +38,12 @@ export async function POST(
       .delete(groupMembers)
       .where(and(eq(groupMembers.groupId, group.id), eq(groupMembers.userId, session.id)));
 
-    await revalidateGroupCaches(group.id, group.slug);
+    try {
+      await revalidateGroupCaches(group.id, group.slug);
+    } catch (cacheError) {
+      console.error("Leave group cache invalidation failed:", cacheError);
+    }
+
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error("Leave group error:", error);

--- a/packages/frontend/src/app/api/groups/[slug]/members/[userId]/role/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/members/[userId]/role/route.ts
@@ -42,6 +42,10 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       getGroupMembership(group.id, userId),
     ]);
 
+    if (!group.isPublic && !actor) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
     if (
       !actor ||
       !target ||
@@ -65,7 +69,12 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       return NextResponse.json({ error: "Member not found" }, { status: 404 });
     }
 
-    await revalidateGroupCaches(group.id, group.slug);
+    try {
+      await revalidateGroupCaches(group.id, group.slug);
+    } catch (cacheError) {
+      console.error("Update group member role cache invalidation failed:", cacheError);
+    }
+
     return NextResponse.json(updated);
   } catch (error) {
     console.error("Update group member role error:", error);

--- a/packages/frontend/src/app/api/groups/[slug]/members/[userId]/role/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/members/[userId]/role/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { and, eq } from "drizzle-orm";
+import { and, eq, ne, sql } from "drizzle-orm";
 import { db, groupMembers } from "@/lib/db";
 import { getSessionFromRequest } from "@/lib/auth/requestSession";
 import { revalidateGroupCaches } from "@/lib/groups/cache";
@@ -53,6 +53,32 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       !canManageGroupRole(actor.role, nextRole)
     ) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    // Demoting an owner would orphan the group if no other owners remain.
+    // The route already rejects nextRole === "owner" above, so reaching this
+    // branch with target.role === "owner" always means we're demoting.
+    if (target.role === "owner") {
+      const [{ count: otherOwnerCount }] = await db
+        .select({ count: sql<number>`COUNT(*)::int` })
+        .from(groupMembers)
+        .where(
+          and(
+            eq(groupMembers.groupId, group.id),
+            eq(groupMembers.role, "owner"),
+            ne(groupMembers.userId, userId),
+          ),
+        );
+
+      if (otherOwnerCount === 0) {
+        return NextResponse.json(
+          {
+            error:
+              "Cannot demote the last owner. Transfer ownership to another member first.",
+          },
+          { status: 400 }
+        );
+      }
     }
 
     const [updated] = await db

--- a/packages/frontend/src/app/api/groups/[slug]/members/[userId]/role/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/members/[userId]/role/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { db, groupMembers } from "@/lib/db";
+import { getSessionFromRequest } from "@/lib/auth/requestSession";
+import { revalidateGroupCaches } from "@/lib/groups/cache";
+import { getGroupMembership } from "@/lib/groups/permissions";
+import { getGroupBySlug } from "@/lib/groups/queries";
+import { canManageGroupRole, isGroupRole } from "@/lib/groups/utils";
+import type { GroupRole } from "@/lib/db";
+
+interface RouteParams {
+  params: Promise<{ slug: string; userId: string }>;
+}
+
+export async function PATCH(request: Request, { params }: RouteParams) {
+  try {
+    const session = await getSessionFromRequest(request);
+    if (!session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const { slug, userId } = await params;
+    const group = await getGroupBySlug(slug);
+    if (!group) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    let body: Record<string, unknown>;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const nextRole = body.role;
+    if (!isGroupRole(nextRole) || nextRole === "owner") {
+      return NextResponse.json({ error: "Role must be member or admin" }, { status: 400 });
+    }
+
+    const [actor, target] = await Promise.all([
+      getGroupMembership(group.id, session.id),
+      getGroupMembership(group.id, userId),
+    ]);
+
+    if (
+      !actor ||
+      !target ||
+      !canManageGroupRole(actor.role, target.role) ||
+      !canManageGroupRole(actor.role, nextRole)
+    ) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const [updated] = await db
+      .update(groupMembers)
+      .set({ role: nextRole as GroupRole })
+      .where(and(eq(groupMembers.groupId, group.id), eq(groupMembers.userId, userId)))
+      .returning({
+        id: groupMembers.id,
+        userId: groupMembers.userId,
+        role: groupMembers.role,
+      });
+
+    if (!updated) {
+      return NextResponse.json({ error: "Member not found" }, { status: 404 });
+    }
+
+    await revalidateGroupCaches(group.id, group.slug);
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error("Update group member role error:", error);
+    return NextResponse.json({ error: "Failed to update role" }, { status: 500 });
+  }
+}

--- a/packages/frontend/src/app/api/groups/[slug]/members/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/members/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { db, groupMembers, users } from "@/lib/db";
+import { getSessionFromRequest } from "@/lib/auth/requestSession";
+import { revalidateGroupCaches } from "@/lib/groups/cache";
+import { canManageGroupMember, getGroupMembership } from "@/lib/groups/permissions";
+import { getGroupBySlug } from "@/lib/groups/queries";
+
+interface RouteParams {
+  params: Promise<{ slug: string }>;
+}
+
+async function resolveGroupAccess(request: Request, slug: string) {
+  const group = await getGroupBySlug(slug);
+  if (!group) {
+    return { response: NextResponse.json({ error: "Group not found" }, { status: 404 }) };
+  }
+
+  const session = await getSessionFromRequest(request);
+  const membership = session ? await getGroupMembership(group.id, session.id) : null;
+
+  if (!group.isPublic && !membership) {
+    return {
+      response: NextResponse.json(
+        { error: session ? "Forbidden" : "Not authenticated" },
+        { status: session ? 403 : 401 }
+      ),
+    };
+  }
+
+  return { group, session, membership };
+}
+
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { slug } = await params;
+    const access = await resolveGroupAccess(request, slug);
+    if ("response" in access) {
+      return access.response;
+    }
+
+    const members = await db
+      .select({
+        id: groupMembers.id,
+        userId: users.id,
+        username: users.username,
+        displayName: users.displayName,
+        avatarUrl: users.avatarUrl,
+        role: groupMembers.role,
+        joinedAt: groupMembers.joinedAt,
+      })
+      .from(groupMembers)
+      .innerJoin(users, eq(groupMembers.userId, users.id))
+      .where(eq(groupMembers.groupId, access.group.id));
+
+    return NextResponse.json({ members });
+  } catch (error) {
+    console.error("List group members error:", error);
+    return NextResponse.json({ error: "Failed to fetch group members" }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request, { params }: RouteParams) {
+  try {
+    const session = await getSessionFromRequest(request);
+    if (!session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const { slug } = await params;
+    const group = await getGroupBySlug(slug);
+    if (!group) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const userId = searchParams.get("userId");
+    if (!userId) {
+      return NextResponse.json({ error: "userId is required" }, { status: 400 });
+    }
+
+    if (userId === session.id) {
+      return NextResponse.json({ error: "Use the leave endpoint to remove yourself" }, { status: 400 });
+    }
+
+    if (!(await canManageGroupMember(group.id, session.id, userId))) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const deleted = await db
+      .delete(groupMembers)
+      .where(and(eq(groupMembers.groupId, group.id), eq(groupMembers.userId, userId)))
+      .returning({ id: groupMembers.id });
+
+    if (deleted.length === 0) {
+      return NextResponse.json({ error: "Member not found" }, { status: 404 });
+    }
+
+    await revalidateGroupCaches(group.id, group.slug);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Remove group member error:", error);
+    return NextResponse.json({ error: "Failed to remove member" }, { status: 500 });
+  }
+}

--- a/packages/frontend/src/app/api/groups/[slug]/members/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/members/route.ts
@@ -20,12 +20,7 @@ async function resolveGroupAccess(request: Request, slug: string) {
   const membership = session ? await getGroupMembership(group.id, session.id) : null;
 
   if (!group.isPublic && !membership) {
-    return {
-      response: NextResponse.json(
-        { error: session ? "Forbidden" : "Not authenticated" },
-        { status: session ? 403 : 401 }
-      ),
-    };
+    return { response: NextResponse.json({ error: "Group not found" }, { status: 404 }) };
   }
 
   return { group, session, membership };
@@ -83,7 +78,12 @@ export async function DELETE(request: Request, { params }: RouteParams) {
       return NextResponse.json({ error: "Use the leave endpoint to remove yourself" }, { status: 400 });
     }
 
-    if (!(await canManageGroupMember(group.id, session.id, userId))) {
+    const membership = await getGroupMembership(group.id, session.id);
+    if (!group.isPublic && !membership) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    if (!membership || !(await canManageGroupMember(group.id, session.id, userId))) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
@@ -96,7 +96,12 @@ export async function DELETE(request: Request, { params }: RouteParams) {
       return NextResponse.json({ error: "Member not found" }, { status: 404 });
     }
 
-    await revalidateGroupCaches(group.id, group.slug);
+    try {
+      await revalidateGroupCaches(group.id, group.slug);
+    } catch (cacheError) {
+      console.error("Remove group member cache invalidation failed:", cacheError);
+    }
+
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error("Remove group member error:", error);

--- a/packages/frontend/src/app/api/groups/[slug]/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/route.ts
@@ -4,7 +4,7 @@ import { eq } from "drizzle-orm";
 import { db, groups } from "@/lib/db";
 import { getSessionFromRequest } from "@/lib/auth/requestSession";
 import { revalidateGroupCaches } from "@/lib/groups/cache";
-import { getGroupMembership, requireGroupRole } from "@/lib/groups/permissions";
+import { getGroupMembership } from "@/lib/groups/permissions";
 import { getGroupBySlug, getGroupMemberCount } from "@/lib/groups/queries";
 import { generateUniqueGroupSlug } from "@/lib/groups/slugs";
 
@@ -16,22 +16,41 @@ function parseString(value: unknown): string | null {
   return typeof value === "string" ? value.trim() : null;
 }
 
+function parseNullableStringField(
+  value: unknown,
+  fieldName: string
+): { value: string | null } | { response: NextResponse } {
+  if (value === null) {
+    return { value: null };
+  }
+
+  if (typeof value === "string") {
+    return { value: value.trim() };
+  }
+
+  return {
+    response: NextResponse.json(
+      { error: `${fieldName} must be a string or null` },
+      { status: 400 }
+    ),
+  };
+}
+
+function groupNotFoundResponse() {
+  return NextResponse.json({ error: "Group not found" }, { status: 404 });
+}
+
 async function authorizeGroupRead(request: Request, slug: string) {
   const group = await getGroupBySlug(slug);
   if (!group) {
-    return { response: NextResponse.json({ error: "Group not found" }, { status: 404 }) };
+    return { response: groupNotFoundResponse() };
   }
 
   const session = await getSessionFromRequest(request);
   const membership = session ? await getGroupMembership(group.id, session.id) : null;
 
   if (!group.isPublic && !membership) {
-    return {
-      response: NextResponse.json(
-        { error: session ? "Forbidden" : "Not authenticated" },
-        { status: session ? 403 : 401 }
-      ),
-    };
+    return { response: groupNotFoundResponse() };
   }
 
   return { group, session, membership };
@@ -68,11 +87,14 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     const { slug } = await params;
     const group = await getGroupBySlug(slug);
     if (!group) {
-      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+      return groupNotFoundResponse();
     }
 
-    const membership = await requireGroupRole(group.id, session.id, "admin");
-    if (!membership) {
+    const membership = await getGroupMembership(group.id, session.id);
+    if (!group.isPublic && !membership) {
+      return groupNotFoundResponse();
+    }
+    if (!membership || membership.role === "member") {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
@@ -107,10 +129,18 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     }
 
     if (body.description !== undefined) {
-      updateData.description = parseString(body.description);
+      const description = parseNullableStringField(body.description, "description");
+      if ("response" in description) {
+        return description.response;
+      }
+      updateData.description = description.value;
     }
     if (body.avatarUrl !== undefined) {
-      updateData.avatarUrl = parseString(body.avatarUrl);
+      const avatarUrl = parseNullableStringField(body.avatarUrl, "avatarUrl");
+      if ("response" in avatarUrl) {
+        return avatarUrl.response;
+      }
+      updateData.avatarUrl = avatarUrl.value;
     }
     if (typeof body.isPublic === "boolean") {
       updateData.isPublic = body.isPublic;
@@ -122,9 +152,18 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       .where(eq(groups.id, group.id))
       .returning();
 
-    await revalidateGroupCaches(group.id, updated?.slug ?? group.slug);
+    try {
+      await revalidateGroupCaches(group.id, updated?.slug ?? group.slug);
+    } catch (cacheError) {
+      console.error("Update group cache invalidation failed:", cacheError);
+    }
+
     if (updated?.slug && updated.slug !== group.slug) {
-      revalidatePath(`/groups/${group.slug}`);
+      try {
+        revalidatePath(`/groups/${group.slug}`);
+      } catch (cacheError) {
+        console.error("Old group path revalidation failed:", cacheError);
+      }
     }
 
     return NextResponse.json(updated);
@@ -144,10 +183,13 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     const { slug } = await params;
     const group = await getGroupBySlug(slug);
     if (!group) {
-      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+      return groupNotFoundResponse();
     }
 
     const membership = await getGroupMembership(group.id, session.id);
+    if (!group.isPublic && !membership) {
+      return groupNotFoundResponse();
+    }
     if (!membership || membership.role !== "owner") {
       return NextResponse.json({ error: "Only the owner can delete this group" }, { status: 403 });
     }
@@ -161,7 +203,12 @@ export async function DELETE(request: Request, { params }: RouteParams) {
       return NextResponse.json({ error: "Group not found" }, { status: 404 });
     }
 
-    await revalidateGroupCaches(group.id, group.slug);
+    try {
+      await revalidateGroupCaches(group.id, group.slug);
+    } catch (cacheError) {
+      console.error("Delete group cache invalidation failed:", cacheError);
+    }
+
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error("Delete group error:", error);

--- a/packages/frontend/src/app/api/groups/[slug]/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/route.ts
@@ -1,0 +1,170 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db, groups } from "@/lib/db";
+import { getSessionFromRequest } from "@/lib/auth/requestSession";
+import { revalidateGroupCaches } from "@/lib/groups/cache";
+import { getGroupMembership, requireGroupRole } from "@/lib/groups/permissions";
+import { getGroupBySlug, getGroupMemberCount } from "@/lib/groups/queries";
+import { generateUniqueGroupSlug } from "@/lib/groups/slugs";
+
+interface RouteParams {
+  params: Promise<{ slug: string }>;
+}
+
+function parseString(value: unknown): string | null {
+  return typeof value === "string" ? value.trim() : null;
+}
+
+async function authorizeGroupRead(request: Request, slug: string) {
+  const group = await getGroupBySlug(slug);
+  if (!group) {
+    return { response: NextResponse.json({ error: "Group not found" }, { status: 404 }) };
+  }
+
+  const session = await getSessionFromRequest(request);
+  const membership = session ? await getGroupMembership(group.id, session.id) : null;
+
+  if (!group.isPublic && !membership) {
+    return {
+      response: NextResponse.json(
+        { error: session ? "Forbidden" : "Not authenticated" },
+        { status: session ? 403 : 401 }
+      ),
+    };
+  }
+
+  return { group, session, membership };
+}
+
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { slug } = await params;
+    const authorized = await authorizeGroupRead(request, slug);
+
+    if ("response" in authorized) {
+      return authorized.response;
+    }
+
+    const memberCount = await getGroupMemberCount(authorized.group.id);
+    return NextResponse.json({
+      ...authorized.group,
+      memberCount,
+      membership: authorized.membership,
+    });
+  } catch (error) {
+    console.error("Get group error:", error);
+    return NextResponse.json({ error: "Failed to fetch group" }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: Request, { params }: RouteParams) {
+  try {
+    const session = await getSessionFromRequest(request);
+    if (!session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const { slug } = await params;
+    const group = await getGroupBySlug(slug);
+    if (!group) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    const membership = await requireGroupRole(group.id, session.id, "admin");
+    if (!membership) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    let body: Record<string, unknown>;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const updateData: {
+      name?: string;
+      slug?: string;
+      description?: string | null;
+      isPublic?: boolean;
+      avatarUrl?: string | null;
+      updatedAt: Date;
+    } = { updatedAt: new Date() };
+
+    if (body.name !== undefined) {
+      const name = parseString(body.name);
+      if (!name) {
+        return NextResponse.json({ error: "Group name cannot be empty" }, { status: 400 });
+      }
+      if (name.length > 100) {
+        return NextResponse.json({ error: "Group name must be 100 characters or less" }, { status: 400 });
+      }
+      updateData.name = name;
+      if (name !== group.name) {
+        updateData.slug = await generateUniqueGroupSlug(name);
+      }
+    }
+
+    if (body.description !== undefined) {
+      updateData.description = parseString(body.description);
+    }
+    if (body.avatarUrl !== undefined) {
+      updateData.avatarUrl = parseString(body.avatarUrl);
+    }
+    if (typeof body.isPublic === "boolean") {
+      updateData.isPublic = body.isPublic;
+    }
+
+    const [updated] = await db
+      .update(groups)
+      .set(updateData)
+      .where(eq(groups.id, group.id))
+      .returning();
+
+    await revalidateGroupCaches(group.id, updated?.slug ?? group.slug);
+    if (updated?.slug && updated.slug !== group.slug) {
+      revalidatePath(`/groups/${group.slug}`);
+    }
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error("Update group error:", error);
+    return NextResponse.json({ error: "Failed to update group" }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request, { params }: RouteParams) {
+  try {
+    const session = await getSessionFromRequest(request);
+    if (!session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const { slug } = await params;
+    const group = await getGroupBySlug(slug);
+    if (!group) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    const membership = await getGroupMembership(group.id, session.id);
+    if (!membership || membership.role !== "owner") {
+      return NextResponse.json({ error: "Only the owner can delete this group" }, { status: 403 });
+    }
+
+    const deleted = await db
+      .delete(groups)
+      .where(eq(groups.id, group.id))
+      .returning({ id: groups.id });
+
+    if (deleted.length === 0) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    await revalidateGroupCaches(group.id, group.slug);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Delete group error:", error);
+    return NextResponse.json({ error: "Failed to delete group" }, { status: 500 });
+  }
+}

--- a/packages/frontend/src/app/api/groups/join/[token]/route.ts
+++ b/packages/frontend/src/app/api/groups/join/[token]/route.ts
@@ -41,7 +41,11 @@ export async function POST(request: Request, { params }: RouteParams) {
 
     const { token } = await params;
     const accepted = await acceptGroupInvite(token, session);
-    await revalidateGroupCaches(accepted.group.id, accepted.group.slug);
+    try {
+      await revalidateGroupCaches(accepted.group.id, accepted.group.slug);
+    } catch (cacheError) {
+      console.error("Accept group invite cache invalidation failed:", cacheError);
+    }
 
     return NextResponse.json(accepted);
   } catch (error) {

--- a/packages/frontend/src/app/api/groups/join/[token]/route.ts
+++ b/packages/frontend/src/app/api/groups/join/[token]/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { getSessionFromRequest } from "@/lib/auth/requestSession";
+import { revalidateGroupCaches } from "@/lib/groups/cache";
+import {
+  acceptGroupInvite,
+  getGroupInvitePreview,
+  GroupInviteError,
+} from "@/lib/groups/invites";
+
+interface RouteParams {
+  params: Promise<{ token: string }>;
+}
+
+function errorResponse(error: GroupInviteError) {
+  if (error.code === "not_found") {
+    return NextResponse.json({ error: error.message }, { status: 404 });
+  }
+
+  return NextResponse.json({ error: error.message }, { status: error.code === "invalid" ? 400 : 403 });
+}
+
+export async function GET(_request: Request, { params }: RouteParams) {
+  try {
+    const { token } = await params;
+    return NextResponse.json(await getGroupInvitePreview(token));
+  } catch (error) {
+    if (error instanceof GroupInviteError) {
+      return errorResponse(error);
+    }
+    console.error("Get group invite preview error:", error);
+    return NextResponse.json({ error: "Failed to fetch invite" }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const session = await getSessionFromRequest(request);
+    if (!session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const { token } = await params;
+    const accepted = await acceptGroupInvite(token, session);
+    await revalidateGroupCaches(accepted.group.id, accepted.group.slug);
+
+    return NextResponse.json(accepted);
+  } catch (error) {
+    if (error instanceof GroupInviteError) {
+      return errorResponse(error);
+    }
+    console.error("Accept group invite error:", error);
+    return NextResponse.json({ error: "Failed to accept invite" }, { status: 500 });
+  }
+}

--- a/packages/frontend/src/app/api/groups/route.ts
+++ b/packages/frontend/src/app/api/groups/route.ts
@@ -1,0 +1,94 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse } from "next/server";
+import { db, groupMembers, groups } from "@/lib/db";
+import { getSessionFromRequest } from "@/lib/auth/requestSession";
+import { generateUniqueGroupSlug } from "@/lib/groups/slugs";
+import { listPublicGroups, listUserGroups } from "@/lib/groups/queries";
+
+function parseIntSafe(value: string | null, defaultValue: number): number {
+  if (!value) return defaultValue;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.floor(parsed) : defaultValue;
+}
+
+function parseString(value: unknown): string | null {
+  return typeof value === "string" ? value.trim() : null;
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const page = Math.max(1, parseIntSafe(searchParams.get("page"), 1));
+    const limit = Math.min(100, Math.max(1, parseIntSafe(searchParams.get("limit"), 20)));
+    const session = await getSessionFromRequest(request);
+
+    if (searchParams.get("my") === "true") {
+      if (!session) {
+        return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+      }
+
+      return NextResponse.json(await listUserGroups(session.id, page, limit));
+    }
+
+    return NextResponse.json(await listPublicGroups(page, limit));
+  } catch (error) {
+    console.error("List groups error:", error);
+    return NextResponse.json({ error: "Failed to fetch groups" }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const session = await getSessionFromRequest(request);
+    if (!session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    let body: Record<string, unknown>;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const name = parseString(body.name);
+    if (!name) {
+      return NextResponse.json({ error: "Group name is required" }, { status: 400 });
+    }
+
+    if (name.length > 100) {
+      return NextResponse.json({ error: "Group name must be 100 characters or less" }, { status: 400 });
+    }
+
+    const description = parseString(body.description);
+    const isPublic = typeof body.isPublic === "boolean" ? body.isPublic : true;
+
+    const createdGroup = await db.transaction(async (tx) => {
+      const slug = await generateUniqueGroupSlug(name, tx);
+      const [newGroup] = await tx
+        .insert(groups)
+        .values({
+          name,
+          slug,
+          description,
+          isPublic,
+          createdBy: session.id,
+        })
+        .returning();
+
+      await tx.insert(groupMembers).values({
+        groupId: newGroup.id,
+        userId: session.id,
+        role: "owner",
+      });
+
+      return newGroup;
+    });
+
+    revalidatePath("/groups");
+    return NextResponse.json(createdGroup, { status: 201 });
+  } catch (error) {
+    console.error("Create group error:", error);
+    return NextResponse.json({ error: "Failed to create group" }, { status: 500 });
+  }
+}

--- a/packages/frontend/src/app/api/settings/submitted-data/route.ts
+++ b/packages/frontend/src/app/api/settings/submitted-data/route.ts
@@ -45,9 +45,8 @@ export async function DELETE(request: Request) {
       return deleted;
     });
 
+    const usernameCacheKey = normalizeUsernameCacheKey(user.username);
     try {
-      const usernameCacheKey = normalizeUsernameCacheKey(user.username);
-
       revalidateTag("leaderboard", "max");
       revalidateTag(`user:${usernameCacheKey}`, "max");
       revalidateTag("user-rank", "max");
@@ -55,13 +54,22 @@ export async function DELETE(request: Request) {
       revalidateTag(`embed-user:${usernameCacheKey}`, "max");
       revalidateTag(`embed-user:${usernameCacheKey}:tokens`, "max");
       revalidateTag(`embed-user:${usernameCacheKey}:cost`, "max");
-      await revalidateUserGroupLeaderboards(user.id);
+    } catch (cacheError) {
+      console.error("Public cache invalidation failed after deletion:", cacheError);
+    }
 
+    try {
+      await revalidateUserGroupLeaderboards(user.id);
+    } catch (cacheError) {
+      console.error("Group cache invalidation failed after deletion:", cacheError);
+    }
+
+    try {
       revalidatePath("/leaderboard");
       revalidatePath("/profile");
       revalidateUsernamePaths(user.username);
     } catch (cacheError) {
-      console.error("Cache invalidation failed after deletion:", cacheError);
+      console.error("Path revalidation failed after deletion:", cacheError);
     }
 
     return NextResponse.json({

--- a/packages/frontend/src/app/api/settings/submitted-data/route.ts
+++ b/packages/frontend/src/app/api/settings/submitted-data/route.ts
@@ -6,6 +6,7 @@ import { authenticatePersonalToken } from "@/lib/auth/personalTokens";
 import { db, submissions, submittedDevices } from "@/lib/db";
 import { normalizeUsernameCacheKey, revalidateUsernamePaths } from "@/lib/db/usernameLookup";
 import { getBearerToken } from "../../../../lib/auth/bearerToken";
+import { revalidateUserGroupLeaderboards } from "@/lib/groups/cache";
 
 async function resolveUser(request: Request): Promise<{ id: string; username: string } | null> {
   const token = getBearerToken(request.headers.get("Authorization"));
@@ -54,6 +55,7 @@ export async function DELETE(request: Request) {
       revalidateTag(`embed-user:${usernameCacheKey}`, "max");
       revalidateTag(`embed-user:${usernameCacheKey}:tokens`, "max");
       revalidateTag(`embed-user:${usernameCacheKey}:cost`, "max");
+      await revalidateUserGroupLeaderboards(user.id);
 
       revalidatePath("/leaderboard");
       revalidatePath("/profile");

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -483,17 +483,26 @@ export async function POST(request: Request) {
       };
     });
 
+    const usernameCacheKey = normalizeUsernameCacheKey(tokenRecord.username);
     try {
-      const usernameCacheKey = normalizeUsernameCacheKey(tokenRecord.username);
-
       revalidateTag("leaderboard", "max");
       revalidateTag(`user:${usernameCacheKey}`, "max");
       revalidateTag("user-rank", "max");
       revalidateTag(`user-rank:${usernameCacheKey}`, "max");
+    } catch (e) {
+      console.error("Public cache invalidation failed:", e);
+    }
+
+    try {
       await revalidateUserGroupLeaderboards(tokenRecord.userId);
+    } catch (e) {
+      console.error("Group leaderboard cache invalidation failed:", e);
+    }
+
+    try {
       revalidateUsernamePaths(tokenRecord.username);
     } catch (e) {
-      console.error("Cache invalidation failed:", e);
+      console.error("Username path revalidation failed:", e);
     }
 
     return NextResponse.json({

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -18,6 +18,7 @@ import {
   type ClientBreakdownData,
 } from "@/lib/db/helpers";
 import { normalizeUsernameCacheKey, revalidateUsernamePaths } from "@/lib/db/usernameLookup";
+import { revalidateUserGroupLeaderboards } from "@/lib/groups/cache";
 
 const LEGACY_SUBMIT_DEVICE_KEY = "legacy-default";
 const LEGACY_SUBMIT_DEVICE_NAME = "Legacy submissions";
@@ -489,6 +490,7 @@ export async function POST(request: Request) {
       revalidateTag(`user:${usernameCacheKey}`, "max");
       revalidateTag("user-rank", "max");
       revalidateTag(`user-rank:${usernameCacheKey}`, "max");
+      await revalidateUserGroupLeaderboards(tokenRecord.userId);
       revalidateUsernamePaths(tokenRecord.username);
     } catch (e) {
       console.error("Cache invalidation failed:", e);

--- a/packages/frontend/src/app/api/users/[username]/groups/route.ts
+++ b/packages/frontend/src/app/api/users/[username]/groups/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { and, eq, sql } from "drizzle-orm";
+import { db, groupMembers, groups, users } from "@/lib/db";
+import { getSessionFromRequest } from "@/lib/auth/requestSession";
+import {
+  USERNAME_LOOKUP_LIMIT,
+  getSingleUsernameMatch,
+  usernameEqualsIgnoreCase,
+} from "@/lib/db/usernameLookup";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ username: string }> }
+) {
+  try {
+    const { username } = await params;
+    const session = await getSessionFromRequest(request);
+    const userRows = await db
+      .select({ id: users.id, username: users.username })
+      .from(users)
+      .where(usernameEqualsIgnoreCase(username))
+      .limit(USERNAME_LOOKUP_LIMIT);
+    const user = getSingleUsernameMatch(userRows, username);
+
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const showPrivate = session?.id === user.id;
+    const rows = await db
+      .select({
+        id: groups.id,
+        name: groups.name,
+        slug: groups.slug,
+        description: groups.description,
+        avatarUrl: groups.avatarUrl,
+        isPublic: groups.isPublic,
+        role: groupMembers.role,
+        memberCount: sql<number>`CAST((SELECT COUNT(*) FROM "group_members" WHERE "group_members"."group_id" = ${groups.id}) AS integer)`.as("member_count"),
+      })
+      .from(groupMembers)
+      .innerJoin(groups, eq(groupMembers.groupId, groups.id))
+      .where(
+        showPrivate
+          ? eq(groupMembers.userId, user.id)
+          : and(eq(groupMembers.userId, user.id), eq(groups.isPublic, true))
+      );
+
+    return NextResponse.json({
+      groups: rows.map((row) => ({
+        ...row,
+        memberCount: Number(row.memberCount) || 0,
+      })),
+    });
+  } catch (error) {
+    console.error("Fetch user groups error:", error);
+    return NextResponse.json({ error: "Failed to fetch user groups" }, { status: 500 });
+  }
+}

--- a/packages/frontend/src/components/layout/Navigation.tsx
+++ b/packages/frontend/src/components/layout/Navigation.tsx
@@ -629,6 +629,10 @@ function UserMenu({ user, onSignOut }: { user: User; onSignOut: () => void }) {
               <MenuIconSlot><PersonIcon /></MenuIconSlot>
               Your Profile
             </MenuItem>
+            <MenuItem href="/groups" onClick={handleClose}>
+              <MenuIconSlot><PersonIcon /></MenuIconSlot>
+              Groups
+            </MenuItem>
             <MenuItem href="/settings" onClick={handleClose}>
               <MenuIconSlot><GearIcon /></MenuIconSlot>
               Settings
@@ -694,6 +698,9 @@ export function Navigation() {
           <NavItemLink href="/leaderboard" $isActive={pathname === "/leaderboard"}>
             Leaderboard
           </NavItemLink>
+          <NavItemLink href="/groups" $isActive={pathname.startsWith("/groups")}>
+            Groups
+          </NavItemLink>
           <NavItemLink href="/profile" $isActive={pathname === "/profile" || pathname.startsWith("/u/")}>
             Profile
           </NavItemLink>
@@ -738,6 +745,9 @@ export function Navigation() {
           <DropdownNavLink href="/leaderboard" $isActive={pathname === "/leaderboard"} onClick={closeMobileMenu}>
             Leaderboard
           </DropdownNavLink>
+          <DropdownNavLink href="/groups" $isActive={pathname.startsWith("/groups")} onClick={closeMobileMenu}>
+            Groups
+          </DropdownNavLink>
           <DropdownNavLink href="/profile" $isActive={pathname === "/profile" || pathname.startsWith("/u/")} onClick={closeMobileMenu}>
             Profile
           </DropdownNavLink>
@@ -771,6 +781,10 @@ export function Navigation() {
               <DropdownUserAction href={`/u/${user.username}`} onClick={closeMobileMenu}>
                 <PersonIcon size={16} />
                 Your Profile
+              </DropdownUserAction>
+              <DropdownUserAction href="/groups" onClick={closeMobileMenu}>
+                <PersonIcon size={16} />
+                Groups
               </DropdownUserAction>
               <DropdownUserAction href="/settings" onClick={closeMobileMenu}>
                 <GearIcon size={16} />

--- a/packages/frontend/src/lib/auth/requestSession.ts
+++ b/packages/frontend/src/lib/auth/requestSession.ts
@@ -1,0 +1,9 @@
+import { getSession, getSessionFromHeader, type SessionUser } from "./session";
+
+export async function getSessionFromRequest(request: Request): Promise<SessionUser | null> {
+  if (request.headers.get("Authorization")) {
+    return getSessionFromHeader(request);
+  }
+
+  return getSession();
+}

--- a/packages/frontend/src/lib/db/migrations/0009_add_groups.sql
+++ b/packages/frontend/src/lib/db/migrations/0009_add_groups.sql
@@ -1,0 +1,68 @@
+-- Groups feature: scoped leaderboards, membership roles, and hashed invite links.
+
+CREATE TABLE IF NOT EXISTS "groups" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "name" varchar(100) NOT NULL,
+  "slug" varchar(100) NOT NULL,
+  "description" text,
+  "avatar_url" text,
+  "is_public" boolean DEFAULT true NOT NULL,
+  "created_by" uuid NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "groups_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "group_members" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "group_id" uuid NOT NULL,
+  "user_id" uuid NOT NULL,
+  "role" varchar(10) DEFAULT 'member' NOT NULL,
+  "invited_by" uuid,
+  "joined_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "group_members_group_user_unique" UNIQUE("group_id", "user_id")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "group_invites" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "group_id" uuid NOT NULL,
+  "invited_username" varchar(39),
+  "invited_username_normalized" varchar(39),
+  "invited_user_id" uuid,
+  "invited_by" uuid NOT NULL,
+  "role" varchar(10) DEFAULT 'member' NOT NULL,
+  "status" varchar(10) DEFAULT 'pending' NOT NULL,
+  "token_hash" varchar(64) NOT NULL,
+  "expires_at" timestamp with time zone NOT NULL,
+  "accepted_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "group_invites_token_hash_unique" UNIQUE("token_hash")
+);
+--> statement-breakpoint
+ALTER TABLE "groups" ADD CONSTRAINT "groups_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "group_members" ADD CONSTRAINT "group_members_group_id_groups_id_fk" FOREIGN KEY ("group_id") REFERENCES "public"."groups"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "group_members" ADD CONSTRAINT "group_members_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "group_members" ADD CONSTRAINT "group_members_invited_by_users_id_fk" FOREIGN KEY ("invited_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "group_invites" ADD CONSTRAINT "group_invites_group_id_groups_id_fk" FOREIGN KEY ("group_id") REFERENCES "public"."groups"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "group_invites" ADD CONSTRAINT "group_invites_invited_user_id_users_id_fk" FOREIGN KEY ("invited_user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "group_invites" ADD CONSTRAINT "group_invites_invited_by_users_id_fk" FOREIGN KEY ("invited_by") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_groups_created_by" ON "groups" USING btree ("created_by");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_groups_visibility_updated" ON "groups" USING btree ("is_public", "updated_at");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_group_members_user_id" ON "group_members" USING btree ("user_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_group_invites_group_status" ON "group_invites" USING btree ("group_id", "status");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_group_invites_invited_user_status" ON "group_invites" USING btree ("invited_user_id", "status");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_group_invites_invited_username_status" ON "group_invites" USING btree ("invited_username_normalized", "status");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_group_invites_expires_at" ON "group_invites" USING btree ("expires_at");

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1778112000000,
       "tag": "0008_add_time_metrics_to_submissions",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1778198400000,
+      "tag": "0009_add_groups",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -54,6 +54,9 @@ export const usersRelations = relations(users, ({ many }) => ({
   apiTokens: many(apiTokens),
   submissions: many(submissions),
   submittedDevices: many(submittedDevices),
+  groupMemberships: many(groupMembers, { relationName: "memberUser" }),
+  createdGroups: many(groups, { relationName: "groupCreator" }),
+  createdGroupInvites: many(groupInvites, { relationName: "groupInviteCreator" }),
 }));
 
 // ============================================================================
@@ -327,6 +330,139 @@ export const dailyBreakdownRelations = relations(dailyBreakdown, ({ one }) => ({
 }));
 
 // ============================================================================
+// GROUPS
+// ============================================================================
+export const groupRoles = ["owner", "admin", "member"] as const;
+export type GroupRole = (typeof groupRoles)[number];
+
+export const groupInviteStatuses = ["pending", "accepted", "declined", "expired"] as const;
+export type GroupInviteStatus = (typeof groupInviteStatuses)[number];
+
+export const groups = pgTable(
+  "groups",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    name: varchar("name", { length: 100 }).notNull(),
+    slug: varchar("slug", { length: 100 }).notNull().unique(),
+    description: text("description"),
+    avatarUrl: text("avatar_url"),
+    isPublic: boolean("is_public").notNull().default(true),
+    createdBy: uuid("created_by")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_groups_created_by").on(table.createdBy),
+    index("idx_groups_visibility_updated").on(table.isPublic, table.updatedAt),
+  ]
+);
+
+export const groupsRelations = relations(groups, ({ one, many }) => ({
+  creator: one(users, {
+    fields: [groups.createdBy],
+    references: [users.id],
+    relationName: "groupCreator",
+  }),
+  members: many(groupMembers),
+  invites: many(groupInvites),
+}));
+
+export const groupMembers = pgTable(
+  "group_members",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    groupId: uuid("group_id")
+      .notNull()
+      .references(() => groups.id, { onDelete: "cascade" }),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    role: varchar("role", { length: 10 }).notNull().default("member").$type<GroupRole>(),
+    invitedBy: uuid("invited_by").references(() => users.id, { onDelete: "set null" }),
+    joinedAt: timestamp("joined_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_group_members_user_id").on(table.userId),
+    unique("group_members_group_user_unique").on(table.groupId, table.userId),
+  ]
+);
+
+export const groupMembersRelations = relations(groupMembers, ({ one }) => ({
+  group: one(groups, {
+    fields: [groupMembers.groupId],
+    references: [groups.id],
+  }),
+  user: one(users, {
+    fields: [groupMembers.userId],
+    references: [users.id],
+    relationName: "memberUser",
+  }),
+  inviter: one(users, {
+    fields: [groupMembers.invitedBy],
+    references: [users.id],
+    relationName: "memberInviter",
+  }),
+}));
+
+export const groupInvites = pgTable(
+  "group_invites",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    groupId: uuid("group_id")
+      .notNull()
+      .references(() => groups.id, { onDelete: "cascade" }),
+    invitedUsername: varchar("invited_username", { length: 39 }),
+    invitedUsernameNormalized: varchar("invited_username_normalized", { length: 39 }),
+    invitedUserId: uuid("invited_user_id").references(() => users.id, { onDelete: "cascade" }),
+    invitedBy: uuid("invited_by")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    role: varchar("role", { length: 10 }).notNull().default("member").$type<GroupRole>(),
+    status: varchar("status", { length: 10 }).notNull().default("pending").$type<GroupInviteStatus>(),
+    tokenHash: varchar("token_hash", { length: 64 }).notNull().unique(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    acceptedAt: timestamp("accepted_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_group_invites_group_status").on(table.groupId, table.status),
+    index("idx_group_invites_invited_user_status").on(table.invitedUserId, table.status),
+    index("idx_group_invites_invited_username_status").on(
+      table.invitedUsernameNormalized,
+      table.status
+    ),
+    index("idx_group_invites_expires_at").on(table.expiresAt),
+  ]
+);
+
+export const groupInvitesRelations = relations(groupInvites, ({ one }) => ({
+  group: one(groups, {
+    fields: [groupInvites.groupId],
+    references: [groups.id],
+  }),
+  invitedUser: one(users, {
+    fields: [groupInvites.invitedUserId],
+    references: [users.id],
+    relationName: "groupInviteTarget",
+  }),
+  inviter: one(users, {
+    fields: [groupInvites.invitedBy],
+    references: [users.id],
+    relationName: "groupInviteCreator",
+  }),
+}));
+
+// ============================================================================
 // TYPE EXPORTS
 // ============================================================================
 export type User = typeof users.$inferSelect;
@@ -343,3 +479,9 @@ export type SubmittedDevice = typeof submittedDevices.$inferSelect;
 export type NewSubmittedDevice = typeof submittedDevices.$inferInsert;
 export type DailyBreakdown = typeof dailyBreakdown.$inferSelect;
 export type NewDailyBreakdown = typeof dailyBreakdown.$inferInsert;
+export type Group = typeof groups.$inferSelect;
+export type NewGroup = typeof groups.$inferInsert;
+export type GroupMember = typeof groupMembers.$inferSelect;
+export type NewGroupMember = typeof groupMembers.$inferInsert;
+export type GroupInvite = typeof groupInvites.$inferSelect;
+export type NewGroupInvite = typeof groupInvites.$inferInsert;

--- a/packages/frontend/src/lib/groups/cache.ts
+++ b/packages/frontend/src/lib/groups/cache.ts
@@ -1,0 +1,25 @@
+import { revalidatePath, revalidateTag } from "next/cache";
+import { eq } from "drizzle-orm";
+import { db, groupMembers } from "@/lib/db";
+
+export async function revalidateGroupCaches(groupId: string, slug?: string): Promise<void> {
+  revalidateTag(`group:${groupId}`, "max");
+  revalidateTag(`group-leaderboard:${groupId}`, "max");
+  revalidatePath("/groups");
+
+  if (slug) {
+    revalidatePath(`/groups/${slug}`);
+  }
+}
+
+export async function revalidateUserGroupLeaderboards(userId: string): Promise<void> {
+  const memberships = await db
+    .select({ groupId: groupMembers.groupId })
+    .from(groupMembers)
+    .where(eq(groupMembers.userId, userId));
+
+  for (const membership of memberships) {
+    revalidateTag(`group:${membership.groupId}`, "max");
+    revalidateTag(`group-leaderboard:${membership.groupId}`, "max");
+  }
+}

--- a/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
+++ b/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
@@ -173,6 +173,7 @@ function buildPeriodGroupLeaderboardData(
       role: row.role,
       totalTokens: row.tokens,
       totalCost: row.cost,
+      totalActiveTimeMs: null,
       submissionCount: null,
       lastSubmission: row.updatedAt,
       submissionFreshness: buildSubmissionFreshness({
@@ -312,6 +313,7 @@ async function fetchAllTimeRows(groupId: string, sortBy: SortBy): Promise<GroupL
     role: row.role,
     totalTokens: Number(row.totalTokens) || 0,
     totalCost: Number(row.totalCost) || 0,
+    totalActiveTimeMs: null,
     submissionCount: Number(row.submissionCount) || 0,
     lastSubmission: row.lastSubmission,
     submissionFreshness: buildSubmissionFreshness({

--- a/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
+++ b/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
@@ -1,5 +1,5 @@
 import { unstable_cache } from "next/cache";
-import { and, desc, eq, gte, lte, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gte, lte, sql } from "drizzle-orm";
 import { db, dailyBreakdown, groupMembers, submissions, users } from "@/lib/db";
 import { buildSubmissionFreshness } from "@/lib/submissionFreshness";
 import type { LeaderboardUser, Period, SortBy } from "@/lib/leaderboard/types";
@@ -257,9 +257,12 @@ async function fetchPeriodRows(
 }
 
 async function fetchAllTimeRows(groupId: string, sortBy: SortBy): Promise<GroupLeaderboardUser[]> {
-  const orderByColumn = sortBy === "cost"
+  const primaryOrderByColumn = sortBy === "cost"
     ? sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`
     : sql`SUM(${submissions.totalTokens})`;
+  const secondaryOrderByColumn = sortBy === "cost"
+    ? sql`SUM(${submissions.totalTokens})`
+    : sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`;
 
   const rows = await db
     .select({
@@ -275,12 +278,12 @@ async function fetchAllTimeRows(groupId: string, sortBy: SortBy): Promise<GroupL
       cliVersion: sql<string | null>`(
         SELECT s2.cli_version FROM submissions s2
         WHERE s2.user_id = ${users.id}
-        ORDER BY s2.updated_at DESC LIMIT 1
+        ORDER BY s2.updated_at DESC, s2.id DESC LIMIT 1
       )`.as("cli_version"),
       schemaVersion: sql<number>`COALESCE((
         SELECT s2.schema_version FROM submissions s2
         WHERE s2.user_id = ${users.id}
-        ORDER BY s2.updated_at DESC LIMIT 1
+        ORDER BY s2.updated_at DESC, s2.id DESC LIMIT 1
       ), 0)`.as("schema_version"),
     })
     .from(submissions)
@@ -293,7 +296,12 @@ async function fetchAllTimeRows(groupId: string, sortBy: SortBy): Promise<GroupL
       )
     )
     .groupBy(users.id, users.username, users.displayName, users.avatarUrl, groupMembers.role)
-    .orderBy(desc(orderByColumn));
+    .orderBy(
+      desc(primaryOrderByColumn),
+      desc(secondaryOrderByColumn),
+      asc(users.username),
+      asc(users.id)
+    );
 
   return (rows as GroupLeaderboardDbRow[]).map((row, index) => ({
     rank: index + 1,

--- a/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
+++ b/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
@@ -1,0 +1,370 @@
+import { unstable_cache } from "next/cache";
+import { and, desc, eq, gte, lte, sql } from "drizzle-orm";
+import { db, dailyBreakdown, groupMembers, submissions, users } from "@/lib/db";
+import { buildSubmissionFreshness } from "@/lib/submissionFreshness";
+import type { LeaderboardUser, Period, SortBy } from "@/lib/leaderboard/types";
+
+interface GroupLeaderboardPeriodRow {
+  userId: string;
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  role: string;
+  tokens: number;
+  cost: number;
+  updatedAt: string;
+  cliVersion: string | null;
+  schemaVersion: number;
+}
+
+interface GroupLeaderboardDbRow {
+  userId: string;
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  role: string;
+  totalTokens: number | string | null;
+  totalCost: number | string | null;
+  submissionCount: number | string | null;
+  lastSubmission: string;
+  cliVersion: string | null;
+  schemaVersion: number | null;
+}
+
+export interface GroupLeaderboardUser extends LeaderboardUser {
+  role: string;
+}
+
+export interface GroupLeaderboardData {
+  users: GroupLeaderboardUser[];
+  pagination: {
+    page: number;
+    limit: number;
+    totalUsers: number;
+    totalPages: number;
+    hasNext: boolean;
+    hasPrev: boolean;
+  };
+  stats: {
+    totalTokens: number;
+    totalCost: number;
+    totalSubmissions: number | null;
+    uniqueUsers: number;
+    activeUsers: number;
+    totalMembers: number;
+  };
+  period: Period;
+  sortBy: SortBy;
+}
+
+function toUtcDateString(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function getPeriodDateRange(period: Period, now: Date = new Date()) {
+  if (period === "all") {
+    return null;
+  }
+
+  const end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  if (period === "week") {
+    const start = new Date(end);
+    start.setUTCDate(start.getUTCDate() - 6);
+    return { start: toUtcDateString(start), end: toUtcDateString(end) };
+  }
+
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+  return { start: toUtcDateString(start), end: toUtcDateString(end) };
+}
+
+function compareGroupUsers(
+  left: Omit<GroupLeaderboardUser, "rank">,
+  right: Omit<GroupLeaderboardUser, "rank">,
+  sortBy: SortBy
+): number {
+  const primary = sortBy === "cost"
+    ? right.totalCost - left.totalCost
+    : right.totalTokens - left.totalTokens;
+
+  if (primary !== 0) return primary;
+
+  const secondary = sortBy === "cost"
+    ? right.totalTokens - left.totalTokens
+    : right.totalCost - left.totalCost;
+
+  if (secondary !== 0) return secondary;
+
+  return left.username.localeCompare(right.username);
+}
+
+function matchesSearch(user: Pick<GroupLeaderboardUser, "username">, search: string): boolean {
+  return !search || user.username.toLowerCase().includes(search.toLowerCase());
+}
+
+function paginateRankedUsers(
+  usersWithRanks: GroupLeaderboardUser[],
+  page: number,
+  limit: number,
+  period: Period,
+  sortBy: SortBy,
+  search: string,
+  totalMembers: number,
+  totalSubmissions: number | null
+): GroupLeaderboardData {
+  const offset = (page - 1) * limit;
+  const filteredUsers = usersWithRanks.filter((user) => matchesSearch(user, search));
+  const pagedUsers = filteredUsers.slice(offset, offset + limit);
+
+  return {
+    users: pagedUsers,
+    pagination: {
+      page,
+      limit,
+      totalUsers: filteredUsers.length,
+      totalPages: Math.ceil(filteredUsers.length / limit),
+      hasNext: offset + limit < filteredUsers.length,
+      hasPrev: page > 1,
+    },
+    stats: {
+      totalTokens: usersWithRanks.reduce((sum, user) => sum + user.totalTokens, 0),
+      totalCost: usersWithRanks.reduce((sum, user) => sum + user.totalCost, 0),
+      totalSubmissions,
+      uniqueUsers: usersWithRanks.length,
+      activeUsers: usersWithRanks.length,
+      totalMembers,
+    },
+    period,
+    sortBy,
+  };
+}
+
+function buildPeriodGroupLeaderboardData(
+  rows: GroupLeaderboardPeriodRow[],
+  page: number,
+  limit: number,
+  period: Period,
+  sortBy: SortBy,
+  search: string,
+  totalMembers: number
+): GroupLeaderboardData {
+  const usersById = new Map<string, Omit<GroupLeaderboardUser, "rank">>();
+
+  for (const row of rows) {
+    const existing = usersById.get(row.userId);
+    if (existing) {
+      existing.totalTokens += row.tokens;
+      existing.totalCost += row.cost;
+      if (row.updatedAt > existing.lastSubmission) {
+        existing.lastSubmission = row.updatedAt;
+        existing.submissionFreshness = buildSubmissionFreshness({
+          updatedAt: row.updatedAt,
+          cliVersion: row.cliVersion,
+          schemaVersion: row.schemaVersion,
+        });
+      }
+      continue;
+    }
+
+    usersById.set(row.userId, {
+      userId: row.userId,
+      username: row.username,
+      displayName: row.displayName,
+      avatarUrl: row.avatarUrl,
+      role: row.role,
+      totalTokens: row.tokens,
+      totalCost: row.cost,
+      submissionCount: null,
+      lastSubmission: row.updatedAt,
+      submissionFreshness: buildSubmissionFreshness({
+        updatedAt: row.updatedAt,
+        cliVersion: row.cliVersion,
+        schemaVersion: row.schemaVersion,
+      }),
+    });
+  }
+
+  const rankedUsers = Array.from(usersById.values())
+    .sort((left, right) => compareGroupUsers(left, right, sortBy))
+    .map((user, index) => ({ ...user, rank: index + 1 }));
+
+  return paginateRankedUsers(
+    rankedUsers,
+    page,
+    limit,
+    period,
+    sortBy,
+    search,
+    totalMembers,
+    null
+  );
+}
+
+async function countGroupMembers(groupId: string): Promise<number> {
+  const memberCount = await db
+    .select({ count: sql<number>`CAST(COUNT(*) AS integer)`.as("count") })
+    .from(groupMembers)
+    .where(eq(groupMembers.groupId, groupId));
+
+  return Number(memberCount[0]?.count) || 0;
+}
+
+async function fetchPeriodRows(
+  groupId: string,
+  period: Exclude<Period, "all">
+): Promise<GroupLeaderboardPeriodRow[]> {
+  const dateRange = getPeriodDateRange(period);
+  if (!dateRange) return [];
+
+  const rows = await db
+    .select({
+      userId: users.id,
+      username: users.username,
+      displayName: users.displayName,
+      avatarUrl: users.avatarUrl,
+      role: groupMembers.role,
+      tokens: dailyBreakdown.tokens,
+      cost: dailyBreakdown.cost,
+      updatedAt: submissions.updatedAt,
+      cliVersion: submissions.cliVersion,
+      schemaVersion: submissions.schemaVersion,
+    })
+    .from(dailyBreakdown)
+    .innerJoin(submissions, eq(dailyBreakdown.submissionId, submissions.id))
+    .innerJoin(users, eq(submissions.userId, users.id))
+    .innerJoin(
+      groupMembers,
+      and(
+        eq(groupMembers.userId, submissions.userId),
+        eq(groupMembers.groupId, groupId)
+      )
+    )
+    .where(and(gte(dailyBreakdown.date, dateRange.start), lte(dailyBreakdown.date, dateRange.end)));
+
+  return rows.map((row) => ({
+    userId: row.userId,
+    username: row.username,
+    displayName: row.displayName,
+    avatarUrl: row.avatarUrl,
+    role: row.role,
+    tokens: Number(row.tokens) || 0,
+    cost: Number(row.cost) || 0,
+    updatedAt: row.updatedAt instanceof Date
+      ? row.updatedAt.toISOString()
+      : new Date(row.updatedAt).toISOString(),
+    cliVersion: row.cliVersion,
+    schemaVersion: Number(row.schemaVersion) || 0,
+  }));
+}
+
+async function fetchAllTimeRows(groupId: string, sortBy: SortBy): Promise<GroupLeaderboardUser[]> {
+  const orderByColumn = sortBy === "cost"
+    ? sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`
+    : sql`SUM(${submissions.totalTokens})`;
+
+  const rows = await db
+    .select({
+      userId: users.id,
+      username: users.username,
+      displayName: users.displayName,
+      avatarUrl: users.avatarUrl,
+      role: groupMembers.role,
+      totalTokens: sql<number>`SUM(${submissions.totalTokens})`.as("total_tokens"),
+      totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`.as("total_cost"),
+      submissionCount: sql<number>`COALESCE(SUM(${submissions.submitCount}), 0)`.as("submission_count"),
+      lastSubmission: sql<string>`MAX(${submissions.updatedAt})`.as("last_submission"),
+      cliVersion: sql<string | null>`(
+        SELECT s2.cli_version FROM submissions s2
+        WHERE s2.user_id = ${users.id}
+        ORDER BY s2.updated_at DESC LIMIT 1
+      )`.as("cli_version"),
+      schemaVersion: sql<number>`COALESCE((
+        SELECT s2.schema_version FROM submissions s2
+        WHERE s2.user_id = ${users.id}
+        ORDER BY s2.updated_at DESC LIMIT 1
+      ), 0)`.as("schema_version"),
+    })
+    .from(submissions)
+    .innerJoin(users, eq(submissions.userId, users.id))
+    .innerJoin(
+      groupMembers,
+      and(
+        eq(groupMembers.userId, submissions.userId),
+        eq(groupMembers.groupId, groupId)
+      )
+    )
+    .groupBy(users.id, users.username, users.displayName, users.avatarUrl, groupMembers.role)
+    .orderBy(desc(orderByColumn));
+
+  return (rows as GroupLeaderboardDbRow[]).map((row, index) => ({
+    rank: index + 1,
+    userId: row.userId,
+    username: row.username,
+    displayName: row.displayName,
+    avatarUrl: row.avatarUrl,
+    role: row.role,
+    totalTokens: Number(row.totalTokens) || 0,
+    totalCost: Number(row.totalCost) || 0,
+    submissionCount: Number(row.submissionCount) || 0,
+    lastSubmission: row.lastSubmission,
+    submissionFreshness: buildSubmissionFreshness({
+      updatedAt: row.lastSubmission,
+      cliVersion: row.cliVersion,
+      schemaVersion: row.schemaVersion,
+    }),
+  }));
+}
+
+async function fetchGroupLeaderboardData(
+  groupId: string,
+  period: Period,
+  page: number,
+  limit: number,
+  sortBy: SortBy,
+  search: string
+): Promise<GroupLeaderboardData> {
+  const totalMembers = await countGroupMembers(groupId);
+
+  if (period !== "all") {
+    const rows = await fetchPeriodRows(groupId, period);
+    return buildPeriodGroupLeaderboardData(rows, page, limit, period, sortBy, search, totalMembers);
+  }
+
+  const usersWithRanks = await fetchAllTimeRows(groupId, sortBy);
+  const totalSubmissions = usersWithRanks.reduce(
+    (sum, user) => sum + (user.submissionCount ?? 0),
+    0
+  );
+
+  return paginateRankedUsers(
+    usersWithRanks,
+    page,
+    limit,
+    period,
+    sortBy,
+    search,
+    totalMembers,
+    totalSubmissions
+  );
+}
+
+export function getGroupLeaderboardData(
+  groupId: string,
+  period: Period = "all",
+  page: number = 1,
+  limit: number = 50,
+  sortBy: SortBy = "tokens",
+  search: string = ""
+): Promise<GroupLeaderboardData> {
+  return unstable_cache(
+    () => fetchGroupLeaderboardData(groupId, period, page, limit, sortBy, search),
+    [`group-leaderboard:${groupId}:${period}:${page}:${limit}:${sortBy}:${search}`],
+    {
+      tags: [
+        `group:${groupId}`,
+        `group-leaderboard:${groupId}`,
+        `group-leaderboard:${groupId}:${period}`,
+      ],
+      revalidate: 60,
+    }
+  )();
+}

--- a/packages/frontend/src/lib/groups/index.ts
+++ b/packages/frontend/src/lib/groups/index.ts
@@ -1,0 +1,15 @@
+export {
+  GROUP_SLUG_MAX_LENGTH,
+  canManageGroupRole,
+  createGroupInviteToken,
+  hashGroupInviteToken,
+  hasGroupRole,
+  isGroupRole,
+  normalizeInvitedUsername,
+  slugifyGroupName,
+} from "./utils";
+
+export type {
+  GroupInviteStatus,
+  GroupRole,
+} from "@/lib/db/schema";

--- a/packages/frontend/src/lib/groups/invites.ts
+++ b/packages/frontend/src/lib/groups/invites.ts
@@ -1,0 +1,199 @@
+import { and, eq, gt } from "drizzle-orm";
+import { db, groupInvites, groupMembers, groups, type GroupRole } from "@/lib/db";
+import type { SessionUser } from "@/lib/auth/session";
+import { isValidGitHubUsername } from "@/lib/validation/username";
+import {
+  createGroupInviteToken,
+  hashGroupInviteToken,
+  isGroupRole,
+  normalizeInvitedUsername,
+} from "./utils";
+
+export class GroupInviteError extends Error {
+  constructor(
+    public readonly code: "not_found" | "forbidden" | "invalid",
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+interface GroupInviteRow {
+  invite: typeof groupInvites.$inferSelect;
+  group: typeof groups.$inferSelect;
+}
+
+export interface GroupInvitePreview {
+  group: {
+    name: string;
+    slug: string;
+    isPublic: boolean;
+  };
+  role: GroupRole;
+  invitedUsername: string | null;
+  expiresAt: string;
+}
+
+export interface CreateGroupInviteInput {
+  groupId: string;
+  invitedBy: string;
+  role: GroupRole;
+  invitedUsername?: string | null;
+  invitedUserId?: string | null;
+  expiresAt?: Date;
+}
+
+export interface CreatedGroupInvite {
+  id: string;
+  token: string;
+  role: GroupRole;
+  invitedUsername: string | null;
+  expiresAt: Date;
+}
+
+function assertInviteRole(role: GroupRole): void {
+  if (!isGroupRole(role) || role === "owner") {
+    throw new GroupInviteError("invalid", "Invite role must be member or admin");
+  }
+}
+
+async function findPendingInviteByToken(token: string): Promise<GroupInviteRow | null> {
+  const tokenHash = hashGroupInviteToken(token);
+  const result = await db
+    .select({
+      invite: groupInvites,
+      group: groups,
+    })
+    .from(groupInvites)
+    .innerJoin(groups, eq(groupInvites.groupId, groups.id))
+    .where(
+      and(
+        eq(groupInvites.tokenHash, tokenHash),
+        eq(groupInvites.status, "pending"),
+        gt(groupInvites.expiresAt, new Date())
+      )
+    )
+    .limit(1);
+
+  return result[0] ?? null;
+}
+
+export async function getGroupInvitePreview(token: string): Promise<GroupInvitePreview> {
+  const row = await findPendingInviteByToken(token);
+
+  if (!row) {
+    throw new GroupInviteError("not_found", "Invalid or expired invite");
+  }
+
+  return {
+    group: {
+      name: row.group.name,
+      slug: row.group.slug,
+      isPublic: row.group.isPublic,
+    },
+    role: row.invite.role,
+    invitedUsername: row.invite.invitedUsername,
+    expiresAt: row.invite.expiresAt.toISOString(),
+  };
+}
+
+export async function createGroupInvite({
+  groupId,
+  invitedBy,
+  role,
+  invitedUsername = null,
+  invitedUserId = null,
+  expiresAt = new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+}: CreateGroupInviteInput): Promise<CreatedGroupInvite> {
+  assertInviteRole(role);
+
+  const normalizedUsername = invitedUsername
+    ? normalizeInvitedUsername(invitedUsername)
+    : null;
+
+  if (normalizedUsername && !isValidGitHubUsername(normalizedUsername)) {
+    throw new GroupInviteError("invalid", "Invalid GitHub username");
+  }
+
+  const token = createGroupInviteToken();
+  const tokenHash = hashGroupInviteToken(token);
+  const [created] = await db
+    .insert(groupInvites)
+    .values({
+      groupId,
+      invitedBy,
+      role,
+      invitedUsername: normalizedUsername,
+      invitedUsernameNormalized: normalizedUsername,
+      invitedUserId,
+      tokenHash,
+      expiresAt,
+    })
+    .returning({
+      id: groupInvites.id,
+      role: groupInvites.role,
+      invitedUsername: groupInvites.invitedUsername,
+      expiresAt: groupInvites.expiresAt,
+    });
+
+  return {
+    ...created,
+    token,
+  };
+}
+
+export async function acceptGroupInvite(token: string, session: SessionUser) {
+  const row = await findPendingInviteByToken(token);
+
+  if (!row) {
+    throw new GroupInviteError("not_found", "Invalid or expired invite");
+  }
+
+  const { invite, group } = row;
+  const normalizedSessionUsername = normalizeInvitedUsername(session.username);
+
+  if (invite.invitedUserId && invite.invitedUserId !== session.id) {
+    throw new GroupInviteError("forbidden", "This invite is not for your account");
+  }
+
+  if (
+    invite.invitedUsernameNormalized &&
+    invite.invitedUsernameNormalized !== normalizedSessionUsername
+  ) {
+    throw new GroupInviteError("forbidden", "This invite is not for your GitHub username");
+  }
+
+  await db.transaction(async (tx) => {
+    const existingMember = await tx
+      .select({ id: groupMembers.id })
+      .from(groupMembers)
+      .where(and(eq(groupMembers.groupId, group.id), eq(groupMembers.userId, session.id)))
+      .limit(1);
+
+    if (existingMember.length === 0) {
+      await tx.insert(groupMembers).values({
+        groupId: group.id,
+        userId: session.id,
+        role: invite.role,
+        invitedBy: invite.invitedBy,
+      });
+    }
+
+    await tx
+      .update(groupInvites)
+      .set({
+        status: "accepted",
+        acceptedAt: new Date(),
+      })
+      .where(eq(groupInvites.id, invite.id));
+  });
+
+  return {
+    group: {
+      id: group.id,
+      name: group.name,
+      slug: group.slug,
+    },
+    role: invite.role,
+  };
+}

--- a/packages/frontend/src/lib/groups/invites.ts
+++ b/packages/frontend/src/lib/groups/invites.ts
@@ -163,29 +163,39 @@ export async function acceptGroupInvite(token: string, session: SessionUser) {
     throw new GroupInviteError("forbidden", "This invite is not for your GitHub username");
   }
 
-  await db.transaction(async (tx) => {
-    const existingMember = await tx
-      .select({ id: groupMembers.id })
-      .from(groupMembers)
-      .where(and(eq(groupMembers.groupId, group.id), eq(groupMembers.userId, session.id)))
-      .limit(1);
+  const acceptedAt = new Date();
 
-    if (existingMember.length === 0) {
-      await tx.insert(groupMembers).values({
+  await db.transaction(async (tx) => {
+    const claimed = await tx
+      .update(groupInvites)
+      .set({
+        status: "accepted",
+        acceptedAt,
+      })
+      .where(
+        and(
+          eq(groupInvites.id, invite.id),
+          eq(groupInvites.status, "pending"),
+          gt(groupInvites.expiresAt, acceptedAt)
+        )
+      )
+      .returning({ id: groupInvites.id });
+
+    if (claimed.length === 0) {
+      throw new GroupInviteError("not_found", "Invalid or expired invite");
+    }
+
+    await tx
+      .insert(groupMembers)
+      .values({
         groupId: group.id,
         userId: session.id,
         role: invite.role,
         invitedBy: invite.invitedBy,
-      });
-    }
-
-    await tx
-      .update(groupInvites)
-      .set({
-        status: "accepted",
-        acceptedAt: new Date(),
       })
-      .where(eq(groupInvites.id, invite.id));
+      .onConflictDoNothing({
+        target: [groupMembers.groupId, groupMembers.userId],
+      });
   });
 
   return {

--- a/packages/frontend/src/lib/groups/permissions.ts
+++ b/packages/frontend/src/lib/groups/permissions.ts
@@ -1,0 +1,47 @@
+import { and, eq } from "drizzle-orm";
+import { db, groupMembers, type GroupRole } from "@/lib/db";
+import { canManageGroupRole, hasGroupRole } from "./utils";
+
+export interface GroupMembership {
+  role: GroupRole;
+}
+
+export async function getGroupMembership(
+  groupId: string,
+  userId: string
+): Promise<GroupMembership | null> {
+  const result = await db
+    .select({ role: groupMembers.role })
+    .from(groupMembers)
+    .where(and(eq(groupMembers.groupId, groupId), eq(groupMembers.userId, userId)))
+    .limit(1);
+
+  return result[0] ? { role: result[0].role } : null;
+}
+
+export async function requireGroupRole(
+  groupId: string,
+  userId: string,
+  requiredRole: GroupRole
+): Promise<GroupMembership | null> {
+  const membership = await getGroupMembership(groupId, userId);
+
+  if (!membership || !hasGroupRole(membership.role, requiredRole)) {
+    return null;
+  }
+
+  return membership;
+}
+
+export async function canManageGroupMember(
+  groupId: string,
+  actorUserId: string,
+  targetUserId: string
+): Promise<boolean> {
+  const [actor, target] = await Promise.all([
+    getGroupMembership(groupId, actorUserId),
+    getGroupMembership(groupId, targetUserId),
+  ]);
+
+  return !!actor && !!target && canManageGroupRole(actor.role, target.role);
+}

--- a/packages/frontend/src/lib/groups/queries.ts
+++ b/packages/frontend/src/lib/groups/queries.ts
@@ -1,0 +1,127 @@
+import { and, desc, eq, sql } from "drizzle-orm";
+import { db, groupMembers, groups, type Group, type GroupRole } from "@/lib/db";
+
+export interface GroupSummary extends Group {
+  memberCount: number;
+  role?: GroupRole;
+}
+
+function mapGroupSummary(row: Group & { memberCount?: number | string; role?: GroupRole }): GroupSummary {
+  return {
+    ...row,
+    memberCount: Number(row.memberCount) || 0,
+    role: row.role,
+  };
+}
+
+export async function getGroupBySlug(slug: string): Promise<Group | null> {
+  const result = await db.select().from(groups).where(eq(groups.slug, slug)).limit(1);
+  return result[0] ?? null;
+}
+
+export async function getGroupMemberCount(groupId: string): Promise<number> {
+  const result = await db
+    .select({ count: sql<number>`CAST(COUNT(*) AS integer)`.as("count") })
+    .from(groupMembers)
+    .where(eq(groupMembers.groupId, groupId));
+
+  return Number(result[0]?.count) || 0;
+}
+
+export async function listPublicGroups(page: number, limit: number) {
+  const offset = (page - 1) * limit;
+  const [items, countRows] = await Promise.all([
+    db
+      .select({
+        id: groups.id,
+        name: groups.name,
+        slug: groups.slug,
+        description: groups.description,
+        avatarUrl: groups.avatarUrl,
+        isPublic: groups.isPublic,
+        createdBy: groups.createdBy,
+        createdAt: groups.createdAt,
+        updatedAt: groups.updatedAt,
+        memberCount: sql<number>`CAST(COUNT(${groupMembers.id}) AS integer)`.as("member_count"),
+      })
+      .from(groups)
+      .leftJoin(groupMembers, eq(groupMembers.groupId, groups.id))
+      .where(eq(groups.isPublic, true))
+      .groupBy(groups.id)
+      .orderBy(desc(groups.updatedAt))
+      .limit(limit)
+      .offset(offset),
+    db
+      .select({ count: sql<number>`CAST(COUNT(*) AS integer)`.as("count") })
+      .from(groups)
+      .where(eq(groups.isPublic, true)),
+  ]);
+
+  const total = Number(countRows[0]?.count) || 0;
+
+  return {
+    groups: items.map(mapGroupSummary),
+    pagination: {
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit),
+      hasNext: offset + items.length < total,
+      hasPrev: page > 1,
+    },
+  };
+}
+
+export async function listUserGroups(userId: string, page: number, limit: number) {
+  const offset = (page - 1) * limit;
+  const [items, countRows] = await Promise.all([
+    db
+      .select({
+        id: groups.id,
+        name: groups.name,
+        slug: groups.slug,
+        description: groups.description,
+        avatarUrl: groups.avatarUrl,
+        isPublic: groups.isPublic,
+        createdBy: groups.createdBy,
+        createdAt: groups.createdAt,
+        updatedAt: groups.updatedAt,
+        role: groupMembers.role,
+        memberCount: sql<number>`CAST((SELECT COUNT(*) FROM "group_members" WHERE "group_members"."group_id" = ${groups.id}) AS integer)`.as("member_count"),
+      })
+      .from(groupMembers)
+      .innerJoin(groups, eq(groupMembers.groupId, groups.id))
+      .where(eq(groupMembers.userId, userId))
+      .orderBy(desc(groups.updatedAt))
+      .limit(limit)
+      .offset(offset),
+    db
+      .select({ count: sql<number>`CAST(COUNT(*) AS integer)`.as("count") })
+      .from(groupMembers)
+      .where(eq(groupMembers.userId, userId)),
+  ]);
+
+  const total = Number(countRows[0]?.count) || 0;
+
+  return {
+    groups: items.map(mapGroupSummary),
+    pagination: {
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit),
+      hasNext: offset + items.length < total,
+      hasPrev: page > 1,
+    },
+  };
+}
+
+export async function isGroupMember(groupId: string, userId: string): Promise<boolean> {
+  const result = await db
+    .select({ id: groupMembers.id })
+    .from(groupMembers)
+    .where(and(eq(groupMembers.groupId, groupId), eq(groupMembers.userId, userId)))
+    .limit(1);
+
+  return result.length > 0;
+}

--- a/packages/frontend/src/lib/groups/slugs.ts
+++ b/packages/frontend/src/lib/groups/slugs.ts
@@ -1,0 +1,27 @@
+import { eq } from "drizzle-orm";
+import { db, groups } from "@/lib/db";
+import { slugifyGroupName } from "./utils";
+
+interface SlugDb {
+  select: typeof db.select;
+}
+
+export async function generateUniqueGroupSlug(
+  name: string,
+  queryDb: SlugDb = db
+): Promise<string> {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    const slug = slugifyGroupName(name, attempt === 0 ? {} : { suffix: attempt });
+    const existing = await queryDb
+      .select({ id: groups.id })
+      .from(groups)
+      .where(eq(groups.slug, slug))
+      .limit(1);
+
+    if (existing.length === 0) {
+      return slug;
+    }
+  }
+
+  return slugifyGroupName(name, { suffix: Date.now().toString(36) });
+}

--- a/packages/frontend/src/lib/groups/utils.ts
+++ b/packages/frontend/src/lib/groups/utils.ts
@@ -1,0 +1,63 @@
+import { generateRandomString, hashToken } from "../auth/utils";
+import { groupRoles, type GroupRole } from "../db/schema";
+
+export const GROUP_SLUG_MAX_LENGTH = 100;
+
+const RESERVED_GROUP_SLUGS = new Set(["new", "join", "settings", "members"]);
+const ROLE_LEVEL: Record<GroupRole, number> = {
+  owner: 3,
+  admin: 2,
+  member: 1,
+};
+
+interface SlugOptions {
+  suffix?: string | number;
+}
+
+export function isGroupRole(role: unknown): role is GroupRole {
+  return typeof role === "string" && groupRoles.includes(role as GroupRole);
+}
+
+export function hasGroupRole(userRole: GroupRole, requiredRole: GroupRole): boolean {
+  return ROLE_LEVEL[userRole] >= ROLE_LEVEL[requiredRole];
+}
+
+export function canManageGroupRole(actorRole: GroupRole, targetRole: GroupRole): boolean {
+  return ROLE_LEVEL[actorRole] > ROLE_LEVEL[targetRole];
+}
+
+export function normalizeInvitedUsername(username: string): string {
+  return username.trim().replace(/^@/, "").toLowerCase();
+}
+
+export function slugifyGroupName(name: string, options: SlugOptions = {}): string {
+  const rawBase = name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/[\s_]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+
+  let base = rawBase;
+  if (!base || RESERVED_GROUP_SLUGS.has(base)) {
+    const suffix = generateRandomString(8);
+    base = base ? `${base}-${suffix}` : `group-${suffix}`;
+  }
+
+  const suffix = options.suffix === undefined ? "" : `-${options.suffix}`;
+  const maxBaseLength = GROUP_SLUG_MAX_LENGTH - suffix.length;
+  const trimmedBase = base
+    .slice(0, Math.max(1, maxBaseLength))
+    .replace(/-+$/g, "");
+
+  return `${trimmedBase}${suffix}`.slice(0, GROUP_SLUG_MAX_LENGTH);
+}
+
+export function createGroupInviteToken(): string {
+  return `tg_${generateRandomString(48)}`;
+}
+
+export function hashGroupInviteToken(token: string): string {
+  return hashToken(token);
+}

--- a/packages/frontend/src/lib/groups/utils.ts
+++ b/packages/frontend/src/lib/groups/utils.ts
@@ -34,8 +34,8 @@ export function slugifyGroupName(name: string, options: SlugOptions = {}): strin
   const rawBase = name
     .toLowerCase()
     .trim()
-    .replace(/[^a-z0-9\s-]/g, "")
     .replace(/[\s_]+/g, "-")
+    .replace(/[^a-z0-9-]/g, "")
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "");
 


### PR DESCRIPTION
## Summary
* Add group-scoped leaderboards so teams, workspaces, and cohorts can compare usage independently from the global leaderboard.
* Add public/private groups, owner/admin/member roles, hashed invite links, optional username-targeted invites, and member management APIs.
* Add the `/groups` UI flow for listing groups, creating groups, joining by invite, viewing a scoped leaderboard, copying invite links, leaving groups, and managing members.
* Invalidate group leaderboard caches when a user's submitted usage is created, replaced, or deleted.

## Why
The global leaderboard is useful for public ranking, but it does not cover private teams or custom communities that need scoped usage comparisons. This change keeps the existing global leaderboard intact and adds a membership-gated leaderboard surface for groups. Related to #462.

## Diff scope
* Database: adds `groups`, `group_members`, and `group_invites` through `packages/frontend/src/lib/db/migrations/0006_add_groups.sql`, with schema relations and supporting indexes in Drizzle.
* Server APIs: adds group creation/list/detail, invite, join, leave, member listing, member role update/removal, user-group listing, and group leaderboard routes.
* Leaderboard logic: adds `packages/frontend/src/lib/groups/getGroupLeaderboard.ts` with all-time, weekly, and monthly scoped ranking support over group membership.
* Auth and permissions: adds request-session lookup plus group role helpers for owner/admin/member access checks.
* UI: adds `/groups`, `/groups/new`, `/groups/[slug]`, and `/groups/join/[token]`, plus navigation entry.
* Cache invalidation: clears group leaderboard caches after submit and submitted-data delete paths.
* Tests: adds API and library coverage for invite/join behavior, scoped leaderboard behavior, helper logic, and cache invalidation integration.

## Branch integrity
* Base branch: `main`
* Validated base SHA: `3a9045bc1b9aa245ca44ffcdca68bdaaa09520eb`
* Head branch: `IvGolovach:codex/group-scoped-leaderboards`
* Head SHA: `68ad3c4f25ac75f43b68ffbf24c7f1e2fee0ea37`
* Ahead/behind: `0 behind, 1 ahead`
* Merge base: `3a9045bc1b9aa245ca44ffcdca68bdaaa09520eb`
* Fast-forward safety: `origin/main` is an ancestor of this branch.

## Commit integrity
* `68ad3c4f25ac75f43b68ffbf24c7f1e2fee0ea37 feat(groups): add scoped leaderboards with invites`
* One logical feature commit.
* Final PR diff contains only the group leaderboard feature, its migration, its API/UI/library tests, and required submit/delete cache invalidation.

## Diff hygiene
* `git diff --name-status origin/main...HEAD`: PASS, 38 intended frontend files changed.
* `git diff --check origin/main...HEAD`: PASS, no output.


## Validation mode and proof
* Validation mode: Mode 3 — this adds a frontend database migration, access-controlled API routes, cache invalidation paths, and a user-facing group leaderboard flow.
* `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS
* `git diff --check`: PASS
* `git diff --cached --check`: PASS
* `git diff --check origin/main...HEAD`: PASS, no output
* `bunx vitest run`: PASS, 25 files and 188 tests
* `bun run lint`: PASS, 0 errors; existing warnings remain outside this change
* `bun run build`: PASS
* Remote CI: Pending — this PR page has not been submitted yet.

## Migration notes
* Migration file: `packages/frontend/src/lib/db/migrations/0006_add_groups.sql`
* Classification: additive.
* New tables: `groups`, `group_members`, `group_invites`.
* Existing data: no existing users, submissions, sessions, API tokens, or leaderboard rows are rewritten.
* Backfill: not required.
* Existing-state guards: tables and indexes use `IF NOT EXISTS`; group slugs, group membership, and invite token hashes are protected by uniqueness constraints.
* Rollback caveat: if the migration has already been applied, rollback requires removing the new group tables and related indexes after deciding whether any post-deploy group data should be retained.

## Runtime safety
* Reviewed runtime paths: group API routes, group permission helpers, invite token hashing/lookup, scoped leaderboard queries, submit cache invalidation, and submitted-data delete cache invalidation.
* No new blocking locks, unbounded queues, background jobs, or external service calls are introduced.
* No invariant regression introduced.

## Documentation integrity
Not applicable — no docs, runbooks, release procedures, commands, or operational instructions changed.

## Rollback plan
* Code rollback: revert this PR.
* DB downgrade: if the migration was applied, drop the new group tables and their indexes/constraints after preserving any group data that must survive rollback.
* Data repair: not applicable for existing usage submissions or global leaderboard data.
* Operational caveats: the group UI/API requires the additive migration before use.

## Known residual risks
* The feature is intentionally additive, but production use depends on the database migration being applied before users access group routes.



