### PR TITLE
feat(tui): open daily detail rows for selected date

### DIFF
--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -4,6 +4,7 @@ use std::rc::Rc;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
+use chrono::NaiveDate;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Rect;
 use tokscale_core::ClientId;
@@ -12,7 +13,9 @@ use crate::ClientFilter;
 
 use ratatui::style::Color;
 
-use super::data::{AgentUsage, DailyUsage, DataLoader, HourlyUsage, ModelUsage, UsageData};
+use super::data::{
+    AgentUsage, DailyUsage, DataLoader, HourlyUsage, ModelUsage, TokenBreakdown, UsageData,
+};
 use super::settings::Settings;
 use super::themes::{Theme, ThemeName};
 use super::ui::dialog::{ClientPickerDialog, DialogStack};
@@ -129,6 +132,17 @@ pub struct ClickArea {
     pub action: ClickAction,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct DailyDetailRow<'a> {
+    pub source: &'a str,
+    pub provider: &'a str,
+    pub model: &'a str,
+    pub color_key: &'a str,
+    pub tokens: &'a TokenBreakdown,
+    pub cost: f64,
+    pub messages: u64,
+}
+
 #[derive(Debug, Clone)]
 pub enum ClickAction {
     Tab(Tab),
@@ -160,6 +174,9 @@ pub struct App {
     pub scroll_offset: usize,
     pub selected_index: usize,
     pub max_visible_items: usize,
+    pub selected_daily_detail_date: Option<NaiveDate>,
+    daily_list_selected_index: usize,
+    daily_list_scroll_offset: usize,
 
     pub selected_graph_cell: Option<(usize, usize)>,
     pub stats_breakdown_total_lines: usize,
@@ -258,6 +275,9 @@ impl App {
             scroll_offset: 0,
             selected_index: 0,
             max_visible_items: 20,
+            selected_daily_detail_date: None,
+            daily_list_selected_index: 0,
+            daily_list_scroll_offset: 0,
             selected_graph_cell: None,
             stats_breakdown_total_lines: 0,
             auto_refresh,
@@ -468,8 +488,16 @@ impl App {
             KeyCode::Char('g') => {
                 self.open_group_by_picker();
             }
+            KeyCode::Enter if self.current_tab == Tab::Daily => {
+                self.open_selected_daily_detail();
+            }
             KeyCode::Enter if self.current_tab == Tab::Stats => {
                 self.handle_graph_selection();
+            }
+            KeyCode::Esc | KeyCode::Backspace
+                if self.current_tab == Tab::Daily && self.is_daily_detail_active() =>
+            {
+                self.close_daily_detail();
             }
             KeyCode::Esc if self.selected_graph_cell.is_some() => {
                 self.selected_graph_cell = None;
@@ -573,6 +601,9 @@ impl App {
     fn reset_selection(&mut self) {
         self.scroll_offset = 0;
         self.selected_index = 0;
+        self.selected_daily_detail_date = None;
+        self.daily_list_selected_index = 0;
+        self.daily_list_scroll_offset = 0;
         self.selected_graph_cell = None;
         self.stats_breakdown_total_lines = 0;
     }
@@ -581,6 +612,9 @@ impl App {
         self.persist_current_sort();
 
         self.current_tab = target;
+        if target != Tab::Daily {
+            self.selected_daily_detail_date = None;
+        }
 
         let (field, dir) = self
             .tab_sort_state
@@ -715,6 +749,9 @@ impl App {
         match self.current_tab {
             Tab::Overview | Tab::Models => self.data.models.len(),
             Tab::Agents => self.data.agents.len(),
+            Tab::Daily if self.is_daily_detail_active() => {
+                self.get_sorted_daily_detail_rows().len()
+            }
             Tab::Daily => self.data.daily.len(),
             Tab::Hourly => self.data.hourly.len(),
             Tab::Stats => {
@@ -738,7 +775,12 @@ impl App {
             self.sort_direction = SortDirection::Descending;
         }
         self.persist_current_sort();
-        self.reset_selection();
+        if self.current_tab == Tab::Daily && self.is_daily_detail_active() {
+            self.selected_index = 0;
+            self.scroll_offset = 0;
+        } else {
+            self.reset_selection();
+        }
         self.set_status(&format!(
             "Sorted by {:?} {:?}",
             self.sort_field, self.sort_direction
@@ -749,6 +791,7 @@ impl App {
         if self.current_tab != Tab::Daily {
             return;
         }
+        self.selected_daily_detail_date = None;
 
         let today = chrono::Local::now().date_naive();
         let (today_index, total_len) = {
@@ -836,6 +879,39 @@ impl App {
         self.dialog_stack.show(Box::new(dialog));
     }
 
+    fn open_selected_daily_detail(&mut self) {
+        if self.is_daily_detail_active() {
+            return;
+        }
+
+        let selected_date = {
+            let daily = self.get_sorted_daily();
+            daily.get(self.selected_index).map(|day| day.date)
+        };
+
+        if let Some(date) = selected_date {
+            self.daily_list_selected_index = self.selected_index;
+            self.daily_list_scroll_offset = self.scroll_offset;
+            self.selected_daily_detail_date = Some(date);
+            self.selected_index = 0;
+            self.scroll_offset = 0;
+            self.set_status(&format!("Viewing daily details for {}", date));
+            self.clamp_selection();
+        }
+    }
+
+    fn close_daily_detail(&mut self) {
+        if !self.is_daily_detail_active() {
+            return;
+        }
+
+        self.selected_daily_detail_date = None;
+        self.selected_index = self.daily_list_selected_index;
+        self.scroll_offset = self.daily_list_scroll_offset;
+        self.set_status("Returned to daily usage");
+        self.clamp_selection();
+    }
+
     fn toggle_auto_refresh(&mut self) {
         self.auto_refresh = !self.auto_refresh;
         self.settings.auto_refresh_enabled = self.auto_refresh;
@@ -893,6 +969,18 @@ impl App {
                 .get_sorted_agents()
                 .get(self.selected_index)
                 .map(|a| format!("{}: {} tokens, ${:.4}", a.agent, a.tokens.total(), a.cost)),
+            Tab::Daily if self.is_daily_detail_active() => self
+                .get_sorted_daily_detail_rows()
+                .get(self.selected_index)
+                .map(|row| {
+                    format!(
+                        "{} / {}: {} tokens, ${:.4}",
+                        row.source,
+                        row.model,
+                        row.tokens.total(),
+                        row.cost
+                    )
+                }),
             Tab::Daily => self
                 .get_sorted_daily()
                 .get(self.selected_index)
@@ -1048,6 +1136,73 @@ impl App {
         daily
     }
 
+    pub fn is_daily_detail_active(&self) -> bool {
+        self.selected_daily_detail_date.is_some()
+    }
+
+    pub fn daily_detail_date(&self) -> Option<NaiveDate> {
+        self.selected_daily_detail_date
+    }
+
+    pub fn get_sorted_daily_detail_rows(&self) -> Vec<DailyDetailRow<'_>> {
+        let Some(date) = self.selected_daily_detail_date else {
+            return Vec::new();
+        };
+        let Some(day) = self.data.daily.iter().find(|day| day.date == date) else {
+            return Vec::new();
+        };
+
+        let mut rows: Vec<DailyDetailRow<'_>> = day
+            .source_breakdown
+            .iter()
+            .flat_map(|(source, source_info)| {
+                source_info
+                    .models
+                    .values()
+                    .map(move |model_info| DailyDetailRow {
+                        source,
+                        provider: &model_info.provider,
+                        model: &model_info.display_name,
+                        color_key: &model_info.color_key,
+                        tokens: &model_info.tokens,
+                        cost: model_info.cost,
+                        messages: model_info.messages,
+                    })
+            })
+            .collect();
+
+        let tie_breaker = |a: &DailyDetailRow<'_>, b: &DailyDetailRow<'_>| {
+            a.source
+                .cmp(b.source)
+                .then_with(|| a.model.cmp(b.model))
+                .then_with(|| a.provider.cmp(b.provider))
+        };
+
+        match (self.sort_field, self.sort_direction) {
+            (SortField::Cost, SortDirection::Descending) => {
+                rows.sort_by(|a, b| b.cost.total_cmp(&a.cost).then_with(|| tie_breaker(a, b)))
+            }
+            (SortField::Cost, SortDirection::Ascending) => {
+                rows.sort_by(|a, b| a.cost.total_cmp(&b.cost).then_with(|| tie_breaker(a, b)))
+            }
+            (SortField::Tokens, SortDirection::Descending) => rows.sort_by(|a, b| {
+                b.tokens
+                    .total()
+                    .cmp(&a.tokens.total())
+                    .then_with(|| tie_breaker(a, b))
+            }),
+            (SortField::Tokens, SortDirection::Ascending) => rows.sort_by(|a, b| {
+                a.tokens
+                    .total()
+                    .cmp(&b.tokens.total())
+                    .then_with(|| tie_breaker(a, b))
+            }),
+            (SortField::Date, _) => rows.sort_by(tie_breaker),
+        }
+
+        rows
+    }
+
     pub fn get_sorted_hourly(&self) -> Vec<&HourlyUsage> {
         let mut hourly: Vec<&HourlyUsage> = self.data.hourly.iter().collect();
 
@@ -1096,7 +1251,9 @@ impl App {
 mod tests {
     use super::super::ui::widgets::get_provider_shade;
     use super::*;
-    use crate::tui::data::{ModelUsage, TokenBreakdown};
+    use crate::tui::data::{DailyModelInfo, DailySourceInfo, ModelUsage, TokenBreakdown};
+    use chrono::NaiveDate;
+    use std::collections::BTreeMap;
 
     #[test]
     fn test_tab_all() {
@@ -1411,6 +1568,57 @@ mod tests {
         app
     }
 
+    fn daily_usage(date: &str, cost: f64, models: Vec<(&str, &str, f64)>) -> DailyUsage {
+        let mut model_breakdown = BTreeMap::new();
+        let mut total_tokens = TokenBreakdown::default();
+        let mut total_cost = 0.0;
+
+        for (model, provider, model_cost) in models {
+            let tokens = TokenBreakdown {
+                input: (model_cost * 100.0) as u64,
+                output: 10,
+                cache_read: 5,
+                cache_write: 0,
+                reasoning: 0,
+            };
+            total_tokens.input = total_tokens.input.saturating_add(tokens.input);
+            total_tokens.output = total_tokens.output.saturating_add(tokens.output);
+            total_tokens.cache_read = total_tokens.cache_read.saturating_add(tokens.cache_read);
+            total_cost += model_cost;
+
+            model_breakdown.insert(
+                model.to_string(),
+                DailyModelInfo {
+                    provider: provider.to_string(),
+                    display_name: model.to_string(),
+                    color_key: model.to_string(),
+                    tokens,
+                    cost: model_cost,
+                    messages: 1,
+                },
+            );
+        }
+
+        let mut source_breakdown = BTreeMap::new();
+        source_breakdown.insert(
+            "claude".to_string(),
+            DailySourceInfo {
+                tokens: total_tokens.clone(),
+                cost: total_cost,
+                models: model_breakdown,
+            },
+        );
+
+        DailyUsage {
+            date: NaiveDate::parse_from_str(date, "%Y-%m-%d").unwrap(),
+            tokens: total_tokens,
+            cost: if cost > 0.0 { cost } else { total_cost },
+            source_breakdown,
+            message_count: 1,
+            turn_count: 1,
+        }
+    }
+
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
     }
@@ -1581,6 +1789,60 @@ mod tests {
         assert_eq!(app.selected_index, 0);
         assert_eq!(app.scroll_offset, 0);
         assert_eq!(app.selected_graph_cell, None);
+    }
+
+    #[test]
+    fn test_enter_on_daily_opens_selected_day_detail_rows() {
+        let mut app = make_app();
+        app.current_tab = Tab::Daily;
+        app.sort_field = SortField::Date;
+        app.sort_direction = SortDirection::Descending;
+        app.data.daily = vec![
+            daily_usage("2026-05-10", 1.0, vec![("old-model", "anthropic", 1.0)]),
+            daily_usage(
+                "2026-05-17",
+                7.0,
+                vec![("target-a", "openai", 5.0), ("target-b", "anthropic", 2.0)],
+            ),
+            daily_usage("2026-05-18", 3.0, vec![("other-model", "google", 3.0)]),
+        ];
+
+        app.selected_index = 0;
+        app.handle_key_event(key(KeyCode::Down));
+        app.handle_key_event(key(KeyCode::Enter));
+
+        assert_eq!(app.get_current_list_len(), 2);
+    }
+
+    #[test]
+    fn test_esc_from_daily_detail_restores_daily_selection() {
+        let mut app = make_app();
+        app.current_tab = Tab::Daily;
+        app.sort_field = SortField::Date;
+        app.sort_direction = SortDirection::Descending;
+        app.data.daily = vec![
+            daily_usage("2026-05-10", 1.0, vec![("old-model", "anthropic", 1.0)]),
+            daily_usage(
+                "2026-05-17",
+                7.0,
+                vec![("target-a", "openai", 5.0), ("target-b", "anthropic", 2.0)],
+            ),
+            daily_usage("2026-05-18", 3.0, vec![("other-model", "google", 3.0)]),
+        ];
+
+        app.max_visible_items = 2;
+        app.selected_index = 1;
+        app.scroll_offset = 1;
+        app.handle_key_event(key(KeyCode::Enter));
+        app.handle_key_event(key(KeyCode::Down));
+        assert_eq!(app.selected_index, 1);
+
+        app.handle_key_event(key(KeyCode::Esc));
+
+        assert_eq!(app.current_tab, Tab::Daily);
+        assert_eq!(app.selected_index, 1);
+        assert_eq!(app.scroll_offset, 1);
+        assert_eq!(app.get_current_list_len(), 3);
     }
 
     // ── handle_key_event: sort ──────────────────────────────────────

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -313,6 +313,18 @@ impl App {
         self.data = data;
         self.last_refresh = Instant::now();
         self.build_model_shade_map();
+
+        // Exit Daily-detail mode if the refresh dropped the day we were
+        // viewing; otherwise `get_sorted_daily_detail_rows()` would return
+        // empty while the user is still nominally in detail mode.
+        if let Some(date) = self.selected_daily_detail_date {
+            if !self.data.daily.iter().any(|day| day.date == date) {
+                self.selected_daily_detail_date = None;
+                self.selected_index = self.daily_list_selected_index;
+                self.scroll_offset = self.daily_list_scroll_offset;
+            }
+        }
+
         self.clamp_selection();
     }
 
@@ -901,13 +913,31 @@ impl App {
     }
 
     fn close_daily_detail(&mut self) {
-        if !self.is_daily_detail_active() {
+        let Some(detail_date) = self.selected_daily_detail_date else {
             return;
-        }
+        };
 
         self.selected_daily_detail_date = None;
-        self.selected_index = self.daily_list_selected_index;
-        self.scroll_offset = self.daily_list_scroll_offset;
+
+        // Re-anchor by date so a sort change inside detail mode still
+        // restores the same day rather than the stale list index.
+        let restored_index = self
+            .get_sorted_daily()
+            .iter()
+            .position(|day| day.date == detail_date)
+            .unwrap_or(self.daily_list_selected_index);
+
+        self.selected_index = restored_index;
+
+        let max_visible = self.max_visible_items.max(1);
+        let viewport_still_holds = restored_index >= self.daily_list_scroll_offset
+            && restored_index < self.daily_list_scroll_offset + max_visible;
+        self.scroll_offset = if viewport_still_holds {
+            self.daily_list_scroll_offset
+        } else {
+            restored_index.saturating_sub(max_visible / 2)
+        };
+
         self.set_status("Returned to daily usage");
         self.clamp_selection();
     }
@@ -1843,6 +1873,113 @@ mod tests {
         assert_eq!(app.selected_index, 1);
         assert_eq!(app.scroll_offset, 1);
         assert_eq!(app.get_current_list_len(), 3);
+    }
+
+    #[test]
+    fn test_close_daily_detail_reanchors_selection_by_date_after_sort_change() {
+        let mut app = make_app();
+        app.current_tab = Tab::Daily;
+        app.sort_field = SortField::Date;
+        app.sort_direction = SortDirection::Descending;
+        app.data.daily = vec![
+            daily_usage("2026-05-10", 1.0, vec![("old-model", "anthropic", 1.0)]),
+            daily_usage(
+                "2026-05-17",
+                7.0,
+                vec![("target-a", "openai", 5.0), ("target-b", "anthropic", 2.0)],
+            ),
+            daily_usage("2026-05-18", 3.0, vec![("other-model", "google", 3.0)]),
+        ];
+
+        app.selected_index = 1;
+        let target_date = app.get_sorted_daily()[app.selected_index].date;
+
+        app.handle_key_event(key(KeyCode::Enter));
+        assert!(app.is_daily_detail_active());
+        assert_eq!(app.daily_detail_date(), Some(target_date));
+
+        app.handle_key_event(key(KeyCode::Char('c')));
+        assert_eq!(app.sort_field, SortField::Cost);
+
+        app.handle_key_event(key(KeyCode::Esc));
+
+        assert!(!app.is_daily_detail_active());
+        let restored_index = app.selected_index;
+        let restored_date = app.get_sorted_daily()[restored_index].date;
+        assert_eq!(
+            restored_date, target_date,
+            "Closing detail after sort change should re-anchor on the original date"
+        );
+    }
+
+    #[test]
+    fn test_update_data_exits_daily_detail_when_date_disappears() {
+        let mut app = make_app();
+        app.current_tab = Tab::Daily;
+        app.sort_field = SortField::Date;
+        app.sort_direction = SortDirection::Descending;
+        app.data.daily = vec![
+            daily_usage("2026-05-10", 1.0, vec![("old-model", "anthropic", 1.0)]),
+            daily_usage(
+                "2026-05-17",
+                7.0,
+                vec![("target-a", "openai", 5.0), ("target-b", "anthropic", 2.0)],
+            ),
+            daily_usage("2026-05-18", 3.0, vec![("other-model", "google", 3.0)]),
+        ];
+
+        app.selected_index = 1;
+        app.handle_key_event(key(KeyCode::Enter));
+        assert!(app.is_daily_detail_active());
+
+        let mut refreshed = UsageData::default();
+        refreshed.daily = vec![
+            daily_usage("2026-05-10", 1.0, vec![("old-model", "anthropic", 1.0)]),
+            daily_usage("2026-05-18", 3.0, vec![("other-model", "google", 3.0)]),
+        ];
+        app.update_data(refreshed);
+
+        assert!(
+            !app.is_daily_detail_active(),
+            "update_data should drop detail mode when the selected date is gone"
+        );
+        assert_eq!(app.daily_detail_date(), None);
+        assert!(app.get_sorted_daily_detail_rows().is_empty());
+    }
+
+    #[test]
+    fn test_update_data_keeps_daily_detail_when_date_still_present() {
+        let mut app = make_app();
+        app.current_tab = Tab::Daily;
+        app.sort_field = SortField::Date;
+        app.sort_direction = SortDirection::Descending;
+        app.data.daily = vec![
+            daily_usage("2026-05-10", 1.0, vec![("old-model", "anthropic", 1.0)]),
+            daily_usage(
+                "2026-05-17",
+                7.0,
+                vec![("target-a", "openai", 5.0), ("target-b", "anthropic", 2.0)],
+            ),
+        ];
+
+        app.selected_index = 1;
+        let target_date = app.get_sorted_daily()[app.selected_index].date;
+        app.handle_key_event(key(KeyCode::Enter));
+        assert!(app.is_daily_detail_active());
+
+        let mut refreshed = UsageData::default();
+        refreshed.daily = vec![
+            daily_usage("2026-05-10", 1.0, vec![("old-model", "anthropic", 1.0)]),
+            daily_usage(
+                "2026-05-17",
+                9.0,
+                vec![("target-a", "openai", 7.0), ("target-b", "anthropic", 2.0)],
+            ),
+        ];
+        app.update_data(refreshed);
+
+        assert!(app.is_daily_detail_active());
+        assert_eq!(app.daily_detail_date(), Some(target_date));
     }
 
     // ── handle_key_event: sort ──────────────────────────────────────

--- a/crates/tokscale-cli/src/tui/ui/daily.rs
+++ b/crates/tokscale-cli/src/tui/ui/daily.rs
@@ -4,10 +4,18 @@ use ratatui::widgets::{
     Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, ScrollbarState, Table,
 };
 
-use super::widgets::{format_cache_hit_rate, format_cost, format_tokens};
+use super::widgets::{
+    format_cache_hit_rate, format_cost, format_tokens, get_client_display_name,
+    get_provider_display_name,
+};
 use crate::tui::app::{App, SortDirection, SortField};
 
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
+    if app.is_daily_detail_active() {
+        render_detail(frame, app, area);
+        return;
+    }
+
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(app.theme.border))
@@ -274,5 +282,242 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             }),
             &mut scrollbar_state,
         );
+    }
+}
+
+fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
+    let title = app
+        .daily_detail_date()
+        .map(|date| format!(" Daily Detail: {} ", date))
+        .unwrap_or_else(|| " Daily Detail ".to_string());
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(app.theme.border))
+        .title(Span::styled(
+            title,
+            Style::default()
+                .fg(app.theme.accent)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .style(Style::default().bg(app.theme.background));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let visible_height = inner.height.saturating_sub(1) as usize;
+    app.set_max_visible_items(visible_height);
+
+    let rows_data = app.get_sorted_daily_detail_rows();
+    if rows_data.is_empty() {
+        let empty_msg =
+            Paragraph::new("No model details found for this day. Press Esc to go back.")
+                .style(Style::default().fg(app.theme.muted))
+                .alignment(Alignment::Center);
+        frame.render_widget(empty_msg, inner);
+        return;
+    }
+
+    let is_narrow = app.is_narrow();
+    let is_very_narrow = app.is_very_narrow();
+    let sort_field = app.sort_field;
+    let sort_direction = app.sort_direction;
+    let scroll_offset = app.scroll_offset;
+    let selected_index = app.selected_index;
+    let theme_accent = app.theme.accent;
+    let theme_muted = app.theme.muted;
+    let theme_selection = app.theme.selection;
+
+    let header_cells = if is_very_narrow {
+        vec!["Model", "Cost"]
+    } else if is_narrow {
+        vec!["Model", "Source", "Msgs", "Tokens", "Cost"]
+    } else {
+        vec![
+            "#", "Model", "Provider", "Source", "Msgs", "Input", "Output", "Cache R", "Cache W",
+            "Cache×", "Total", "Cost",
+        ]
+    };
+
+    let sort_indicator = |field: SortField| -> &'static str {
+        if sort_field == field {
+            match sort_direction {
+                SortDirection::Ascending => " ▲",
+                SortDirection::Descending => " ▼",
+            }
+        } else {
+            ""
+        }
+    };
+
+    let header = Row::new(
+        header_cells
+            .iter()
+            .enumerate()
+            .map(|(i, h)| {
+                let indicator = match (i, is_narrow, is_very_narrow) {
+                    (10, false, false) => sort_indicator(SortField::Tokens),
+                    (11, false, false) => sort_indicator(SortField::Cost),
+                    (3, true, false) => sort_indicator(SortField::Tokens),
+                    (4, true, false) => sort_indicator(SortField::Cost),
+                    (1, _, true) => sort_indicator(SortField::Cost),
+                    _ => "",
+                };
+                Cell::from(format!("{}{}", h, indicator))
+            })
+            .collect::<Vec<_>>(),
+    )
+    .style(
+        Style::default()
+            .fg(theme_accent)
+            .add_modifier(Modifier::BOLD),
+    )
+    .height(1);
+
+    let detail_len = rows_data.len();
+    let start = scroll_offset.min(detail_len);
+    let end = (start + visible_height).min(detail_len);
+
+    if start >= detail_len {
+        return;
+    }
+
+    let rows: Vec<Row> = rows_data[start..end]
+        .iter()
+        .enumerate()
+        .map(|(i, row)| {
+            let idx = i + start;
+            let is_selected = idx == selected_index;
+            let is_striped = idx % 2 == 1;
+            let model_color = app.model_color_for(row.provider, row.color_key);
+
+            let cells: Vec<Cell> = if is_very_narrow {
+                vec![
+                    Cell::from(truncate(row.model, 18)).style(
+                        Style::default()
+                            .fg(model_color)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Cell::from(format_cost(row.cost)).style(Style::default().fg(Color::Green)),
+                ]
+            } else if is_narrow {
+                vec![
+                    Cell::from(truncate(row.model, 24)).style(
+                        Style::default()
+                            .fg(model_color)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Cell::from(get_client_display_name(row.source))
+                        .style(Style::default().fg(theme_muted)),
+                    Cell::from(row.messages.to_string()),
+                    Cell::from(format_tokens(row.tokens.total())),
+                    Cell::from(format_cost(row.cost)).style(Style::default().fg(Color::Green)),
+                ]
+            } else {
+                vec![
+                    Cell::from(format!("{}", idx + 1)).style(Style::default().fg(theme_muted)),
+                    Cell::from(truncate(row.model, 30)).style(
+                        Style::default()
+                            .fg(model_color)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Cell::from(get_provider_display_name(row.provider)),
+                    Cell::from(get_client_display_name(row.source))
+                        .style(Style::default().fg(theme_muted)),
+                    Cell::from(row.messages.to_string()),
+                    Cell::from(format_tokens(row.tokens.input))
+                        .style(Style::default().fg(Color::Rgb(100, 200, 100))),
+                    Cell::from(format_tokens(row.tokens.output))
+                        .style(Style::default().fg(Color::Rgb(200, 100, 100))),
+                    Cell::from(format_tokens(row.tokens.cache_read))
+                        .style(Style::default().fg(Color::Rgb(100, 150, 200))),
+                    Cell::from(format_tokens(row.tokens.cache_write))
+                        .style(Style::default().fg(Color::Rgb(200, 150, 100))),
+                    Cell::from(format_cache_hit_rate(
+                        row.tokens.cache_read,
+                        row.tokens.input,
+                        row.tokens.cache_write,
+                    ))
+                    .style(Style::default().fg(Color::Cyan)),
+                    Cell::from(format_tokens(row.tokens.total())),
+                    Cell::from(format_cost(row.cost)).style(Style::default().fg(Color::Green)),
+                ]
+            };
+
+            let row_style = if is_selected {
+                Style::default().bg(theme_selection)
+            } else if is_striped {
+                Style::default().bg(Color::Rgb(20, 24, 30))
+            } else {
+                Style::default()
+            };
+
+            Row::new(cells).style(row_style).height(1)
+        })
+        .collect();
+
+    let widths = if is_very_narrow {
+        vec![Constraint::Percentage(70), Constraint::Percentage(30)]
+    } else if is_narrow {
+        vec![
+            Constraint::Percentage(42),
+            Constraint::Percentage(18),
+            Constraint::Percentage(12),
+            Constraint::Percentage(15),
+            Constraint::Percentage(13),
+        ]
+    } else {
+        vec![
+            Constraint::Length(3),
+            Constraint::Min(20),
+            Constraint::Length(16),
+            Constraint::Length(14),
+            Constraint::Length(6),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(8),
+            Constraint::Length(10),
+            Constraint::Length(10),
+        ]
+    };
+
+    let table = Table::new(rows, widths)
+        .header(header)
+        .row_highlight_style(Style::default().bg(theme_selection));
+
+    frame.render_widget(table, inner);
+
+    if detail_len > visible_height {
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(Some("▲"))
+            .end_symbol(Some("▼"));
+
+        let mut scrollbar_state = ScrollbarState::new(detail_len).position(scroll_offset);
+
+        frame.render_stateful_widget(
+            scrollbar,
+            area.inner(Margin {
+                horizontal: 0,
+                vertical: 1,
+            }),
+            &mut scrollbar_state,
+        );
+    }
+}
+
+fn truncate(s: &str, max_chars: usize) -> String {
+    if max_chars == 0 {
+        return String::new();
+    }
+    let char_count = s.chars().count();
+    if char_count <= max_chars {
+        s.to_string()
+    } else if max_chars <= 3 {
+        s.chars().take(max_chars).collect()
+    } else {
+        let head: String = s.chars().take(max_chars - 3).collect();
+        format!("{}...", head)
     }
 }

--- a/crates/tokscale-cli/src/tui/ui/footer.rs
+++ b/crates/tokscale-cli/src/tui/ui/footer.rs
@@ -152,6 +152,9 @@ fn current_count_label(app: &App) -> String {
     match app.current_tab {
         Tab::Overview | Tab::Models => format!(" ({} models)", app.data.models.len()),
         Tab::Agents => format!(" ({} agents)", app.data.agents.len()),
+        Tab::Daily if app.is_daily_detail_active() => {
+            format!(" ({} models)", app.get_sorted_daily_detail_rows().len())
+        }
         Tab::Daily => format!(" ({} days)", app.data.daily.len()),
         Tab::Hourly => format!(" ({} hours)", app.data.hourly.len()),
         Tab::Stats => String::new(),
@@ -181,7 +184,13 @@ fn render_help_row(frame: &mut Frame, app: &App, area: Rect) {
         ];
         if app.current_tab == Tab::Daily {
             spans.push(Span::styled("·", Style::default().fg(app.theme.muted)));
-            spans.push(Span::styled("j", Style::default().fg(Color::Yellow)));
+            if app.is_daily_detail_active() {
+                spans.push(Span::styled("esc", Style::default().fg(Color::Yellow)));
+            } else {
+                spans.push(Span::styled("↵", Style::default().fg(Color::Yellow)));
+                spans.push(Span::styled("·", Style::default().fg(app.theme.muted)));
+                spans.push(Span::styled("j", Style::default().fg(Color::Yellow)));
+            }
         }
         if app.current_tab == Tab::Hourly {
             spans.push(Span::styled("·", Style::default().fg(app.theme.muted)));
@@ -198,10 +207,22 @@ fn render_help_row(frame: &mut Frame, app: &App, area: Rect) {
             Span::styled(" • ", Style::default().fg(app.theme.muted)),
         ];
         if app.current_tab == Tab::Daily {
-            spans.push(Span::styled(
-                "[j:today]",
-                Style::default().fg(Color::Yellow),
-            ));
+            if app.is_daily_detail_active() {
+                spans.push(Span::styled(
+                    "[esc:back]",
+                    Style::default().fg(Color::Yellow),
+                ));
+            } else {
+                spans.push(Span::styled(
+                    "[enter:details]",
+                    Style::default().fg(Color::Yellow),
+                ));
+                spans.push(Span::styled(" ", Style::default()));
+                spans.push(Span::styled(
+                    "[j:today]",
+                    Style::default().fg(Color::Yellow),
+                ));
+            }
             spans.push(Span::styled(" • ", Style::default().fg(app.theme.muted)));
         }
         if app.current_tab == Tab::Hourly {


### PR DESCRIPTION
## Summary
- Adds an Enter-driven detail view for the selected date in the Daily tab.
- Renders selected-day usage with model-style detail rows for client/provider/model/workspace breakdowns.
- Updates Esc handling and footer hints so users can return cleanly from the detail view.

## Test Plan
- [x] `cargo test` from `crates/tokscale-cli`
- [x] `cargo fmt --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Daily detail view with per-source/provider/model breakdown; Enter opens, Esc/Backspace returns. Closing detail now restores the same day after sort changes, and refresh exits detail if the day disappears.

- **New Features**
  - Enter opens model detail rows for the selected day; columns adapt to narrow/very narrow layouts, with sort indicators for tokens/cost.
  - Sorting in detail view respects tokens/cost; selection and scroll are preserved when entering/exiting.
  - Footer updates with "enter:details" or "esc:back", and the right-side count shows models in the detail view.

- **Bug Fixes**
  - Closing detail re-anchors the Daily list by date, keeping the same day highlighted after sort changes; viewport preserved when possible.
  - Auto-refresh exits detail mode if the selected date is removed to avoid a stuck empty view.

<sup>Written for commit e6cf3d898ffb5f86347a03131d1b65c45b09b45e. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/564?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

