### PR TITLE
fix(submit): accept Zed usage payloads

### DIFF
--- a/packages/frontend/__tests__/api/submit.test.ts
+++ b/packages/frontend/__tests__/api/submit.test.ts
@@ -143,6 +143,13 @@ describe('POST /api/submit - Client-Level Merge', () => {
       expect(data.contributions[0].clients[0].client).toBe('hermes');
     });
 
+    it('should support zed client in submission payload', () => {
+      const data = createMockSubmissionData({ clients: ['zed'] });
+
+      expect(data.summary.clients).toContain('zed');
+      expect(data.contributions[0].clients[0].client).toBe('zed');
+    });
+
     it('should pass validation for kilo client submissions', () => {
       const payload = {
         meta: { generatedAt: new Date().toISOString(), version: '1.0.0', dateRange: { start: '2024-12-01', end: '2024-12-01' } },
@@ -176,6 +183,44 @@ describe('POST /api/submit - Client-Level Merge', () => {
             { client: 'kilo' as const, modelId: 'claude-sonnet-4', tokens: { input: 1000, output: 500, cacheRead: 0, cacheWrite: 0, reasoning: 0 }, cost: 1.5, messages: 5 },
             { client: 'kilocode' as const, modelId: 'claude-sonnet-4', tokens: { input: 1000, output: 500, cacheRead: 0, cacheWrite: 0, reasoning: 0 }, cost: 1.5, messages: 5 },
           ],
+        }],
+      };
+      const result = validateSubmission(payload);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should pass validation for zed client submissions', () => {
+      const payload = {
+        meta: { generatedAt: new Date().toISOString(), version: '1.0.0', dateRange: { start: '2024-12-01', end: '2024-12-01' } },
+        summary: { totalTokens: 1500, totalCost: 1.5, totalDays: 1, activeDays: 1, averagePerDay: 1.5, maxCostInSingleDay: 1.5, clients: ['zed' as const], models: ['claude-sonnet-4'] },
+        years: [{ year: '2024', totalTokens: 1500, totalCost: 1.5, range: { start: '2024-12-01', end: '2024-12-01' } }],
+        contributions: [{
+          date: '2024-12-01',
+          totals: { tokens: 1500, cost: 1.5, messages: 5 },
+          intensity: 2 as const,
+          tokenBreakdown: { input: 1000, output: 500, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+          clients: [{ client: 'zed' as const, modelId: 'claude-sonnet-4', tokens: { input: 1000, output: 500, cacheRead: 0, cacheWrite: 0, reasoning: 0 }, cost: 1.5, messages: 5 }],
+        }],
+      };
+      const result = validateSubmission(payload);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should pass validation for legacy zed source submissions', () => {
+      const payload = {
+        meta: { generatedAt: new Date().toISOString(), version: '1.0.0', dateRange: { start: '2024-12-01', end: '2024-12-01' } },
+        summary: { totalTokens: 1500, totalCost: 1.5, totalDays: 1, activeDays: 1, averagePerDay: 1.5, maxCostInSingleDay: 1.5, sources: ['zed'], models: ['claude-sonnet-4'] },
+        years: [{ year: '2024', totalTokens: 1500, totalCost: 1.5, range: { start: '2024-12-01', end: '2024-12-01' } }],
+        contributions: [{
+          date: '2024-12-01',
+          totals: { tokens: 1500, cost: 1.5, messages: 5 },
+          intensity: 2 as const,
+          tokenBreakdown: { input: 1000, output: 500, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+          sources: [{ source: 'zed', modelId: 'claude-sonnet-4', tokens: { input: 1000, output: 500, cacheRead: 0, cacheWrite: 0, reasoning: 0 }, cost: 1.5, messages: 5 }],
         }],
       };
       const result = validateSubmission(payload);

--- a/packages/frontend/src/components/SourceLogo.tsx
+++ b/packages/frontend/src/components/SourceLogo.tsx
@@ -2,8 +2,6 @@
 
 import styled from "styled-components";
 
-/* eslint-disable @next/next/no-img-element */
-
 interface SourceLogoProps {
   sourceId: string;
   height?: number;
@@ -63,6 +61,8 @@ export function SourceLogo({ sourceId, height = 14, className = "" }: SourceLogo
         return "https://raw.githubusercontent.com/junhoyeo/tokscale/main/.github/assets/client-crush.png";
       case "kiro":
         return "/assets/logos/kiro.ico";
+      case "zed":
+        return "https://raw.githubusercontent.com/junhoyeo/tokscale/main/.github/assets/client-zed.webp";
       case "synthetic":
         return "/assets/logos/synthetic.png";
       default:

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type ClientType = "opencode" | "claude" | "codex" | "copilot" | "gemini" | "cursor" | "amp" | "droid" | "openclaw" | "hermes" | "pi" | "kimi" | "qwen" | "roocode" | "kilocode" | "kilo" | "mux" | "crush" | "kiro" | "synthetic";
+export type ClientType = "opencode" | "claude" | "codex" | "copilot" | "gemini" | "cursor" | "amp" | "droid" | "openclaw" | "hermes" | "pi" | "kimi" | "qwen" | "roocode" | "kilocode" | "kilo" | "mux" | "crush" | "kiro" | "zed" | "synthetic";
 
 export interface TokenBreakdown {
   input: number;

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -38,6 +38,7 @@ const SUPPORTED_SOURCES = [
   "mux",
   "crush",
   "kiro",
+  "zed",
   "synthetic",
 ] as const;
 const SourceSchema = z.enum(SUPPORTED_SOURCES);


### PR DESCRIPTION
## Summary
- Adds Zed to frontend submission validation/types/logo handling and covers both current client payloads and legacy source payloads in submit validation tests.

## Validation
- \bun install v1.3.13 (bf2e2cec)

Checked 483 installs across 634 packages (no changes) [93.00ms]; \
 RUN  v4.0.16 /Users/junhoyeo/tokscale/packages/frontend

 ✓ __tests__/api/submit.test.ts (24 tests) 7ms

 Test Files  1 passed (1)
      Tests  24 passed (24)
   Start at  14:40:02
   Duration  206ms (transform 45ms, setup 0ms, import 66ms, tests 7ms, environment 0ms); \
/Users/junhoyeo/tokscale/packages/frontend/src/components/SourceLogo.tsx
  5:1  warning  Unused eslint-disable directive (no problems were reported from '@next/next/no-img-element')

✖ 1 problem (0 errors, 1 warning)
  0 errors and 1 warning potentially fixable with the `--fix` option..

## Risk
- Frontend-only validation/UI wiring; full frontend typecheck was not rerun because existing repo-wide type errors were observed during the review pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept Zed usage submissions by updating frontend validation, types, and logo mapping. Supports both client-based and legacy source-based payloads.

- **New Features**
  - Added `zed` to `ClientType` and submission validation (`SUPPORTED_SOURCES`).
  - Added Zed logo mapping in `SourceLogo`.
  - Extended submit tests to validate Zed for both client and legacy source payloads.

<sup>Written for commit 80db6445119c15b3b37d6a79a2223bbfdc2a47b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

