### PR TITLE
feat(core,cli): add session and client+session group-by

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Press `g` in the TUI or use `--group-by` in `--light`/`--json` mode to control h
 | **Model** | `--group-by model` | ✅ | One row per model — merges all clients and providers |
 | **Client + Model** | `--group-by client,model` | | One row per client-model pair |
 | **Client + Provider + Model** | `--group-by client,provider,model` | | Most granular — no merging |
+| **Workspace + Model** | `--group-by workspace,model` | | Group local usage by workspace key, then model |
 | **Session + Model** | `--group-by session,model` | | One row per `session_id` and model — attribute cost to a specific agent-CLI session |
 | **Client + Session + Model** | `--group-by client,session,model` | | One row per client, session, and model — useful for multi-agent runners that join on `session_id` |
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ The interactive TUI mode provides:
   - `c/d/t`: Sort by cost/date/tokens
   - `j`: Jump to today
   - `s`: Open source picker dialog
-  - `g`: Open group-by picker dialog (model, client+model, client+provider+model)
+  - `g`: Open group-by picker dialog (model, client+model, client+provider+model, workspace+model, session+model, client+session+model)
   - `h`: Toggle Daily/Hourly chart granularity (Overview tab)
   - `v`: Toggle Table/Profile view (Hourly tab)
   - `y`: Copy selected row to clipboard
@@ -278,6 +278,8 @@ Press `g` in the TUI or use `--group-by` in `--light`/`--json` mode to control h
 | **Model** | `--group-by model` | ✅ | One row per model — merges all clients and providers |
 | **Client + Model** | `--group-by client,model` | | One row per client-model pair |
 | **Client + Provider + Model** | `--group-by client,provider,model` | | Most granular — no merging |
+| **Session + Model** | `--group-by session,model` | | One row per `session_id` and model — attribute cost to a specific agent-CLI session |
+| **Client + Session + Model** | `--group-by client,session,model` | | One row per client, session, and model — useful for multi-agent runners that join on `session_id` |
 
 **`--group-by model`** (most consolidated)
 
@@ -300,6 +302,33 @@ Press `g` in the TUI or use `--group-by` in `--light`/`--json` mode to control h
 | OpenCode | github-copilot | claude-opus-4-5 | $1,200 |
 | OpenCode | anthropic | claude-opus-4-5 | $168 |
 | Claude | anthropic | claude-opus-4-5 | $970 |
+
+**`--group-by session,model`** (per-session cost attribution)
+
+`tokscale models --json --group-by session,model` emits one entry per `(session_id, model)`. Each entry includes a top-level `sessionId` field so downstream tools (e.g. multi-agent IDEs) can join cost data back to a specific agent-CLI session:
+
+```json
+{
+  "groupBy": "session,model",
+  "entries": [
+    {
+      "sessionId": "019e1e27-af49-7cd1-89b7-7bad1c3f3be2",
+      "client": "codex",
+      "provider": "openai",
+      "model": "gpt-5",
+      "input": 25251,
+      "output": 47,
+      "cacheRead": 1920,
+      "cacheWrite": 0,
+      "reasoning": 40,
+      "messageCount": 12,
+      "cost": 0.0123
+    }
+  ]
+}
+```
+
+Use `--group-by client,session,model` when you also need the client name on every row (one spawn across all 20+ supported CLIs at once).
 
 ### Filtering by Platform
 

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -79,7 +79,7 @@ struct Cli {
         long,
         value_name = "STRATEGY",
         default_value = "client,model",
-        help = "Grouping strategy for --light and --json output: model, client,model, client,provider,model, workspace,model"
+        help = "Grouping strategy for --light and --json output: model, client,model, client,provider,model, workspace,model, session,model, client,session,model"
     )]
     group_by: String,
 
@@ -105,7 +105,7 @@ enum Commands {
             long,
             value_name = "STRATEGY",
             default_value = "client,model",
-            help = "Grouping strategy for --light and --json output: model, client,model, client,provider,model, workspace,model"
+            help = "Grouping strategy for --light and --json output: model, client,model, client,provider,model, workspace,model, session,model, client,session,model"
         )]
         group_by: String,
         #[arg(
@@ -1522,6 +1522,8 @@ fn run_models_report(
             workspace_key: Option<serde_json::Value>,
             #[serde(skip_serializing_if = "Option::is_none")]
             workspace_label: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            session_id: Option<String>,
             model: String,
             provider: String,
             input: i64,
@@ -1564,6 +1566,11 @@ fn run_models_report(
                     },
                     workspace_label: if group_by == GroupBy::WorkspaceModel {
                         e.workspace_label
+                    } else {
+                        None
+                    },
+                    session_id: if matches!(group_by, GroupBy::Session | GroupBy::ClientSession) {
+                        e.session_id
                     } else {
                         None
                     },
@@ -1723,6 +1730,74 @@ fn run_models_report(
                             .set_alignment(CellAlignment::Right),
                     ]);
                 }
