### PR TITLE
fix(submit): reject implausible submitted totals

### DIFF
--- a/packages/frontend/__tests__/api/submit.test.ts
+++ b/packages/frontend/__tests__/api/submit.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import type { ClientType } from "../../src/lib/types";
-import { validateSubmission } from "../../src/lib/validation/submission";
+import {
+  generateSubmissionHash,
+  validateSubmission,
+} from "../../src/lib/validation/submission";
 
 /**
  * Test suite for POST /api/submit - Client-Level Merge
@@ -88,6 +91,79 @@ function createMockSubmissionData(overrides: Partial<{
         messages: client.messages,
       })),
     })),
+  };
+}
+
+function createValidationPayload(overrides: Partial<{
+  date: string;
+  generatedAt: string;
+  totalTokens: number;
+  totalCost: number;
+  messages: number;
+  tokenBreakdown: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    reasoning: number;
+  };
+  clientCost: number;
+  clientMessages: number;
+}> = {}) {
+  const date = overrides.date ?? "2024-12-01";
+  const tokenBreakdown = overrides.tokenBreakdown ?? {
+    input: overrides.totalTokens ?? 1000,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    reasoning: 0,
+  };
+  const totalTokens = overrides.totalTokens ?? (
+    tokenBreakdown.input +
+    tokenBreakdown.output +
+    tokenBreakdown.cacheRead +
+    tokenBreakdown.cacheWrite +
+    tokenBreakdown.reasoning
+  );
+  const totalCost = overrides.totalCost ?? 1.5;
+  const messages = overrides.messages ?? 5;
+
+  return {
+    meta: {
+      generatedAt: overrides.generatedAt ?? "2024-12-02T00:00:00.000Z",
+      version: "2.1.1",
+      dateRange: { start: date, end: date },
+    },
+    summary: {
+      totalTokens,
+      totalCost,
+      totalDays: 1,
+      activeDays: totalTokens > 0 ? 1 : 0,
+      averagePerDay: totalCost,
+      maxCostInSingleDay: totalCost,
+      clients: ["claude" as const],
+      models: ["claude-sonnet-4-20250514"],
+    },
+    years: [{
+      year: date.slice(0, 4),
+      totalTokens,
+      totalCost,
+      range: { start: date, end: date },
+    }],
+    contributions: [{
+      date,
+      totals: { tokens: totalTokens, cost: totalCost, messages },
+      intensity: 2 as const,
+      tokenBreakdown,
+      clients: [{
+        client: "claude" as const,
+        modelId: "claude-sonnet-4-20250514",
+        providerId: "anthropic",
+        tokens: tokenBreakdown,
+        cost: overrides.clientCost ?? totalCost,
+        messages: overrides.clientMessages ?? messages,
+      }],
+    }],
   };
 }
 
@@ -227,6 +303,116 @@ describe('POST /api/submit - Client-Level Merge', () => {
 
       expect(result.valid).toBe(true);
       expect(result.errors).toHaveLength(0);
+    });
+  });
+
+  describe("Submission validation guardrails", () => {
+    it("rejects one-day fabricated token totals above the submission cap", () => {
+      const payload = createValidationPayload({
+        totalTokens: 1_000_000_000_000,
+        tokenBreakdown: {
+          input: 1_000_000_000_000,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          reasoning: 0,
+        },
+      });
+
+      const result = validateSubmission(payload);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.join("\n")).toContain("Daily token total exceeds");
+    });
+
+    it("rejects submitted cost that is implausible for the reported tokens", () => {
+      const payload = createValidationPayload({
+        totalTokens: 5,
+        totalCost: 1_000_000_000,
+        tokenBreakdown: {
+          input: 5,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          reasoning: 0,
+        },
+      });
+
+      const result = validateSubmission(payload);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.join("\n")).toContain("Cost per million tokens exceeds");
+    });
+
+    it("rejects submitted cost without corresponding tokens", () => {
+      const payload = createValidationPayload({
+        totalTokens: 0,
+        totalCost: 25,
+        tokenBreakdown: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          reasoning: 0,
+        },
+      });
+
+      const result = validateSubmission(payload);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.join("\n")).toContain("Cost submitted without tokens");
+    });
+
+    it("rejects day cost totals that do not match client costs", () => {
+      const payload = createValidationPayload({
+        totalTokens: 1000,
+        totalCost: 100,
+        clientCost: 1,
+      });
+
+      const result = validateSubmission(payload);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.join("\n")).toContain("client cost");
+    });
+
+    it("hashes content changes while ignoring generatedAt churn", () => {
+      const lowerPayload = createValidationPayload({
+        generatedAt: "2024-12-02T00:00:00.000Z",
+        totalTokens: 1000,
+        totalCost: 1,
+      });
+      const samePayloadNewGeneratedAt = createValidationPayload({
+        generatedAt: "2024-12-03T00:00:00.000Z",
+        totalTokens: 1000,
+        totalCost: 1,
+      });
+      const higherPayload = createValidationPayload({
+        generatedAt: "2024-12-02T00:00:00.000Z",
+        totalTokens: 2000,
+        totalCost: 2,
+        tokenBreakdown: {
+          input: 2000,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          reasoning: 0,
+        },
+      });
+
+      const lowerResult = validateSubmission(lowerPayload);
+      const sameResult = validateSubmission(samePayloadNewGeneratedAt);
+      const higherResult = validateSubmission(higherPayload);
+
+      expect(lowerResult.valid).toBe(true);
+      expect(sameResult.valid).toBe(true);
+      expect(higherResult.valid).toBe(true);
+      expect(generateSubmissionHash(lowerResult.data!)).toBe(
+        generateSubmissionHash(sameResult.data!)
+      );
+      expect(generateSubmissionHash(lowerResult.data!)).not.toBe(
+        generateSubmissionHash(higherResult.data!)
+      );
     });
   });
 

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -195,6 +195,8 @@ describe("POST /api/submit auth path", () => {
     });
     expect(mockState.validateSubmission).toHaveBeenCalledTimes(1);
     expect(mockState.db.transaction).not.toHaveBeenCalled();
+    expect(mockState.revalidateTag).not.toHaveBeenCalled();
+    expect(mockState.revalidateUsernamePaths).not.toHaveBeenCalled();
     expect(await response.json()).toEqual({
       error: "Validation failed",
       details: ["bad payload"],

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -1,22 +1,35 @@
 /**
  * Submission Validation (Level 1)
  * - Mathematical consistency (no negatives, totals match)
+ * - Server-side sanity caps for self-reported usage
  * - No future dates
  * - Required fields present
  */
 
