### PR TITLE
feat(leaderboard): show search on all periods and match displayName

### DIFF
--- a/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
@@ -1160,33 +1160,31 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
           onTabChange={(tab) => {
             setPeriod(tab);
             setPage(1);
-            if (tab !== "all") {
-              setSearchQuery("");
-              setDebouncedSearch("");
+            if (tab !== "custom") {
+              setAppliedFrom("");
+              setAppliedTo("");
             }
           }}
         />
       </TabSection>
 
       <SearchSortRow>
-        {period === "all" && (
-          <SearchInputWrapper>
-            <SearchInputIcon>
-              <SearchIcon size={16} />
-            </SearchInputIcon>
-            <SearchInput
-              type="text"
-              placeholder="Search users..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-            />
-            {searchQuery && (
-              <ClearSearchButton onClick={() => setSearchQuery("")} aria-label="Clear search">
-                <XIcon size={16} />
-              </ClearSearchButton>
-            )}
-          </SearchInputWrapper>
-        )}
+        <SearchInputWrapper>
+          <SearchInputIcon>
+            <SearchIcon size={16} />
+          </SearchInputIcon>
+          <SearchInput
+            type="text"
+            placeholder="Search users..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+          {searchQuery && (
+            <ClearSearchButton onClick={() => setSearchQuery("")} aria-label="Clear search">
+              <XIcon size={16} />
+            </ClearSearchButton>
+          )}
+        </SearchInputWrapper>
         <SortToggleInner>
           <SortLabel>Sort by:</SortLabel>
           <Switch

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -160,14 +160,21 @@ function aggregatePeriodRows(
 }
 
 function matchesLeaderboardSearch(
-  user: Pick<LeaderboardUser, "username">,
+  user: Pick<LeaderboardUser, "username" | "displayName">,
   search: string
 ): boolean {
   if (!search) {
     return true;
   }
 
-  return user.username.toLowerCase().includes(search.toLowerCase());
+  const lowerSearch = search.toLowerCase();
+  if (user.username.toLowerCase().includes(lowerSearch)) {
+    return true;
+  }
+  if (user.displayName && user.displayName.toLowerCase().includes(lowerSearch)) {
+    return true;
+  }
+  return false;
 }
 
 function buildPeriodLeaderboardData(
@@ -332,7 +339,7 @@ async function fetchLeaderboardData(
     const results = await db
       .select()
       .from(rankedSubquery)
-      .where(sql`LOWER(${rankedSubquery.username}) LIKE ${searchPattern}`)
+      .where(sql`(LOWER(${rankedSubquery.username}) LIKE ${searchPattern} OR LOWER(COALESCE(${rankedSubquery.displayName}, '')) LIKE ${searchPattern})`)
       .orderBy(sql`${rankedSubquery.rank} ASC`)
       .limit(limit)
       .offset(offset);
@@ -341,7 +348,7 @@ async function fetchLeaderboardData(
     const countResult = await db
       .select({ count: sql<number>`COUNT(*)`.as("count") })
       .from(rankedSubquery)
-      .where(sql`LOWER(${rankedSubquery.username}) LIKE ${searchPattern}`);
+      .where(sql`(LOWER(${rankedSubquery.username}) LIKE ${searchPattern} OR LOWER(COALESCE(${rankedSubquery.displayName}, '')) LIKE ${searchPattern})`);
 
     const totalUsers = Number(countResult[0]?.count) || 0;
     const totalPages = Math.ceil(totalUsers / limit);


### PR DESCRIPTION
## Summary

Show the leaderboard search field on all time periods (not just All Time) and extend search to match both `username` and `displayName`.

## Changes

- **UI**: Remove `period === "all"` conditional that hid the search input — search is now visible on All Time, This Month, This Week, and Custom periods
- **UI**: Remove search state reset when switching away from All Time tab (search query persists across tab switches)
- **Backend (period leaderboards)**: Update `matchesLeaderboardSearch` to match both `username` and `displayName` fields
- **Backend (All Time SQL)**: Update WHERE clause to include `LOWER(COALESCE(displayName, '')) LIKE ...` alongside username matching

## Testing

- All 10 existing leaderboard tests pass (`getLeaderboard.test.ts` + `getLeaderboardAllTime.test.ts`)
- No TypeScript errors
- Verified locally on dev server

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable leaderboard search on all periods and expand matching to both username and displayName. Search now persists when switching tabs.

- New Features
  - Show search input on All Time, This Month, This Week, and Custom.
  - Keep the search query when changing tabs.
  - Match both `username` and `displayName` in filtering, including All Time SQL via `COALESCE(displayName, '')`.

<sup>Written for commit 9b5f47f50c653a62bb33081580f6c89adb278df2. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/582?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

