### PR TITLE
fix(cli): avoid stale PATH launcher fallback

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -169,21 +169,6 @@ function isSelfReference(p: string): boolean {
 let binary = searchPaths.find((p) => existsSync(p) && !isSelfReference(p));
 
 if (!binary) {
-  try {
-    const whichCmd = process.platform === "win32" ? "where" : "which";
-    const found = execSync(`${whichCmd} ${binaryName}`, {
-      encoding: "utf-8",
-      stdio: ["pipe", "pipe", "pipe"],
-    })
-      .trim()
-      .split("\n")[0];
-    if (found && existsSync(found) && !isSelfReference(found)) {
-      binary = found;
-    }
-  } catch {}
-}
-
-if (!binary) {
   console.error("Error: tokscale binary not found");
   console.error("Build from source: cargo build --release -p tokscale-cli");
   if (targetPackage) {

--- a/scripts/test-package-launchers.sh
+++ b/scripts/test-package-launchers.sh
@@ -17,6 +17,7 @@ fi
 BUN_BIN="${BUN_BIN:-$(command -v bun)}"
 NODE_BIN="${NODE_BIN:-$(command -v node)}"
 LDD_BIN="${LDD_BIN:-$(command -v ldd || true)}"
+WHICH_BIN="${WHICH_BIN:-$(command -v which || true)}"
 
 PLATFORM_PACKAGE="$(node --input-type=module <<'NODE'
 import { execSync } from "node:child_process";
@@ -89,6 +90,7 @@ NPM_CACHE="${TMP_ROOT}/npm-cache"
 EMPTY_PATH_DIR="${TMP_ROOT}/empty-path"
 BUN_ONLY_DIR="${TMP_ROOT}/bun-only-path"
 NODE_ONLY_DIR="${TMP_ROOT}/node-only-path"
+STALE_PATH_DIR="${TMP_ROOT}/stale-path"
 
 cp -R packages/cli "${CLI_STAGE}"
 cp -R packages/tokscale "${WRAPPER_STAGE}"
@@ -99,16 +101,26 @@ mkdir -p \
   "${NPM_CACHE}" \
   "${EMPTY_PATH_DIR}" \
   "${BUN_ONLY_DIR}" \
-  "${NODE_ONLY_DIR}"
+  "${NODE_ONLY_DIR}" \
+  "${STALE_PATH_DIR}"
 cp target/release/tokscale "${PLATFORM_STAGE}/bin/tokscale"
 
 chmod +x "${CLI_STAGE}/bin.js" "${WRAPPER_STAGE}/bin.js" "${PLATFORM_STAGE}/bin/tokscale"
+
+cat > "${STALE_PATH_DIR}/tokscale" <<'SH'
+#!/bin/sh
+echo "tokscale 2.0.0"
+SH
+chmod +x "${STALE_PATH_DIR}/tokscale"
 
 ln -s "${BUN_BIN}" "${BUN_ONLY_DIR}/bun"
 ln -s "${NODE_BIN}" "${NODE_ONLY_DIR}/node"
 if [[ -n "${LDD_BIN}" ]]; then
   ln -s "${LDD_BIN}" "${BUN_ONLY_DIR}/ldd"
   ln -s "${LDD_BIN}" "${NODE_ONLY_DIR}/ldd"
+fi
+if [[ -n "${WHICH_BIN}" ]]; then
+  ln -s "${WHICH_BIN}" "${NODE_ONLY_DIR}/which"
 fi
 
 BUN_ONLY_PATH="${BUN_ONLY_DIR}"
@@ -147,6 +159,32 @@ echo "Checking installed launcher with Node-only PATH..."
 INSTALLED_VERSION_NODE="$(env PATH="${NODE_ONLY_PATH}" "${INSTALLED_BIN}" --version)"
 [[ "${INSTALLED_VERSION_NODE}" == tokscale* ]] || {
   echo "Unexpected Node-only launcher output: ${INSTALLED_VERSION_NODE}" >&2
+  exit 1
+}
+
+echo "Checking missing platform binary does not fall back to stale PATH tokscale..."
+rm -f "${INSTALL_DIR}/node_modules/@tokscale/${PLATFORM_PACKAGE}/bin/tokscale"
+rm -f "${INSTALL_DIR}/node_modules/@tokscale/cli/node_modules/@tokscale/${PLATFORM_PACKAGE}/bin/tokscale"
+rm -f "${INSTALL_DIR}/node_modules/@tokscale/node_modules/@tokscale/${PLATFORM_PACKAGE}/bin/tokscale"
+rm -f "${INSTALL_DIR}/node_modules/node_modules/@tokscale/${PLATFORM_PACKAGE}/bin/tokscale"
+rm -f "${INSTALL_DIR}/node_modules/packages/${PLATFORM_PACKAGE}/bin/tokscale"
+rm -f "${INSTALL_DIR}/node_modules/target/release/tokscale"
+rm -f "${INSTALL_DIR}/node_modules/@tokscale/cli/bin/tokscale"
+set +e
+STALE_OUTPUT="$(env PATH="${STALE_PATH_DIR}:${NODE_ONLY_PATH}" "${INSTALLED_BIN}" --version 2>&1)"
+STALE_CODE=$?
+set -e
+if [[ ${STALE_CODE} -eq 0 ]]; then
+  echo "Expected launcher to fail instead of executing stale PATH tokscale" >&2
+  echo "Launcher output: ${STALE_OUTPUT}" >&2
+  exit 1
+fi
+if [[ "${STALE_OUTPUT}" == *"tokscale 2.0.0"* ]]; then
+  echo "Launcher executed stale PATH tokscale: ${STALE_OUTPUT}" >&2
+  exit 1
+fi
+[[ "${STALE_OUTPUT}" == *"tokscale binary not found"* ]] || {
+  echo "Unexpected missing-binary error output: ${STALE_OUTPUT}" >&2
   exit 1
 }
 


### PR DESCRIPTION
## Summary
- Remove the generic `PATH` fallback from the npm CLI launcher so an installed package cannot silently run a stale global `tokscale` binary.
- Keep launcher resolution limited to package-owned and workspace-owned binary locations.
- Add a package-launcher smoke test that plants a fake stale `tokscale` on `PATH` and verifies the launcher fails honestly instead of executing it.

## Why
The package launcher should only execute the binary that belongs to the installed package. Falling back to `which tokscale` or `where tokscale` can hide a missing platform binary by invoking an unrelated global installation, which makes version checks and CI smoke tests report a false success.

## Diff scope
- `packages/cli/src/index.ts`
- `scripts/test-package-launchers.sh`
- No Rust parser logic, pricing logic, TUI behavior, database schema, package metadata, or release files changed.

## Branch integrity
- Base branch: `main`
- Validated base SHA: `270d64c4d268d5bcc380690441d6a891687d6794`
- Ahead/behind against `origin/main`: `0 behind / 1 ahead`
- Introduced commit: `25f08626174c4359727f4cc393d83b3df0058871 fix(cli): avoid stale PATH launcher fallback`

## Validation mode and proof
Mode 2 - narrow runtime change. The diff is isolated to the JavaScript package launcher and its focused smoke-test coverage.

Local validation on the final branch SHA:
- `bun run --cwd packages/cli build`: PASS
- `bash scripts/test-package-launchers.sh`: PASS
- `git diff --check origin/main...HEAD`: PASS, no output
- `git diff --cached --check`: PASS, no output

Ledger: not applicable - not required for this change family.
Version: not applicable - no package or release version changed.
Remote CI: Pending - not available until the pull request is opened.

## Runtime safety
The launcher now resolves only bundled or workspace-owned binary candidates. If those candidates are unavailable, it reports the missing supported-platform binary instead of delegating to an unrelated executable from `PATH`. No background tasks, persistence paths, network calls, or package install behavior were added.

## Rollback plan
Rollback: revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: reverting would restore the stale-`PATH` fallback behavior.

## Known residual risks
No known residual risks. Remote CI should validate the final PR SHA after the pull request is opened.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent the CLI launcher from falling back to `PATH`, so it never runs a stale global `tokscale`. It now only uses package/workspace binaries and fails clearly when missing, preventing false CI passes.

- **Bug Fixes**
  - Removed `PATH` fallback from `packages/cli/src/index.ts` (no more `which/where` resolution).
  - Hardened `scripts/test-package-launchers.sh`: adds a fake `tokscale` on `PATH` and a `which` symlink, verifies the launcher fails with "tokscale binary not found" and never executes the fake binary.

<sup>Written for commit 15ce61b9f7c5ba8b8dc19515eb55a214d4ddf8f7. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/576?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

