### PR TITLE
feat(pricing): add custom pricing overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,19 +357,55 @@ tokscale pricing "grok-code"
 # Force specific provider source
 tokscale pricing "grok-code" --provider openrouter
 tokscale pricing "claude-3-5-sonnet" --provider litellm
+
+# Inspect custom pricing overrides
+tokscale pricing list-overrides
 ```
 
 **Lookup Strategy:**
 
 The pricing lookup uses a multi-step resolution strategy:
 
-1. **Exact Match** - Direct lookup in LiteLLM/OpenRouter databases
-2. **Alias Resolution** - Resolves friendly names (e.g., `big-pickle` → `glm-4.7`)
-3. **Tier Suffix Stripping** - Removes quality tiers (`gpt-5.2-xhigh` → `gpt-5.2`)
-4. **Version Normalization** - Handles version formats (`claude-3-5-sonnet` ↔ `claude-3.5-sonnet`)
-5. **Provider Prefix Matching** - Tries common prefixes (`anthropic/`, `openai/`, etc.)
-6. **Cursor Model Pricing** - Hardcoded pricing for models not yet in LiteLLM/OpenRouter (e.g., `gpt-5.3-codex`)
-7. **Fuzzy Matching** - Word-boundary matching for partial model names
+1. **Custom Pricing Overrides** - Exact user-defined entries from `~/.config/tokscale/custom-pricing.json`
+2. **Exact Match** - Direct lookup in LiteLLM/OpenRouter databases
+3. **Alias Resolution** - Resolves friendly names (e.g., `big-pickle` → `glm-4.7`)
+4. **Tier Suffix Stripping** - Removes quality tiers (`gpt-5.2-xhigh` → `gpt-5.2`)
+5. **Version Normalization** - Handles version formats (`claude-3-5-sonnet` ↔ `claude-3.5-sonnet`)
+6. **Provider Prefix Matching** - Tries common prefixes (`anthropic/`, `openai/`, etc.)
+7. **Cursor Model Pricing** - Hardcoded pricing for models not yet in LiteLLM/OpenRouter (e.g., `gpt-5.3-codex`)
+8. **Fuzzy Matching** - Word-boundary matching for partial model names
+
+### Custom Pricing Overrides
+
+Create `custom-pricing.json` in Tokscale's config directory (`~/.config/tokscale/custom-pricing.json` on macOS/Linux by default; the same directory resolved by `TOKSCALE_CONFIG_DIR` when set) to override prices for model IDs that upstream pricing databases do not yet cover correctly.
+
+```json
+{
+  "$schema": "https://tokscale.dev/custom-pricing.schema.json",
+  "models": {
+    "accounts/fireworks/routers/kimi-k2p6-turbo": {
+      "input_cost_per_million_tokens": 2.00,
+      "output_cost_per_million_tokens": 8.00,
+      "cache_read_input_token_cost_per_million_tokens": 0.30,
+      "source": "https://docs.fireworks.ai/serverless/pricing",
+      "notes": "Fireworks Kimi K2.6 Turbo (preview)"
+    },
+    "accounts/fireworks/models/kimi-k2p6": {
+      "input_cost_per_million_tokens": 0.95,
+      "output_cost_per_million_tokens": 4.00,
+      "cache_read_input_token_cost_per_million_tokens": 0.16
+    },
+    "kimi-k2p6-turbo": {
+      "input_cost_per_million_tokens": 2.00,
+      "output_cost_per_million_tokens": 8.00
+    }
+  }
+}
+```
+
+Override prices are entered in dollars per million tokens, matching how most API providers publish pricing; Tokscale converts them to per-token rates internally. At least one of `input_cost_per_million_tokens` or `output_cost_per_million_tokens` must be present and positive, and cache-read/cache-creation fields are optional. LiteLLM-style per-token field names such as `input_cost_per_token`, `output_cost_per_token`, and `cache_read_input_token_cost` are also accepted for copy/paste compatibility, but the per-million names are the recommended user-facing form. To omit a tier or cache price, leave the field out; negative or non-finite values are treated as invalid and the whole model entry is skipped so typos do not silently alter accounting. Optional `source` and `notes` fields are ignored by Tokscale and can be used for your own bookkeeping.
+
+Overrides are exact-only and case-insensitive. Tokscale checks the raw model ID first, then the existing synthetic `/models/` normalization, then falls through to LiteLLM, OpenRouter, Cursor pricing, and fuzzy matching if no override matches. Raw exact matches beat normalized exact matches, so `accounts/fireworks/routers/kimi-k2p6-turbo` can override one gateway-specific model while `kimi-k2p6-turbo` can cover normalized `/models/` paths. Overrides are loaded once at startup; restart the command after editing the file. This is the recommended local fix for wrong-model pricing bugs while waiting on upstream LiteLLM pricing updates.
 
 **Provider Preference:**
 

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -156,10 +156,14 @@ enum Commands {
     },
     #[command(about = "Show pricing for a model")]
     Pricing {
+        #[arg(help = "Model ID to look up, or `list-overrides`")]
         model_id: String,
         #[arg(long, help = "Output as JSON")]
         json: bool,
-        #[arg(long, help = "Force specific provider (litellm or openrouter)")]
+        #[arg(
+            long,
+            help = "Force specific provider (custom, litellm, or openrouter)"
+        )]
         provider: Option<String>,
         #[arg(long, help = "Disable spinner")]
         no_spinner: bool,
@@ -2599,16 +2603,20 @@ fn run_pricing_lookup(
     use tokio::runtime::Runtime;
     use tokscale_core::pricing::PricingService;
 
+    if model_id.eq_ignore_ascii_case("list-overrides") {
+        return run_pricing_list_overrides(json);
+    }
+
     let provider_normalized = provider.map(|p| p.to_lowercase());
     if let Some(ref p) = provider_normalized {
-        if p != "litellm" && p != "openrouter" {
+        if p != "custom" && p != "litellm" && p != "openrouter" {
             println!(
                 "\n  {}",
                 format!("Invalid provider: {}", provider.unwrap_or("")).red()
             );
             println!(
                 "{}\n",
-                "  Valid providers: litellm, openrouter".bright_black()
+                "  Valid providers: custom, litellm, openrouter".bright_black()
             );
             std::process::exit(1);
         }
@@ -2720,10 +2728,11 @@ fn run_pricing_lookup(
             Some(pricing) => {
                 println!("\n  Pricing for: {}", model_id.bold());
                 println!("  Matched key: {}", pricing.matched_key);
-                let source_label = if pricing.source.eq_ignore_ascii_case("litellm") {
-                    "LiteLLM"
-                } else {
-                    "OpenRouter"
+                let source_label = match pricing.source.to_lowercase().as_str() {
+                    "custom" => "Custom",
+                    "litellm" => "LiteLLM",
+                    "openrouter" => "OpenRouter",
+                    _ => pricing.source.as_str(),
                 };
                 println!("  Source: {}", source_label);
                 println!();
@@ -2751,6 +2760,105 @@ fn run_pricing_lookup(
             }
         }
     }
+
+    Ok(())
+}
+
+fn run_pricing_list_overrides(json: bool) -> Result<()> {
+    use colored::Colorize;
+    use tokscale_core::pricing::custom::CustomPricing;
+    use tokscale_core::pricing::ModelPricing;
+
+    fn per_million(value: Option<f64>) -> Option<f64> {
+        value.map(|v| v * 1_000_000.0)
+    }
+
+    #[derive(serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct OverrideEntry {
+        model_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        input_cost_per_million_tokens: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        output_cost_per_million_tokens: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_read_input_token_cost_per_million_tokens: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_creation_input_token_cost_per_million_tokens: Option<f64>,
+    }
+
+    fn entry(model_id: &str, pricing: &ModelPricing) -> OverrideEntry {
+        OverrideEntry {
+            model_id: model_id.to_string(),
+            input_cost_per_million_tokens: per_million(pricing.input_cost_per_token),
+            output_cost_per_million_tokens: per_million(pricing.output_cost_per_token),
+            cache_read_input_token_cost_per_million_tokens: per_million(
+                pricing.cache_read_input_token_cost,
+            ),
+            cache_creation_input_token_cost_per_million_tokens: per_million(
+                pricing.cache_creation_input_token_cost,
+            ),
+        }
+    }
+
+    let path = CustomPricing::default_path();
+    let overrides = CustomPricing::load_from_path(&path);
+    let mut entries: Vec<OverrideEntry> = overrides
+        .entries()
+        .map(|(model_id, pricing)| entry(model_id, pricing))
+        .collect();
+    entries.sort_by(|a, b| a.model_id.cmp(&b.model_id));
+
+    if json {
+        #[derive(serde::Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Output {
+            path: String,
+            count: usize,
+            models: Vec<OverrideEntry>,
+        }
+
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&Output {
+                path: path.display().to_string(),
+                count: entries.len(),
+                models: entries,
+            })?
+        );
+        return Ok(());
+    }
+
+    if entries.is_empty() {
+        println!(
+            "\n  {}\n  Tried: {}\n",
+            "No custom pricing overrides loaded".yellow(),
+            path.display()
+        );
+        return Ok(());
+    }
+
+    println!("\n  {}", "Custom pricing overrides".bold());
+    println!("  Path: {}", path.display());
+    println!("  Loaded once at startup; restart tokscale after editing this file.");
+    println!();
+
+    for entry in entries {
+        println!("  {}", entry.model_id.bold());
+        if let Some(input) = entry.input_cost_per_million_tokens {
+            println!("    Input:  ${:.2} / 1M tokens", input);
+        }
+        if let Some(output) = entry.output_cost_per_million_tokens {
+            println!("    Output: ${:.2} / 1M tokens", output);
+        }
+        if let Some(cache_read) = entry.cache_read_input_token_cost_per_million_tokens {
+            println!("    Cache Read:  ${:.2} / 1M tokens", cache_read);
+        }
+        if let Some(cache_write) = entry.cache_creation_input_token_cost_per_million_tokens {
+            println!("    Cache Write: ${:.2} / 1M tokens", cache_write);
+        }
+    }
+    println!();
 
     Ok(())
 }

--- a/crates/tokscale-core/src/pricing/custom.rs
+++ b/crates/tokscale-core/src/pricing/custom.rs
@@ -1,0 +1,813 @@
+use super::litellm::ModelPricing;
+use crate::sessions::synthetic::normalize_synthetic_model;
+use serde::de::{MapAccess, Visitor};
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const CUSTOM_PRICING_FILENAME: &str = "custom-pricing.json";
+const TOKENS_PER_MILLION: f64 = 1_000_000.0;
+const MAX_CUSTOM_PRICING_FILE_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_CUSTOM_PRICING_MODEL_CAPACITY: usize = 10_000;
+
+#[derive(Clone, Default)]
+pub struct CustomPricing {
+    models: HashMap<String, ModelPricing>,
+}
+
+pub struct CustomLookupResult<'a> {
+    pub matched_key: &'a str,
+    pub pricing: &'a ModelPricing,
+}
+
+#[derive(Deserialize)]
+struct RawCustomPricingFile {
+    #[serde(default, deserialize_with = "deserialize_models")]
+    models: Vec<(String, Value)>,
+}
+
+#[derive(Deserialize)]
+struct CustomModelPricing {
+    input_cost_per_million_tokens: Option<f64>,
+    input_cost_per_million_tokens_above_128k_tokens: Option<f64>,
+    input_cost_per_million_tokens_above_200k_tokens: Option<f64>,
+    input_cost_per_million_tokens_above_256k_tokens: Option<f64>,
+    input_cost_per_million_tokens_above_272k_tokens: Option<f64>,
+    input_cost_per_token: Option<f64>,
+    input_cost_per_token_above_128k_tokens: Option<f64>,
+    input_cost_per_token_above_200k_tokens: Option<f64>,
+    input_cost_per_token_above_256k_tokens: Option<f64>,
+    input_cost_per_token_above_272k_tokens: Option<f64>,
+    output_cost_per_million_tokens: Option<f64>,
+    output_cost_per_million_tokens_above_128k_tokens: Option<f64>,
+    output_cost_per_million_tokens_above_200k_tokens: Option<f64>,
+    output_cost_per_million_tokens_above_256k_tokens: Option<f64>,
+    output_cost_per_million_tokens_above_272k_tokens: Option<f64>,
+    output_cost_per_token: Option<f64>,
+    output_cost_per_token_above_128k_tokens: Option<f64>,
+    output_cost_per_token_above_200k_tokens: Option<f64>,
+    output_cost_per_token_above_256k_tokens: Option<f64>,
+    output_cost_per_token_above_272k_tokens: Option<f64>,
+    cache_creation_input_token_cost_per_million_tokens: Option<f64>,
+    cache_creation_input_token_cost_per_million_tokens_above_200k_tokens: Option<f64>,
+    cache_creation_input_token_cost: Option<f64>,
+    cache_creation_input_token_cost_above_200k_tokens: Option<f64>,
+    cache_read_input_token_cost_per_million_tokens: Option<f64>,
+    cache_read_input_token_cost_per_million_tokens_above_200k_tokens: Option<f64>,
+    cache_read_input_token_cost_per_million_tokens_above_272k_tokens: Option<f64>,
+    cache_read_input_token_cost: Option<f64>,
+    cache_read_input_token_cost_above_200k_tokens: Option<f64>,
+    cache_read_input_token_cost_above_272k_tokens: Option<f64>,
+}
+
+impl CustomModelPricing {
+    fn into_model_pricing(self) -> Result<ModelPricing, String> {
+        let input_cost_per_token = base_price(
+            self.input_cost_per_million_tokens,
+            self.input_cost_per_token,
+            "input_cost_per_million_tokens",
+            "input_cost_per_token",
+        )?;
+        let output_cost_per_token = base_price(
+            self.output_cost_per_million_tokens,
+            self.output_cost_per_token,
+            "output_cost_per_million_tokens",
+            "output_cost_per_token",
+        )?;
+
+        if !input_cost_per_token.is_some_and(|value| value > 0.0)
+            && !output_cost_per_token.is_some_and(|value| value > 0.0)
+        {
+            return Err(
+                "at least one of input or output pricing must be present and positive".into(),
+            );
+        }
+
+        Ok(ModelPricing {
+            input_cost_per_token,
+            input_cost_per_token_above_128k_tokens: price_field(
+                self.input_cost_per_million_tokens_above_128k_tokens,
+                self.input_cost_per_token_above_128k_tokens,
+                "input_cost_per_million_tokens_above_128k_tokens",
+                "input_cost_per_token_above_128k_tokens",
+            )?,
+            input_cost_per_token_above_200k_tokens: price_field(
+                self.input_cost_per_million_tokens_above_200k_tokens,
+                self.input_cost_per_token_above_200k_tokens,
+                "input_cost_per_million_tokens_above_200k_tokens",
+                "input_cost_per_token_above_200k_tokens",
+            )?,
+            input_cost_per_token_above_256k_tokens: price_field(
+                self.input_cost_per_million_tokens_above_256k_tokens,
+                self.input_cost_per_token_above_256k_tokens,
+                "input_cost_per_million_tokens_above_256k_tokens",
+                "input_cost_per_token_above_256k_tokens",
+            )?,
+            input_cost_per_token_above_272k_tokens: price_field(
+                self.input_cost_per_million_tokens_above_272k_tokens,
+                self.input_cost_per_token_above_272k_tokens,
+                "input_cost_per_million_tokens_above_272k_tokens",
+                "input_cost_per_token_above_272k_tokens",
+            )?,
+            output_cost_per_token,
+            output_cost_per_token_above_128k_tokens: price_field(
+                self.output_cost_per_million_tokens_above_128k_tokens,
+                self.output_cost_per_token_above_128k_tokens,
+                "output_cost_per_million_tokens_above_128k_tokens",
+                "output_cost_per_token_above_128k_tokens",
+            )?,
+            output_cost_per_token_above_200k_tokens: price_field(
+                self.output_cost_per_million_tokens_above_200k_tokens,
+                self.output_cost_per_token_above_200k_tokens,
+                "output_cost_per_million_tokens_above_200k_tokens",
+                "output_cost_per_token_above_200k_tokens",
+            )?,
+            output_cost_per_token_above_256k_tokens: price_field(
+                self.output_cost_per_million_tokens_above_256k_tokens,
+                self.output_cost_per_token_above_256k_tokens,
+                "output_cost_per_million_tokens_above_256k_tokens",
+                "output_cost_per_token_above_256k_tokens",
+            )?,
+            output_cost_per_token_above_272k_tokens: price_field(
+                self.output_cost_per_million_tokens_above_272k_tokens,
+                self.output_cost_per_token_above_272k_tokens,
+                "output_cost_per_million_tokens_above_272k_tokens",
+                "output_cost_per_token_above_272k_tokens",
+            )?,
+            cache_creation_input_token_cost: price_field(
+                self.cache_creation_input_token_cost_per_million_tokens,
+                self.cache_creation_input_token_cost,
+                "cache_creation_input_token_cost_per_million_tokens",
+                "cache_creation_input_token_cost",
+            )?,
+            cache_creation_input_token_cost_above_200k_tokens: price_field(
+                self.cache_creation_input_token_cost_per_million_tokens_above_200k_tokens,
+                self.cache_creation_input_token_cost_above_200k_tokens,
+                "cache_creation_input_token_cost_per_million_tokens_above_200k_tokens",
+                "cache_creation_input_token_cost_above_200k_tokens",
+            )?,
+            cache_read_input_token_cost: price_field(
+                self.cache_read_input_token_cost_per_million_tokens,
+                self.cache_read_input_token_cost,
+                "cache_read_input_token_cost_per_million_tokens",
+                "cache_read_input_token_cost",
+            )?,
+            cache_read_input_token_cost_above_200k_tokens: price_field(
+                self.cache_read_input_token_cost_per_million_tokens_above_200k_tokens,
+                self.cache_read_input_token_cost_above_200k_tokens,
+                "cache_read_input_token_cost_per_million_tokens_above_200k_tokens",
+                "cache_read_input_token_cost_above_200k_tokens",
+            )?,
+            cache_read_input_token_cost_above_272k_tokens: price_field(
+                self.cache_read_input_token_cost_per_million_tokens_above_272k_tokens,
+                self.cache_read_input_token_cost_above_272k_tokens,
+                "cache_read_input_token_cost_per_million_tokens_above_272k_tokens",
+                "cache_read_input_token_cost_above_272k_tokens",
+            )?,
+        })
+    }
+}
+
+impl CustomPricing {
+    pub fn default_path() -> PathBuf {
+        crate::paths::get_config_dir().join(CUSTOM_PRICING_FILENAME)
+    }
+
+    pub fn load_from_default_path() -> Self {
+        Self::load_from_path(&Self::default_path())
+    }
+
+    pub fn load_from_path(path: &Path) -> Self {
+        let metadata = match fs::metadata(path) {
+            Ok(metadata) => metadata,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Self::default(),
+            Err(err) => {
+                warn_custom_pricing(path, format_args!("failed to stat file: {err}"));
+                return Self::default();
+            }
+        };
+
+        if metadata.len() > MAX_CUSTOM_PRICING_FILE_BYTES {
+            warn_custom_pricing(
+                path,
+                format_args!(
+                    "file is too large ({} bytes; max {} bytes)",
+                    metadata.len(),
+                    MAX_CUSTOM_PRICING_FILE_BYTES
+                ),
+            );
+            return Self::default();
+        }
+
+        let content = match fs::read_to_string(path) {
+            Ok(content) => content,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Self::default(),
+            Err(err) => {
+                warn_custom_pricing(path, format_args!("failed to read file: {err}"));
+                return Self::default();
+            }
+        };
+
+        Self::load_from_str(&content, path)
+    }
+
+    pub fn from_models(models: HashMap<String, ModelPricing>) -> Self {
+        let mut normalized =
+            HashMap::with_capacity(models.len().min(MAX_CUSTOM_PRICING_MODEL_CAPACITY));
+        for (key, pricing) in models {
+            normalized.insert(key.to_lowercase(), pricing);
+        }
+        Self { models: normalized }
+    }
+
+    pub fn len(&self) -> usize {
+        self.models.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.models.is_empty()
+    }
+
+    pub fn entries(&self) -> impl Iterator<Item = (&str, &ModelPricing)> {
+        self.models
+            .iter()
+            .map(|(model_id, pricing)| (model_id.as_str(), pricing))
+    }
+
+    pub fn lookup(&self, model_id: &str) -> Option<&ModelPricing> {
+        self.lookup_with_key(model_id).map(|result| result.pricing)
+    }
+
+    pub fn lookup_with_key(&self, model_id: &str) -> Option<CustomLookupResult<'_>> {
+        let raw_key = model_id.to_lowercase();
+        if let Some(pricing) = self.models.get_key_value(&raw_key) {
+            return Some(CustomLookupResult {
+                matched_key: pricing.0,
+                pricing: pricing.1,
+            });
+        }
+
+        let normalized_key = normalize_synthetic_model(model_id).to_lowercase();
+        if normalized_key != raw_key {
+            if let Some(pricing) = self.models.get_key_value(&normalized_key) {
+                return Some(CustomLookupResult {
+                    matched_key: pricing.0,
+                    pricing: pricing.1,
+                });
+            }
+        }
+
+        None
+    }
+
+    fn load_from_str(content: &str, path: &Path) -> Self {
+        let raw: RawCustomPricingFile = match serde_json::from_str(content) {
+            Ok(raw) => raw,
+            Err(err) => {
+                warn_custom_pricing(path, format_args!("failed to parse JSON: {err}"));
+                return Self::default();
+            }
+        };
+
+        let mut models =
+            HashMap::with_capacity(raw.models.len().min(MAX_CUSTOM_PRICING_MODEL_CAPACITY));
+        for (model_id, value) in raw.models {
+            let lower_key = model_id.to_lowercase();
+            let entry: CustomModelPricing = match serde_json::from_value(value) {
+                Ok(entry) => entry,
+                Err(err) => {
+                    warn_custom_pricing(
+                        path,
+                        format_args!("skipping {model_id}: malformed pricing entry: {err}"),
+                    );
+                    continue;
+                }
+            };
+            let pricing = match entry.into_model_pricing() {
+                Ok(pricing) => pricing,
+                Err(err) => {
+                    warn_custom_pricing(path, format_args!("skipping {model_id}: {err}"));
+                    continue;
+                }
+            };
+
+            if models.insert(lower_key.clone(), pricing).is_some() {
+                warn_custom_pricing(
+                    path,
+                    format_args!(
+                        "duplicate model key after lowercasing, last entry wins: {lower_key}"
+                    ),
+                );
+            }
+        }
+
+        Self { models }
+    }
+}
+
+fn base_price(
+    per_million: Option<f64>,
+    per_token: Option<f64>,
+    per_million_field: &str,
+    per_token_field: &str,
+) -> Result<Option<f64>, String> {
+    price_field(per_million, per_token, per_million_field, per_token_field)
+}
+
+fn price_field(
+    per_million: Option<f64>,
+    per_token: Option<f64>,
+    per_million_field: &str,
+    per_token_field: &str,
+) -> Result<Option<f64>, String> {
+    match (per_million, per_token) {
+        (Some(_), Some(_)) => Err(format!(
+            "{per_million_field} and {per_token_field} cannot both be set"
+        )),
+        (Some(value), None) => validate_non_negative(value, per_million_field).map(to_per_token),
+        (None, Some(value)) => validate_non_negative(value, per_token_field),
+        (None, None) => Ok(None),
+    }
+}
+
+fn validate_non_negative(value: f64, field: &str) -> Result<Option<f64>, String> {
+    if value.is_finite() && value >= 0.0 {
+        Ok(Some(value))
+    } else {
+        Err(format!("{field} must be non-negative and finite"))
+    }
+}
+
+fn to_per_token(per_million: Option<f64>) -> Option<f64> {
+    let per_million = per_million?;
+    Some(per_million / TOKENS_PER_MILLION)
+}
+
+fn warn_custom_pricing(path: &Path, message: fmt::Arguments<'_>) {
+    eprintln!(
+        "[tokscale] Warning: custom pricing {}: {message}",
+        path.display()
+    );
+}
+
+fn deserialize_models<'de, D>(deserializer: D) -> Result<Vec<(String, Value)>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct ModelsVisitor;
+
+    impl<'de> Visitor<'de> for ModelsVisitor {
+        type Value = Vec<(String, Value)>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("a map of model ids to pricing entries")
+        }
+
+        fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            let mut entries = Vec::with_capacity(
+                access
+                    .size_hint()
+                    .unwrap_or(0)
+                    .min(MAX_CUSTOM_PRICING_MODEL_CAPACITY),
+            );
+            while let Some((key, value)) = access.next_entry::<String, Value>()? {
+                entries.push((key, value));
+            }
+            Ok(entries)
+        }
+    }
+
+    deserializer.deserialize_map(ModelsVisitor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn pricing(input: f64, output: f64) -> ModelPricing {
+        ModelPricing {
+            input_cost_per_token: Some(input),
+            output_cost_per_token: Some(output),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn loads_empty_when_file_missing() {
+        let temp = TempDir::new().unwrap();
+        let loaded = CustomPricing::load_from_path(&temp.path().join("missing.json"));
+
+        assert!(loaded.lookup("anything").is_none());
+    }
+
+    #[test]
+    fn loads_valid_file() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("custom-pricing.json");
+        fs::write(
+            &path,
+            r#"{
+                "$schema": "https://tokscale.dev/custom-pricing.schema.json",
+                "models": {
+                        "accounts/fireworks/routers/kimi-k2p6-turbo": {
+                        "input_cost_per_million_tokens": 2.00,
+                        "output_cost_per_million_tokens": 8.00,
+                        "cache_read_input_token_cost_per_million_tokens": 0.30,
+                        "source": "https://docs.fireworks.ai/serverless/pricing",
+                        "notes": "Fireworks Kimi K2.6 Turbo"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let loaded = CustomPricing::load_from_path(&path);
+        let pricing = loaded
+            .lookup("accounts/fireworks/routers/kimi-k2p6-turbo")
+            .unwrap();
+
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(pricing.input_cost_per_token, Some(0.000002));
+        assert_eq!(pricing.output_cost_per_token, Some(0.000008));
+        assert_eq!(pricing.cache_read_input_token_cost, Some(0.0000003));
+    }
+
+    #[test]
+    fn loads_litellm_per_token_fields() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("custom-pricing.json");
+        fs::write(
+            &path,
+            r#"{
+                "models": {
+                    "copy-pasted": {
+                        "input_cost_per_token": 0.000002,
+                        "output_cost_per_token": 0.000008,
+                        "cache_read_input_token_cost": 0.0000003,
+                        "source": "copied from LiteLLM-shaped JSON"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let loaded = CustomPricing::load_from_path(&path);
+        let pricing = loaded.lookup("copy-pasted").unwrap();
+
+        assert_eq!(pricing.input_cost_per_token, Some(0.000002));
+        assert_eq!(pricing.output_cost_per_token, Some(0.000008));
+        assert_eq!(pricing.cache_read_input_token_cost, Some(0.0000003));
+    }
+
+    #[test]
+    fn loads_mixed_per_million_and_litellm_per_token_entries() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("custom-pricing.json");
+        fs::write(
+            &path,
+            r#"{
+                "models": {
+                    "per-million": {
+                        "input_cost_per_million_tokens": 2.00,
+                        "output_cost_per_million_tokens": 8.00
+                    },
+                    "per-token": {
+                        "input_cost_per_token": 0.00000095,
+                        "output_cost_per_token": 0.000004
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let loaded = CustomPricing::load_from_path(&path);
+
+        assert_eq!(
+            loaded.lookup("per-million").unwrap().input_cost_per_token,
+            Some(0.000002)
+        );
+        assert_eq!(
+            loaded.lookup("per-token").unwrap().input_cost_per_token,
+            Some(0.00000095)
+        );
+    }
+
+    #[test]
+    fn drops_entry_when_per_million_and_per_token_alias_both_set() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("custom-pricing.json");
+        fs::write(
+            &path,
+            r#"{
+                "models": {
+                    "ambiguous": {
+                        "input_cost_per_million_tokens": 2.00,
+                        "input_cost_per_token": 0.000002,
+                        "output_cost_per_million_tokens": 8.00
+                    },
+                    "good": {
+                        "input_cost_per_million_tokens": 1.00,
+                        "output_cost_per_million_tokens": 4.00
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let loaded = CustomPricing::load_from_path(&path);
+
+        assert!(loaded.lookup("ambiguous").is_none());
+        assert_eq!(
+            loaded.lookup("good").unwrap().input_cost_per_token,
+            Some(0.000001)
+        );
+    }
+
+    #[test]
+    fn rejects_out_of_range_json_number_before_loading_entries() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("custom-pricing.json");
+        fs::write(
+            &path,
+            r#"{
+                "models": {
+                    "too-large": {
+                        "input_cost_per_million_tokens": 1e500,
+                        "output_cost_per_million_tokens": 8.00
+                    },
+                    "good": {
+                        "input_cost_per_million_tokens": 2.00,
+                        "output_cost_per_million_tokens": 8.00
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let loaded = CustomPricing::load_from_path(&path);
+
+        assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn tolerates_malformed_json() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("custom-pricing.json");
+        fs::write(&path, r#"{"models": {"#).unwrap();
+
+        let loaded = CustomPricing::load_from_path(&path);
+
+        assert!(loaded.is_empty());
+        assert!(loaded.lookup("model").is_none());
+    }
+
+    #[test]
+    fn tolerates_malformed_entry_keeps_others() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("custom-pricing.json");
+        fs::write(
+            &path,
+            r#"{
+                "models": {
+                    "bad": {
+                        "input_cost_per_million_tokens": "not-a-number",
+                        "output_cost_per_million_tokens": 8.00
+                    },
+                    "good": {
+                        "input_cost_per_million_tokens": 2.00,
+                        "output_cost_per_million_tokens": 8.00
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let loaded = CustomPricing::load_from_path(&path);
+
+        assert!(loaded.lookup("bad").is_none());
+        assert_eq!(
+            loaded.lookup("good").unwrap().input_cost_per_token,
+            Some(0.000002)
+        );
+    }
+
+    #[test]
+    fn keeps_entries_with_input_or_output_price() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("custom-pricing.json");
+        fs::write(
+            &path,
+            r#"{
+                "models": {
+                    "missing-output": {
+                        "input_cost_per_million_tokens": 2.00
+                    },
+                    "missing-input": {
+                        "output_cost_per_million_tokens": 8.00
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let loaded = CustomPricing::load_from_path(&path);
+
+        assert_eq!(
+            loaded
+                .lookup("missing-output")
+                .unwrap()
+                .input_cost_per_token,
+            Some(0.000002)
+        );
+        assert_eq!(
+            loaded
+                .lookup("missing-input")
+                .unwrap()
+                .output_cost_per_token,
+            Some(0.000008)
+        );
+    }
+
+    #[test]
+    fn drops_entries_with_no_input_or_output_prices() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("custom-pricing.json");
+        fs::write(
+            &path,
+            r#"{
+                "models": {
+                    "cache-only": {
+                        "cache_read_input_token_cost_per_million_tokens": 0.30
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let loaded = CustomPricing::load_from_path(&path);
+
+        assert!(loaded.lookup("cache-only").is_none());
+    }
+
+    #[test]
+    fn drops_entries_with_zero_prices() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("custom-pricing.json");
+        fs::write(
+            &path,
+            r#"{
+                "models": {
+                    "all-zero": {
+                        "input_cost_per_million_tokens": 0.0,
+                        "output_cost_per_million_tokens": 0.0
+                    },
+                    "free-input": {
+                        "input_cost_per_million_tokens": 0.0,
+                        "output_cost_per_million_tokens": 8.00
+                    },
+                    "negative-output": {
+                        "input_cost_per_million_tokens": 2.00,
+                        "output_cost_per_million_tokens": -8.00
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let loaded = CustomPricing::load_from_path(&path);
+
+        assert!(loaded.lookup("all-zero").is_none());
+        assert_eq!(
+            loaded.lookup("free-input").unwrap().output_cost_per_token,
+            Some(0.000008)
+        );
+        assert!(loaded.lookup("negative-output").is_none());
+    }
+
+    #[test]
+    fn rejects_non_finite_prices() {
+        assert!(validate_non_negative(f64::NAN, "input").is_err());
+        assert!(validate_non_negative(f64::INFINITY, "input").is_err());
+        assert!(validate_non_negative(f64::NEG_INFINITY, "input").is_err());
+    }
+
+    #[test]
+    fn ignores_unknown_bookkeeping_fields() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("custom-pricing.json");
+        fs::write(
+            &path,
+            r#"{
+                "models": {
+                    "annotated": {
+                        "input_cost_per_million_tokens": 2.00,
+                        "output_cost_per_million_tokens": 8.00,
+                        "source": "https://example.com/pricing",
+                        "notes": "kept for the user, ignored by tokscale"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let loaded = CustomPricing::load_from_path(&path);
+
+        assert_eq!(
+            loaded.lookup("annotated").unwrap().input_cost_per_token,
+            Some(0.000002)
+        );
+    }
+
+    #[test]
+    fn drops_oversized_file() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("custom-pricing.json");
+        let file = fs::File::create(&path).unwrap();
+        file.set_len(MAX_CUSTOM_PRICING_FILE_BYTES + 1).unwrap();
+
+        let loaded = CustomPricing::load_from_path(&path);
+
+        assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn case_insensitive_lookup() {
+        let mut models = HashMap::new();
+        models.insert("MiXeD-Model".to_string(), pricing(0.000002, 0.000008));
+        let loaded = CustomPricing::from_models(models);
+
+        assert_eq!(
+            loaded.lookup("mixed-model").unwrap().input_cost_per_token,
+            Some(0.000002)
+        );
+        assert_eq!(
+            loaded.lookup("MIXED-MODEL").unwrap().output_cost_per_token,
+            Some(0.000008)
+        );
+    }
+
+    #[test]
+    fn duplicate_keys_last_wins() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("custom-pricing.json");
+        fs::write(
+            &path,
+            r#"{
+                "models": {
+                    "Model-A": {
+                        "input_cost_per_million_tokens": 1.00,
+                        "output_cost_per_million_tokens": 4.00
+                    },
+                    "model-a": {
+                        "input_cost_per_million_tokens": 2.00,
+                        "output_cost_per_million_tokens": 8.00
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let loaded = CustomPricing::load_from_path(&path);
+
+        assert_eq!(
+            loaded.lookup("MODEL-A").unwrap().input_cost_per_token,
+            Some(0.000002)
+        );
+    }
+
+    #[test]
+    fn literal_duplicate_keys_last_wins() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("custom-pricing.json");
+        fs::write(
+            &path,
+            r#"{
+                "models": {
+                    "model-a": {
+                        "input_cost_per_million_tokens": 1.00,
+                        "output_cost_per_million_tokens": 4.00
+                    },
+                    "model-a": {
+                        "input_cost_per_million_tokens": 2.00,
+                        "output_cost_per_million_tokens": 8.00
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let loaded = CustomPricing::load_from_path(&path);
+
+        assert_eq!(
+            loaded.lookup("model-a").unwrap().input_cost_per_token,
+            Some(0.000002)
+        );
+    }
+}

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -1,10 +1,12 @@
 pub mod aliases;
 pub mod cache;
+pub mod custom;
 pub mod litellm;
 pub mod lookup;
 pub mod openrouter;
 
-use lookup::{LookupResult, PricingLookup};
+use custom::CustomPricing;
+use lookup::{compute_cost, LookupResult, PricingLookup};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::OnceCell;
@@ -22,6 +24,7 @@ static PRICING_SERVICE: OnceCell<Arc<PricingService>> = OnceCell::const_new();
 const EXCLUDED_LITELLM_PREFIXES: &[&str] = &["github_copilot/"];
 
 pub struct PricingService {
+    custom: CustomPricing,
     lookup: PricingLookup,
 }
 
@@ -30,7 +33,16 @@ impl PricingService {
         litellm_data: HashMap<String, ModelPricing>,
         openrouter_data: HashMap<String, ModelPricing>,
     ) -> Self {
+        Self::new_with_custom(CustomPricing::default(), litellm_data, openrouter_data)
+    }
+
+    pub fn new_with_custom(
+        custom: CustomPricing,
+        litellm_data: HashMap<String, ModelPricing>,
+        openrouter_data: HashMap<String, ModelPricing>,
+    ) -> Self {
         Self {
+            custom,
             lookup: PricingLookup::new(
                 litellm_data,
                 openrouter_data,
@@ -106,7 +118,11 @@ impl PricingService {
         let litellm_data = litellm_result.map_err(|e| e.to_string())?;
         let litellm_data = Self::filter_litellm_data(litellm_data);
 
-        Ok(Self::new(litellm_data, openrouter_data))
+        Ok(Self::new_with_custom(
+            CustomPricing::load_from_default_path(),
+            litellm_data,
+            openrouter_data,
+        ))
     }
 
     fn from_cached_datasets(
@@ -117,7 +133,8 @@ impl PricingService {
             return None;
         }
 
-        Some(Self::new(
+        Some(Self::new_with_custom(
+            CustomPricing::load_from_default_path(),
             Self::filter_litellm_data(litellm_data.unwrap_or_default()),
             openrouter_data.unwrap_or_default(),
         ))
@@ -142,6 +159,18 @@ impl PricingService {
         model_id: &str,
         force_source: Option<&str>,
     ) -> Option<LookupResult> {
+        match force_source {
+            Some(source) if source.eq_ignore_ascii_case("custom") => {
+                return self.lookup_custom(model_id);
+            }
+            None => {
+                if let Some(result) = self.lookup_custom(model_id) {
+                    return Some(result);
+                }
+            }
+            Some(_) => {}
+        }
+
         self.lookup.lookup_with_source(model_id, force_source)
     }
 
@@ -151,6 +180,18 @@ impl PricingService {
         force_source: Option<&str>,
         provider_id: Option<&str>,
     ) -> Option<LookupResult> {
+        match force_source {
+            Some(source) if source.eq_ignore_ascii_case("custom") => {
+                return self.lookup_custom(model_id);
+            }
+            None => {
+                if let Some(result) = self.lookup_custom(model_id) {
+                    return Some(result);
+                }
+            }
+            Some(_) => {}
+        }
+
         self.lookup
             .lookup_with_source_and_provider(model_id, force_source, provider_id)
     }
@@ -180,14 +221,51 @@ impl PricingService {
         provider_id: Option<&str>,
         usage: &TokenBreakdown,
     ) -> f64 {
+        if let Some(result) = self.custom.lookup_with_key(model_id) {
+            return compute_cost(
+                result.pricing,
+                usage.input,
+                usage.output,
+                usage.cache_read,
+                usage.cache_write,
+                usage.reasoning,
+            );
+        }
+
         self.lookup
             .calculate_cost_with_provider(model_id, provider_id, usage)
+    }
+
+    fn lookup_custom(&self, model_id: &str) -> Option<LookupResult> {
+        self.custom
+            .lookup_with_key(model_id)
+            .map(|result| LookupResult {
+                pricing: result.pricing.clone(),
+                source: "Custom".into(),
+                matched_key: result.matched_key.to_string(),
+            })
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn model_pricing(input: f64, output: f64) -> ModelPricing {
+        ModelPricing {
+            input_cost_per_token: Some(input),
+            output_cost_per_token: Some(output),
+            ..Default::default()
+        }
+    }
+
+    fn custom_service(
+        custom: HashMap<String, ModelPricing>,
+        litellm: HashMap<String, ModelPricing>,
+        openrouter: HashMap<String, ModelPricing>,
+    ) -> PricingService {
+        PricingService::new_with_custom(CustomPricing::from_models(custom), litellm, openrouter)
+    }
 
     #[test]
     fn test_filter_excludes_github_copilot() {
@@ -502,5 +580,192 @@ mod tests {
         assert!(service
             .lookup_with_source("gpt-5.2", Some("litellm"))
             .is_some());
+    }
+
+    #[test]
+    fn custom_override_wins_over_litellm() {
+        let mut custom = HashMap::new();
+        custom.insert("gpt-4o".into(), model_pricing(0.000002, 0.000008));
+        let mut litellm = HashMap::new();
+        litellm.insert("gpt-4o".into(), model_pricing(0.00001, 0.00003));
+
+        let service = custom_service(custom, litellm, HashMap::new());
+        let result = service.lookup_with_source("gpt-4o", None).unwrap();
+
+        assert_eq!(result.source, "Custom");
+        assert_eq!(result.matched_key, "gpt-4o");
+        assert_eq!(result.pricing.input_cost_per_token, Some(0.000002));
+    }
+
+    #[test]
+    fn custom_override_wins_over_openrouter() {
+        let mut custom = HashMap::new();
+        custom.insert("grok-code".into(), model_pricing(0.000002, 0.000008));
+        let mut openrouter = HashMap::new();
+        openrouter.insert("x-ai/grok-code".into(), model_pricing(0.00001, 0.00003));
+
+        let service = custom_service(custom, HashMap::new(), openrouter);
+        let result = service.lookup_with_source("grok-code", None).unwrap();
+
+        assert_eq!(result.source, "Custom");
+        assert_eq!(result.matched_key, "grok-code");
+        assert_eq!(result.pricing.output_cost_per_token, Some(0.000008));
+    }
+
+    #[test]
+    fn custom_override_respects_force_source() {
+        let mut custom = HashMap::new();
+        custom.insert("gpt-4o".into(), model_pricing(0.000002, 0.000008));
+        let mut litellm = HashMap::new();
+        litellm.insert("gpt-4o".into(), model_pricing(0.00001, 0.00003));
+        let mut openrouter = HashMap::new();
+        openrouter.insert("openai/gpt-4o".into(), model_pricing(0.000003, 0.000012));
+
+        let service = custom_service(custom, litellm, openrouter);
+
+        let litellm_result = service
+            .lookup_with_source("gpt-4o", Some("litellm"))
+            .unwrap();
+        assert_eq!(litellm_result.source, "LiteLLM");
+        assert_eq!(litellm_result.pricing.input_cost_per_token, Some(0.00001));
+
+        let openrouter_result = service
+            .lookup_with_source("gpt-4o", Some("openrouter"))
+            .unwrap();
+        assert_eq!(openrouter_result.source, "OpenRouter");
+        assert_eq!(
+            openrouter_result.pricing.input_cost_per_token,
+            Some(0.000003)
+        );
+
+        let custom_result = service
+            .lookup_with_source("gpt-4o", Some("custom"))
+            .unwrap();
+        assert_eq!(custom_result.source, "Custom");
+        assert_eq!(custom_result.pricing.input_cost_per_token, Some(0.000002));
+    }
+
+    #[test]
+    fn custom_force_source_does_not_fall_through_on_miss() {
+        let mut litellm = HashMap::new();
+        litellm.insert("gpt-4o".into(), model_pricing(0.0000025, 0.00001));
+
+        let service = custom_service(HashMap::new(), litellm, HashMap::new());
+
+        assert!(service
+            .lookup_with_source("gpt-4o", Some("custom"))
+            .is_none());
+    }
+
+    #[test]
+    fn custom_override_raw_match_wins() {
+        let mut custom = HashMap::new();
+        custom.insert(
+            "accounts/fireworks/routers/kimi-k2p6-turbo".into(),
+            model_pricing(0.000002, 0.000008),
+        );
+        let mut litellm = HashMap::new();
+        litellm.insert("kimi-k2.6".into(), model_pricing(0.00000095, 0.000004));
+
+        let service = custom_service(custom, litellm, HashMap::new());
+        let result = service
+            .lookup_with_source("accounts/fireworks/routers/kimi-k2p6-turbo", None)
+            .unwrap();
+
+        assert_eq!(result.source, "Custom");
+        assert_eq!(
+            result.matched_key,
+            "accounts/fireworks/routers/kimi-k2p6-turbo"
+        );
+        assert_eq!(result.pricing.input_cost_per_token, Some(0.000002));
+    }
+
+    #[test]
+    fn custom_override_normalized_match_wins() {
+        let mut custom = HashMap::new();
+        custom.insert("kimi-k2p6".into(), model_pricing(0.00000095, 0.000004));
+        let mut litellm = HashMap::new();
+        litellm.insert("gpt-4-turbo".into(), model_pricing(0.00001, 0.00003));
+
+        let service = custom_service(custom, litellm, HashMap::new());
+        let result = service
+            .lookup_with_source("accounts/fireworks/models/kimi-k2p6", None)
+            .unwrap();
+
+        assert_eq!(result.source, "Custom");
+        assert_eq!(result.matched_key, "kimi-k2p6");
+        assert_eq!(result.pricing.output_cost_per_token, Some(0.000004));
+    }
+
+    #[test]
+    fn custom_override_raw_beats_normalized() {
+        let mut custom = HashMap::new();
+        custom.insert("kimi-k2p6-turbo".into(), model_pricing(0.000001, 0.000004));
+        custom.insert(
+            "accounts/fireworks/models/kimi-k2p6-turbo".into(),
+            model_pricing(0.000002, 0.000008),
+        );
+
+        let service = custom_service(custom, HashMap::new(), HashMap::new());
+        let result = service
+            .lookup_with_source("accounts/fireworks/models/kimi-k2p6-turbo", None)
+            .unwrap();
+
+        assert_eq!(
+            result.matched_key,
+            "accounts/fireworks/models/kimi-k2p6-turbo"
+        );
+        assert_eq!(result.pricing.input_cost_per_token, Some(0.000002));
+    }
+
+    #[test]
+    fn custom_override_skips_fuzzy_chain() {
+        let mut custom = HashMap::new();
+        custom.insert("kimi-k2p6-turbo".into(), model_pricing(0.000002, 0.000008));
+
+        let service = custom_service(custom, HashMap::new(), HashMap::new());
+
+        assert!(service
+            .lookup_with_source("my-kimi-k2p6-turbo", None)
+            .is_none());
+    }
+
+    #[test]
+    fn no_custom_falls_through_to_litellm() {
+        let mut litellm = HashMap::new();
+        litellm.insert("gpt-4o".into(), model_pricing(0.0000025, 0.00001));
+
+        let service = custom_service(HashMap::new(), litellm, HashMap::new());
+        let result = service.lookup_with_source("gpt-4o", None).unwrap();
+
+        assert_eq!(result.source, "LiteLLM");
+        assert_eq!(result.pricing.input_cost_per_token, Some(0.0000025));
+    }
+
+    #[test]
+    fn custom_calculate_cost_uses_override() {
+        let mut custom = HashMap::new();
+        custom.insert(
+            "accounts/fireworks/routers/kimi-k2p6-turbo".into(),
+            model_pricing(0.000002, 0.000008),
+        );
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "accounts/fireworks/routers/kimi-k2p6-turbo".into(),
+            model_pricing(0.00001, 0.00003),
+        );
+
+        let service = custom_service(custom, litellm, HashMap::new());
+        let cost = service.calculate_cost(
+            "accounts/fireworks/routers/kimi-k2p6-turbo",
+            1_000_000,
+            100_000,
+            0,
+            0,
+            0,
+        );
+
+        let expected = 1_000_000.0 * 0.000002 + 100_000.0 * 0.000008;
+        assert!((cost - expected).abs() < 1e-10);
     }
 }


### PR DESCRIPTION
## Summary

Adds a local `custom-pricing.json` override layer for exact model pricing fixes. Overrides are loaded from tokscale's config directory, checked before LiteLLM/OpenRouter/Cursor fallback pricing, and use exact matching only so user-specified accounting fixes cannot fuzzy-match into unrelated models.

This is one possible implementation for #548. In the age of agentic development, maintainers may reasonably choose to have their own agents design or implement a different solution if the issue is accepted; this PR is intended as a concrete, tested example of how the feature could work.

## What changed

- Add `crates/tokscale-core/src/pricing/custom.rs` for loading and validating `custom-pricing.json`.
- Support provider-style per-million fields such as `input_cost_per_million_tokens`, plus LiteLLM-compatible per-token fields such as `input_cost_per_token`.
- Check custom overrides with raw exact match first, then existing synthetic `/models/` normalization, before falling through to the current pricing resolver.
- Preserve explicit source forcing: `--provider litellm` and `--provider openrouter` bypass custom overrides, while `--provider custom` checks only custom overrides.
- Add `tokscale pricing list-overrides` with text and JSON output.
- Document custom pricing overrides in the README.

## AI disclosure

This PR was AI generated with `GPT-5.5 (xhigh)` and reviewed iteratively with `Opus 4.7 (Max)`. I manually tested the resulting worktree and pushed the branch from my fork.

## Validation

```bash
cargo test --workspace
cargo clippy --workspace --all-targets -- -D warnings
cargo build --release --bin tokscale
```

Also smoke-tested a Fireworks Kimi K2.6 Turbo override:

```bash
./target/release/tokscale pricing accounts/fireworks/routers/kimi-k2p6-turbo --provider custom --no-spinner
```

which reports the custom `$2.00 / $8.00 / $0.30` per-1M pricing.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add local custom pricing overrides via `custom-pricing.json` so users can fix or pin model prices. Overrides take precedence over `LiteLLM`/`OpenRouter` in lookups and cost calculations, unless a provider is explicitly forced.

- **New Features**
  - Load exact-match overrides from `~/.config/tokscale/custom-pricing.json` (or `TOKSCALE_CONFIG_DIR`).
  - Supports per-million fields (e.g., `input_cost_per_million_tokens`) and LiteLLM-style per-token fields (e.g., `input_cost_per_token`).
  - Lookup order: raw exact match → normalized `/models/` match → existing sources (`LiteLLM`, `OpenRouter`, `Cursor`) → fuzzy.
  - Provider forcing preserved: `--provider custom` checks only custom, `--provider litellm|openrouter` bypasses custom.
  - Add `tokscale pricing list-overrides` (text or `--json`) to inspect loaded overrides.
  - Overrides are loaded once at startup; restart `tokscale` after editing the file.
  - Docs updated with schema, examples, and usage.

<sup>Written for commit 14176300aac56b08675d99f4e4a9406d1a169ade. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

