### PR TITLE
fix(pricing): require exact matches for provider-scoped models

### DIFF
--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -381,6 +381,49 @@ fn write_pricing_cache(base: &Path, timestamp: u64) {
     }
 }
 
+fn write_fireworks_pricing_cache(base: &Path) {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before unix epoch")
+        .as_secs();
+    let litellm = serde_json::json!({
+        "timestamp": now,
+        "data": {
+            "fireworks_ai/accounts/fireworks/models/deepseek-r1-0528-distill-qwen3-8b": {
+                "input_cost_per_token": 0.0000002,
+                "output_cost_per_token": 0.0000002
+            }
+        }
+    });
+    let openrouter = serde_json::json!({
+        "timestamp": now,
+        "data": {
+            "deepseek/deepseek-v4-pro": {
+                "input_cost_per_token": 0.000001,
+                "output_cost_per_token": 0.000002
+            }
+        }
+    });
+
+    for dir in [
+        base.join(".config/tokscale/cache"),
+        base.join("Library/Caches/tokscale"),
+        base.join(".cache/tokscale"),
+    ] {
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("pricing-litellm.json"),
+            serde_json::to_vec(&litellm).unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            dir.join("pricing-openrouter.json"),
+            serde_json::to_vec(&openrouter).unwrap(),
+        )
+        .unwrap();
+    }
+}
+
 fn write_fake_credentials(base: &Path) {
     let creds_dir = base.join(".config/tokscale");
     fs::create_dir_all(&creds_dir).unwrap();
@@ -1535,6 +1578,32 @@ fn test_pricing_command_invalid_provider() {
     ])
     .assert()
     .failure();
