### PR TITLE
fix(gemini): include tool tokens in reported totals

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1100,14 +1100,13 @@ fn parse_all_messages_with_pricing_with_env_strategy(
     }
 
     if let Some(db_path) = &scan_result.kiro_db {
-        let kiro_db_messages: Vec<UnifiedMessage> =
-            sessions::kiro::parse_kiro_sqlite(db_path)
-                .into_iter()
-                .map(|mut msg| {
-                    apply_pricing_if_available(&mut msg, pricing);
-                    msg
-                })
-                .collect();
+        let kiro_db_messages: Vec<UnifiedMessage> = sessions::kiro::parse_kiro_sqlite(db_path)
+            .into_iter()
+            .map(|mut msg| {
+                apply_pricing_if_available(&mut msg, pricing);
+                msg
+            })
+            .collect();
         all_messages.extend(kiro_db_messages);
     }
 

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -10,7 +10,7 @@ use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
-const CACHE_SCHEMA_VERSION: u32 = 12;
+const CACHE_SCHEMA_VERSION: u32 = 13;
 const CACHE_FILENAME: &str = "source-message-cache.bin";
 const CACHE_LOCK_FILENAME: &str = "source-message-cache.lock";
 const MAX_CACHE_FILE_BYTES: u64 = 256 * 1024 * 1024;

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -911,10 +911,7 @@ fn scan_all_clients_with_env_strategy_inner(
     }
 
     if enabled.contains(&ClientId::Kiro) {
-        let xdg_path = PathBuf::from(format!(
-            "{}/.local/share/kiro-cli/data.sqlite3",
-            home_dir
-        ));
+        let xdg_path = PathBuf::from(format!("{}/.local/share/kiro-cli/data.sqlite3", home_dir));
         if xdg_path.is_file() {
             result.kiro_db = Some(xdg_path);
         }

--- a/crates/tokscale-core/src/sessions/gemini.rs
+++ b/crates/tokscale-core/src/sessions/gemini.rs
@@ -174,6 +174,8 @@ fn build_gemini_token_message(
         tokens.total,
     );
 
+    let tool = tokens.tool.unwrap_or(0).max(0);
+
     UnifiedMessage::new(
         "gemini",
         model,
@@ -181,7 +183,7 @@ fn build_gemini_token_message(
         session_id.to_string(),
         timestamp,
         TokenBreakdown {
-            input,
+            input: input.saturating_add(tool),
             output: tokens.output.unwrap_or(0).max(0),
             cache_read,
             cache_write: 0,
@@ -739,7 +741,7 @@ mod tests {
     #[test]
     fn test_parse_gemini_stream_jsonl_direct_tokens() {
         let content = r#"{"sessionId":"gemini-session-1","projectHash":"abc123","startTime":"2026-05-01T00:00:00.000Z","lastUpdated":"2026-05-01T00:01:00.000Z"}
-{"id":"msg-1","timestamp":"2026-05-01T00:01:00.000Z","type":"gemini","model":"gemini-3.1-pro-preview","tokens":{"input":14918,"output":60,"cached":0,"thoughts":863,"tool":0,"total":15841}}"#;
+{"id":"msg-1","timestamp":"2026-05-01T00:01:00.000Z","type":"gemini","model":"gemini-3.1-pro-preview","tokens":{"input":14918,"output":60,"cached":0,"thoughts":863,"tool":7,"total":15848}}"#;
         let dir = TempDir::new().unwrap();
         let chats_dir = dir.path().join(".gemini/tmp/123/chats");
         std::fs::create_dir_all(&chats_dir).unwrap();
@@ -752,11 +754,11 @@ mod tests {
         assert_eq!(messages[0].session_id, "gemini-session-1");
         assert_eq!(messages[0].model_id, "gemini-3.1-pro-preview");
         assert_eq!(messages[0].provider_id, "google");
-        assert_eq!(messages[0].tokens.input, 14918);
+        assert_eq!(messages[0].tokens.input, 14925);
         assert_eq!(messages[0].tokens.output, 60);
         assert_eq!(messages[0].tokens.cache_read, 0);
         assert_eq!(messages[0].tokens.reasoning, 863);
-        assert_eq!(messages[0].tokens.total(), 15841);
+        assert_eq!(messages[0].tokens.total(), 15848);
     }
 
     #[test]
@@ -874,7 +876,7 @@ not-json\n\
 
     #[test]
     fn test_parse_gemini_json_direct_tokens() {
-        let json = r#"{"type":"gemini","model":"gemini-3.1-pro-preview","tokens":{"input":20,"output":2,"cached":5,"thoughts":3,"tool":0,"total":25}}"#;
+        let json = r#"{"type":"gemini","model":"gemini-3.1-pro-preview","tokens":{"input":20,"output":2,"cached":5,"thoughts":3,"tool":4,"total":29}}"#;
         let file = tempfile::Builder::new()
             .prefix("session-")
             .suffix(".json")
@@ -886,11 +888,11 @@ not-json\n\
 
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].model_id, "gemini-3.1-pro-preview");
-        assert_eq!(messages[0].tokens.input, 15);
+        assert_eq!(messages[0].tokens.input, 19);
         assert_eq!(messages[0].tokens.output, 2);
         assert_eq!(messages[0].tokens.cache_read, 5);
         assert_eq!(messages[0].tokens.reasoning, 3);
-        assert_eq!(messages[0].tokens.total(), 25);
+        assert_eq!(messages[0].tokens.total(), 29);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -446,7 +446,12 @@ mod tests {
     use std::io::Write;
     use tempfile::TempDir;
 
-    fn create_session_files(dir: &TempDir, stem: &str, json: &str, jsonl: &str) -> std::path::PathBuf {
+    fn create_session_files(
+        dir: &TempDir,
+        stem: &str,
+        json: &str,
+        jsonl: &str,
+    ) -> std::path::PathBuf {
         let json_path = dir.path().join(format!("{}.json", stem));
         let jsonl_path = dir.path().join(format!("{}.jsonl", stem));
         let mut f = std::fs::File::create(&json_path).unwrap();


### PR DESCRIPTION
## Summary
- Count Gemini direct `tool` tokens in the reported token total by carrying them into the input bucket until Tokscale has a dedicated tool-token bucket.
- Invalidate persisted source-message-cache entries so existing users are reparsed with the updated accounting.
- Add JSON and JSONL regressions for non-zero tool counts.

## Validation
- `rustfmt --edition 2021 --check crates/tokscale-core/src/message_cache.rs crates/tokscale-core/src/sessions/gemini.rs`
- `cargo test -p tokscale-core gemini --quiet`
- `cargo test -p tokscale-core message_cache --quiet`
- `cargo check -p tokscale-core --quiet`
- Old-cache upgrade repro: main/schema12 cached input 10, PR/schema13 reparsed input 17 for a Gemini JSONL row with `tool: 7`.

## Risk
- Source-message-cache schema bump invalidates persisted parsed-message cache once. Tool tokens are counted as input because Tokscale currently has no dedicated tool-token bucket.
