### PR TITLE
Pricing support for composer 2.5

### DIFF
--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -473,7 +473,9 @@ mod tests {
     #[test]
     fn test_cursor_returns_pricing_for_composer_2_5_fast() {
         let service = PricingService::new(HashMap::new(), HashMap::new());
-        let result = service.lookup_with_source("composer-2.5-fast", None).unwrap();
+        let result = service
+            .lookup_with_source("composer-2.5-fast", None)
+            .unwrap();
         assert_eq!(result.source, "Cursor");
         assert_eq!(result.matched_key, "composer-2.5-fast");
         assert_eq!(result.pricing.input_cost_per_token, Some(1.5e-6));

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -81,6 +81,11 @@ impl PricingService {
             ("composer-2", 5e-7, 2.5e-6, Some(2e-7)),
             ("composer 2 fast", 1.5e-6, 7.5e-6, Some(3.5e-7)),
             ("composer-2-fast", 1.5e-6, 7.5e-6, Some(3.5e-7)),
+            // Composer 2: $0.50/$2.50 per 1M input/output, $0.20/M cache read; cache creation free
+            // Composer 2 Fast: $1.50/$7.50 per 1M, $0.35/M cache read; cache creation free
+            // Source: Cursor docs (cursor.com/docs/models#model-pricing)
+            ("composer-2.5", 5e-7, 2.5e-6, Some(2e-7)),
+            ("composer-2.5-fast", 1.5e-6, 7.5e-6, Some(3.5e-7)),
         ];
 
         let mut overrides = HashMap::with_capacity(entries.len());
@@ -450,6 +455,65 @@ mod tests {
         assert!(
             (with_write - without_write).abs() < 1e-10,
             "Cache creation should be free for Composer 2 Fast"
+        );
+    }
+
+    #[test]
+    fn test_cursor_returns_pricing_for_composer_2_5() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let result = service.lookup_with_source("composer-2.5", None).unwrap();
+        assert_eq!(result.source, "Cursor");
+        assert_eq!(result.matched_key, "composer-2.5");
+        assert_eq!(result.pricing.input_cost_per_token, Some(5e-7));
+        assert_eq!(result.pricing.output_cost_per_token, Some(2.5e-6));
+        assert_eq!(result.pricing.cache_read_input_token_cost, Some(2e-7));
+        assert_eq!(result.pricing.cache_creation_input_token_cost, None);
+    }
+
+    #[test]
+    fn test_cursor_returns_pricing_for_composer_2_5_fast() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let result = service.lookup_with_source("composer-2.5-fast", None).unwrap();
+        assert_eq!(result.source, "Cursor");
+        assert_eq!(result.matched_key, "composer-2.5-fast");
+        assert_eq!(result.pricing.input_cost_per_token, Some(1.5e-6));
+        assert_eq!(result.pricing.output_cost_per_token, Some(7.5e-6));
+        assert_eq!(result.pricing.cache_read_input_token_cost, Some(3.5e-7));
+        assert_eq!(result.pricing.cache_creation_input_token_cost, None);
+    }
+
+    #[test]
+    fn test_cursor_calculate_cost_for_composer_2_5() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let cost = service.calculate_cost("composer-2.5", 1_000_000, 100_000, 50_000, 0, 0);
+        let expected = 1_000_000.0 * 5e-7 + 100_000.0 * 2.5e-6 + 50_000.0 * 2e-7;
+        assert!((cost - expected).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_cursor_calculate_cost_composer_2_5_cache_write_free() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let with_write = service.calculate_cost("composer-2.5", 0, 0, 0, 500_000, 0);
+        let without_write = service.calculate_cost("composer-2.5", 0, 0, 0, 0, 0);
+        assert!((with_write - without_write).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_cursor_calculate_cost_for_composer_2_5_fast() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let cost = service.calculate_cost("composer-2.5-fast", 1_000_000, 100_000, 50_000, 0, 0);
+        let expected = 1_000_000.0 * 1.5e-6 + 100_000.0 * 7.5e-6 + 50_000.0 * 3.5e-7;
+        assert!((cost - expected).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_cursor_calculate_cost_composer_2_5_fast_cache_write_free() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let with_write = service.calculate_cost("composer-2.5-fast", 0, 0, 0, 500_000, 0);
+        let without_write = service.calculate_cost("composer-2.5-fast", 0, 0, 0, 0, 0);
+        assert!(
+            (with_write - without_write).abs() < 1e-10,
+            "Cache creation should be free for Composer 2.5 Fast"
         );
     }
 


### PR DESCRIPTION
Updates pricing to support the recently released composer 2.5 (it was being picked up but priced at $0)

Follows previous PR for composer 2 #361

<img width="1099" height="102" alt="Screenshot 2026-05-21 at 20 58 07" src="https://github.com/user-attachments/assets/de5589b0-503a-4292-8fd2-effa9f023ae5" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add correct pricing for `composer-2.5` and `composer-2.5-fast` so usage is billed instead of $0, aligned with Cursor docs. Includes tests for lookups, cost calculations, and free cache writes.

- **Bug Fixes**
  - Added pricing entries for `composer-2.5` and `composer-2.5-fast` (input/output per-token and cache-read costs; cache creation free).
  - Added unit tests covering lookup keys, cost math, and zero-cost cache creation.

<sup>Written for commit 2329d801fe8f896991e408b20740ccdc9e3bb9b7. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/581?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

