### PR TITLE
fix(hermes): include Hermes usage in agent totals

### DIFF
--- a/crates/tokscale-core/src/sessions/hermes.rs
+++ b/crates/tokscale-core/src/sessions/hermes.rs
@@ -10,6 +10,8 @@ use rusqlite::Connection;
 use std::path::Path;
 use tracing::warn;
 
+const HERMES_AGENT_NAME: &str = "Hermes Agent";
+
 fn timestamp_secs_to_ms(timestamp: f64) -> i64 {
     if timestamp > 1e12 {
         timestamp as i64
@@ -135,7 +137,7 @@ pub fn parse_hermes_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             actual_cost,
         )| {
             let provider = resolved_provider(billing_provider, &model_id);
-            let mut msg = UnifiedMessage::new(
+            let mut msg = UnifiedMessage::new_with_agent(
                 "hermes",
                 model_id,
                 provider,
@@ -149,6 +151,7 @@ pub fn parse_hermes_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
                     reasoning: reasoning.max(0),
                 },
                 actual_cost.or(estimated_cost).unwrap_or(0.0).max(0.0),
+                Some(HERMES_AGENT_NAME.to_string()),
             );
             msg.message_count = message_count.max(0);
             msg.dedup_key = Some(session_id);

--- a/crates/tokscale-core/tests/hermes.rs
+++ b/crates/tokscale-core/tests/hermes.rs
@@ -65,6 +65,7 @@ fn test_parse_hermes_sqlite_reads_session_rows_and_preserves_message_count() {
 
     let msg = &messages[0];
     assert_eq!(msg.client, "hermes");
+    assert_eq!(msg.agent.as_deref(), Some("Hermes Agent"));
     assert_eq!(msg.session_id, "session-1");
     assert_eq!(msg.model_id, "claude-sonnet-4");
     assert_eq!(msg.provider_id, "anthropic");


### PR DESCRIPTION
## Summary

- Adds `Hermes Agent` as the agent metadata label for parsed Hermes session rows.
- Keeps the existing Hermes token, cost, provider, timestamp, message count, and dedup behavior unchanged.
- Makes Hermes usage available to the existing TUI Agents aggregation instead of only model/hourly totals.

Fixes #544.

## Why

Hermes usage already appears in model and hourly totals because the parser emits normal `UnifiedMessage` rows. The Agents tab only aggregates rows with `UnifiedMessage.agent`, and Hermes rows were emitted without that field even though Hermes itself is an agent-level client.

## Diff Scope

- `crates/tokscale-core/src/sessions/hermes.rs`: emits Hermes rows with `UnifiedMessage::new_with_agent(..., Some("Hermes Agent"))`.
- `crates/tokscale-core/tests/hermes.rs`: asserts parsed Hermes rows carry the agent label while preserving the existing usage fields.
- No frontend, API, submit, DB, migration, or pricing changes.

## Branch Integrity

- Base: `origin/main`
- Validated base SHA: `ca7e4784752046630f22d28b9e39ddfe386370a5`
- Ahead/behind: `0 behind / 1 ahead`
- Merge-base SHA: `ca7e4784752046630f22d28b9e39ddfe386370a5`
- Fast-forward safety: `origin/main` is an ancestor of this branch.

## Commit Integrity

- `d942ec29af59bd9bbe5010cacf885b1fd3219ff9 fix(hermes): include agent metadata in parsed usage`
- Final PR diff contains only the intended Hermes parser and parser test files.

## Diff Hygiene

- `git diff --name-status origin/main...HEAD`: `crates/tokscale-core/src/sessions/hermes.rs` and `crates/tokscale-core/tests/hermes.rs`
- `git diff --check origin/main...HEAD`: PASS, no output


## Validation Mode And Proof

Mode 2 - Narrow runtime change. The change is limited to Hermes parser metadata and is covered by targeted parser plus existing TUI agent aggregation tests.

- `cargo test -p tokscale-core --test hermes`: PASS, 3 passed
- `cargo test -p tokscale-cli tui::data::tests::test_aggregate_messages_builds_agent_usage`: PASS, 1 passed
- `cargo fmt --check`: PASS
- `git diff --check origin/main...HEAD`: PASS, no output

Not run:

- Full workspace tests: not required locally for this narrow parser metadata change; remote CI can provide broader final-SHA proof if required.

## Ledger And Version Proof

- Ledger: not applicable — not required for selected validation mode/change family.
- Version: not applicable — not required for selected validation mode/change family.

## Migration Notes

Not applicable — no DB migration changed.

## CI Context Confirmation

Pending — required CI can only run after the PR is opened. CI workflow names are unchanged.

## Runtime Safety

No new parsing paths, blocking locks, background jobs, or external calls were added. No invariant regression introduced.

## Rollback Plan

Rollback: revert this PR.

DB downgrade: not applicable.

Data repair: not applicable.

Operational caveats: users may need the TUI background refresh or a manual refresh to replace already displayed cached data.

## Known Residual Risks

- Hermes currently exposes session-level usage rather than per-subagent identities, so the Agents tab will show one `Hermes Agent` bucket instead of a deeper breakdown.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks parsed Hermes sessions with an agent label so Hermes usage appears in Agents totals and fixes #544. All other Hermes usage fields remain unchanged.

- **Bug Fixes**
  - Emit Hermes rows with agent metadata ("Hermes Agent") so TUI Agents aggregation includes Hermes.
  - No changes to tokens, costs, provider, timestamps, message counts, or dedup; tests updated to cover the agent label.

<sup>Written for commit d942ec29af59bd9bbe5010cacf885b1fd3219ff9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

