### PR TITLE
fix(cursor): require fresh cache for each saved account

### DIFF
--- a/crates/tokscale-cli/src/cursor.rs
+++ b/crates/tokscale-cli/src/cursor.rs
@@ -13,10 +13,11 @@ use std::time::{Duration, SystemTime};
 /// proceeds against cached data after this timeout instead of stalling forever.
 const CURSOR_HTTP_TIMEOUT: Duration = Duration::from_secs(8);
 
-/// Skip implicit pre-report sync when the active account's `usage.csv` was
-/// modified within this window. Prevents `tokscale models` (and its siblings)
-/// from issuing a Cursor API call on every invocation. The manual `tokscale
-/// cursor sync` command bypasses this — explicit user intent is always honored.
+/// Skip implicit pre-report sync when every expected Cursor account cache file
+/// was modified within this window. Prevents `tokscale models` (and its
+/// siblings) from issuing a Cursor API call on every invocation. The manual
+/// `tokscale cursor sync` command bypasses this — explicit user intent is
+/// always honored.
 pub const CURSOR_AUTO_SYNC_FRESHNESS: Duration = Duration::from_secs(5 * 60);
 
 fn build_cursor_http_client() -> Result<reqwest::Client> {
@@ -655,33 +656,36 @@ pub fn has_cursor_usage_cache() -> bool {
     }
 }
 