+                GroupBy::Session | GroupBy::ClientSession => {
+                    let show_client = group_by == GroupBy::ClientSession;
+                    let mut header = Vec::with_capacity(6);
+                    if show_client {
+                        header.push(Cell::new("Client").fg(Color::Cyan));
+                    }
+                    header.extend([
+                        Cell::new("Session").fg(Color::Cyan),
+                        Cell::new("Model").fg(Color::Cyan),
+                        Cell::new("Total").fg(Color::Cyan),
+                        Cell::new("Cost").fg(Color::Cyan),
+                    ]);
+                    table.set_header(header);
+
+                    for entry in &report.entries {
+                        let total_tokens =
+                            entry.input + entry.output + entry.cache_read + entry.cache_write;
+                        let session_label = entry
+                            .session_id
+                            .clone()
+                            .unwrap_or_else(|| "(unknown)".to_string());
+                        let mut row = Vec::with_capacity(6);
+                        if show_client {
+                            row.push(Cell::new(capitalize_client(&entry.client)));
+                        }
+                        row.extend([
+                            Cell::new(session_label),
+                            Cell::new(&entry.model),
+                            Cell::new(format_tokens_with_commas(total_tokens))
+                                .set_alignment(CellAlignment::Right),
+                            Cell::new(format_currency(entry.cost))
+                                .set_alignment(CellAlignment::Right),
+                        ]);
+                        table.add_row(row);
+                    }
+
+                    let total_all = report.total_input
+                        + report.total_output
+                        + report.total_cache_read
+                        + report.total_cache_write;
+                    let mut total_row = Vec::with_capacity(6);
+                    if show_client {
+                        total_row.push(
+                            Cell::new("Total")
+                                .fg(Color::Yellow)
+                                .add_attribute(Attribute::Bold),
+                        );
+                        total_row.push(Cell::new(""));
+                    } else {
+                        total_row.push(
+                            Cell::new("Total")
+                                .fg(Color::Yellow)
+                                .add_attribute(Attribute::Bold),
+                        );
+                    }
+                    total_row.push(Cell::new(""));
+                    total_row.push(
+                        Cell::new(format_tokens_with_commas(total_all))
+                            .fg(Color::Yellow)
+                            .set_alignment(CellAlignment::Right),
+                    );
+                    total_row.push(
+                        Cell::new(format_currency(report.total_cost))
+                            .fg(Color::Yellow)
+                            .set_alignment(CellAlignment::Right),
+                    );
+                    table.add_row(total_row);
+                }
                 GroupBy::WorkspaceModel => {
                     table.set_header(vec![
                         Cell::new("Workspace").fg(Color::Cyan),
@@ -1829,6 +1904,94 @@ fn run_models_report(
                             .fg(Color::Yellow)
                             .set_alignment(CellAlignment::Right),
                     ]);
+                }
+                GroupBy::Session | GroupBy::ClientSession => {
+                    let show_client = group_by == GroupBy::ClientSession;
+                    let mut header = Vec::with_capacity(9);
+                    if show_client {
+                        header.push(Cell::new("Client").fg(Color::Cyan));
+                    }
+                    header.extend([
+                        Cell::new("Session").fg(Color::Cyan),
+                        Cell::new("Provider").fg(Color::Cyan),
+                        Cell::new("Model").fg(Color::Cyan),
+                        Cell::new("Input").fg(Color::Cyan),
+                        Cell::new("Output").fg(Color::Cyan),
+                        Cell::new("Total").fg(Color::Cyan),
+                        Cell::new("Cost").fg(Color::Cyan),
+                        Cell::new("Cost/1M").fg(Color::Cyan),
+                    ]);
+                    table.set_header(header);
+
+                    for entry in &report.entries {
+                        let total =
+                            entry.input + entry.output + entry.cache_write + entry.cache_read;
+                        let session_label = entry
+                            .session_id
+                            .clone()
+                            .unwrap_or_else(|| "(unknown)".to_string());
+                        let mut row = Vec::with_capacity(9);
+                        if show_client {
+                            row.push(Cell::new(capitalize_client(&entry.client)));
+                        }
+                        row.extend([
+                            Cell::new(session_label),
+                            Cell::new(&entry.provider).add_attribute(Attribute::Dim),
+                            Cell::new(&entry.model),
+                            Cell::new(format_tokens_with_commas(entry.input))
+                                .set_alignment(CellAlignment::Right),
+                            Cell::new(format_tokens_with_commas(entry.output))
+                                .set_alignment(CellAlignment::Right),
+                            Cell::new(format_tokens_with_commas(total))
+                                .set_alignment(CellAlignment::Right),
+                            Cell::new(format_currency(entry.cost))
+                                .set_alignment(CellAlignment::Right),
+                            Cell::new(format_cost_per_million(entry.cost, total))
+                                .set_alignment(CellAlignment::Right),
+                        ]);
+                        table.add_row(row);
+                    }
+
+                    let total_all = report.total_input
+                        + report.total_output
+                        + report.total_cache_write
+                        + report.total_cache_read;
+                    let mut total_row: Vec<Cell> = Vec::with_capacity(9);
+                    total_row.push(
+                        Cell::new("Total")
+                            .fg(Color::Yellow)
+                            .add_attribute(Attribute::Bold),
+                    );
+                    let blanks = if show_client { 3 } else { 2 };
+                    for _ in 0..blanks {
+                        total_row.push(Cell::new(""));
+                    }
+                    total_row.push(
+                        Cell::new(format_tokens_with_commas(report.total_input))
+                            .fg(Color::Yellow)
+                            .set_alignment(CellAlignment::Right),
+                    );
+                    total_row.push(
+                        Cell::new(format_tokens_with_commas(report.total_output))
+                            .fg(Color::Yellow)
+                            .set_alignment(CellAlignment::Right),
+                    );
+                    total_row.push(
+                        Cell::new(format_tokens_with_commas(total_all))
+                            .fg(Color::Yellow)
+                            .set_alignment(CellAlignment::Right),
+                    );
+                    total_row.push(
+                        Cell::new(format_currency(report.total_cost))
+                            .fg(Color::Yellow)
+                            .set_alignment(CellAlignment::Right),
+                    );
+                    total_row.push(
+                        Cell::new(format_cost_per_million(report.total_cost, total_all))
+                            .fg(Color::Yellow)
+                            .set_alignment(CellAlignment::Right),
+                    );
+                    table.add_row(total_row);
                 }
                 GroupBy::ClientModel | GroupBy::ClientProviderModel => {
                     table.set_header(vec![

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -208,7 +208,9 @@ fn daily_source_model_key(
     match group_by {
         GroupBy::WorkspaceModel => workspace_model_daily_key(workspace_group_key, model),
         GroupBy::ClientProviderModel => format!("{provider_id}:{model}"),
-        GroupBy::Model | GroupBy::ClientModel => model.to_string(),
+        GroupBy::Model | GroupBy::ClientModel | GroupBy::Session | GroupBy::ClientSession => {
+            model.to_string()
+        }
     }
 }
 
@@ -221,28 +223,42 @@ fn daily_source_model_display_name(
     match group_by {
         GroupBy::WorkspaceModel => workspace_model_display_label(workspace_label, model),
         GroupBy::ClientProviderModel => format!("{provider_id} / {model}"),
-        GroupBy::Model | GroupBy::ClientModel => model.to_string(),
+        GroupBy::Model | GroupBy::ClientModel | GroupBy::Session | GroupBy::ClientSession => {
+            model.to_string()
+        }
     }
 }
 
 fn model_color_key(group_by: &GroupBy, _provider_id: &str, model: &str) -> String {
     match group_by {
         GroupBy::ClientProviderModel => model.to_string(),
-        GroupBy::Model | GroupBy::ClientModel | GroupBy::WorkspaceModel => model.to_string(),
+        GroupBy::Model
+        | GroupBy::ClientModel
+        | GroupBy::WorkspaceModel
+        | GroupBy::Session
+        | GroupBy::ClientSession => model.to_string(),
     }
 }
 
 fn hourly_model_key(group_by: &GroupBy, provider_id: &str, model: &str) -> String {
     match group_by {
         GroupBy::ClientProviderModel => format!("{provider_id}:{model}"),
-        GroupBy::Model | GroupBy::ClientModel | GroupBy::WorkspaceModel => model.to_string(),
+        GroupBy::Model
+        | GroupBy::ClientModel
+        | GroupBy::WorkspaceModel
+        | GroupBy::Session
+        | GroupBy::ClientSession => model.to_string(),
     }
 }
 
 fn hourly_model_display_name(group_by: &GroupBy, provider_id: &str, model: &str) -> String {
     match group_by {
         GroupBy::ClientProviderModel => format!("{provider_id} / {model}"),
-        GroupBy::Model | GroupBy::ClientModel | GroupBy::WorkspaceModel => model.to_string(),
+        GroupBy::Model
+        | GroupBy::ClientModel
+        | GroupBy::WorkspaceModel
+        | GroupBy::Session
+        | GroupBy::ClientSession => model.to_string(),
     }
 }
 
@@ -402,6 +418,10 @@ impl DataLoader {
                 }
                 GroupBy::WorkspaceModel => {
                     format!("{}:{}", workspace_group_key, normalized_model)
+                }
+                GroupBy::Session => format!("{}:{}", msg.session_id, normalized_model),
+                GroupBy::ClientSession => {
+                    format!("{}:{}:{}", msg.client, msg.session_id, normalized_model)
                 }
             };
             let merge_clients = matches!(group_by, GroupBy::Model | GroupBy::WorkspaceModel);

--- a/crates/tokscale-cli/src/tui/ui/dialog/group_by_picker.rs
+++ b/crates/tokscale-cli/src/tui/ui/dialog/group_by_picker.rs
@@ -53,6 +53,16 @@ impl GroupByPickerDialog {
                 label: "Workspace + Model",
                 description: "Group local usage by workspace key, then model",
             },
+            GroupByOption {
+                value: GroupBy::Session,
+                label: "Session + Model",
+                description: "One row per session_id and model (attribute cost per session)",
+            },
+            GroupByOption {
+                value: GroupBy::ClientSession,
+                label: "Client + Session + Model",
+                description: "One row per client, session_id, and model",
+            },
         ];
 
         let cursor = options.iter().position(|o| o.value == current).unwrap_or(1);

--- a/crates/tokscale-cli/src/tui/ui/dialog/group_by_picker.rs
+++ b/crates/tokscale-cli/src/tui/ui/dialog/group_by_picker.rs
@@ -87,8 +87,12 @@ impl GroupByPickerDialog {
 
 impl DialogContent for GroupByPickerDialog {
     fn desired_size(&self, viewport: Rect) -> (u16, u16) {
+        // 6 options render as 2 lines each (label + description) = 12 rows,
+        // plus header (1) + divider (1) + hint (1) + borders (2). Cap at 18
+        // so every option stays visible without scrolling on a typical
+        // terminal; matches source_picker's sizing.
         let width = 52u16.min(viewport.width.saturating_sub(4));
-        let height = 14u16.min(viewport.height.saturating_sub(4));
+        let height = 18u16.min(viewport.height.saturating_sub(4));
         (width, height)
     }
 

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -1407,6 +1407,74 @@ fn test_models_json_with_group_by_model() {
             entry.get("workspaceLabel").is_none(),
             "group-by model entries should not expose workspaceLabel"
         );
+        assert!(
+            entry.get("sessionId").is_none(),
+            "group-by model entries should not expose sessionId"
+        );
+    }
+}
+
+#[test]
+fn test_models_group_by_session_emits_session_id_per_entry() {
+    let tmp = create_temp_fixture_dir();
+    let output = cmd_with_home(tmp.path())
+        .args(["models", "--json", "--opencode", "--no-spinner"])
+        .args(["--group-by", "session,model"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "command failed: {:?}", output);
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["groupBy"].as_str().unwrap(), "session,model");
+
+    let entries = json["entries"].as_array().unwrap();
+    assert!(!entries.is_empty(), "expected at least one entry");
+
+    let mut session_ids: Vec<&str> = entries
+        .iter()
+        .map(|e| {
+            e.get("sessionId")
+                .and_then(|v| v.as_str())
+                .expect("session,model entries must include sessionId")
+        })
+        .collect();
+    session_ids.sort();
+    session_ids.dedup();
+    // Fixture has two sessions ("session1", "session2"); expect both to appear.
+    assert!(
+        session_ids.contains(&"session1") && session_ids.contains(&"session2"),
+        "expected both fixture sessions to appear in output, got {:?}",
+        session_ids
+    );
+
+    for entry in entries {
+        assert!(
+            entry.get("workspaceKey").is_none(),
+            "session grouping should not expose workspaceKey"
+        );
+        assert!(entry.get("model").is_some());
+        assert!(entry.get("provider").is_some());
+        assert!(entry.get("cost").is_some());
+    }
+}
+
+#[test]
+fn test_models_group_by_client_session_includes_client_and_session() {
+    let tmp = create_temp_fixture_dir();
+    let output = cmd_with_home(tmp.path())
+        .args(["models", "--json", "--opencode", "--no-spinner"])
+        .args(["--group-by", "client,session,model"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "command failed: {:?}", output);
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["groupBy"].as_str().unwrap(), "client,session,model");
+
+    let entries = json["entries"].as_array().unwrap();
+    assert!(!entries.is_empty());
+    for entry in entries {
+        assert!(entry.get("sessionId").and_then(|v| v.as_str()).is_some());
+        assert!(entry.get("client").and_then(|v| v.as_str()).is_some());
+        assert!(entry.get("model").is_some());
     }
 }
 

--- a/crates/tokscale-core/src/aggregator.rs
+++ b/crates/tokscale-core/src/aggregator.rs
@@ -5,7 +5,7 @@
 use crate::sessions::UnifiedMessage;
 use crate::{
     ClientContribution, DailyContribution, DailyTotals, DataSummary, GraphMeta, GraphResult,
-    TokenBreakdown, YearSummary,
+    SessionContribution, TokenBreakdown, YearSummary,
 };
 use rayon::prelude::*;
 use std::collections::HashMap;
@@ -53,6 +53,49 @@ pub fn aggregate_by_date(messages: Vec<UnifiedMessage>) -> Vec<DailyContribution
 
     // Calculate intensities based on max cost
     calculate_intensities(&mut contributions);
+
+    contributions
+}
+
+/// Aggregate messages into per-session contributions, keyed on `session_id`.
+///
+/// Each returned [`SessionContribution`] sums all token buckets and cost for a
+/// single session and exposes the same client/model breakdown shape as
+/// [`aggregate_by_date`].  Sessions are sorted by `last_seen` descending so the
+/// most recently active sessions appear first.
+pub fn aggregate_by_session(messages: Vec<UnifiedMessage>) -> Vec<SessionContribution> {
+    if messages.is_empty() {
+        return Vec::new();
+    }
+
+    let session_map: HashMap<String, SessionAccumulator> = messages
+        .into_par_iter()
+        .fold(
+            HashMap::new,
+            |mut acc: HashMap<String, SessionAccumulator>, msg| {
+                let entry = acc.entry(msg.session_id.clone()).or_default();
+                entry.add_message(&msg);
+                acc
+            },
+        )
+        .reduce(HashMap::new, |mut a, b| {
+            for (id, acc) in b {
+                a.entry(id).or_default().merge(acc);
+            }
+            a
+        });
+
+    let mut contributions: Vec<SessionContribution> = session_map
+        .into_iter()
+        .map(|(session_id, acc)| acc.into_contribution(session_id))
+        .collect();
+
+    // Most recently active first; stable sort by session_id when ties.
+    contributions.sort_by(|a, b| {
+        b.last_seen
+            .cmp(&a.last_seen)
+            .then_with(|| a.session_id.cmp(&b.session_id))
+    });
 
     contributions
 }
@@ -391,6 +434,256 @@ impl DayAccumulator {
             intensity: 0,
             token_breakdown,
             clients,
+        }
+    }
+}
+
+struct SessionAccumulator {
+    totals: DailyTotals,
+    token_breakdown: TokenBreakdown,
+    clients: HashMap<String, ClientContribution>,
+    /// Tracks the most-active (client, provider, model) for the session, used
+    /// as the canonical top-level fields on `SessionContribution`.
+    top_client: String,
+    top_provider: String,
+    top_model: String,
+    top_cost: f64,
+    first_seen: i64,
+    last_seen: i64,
+}
+
+impl Default for SessionAccumulator {
+    fn default() -> Self {
+        Self {
+            totals: DailyTotals::default(),
+            token_breakdown: TokenBreakdown::default(),
+            clients: HashMap::with_capacity(2),
+            top_client: String::new(),
+            top_provider: String::new(),
+            top_model: String::new(),
+            top_cost: f64::NEG_INFINITY,
+            first_seen: i64::MAX,
+            last_seen: i64::MIN,
+        }
+    }
+}
+
+impl SessionAccumulator {
+    fn add_message(&mut self, msg: &UnifiedMessage) {
+        let total_tokens = msg
+            .tokens
+            .input
+            .saturating_add(msg.tokens.output)
+            .saturating_add(msg.tokens.cache_read)
+            .saturating_add(msg.tokens.cache_write)
+            .saturating_add(msg.tokens.reasoning);
+
+        self.totals.tokens = self.totals.tokens.saturating_add(total_tokens);
+        self.totals.cost += msg.cost;
+        self.totals.messages = self
+            .totals
+            .messages
+            .saturating_add(msg.message_count.max(0));
+
+        self.token_breakdown.input = self.token_breakdown.input.saturating_add(msg.tokens.input);
+        self.token_breakdown.output = self
+            .token_breakdown
+            .output
+            .saturating_add(msg.tokens.output);
+        self.token_breakdown.cache_read = self
+            .token_breakdown
+            .cache_read
+            .saturating_add(msg.tokens.cache_read);
+        self.token_breakdown.cache_write = self
+            .token_breakdown
+            .cache_write
+            .saturating_add(msg.tokens.cache_write);
+        self.token_breakdown.reasoning = self
+            .token_breakdown
+            .reasoning
+            .saturating_add(msg.tokens.reasoning);
+
+        // Track tightest (client, provider, model) by cost contribution.
+        let normalized_model = crate::normalize_model_for_grouping(&msg.model_id);
+        let key = format!("{}:{}:{}", msg.client, msg.provider_id, normalized_model);
+        let client_entry = self
+            .clients
+            .entry(key)
+            .or_insert_with(|| ClientContribution {
+                client: msg.client.clone(),
+                model_id: normalized_model.clone(),
+                provider_id: msg.provider_id.clone(),
+                tokens: TokenBreakdown::default(),
+                cost: 0.0,
+                messages: 0,
+            });
+        client_entry.tokens.input = client_entry.tokens.input.saturating_add(msg.tokens.input);
+        client_entry.tokens.output = client_entry.tokens.output.saturating_add(msg.tokens.output);
+        client_entry.tokens.cache_read = client_entry
+            .tokens
+            .cache_read
+            .saturating_add(msg.tokens.cache_read);
+        client_entry.tokens.cache_write = client_entry
+            .tokens
+            .cache_write
+            .saturating_add(msg.tokens.cache_write);
+        client_entry.tokens.reasoning = client_entry
+            .tokens
+            .reasoning
+            .saturating_add(msg.tokens.reasoning);
+        client_entry.cost += msg.cost;
+        client_entry.messages = client_entry
+            .messages
+            .saturating_add(msg.message_count.max(0));
+
+        if client_entry.cost > self.top_cost {
+            self.top_cost = client_entry.cost;
+            self.top_client = client_entry.client.clone();
+            self.top_provider = client_entry.provider_id.clone();
+            self.top_model = client_entry.model_id.clone();
+        }
+
+        // Timestamps in UnifiedMessage are stored in milliseconds in most
+        // parsers; normalize to seconds for the contribution wire format.
+        let secs = if msg.timestamp.abs() > 1_000_000_000_000 {
+            msg.timestamp / 1000
+        } else {
+            msg.timestamp
+        };
+        if secs < self.first_seen {
+            self.first_seen = secs;
+        }
+        if secs > self.last_seen {
+            self.last_seen = secs;
+        }
+    }
+
+    fn merge(&mut self, other: SessionAccumulator) {
+        self.totals.tokens = self.totals.tokens.saturating_add(other.totals.tokens);
+        self.totals.cost += other.totals.cost;
+        self.totals.messages = self.totals.messages.saturating_add(other.totals.messages);
+
+        self.token_breakdown.input = self
+            .token_breakdown
+            .input
+            .saturating_add(other.token_breakdown.input);
+        self.token_breakdown.output = self
+            .token_breakdown
+            .output
+            .saturating_add(other.token_breakdown.output);
+        self.token_breakdown.cache_read = self
+            .token_breakdown
+            .cache_read
+            .saturating_add(other.token_breakdown.cache_read);
+        self.token_breakdown.cache_write = self
+            .token_breakdown
+            .cache_write
+            .saturating_add(other.token_breakdown.cache_write);
+        self.token_breakdown.reasoning = self
+            .token_breakdown
+            .reasoning
+            .saturating_add(other.token_breakdown.reasoning);
+
+        for (key, contrib) in other.clients {
+            let entry = self
+                .clients
+                .entry(key)
+                .or_insert_with(|| ClientContribution {
+                    client: contrib.client.clone(),
+                    model_id: contrib.model_id.clone(),
+                    provider_id: contrib.provider_id.clone(),
+                    tokens: TokenBreakdown::default(),
+                    cost: 0.0,
+                    messages: 0,
+                });
+            entry.tokens.input = entry.tokens.input.saturating_add(contrib.tokens.input);
+            entry.tokens.output = entry.tokens.output.saturating_add(contrib.tokens.output);
+            entry.tokens.cache_read = entry
+                .tokens
+                .cache_read
+                .saturating_add(contrib.tokens.cache_read);
+            entry.tokens.cache_write = entry
+                .tokens
+                .cache_write
+                .saturating_add(contrib.tokens.cache_write);
+            entry.tokens.reasoning = entry
+                .tokens
+                .reasoning
+                .saturating_add(contrib.tokens.reasoning);
+            entry.cost += contrib.cost;
+            entry.messages = entry.messages.saturating_add(contrib.messages);
+
+            if entry.cost > self.top_cost {
+                self.top_cost = entry.cost;
+                self.top_client = entry.client.clone();
+                self.top_provider = entry.provider_id.clone();
+                self.top_model = entry.model_id.clone();
+            }
+        }
+
+        if other.first_seen < self.first_seen {
+            self.first_seen = other.first_seen;
+        }
+        if other.last_seen > self.last_seen {
+            self.last_seen = other.last_seen;
+        }
+    }
+
+    fn into_contribution(self, session_id: String) -> SessionContribution {
+        let token_breakdown = TokenBreakdown {
+            input: self.token_breakdown.input.max(0),
+            output: self.token_breakdown.output.max(0),
+            cache_read: self.token_breakdown.cache_read.max(0),
+            cache_write: self.token_breakdown.cache_write.max(0),
+            reasoning: self.token_breakdown.reasoning.max(0),
+        };
+
+        let mut clients: Vec<ClientContribution> = self
+            .clients
+            .into_values()
+            .map(|mut c| {
+                c.tokens.input = c.tokens.input.max(0);
+                c.tokens.output = c.tokens.output.max(0);
+                c.tokens.cache_read = c.tokens.cache_read.max(0);
+                c.tokens.cache_write = c.tokens.cache_write.max(0);
+                c.tokens.reasoning = c.tokens.reasoning.max(0);
+                c.cost = c.cost.max(0.0);
+                c
+            })
+            .collect();
+        clients.sort_by(|a, b| {
+            b.cost
+                .partial_cmp(&a.cost)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.client.cmp(&b.client))
+                .then_with(|| a.model_id.cmp(&b.model_id))
+        });
+
+        let first_seen = if self.first_seen == i64::MAX {
+            0
+        } else {
+            self.first_seen
+        };
+        let last_seen = if self.last_seen == i64::MIN {
+            0
+        } else {
+            self.last_seen
+        };
+
+        SessionContribution {
+            session_id,
+            client: self.top_client,
+            provider: self.top_provider,
+            model: self.top_model,
+            totals: DailyTotals {
+                tokens: self.totals.tokens.max(0),
+                cost: self.totals.cost.max(0.0),
+                messages: self.totals.messages.max(0),
+            },
+            token_breakdown,
+            clients,
+            first_seen,
+            last_seen,
         }
     }
 }
