### PR TITLE
feat(cli): add 'qr' command for transferring API token to mobile apps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +334,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +399,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +437,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1527,6 +1566,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -3381,12 +3430,15 @@ dependencies = [
 
 [[package]]
 name = "tokscale-cli"
-version = "2.1.1"
+version = "2.1.3"
 dependencies = [
  "ab_glyph",
+ "aes",
  "anyhow",
  "arboard",
  "assert_cmd",
+ "base64",
+ "cbc",
  "chrono",
  "clap",
  "colored",
@@ -3421,7 +3473,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-core"
-version = "2.1.1"
+version = "2.1.3"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,17 +25,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,15 +323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-padding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,15 +379,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cbc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,16 +408,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
 ]
 
 [[package]]
@@ -1569,16 +1530,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "block-padding",
- "generic-array",
-]
-
-[[package]]
 name = "instability"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2399,6 +2350,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
+dependencies = [
+ "image",
 ]
 
 [[package]]
@@ -3421,15 +3381,12 @@ dependencies = [
 
 [[package]]
 name = "tokscale-cli"
-version = "2.1.3"
+version = "2.1.1"
 dependencies = [
  "ab_glyph",
- "aes",
  "anyhow",
  "arboard",
  "assert_cmd",
- "base64",
- "cbc",
  "chrono",
  "clap",
  "colored",
@@ -3442,6 +3399,7 @@ dependencies = [
  "imageproc",
  "indicatif",
  "predicates",
+ "qrcode",
  "ratatui",
  "rayon",
  "reqwest",
@@ -3463,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-core"
-version = "2.1.3"
+version = "2.1.1"
 dependencies = [
  "bincode",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -472,6 +472,10 @@ tokscale login --token tt_xxx
 # Check who you're logged in as
 tokscale whoami
 
+# Display your saved API token as a QR code (useful for sharing to another device)
+# Encodes {"token":"tt_xxx","username":"..."} — scan with any QR reader
+tokscale qr
+
 # Submit your usage data to the leaderboard
 tokscale submit
 

--- a/crates/tokscale-cli/Cargo.toml
+++ b/crates/tokscale-cli/Cargo.toml
@@ -37,6 +37,7 @@ ab_glyph = "0.2"
 resvg = "0.43"
 usvg = "0.43"
 hostname = "0.4"
+qrcode = "0.14"
 uuid = { version = "1.0", features = ["v4"] }
 rpassword = "7.0"
 sha2 = "0.10"

--- a/crates/tokscale-cli/src/auth.rs
+++ b/crates/tokscale-cli/src/auth.rs
@@ -454,6 +454,54 @@ pub fn whoami() -> Result<()> {
     Ok(())
 }
 
+pub fn show_qr() -> Result<()> {
+    use colored::Colorize;
+    use qrcode::render::unicode;
+    use qrcode::QrCode;
+
+    let Some(creds) = load_credentials() else {
+        println!("\n  {}", "Not logged in.".yellow());
+        println!(
+            "{}",
+            "  Run 'bunx tokscale@latest login' to authenticate.\n".bright_black()
+        );
+        return Ok(());
+    };
+
+    let payload = format!(
+        r#"{{"token":"{}","username":"{}"}}"#,
+        creds.token, creds.username
+    );
+    let code = QrCode::new(payload.as_bytes()).context("Failed to generate QR code")?;
+
+    let image = code
+        .render::<unicode::Dense1x2>()
+        .dark_color(unicode::Dense1x2::Light)
+        .light_color(unicode::Dense1x2::Dark)
+        .quiet_zone(true)
+        .build();
+
+    println!("\n  {}\n", "Tokscale - API Token QR Code".cyan());
+    println!("  {}\n", "Scan to get your API token:".bright_black());
+
+    for line in image.lines() {
+        println!("  {}", line);
+    }
+
+    println!(
+        "\n  {}: {}",
+        "Token".bright_black(),
+        creds.token.bold()
+    );
+    println!(
+        "  {}: {}\n",
+        "User".bright_black(),
+        creds.username.bold()
+    );
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tokscale-cli/src/auth.rs
+++ b/crates/tokscale-cli/src/auth.rs
@@ -454,7 +454,19 @@ pub fn whoami() -> Result<()> {
     Ok(())
 }
 
-pub fn show_qr() -> Result<()> {
+/// Build the JSON payload encoded into the login QR code.
+///
+/// Uses `serde_json` so that usernames or tokens containing `"` / `\` cannot
+/// break the payload structure or inject extra fields. Exposed for tests.
+pub(crate) fn qr_login_payload(token: &str, username: &str) -> Result<String> {
+    serde_json::to_string(&serde_json::json!({
+        "token": token,
+        "username": username,
+    }))
+    .context("Failed to encode QR payload")
+}
+
+pub fn show_qr(yes: bool) -> Result<()> {
     use colored::Colorize;
     use qrcode::render::unicode;
     use qrcode::QrCode;
@@ -468,10 +480,44 @@ pub fn show_qr() -> Result<()> {
         return Ok(());
     };
 
-    let payload = format!(
-        r#"{{"token":"{}","username":"{}"}}"#,
-        creds.token, creds.username
+    // Anyone who can see the terminal can scan and replay the token: screen
+    // shares, recorded demos, office cameras, shoulder surfing. Block unless
+    // the user explicitly confirms (or passes --yes for scripted use).
+    println!();
+    println!(
+        "  {}",
+        "⚠  This will render your API token as a QR code on screen.".yellow()
     );
+    println!(
+        "  {}",
+        "Anyone who can see your terminal (screen share, recording, camera)"
+            .bright_black()
+    );
+    println!(
+        "  {}",
+        "can scan it and gain full access to your tokscale account.".bright_black()
+    );
+    println!();
+
+    if !yes {
+        if !std::io::stdin().is_terminal() {
+            anyhow::bail!(
+                "Refusing to render token QR: stdin is not a TTY. Pass --yes to bypass."
+            );
+        }
+        print!("  Continue? [y/N] ");
+        std::io::stdout().flush().ok();
+        let mut answer = String::new();
+        std::io::stdin()
+            .read_line(&mut answer)
+            .context("Failed to read confirmation")?;
+        if !matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+            println!("\n  {}\n", "Aborted.".bright_black());
+            return Ok(());
+        }
+    }
+
+    let payload = qr_login_payload(&creds.token, &creds.username)?;
     let code = QrCode::new(payload.as_bytes()).context("Failed to generate QR code")?;
 
     let image = code
@@ -488,16 +534,7 @@ pub fn show_qr() -> Result<()> {
         println!("  {}", line);
     }
 
-    println!(
-        "\n  {}: {}",
-        "Token".bright_black(),
-        creds.token.bold()
-    );
-    println!(
-        "  {}: {}\n",
-        "User".bright_black(),
-        creds.username.bold()
-    );
+    println!("\n  {}: {}\n", "User".bright_black(), creds.username.bold());
 
     Ok(())
 }
@@ -902,5 +939,42 @@ mod tests {
         assert_eq!(auth.token, "tt_env_token");
         assert_eq!(auth.username.as_deref(), None);
         assert_eq!(auth.source, ApiTokenSource::Environment);
+    }
+
+    #[test]
+    fn qr_login_payload_round_trips_through_json() {
+        let payload = qr_login_payload("tok_abc123", "alice").unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(parsed["token"], "tok_abc123");
+        assert_eq!(parsed["username"], "alice");
+    }
+
+    #[test]
+    fn qr_login_payload_escapes_dangerous_username_chars() {
+        // The old hand-rolled format!() would have produced invalid JSON for
+        // any of these inputs; serde_json must escape them safely.
+        for bad in [
+            "alice\"; DROP TABLE users;--",
+            "alice\\",
+            "with\nnewline",
+            "tab\there",
+            r#"quote"and\backslash"#,
+        ] {
+            let payload = qr_login_payload("tok", bad).unwrap();
+            let parsed: serde_json::Value =
+                serde_json::from_str(&payload).expect("must remain valid JSON");
+            assert_eq!(
+                parsed["username"], bad,
+                "round-trip must preserve the original username"
+            );
+        }
+    }
+
+    #[test]
+    fn qr_login_payload_escapes_dangerous_token_chars() {
+        let payload = qr_login_payload(r#"tok"with"quotes"#, "bob").unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(parsed["token"], r#"tok"with"quotes"#);
+        assert_eq!(parsed["username"], "bob");
     }
 }

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -188,7 +188,10 @@ enum Commands {
     #[command(about = "Show current logged in user")]
     Whoami,
     #[command(about = "Display saved API token as QR code")]
-    Qr,
+    Qr {
+        #[arg(long, help = "Skip the on-screen warning + confirmation prompt")]
+        yes: bool,
+    },
     #[command(about = "Export contribution graph data as JSON")]
     Graph {
         #[arg(long, help = "Write to file instead of stdout")]
@@ -543,9 +546,9 @@ fn main() -> Result<()> {
             reject_unsupported_home_override(&cli.home, "whoami")?;
             run_whoami_command()
         }
-        Some(Commands::Qr) => {
+        Some(Commands::Qr { yes }) => {
             reject_unsupported_home_override(&cli.home, "qr")?;
-            run_qr_command()
+            run_qr_command(yes)
         }
         Some(Commands::Graph {
             output,
@@ -3761,8 +3764,8 @@ fn run_whoami_command() -> Result<()> {
     auth::whoami()
 }
 
-fn run_qr_command() -> Result<()> {
-    auth::show_qr()
+fn run_qr_command(yes: bool) -> Result<()> {
+    auth::show_qr(yes)
 }
 
 fn run_delete_data_command() -> Result<()> {

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -187,6 +187,8 @@ enum Commands {
     Logout,
     #[command(about = "Show current logged in user")]
     Whoami,
+    #[command(about = "Display saved API token as QR code")]
+    Qr,
     #[command(about = "Export contribution graph data as JSON")]
     Graph {
         #[arg(long, help = "Write to file instead of stdout")]
@@ -540,6 +542,10 @@ fn main() -> Result<()> {
         Some(Commands::Whoami) => {
             reject_unsupported_home_override(&cli.home, "whoami")?;
             run_whoami_command()
+        }
+        Some(Commands::Qr) => {
+            reject_unsupported_home_override(&cli.home, "qr")?;
+            run_qr_command()
         }
         Some(Commands::Graph {
             output,
@@ -3753,6 +3759,10 @@ fn run_logout_command() -> Result<()> {
 
 fn run_whoami_command() -> Result<()> {
     auth::whoami()
+}
+
+fn run_qr_command() -> Result<()> {
+    auth::show_qr()
 }
 
 fn run_delete_data_command() -> Result<()> {


### PR DESCRIPTION
## Summary

Adds a new `tokscale qr` subcommand that renders the locally saved API token (from `~/.config/tokscale/credentials.json`) as a QR code directly in the terminal. The QR payload is a JSON blob containing both the token and the username, so a companion app can authenticate **and** identify the user from a single scan.

## Why

Tokscale is desktop-first today, but the account/leaderboard is a natural fit for a companion mobile app (on-the-go leaderboard, weekly summary push notifications, badge sharing, etc.). Mobile apps need a frictionless way to log in — typing a 50+ char `tt_xxx` token on a phone keyboard, or running the browser device-code flow a second time on mobile, is exactly the kind of paper-cut that kills a companion-app funnel.

Today's options are all unergonomic:

- **Browser device flow on mobile** — works, but the user has to open the leaderboard, copy a code, switch apps. High enough friction that most users will give up.
- **Manual paste** — `tt_` tokens are 50+ characters; mobile keyboards make this miserable and error-prone.
- **Email / messenger / cloud notes** — leaks the bearer token through extra surface area.

A QR code displayed by the already-trusted CLI is the de-facto standard for this exact problem (Discord, Signal, WhatsApp Web, GitHub CLI device flow all do variants of it):

1. User runs `tokscale qr` on the machine where they already authenticated via `tokscale login`.
2. Mobile app scans the QR with its built-in camera, parses the JSON payload, and is logged in.
3. No retyping, no second browser round-trip, no token sent over email/Slack.

JSON (not bare token, not URL) was chosen for the payload so mobile apps can also display the username next to the avatar **before** activating the session — i.e. show a `Sign in as @eugenn?` confirmation step, which is a meaningful safety check when the QR may have been displayed on a screen the user no longer fully controls.

## What changed

- New `tokscale qr` subcommand wired in `crates/tokscale-cli/src/main.rs` (added to the `Commands` enum and routed to `auth::show_qr`).
- New `auth::show_qr()` in `crates/tokscale-cli/src/auth.rs`:
  - Reads saved credentials via the existing `load_credentials()` helper. If the user isn't logged in, prints the same hint that `whoami` uses and exits cleanly (no crash, no error).
  - Builds a JSON payload `{"token":"tt_xxx","username":"<name>"}` and feeds it to `qrcode::QrCode::new`.
  - Renders the QR with `unicode::Dense1x2` (two modules per terminal row → compact, square-aspect output). Colors are inverted so the QR is visible on a typical dark terminal background.
  - Prints `Token:` and `User:` plaintext below the QR for fallback / debugging.
- Dependency: `qrcode = "0.14"` added under `crates/tokscale-cli/Cargo.toml`. Default features only; no FFI; MIT/Apache-2.0 dual-licensed.
- README: documents the command in the existing Social section, with a note about the JSON payload shape.

No server-side, frontend, or shared-protocol changes. The mobile-app contract is just "scan, parse JSON, use `token` as bearer" — exactly the auth the CLI itself uses against `/api/auth/token`.

## Usage

```
$ tokscale qr

  Tokscale - API Token QR Code

  Scan to get your API token:

  █████████████████████████████████████████████
  █████████████████████████████████████████████
  ████ ▄▄▄▄▄ ██▀ ▄▀██▄▀▀▀▀▀▀▄▀▄█▀▀▄█ ▄▄▄▄▄ ████
  ...
  █████████████████████████████████████████████

  Token: tt_5be17ed8c9b94...
  User:  eugenn
```

Decoded QR contents:

```json
{"token":"tt_5be17ed8c9b94...","username":"eugenn"}
```

## Validation

- `cargo build -p tokscale-cli` (debug + release) — clean, no new warnings.
- Manual: ran `tokscale qr` against a real credentials file. QR scans cleanly with iOS Camera and yields the expected JSON payload. The "not logged in" branch was exercised by temporarily moving `credentials.json` out of the way — prints the same hint as `whoami`, exits 0.
- No existing code paths touched — `login`, `logout`, `whoami`, `submit` etc. are byte-for-byte unchanged.

## Risk

- New, opt-in subcommand. Users who never run `tokscale qr` are entirely unaffected.
- The QR encodes the **same** bearer token that already lives in `~/.config/tokscale/credentials.json` — no new secret material is created or exposed by this PR. The QR is only ever rendered to the user's own terminal output; there is no networking and no file write.
- One new direct dependency (`qrcode` 0.14): pure Rust, no FFI, ~1.5k LOC, widely used.

## Follow-ups (not in this PR)

- Mobile app side: parse the JSON payload and call the existing `/api/auth/token` validator before persisting the token, mirroring `login_with_token` in `auth.rs`.
- Optional: also accept `tokscale://login?token=...&username=...` once mobile apps register a URL scheme, so iOS/Android can deep-link straight from the system camera without an in-app QR reader.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `tokscale qr` command to show your saved API token and username as a QR code for fast mobile sign-in. Secured with a confirmation prompt and safer JSON encoding, and the token is only inside the QR.

- New Features
  - New CLI subcommand `tokscale qr` with `--yes` to skip the prompt for scripts.
  - Reads saved credentials; if not logged in, prints the same hint as `whoami` and exits.
  - QR payload is JSON `{"token":"tt_xxx","username":"..."}` encoded via `serde_json` to safely handle quotes and backslashes.
  - Renders with Unicode `Dense1x2` and inverted colors; shows `User` below the QR only.
  - Requires on-screen confirmation; non-TTY stdin aborts unless `--yes` is passed.

- Dependencies
  - Add `qrcode` 0.14 to `tokscale-cli` (pure Rust).

<sup>Written for commit 87e47b28498ffae49600a14f688579bada319acb. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/545?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

