### PR TITLE
fix(claude): normalize anthropic model variants

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -82,7 +82,28 @@ pub fn normalize_model_for_grouping(model_id: &str) -> String {
         name = result;
     }
 
+    if let Some(canonical) = normalize_anthropic_prefixed_claude_model(&name) {
+        name = canonical;
+    }
+
     name
+}
+
+fn normalize_anthropic_prefixed_claude_model(model_id: &str) -> Option<String> {
+    let rest = model_id.strip_prefix("anthropic/claude-")?;
+    let mut parts = rest.split('-');
+    let major = parts.next()?;
+    let minor = parts.next()?;
+    let family = parts.next()?;
+    if parts.next().is_some() {
+        return None;
+    }
+
+    if !matches!(family, "opus" | "sonnet" | "haiku") {
+        return None;
+    }
+
+    Some(format!("claude-{family}-{major}-{minor}"))
 }
 
 fn retain_for_requested_clients(
@@ -2380,6 +2401,18 @@ mod tests {
             normalize_model_for_grouping("claude-opus-4.6"),
             "claude-opus-4-6"
         );
+        assert_eq!(
+            normalize_model_for_grouping("anthropic/claude-4-6-sonnet"),
+            "claude-sonnet-4-6"
+        );
+        assert_eq!(
+            normalize_model_for_grouping("anthropic/claude-4-5-haiku"),
+            "claude-haiku-4-5"
+        );
+        assert_eq!(
+            normalize_model_for_grouping("anthropic/claude-4-6-opus"),
+            "claude-opus-4-6"
+        );
 
         assert_eq!(normalize_model_for_grouping("gpt-5.2"), "gpt-5.2");
         assert_eq!(normalize_model_for_grouping("gpt-5.4(xhigh)"), "gpt-5.4");
@@ -2536,6 +2569,40 @@ mod tests {
         assert_eq!(entries[0].cost, 4.0);
         assert_eq!(entries[0].message_count, 2);
         assert_eq!(entries[0].merged_clients.as_deref(), Some("claude, qwen"));
+    }
+
+    #[test]
+    fn test_model_grouping_merges_anthropic_prefixed_claude_variant_with_canonical_model() {
+        let entries = aggregate_model_usage_entries(
+            vec![
+                make_workspace_message(
+                    "claude",
+                    "anthropic/claude-4-6-sonnet",
+                    "anthropic",
+                    "session-1",
+                    1.25,
+                    Some("/repo-a"),
+                    Some("repo-a"),
+                ),
+                make_workspace_message(
+                    "claude",
+                    "claude-sonnet-4-6",
+                    "anthropic",
+                    "session-2",
+                    2.75,
+                    Some("/repo-b"),
+                    Some("repo-b"),
+                ),
+            ],
+            &GroupBy::ClientModel,
+        );
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].model, "claude-sonnet-4-6");
+        assert_eq!(entries[0].input, 20);
+        assert_eq!(entries[0].output, 10);
+        assert_eq!(entries[0].cost, 4.0);
+        assert_eq!(entries[0].message_count, 2);
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/aliases.rs
+++ b/crates/tokscale-core/src/pricing/aliases.rs
@@ -27,6 +27,12 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     m.insert("claude-opus-4.6", "claude-opus-4-6");
     m.insert("claude-sonnet-4.6", "claude-sonnet-4-6");
     m.insert("claude-haiku-4.6", "claude-haiku-4-6");
+    m.insert("anthropic/claude-4-5-opus", "claude-opus-4-5");
+    m.insert("anthropic/claude-4-5-sonnet", "claude-sonnet-4-5");
+    m.insert("anthropic/claude-4-5-haiku", "claude-haiku-4-5");
+    m.insert("anthropic/claude-4-6-opus", "claude-opus-4-6");
+    m.insert("anthropic/claude-4-6-sonnet", "claude-sonnet-4-6");
+    m.insert("anthropic/claude-4-6-haiku", "claude-haiku-4-6");
     m.insert("gemini-3.1-pro-high", "gemini-3.1-pro");
     m.insert("gemini-3.1-pro-low", "gemini-3.1-pro");
     m.insert("gemini-3-pro-high", "gemini-3-pro");
@@ -69,6 +75,14 @@ mod tests {
         assert_eq!(
             resolve_alias("claude-opus-4.6-thinking"),
             Some("claude-opus-4-6")
+        );
+        assert_eq!(
+            resolve_alias("anthropic/claude-4-5-haiku"),
+            Some("claude-haiku-4-5")
+        );
+        assert_eq!(
+            resolve_alias("anthropic/claude-4-6-sonnet"),
+            Some("claude-sonnet-4-6")
         );
     }
 }

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -3283,6 +3283,54 @@ mod tests {
         assert!((cost - expected).abs() < 1e-12);
     }
 