@@ -967,5 +1260,278 @@ mod tests {
             assert_eq!(contribution.totals.tokens, 10000);
             assert!((contribution.totals.cost - 0.5).abs() < 0.0001);
         }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn session_message(
+        session_id: &str,
+        client: &str,
+        provider: &str,
+        model: &str,
+        date: &str,
+        timestamp_ms: i64,
+        tokens: TokenBreakdown,
+        cost: f64,
+    ) -> UnifiedMessage {
+        UnifiedMessage {
+            client: client.to_string(),
+            model_id: model.to_string(),
+            provider_id: provider.to_string(),
+            session_id: session_id.to_string(),
+            workspace_key: None,
+            workspace_label: None,
+            timestamp: timestamp_ms,
+            date: date.to_string(),
+            tokens,
+            cost,
+            message_count: 1,
+            agent: None,
+            dedup_key: None,
+            is_turn_start: false,
+        }
+    }
+
+    #[test]
+    fn test_aggregate_by_session_empty() {
+        assert!(aggregate_by_session(Vec::new()).is_empty());
+    }
+
+    #[test]
+    fn test_aggregate_by_session_groups_three_sessions() {
+        let t = TokenBreakdown {
+            input: 100,
+            output: 50,
+            cache_read: 0,
+            cache_write: 0,
+            reasoning: 0,
+        };
+        // 10 rows across 3 sessions.
+        let messages = vec![
+            session_message(
+                "s-a",
+                "codex",
+                "openai",
+                "gpt-5",
+                "2026-05-10",
+                1_700_000_001_000,
+                t.clone(),
+                0.01,
+            ),
+            session_message(
+                "s-a",
+                "codex",
+                "openai",
+                "gpt-5",
+                "2026-05-10",
+                1_700_000_002_000,
+                t.clone(),
+                0.01,
+            ),
+            session_message(
+                "s-a",
+                "codex",
+                "openai",
+                "gpt-5",
+                "2026-05-10",
+                1_700_000_003_000,
+                t.clone(),
+                0.01,
+            ),
+            session_message(
+                "s-a",
+                "codex",
+                "openai",
+                "gpt-5",
+                "2026-05-10",
+                1_700_000_004_000,
+                t.clone(),
+                0.01,
+            ),
+            session_message(
+                "s-b",
+                "amp",
+                "anthropic",
+                "claude-haiku-4-5",
+                "2026-05-10",
+                1_700_000_005_000,
+                t.clone(),
+                0.02,
+            ),
+            session_message(
+                "s-b",
+                "amp",
+                "anthropic",
+                "claude-haiku-4-5",
+                "2026-05-10",
+                1_700_000_006_000,
+                t.clone(),
+                0.02,
+            ),
+            session_message(
+                "s-b",
+                "amp",
+                "anthropic",
+                "claude-haiku-4-5",
+                "2026-05-10",
+                1_700_000_007_000,
+                t.clone(),
+                0.02,
+            ),
+            session_message(
+                "s-c",
+                "claude",
+                "anthropic",
+                "claude-sonnet-4-5",
+                "2026-05-11",
+                1_700_000_100_000,
+                t.clone(),
+                0.05,
+            ),
+            session_message(
+                "s-c",
+                "claude",
+                "anthropic",
+                "claude-sonnet-4-5",
+                "2026-05-11",
+                1_700_000_101_000,
+                t.clone(),
+                0.05,
+            ),
+            session_message(
+                "s-c",
+                "claude",
+                "anthropic",
+                "claude-sonnet-4-5",
+                "2026-05-11",
+                1_700_000_102_000,
+                t.clone(),
+                0.05,
+            ),
+        ];
+
+        let result = aggregate_by_session(messages);
+        assert_eq!(result.len(), 3, "expected 3 sessions");
+
+        // Most-recent-first ordering: s-c last_seen=1_700_000_102 wins.
+        assert_eq!(result[0].session_id, "s-c");
+        assert_eq!(result[1].session_id, "s-b");
+        assert_eq!(result[2].session_id, "s-a");
+
+        let s_a = result.iter().find(|s| s.session_id == "s-a").unwrap();
+        assert_eq!(s_a.totals.messages, 4);
+        assert_eq!(s_a.totals.tokens, 4 * 150); // (100 input + 50 output) * 4
+        assert!((s_a.totals.cost - 0.04).abs() < 1e-9);
+        assert_eq!(s_a.token_breakdown.input, 400);
+        assert_eq!(s_a.token_breakdown.output, 200);
+        assert_eq!(s_a.client, "codex");
+        assert_eq!(s_a.provider, "openai");
+        assert_eq!(s_a.model, "gpt-5");
+        // Timestamps converted to seconds.
+        assert_eq!(s_a.first_seen, 1_700_000_001);
+        assert_eq!(s_a.last_seen, 1_700_000_004);
+
+        let s_b = result.iter().find(|s| s.session_id == "s-b").unwrap();
+        assert_eq!(s_b.totals.messages, 3);
+        assert!((s_b.totals.cost - 0.06).abs() < 1e-9);
+
+        let s_c = result.iter().find(|s| s.session_id == "s-c").unwrap();
+        assert_eq!(s_c.totals.messages, 3);
+        assert!((s_c.totals.cost - 0.15).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_aggregate_by_session_picks_top_client_by_cost() {
+        // Same session_id but two different clients — top-level fields should
+        // reflect the client with the larger cost share.
+        let small = TokenBreakdown {
+            input: 10,
+            output: 10,
+            cache_read: 0,
+            cache_write: 0,
+            reasoning: 0,
+        };
+        let big = TokenBreakdown {
+            input: 1000,
+            output: 500,
+            cache_read: 0,
+            cache_write: 0,
+            reasoning: 0,
+        };
+        let messages = vec![
+            session_message(
+                "shared",
+                "amp",
+                "anthropic",
+                "claude-haiku-4-5",
+                "2026-05-10",
+                1_700_000_001_000,
+                small,
+                0.001,
+            ),
+            session_message(
+                "shared",
+                "codex",
+                "openai",
+                "gpt-5",
+                "2026-05-10",
+                1_700_000_002_000,
+                big,
+                0.50,
+            ),
+        ];
+
+        let result = aggregate_by_session(messages);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].client, "codex");
+        assert_eq!(result[0].provider, "openai");
+        assert_eq!(result[0].model, "gpt-5");
+        // Per-client breakdown should preserve both clients.
+        assert_eq!(result[0].clients.len(), 2);
+        assert_eq!(result[0].clients[0].client, "codex");
+        assert!((result[0].totals.cost - 0.501).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_session_contribution_serde_round_trip() {
+        let contrib = SessionContribution {
+            session_id: "019e1e27-af49-7cd1-89b7-7bad1c3f3be2".to_string(),
+            client: "codex".to_string(),
+            provider: "openai".to_string(),
+            model: "gpt-5".to_string(),
+            totals: DailyTotals {
+                tokens: 25298,
+                cost: 0.0123,
+                messages: 12,
+            },
+            token_breakdown: TokenBreakdown {
+                input: 25_251,
+                output: 47,
+                cache_read: 1_920,
+                cache_write: 0,
+                reasoning: 40,
+            },
+            clients: vec![ClientContribution {
+                client: "codex".to_string(),
+                model_id: "gpt-5".to_string(),
+                provider_id: "openai".to_string(),
+                tokens: TokenBreakdown {
+                    input: 25_251,
+                    output: 47,
+                    cache_read: 1_920,
+                    cache_write: 0,
+                    reasoning: 40,
+                },
+                cost: 0.0123,
+                messages: 12,
+            }],
+            first_seen: 1_715_551_577,
+            last_seen: 1_715_551_612,
+        };
+
+        let json = serde_json::to_string(&contrib).expect("serialize");
+        let parsed: SessionContribution = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed, contrib);
+        // Spot-check key field is present in JSON.
+        assert!(json.contains("\"session_id\":\"019e1e27"));
     }
 }

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -124,6 +124,8 @@ pub enum GroupBy {
     ClientModel,
     ClientProviderModel,
     WorkspaceModel,
+    Session,
+    ClientSession,
 }
 
 impl std::fmt::Display for GroupBy {
@@ -133,6 +135,8 @@ impl std::fmt::Display for GroupBy {
             GroupBy::ClientModel => write!(f, "client,model"),
             GroupBy::ClientProviderModel => write!(f, "client,provider,model"),
             GroupBy::WorkspaceModel => write!(f, "workspace,model"),
+            GroupBy::Session => write!(f, "session,model"),
+            GroupBy::ClientSession => write!(f, "client,session,model"),
         }
     }
 }
