### PR TITLE
fix(tui): keep tab sort defaults in sync

### DIFF
--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -239,18 +239,20 @@ impl App {
         let has_data = !data.models.is_empty();
         let dialog_stack = DialogStack::new(theme.clone());
         let dialog_needs_reload = Rc::new(RefCell::new(false));
+        let current_tab = config.initial_tab.unwrap_or(Tab::Overview);
+        let (sort_field, sort_direction) = Self::default_sort_for_tab(current_tab);
 
         let mut app = Self {
             should_quit: false,
-            current_tab: config.initial_tab.unwrap_or(Tab::Overview),
+            current_tab,
             theme,
             settings,
             data,
             data_loader,
             enabled_clients: Rc::new(RefCell::new(enabled_clients)),
             group_by: Rc::new(RefCell::new(tokscale_core::GroupBy::Model)),
-            sort_field: SortField::Cost,
-            sort_direction: SortDirection::Descending,
+            sort_field,
+            sort_direction,
             tab_sort_state: HashMap::new(),
             chart_granularity: ChartGranularity::default(),
             scroll_offset: 0,
@@ -576,22 +578,30 @@ impl App {
     }
 
     fn switch_tab(&mut self, target: Tab) {
-        self.tab_sort_state
-            .insert(self.current_tab, (self.sort_field, self.sort_direction));
+        self.persist_current_sort();
 
         self.current_tab = target;
 
-        let (field, dir) =
-            self.tab_sort_state
-                .get(&target)
-                .copied()
-                .unwrap_or(if target == Tab::Hourly {
-                    (SortField::Date, SortDirection::Descending)
-                } else {
-                    (SortField::Cost, SortDirection::Descending)
-                });
+        let (field, dir) = self
+            .tab_sort_state
+            .get(&target)
+            .copied()
+            .unwrap_or_else(|| Self::default_sort_for_tab(target));
         self.sort_field = field;
         self.sort_direction = dir;
+    }
+
+    fn default_sort_for_tab(tab: Tab) -> (SortField, SortDirection) {
+        if tab == Tab::Hourly {
+            (SortField::Date, SortDirection::Descending)
+        } else {
+            (SortField::Cost, SortDirection::Descending)
+        }
+    }
+
+    fn persist_current_sort(&mut self) {
+        self.tab_sort_state
+            .insert(self.current_tab, (self.sort_field, self.sort_direction));
     }
 
     fn move_selection_up(&mut self) {
@@ -727,6 +737,7 @@ impl App {
             self.sort_field = field;
             self.sort_direction = SortDirection::Descending;
         }
+        self.persist_current_sort();
         self.reset_selection();
         self.set_status(&format!(
             "Sorted by {:?} {:?}",
@@ -1626,6 +1637,26 @@ mod tests {
     }
 
     #[test]
+    fn test_initial_hourly_tab_uses_hourly_sort_default() {
+        let config = TuiConfig {
+            theme: "blue".to_string(),
+            refresh: 0,
+            sessions_path: None,
+            clients: None,
+            since: None,
+            until: None,
+            year: None,
+            initial_tab: Some(Tab::Hourly),
+        };
+
+        let app = App::new_with_cached_data(config, None).unwrap();
+
+        assert_eq!(app.current_tab, Tab::Hourly);
+        assert_eq!(app.sort_field, SortField::Date);
+        assert_eq!(app.sort_direction, SortDirection::Descending);
+    }
+
+    #[test]
     fn test_switch_tab_preserves_user_sort() {
         let mut app = make_app();
         app.switch_tab(Tab::Models);
@@ -1639,6 +1670,24 @@ mod tests {
 
         app.switch_tab(Tab::Models);
         assert_eq!(app.sort_field, SortField::Tokens);
+        assert_eq!(app.sort_direction, SortDirection::Descending);
+    }
+
+    #[test]
+    fn test_switch_tab_preserves_daily_sort_after_hourly_roundtrip() {
+        let mut app = make_app();
+
+        app.switch_tab(Tab::Daily);
+        app.set_sort(SortField::Date);
+        assert_eq!(app.sort_field, SortField::Date);
+        assert_eq!(app.sort_direction, SortDirection::Descending);
+
+        app.switch_tab(Tab::Hourly);
+        assert_eq!(app.sort_field, SortField::Date);
+        assert_eq!(app.sort_direction, SortDirection::Descending);
+
+        app.switch_tab(Tab::Daily);
+        assert_eq!(app.sort_field, SortField::Date);
         assert_eq!(app.sort_direction, SortDirection::Descending);
     }
 

--- a/crates/tokscale-cli/src/tui/ui/footer.rs
+++ b/crates/tokscale-cli/src/tui/ui/footer.rs
@@ -136,10 +136,7 @@ fn render_main_row(frame: &mut Frame, app: &mut App, area: Rect) {
 
     // Current list count
     if !is_very_narrow {
-        let count_label = match app.current_tab {
-            Tab::Agents => format!(" ({} agents)", app.data.agents.len()),
-            _ => format!(" ({} models)", app.data.models.len()),
-        };
+        let count_label = current_count_label(app);
         right_spans.push(Span::styled(
             count_label,
             Style::default().fg(app.theme.muted),
@@ -149,6 +146,16 @@ fn render_main_row(frame: &mut Frame, app: &mut App, area: Rect) {
     let right_line = Line::from(right_spans);
     let right_para = Paragraph::new(right_line).alignment(Alignment::Right);
     frame.render_widget(right_para, chunks[1]);
+}
+
+fn current_count_label(app: &App) -> String {
+    match app.current_tab {
+        Tab::Overview | Tab::Models => format!(" ({} models)", app.data.models.len()),
+        Tab::Agents => format!(" ({} agents)", app.data.agents.len()),
+        Tab::Daily => format!(" ({} days)", app.data.daily.len()),
+        Tab::Hourly => format!(" ({} hours)", app.data.hourly.len()),
+        Tab::Stats => String::new(),
+    }
 }
 
 fn render_help_row(frame: &mut Frame, app: &App, area: Rect) {
@@ -306,4 +313,40 @@ fn render_status_row(frame: &mut Frame, app: &App, area: Rect) {
     let line = Line::from(spans);
     let paragraph = Paragraph::new(line);
     frame.render_widget(paragraph, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::app::TuiConfig;
+    use crate::tui::data::UsageData;
+
+    fn make_app_on(tab: Tab) -> App {
+        let config = TuiConfig {
+            theme: "blue".to_string(),
+            refresh: 0,
+            sessions_path: None,
+            clients: None,
+            since: None,
+            until: None,
+            year: None,
+            initial_tab: Some(tab),
+        };
+        App::new_with_cached_data(config, Some(UsageData::default())).unwrap()
+    }
+
+    #[test]
+    fn test_current_count_label_matches_active_tab() {
+        assert_eq!(
+            current_count_label(&make_app_on(Tab::Models)),
+            " (0 models)"
+        );
+        assert_eq!(
+            current_count_label(&make_app_on(Tab::Agents)),
+            " (0 agents)"
+        );
+        assert_eq!(current_count_label(&make_app_on(Tab::Daily)), " (0 days)");
+        assert_eq!(current_count_label(&make_app_on(Tab::Hourly)), " (0 hours)");
+        assert_eq!(current_count_label(&make_app_on(Tab::Stats)), "");
+    }
 }


### PR DESCRIPTION
## Summary
- Preserve each TUI tab's active sort state immediately when the user changes sort order.
- Apply the Hourly tab's Date/Descending default when the TUI starts directly on Hourly, not only after a tab switch.
- Show tab-appropriate footer counts for Daily and Hourly instead of labeling those views as models.

Closes #461.

## Why
The Daily tab already had partial sort-state preservation, but the sort model still had two gaps: direct initialization on Hourly bypassed the Hourly default, and the current tab's selected sort was only persisted when leaving the tab. This made the behavior fragile around tab defaults and user-visible footer state. The footer also reported Daily/Hourly rows as model counts, which made the bottom text misleading for the affected views.

## Diff Scope
- `crates/tokscale-cli/src/tui/app.rs`: centralizes per-tab sort defaults, initializes the selected tab with its correct default, persists sort state on sort changes, and adds regression coverage for Daily -> Hourly -> Daily.
- `crates/tokscale-cli/src/tui/ui/footer.rs`: extracts the current-count label and reports `days`/`hours` for Daily/Hourly with focused tests.

## Branch Integrity
- Base branch: `main`
- Validated base SHA: `ca7e4784752046630f22d28b9e39ddfe386370a5`
- Ahead/behind: `0 behind / 1 ahead`
- Merge base: `ca7e4784752046630f22d28b9e39ddfe386370a5`
- Diff proof computed against freshly fetched `origin/main`.

## Commit Integrity
- Introduced commit: `d23a7ad8636b08272a40445c90dd34eb20c618e8 fix(tui): keep tab sort defaults in sync`
- Final PR diff contains only the intended TUI state/footer files.

## Ledger / Version Proof
- Ledger: not applicable — not required for selected validation mode/change family.
- Version: not applicable — not required for selected validation mode/change family.

## Diff Hygiene
- `git diff --name-status origin/main...HEAD`: `crates/tokscale-cli/src/tui/app.rs`, `crates/tokscale-cli/src/tui/ui/footer.rs`
- `git diff --check origin/main...HEAD`: PASS, no output


## Validation Mode And Proof
Selected mode: Mode 2 — narrow runtime change. The diff is limited to CLI TUI state and footer display behavior, with focused regression tests plus the full TUI binary unit-test suite.

Local validation:
- `cargo test -p tokscale-cli test_initial_hourly_tab_uses_hourly_sort_default`: PASS
- `cargo test -p tokscale-cli test_switch_tab_preserves_daily_sort_after_hourly_roundtrip`: PASS
- `cargo test -p tokscale-cli test_current_count_label_matches_active_tab`: PASS
- `cargo test -p tokscale-cli --bin tokscale`: PASS, 482 passed, 1 ignored
- `cargo fmt --all --check`: PASS
- `rustup run stable cargo clippy -p tokscale-cli --bin tokscale --all-features -- -D warnings`: PASS
- `git diff --check`: PASS
- `git diff --cached --check`: PASS

Additional note: `cargo test -p tokscale-cli` was attempted and failed only in three pricing integration tests because external LiteLLM/OpenRouter fetches failed. Those tests are outside this TUI diff and the targeted TUI/binary validation above passed.

## Migration Notes
Not applicable — no database migration changed.

## CI Context Confirmation
Not applicable — no CI/workflow context names changed. Required remote CI is pending until the PR is opened.

## Runtime Safety
This only adjusts in-memory TUI state and footer labels. No new blocking locks, no new queues, no persistence changes, and no invariant regression introduced.

## Documentation Integrity
Not applicable — no documented commands, APIs, or runbooks changed.

## Rollback Plan
Rollback: revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known Residual Risks
Open TUI feature PRs that add new tabs may need a trivial conflict resolution around the shared `Tab` enum and per-tab default-sort helper if they merge first.

