### PR TITLE
fix(auth): serialize device auth polling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-cli"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-core"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "bincode",
  "chrono",

--- a/packages/frontend/__tests__/api/devicePoll.test.ts
+++ b/packages/frontend/__tests__/api/devicePoll.test.ts
@@ -152,7 +152,8 @@ describe("POST /api/auth/device/poll", () => {
     expect(response.status).toBe(200);
     expect(mockState.db.transaction).toHaveBeenCalledTimes(1);
     expect(mockState.forUpdateCalls).toEqual(["update"]);
-    expect(issuePersonalTokenInTransaction).toHaveBeenCalledWith(expect.anything(), {
+    expect(issuePersonalTokenInTransaction).toHaveBeenCalledTimes(1);
+    expect(issuePersonalTokenInTransaction).toHaveBeenNthCalledWith(1, expect.anything(), {
       userId: "user-1",
       name: "CLI on macbook",
       ensureUniqueName: true,

--- a/packages/frontend/__tests__/api/devicePoll.test.ts
+++ b/packages/frontend/__tests__/api/devicePoll.test.ts
@@ -3,12 +3,14 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 const mockState = vi.hoisted(() => {
   const selectResults: Array<Array<Record<string, unknown>>> = [];
   const deleteResults: Array<Array<Record<string, unknown>>> = [];
+  const forUpdateCalls: string[] = [];
 
   const tables = {
     deviceCodes: {
       id: "deviceCodes.id",
       deviceCode: "deviceCodes.deviceCode",
       expiresAt: "deviceCodes.expiresAt",
+      userId: "deviceCodes.userId",
     },
     users: {
       id: "users.id",
@@ -28,6 +30,10 @@ const mockState = vi.hoisted(() => {
       const builder = {
         from: vi.fn(() => builder),
         where: vi.fn(() => builder),
+        for: vi.fn((mode: string) => {
+          forUpdateCalls.push(mode);
+          return builder;
+        }),
         limit: vi.fn(async () => nextResult(selectResults)),
       };
 
@@ -40,6 +46,12 @@ const mockState = vi.hoisted(() => {
 
       return builder;
     }),
+    transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => callback(tx)),
+  };
+
+  const tx = {
+    select: db.select,
+    delete: db.delete,
   };
 
   return {
@@ -48,11 +60,14 @@ const mockState = vi.hoisted(() => {
     eq,
     and,
     gt,
+    forUpdateCalls,
     reset() {
       selectResults.length = 0;
       deleteResults.length = 0;
+      forUpdateCalls.length = 0;
       db.select.mockClear();
       db.delete.mockClear();
+      db.transaction.mockClear();
       eq.mockClear();
       and.mockClear();
       gt.mockClear();
@@ -66,7 +81,7 @@ const mockState = vi.hoisted(() => {
   };
 });
 
-const issuePersonalToken = vi.fn();
+const issuePersonalTokenInTransaction = vi.fn();
 
 vi.mock("@/lib/db", () => ({
   db: mockState.db,
@@ -81,7 +96,7 @@ vi.mock("drizzle-orm", () => ({
 }));
 
 vi.mock("@/lib/auth/personalTokens", () => ({
-  issuePersonalToken,
+  issuePersonalTokenInTransaction,
 }));
 
 type ModuleExports = typeof import("../../src/app/api/auth/device/poll/route");
@@ -95,11 +110,11 @@ beforeAll(async () => {
 
 beforeEach(() => {
   mockState.reset();
-  issuePersonalToken.mockReset();
+  issuePersonalTokenInTransaction.mockReset();
 });
 
 describe("POST /api/auth/device/poll", () => {
-  it("issues the token through the shared personal token service", async () => {
+  it("locks the device code row and issues the token inside the transaction", async () => {
     mockState.pushSelectResult([
       {
         id: "device-1",
@@ -116,7 +131,7 @@ describe("POST /api/auth/device/poll", () => {
       },
     ]);
     mockState.pushDeleteResult();
-    issuePersonalToken.mockResolvedValue({
+    issuePersonalTokenInTransaction.mockResolvedValue({
       id: "token-1",
       userId: "user-1",
       name: "CLI on macbook",
@@ -135,7 +150,9 @@ describe("POST /api/auth/device/poll", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(issuePersonalToken).toHaveBeenCalledWith({
+    expect(mockState.db.transaction).toHaveBeenCalledTimes(1);
+    expect(mockState.forUpdateCalls).toEqual(["update"]);
+    expect(issuePersonalTokenInTransaction).toHaveBeenCalledWith(expect.anything(), {
       userId: "user-1",
       name: "CLI on macbook",
       ensureUniqueName: true,
@@ -178,6 +195,8 @@ describe("POST /api/auth/device/poll", () => {
 
     expect(response.status).toBe(200);
     expect(body).toEqual({ status: "expired" });
+    expect(mockState.forUpdateCalls).toEqual(["update"]);
+    expect(issuePersonalTokenInTransaction).not.toHaveBeenCalled();
   });
 
   it("returns pending status when user has not yet authorized", async () => {
@@ -200,6 +219,8 @@ describe("POST /api/auth/device/poll", () => {
 
     expect(response.status).toBe(200);
     expect(body).toEqual({ status: "pending" });
+    expect(mockState.forUpdateCalls).toEqual(["update"]);
+    expect(issuePersonalTokenInTransaction).not.toHaveBeenCalled();
   });
 
   it("returns 500 when authorized user is not found in users table", async () => {

--- a/packages/frontend/src/app/api/auth/device/poll/route.ts
+++ b/packages/frontend/src/app/api/auth/device/poll/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { db, deviceCodes, users } from "@/lib/db";
 import { eq, and, gt } from "drizzle-orm";
-import { issuePersonalToken } from "@/lib/auth/personalTokens";
+import { issuePersonalTokenInTransaction } from "@/lib/auth/personalTokens";
 
 export async function POST(request: Request) {
   try {
@@ -15,58 +15,67 @@ export async function POST(request: Request) {
       );
     }
 
-    // Find the device code record
-    const [record] = await db
-      .select()
-      .from(deviceCodes)
-      .where(
-        and(
-          eq(deviceCodes.deviceCode, deviceCode),
-          gt(deviceCodes.expiresAt, new Date())
+    const result = await db.transaction(async (tx) => {
+      // Lock the device code row so concurrent polls cannot issue duplicate tokens.
+      const [record] = await tx
+        .select()
+        .from(deviceCodes)
+        .where(
+          and(
+            eq(deviceCodes.deviceCode, deviceCode),
+            gt(deviceCodes.expiresAt, new Date())
+          )
         )
-      )
-      .limit(1);
+        .for("update")
+        .limit(1);
 
-    if (!record) {
-      return NextResponse.json({ status: "expired" });
-    }
+      if (!record) {
+        return { status: "expired" as const };
+      }
 
-    // Check if user has authorized
-    if (!record.userId) {
-      return NextResponse.json({ status: "pending" });
-    }
+      // Check if user has authorized
+      if (!record.userId) {
+        return { status: "pending" as const };
+      }
 
-    // User has authorized - create API token
-    const [user] = await db
-      .select()
-      .from(users)
-      .where(eq(users.id, record.userId))
-      .limit(1);
+      // User has authorized - create API token
+      const [user] = await tx
+        .select()
+        .from(users)
+        .where(eq(users.id, record.userId))
+        .limit(1);
 
-    if (!user) {
+      if (!user) {
+        return { status: "user_not_found" as const };
+      }
+
+      const issuedToken = await issuePersonalTokenInTransaction(tx, {
+        userId: user.id,
+        name: record.deviceName || "CLI",
+        ensureUniqueName: true,
+      });
+
+      // Delete the device code (one-time use) before committing the transaction.
+      await tx.delete(deviceCodes).where(eq(deviceCodes.id, record.id));
+
+      return {
+        status: "complete" as const,
+        token: issuedToken.token,
+        user: {
+          username: user.username,
+          avatarUrl: user.avatarUrl,
+        },
+      };
+    });
+
+    if (result.status === "user_not_found") {
       return NextResponse.json(
         { error: "User not found" },
         { status: 500 }
       );
     }
 
-    const issuedToken = await issuePersonalToken({
-      userId: user.id,
-      name: record.deviceName || "CLI",
-      ensureUniqueName: true,
-    });
-
-    // Delete the device code (one-time use)
-    await db.delete(deviceCodes).where(eq(deviceCodes.id, record.id));
-
-    return NextResponse.json({
-      status: "complete",
-      token: issuedToken.token,
-      user: {
-        username: user.username,
-        avatarUrl: user.avatarUrl,
-      },
-    });
+    return NextResponse.json(result);
   } catch (error) {
     console.error("Device poll error:", error);
     return NextResponse.json(

--- a/packages/frontend/src/lib/auth/personalTokens.ts
+++ b/packages/frontend/src/lib/auth/personalTokens.ts
@@ -43,6 +43,8 @@ export interface AuthenticatePersonalTokenOptions {
 
 const TOKEN_NAME_LOCK_NAMESPACE = "personal_token_names";
 
+type PersonalTokenDb = Pick<typeof db, "execute" | "insert" | "select">;
+
 function getUniqueTokenName(baseName: string, existingNames: Iterable<string>): string {
   const names = new Set(existingNames);
   let finalName = baseName;
@@ -56,6 +58,79 @@ function getUniqueTokenName(baseName: string, existingNames: Iterable<string>): 
   return finalName;
 }
 
+async function insertPersonalToken(
+  client: PersonalTokenDb,
+  {
+    userId,
+    name,
+    expiresAt,
+  }: {
+    userId: string;
+    name: string;
+    expiresAt: Date | null;
+  }
+): Promise<IssuedPersonalToken> {
+  const token = generateApiToken();
+  const tokenHashed = hashToken(token);
+  const [createdToken] = await client
+    .insert(apiTokens)
+    .values({
+      userId,
+      token: tokenHashed,
+      name,
+      expiresAt,
+    })
+    .returning({
+      id: apiTokens.id,
+      userId: apiTokens.userId,
+      name: apiTokens.name,
+      createdAt: apiTokens.createdAt,
+      lastUsedAt: apiTokens.lastUsedAt,
+      expiresAt: apiTokens.expiresAt,
+    });
+
+  return {
+    ...createdToken,
+    token,
+  };
+}
+
+export async function issuePersonalTokenInTransaction(
+  tx: PersonalTokenDb,
+  {
+    userId,
+    name,
+    expiresAt = null,
+    ensureUniqueName = false,
+  }: IssuePersonalTokenInput
+): Promise<IssuedPersonalToken> {
+  if (!ensureUniqueName) {
+    return insertPersonalToken(tx, { userId, name, expiresAt });
+  }
+
+  await tx.execute(sql`
+    SELECT pg_advisory_xact_lock(
+      hashtext(${TOKEN_NAME_LOCK_NAMESPACE}),
+      hashtext(${userId})
+    )
+  `);
+
+  const existingTokens = await tx
+    .select({
+      name: apiTokens.name,
+    })
+    .from(apiTokens)
+    .where(eq(apiTokens.userId, userId))
+    .orderBy(desc(apiTokens.createdAt));
+
+  const finalName = getUniqueTokenName(
+    name,
+    existingTokens.map((token) => token.name)
+  );
+
+  return insertPersonalToken(tx, { userId, name: finalName, expiresAt });
+}
+
 export async function issuePersonalToken({
   userId,
   name,
@@ -63,74 +138,21 @@ export async function issuePersonalToken({
   ensureUniqueName = false,
 }: IssuePersonalTokenInput): Promise<IssuedPersonalToken> {
   if (!ensureUniqueName) {
-    const token = generateApiToken();
-    const tokenHashed = hashToken(token);
-    const [createdToken] = await db
-      .insert(apiTokens)
-      .values({
-        userId,
-        token: tokenHashed,
-        name,
-        expiresAt,
-      })
-      .returning({
-        id: apiTokens.id,
-        userId: apiTokens.userId,
-        name: apiTokens.name,
-        createdAt: apiTokens.createdAt,
-        lastUsedAt: apiTokens.lastUsedAt,
-        expiresAt: apiTokens.expiresAt,
-      });
-
-    return {
-      ...createdToken,
-      token,
-    };
+    return issuePersonalTokenInTransaction(db, {
+      userId,
+      name,
+      expiresAt,
+      ensureUniqueName,
+    });
   }
 
   return db.transaction(async (tx) => {
-    await tx.execute(sql`
-      SELECT pg_advisory_xact_lock(
-        hashtext(${TOKEN_NAME_LOCK_NAMESPACE}),
-        hashtext(${userId})
-      )
-    `);
-
-    const existingTokens = await tx
-      .select({
-        name: apiTokens.name,
-      })
-      .from(apiTokens)
-      .where(eq(apiTokens.userId, userId))
-      .orderBy(desc(apiTokens.createdAt));
-
-    const finalName = getUniqueTokenName(
+    return issuePersonalTokenInTransaction(tx, {
+      userId,
       name,
-      existingTokens.map((token) => token.name)
-    );
-    const token = generateApiToken();
-    const tokenHashed = hashToken(token);
-    const [createdToken] = await tx
-      .insert(apiTokens)
-      .values({
-        userId,
-        token: tokenHashed,
-        name: finalName,
-        expiresAt,
-      })
-      .returning({
-        id: apiTokens.id,
-        userId: apiTokens.userId,
-        name: apiTokens.name,
-        createdAt: apiTokens.createdAt,
-        lastUsedAt: apiTokens.lastUsedAt,
-        expiresAt: apiTokens.expiresAt,
-      });
-
-    return {
-      ...createdToken,
-      token,
-    };
+      expiresAt,
+      ensureUniqueName,
+    });
   });
 }
 


### PR DESCRIPTION
Device auth approval can be consumed by concurrent poll requests, so this locks the device code row and creates the personal token inside the same transaction before deleting the one-time code.

Constraint: Device auth poll must not issue multiple personal tokens for one approved device code

Confidence: high

Scope-risk: narrow

Tested: bunx vitest run __tests__/api/devicePoll.test.ts __tests__/lib/personalTokens.test.ts

Tested: bun run --cwd packages/frontend lint

Tested: cargo check --workspace --quiet

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize device auth polling to prevent duplicate personal tokens when multiple requests hit an approved device code. Lock the device code row and issue the token in the same DB transaction, then delete the one-time code.

- **Bug Fixes**
  - Lock `deviceCodes` row with FOR UPDATE during poll.
  - Run user lookup, token issuance, and device code deletion inside a single DB transaction.
  - Add `issuePersonalTokenInTransaction(tx, ...)` and have `issuePersonalToken` delegate to it for consistent issuance.
  - Strengthen tests to assert a single token issuance, transaction usage, and row locking.

<sup>Written for commit 73c116b2a02c41e906075bf78e4bf7798f614620. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

