### PR TITLE
docs(readme): use Deno quickstart without alias setup

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -161,8 +161,8 @@ npx tokscale@latest
 # またはbunxを使用
 bunx tokscale@latest
 
-# たはdeno dxを使用
-dx tokscale@latest
+# またはエイリアスをインストールせずにDenoを使用
+deno x npm:tokscale@latest
 
 # ライトモード（テーブルレンダリングのみ）
 npx tokscale@latest --light

--- a/README.ko.md
+++ b/README.ko.md
@@ -161,8 +161,8 @@ npx tokscale@latest
 # 또는 bunx 사용
 bunx tokscale@latest
 
-# 또는 deno dx 사용
-dx tokscale@latest
+# 별칭 설치 없이 Deno 사용
+deno x npm:tokscale@latest
 
 # 라이트 모드 (테이블 렌더링만)
 npx tokscale@latest --light

--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ npx tokscale@latest
 # Or use bunx
 bunx tokscale@latest
 
-# Or use deno dx
-dx tokscale@latest
+# Or use Deno without installing an alias
+deno x npm:tokscale@latest
 
 # Light mode (table rendering only)
 npx tokscale@latest --light

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -161,8 +161,8 @@ npx tokscale@latest
 # 或使用 bunx
 bunx tokscale@latest
 
-# 或使用 deno dx
-dx tokscale@latest
+# 或使用 Deno（无需安装别名）
+deno x npm:tokscale@latest
 
 # 轻量模式（仅表格渲染）
 npx tokscale@latest --light


### PR DESCRIPTION
## Summary
- Replaces the Deno quickstart snippets with \ across localized READMEs and fixes the Japanese quickstart typo.

## Validation
- \README.md:166:# Or use deno dx
README.md:167:dx tokscale@latest
README.zh-cn.md:164:# 或使用 deno dx
README.zh-cn.md:165:dx tokscale@latest
README.ko.md:164:# 또는 deno dx 사용
README.ko.md:165:dx tokscale@latest
README.ja.md:57:| <img width="48px" src=".github/assets/client-opencode.png" alt="OpenCode" /> | [OpenCode](https://github.com/sst/opencode) | `~/.local/share/opencode/opencode.db` (1.2+、`opencode-stable.db` など全チャンネル対応) または `~/.local/share/opencode/storage/message/` | ✅ 対応 |
README.ja.md:161:# またはbunxを使用
README.ja.md:164:# たはdeno dxを使用
README.ja.md:165:dx tokscale@latest
README.ja.md:178:- [Node.js](https://nodejs.org/) または [Bun](https://bun.sh/)
README.ja.md:183:ローカル開発またはソースからビルドする場合：
README.ja.md:248:  - `1-6`または`←/→/Tab`: ビュー切り替え
README.ja.md:638:  - `sort=tokens`（デフォルト）または`sort=cost` ランキング基準を制御
README.ja.md:653:  - `metric=tokens`（デフォルト）、`metric=cost`、または`metric=rank`
README.ja.md:654:  - `style=flat`（デフォルト）または`style=flat-square`
README.ja.md:655:  - `sort=tokens`（デフォルト）または`sort=cost` ランキング基準を制御
README.ja.md:738:# またはレガシーCLIモードを使用
README.ja.md:926:デフォルトでは、一部のAIコーディングアシスタントは古いセッションファイルを自動的に削除します。正確な追跡のために使用履歴を保持するには、クリーンアップ期間を無効化または延長してください。
README.ja.md:963:または非常に長い保持期間を設定：
README.ja.md:997:場所: `~/.local/share/opencode/opencode.db` (v1.2+) または `storage/message/{sessionId}/*.json` (レガシー)
README.ja.md:1040:場所: `~/.copilot/otel/*.jsonl` または `COPILOT_OTEL_FILE_EXPORTER_PATH` に明示されたパス
README.ja.md:1121:HermesはSQLiteの`sessions`テーブルにセッションレベルの使用量を保存します。Tokscaleは`model`が存在しトークンまたはコスト合計が0でない行をインポートし、`started_at`をタイムスタンプとして使用し、`message_count`を保持し、`actual_cost_usd`を`estimated_cost_usd`より優先します。
README.ja.md:1208:Crushはプロジェクトごとのデータベース（`crush.db`）に使用量を保存します。Crushは信頼できるメッセージごとまたはモデルごとのトークン集計を提供しないため、Tokscaleはルートセッションのセッションレベルのコスト合計のみをインポートします。レコードは`model=session-total`として表示され、トークン内訳はゼロです。
README.ja.md:1224:Synthetic は他ソースのメッセージを後処理で再帰属します。`hf:`プレフィックスのモデル ID または `synthetic` / `glhf` / `octofriend` プロバイダを検出した場合、ソースを `synthetic` として扱います。
README.ja.md:1288:このプロジェクトが興味深いと感じたら、**スターを付けてください ⭐** または[GitHubでフォロー](https://github.com/junhoyeo)して旅に参加してください（すでに1.1k以上が乗船中）。私は24時間コーディングし、定期的に驚くべきものを出荷しています—あなたのサポートは無駄になりません。.

## Risk
- Docs-only change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Deno quickstart in all localized READMEs to use `deno x npm:tokscale@latest`, removing the need for the `dx` alias. Also fixes a typo in the Japanese quickstart.

<sup>Written for commit a946c3df53eff130e00d290128c20c2bd4beb4d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

