### PR TITLE
feat(tui): add Minutely tab for per-minute token breakdown

### DIFF
--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -257,13 +257,19 @@ impl App {
             config.since,
             config.until,
             config.year,
-        );
+        )
+        .with_minutely_enabled(settings.minutely_tab_enabled);
 
         let data = cached_data.unwrap_or_default();
         let has_data = !data.models.is_empty();
         let dialog_stack = DialogStack::new(theme.clone());
         let dialog_needs_reload = Rc::new(RefCell::new(false));
-        let current_tab = config.initial_tab.unwrap_or(Tab::Overview);
+        let requested_tab = config.initial_tab.unwrap_or(Tab::Overview);
+        let current_tab = if Self::tab_visible(&settings, requested_tab) {
+            requested_tab
+        } else {
+            Tab::Overview
+        };
         let (sort_field, sort_direction) = Self::default_sort_for_tab(current_tab);
 
         let mut app = Self {
@@ -414,22 +420,22 @@ impl App {
                 return true;
             }
             KeyCode::Tab => {
-                let next = self.current_tab.next();
+                let next = self.next_visible_tab();
                 self.switch_tab(next);
                 self.reset_selection();
             }
             KeyCode::BackTab => {
-                let prev = self.current_tab.prev();
+                let prev = self.prev_visible_tab();
                 self.switch_tab(prev);
                 self.reset_selection();
             }
             KeyCode::Left => {
-                let prev = self.current_tab.prev();
+                let prev = self.prev_visible_tab();
                 self.switch_tab(prev);
                 self.reset_selection();
             }
             KeyCode::Right => {
-                let next = self.current_tab.next();
+                let next = self.next_visible_tab();
                 self.switch_tab(next);
                 self.reset_selection();
             }
@@ -650,6 +656,33 @@ impl App {
         } else {
             (SortField::Cost, SortDirection::Descending)
         }
+    }
+
+    pub(crate) fn tab_visible(settings: &Settings, tab: Tab) -> bool {
+        match tab {
+            Tab::Minutely => settings.minutely_tab_enabled,
+            _ => true,
+        }
+    }
+
+    pub(crate) fn is_tab_visible(&self, tab: Tab) -> bool {
+        Self::tab_visible(&self.settings, tab)
+    }
+
+    fn next_visible_tab(&self) -> Tab {
+        let mut candidate = self.current_tab.next();
+        while !self.is_tab_visible(candidate) && candidate != self.current_tab {
+            candidate = candidate.next();
+        }
+        candidate
+    }
+
+    fn prev_visible_tab(&self) -> Tab {
+        let mut candidate = self.current_tab.prev();
+        while !self.is_tab_visible(candidate) && candidate != self.current_tab {
+            candidate = candidate.prev();
+        }
+        candidate
     }
 
     fn persist_current_sort(&mut self) {
@@ -1753,9 +1786,6 @@ mod tests {
         assert_eq!(app.current_tab, Tab::Hourly);
 
         app.handle_key_event(key(KeyCode::Tab));
-        assert_eq!(app.current_tab, Tab::Minutely);
-
-        app.handle_key_event(key(KeyCode::Tab));
         assert_eq!(app.current_tab, Tab::Stats);
 
         app.handle_key_event(key(KeyCode::Tab));
@@ -1777,9 +1807,6 @@ mod tests {
         assert_eq!(app.current_tab, Tab::Stats);
 
         app.handle_key_event(key(KeyCode::BackTab));
-        assert_eq!(app.current_tab, Tab::Minutely);
-
-        app.handle_key_event(key(KeyCode::BackTab));
         assert_eq!(app.current_tab, Tab::Hourly);
 
         app.handle_key_event(key(KeyCode::BackTab));
@@ -1787,6 +1814,42 @@ mod tests {
 
         app.handle_key_event(key(KeyCode::BackTab));
         assert_eq!(app.current_tab, Tab::Models);
+    }
+
+    #[test]
+    fn test_handle_key_tab_switch_with_minutely_enabled_includes_minutely() {
+        let mut app = make_app();
+        app.settings.minutely_tab_enabled = true;
+        assert_eq!(app.current_tab, Tab::Overview);
+
+        for expected in [
+            Tab::Models,
+            Tab::Daily,
+            Tab::Hourly,
+            Tab::Minutely,
+            Tab::Stats,
+            Tab::Agents,
+            Tab::Overview,
+        ] {
+            app.handle_key_event(key(KeyCode::Tab));
+            assert_eq!(app.current_tab, expected);
+        }
+    }
+
+    #[test]
+    fn test_initial_minutely_tab_clamps_to_overview_when_flag_off() {
+        let config = TuiConfig {
+            theme: "blue".to_string(),
+            refresh: 0,
+            sessions_path: None,
+            clients: None,
+            since: None,
+            until: None,
+            year: None,
+            initial_tab: Some(Tab::Minutely),
+        };
+        let app = App::new_with_cached_data(config, Some(UsageData::default())).unwrap();
+        assert_eq!(app.current_tab, Tab::Overview);
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -14,7 +14,8 @@ use crate::ClientFilter;
 use ratatui::style::Color;
 
 use super::data::{
-    AgentUsage, DailyUsage, DataLoader, HourlyUsage, ModelUsage, TokenBreakdown, UsageData,
+    AgentUsage, DailyUsage, DataLoader, HourlyUsage, MinutelyUsage, ModelUsage, TokenBreakdown,
+    UsageData,
 };
 use super::settings::Settings;
 use super::themes::{Theme, ThemeName};
@@ -39,6 +40,7 @@ pub enum Tab {
     Models,
     Daily,
     Hourly,
+    Minutely,
     Stats,
     Agents,
 }
@@ -50,6 +52,7 @@ impl Tab {
             Tab::Models,
             Tab::Daily,
             Tab::Hourly,
+            Tab::Minutely,
             Tab::Stats,
             Tab::Agents,
         ]
@@ -61,6 +64,7 @@ impl Tab {
             Tab::Models => "Models",
             Tab::Daily => "Daily",
             Tab::Hourly => "Hourly",
+            Tab::Minutely => "Minutely",
             Tab::Stats => "Stats",
             Tab::Agents => "Agents",
         }
@@ -72,6 +76,7 @@ impl Tab {
             Tab::Models => "Mod",
             Tab::Daily => "Day",
             Tab::Hourly => "Hr",
+            Tab::Minutely => "Min",
             Tab::Stats => "Sta",
             Tab::Agents => "Agt",
         }
@@ -82,7 +87,8 @@ impl Tab {
             Tab::Overview => Tab::Models,
             Tab::Models => Tab::Daily,
             Tab::Daily => Tab::Hourly,
-            Tab::Hourly => Tab::Stats,
+            Tab::Hourly => Tab::Minutely,
+            Tab::Minutely => Tab::Stats,
             Tab::Stats => Tab::Agents,
             Tab::Agents => Tab::Overview,
         }
@@ -94,7 +100,8 @@ impl Tab {
             Tab::Models => Tab::Overview,
             Tab::Daily => Tab::Models,
             Tab::Hourly => Tab::Daily,
-            Tab::Stats => Tab::Hourly,
+            Tab::Minutely => Tab::Hourly,
+            Tab::Stats => Tab::Minutely,
             Tab::Agents => Tab::Stats,
         }
     }
@@ -638,7 +645,7 @@ impl App {
     }
 
     fn default_sort_for_tab(tab: Tab) -> (SortField, SortDirection) {
-        if tab == Tab::Hourly {
+        if matches!(tab, Tab::Hourly | Tab::Minutely) {
             (SortField::Date, SortDirection::Descending)
         } else {
             (SortField::Cost, SortDirection::Descending)
@@ -766,6 +773,7 @@ impl App {
             }
             Tab::Daily => self.data.daily.len(),
             Tab::Hourly => self.data.hourly.len(),
+            Tab::Minutely => self.data.minutely.len(),
             Tab::Stats => {
                 if self.selected_graph_cell.is_some() {
                     self.stats_breakdown_total_lines
@@ -1023,6 +1031,17 @@ impl App {
                     h.cost
                 )
             }),
+            Tab::Minutely => self
+                .get_sorted_minutely()
+                .get(self.selected_index)
+                .map(|m| {
+                    format!(
+                        "{}: {} tokens, ${:.4}",
+                        m.datetime.format("%Y-%m-%d %H:%M"),
+                        m.tokens.total(),
+                        m.cost
+                    )
+                }),
             Tab::Stats => None,
         };
 
@@ -1268,6 +1287,41 @@ impl App {
         hourly
     }
 
+    pub fn get_sorted_minutely(&self) -> Vec<&MinutelyUsage> {
+        let mut minutely: Vec<&MinutelyUsage> = self.data.minutely.iter().collect();
+
+        match (self.sort_field, self.sort_direction) {
+            (SortField::Cost, SortDirection::Descending) => minutely.sort_by(|a, b| {
+                b.cost
+                    .total_cmp(&a.cost)
+                    .then_with(|| a.datetime.cmp(&b.datetime))
+            }),
+            (SortField::Cost, SortDirection::Ascending) => minutely.sort_by(|a, b| {
+                a.cost
+                    .total_cmp(&b.cost)
+                    .then_with(|| a.datetime.cmp(&b.datetime))
+            }),
+            (SortField::Tokens, SortDirection::Descending) => minutely.sort_by(|a, b| {
+                b.tokens
+                    .total()
+                    .cmp(&a.tokens.total())
+                    .then_with(|| a.datetime.cmp(&b.datetime))
+            }),
+            (SortField::Tokens, SortDirection::Ascending) => minutely.sort_by(|a, b| {
+                a.tokens
+                    .total()
+                    .cmp(&b.tokens.total())
+                    .then_with(|| a.datetime.cmp(&b.datetime))
+            }),
+            (SortField::Date, SortDirection::Descending) => {
+                minutely.sort_by_key(|b| std::cmp::Reverse(b.datetime))
+            }
+            (SortField::Date, SortDirection::Ascending) => minutely.sort_by_key(|a| a.datetime),
+        }
+
+        minutely
+    }
+
     pub fn is_narrow(&self) -> bool {
         self.terminal_width < 80
     }
@@ -1288,13 +1342,14 @@ mod tests {
     #[test]
     fn test_tab_all() {
         let tabs = Tab::all();
-        assert_eq!(tabs.len(), 6);
+        assert_eq!(tabs.len(), 7);
         assert_eq!(tabs[0], Tab::Overview);
         assert_eq!(tabs[1], Tab::Models);
         assert_eq!(tabs[2], Tab::Daily);
         assert_eq!(tabs[3], Tab::Hourly);
-        assert_eq!(tabs[4], Tab::Stats);
-        assert_eq!(tabs[5], Tab::Agents);
+        assert_eq!(tabs[4], Tab::Minutely);
+        assert_eq!(tabs[5], Tab::Stats);
+        assert_eq!(tabs[6], Tab::Agents);
     }
 
     #[test]
@@ -1302,7 +1357,8 @@ mod tests {
         assert_eq!(Tab::Overview.next(), Tab::Models);
         assert_eq!(Tab::Models.next(), Tab::Daily);
         assert_eq!(Tab::Daily.next(), Tab::Hourly);
-        assert_eq!(Tab::Hourly.next(), Tab::Stats);
+        assert_eq!(Tab::Hourly.next(), Tab::Minutely);
+        assert_eq!(Tab::Minutely.next(), Tab::Stats);
         assert_eq!(Tab::Stats.next(), Tab::Agents);
         assert_eq!(Tab::Agents.next(), Tab::Overview);
     }
@@ -1313,7 +1369,8 @@ mod tests {
         assert_eq!(Tab::Models.prev(), Tab::Overview);
         assert_eq!(Tab::Daily.prev(), Tab::Models);
         assert_eq!(Tab::Hourly.prev(), Tab::Daily);
-        assert_eq!(Tab::Stats.prev(), Tab::Hourly);
+        assert_eq!(Tab::Minutely.prev(), Tab::Hourly);
+        assert_eq!(Tab::Stats.prev(), Tab::Minutely);
         assert_eq!(Tab::Agents.prev(), Tab::Stats);
     }
 
@@ -1323,6 +1380,8 @@ mod tests {
         assert_eq!(Tab::Models.as_str(), "Models");
         assert_eq!(Tab::Agents.as_str(), "Agents");
         assert_eq!(Tab::Daily.as_str(), "Daily");
+        assert_eq!(Tab::Hourly.as_str(), "Hourly");
+        assert_eq!(Tab::Minutely.as_str(), "Minutely");
         assert_eq!(Tab::Stats.as_str(), "Stats");
     }
 
@@ -1332,6 +1391,8 @@ mod tests {
         assert_eq!(Tab::Models.short_name(), "Mod");
         assert_eq!(Tab::Agents.short_name(), "Agt");
         assert_eq!(Tab::Daily.short_name(), "Day");
+        assert_eq!(Tab::Hourly.short_name(), "Hr");
+        assert_eq!(Tab::Minutely.short_name(), "Min");
         assert_eq!(Tab::Stats.short_name(), "Sta");
     }
 
@@ -1692,6 +1753,9 @@ mod tests {
         assert_eq!(app.current_tab, Tab::Hourly);
 
         app.handle_key_event(key(KeyCode::Tab));
+        assert_eq!(app.current_tab, Tab::Minutely);
+
+        app.handle_key_event(key(KeyCode::Tab));
         assert_eq!(app.current_tab, Tab::Stats);
 
         app.handle_key_event(key(KeyCode::Tab));
@@ -1711,6 +1775,9 @@ mod tests {
 
         app.handle_key_event(key(KeyCode::BackTab));
         assert_eq!(app.current_tab, Tab::Stats);
+
+        app.handle_key_event(key(KeyCode::BackTab));
+        assert_eq!(app.current_tab, Tab::Minutely);
 
         app.handle_key_event(key(KeyCode::BackTab));
         assert_eq!(app.current_tab, Tab::Hourly);

--- a/crates/tokscale-cli/src/tui/cache.rs
+++ b/crates/tokscale-cli/src/tui/cache.rs
@@ -589,6 +589,10 @@ impl TryFrom<CachedUsageData> for UsageData {
             agents: normalize_cached_agents(u.agents),
             daily: daily?,
             hourly: hourly?,
+            // Minutely data is recomputed on each load (high cardinality,
+            // not worth round-tripping through the on-disk cache); the
+            // first foreground refresh after cache hit will populate it.
+            minutely: Vec::new(),
             graph: graph.transpose()?,
             total_tokens: u.total_tokens,
             total_cost: u.total_cost,

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -121,6 +121,17 @@ pub struct HourlyUsage {
 }
 
 #[derive(Debug, Clone)]
+pub struct MinutelyUsage {
+    pub datetime: NaiveDateTime,
+    pub tokens: TokenBreakdown,
+    pub cost: f64,
+    pub clients: BTreeSet<String>,
+    pub models: BTreeMap<String, HourlyModelInfo>,
+    pub message_count: u32,
+    pub turn_count: u32,
+}
+
+#[derive(Debug, Clone)]
 pub struct ContributionDay {
     pub date: NaiveDate,
     pub tokens: u64,
@@ -139,6 +150,7 @@ pub struct UsageData {
     pub agents: Vec<AgentUsage>,
     pub daily: Vec<DailyUsage>,
     pub hourly: Vec<HourlyUsage>,
+    pub minutely: Vec<MinutelyUsage>,
     pub graph: Option<GraphData>,
     pub total_tokens: u64,
     pub total_cost: f64,
@@ -368,6 +380,7 @@ impl DataLoader {
         let mut agent_clients: HashMap<String, BTreeSet<String>> = HashMap::new();
         let mut daily_map: HashMap<NaiveDate, DailyUsage> = HashMap::new();
         let mut hourly_map: HashMap<NaiveDateTime, HourlyUsage> = HashMap::new();
+        let mut minutely_map: HashMap<NaiveDateTime, MinutelyUsage> = HashMap::new();
         let mut model_session_ids: HashMap<String, HashSet<String>> = HashMap::new();
 
         for msg in &messages {
@@ -703,6 +716,97 @@ impl DataLoader {
                     .saturating_add(msg.tokens.reasoning.max(0) as u64);
                 h_model.cost += h_cost;
             }
+
+            // Minute aggregation: same fallback semantics as hourly, but
+            // truncated to the minute. Used by the Minutely tab.
+            if let Some(minute_dt) = minute_bucket_with_fallback(msg.timestamp, &msg.date) {
+                let minutely_entry =
+                    minutely_map
+                        .entry(minute_dt)
+                        .or_insert_with(|| MinutelyUsage {
+                            datetime: minute_dt,
+                            tokens: TokenBreakdown::default(),
+                            cost: 0.0,
+                            clients: BTreeSet::new(),
+                            models: BTreeMap::new(),
+                            message_count: 0,
+                            turn_count: 0,
+                        });
+
+                minutely_entry.tokens.input = minutely_entry
+                    .tokens
+                    .input
+                    .saturating_add(msg.tokens.input.max(0) as u64);
+                minutely_entry.tokens.output = minutely_entry
+                    .tokens
+                    .output
+                    .saturating_add(msg.tokens.output.max(0) as u64);
+                minutely_entry.tokens.cache_read = minutely_entry
+                    .tokens
+                    .cache_read
+                    .saturating_add(msg.tokens.cache_read.max(0) as u64);
+                minutely_entry.tokens.cache_write = minutely_entry
+                    .tokens
+                    .cache_write
+                    .saturating_add(msg.tokens.cache_write.max(0) as u64);
+                minutely_entry.tokens.reasoning = minutely_entry
+                    .tokens
+                    .reasoning
+                    .saturating_add(msg.tokens.reasoning.max(0) as u64);
+                let m_cost = if msg.cost.is_finite() && msg.cost >= 0.0 {
+                    msg.cost
+                } else {
+                    0.0
+                };
+                minutely_entry.cost += m_cost;
+                minutely_entry.message_count += msg.message_count.max(0) as u32;
+                if msg.is_turn_start {
+                    minutely_entry.turn_count += 1;
+                }
+                minutely_entry.clients.insert(msg.client.clone());
+
+                let m_model_key = hourly_model_key(group_by, &msg.provider_id, &normalized_model);
+                let m_model =
+                    minutely_entry
+                        .models
+                        .entry(m_model_key)
+                        .or_insert_with(|| HourlyModelInfo {
+                            provider: msg.provider_id.clone(),
+                            display_name: hourly_model_display_name(
+                                group_by,
+                                &msg.provider_id,
+                                &normalized_model,
+                            ),
+                            color_key: model_color_key(
+                                group_by,
+                                &msg.provider_id,
+                                &normalized_model,
+                            ),
+                            tokens: TokenBreakdown::default(),
+                            cost: 0.0,
+                        });
+                m_model.tokens.input = m_model
+                    .tokens
+                    .input
+                    .saturating_add(msg.tokens.input.max(0) as u64);
+                m_model.tokens.output = m_model
+                    .tokens
+                    .output
+                    .saturating_add(msg.tokens.output.max(0) as u64);
+                m_model.tokens.cache_read = m_model
+                    .tokens
+                    .cache_read
+                    .saturating_add(msg.tokens.cache_read.max(0) as u64);
+                m_model.tokens.cache_write = m_model
+                    .tokens
+                    .cache_write
+                    .saturating_add(msg.tokens.cache_write.max(0) as u64);
+                m_model.tokens.reasoning = m_model
+                    .tokens
+                    .reasoning
+                    .saturating_add(msg.tokens.reasoning.max(0) as u64);
+                m_model.cost += m_cost;
+            }
         }
 
         let mut models: Vec<ModelUsage> = model_map.into_values().collect();
@@ -733,6 +837,9 @@ impl DataLoader {
         let mut hourly: Vec<HourlyUsage> = hourly_map.into_values().collect();
         hourly.sort_by_key(|b| std::cmp::Reverse(b.datetime));
 
+        let mut minutely: Vec<MinutelyUsage> = minutely_map.into_values().collect();
+        minutely.sort_by_key(|b| std::cmp::Reverse(b.datetime));
+
         let total_tokens: u64 = models.iter().map(|m| m.tokens.total()).sum();
         let total_cost: f64 = models
             .iter()
@@ -747,6 +854,7 @@ impl DataLoader {
             agents,
             daily,
             hourly,
+            minutely,
             graph: Some(graph),
             total_tokens,
             total_cost,
@@ -789,6 +897,37 @@ fn timestamp_to_hour(timestamp_ms: i64) -> Option<NaiveDateTime> {
 /// CLI hourly bucketing behavior in `tokscale-core::lib::get_hourly_report`.
 fn hour_bucket_with_fallback(timestamp_ms: i64, date_str: &str) -> Option<NaiveDateTime> {
     if let Some(dt) = timestamp_to_hour(timestamp_ms) {
+        return Some(dt);
+    }
+    parse_date(date_str).and_then(|d| d.and_hms_opt(0, 0, 0))
+}
+
+/// Convert Unix ms timestamp to a NaiveDateTime truncated to the minute (local tz).
+fn timestamp_to_minute(timestamp_ms: i64) -> Option<NaiveDateTime> {
+    use chrono::TimeZone;
+    if timestamp_ms <= 0 {
+        return None;
+    }
+    let ts_secs = timestamp_ms / 1000;
+    match Local.timestamp_opt(ts_secs, 0) {
+        chrono::LocalResult::Single(dt) => {
+            let naive = dt.naive_local();
+            Some(
+                naive
+                    .date()
+                    .and_hms_opt(naive.hour(), naive.minute(), 0)
+                    .unwrap_or(naive),
+            )
+        }
+        _ => None,
+    }
+}
+
+/// Derive a minute-truncated NaiveDateTime from `msg.timestamp` when present,
+/// otherwise fall back to `msg.date`'s 00:00 bucket so messages with missing
+/// timestamps are not silently dropped from minutely aggregation.
+fn minute_bucket_with_fallback(timestamp_ms: i64, date_str: &str) -> Option<NaiveDateTime> {
+    if let Some(dt) = timestamp_to_minute(timestamp_ms) {
         return Some(dt);
     }
     parse_date(date_str).and_then(|d| d.and_hms_opt(0, 0, 0))

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -165,6 +165,7 @@ pub struct DataLoader {
     pub since: Option<String>,
     pub until: Option<String>,
     pub year: Option<String>,
+    pub minutely_enabled: bool,
 }
 
 const UNKNOWN_WORKSPACE_LABEL: &str = "Unknown workspace";
@@ -252,6 +253,7 @@ impl DataLoader {
             since: None,
             until: None,
             year: None,
+            minutely_enabled: false,
         }
     }
 
@@ -266,7 +268,13 @@ impl DataLoader {
             since,
             until,
             year,
+            minutely_enabled: false,
         }
+    }
+
+    pub fn with_minutely_enabled(mut self, enabled: bool) -> Self {
+        self.minutely_enabled = enabled;
+        self
     }
 
     pub fn load(
@@ -718,8 +726,15 @@ impl DataLoader {
             }
 
             // Minute aggregation: same fallback semantics as hourly, but
-            // truncated to the minute. Used by the Minutely tab.
-            if let Some(minute_dt) = minute_bucket_with_fallback(msg.timestamp, &msg.date) {
+            // truncated to the minute. Used by the Minutely tab. Gated
+            // on `Settings::minutely_tab_enabled` so users who never open
+            // the tab do not pay the per-minute bucketing cost.
+            let minute_bucket = if self.minutely_enabled {
+                minute_bucket_with_fallback(msg.timestamp, &msg.date)
+            } else {
+                None
+            };
+            if let Some(minute_dt) = minute_bucket {
                 let minutely_entry =
                     minutely_map
                         .entry(minute_dt)
@@ -2381,5 +2396,119 @@ after"#,
         let (current, longest) = calculate_streaks_for_today(&daily, today);
         assert_eq!(current, 2);
         assert_eq!(longest, 2);
+    }
+
+    fn make_msg(timestamp_ms: i64, input: i64, output: i64, cost: f64) -> UnifiedMessage {
+        UnifiedMessage::new(
+            "claude",
+            "claude-sonnet-4-5-20250929",
+            "anthropic",
+            format!("session-{timestamp_ms}"),
+            timestamp_ms,
+            tokscale_core::TokenBreakdown {
+                input,
+                output,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            cost,
+        )
+    }
+
+    #[test]
+    fn test_minutely_aggregation_skipped_when_flag_disabled() {
+        let loader = DataLoader::new(None);
+        assert!(!loader.minutely_enabled);
+        let usage = loader
+            .aggregate_messages(
+                vec![make_msg(1_735_689_600_000, 10, 5, 1.0)],
+                &GroupBy::Model,
+            )
+            .unwrap();
+        assert!(
+            usage.minutely.is_empty(),
+            "minutely aggregation should be skipped when flag is off"
+        );
+        assert_eq!(usage.hourly.len(), 1, "hourly should still aggregate");
+    }
+
+    #[test]
+    fn test_minutely_aggregation_runs_when_flag_enabled() {
+        let loader = DataLoader::new(None).with_minutely_enabled(true);
+        assert!(loader.minutely_enabled);
+        let usage = loader
+            .aggregate_messages(
+                vec![make_msg(1_735_689_600_000, 10, 5, 1.0)],
+                &GroupBy::Model,
+            )
+            .unwrap();
+        assert_eq!(usage.minutely.len(), 1);
+        let bucket = &usage.minutely[0];
+        assert_eq!(bucket.tokens.input, 10);
+        assert_eq!(bucket.tokens.output, 5);
+        assert_eq!(bucket.cost, 1.0);
+        assert_eq!(bucket.message_count, 1);
+    }
+
+    #[test]
+    fn test_minutely_aggregation_groups_same_minute_messages() {
+        let loader = DataLoader::new(None).with_minutely_enabled(true);
+        let base_ms = 1_735_689_600_000_i64;
+        let usage = loader
+            .aggregate_messages(
+                vec![
+                    make_msg(base_ms, 10, 5, 1.0),
+                    make_msg(base_ms + 30_000, 20, 10, 2.0),
+                ],
+                &GroupBy::Model,
+            )
+            .unwrap();
+        assert_eq!(
+            usage.minutely.len(),
+            1,
+            "two messages within the same minute should share a bucket"
+        );
+        let bucket = &usage.minutely[0];
+        assert_eq!(bucket.tokens.input, 30);
+        assert_eq!(bucket.tokens.output, 15);
+        assert_eq!(bucket.cost, 3.0);
+        assert_eq!(bucket.message_count, 2);
+    }
+
+    #[test]
+    fn test_minutely_aggregation_splits_adjacent_minutes() {
+        let loader = DataLoader::new(None).with_minutely_enabled(true);
+        let base_ms = 1_735_689_600_000_i64;
+        let usage = loader
+            .aggregate_messages(
+                vec![
+                    make_msg(base_ms, 10, 5, 1.0),
+                    make_msg(base_ms + 60_000, 20, 10, 2.0),
+                ],
+                &GroupBy::Model,
+            )
+            .unwrap();
+        assert_eq!(
+            usage.minutely.len(),
+            2,
+            "messages one minute apart should land in distinct buckets"
+        );
+    }
+
+    #[test]
+    fn test_minutely_aggregation_clamps_negative_tokens_and_cost() {
+        let loader = DataLoader::new(None).with_minutely_enabled(true);
+        let usage = loader
+            .aggregate_messages(
+                vec![make_msg(1_735_689_600_000, -50, -50, -10.0)],
+                &GroupBy::Model,
+            )
+            .unwrap();
+        assert_eq!(usage.minutely.len(), 1);
+        let bucket = &usage.minutely[0];
+        assert_eq!(bucket.tokens.input, 0);
+        assert_eq!(bucket.tokens.output, 0);
+        assert_eq!(bucket.cost, 0.0);
     }
 }

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -61,6 +61,13 @@ pub struct Settings {
     pub default_clients: Vec<String>,
     #[serde(default)]
     pub light: LightSettings,
+    /// Opt-in toggle for the per-minute breakdown tab. Default is `false`
+    /// to keep the tab strip focused on the daily/hourly views most users
+    /// want and to skip the minute-bucket aggregation cost in DataLoader
+    /// for users who never need it. Set to `true` to surface the Minutely
+    /// tab and enable its aggregation in subsequent loads.
+    #[serde(default)]
+    pub minutely_tab_enabled: bool,
 }
 
 /// Lossy deserializer for `defaultClients`: accepts an array of arbitrary
@@ -105,6 +112,7 @@ impl Default for Settings {
             scanner: ScannerSettings::default(),
             default_clients: Vec::new(),
             light: LightSettings::default(),
+            minutely_tab_enabled: false,
         }
     }
 }
@@ -543,5 +551,30 @@ mod tests {
         let serialized = serde_json::to_string(&light).unwrap();
         let parsed: LightSettings = serde_json::from_str(&serialized).unwrap();
         assert!(parsed.write_cache);
+    }
+
+    #[test]
+    fn settings_minutely_tab_enabled_defaults_to_false() {
+        let json = r#"{ "colorPalette": "blue" }"#;
+        let parsed: Settings = serde_json::from_str(json).unwrap();
+        assert!(!parsed.minutely_tab_enabled);
+        assert!(!Settings::default().minutely_tab_enabled);
+    }
+
+    #[test]
+    fn settings_minutely_tab_enabled_round_trips_when_set() {
+        let json = r#"{
+            "colorPalette": "blue",
+            "minutelyTabEnabled": true
+        }"#;
+        let parsed: Settings = serde_json::from_str(json).unwrap();
+        assert!(parsed.minutely_tab_enabled);
+
+        let serialized = serde_json::to_string(&parsed).unwrap();
+        let round_trip: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(
+            round_trip["minutelyTabEnabled"],
+            serde_json::Value::Bool(true)
+        );
     }
 }

--- a/crates/tokscale-cli/src/tui/ui/footer.rs
+++ b/crates/tokscale-cli/src/tui/ui/footer.rs
@@ -157,6 +157,7 @@ fn current_count_label(app: &App) -> String {
         }
         Tab::Daily => format!(" ({} days)", app.data.daily.len()),
         Tab::Hourly => format!(" ({} hours)", app.data.hourly.len()),
+        Tab::Minutely => format!(" ({} minutes)", app.data.minutely.len()),
         Tab::Stats => String::new(),
     }
 }
@@ -368,6 +369,10 @@ mod tests {
         );
         assert_eq!(current_count_label(&make_app_on(Tab::Daily)), " (0 days)");
         assert_eq!(current_count_label(&make_app_on(Tab::Hourly)), " (0 hours)");
+        assert_eq!(
+            current_count_label(&make_app_on(Tab::Minutely)),
+            " (0 minutes)"
+        );
         assert_eq!(current_count_label(&make_app_on(Tab::Stats)), "");
     }
 }

--- a/crates/tokscale-cli/src/tui/ui/footer.rs
+++ b/crates/tokscale-cli/src/tui/ui/footer.rs
@@ -369,10 +369,14 @@ mod tests {
         );
         assert_eq!(current_count_label(&make_app_on(Tab::Daily)), " (0 days)");
         assert_eq!(current_count_label(&make_app_on(Tab::Hourly)), " (0 hours)");
-        assert_eq!(
-            current_count_label(&make_app_on(Tab::Minutely)),
-            " (0 minutes)"
-        );
         assert_eq!(current_count_label(&make_app_on(Tab::Stats)), "");
+    }
+
+    #[test]
+    fn test_current_count_label_minutely_when_flag_enabled() {
+        let mut app = make_app_on(Tab::Models);
+        app.settings.minutely_tab_enabled = true;
+        app.current_tab = Tab::Minutely;
+        assert_eq!(current_count_label(&app), " (0 minutes)");
     }
 }

--- a/crates/tokscale-cli/src/tui/ui/header.rs
+++ b/crates/tokscale-cli/src/tui/ui/header.rs
@@ -6,7 +6,13 @@ use crate::tui::app::{App, ClickAction, Tab};
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let is_very_narrow = app.is_very_narrow();
 
-    let titles: Vec<Line> = Tab::all()
+    let visible_tabs: Vec<Tab> = Tab::all()
+        .iter()
+        .copied()
+        .filter(|t| app.is_tab_visible(*t))
+        .collect();
+
+    let titles: Vec<Line> = visible_tabs
         .iter()
         .map(|t| {
             let name = if is_very_narrow {
@@ -25,7 +31,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         })
         .collect();
 
-    let selected = Tab::all()
+    let selected = visible_tabs
         .iter()
         .position(|t| *t == app.current_tab)
         .unwrap_or(0);
@@ -75,14 +81,20 @@ fn register_tab_click_areas(app: &mut App, area: Rect) {
     let y = area.y + 1;
     let mut x = inner_x;
 
-    for tab in Tab::all() {
+    let visible_tabs: Vec<Tab> = Tab::all()
+        .iter()
+        .copied()
+        .filter(|t| app.is_tab_visible(*t))
+        .collect();
+
+    for tab in visible_tabs {
         let name_len = if is_very_narrow {
             tab.short_name().len()
         } else {
             tab.as_str().len()
         };
         let width = name_len as u16 + 3;
-        app.add_click_area(Rect::new(x, y, width, 1), ClickAction::Tab(*tab));
+        app.add_click_area(Rect::new(x, y, width, 1), ClickAction::Tab(tab));
         x += width;
     }
 }

--- a/crates/tokscale-cli/src/tui/ui/minutely.rs
+++ b/crates/tokscale-cli/src/tui/ui/minutely.rs
@@ -1,0 +1,302 @@
+use chrono::{Local, Timelike};
+use ratatui::prelude::*;
+use ratatui::widgets::{
+    Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, ScrollbarState, Table,
+};
+
+use super::widgets::{format_cache_hit_rate, format_cost, format_tokens};
+use crate::tui::app::{App, SortDirection, SortField};
+
+pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(app.theme.border))
+        .title(Span::styled(
+            " Minutely Usage ",
+            Style::default()
+                .fg(app.theme.accent)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .style(Style::default().bg(app.theme.background));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let visible_height = inner.height.saturating_sub(1) as usize;
+    app.set_max_visible_items(visible_height);
+
+    let minutely = app.get_sorted_minutely();
+    if minutely.is_empty() {
+        let empty_msg = Paragraph::new("No minutely usage data found. Press 'r' to refresh.")
+            .style(Style::default().fg(app.theme.muted))
+            .alignment(Alignment::Center);
+        frame.render_widget(empty_msg, inner);
+        return;
+    }
+
+    let is_narrow = app.is_narrow();
+    let is_very_narrow = app.is_very_narrow();
+    let has_turn_data = minutely.iter().any(|m| m.turn_count > 0);
+    let sort_field = app.sort_field;
+    let sort_direction = app.sort_direction;
+    let scroll_offset = app.scroll_offset;
+    let selected_index = app.selected_index;
+    let theme_accent = app.theme.accent;
+    let theme_selection = app.theme.selection;
+    let now = Local::now().naive_local();
+    let current_minute = now
+        .date()
+        .and_hms_opt(now.hour(), now.minute(), 0)
+        .unwrap_or(now);
+
+    let header_cells = if is_very_narrow {
+        vec!["Minute", "Cost"]
+    } else if is_narrow {
+        if has_turn_data {
+            vec!["Minute", "Source", "Turn", "Msgs", "Tokens", "Cost"]
+        } else {
+            vec!["Minute", "Source", "Msgs", "Tokens", "Cost"]
+        }
+    } else if has_turn_data {
+        vec![
+            "Minute", "Source", "Turn", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache×",
+            "Total", "Cost",
+        ]
+    } else {
+        vec![
+            "Minute", "Source", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache×", "Total",
+            "Cost",
+        ]
+    };
+
+    let sort_indicator = |field: SortField| -> &'static str {
+        if sort_field == field {
+            match sort_direction {
+                SortDirection::Ascending => " ▲",
+                SortDirection::Descending => " ▼",
+            }
+        } else {
+            ""
+        }
+    };
+
+    let header = Row::new(
+        header_cells
+            .iter()
+            .enumerate()
+            .map(|(i, h)| {
+                let indicator = match (i, is_narrow, is_very_narrow) {
+                    (0, _, _) => sort_indicator(SortField::Date),
+                    (9, false, false) if has_turn_data => sort_indicator(SortField::Tokens),
+                    (8, false, false) if !has_turn_data => sort_indicator(SortField::Tokens),
+                    (4, true, false) if has_turn_data => sort_indicator(SortField::Tokens),
+                    (3, true, false) if !has_turn_data => sort_indicator(SortField::Tokens),
+                    (10, false, false) if has_turn_data => sort_indicator(SortField::Cost),
+                    (9, false, false) if !has_turn_data => sort_indicator(SortField::Cost),
+                    (5, true, false) if has_turn_data => sort_indicator(SortField::Cost),
+                    (4, true, false) if !has_turn_data => sort_indicator(SortField::Cost),
+                    (1, _, true) => sort_indicator(SortField::Cost),
+                    _ => "",
+                };
+                Cell::from(format!("{}{}", h, indicator))
+            })
+            .collect::<Vec<_>>(),
+    )
+    .style(
+        Style::default()
+            .fg(theme_accent)
+            .add_modifier(Modifier::BOLD),
+    )
+    .height(1);
+
+    let minutely_len = minutely.len();
+    let start = scroll_offset.min(minutely_len);
+    let end = (start + visible_height).min(minutely_len);
+
+    if start >= minutely_len {
+        return;
+    }
+
+    let rows: Vec<Row> = minutely[start..end]
+        .iter()
+        .enumerate()
+        .map(|(i, minute)| {
+            let idx = i + start;
+            let is_selected = idx == selected_index;
+            let is_striped = idx % 2 == 1;
+            let is_current = minute.datetime == current_minute;
+
+            let clients_str: String = {
+                let mut c: Vec<&str> = minute.clients.iter().map(String::as_str).collect();
+                c.sort();
+                c.join(", ")
+            };
+
+            let cells: Vec<Cell> = if is_very_narrow {
+                vec![
+                    Cell::from(minute.datetime.format("%m/%d %H:%M").to_string()).style(
+                        if is_current {
+                            Style::default()
+                                .fg(Color::Yellow)
+                                .add_modifier(Modifier::BOLD)
+                        } else {
+                            Style::default()
+                        },
+                    ),
+                    Cell::from(format_cost(minute.cost)).style(Style::default().fg(Color::Green)),
+                ]
+            } else if is_narrow {
+                let mut cells = vec![
+                    Cell::from(minute.datetime.format("%m-%d %H:%M").to_string()).style(
+                        if is_current {
+                            Style::default()
+                                .fg(Color::Yellow)
+                                .add_modifier(Modifier::BOLD)
+                        } else {
+                            Style::default()
+                        },
+                    ),
+                    Cell::from(clients_str),
+                ];
+                if has_turn_data {
+                    let turn_str = if minute.turn_count > 0 {
+                        minute.turn_count.to_string()
+                    } else {
+                        "\u{2014}".to_string()
+                    };
+                    cells.push(Cell::from(turn_str));
+                }
+                cells.extend([
+                    Cell::from(minute.message_count.to_string()),
+                    Cell::from(format_tokens(minute.tokens.total())),
+                    Cell::from(format_cost(minute.cost)).style(Style::default().fg(Color::Green)),
+                ]);
+                cells
+            } else {
+                let mut cells = vec![
+                    Cell::from(minute.datetime.format("%Y-%m-%d %H:%M").to_string()).style(
+                        if is_current {
+                            Style::default()
+                                .fg(Color::Yellow)
+                                .add_modifier(Modifier::BOLD)
+                        } else {
+                            Style::default().add_modifier(Modifier::BOLD)
+                        },
+                    ),
+                    Cell::from(clients_str),
+                ];
+                if has_turn_data {
+                    let turn_str = if minute.turn_count > 0 {
+                        minute.turn_count.to_string()
+                    } else {
+                        "\u{2014}".to_string()
+                    };
+                    cells.push(Cell::from(turn_str));
+                }
+                cells.extend([
+                    Cell::from(minute.message_count.to_string()),
+                    Cell::from(format_tokens(minute.tokens.input))
+                        .style(Style::default().fg(Color::Rgb(100, 200, 100))),
+                    Cell::from(format_tokens(minute.tokens.output))
+                        .style(Style::default().fg(Color::Rgb(200, 100, 100))),
+                    Cell::from(format_tokens(minute.tokens.cache_read))
+                        .style(Style::default().fg(Color::Rgb(100, 150, 200))),
+                    Cell::from(format_tokens(minute.tokens.cache_write))
+                        .style(Style::default().fg(Color::Rgb(200, 150, 100))),
+                    Cell::from(format_cache_hit_rate(
+                        minute.tokens.cache_read,
+                        minute.tokens.input,
+                        minute.tokens.cache_write,
+                    ))
+                    .style(Style::default().fg(Color::Cyan)),
+                    Cell::from(format_tokens(minute.tokens.total())),
+                    Cell::from(format_cost(minute.cost)).style(Style::default().fg(Color::Green)),
+                ]);
+                cells
+            };
+
+            let row_style = if is_selected {
+                Style::default().bg(theme_selection)
+            } else if is_current {
+                Style::default().bg(Color::Rgb(28, 42, 34))
+            } else if is_striped {
+                Style::default().bg(Color::Rgb(20, 24, 30))
+            } else {
+                Style::default()
+            };
+
+            Row::new(cells).style(row_style).height(1)
+        })
+        .collect();
+
+    let widths = if is_very_narrow {
+        vec![Constraint::Percentage(60), Constraint::Percentage(40)]
+    } else if is_narrow && has_turn_data {
+        vec![
+            Constraint::Percentage(32),
+            Constraint::Percentage(18),
+            Constraint::Percentage(10),
+            Constraint::Percentage(10),
+            Constraint::Percentage(15),
+            Constraint::Percentage(15),
+        ]
+    } else if is_narrow {
+        vec![
+            Constraint::Percentage(32),
+            Constraint::Percentage(23),
+            Constraint::Percentage(15),
+            Constraint::Percentage(15),
+            Constraint::Percentage(15),
+        ]
+    } else if has_turn_data {
+        vec![
+            Constraint::Length(18),
+            Constraint::Length(14),
+            Constraint::Length(6),
+            Constraint::Length(6),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(8),
+            Constraint::Length(10),
+            Constraint::Length(10),
+        ]
+    } else {
+        vec![
+            Constraint::Length(18),
+            Constraint::Length(14),
+            Constraint::Length(6),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(8),
+            Constraint::Length(10),
+            Constraint::Length(10),
+        ]
+    };
+
+    let table = Table::new(rows, widths)
+        .header(header)
+        .row_highlight_style(Style::default().bg(theme_selection));
+
+    frame.render_widget(table, inner);
+
+    if minutely_len > visible_height {
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(Some("▲"))
+            .end_symbol(Some("▼"));
+
+        let mut scrollbar_state = ScrollbarState::new(minutely_len).position(scroll_offset);
+
+        frame.render_stateful_widget(
+            scrollbar,
+            area.inner(Margin {
+                horizontal: 0,
+                vertical: 1,
+            }),
+            &mut scrollbar_state,
+        );
+    }
+}

--- a/crates/tokscale-cli/src/tui/ui/mod.rs
+++ b/crates/tokscale-cli/src/tui/ui/mod.rs
@@ -6,6 +6,7 @@ mod footer;
 mod header;
 mod hourly;
 mod hourly_profile;
+mod minutely;
 mod models;
 mod overview;
 pub mod spinner;
@@ -48,6 +49,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
             Tab::Agents => agents::render(frame, app, chunks[1]),
             Tab::Daily => daily::render(frame, app, chunks[1]),
             Tab::Hourly => hourly::render(frame, app, chunks[1]),
+            Tab::Minutely => minutely::render(frame, app, chunks[1]),
             Tab::Stats => stats::render(frame, app, chunks[1]),
         }
     }


### PR DESCRIPTION
## Summary

Adds a new **Minutely** tab to the TUI that shows token usage aggregated per minute. This complements the existing Hourly tab and is useful for seeing burst patterns during focused coding sessions.

## Changes

- Added `Tab::Minutely` variant with navigation/sorting support
- New `MinutelyUsage` data model with per-minute aggregation logic
- New `minutely.rs` UI renderer for the table view
- Wired into the TUI tab bar and cache layer
- Updated unit tests for tab order, prev/next navigation, and keyboard shortcuts

## Usage

Open the TUI and press `Tab` / `Shift+Tab` or `←/→` to navigate to the **Minutely** tab (`Min`).

## Testing

- `cargo test` passes in `crates/tokscale-cli`
- Tab order, short name, and keyboard navigation covered by existing `mod tests`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Minutely tab in the TUI for per-minute token and cost breakdowns to help spot short bursts. The tab is gated behind a `minutelyTabEnabled` setting (default off) to avoid extra aggregation work unless enabled.

- **New Features**
  - Added Minutely tab (“Min”) between Hourly and Stats; supports sorting by Date/Tokens/Cost and navigation via Tab/Shift+Tab or ←/→.
  - New `minutelyTabEnabled` in `settings.json` (camelCase, default false). When off: DataLoader skips minute aggregation, the tab is hidden from the header and mouse targets, keyboard/tab cycling skips it, and a requested initial Minutely tab clamps to Overview.
  - Introduced `MinutelyUsage` with per-minute buckets (tokens, cost, messages, turns, clients, per-model stats); uses timestamp when available, falls back to message date; recomputed on load and not cached.
  - New `minutely.rs` table UI with responsive columns, cache read/write and hit-rate metrics, current-minute highlight, scrollbar, and an empty state.
  - Wired into app state, footer count label (“(x minutes)”), and tab bar; tests cover flag defaults/round-trip, tab visibility and navigation, minutely aggregation on/off, minute grouping/splitting, and clamping negative tokens/cost.

<sup>Written for commit 7cad4bc00a6641d7ce69cde6882fa3e03ad680b2. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/542?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

