### PR TITLE
feat(cursor): add Cursor CLI local usage support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-cli"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-core"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "bincode",
  "chrono",

--- a/README.ja.md
+++ b/README.ja.md
@@ -62,7 +62,7 @@
 | <img width="48px" src=".github/assets/client-hermes.png" alt="Hermes Agent" /> | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `$HERMES_HOME/state.db`（フォールバック: `~/.hermes/state.db`） | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `~/.gemini/tmp/*/chats/*.json` | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | `~/.config/tokscale/cursor-cache/`経由でAPI同期 | ✅ 対応 |
-| <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor CLI" /> | [Cursor CLI](https://cursor.com/cli) | Cursor内部/非公式の `~/.config/Cursor/User/globalStorage/state.vscdb` からのローカルメタデータ（ベストエフォート） | ✅ 対応 |
+| <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor CLI" /> | [Cursor CLI](https://cursor.com/cli) | Cursor内部/非公式の `~/.config/Cursor/User/globalStorage/state.vscdb` からのローカルメタデータ（ベストエフォート）（macOS: `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb`; Windows: `%APPDATA%/Cursor/User/globalStorage/state.vscdb`） | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-amp.png" alt="Amp" /> | [Amp (AmpCode)](https://ampcode.com/) | `~/.local/share/amp/threads/` | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-codebuff.png" alt="Codebuff" /> | [Codebuff](https://codebuff.com/) | `~/.config/manicode/` (+ `manicode-dev`、`manicode-staging`; `CODEBUFF_DATA_DIR` でオーバーライド可能) | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-droid.png" alt="Droid" /> | [Droid (Factory Droid)](https://factory.ai/) | `~/.factory/sessions/` | ✅ 対応 |

--- a/README.ja.md
+++ b/README.ja.md
@@ -62,6 +62,7 @@
 | <img width="48px" src=".github/assets/client-hermes.png" alt="Hermes Agent" /> | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `$HERMES_HOME/state.db`（フォールバック: `~/.hermes/state.db`） | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `~/.gemini/tmp/*/chats/*.json` | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | `~/.config/tokscale/cursor-cache/`経由でAPI同期 | ✅ 対応 |
+| <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor CLI" /> | [Cursor CLI](https://cursor.com/cli) | Cursor内部/非公式の `~/.config/Cursor/User/globalStorage/state.vscdb` からのローカルメタデータ（ベストエフォート） | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-amp.png" alt="Amp" /> | [Amp (AmpCode)](https://ampcode.com/) | `~/.local/share/amp/threads/` | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-codebuff.png" alt="Codebuff" /> | [Codebuff](https://codebuff.com/) | `~/.config/manicode/` (+ `manicode-dev`、`manicode-staging`; `CODEBUFF_DATA_DIR` でオーバーライド可能) | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-droid.png" alt="Droid" /> | [Droid (Factory Droid)](https://factory.ai/) | `~/.factory/sessions/` | ✅ 対応 |
@@ -142,7 +143,7 @@ AI支援開発の時代において、**トークンは新しいエネルギー*
   - 9色テーマのGitHubスタイル貢献グラフ
   - リアルタイムフィルタリングとソート
   - ゼロフリッカーレンダリング
-- **マルチプラットフォームサポート** - OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Synthetic全体の使用量追跡
+- **マルチプラットフォームサポート** - OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Cursor CLI、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Synthetic全体の使用量追跡
 - **リアルタイム価格** - 1時間ディスクキャッシュ付きでLiteLLMから現在の価格を取得；OpenRouter自動フォールバックと新規モデル向けCursor価格サポート
 - **詳細な内訳** - 入力、出力、キャッシュ読み書き、推論トークン追跡
 - **ネイティブRustコア** - 10倍高速な処理のため、すべての解析と集計をRustで実行

--- a/README.ko.md
+++ b/README.ko.md
@@ -62,6 +62,7 @@
 | <img width="48px" src=".github/assets/client-hermes.png" alt="Hermes Agent" /> | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `$HERMES_HOME/state.db` (폴백: `~/.hermes/state.db`) | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `~/.gemini/tmp/*/chats/*.json` | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | `~/.config/tokscale/cursor-cache/`를 통한 API 동기화 | ✅ 지원 |
+| <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor CLI" /> | [Cursor CLI](https://cursor.com/cli) | Cursor 내부/비공식 `~/.config/Cursor/User/globalStorage/state.vscdb`의 로컬 메타데이터(최선 노력) | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-amp.png" alt="Amp" /> | [Amp (AmpCode)](https://ampcode.com/) | `~/.local/share/amp/threads/` | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-codebuff.png" alt="Codebuff" /> | [Codebuff](https://codebuff.com/) | `~/.config/manicode/` (+ `manicode-dev`, `manicode-staging`; `CODEBUFF_DATA_DIR`로 오버라이드 가능) | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-droid.png" alt="Droid" /> | [Droid (Factory Droid)](https://factory.ai/) | `~/.factory/sessions/` | ✅ 지원 |
@@ -142,7 +143,7 @@ AI 지원 개발 시대에 **토큰은 새로운 에너지**입니다. 토큰은
   - 9가지 테마의 GitHub 스타일 기여 그래프
   - 실시간 필터링 및 정렬
   - 깜빡임 없는 렌더링
-- **멀티 플랫폼 지원** - OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Synthetic 사용량 통합 추적
+- **멀티 플랫폼 지원** - OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Cursor CLI, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Synthetic 사용량 통합 추적
 - **실시간 가격 반영** - LiteLLM에서 최신 가격을 가져와(디스크 캐시 1시간) 비용 계산; OpenRouter 자동 폴백 및 신규 모델용 Cursor 가격 지원
 - **상세 분석** - 입력, 출력, 캐시 읽기/쓰기, 추론 토큰까지 추적
 - **네이티브 Rust 코어** - 모든 파싱과 집계를 Rust로 처리해 최대 10배 빠른 성능

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
 | <img width="48px" src=".github/assets/client-hermes.png" alt="Hermes Agent" /> | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `$HERMES_HOME/state.db` (fallback: `~/.hermes/state.db`) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `~/.gemini/tmp/*/chats/*.json` | ✅ Yes |
 | <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | API sync via `~/.config/tokscale/cursor-cache/` | ✅ Yes |
+| <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor CLI" /> | [Cursor CLI](https://cursor.com/cli) | Best-effort local token metadata from Cursor's internal/unsupported `~/.config/Cursor/User/globalStorage/state.vscdb` (macOS: `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb`; Windows: `%APPDATA%/Cursor/User/globalStorage/state.vscdb`) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-amp.png" alt="Amp" /> | [Amp (AmpCode)](https://ampcode.com/) | `~/.local/share/amp/threads/` | ✅ Yes |
 | <img width="48px" src=".github/assets/client-codebuff.png" alt="Codebuff" /> | [Codebuff](https://codebuff.com/) | `~/.config/manicode/` (+ `manicode-dev`, `manicode-staging`; override via `CODEBUFF_DATA_DIR`) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-droid.png" alt="Droid" /> | [Droid (Factory Droid)](https://factory.ai/) | `~/.factory/sessions/` | ✅ Yes |
@@ -143,7 +144,7 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
   - GitHub-style contribution graph with 9 color themes
   - Real-time filtering and sorting
   - Zero flicker rendering
-- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, and Synthetic
+- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Cursor CLI, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, and Synthetic
 - **Real-time pricing** - Fetches current pricing from LiteLLM with 1-hour disk cache; automatic OpenRouter fallback and Cursor model pricing for newly released models
 - **Detailed breakdowns** - Input, output, cache read/write, and reasoning token tracking
 - **Native Rust core** - All parsing and aggregation done in Rust for 10x faster processing
@@ -310,6 +311,9 @@ tokscale -c opencode -c claude
 # Cursor IDE requires `tokscale cursor login` first
 tokscale --client cursor
 
+# Cursor CLI reads local best-effort metadata from Cursor's internal state DB
+tokscale --client cursorcli
+
 # Synthetic (synthetic.new) is detected from other agent sessions
 tokscale --client synthetic
 
@@ -317,7 +321,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-Possible values: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `synthetic`.
+Possible values: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `cursorcli`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `zed`, `kiro`, `synthetic`.
 
 > **Deprecation notice**: The legacy single-client flags (`--opencode`, `--claude`, `--codex`, etc.) still work for backward compatibility but are hidden from `--help` and will be removed in the next major release. Migrate to `--client` whenever possible. Running tokscale in an interactive terminal will print a one-line warning when a legacy flag is used.
 
@@ -638,7 +642,7 @@ The frontend provides a GitHub-style contribution graph visualization:
 - **Interactive tooltips**: Hover for detailed daily breakdowns
 - **Day breakdown panel**: Click to see per-source and per-model details
 - **Year filtering**: Navigate between years
-- **Source filtering**: Filter by platform (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Synthetic)
+- **Source filtering**: Filter by platform (OpenCode, Claude, Codex, Copilot, Cursor IDE, Cursor CLI, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Zed Agent, Kiro, Synthetic)
 - **Stats panel**: Total cost, tokens, active days, streaks
 - **FOUC prevention**: Theme applied before React hydrates (no flash)
 
@@ -936,6 +940,7 @@ AI coding tools store their session data in cross-platform locations. Most tools
 | Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | Same path on all platforms |
 | Amp | `~/.local/share/amp/` | `%USERPROFILE%\.local\share\amp\` | Uses `xdg-basedir` like OpenCode |
 | Cursor | API sync | API sync | Data fetched via API, cached in `%USERPROFILE%\.config\tokscale\cursor-cache\` |
+| Cursor CLI | `~/.config/Cursor/User/globalStorage/state.vscdb` (macOS: `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb`) | `%APPDATA%\Cursor\User\globalStorage\state.vscdb` | Best-effort local token metadata from Cursor's internal/unsupported state database |
 | Droid | `~/.factory/` | `%USERPROFILE%\.factory\` | Same path on all platforms |
 | Pi | `~/.pi/` and `~/.omp/` | `%USERPROFILE%\.pi\` and `%USERPROFILE%\.omp\` | Same path on all platforms (supports both Pi and [Oh My Pi](https://github.com/can1357/oh-my-pi)) |
 | Kimi CLI | `~/.kimi/` | `%USERPROFILE%\.kimi\` | Same path on all platforms |

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@
 | <img width="48px" src=".github/assets/client-roocode.png" alt="Roo Code" /> | [Roo Code](https://github.com/RooCodeInc/Roo-Code) | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` (+ server: `~/.vscode-server/data/User/globalStorage/rooveterinaryinc.roo-cline/tasks/`) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-kilocode.png" alt="Kilo" /> | [Kilo](https://github.com/Kilo-Org/kilocode) | `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks/` (+ server: `~/.vscode-server/data/User/globalStorage/kilocode.kilo-code/tasks/`) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-kilocode.png" alt="Kilo CLI" /> | [Kilo CLI](https://github.com/nicepkg/kilo) | `~/.local/share/kilo/kilo.db` | ✅ Yes |
+| <img width="48px" src=".github/assets/client-kiro.png" alt="Kiro" /> | [Kiro CLI](https://kiro.dev/) | `~/.local/share/kiro-cli/data.sqlite3` (macOS: `~/Library/Application Support/kiro-cli/data.sqlite3`) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-mux.png" alt="Mux" /> | [Mux](https://github.com/coder/mux) | `~/.mux/sessions/` | ✅ Yes |
 | <img width="48px" src=".github/assets/client-crush.png" alt="Crush" /> | [Crush](https://crush.ai/) | `$XDG_DATA_HOME/crush/projects.json` (project registry; fallback: `~/.local/share/crush/projects.json`) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-goose.png" alt="Goose" /> | [Goose](https://github.com/aaif-goose/goose) | `~/.local/share/goose/sessions/sessions.db` (+ macOS Application Support, legacy Block/goose paths; override via `GOOSE_PATH_ROOT`) | ✅ Yes |
@@ -950,6 +951,7 @@ AI coding tools store their session data in cross-platform locations. Most tools
 | Mux | `~/.mux/sessions/` | `%USERPROFILE%\.mux\sessions\` | Same path on all platforms |
 | Codebuff | `~/.config/manicode/projects/` (+ `manicode-dev`, `manicode-staging`) | `%USERPROFILE%\.config\manicode\projects\` | Override via `CODEBUFF_DATA_DIR` env var |
 | Kilo CLI | `~/.local/share/kilo/` | `%USERPROFILE%\.local\share\kilo\` | Uses `xdg-basedir` like OpenCode |
+| Kiro CLI | `~/.local/share/kiro-cli/` (macOS: `~/Library/Application Support/kiro-cli/`) | `%USERPROFILE%\.local\share\kiro-cli\` | Uses `xdg-basedir`; macOS uses Application Support |
 | Crush | `$XDG_DATA_HOME/crush/` (fallback: `~/.local/share/crush/`) | `%USERPROFILE%\.local\share\crush\` (or `%XDG_DATA_HOME%\crush\` if set) | Uses XDG data directory with fallback |
 | Goose | `~/.local/share/goose/sessions/` (+ macOS Application Support, legacy Block paths) | `%USERPROFILE%\.local\share\goose\sessions\` | Configurable via `GOOSE_PATH_ROOT` env var |
 | Antigravity | `~/.config/tokscale/antigravity-cache/sessions/` | — | `tokscale antigravity sync` is currently supported on macOS/Linux only |

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -62,6 +62,7 @@
 | <img width="48px" src=".github/assets/client-hermes.png" alt="Hermes Agent" /> | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `$HERMES_HOME/state.db`（回退：`~/.hermes/state.db`） | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `~/.gemini/tmp/*/chats/*.json` | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | 通过 `~/.config/tokscale/cursor-cache/` API 同步 | ✅ 支持 |
+| <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor CLI" /> | [Cursor CLI](https://cursor.com/cli) | 来自 Cursor 内部/非官方 `~/.config/Cursor/User/globalStorage/state.vscdb` 的本地元数据（尽力而为） | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-amp.png" alt="Amp" /> | [Amp (AmpCode)](https://ampcode.com/) | `~/.local/share/amp/threads/` | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-codebuff.png" alt="Codebuff" /> | [Codebuff](https://codebuff.com/) | `~/.config/manicode/`（+ `manicode-dev`、`manicode-staging`；可通过 `CODEBUFF_DATA_DIR` 覆盖） | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-droid.png" alt="Droid" /> | [Droid (Factory Droid)](https://factory.ai/) | `~/.factory/sessions/` | ✅ 支持 |
@@ -142,7 +143,7 @@
   - 9 种颜色主题的 GitHub 风格贡献图
   - 实时筛选和排序
   - 零闪烁渲染
-- **多平台支持** - 跟踪 OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity 和 Synthetic 的使用情况
+- **多平台支持** - 跟踪 OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Cursor CLI、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity 和 Synthetic 的使用情况
 - **实时定价** - 从 LiteLLM 获取当前价格，带 1 小时磁盘缓存；OpenRouter 自动回退和新模型的 Cursor 定价支持
 - **详细分解** - 输入、输出、缓存读写和推理 Token 跟踪
 - **原生 Rust 核心** - 所有解析和聚合在 Rust 中完成，处理速度提升 10 倍

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -707,6 +707,7 @@ pub enum ClientFilter {
     Antigravity,
     Zed,
     Kiro,
+    Cursorcli,
     Synthetic,
 }
 
@@ -739,6 +740,7 @@ impl ClientFilter {
             Self::Antigravity => "antigravity",
             Self::Zed => "zed",
             Self::Kiro => "kiro",
+            Self::Cursorcli => "cursorcli",
             Self::Synthetic => "synthetic",
         }
     }
@@ -774,6 +776,7 @@ impl ClientFilter {
             Self::Antigravity => Some(ClientId::Antigravity),
             Self::Zed => Some(ClientId::Zed),
             Self::Kiro => Some(ClientId::Kiro),
+            Self::Cursorcli => Some(ClientId::CursorCli),
             Self::Synthetic => None,
         }
     }
@@ -806,6 +809,7 @@ impl ClientFilter {
             ClientId::Antigravity => Self::Antigravity,
             ClientId::Zed => Self::Zed,
             ClientId::Kiro => Self::Kiro,
+            ClientId::CursorCli => Self::Cursorcli,
         }
     }
 
@@ -905,6 +909,8 @@ pub struct ClientFlags {
     #[arg(long, hide = true)]
     pub kiro: bool,
     #[arg(long, hide = true)]
+    pub cursorcli: bool,
+    #[arg(long, hide = true)]
     pub synthetic: bool,
 }
 
@@ -958,7 +964,7 @@ fn build_client_filter_with_defaults(
         }
     }
 
-    let legacy: [(bool, ClientFilter); 24] = [
+    let legacy: [(bool, ClientFilter); 25] = [
         (flags.opencode, ClientFilter::Opencode),
         (flags.claude, ClientFilter::Claude),
         (flags.codex, ClientFilter::Codex),
@@ -982,6 +988,7 @@ fn build_client_filter_with_defaults(
         (flags.antigravity, ClientFilter::Antigravity),
         (flags.zed, ClientFilter::Zed),
         (flags.kiro, ClientFilter::Kiro),
+        (flags.cursorcli, ClientFilter::Cursorcli),
         (flags.synthetic, ClientFilter::Synthetic),
     ];
 
@@ -4666,6 +4673,7 @@ mod tests {
             antigravity: true,
             zed: true,
             kiro: true,
+            cursorcli: true,
             synthetic: true,
             ..ClientFlags::default()
         };
@@ -4699,6 +4707,7 @@ mod tests {
             "antigravity",
             "zed",
             "kiro",
+            "cursorcli",
             "synthetic",
         ] {
             assert!(

--- a/crates/tokscale-cli/src/paths.rs
+++ b/crates/tokscale-cli/src/paths.rs
@@ -38,7 +38,9 @@ pub fn legacy_macos_config_dir() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(target_os = "macos")]
     use serial_test::serial;
+    #[cfg(target_os = "macos")]
     use std::env;
 
     #[test]

--- a/crates/tokscale-cli/src/tui/client_ui.rs
+++ b/crates/tokscale-cli/src/tui/client_ui.rs
@@ -98,6 +98,10 @@ pub const CLIENT_UI: [ClientUi; ClientId::COUNT] = [
         display_name: "Kiro",
         hotkey: 'i',
     },
+    ClientUi {
+        display_name: "Cursor CLI",
+        hotkey: 'v',
+    },
 ];
 
 pub fn display_name(client: ClientId) -> &'static str {

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -1144,7 +1144,7 @@ mod tests {
     #[test]
     fn test_client_all() {
         let clients = ClientId::ALL;
-        assert_eq!(clients.len(), 23);
+        assert_eq!(clients.len(), 24);
         assert_eq!(clients[0], ClientId::OpenCode);
         assert_eq!(clients[1], ClientId::Claude);
         assert_eq!(clients[2], ClientId::Codex);
@@ -1168,6 +1168,7 @@ mod tests {
         assert_eq!(clients[20], ClientId::Antigravity);
         assert_eq!(clients[21], ClientId::Zed);
         assert_eq!(clients[22], ClientId::Kiro);
+        assert_eq!(clients[23], ClientId::CursorCli);
     }
 
     #[test]
@@ -1241,6 +1242,10 @@ mod tests {
             crate::tui::client_ui::display_name(ClientId::Zed),
             "Zed Agent"
         );
+        assert_eq!(
+            crate::tui::client_ui::display_name(ClientId::CursorCli),
+            "Cursor CLI"
+        );
     }
 
     #[test]
@@ -1266,6 +1271,7 @@ mod tests {
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Codebuff), 'b');
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Antigravity), 'a');
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Zed), 'z');
+        assert_eq!(crate::tui::client_ui::hotkey(ClientId::CursorCli), 'v');
     }
 
     #[test]
@@ -1342,6 +1348,10 @@ mod tests {
             Some(ClientId::Antigravity)
         );
         assert_eq!(crate::tui::client_ui::from_hotkey('z'), Some(ClientId::Zed));
+        assert_eq!(
+            crate::tui::client_ui::from_hotkey('v'),
+            Some(ClientId::CursorCli)
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -380,6 +380,15 @@ define_clients!(
         headless: false,
         parse_local: true,
         submit_default: true
+    },
+    CursorCli = 23 => {
+        id: "cursorcli",
+        root: PathRoot::Home,
+        relative: ".config/Cursor/User/globalStorage",
+        pattern: "state.vscdb",
+        headless: false,
+        parse_local: true,
+        submit_default: true
     }
 );
 
@@ -432,7 +441,7 @@ mod tests {
 
     #[test]
     fn test_client_id_count() {
-        assert_eq!(ClientId::COUNT, 23);
+        assert_eq!(ClientId::COUNT, 24);
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -893,6 +893,22 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         }
     }
 
+    let cursorcli_outcomes: Vec<CachedParseOutcome> = scan_result
+        .get(ClientId::CursorCli)
+        .par_iter()
+        .map(|path| {
+            load_or_parse_sqlite_source(path, &source_cache, pricing, |path| {
+                sessions::cursorcli::parse_cursorcli_sqlite(path)
+            })
+        })
+        .collect();
+    for outcome in cursorcli_outcomes {
+        all_messages.extend(outcome.messages);
+        if let Some(entry) = outcome.cache_entry {
+            source_cache.insert(entry);
+        }
+    }
+
     let amp_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::Amp)
         .par_iter()
@@ -1889,6 +1905,20 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     let gemini_count = gemini_msgs.len() as i32;
     counts.set(ClientId::Gemini, gemini_count);
     messages.extend(gemini_msgs);
+
+    let cursorcli_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::CursorCli)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::cursorcli::parse_cursorcli_sqlite(path)
+                .into_iter()
+                .map(|msg| unified_to_parsed(&msg))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let cursorcli_count = summed_parsed_message_count(&cursorcli_msgs);
+    counts.set(ClientId::CursorCli, cursorcli_count);
+    messages.extend(cursorcli_msgs);
 
     let amp_msgs: Vec<ParsedMessage> = scan_result
         .get(ClientId::Amp)

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -342,14 +342,21 @@ fn discover_cursorcli_state_dbs(home_dir: &str, use_env_roots: bool) -> Vec<Path
         }
     }
 
-    candidates.sort_unstable();
-    candidates.dedup();
-    candidates
+    // Build full DB paths, filter to valid files, then deduplicate by
+    // canonical path identity. On case-insensitive filesystems (macOS
+    // default), `~/.config/Cursor/...` and `~/.config/cursor/...` resolve
+    // to the same file, so string-level dedup is insufficient.
+    let mut dbs: Vec<PathBuf> = candidates
         .into_iter()
         .filter(|base| path_has_no_symlink_components(base))
         .map(|base| base.join("state.vscdb"))
         .filter(|path| is_regular_file_without_symlink(path))
-        .collect()
+        .filter_map(|path| std::fs::canonicalize(&path).ok())
+        .collect();
+
+    dbs.sort_unstable();
+    dbs.dedup();
+    dbs
 }
 
 fn is_regular_file_without_symlink(path: &Path) -> bool {
@@ -1211,6 +1218,35 @@ mod tests {
         let enabled: HashSet<ClientId> = [ClientId::CursorCli].into_iter().collect();
         let dirs = parse_extra_dirs("cursorcli:/tmp/cursor", &enabled);
         assert!(dirs.is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn test_cursorcli_deduplicates_canonical_same_path() {
+        // When multiple candidate paths resolve to the same file (e.g. via
+        // XDG_CONFIG_HOME pointing at ~/.config), only one DB should be returned.
+        let temp_dir = TempDir::new().unwrap();
+        let home = temp_dir.path();
+
+        // Create the DB at ~/.config/Cursor/User/globalStorage/state.vscdb
+        let db_dir = home.join(".config/Cursor/User/globalStorage");
+        fs::create_dir_all(&db_dir).unwrap();
+        let db_path = db_dir.join("state.vscdb");
+        File::create(&db_path).unwrap();
+
+        // Point XDG_CONFIG_HOME at ~/.config so that both the hardcoded
+        // ~/.config/Cursor/... and $XDG_CONFIG_HOME/Cursor/... candidates
+        // resolve to the same canonical path.
+        std::env::set_var("XDG_CONFIG_HOME", home.join(".config"));
+
+        let dbs = discover_cursorcli_state_dbs(home.to_str().unwrap(), true);
+
+        // Clean up env var
+        std::env::remove_var("XDG_CONFIG_HOME");
+
+        // Should return exactly one DB, not two.
+        assert_eq!(dbs.len(), 1, "Expected one DB but got {dbs:?}");
+        assert_eq!(dbs[0], std::fs::canonicalize(&db_path).unwrap());
     }
 
     #[test]

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -233,6 +233,7 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
                 "ui_messages.json" => file_name == "ui_messages.json",
                 "session-usage.json" => file_name == "session-usage.json",
                 "chat-messages.json" => file_name == "chat-messages.json",
+                "state.vscdb" => file_name == "state.vscdb",
                 _ => false,
             }
         })
@@ -314,6 +315,61 @@ pub fn built_in_extra_scan_paths_for(
     }
 
     paths
+}
+
+fn discover_cursorcli_state_dbs(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
+    let mut candidates = vec![
+        PathBuf::from(format!("{home_dir}/.config/Cursor/User/globalStorage")),
+        PathBuf::from(format!("{home_dir}/.config/cursor/User/globalStorage")),
+        PathBuf::from(format!(
+            "{home_dir}/Library/Application Support/Cursor/User/globalStorage"
+        )),
+    ];
+
+    if use_env_roots {
+        if let Ok(xdg_config_home) = std::env::var("XDG_CONFIG_HOME") {
+            candidates.push(PathBuf::from(format!(
+                "{xdg_config_home}/Cursor/User/globalStorage"
+            )));
+            candidates.push(PathBuf::from(format!(
+                "{xdg_config_home}/cursor/User/globalStorage"
+            )));
+        }
+
+        #[cfg(target_os = "windows")]
+        if let Some(config_dir) = dirs::config_dir() {
+            candidates.push(config_dir.join("Cursor/User/globalStorage"));
+        }
+    }
+
+    candidates.sort_unstable();
+    candidates.dedup();
+    candidates
+        .into_iter()
+        .filter(|base| path_has_no_symlink_components(base))
+        .map(|base| base.join("state.vscdb"))
+        .filter(|path| is_regular_file_without_symlink(path))
+        .collect()
+}
+
+fn is_regular_file_without_symlink(path: &Path) -> bool {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
+        Err(_) => false,
+    }
+}
+
+fn path_has_no_symlink_components(path: &Path) -> bool {
+    let mut current = PathBuf::new();
+    for component in path.components() {
+        current.push(component.as_os_str());
+        match std::fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => return false,
+            Ok(_) => {}
+            Err(_) => return false,
+        }
+    }
+    true
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -452,13 +508,17 @@ fn discover_crush_dbs(home_dir: &str, use_env_roots: bool) -> Vec<CrushDbSource>
 }
 
 fn supports_extra_dir_scanning(client_id: ClientId) -> bool {
-    // Kilo CLI currently loads a single SQLite DB via `scan_result.kilo_db`
-    // Kilo CLI and Hermes use SQLite database paths, Roo/KiloCode require local + remote
-    // and server task roots, and Crush discovers SQLite DBs via the project
-    // registry rather than scanned file paths.
+    // SQLite-backed clients with exact DB discovery should not accept recursive
+    // extra scan roots. Cursor CLI reads an internal Cursor state DB, so keep it
+    // constrained to known exact paths instead of arbitrary roots.
     !matches!(
         client_id,
-        ClientId::Kilo | ClientId::Crush | ClientId::Hermes | ClientId::Goose | ClientId::Zed
+        ClientId::Kilo
+            | ClientId::Crush
+            | ClientId::Hermes
+            | ClientId::Goose
+            | ClientId::Zed
+            | ClientId::CursorCli
     )
 }
 
@@ -599,6 +659,7 @@ fn scan_all_clients_with_env_strategy_inner(
                 | ClientId::Zed
                 | ClientId::Crush
                 | ClientId::Codebuff
+                | ClientId::CursorCli
         ) {
             continue;
         }
@@ -979,6 +1040,15 @@ fn scan_all_clients_with_env_strategy_inner(
         }
     }
 
+    if enabled.contains(&ClientId::CursorCli) {
+        for path in discover_cursorcli_state_dbs(home_dir, use_env_roots) {
+            if seen.insert(path.clone()) {
+                result.get_mut(ClientId::CursorCli).push(path);
+            }
+        }
+        result.get_mut(ClientId::CursorCli).sort_unstable();
+    }
+
     if enabled.contains(&ClientId::Copilot) {
         if let Some(path) = copilot_exporter_path_with_env_strategy(use_env_roots) {
             if path.is_file() && seen.insert(path.clone()) {
@@ -1021,6 +1091,14 @@ mod tests {
         let file_path = sessions_dir.join("copilot.jsonl");
         let mut file = File::create(file_path).unwrap();
         writeln!(file, "{{\"type\":\"span\",\"name\":\"chat gpt-5.4-mini\"}}").unwrap();
+    }
+
+    fn setup_mock_cursorcli_db(home: &Path) -> PathBuf {
+        let db_dir = home.join(".config/Cursor/User/globalStorage");
+        fs::create_dir_all(&db_dir).unwrap();
+        let db_path = db_dir.join("state.vscdb");
+        File::create(&db_path).unwrap();
+        db_path
     }
 
     #[test]
@@ -1070,6 +1148,69 @@ mod tests {
         assert_eq!(all[3], (ClientId::Cursor, PathBuf::from("e.csv")));
         assert_eq!(all[4], (ClientId::Gemini, PathBuf::from("d.json")));
         assert_eq!(all[5], (ClientId::Pi, PathBuf::from("f.jsonl")));
+    }
+
+    #[test]
+    fn test_scan_all_clients_cursorcli_exact_state_db() {
+        let temp_dir = TempDir::new().unwrap();
+        let home = temp_dir.path();
+        let expected = setup_mock_cursorcli_db(home);
+
+        let result = scan_all_clients_with_env_strategy(
+            home.to_str().unwrap(),
+            &["cursorcli".to_string()],
+            false,
+        );
+
+        assert_eq!(result.get(ClientId::CursorCli), &vec![expected]);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_scan_all_clients_cursorcli_rejects_symlinked_state_db() {
+        let temp_dir = TempDir::new().unwrap();
+        let home = temp_dir.path();
+        let db_dir = home.join(".config/Cursor/User/globalStorage");
+        fs::create_dir_all(&db_dir).unwrap();
+        let target = temp_dir.path().join("elsewhere.vscdb");
+        File::create(&target).unwrap();
+        std::os::unix::fs::symlink(&target, db_dir.join("state.vscdb")).unwrap();
+
+        let result = scan_all_clients_with_env_strategy(
+            home.to_str().unwrap(),
+            &["cursorcli".to_string()],
+            false,
+        );
+
+        assert!(result.get(ClientId::CursorCli).is_empty());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_scan_all_clients_cursorcli_rejects_symlinked_parent() {
+        let temp_dir = TempDir::new().unwrap();
+        let home = temp_dir.path();
+        let real_dir = temp_dir.path().join("real-global-storage");
+        fs::create_dir_all(&real_dir).unwrap();
+        File::create(real_dir.join("state.vscdb")).unwrap();
+        let parent = home.join(".config/Cursor/User");
+        fs::create_dir_all(&parent).unwrap();
+        std::os::unix::fs::symlink(&real_dir, parent.join("globalStorage")).unwrap();
+
+        let result = scan_all_clients_with_env_strategy(
+            home.to_str().unwrap(),
+            &["cursorcli".to_string()],
+            false,
+        );
+
+        assert!(result.get(ClientId::CursorCli).is_empty());
+    }
+
+    #[test]
+    fn test_parse_extra_dirs_skips_cursorcli() {
+        let enabled: HashSet<ClientId> = [ClientId::CursorCli].into_iter().collect();
+        let dirs = parse_extra_dirs("cursorcli:/tmp/cursor", &enabled);
+        assert!(dirs.is_empty());
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/cursorcli.rs
+++ b/crates/tokscale-core/src/sessions/cursorcli.rs
@@ -1,0 +1,286 @@
+//! Cursor CLI local usage parser.
+//!
+//! Cursor's documented CLI output currently does not expose token counts, so
+//! this parser reads the local Cursor state database as a best-effort metadata
+//! source. It intentionally queries only usage fields from `bubbleId:*` rows and
+//! never selects prompt text, rich text, tool results, blob payloads, or auth
+//! fields from the database.
+
+use super::utils::parse_timestamp_str;
+use super::UnifiedMessage;
+use crate::{provider_identity, TokenBreakdown};
+use rusqlite::{Connection, OpenFlags};
+use sha2::{Digest, Sha256};
+use std::path::Path;
+use tracing::warn;
+
+const CURSOR_CLI_CLIENT_ID: &str = "cursorcli";
+const MAX_CURSOR_BUBBLE_JSON_BYTES: i64 = 512 * 1024;
+
+#[derive(Debug)]
+struct CursorCliBubbleRow {
+    key: String,
+    bubble_id: Option<String>,
+    request_id: Option<String>,
+    created_at: Option<String>,
+    model_name: Option<String>,
+    input_tokens: Option<i64>,
+    output_tokens: Option<i64>,
+}
+
+pub fn parse_cursorcli_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
+    let conn = match Connection::open_with_flags(
+        db_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    ) {
+        Ok(conn) => conn,
+        Err(err) => {
+            warn!(
+                db_path = %db_path.display(),
+                error = %err,
+                "Failed to open Cursor CLI state database"
+            );
+            return Vec::new();
+        }
+    };
+
+    let mut stmt = match conn.prepare(
+        "SELECT
+            key,
+            json_extract(CAST(value AS TEXT), '$.bubbleId') AS bubble_id,
+            json_extract(CAST(value AS TEXT), '$.requestId') AS request_id,
+            json_extract(CAST(value AS TEXT), '$.createdAt') AS created_at,
+            json_extract(CAST(value AS TEXT), '$.modelInfo.modelName') AS model_name,
+            CAST(json_extract(CAST(value AS TEXT), '$.tokenCount.inputTokens') AS INTEGER) AS input_tokens,
+            CAST(json_extract(CAST(value AS TEXT), '$.tokenCount.outputTokens') AS INTEGER) AS output_tokens
+         FROM cursorDiskKV
+         WHERE key LIKE 'bubbleId:%'
+           AND length(value) <= ?1
+           AND json_valid(CAST(value AS TEXT))
+         LIMIT 100000",
+    ) {
+        Ok(stmt) => stmt,
+        Err(err) => {
+            warn!(
+                db_path = %db_path.display(),
+                error = %err,
+                "Failed to prepare Cursor CLI usage query"
+            );
+            return Vec::new();
+        }
+    };
+
+    let rows = match stmt.query_map([MAX_CURSOR_BUBBLE_JSON_BYTES], |row| {
+        Ok(CursorCliBubbleRow {
+            key: row.get(0)?,
+            bubble_id: row.get(1)?,
+            request_id: row.get(2)?,
+            created_at: row.get(3)?,
+            model_name: row.get(4)?,
+            input_tokens: row.get(5)?,
+            output_tokens: row.get(6)?,
+        })
+    }) {
+        Ok(rows) => rows,
+        Err(err) => {
+            warn!(
+                db_path = %db_path.display(),
+                error = %err,
+                "Failed to query Cursor CLI usage rows"
+            );
+            return Vec::new();
+        }
+    };
+
+    rows.filter_map(|row| match row {
+        Ok(row) => parse_bubble_row(row),
+        Err(err) => {
+            warn!(
+                db_path = %db_path.display(),
+                error = %err,
+                "Failed to decode Cursor CLI usage row"
+            );
+            None
+        }
+    })
+    .collect()
+}
+
+fn parse_bubble_row(row: CursorCliBubbleRow) -> Option<UnifiedMessage> {
+    let created_at = row.created_at.as_deref()?.trim();
+    let timestamp = parse_timestamp_str(created_at)?;
+
+    let model_id = row.model_name.as_deref()?.trim();
+    if model_id.is_empty() {
+        return None;
+    }
+
+    let tokens = TokenBreakdown {
+        input: row.input_tokens.unwrap_or(0).max(0),
+        output: row.output_tokens.unwrap_or(0).max(0),
+        cache_read: 0,
+        cache_write: 0,
+        reasoning: 0,
+    };
+    if tokens.total() <= 0 {
+        return None;
+    }
+
+    let session_id_seed = session_id_from_key(&row.key)
+        .or_else(|| non_empty(row.request_id.as_deref()))
+        .or_else(|| non_empty(row.bubble_id.as_deref()))
+        .unwrap_or_else(|| "unknown".to_string());
+    let session_id = format!("cursorcli-session-{}", stable_hash(&session_id_seed));
+    let provider_id = provider_identity::inferred_provider_from_model(model_id).unwrap_or("cursor");
+    let dedup_seed = non_empty(row.request_id.as_deref())
+        .or_else(|| non_empty(row.bubble_id.as_deref()))
+        .unwrap_or_else(|| row.key.clone());
+
+    let mut message = UnifiedMessage::new(
+        CURSOR_CLI_CLIENT_ID,
+        model_id,
+        provider_id,
+        session_id,
+        timestamp,
+        tokens,
+        0.0,
+    );
+    message.dedup_key = Some(format!("cursorcli:{}", stable_hash(&dedup_seed)));
+    Some(message)
+}
+
+fn stable_hash(value: &str) -> String {
+    let digest = Sha256::digest(value.as_bytes());
+    digest[..16]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn session_id_from_key(key: &str) -> Option<String> {
+    let mut parts = key.split(':');
+    match (parts.next(), parts.next()) {
+        (Some("bubbleId"), Some(session_id)) if !session_id.trim().is_empty() => {
+            Some(session_id.trim().to_string())
+        }
+        _ => None,
+    }
+}
+
+fn non_empty(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::params;
+    use tempfile::TempDir;
+
+    fn create_db(rows: &[(&str, &str)]) -> (TempDir, std::path::PathBuf) {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("state.vscdb");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute(
+            "CREATE TABLE cursorDiskKV (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB)",
+            [],
+        )
+        .unwrap();
+        for (key, value) in rows {
+            conn.execute(
+                "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+                params![key, value.as_bytes()],
+            )
+            .unwrap();
+        }
+        drop(conn);
+        (temp, path)
+    }
+
+    #[test]
+    fn parses_valid_bubble_usage_row() {
+        let (_temp, path) = create_db(&[(
+            "bubbleId:session-123:bubble-456",
+            r#"{
+                "bubbleId":"bubble-456",
+                "requestId":"request-789",
+                "createdAt":"2026-05-15T12:34:56.000Z",
+                "modelInfo":{"modelName":"gpt-5.5"},
+                "tokenCount":{"inputTokens":123,"outputTokens":45},
+                "text":"must not be selected by the parser",
+                "richText":"must not be selected by the parser",
+                "toolResults":[{"secret":"ignored"}]
+            }"#,
+        )]);
+
+        let messages = parse_cursorcli_sqlite(&path);
+        assert_eq!(messages.len(), 1);
+        let message = &messages[0];
+        assert_eq!(message.client, "cursorcli");
+        assert_eq!(
+            message.session_id,
+            format!("cursorcli-session-{}", stable_hash("session-123"))
+        );
+        assert_eq!(message.model_id, "gpt-5.5");
+        assert_eq!(message.provider_id, "openai");
+        assert_eq!(message.tokens.input, 123);
+        assert_eq!(message.tokens.output, 45);
+        assert_eq!(
+            message.dedup_key.as_deref(),
+            Some(format!("cursorcli:{}", stable_hash("request-789")).as_str())
+        );
+        assert!(!message.session_id.contains("session-123"));
+        assert_ne!(message.dedup_key.as_deref(), Some("cursorcli:request-789"));
+    }
+
+    #[test]
+    fn ignores_malformed_json_and_non_bubble_rows() {
+        let (_temp, path) = create_db(&[
+            ("bubbleId:session:bad", "{not json"),
+            (
+                "composerData:session",
+                r#"{"createdAt":"2026-05-15T12:34:56.000Z","modelInfo":{"modelName":"gpt-5.5"},"tokenCount":{"inputTokens":1,"outputTokens":1}}"#,
+            ),
+        ]);
+
+        assert!(parse_cursorcli_sqlite(&path).is_empty());
+    }
+
+    #[test]
+    fn skips_zero_token_rows() {
+        let (_temp, path) = create_db(&[(
+            "bubbleId:session:zero",
+            r#"{"createdAt":"2026-05-15T12:34:56.000Z","modelInfo":{"modelName":"gpt-5.5"},"tokenCount":{"inputTokens":0,"outputTokens":0}}"#,
+        )]);
+
+        assert!(parse_cursorcli_sqlite(&path).is_empty());
+    }
+
+    #[test]
+    fn clamps_negative_tokens() {
+        let (_temp, path) = create_db(&[(
+            "bubbleId:session:negative",
+            r#"{"createdAt":"2026-05-15T12:34:56.000Z","modelInfo":{"modelName":"claude-sonnet-4-5"},"tokenCount":{"inputTokens":-12,"outputTokens":8}}"#,
+        )]);
+
+        let messages = parse_cursorcli_sqlite(&path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 0);
+        assert_eq!(messages[0].tokens.output, 8);
+        assert_eq!(messages[0].provider_id, "anthropic");
+    }
+
+    #[test]
+    fn skips_oversized_rows_before_json_extraction() {
+        let large_text = "x".repeat((MAX_CURSOR_BUBBLE_JSON_BYTES as usize) + 1);
+        let value = format!(
+            r#"{{"createdAt":"2026-05-15T12:34:56.000Z","modelInfo":{{"modelName":"gpt-5.5"}},"tokenCount":{{"inputTokens":1,"outputTokens":1}},"text":"{large_text}"}}"#
+        );
+        let (_temp, path) = create_db(&[("bubbleId:session:large", value.as_str())]);
+
+        assert!(parse_cursorcli_sqlite(&path).is_empty());
+    }
+}

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -10,6 +10,7 @@ pub mod codex;
 pub mod copilot;
 pub mod crush;
 pub mod cursor;
+pub mod cursorcli;
 pub mod droid;
 pub mod gemini;
 pub mod goose;


### PR DESCRIPTION
## Summary

- Add Cursor CLI support by parsing local `state.vscdb` SQLite database for token usage metadata
- Implement security measures: hashed session IDs, symlink rejection, SQL row size limits, and exclusion from extra scan roots
- Update documentation across all locales (EN, JA, KO, ZH-CN) marking source as best-effort/internal

## How It Works

Cursor CLI doesn't expose stable token totals via documented output. This implementation reads best-effort metadata from Cursor's internal `cursorDiskKV` bubble rows in `state.vscdb`. The parser:

- Discovers exact known paths for `state.vscdb` across platforms
- Rejects symlink components to prevent arbitrary file access
- Hashes internal session/dedup IDs using SHA-256 (truncated) to avoid exposing raw Cursor keys
- Applies SQL row size and limit guards to prevent DoS
- Excludes Cursor CLI from `TOKSCALE_EXTRA_DIRS` and `scanner.extraScanPaths` to prevent arbitrary root scanning

## Testing

- All tests pass: `cargo test -p tokscale-core cursorcli`
- Clippy clean: `cargo clippy -p tokscale-core -p tokscale-cli`
- Build succeeds: `cargo build --release`

### Vibecode warning

This feature was built entirely by AI agents:
- **Core implementation**: Generated by GPT-5.5 for the Rust parsing logic and security model
- **Wrapper & integration**: Built using OpenCode with multi-agent subagent coordination for CLI wiring, TUI integration, and documentation updates

Cursor CLI support reads from Cursor's internal/unsupported `state.vscdb` database. This is best-effort parsing of internal metadata that Cursor does not document or guarantee to remain stable. Token totals may be incomplete or inaccurate as Cursor updates its internal storage format. Use this data for directional insights only, not for billing or precise accounting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add local Cursor CLI usage support by reading best‑effort token metadata from Cursor’s internal `state.vscdb`. You can now filter with `--client cursorcli` and see Cursor CLI usage in the TUI.

- **New Features**
  - New `cursorcli` client with exact discovery of `state.vscdb` (Linux: `~/.config/Cursor/User/globalStorage`, macOS: `~/Library/Application Support/Cursor/User/globalStorage`, Windows: `%APPDATA%/Cursor/User/globalStorage`), with no extra scan roots.
  - SQLite parser reads `cursorDiskKV` “bubble” rows and extracts model, timestamp, and input/output tokens only; no prompts or secrets.
  - Security hardening: reject symlinked paths, cap row bytes, and SHA‑256–hash session/dedup IDs.
  - CLI/TUI: `--client cursorcli` (legacy `--cursorcli` hidden) and a “Cursor CLI” TUI entry with hotkey `v`.
  - Docs updated across EN/JA/KO/ZH‑CN with examples and path tables; added Kiro CLI entries and fixed JA cross‑platform Cursor CLI paths.

- **Bug Fixes**
  - Deduplicate Cursor CLI DB paths by canonical identity to avoid double‑counting on case‑insensitive filesystems (e.g., macOS).

<sup>Written for commit 62d1a7199721bcce569477095940f828141da2db. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/556?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

