### PR TITLE
fix(ci): gate macOS-only Zed scanner test and quiet test-only clippy lints

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -2311,6 +2311,7 @@ mod tests {
         msg
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn build_opencode_sqlite_payload(
         created_ms: f64,
         completed_ms: f64,

--- a/crates/tokscale-core/src/paths.rs
+++ b/crates/tokscale-core/src/paths.rs
@@ -111,6 +111,7 @@ mod tests {
     use super::*;
     use serial_test::serial;
     use std::env;
+    use std::path::Path;
 
     fn save_env() -> (
         Option<std::ffi::OsString>,
@@ -253,7 +254,7 @@ mod tests {
             "empty override must not resolve to the empty path"
         );
         assert!(
-            resolved.is_absolute() || resolved == PathBuf::from(".tokscale"),
+            resolved.is_absolute() || resolved == Path::new(".tokscale"),
             "empty override must fall through to platform default, got {resolved:?}"
         );
         restore_env(prev);

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -1318,6 +1318,7 @@ mod tests {
         zed_db
     }
 
+    #[cfg(target_os = "macos")]
     fn setup_mock_zed_macos_db(base: &std::path::Path) -> PathBuf {
         let zed_db = base.join("Library/Application Support/Zed/threads/threads.db");
         fs::create_dir_all(zed_db.parent().unwrap()).unwrap();
@@ -1961,6 +1962,7 @@ mod tests {
         restore_env("XDG_DATA_HOME", previous_xdg);
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     #[serial]
     fn test_scan_all_clients_zed_macos_fallback() {


### PR DESCRIPTION
## Summary
- Gate `test_scan_all_clients_zed_macos_fallback` and its helper with `#[cfg(target_os = "macos")]` so ubuntu CI doesn't try to exercise the macOS-only branch in `scanner.rs`. The actual macOS-fallback code already has the cfg gate; the test was missing it.
- Add `#[allow(clippy::too_many_arguments)]` to `build_opencode_sqlite_payload` test helper (8 args; restructuring would churn 6 callers for a test fixture).
- Replace `resolved == PathBuf::from(".tokscale")` with `resolved == Path::new(".tokscale")` in `paths.rs` tests to satisfy `clippy::cmp_owned`.

## Why now
Main has been red since #531. CI failure: `scanner::tests::test_scan_all_clients_zed_macos_fallback` (ubuntu). The clippy lints would also have failed `cargo clippy --workspace --all-targets -- -D warnings`.

## Validation
- `cargo test --workspace --quiet` — all pass
- `cargo clippy --workspace --all-targets --no-deps -- -D warnings` — clean
- `cargo fmt --all --check` — clean

## Risk
Test-only changes. No production code touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI by gating the macOS-only Zed scanner test to macOS and cleaning up test-only clippy lints so `cargo clippy --all-targets` passes. Test-only changes; no production code touched.

- **Bug Fixes**
  - Gate `setup_mock_zed_macos_db` and `test_scan_all_clients_zed_macos_fallback` with `#[cfg(target_os = "macos")]` so Linux CI doesn’t run macOS code paths.
  - Add `#[allow(clippy::too_many_arguments)]` to the `build_opencode_sqlite_payload` test helper.
  - Replace `PathBuf::from(".tokscale")` with `Path::new(".tokscale")` in tests to satisfy `clippy::cmp_owned`.

<sup>Written for commit 310a439b6395348e02f9391bdb1f299de886f678. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

