### PR TITLE
fix(pricing): map opus-4-7 ids to claude-opus-4-7 instead of legacy claude-opus-4

### DIFF
--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -962,7 +962,11 @@ fn normalize_model_name(model_id: &str) -> Option<String> {
     let lower = model_id.to_lowercase();
 
     if lower.contains("opus") {
-        if contains_delimited_fragment(&lower, "4.6") || contains_delimited_fragment(&lower, "4-6")
+        if contains_delimited_fragment(&lower, "4.7") || contains_delimited_fragment(&lower, "4-7")
+        {
+            return Some("claude-opus-4-7".into());
+        } else if contains_delimited_fragment(&lower, "4.6")
+            || contains_delimited_fragment(&lower, "4-6")
         {
             return Some("claude-opus-4-6".into());
         } else if contains_delimited_fragment(&lower, "4.5")
@@ -2446,6 +2450,109 @@ mod tests {
         let result = lookup.lookup("opus-4-60").unwrap();
         assert_eq!(result.matched_key, "claude-opus-4");
         assert_ne!(result.matched_key, "claude-opus-4-6");
+    }
+
+    #[test]
+    fn test_normalize_opus_4_7_prefers_4_7_over_4() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-opus-4".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000015),
+                output_cost_per_token: Some(0.000075),
+                ..Default::default()
+            },
+        );
+        litellm.insert(
+            "claude-opus-4-7".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000005),
+                output_cost_per_token: Some(0.000025),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+        let result = lookup.lookup("opus-4-7").unwrap();
+        assert_eq!(result.matched_key, "claude-opus-4-7");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    #[test]
+    fn test_normalize_opus_4_7_dot_prefers_4_7_over_4() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-opus-4".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000015),
+                output_cost_per_token: Some(0.000075),
+                ..Default::default()
+            },
+        );
+        litellm.insert(
+            "claude-opus-4-7".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000005),
+                output_cost_per_token: Some(0.000025),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+        let result = lookup.lookup("opus-4.7").unwrap();
+        assert_eq!(result.matched_key, "claude-opus-4-7");
+        assert_eq!(result.source, "LiteLLM");
+    }
+
+    /// Regression: `aws.claude-opus-4-7` (Bedrock-style id) used to degrade
+    /// to OpenRouter's `anthropic/claude-opus-4` ($15/$75/$1.50/$18.75 per M)
+    /// because `normalize_model_name` only knew 4.5/4.6 and fell through to
+    /// the bare `claude-opus-4` branch — which OpenRouter then resolved via
+    /// `model_part` index to the legacy opus 4 entry. Result was ~3x overcharge.
+    #[test]
+    fn test_aws_opus_4_7_does_not_degrade_to_opus_4() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-opus-4-7".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000005),
+                output_cost_per_token: Some(0.000025),
+                cache_read_input_token_cost: Some(5e-7),
+                cache_creation_input_token_cost: Some(0.00000625),
+                ..Default::default()
+            },
+        );
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "anthropic/claude-opus-4".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000015),
+                output_cost_per_token: Some(0.000075),
+                cache_read_input_token_cost: Some(0.0000015),
+                cache_creation_input_token_cost: Some(0.00001875),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, openrouter, HashMap::new());
+        let result = lookup.lookup("aws.claude-opus-4-7").unwrap();
+        assert_eq!(result.matched_key, "claude-opus-4-7");
+        assert_ne!(result.matched_key, "anthropic/claude-opus-4");
+
+        // 8.4M input + 873K output + 41.3M cache_read + 12.1M cache_write
+        // at opus-4-7 rates should be ~$160, not ~$480 (legacy opus 4).
+        let cost = lookup.calculate_cost(
+            "aws.claude-opus-4-7",
+            8_400_000,
+            873_000,
+            41_300_000,
+            12_100_000,
+            0,
+        );
+        assert!(
+            (140.0..=180.0).contains(&cost),
+            "expected opus-4-7 priced cost around $160, got ${cost:.2}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `normalize_model_name` only had explicit branches for opus 4.5 and 4.6; anything else with "opus" + "4" fell through to a catch-all that returned `claude-opus-4`.
- For ids like `aws.claude-opus-4-7` this caused `exact_match_openrouter` to reach `anthropic/claude-opus-4` via the `model_part` index — the legacy opus 4 entry priced at \$15/\$75 per M instead of opus 4.7's \$5/\$25.
- Add an explicit 4.7 branch in front of 4.6 so opus-4-7 ids resolve to `claude-opus-4-7`. Catch-all is left in place to preserve the existing behavior tests rely on (e.g. `test_normalize_opus_4_60_does_not_map_to_4_6`).

## Why this matters
A real session with **8.4M input / 873K output / 41.3M cache-read / 12.1M cache-write** tokens on `aws.claude-opus-4-7` was being billed at **~\$480** instead of the correct **~\$160** — a roughly 3x overcharge — because the resolver picked the legacy opus 4 price table.

## How I traced it
The lookup chain for `aws.claude-opus-4-7`:
1. `aws.` is not in `PROVIDER_PREFIXES`, so `strip_known_provider_prefix` skips it.
2. No exact LiteLLM/OpenRouter match.
3. `normalize_version_separator` produces `aws.claude-opus-4.7` — still no match.
4. **`normalize_model_name` falls through to `claude-opus-4`** (the bug).
5. `exact_match_openrouter("claude-opus-4")` reaches `anthropic/claude-opus-4` via `openrouter_model_part`, returning the legacy \$15/\$75 entry.

After the fix, step 4 short-circuits to `claude-opus-4-7`, which exists in upstream LiteLLM data and prices correctly.

## Relationship to #578
Independent. #578 normalizes `anthropic/claude-{major}-{minor}-{family}` (family-suffix order, e.g. `anthropic/claude-4-6-sonnet`) and adds 4.5/4.6 aliases. It does not touch `normalize_model_name`, has no 4.7 entries, and `aws.`-prefixed ids never reach its new code path. The two fixes don't overlap and won't conflict at merge.

## Test plan
- [x] `cargo test -p tokscale-core --lib pricing::lookup` — 129 passed, 0 failed (3 new tests included)
- [x] `cargo test -p tokscale-core` — 674 + 10 + 3 + 0 passed across all suites, 0 failed
- [x] New regression tests:
  - `test_normalize_opus_4_7_prefers_4_7_over_4` — short-form `opus-4-7`
  - `test_normalize_opus_4_7_dot_prefers_4_7_over_4` — dot-form `opus-4.7`
  - `test_aws_opus_4_7_does_not_degrade_to_opus_4` — the actual reported case, asserts both the resolved key (`claude-opus-4-7`) and that computed cost lands in the 4.7 band (~\$160) rather than legacy opus-4 band (~\$480)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix pricing normalization for Opus 4.7 so IDs resolve to `claude-opus-4-7` instead of the legacy `claude-opus-4`. This corrects cost calculations for `aws.claude-opus-4-7` and prevents ~3x overcharges.

- **Bug Fixes**
  - Add explicit 4.7 branch in `normalize_model_name` (before 4.6) to route `opus-4-7` and `opus-4.7` to `claude-opus-4-7`.
  - Stop `aws.claude-opus-4-7` from falling back to `anthropic/claude-opus-4`; add regression tests to verify the resolved key and 4.7 pricing.

<sup>Written for commit 6f05b844ac1148d4eed9de109a39a8e711d33ac2. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/580?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

