### PR TITLE
fix(tui): use compatible colors in Apple Terminal

### DIFF
--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -222,7 +222,7 @@ impl App {
             .theme
             .parse()
             .unwrap_or_else(|_| settings.theme_name());
-        let theme = Theme::from_name(theme_name);
+        let theme = Theme::from_name_for_current_terminal(theme_name);
 
         let enabled_clients: HashSet<ClientFilter> = if let Some(ref cli_clients) = config.clients {
             // CLI-provided filter list. Each entry is the canonical
@@ -876,7 +876,7 @@ impl App {
 
     fn cycle_theme(&mut self) {
         let new_theme = self.theme.name.next();
-        self.theme = Theme::from_name(new_theme);
+        self.theme = Theme::from_name_for_current_terminal(new_theme);
         self.dialog_stack.set_theme(self.theme.clone());
         self.settings.set_theme(new_theme);
         if let Err(e) = self.settings.save() {

--- a/crates/tokscale-cli/src/tui/themes.rs
+++ b/crates/tokscale-cli/src/tui/themes.rs
@@ -1,6 +1,51 @@
 use ratatui::style::Color;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TerminalColorMode {
+    FullColor,
+    Compatible,
+}
+
+impl TerminalColorMode {
+    pub(crate) fn from_env<I, K, V>(env: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<str>,
+        V: AsRef<str>,
+    {
+        let mut term = String::new();
+        let mut term_program = String::new();
+        let mut colorterm = String::new();
+        let mut no_color = false;
+
+        for (key, value) in env {
+            let key = key.as_ref();
+            let value = value.as_ref();
+            match key {
+                "TERM" => term = value.to_ascii_lowercase(),
+                "TERM_PROGRAM" => term_program = value.to_ascii_lowercase(),
+                "COLORTERM" => colorterm = value.to_ascii_lowercase(),
+                "NO_COLOR" => no_color = true,
+                _ => {}
+            }
+        }
+
+        if no_color || term == "dumb" || term_program == "apple_terminal" {
+            return Self::Compatible;
+        }
+
+        if matches!(colorterm.as_str(), "truecolor" | "24bit")
+            || term.contains("truecolor")
+            || term.contains("24bit")
+        {
+            return Self::FullColor;
+        }
+
+        Self::FullColor
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ThemeName {
     Green,
     Halloween,
@@ -82,7 +127,14 @@ pub struct Theme {
 }
 
 impl Theme {
-    pub fn from_name(name: ThemeName) -> Self {
+    pub fn from_name_for_current_terminal(name: ThemeName) -> Self {
+        Self::from_name_with_color_mode(name, TerminalColorMode::from_env(std::env::vars()))
+    }
+
+    pub(crate) fn from_name_with_color_mode(
+        name: ThemeName,
+        color_mode: TerminalColorMode,
+    ) -> Self {
         let colors = match name {
             // Colors match frontend contribution graph palettes (higher grade = darker = more activity)
             ThemeName::Green => [
@@ -150,7 +202,7 @@ impl Theme {
             ],
         };
 
-        Self {
+        let mut theme = Self {
             name,
             colors,
             background: Color::Rgb(13, 17, 23),
@@ -160,6 +212,82 @@ impl Theme {
             muted: Color::Rgb(139, 148, 158),
             accent: Color::Cyan,
             selection: Color::Rgb(48, 54, 61),
+        };
+
+        if color_mode == TerminalColorMode::Compatible {
+            theme.colors = [
+                Color::Black,
+                Color::DarkGray,
+                Color::Gray,
+                Color::White,
+                Color::Cyan,
+            ];
+            theme.background = Color::Black;
+            theme.foreground = Color::White;
+            theme.border = Color::DarkGray;
+            theme.highlight = Color::Cyan;
+            theme.muted = Color::DarkGray;
+            theme.accent = Color::Cyan;
+            theme.selection = Color::DarkGray;
         }
+
+        theme
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
+        pairs
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn apple_terminal_uses_compatible_color_mode() {
+        let mode = TerminalColorMode::from_env(env(&[
+            ("TERM_PROGRAM", "Apple_Terminal"),
+            ("TERM", "xterm-256color"),
+        ]));
+
+        assert_eq!(mode, TerminalColorMode::Compatible);
+    }
+
+    #[test]
+    fn vscode_truecolor_keeps_full_color_mode() {
+        let mode = TerminalColorMode::from_env(env(&[
+            ("TERM_PROGRAM", "vscode"),
+            ("TERM", "xterm-256color"),
+            ("COLORTERM", "truecolor"),
+        ]));
+
+        assert_eq!(mode, TerminalColorMode::FullColor);
+    }
+
+    #[test]
+    fn no_color_forces_compatible_color_mode() {
+        let mode =
+            TerminalColorMode::from_env(env(&[("NO_COLOR", "1"), ("COLORTERM", "truecolor")]));
+
+        assert_eq!(mode, TerminalColorMode::Compatible);
+    }
+
+    #[test]
+    fn compatible_theme_preserves_name_and_avoids_rgb_palette() {
+        let theme =
+            Theme::from_name_with_color_mode(ThemeName::Green, TerminalColorMode::Compatible);
+
+        assert_eq!(theme.name, ThemeName::Green);
+        assert!(theme
+            .colors
+            .iter()
+            .all(|color| !matches!(color, Color::Rgb(..))));
+        assert!(!matches!(theme.background, Color::Rgb(..)));
+        assert_ne!(theme.background, Color::Reset);
+        assert!(!matches!(theme.foreground, Color::Rgb(..)));
+        assert!(!matches!(theme.selection, Color::Rgb(..)));
     }
 }


### PR DESCRIPTION
## Summary
- Detect terminal color capability for the TUI theme system and use a compatible color mode in Apple Terminal, `NO_COLOR`, and dumb-terminal environments.
- Preserve the selected theme name while replacing RGB-only palette entries with terminal-safe named colors when truecolor output is not appropriate.
- Keep theme cycling compatible with the detected terminal mode so pressing `p` does not reintroduce RGB colors in Apple Terminal.

## Why
Apple Terminal can render RGB-heavy TUI themes poorly compared with truecolor-capable terminals. The TUI should keep the existing theme experience where supported, but use a safer palette in environments where RGB output is unreliable or explicitly disabled.

## Diff scope
- `crates/tokscale-cli/src/tui/themes.rs`
- `crates/tokscale-cli/src/tui/app.rs`
- Adds terminal color mode detection for theme selection.
- Applies compatible theme colors during app initialization and theme cycling.
- No CLI flags, parser behavior, pricing logic, database schema, package metadata, or release files changed.

## Branch integrity
- Base branch: `main`
- Validated base SHA: `270d64c4d268d5bcc380690441d6a891687d6794`
- Ahead/behind against `origin/main`: `0 behind / 1 ahead`
- Introduced commit: `ecf60dc85dca75bed9ca330bd1ef5dee62964981 fix(tui): use compatible colors in Apple Terminal`

## Validation mode and proof
Mode 2 - narrow runtime change. The diff is isolated to TUI theme selection and rendering palette choices, with focused tests for terminal-mode behavior and theme cycling.

Local validation on the final branch SHA:
- `cargo test -p tokscale-cli tui::themes::tests`: PASS
- `cargo test -p tokscale-cli tui::app::tests::test_handle_key_theme_cycle`: PASS
- `cargo fmt --all --check`: PASS
- `rustup run stable cargo clippy -p tokscale-cli --bin tokscale -- -D warnings`: PASS
- `git diff --check origin/main...HEAD`: PASS, no output
- `git diff --cached --check`: PASS, no output

Ledger: not applicable - not required for this change family.
Version: not applicable - no package or release version changed.
Remote CI: Pending - not available until the pull request is opened.

## Runtime safety
The change is confined to selecting TUI color values before rendering. It does not change data loading, aggregation, sorting, persistence, network behavior, or process management. No blocking locks, background tasks, unbounded queues, or invariant removals were added. No invariant regression introduced.

## Rollback plan
Rollback: revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: reverting would restore RGB-heavy rendering in Apple Terminal.

## Known residual risks
No known residual risks. Remote CI should validate the final PR SHA after the pull request is opened.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects terminal color capability and switches the TUI to a compatible palette in Apple Terminal, `NO_COLOR`, and dumb terminals to fix poor RGB rendering. Keeps theme names and cycling while replacing RGB-only colors with safe named colors when truecolor isn’t appropriate.

- **Bug Fixes**
  - Added `TerminalColorMode` reading `TERM`, `TERM_PROGRAM`, `COLORTERM`, and `NO_COLOR` (Apple Terminal/`dumb`/`NO_COLOR` => Compatible; `truecolor`/`24bit` => FullColor).
  - In Compatible mode, apply a named-color palette and avoid all RGB (including background, selection, and borders).
  - Replaced `Theme::from_name` with `Theme::from_name_for_current_terminal` for init and theme cycling.
  - Added tests for Apple Terminal, `NO_COLOR`, truecolor detection, and palette RGB avoidance.

<sup>Written for commit fefacca087d879bc369e99b3495357ae55627779. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/577?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