+}
+
+#[test]
+fn test_pricing_command_does_not_fuzzy_match_provider_scoped_fireworks_model() {
+    let tmp = TempDir::new().expect("failed to create temp dir");
+    write_fireworks_pricing_cache(tmp.path());
+
+    let output = cmd_with_home(tmp.path())
+        .args([
+            "pricing",
+            "accounts/fireworks/models/deepseek-v4-pro",
+            "--no-spinner",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Model not found: accounts/fireworks/models/deepseek-v4-pro"),
+        "expected a not-found message, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("deepseek-r1-0528-distill-qwen3-8b"),
+        "provider-scoped pricing lookup must not report the wrong Fireworks match: {stdout}"
+    );
 }
 
 // ── Clients command tests ──────────────────────────────────────────────────

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -4448,6 +4448,50 @@ mod tests {
     }
 
     #[test]
+    fn test_apply_pricing_if_available_keeps_scoped_fireworks_cost_without_exact_pricing() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "fireworks_ai/accounts/fireworks/models/deepseek-r1-0528-distill-qwen3-8b".into(),
+            pricing::ModelPricing {
+                input_cost_per_token: Some(0.0000002),
+                output_cost_per_token: Some(0.0000002),
+                ..Default::default()
+            },
+        );
+
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "deepseek/deepseek-v4-pro".into(),
+            pricing::ModelPricing {
+                input_cost_per_token: Some(0.000001),
+                output_cost_per_token: Some(0.000002),
+                ..Default::default()
+            },
+        );
+
+        let pricing = pricing::PricingService::new(litellm, openrouter);
+        let mut msg = UnifiedMessage::new(
+            "opencode",
+            "accounts/fireworks/models/deepseek-v4-pro",
+            "fireworks",
+            "session-1",
+            1_733_011_200_000,
+            TokenBreakdown {
+                input: 10,
+                output: 5,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            0.123,
+        );
+
+        apply_pricing_if_available(&mut msg, Some(&pricing));
+
+        assert_eq!(msg.cost, 0.123);
+    }
+
+    #[test]
     fn test_apply_pricing_if_available_prefers_provider_specific_exact_match_over_plain_exact() {
         let mut litellm = HashMap::new();
         litellm.insert(

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -78,6 +78,11 @@ struct KeyModelPart {
     lower_model_part: String,
 }
 
+struct ProviderScopedModelPath<'a> {
+    provider: &'a str,
+    terminal_model_id: &'a str,
+}
+
 pub struct PricingLookup {
     litellm: HashMap<String, ModelPricing>,
     openrouter: HashMap<String, ModelPricing>,
@@ -268,6 +273,10 @@ impl PricingLookup {
             return Some(result);
         }
 
+        if parse_provider_scoped_model_path(lower_ref).is_some() {
+            return None;
+        }
+
         // 2. Try stripping unknown suffixes (e.g., -thinking, -high, -codex)
         if let Some(result) = try_strip_unknown_suffix(lower_ref, do_lookup) {
             return Some(result);
@@ -283,6 +292,13 @@ impl PricingLookup {
     }
 
     fn lookup_auto(&self, model_id: &str, provider_id: Option<&str>) -> Option<LookupResult> {
+        if let Some(result) = self.lookup_provider_scoped_path(model_id, provider_id) {
+            return Some(result);
+        }
+        if parse_provider_scoped_model_path(model_id).is_some() {
+            return None;
+        }
+
         if let Some(stripped) = strip_known_provider_prefix(model_id) {
             let prefix_matches_hint =
                 provider_id.is_none() || model_prefix_matches_provider(model_id, provider_id);
@@ -442,6 +458,13 @@ impl PricingLookup {
         model_id: &str,
         provider_id: Option<&str>,
     ) -> Option<LookupResult> {
+        if let Some(result) = self.lookup_provider_scoped_path_litellm(model_id, provider_id) {
+            return Some(result);
+        }
+        if parse_provider_scoped_model_path(model_id).is_some() {
+            return None;
+        }
+
         if let Some(result) = self.exact_or_normalized_litellm(model_id, provider_id) {
             return Some(result);
         }
@@ -471,6 +494,13 @@ impl PricingLookup {
         model_id: &str,
         provider_id: Option<&str>,
     ) -> Option<LookupResult> {
+        if let Some(result) = self.lookup_provider_scoped_path_openrouter(model_id, provider_id) {
+            return Some(result);
+        }
+        if parse_provider_scoped_model_path(model_id).is_some() {
+            return None;
+        }
+
         if let Some(result) = self.exact_match_openrouter_with_provider(model_id, provider_id) {
             return Some(result);
         }
@@ -502,6 +532,76 @@ impl PricingLookup {
             }
         }
         None
+    }
+
+    fn lookup_provider_scoped_path(
+        &self,
+        model_id: &str,
+        provider_id: Option<&str>,
+    ) -> Option<LookupResult> {
+        let scoped = parse_provider_scoped_model_path(model_id)?;
+        if !provider_hint_matches_scoped_provider(provider_id, scoped.provider) {
+            return None;
+        }
+
+        choose_best_source_result(
+            self.lookup_provider_scoped_path_litellm(model_id, provider_id),
+            self.lookup_provider_scoped_path_openrouter(model_id, provider_id),
+            Some(scoped.provider),
+        )
+    }
+
+    fn lookup_provider_scoped_path_litellm(
+        &self,
+        model_id: &str,
+        provider_id: Option<&str>,
+    ) -> Option<LookupResult> {
+        let scoped = parse_provider_scoped_model_path(model_id)?;
+        if !provider_hint_matches_scoped_provider(provider_id, scoped.provider) {
+            return None;
+        }
+
+        if let Some(result) = self.exact_match_litellm(model_id) {
+            return Some(result);
+        }
+
+        let scoped_tags = provider_identity::provider_tags(scoped.provider);
+        for prefix in RESELLER_PROVIDER_PREFIXES {
+            if !provider_prefix_matches_scoped_provider(prefix, &scoped_tags) {
+                continue;
+            }
+
+            let key = format!("{}{}", prefix, model_id);
+            if let Some(litellm_key) = self.litellm_lower.get(&key) {
+                if let Some(pricing) = self.litellm.get(litellm_key) {
+                    return Some(LookupResult {
+                        pricing: pricing.clone(),
+                        source: "LiteLLM".into(),
+                        matched_key: litellm_key.clone(),
+                    });
+                }
+            }
+        }
+
+        self.exact_match_litellm_for_provider(scoped.terminal_model_id, Some(scoped.provider))
+    }
+
+    fn lookup_provider_scoped_path_openrouter(
+        &self,
+        model_id: &str,
+        provider_id: Option<&str>,
+    ) -> Option<LookupResult> {
+        let scoped = parse_provider_scoped_model_path(model_id)?;
+        if !provider_hint_matches_scoped_provider(provider_id, scoped.provider) {
+            return None;
+        }
+
+        self.exact_match_openrouter(model_id).or_else(|| {
+            self.exact_match_openrouter_for_provider(
+                scoped.terminal_model_id,
+                Some(scoped.provider),
+            )
+        })
     }
 
     fn exact_match_litellm_for_provider(
@@ -1335,6 +1435,47 @@ fn model_prefix_matches_provider(model_id: &str, provider_id: Option<&str>) -> b
         (Some(p), Some(h)) => p == h,
         _ => false,
     }
+}
+
+fn parse_provider_scoped_model_path(model_id: &str) -> Option<ProviderScopedModelPath<'_>> {
+    let rest = model_id.strip_prefix("accounts/")?;
+    let (provider, rest) = rest.split_once('/')?;
+    let (scope, terminal_model_id) = rest.split_once('/')?;
+
+    if provider.is_empty() || terminal_model_id.is_empty() {
+        return None;
+    }
+
+    match scope {
+        "models" | "routers" => Some(ProviderScopedModelPath {
+            provider,
+            terminal_model_id,
+        }),
+        _ => None,
+    }
+}
+
+fn provider_hint_matches_scoped_provider(provider_id: Option<&str>, scoped_provider: &str) -> bool {
+    let Some(provider_id) = provider_id else {
+        return true;
+    };
+
+    let scoped_tags = provider_identity::provider_tags(scoped_provider);
+    let hint_tags = provider_identity::provider_tags(provider_id);
+    !scoped_tags.is_empty()
+        && scoped_tags
+            .iter()
+            .any(|scoped| hint_tags.iter().any(|hint| hint == scoped))
+}
+
+fn provider_prefix_matches_scoped_provider(prefix: &str, scoped_tags: &[String]) -> bool {
+    if scoped_tags.is_empty() {
+        return false;
+    }
+
+    provider_identity::provider_tags(prefix.trim_end_matches('/'))
+        .iter()
+        .any(|prefix_tag| scoped_tags.iter().any(|scoped| scoped == prefix_tag))
 }
 
 fn normalize_provider_hint(provider_id: Option<&str>) -> Option<&str> {
@@ -2183,6 +2324,95 @@ mod tests {
             .unwrap();
         assert_eq!(result.matched_key, "fireworks_ai/deepseek-v3-0324");
         assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_provider_scoped_path_does_not_strip_into_wrong_fireworks_model() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "fireworks_ai/accounts/fireworks/models/deepseek-r1-0528-distill-qwen3-8b".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0000002),
+                output_cost_per_token: Some(0.0000002),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        assert!(
+            lookup
+                .lookup("accounts/fireworks/models/deepseek-v4-pro")
+                .is_none(),
+            "provider-scoped model paths should not be shortened into unrelated fuzzy matches"
+        );
+    }
+
+    #[test]
+    fn test_provider_scoped_path_matches_exact_litellm_reseller_key() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "fireworks_ai/accounts/fireworks/models/deepseek-v4-pro".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0000003),
+                output_cost_per_token: Some(0.0000004),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+        let result = lookup
+            .lookup("accounts/fireworks/models/deepseek-v4-pro")
+            .unwrap();
+
+        assert_eq!(
+            result.matched_key,
+            "fireworks_ai/accounts/fireworks/models/deepseek-v4-pro"
+        );
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_provider_scoped_path_matches_exact_terminal_provider_key() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "fireworks_ai/deepseek-v4-pro".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0000003),
+                output_cost_per_token: Some(0.0000004),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+        let result = lookup
+            .lookup("accounts/fireworks/models/deepseek-v4-pro")
+            .unwrap();
+
+        assert_eq!(result.matched_key, "fireworks_ai/deepseek-v4-pro");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_provider_scoped_path_does_not_use_upstream_openrouter_exact() {
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "deepseek/deepseek-v4-pro".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000001),
+                output_cost_per_token: Some(0.000002),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(HashMap::new(), openrouter, HashMap::new());
+
+        assert!(
+            lookup
+                .lookup("accounts/fireworks/models/deepseek-v4-pro")
+                .is_none(),
+            "Fireworks-scoped usage should not be priced with upstream DeepSeek rates"
+        );
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

Fixes #523.

Provider-scoped model IDs such as `accounts/fireworks/models/deepseek-v4-pro` now resolve through exact/provider-exact pricing paths only. If Tokscale cannot find an exact Fireworks-scoped price, it reports no pricing instead of stripping the model suffix and fuzzy-matching an unrelated Fireworks DeepSeek model.

## Why

The previous fallback path could shorten structured gateway IDs before fuzzy lookup. For Fireworks this allowed `accounts/fireworks/models/deepseek-v4-pro` to match a different key such as `fireworks_ai/accounts/fireworks/models/deepseek-r1-0528-distill-qwen3-8b`, producing incorrect cost estimates.

## Diff scope

- Detect structured `accounts/<provider>/models/<model>` and `accounts/<provider>/routers/<model>` pricing IDs in the core resolver.
- Allow raw exact matches, reseller-prefixed exact matches, and provider-aware exact matches on the terminal model ID.
- Block suffix stripping, prefix stripping, and broad fuzzy matching for provider-scoped paths when no exact provider-scoped price exists.
- Add core resolver, repricing, and CLI regression coverage for the reported Fireworks command.

## Validation

- `cargo fmt --check`: PASS
- `git diff --check`: PASS
- `cargo test -p tokscale-core provider_scoped_path -- --nocapture`: PASS, 4 passed
- `cargo test -p tokscale-core pricing::lookup -- --nocapture`: PASS, 130 passed
- `cargo test -p tokscale-core`: PASS, 673 passed, 1 ignored
- `cargo test -p tokscale-cli test_pricing_command_does_not_fuzzy_match_provider_scoped_fireworks_model --test cli_tests -- --exact --nocapture`: PASS, 1 passed
- `cargo clippy -p tokscale-core --all-targets -- -D warnings`: PASS

## Rollback

Revert this PR.

## Known residual risks

This intentionally returns "model not found" for provider-scoped gateway IDs when the matching provider-specific price is absent. That is safer than applying a different provider or model price; custom pricing overrides can still address missing upstream data separately.


