### PR TITLE
fix(gemini): avoid caching partial JSONL parses

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -425,23 +425,6 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         messages
     }
 
-    fn parse_uncached_messages<F>(
-        path: &Path,
-        pricing: Option<&pricing::PricingService>,
-        parse: F,
-    ) -> CachedParseOutcome
-    where
-        F: Fn(&Path) -> Vec<UnifiedMessage>,
-    {
-        let mut messages = parse(path);
-        apply_pricing_to_messages(&mut messages, pricing);
-        CachedParseOutcome {
-            messages,
-            cache_entry: None,
-            invalidate_cache: false,
-        }
-    }
-
     fn parse_full_log_source(
         path: &Path,
         pricing: Option<&pricing::PricingService>,
@@ -534,7 +517,7 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         ))
     }
 
-    fn load_or_parse_source_with_fingerprint<F>(
+    fn load_or_parse_source_with_fingerprint_and_policy<F>(
         path: &Path,
         source_cache: &message_cache::SourceMessageCache,
         pricing: Option<&pricing::PricingService>,
@@ -542,10 +525,16 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         parse: F,
     ) -> CachedParseOutcome
     where
-        F: Fn(&Path) -> Vec<UnifiedMessage>,
+        F: Fn(&Path) -> (Vec<UnifiedMessage>, bool),
     {
         let Some(fingerprint) = fingerprint_from_path(path) else {
-            return parse_uncached_messages(path, pricing, parse);
+            let (mut messages, _) = parse(path);
+            apply_pricing_to_messages(&mut messages, pricing);
+            return CachedParseOutcome {
+                messages,
+                cache_entry: None,
+                invalidate_cache: false,
+            };
         };
 
         if let Some(cached) = source_cache.get(path) {
@@ -558,9 +547,8 @@ fn parse_all_messages_with_pricing_with_env_strategy(
             }
         }
 
-        let messages = parse(path);
-        let mut messages = messages;
-        let cache_entry = if messages.is_empty() {
+        let (mut messages, cacheable) = parse(path);
+        let cache_entry = if messages.is_empty() || !cacheable {
             None
         } else {
             Some(message_cache::CachedSourceEntry::new(
@@ -576,8 +564,27 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         CachedParseOutcome {
             messages,
             cache_entry,
-            invalidate_cache: false,
+            invalidate_cache: !cacheable,
         }
+    }
+
+    fn load_or_parse_source_with_fingerprint<F>(
+        path: &Path,
+        source_cache: &message_cache::SourceMessageCache,
+        pricing: Option<&pricing::PricingService>,
+        fingerprint_from_path: fn(&Path) -> Option<message_cache::SourceFingerprint>,
+        parse: F,
+    ) -> CachedParseOutcome
+    where
+        F: Fn(&Path) -> Vec<UnifiedMessage>,
+    {
+        load_or_parse_source_with_fingerprint_and_policy(
+            path,
+            source_cache,
+            pricing,
+            fingerprint_from_path,
+            |path| (parse(path), true),
+        )
     }
 
     fn load_or_parse_source<F>(
@@ -844,19 +851,29 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         }
     }
 
-    let gemini_outcomes: Vec<CachedParseOutcome> = scan_result
+    let gemini_outcomes: Vec<(PathBuf, CachedParseOutcome)> = scan_result
         .get(ClientId::Gemini)
         .par_iter()
         .map(|path| {
-            load_or_parse_source(path, &source_cache, pricing, |path| {
-                sessions::gemini::parse_gemini_file(path)
-            })
+            let outcome = load_or_parse_source_with_fingerprint_and_policy(
+                path,
+                &source_cache,
+                pricing,
+                message_cache::SourceFingerprint::from_path,
+                |path| {
+                    let parsed = sessions::gemini::parse_gemini_file_with_cache_status(path);
+                    (parsed.messages, parsed.cacheable)
+                },
+            );
+            (path.clone(), outcome)
         })
         .collect();
-    for outcome in gemini_outcomes {
+    for (path, outcome) in gemini_outcomes {
         all_messages.extend(outcome.messages);
         if let Some(entry) = outcome.cache_entry {
             source_cache.insert(entry);
+        } else if outcome.invalidate_cache {
+            source_cache.remove(&path);
         }
     }
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1117,14 +1117,13 @@ fn parse_all_messages_with_pricing_with_env_strategy(
     }
 
     if let Some(db_path) = &scan_result.kiro_db {
-        let kiro_db_messages: Vec<UnifiedMessage> =
-            sessions::kiro::parse_kiro_sqlite(db_path)
-                .into_iter()
-                .map(|mut msg| {
-                    apply_pricing_if_available(&mut msg, pricing);
-                    msg
-                })
-                .collect();
+        let kiro_db_messages: Vec<UnifiedMessage> = sessions::kiro::parse_kiro_sqlite(db_path)
+            .into_iter()
+            .map(|mut msg| {
+                apply_pricing_if_available(&mut msg, pricing);
+                msg
+            })
+            .collect();
         all_messages.extend(kiro_db_messages);
     }
 

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -10,7 +10,7 @@ use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
-const CACHE_SCHEMA_VERSION: u32 = 12;
+const CACHE_SCHEMA_VERSION: u32 = 13;
 const CACHE_FILENAME: &str = "source-message-cache.bin";
 const CACHE_LOCK_FILENAME: &str = "source-message-cache.lock";
 const MAX_CACHE_FILE_BYTES: u64 = 256 * 1024 * 1024;

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -911,10 +911,7 @@ fn scan_all_clients_with_env_strategy_inner(
     }
 
     if enabled.contains(&ClientId::Kiro) {
-        let xdg_path = PathBuf::from(format!(
-            "{}/.local/share/kiro-cli/data.sqlite3",
-            home_dir
-        ));
+        let xdg_path = PathBuf::from(format!("{}/.local/share/kiro-cli/data.sqlite3", home_dir));
         if xdg_path.is_file() {
             result.kiro_db = Some(xdg_path);
         }

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -911,7 +911,10 @@ fn scan_all_clients_with_env_strategy_inner(
     }
 
     if enabled.contains(&ClientId::Kiro) {
-        let xdg_path = PathBuf::from(format!("{}/.local/share/kiro-cli/data.sqlite3", home_dir));
+        let xdg_path = PathBuf::from(format!(
+            "{}/.local/share/kiro-cli/data.sqlite3",
+            home_dir
+        ));
         if xdg_path.is_file() {
             result.kiro_db = Some(xdg_path);
         }

--- a/crates/tokscale-core/src/sessions/gemini.rs
+++ b/crates/tokscale-core/src/sessions/gemini.rs
@@ -55,8 +55,17 @@ pub struct GeminiTokens {
     pub total: Option<i64>,
 }
 
-/// Parse a Gemini session file
+pub(crate) struct GeminiParseResult {
+    pub messages: Vec<UnifiedMessage>,
+    pub cacheable: bool,
+}
+
+/// Parse a Gemini session file.
 pub fn parse_gemini_file(path: &Path) -> Vec<UnifiedMessage> {
+    parse_gemini_file_with_cache_status(path).messages
+}
+
+pub(crate) fn parse_gemini_file_with_cache_status(path: &Path) -> GeminiParseResult {
     let fallback_timestamp = file_modified_timestamp_ms(path);
 
     if path.extension().and_then(|s| s.to_str()) == Some("jsonl") {
@@ -94,17 +103,26 @@ pub fn parse_gemini_file(path: &Path) -> Vec<UnifiedMessage> {
             }
         }
         if !ok {
-            return Vec::new();
+            return GeminiParseResult {
+                messages: Vec::new(),
+                cacheable: true,
+            };
         }
     }
 
     let Some(data) = read_file_or_none(path) else {
-        return Vec::new();
+        return GeminiParseResult {
+            messages: Vec::new(),
+            cacheable: true,
+        };
     };
 
     let mut bytes = data.clone();
     if let Ok(session) = simd_json::from_slice::<GeminiSession>(&mut bytes) {
-        return parse_gemini_session(session, fallback_timestamp);
+        return GeminiParseResult {
+            messages: parse_gemini_session(session, fallback_timestamp),
+            cacheable: true,
+        };
     }
 
     let mut bytes = data;
@@ -116,7 +134,10 @@ pub fn parse_gemini_file(path: &Path) -> Vec<UnifiedMessage> {
             .to_string();
         let messages = parse_gemini_headless_value(&value, &session_id, fallback_timestamp);
         if !messages.is_empty() {
-            return messages;
+            return GeminiParseResult {
+                messages,
+                cacheable: true,
+            };
         }
     }
 
@@ -207,10 +228,15 @@ fn parse_direct_gemini_token_message(
     ))
 }
 
-fn parse_gemini_headless_jsonl(path: &Path, fallback_timestamp: i64) -> Vec<UnifiedMessage> {
+fn parse_gemini_headless_jsonl(path: &Path, fallback_timestamp: i64) -> GeminiParseResult {
     let file = match std::fs::File::open(path) {
         Ok(f) => f,
-        Err(_) => return Vec::new(),
+        Err(_) => {
+            return GeminiParseResult {
+                messages: Vec::new(),
+                cacheable: true,
+            };
+        }
     };
 
     let mut session_id = path
@@ -224,12 +250,16 @@ fn parse_gemini_headless_jsonl(path: &Path, fallback_timestamp: i64) -> Vec<Unif
     let mut direct_message_indices: HashMap<String, usize> = HashMap::new();
     let mut line_buffer = Vec::with_capacity(4096);
     let mut json_buffer = Vec::with_capacity(4096);
+    let mut skipped_malformed_line = false;
 
     loop {
         line_buffer.clear();
         let bytes_read = match reader.read_until(b'\n', &mut line_buffer) {
             Ok(n) => n,
-            Err(_) => break,
+            Err(_) => {
+                skipped_malformed_line = true;
+                break;
+            }
         };
         if bytes_read == 0 {
             break;
@@ -244,7 +274,10 @@ fn parse_gemini_headless_jsonl(path: &Path, fallback_timestamp: i64) -> Vec<Unif
         json_buffer.extend_from_slice(trimmed);
         let value: Value = match simd_json::from_slice(&mut json_buffer) {
             Ok(v) => v,
-            Err(_) => continue,
+            Err(_) => {
+                skipped_malformed_line = true;
+                continue;
+            }
         };
 
         let event_type = value.get("type").and_then(|val| val.as_str()).unwrap_or("");
@@ -304,7 +337,10 @@ fn parse_gemini_headless_jsonl(path: &Path, fallback_timestamp: i64) -> Vec<Unif
         }
     }
 
-    messages
+    GeminiParseResult {
+        messages,
+        cacheable: !skipped_malformed_line,
+    }
 }
 
 fn trim_ascii_bytes(bytes: &[u8]) -> &[u8] {
@@ -805,13 +841,14 @@ not-json\n\
         let file_path = chats_dir.join("corrupt.jsonl");
         std::fs::write(&file_path, content).unwrap();
 
-        let messages = parse_gemini_file(&file_path);
+        let result = parse_gemini_file_with_cache_status(&file_path);
 
-        assert_eq!(messages.len(), 1);
-        assert_eq!(messages[0].session_id, "session-1");
-        assert_eq!(messages[0].model_id, "gemini-2.5-pro");
-        assert_eq!(messages[0].tokens.input, 10);
-        assert_eq!(messages[0].tokens.output, 20);
+        assert_eq!(result.messages.len(), 1);
+        assert_eq!(result.messages[0].session_id, "session-1");
+        assert_eq!(result.messages[0].model_id, "gemini-2.5-pro");
+        assert_eq!(result.messages[0].tokens.input, 10);
+        assert_eq!(result.messages[0].tokens.output, 20);
+        assert!(!result.cacheable);
     }
 
     #[test]
@@ -826,12 +863,13 @@ not-json\n\
         let file_path = chats_dir.join("truncated.jsonl");
         std::fs::write(&file_path, content).unwrap();
 
-        let messages = parse_gemini_file(&file_path);
+        let result = parse_gemini_file_with_cache_status(&file_path);
 
-        assert_eq!(messages.len(), 1);
-        assert_eq!(messages[0].model_id, "gemini-2.5-pro");
-        assert_eq!(messages[0].tokens.input, 10);
-        assert_eq!(messages[0].tokens.output, 20);
+        assert_eq!(result.messages.len(), 1);
+        assert_eq!(result.messages[0].model_id, "gemini-2.5-pro");
+        assert_eq!(result.messages[0].tokens.input, 10);
+        assert_eq!(result.messages[0].tokens.output, 20);
+        assert!(!result.cacheable);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -446,7 +446,12 @@ mod tests {
     use std::io::Write;
     use tempfile::TempDir;
 
-    fn create_session_files(dir: &TempDir, stem: &str, json: &str, jsonl: &str) -> std::path::PathBuf {
+    fn create_session_files(
+        dir: &TempDir,
+        stem: &str,
+        json: &str,
+        jsonl: &str,
+    ) -> std::path::PathBuf {
         let json_path = dir.path().join(format!("{}.json", stem));
         let jsonl_path = dir.path().join(format!("{}.jsonl", stem));
         let mut f = std::fs::File::create(&json_path).unwrap();

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -446,12 +446,7 @@ mod tests {
     use std::io::Write;
     use tempfile::TempDir;
 
-    fn create_session_files(
-        dir: &TempDir,
-        stem: &str,
-        json: &str,
-        jsonl: &str,
-    ) -> std::path::PathBuf {
+    fn create_session_files(dir: &TempDir, stem: &str, json: &str, jsonl: &str) -> std::path::PathBuf {
         let json_path = dir.path().join(format!("{}.json", stem));
         let jsonl_path = dir.path().join(format!("{}.jsonl", stem));
         let mut f = std::fs::File::create(&json_path).unwrap();


### PR DESCRIPTION
## Summary
- Preserve valid Gemini JSONL rows after malformed rows while marking the parse as non-cacheable.
- Suppress stale or partial source-message cache persistence for malformed Gemini JSONL input.
- Invalidate persisted source-message-cache entries so existing malformed JSONL cache entries cannot bypass the new non-cacheable parse policy.

## Validation
- `rustfmt --edition 2021 --check crates/tokscale-core/src/message_cache.rs crates/tokscale-core/src/sessions/gemini.rs`
- `cargo test -p tokscale-core gemini --quiet`
- `cargo test -p tokscale-core message_cache --quiet`
- `cargo check -p tokscale-core --quiet`
- Old-cache upgrade repro: main/schema12 cache for malformed Gemini JSONL was ignored by PR/schema13, valid rows still parsed, and the old cache file was not rewritten for the non-cacheable malformed source.

## Risk
- Source-message-cache schema bump invalidates persisted parsed-message cache once. Shared cache helper defaults stay cacheable for existing callers; Gemini is the only source using the new non-cacheable policy.
