### PR TITLE
fix(tui): preserve minutely aggregation in background loads

### DIFF
--- a/crates/tokscale-cli/src/tui/mod.rs
+++ b/crates/tokscale-cli/src/tui/mod.rs
@@ -51,6 +51,15 @@ fn decide_initial_data(load_result: CacheResult) -> (Option<UsageData>, bool) {
     (cached_data, true)
 }
 
+fn background_data_loader(
+    since: Option<String>,
+    until: Option<String>,
+    year: Option<String>,
+    minutely_enabled: bool,
+) -> DataLoader {
+    DataLoader::with_filters(None, since, until, year).with_minutely_enabled(minutely_enabled)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn run(
     theme: &str,
@@ -153,9 +162,10 @@ pub fn run(
         let bg_year = year.clone();
         let bg_enabled_clients = enabled_clients.clone();
         let bg_group_by = app.group_by.borrow().clone();
+        let bg_minutely_enabled = app.settings.minutely_tab_enabled;
 
         thread::spawn(move || {
-            let loader = DataLoader::with_filters(None, bg_since, bg_until, bg_year);
+            let loader = background_data_loader(bg_since, bg_until, bg_year, bg_minutely_enabled);
             let result = loader.load(&bg_clients, &bg_group_by, bg_include_synthetic);
 
             if let Ok(ref data) = result {
@@ -270,9 +280,10 @@ fn run_loop_with_background(
             let year = app.data_loader.year.clone();
             let enabled_clients = app.enabled_clients.borrow().clone();
             let group_by = app.group_by.borrow().clone();
+            let minutely_enabled = app.settings.minutely_tab_enabled;
 
             thread::spawn(move || {
-                let loader = DataLoader::with_filters(None, since, until, year);
+                let loader = background_data_loader(since, until, year, minutely_enabled);
                 let result = loader.load(&clients, &group_by, include_synthetic);
                 if let Ok(ref data) = result {
                     save_cached_data(data, &enabled_clients, &group_by);
@@ -371,5 +382,14 @@ mod tests {
 
         assert!(cached_data.is_none());
         assert!(needs_background_load);
+    }
+
+    #[test]
+    fn background_loader_preserves_minutely_toggle() {
+        let enabled = background_data_loader(None, None, None, true);
+        assert!(enabled.minutely_enabled);
+
+        let disabled = background_data_loader(None, None, None, false);
+        assert!(!disabled.minutely_enabled);
     }
 }


### PR DESCRIPTION
## Summary
* Preserve `minutelyTabEnabled` when the TUI spawns background data loaders after a stale cache load or manual refresh.
* Add a focused unit test to cover the enabled and disabled minutely aggregation states for the background loader path.

## Testing
* `cargo test -p tokscale-cli background_loader_preserves_minutely_toggle`
* `cargo fmt -- --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the minutely aggregation toggle in background loads, so the TUI shows correct minutely data after stale cache loads and manual refreshes.

- **Bug Fixes**
  - Background loaders now respect the `minutely_tab_enabled` setting.
  - Added a unit test covering both enabled and disabled states for this path.

<sup>Written for commit d0d17cc5f57c88224e204fc8ecc30d11088c432e. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/570?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

