### PR TITLE
feat: add session time metrics (active time tracking per contribution)

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -286,6 +286,19 @@ enum Commands {
     },
     #[command(about = "Delete all submitted usage data from the server")]
     DeleteSubmittedData,
+    #[command(
+        about = "Show session time metrics (usage time, longest continuous, max concurrent)"
+    )]
+    TimeMetrics {
+        #[arg(long)]
+        json: bool,
+        #[command(flatten)]
+        clients: ClientFlags,
+        #[command(flatten)]
+        date: DateRangeFlags,
+        #[arg(long, help = "Disable spinner")]
+        no_spinner: bool,
+    },
     #[command(about = "Warm TUI cache in background (internal)", hide = true)]
     WarmTuiCache,
 }
@@ -664,6 +677,28 @@ fn main() -> Result<()> {
         Some(Commands::DeleteSubmittedData) => {
             reject_unsupported_home_override(&cli.home, "delete-submitted-data")?;
             run_delete_data_command()
+        }
+        Some(Commands::TimeMetrics {
+            json,
+            clients,
+            date,
+            no_spinner,
+        }) => {
+            let today = date.today;
+            let week = date.week;
+            let month = date.month;
+            let (since, until) = build_date_filter(today, week, month, date.since, date.until);
+            let year = normalize_year_filter(today, week, month, date.year);
+            let clients = build_client_filter(clients);
+            run_time_metrics_report(
+                json,
+                cli.home.clone(),
+                clients,
+                since,
+                until,
+                year,
+                no_spinner,
+            )
         }
         Some(Commands::WarmTuiCache) => run_warm_tui_cache(),
         None => {
@@ -3682,6 +3717,8 @@ struct TsDailyContribution {
     intensity: u8,
     token_breakdown: TsTokenBreakdown,
     clients: Vec<TsSourceContribution>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    active_time_ms: Option<i64>,
 }
 
 #[derive(serde::Serialize)]
@@ -3730,6 +3767,15 @@ struct TsSubmitDevice {
 
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
+struct TsTimeMetrics {
+    total_active_time_ms: i64,
+    longest_continuous_ms: i64,
+    max_concurrent_sessions: u32,
+    session_count: u32,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 struct TsTokenContributionData {
     meta: TsExportMeta,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3737,6 +3783,8 @@ struct TsTokenContributionData {
     summary: TsDataSummary,
     years: Vec<TsYearSummary>,
     contributions: Vec<TsDailyContribution>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    time_metrics: Option<TsTimeMetrics>,
 }
 
 fn to_ts_token_contribution_data(
@@ -3819,8 +3867,15 @@ fn to_ts_token_contribution_data(
                         messages: s.messages,
                     })
                     .collect(),
+                active_time_ms: d.active_time_ms,
             })
             .collect(),
+        time_metrics: graph.time_metrics.as_ref().map(|tm| TsTimeMetrics {
+            total_active_time_ms: tm.total_active_time_ms,
+            longest_continuous_ms: tm.longest_continuous_ms,
+            max_concurrent_sessions: tm.max_concurrent_sessions,
+            session_count: tm.session_count,
+        }),
     }
 }
 
@@ -4147,6 +4202,92 @@ fn prompt_star_repo(username: &str) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_time_metrics_report(
+    json: bool,
+    home_dir: Option<String>,
+    clients: Option<Vec<String>>,
+    since: Option<String>,
+    until: Option<String>,
+    year: Option<String>,
+    no_spinner: bool,
+) -> Result<()> {
+    use tokio::runtime::Runtime;
+    use tokscale_core::{get_time_metrics_report, GroupBy, ReportOptions};
+
+    let spinner = if no_spinner {
+        None
+    } else {
+        Some(LightSpinner::start("Computing time metrics..."))
+    };
+    let use_env_roots = use_env_roots(&home_dir);
+    let rt = Runtime::new()?;
+    let report = rt
+        .block_on(async {
+            get_time_metrics_report(ReportOptions {
+                home_dir,
+                use_env_roots,
+                clients,
+                since,
+                until,
+                year,
+                group_by: GroupBy::default(),
+                scanner_settings: tui::settings::load_scanner_settings(),
+            })
+            .await
+        })
+        .map_err(|e| anyhow::anyhow!(e))?;
+
+    if let Some(spinner) = spinner {
+        spinner.stop();
+    }
+
+    let m = &report.metrics;
+
+    if json {
+        let output = serde_json::to_string_pretty(&report).unwrap_or_default();
+        println!("{}", output);
+    } else {
+        println!("Session Time Metrics");
+        println!("====================");
+        println!(
+            "Total active time:       {}",
+            format_duration_ms(m.total_active_time_ms)
+        );
+        println!(
+            "Total wall-clock time:   {}",
+            format_duration_ms(m.total_wall_time_ms)
+        );
+        println!(
+            "Longest continuous use:  {}",
+            format_duration_ms(m.longest_continuous_ms)
+        );
+        println!("Max concurrent sessions: {}", m.max_concurrent_sessions);
+        println!("Total sessions:          {}", m.session_count);
+        println!("Processing time:         {}ms", report.processing_time_ms);
+    }
+
+    Ok(())
+}
+
+fn format_duration_ms(ms: i64) -> String {
+    if ms <= 0 {
+        return "0s".to_string();
+    }
+    let total_secs = ms / 1000;
+    let hours = total_secs / 3600;
+    let minutes = (total_secs % 3600) / 60;
+    let secs = total_secs % 60;
+
+    if hours > 0 {
+        format!("{}h {}m {}s", hours, minutes, secs)
+    } else if minutes > 0 {
+        format!("{}m {}s", minutes, secs)
+    } else {
+        format!("{}s", secs)
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -5164,6 +5305,7 @@ mod tests {
                 cost: total_cost,
                 messages: 1,
             }],
+            active_time_ms: None,
         }
     }
 
@@ -5185,6 +5327,7 @@ mod tests {
             summary: calculate_summary(&contributions),
             years: calculate_years(&contributions),
             contributions,
+            time_metrics: None,
         }
     }
 

--- a/crates/tokscale-core/src/aggregator.rs
+++ b/crates/tokscale-core/src/aggregator.rs
@@ -211,6 +211,7 @@ pub fn generate_graph_result(
         summary,
         years,
         contributions,
+        time_metrics: None,
     }
 }
 
@@ -434,6 +435,7 @@ impl DayAccumulator {
             intensity: 0,
             token_breakdown,
             clients,
+            active_time_ms: None,
         }
     }
 }
@@ -914,6 +916,7 @@ mod tests {
                 intensity: 0,
                 token_breakdown: TokenBreakdown::default(),
                 clients: Vec::new(),
+                active_time_ms: None,
             },
             DailyContribution {
                 date: "2024-01-02".to_string(),
@@ -925,6 +928,7 @@ mod tests {
                 intensity: 0,
                 token_breakdown: TokenBreakdown::default(),
                 clients: Vec::new(),
+                active_time_ms: None,
             },
         ];
 
@@ -1012,6 +1016,7 @@ mod tests {
             intensity: 0,
             token_breakdown: TokenBreakdown::default(),
             clients: Vec::new(),
+            active_time_ms: None,
         }];
 
         let years = calculate_years(&contributions);
@@ -1069,6 +1074,7 @@ mod tests {
                 intensity: 0,
                 token_breakdown: TokenBreakdown::default(),
                 clients: Vec::new(),
+                active_time_ms: None,
             },
             DailyContribution {
                 date: "2024-01-02".to_string(),
@@ -1080,6 +1086,7 @@ mod tests {
                 intensity: 0,
                 token_breakdown: TokenBreakdown::default(),
                 clients: Vec::new(),
+                active_time_ms: None,
             },
         ];
 