+import { createHash } from "node:crypto";
 import { z } from "zod";
 
 // ============================================================================
 // SCHEMAS
 // ============================================================================
 
+const MAX_DAILY_TOKENS = 10_000_000_000;
+const MAX_DAILY_COST = 10_000;
+const MAX_COST_PER_MILLION_TOKENS = 10_000;
+const COST_RELATIVE_TOLERANCE = 0.01;
+const COST_ABSOLUTE_TOLERANCE = 0.1;
+const TOKEN_RELATIVE_TOLERANCE = 0.01;
+const TOKEN_ABSOLUTE_TOLERANCE = 100;
+
+const NonNegativeIntegerSchema = z.number().finite().int().min(0).max(Number.MAX_SAFE_INTEGER);
+const NonNegativeNumberSchema = z.number().finite().min(0);
+
 const TokenBreakdownSchema = z.object({
-  input: z.number().int().min(0),
-  output: z.number().int().min(0),
-  cacheRead: z.number().int().min(0),
-  cacheWrite: z.number().int().min(0),
-  reasoning: z.number().int().min(0),
+  input: NonNegativeIntegerSchema,
+  output: NonNegativeIntegerSchema,
+  cacheRead: NonNegativeIntegerSchema,
+  cacheWrite: NonNegativeIntegerSchema,
+  reasoning: NonNegativeIntegerSchema,
 });
 
 const SUPPORTED_SOURCES = [
@@ -48,27 +61,27 @@ const ClientContributionSchema = z.object({
   modelId: z.string().min(1),
   providerId: z.string().optional(),
   tokens: TokenBreakdownSchema,
-  cost: z.number().min(0),
-  messages: z.number().int().min(0),
+  cost: NonNegativeNumberSchema,
+  messages: NonNegativeIntegerSchema,
 });
 
 const DailyContributionSchema = z.object({
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   timestampMs: z.number().int().min(1e12).max(Number.MAX_SAFE_INTEGER).optional(),
   totals: z.object({
-    tokens: z.number().int().min(0),
-    cost: z.number().min(0),
-    messages: z.number().int().min(0),
+    tokens: NonNegativeIntegerSchema,
+    cost: NonNegativeNumberSchema,
+    messages: NonNegativeIntegerSchema,
   }),
-  intensity: z.number().int().min(0).max(4),
+  intensity: NonNegativeIntegerSchema.max(4),
   tokenBreakdown: TokenBreakdownSchema,
   clients: z.array(ClientContributionSchema),
 });
 
 const YearSummarySchema = z.object({
   year: z.string().regex(/^\d{4}$/),
-  totalTokens: z.number().int().min(0),
-  totalCost: z.number().min(0),
+  totalTokens: NonNegativeIntegerSchema,
+  totalCost: NonNegativeNumberSchema,
   range: z.object({
     start: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
     end: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
@@ -76,12 +89,12 @@ const YearSummarySchema = z.object({
 });
 
 const DataSummarySchema = z.object({
-  totalTokens: z.number().int().min(0),
-  totalCost: z.number().min(0),
-  totalDays: z.number().int().min(0),
-  activeDays: z.number().int().min(0),
-  averagePerDay: z.number().min(0),
-  maxCostInSingleDay: z.number().min(0),
+  totalTokens: NonNegativeIntegerSchema,
+  totalCost: NonNegativeNumberSchema,
+  totalDays: NonNegativeIntegerSchema,
+  activeDays: NonNegativeIntegerSchema,
+  averagePerDay: NonNegativeNumberSchema,
+  maxCostInSingleDay: NonNegativeNumberSchema,
   clients: z.array(SourceSchema),
   models: z.array(z.string()),
 });
@@ -167,6 +180,8 @@ const SubmissionDataSchema = z.preprocess(normalizeLegacySources, z.object({
 
 export type SubmissionData = z.infer<typeof SubmissionDataSchema>;
 
+type TokenBreakdown = SubmissionData["contributions"][number]["tokenBreakdown"];
+
 // ============================================================================
 // VALIDATION FUNCTIONS
 // ============================================================================
@@ -176,6 +191,42 @@ export interface ValidationResult {
   errors: string[];
   warnings: string[];
   data?: SubmissionData;
+}
+
+function tokenTotal(tokens: TokenBreakdown): number {
+  return tokens.input + tokens.output + tokens.cacheRead + tokens.cacheWrite + tokens.reasoning;
+}
+
+function exceedsTolerance(
+  actual: number,
+  expected: number,
+  relativeTolerance: number,
+  absoluteTolerance: number
+): boolean {
+  return Math.abs(actual - expected) > Math.max(Math.abs(expected) * relativeTolerance, absoluteTolerance);
+}
+
+function pushCostSanityErrors(
+  errors: string[],
+  label: string,
+  cost: number,
+  tokens: number
+): void {
+  if (cost > 0 && tokens === 0) {
+    errors.push(`${label}: Cost submitted without tokens`);
+    return;
+  }
+
+  if (cost <= 1 || tokens === 0) {
+    return;
+  }
+
+  const costPerMillion = (cost * 1_000_000) / tokens;
+  if (costPerMillion > MAX_COST_PER_MILLION_TOKENS) {
+    errors.push(
+      `${label}: Cost per million tokens exceeds ${MAX_COST_PER_MILLION_TOKENS.toLocaleString("en-US")}: ${costPerMillion.toFixed(2)}`
+    );
+  }
 }
 
 /**
@@ -223,7 +274,7 @@ export function validateSubmission(data: unknown): ValidationResult {
     }
   }
 
-  // Step 3: Mathematical consistency checks
+  // Step 3: Mathematical consistency and sanity checks
 
   // 3a. Summary totals should match sum of contributions
   const calculatedTotalTokens = submission.contributions.reduce(
@@ -235,7 +286,7 @@ export function validateSubmission(data: unknown): ValidationResult {
     0
   );
 
-  // Allow 1% tolerance for floating point
+  // Allow small tolerance for floating point and legacy rounding.
   const tokenDiff = Math.abs(calculatedTotalTokens - submission.summary.totalTokens);
   const costDiff = Math.abs(calculatedTotalCost - submission.summary.totalCost);
 
@@ -246,10 +297,39 @@ export function validateSubmission(data: unknown): ValidationResult {
   }
 
   if (costDiff > submission.summary.totalCost * 0.01 && costDiff > 0.1) {
-    warnings.push(
-      `Cost total minor mismatch: summary=${submission.summary.totalCost.toFixed(2)}, calculated=${calculatedTotalCost.toFixed(2)}`
+    errors.push(
+      `Cost total mismatch: summary=${submission.summary.totalCost.toFixed(2)}, calculated=${calculatedTotalCost.toFixed(2)}`
     );
   }
+
+  const claimedDays = Math.max(submission.summary.totalDays, submission.contributions.length, 1);
+  const maxSubmissionTokens = MAX_DAILY_TOKENS * claimedDays;
+  const maxSubmissionCost = MAX_DAILY_COST * claimedDays;
+
+  if (submission.summary.totalTokens > maxSubmissionTokens) {
+    errors.push(
+      `Submission token total exceeds ${maxSubmissionTokens.toLocaleString("en-US")} for ${claimedDays} day(s): ${submission.summary.totalTokens.toLocaleString("en-US")}`
+    );
+  }
+
+  if (submission.summary.totalCost > maxSubmissionCost) {
+    errors.push(
+      `Submission cost exceeds ${maxSubmissionCost.toLocaleString("en-US")} for ${claimedDays} day(s): ${submission.summary.totalCost.toFixed(2)}`
+    );
+  }
+
+  if (submission.summary.maxCostInSingleDay > MAX_DAILY_COST) {
+    errors.push(
+      `Summary maxCostInSingleDay exceeds ${MAX_DAILY_COST.toLocaleString("en-US")}: ${submission.summary.maxCostInSingleDay.toFixed(2)}`
+    );
+  }
+
+  pushCostSanityErrors(
+    errors,
+    "Submission summary",
+    submission.summary.totalCost,
+    submission.summary.totalTokens
+  );
 
   // 3b. Active days should match
   const activeDays = submission.contributions.filter((d) => d.totals.tokens > 0).length;
@@ -261,19 +341,69 @@ export function validateSubmission(data: unknown): ValidationResult {
 
   // 3c. Day token breakdown should sum to totals
   for (const day of submission.contributions) {
-    // Check clients sum to day totals
+    if (day.totals.tokens > MAX_DAILY_TOKENS) {
+      errors.push(
+        `Daily token total exceeds ${MAX_DAILY_TOKENS.toLocaleString("en-US")} on ${day.date}: ${day.totals.tokens.toLocaleString("en-US")}`
+      );
+    }
+
+    if (day.totals.cost > MAX_DAILY_COST) {
+      errors.push(
+        `Daily cost exceeds ${MAX_DAILY_COST.toLocaleString("en-US")} on ${day.date}: ${day.totals.cost.toFixed(2)}`
+      );
+    }
+
+    pushCostSanityErrors(errors, `Day ${day.date}`, day.totals.cost, day.totals.tokens);
+
+    const dayBreakdownTokens = tokenTotal(day.tokenBreakdown);
+    if (exceedsTolerance(dayBreakdownTokens, day.totals.tokens, TOKEN_RELATIVE_TOLERANCE, TOKEN_ABSOLUTE_TOLERANCE)) {
+      errors.push(
+        `Day ${day.date}: token breakdown (${dayBreakdownTokens}) does not match total (${day.totals.tokens})`
+      );
+    }
+
+    // Check clients sum to day totals. The route persists client rows and then
+    // recalculates totals from them, so mismatches must not remain warnings.
     if (day.clients.length > 0) {
       const clientsTokenSum = day.clients.reduce((sum, c) => {
         const t = c.tokens;
-        return sum + t.input + t.output + t.cacheRead + t.cacheWrite + t.reasoning;
+        return sum + tokenTotal(t);
       }, 0);
+      const clientsCostSum = day.clients.reduce((sum, c) => sum + c.cost, 0);
 
-      // Allow some tolerance
-      if (Math.abs(clientsTokenSum - day.totals.tokens) > day.totals.tokens * 0.05 && day.totals.tokens > 100) {
-        warnings.push(
-          `Day ${day.date}: client tokens (${clientsTokenSum}) don't match total (${day.totals.tokens})`
+      if (exceedsTolerance(clientsTokenSum, day.totals.tokens, TOKEN_RELATIVE_TOLERANCE, TOKEN_ABSOLUTE_TOLERANCE)) {
+        errors.push(
+          `Day ${day.date}: client tokens (${clientsTokenSum}) do not match total (${day.totals.tokens})`
         );
       }
+
+      if (exceedsTolerance(clientsCostSum, day.totals.cost, COST_RELATIVE_TOLERANCE, COST_ABSOLUTE_TOLERANCE)) {
+        errors.push(
+          `Day ${day.date}: client cost (${clientsCostSum.toFixed(2)}) does not match total (${day.totals.cost.toFixed(2)})`
+        );
+      }
+    }
+
+    for (const client of day.clients) {
+      const clientTokens = tokenTotal(client.tokens);
+      if (clientTokens > MAX_DAILY_TOKENS) {
+        errors.push(
+          `Client ${client.client} on ${day.date}: token total exceeds ${MAX_DAILY_TOKENS.toLocaleString("en-US")}: ${clientTokens.toLocaleString("en-US")}`
+        );
+      }
+
+      if (client.cost > MAX_DAILY_COST) {
+        errors.push(
+          `Client ${client.client} on ${day.date}: cost exceeds ${MAX_DAILY_COST.toLocaleString("en-US")}: ${client.cost.toFixed(2)}`
+        );
+      }
+
+      pushCostSanityErrors(
+        errors,
+        `Client ${client.client}/${client.modelId} on ${day.date}`,
+        client.cost,
+        clientTokens
+      );
     }
   }
 
@@ -331,38 +461,58 @@ export function validateSubmission(data: unknown): ValidationResult {
 }
 
 /**
- * Generate a hash for the submission data (for deduplication)
- * 
- * CHANGED for client-level merge:
- * - Hash is now based on clients + date range (not totals)
- * - Totals change after merge, so they can't be in the hash
- * - This hash identifies "what clients and dates are being submitted"
+ * Generate a content hash for the submitted usage payload.
+ *
+ * generatedAt is intentionally excluded so an idempotent resubmit of the same
+ * usage data keeps the same hash even when the export timestamp changes.
  */
 export function generateSubmissionHash(data: SubmissionData): string {
-  // Sort contributions by date to ensure deterministic hash
-  const sortedDates = data.contributions
-    .map(c => c.date)
-    .sort();
-
   const content = JSON.stringify({
-    // What clients are being submitted
-    clients: data.summary.clients.slice().sort(),
-    // Date range of this submission
-    dateRange: data.meta.dateRange,
-    // Number of days with data (for basic fingerprinting)
-    daysCount: data.contributions.length,
-    // First and last dates FROM SORTED LIST
-    firstDay: sortedDates[0],
-    lastDay: sortedDates[sortedDates.length - 1],
+    meta: {
+      dateRange: data.meta.dateRange,
+    },
+    summary: {
+      totalTokens: data.summary.totalTokens,
+      totalCost: data.summary.totalCost,
+      totalDays: data.summary.totalDays,
+      activeDays: data.summary.activeDays,
+      averagePerDay: data.summary.averagePerDay,
+      maxCostInSingleDay: data.summary.maxCostInSingleDay,
+      clients: data.summary.clients.slice().sort(),
+      models: data.summary.models.slice().sort(),
+    },
+    years: data.years
+      .map((year) => ({
+        year: year.year,
+        totalTokens: year.totalTokens,
+        totalCost: year.totalCost,
+        range: year.range,
+      }))
+      .sort((a, b) => a.year.localeCompare(b.year)),
+    contributions: data.contributions
+      .map((day) => ({
+        date: day.date,
+        timestampMs: day.timestampMs ?? null,
+        totals: day.totals,
+        intensity: day.intensity,
+        tokenBreakdown: day.tokenBreakdown,
+        clients: day.clients
+          .map((client) => ({
+            client: client.client,
+            modelId: client.modelId,
+            providerId: client.providerId ?? null,
+            tokens: client.tokens,
+            cost: client.cost,
+            messages: client.messages,
+          }))
+          .sort((a, b) =>
+            `${a.client}\u0000${a.providerId ?? ""}\u0000${a.modelId}`.localeCompare(
+              `${b.client}\u0000${b.providerId ?? ""}\u0000${b.modelId}`
+            )
+          ),
+      }))
+      .sort((a, b) => a.date.localeCompare(b.date)),
   });
 
-  // Simple synchronous hash (djb2 algorithm)
-  let hash = 5381;
-  for (let i = 0; i < content.length; i++) {
-    const char = content.charCodeAt(i);
-    hash = ((hash << 5) + hash) + char; // hash * 33 + char
-    hash = hash & hash; // Convert to 32-bit integer
-  }
-
-  return Math.abs(hash).toString(16).padStart(16, "0");
+  return createHash("sha256").update(content).digest("hex");
 }


### PR DESCRIPTION
## Summary
Closes #554.

This PR adds server-side ingestion guardrails for self-reported submit payloads so internally consistent but fabricated totals cannot go straight into persisted leaderboard data.

## Why
`POST /api/submit` currently accepts payloads as long as they are structurally valid and internally consistent. That leaves a concrete gap where a payload can report extreme daily token totals, extreme cost, or cost without meaningful token usage, then get persisted into `daily_breakdown` and recomputed into public leaderboard totals.

## Diff scope
The validator now rejects non-finite numeric values, unsafe integer counters, implausible daily/submission token totals, implausible daily/submission costs, cost submitted with zero tokens, extreme cost-per-million-token values, and client/day token or cost mismatches that would otherwise be recalculated into persisted totals.

`generateSubmissionHash()` now uses a SHA-256 hash over canonicalized usage content instead of a shape-only djb2 hash. It intentionally excludes `generatedAt` so an idempotent resubmit of identical usage data keeps the same hash while changed totals, costs, models, dates, or client breakdowns produce a different hash.

## Branch integrity
Base branch: `main`.

Validated base SHA: `ca7e4784752046630f22d28b9e39ddfe386370a5`.

Ahead/behind: `0 behind / 1 ahead`.

Merge base: `ca7e4784752046630f22d28b9e39ddfe386370a5`.

`origin/main` is an ancestor of this branch, so the diff was computed against the fetched base.

## Commit integrity
Introduced commit:

```text
ecc0e9f4779d213962e936c5df3a9450812549a7 fix(submit): reject implausible submitted totals
```

The final PR diff contains only submit validation and directly related frontend tests.

## Diff hygiene
Changed files:

```text
M packages/frontend/__tests__/api/submit.test.ts
M packages/frontend/__tests__/api/submitAuth.test.ts
M packages/frontend/src/lib/validation/submission.ts
```

`git diff --check origin/main...HEAD`: PASS, no output.

No migrations, generated artifacts, local environment files, secrets, credentials, build output, or unrelated files are included.

## Validation mode and proof
Validation mode: Mode 3 — shared frontend ingestion validation affects persisted leaderboard data.

Local validation:

```text
npx vitest run __tests__/api/submit.test.ts __tests__/api/submitAuth.test.ts
PASS, 37 tests

npx vitest run
PASS, 186 tests across 21 files

npx eslint src/lib/validation/submission.ts __tests__/api/submit.test.ts __tests__/api/submitAuth.test.ts
PASS

git diff --check
PASS

git diff --cached --check
PASS
```

Not run locally:

```text
Rust test suite — not required for this frontend-only submit ingestion validation change.
```

Observed unrelated local typecheck issue:

```text
npx tsc --noEmit --pretty false
FAILS on pre-existing embed SVG test fixture type errors and one hero asset import declaration outside this diff.
```

## Ledger and version proof
Ledger: not applicable — not required for this change family.

Version: not applicable — not required for this change family.

## Migration notes
Not applicable — no database migration changed.

## CI context confirmation
Not applicable — no CI workflow or required context names changed.

Remote checks observed after PR open:

```text
WIP: PASS
Can I merge this PR?: PASS
Vercel: PASS
Vercel Preview Comments: PASS
cubic · AI code reviewer: COMPLETED, NEUTRAL
```

## Runtime safety
No new background jobs, locks, queues, external calls, or database writes were added.

This change only tightens validation before the existing transaction path can persist submitted usage.

No invariant regression introduced.

## Documentation integrity
Not applicable — no user-facing commands, runbooks, release procedure, or deployment procedure changed.

## Rollback plan
Rollback: revert this PR.

DB downgrade: not applicable.

Data repair: not applicable.

Operational caveats: none known.

## Known residual risks
This PR intentionally does not add exact model-price-table validation because Tokscale pricing currently lives in Rust code and is not exposed to the Next.js frontend as a shared pricing artifact. Exact cost-vs-pricing verification should be a follow-up built around a deliberate shared pricing boundary rather than duplicating Rust pricing logic in the frontend.