+    #[test]
+    fn test_anthropic_prefixed_sonnet_variant_uses_canonical_pricing() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-sonnet-4-6".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000003),
+                output_cost_per_token: Some(0.000015),
+                cache_read_input_token_cost: Some(0.0000003),
+                cache_creation_input_token_cost: Some(0.00000375),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+        let resolved = lookup.lookup("anthropic/claude-4-6-sonnet").unwrap();
+        assert_eq!(resolved.source, "LiteLLM");
+        assert_eq!(resolved.matched_key, "claude-sonnet-4-6");
+
+        let cost = lookup.calculate_cost("anthropic/claude-4-6-sonnet", 100, 20, 10, 5, 0);
+        let expected = 100.0 * 0.000003 + 20.0 * 0.000015 + 10.0 * 0.0000003 + 5.0 * 0.00000375;
+        assert!((cost - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_anthropic_prefixed_haiku_variant_uses_canonical_pricing() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-haiku-4-5".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0000008),
+                output_cost_per_token: Some(0.000004),
+                cache_read_input_token_cost: Some(0.00000008),
+                cache_creation_input_token_cost: Some(0.000001),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+        let resolved = lookup.lookup("anthropic/claude-4-5-haiku").unwrap();
+        assert_eq!(resolved.source, "LiteLLM");
+        assert_eq!(resolved.matched_key, "claude-haiku-4-5");
+
+        let cost = lookup.calculate_cost("anthropic/claude-4-5-haiku", 100, 20, 10, 5, 0);
+        let expected = 100.0 * 0.0000008 + 20.0 * 0.000004 + 10.0 * 0.00000008 + 5.0 * 0.000001;
+        assert!((cost - expected).abs() < 1e-12);
+    }
+
     /// Regression test for #336: subscription-based resellers (e.g. Perplexity) with
     /// all-None pricing should not shadow valid entries during provider-aware lookup.
     /// `perplexity/anthropic/claude-opus-4-6` matches provider hint "anthropic" via


### PR DESCRIPTION
## Summary
- Normalize Anthropic-prefixed Claude model identifiers into the same grouping keys as canonical Claude model names.
- Add pricing aliases for Anthropic-prefixed Claude 4.5 and 4.6 variants so cost lookup resolves through existing canonical pricing.
- Add focused tests for grouping and pricing behavior across prefixed and canonical Claude model names.

## Why
Some Claude usage sources report models as `anthropic/claude-...` while existing grouping and pricing paths expect canonical Claude names. Without normalization, equivalent Claude usage can split into separate model rows or miss known pricing aliases. This change keeps attribution consistent without changing parser behavior or token accounting.

## Diff scope
- `crates/tokscale-core/src/lib.rs`
- `crates/tokscale-core/src/pricing/aliases.rs`
- `crates/tokscale-core/src/pricing/lookup.rs`
- Normalizes Anthropic-prefixed Claude variants for grouping.
- Adds pricing aliases for the supported prefixed Claude variant forms.
- No CLI flags, TUI behavior, database schema, package metadata, or release files changed.

## Branch integrity
- Base branch: `main`
- Validated base SHA: `270d64c4d268d5bcc380690441d6a891687d6794`
- Ahead/behind against `origin/main`: `0 behind / 1 ahead`
- Introduced commit: `5393e3d5037f41102936fa102cde0acade368be2 fix(claude): normalize anthropic model variants`

## Validation mode and proof
Mode 2 - narrow runtime change. The diff is isolated to model normalization and pricing alias lookup, with focused unit tests for the affected Claude paths.

Local validation on the final branch SHA:
- `cargo test -p tokscale-core test_normalize_model_for_grouping`: PASS
- `cargo test -p tokscale-core anthropic_prefixed`: PASS
- `cargo test -p tokscale-core claude`: PASS
- `cargo test -p tokscale-core pricing::aliases`: PASS
- `cargo fmt --all --check`: PASS
- `rustup run stable cargo clippy -p tokscale-core --all-targets -- -D warnings`: PASS
- `git diff --check origin/main...HEAD`: PASS, no output
- `git diff --cached --check`: PASS, no output

Ledger: not applicable - not required for this change family.
Version: not applicable - no package or release version changed.
Remote CI: Pending - not available until the pull request is opened.

## Runtime safety
The change only maps recognized Anthropic-prefixed Claude model identifiers to existing canonical Claude names and aliases. It does not change token extraction, session parsing, aggregation math, persistence, or network behavior. Unknown model names still flow through existing fallback behavior. No invariant regression introduced.

## Rollback plan
Rollback: revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: reverting would restore split grouping or missing pricing for these Anthropic-prefixed Claude variant names.

## Known residual risks
No known residual risks. Remote CI should validate the final PR SHA after the pull request is opened.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize Anthropic-prefixed Claude model IDs to canonical names so usage groups correctly and pricing lookups use the right rates. Adds aliases for `anthropic/claude` 4.5/4.6 variants to reuse existing canonical pricing.

- **Bug Fixes**
  - Map `anthropic/claude-<major>-<minor>-{opus|sonnet|haiku}` to `claude-{family}-<major>-<minor>` in `tokscale-core` grouping.
  - Add pricing aliases for `anthropic/claude-4-5-*` and `anthropic/claude-4-6-*` so cost lookup matches canonical entries.
  - Add focused tests covering grouping and pricing for prefixed and canonical names.

<sup>Written for commit 5393e3d5037f41102936fa102cde0acade368be2. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/578?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