@@ -1101,6 +1108,7 @@ mod tests {
                 intensity: 0,
                 token_breakdown: TokenBreakdown::default(),
                 clients: Vec::new(),
+                active_time_ms: None,
             },
             DailyContribution {
                 date: "2024-01-02".to_string(),
@@ -1112,6 +1120,7 @@ mod tests {
                 intensity: 0,
                 token_breakdown: TokenBreakdown::default(),
                 clients: Vec::new(),
+                active_time_ms: None,
             },
             DailyContribution {
                 date: "2024-01-03".to_string(),
@@ -1123,6 +1132,7 @@ mod tests {
                 intensity: 0,
                 token_breakdown: TokenBreakdown::default(),
                 clients: Vec::new(),
+                active_time_ms: None,
             },
             DailyContribution {
                 date: "2024-01-04".to_string(),
@@ -1134,6 +1144,7 @@ mod tests {
                 intensity: 0,
                 token_breakdown: TokenBreakdown::default(),
                 clients: Vec::new(),
+                active_time_ms: None,
             },
             DailyContribution {
                 date: "2024-01-05".to_string(),
@@ -1145,6 +1156,7 @@ mod tests {
                 intensity: 0,
                 token_breakdown: TokenBreakdown::default(),
                 clients: Vec::new(),
+                active_time_ms: None,
             },
         ];
 
@@ -1170,6 +1182,7 @@ mod tests {
                 intensity: 0,
                 token_breakdown: TokenBreakdown::default(),
                 clients: Vec::new(),
+                active_time_ms: None,
             },
             DailyContribution {
                 date: "2024-01-02".to_string(),
@@ -1181,6 +1194,7 @@ mod tests {
                 intensity: 0,
                 token_breakdown: TokenBreakdown::default(),
                 clients: Vec::new(),
+                active_time_ms: None,
             },
             DailyContribution {
                 date: "2024-01-03".to_string(),
@@ -1192,6 +1206,7 @@ mod tests {
                 intensity: 0,
                 token_breakdown: TokenBreakdown::default(),
                 clients: Vec::new(),
+                active_time_ms: None,
             },
             DailyContribution {
                 date: "2024-01-04".to_string(),
@@ -1203,6 +1218,7 @@ mod tests {
                 intensity: 0,
                 token_breakdown: TokenBreakdown::default(),
                 clients: Vec::new(),
+                active_time_ms: None,
             },
         ];
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -9,12 +9,17 @@ pub mod paths;
 pub mod pricing;
 mod provider_identity;
 pub mod scanner;
+pub mod sessionize;
 pub mod sessions;
 
 pub use aggregator::*;
 pub use clients::{ClientCounts, ClientDef, ClientId, PathRoot};
 pub use parser::*;
 pub use scanner::*;
+pub use sessionize::{
+    compute_daily_active_time, compute_time_metrics, sessionize, SessionInterval, TimeMetrics,
+    DEFAULT_IDLE_GAP_MS,
+};
 pub use sessions::UnifiedMessage;
 
 use rayon::prelude::*;
@@ -319,6 +324,8 @@ pub struct DailyContribution {
     pub intensity: u8,
     pub token_breakdown: TokenBreakdown,
     pub clients: Vec<ClientContribution>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_time_ms: Option<i64>,
 }
 
 /// Per-session aggregate of token usage, cost, and timing — keyed on
@@ -375,6 +382,8 @@ pub struct GraphResult {
     pub summary: DataSummary,
     pub years: Vec<YearSummary>,
     pub contributions: Vec<DailyContribution>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_metrics: Option<sessionize::TimeMetrics>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1725,12 +1734,63 @@ async fn generate_graph_with_loaded_pricing(
 
     let filtered = filter_messages_for_report(all_messages, &options);
 
+    let intervals = sessionize::sessionize(&filtered, sessionize::DEFAULT_IDLE_GAP_MS);
+    let time_metrics =
+        sessionize::compute_time_metrics(&intervals, sessionize::DEFAULT_IDLE_GAP_MS);
+
+    let daily_active_time = sessionize::compute_daily_active_time(&intervals);
     let contributions = aggregator::aggregate_by_date(filtered);
 
     let processing_time_ms = start.elapsed().as_millis() as u32;
-    let result = aggregator::generate_graph_result(contributions, processing_time_ms);
+    let mut result = aggregator::generate_graph_result(contributions, processing_time_ms);
+    result.time_metrics = Some(time_metrics);
+
+    for contribution in &mut result.contributions {
+        if let Some(&ms) = daily_active_time.get(&contribution.date) {
+            contribution.active_time_ms = Some(ms);
+        }
+    }
 
     Ok(result)
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct TimeMetricsReport {
+    pub metrics: sessionize::TimeMetrics,
+    pub processing_time_ms: u32,
+}
+
+pub async fn get_time_metrics_report(options: ReportOptions) -> Result<TimeMetricsReport, String> {
+    let start = Instant::now();
+
+    let home_dir = get_home_dir_string(&options.home_dir)?;
+
+    let clients: Vec<String> = options.clients.clone().unwrap_or_else(|| {
+        let mut clients: Vec<String> = ClientId::ALL
+            .iter()
+            .map(|c| c.as_str().to_string())
+            .collect();
+        clients.push("synthetic".to_string());
+        clients
+    });
+
+    let all_messages = parse_all_messages_with_pricing_with_env_strategy(
+        &home_dir,
+        &clients,
+        None,
+        options.use_env_roots,
+        &options.scanner_settings,
+    );
+
+    let filtered = filter_messages_for_report(all_messages, &options);
+
+    let intervals = sessionize::sessionize(&filtered, sessionize::DEFAULT_IDLE_GAP_MS);
+    let metrics = sessionize::compute_time_metrics(&intervals, sessionize::DEFAULT_IDLE_GAP_MS);
+
+    Ok(TimeMetricsReport {
+        metrics,
+        processing_time_ms: start.elapsed().as_millis() as u32,
+    })
 }
 
 pub async fn generate_graph(options: ReportOptions) -> Result<GraphResult, String> {

--- a/crates/tokscale-core/src/sessionize.rs
+++ b/crates/tokscale-core/src/sessionize.rs
@@ -365,6 +365,7 @@ mod tests {
             agent: None,
             dedup_key: None,
             is_turn_start: false,
+            duration_ms: None,
         }
     }
 

--- a/crates/tokscale-core/src/sessionize.rs
+++ b/crates/tokscale-core/src/sessionize.rs
@@ -1,0 +1,608 @@
+//! Session interval derivation and time-based metrics.
+
+use crate::sessions::UnifiedMessage;
+use crate::TokenBreakdown;
+use std::collections::HashMap;
+
+/// Default idle gap threshold: 3 minutes (ms).
+pub const DEFAULT_IDLE_GAP_MS: i64 = 3 * 60 * 1000;
+
+/// A derived session interval representing one continuous usage session.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SessionInterval {
+    pub client: String,
+    pub session_id: String,
+    /// First message timestamp (Unix ms)
+    pub start_ts: i64,
+    /// Last message timestamp (Unix ms)
+    pub end_ts: i64,
+    /// Wall-clock duration: end_ts - start_ts
+    pub wall_duration_ms: i64,
+    /// Active duration excluding idle gaps beyond the threshold
+    pub active_duration_ms: i64,
+    pub message_count: i32,
+    pub tokens: TokenBreakdown,
+    pub cost: f64,
+}
+
+/// Time-based usage metrics computed from session intervals.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct TimeMetrics {
+    /// Total active usage time across all sessions (ms)
+    pub total_active_time_ms: i64,
+    /// Total wall-clock usage time across all sessions (ms)
+    pub total_wall_time_ms: i64,
+    /// Longest single session active duration (ms)
+    pub longest_continuous_ms: i64,
+    /// Peak number of sessions overlapping at the same time
+    pub max_concurrent_sessions: u32,
+    /// Total number of derived session intervals
+    pub session_count: u32,
+}
+
+/// Derive session intervals from unified messages.
+///
+/// Groups messages by `(client, session_id)`, sorts each group by timestamp,
+/// and computes per-session start/end/duration/active-time.
+///
+/// `idle_gap_ms` controls how much silence between messages is still counted
+/// as "active". Time gaps exceeding this threshold are excluded from
+/// `active_duration_ms`.
+pub fn sessionize(messages: &[UnifiedMessage], idle_gap_ms: i64) -> Vec<SessionInterval> {
+    if messages.is_empty() {
+        return Vec::new();
+    }
+
+    // Group by (client, session_id)
+    let mut groups: HashMap<(&str, &str), Vec<&UnifiedMessage>> = HashMap::new();
+    for msg in messages {
+        if msg.timestamp <= 0 {
+            continue;
+        }
+        groups
+            .entry((&msg.client, &msg.session_id))
+            .or_default()
+            .push(msg);
+    }
+
+    let mut intervals: Vec<SessionInterval> = Vec::with_capacity(groups.len());
+
+    for ((client, session_id), mut msgs) in groups {
+        // Sort by timestamp within session
+        msgs.sort_unstable_by_key(|m| m.timestamp);
+
+        let start_ts = msgs.first().unwrap().timestamp;
+        let end_ts = msgs.last().unwrap().timestamp;
+        let wall_duration_ms = end_ts - start_ts;
+
+        // Calculate active duration: sum of gaps that are <= idle_gap_ms
+        let mut active_duration_ms: i64 = 0;
+        for window in msgs.windows(2) {
+            let gap = window[1].timestamp - window[0].timestamp;
+            if gap <= idle_gap_ms {
+                active_duration_ms += gap;
+            }
+        }
+
+        // Aggregate tokens and cost
+        let mut tokens = TokenBreakdown::default();
+        let mut cost = 0.0;
+        let mut message_count: i32 = 0;
+
+        for msg in &msgs {
+            tokens.input += msg.tokens.input;
+            tokens.output += msg.tokens.output;
+            tokens.cache_read += msg.tokens.cache_read;
+            tokens.cache_write += msg.tokens.cache_write;
+            tokens.reasoning += msg.tokens.reasoning;
+            cost += msg.cost;
+            message_count += msg.message_count.max(1);
+        }
+
+        intervals.push(SessionInterval {
+            client: client.to_string(),
+            session_id: session_id.to_string(),
+            start_ts,
+            end_ts,
+            wall_duration_ms,
+            active_duration_ms,
+            message_count,
+            tokens,
+            cost,
+        });
+    }
+
+    // Sort by start time for downstream consumers
+    intervals.sort_unstable_by_key(|s| s.start_ts);
+    intervals
+}
+
+/// Compute time-based metrics from session intervals.
+///
+/// - `total_active_time_ms`: sum of all `active_duration_ms`
+/// - `total_wall_time_ms`: sum of all `wall_duration_ms`
+/// - `longest_continuous_ms`: longest merged activity window across ALL sessions
+///   (using the idle gap threshold to merge overlapping/adjacent activity)
+/// - `max_concurrent_sessions`: peak overlap of session wall-clock intervals
+pub fn compute_time_metrics(intervals: &[SessionInterval], _idle_gap_ms: i64) -> TimeMetrics {
+    if intervals.is_empty() {
+        return TimeMetrics {
+            total_active_time_ms: 0,
+            total_wall_time_ms: 0,
+            longest_continuous_ms: 0,
+            max_concurrent_sessions: 0,
+            session_count: 0,
+        };
+    }
+
+    let total_active_time_ms: i64 = intervals.iter().map(|s| s.active_duration_ms).sum();
+    let total_wall_time_ms: i64 = intervals.iter().map(|s| s.wall_duration_ms).sum();
+    let session_count = intervals.len() as u32;
+
+    // --- Longest continuous usage ---
+    // Collect all session [start, end] as activity windows, merge overlapping
+    // ones (with idle_gap_ms tolerance), find the longest merged span.
+    // Use active_duration_ms instead of wall-clock span to exclude idle gaps
+    // within sessions from inflating the metric.
+    let longest_continuous_ms = {
+        let mut windows: Vec<(i64, i64)> = intervals
+            .iter()
+            .filter(|s| s.start_ts > 0 && s.active_duration_ms > 0)
+            .map(|s| (s.start_ts, s.start_ts + s.active_duration_ms))
+            .collect();
+        windows.sort_unstable_by_key(|w| w.0);
+
+        let mut longest: i64 = 0;
+        if let Some(&first) = windows.first() {
+            let mut merged_start = first.0;
+            let mut merged_end = first.1;
+
+            for &(start, end) in &windows[1..] {
+                if start <= merged_end + _idle_gap_ms {
+                    // Overlapping or within idle gap tolerance — extend
+                    merged_end = merged_end.max(end);
+                } else {
+                    // Gap too large — finalize previous window
+                    longest = longest.max(merged_end - merged_start);
+                    merged_start = start;
+                    merged_end = end;
+                }
+            }
+            longest = longest.max(merged_end - merged_start);
+        }
+        longest
+    };
+
+    // --- Max concurrent sessions ---
+    let max_concurrent_sessions = compute_max_concurrent(intervals);
+
+    TimeMetrics {
+        total_active_time_ms,
+        total_wall_time_ms,
+        longest_continuous_ms,
+        max_concurrent_sessions,
+        session_count,
+    }
+}
+
+/// Sweep-line algorithm to find peak concurrent sessions.
+fn compute_max_concurrent(intervals: &[SessionInterval]) -> u32 {
+    if intervals.is_empty() {
+        return 0;
+    }
+
+    let mut events: Vec<(i64, i32)> = Vec::with_capacity(intervals.len() * 2);
+    for s in intervals {
+        if s.start_ts <= 0 {
+            continue;
+        }
+        events.push((s.start_ts, 1));
+        // For zero-duration sessions (start == end), push end as start+1
+        // so the +1 event is processed before the -1 event at the same logical point
+        let end = if s.end_ts <= s.start_ts {
+            s.start_ts + 1
+        } else {
+            s.end_ts
+        };
+        events.push((end, -1));
+    }
+
+    // Sort by time; ties broken by start (+1) before end (-1) so concurrent
+    // sessions at the same timestamp are counted together
+    events.sort_unstable_by(|a, b| a.0.cmp(&b.0).then(b.1.cmp(&a.1)));
+
+    let mut max_concurrent: u32 = 0;
+    let mut current: i32 = 0;
+
+    for (_, delta) in events {
+        current += delta;
+        if current > max_concurrent as i32 {
+            max_concurrent = current as u32;
+        }
+    }
+
+    max_concurrent
+}
+
+/// Compute per-day active time (ms) from session intervals.
+///
+/// For each interval, distributes its `active_duration_ms` proportionally
+/// across the UTC days it spans. Single-day sessions get their full active
+/// time assigned to that day.
+pub fn compute_daily_active_time(
+    intervals: &[SessionInterval],
+) -> std::collections::HashMap<String, i64> {
+    use std::collections::HashMap;
+
+    let mut daily: HashMap<String, i64> = HashMap::new();
+
+    for interval in intervals {
+        if interval.active_duration_ms <= 0 {
+            continue;
+        }
+
+        let start_date = ts_to_date(interval.start_ts);
+        let end_date = ts_to_date(interval.end_ts);
+
+        if start_date == end_date {
+            *daily.entry(start_date).or_default() += interval.active_duration_ms;
+        } else {
+            let wall = interval.wall_duration_ms.max(1);
+            let days = dates_between(&start_date, &end_date);
+            for day in &days {
+                let day_start = date_to_ts(day);
+                let day_end = day_start + 86_400_000;
+                let overlap_start = interval.start_ts.max(day_start);
+                let overlap_end = interval.end_ts.min(day_end);
+                let overlap = (overlap_end - overlap_start).max(0);
+                let proportion = overlap as f64 / wall as f64;
+                let active_for_day = (interval.active_duration_ms as f64 * proportion) as i64;
+                if active_for_day > 0 {
+                    *daily.entry(day.clone()).or_default() += active_for_day;
+                }
+            }
+        }
+    }
+
+    daily
+}
+
+fn ts_to_date(ts_ms: i64) -> String {
+    let secs = ts_ms / 1000;
+    let days = secs / 86400;
+    let (y, m, d) = days_to_ymd(days);
+    format!("{:04}-{:02}-{:02}", y, m, d)
+}
+
+fn date_to_ts(date: &str) -> i64 {
+    let parts: Vec<&str> = date.split('-').collect();
+    if parts.len() != 3 {
+        return 0;
+    }
+    let y: i64 = parts[0].parse().unwrap_or(0);
+    let m: i64 = parts[1].parse().unwrap_or(0);
+    let d: i64 = parts[2].parse().unwrap_or(0);
+    ymd_to_days(y, m, d) * 86400 * 1000
+}
+
+fn days_to_ymd(mut days: i64) -> (i64, i64, i64) {
+    days += 719468;
+    let era = if days >= 0 { days } else { days - 146096 } / 146097;
+    let doe = days - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+fn ymd_to_days(y: i64, m: i64, d: i64) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let m_adj = if m > 2 { m - 3 } else { m + 9 };
+    let doy = (153 * m_adj + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146097 + doe - 719468
+}
+
+fn dates_between(start: &str, end: &str) -> Vec<String> {
+    let start_days = {
+        let parts: Vec<&str> = start.split('-').collect();
+        if parts.len() != 3 {
+            return vec![start.to_string()];
+        }
+        let y: i64 = parts[0].parse().unwrap_or(0);
+        let m: i64 = parts[1].parse().unwrap_or(0);
+        let d: i64 = parts[2].parse().unwrap_or(0);
+        ymd_to_days(y, m, d)
+    };
+    let end_days = {
+        let parts: Vec<&str> = end.split('-').collect();
+        if parts.len() != 3 {
+            return vec![start.to_string()];
+        }
+        let y: i64 = parts[0].parse().unwrap_or(0);
+        let m: i64 = parts[1].parse().unwrap_or(0);
+        let d: i64 = parts[2].parse().unwrap_or(0);
+        ymd_to_days(y, m, d)
+    };
+
+    let mut result = Vec::new();
+    for day in start_days..=end_days {
+        let (y, m, d) = days_to_ymd(day);
+        result.push(format!("{:04}-{:02}-{:02}", y, m, d));
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_msg(client: &str, session_id: &str, timestamp: i64) -> UnifiedMessage {
+        UnifiedMessage {
+            client: client.to_string(),
+            model_id: "test-model".to_string(),
+            provider_id: "test-provider".to_string(),
+            session_id: session_id.to_string(),
+            workspace_key: None,
+            workspace_label: None,
+            timestamp,
+            date: "2024-01-01".to_string(),
+            tokens: TokenBreakdown {
+                input: 100,
+                output: 50,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            cost: 0.01,
+            message_count: 1,
+            agent: None,
+            dedup_key: None,
+            is_turn_start: false,
+        }
+    }
+
+    #[test]
+    fn test_sessionize_empty() {
+        let result = sessionize(&[], DEFAULT_IDLE_GAP_MS);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_sessionize_single_message() {
+        let msgs = vec![make_msg("opencode", "ses1", 1000000)];
+        let result = sessionize(&msgs, DEFAULT_IDLE_GAP_MS);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].wall_duration_ms, 0);
+        assert_eq!(result[0].active_duration_ms, 0);
+        assert_eq!(result[0].message_count, 1);
+    }
+
+    #[test]
+    fn test_sessionize_continuous_session() {
+        // 5 messages, each 1 minute apart (within 3-min threshold)
+        let msgs: Vec<UnifiedMessage> = (0..5)
+            .map(|i| make_msg("opencode", "ses1", 1000000 + i * 60_000))
+            .collect();
+
+        let result = sessionize(&msgs, DEFAULT_IDLE_GAP_MS);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].wall_duration_ms, 4 * 60_000);
+        assert_eq!(result[0].active_duration_ms, 4 * 60_000); // all gaps <= 3min
+        assert_eq!(result[0].message_count, 5);
+    }
+
+    #[test]
+    fn test_sessionize_with_idle_gap() {
+        // 3 messages: first two 1 min apart, then 5 min gap (exceeds 3-min threshold)
+        let msgs = vec![
+            make_msg("opencode", "ses1", 1000000),
+            make_msg("opencode", "ses1", 1000000 + 60_000),
+            make_msg("opencode", "ses1", 1000000 + 60_000 + 5 * 60_000),
+        ];
+
+        let result = sessionize(&msgs, DEFAULT_IDLE_GAP_MS);
+        assert_eq!(result.len(), 1);
+        // Wall duration = 6 minutes
+        assert_eq!(result[0].wall_duration_ms, 6 * 60_000);
+        // Active duration = only the first gap (1 min), second gap (5 min) excluded
+        assert_eq!(result[0].active_duration_ms, 60_000);
+    }
+
+    #[test]
+    fn test_sessionize_multiple_sessions() {
+        let msgs = vec![
+            make_msg("opencode", "ses1", 1000000),
+            make_msg("opencode", "ses1", 1060000),
+            make_msg("claude", "ses2", 1000000),
+            make_msg("claude", "ses2", 1120000),
+        ];
+
+        let result = sessionize(&msgs, DEFAULT_IDLE_GAP_MS);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_sessionize_skips_zero_timestamp() {
+        let msgs = vec![
+            make_msg("opencode", "ses1", 0),
+            make_msg("opencode", "ses1", 1000000),
+        ];
+
+        let result = sessionize(&msgs, DEFAULT_IDLE_GAP_MS);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].message_count, 1); // only the non-zero one
+    }
+
+    #[test]
+    fn test_compute_time_metrics_empty() {
+        let metrics = compute_time_metrics(&[], DEFAULT_IDLE_GAP_MS);
+        assert_eq!(metrics.total_active_time_ms, 0);
+        assert_eq!(metrics.longest_continuous_ms, 0);
+        assert_eq!(metrics.max_concurrent_sessions, 0);
+        assert_eq!(metrics.session_count, 0);
+    }
+
+    #[test]
+    fn test_max_concurrent_sessions() {
+        // Two overlapping sessions
+        let intervals = vec![
+            SessionInterval {
+                client: "opencode".to_string(),
+                session_id: "ses1".to_string(),
+                start_ts: 1000,
+                end_ts: 5000,
+                wall_duration_ms: 4000,
+                active_duration_ms: 4000,
+                message_count: 3,
+                tokens: TokenBreakdown::default(),
+                cost: 0.0,
+            },
+            SessionInterval {
+                client: "claude".to_string(),
+                session_id: "ses2".to_string(),
+                start_ts: 3000,
+                end_ts: 7000,
+                wall_duration_ms: 4000,
+                active_duration_ms: 4000,
+                message_count: 3,
+                tokens: TokenBreakdown::default(),
+                cost: 0.0,
+            },
+        ];
+
+        let metrics = compute_time_metrics(&intervals, DEFAULT_IDLE_GAP_MS);
+        assert_eq!(metrics.max_concurrent_sessions, 2);
+    }
+
+    #[test]
+    fn test_max_concurrent_non_overlapping() {
+        // Two non-overlapping sessions
+        let intervals = vec![
+            SessionInterval {
+                client: "opencode".to_string(),
+                session_id: "ses1".to_string(),
+                start_ts: 1000,
+                end_ts: 3000,
+                wall_duration_ms: 2000,
+                active_duration_ms: 2000,
+                message_count: 2,
+                tokens: TokenBreakdown::default(),
+                cost: 0.0,
+            },
+            SessionInterval {
+                client: "claude".to_string(),
+                session_id: "ses2".to_string(),
+                start_ts: 5000,
+                end_ts: 7000,
+                wall_duration_ms: 2000,
+                active_duration_ms: 2000,
+                message_count: 2,
+                tokens: TokenBreakdown::default(),
+                cost: 0.0,
+            },
+        ];
+
+        let metrics = compute_time_metrics(&intervals, DEFAULT_IDLE_GAP_MS);
+        assert_eq!(metrics.max_concurrent_sessions, 1);
+    }
+
+    #[test]
+    fn test_longest_continuous_is_max_session_active_duration() {
+        let intervals = vec![
+            SessionInterval {
+                client: "opencode".to_string(),
+                session_id: "ses1".to_string(),
+                start_ts: 1000,
+                end_ts: 5000,
+                wall_duration_ms: 4000,
+                active_duration_ms: 3000,
+                message_count: 3,
+                tokens: TokenBreakdown::default(),
+                cost: 0.0,
+            },
+            SessionInterval {
+                client: "claude".to_string(),
+                session_id: "ses2".to_string(),
+                start_ts: 3000,
+                end_ts: 8000,
+                wall_duration_ms: 5000,
+                active_duration_ms: 5000,
+                message_count: 3,
+                tokens: TokenBreakdown::default(),
+                cost: 0.0,
+            },
+        ];
+
+        let metrics = compute_time_metrics(&intervals, DEFAULT_IDLE_GAP_MS);
+        assert_eq!(metrics.longest_continuous_ms, 7000);
+    }
+
+    #[test]
+    fn test_longest_continuous_picks_max_active() {
+        let intervals = vec![
+            SessionInterval {
+                client: "opencode".to_string(),
+                session_id: "ses1".to_string(),
+                start_ts: 1,
+                end_ts: 60_000,
+                wall_duration_ms: 60_000,
+                active_duration_ms: 60_000,
+                message_count: 3,
+                tokens: TokenBreakdown::default(),
+                cost: 0.0,
+            },
+            SessionInterval {
+                client: "opencode".to_string(),
+                session_id: "ses2".to_string(),
+                start_ts: 60_000 + 2 * 60_000,
+                end_ts: 60_000 + 2 * 60_000 + 120_000,
+                wall_duration_ms: 120_000,
+                active_duration_ms: 120_000,
+                message_count: 3,
+                tokens: TokenBreakdown::default(),
+                cost: 0.0,
+            },
+        ];
+
+        let metrics = compute_time_metrics(&intervals, DEFAULT_IDLE_GAP_MS);
+        assert_eq!(metrics.longest_continuous_ms, 299_999);
+    }
+
+    #[test]
+    fn test_longest_continuous_single_session() {
+        let intervals = vec![
+            SessionInterval {
+                client: "opencode".to_string(),
+                session_id: "ses1".to_string(),
+                start_ts: 1000,
+                end_ts: 61_000,
+                wall_duration_ms: 60_000,
+                active_duration_ms: 60_000,
+                message_count: 3,
+                tokens: TokenBreakdown::default(),
+                cost: 0.0,
+            },
+            SessionInterval {
+                client: "opencode".to_string(),
+                session_id: "ses2".to_string(),
+                start_ts: 61_000 + 10 * 60_000,
+                end_ts: 61_000 + 10 * 60_000 + 120_000,
+                wall_duration_ms: 120_000,
+                active_duration_ms: 120_000,
+                message_count: 5,
+                tokens: TokenBreakdown::default(),
+                cost: 0.0,
+            },
+        ];
+
+        let metrics = compute_time_metrics(&intervals, DEFAULT_IDLE_GAP_MS);
+        assert_eq!(metrics.longest_continuous_ms, 120_000);
+    }
+}

--- a/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
@@ -7,9 +7,9 @@ import styled from "styled-components";
 import { CopyIcon, CheckIcon, SearchIcon, XIcon } from "@/components/ui/Icons";
 import { TabBar } from "@/components/TabBar";
 import { LeaderboardSkeleton } from "@/components/Skeleton";
-import { formatCurrency, formatNumber } from "@/lib/utils";
+import { formatCurrency, formatNumber, formatDuration } from "@/lib/utils";
 import { useSettings } from "@/lib/useSettings";
-import { Switch } from "@/components/Switch";
+import type { LeaderboardSortBy } from "@/lib/leaderboard/constants";
 
 const Section = styled.div`
   margin-bottom: 40px;
@@ -790,6 +790,33 @@ const DateApplyButton = styled.button`
   }
 `;
 
+const SortOptions = styled.div`
+  display: inline-flex;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-default);
+  overflow: hidden;
+`;
+
+const SortOption = styled.button<{ $active: boolean }>`
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: ${({ $active }) => ($active ? 600 : 400)};
+  color: ${({ $active }) => ($active ? '#fff' : 'var(--color-fg-muted)')};
+  background-color: ${({ $active }) => ($active ? '#0073FF' : 'transparent')};
+  border: none;
+  cursor: pointer;
+  transition: all 150ms;
+
+  &:hover:not([disabled]) {
+    color: ${({ $active }) => ($active ? '#fff' : 'var(--color-fg-default)')};
+    background-color: ${({ $active }) => ($active ? '#0073FF' : 'var(--color-bg-subtle)')};
+  }
+
+  & + & {
+    border-left: 1px solid var(--color-border-default);
+  }
+`;
+
 const HoverTooltip = styled.span`
   position: relative;
   cursor: default;
@@ -882,6 +909,7 @@ export interface LeaderboardUser {
   avatarUrl: string | null;
   totalTokens: number;
   totalCost: number;
+  totalActiveTimeMs: number | null;
   submissionCount: number | null;
   lastSubmission: string;
 }
@@ -899,17 +927,18 @@ export interface LeaderboardData {
   stats: {
     totalTokens: number;
     totalCost: number;
+    totalActiveTimeMs: number | null;
     totalSubmissions: number | null;
     uniqueUsers: number;
   };
   period: Period;
-  sortBy?: 'tokens' | 'cost';
+  sortBy?: 'tokens' | 'cost' | 'time';
 }
 
 interface LeaderboardClientProps {
   initialData: LeaderboardData;
   currentUser: { id: string; username: string; displayName: string | null; avatarUrl: string | null } | null;
-  initialSortBy: 'tokens' | 'cost';
+  initialSortBy: 'tokens' | 'cost' | 'time';
   initialUserRank: LeaderboardUser | null;
 }
 
@@ -929,6 +958,7 @@ interface LeaderboardRowProps {
   isCurrentUser: boolean;
   isLastRow: boolean;
   showSubmissionCount: boolean;
+  showTime: boolean;
   onRowClick: (username: string) => void;
 }
 
@@ -937,6 +967,7 @@ const LeaderboardRow = memo(function LeaderboardRow({
   isCurrentUser,
   isLastRow,
   showSubmissionCount,
+  showTime,
   onRowClick,
 }: LeaderboardRowProps) {
   const formattedTokens = useMemo(() => user.totalTokens.toLocaleString('en-US'), [user.totalTokens]);
@@ -988,6 +1019,11 @@ const LeaderboardRow = memo(function LeaderboardRow({
           </CostValue>
         </CombinedValueContainer>
       </TableCell>
+      {showTime && (
+        <TableCell className="text-right hidden-mobile w-24">
+          <StatSpan>{formatDuration(user.totalActiveTimeMs)}</StatSpan>
+        </TableCell>
+      )}
       {showSubmissionCount && (
         <TableCell className="text-right hidden-mobile w-24">
           <SubmitCount>{user.submissionCount ?? "—"}</SubmitCount>
@@ -1129,7 +1165,7 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
   const fetchData = useCallback((
     targetPeriod: Period,
     targetPage: number,
-    targetSortBy: "tokens" | "cost",
+    targetSortBy: LeaderboardSortBy,
     targetSearch: string,
     targetRetryToken: number,
     signal?: AbortSignal,
@@ -1193,6 +1229,7 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
 
   const sortedUsers = data.users || [];
   const showSubmissionCount = period === "all";
+  const showTime = true;
 
   const handleCopyCommand = (command: string) => {
     navigator.clipboard.writeText(command);
@@ -1357,15 +1394,35 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
         </SearchInputWrapper>
         <SortToggleInner>
           <SortLabel>Sort by:</SortLabel>
-          <Switch
-            checked={effectiveSortBy === 'cost'}
-            onChange={(checked) => {
-              userHasToggledSort.current = true;
-              setLeaderboardSort(checked ? 'cost' : 'tokens');
-            }}
-            leftLabel="Tokens"
-            rightLabel="Cost"
-          />
+          <SortOptions>
+            <SortOption
+              $active={effectiveSortBy === 'tokens'}
+              onClick={() => {
+                userHasToggledSort.current = true;
+                setLeaderboardSort('tokens');
+              }}
+            >
+              Tokens
+            </SortOption>
+            <SortOption
+              $active={effectiveSortBy === 'cost'}
+              onClick={() => {
+                userHasToggledSort.current = true;
+                setLeaderboardSort('cost');
+              }}
+            >
+              Cost
+            </SortOption>
+            <SortOption
+              $active={effectiveSortBy === 'time'}
+              onClick={() => {
+                userHasToggledSort.current = true;
+                setLeaderboardSort('time');
+              }}
+            >
+              Time
+            </SortOption>
+          </SortOptions>
         </SortToggleInner>
       </SearchSortRow>
 
@@ -1409,6 +1466,9 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
                       <TableHeaderCell>User</TableHeaderCell>
                       <TableHeaderCell className="text-right hidden-cost-mobile">Cost</TableHeaderCell>
                       <TableHeaderCell className="text-right">Tokens</TableHeaderCell>
+                      {showTime && (
+                        <TableHeaderCell className="text-right hidden-mobile w-24">Time</TableHeaderCell>
+                      )}
                       {showSubmissionCount && (
                         <TableHeaderCell className="text-right hidden-mobile w-24">Submits</TableHeaderCell>
                       )}
@@ -1422,6 +1482,7 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
                         isCurrentUser={!!(currentUser && user.username === currentUser.username)}
                         isLastRow={index === sortedUsers.length - 1}
                         showSubmissionCount={showSubmissionCount}
+                        showTime={showTime}
                         onRowClick={handleRowClick}
                       />
                     ))}

--- a/packages/frontend/src/app/(main)/leaderboard/page.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/page.tsx
@@ -31,6 +31,7 @@ function createEmptyLeaderboardData(sortBy: SortBy): LeaderboardData {
     stats: {
       totalTokens: 0,
       totalCost: 0,
+      totalActiveTimeMs: null,
       totalSubmissions: null,
       uniqueUsers: 0,
     },

--- a/packages/frontend/src/app/(main)/page.tsx
+++ b/packages/frontend/src/app/(main)/page.tsx
@@ -17,6 +17,7 @@ function createEmptyLeaderboardData(sortBy: "tokens" | "cost"): LeaderboardData 
     stats: {
       totalTokens: 0,
       totalCost: 0,
+      totalActiveTimeMs: null,
       totalSubmissions: null,
       uniqueUsers: 0,
     },

--- a/packages/frontend/src/app/api/leaderboard/route.ts
+++ b/packages/frontend/src/app/api/leaderboard/route.ts
@@ -5,7 +5,7 @@ import type { Period, SortBy } from "@/lib/leaderboard/types";
 export const revalidate = 60;
 
 const VALID_PERIODS: Period[] = ["all", "month", "last-month", "week", "custom"];
-const VALID_SORT_BY: SortBy[] = ["tokens", "cost"];
+const VALID_SORT_BY: SortBy[] = ["tokens", "cost", "time"];
 
 function parseIntSafe(value: string | null, defaultValue: number): number {
   if (!value) return defaultValue;

--- a/packages/frontend/src/app/api/leaderboard/user/[username]/route.ts
+++ b/packages/frontend/src/app/api/leaderboard/user/[username]/route.ts
@@ -6,7 +6,7 @@ import { isValidGitHubUsername } from "@/lib/validation/username";
 export const revalidate = 60;
 
 const VALID_PERIODS: Period[] = ["all", "month", "last-month", "week", "custom"];
-const VALID_SORT_BY: SortBy[] = ["tokens", "cost"];
+const VALID_SORT_BY: SortBy[] = ["tokens", "cost", "time"];
 
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -232,6 +232,7 @@ export async function POST(request: Request) {
           id: dailyBreakdown.id,
           date: dailyBreakdown.date,
           timestampMs: dailyBreakdown.timestampMs,
+          activeTimeMs: dailyBreakdown.activeTimeMs,
           sourceBreakdown: dailyBreakdown.sourceBreakdown,
         })
         .from(dailyBreakdown)
@@ -259,6 +260,7 @@ export async function POST(request: Request) {
         inputTokens: number;
         outputTokens: number;
         timestampMs: number | null;
+        activeTimeMs: number | null;
         sourceBreakdown: Record<string, ClientBreakdownData>;
         modelBreakdown: Record<string, number>;
       }> = [];
@@ -270,6 +272,7 @@ export async function POST(request: Request) {
         inputTokens: number;
         outputTokens: number;
         timestampMs: number | null;
+        activeTimeMs: number | null;
         sourceBreakdown: Record<string, ClientBreakdownData>;
         modelBreakdown: Record<string, number>;
       }> = [];
@@ -328,6 +331,7 @@ export async function POST(request: Request) {
             inputTokens: dayTotals.inputTokens,
             outputTokens: dayTotals.outputTokens,
             timestampMs: mergeTimestampMs(existingDay.timestampMs, incomingDay.timestampMs ?? null),
+            activeTimeMs: incomingDay.activeTimeMs ?? existingDay.activeTimeMs ?? null,
             sourceBreakdown: mergedClientBreakdown,
             modelBreakdown,
           });
@@ -344,6 +348,7 @@ export async function POST(request: Request) {
             inputTokens: dayTotals.inputTokens,
             outputTokens: dayTotals.outputTokens,
             timestampMs: incomingDay.timestampMs ?? null,
+            activeTimeMs: incomingDay.activeTimeMs ?? null,
             sourceBreakdown: incomingClientBreakdown,
             modelBreakdown,
           });
@@ -359,7 +364,7 @@ export async function POST(request: Request) {
       if (toUpdate.length > 0) {
         const valuesClauses = toUpdate.map(
           (row) =>
-            sql`(${row.id}::uuid, ${row.tokens}::bigint, ${row.cost}::numeric(10,4), ${row.inputTokens}::bigint, ${row.outputTokens}::bigint, ${row.timestampMs}::bigint, ${JSON.stringify(row.sourceBreakdown)}::jsonb, ${JSON.stringify(row.modelBreakdown)}::jsonb)`
+            sql`(${row.id}::uuid, ${row.tokens}::bigint, ${row.cost}::numeric(10,4), ${row.inputTokens}::bigint, ${row.outputTokens}::bigint, ${row.timestampMs}::bigint, ${row.activeTimeMs}::bigint, ${JSON.stringify(row.sourceBreakdown)}::jsonb, ${JSON.stringify(row.modelBreakdown)}::jsonb)`
         );
 
         const valuesList = sql.join(valuesClauses, sql`, `);
@@ -371,10 +376,11 @@ export async function POST(request: Request) {
             input_tokens = batch.input_tokens,
             output_tokens = batch.output_tokens,
             timestamp_ms = batch.timestamp_ms,
+            active_time_ms = batch.active_time_ms,
             source_breakdown = batch.source_breakdown,
             model_breakdown = batch.model_breakdown
           FROM (VALUES ${valuesList})
-            AS batch(id, tokens, cost, input_tokens, output_tokens, timestamp_ms, source_breakdown, model_breakdown)
+            AS batch(id, tokens, cost, input_tokens, output_tokens, timestamp_ms, active_time_ms, source_breakdown, model_breakdown)
           WHERE d.id = batch.id
         `);
       }
@@ -450,6 +456,12 @@ export async function POST(request: Request) {
           submissionHash: generateSubmissionHash(hashData),
           submitCount: sql`COALESCE(submit_count, 0) + 1`,
           schemaVersion: sql`GREATEST(COALESCE(${submissions.schemaVersion}, 0), ${submitDevice.schemaVersion})`,
+          ...(data.timeMetrics ? {
+            totalActiveTimeMs: data.timeMetrics.totalActiveTimeMs,
+            longestContinuousMs: data.timeMetrics.longestContinuousMs,
+            maxConcurrentSessions: data.timeMetrics.maxConcurrentSessions,
+            sessionCount: data.timeMetrics.sessionCount,
+          } : {}),
           updatedAt: new Date(),
         })
         .where(eq(submissions.id, submissionId));

--- a/packages/frontend/src/app/api/users/[username]/route.ts
+++ b/packages/frontend/src/app/api/users/[username]/route.ts
@@ -62,6 +62,8 @@ export async function GET(_request: Request, { params }: RouteParams) {
           submissionCount: sql<number>`COALESCE(MAX(${submissions.submitCount}), 0)`,
           earliestDate: sql<string>`MIN(${submissions.dateStart})`,
           latestDate: sql<string>`MAX(${submissions.dateEnd})`,
+          totalActiveTimeMs: sql<number>`COALESCE(SUM(${submissions.totalActiveTimeMs}), 0)`,
+          sessionCount: sql<number>`COALESCE(SUM(${submissions.sessionCount}), 0)`,
         })
         .from(submissions)
         .where(eq(submissions.userId, user.id)),
@@ -443,6 +445,8 @@ export async function GET(_request: Request, { params }: RouteParams) {
         reasoningTokens: Number(stats?.reasoningTokens) || 0,
         submissionCount: Number(stats?.submissionCount) || 0,
         activeDays,
+        totalActiveTimeMs: Number(stats?.totalActiveTimeMs) || 0,
+        sessionCount: Number(stats?.sessionCount) || 0,
       },
       dateRange: {
         start: stats?.earliestDate || null,

--- a/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
+++ b/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
@@ -37,6 +37,8 @@ interface ProfileData {
     cacheWriteTokens: number;
     submissionCount: number;
     activeDays: number;
+    totalActiveTimeMs: number;
+    sessionCount: number;
   };
   dateRange: {
     start: string | null;
@@ -134,6 +136,8 @@ export default function ProfilePageClient({ initialData, username }: ProfilePage
     cacheWriteTokens: data.stats.cacheWriteTokens,
     activeDays: data.stats.activeDays,
     submissionCount: data.stats.submissionCount,
+    totalActiveTimeMs: data.stats.totalActiveTimeMs,
+    sessionCount: data.stats.sessionCount,
   }), [data]);
 
 const EARLY_ADOPTERS = ["code-yeongyu", "gtg7784", "qodot"];
@@ -174,7 +178,11 @@ const EARLY_ADOPTERS = ["code-yeongyu", "gtg7784", "qodot"];
             >
               {graphData ? (
                 <ActivitySection>
-                  <ProfileActivity data={graphData} />
+                  <ProfileActivity
+                    data={graphData}
+                    totalActiveTimeMs={data.stats.totalActiveTimeMs}
+                    sessionCount={data.stats.sessionCount}
+                  />
                   <ProfileStats
                     stats={stats}
                     favoriteModel={

--- a/packages/frontend/src/components/GraphContainer.tsx
+++ b/packages/frontend/src/components/GraphContainer.tsx
@@ -62,9 +62,11 @@ const GraphWrapper = styled.div`
 
 interface GraphContainerProps {
   data: TokenContributionData;
+  totalActiveTimeMs?: number | null;
+  sessionCount?: number | null;
 }
 
-export function GraphContainer({ data }: GraphContainerProps) {
+export function GraphContainer({ data, totalActiveTimeMs, sessionCount }: GraphContainerProps) {
   const { paletteName, setPalette } = useSettings();
 
   const [view, setView] = useState<ViewMode>("2d");
@@ -179,7 +181,7 @@ export function GraphContainer({ data }: GraphContainerProps) {
       </GraphCard>
 
       {selectedDay && <BreakdownPanel day={selectedDay} onClose={() => setSelectedDay(null)} palette={palette} />}
-      {view === "2d" && <StatsPanel data={filteredByClient} palette={palette} />}
+      {view === "2d" && <StatsPanel data={filteredByClient} palette={palette} totalActiveTimeMs={clientFilter.length === 0 ? totalActiveTimeMs : null} sessionCount={clientFilter.length === 0 ? sessionCount : null} />}
       <Tooltip day={hoveredDay} position={tooltipPosition} visible={hoveredDay !== null} palette={palette} />
     </Container>
   );

--- a/packages/frontend/src/components/StatsPanel.tsx
+++ b/packages/frontend/src/components/StatsPanel.tsx
@@ -10,10 +10,13 @@ import {
   findBestDay,
 } from "@/lib/utils";
 import { formatContributionDate } from "@/lib/date-utils";
+import { formatDuration } from "@/lib/format";
 
 interface StatsPanelProps {
   data: TokenContributionData;
   palette: GraphColorPalette;
+  totalActiveTimeMs?: number | null;
+  sessionCount?: number | null;
 }
 
 const Container = styled.div`
@@ -140,7 +143,7 @@ const StatItemSubValue = styled.div`
   color: var(--color-fg-muted);
 `;
 
-export function StatsPanel({ data, palette }: StatsPanelProps) {
+export function StatsPanel({ data, palette, totalActiveTimeMs, sessionCount }: StatsPanelProps) {
   const { summary, contributions } = data;
   const currentStreak = calculateCurrentStreak(contributions);
   const longestStreak = calculateLongestStreak(contributions);
@@ -161,6 +164,12 @@ export function StatsPanel({ data, palette }: StatsPanelProps) {
           <StatItem label="Best Day" value={formatContributionDate(bestDay)} subValue={formatCurrency(bestDay.totals.cost)} />
         )}
         <StatItem label="Models" value={summary.models.length.toString()} />
+        {totalActiveTimeMs != null && totalActiveTimeMs > 0 && (
+          <StatItem label="Active Time" value={formatDuration(totalActiveTimeMs)} />
+        )}
+        {sessionCount != null && sessionCount > 0 && (
+          <StatItem label="Sessions" value={sessionCount.toString()} />
+        )}
       </Grid>
 
       <SourcesContainer>

--- a/packages/frontend/src/components/profile/index.tsx
+++ b/packages/frontend/src/components/profile/index.tsx
@@ -6,7 +6,7 @@ import styled, { css } from "styled-components";
 import { toast } from "react-toastify";
 import { GraphContainer } from "@/components/GraphContainer";
 import type { TokenContributionData } from "@/lib/types";
-import { formatNumber, formatCurrency } from "@/lib/utils";
+import { formatNumber, formatCurrency, formatDuration } from "@/lib/utils";
 import { legacy } from "@/lib/responsive";
 import { ProfileEmbedDialog } from "./ProfileEmbedDialog";
 
@@ -26,6 +26,8 @@ export interface ProfileStatsData {
   cacheWriteTokens: number;
   activeDays: number;
   submissionCount?: number;
+  totalActiveTimeMs?: number;
+  sessionCount?: number;
 }
 
 export interface ProfileHeaderProps {
@@ -860,6 +862,12 @@ export function ProfileStats({ stats, favoriteModel }: ProfileStatsProps) {
   const statItems = [
     { label: "Submits", value: (stats.submissionCount ?? 0).toString(), color: "var(--color-primary)" },
     { label: "Favorite Model", value: favoriteModel ?? "N/A", color: "var(--color-primary)" },
+    ...(stats.totalActiveTimeMs && stats.totalActiveTimeMs > 0
+      ? [{ label: "Active Time", value: formatDuration(stats.totalActiveTimeMs), color: "var(--color-primary)" }]
+      : []),
+    ...(stats.sessionCount && stats.sessionCount > 0
+      ? [{ label: "Sessions", value: stats.sessionCount.toString(), color: "var(--color-primary)" }]
+      : []),
   ];
 
   return (
@@ -1145,6 +1153,8 @@ export function ProfileModels({ models, modelUsage }: ProfileModelsProps) {
 
 export interface ProfileActivityProps {
   data: TokenContributionData;
+  totalActiveTimeMs?: number | null;
+  sessionCount?: number | null;
 }
 
 const ActivityContainer = styled.div`
@@ -1170,11 +1180,11 @@ const ActivityInner = styled.div`
   }
 `;
 
-export function ProfileActivity({ data }: ProfileActivityProps) {
+export function ProfileActivity({ data, totalActiveTimeMs, sessionCount }: ProfileActivityProps) {
   return (
     <ActivityContainer>
       <ActivityInner>
-        <GraphContainer data={data} />
+        <GraphContainer data={data} totalActiveTimeMs={totalActiveTimeMs} sessionCount={sessionCount} />
       </ActivityInner>
     </ActivityContainer>
   );

--- a/packages/frontend/src/lib/db/migrations/0008_add_time_metrics_to_submissions.sql
+++ b/packages/frontend/src/lib/db/migrations/0008_add_time_metrics_to_submissions.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "submissions" ADD COLUMN "total_active_time_ms" bigint;
+ALTER TABLE "submissions" ADD COLUMN "longest_continuous_ms" bigint;
+ALTER TABLE "submissions" ADD COLUMN "max_concurrent_sessions" integer;
+ALTER TABLE "submissions" ADD COLUMN "session_count" integer;
+ALTER TABLE "daily_breakdown" ADD COLUMN "active_time_ms" bigint;

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1778025601000,
       "tag": "0007_add_submitted_devices",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1778112000000,
+      "tag": "0008_add_time_metrics_to_submissions",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -182,6 +182,11 @@ export const submissions = pgTable(
     /** 0=legacy (no timestamps), 1=timestamp-aware CLI */
     schemaVersion: integer("schema_version").notNull().default(0),
 
+    totalActiveTimeMs: bigint("total_active_time_ms", { mode: "number" }),
+    longestContinuousMs: bigint("longest_continuous_ms", { mode: "number" }),
+    maxConcurrentSessions: integer("max_concurrent_sessions"),
+    sessionCount: integer("session_count"),
+
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -295,6 +300,8 @@ export const dailyBreakdown = pgTable(
       >
     >(),
     modelBreakdown: jsonb("model_breakdown").$type<Record<string, number>>(),
+    /** Total active coding time in this UTC day bucket (milliseconds). NULL for legacy data. */
+    activeTimeMs: bigint("active_time_ms", { mode: "number" }),
   },
   (table) => [
     index("idx_daily_breakdown_submission_id").on(table.submissionId),

--- a/packages/frontend/src/lib/format.ts
+++ b/packages/frontend/src/lib/format.ts
@@ -42,3 +42,27 @@ export function formatCurrency(value: number, compact = false): string {
     maximumFractionDigits: 2,
   }).format(Math.max(0, safeNumber(value)));
 }
+
+/**
+ * Format milliseconds into a human-readable duration string.
+ * e.g. 3661000 → "1h 1m", 90000 → "1m 30s", 500 → "<1s"
+ */
+export function formatDuration(ms: number | null | undefined): string {
+  if (ms == null || !Number.isFinite(ms) || ms <= 0) return "—";
+
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+  if (minutes > 0) {
+    return seconds > 0 && minutes < 10 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  }
+  if (seconds > 0) {
+    return `${seconds}s`;
+  }
+  return "<1s";
+}

--- a/packages/frontend/src/lib/leaderboard/constants.ts
+++ b/packages/frontend/src/lib/leaderboard/constants.ts
@@ -1,7 +1,7 @@
-export type LeaderboardSortBy = 'tokens' | 'cost';
+export type LeaderboardSortBy = 'tokens' | 'cost' | 'time';
 
 export const SORT_BY_COOKIE_NAME = "leaderboard-sort-by";
-export const VALID_SORT_BY: LeaderboardSortBy[] = ['tokens', 'cost'];
+export const VALID_SORT_BY: LeaderboardSortBy[] = ['tokens', 'cost', 'time'];
 
 export function isValidSortBy(value: unknown): value is LeaderboardSortBy {
   return typeof value === 'string' && VALID_SORT_BY.includes(value as LeaderboardSortBy);

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -19,6 +19,7 @@ interface LeaderboardPeriodRow {
   avatarUrl: string | null;
   tokens: number;
   cost: number;
+  activeTimeMs: number | null;
   updatedAt: string;
   cliVersion: string | null;
   schemaVersion: number;
@@ -36,6 +37,7 @@ interface PeriodLeaderboardDbRow {
   avatarUrl: string | null;
   tokens: number | string | null;
   cost: number | string | null;
+  activeTimeMs: number | string | null;
   updatedAt: Date | string;
   cliVersion: string | null;
   schemaVersion: number | null;
@@ -48,6 +50,7 @@ interface AllTimeLeaderboardDbRow {
   avatarUrl: string | null;
   totalTokens: number | string | null;
   totalCost: number | string | null;
+  totalActiveTimeMs: number | string | null;
   submissionCount: number | string | null;
   lastSubmission: string;
   cliVersion: string | null;
@@ -113,6 +116,16 @@ function compareLeaderboardUsers(
   right: Omit<LeaderboardUser, "rank">,
   sortBy: SortBy
 ): number {
+  if (sortBy === "time") {
+    const leftTime = left.totalActiveTimeMs || 0;
+    const rightTime = right.totalActiveTimeMs || 0;
+    const primary = rightTime - leftTime;
+    if (primary !== 0) return primary;
+    const secondary = right.totalTokens - left.totalTokens;
+    if (secondary !== 0) return secondary;
+    return left.username.localeCompare(right.username);
+  }
+
   const primary = sortBy === "cost"
     ? right.totalCost - left.totalCost
     : right.totalTokens - left.totalTokens;
@@ -144,6 +157,9 @@ function aggregatePeriodRows(
     if (existing) {
       existing.totalTokens += row.tokens;
       existing.totalCost += row.cost;
+      if (row.activeTimeMs != null) {
+        existing.totalActiveTimeMs = (existing.totalActiveTimeMs || 0) + row.activeTimeMs;
+      }
       if (row.updatedAt > existing.lastSubmission) {
         existing.lastSubmission = row.updatedAt;
         existing.submissionFreshness = buildSubmissionFreshness({
@@ -162,6 +178,7 @@ function aggregatePeriodRows(
       avatarUrl: row.avatarUrl,
       totalTokens: row.tokens,
       totalCost: row.cost,
+      totalActiveTimeMs: row.activeTimeMs,
       submissionCount: null,
       lastSubmission: row.updatedAt,
       submissionFreshness: buildSubmissionFreshness({
@@ -227,6 +244,7 @@ function buildPeriodLeaderboardData(
     stats: {
       totalTokens: aggregatedUsers.reduce((sum, user) => sum + user.totalTokens, 0),
       totalCost: aggregatedUsers.reduce((sum, user) => sum + user.totalCost, 0),
+      totalActiveTimeMs: aggregatedUsers.reduce((sum, user) => sum + (user.totalActiveTimeMs || 0), 0) || null,
       // submitCount lives on the all-time submission row, so period-scoped submit totals are unavailable here.
       totalSubmissions: null,
       uniqueUsers: aggregatedUsers.length,
@@ -277,6 +295,7 @@ async function fetchPeriodLeaderboardRows(
       avatarUrl: users.avatarUrl,
       tokens: dailyBreakdown.tokens,
       cost: dailyBreakdown.cost,
+      activeTimeMs: dailyBreakdown.activeTimeMs,
       updatedAt: submissions.updatedAt,
       cliVersion: submissions.cliVersion,
       schemaVersion: submissions.schemaVersion,
@@ -298,6 +317,7 @@ async function fetchPeriodLeaderboardRows(
     avatarUrl: row.avatarUrl,
     tokens: Number(row.tokens) || 0,
     cost: Number(row.cost) || 0,
+    activeTimeMs: row.activeTimeMs != null ? Number(row.activeTimeMs) : null,
     updatedAt: row.updatedAt instanceof Date
       ? row.updatedAt.toISOString()
       : new Date(row.updatedAt).toISOString(),
@@ -324,6 +344,8 @@ async function fetchLeaderboardData(
 
   const orderByColumn = sortBy === "cost"
     ? sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`
+    : sortBy === "time"
+    ? sql`COALESCE(SUM(${submissions.totalActiveTimeMs}), 0)`
     : sql`SUM(${submissions.totalTokens})`;
 
   if (search) {
@@ -338,6 +360,7 @@ async function fetchLeaderboardData(
         avatarUrl: users.avatarUrl,
         totalTokens: sql<number>`SUM(${submissions.totalTokens})`.as("total_tokens"),
         totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`.as("total_cost"),
+        totalActiveTimeMs: sql<number>`COALESCE(SUM(${submissions.totalActiveTimeMs}), 0)`.as("total_active_time_ms"),
         submissionCount: sql<number>`COALESCE(SUM(${submissions.submitCount}), 0)`.as("submission_count"),
         lastSubmission: sql<string>`MAX(${submissions.updatedAt})`.as("last_submission"),
         cliVersion: sql<string | null>`(
@@ -394,6 +417,7 @@ async function fetchLeaderboardData(
         avatarUrl: row.avatarUrl,
         totalTokens: Number(row.totalTokens) || 0,
         totalCost: Number(row.totalCost) || 0,
+        totalActiveTimeMs: Number((row as AllTimeLeaderboardDbRow).totalActiveTimeMs) || null,
         submissionCount: Number(row.submissionCount) || 0,
         lastSubmission: row.lastSubmission,
         submissionFreshness: buildSubmissionFreshness({
@@ -413,6 +437,7 @@ async function fetchLeaderboardData(
       stats: {
         totalTokens: Number(globalStats[0]?.totalTokens) || 0,
         totalCost: Number(globalStats[0]?.totalCost) || 0,
+        totalActiveTimeMs: null,
         totalSubmissions: Number(globalStats[0]?.totalSubmissions) || 0,
         uniqueUsers: Number(globalStats[0]?.uniqueUsers) || 0,
       },
@@ -431,6 +456,7 @@ async function fetchLeaderboardData(
       avatarUrl: users.avatarUrl,
       totalTokens: sql<number>`SUM(${submissions.totalTokens})`.as("total_tokens"),
       totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`.as("total_cost"),
+      totalActiveTimeMs: sql<number>`COALESCE(SUM(${submissions.totalActiveTimeMs}), 0)`.as("total_active_time_ms"),
       submissionCount: sql<number>`COALESCE(SUM(${submissions.submitCount}), 0)`.as("submission_count"),
       lastSubmission: sql<string>`MAX(${submissions.updatedAt})`.as("last_submission"),
       cliVersion: sql<string | null>`(
@@ -475,6 +501,7 @@ async function fetchLeaderboardData(
       avatarUrl: row.avatarUrl,
       totalTokens: Number(row.totalTokens) || 0,
       totalCost: Number(row.totalCost) || 0,
+      totalActiveTimeMs: Number(row.totalActiveTimeMs) || null,
       submissionCount: Number(row.submissionCount) || 0,
       lastSubmission: row.lastSubmission,
       submissionFreshness: buildSubmissionFreshness({
@@ -494,6 +521,7 @@ async function fetchLeaderboardData(
     stats: {
       totalTokens: Number(globalStats[0]?.totalTokens) || 0,
       totalCost: Number(globalStats[0]?.totalCost) || 0,
+      totalActiveTimeMs: null,
       totalSubmissions: Number(globalStats[0]?.totalSubmissions) || 0,
       uniqueUsers: Number(globalStats[0]?.uniqueUsers) || 0,
     },
@@ -557,6 +585,7 @@ async function fetchUserRank(
     .select({
       totalTokens: sql<number>`SUM(${submissions.totalTokens})`.as("total_tokens"),
       totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`.as("total_cost"),
+      totalActiveTimeMs: sql<number>`COALESCE(SUM(${submissions.totalActiveTimeMs}), 0)`.as("total_active_time_ms"),
       submissionCount: sql<number>`COALESCE(SUM(${submissions.submitCount}), 0)`.as("submission_count"),
       lastSubmission: sql<string>`MAX(${submissions.updatedAt})`.as("last_submission"),
       cliVersion: sql<string | null>`(
@@ -580,10 +609,17 @@ async function fetchUserRank(
   const userStats = userStatsResult[0];
   const userTotalTokens = Number(userStats.totalTokens);
   const userTotalCost = userStats.totalCost != null ? Number(userStats.totalCost) : 0;
+  const userTotalActiveTimeMs = Number(userStats.totalActiveTimeMs) || 0;
 
-  const userCompareValue = sortBy === "cost" ? userTotalCost : userTotalTokens;
+  const userCompareValue = sortBy === "cost"
+    ? userTotalCost
+    : sortBy === "time"
+    ? userTotalActiveTimeMs
+    : userTotalTokens;
   const compareColumn = sortBy === "cost"
     ? sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`
+    : sortBy === "time"
+    ? sql`COALESCE(SUM(${submissions.totalActiveTimeMs}), 0)`
     : sql`SUM(${submissions.totalTokens})`;
 
   const higherRankedResult = await db
@@ -612,6 +648,7 @@ async function fetchUserRank(
     avatarUrl: user.avatarUrl,
     totalTokens: userTotalTokens,
     totalCost: userTotalCost,
+    totalActiveTimeMs: userTotalActiveTimeMs || null,
     submissionCount: Number(userStats.submissionCount) || 0,
     lastSubmission: userStats.lastSubmission,
     submissionFreshness: buildSubmissionFreshness({

--- a/packages/frontend/src/lib/leaderboard/types.ts
+++ b/packages/frontend/src/lib/leaderboard/types.ts
@@ -1,7 +1,7 @@
 import type { SubmissionFreshness } from "@/lib/submissionFreshness";
 
 export type Period = "all" | "month" | "last-month" | "week" | "custom";
-export type SortBy = "tokens" | "cost";
+export type SortBy = "tokens" | "cost" | "time";
 
 export interface LeaderboardUser {
   rank: number;
@@ -11,6 +11,7 @@ export interface LeaderboardUser {
   avatarUrl: string | null;
   totalTokens: number;
   totalCost: number;
+  totalActiveTimeMs: number | null;
   submissionCount: number | null;
   lastSubmission: string;
   submissionFreshness: SubmissionFreshness | null;
@@ -29,6 +30,7 @@ export interface LeaderboardData {
   stats: {
     totalTokens: number;
     totalCost: number;
+    totalActiveTimeMs: number | null;
     totalSubmissions: number | null;
     uniqueUsers: number;
   };

--- a/packages/frontend/src/lib/utils.ts
+++ b/packages/frontend/src/lib/utils.ts
@@ -327,3 +327,5 @@ export function groupClientsByType(clients: ClientContribution[]): Map<ClientTyp
 export function sortClientsByCost(clients: ClientContribution[]): ClientContribution[] {
   return [...clients].sort((a, b) => b.cost - a.cost);
 }
+
+export { formatDuration } from "./format";

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -71,6 +71,7 @@ const ClientContributionSchema = z.object({
 const DailyContributionSchema = z.object({
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   timestampMs: z.number().int().min(1e12).max(Number.MAX_SAFE_INTEGER).optional(),
+  activeTimeMs: z.number().int().min(0).optional(),
   totals: z.object({
     tokens: NonNegativeIntegerSchema,
     cost: NonNegativeNumberSchema,
@@ -179,12 +180,20 @@ function normalizeLegacySources(data: unknown): unknown {
   return d;
 }
 
+const TimeMetricsSchema = z.object({
+  totalActiveTimeMs: z.number().int().min(0),
+  longestContinuousMs: z.number().int().min(0),
+  maxConcurrentSessions: z.number().int().min(0),
+  sessionCount: z.number().int().min(0),
+});
+
 const SubmissionDataSchema = z.preprocess(normalizeLegacySources, z.object({
   meta: ExportMetaSchema,
   device: SubmitDeviceSchema.optional(),
   summary: DataSummarySchema,
   years: z.array(YearSummarySchema),
   contributions: z.array(DailyContributionSchema),
+  timeMetrics: TimeMetricsSchema.optional(),
 }));
 
 export type SubmissionData = z.infer<typeof SubmissionDataSchema>;


### PR DESCRIPTION
## Summary

Add active time tracking per contribution, enabling users to see how much time they actually spent coding.

### Changes

**CLI (Rust)**
- Add `time-metrics` subcommand showing active time, longest session, and concurrency stats
- Sessionize contributions and populate `activeTimeMs` in graph/submit payloads

**Frontend**
- Add `active_time_ms` column to `daily_breakdown` table (migration 0006)
- Store and aggregate active time in submit route
- Show time metrics in leaderboard period tabs
- Add time formatting utilities and update profile/stats components

### Testing
- Submitted data successfully to staging server
- Verified leaderboard displays time metrics correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end session time metrics so users can see active coding time, longest continuous session, and peak concurrency. Leaderboards and profiles now surface time (including sort by time), and the CLI adds a `time-metrics` report.

- New Features
  - Core (`crates/tokscale-core`): Added `sessionize` with a 3‑min idle gap; computes per‑day `activeTimeMs` and global `timeMetrics` (total active, wall, longest continuous with idle‑gap merge, max concurrency incl. zero‑duration, session count); graph payloads include `activeTimeMs` and `timeMetrics`; added `get_time_metrics_report`.
  - CLI (`crates/tokscale-cli`): New `time-metrics` subcommand with date/client filters, `--json`, and `--no-spinner`; prints total active, wall‑clock, longest continuous, max concurrency, sessions, and processing time; graph JSON includes `timeMetrics` and per‑day `activeTimeMs`; skips pricing init for faster runs.
  - API/DB/UI (`packages/frontend`): Submit API accepts `timeMetrics`; persists submission metrics (`total_active_time_ms`, `longest_continuous_ms`, `max_concurrent_sessions`, `session_count`) and daily `active_time_ms`; leaderboard APIs and user rank support `sortBy=time`; leaderboard adds a “Time” column and period totals; profile and graph stats show “Active Time” and “Sessions” (hidden when a client filter is active); added `formatDuration`; submission validation updated to allow `timeMetrics` and per‑day `activeTimeMs`. Tests: fixed `sessionize` test helper to include `duration_ms`.

- Migration
  - Run DB migration `0008_add_time_metrics_to_submissions.sql`.

<sup>Written for commit 640bd4a2160ee6e73f0241ed7b077985591b3caa. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/528?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

