### PR TITLE
fix(gemini): detect Gemini CLI usage with configurable path and new token formats

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -60,7 +60,7 @@
 | <img width="48px" src=".github/assets/client-openai.jpg" alt="Codex" /> | [Codex CLI](https://github.com/openai/codex) | `~/.codex/sessions/` | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-copilot.jpg" alt="Copilot" /> | [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-the-github-copilot-coding-agent-in-cli) | `~/.copilot/otel/*.jsonl` (+ `COPILOT_OTEL_FILE_EXPORTER_PATH`) | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-hermes.png" alt="Hermes Agent" /> | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `$HERMES_HOME/state.db`（フォールバック: `~/.hermes/state.db`） | ✅ 対応 |
-| <img width="48px" src=".github/assets/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `~/.gemini/tmp/*/chats/*.json` | ✅ 対応 |
+| <img width="48px" src=".github/assets/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `$GEMINI_CLI_HOME/tmp/*/chats/*.json`（フォールバック: `~/.gemini/tmp/*/chats/*.json`） | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | `~/.config/tokscale/cursor-cache/`経由でAPI同期 | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-amp.png" alt="Amp" /> | [Amp (AmpCode)](https://ampcode.com/) | `~/.local/share/amp/threads/` | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-codebuff.png" alt="Codebuff" /> | [Codebuff](https://codebuff.com/) | `~/.config/manicode/` (+ `manicode-dev`、`manicode-staging`; `CODEBUFF_DATA_DIR` でオーバーライド可能) | ✅ 対応 |
@@ -894,7 +894,7 @@ AIコーディングツールはクロスプラットフォームの場所にセ
 | Codex CLI | `~/.codex/` | `%USERPROFILE%\.codex\` | `CODEX_HOME`環境変数で設定可能（[ソース](https://github.com/openai/codex)） |
 | Copilot CLI | `~/.copilot/otel/` | `%USERPROFILE%\.copilot\otel\` | OTELファイル書き出しが必要; `COPILOT_OTEL_FILE_EXPORTER_PATH`も自動取り込み |
 | Hermes Agent | `~/.hermes/` | `%USERPROFILE%\.hermes\` | `HERMES_HOME`環境変数で設定可能（[ソース](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/developer-guide/session-storage.md)） |
-| Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | すべてのプラットフォームで同じパス |
+| Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | `GEMINI_CLI_HOME`環境変数で設定可能 |
 | Amp | `~/.local/share/amp/` | `%USERPROFILE%\.local\share\amp\` | OpenCodeと同様に`xdg-basedir`を使用 |
 | Cursor | API同期 | API同期 | APIでデータを取得、`%USERPROFILE%\.config\tokscale\cursor-cache\`にキャッシュ |
 | Droid | `~/.factory/` | `%USERPROFILE%\.factory\` | すべてのプラットフォームで同じパス |
@@ -1071,7 +1071,7 @@ Tokscaleは `chat` spanをトークン集計の信頼源として扱い、ツー
 
 ### Gemini CLI
 
-場所: `~/.gemini/tmp/{projectHash}/chats/*.json`
+場所: `$GEMINI_CLI_HOME/tmp/{projectHash}/chats/*.json`（フォールバック: `~/.gemini/tmp/{projectHash}/chats/*.json`）
 
 メッセージ配列を含むセッションファイル:
 ```json

--- a/README.ja.md
+++ b/README.ja.md
@@ -929,7 +929,7 @@ Tokscaleは以下の場所に設定を保存します：
 | プラットフォーム | デフォルト | 設定ファイル | 無効化設定 | ソース |
 |----------|---------|-------------|-------------------|--------|
 | Claude Code | **⚠️ 30日** | `~/.claude/settings.json` | `"cleanupPeriodDays": 9999999999` | [ドキュメント](https://docs.anthropic.com/en/docs/claude-code/settings) |
-| Gemini CLI | 無効 | `~/.gemini/settings.json` | `"general.sessionRetention.enabled": false` | [ドキュメント](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/session-management.md) |
+| Gemini CLI | 無効 | `$GEMINI_CLI_HOME/settings.json`（フォールバック: `~/.gemini/settings.json`） | `"general.sessionRetention.enabled": false` | [ドキュメント](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/session-management.md) |
 | Codex CLI | 無効 | N/A | クリーンアップ機能なし | [#6015](https://github.com/openai/codex/issues/6015) |
 | OpenCode | 無効 | N/A | クリーンアップ機能なし | [#4980](https://github.com/sst/opencode/issues/4980) |
 
@@ -950,7 +950,7 @@ Tokscaleは以下の場所に設定を保存します：
 
 **デフォルト**: クリーンアップ無効（セッションは永久に保持）
 
-クリーンアップを有効にしてから無効にしたい場合は、`~/.gemini/settings.json`で削除するか`enabled: false`に設定：
+クリーンアップを有効にしてから無効にしたい場合は、`$GEMINI_CLI_HOME/settings.json`（フォールバック: `~/.gemini/settings.json`）で削除するか`enabled: false`に設定：
 ```json
 {
   "general": {

--- a/README.ko.md
+++ b/README.ko.md
@@ -928,7 +928,7 @@ Tokscale은 다음 위치에 설정을 저장합니다:
 | 플랫폼 | 기본값 | 설정 파일 | 비활성화 설정 | 출처 |
 |----------|---------|-------------|-------------------|--------|
 | Claude Code | **⚠️ 30일** | `~/.claude/settings.json` | `"cleanupPeriodDays": 9999999999` | [문서](https://docs.anthropic.com/en/docs/claude-code/settings) |
-| Gemini CLI | 비활성화됨 | `~/.gemini/settings.json` | `"general.sessionRetention.enabled": false` | [문서](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/session-management.md) |
+| Gemini CLI | 비활성화됨 | `$GEMINI_CLI_HOME/settings.json` (폴백: `~/.gemini/settings.json`) | `"general.sessionRetention.enabled": false` | [문서](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/session-management.md) |
 | Codex CLI | 비활성화됨 | N/A | 정리 기능 없음 | [#6015](https://github.com/openai/codex/issues/6015) |
 | OpenCode | 비활성화됨 | N/A | 정리 기능 없음 | [#4980](https://github.com/sst/opencode/issues/4980) |
 
@@ -949,7 +949,7 @@ Tokscale은 다음 위치에 설정을 저장합니다:
 
 **기본값**: 정리 비활성화됨 (세션이 영구 보존)
 
-정리를 활성화했다가 비활성화하려면 `~/.gemini/settings.json`에서 제거하거나 `enabled: false`로 설정:
+정리를 활성화했다가 비활성화하려면 `$GEMINI_CLI_HOME/settings.json` (폴백: `~/.gemini/settings.json`)에서 제거하거나 `enabled: false`로 설정:
 ```json
 {
   "general": {

--- a/README.ko.md
+++ b/README.ko.md
@@ -60,7 +60,7 @@
 | <img width="48px" src=".github/assets/client-openai.jpg" alt="Codex" /> | [Codex CLI](https://github.com/openai/codex) | `~/.codex/sessions/` | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-copilot.jpg" alt="Copilot" /> | [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-the-github-copilot-coding-agent-in-cli) | `~/.copilot/otel/*.jsonl` (+ `COPILOT_OTEL_FILE_EXPORTER_PATH`) | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-hermes.png" alt="Hermes Agent" /> | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `$HERMES_HOME/state.db` (폴백: `~/.hermes/state.db`) | ✅ 지원 |
-| <img width="48px" src=".github/assets/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `~/.gemini/tmp/*/chats/*.json` | ✅ 지원 |
+| <img width="48px" src=".github/assets/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `$GEMINI_CLI_HOME/tmp/*/chats/*.json` (폴백: `~/.gemini/tmp/*/chats/*.json`) | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | `~/.config/tokscale/cursor-cache/`를 통한 API 동기화 | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-amp.png" alt="Amp" /> | [Amp (AmpCode)](https://ampcode.com/) | `~/.local/share/amp/threads/` | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-codebuff.png" alt="Codebuff" /> | [Codebuff](https://codebuff.com/) | `~/.config/manicode/` (+ `manicode-dev`, `manicode-staging`; `CODEBUFF_DATA_DIR`로 오버라이드 가능) | ✅ 지원 |
@@ -893,7 +893,7 @@ AI 코딩 도구들은 크로스 플랫폼 위치에 세션 데이터를 저장�
 | Codex CLI | `~/.codex/` | `%USERPROFILE%\.codex\` | `CODEX_HOME` 환경변수로 설정 가능 ([소스](https://github.com/openai/codex)) |
 | Copilot CLI | `~/.copilot/otel/ ` | `%USERPROFILE%\.copilot\otel\` | OTEL 파일 내보내기 필요; `COPILOT_OTEL_FILE_EXPORTER_PATH`도 자동 수집 |
 | Hermes Agent | `~/.hermes/` | `%USERPROFILE%\.hermes\` | `HERMES_HOME` 환경변수로 설정 가능 ([소스](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/developer-guide/session-storage.md)) |
-| Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | 모든 플랫폼에서 동일한 경로 |
+| Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | `GEMINI_CLI_HOME` 환경변수로 설정 가능 |
 | Amp | `~/.local/share/amp/` | `%USERPROFILE%\.local\share\amp\` | OpenCode와 동일하게 `xdg-basedir` 사용 |
 | Cursor | API 동기화 | API 동기화 | API를 통해 데이터 가져오기, `%USERPROFILE%\.config\tokscale\cursor-cache\`에 캐시 |
 | Droid | `~/.factory/` | `%USERPROFILE%\.factory\` | 모든 플랫폼에서 동일한 경로 |
@@ -1070,7 +1070,7 @@ Tokscale은 `chat` span을 토큰 집계의 출처로 취급하고, 도구 span�
 
 ### Gemini CLI
 
-위치: `~/.gemini/tmp/{projectHash}/chats/*.json`
+위치: `$GEMINI_CLI_HOME/tmp/{projectHash}/chats/*.json` (폴백: `~/.gemini/tmp/{projectHash}/chats/*.json`)
 
 메시지 배열을 포함한 세션 파일:
 ```json

--- a/README.md
+++ b/README.md
@@ -968,7 +968,7 @@ By default, some AI coding assistants automatically delete old session files. To
 | Platform | Default | Config File | Setting to Disable | Source |
 |----------|---------|-------------|-------------------|--------|
 | Claude Code | **⚠️ 30 days** | `~/.claude/settings.json` | `"cleanupPeriodDays": 9999999999` | [Docs](https://docs.anthropic.com/en/docs/claude-code/settings) |
-| Gemini CLI | Disabled | `~/.gemini/settings.json` | `"general.sessionRetention.enabled": false` | [Docs](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/session-management.md) |
+| Gemini CLI | Disabled | `$GEMINI_CLI_HOME/settings.json` (fallback: `~/.gemini/settings.json`) | `"general.sessionRetention.enabled": false` | [Docs](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/session-management.md) |
 | Codex CLI | Disabled | N/A | No cleanup feature | [#6015](https://github.com/openai/codex/issues/6015) |
 | OpenCode | Disabled | N/A | No cleanup feature | [#4980](https://github.com/sst/opencode/issues/4980) |
 
@@ -989,7 +989,7 @@ Add to `~/.claude/settings.json`:
 
 **Default**: Cleanup disabled (sessions persist forever)
 
-If you've enabled cleanup and want to disable it, remove or set `enabled: false` in `~/.gemini/settings.json`:
+If you've enabled cleanup and want to disable it, remove or set `enabled: false` in `$GEMINI_CLI_HOME/settings.json` (fallback: `~/.gemini/settings.json`):
 ```json
 {
   "general": {

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 | <img width="48px" src=".github/assets/client-openai.jpg" alt="Codex" /> | [Codex CLI](https://github.com/openai/codex) | `~/.codex/sessions/` | ✅ Yes |
 | <img width="48px" src=".github/assets/client-copilot.jpg" alt="Copilot" /> | [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-the-github-copilot-coding-agent-in-cli) | `~/.copilot/otel/*.jsonl` (+ `COPILOT_OTEL_FILE_EXPORTER_PATH`) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-hermes.png" alt="Hermes Agent" /> | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `$HERMES_HOME/state.db` (fallback: `~/.hermes/state.db`) | ✅ Yes |
-| <img width="48px" src=".github/assets/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `~/.gemini/tmp/*/chats/*.json` | ✅ Yes |
+| <img width="48px" src=".github/assets/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `$GEMINI_CLI_HOME/tmp/*/chats/*.json` (fallback: `~/.gemini/tmp/*/chats/*.json`) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | API sync via `~/.config/tokscale/cursor-cache/` | ✅ Yes |
 | <img width="48px" src=".github/assets/client-amp.png" alt="Amp" /> | [Amp (AmpCode)](https://ampcode.com/) | `~/.local/share/amp/threads/` | ✅ Yes |
 | <img width="48px" src=".github/assets/client-codebuff.png" alt="Codebuff" /> | [Codebuff](https://codebuff.com/) | `~/.config/manicode/` (+ `manicode-dev`, `manicode-staging`; override via `CODEBUFF_DATA_DIR`) | ✅ Yes |
@@ -933,7 +933,7 @@ AI coding tools store their session data in cross-platform locations. Most tools
 | Codex CLI | `~/.codex/` | `%USERPROFILE%\.codex\` | Configurable via `CODEX_HOME` env var ([source](https://github.com/openai/codex)) |
 | Copilot CLI | `~/.copilot/otel/` | `%USERPROFILE%\.copilot\otel\` | Requires OTEL file export; also auto-ingests `COPILOT_OTEL_FILE_EXPORTER_PATH` |
 | Hermes Agent | `~/.hermes/` | `%USERPROFILE%\.hermes\` | Configurable via `HERMES_HOME` env var ([source](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/developer-guide/session-storage.md)) |
-| Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | Same path on all platforms |
+| Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | Configurable via `GEMINI_CLI_HOME` env var |
 | Amp | `~/.local/share/amp/` | `%USERPROFILE%\.local\share\amp\` | Uses `xdg-basedir` like OpenCode |
 | Cursor | API sync | API sync | Data fetched via API, cached in `%USERPROFILE%\.config\tokscale\cursor-cache\` |
 | Droid | `~/.factory/` | `%USERPROFILE%\.factory\` | Same path on all platforms |
@@ -1146,7 +1146,7 @@ Tokscale treats `chat` spans as the source of truth for token accounting and ign
 
 ### Gemini CLI
 
-Location: `~/.gemini/tmp/{projectHash}/chats/*.json`
+Location: `$GEMINI_CLI_HOME/tmp/{projectHash}/chats/*.json` (fallback: `~/.gemini/tmp/{projectHash}/chats/*.json`)
 
 Session files containing message arrays:
 ```json

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -60,7 +60,7 @@
 | <img width="48px" src=".github/assets/client-openai.jpg" alt="Codex" /> | [Codex CLI](https://github.com/openai/codex) | `~/.codex/sessions/` | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-copilot.jpg" alt="Copilot" /> | [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-the-github-copilot-coding-agent-in-cli) | `~/.copilot/otel/*.jsonl` (+ `COPILOT_OTEL_FILE_EXPORTER_PATH`) | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-hermes.png" alt="Hermes Agent" /> | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `$HERMES_HOME/state.db`（回退：`~/.hermes/state.db`） | ✅ 支持 |
-| <img width="48px" src=".github/assets/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `~/.gemini/tmp/*/chats/*.json` | ✅ 支持 |
+| <img width="48px" src=".github/assets/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `$GEMINI_CLI_HOME/tmp/*/chats/*.json`（回退：`~/.gemini/tmp/*/chats/*.json`） | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | 通过 `~/.config/tokscale/cursor-cache/` API 同步 | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-amp.png" alt="Amp" /> | [Amp (AmpCode)](https://ampcode.com/) | `~/.local/share/amp/threads/` | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-codebuff.png" alt="Codebuff" /> | [Codebuff](https://codebuff.com/) | `~/.config/manicode/`（+ `manicode-dev`、`manicode-staging`；可通过 `CODEBUFF_DATA_DIR` 覆盖） | ✅ 支持 |
@@ -894,7 +894,7 @@ AI 编程工具将会话数据存储在跨平台位置。大多数工具在所�
 | Codex CLI | `~/.codex/` | `%USERPROFILE%\.codex\` | 可通过 `CODEX_HOME` 环境变量配置（[源码](https://github.com/openai/codex)） |
 | Copilot CLI | `~/.copilot/otel/` | `%USERPROFILE%\.copilot\otel\` | 需要 OTEL 文件导出；同时自动采集 `COPILOT_OTEL_FILE_EXPORTER_PATH` |
 | Hermes Agent | `~/.hermes/` | `%USERPROFILE%\.hermes\` | 可通过 `HERMES_HOME` 环境变量配置（[源码](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/developer-guide/session-storage.md)） |
-| Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | 所有平台使用相同路径 |
+| Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | 可通过 `GEMINI_CLI_HOME` 环境变量配置 |
 | Amp | `~/.local/share/amp/` | `%USERPROFILE%\.local\share\amp\` | 与 OpenCode 一样使用 `xdg-basedir` |
 | Cursor | API 同步 | API 同步 | 通过 API 获取数据，缓存在 `%USERPROFILE%\.config\tokscale\cursor-cache\` |
 | Droid | `~/.factory/` | `%USERPROFILE%\.factory\` | 所有平台使用相同路径 |
@@ -1071,7 +1071,7 @@ Tokscale 将 `chat` span 作为 Token 统计的真实来源，并在第一阶段
 
 ### Gemini CLI
 
-位置：`~/.gemini/tmp/{projectHash}/chats/*.json`
+位置：`$GEMINI_CLI_HOME/tmp/{projectHash}/chats/*.json`（回退：`~/.gemini/tmp/{projectHash}/chats/*.json`）
 
 包含消息数组的会话文件：
 ```json

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -929,7 +929,7 @@ Tokscale 将配置存储在：
 | 平台 | 默认值 | 配置文件 | 禁用设置 | 来源 |
 |----------|---------|-------------|-------------------|--------|
 | Claude Code | **⚠️ 30 天** | `~/.claude/settings.json` | `"cleanupPeriodDays": 9999999999` | [文档](https://docs.anthropic.com/en/docs/claude-code/settings) |
-| Gemini CLI | 禁用 | `~/.gemini/settings.json` | `"general.sessionRetention.enabled": false` | [文档](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/session-management.md) |
+| Gemini CLI | 禁用 | `$GEMINI_CLI_HOME/settings.json`（回退：`~/.gemini/settings.json`） | `"general.sessionRetention.enabled": false` | [文档](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/session-management.md) |
 | Codex CLI | 禁用 | N/A | 无清理功能 | [#6015](https://github.com/openai/codex/issues/6015) |
 | OpenCode | 禁用 | N/A | 无清理功能 | [#4980](https://github.com/sst/opencode/issues/4980) |
 
@@ -950,7 +950,7 @@ Tokscale 将配置存储在：
 
 **默认**：清理已禁用（会话永久保留）
 
-如果您已启用清理并想禁用它，请在 `~/.gemini/settings.json` 中删除或设置 `enabled: false`：
+如果您已启用清理并想禁用它，请在 `$GEMINI_CLI_HOME/settings.json`（回退：`~/.gemini/settings.json`）中删除或设置 `enabled: false`：
 ```json
 {
   "general": {

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -56,8 +56,12 @@ impl PathRoot {
                 fallback_relative,
             } => {
                 if use_env_roots {
-                    std::env::var(var)
-                        .unwrap_or_else(|_| format!("{}/{}", home_dir, fallback_relative))
+                    let val = std::env::var(var).unwrap_or_default();
+                    if val.trim().is_empty() {
+                        format!("{}/{}", home_dir, fallback_relative)
+                    } else {
+                        val
+                    }
                 } else {
                     format!("{}/{}", home_dir, fallback_relative)
                 }
@@ -206,8 +210,11 @@ define_clients!(
     },
     Gemini = 4 => {
         id: "gemini",
-        root: PathRoot::Home,
-        relative: ".gemini/tmp",
+        root: PathRoot::EnvVar {
+            var: "GEMINI_CLI_HOME",
+            fallback_relative: ".gemini",
+        },
+        relative: "tmp",
         pattern: "*.json|*.jsonl",
         headless: false,
         parse_local: true,

--- a/crates/tokscale-core/src/sessions/gemini.rs
+++ b/crates/tokscale-core/src/sessions/gemini.rs
@@ -47,11 +47,17 @@ pub struct GeminiMessage {
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 pub struct GeminiTokens {
+    #[serde(alias = "prompt", alias = "input_tokens", alias = "prompt_tokens", alias = "promptTokenCount")]
     pub input: Option<i64>,
+    #[serde(alias = "candidates", alias = "output_tokens", alias = "completion_tokens", alias = "candidatesTokenCount")]
     pub output: Option<i64>,
+    #[serde(alias = "cached_tokens", alias = "cachedContentTokenCount")]
     pub cached: Option<i64>,
+    #[serde(alias = "reasoning", alias = "thoughts_tokens")]
     pub thoughts: Option<i64>,
+    #[serde(alias = "tool_tokens")]
     pub tool: Option<i64>,
+    #[serde(alias = "totalTokenCount", alias = "total_tokens")]
     pub total: Option<i64>,
 }
 
@@ -84,14 +90,13 @@ pub(crate) fn parse_gemini_file_with_cache_status(path: &Path) -> GeminiParseRes
         .unwrap_or(false)
     {
         use std::ffi::OsStr;
-        // All scanned paths live under ~/.gemini/tmp (scanner root). Enforce the expected subdirectory pattern.
+        // Enforce the expected subdirectory pattern: tmp/<some_id>/chats/<file>
         let comps: Vec<&OsStr> = path.components().map(|c| c.as_os_str()).collect();
         let mut ok = false;
-        // Look for ".gemini" immediately followed by "tmp" to avoid matching /tmp paths.
-        'outer: for i in 0..comps.len().saturating_sub(2) {
-            if comps[i] == ".gemini" && comps[i + 1] == "tmp" {
+        'outer: for i in 0..comps.len().saturating_sub(1) {
+            if comps[i] == "tmp" {
                 // After "tmp", expect exactly 3 components: <some_id>, "chats", and the filename.
-                let after_tmp = &comps[i + 2..];
+                let after_tmp = &comps[i + 1..];
                 if after_tmp.len() == 3 {
                     let chats_dir = after_tmp[1];
                     let last = after_tmp[2];
@@ -149,11 +154,7 @@ fn parse_gemini_session(session: GeminiSession, fallback_timestamp: i64) -> Vec<
     let session_id = session.session_id.clone();
 
     for msg in session.messages {
-        // Only process gemini messages with token data
-        if msg.message_type != "gemini" {
-            continue;
-        }
-
+        // Only process messages with token data
         let tokens = match msg.tokens {
             Some(t) => t,
             None => continue,
@@ -300,7 +301,7 @@ fn parse_gemini_headless_jsonl(path: &Path, fallback_timestamp: i64) -> GeminiPa
             session_id = id;
         }
 
-        if event_type == "gemini" {
+        if event_type == "gemini" || value.get("tokens").is_some() {
             if let Some(model) = extract_string(value.get("model")) {
                 current_model = Some(model);
             }
@@ -365,7 +366,7 @@ fn parse_gemini_headless_value(
     session_id: &str,
     fallback_timestamp: i64,
 ) -> Vec<UnifiedMessage> {
-    if value.get("type").and_then(|val| val.as_str()) == Some("gemini") {
+    if value.get("type").and_then(|val| val.as_str()) == Some("gemini") || value.get("tokens").is_some() {
         if let Some(message) =
             parse_direct_gemini_token_message(value, None, session_id, fallback_timestamp)
         {
@@ -1020,5 +1021,202 @@ not-json\n\
         let messages = parse_gemini_file(&file_path);
 
         assert_eq!(messages.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_gemini_tokens_with_camel_case_aliases() {
+        let json = r#"{
+            "sessionId": "ses_alias",
+            "projectHash": "abc123",
+            "startTime": "2025-06-15T12:00:00Z",
+            "lastUpdated": "2025-06-15T12:30:00Z",
+            "messages": [
+                {
+                    "id": "msg_1",
+                    "timestamp": "2025-06-15T12:01:00Z",
+                    "type": "gemini",
+                    "model": "gemini-3-flash-preview",
+                    "tokens": {
+                        "promptTokenCount": 100,
+                        "candidatesTokenCount": 50,
+                        "cachedContentTokenCount": 20,
+                        "totalTokenCount": 150
+                    }
+                }
+            ]
+        }"#;
+        let file = tempfile::Builder::new()
+            .prefix("session-")
+            .suffix(".json")
+            .tempfile()
+            .unwrap();
+        std::fs::write(file.path(), json).unwrap();
+
+        let messages = parse_gemini_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gemini-3-flash-preview");
+        assert_eq!(messages[0].tokens.input, 80);
+        assert_eq!(messages[0].tokens.output, 50);
+        assert_eq!(messages[0].tokens.cache_read, 20);
+        assert_eq!(messages[0].tokens.total(), 150);
+    }
+
+    #[test]
+    fn test_parse_gemini_tokens_with_snake_case_aliases() {
+        let json = r#"{
+            "sessionId": "ses_snake",
+            "projectHash": "abc123",
+            "startTime": "2025-06-15T12:00:00Z",
+            "lastUpdated": "2025-06-15T12:30:00Z",
+            "messages": [
+                {
+                    "id": "msg_1",
+                    "timestamp": "2025-06-15T12:01:00Z",
+                    "type": "gemini",
+                    "model": "gemini-3-flash-preview",
+                    "tokens": {
+                        "prompt": 200,
+                        "candidates": 80,
+                        "cached_tokens": 30,
+                        "reasoning": 10,
+                        "tool_tokens": 5,
+                        "total_tokens": 295
+                    }
+                }
+            ]
+        }"#;
+        let file = tempfile::Builder::new()
+            .prefix("session-")
+            .suffix(".json")
+            .tempfile()
+            .unwrap();
+        std::fs::write(file.path(), json).unwrap();
+
+        let messages = parse_gemini_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 175);
+        assert_eq!(messages[0].tokens.output, 80);
+        assert_eq!(messages[0].tokens.cache_read, 30);
+        assert_eq!(messages[0].tokens.reasoning, 10);
+        assert_eq!(messages[0].tokens.total(), 295);
+    }
+
+    #[test]
+    fn test_parse_gemini_session_non_gemini_type_with_tokens() {
+        let json = r#"{
+            "sessionId": "ses_nongemini",
+            "projectHash": "abc123",
+            "startTime": "2025-06-15T12:00:00Z",
+            "lastUpdated": "2025-06-15T12:30:00Z",
+            "messages": [
+                {
+                    "id": "msg_1",
+                    "timestamp": "2025-06-15T12:01:00Z",
+                    "type": "assistant",
+                    "model": "gemini-3-flash-preview",
+                    "tokens": {
+                        "input": 150,
+                        "output": 40,
+                        "cached": 10,
+                        "total": 190
+                    }
+                }
+            ]
+        }"#;
+        let file = tempfile::Builder::new()
+            .prefix("session-")
+            .suffix(".json")
+            .tempfile()
+            .unwrap();
+        std::fs::write(file.path(), json).unwrap();
+
+        let messages = parse_gemini_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gemini-3-flash-preview");
+        assert_eq!(messages[0].tokens.input, 140);
+        assert_eq!(messages[0].tokens.output, 40);
+        assert_eq!(messages[0].tokens.cache_read, 10);
+        assert_eq!(messages[0].tokens.total(), 190);
+    }
+
+    #[test]
+    fn test_parse_gemini_valid_path_without_gemini_component() {
+        let json = r#"{
+            "sessionId": "ses_custom",
+            "projectHash": "abc123",
+            "startTime": "2025-06-15T12:00:00Z",
+            "lastUpdated": "2025-06-15T12:30:00Z",
+            "messages": [
+                {
+                    "id": "msg_1",
+                    "timestamp": "2025-06-15T12:01:00Z",
+                    "type": "gemini",
+                    "model": "gemini-2.0-flash",
+                    "tokens": {
+                        "input": 10,
+                        "output": 20
+                    }
+                }
+            ]
+        }"#;
+
+        let dir = TempDir::new().unwrap();
+        let base = dir.path();
+        let chats_dir = base.join("custom_home/tmp/abc123/chats");
+        std::fs::create_dir_all(&chats_dir).unwrap();
+        let file_path = chats_dir.join("session.json");
+        std::fs::write(&file_path, json).unwrap();
+
+        let messages = parse_gemini_file(&file_path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gemini-2.0-flash");
+        assert_eq!(messages[0].tokens.input, 10);
+        assert_eq!(messages[0].tokens.output, 20);
+    }
+
+    #[test]
+    fn test_parse_gemini_stream_jsonl_direct_tokens_without_gemini_prefix() {
+        let content = r#"{"sessionId":"ses-nogem","projectHash":"abc123","startTime":"2026-05-01T00:00:00.000Z","lastUpdated":"2026-05-01T00:01:00.000Z"}
+{"id":"msg-1","timestamp":"2026-05-01T00:01:00.000Z","type":"gemini","model":"gemini-3.1-pro-preview","tokens":{"input":500,"output":30,"cached":0,"thoughts":100,"tool":5,"total":635}}"#;
+        let dir = TempDir::new().unwrap();
+        let chats_dir = dir.path().join("my_gemini/tmp/456/chats");
+        std::fs::create_dir_all(&chats_dir).unwrap();
+        let file_path = chats_dir.join("session.jsonl");
+        std::fs::write(&file_path, content).unwrap();
+
+        let messages = parse_gemini_file(&file_path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].session_id, "ses-nogem");
+        assert_eq!(messages[0].model_id, "gemini-3.1-pro-preview");
+        assert_eq!(messages[0].tokens.input, 505);
+        assert_eq!(messages[0].tokens.output, 30);
+        assert_eq!(messages[0].tokens.cache_read, 0);
+        assert_eq!(messages[0].tokens.reasoning, 100);
+        assert_eq!(messages[0].tokens.total(), 635);
+    }
+
+    #[test]
+    fn test_parse_headless_jsonl_non_gemini_type_with_direct_tokens() {
+        let content = r#"{"type":"init","model":"gemini-3-flash-preview","session_id":"session-tokens"}
+{"type":"result","id":"msg-1","tokens":{"input":100,"output":25,"cached":10,"total":125}}"#;
+        let dir = TempDir::new().unwrap();
+        let chats_dir = dir.path().join("custom_root/tmp/789/chats");
+        std::fs::create_dir_all(&chats_dir).unwrap();
+        let file_path = chats_dir.join("session.jsonl");
+        std::fs::write(&file_path, content).unwrap();
+
+        let messages = parse_gemini_file(&file_path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gemini-3-flash-preview");
+        assert_eq!(messages[0].tokens.input, 90);
+        assert_eq!(messages[0].tokens.output, 25);
+        assert_eq!(messages[0].tokens.cache_read, 10);
+        assert_eq!(messages[0].tokens.total(), 125);
     }
 }

--- a/crates/tokscale-core/src/sessions/gemini.rs
+++ b/crates/tokscale-core/src/sessions/gemini.rs
@@ -39,25 +39,55 @@ pub struct GeminiMessage {
     pub timestamp: Option<String>,
     #[serde(rename = "type")]
     pub message_type: String,
-    pub tokens: Option<GeminiTokens>,
+    pub tokens: Option<Value>,
     pub model: Option<String>,
 }
 
-/// Gemini token structure
-#[derive(Debug, Deserialize)]
+fn first_i64(value: &Value, keys: &[&str]) -> Option<i64> {
+    keys.iter()
+        .find_map(|k| value.get(k).and_then(|v| v.as_i64()))
+}
+
+fn deserialize_tokens(value: &Value) -> Option<GeminiTokens> {
+    Some(GeminiTokens {
+        input: first_i64(
+            value,
+            &[
+                "input",
+                "prompt",
+                "input_tokens",
+                "prompt_tokens",
+                "promptTokenCount",
+            ],
+        ),
+        output: first_i64(
+            value,
+            &[
+                "output",
+                "candidates",
+                "output_tokens",
+                "completion_tokens",
+                "candidatesTokenCount",
+            ],
+        ),
+        cached: first_i64(
+            value,
+            &["cached", "cached_tokens", "cachedContentTokenCount"],
+        ),
+        thoughts: first_i64(value, &["thoughts", "reasoning", "thoughts_tokens"]),
+        tool: first_i64(value, &["tool", "tool_tokens"]),
+        total: first_i64(value, &["total", "totalTokenCount", "total_tokens"]),
+    })
+}
+
+#[derive(Debug)]
 #[allow(dead_code)]
 pub struct GeminiTokens {
-    #[serde(alias = "prompt", alias = "input_tokens", alias = "prompt_tokens", alias = "promptTokenCount")]
     pub input: Option<i64>,
-    #[serde(alias = "candidates", alias = "output_tokens", alias = "completion_tokens", alias = "candidatesTokenCount")]
     pub output: Option<i64>,
-    #[serde(alias = "cached_tokens", alias = "cachedContentTokenCount")]
     pub cached: Option<i64>,
-    #[serde(alias = "reasoning", alias = "thoughts_tokens")]
     pub thoughts: Option<i64>,
-    #[serde(alias = "tool_tokens")]
     pub tool: Option<i64>,
-    #[serde(alias = "totalTokenCount", alias = "total_tokens")]
     pub total: Option<i64>,
 }
 
@@ -155,7 +185,7 @@ fn parse_gemini_session(session: GeminiSession, fallback_timestamp: i64) -> Vec<
 
     for msg in session.messages {
         // Only process messages with token data
-        let tokens = match msg.tokens {
+        let tokens = match msg.tokens.as_ref().and_then(deserialize_tokens) {
             Some(t) => t,
             None => continue,
         };
@@ -223,7 +253,7 @@ fn parse_direct_gemini_token_message(
 ) -> Option<UnifiedMessage> {
     let model = extract_string(value.get("model")).or(model_hint)?;
     let tokens_value = value.get("tokens")?;
-    let tokens: GeminiTokens = serde_json::from_value(tokens_value.clone()).ok()?;
+    let tokens = deserialize_tokens(tokens_value)?;
     let timestamp = extract_timestamp_from_value(value).unwrap_or(fallback_timestamp);
 
     Some(build_gemini_token_message(
@@ -366,7 +396,9 @@ fn parse_gemini_headless_value(
     session_id: &str,
     fallback_timestamp: i64,
 ) -> Vec<UnifiedMessage> {
-    if value.get("type").and_then(|val| val.as_str()) == Some("gemini") || value.get("tokens").is_some() {
+    if value.get("type").and_then(|val| val.as_str()) == Some("gemini")
+        || value.get("tokens").is_some()
+    {
         if let Some(message) =
             parse_direct_gemini_token_message(value, None, session_id, fallback_timestamp)
         {
@@ -1218,5 +1250,45 @@ not-json\n\
         assert_eq!(messages[0].tokens.output, 25);
         assert_eq!(messages[0].tokens.cache_read, 10);
         assert_eq!(messages[0].tokens.total(), 125);
+    }
+
+    #[test]
+    fn test_parse_gemini_tokens_with_mixed_duplicate_fields() {
+        let json = r#"{
+            "sessionId": "ses_dup",
+            "projectHash": "abc123",
+            "startTime": "2025-06-15T12:00:00Z",
+            "lastUpdated": "2025-06-15T12:30:00Z",
+            "messages": [
+                {
+                    "id": "msg_1",
+                    "timestamp": "2025-06-15T12:01:00Z",
+                    "type": "gemini",
+                    "model": "gemini-3-flash-preview",
+                    "tokens": {
+                        "input": 100,
+                        "prompt": 200,
+                        "output": 50,
+                        "candidates": 60,
+                        "cached": 5,
+                        "total": 215
+                    }
+                }
+            ]
+        }"#;
+        let file = tempfile::Builder::new()
+            .prefix("session-")
+            .suffix(".json")
+            .tempfile()
+            .unwrap();
+        std::fs::write(file.path(), json).unwrap();
+
+        let messages = parse_gemini_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gemini-3-flash-preview");
+        assert_eq!(messages[0].tokens.input, 100);
+        assert_eq!(messages[0].tokens.output, 50);
+        assert_eq!(messages[0].tokens.cache_read, 5);
     }
 }


### PR DESCRIPTION
## Summary
Fixes Gemini CLI detection by adding support for configurable data paths via `GEMINI_CLI_HOME` environment variable and handling new token field naming formats from different Gemini CLI versions. The parser now accepts multiple alias formats for token fields and correctly detects sessions even when message types vary across CLI versions.

## Bug Description
- **What was happening:** Gemini CLI data paths were hardcoded to `~/.gemini/tmp`, preventing users from customizing the location. Token parsing failed with newer CLI versions that use different field names (camelCase vs snake_case). Empty environment variables caused incorrect path resolution.
- **Expected behavior:** Users should be able to configure the Gemini CLI data directory via `GEMINI_CLI_HOME` (consistent with other tools), and the parser should handle all known token field naming formats.
- **Root cause:** Hardcoded path logic, single-format token parsing, and lack of empty string handling for environment variables.

## Changes Made
- **Path configuration** (clients.rs): Changed from hardcoded `~/.gemini/tmp` to configurable `GEMINI_CLI_HOME` env var with fallback to `~/.gemini`; added empty string handling
- **Token parsing** (sessions/gemini.rs): Added serde aliases to support multiple token field name formats (prompt/promptTokenCount, candidates/candidatesTokenCount, cached_tokens/cachedContentTokenCount, reasoning/thoughts_tokens, etc.)
- **Path detection**: Simplified logic to detect `tmp/<id>/chats/<file>` pattern regardless of base directory, now works with custom `GEMINI_CLI_HOME` paths
- **Message detection**: Updated parsing to process any message containing token data, not just those with `type == "gemini"`
- **Tests**: Added comprehensive tests for camelCase/snake_case aliases, non-gemini message types, custom paths, and JSONL streaming variations
- **Documentation**: Updated all README files to reflect configurable path via `GEMINI_CLI_HOME`

## Testing
- [x] Tested locally
- [x] Unit tests added/updated (6 new tests, 24 total passing)
- [x] No regressions

## Related Issues
Fixes #476

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Gemini CLI detection by supporting `GEMINI_CLI_HOME` and robust token parsing across CLI versions, including mixed field formats. Restores session import for custom installs and newer JSONL streams.

- **Bug Fixes**
  - Path is now configurable via `GEMINI_CLI_HOME` with fallback to `~/.gemini`; empty env values are ignored. Scanner accepts any `tmp/<id>/chats/*` base.
  - Replaced token parsing with a resilient Value-based approach that handles mixed/duplicate fields and supports camelCase/snake_case variants for input/output/cached/reasoning/tool/total.
  - Processes any message with a `tokens` object (not only `type: "gemini"`), including headless JSONL events.
  - Updated docs to show `$GEMINI_CLI_HOME/tmp/*/chats/*.json` and session retention at `$GEMINI_CLI_HOME/settings.json` (fallbacks included); added tests for aliases, mixed fields, custom paths, and stream formats.

<sup>Written for commit 9bc16ca609a413e9a269aabd693b0c2b933a5303. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