-/// Returns the freshest mtime across all cached `usage*.csv` files in the
-/// given home directory. Returns `None` when the cache dir is missing, no
-/// cache files exist, or all mtime reads fail (callers should treat that as
-/// stale and re-sync).
-fn cursor_usage_cache_mtime_in(home_dir: &Path) -> Option<SystemTime> {
+fn expected_cursor_usage_cache_paths_in(home_dir: &Path) -> Vec<PathBuf> {
     let cache_dir = cursor_cache_dir(home_dir);
-    if !cache_dir.exists() {
-        return None;
+
+    if let Some(store) = load_credentials_store_from_home(home_dir) {
+        if !store.accounts.is_empty() {
+            let mut paths = store
+                .accounts
+                .keys()
+                .map(|account_id| {
+                    if account_id == &store.active_account_id {
+                        cache_dir.join("usage.csv")
+                    } else {
+                        cache_dir.join(format!(
+                            "usage.{}.csv",
+                            sanitize_account_id_for_filename(account_id)
+                        ))
+                    }
+                })
+                .collect::<Vec<_>>();
+            paths.sort_unstable();
+            paths.dedup();
+            return paths;
+        }
     }
 
-    fs::read_dir(&cache_dir)
-        .ok()?
-        .filter_map(|entry| entry.ok())
-        .filter(|entry| {
-            entry
-                .file_name()
-                .into_string()
-                .ok()
-                .is_some_and(|name| is_cursor_usage_csv_filename(&name))
-        })
-        .filter_map(|entry| entry.metadata().ok())
-        .filter_map(|meta| meta.modified().ok())
-        .max()
+    vec![cache_dir.join("usage.csv")]
 }
 
-fn cursor_usage_cache_is_fresh_in(home_dir: &Path, max_age: Duration) -> bool {
-    let Some(mtime) = cursor_usage_cache_mtime_in(home_dir) else {
+fn cursor_usage_cache_file_is_fresh(path: &Path, max_age: Duration) -> bool {
+    let Ok(mtime) = path.metadata().and_then(|meta| meta.modified()) else {
         return false;
     };
     match SystemTime::now().duration_since(mtime) {
@@ -693,10 +697,21 @@ fn cursor_usage_cache_is_fresh_in(home_dir: &Path, max_age: Duration) -> bool {
     }
 }
 
-/// True when the cursor usage cache was refreshed within `max_age`. Used by
-/// the implicit pre-report sync path to avoid hitting the Cursor API on every
-/// invocation. The manual `tokscale cursor sync` CLI bypasses this — explicit
-/// user intent is always honored.
+fn cursor_usage_cache_is_fresh_in(home_dir: &Path, max_age: Duration) -> bool {
+    let cache_dir = cursor_cache_dir(home_dir);
+    if !cache_dir.exists() {
+        return false;
+    }
+
+    expected_cursor_usage_cache_paths_in(home_dir)
+        .iter()
+        .all(|path| cursor_usage_cache_file_is_fresh(path, max_age))
+}
+
+/// True when every expected cursor usage cache file was refreshed within
+/// `max_age`. Used by the implicit pre-report sync path to avoid hitting the
+/// Cursor API on every invocation. The manual `tokscale cursor sync` CLI
+/// bypasses this — explicit user intent is always honored.
 pub fn cursor_usage_cache_is_fresh(max_age: Duration) -> bool {
     let Ok(home_dir) = home_dir() else {
         return false;
@@ -1441,10 +1456,10 @@ mod tests {
     }
 
     #[test]
-    fn test_cursor_usage_cache_is_fresh_uses_freshest_csv() {
-        // When multiple usage*.csv files exist the freshest mtime wins, so
-        // a recently-synced secondary account keeps the active stale file
-        // from triggering a refresh.
+    fn test_cursor_usage_cache_is_fresh_requires_active_usage_csv_when_secondary_is_fresh() {
+        // A recently-synced secondary account must not mask a stale active
+        // account cache. The implicit sync gate should refresh the cache that
+        // local reports read from `usage.csv`.
         let temp = tempfile::tempdir().unwrap();
         let cache_dir = cursor_cache_dir(temp.path());
         fs::create_dir_all(&cache_dir).unwrap();
@@ -1460,10 +1475,129 @@ mod tests {
         drop(stale);
         // Secondary account written just now.
         fs::write(cache_dir.join("usage.team-a.csv"), "Date,Model\n").unwrap();
-        assert!(cursor_usage_cache_is_fresh_in(
+        assert!(!cursor_usage_cache_is_fresh_in(
             temp.path(),
             Duration::from_secs(300)
         ));
+    }
+
+    #[test]
+    fn test_cursor_usage_cache_is_fresh_returns_false_when_active_cache_missing() {
+        // A fresh secondary account cache alone is not enough: without the
+        // active account's `usage.csv`, the next report would use stale/missing
+        // active data unless the implicit sync runs.
+        let temp = tempfile::tempdir().unwrap();
+        let cache_dir = cursor_cache_dir(temp.path());
+        fs::create_dir_all(&cache_dir).unwrap();
+        fs::write(cache_dir.join("usage.team-a.csv"), "Date,Model\n").unwrap();
+        assert!(!cursor_usage_cache_is_fresh_in(
+            temp.path(),
+            Duration::from_secs(300)
+        ));
+    }
+
+    #[test]
+    fn test_cursor_usage_cache_is_fresh_requires_all_expected_account_files() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let mut accounts = HashMap::new();
+        accounts.insert(
+            "active-account".to_string(),
+            CursorCredentials {
+                session_token: "token-active".to_string(),
+                user_id: Some("active-account".to_string()),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                expires_at: None,
+                label: Some("work".to_string()),
+            },
+        );
+        accounts.insert(
+            "team/account".to_string(),
+            CursorCredentials {
+                session_token: "token-secondary".to_string(),
+                user_id: Some("team/account".to_string()),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                expires_at: None,
+                label: Some("personal".to_string()),
+            },
+        );
+        save_credentials_store_in_home(
+            temp_dir.path(),
+            &CursorCredentialsStore {
+                version: 1,
+                active_account_id: "active-account".to_string(),
+                accounts,
+            },
+        )?;
+
+        let cache_dir = cursor_cache_dir(temp_dir.path());
+        fs::create_dir_all(&cache_dir)?;
+        fs::write(cache_dir.join("usage.csv"), "Date,Model\n")?;
+
+        assert!(!cursor_usage_cache_is_fresh_in(
+            temp_dir.path(),
+            Duration::from_secs(300)
+        ));
+
+        fs::write(cache_dir.join("usage.team-account.csv"), "Date,Model\n")?;
+        assert!(cursor_usage_cache_is_fresh_in(
+            temp_dir.path(),
+            Duration::from_secs(300)
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cursor_expected_cache_paths_dedupes_sanitized_account_collisions() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut accounts = HashMap::new();
+        accounts.insert(
+            "active-account".to_string(),
+            CursorCredentials {
+                session_token: "token-active".to_string(),
+                user_id: Some("active-account".to_string()),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                expires_at: None,
+                label: Some("active".to_string()),
+            },
+        );
+        accounts.insert(
+            "team/account-a".to_string(),
+            CursorCredentials {
+                session_token: "token-team-a".to_string(),
+                user_id: Some("team/account-a".to_string()),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                expires_at: None,
+                label: Some("team-a".to_string()),
+            },
+        );
+        accounts.insert(
+            "team@account-a".to_string(),
+            CursorCredentials {
+                session_token: "token-team-b".to_string(),
+                user_id: Some("team@account-a".to_string()),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                expires_at: None,
+                label: Some("team-b".to_string()),
+            },
+        );
+        save_credentials_store_in_home(
+            temp_dir.path(),
+            &CursorCredentialsStore {
+                version: 1,
+                active_account_id: "active-account".to_string(),
+                accounts,
+            },
+        )
+        .unwrap();
+
+        let paths = expected_cursor_usage_cache_paths_in(temp_dir.path());
+        let cache_dir = cursor_cache_dir(temp_dir.path());
+        let expected = vec![
+            cache_dir.join("usage.csv"),
+            cache_dir.join("usage.team-account-a.csv"),
+        ];
+        assert_eq!(paths, expected);
     }
 
     #[test]

--- a/crates/tokscale-cli/src/cursor.rs
+++ b/crates/tokscale-cli/src/cursor.rs
@@ -51,6 +51,12 @@ const USAGE_CSV_ENDPOINT: &str =
     "https://cursor.com/api/dashboard/export-usage-events-csv?strategy=tokens";
 const USAGE_SUMMARY_ENDPOINT: &str = "https://cursor.com/api/usage-summary";
 
+/// Marker file touched at the end of every `sync_cursor_cache` run (even when
+/// some accounts fail). Its mtime gates secondary-account freshness checks so
+/// a permanently-stale secondary (expired token, removed account, network
+/// partition) does not force an implicit sync on every invocation.
+const CURSOR_SYNC_ATTEMPT_MARKER: &str = "usage.last-sync-attempt";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CursorCredentials {
     #[serde(rename = "sessionToken")]
@@ -703,15 +709,36 @@ fn cursor_usage_cache_is_fresh_in(home_dir: &Path, max_age: Duration) -> bool {
         return false;
     }
 
+    // The active account's cache is non-negotiable: if it is stale or missing,
+    // implicit sync must run so reports read current data.
+    let active_path = cache_dir.join("usage.csv");
+    if !cursor_usage_cache_file_is_fresh(&active_path, max_age) {
+        return false;
+    }
+
+    // For secondaries, a fresh sync-attempt marker is sufficient. This avoids
+    // forcing a sync on every invocation when a secondary account is
+    // permanently stale (expired token, removed account, persistent API
+    // failure). Without the marker, `.all(...)` would return `false` forever.
+    let marker_fresh =
+        cursor_usage_cache_file_is_fresh(&cache_dir.join(CURSOR_SYNC_ATTEMPT_MARKER), max_age);
+
     expected_cursor_usage_cache_paths_in(home_dir)
         .iter()
-        .all(|path| cursor_usage_cache_file_is_fresh(path, max_age))
+        .filter(|p| *p != &active_path)
+        .all(|p| cursor_usage_cache_file_is_fresh(p, max_age) || marker_fresh)
 }
 
-/// True when every expected cursor usage cache file was refreshed within
-/// `max_age`. Used by the implicit pre-report sync path to avoid hitting the
-/// Cursor API on every invocation. The manual `tokscale cursor sync` CLI
-/// bypasses this — explicit user intent is always honored.
+/// True when the active cursor usage cache (`usage.csv`) was refreshed within
+/// `max_age` AND every secondary account cache is either fresh or a recent
+/// sync-attempt marker exists. The active cache is unconditionally required —
+/// a stale active means reports would show out-of-date data. Secondaries are
+/// best-effort: when a secondary is permanently stale (expired token, removed
+/// account, persistent API failure) the marker short-circuits the check so we
+/// don't force an implicit sync on every invocation. Used by the implicit
+/// pre-report sync path to avoid hitting the Cursor API on every invocation.
+/// The manual `tokscale cursor sync` CLI bypasses this — explicit user intent
+/// is always honored.
 pub fn cursor_usage_cache_is_fresh(max_age: Duration) -> bool {
     let Ok(home_dir) = home_dir() else {
         return false;
@@ -951,6 +978,18 @@ where
             }
         }
     }
+
+    // Touch the sync-attempt marker unconditionally after the per-account loop
+    // (regardless of partial failures). The marker's mtime short-circuits the
+    // secondary-account freshness check so a permanently-stale secondary
+    // doesn't force an implicit sync on every invocation. We ignore errors
+    // here — if the marker can't be written (e.g. disk full) the gate simply
+    // falls through to the CSV-freshness check as before.
+    let _ = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(cache_dir.join(CURSOR_SYNC_ATTEMPT_MARKER));
 
     if success_count == 0 {
         return SyncCursorResult {
@@ -1854,6 +1893,168 @@ mod tests {
         assert!(dst.exists());
         assert_eq!(fs::read_dir(&dst)?.count(), 0);
 
+        Ok(())
+    }
+
+    /// Helper: build a two-account credentials store in `home_dir`.
+    fn setup_two_account_store(home_dir: &std::path::Path) -> Result<()> {
+        let mut accounts = HashMap::new();
+        accounts.insert(
+            "active-account".to_string(),
+            CursorCredentials {
+                session_token: "token-active".to_string(),
+                user_id: Some("active-account".to_string()),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                expires_at: None,
+                label: Some("work".to_string()),
+            },
+        );
+        accounts.insert(
+            "team/account".to_string(),
+            CursorCredentials {
+                session_token: "token-secondary".to_string(),
+                user_id: Some("team/account".to_string()),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                expires_at: None,
+                label: Some("personal".to_string()),
+            },
+        );
+        save_credentials_store_in_home(
+            home_dir,
+            &CursorCredentialsStore {
+                version: 1,
+                active_account_id: "active-account".to_string(),
+                accounts,
+            },
+        )
+    }
+
+    /// Helper: backdate a file's mtime by `secs` seconds. Returns `false` if
+    /// the platform refuses to set mtime (exotic FS), signalling the caller to
+    /// skip the test.
+    fn backdate_file(path: &std::path::Path, secs: u64) -> bool {
+        let f = match std::fs::OpenOptions::new().write(true).open(path) {
+            Ok(f) => f,
+            Err(_) => return false,
+        };
+        f.set_modified(SystemTime::now() - Duration::from_secs(secs))
+            .is_ok()
+    }
+
+    #[test]
+    fn test_freshness_gate_passes_when_active_fresh_and_marker_fresh_despite_stale_secondary(
+    ) -> Result<()> {
+        // Active CSV fresh + stale secondary CSV + fresh marker → gate passes.
+        // This is the key scenario: a permanently-stale secondary must not
+        // thrash implicit sync when the marker proves we already tried recently.
+        let temp_dir = TempDir::new()?;
+        setup_two_account_store(temp_dir.path())?;
+
+        let cache_dir = cursor_cache_dir(temp_dir.path());
+        fs::create_dir_all(&cache_dir)?;
+
+        // Fresh active cache.
+        fs::write(cache_dir.join("usage.csv"), "Date,Model\n")?;
+
+        // Stale secondary cache.
+        let secondary = cache_dir.join("usage.team-account.csv");
+        fs::write(&secondary, "Date,Model\n")?;
+        if !backdate_file(&secondary, 3600) {
+            return Ok(()); // platform can't set mtime — skip
+        }
+
+        // Fresh sync-attempt marker.
+        fs::write(cache_dir.join(CURSOR_SYNC_ATTEMPT_MARKER), "")?;
+
+        assert!(
+            cursor_usage_cache_is_fresh_in(temp_dir.path(), Duration::from_secs(300)),
+            "fresh marker should short-circuit stale secondary"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_freshness_gate_fails_when_active_fresh_but_no_marker_and_stale_secondary() -> Result<()>
+    {
+        // Active CSV fresh + stale secondary CSV + NO marker → gate fails so
+        // an implicit sync is triggered to try fetching the secondary again.
+        let temp_dir = TempDir::new()?;
+        setup_two_account_store(temp_dir.path())?;
+
+        let cache_dir = cursor_cache_dir(temp_dir.path());
+        fs::create_dir_all(&cache_dir)?;
+
+        fs::write(cache_dir.join("usage.csv"), "Date,Model\n")?;
+
+        let secondary = cache_dir.join("usage.team-account.csv");
+        fs::write(&secondary, "Date,Model\n")?;
+        if !backdate_file(&secondary, 3600) {
+            return Ok(());
+        }
+
+        // No marker written.
+
+        assert!(
+            !cursor_usage_cache_is_fresh_in(temp_dir.path(), Duration::from_secs(300)),
+            "without marker, stale secondary should trigger sync"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_freshness_gate_fails_when_active_stale_even_with_fresh_marker() -> Result<()> {
+        // Stale active CSV + fresh marker → gate still fails. The marker must
+        // never mask a stale active cache — the active data is what reports
+        // read from.
+        let temp_dir = TempDir::new()?;
+        setup_two_account_store(temp_dir.path())?;
+
+        let cache_dir = cursor_cache_dir(temp_dir.path());
+        fs::create_dir_all(&cache_dir)?;
+
+        // Stale active cache.
+        let active = cache_dir.join("usage.csv");
+        fs::write(&active, "Date,Model\n")?;
+        if !backdate_file(&active, 3600) {
+            return Ok(());
+        }
+
+        // Fresh secondary and fresh marker.
+        fs::write(cache_dir.join("usage.team-account.csv"), "Date,Model\n")?;
+        fs::write(cache_dir.join(CURSOR_SYNC_ATTEMPT_MARKER), "")?;
+
+        assert!(
+            !cursor_usage_cache_is_fresh_in(temp_dir.path(), Duration::from_secs(300)),
+            "stale active cache must always trigger sync regardless of marker"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_sync_writes_attempt_marker() -> Result<()> {
+        // After sync_cursor_cache_with_fetcher_in_home completes (even with a
+        // partial failure), the marker file must exist in the cache dir.
+        let temp_dir = TempDir::new()?;
+        setup_two_account_store(temp_dir.path())?;
+
+        let runtime = tokio::runtime::Runtime::new()?;
+        let _result = runtime.block_on(sync_cursor_cache_with_fetcher_in_home(
+            temp_dir.path(),
+            |session_token| {
+                // Secondary deliberately fails to simulate a broken account.
+                let result: Result<String> = match session_token.as_str() {
+                    "token-active" => Ok("Date,Model,Tokens\n2026-01-01,gpt-5,10\n".to_string()),
+                    _ => Err(anyhow::anyhow!("simulated fetch failure")),
+                };
+                async move { result }
+            },
+        ));
+
+        let cache_dir = cursor_cache_dir(temp_dir.path());
+        assert!(
+            cache_dir.join(CURSOR_SYNC_ATTEMPT_MARKER).exists(),
+            "marker must be written even when a secondary account fetch fails"
+        );
         Ok(())
     }
 }

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1068,9 +1068,10 @@ fn auto_sync_cursor_for_local_report(
         return None;
     }
 
-    // Skip the implicit refresh when the cache is recent enough — running
-    // `tokscale models` 30× in a script must not produce 30 Cursor API
-    // calls. The manual `tokscale cursor sync` command bypasses this gate.
+    // Skip the implicit refresh when each expected Cursor account cache is
+    // recent enough — running `tokscale models` 30× in a script must not
+    // produce 30 Cursor API calls. The manual `tokscale cursor sync` command
+    // bypasses this gate.
     if cursor::cursor_usage_cache_is_fresh(cursor::CURSOR_AUTO_SYNC_FRESHNESS) {
         return None;
     }

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1100,14 +1100,13 @@ fn parse_all_messages_with_pricing_with_env_strategy(
     }
 
     if let Some(db_path) = &scan_result.kiro_db {
-        let kiro_db_messages: Vec<UnifiedMessage> =
-            sessions::kiro::parse_kiro_sqlite(db_path)
-                .into_iter()
-                .map(|mut msg| {
-                    apply_pricing_if_available(&mut msg, pricing);
-                    msg
-                })
-                .collect();
+        let kiro_db_messages: Vec<UnifiedMessage> = sessions::kiro::parse_kiro_sqlite(db_path)
+            .into_iter()
+            .map(|mut msg| {
+                apply_pricing_if_available(&mut msg, pricing);
+                msg
+            })
+            .collect();
         all_messages.extend(kiro_db_messages);
     }
 

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -911,10 +911,7 @@ fn scan_all_clients_with_env_strategy_inner(
     }
 
     if enabled.contains(&ClientId::Kiro) {
-        let xdg_path = PathBuf::from(format!(
-            "{}/.local/share/kiro-cli/data.sqlite3",
-            home_dir
-        ));
+        let xdg_path = PathBuf::from(format!("{}/.local/share/kiro-cli/data.sqlite3", home_dir));
         if xdg_path.is_file() {
             result.kiro_db = Some(xdg_path);
         }

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -446,7 +446,12 @@ mod tests {
     use std::io::Write;
     use tempfile::TempDir;
 
-    fn create_session_files(dir: &TempDir, stem: &str, json: &str, jsonl: &str) -> std::path::PathBuf {
+    fn create_session_files(
+        dir: &TempDir,
+        stem: &str,
+        json: &str,
+        jsonl: &str,
+    ) -> std::path::PathBuf {
         let json_path = dir.path().join(format!("{}.json", stem));
         let jsonl_path = dir.path().join(format!("{}.jsonl", stem));
         let mut f = std::fs::File::create(&json_path).unwrap();


### PR DESCRIPTION
## Summary
- Makes implicit Cursor auto-sync freshness account-aware so a fresh secondary account CSV cannot mask missing or stale active-account cache data.

## Validation
- \; \
running 5 tests
.....
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 468 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 88 filtered out; finished in 0.00s; \.

## Risk
- Narrowly changes the freshness gate for implicit pre-report sync; manual sync remains unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Cursor auto-sync freshness account-aware and add a retry cap so a permanently stale secondary account doesn’t force sync every run. Active `usage.csv` must be fresh; secondaries must be fresh or have a recent `usage.last-sync-attempt`.

- **Bug Fixes**
  - Skip implicit sync only when the active cache is fresh and each secondary cache is fresh or the `usage.last-sync-attempt` marker is recent; a missing cache dir or missing active cache is stale.
  - Touch `usage.last-sync-attempt` at the end of every sync (even on partial failures) to avoid repeated syncs when a secondary is broken.
  - Preserve the original fix so a fresh secondary can’t mask a stale/missing active cache, and dedupe expected paths when sanitized account IDs collide; add tests for these cases and the marker behavior.

<sup>Written for commit f9feae3575ceb3b32b8141879818519757945b57. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

