### PR TITLE
feat(models): add token timing and Claude Code stream dedupe

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1554,6 +1554,7 @@ fn run_models_report(
             reasoning: i64,
             message_count: i32,
             cost: f64,
+            performance: tokscale_core::ModelPerformance,
         }
 
         #[derive(serde::Serialize)]
@@ -1606,6 +1607,7 @@ fn run_models_report(
                     reasoning: e.reasoning,
                     message_count: e.message_count,
                     cost: e.cost,
+                    performance: e.performance,
                 })
                 .collect(),
             total_input: report.total_input,
@@ -1620,6 +1622,7 @@ fn run_models_report(
     } else {
         use comfy_table::{Attribute, Cell, CellAlignment, Color, ContentArrangement, Table};
 
+        let total_performance = aggregate_model_report_performance(&report.entries);
         let term_width = crossterm::terminal::size()
             .map(|(w, _)| w as usize)
             .unwrap_or(120);
@@ -1646,6 +1649,7 @@ fn run_models_report(
                         Cell::new("Model").fg(Color::Cyan),
                         Cell::new("Input").fg(Color::Cyan),
                         Cell::new("Output").fg(Color::Cyan),
+                        Cell::new("ms/1K").fg(Color::Cyan),
                         Cell::new("Cost").fg(Color::Cyan),
                         Cell::new("Cost/1M").fg(Color::Cyan),
                     ]);
