### PR TITLE
chore(kiro): format parser changes

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1100,14 +1100,13 @@ fn parse_all_messages_with_pricing_with_env_strategy(
     }
 
     if let Some(db_path) = &scan_result.kiro_db {
-        let kiro_db_messages: Vec<UnifiedMessage> =
-            sessions::kiro::parse_kiro_sqlite(db_path)
-                .into_iter()
-                .map(|mut msg| {
-                    apply_pricing_if_available(&mut msg, pricing);
-                    msg
-                })
-                .collect();
+        let kiro_db_messages: Vec<UnifiedMessage> = sessions::kiro::parse_kiro_sqlite(db_path)
+            .into_iter()
+            .map(|mut msg| {
+                apply_pricing_if_available(&mut msg, pricing);
+                msg
+            })
+            .collect();
         all_messages.extend(kiro_db_messages);
     }
 

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -911,10 +911,7 @@ fn scan_all_clients_with_env_strategy_inner(
     }
 
     if enabled.contains(&ClientId::Kiro) {
-        let xdg_path = PathBuf::from(format!(
-            "{}/.local/share/kiro-cli/data.sqlite3",
-            home_dir
-        ));
+        let xdg_path = PathBuf::from(format!("{}/.local/share/kiro-cli/data.sqlite3", home_dir));
         if xdg_path.is_file() {
             result.kiro_db = Some(xdg_path);
         }

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -140,7 +140,11 @@ pub fn parse_kiro_file(path: &Path) -> Vec<UnifiedMessage> {
         let reader = BufReader::new(jsonl_file);
         let mut pending_prompt: Option<(usize, Option<i64>)> = None;
 
-        for line in reader.lines().filter_map(Result::ok) {
+        for line in reader.lines() {
+            let line = match line {
+                Ok(l) => l,
+                Err(_) => continue,
+            };
             let trimmed = line.trim();
             if trimmed.is_empty() {
                 continue;
@@ -446,7 +450,12 @@ mod tests {
     use std::io::Write;
     use tempfile::TempDir;
 
-    fn create_session_files(dir: &TempDir, stem: &str, json: &str, jsonl: &str) -> std::path::PathBuf {
+    fn create_session_files(
+        dir: &TempDir,
+        stem: &str,
+        json: &str,
+        jsonl: &str,
+    ) -> std::path::PathBuf {
         let json_path = dir.path().join(format!("{}.json", stem));
         let jsonl_path = dir.path().join(format!("{}.jsonl", stem));
         let mut f = std::fs::File::create(&json_path).unwrap();
@@ -490,5 +499,20 @@ mod tests {
         let messages = parse_kiro_file(&path);
 
         assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_parse_kiro_skips_malformed_jsonl_lines() {
+        let dir = TempDir::new().unwrap();
+        let json = r#"{"session_id":"session-3","cwd":"/tmp/project","session_state":{"rts_model_state":{"model_info":{"model_id":"claude-sonnet-4-5"}},"conversation_metadata":{"user_turn_metadatas":[{"input_token_count":0,"output_token_count":0,"turn_duration":100,"end_timestamp":1770983427,"total_request_count":2,"message_ids":["prompt-3","assistant-3"]}]}}}"#;
+        let jsonl = r#"{"version":"v1","kind":"Prompt","data":{"message_id":"prompt-3","content":[{"kind":"text","data":"hello world"}],"meta":{"timestamp":1770983426.420942}}}
+not valid json at all
+{"version":"v1","kind":"AssistantMessage","data":{"message_id":"assistant-3","content":[{"kind":"text","data":"response text"}]}}"#;
+        let path = create_session_files(&dir, "session-3", json, jsonl);
+
+        let messages = parse_kiro_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].tokens.input > 0 || messages[0].tokens.output > 0);
     }
 }


### PR DESCRIPTION
## Summary
- Apply rustfmt to Kiro parser integration files so formatting checks pass without mixing behavior changes into this formatting diff.
- This PR is intentionally stacked on #536 because `main` currently has the Kiro `lines_filter_map_ok` clippy failure; the head diff here remains formatting-only.

## Validation
- `cargo fmt --all --check`

## Risk
- Formatting-only change. Merge after #536.
