### PR TITLE
fix(tui): align tab mouse hitboxes with rendered labels

### DIFF
--- a/crates/tokscale-cli/src/tui/ui/header.rs
+++ b/crates/tokscale-cli/src/tui/ui/header.rs
@@ -3,6 +3,10 @@ use ratatui::widgets::{Block, Borders, Tabs};
 
 use crate::tui::app::{App, ClickAction, Tab};
 
+const TAB_PADDING_LEFT_WIDTH: u16 = 1;
+const TAB_PADDING_RIGHT_WIDTH: u16 = 1;
+const TAB_DIVIDER_WIDTH: u16 = 3;
+
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let is_very_narrow = app.is_very_narrow();
 
@@ -15,11 +19,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let titles: Vec<Line> = visible_tabs
         .iter()
         .map(|t| {
-            let name = if is_very_narrow {
-                t.short_name()
-            } else {
-                t.as_str()
-            };
+            let name = tab_label(*t, is_very_narrow);
             let style = if *t == app.current_tab {
                 Style::default()
                     .fg(app.theme.accent)
@@ -76,25 +76,118 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
 }
 
 fn register_tab_click_areas(app: &mut App, area: Rect) {
+    if area.width <= 2 || area.height <= 2 {
+        return;
+    }
+
     let is_very_narrow = app.is_very_narrow();
-    let inner_x = area.x + 12;
-    let y = area.y + 1;
-    let mut x = inner_x;
+    let y = area.y.saturating_add(1);
+    let right = area.right().saturating_sub(1);
+    let mut x = area.x.saturating_add(1);
 
     let visible_tabs: Vec<Tab> = Tab::all()
         .iter()
         .copied()
         .filter(|t| app.is_tab_visible(*t))
         .collect();
+    let tab_count = visible_tabs.len();
 
-    for tab in visible_tabs {
-        let name_len = if is_very_narrow {
-            tab.short_name().len()
-        } else {
-            tab.as_str().len()
+    for (index, tab) in visible_tabs.into_iter().enumerate() {
+        let remaining_width = right.saturating_sub(x);
+        if remaining_width == 0 {
+            break;
+        }
+
+        let left_padding_width = TAB_PADDING_LEFT_WIDTH.min(remaining_width);
+        let remaining_width = remaining_width.saturating_sub(left_padding_width);
+        let title_width = tab_label_width(tab, is_very_narrow).min(remaining_width);
+        let remaining_width = remaining_width.saturating_sub(title_width);
+        let right_padding_width = TAB_PADDING_RIGHT_WIDTH.min(remaining_width);
+        let click_width = left_padding_width + title_width + right_padding_width;
+
+        app.add_click_area(Rect::new(x, y, click_width, 1), ClickAction::Tab(tab));
+        x = x.saturating_add(click_width);
+
+        let remaining_width = right.saturating_sub(x);
+        if remaining_width == 0 || index + 1 == tab_count {
+            break;
+        }
+
+        x = x.saturating_add(TAB_DIVIDER_WIDTH.min(remaining_width));
+    }
+}
+
+fn tab_label(tab: Tab, is_very_narrow: bool) -> &'static str {
+    if is_very_narrow {
+        tab.short_name()
+    } else {
+        tab.as_str()
+    }
+}
+
+fn tab_label_width(tab: Tab, is_very_narrow: bool) -> u16 {
+    Line::from(tab_label(tab, is_very_narrow)).width() as u16
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+    use ratatui::{backend::TestBackend, Terminal};
+
+    use crate::tui::app::TuiConfig;
+
+    fn make_app(width: u16) -> App {
+        let config = TuiConfig {
+            theme: "blue".to_string(),
+            refresh: 0,
+            sessions_path: None,
+            clients: None,
+            since: None,
+            until: None,
+            year: None,
+            initial_tab: None,
         };
-        let width = name_len as u16 + 3;
-        app.add_click_area(Rect::new(x, y, width, 1), ClickAction::Tab(tab));
-        x += width;
+        let mut app = App::new_with_cached_data(config, None).unwrap();
+        app.terminal_width = width;
+        app
+    }
+
+    fn render_header(app: &mut App, width: u16) {
+        let backend = TestBackend::new(width, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render(frame, app, Rect::new(0, 0, width, 3)))
+            .unwrap();
+    }
+
+    fn click_header(app: &mut App, column: u16) {
+        app.handle_mouse_event(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column,
+            row: 1,
+            modifiers: KeyModifiers::NONE,
+        });
+    }
+
+    #[test]
+    fn daily_label_click_uses_rendered_normal_tab_position() {
+        let mut app = make_app(80);
+
+        render_header(&mut app, 80);
+        click_header(&mut app, 26);
+
+        assert_eq!(app.current_tab, Tab::Daily);
+    }
+
+    #[test]
+    fn daily_short_label_click_uses_rendered_very_narrow_tab_position() {
+        let mut app = make_app(59);
+
+        render_header(&mut app, 59);
+        click_header(&mut app, 18);
+
+        assert_eq!(app.current_tab, Tab::Daily);
     }
 }


### PR DESCRIPTION
## Summary

Fixes a TUI tab mouse hitbox alignment bug where clicking directly on the visible `Daily` tab label could activate the tab to its left, requiring users to click farther right than the rendered label.

The header previously rebuilt tab click areas with a hard-coded horizontal offset (`area.x + 12`) while Ratatui renders `Tabs` inside the bordered block's inner area. The registered mouse hitboxes now follow the same geometry as the rendered tab strip: block inner area, left/right tab padding, rendered label width, and the custom `" │ "` divider.

## Changes

- Replaced the hard-coded tab click-area start offset with Ratatui-aligned tab geometry.
- Reused a single tab-label helper for rendered labels and hitbox width calculation.
- Added regression coverage for clicking the rendered `Daily` label in the normal tab layout.
- Added regression coverage for clicking the rendered `Day` short label in the very-narrow tab layout.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo check -p tokscale-cli`
- [x] `cargo test -p tokscale-cli daily_label_click_uses_rendered_normal_tab_position`
- [x] `cargo test -p tokscale-cli daily_short_label_click_uses_rendered_very_narrow_tab_position`
- [x] `cargo test -p tokscale-cli`
- [x] `git diff --check`

## Manual QA

- [x] Ran `cargo run -p tokscale-cli -- tui`
- [x] Clicked directly on the visible `Daily` tab label and confirmed it switches to Daily without needing to click to the right of the label.

## CI Notes

This touches `crates/tokscale-cli/**`, so the native CLI build workflow is expected to run. The broader Rust CI may also run workspace formatting, clippy, and tests.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TUI tab hitboxes so clicking directly on a label selects the correct tab. Click areas now match the rendered `ratatui` `Tabs` geometry, removing the rightward offset.

- **Bug Fixes**
  - Compute click areas from the block’s inner area, label width, left/right padding, and the " │ " divider.
  - Reuse one tab-label helper for rendering and hitbox width.
  - Add regression tests for normal and very narrow layouts (clicking "Daily").

<sup>Written for commit 059b2162d5faccb61c5c51f747b4d71b89b1751b. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/573?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