@@ -147,8 +151,12 @@ impl std::str::FromStr for GroupBy {
             "client,model" | "client-model" => Ok(GroupBy::ClientModel),
             "client,provider,model" | "client-provider-model" => Ok(GroupBy::ClientProviderModel),
             "workspace,model" | "workspace-model" => Ok(GroupBy::WorkspaceModel),
+            "session" | "session,model" | "session-model" => Ok(GroupBy::Session),
+            "client,session" | "client-session" | "client,session,model" | "client-session-model" => {
+                Ok(GroupBy::ClientSession)
+            }
             _ => Err(format!(
-                "Invalid group-by value: '{}'. Valid options: model, client,model, client,provider,model, workspace,model",
+                "Invalid group-by value: '{}'. Valid options: model, client,model, client,provider,model, workspace,model, session,model, client,session,model",
                 s
             )),
         }
@@ -235,14 +243,14 @@ pub struct LocalParseOptions {
     pub scanner_settings: scanner::ScannerSettings,
 }
 
-#[derive(Debug, Clone, Default, serde::Serialize)]
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct DailyTotals {
     pub tokens: i64,
     pub cost: f64,
     pub messages: i32,
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ClientContribution {
     pub client: String,
     pub model_id: String,
@@ -259,6 +267,24 @@ pub struct DailyContribution {
     pub intensity: u8,
     pub token_breakdown: TokenBreakdown,
     pub clients: Vec<ClientContribution>,
+}
+
+/// Per-session aggregate of token usage, cost, and timing — keyed on
+/// `session_id` so downstream consumers can attribute cost to a specific
+/// agent-CLI session rather than just a date or model rollup.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct SessionContribution {
+    pub session_id: String,
+    pub client: String,
+    pub provider: String,
+    pub model: String,
+    pub totals: DailyTotals,
+    pub token_breakdown: TokenBreakdown,
+    pub clients: Vec<ClientContribution>,
+    /// Earliest message timestamp (unix seconds) in the session.
+    pub first_seen: i64,
+    /// Latest message timestamp (unix seconds) in the session.
+    pub last_seen: i64,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -319,6 +345,7 @@ pub struct ModelUsage {
     pub merged_clients: Option<String>,
     pub workspace_key: Option<String>,
     pub workspace_label: Option<String>,
+    pub session_id: Option<String>,
     pub model: String,
     pub provider: String,
     pub input: i64,
@@ -1275,8 +1302,13 @@ fn aggregate_model_usage_entries(
                 format!("{}:{}:{}", msg.client, msg.provider_id, normalized)
             }
             GroupBy::WorkspaceModel => format!("{}:{}", workspace_group_key, normalized),
+            GroupBy::Session => format!("{}:{}", msg.session_id, normalized),
+            GroupBy::ClientSession => {
+                format!("{}:{}:{}", msg.client, msg.session_id, normalized)
+            }
         };
         let merge_clients = matches!(group_by, GroupBy::Model | GroupBy::WorkspaceModel);
+        let session_grouped = matches!(group_by, GroupBy::Session | GroupBy::ClientSession);
         let entry = model_map.entry(key).or_insert_with(|| ModelUsage {
             client: msg.client.clone(),
             merged_clients: if merge_clients {
@@ -1291,6 +1323,11 @@ fn aggregate_model_usage_entries(
             },
             workspace_label: if matches!(group_by, GroupBy::WorkspaceModel) {
                 Some(workspace_label.clone())
+            } else {
+                None
+            },
+            session_id: if session_grouped {
+                Some(msg.session_id.clone())
             } else {
                 None
             },
@@ -2517,6 +2554,27 @@ mod tests {
             GroupBy::from_str("workspace-model").unwrap(),
             GroupBy::WorkspaceModel
         );
+        assert_eq!(GroupBy::from_str("session").unwrap(), GroupBy::Session);
+        assert_eq!(
+            GroupBy::from_str("session,model").unwrap(),
+            GroupBy::Session
+        );
+        assert_eq!(
+            GroupBy::from_str("session-model").unwrap(),
+            GroupBy::Session
+        );
+        assert_eq!(
+            GroupBy::from_str("client,session").unwrap(),
+            GroupBy::ClientSession
+        );
+        assert_eq!(
+            GroupBy::from_str("client,session,model").unwrap(),
+            GroupBy::ClientSession
+        );
+        assert_eq!(
+            GroupBy::from_str("client-session-model").unwrap(),
+            GroupBy::ClientSession
+        );
         assert!(GroupBy::from_str("unknown").is_err());
     }
 
@@ -2532,6 +2590,8 @@ mod tests {
             GroupBy::ClientModel,
             GroupBy::ClientProviderModel,
             GroupBy::WorkspaceModel,
+            GroupBy::Session,
+            GroupBy::ClientSession,
         ];
 
         for variant in variants {
@@ -2770,6 +2830,135 @@ mod tests {
                 && entry.workspace_label.as_deref() == Some(UNKNOWN_WORKSPACE_LABEL)
                 && (entry.cost - 2.0).abs() < f64::EPSILON
         }));
+    }
+
+    #[test]
+    fn test_session_grouping_merges_same_session_and_model() {
+        // Two messages with the same session_id + same model — should collapse
+        // into one row regardless of the client that produced them, because
+        // GroupBy::Session keys on (session_id, model) only.
+        let entries = aggregate_model_usage_entries(
+            vec![
+                make_workspace_message(
+                    "claude",
+                    "claude-sonnet-4-5-20250929",
+                    "anthropic",
+                    "session-shared",
+                    1.25,
+                    None,
+                    None,
+                ),
+                make_workspace_message(
+                    "amp",
+                    "claude-sonnet-4-5-20250929",
+                    "anthropic",
+                    "session-shared",
+                    2.75,
+                    None,
+                    None,
+                ),
+            ],
+            &GroupBy::Session,
+        );
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].session_id.as_deref(), Some("session-shared"));
+        assert_eq!(entries[0].model, "claude-sonnet-4-5");
+        assert!((entries[0].cost - 4.0).abs() < f64::EPSILON);
+        assert_eq!(entries[0].message_count, 2);
+        assert!(entries[0].workspace_key.is_none());
+        assert!(entries[0].workspace_label.is_none());
+        // Session grouping does not merge_clients into a comma list.
+        assert!(entries[0].merged_clients.is_none());
+    }
+
+    #[test]
+    fn test_session_grouping_separates_different_sessions() {
+        let entries = aggregate_model_usage_entries(
+            vec![
+                make_workspace_message("codex", "gpt-5", "openai", "session-a", 1.0, None, None),
+                make_workspace_message("codex", "gpt-5", "openai", "session-b", 2.0, None, None),
+            ],
+            &GroupBy::Session,
+        );
+
+        assert_eq!(entries.len(), 2);
+        let session_ids: HashSet<_> = entries
+            .iter()
+            .map(|e| e.session_id.as_deref().unwrap())
+            .collect();
+        assert_eq!(session_ids, HashSet::from(["session-a", "session-b"]));
+    }
+
+    #[test]
+    fn test_client_session_grouping_keeps_clients_separate() {
+        // Same session_id seen by two different clients (unusual in practice
+        // but possible if parsers collide on an id space). ClientSession
+        // must yield two rows; Session would yield one (covered above).
+        let entries = aggregate_model_usage_entries(
+            vec![
+                make_workspace_message(
+                    "claude",
+                    "claude-sonnet-4-5-20250929",
+                    "anthropic",
+                    "session-shared",
+                    1.0,
+                    None,
+                    None,
+                ),
+                make_workspace_message(
+                    "amp",
+                    "claude-sonnet-4-5-20250929",
+                    "anthropic",
+                    "session-shared",
+                    3.0,
+                    None,
+                    None,
+                ),
+            ],
+            &GroupBy::ClientSession,
+        );
+
+        assert_eq!(entries.len(), 2);
+        for entry in &entries {
+            assert_eq!(entry.session_id.as_deref(), Some("session-shared"));
+            assert!(entry.merged_clients.is_none());
+        }
+        let by_client: HashSet<_> = entries.iter().map(|e| e.client.as_str()).collect();
+        assert_eq!(by_client, HashSet::from(["claude", "amp"]));
+    }
+
+    #[test]
+    fn test_non_session_grouping_does_not_populate_session_id() {
+        // Defensive: only Session/ClientSession variants should set the
+        // session_id field on ModelUsage — every other group_by must leave
+        // it None so the camelCase JSON output omits it via
+        // `skip_serializing_if = "Option::is_none"`.
+        for group_by in &[
+            GroupBy::Model,
+            GroupBy::ClientModel,
+            GroupBy::ClientProviderModel,
+            GroupBy::WorkspaceModel,
+        ] {
+            let entries = aggregate_model_usage_entries(
+                vec![make_workspace_message(
+                    "codex",
+                    "gpt-5",
+                    "openai",
+                    "session-x",
+                    1.0,
+                    None,
+                    None,
+                )],
+                group_by,
+            );
+            assert_eq!(entries.len(), 1);
+            assert!(
+                entries[0].session_id.is_none(),
+                "session_id leaked into {:?} grouping",
+                group_by
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Why

Tokscale already extracts `session_id` during parsing for dedup; this PR surfaces it as a group-by strategy on the CLI + JSON output so kandev can spawn `tokscale --json --group-by client,session,model` once and join each row against its own session id.

Downstream consumers - for example [kdlbs/kandev](https://github.com/kdlbs/kandev), a multi-agent IDE runner - need to attribute cost to specific agent-CLI sessions, not just to dates or model rollups. Which this grouping we can match ACP sessions with their cost via tokscale.

## What changed

- Added `GroupBy::Session` (`session,model`) and `GroupBy::ClientSession` (`client,session,model`) to `crates/tokscale-core/src/lib.rs:100`, including `FromStr`/`Display` and aliases (`session`, `session-model`, `client,session`, `client-session-model`).
- Added an optional `session_id` field to `ModelUsage` populated only for the new variants, and a new `aggregate_by_session()` + `SessionContribution` pair in `crates/tokscale-core/src/aggregator.rs` (mirrors the shape of `aggregate_by_date` / `DailyContribution`, sorted by `last_seen` desc).
- CLI: `--group-by session,model` and `--group-by client,session,model` now emit a top-level `sessionId` key per JSON row, and the text-mode tables render Client/Session/Provider/Model/Cost columns.
- TUI: the `g` picker exposes "Session + Model" and "Client + Session + Model" options.
- README: documents both strategies and shows an example JSON payload.

## Output sample

`tokscale models --json --group-by session,model --opencode` against the integration-test fixture:

```json
{
  "groupBy": "session,model",
  "entries": [
    {
      "client": "opencode",
      "mergedClients": null,
      "sessionId": "session1",
      "model": "claude-sonnet-4",
      "provider": "anthropic",
      "input": 1800,
      "output": 800,
      "cacheRead": 350,
      "cacheWrite": 80,
      "reasoning": 0,
      "messageCount": 2,
      "cost": 0.08
    },
    {
      "client": "opencode",
      "mergedClients": null,
      "sessionId": "session2",
      "model": "gpt-4o",
      "provider": "openai",
      "input": 600,
      "output": 200,
      "cacheRead": 100,
      "cacheWrite": 20,
      "reasoning": 0,
      "messageCount": 1,
      "cost": 0.02
    }
  ]
}
```

The `sessionId` key is omitted entirely (via `skip_serializing_if = Option::is_none`) for every non-session group-by mode, so existing consumers see no schema change.

## Tests

- Unit: `aggregate_by_session()` over 10 messages / 3 sessions, top-client tiebreaker, serde round-trip for `SessionContribution` — in `crates/tokscale-core/src/aggregator.rs`.
- Unit: `aggregate_model_usage_entries` under `GroupBy::Session` (merges across clients) and `GroupBy::ClientSession` (keeps clients separate), plus a defensive check that no other variant populates `session_id` — in `crates/tokscale-core/src/lib.rs`.
- CLI integration: `--group-by session,model` and `--group-by client,session,model` against the OpenCode fixture, and a negative assertion in `test_models_json_with_group_by_model` — in `crates/tokscale-cli/tests/cli_tests.rs`.
- `cargo fmt && cargo clippy --all-targets -- -D warnings && cargo test` clean (1258 passed).

Per-provider session parsers, pricing, scanner, and TUI layout were left untouched.

## More improvements

- Codex `session_id` today is the rollout filename stem (`rollout-<ts>-<uuid>`), not the canonical UUID from `session_meta.payload.id`. Worth normalizing in a follow-up so the value matches the ACP session new-response hash.
- `input` currently includes cached input tokens. For session attribution it can be useful to split `totalInput` vs `nonCachedInput`, or just document the convention in the JSON schema. Applies to every group-by mode; happy to open a separate issue.

Will open follow up PRs for these if its okay.