@@ -1667,6 +1671,8 @@ fn run_models_report(
                                 .set_alignment(CellAlignment::Right),
                             Cell::new(format_tokens_with_commas(entry.output))
                                 .set_alignment(CellAlignment::Right),
+                            Cell::new(format_ms_per_1k(entry.performance.ms_per_1k_tokens))
+                                .set_alignment(CellAlignment::Right),
                             Cell::new(format_currency(entry.cost))
                                 .set_alignment(CellAlignment::Right),
                             Cell::new(format_cost_per_million(entry.cost, total_tokens))
@@ -1688,6 +1694,9 @@ fn run_models_report(
                             .fg(Color::Yellow)
                             .set_alignment(CellAlignment::Right),
                         Cell::new(format_tokens_with_commas(report.total_output))
+                            .fg(Color::Yellow)
+                            .set_alignment(CellAlignment::Right),
+                        Cell::new(format_ms_per_1k(total_performance.ms_per_1k_tokens))
                             .fg(Color::Yellow)
                             .set_alignment(CellAlignment::Right),
                         Cell::new(format_currency(report.total_cost))
@@ -1705,6 +1714,7 @@ fn run_models_report(
                         Cell::new("Model").fg(Color::Cyan),
                         Cell::new("Input").fg(Color::Cyan),
                         Cell::new("Output").fg(Color::Cyan),
+                        Cell::new("ms/1K").fg(Color::Cyan),
                         Cell::new("Cost").fg(Color::Cyan),
                         Cell::new("Cost/1M").fg(Color::Cyan),
                     ]);
@@ -1719,6 +1729,8 @@ fn run_models_report(
                             Cell::new(format_tokens_with_commas(entry.input))
                                 .set_alignment(CellAlignment::Right),
                             Cell::new(format_tokens_with_commas(entry.output))
+                                .set_alignment(CellAlignment::Right),
+                            Cell::new(format_ms_per_1k(entry.performance.ms_per_1k_tokens))
                                 .set_alignment(CellAlignment::Right),
                             Cell::new(format_currency(entry.cost))
                                 .set_alignment(CellAlignment::Right),
@@ -1741,6 +1753,9 @@ fn run_models_report(
                             .fg(Color::Yellow)
                             .set_alignment(CellAlignment::Right),
                         Cell::new(format_tokens_with_commas(report.total_output))
+                            .fg(Color::Yellow)
+                            .set_alignment(CellAlignment::Right),
+                        Cell::new(format_ms_per_1k(total_performance.ms_per_1k_tokens))
                             .fg(Color::Yellow)
                             .set_alignment(CellAlignment::Right),
                         Cell::new(format_currency(report.total_cost))
@@ -1823,6 +1838,7 @@ fn run_models_report(
                     table.set_header(vec![
                         Cell::new("Workspace").fg(Color::Cyan),
                         Cell::new("Model").fg(Color::Cyan),
+                        Cell::new("ms/1K").fg(Color::Cyan),
                         Cell::new("Cost").fg(Color::Cyan),
                     ]);
 
@@ -1830,6 +1846,8 @@ fn run_models_report(
                         table.add_row(vec![
                             Cell::new(workspace_name(entry.workspace_label.as_deref())),
                             Cell::new(&entry.model),
+                            Cell::new(format_ms_per_1k(entry.performance.ms_per_1k_tokens))
+                                .set_alignment(CellAlignment::Right),
                             Cell::new(format_currency(entry.cost))
                                 .set_alignment(CellAlignment::Right),
                         ]);
@@ -1840,6 +1858,9 @@ fn run_models_report(
                             .fg(Color::Yellow)
                             .add_attribute(Attribute::Bold),
                         Cell::new(""),
+                        Cell::new(format_ms_per_1k(total_performance.ms_per_1k_tokens))
+                            .fg(Color::Yellow)
+                            .set_alignment(CellAlignment::Right),
                         Cell::new(format_currency(report.total_cost))
                             .fg(Color::Yellow)
                             .set_alignment(CellAlignment::Right),
@@ -1858,6 +1879,7 @@ fn run_models_report(
                         Cell::new("Cache Write").fg(Color::Cyan),
                         Cell::new("Cache Read").fg(Color::Cyan),
                         Cell::new("Total").fg(Color::Cyan),
+                        Cell::new("ms/1K").fg(Color::Cyan),
                         Cell::new("Cost").fg(Color::Cyan),
                         Cell::new("Cost/1M").fg(Color::Cyan),
                     ]);
@@ -1885,6 +1907,8 @@ fn run_models_report(
                             Cell::new(format_tokens_with_commas(entry.cache_read))
                                 .set_alignment(CellAlignment::Right),
                             Cell::new(format_tokens_with_commas(total))
+                                .set_alignment(CellAlignment::Right),
+                            Cell::new(format_ms_per_1k(entry.performance.ms_per_1k_tokens))
                                 .set_alignment(CellAlignment::Right),
                             Cell::new(format_currency(entry.cost))
                                 .set_alignment(CellAlignment::Right),
@@ -1916,6 +1940,9 @@ fn run_models_report(
                             .fg(Color::Yellow)
                             .set_alignment(CellAlignment::Right),
                         Cell::new(format_tokens_with_commas(total_all))
+                            .fg(Color::Yellow)
+                            .set_alignment(CellAlignment::Right),
+                        Cell::new(format_ms_per_1k(total_performance.ms_per_1k_tokens))
                             .fg(Color::Yellow)
                             .set_alignment(CellAlignment::Right),
                         Cell::new(format_currency(report.total_cost))
@@ -2025,6 +2052,7 @@ fn run_models_report(
                         Cell::new("Cache Write").fg(Color::Cyan),
                         Cell::new("Cache Read").fg(Color::Cyan),
                         Cell::new("Total").fg(Color::Cyan),
+                        Cell::new("ms/1K").fg(Color::Cyan),
                         Cell::new("Cost").fg(Color::Cyan),
                         Cell::new("Cost/1M").fg(Color::Cyan),
                     ]);
@@ -2047,6 +2075,8 @@ fn run_models_report(
                             Cell::new(format_tokens_with_commas(entry.cache_read))
                                 .set_alignment(CellAlignment::Right),
                             Cell::new(format_tokens_with_commas(total))
+                                .set_alignment(CellAlignment::Right),
+                            Cell::new(format_ms_per_1k(entry.performance.ms_per_1k_tokens))
                                 .set_alignment(CellAlignment::Right),
                             Cell::new(format_currency(entry.cost))
                                 .set_alignment(CellAlignment::Right),
@@ -2081,6 +2111,9 @@ fn run_models_report(
                         Cell::new(format_tokens_with_commas(total_all))
                             .fg(Color::Yellow)
                             .set_alignment(CellAlignment::Right),
+                        Cell::new(format_ms_per_1k(total_performance.ms_per_1k_tokens))
+                            .fg(Color::Yellow)
+                            .set_alignment(CellAlignment::Right),
                         Cell::new(format_currency(report.total_cost))
                             .fg(Color::Yellow)
                             .set_alignment(CellAlignment::Right),
@@ -2100,6 +2133,7 @@ fn run_models_report(
                         Cell::new("Cache Write").fg(Color::Cyan),
                         Cell::new("Cache Read").fg(Color::Cyan),
                         Cell::new("Total").fg(Color::Cyan),
+                        Cell::new("ms/1K").fg(Color::Cyan),
                         Cell::new("Cost").fg(Color::Cyan),
                     ]);
 
@@ -2127,6 +2161,8 @@ fn run_models_report(
                             Cell::new(format_tokens_with_commas(entry.cache_read))
                                 .set_alignment(CellAlignment::Right),
                             Cell::new(format_tokens_with_commas(total))
+                                .set_alignment(CellAlignment::Right),
+                            Cell::new(format_ms_per_1k(entry.performance.ms_per_1k_tokens))
                                 .set_alignment(CellAlignment::Right),
                             Cell::new(format_currency(entry.cost))
                                 .set_alignment(CellAlignment::Right),
@@ -2157,6 +2193,9 @@ fn run_models_report(
                             .fg(Color::Yellow)
                             .set_alignment(CellAlignment::Right),
                         Cell::new(format_tokens_with_commas(total_all))
+                            .fg(Color::Yellow)
+                            .set_alignment(CellAlignment::Right),
+                        Cell::new(format_ms_per_1k(total_performance.ms_per_1k_tokens))
                             .fg(Color::Yellow)
                             .set_alignment(CellAlignment::Right),
                         Cell::new(format_currency(report.total_cost))
@@ -3107,6 +3146,47 @@ fn format_cost_per_million(cost: f64, total_tokens: i64) -> String {
     } else {
         format!("${:.2}/M", cost_per_m)
     }
+}
+
+fn format_ms_per_1k(ms_per_1k_tokens: Option<f64>) -> String {
+    let Some(value) = ms_per_1k_tokens else {
+        return "—".to_string();
+    };
+    if !value.is_finite() || value <= 0.0 {
+        "—".to_string()
+    } else if value >= 1000.0 {
+        format!("{:.1}s", value / 1000.0)
+    } else {
+        format!("{:.0}ms", value)
+    }
+}
+
+fn model_entry_total_tokens(entry: &tokscale_core::ModelUsage) -> i64 {
+    entry.input.max(0)
+        + entry.output.max(0)
+        + entry.cache_read.max(0)
+        + entry.cache_write.max(0)
+        + entry.reasoning.max(0)
+}
+
+fn aggregate_model_report_performance(
+    entries: &[tokscale_core::ModelUsage],
+) -> tokscale_core::ModelPerformance {
+    let mut performance = tokscale_core::ModelPerformance::default();
+    for entry in entries {
+        performance.total_duration_ms = performance
+            .total_duration_ms
+            .saturating_add(entry.performance.total_duration_ms);
+        performance.timed_tokens = performance
+            .timed_tokens
+            .saturating_add(entry.performance.timed_tokens);
+        performance.sample_count = performance
+            .sample_count
+            .saturating_add(entry.performance.sample_count);
+    }
+    let total_tokens = entries.iter().map(model_entry_total_tokens).sum();
+    performance.finalize(total_tokens);
+    performance
 }
 
 /// Format a URL as an OSC 8 clickable hyperlink for supported terminals.

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -1613,6 +1613,7 @@ mod tests {
                 client: "opencode".to_string(),
                 tokens: TokenBreakdown::default(),
                 cost: 0.0,
+                performance: Default::default(),
                 session_count: 1,
                 workspace_key: None,
                 workspace_label: None,
@@ -1623,6 +1624,7 @@ mod tests {
                 client: "opencode".to_string(),
                 tokens: TokenBreakdown::default(),
                 cost: 0.0,
+                performance: Default::default(),
                 session_count: 1,
                 workspace_key: None,
                 workspace_label: None,
@@ -1660,6 +1662,7 @@ mod tests {
                 client: "opencode".to_string(),
                 tokens: TokenBreakdown::default(),
                 cost: 0.0,
+                performance: Default::default(),
                 session_count: 1,
                 workspace_key: None,
                 workspace_label: None,
@@ -1670,6 +1673,7 @@ mod tests {
                 client: "opencode".to_string(),
                 tokens: TokenBreakdown::default(),
                 cost: 0.0,
+                performance: Default::default(),
                 session_count: 1,
                 workspace_key: None,
                 workspace_label: None,
@@ -1706,6 +1710,7 @@ mod tests {
             client: "opencode".to_string(),
             tokens: TokenBreakdown::default(),
             cost: 0.0,
+            performance: Default::default(),
             session_count: 1,
             workspace_key: None,
             workspace_label: None,
@@ -1821,6 +1826,7 @@ mod tests {
                 client: "opencode".to_string(),
                 tokens: TokenBreakdown::default(),
                 cost: 0.0,
+                performance: Default::default(),
                 session_count: 1,
                 workspace_key: None,
                 workspace_label: None,
@@ -2984,6 +2990,7 @@ mod tests {
             workspace_label: workspace.map(String::from),
             tokens: TokenBreakdown::default(),
             cost,
+            performance: Default::default(),
             session_count: 1,
         }
     }
@@ -3133,6 +3140,7 @@ mod tests {
                 workspace_label: None,
                 tokens: TokenBreakdown::default(),
                 cost: 10.0,
+                performance: Default::default(),
                 session_count: 1,
             },
             ModelUsage {
@@ -3143,6 +3151,7 @@ mod tests {
                 workspace_label: None,
                 tokens: TokenBreakdown::default(),
                 cost: 1.0,
+                performance: Default::default(),
                 session_count: 1,
             },
         ];
@@ -3198,6 +3207,7 @@ mod tests {
                 workspace_label: None,
                 tokens: TokenBreakdown::default(),
                 cost: 10.0,
+                performance: Default::default(),
                 session_count: 1,
             },
             ModelUsage {
@@ -3208,6 +3218,7 @@ mod tests {
                 workspace_label: None,
                 tokens: TokenBreakdown::default(),
                 cost: 5.0,
+                performance: Default::default(),
                 session_count: 1,
             },
         ];

--- a/crates/tokscale-cli/src/tui/cache.rs
+++ b/crates/tokscale-cli/src/tui/cache.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
-use tokscale_core::{sessions, GroupBy};
+use tokscale_core::{sessions, GroupBy, ModelPerformance};
 
 use crate::ClientFilter;
 
@@ -21,7 +21,7 @@ use super::data::{
 
 /// Cache staleness threshold: 5 minutes (matches TS implementation)
 const CACHE_STALE_THRESHOLD_MS: u64 = 5 * 60 * 1000;
-const CACHE_SCHEMA_VERSION: u32 = 7;
+const CACHE_SCHEMA_VERSION: u32 = 8;
 
 /// Get the cache directory path
 /// Uses `~/.cache/tokscale/` to match TypeScript implementation for cache sharing
@@ -98,6 +98,8 @@ struct CachedModelUsage {
     workspace_label: Option<String>,
     tokens: CachedTokenBreakdown,
     cost: f64,
+    #[serde(default)]
+    performance: ModelPerformance,
     session_count: u32,
 }
 
@@ -230,6 +232,7 @@ impl From<&ModelUsage> for CachedModelUsage {
             workspace_label: m.workspace_label.clone(),
             tokens: (&m.tokens).into(),
             cost: m.cost,
+            performance: m.performance.clone(),
             session_count: m.session_count,
         }
     }
@@ -245,6 +248,7 @@ impl From<CachedModelUsage> for ModelUsage {
             workspace_label: m.workspace_label,
             tokens: m.tokens.into(),
             cost: m.cost,
+            performance: m.performance,
             session_count: m.session_count,
         }
     }
@@ -1228,7 +1232,7 @@ mod tests {
         fs::write(
             &cache_path,
             r#"{
-  "schemaVersion": 7,
+  "schemaVersion": 8,
   "timestamp": 9999999999999,
   "enabledClients": ["claude", "cursor"],
   "includeSynthetic": false,
@@ -1510,7 +1514,7 @@ mod tests {
         fs::write(
             &legacy_path,
             r#"{
-  "schemaVersion": 7,
+  "schemaVersion": 8,
   "timestamp": 9999999999999,
   "enabledClients": ["claude"],
   "includeSynthetic": false,

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -8,7 +8,7 @@ use tokio::runtime::{Handle, Runtime};
 use tokscale_core::sessions::UnifiedMessage;
 use tokscale_core::{
     normalize_model_for_grouping, parse_local_unified_messages, sessions, ClientId, GroupBy,
-    LocalParseOptions,
+    LocalParseOptions, ModelPerformance,
 };
 
 /// Returns the scanner settings that `DataLoader` should use when building
@@ -54,6 +54,7 @@ pub struct ModelUsage {
     pub workspace_label: Option<String>,
     pub tokens: TokenBreakdown,
     pub cost: f64,
+    pub performance: ModelPerformance,
     pub session_count: u32,
 }
 
@@ -186,6 +187,14 @@ fn workspace_bucket(msg: &UnifiedMessage) -> (String, Option<String>, String) {
             UNKNOWN_WORKSPACE_LABEL.to_string(),
         ),
     }
+}
+
+fn positive_unified_token_total(tokens: &tokscale_core::TokenBreakdown) -> i64 {
+    tokens.input.max(0)
+        + tokens.output.max(0)
+        + tokens.cache_read.max(0)
+        + tokens.cache_write.max(0)
+        + tokens.reasoning.max(0)
 }
 
 fn workspace_model_display_label(workspace_label: &str, model: &str) -> String {
@@ -442,6 +451,7 @@ impl DataLoader {
                 },
                 tokens: TokenBreakdown::default(),
                 cost: 0.0,
+                performance: ModelPerformance::default(),
                 session_count: 0,
             });
 
@@ -484,6 +494,10 @@ impl DataLoader {
                 0.0
             };
             model_entry.cost += msg_cost;
+            model_entry.performance.record_message(
+                positive_unified_token_total(&msg.tokens),
+                msg.duration_ms,
+            );
 
             let session_key = format!("{}:{}", msg.client, msg.session_id);
             let model_sessions = model_session_ids.entry(key).or_default();
@@ -844,7 +858,13 @@ impl DataLoader {
             }
         }
 
-        let mut models: Vec<ModelUsage> = model_map.into_values().collect();
+        let mut models: Vec<ModelUsage> = model_map
+            .into_values()
+            .map(|mut model| {
+                model.performance.finalize(model.tokens.total() as i64);
+                model
+            })
+            .collect();
         models.sort_by(|a, b| {
             b.cost
                 .total_cmp(&a.cost)

--- a/crates/tokscale-cli/src/tui/export.rs
+++ b/crates/tokscale-cli/src/tui/export.rs
@@ -20,6 +20,7 @@ pub fn build_export_json(data: &UsageData) -> Result<String> {
                 "total": m.tokens.total()
             },
             "cost": m.cost,
+            "performance": m.performance,
             "sessionCount": m.session_count
         })).collect::<Vec<_>>(),
         "agents": data.agents.iter().map(|a| json!({

--- a/crates/tokscale-cli/src/tui/ui/models.rs
+++ b/crates/tokscale-cli/src/tui/ui/models.rs
@@ -4,7 +4,7 @@ use ratatui::widgets::{
 };
 
 use super::widgets::{
-    format_cache_hit_rate, format_cost, format_tokens, get_client_display_name,
+    format_cache_hit_rate, format_cost, format_ms_per_1k, format_tokens, get_client_display_name,
     get_provider_display_name,
 };
 use crate::tui::app::{App, SortDirection, SortField};
@@ -81,12 +81,13 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             "Cache Read",
             "Cache Write",
             "Total",
+            "ms/1K",
             "Cost",
         ]
     } else {
         vec![
             "#", "Model", "Provider", "Source", "Input", "Output", "Cache R", "Cache W", "Cache×",
-            "Total", "Cost",
+            "Total", "ms/1K", "Cost",
         ]
     };
 
@@ -108,7 +109,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             .map(|(i, h)| {
                 let indicator = match i {
                     9 if !is_narrow => sort_indicator(SortField::Tokens),
-                    10 if !is_narrow => sort_indicator(SortField::Cost),
+                    11 if !is_narrow => sort_indicator(SortField::Cost),
                     1 if is_very_narrow => sort_indicator(SortField::Cost),
                     2 if is_narrow && !is_very_narrow => sort_indicator(SortField::Cost),
                     1 if is_narrow && !is_very_narrow => sort_indicator(SortField::Tokens),
@@ -180,6 +181,8 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                     Cell::from(format_tokens(model.tokens.cache_write))
                         .style(Style::default().fg(Color::Rgb(200, 150, 100))),
                     Cell::from(format_tokens(model.tokens.total())),
+                    Cell::from(format_ms_per_1k(model.performance.ms_per_1k_tokens))
+                        .style(Style::default().fg(Color::Yellow)),
                     Cell::from(format_cost(model.cost)).style(Style::default().fg(Color::Green)),
                 ]
             } else {
@@ -208,6 +211,8 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                     ))
                     .style(Style::default().fg(Color::Cyan)),
                     Cell::from(format_tokens(model.tokens.total())),
+                    Cell::from(format_ms_per_1k(model.performance.ms_per_1k_tokens))
+                        .style(Style::default().fg(Color::Yellow)),
                     Cell::from(format_cost(model.cost)).style(Style::default().fg(Color::Green)),
                 ]
             };
@@ -245,6 +250,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             Constraint::Length(12),
             Constraint::Length(10),
             Constraint::Length(10),
+            Constraint::Length(10),
         ]
     } else {
         vec![
@@ -257,6 +263,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             Constraint::Length(10),
             Constraint::Length(10),
             Constraint::Length(8),
+            Constraint::Length(10),
             Constraint::Length(10),
             Constraint::Length(10),
         ]

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -59,6 +59,19 @@ pub fn format_cache_hit_rate(cache_read: u64, input: u64, cache_write: u64) -> S
     format!("{:.1}x", ratio)
 }
 
+pub fn format_ms_per_1k(ms_per_1k_tokens: Option<f64>) -> String {
+    let Some(value) = ms_per_1k_tokens else {
+        return "—".to_string();
+    };
+    if !value.is_finite() || value <= 0.0 {
+        "—".to_string()
+    } else if value >= 1000.0 {
+        format!("{:.1}s", value / 1000.0)
+    } else {
+        format!("{:.0}ms", value)
+    }
+}
+
 pub fn get_model_color(model: &str) -> Color {
     get_provider_shade(get_provider_from_model(model), 0)
 }

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -70,7 +70,7 @@ fn create_temp_fixture_dir_with_pricing_cache(with_pricing_cache: bool) -> TempD
             "reasoning": 0,
             "cache": { "read": 200, "write": 50 }
         },
-        "time": { "created": 1718452800000.0 }
+        "time": { "created": 1718452800000.0, "completed": 1718452803500.0 }
     }"#;
     fs::write(session1.join("msg_a.json"), msg_a).unwrap();
 
@@ -88,7 +88,7 @@ fn create_temp_fixture_dir_with_pricing_cache(with_pricing_cache: bool) -> TempD
             "reasoning": 0,
             "cache": { "read": 150, "write": 30 }
         },
-        "time": { "created": 1718456400000.0 }
+        "time": { "created": 1718456400000.0, "completed": 1718456402560.0 }
     }"#;
     fs::write(session1.join("msg_b.json"), msg_b).unwrap();
 
@@ -110,7 +110,7 @@ fn create_temp_fixture_dir_with_pricing_cache(with_pricing_cache: bool) -> TempD
             "reasoning": 0,
             "cache": { "read": 100, "write": 20 }
         },
-        "time": { "created": 1736510400000.0 }
+        "time": { "created": 1736510400000.0, "completed": 1736510400920.0 }
     }"#;
     fs::write(session2.join("msg_c.json"), msg_c).unwrap();
 
@@ -1029,6 +1029,17 @@ fn test_models_json_output() {
     assert!(first.get("cacheRead").is_some());
     assert!(first.get("cacheWrite").is_some());
     assert!(first.get("cost").is_some());
+    let performance = first
+        .get("performance")
+        .expect("Missing performance")
+        .as_object()
+        .expect("performance should be an object");
+    assert!(performance.contains_key("msPer1KTokens"));
+    assert!(performance.contains_key("totalDurationMs"));
+    assert!(performance.contains_key("timedTokens"));
+    assert!(performance.contains_key("sampleCount"));
+    assert!(performance.contains_key("tokenCoverage"));
+    assert!(performance["msPer1KTokens"].as_f64().unwrap() > 0.0);
 }
 
 #[test]
@@ -1836,7 +1847,8 @@ fn test_models_light_output() {
         .args(["models", "--light", "--opencode", "--no-spinner"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Token Usage Report by Model"));
+        .stdout(predicate::str::contains("Token Usage Report by Model"))
+        .stdout(predicate::str::contains("ms/1K"));
 }
 
 #[test]

--- a/crates/tokscale-core/src/aggregator.rs
+++ b/crates/tokscale-core/src/aggregator.rs
@@ -758,6 +758,7 @@ mod tests {
                 reasoning: 0,
             },
             cost,
+            duration_ms: None,
             message_count: 1,
             agent: None,
             dedup_key: None,

--- a/crates/tokscale-core/src/aggregator.rs
+++ b/crates/tokscale-core/src/aggregator.rs
@@ -1289,6 +1289,7 @@ mod tests {
             agent: None,
             dedup_key: None,
             is_turn_start: false,
+            duration_ms: None,
         }
     }
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -178,6 +178,57 @@ impl TokenBreakdown {
     }
 }
 
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelPerformance {
+    #[serde(rename = "msPer1KTokens")]
+    pub ms_per_1k_tokens: Option<f64>,
+    pub total_duration_ms: i64,
+    pub timed_tokens: i64,
+    pub sample_count: i32,
+    pub token_coverage: f64,
+}
+
+impl ModelPerformance {
+    pub fn record_message(&mut self, token_total: i64, duration_ms: Option<i64>) {
+        let Some(duration_ms) = duration_ms else {
+            return;
+        };
+        if duration_ms <= 0 || token_total <= 0 {
+            return;
+        }
+
+        self.total_duration_ms = self.total_duration_ms.saturating_add(duration_ms);
+        self.timed_tokens = self.timed_tokens.saturating_add(token_total);
+        self.sample_count = self.sample_count.saturating_add(1);
+    }
+
+    pub fn finalize(&mut self, total_tokens: i64) {
+        self.ms_per_1k_tokens = if self.timed_tokens > 0 && self.total_duration_ms > 0 {
+            Some(self.total_duration_ms as f64 * 1000.0 / self.timed_tokens as f64)
+        } else {
+            None
+        };
+
+        self.token_coverage = if total_tokens > 0 {
+            (self.timed_tokens as f64 / total_tokens as f64).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+    }
+
+    pub fn from_totals(total_duration_ms: i64, timed_tokens: i64, sample_count: i32) -> Self {
+        let mut performance = Self {
+            total_duration_ms,
+            timed_tokens,
+            sample_count,
+            ..Self::default()
+        };
+        performance.finalize(timed_tokens);
+        performance
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ParsedMessage {
     pub client: String,
@@ -193,6 +244,7 @@ pub struct ParsedMessage {
     pub cache_read: i64,
     pub cache_write: i64,
     pub reasoning: i64,
+    pub duration_ms: Option<i64>,
     pub message_count: i32,
     pub agent: Option<String>,
 }
@@ -355,6 +407,7 @@ pub struct ModelUsage {
     pub reasoning: i64,
     pub message_count: i32,
     pub cost: f64,
+    pub performance: ModelPerformance,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -1340,6 +1393,7 @@ fn aggregate_model_usage_entries(
             reasoning: 0,
             message_count: 0,
             cost: 0.0,
+            performance: ModelPerformance::default(),
         });
 
         if merge_clients {
@@ -1367,11 +1421,21 @@ fn aggregate_model_usage_entries(
         entry.reasoning += msg.tokens.reasoning;
         entry.message_count += msg.message_count.max(0);
         entry.cost += msg.cost;
+        entry.performance.record_message(
+            positive_token_total(&msg.tokens),
+            msg.duration_ms,
+        );
     }
 
     let mut entries: Vec<ModelUsage> = model_map
         .into_values()
         .map(|mut entry| {
+            let total_tokens = entry.input.max(0)
+                + entry.output.max(0)
+                + entry.cache_read.max(0)
+                + entry.cache_write.max(0)
+                + entry.reasoning.max(0);
+            entry.performance.finalize(total_tokens);
             let mut providers: Vec<&str> = entry.provider.split(", ").collect();
             providers.sort_unstable();
             providers.dedup();
@@ -1390,6 +1454,14 @@ fn aggregate_model_usage_entries(
     });
 
     entries
+}
+
+fn positive_token_total(tokens: &TokenBreakdown) -> i64 {
+    tokens.input.max(0)
+        + tokens.output.max(0)
+        + tokens.cache_read.max(0)
+        + tokens.cache_write.max(0)
+        + tokens.reasoning.max(0)
 }
 
 pub async fn get_model_report(options: ReportOptions) -> Result<ModelReport, String> {
@@ -2280,6 +2352,7 @@ fn unified_to_parsed(msg: &UnifiedMessage) -> ParsedMessage {
         cache_read: msg.tokens.cache_read,
         cache_write: msg.tokens.cache_write,
         reasoning: msg.tokens.reasoning,
+        duration_ms: msg.duration_ms,
         message_count: msg.message_count,
         agent: msg.agent.clone(),
     }
@@ -2339,6 +2412,7 @@ pub fn parsed_to_unified(msg: &ParsedMessage, cost: f64) -> UnifiedMessage {
             reasoning: msg.reasoning,
         },
         cost,
+        duration_ms: msg.duration_ms,
         message_count: msg.message_count,
         agent: msg.agent.clone(),
         dedup_key: None,
@@ -2619,6 +2693,76 @@ mod tests {
     }
 
     #[test]
+    fn test_model_usage_performance_uses_only_timed_positive_token_messages() {
+        let mut timed = make_workspace_message(
+            "opencode",
+            "gpt-5.4",
+            "openai",
+            "session-1",
+            0.0,
+            None,
+            None,
+        );
+        timed.tokens = TokenBreakdown {
+            input: 100,
+            output: 50,
+            cache_read: 25,
+            cache_write: 0,
+            reasoning: 25,
+        };
+        timed.duration_ms = Some(400);
+
+        let mut untimed = make_workspace_message(
+            "opencode",
+            "gpt-5.4",
+            "openai",
+            "session-2",
+            0.0,
+            None,
+            None,
+        );
+        untimed.tokens = TokenBreakdown {
+            input: 300,
+            output: 0,
+            cache_read: 0,
+            cache_write: 0,
+            reasoning: 0,
+        };
+
+        let entries = aggregate_model_usage_entries(vec![timed, untimed], &GroupBy::ClientModel);
+
+        assert_eq!(entries.len(), 1);
+        let performance = &entries[0].performance;
+        assert_eq!(performance.total_duration_ms, 400);
+        assert_eq!(performance.timed_tokens, 200);
+        assert_eq!(performance.sample_count, 1);
+        assert_eq!(performance.ms_per_1k_tokens, Some(2000.0));
+        assert!((performance.token_coverage - 0.4).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_model_usage_performance_is_null_without_duration_samples() {
+        let entries = aggregate_model_usage_entries(
+            vec![make_workspace_message(
+                "claude",
+                "claude-sonnet-4-5",
+                "anthropic",
+                "session-1",
+                0.0,
+                None,
+                None,
+            )],
+            &GroupBy::ClientModel,
+        );
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].performance.ms_per_1k_tokens, None);
+        assert_eq!(entries[0].performance.total_duration_ms, 0);
+        assert_eq!(entries[0].performance.timed_tokens, 0);
+        assert_eq!(entries[0].performance.token_coverage, 0.0);
+    }
+
+    #[test]
     fn test_workspace_model_grouping_merges_same_workspace_and_model() {
         let entries = aggregate_model_usage_entries(
             vec![
@@ -2778,6 +2922,7 @@ mod tests {
             Some("//server/share/demo-workspace".to_string()),
             Some("demo-workspace".to_string()),
         );
+        unified.duration_ms = Some(2500);
 
         let parsed = unified_to_parsed(&unified);
         let round_tripped = parsed_to_unified(&parsed, 2.5);
@@ -2791,6 +2936,7 @@ mod tests {
             Some("demo-workspace")
         );
         assert_eq!(round_tripped.cost, 2.5);
+        assert_eq!(round_tripped.duration_ms, Some(2500));
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -513,6 +513,13 @@ pub fn parse_claude_file_with_cache(
                 }
                 messages.push(unified);
                 provider_confidences.push(provider_confidence);
+                // Consume the pending request-start timestamp so a back-to-back
+                // assistant message with no intervening user entry doesn't reuse
+                // it and report an inflated duration. Streaming duplicates of
+                // this same message have already been captured in the dedup map
+                // above, so they merge via merge_claude_duplicate without needing
+                // the global pending value again.
+                pending_request_start_timestamp_ms = None;
                 handled = true;
             }
         }
@@ -595,9 +602,22 @@ fn merge_claude_duplicate(
 
     if let Some(timestamp_ms) = parsed_timestamp {
         if timestamp_ms >= existing.timestamp {
+            // Recover the original request-start timestamp from the existing
+            // message's recorded duration. The parent loop clears
+            // `pending_request_start_timestamp_ms` after the first chunk of a
+            // message commits (so a NEW message with no preceding user doesn't
+            // inflate by reusing a stale start), which would otherwise blank
+            // out streaming duplicates' duration. Recovering from
+            // `existing.timestamp - existing.duration_ms` keeps the duration
+            // honest for late chunks of the same logical message.
+            let recovered_start = existing
+                .duration_ms
+                .map(|d| existing.timestamp - d)
+                .or(request_start_timestamp_ms);
             existing.set_timestamp(timestamp_ms);
-            existing.duration_ms =
-                duration_between_ms(request_start_timestamp_ms, parsed_timestamp);
+            if let Some(new_duration) = duration_between_ms(recovered_start, Some(timestamp_ms)) {
+                existing.duration_ms = Some(new_duration);
+            }
         }
     }
 }
@@ -1185,6 +1205,33 @@ mod tests {
         assert_eq!(
             messages[0].dedup_key.as_deref(),
             Some("message:msg_stream")
+        );
+    }
+
+    #[test]
+    fn test_pending_request_start_is_cleared_between_assistant_messages() {
+        // Regression: previously, the user-entry timestamp was set into
+        // `pending_request_start_timestamp_ms` and never cleared after the
+        // first assistant message consumed it. A subsequent assistant message
+        // with no intervening user entry would then reuse the stale start
+        // timestamp and report a wildly inflated duration.
+        let content = r#"{"type":"user","timestamp":"2024-12-01T10:00:00.000Z","message":{"content":"Hello"}}
+{"type":"assistant","timestamp":"2024-12-01T10:00:01.000Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50}}}
+{"type":"assistant","timestamp":"2024-12-01T10:01:30.000Z","requestId":"req_002","message":{"id":"msg_002","model":"claude-3-5-sonnet","usage":{"input_tokens":200,"output_tokens":80}}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(
+            messages[0].duration_ms,
+            Some(1_000),
+            "first assistant should report duration vs the user entry (1s)"
+        );
+        assert_eq!(
+            messages[1].duration_ms, None,
+            "second assistant has no preceding user entry; duration must NOT \
+             reuse the stale pending_request_start_timestamp_ms"
         );
     }
 

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -343,6 +343,7 @@ pub fn parse_claude_file_with_cache(
     // Tracks whether the previous entry was a user message,
     // so the next assistant message can be marked as a turn start.
     let mut pending_turn_start = false;
+    let mut pending_request_start_timestamp_ms: Option<i64> = None;
     // Sidechain detection state (resolved lazily on first parseable entry)
     let mut sidechain_agent: Option<String> = None;
     let mut sidechain_detected = false;
@@ -381,6 +382,11 @@ pub fn parse_claude_file_with_cache(
             }
 
             if entry.entry_type == "user" {
+                if let Some(timestamp_ms) =
+                    parse_claude_entry_timestamp(entry.timestamp.as_deref())
+                {
+                    pending_request_start_timestamp_ms = Some(timestamp_ms);
+                }
                 // Distinguish real human input from tool results / system messages.
                 // Tool results have content as a JSON array (e.g. [{"type":"tool_result",...}]).
                 // System messages have XML-tagged content (e.g. <local-command-stdout>).
@@ -418,18 +424,32 @@ pub fn parse_claude_file_with_cache(
                     (Some(msg_id), Some(req_id)) => {
                         let hash = format!("{}:{}", msg_id, req_id);
                         if let Some(&existing_idx) = processed_hashes.get(&hash) {
-                            // Per-field max merge: each token field is updated independently
-                            {
-                                let t = &mut messages[existing_idx].tokens;
-                                t.input = t.input.max(usage.input_tokens.unwrap_or(0).max(0));
-                                t.output = t.output.max(usage.output_tokens.unwrap_or(0).max(0));
-                                t.cache_read = t
-                                    .cache_read
-                                    .max(usage.cache_read_input_tokens.unwrap_or(0).max(0));
-                                t.cache_write = t
-                                    .cache_write
-                                    .max(usage.cache_creation_input_tokens.unwrap_or(0).max(0));
+                            merge_claude_duplicate(
+                                &mut messages[existing_idx],
+                                &usage,
+                                parse_claude_entry_timestamp(entry.timestamp.as_deref()),
+                                pending_request_start_timestamp_ms,
+                            );
+                            if let Some(choice) = duplicate_provider_choice {
+                                update_claude_provider_id(
+                                    &mut messages[existing_idx].provider_id,
+                                    &mut provider_confidences[existing_idx],
+                                    choice,
+                                );
                             }
+                            continue;
+                        }
+                        Some(hash)
+                    }
+                    (Some(msg_id), None) => {
+                        let hash = format!("message:{}", msg_id);
+                        if let Some(&existing_idx) = processed_hashes.get(&hash) {
+                            merge_claude_duplicate(
+                                &mut messages[existing_idx],
+                                &usage,
+                                parse_claude_entry_timestamp(entry.timestamp.as_deref()),
+                                pending_request_start_timestamp_ms,
+                            );
                             if let Some(choice) = duplicate_provider_choice {
                                 update_claude_provider_id(
                                     &mut messages[existing_idx].provider_id,
@@ -457,11 +477,10 @@ pub fn parse_claude_file_with_cache(
                 );
                 let provider_confidence = provider_choice.confidence;
 
-                let timestamp = entry
-                    .timestamp
-                    .and_then(|ts| chrono::DateTime::parse_from_rfc3339(&ts).ok())
-                    .map(|dt| dt.timestamp_millis())
-                    .unwrap_or(fallback_timestamp);
+                let parsed_timestamp = parse_claude_entry_timestamp(entry.timestamp.as_deref());
+                let timestamp = parsed_timestamp.unwrap_or(fallback_timestamp);
+                let duration_ms =
+                    duration_between_ms(pending_request_start_timestamp_ms, parsed_timestamp);
 
                 // Insert dedup index only after all checks pass, right before push
                 let dedup_key = pending_hash.inspect(|hash| {
@@ -484,6 +503,7 @@ pub fn parse_claude_file_with_cache(
                     0.0,
                     dedup_key,
                 );
+                unified.duration_ms = duration_ms;
                 unified.agent = sidechain_agent.clone();
                 unified.set_workspace(workspace_key.clone(), workspace_label.clone());
                 // Mark the first assistant response after a user message as a turn start
@@ -543,6 +563,43 @@ fn claude_workspace_from_path(path: &Path) -> (Option<String>, Option<String>) {
     }
 
     (None, None)
+}
+
+fn parse_claude_entry_timestamp(timestamp: Option<&str>) -> Option<i64> {
+    timestamp
+        .and_then(|ts| chrono::DateTime::parse_from_rfc3339(ts).ok())
+        .map(|dt| dt.timestamp_millis())
+}
+
+fn duration_between_ms(start_ms: Option<i64>, end_ms: Option<i64>) -> Option<i64> {
+    let duration = end_ms?.saturating_sub(start_ms?);
+    (duration > 0).then_some(duration)
+}
+
+fn merge_claude_duplicate(
+    existing: &mut UnifiedMessage,
+    usage: &ClaudeUsage,
+    parsed_timestamp: Option<i64>,
+    request_start_timestamp_ms: Option<i64>,
+) {
+    // Per-field max merge: each token field is updated independently.
+    let t = &mut existing.tokens;
+    t.input = t.input.max(usage.input_tokens.unwrap_or(0).max(0));
+    t.output = t.output.max(usage.output_tokens.unwrap_or(0).max(0));
+    t.cache_read = t
+        .cache_read
+        .max(usage.cache_read_input_tokens.unwrap_or(0).max(0));
+    t.cache_write = t
+        .cache_write
+        .max(usage.cache_creation_input_tokens.unwrap_or(0).max(0));
+
+    if let Some(timestamp_ms) = parsed_timestamp {
+        if timestamp_ms >= existing.timestamp {
+            existing.set_timestamp(timestamp_ms);
+            existing.duration_ms =
+                duration_between_ms(request_start_timestamp_ms, parsed_timestamp);
+        }
+    }
 }
 
 #[derive(Default)]
@@ -1109,6 +1166,25 @@ mod tests {
             messages.len(),
             2,
             "Different requestId should not be deduplicated"
+        );
+    }
+
+    #[test]
+    fn test_deduplication_uses_message_id_without_request_id_and_keeps_final_duration() {
+        let content = r#"{"type":"user","timestamp":"2024-12-01T10:00:00.000Z","message":{"content":"Hello"}}
+{"type":"assistant","timestamp":"2024-12-01T10:00:01.000Z","message":{"id":"msg_stream","model":"claude-3-5-sonnet","usage":{"input_tokens":10,"output_tokens":25}}}
+{"type":"assistant","timestamp":"2024-12-01T10:00:03.500Z","message":{"id":"msg_stream","model":"claude-3-5-sonnet","usage":{"input_tokens":10,"output_tokens":250}}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.output, 250);
+        assert_eq!(messages[0].timestamp, 1_733_047_203_500);
+        assert_eq!(messages[0].duration_ms, Some(3500));
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some("message:msg_stream")
         );
     }
 

--- a/crates/tokscale-core/src/sessions/codex.rs
+++ b/crates/tokscale-core/src/sessions/codex.rs
@@ -153,6 +153,8 @@ impl CodexTotals {
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub(crate) struct CodexParseState {
     pub current_model: Option<String>,
+    #[serde(default)]
+    pub current_turn_start_ms: Option<i64>,
     pub previous_totals: Option<CodexTotals>,
     pub session_is_headless: bool,
     pub session_id_from_meta: Option<String>,
@@ -321,6 +323,8 @@ fn parse_codex_reader<R: BufRead>(
                 // Extract model from turn_context
                 if entry.entry_type == "turn_context" {
                     state.current_model = payload_model.clone();
+                    state.current_turn_start_ms =
+                        parse_codex_entry_timestamp(entry.timestamp.as_deref());
                     if let Some(model) = state.current_model.clone() {
                         flush_pending_model_messages(
                             &mut pending_model_messages,
@@ -428,11 +432,10 @@ fn parse_codex_reader<R: BufRead>(
 
                     state.previous_totals = next_totals;
 
-                    let parsed_timestamp = entry
-                        .timestamp
-                        .and_then(|ts| chrono::DateTime::parse_from_rfc3339(&ts).ok())
-                        .map(|dt| dt.timestamp_millis());
+                    let parsed_timestamp = parse_codex_entry_timestamp(entry.timestamp.as_deref());
                     let timestamp = parsed_timestamp.unwrap_or(fallback_timestamp);
+                    let duration_ms =
+                        duration_between_ms(state.current_turn_start_ms, parsed_timestamp);
 
                     let agent = if state.session_is_headless {
                         Some("headless".to_string())
@@ -452,6 +455,7 @@ fn parse_codex_reader<R: BufRead>(
                         0.0,
                         agent,
                     );
+                    message.duration_ms = duration_ms;
                     if parsed_timestamp.is_some() {
                         if let Some(model) = model.as_deref() {
                             set_codex_dedup_key(&mut message, model);
@@ -555,6 +559,17 @@ fn parse_codex_reader<R: BufRead>(
 
 fn codex_source_is_exec(source: Option<&Value>) -> bool {
     source.and_then(Value::as_str) == Some("exec")
+}
+
+fn parse_codex_entry_timestamp(timestamp: Option<&str>) -> Option<i64> {
+    timestamp
+        .and_then(|ts| chrono::DateTime::parse_from_rfc3339(ts).ok())
+        .map(|dt| dt.timestamp_millis())
+}
+
+fn duration_between_ms(start_ms: Option<i64>, end_ms: Option<i64>) -> Option<i64> {
+    let duration = end_ms?.saturating_sub(start_ms?);
+    (duration > 0).then_some(duration)
 }
 
 fn codex_token_count_dedup_key(message: &UnifiedMessage, model: &str) -> String {
@@ -1431,6 +1446,7 @@ mod tests {
 
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].model_id, "o3-pro");
+        assert_eq!(messages[0].duration_ms, Some(1000));
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/copilot.rs
+++ b/crates/tokscale-core/src/sessions/copilot.rs
@@ -94,6 +94,7 @@ struct CopilotUsageCandidate {
     provider_id: String,
     session_id: String,
     timestamp_ms: i64,
+    duration_ms: Option<i64>,
     tokens: TokenBreakdown,
     dedup_key: String,
 }
@@ -108,7 +109,7 @@ enum SessionIdPriority {
 
 impl CopilotUsageCandidate {
     fn into_message(self) -> UnifiedMessage {
-        UnifiedMessage::new_with_dedup(
+        let mut message = UnifiedMessage::new_with_dedup(
             "copilot",
             self.model,
             self.provider_id,
@@ -117,7 +118,9 @@ impl CopilotUsageCandidate {
             self.tokens,
             0.0,
             Some(self.dedup_key),
-        )
+        );
+        message.duration_ms = self.duration_ms;
+        message
     }
 }
 
@@ -272,6 +275,7 @@ fn candidate_from_attributes(
         .unwrap_or("unknown-session")
         .to_string();
     let timestamp_ms = timestamp_ms_from_record(record).unwrap_or(fallback_timestamp);
+    let duration_ms = duration_ms_from_record(record);
     let dedup_key = dedup_key_for_record(
         source,
         record,
@@ -290,6 +294,7 @@ fn candidate_from_attributes(
         provider_id,
         session_id,
         timestamp_ms,
+        duration_ms,
         tokens,
         dedup_key,
     })
@@ -602,6 +607,43 @@ fn timestamp_ms_from_record(value: &Value) -> Option<i64> {
         })
 }
 
+fn duration_ms_from_record(value: &Value) -> Option<i64> {
+    if let (Some(start_ms), Some(end_ms)) = (
+        value.get("startTime").and_then(timestamp_ms_from_value),
+        value.get("endTime").and_then(timestamp_ms_from_value),
+    ) {
+        let duration = end_ms.saturating_sub(start_ms);
+        if duration > 0 {
+            return Some(duration);
+        }
+    }
+
+    value.get("duration").and_then(duration_ms_from_value)
+}
+
+fn duration_ms_from_value(value: &Value) -> Option<i64> {
+    if let Some(parts) = value.as_array() {
+        let seconds = parts.first().and_then(value_as_i64)?;
+        let nanos = parts.get(1).and_then(value_as_i64).unwrap_or(0);
+        let duration = seconds.saturating_mul(1000).saturating_add(nanos / 1_000_000);
+        return (duration > 0).then_some(duration);
+    }
+
+    let duration = value
+        .as_f64()
+        .or_else(|| value.as_str().and_then(|value| value.parse::<f64>().ok()))?;
+    if !duration.is_finite() || duration <= 0.0 {
+        return None;
+    }
+
+    let duration_ms = if duration >= 1_000_000.0 {
+        (duration / 1_000_000.0) as i64
+    } else {
+        duration as i64
+    };
+    (duration_ms > 0).then_some(duration_ms)
+}
+
 fn timestamp_ms_from_value(value: &Value) -> Option<i64> {
     let parts = value.as_array()?;
     let seconds = parts.first().and_then(value_as_i64)?;
@@ -661,6 +703,7 @@ mod tests {
         assert_eq!(message.tokens.cache_read, 123);
         assert_eq!(message.tokens.reasoning, 128);
         assert_eq!(message.timestamp, 1_775_934_264_967);
+        assert_eq!(message.duration_ms, Some(4834));
         assert_eq!(message.dedup_key.as_deref(), Some("trace-1:span-1"));
     }
 

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -232,8 +232,10 @@ pub fn parse_kiro_file(path: &Path) -> Vec<UnifiedMessage> {
                 return None;
             }
 
+            let end_timestamp_ms = parse_timestamp_value(turn.end_timestamp.as_ref());
+            let duration_ms = duration_between_ms(prompt_timestamp_ms, end_timestamp_ms);
             let timestamp = prompt_timestamp_ms
-                .or_else(|| parse_timestamp_value(turn.end_timestamp.as_ref()))
+                .or(end_timestamp_ms)
                 .unwrap_or(fallback_timestamp);
 
             let mut message = UnifiedMessage::new_with_dedup(
@@ -253,6 +255,7 @@ pub fn parse_kiro_file(path: &Path) -> Vec<UnifiedMessage> {
                 Some(format!("{}:{}", session_id, index)),
             );
             message.message_count = turn.total_request_count.unwrap_or(1).max(1);
+            message.duration_ms = duration_ms;
             message.is_turn_start = true;
             message.set_workspace(workspace_key.clone(), workspace_label.clone());
             Some(message)
@@ -277,6 +280,11 @@ fn estimate_tokens(chars: usize) -> i64 {
 
 fn seconds_to_millis(seconds: f64) -> i64 {
     (seconds * 1000.0) as i64
+}
+
+fn duration_between_ms(start_ms: Option<i64>, end_ms: Option<i64>) -> Option<i64> {
+    let duration = end_ms?.saturating_sub(start_ms?);
+    (duration > 0).then_some(duration)
 }
 
 fn parse_timestamp_value(value: Option<&serde_json::Value>) -> Option<i64> {
@@ -394,6 +402,8 @@ pub fn parse_kiro_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
                 continue;
             }
 
+            let duration_ms =
+                duration_between_ms(meta.request_start_timestamp_ms, meta.stream_end_timestamp_ms);
             let timestamp = meta
                 .request_start_timestamp_ms
                 .or(meta.stream_end_timestamp_ms)
@@ -416,6 +426,7 @@ pub fn parse_kiro_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
                 Some(format!("{}:{}", conversation_id, index)),
             );
             message.message_count = 1;
+            message.duration_ms = duration_ms;
             message.is_turn_start = true;
             message.set_workspace(workspace_key.clone(), workspace_label.clone());
             messages.push(message);
@@ -485,6 +496,7 @@ mod tests {
         assert_eq!(messages[0].message_count, 2);
         assert!(messages[0].is_turn_start);
         assert_eq!(messages[0].timestamp, 1770983426420);
+        assert_eq!(messages[0].duration_ms, Some(580));
         assert_eq!(messages[0].workspace_key, Some("/tmp/project".to_string()));
         assert_eq!(messages[0].workspace_label, Some("project".to_string()));
     }
@@ -514,5 +526,45 @@ not valid json at all
 
         assert_eq!(messages.len(), 1);
         assert!(messages[0].tokens.input > 0 || messages[0].tokens.output > 0);
+    }
+
+    #[test]
+    fn test_parse_kiro_sqlite_sets_duration_from_request_metadata() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("data.sqlite3");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            "CREATE TABLE conversations_v2 (key TEXT, conversation_id TEXT, value TEXT)",
+            [],
+        )
+        .unwrap();
+        let value = r#"{
+            "model_info": {
+                "model_id": "claude-sonnet-4-5",
+                "context_window_tokens": 1000
+            },
+            "history": [{
+                "request_metadata": {
+                    "context_usage_percentage": 10,
+                    "response_size": 40,
+                    "request_start_timestamp_ms": 1770983426000,
+                    "stream_end_timestamp_ms": 1770983427500
+                }
+            }]
+        }"#;
+        conn.execute(
+            "INSERT INTO conversations_v2 (key, conversation_id, value) VALUES (?1, ?2, ?3)",
+            (&"/tmp/project", &"conv-1", &value),
+        )
+        .unwrap();
+        drop(conn);
+
+        let messages = parse_kiro_sqlite(&db_path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].timestamp, 1770983426000);
+        assert_eq!(messages[0].duration_ms, Some(1500));
+        assert_eq!(messages[0].tokens.input, 100);
+        assert_eq!(messages[0].tokens.output, 10);
     }
 }

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -43,6 +43,8 @@ pub struct UnifiedMessage {
     pub date: String,
     pub tokens: TokenBreakdown,
     pub cost: f64,
+    #[serde(default)]
+    pub duration_ms: Option<i64>,
     #[serde(default = "default_message_count")]
     pub message_count: i32,
     pub agent: Option<String>,
@@ -285,6 +287,7 @@ impl UnifiedMessage {
             date,
             tokens,
             cost,
+            duration_ms: None,
             message_count: default_message_count(),
             agent,
             dedup_key,

--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -129,6 +129,15 @@ fn merge_duplicate_workspace(
     }
 }
 
+fn opencode_duration_ms(time: &OpenCodeTime) -> Option<i64> {
+    let duration = time.completed? - time.created;
+    if duration.is_finite() && duration > 0.0 {
+        Some(duration as i64)
+    } else {
+        None
+    }
+}
+
 pub fn parse_opencode_file(path: &Path) -> Option<UnifiedMessage> {
     let data = read_file_or_none(path)?;
     let mut bytes = data;
@@ -174,6 +183,7 @@ pub fn parse_opencode_file(path: &Path) -> Option<UnifiedMessage> {
         msg.cost.unwrap_or(0.0).max(0.0),
         agent,
     );
+    unified.duration_ms = opencode_duration_ms(&msg.time);
     unified.dedup_key = dedup_key;
     set_workspace_from_root(&mut unified, workspace_root.as_deref());
     Some(unified)
@@ -297,6 +307,7 @@ pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             cost,
             agent,
         );
+        unified.duration_ms = opencode_duration_ms(&msg.time);
         unified.dedup_key = Some(dedup_key);
         let workspace_root = row_workspace_root
             .as_deref()
@@ -606,6 +617,33 @@ mod tests {
             Some("msg_dedup_001".to_string()),
             "dedup_key should use msg.id from JSON"
         );
+    }
+
+    #[test]
+    fn test_parse_opencode_file_sets_duration_from_completed_time() {
+        use std::io::Write;
+
+        let json = r#"{
+            "id": "msg_timed",
+            "sessionID": "ses_001",
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "cost": 0.01,
+            "tokens": {
+                "input": 100,
+                "output": 50,
+                "reasoning": 0,
+                "cache": { "read": 0, "write": 0 }
+            },
+            "time": { "created": 1700000000000.0, "completed": 1700000001234.0 }
+        }"#;
+
+        let mut temp_file = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+        temp_file.write_all(json.as_bytes()).unwrap();
+
+        let msg = parse_opencode_file(temp_file.path()).expect("Should parse");
+        assert_eq!(msg.duration_ms, Some(1234));
     }
 
     /// JSON dedup_key falls back to file stem when msg.id is absent


### PR DESCRIPTION
## Motivation

Tokscale already reports token volume and cost by model/provider, but those numbers do not show how fast each model actually responds. Comparing raw request duration is also misleading because requests vary a lot in token count.

This PR adds a normalized performance metric, `ms per 1K tokens`, so users can compare different providers and models on a common scale using the local usage data Tokscale already parses.

## What changed

- Adds `ModelPerformance` to model usage reports with:
  - `msPer1KTokens`
  - `totalDurationMs`
  - `timedTokens`
  - `sampleCount`
  - `tokenCoverage`
- Carries per-request `duration_ms` through unified parsed messages.
- Extracts request duration from supported local data sources:
  - Claude Code: user request timestamp to assistant usage timestamp, with streaming duplicate merge handling.
  - Codex: `turn_context` timestamp to `token_count` timestamp.
  - Copilot: chat span `startTime`/`endTime` or duration fields from telemetry records.
  - Kiro: prompt/request start timestamp to end/stream-end timestamp.
  - OpenCode: `time.completed - time.created`.
- Shows `ms/1K` in the `models` CLI table and includes `performance` in `models --json`.
- Persists performance data in TUI model cache data and bumps the cache schema so older caches refresh.

## Calculation

For each parsed message, Tokscale only records performance when both values are available and positive:

```text
messageTokens = input + output + cacheRead + cacheWrite + reasoning
durationMs = requestEndTime - requestStartTime
```

For each grouped model/provider/client entry:

```text
timedTokens += messageTokens
totalDurationMs += durationMs
sampleCount += 1
```

After aggregation:

```text
msPer1KTokens = totalDurationMs * 1000 / timedTokens
tokenCoverage = timedTokens / totalTokens
```

`tokenCoverage` indicates how much of the model's total token volume had usable timing data. If a model has tokens but no reliable duration samples, `msPer1KTokens` is `null` in JSON and rendered as an empty placeholder in tables.

Totals are computed from summed durations and summed timed tokens, not by averaging already-rounded per-model values. This keeps larger samples weighted correctly.

## Notes and limitations

- This measures observed local request wall time from client logs, not provider-side model inference latency.
- Missing or non-positive duration samples are ignored rather than treated as zero.
- The metric is best-effort because each client records timing data differently.
- Generated image/report rendering is intentionally unchanged in this PR.

## Testing

- `cargo test -p tokscale-core performance`
- `cargo test -p tokscale-cli --test cli_tests test_models_json_output`
- `cargo test -p tokscale-cli --bin tokscale tui::cache::tests`
- `cargo test --workspace --all-features` currently fails on 3 Cursor freshness tests that also fail on `main`:
  - `cursor::tests::test_cursor_usage_cache_is_fresh_requires_all_expected_account_files`
  - `cursor::tests::test_cursor_usage_cache_is_fresh_returns_true_for_recent_file`
  - `cursor::tests::test_freshness_gate_passes_when_active_fresh_and_marker_fresh_despite_stale_secondary`
- `cargo fmt --all -- --check` could not run because `cargo-fmt`/rustfmt is not installed for the local stable toolchain.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a normalized performance metric, ms per 1K tokens, so you can compare model speed across providers using local logs. Also fixes inflated Claude Code durations by clearing stale start times and preserving correct timing when merging streaming duplicates.

- New Features
  - `tokscale-core`
    - Added `ModelPerformance { msPer1KTokens, totalDurationMs, timedTokens, sampleCount, tokenCoverage }`.
    - `UnifiedMessage`/`ParsedMessage` now carry `duration_ms`.
    - Duration extraction from local sources:
      - Claude Code: user → assistant timing, with stream-chunk dedupe and correct duration carryover.
      - Codex: `turn_context` → `token_count`.
      - Copilot: `startTime`/`endTime` or numeric `duration`.
      - Kiro: request start → end/stream-end.
      - OpenCode: `time.completed - time.created`.
    - Aggregation computes `msPer1KTokens` from summed durations and timed tokens; ignores missing/non-positive samples; sets `tokenCoverage`.
  - `tokscale-cli`/TUI
    - Models tables add “ms/1K”; totals row shows the aggregated value.
    - `models --json` includes `performance`; TUI export JSON includes `performance`.

- Migration
  - TUI model cache schema bumped to v8; old caches auto-refresh.
  - JSON now includes `performance`; `msPer1KTokens` can be null when no timing data is available. Adjust downstream consumers.

<sup>Written for commit 61a89e25dacee3c6e809d749b11956277a4cbf2b. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/563?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

