### PR TITLE
feat: aggregate token usage across multiple devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-cli"
-version = "2.1.0"
+version = "2.1.3"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-core"
-version = "2.1.0"
+version = "2.1.3"
 dependencies = [
  "bincode",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -422,6 +422,10 @@ tokscale submit --client opencode,claude --since 2024-01-01
 # Preview what would be submitted (dry run)
 tokscale submit --dry-run
 
+# Name this machine (persisted locally); usage from each machine is
+# aggregated per device on your profile
+tokscale submit --device-name "MacBook Pro"
+
 # Logout
 tokscale logout
 ```

--- a/crates/tokscale-cli/src/auth.rs
+++ b/crates/tokscale-cli/src/auth.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::IsTerminal;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const API_TOKEN_ENV_VAR: &str = "TOKSCALE_API_TOKEN";
 
@@ -164,11 +164,125 @@ pub fn get_api_base_url() -> String {
 }
 
 fn get_device_name() -> String {
-    let hostname = hostname::get()
+    format!("CLI on {}", device_hostname())
+}
+
+/// Raw machine hostname, used as the default device name.
+pub fn device_hostname() -> String {
+    hostname::get()
         .ok()
         .and_then(|h| h.into_string().ok())
-        .unwrap_or_else(|| "unknown".to_string());
-    format!("CLI on {}", hostname)
+        .filter(|h| !h.trim().is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Short OS identifier ("linux", "macos", "windows", ...).
+pub fn device_os() -> &'static str {
+    std::env::consts::OS
+}
+
+/// Stable identity of this machine, persisted in
+/// `~/.config/tokscale/device.json`. `device_id` is a UUID generated once;
+/// `name` defaults to the hostname.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeviceIdentity {
+    #[serde(rename = "deviceId")]
+    pub device_id: String,
+    pub name: String,
+}
+
+fn get_device_identity_path() -> Result<PathBuf> {
+    Ok(home_dir()?.join(".config/tokscale/device.json"))
+}
+
+pub fn save_device_identity(identity: &DeviceIdentity) -> Result<()> {
+    ensure_config_dir()?;
+    let path = get_device_identity_path()?;
+    let json = serde_json::to_string_pretty(identity)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)?;
+        file.write_all(json.as_bytes())?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        fs::write(&path, json)?;
+    }
+
+    Ok(())
+}
+
+/// Load this machine's device identity, creating it on first use. A corrupt or
+/// unreadable file is a hard error, not a silent regeneration — minting a fresh
+/// id would re-upload this machine's history and double-count it.
+pub fn load_or_create_device_identity() -> Result<DeviceIdentity> {
+    let path = get_device_identity_path()?;
+
+    match fs::read_to_string(&path) {
+        Ok(content) => {
+            let identity: DeviceIdentity = serde_json::from_str(&content).with_context(|| {
+                format!(
+                    "Device identity file is corrupt: {}. Delete it to regenerate.",
+                    path.display()
+                )
+            })?;
+            if identity.device_id.trim().is_empty() {
+                anyhow::bail!(
+                    "Device identity file has an empty device id: {}. Delete it to regenerate.",
+                    path.display()
+                );
+            }
+            Ok(identity)
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => create_device_identity(&path),
+        Err(err) => Err(err).with_context(|| {
+            format!("Could not read device identity file: {}", path.display())
+        }),
+    }
+}
+
+/// Create and persist a new device identity. Uses `create_new` so two
+/// concurrent first submits cannot mint two different ids for one machine —
+/// the loser reads back the winner's file.
+fn create_device_identity(path: &Path) -> Result<DeviceIdentity> {
+    let identity = DeviceIdentity {
+        device_id: uuid::Uuid::new_v4().to_string(),
+        name: device_hostname(),
+    };
+    ensure_config_dir()?;
+    let json = serde_json::to_string_pretty(&identity)?;
+
+    let mut open_opts = fs::OpenOptions::new();
+    open_opts.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        open_opts.mode(0o600);
+    }
+
+    match open_opts.open(path) {
+        Ok(mut file) => {
+            file.write_all(json.as_bytes())?;
+            Ok(identity)
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+            let content = fs::read_to_string(path)?;
+            serde_json::from_str(&content).with_context(|| {
+                format!("Device identity file is corrupt: {}", path.display())
+            })
+        }
+        Err(err) => Err(err)
+            .with_context(|| format!("Could not create device identity file: {}", path.display())),
+    }
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -208,6 +208,12 @@ enum Commands {
         #[command(flatten)]
         date: DateRangeFlags,
         #[arg(
+            long = "device-name",
+            value_name = "NAME",
+            help = "Set this machine's display name on Tokscale (persisted locally)"
+        )]
+        device_name: Option<String>,
+        #[arg(
             long,
             help = "Show what would be submitted without actually submitting"
         )]
@@ -542,6 +548,7 @@ fn main() -> Result<()> {
         Some(Commands::Submit {
             clients,
             date,
+            device_name,
             dry_run,
         }) => {
             reject_unsupported_home_override(&cli.home, "submit")?;
@@ -556,7 +563,7 @@ fn main() -> Result<()> {
             // defaultClients view filter (which may exclude clients they still want
             // to upload). Pass an explicit empty defaults slice.
             let clients = build_client_filter_with_defaults(clients, &[]);
-            run_submit_command(clients, since, until, year, dry_run)
+            run_submit_command(clients, since, until, year, device_name, dry_run)
         }
         Some(Commands::Headless {
             source,
@@ -3302,6 +3309,22 @@ struct TsExportMeta {
     date_range: DateRange,
 }
 
+/// Identifies the machine a submission came from, so the server stores usage
+/// per device and sums it instead of letting a second PC overwrite the first.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TsDeviceInfo {
+    device_id: String,
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hostname: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    os: Option<String>,
+    /// True when the user set the name this run via `--device-name`; the
+    /// server only overwrites an existing device's name when this is set.
+    name_explicit: bool,
+}
+
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 struct TsTokenContributionData {
@@ -3309,6 +3332,8 @@ struct TsTokenContributionData {
     summary: TsDataSummary,
     years: Vec<TsYearSummary>,
     contributions: Vec<TsDailyContribution>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    device: Option<TsDeviceInfo>,
 }
 
 fn to_ts_token_contribution_data(graph: &tokscale_core::GraphResult) -> TsTokenContributionData {
@@ -3386,7 +3411,47 @@ fn to_ts_token_contribution_data(graph: &tokscale_core::GraphResult) -> TsTokenC
                     .collect(),
             })
             .collect(),
+        // Set by run_submit_command; None for the converter's other callers.
+        device: None,
     }
+}
+
+/// Resolve this machine's device identity, clamped to the server's field
+/// limits. `device_name`, when set, overrides and persists the stored name.
+fn resolve_submit_device(device_name: Option<&str>) -> Result<TsDeviceInfo> {
+    fn clamp(value: &str, max_chars: usize) -> String {
+        value.chars().take(max_chars).collect()
+    }
+
+    let mut identity = auth::load_or_create_device_identity()?;
+
+    let name_explicit = device_name.map(|n| !n.trim().is_empty()).unwrap_or(false);
+    if let Some(new_name) = device_name {
+        let trimmed = new_name.trim();
+        if !trimmed.is_empty() {
+            identity.name = trimmed.to_string();
+            if let Err(err) = auth::save_device_identity(&identity) {
+                use colored::Colorize;
+                eprintln!(
+                    "{}",
+                    format!("  Warning: could not persist device name: {err}").yellow()
+                );
+            }
+        }
+    }
+
+    let mut name = clamp(identity.name.trim(), 100);
+    if name.is_empty() {
+        name = clamp(&auth::device_hostname(), 100);
+    }
+
+    Ok(TsDeviceInfo {
+        device_id: clamp(identity.device_id.trim(), 64),
+        name,
+        hostname: Some(clamp(&auth::device_hostname(), 255)),
+        os: Some(clamp(auth::device_os(), 32)),
+        name_explicit,
+    })
 }
 
 fn run_login_command(token: Option<String>) -> Result<()> {
@@ -3829,10 +3894,18 @@ struct SubmitResponse {
     submission_id: Option<String>,
     #[allow(dead_code)]
     username: Option<String>,
+    device: Option<SubmitResponseDevice>,
     metrics: Option<SubmitMetrics>,
     warnings: Option<Vec<String>>,
     error: Option<String>,
     details: Option<Vec<String>>,
+}
+
+#[derive(serde::Deserialize)]
+struct SubmitResponseDevice {
+    name: Option<String>,
+    /// Number of devices contributing to the user's aggregated total.
+    count: Option<i32>,
 }
 
 #[derive(serde::Deserialize)]
@@ -3880,6 +3953,7 @@ fn run_submit_command(
     since: Option<String>,
     until: Option<String>,
     year: Option<String>,
+    device_name: Option<String>,
     dry_run: bool,
 ) -> Result<()> {
     use colored::Colorize;
@@ -3965,6 +4039,10 @@ fn run_submit_command(
     let mut graph_result = graph_result;
     cap_graph_result_to_utc_today(&mut graph_result, &utc_today);
 
+    // Abort on identity failure rather than falling back to the server's
+    // "legacy" bucket, which would mis-attribute this machine's usage.
+    let submit_device = resolve_submit_device(device_name.as_deref())?;
+
     println!("{}", "  Data to submit:".white());
     println!(
         "{}",
@@ -4002,6 +4080,10 @@ fn run_submit_command(
         "{}",
         format!("    Models: {} models", graph_result.summary.models.len()).bright_black()
     );
+    println!(
+        "{}",
+        format!("    Device: {}", submit_device.name).bright_black()
+    );
     println!();
 
     if graph_result.summary.total_tokens == 0 {
@@ -4018,7 +4100,8 @@ fn run_submit_command(
 
     let api_url = auth::get_api_base_url();
 
-    let submit_payload = to_ts_token_contribution_data(&graph_result);
+    let mut submit_payload = to_ts_token_contribution_data(&graph_result);
+    submit_payload.device = Some(submit_device);
 
     let response = rt.block_on(async {
         reqwest::Client::new()
@@ -4038,6 +4121,7 @@ fn run_submit_command(
                     .unwrap_or_else(|_| SubmitResponse {
                         submission_id: None,
                         username: None,
+                        device: None,
                         metrics: None,
                         warnings: None,
                         error: Some(format!(
@@ -4088,6 +4172,19 @@ fn run_submit_command(
                 }
                 if let Some(days) = metrics.active_days {
                     println!("{}", format!("    Active days: {}", days).bright_black());
+                }
+            }
+            if let Some(device) = &body.device {
+                if let Some(name) = &device.name {
+                    println!("{}", format!("    Device: {}", name).bright_black());
+                }
+                if let Some(count) = device.count {
+                    if count > 1 {
+                        println!(
+                            "{}",
+                            format!("    Aggregated across {} devices", count).bright_black()
+                        );
+                    }
                 }
             }
             if let Some(username) = body

--- a/packages/frontend/__tests__/api/settingsSubmittedDataDelete.test.ts
+++ b/packages/frontend/__tests__/api/settingsSubmittedDataDelete.test.ts
@@ -25,16 +25,20 @@ const mockState = vi.hoisted(() => {
     }
     return deletedRows;
   });
+  // where() chains .returning() for the submissions delete and is awaited
+  // directly for the devices delete, so it is also thenable.
   const where = vi.fn(() => ({
     returning,
+    then: (resolve: (value: unknown) => unknown) => Promise.resolve(resolve(undefined)),
   }));
   let deletedRows: Array<{ id: string }> = [];
   let deleteError: Error | null = null;
 
+  const txDelete = vi.fn(() => ({ where }));
   const db = {
-    delete: vi.fn(() => ({
-      where,
-    })),
+    transaction: vi.fn(async (callback: (tx: { delete: typeof txDelete }) => unknown) =>
+      callback({ delete: txDelete })
+    ),
   };
 
   return {
@@ -46,6 +50,7 @@ const mockState = vi.hoisted(() => {
     eq,
     db,
     where,
+    txDelete,
     reset() {
       getSession.mockReset();
       authenticatePersonalToken.mockReset();
@@ -53,7 +58,8 @@ const mockState = vi.hoisted(() => {
       revalidatePath.mockReset();
       revalidateUsernamePaths.mockReset();
       eq.mockClear();
-      db.delete.mockClear();
+      db.transaction.mockClear();
+      txDelete.mockClear();
       where.mockClear();
       returning.mockClear();
       deletedRows = [];
@@ -90,6 +96,10 @@ vi.mock("@/lib/db", () => ({
   submissions: {
     id: "submissions.id",
     userId: "submissions.userId",
+  },
+  devices: {
+    id: "devices.id",
+    userId: "devices.userId",
   },
 }));
 
@@ -130,7 +140,7 @@ describe("DELETE /api/settings/submitted-data", () => {
 
     expect(response.status).toBe(401);
     expect(await response.json()).toEqual({ error: "Not authenticated" });
-    expect(mockState.db.delete).not.toHaveBeenCalled();
+    expect(mockState.db.transaction).not.toHaveBeenCalled();
   });
 
   it("deletes submitted data and revalidates public caches", async () => {
@@ -151,8 +161,10 @@ describe("DELETE /api/settings/submitted-data", () => {
       deleted: true,
       deletedSubmissions: 1,
     });
-    expect(mockState.db.delete).toHaveBeenCalledTimes(1);
+    expect(mockState.db.transaction).toHaveBeenCalledTimes(1);
+    expect(mockState.txDelete).toHaveBeenCalledTimes(2);
     expect(mockState.eq).toHaveBeenCalledWith("submissions.userId", "user-1");
+    expect(mockState.eq).toHaveBeenCalledWith("devices.userId", "user-1");
     expect(mockState.where).toHaveBeenCalledWith({
       kind: "eq",
       left: "submissions.userId",

--- a/packages/frontend/__tests__/api/submit.test.ts
+++ b/packages/frontend/__tests__/api/submit.test.ts
@@ -542,3 +542,84 @@ describe('POST /api/submit - Client-Level Merge', () => {
     });
   });
 });
+
+describe('POST /api/submit - Device payload', () => {
+  const base = {
+    meta: {
+      generatedAt: new Date().toISOString(),
+      version: '1.0.0',
+      dateRange: { start: '2024-12-01', end: '2024-12-01' },
+    },
+    summary: {
+      totalTokens: 1500,
+      totalCost: 1.5,
+      totalDays: 1,
+      activeDays: 1,
+      averagePerDay: 1.5,
+      maxCostInSingleDay: 1.5,
+      clients: ['claude' as const],
+      models: ['claude-sonnet-4'],
+    },
+    years: [
+      { year: '2024', totalTokens: 1500, totalCost: 1.5, range: { start: '2024-12-01', end: '2024-12-01' } },
+    ],
+    contributions: [
+      {
+        date: '2024-12-01',
+        totals: { tokens: 1500, cost: 1.5, messages: 5 },
+        intensity: 2 as const,
+        tokenBreakdown: { input: 1000, output: 500, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+        clients: [
+          {
+            client: 'claude' as const,
+            modelId: 'claude-sonnet-4',
+            tokens: { input: 1000, output: 500, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+            cost: 1.5,
+            messages: 5,
+          },
+        ],
+      },
+    ],
+  };
+
+  it('accepts a submission with a valid device', () => {
+    const result = validateSubmission({
+      ...base,
+      device: {
+        deviceId: '1649043c-d63b-4792-9f77-286df1b52ce3',
+        name: 'MacBook Pro',
+        hostname: 'mbp.local',
+        os: 'macos',
+      },
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.data?.device?.name).toBe('MacBook Pro');
+  });
+
+  it('accepts a submission without a device field', () => {
+    const result = validateSubmission(base);
+
+    expect(result.valid).toBe(true);
+    expect(result.data?.device).toBeUndefined();
+  });
+
+  it('accepts a device with nameExplicit set', () => {
+    const result = validateSubmission({
+      ...base,
+      device: { deviceId: 'work-laptop-001', name: 'Work laptop', nameExplicit: true },
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.data?.device?.nameExplicit).toBe(true);
+  });
+
+  it('rejects the reserved "legacy" device id', () => {
+    const result = validateSubmission({
+      ...base,
+      device: { deviceId: 'legacy', name: 'Legacy device' },
+    });
+
+    expect(result.valid).toBe(false);
+  });
+});

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -78,6 +78,7 @@ vi.mock("@/lib/db", () => ({
   dailyBreakdown: {
     id: "dailyBreakdown.id",
     submissionId: "dailyBreakdown.submissionId",
+    deviceId: "dailyBreakdown.deviceId",
     date: "dailyBreakdown.date",
     timestampMs: "dailyBreakdown.timestampMs",
     sourceBreakdown: "dailyBreakdown.sourceBreakdown",
@@ -85,6 +86,17 @@ vi.mock("@/lib/db", () => ({
     cost: "dailyBreakdown.cost",
     inputTokens: "dailyBreakdown.inputTokens",
     outputTokens: "dailyBreakdown.outputTokens",
+  },
+  devices: {
+    id: "devices.id",
+    userId: "devices.userId",
+    deviceId: "devices.deviceId",
+    name: "devices.name",
+    hostname: "devices.hostname",
+    os: "devices.os",
+    cliVersion: "devices.cliVersion",
+    lastSeenAt: "devices.lastSeenAt",
+    updatedAt: "devices.updatedAt",
   },
 }));
 
@@ -313,6 +325,7 @@ describe("POST /api/submit auth path", () => {
         dateEnd: "2026-04-30",
         activeDays: 1,
         rowCount: 1,
+        deviceCount: 1,
       }],
       [{
         sourceBreakdown: {
@@ -350,17 +363,18 @@ describe("POST /api/submit auth path", () => {
       select: vi.fn(() => makeAwaitableBuilder(selectResults.shift() ?? [])),
       insert: vi.fn(() => {
         insertCall += 1;
-        if (insertCall === 1) {
-          const builder = {
-            values: vi.fn(() => builder),
-            returning: vi.fn(() => Promise.resolve([{ id: "submission-1" }])),
-          };
-          return builder;
-        }
-
-        return {
-          values: vi.fn(() => Promise.resolve()),
+        // insertCall 1: submission insert; insertCall 2: device upsert.
+        // The builder is awaitable (`then`) so the batch dailyBreakdown
+        // insert (`await tx.insert(...).values(...)`) also resolves.
+        const id = insertCall === 1 ? "submission-1" : "device-1";
+        const builder = {
+          values: vi.fn(() => builder),
+          onConflictDoUpdate: vi.fn(() => builder),
+          returning: vi.fn(() => Promise.resolve([{ id }])),
+          then: (resolve: (value: unknown) => unknown) =>
+            Promise.resolve(resolve(undefined)),
         };
+        return builder;
       }),
       execute: vi.fn(() => Promise.resolve()),
     };

--- a/packages/frontend/__tests__/api/usersProfile.test.ts
+++ b/packages/frontend/__tests__/api/usersProfile.test.ts
@@ -120,6 +120,12 @@ vi.mock("@/lib/db", () => ({
   dailyBreakdown: mockState.tables.dailyBreakdown,
 }));
 
+// The profile route fetches per-device stats; isolate the route test from the
+// devices query module by stubbing it with an empty result.
+vi.mock("@/lib/db/devices", () => ({
+  getUserDeviceStats: async () => [],
+}));
+
 vi.mock("@/lib/db/usernameLookup", () => {
   class AmbiguousUsernameError extends Error {}
 

--- a/packages/frontend/src/app/api/settings/devices/[deviceId]/route.ts
+++ b/packages/frontend/src/app/api/settings/devices/[deviceId]/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
+import { getSession } from "@/lib/auth/session";
+import { deleteUserDevice } from "@/lib/db/devices";
+import {
+  normalizeUsernameCacheKey,
+  revalidateUsernamePaths,
+} from "@/lib/db/usernameLookup";
+
+interface RouteParams {
+  params: Promise<{ deviceId: string }>;
+}
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * DELETE /api/settings/devices/:deviceId
+ * Remove one of the authenticated user's devices and all of its usage rows,
+ * then recompute the user's submission totals.
+ */
+export async function DELETE(_request: Request, { params }: RouteParams) {
+  try {
+    const session = await getSession();
+    if (!session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const { deviceId } = await params;
+
+    if (!UUID_PATTERN.test(deviceId)) {
+      return NextResponse.json({ error: "Device not found" }, { status: 404 });
+    }
+
+    const deleted = await deleteUserDevice(session.id, deviceId);
+
+    if (!deleted) {
+      return NextResponse.json({ error: "Device not found" }, { status: 404 });
+    }
+
+    try {
+      const usernameCacheKey = normalizeUsernameCacheKey(session.username);
+      revalidateTag("leaderboard", "max");
+      revalidateTag(`user:${usernameCacheKey}`, "max");
+      revalidateTag("user-rank", "max");
+      revalidateTag(`user-rank:${usernameCacheKey}`, "max");
+      revalidateUsernamePaths(session.username);
+    } catch (e) {
+      console.error("Cache invalidation failed:", e);
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Device delete error:", error);
+    return NextResponse.json(
+      { error: "Failed to delete device" },
+      { status: 500 }
+    );
+  }
+}

--- a/packages/frontend/src/app/api/settings/devices/route.ts
+++ b/packages/frontend/src/app/api/settings/devices/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { getUserDeviceStats } from "@/lib/db/devices";
+
+/**
+ * GET /api/settings/devices
+ * List the authenticated user's devices with per-device usage stats.
+ */
+export async function GET() {
+  try {
+    const session = await getSession();
+    if (!session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const devices = await getUserDeviceStats(session.id);
+
+    return NextResponse.json({ devices });
+  } catch (error) {
+    console.error("Devices list error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch devices" },
+      { status: 500 }
+    );
+  }
+}

--- a/packages/frontend/src/app/api/settings/submitted-data/route.ts
+++ b/packages/frontend/src/app/api/settings/submitted-data/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { getSession } from "@/lib/auth/session";
 import { authenticatePersonalToken } from "@/lib/auth/personalTokens";
-import { db, submissions } from "@/lib/db";
+import { db, submissions, devices } from "@/lib/db";
 import { normalizeUsernameCacheKey, revalidateUsernamePaths } from "@/lib/db/usernameLookup";
 import { getBearerToken } from "../../../../lib/auth/bearerToken";
 
@@ -31,10 +31,16 @@ export async function DELETE(request: Request) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }
 
-    const deletedRows = await db
-      .delete(submissions)
-      .where(eq(submissions.userId, user.id))
-      .returning({ id: submissions.id });
+    const deletedRows = await db.transaction(async (tx) => {
+      const deleted = await tx
+        .delete(submissions)
+        .where(eq(submissions.userId, user.id))
+        .returning({ id: submissions.id });
+      // Devices are not children of submissions, so remove them explicitly
+      // for a full data wipe.
+      await tx.delete(devices).where(eq(devices.userId, user.id));
+      return deleted;
+    });
 
     try {
       const usernameCacheKey = normalizeUsernameCacheKey(user.username);

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
-import { db, apiTokens, submissions, dailyBreakdown } from "@/lib/db";
-import { eq, sql } from "drizzle-orm";
+import { db, apiTokens, submissions, dailyBreakdown, devices } from "@/lib/db";
+import { and, eq, sql } from "drizzle-orm";
 import {
   validateSubmission,
   generateSubmissionHash,
@@ -50,16 +50,19 @@ function normalizeSubmissionData(data: unknown): void {
 /**
  * POST /api/submit
  * Submit token usage data from CLI
- * 
- * IMPLEMENTS CLIENT-LEVEL MERGE:
- * - Only updates clients present in submission
- * - Preserves data for clients NOT in submission
- * - Recalculates totals from dailyBreakdown
+ *
+ * IMPLEMENTS DEVICE-SCOPED, CLIENT-LEVEL MERGE:
+ * - Each submission belongs to a device (machine); usage is stored per device
+ *   so submissions from multiple PCs are summed, not overwritten.
+ * - Within a device, only updates clients present in the submission and
+ *   preserves data for clients NOT in the submission.
+ * - Recalculates the per-user submission totals as the SUM across all devices.
  *
  * Headers:
  *   Authorization: Bearer <api_token>
  *
- * Body: TokenContributionData JSON
+ * Body: TokenContributionData JSON (optional `device` field; submissions
+ *       without it are bucketed into a per-user "legacy" device).
  */
 export async function POST(request: Request) {
   try {
@@ -185,7 +188,113 @@ export async function POST(request: Request) {
       }
 
       // ------------------------------------------
-      // STEP 3b: Fetch existing daily breakdown for merge
+      // STEP 3a-2: Resolve the submitting device
+      // ------------------------------------------
+      // Submissions without a `device` field fall back to a per-user "legacy"
+      // device; the first device-aware submission promotes that legacy device
+      // so upgrading a single-PC CLI does not re-scan into a second device.
+      const deviceInput = data.device;
+      const now = new Date();
+      let deviceUuid: string;
+      let resolvedDeviceName: string;
+
+      if (!deviceInput) {
+        // Legacy / pre-device CLI: upsert the per-user "legacy" device.
+        resolvedDeviceName = "Legacy device";
+        const [legacy] = await tx
+          .insert(devices)
+          .values({
+            userId: tokenRecord.userId,
+            deviceId: "legacy",
+            name: resolvedDeviceName,
+            cliVersion: data.meta.version,
+            lastSeenAt: now,
+          })
+          .onConflictDoUpdate({
+            target: [devices.userId, devices.deviceId],
+            set: { cliVersion: data.meta.version, lastSeenAt: now, updatedAt: now },
+          })
+          .returning({ id: devices.id });
+        deviceUuid = legacy.id;
+      } else {
+        resolvedDeviceName = deviceInput.name;
+        const [existingDevice] = await tx
+          .select({ id: devices.id, name: devices.name })
+          .from(devices)
+          .where(
+            and(
+              eq(devices.userId, tokenRecord.userId),
+              eq(devices.deviceId, deviceInput.deviceId)
+            )
+          )
+          .limit(1);
+
+        if (existingDevice) {
+          // Only overwrite the stored name when set explicitly via
+          // --device-name, so routine submits do not clobber a chosen name.
+          await tx
+            .update(devices)
+            .set({
+              ...(deviceInput.nameExplicit ? { name: deviceInput.name } : {}),
+              hostname: deviceInput.hostname ?? null,
+              os: deviceInput.os ?? null,
+              cliVersion: data.meta.version,
+              lastSeenAt: now,
+              updatedAt: now,
+            })
+            .where(eq(devices.id, existingDevice.id));
+          deviceUuid = existingDevice.id;
+          resolvedDeviceName = deviceInput.nameExplicit
+            ? deviceInput.name
+            : existingDevice.name;
+        } else {
+          // First time this device identity is seen. If a "legacy" device
+          // exists, promote it (claim its history); otherwise insert fresh.
+          const [legacy] = await tx
+            .select({ id: devices.id })
+            .from(devices)
+            .where(
+              and(
+                eq(devices.userId, tokenRecord.userId),
+                eq(devices.deviceId, "legacy")
+              )
+            )
+            .limit(1);
+
+          if (legacy) {
+            await tx
+              .update(devices)
+              .set({
+                deviceId: deviceInput.deviceId,
+                name: deviceInput.name,
+                hostname: deviceInput.hostname ?? null,
+                os: deviceInput.os ?? null,
+                cliVersion: data.meta.version,
+                lastSeenAt: now,
+                updatedAt: now,
+              })
+              .where(eq(devices.id, legacy.id));
+            deviceUuid = legacy.id;
+          } else {
+            const [created] = await tx
+              .insert(devices)
+              .values({
+                userId: tokenRecord.userId,
+                deviceId: deviceInput.deviceId,
+                name: deviceInput.name,
+                hostname: deviceInput.hostname ?? null,
+                os: deviceInput.os ?? null,
+                cliVersion: data.meta.version,
+                lastSeenAt: now,
+              })
+              .returning({ id: devices.id });
+            deviceUuid = created.id;
+          }
+        }
+      }
+
+      // ------------------------------------------
+      // STEP 3b: Fetch existing daily breakdown for THIS device's merge
       // ------------------------------------------
       const existingDays = await tx
         .select({
@@ -195,7 +304,12 @@ export async function POST(request: Request) {
           sourceBreakdown: dailyBreakdown.sourceBreakdown,
         })
         .from(dailyBreakdown)
-        .where(eq(dailyBreakdown.submissionId, submissionId))
+        .where(
+          and(
+            eq(dailyBreakdown.submissionId, submissionId),
+            eq(dailyBreakdown.deviceId, deviceUuid)
+          )
+        )
         .for('update');
 
       const existingDaysMap = new Map(
@@ -207,6 +321,7 @@ export async function POST(request: Request) {
       // ------------------------------------------
       const toInsert: Array<{
         submissionId: string;
+        deviceId: string;
         date: string;
         tokens: number;
         cost: string;
@@ -291,6 +406,7 @@ export async function POST(request: Request) {
 
           toInsert.push({
             submissionId,
+            deviceId: deviceUuid,
             date: incomingDay.date,
             tokens: dayTotals.tokens,
             cost: dayTotals.cost.toFixed(4),
@@ -343,8 +459,9 @@ export async function POST(request: Request) {
           outputTokens: sql<number>`COALESCE(SUM(${dailyBreakdown.outputTokens}), 0)::bigint`,
           dateStart: sql<string>`MIN(${dailyBreakdown.date})`,
           dateEnd: sql<string>`MAX(${dailyBreakdown.date})`,
-          activeDays: sql<number>`COUNT(CASE WHEN ${dailyBreakdown.tokens} > 0 THEN 1 END)::int`,
+          activeDays: sql<number>`COUNT(DISTINCT CASE WHEN ${dailyBreakdown.tokens} > 0 THEN ${dailyBreakdown.date} END)::int`,
           rowCount: sql<number>`COUNT(*)::int`,
+          deviceCount: sql<number>`COUNT(DISTINCT ${dailyBreakdown.deviceId})::int`,
         })
         .from(dailyBreakdown)
         .where(eq(dailyBreakdown.submissionId, submissionId));
@@ -410,6 +527,10 @@ export async function POST(request: Request) {
       return {
         submissionId,
         isNewSubmission,
+        device: {
+          name: resolvedDeviceName,
+          count: aggregates.deviceCount,
+        },
         metrics: {
           totalTokens: aggregates.totalTokens,
           totalCost: parseFloat(aggregates.totalCost),
@@ -439,6 +560,7 @@ export async function POST(request: Request) {
       success: true,
       submissionId: result.submissionId,
       username: tokenRecord.username,
+      device: result.device,
       metrics: result.metrics,
       mode: result.isNewSubmission ? "create" : "merge",
       warnings: validation.warnings.length > 0 ? validation.warnings : undefined,

--- a/packages/frontend/src/app/api/users/[username]/route.ts
+++ b/packages/frontend/src/app/api/users/[username]/route.ts
@@ -8,6 +8,7 @@ import {
   usernameEqualsIgnoreCase,
 } from "@/lib/db/usernameLookup";
 import { buildSubmissionFreshness } from "@/lib/submissionFreshness";
+import { getUserDeviceStats } from "@/lib/db/devices";
 
 const LEGACY_CLIENT_ALIASES: Record<string, string> = { kilocode: "kilo" };
 function normalizeClientId(id: string): string {
@@ -49,7 +50,7 @@ export async function GET(_request: Request, { params }: RouteParams) {
     const oneYearAgo = new Date();
     oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
 
-    const [statsResult, latestSubmissionResult, rankResult, dailyData] = await Promise.all([
+    const [statsResult, latestSubmissionResult, rankResult, dailyData, deviceStats] = await Promise.all([
       db
         .select({
           totalTokens: sql<number>`COALESCE(SUM(${submissions.totalTokens}), 0)`,
@@ -99,6 +100,7 @@ export async function GET(_request: Request, { params }: RouteParams) {
       db
         .select({
           date: dailyBreakdown.date,
+          deviceId: dailyBreakdown.deviceId,
           timestampMs: dailyBreakdown.timestampMs,
           tokens: dailyBreakdown.tokens,
           cost: dailyBreakdown.cost,
@@ -116,11 +118,17 @@ export async function GET(_request: Request, { params }: RouteParams) {
           )
         )
         .orderBy(dailyBreakdown.date),
+
+      getUserDeviceStats(user.id),
     ]);
 
     const [stats] = statsResult;
     const [latestSubmission] = latestSubmissionResult;
     const rank = (rankResult as unknown as { rank: number }[])[0]?.rank || null;
+
+    // The aggregatedDaily loop below mutates dailyData rows in place; keep an
+    // independent copy for the per-device pass so it reads unmutated data.
+    const deviceDailyRows = structuredClone(dailyData);
 
     type ModelData = {
       tokens: number;
@@ -401,6 +409,97 @@ export async function GET(_request: Request, { params }: RouteParams) {
       };
     });
 
+    // Per-device daily contributions for the Activity tab's device selector.
+    const rowsByDevice = new Map<string, typeof deviceDailyRows>();
+    for (const row of deviceDailyRows) {
+      const list = rowsByDevice.get(row.deviceId);
+      if (list) list.push(row);
+      else rowsByDevice.set(row.deviceId, [row]);
+    }
+
+    const buildDeviceContributions = (rows: typeof deviceDailyRows) =>
+      rows
+        .slice()
+        .sort((a, b) => a.date.localeCompare(b.date))
+        .map((row) => {
+          const cost = Number(row.cost);
+          const intensity =
+            maxCost === 0 || cost === 0
+              ? 0
+              : cost <= maxCost * 0.25
+              ? 1
+              : cost <= maxCost * 0.5
+              ? 2
+              : cost <= maxCost * 0.75
+              ? 3
+              : 4;
+
+          let cacheRead = 0;
+          let cacheWrite = 0;
+          let reasoning = 0;
+          const clientList: Array<{
+            client: string;
+            modelId: string;
+            models: Record<string, ModelData>;
+            tokens: {
+              input: number;
+              output: number;
+              cacheRead: number;
+              cacheWrite: number;
+              reasoning: number;
+            };
+            cost: number;
+            messages: number;
+          }> = [];
+
+          if (row.sourceBreakdown) {
+            for (const [rawClient, data] of Object.entries(row.sourceBreakdown)) {
+              const b = data as ClientBreakdown;
+              cacheRead += b.cacheRead || 0;
+              cacheWrite += b.cacheWrite || 0;
+              reasoning += b.reasoning || 0;
+              clientList.push({
+                client: normalizeClientId(rawClient),
+                modelId: b.modelId || "",
+                models: b.models || {},
+                tokens: {
+                  input: b.input || 0,
+                  output: b.output || 0,
+                  cacheRead: b.cacheRead || 0,
+                  cacheWrite: b.cacheWrite || 0,
+                  reasoning: b.reasoning || 0,
+                },
+                cost: b.cost || 0,
+                messages: b.messages || 0,
+              });
+            }
+          }
+
+          return {
+            date: row.date,
+            timestampMs: row.timestampMs ?? null,
+            totals: { tokens: Number(row.tokens), cost, messages: 0 },
+            intensity: intensity as 0 | 1 | 2 | 3 | 4,
+            tokenBreakdown: {
+              input: Number(row.inputTokens),
+              output: Number(row.outputTokens),
+              cacheRead,
+              cacheWrite,
+              reasoning,
+            },
+            clients: clientList,
+          };
+        });
+
+    const deviceContributions = deviceStats
+      .filter((device) => (rowsByDevice.get(device.id)?.length ?? 0) > 0)
+      .map((device) => ({
+        id: device.id,
+        name: device.name,
+        os: device.os,
+        contributions: buildDeviceContributions(rowsByDevice.get(device.id) ?? []),
+      }));
+
     const activeDays = contributions.filter((c) => c.tokens > 0).length;
 
     const modelUsageMap = new Map<string, { tokens: number; cost: number }>();
@@ -458,6 +557,19 @@ export async function GET(_request: Request, { params }: RouteParams) {
       models: latestSubmission?.modelsUsed || [],
       modelUsage,
       contributions: graphContributions,
+      // Per-device usage breakdown, public-safe fields only (no hostname).
+      devices: deviceStats
+        .filter((device) => (rowsByDevice.get(device.id)?.length ?? 0) > 0)
+        .map((device) => ({
+          id: device.id,
+          name: device.name,
+          os: device.os,
+          totalTokens: device.totalTokens,
+          totalCost: device.totalCost,
+          activeDays: device.activeDays,
+          lastActiveDate: device.lastActiveDate,
+        })),
+      deviceContributions,
     });
   } catch (error) {
     if (error instanceof AmbiguousUsernameError) {

--- a/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
+++ b/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
@@ -9,6 +9,7 @@ import {
   ProfileTabBar,
   TokenBreakdown,
   ProfileModels,
+  ProfileDevices,
   ProfileActivity,
   ProfileEmptyActivity,
   ProfileStats,
@@ -16,6 +17,7 @@ import {
   type ProfileStatsData,
   type ProfileTab,
   type ModelUsage,
+  type ProfileDevice,
 } from "@/components/profile";
 import type { TokenContributionData, DailyContribution, ClientType } from "@/lib/types";
 
@@ -47,6 +49,15 @@ interface ProfileData {
   models: string[];
   modelUsage?: ModelUsage[];
   contributions: DailyContribution[];
+  devices?: ProfileDevice[];
+  deviceContributions?: DeviceContributionGroup[];
+}
+
+interface DeviceContributionGroup {
+  id: string;
+  name: string;
+  os: string | null;
+  contributions: DailyContribution[];
 }
 
 interface ProfilePageClientProps {
@@ -54,69 +65,251 @@ interface ProfilePageClientProps {
   username: string;
 }
 
+/** Build the contribution-graph payload from a daily contribution list. */
+function buildGraphData(
+  contributions: DailyContribution[],
+  summary: {
+    totalTokens: number;
+    totalCost: number;
+    activeDays: number;
+    clients: string[];
+    models: string[];
+  },
+  dateRange: { start: string | null; end: string | null }
+): TokenContributionData | null {
+  if (contributions.length === 0) return null;
+
+  const maxCost = Math.max(...contributions.map((c) => c.totals.cost), 0);
+
+  const yearMap = new Map<
+    string,
+    { totalTokens: number; totalCost: number; start: string; end: string }
+  >();
+  for (const day of contributions) {
+    const year = day.date.split("-")[0];
+    const existing = yearMap.get(year);
+    if (existing) {
+      existing.totalTokens += day.totals.tokens;
+      existing.totalCost += day.totals.cost;
+      if (day.date < existing.start) existing.start = day.date;
+      if (day.date > existing.end) existing.end = day.date;
+    } else {
+      yearMap.set(year, {
+        totalTokens: day.totals.tokens,
+        totalCost: day.totals.cost,
+        start: day.date,
+        end: day.date,
+      });
+    }
+  }
+
+  const years = Array.from(yearMap.entries())
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([year, s]) => ({
+      year,
+      totalTokens: s.totalTokens,
+      totalCost: s.totalCost,
+      range: { start: s.start, end: s.end },
+    }));
+
+  return {
+    meta: {
+      generatedAt: new Date().toISOString(),
+      version: "1.0.0",
+      dateRange: {
+        start: dateRange.start || contributions[0]?.date || "",
+        end:
+          dateRange.end || contributions[contributions.length - 1]?.date || "",
+      },
+    },
+    summary: {
+      totalTokens: summary.totalTokens,
+      totalCost: summary.totalCost,
+      totalDays: contributions.length,
+      activeDays: summary.activeDays,
+      averagePerDay:
+        summary.activeDays > 0 ? summary.totalCost / summary.activeDays : 0,
+      maxCostInSingleDay: maxCost,
+      clients: summary.clients as ClientType[],
+      models: summary.models,
+    },
+    years,
+    contributions,
+  };
+}
+
+/** Sum per-day stats — used to derive a single device's totals. */
+function deriveStatsFromContributions(contributions: DailyContribution[]) {
+  let totalTokens = 0;
+  let totalCost = 0;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let cacheReadTokens = 0;
+  let cacheWriteTokens = 0;
+  let activeDays = 0;
+  for (const day of contributions) {
+    totalTokens += day.totals.tokens;
+    totalCost += day.totals.cost;
+    inputTokens += day.tokenBreakdown.input;
+    outputTokens += day.tokenBreakdown.output;
+    cacheReadTokens += day.tokenBreakdown.cacheRead;
+    cacheWriteTokens += day.tokenBreakdown.cacheWrite;
+    if (day.totals.tokens > 0) activeDays += 1;
+  }
+  return {
+    totalTokens,
+    totalCost,
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+    activeDays,
+  };
+}
+
+/** Aggregate per-model usage from a daily contribution list. */
+function deriveModelUsage(contributions: DailyContribution[]): {
+  models: string[];
+  modelUsage: ModelUsage[];
+} {
+  const map = new Map<string, { tokens: number; cost: number }>();
+  const add = (modelId: string, tokens: number, cost: number) => {
+    const entry = map.get(modelId) ?? { tokens: 0, cost: 0 };
+    entry.tokens += tokens;
+    entry.cost += cost;
+    map.set(modelId, entry);
+  };
+  for (const day of contributions) {
+    for (const client of day.clients) {
+      if (client.models && Object.keys(client.models).length > 0) {
+        for (const [modelId, m] of Object.entries(client.models)) {
+          add(modelId, m.tokens || 0, m.cost || 0);
+        }
+      } else if (client.modelId) {
+        // Legacy rows carry a single modelId without a nested models map.
+        const t = client.tokens;
+        add(
+          client.modelId,
+          (t.input || 0) +
+            (t.output || 0) +
+            (t.cacheRead || 0) +
+            (t.cacheWrite || 0) +
+            (t.reasoning || 0),
+          client.cost || 0
+        );
+      }
+    }
+  }
+  const totalCost = Array.from(map.values()).reduce((sum, m) => sum + m.cost, 0);
+  const modelUsage = Array.from(map.entries())
+    .filter(([model]) => model !== "<synthetic>")
+    .map(([model, d]) => ({
+      model,
+      tokens: d.tokens,
+      cost: d.cost,
+      percentage: totalCost > 0 ? (d.cost / totalCost) * 100 : 0,
+    }))
+    .sort((a, b) => b.cost - a.cost || b.tokens - a.tokens);
+  return { models: modelUsage.map((m) => m.model), modelUsage };
+}
+
+/** Total / per-device segmented filter, shared by the Activity and Models tabs. */
+function DeviceFilterBar({
+  devices,
+  selected,
+  onSelect,
+}: {
+  devices: DeviceContributionGroup[];
+  selected: string;
+  onSelect: (value: string) => void;
+}) {
+  return (
+    <DeviceSelector aria-label="Filter by device">
+      <DeviceSelectorButton
+        type="button"
+        data-active={selected === "total"}
+        onClick={() => onSelect("total")}
+      >
+        Total
+      </DeviceSelectorButton>
+      {devices.map((device) => (
+        <DeviceSelectorButton
+          key={device.id}
+          type="button"
+          data-active={selected === device.id}
+          onClick={() => onSelect(device.id)}
+        >
+          {device.name}
+        </DeviceSelectorButton>
+      ))}
+    </DeviceSelector>
+  );
+}
+
 export default function ProfilePageClient({ initialData, username }: ProfilePageClientProps) {
   const [activeTab, setActiveTab] = useState<ProfileTab>("activity");
   const data = initialData;
 
-  const graphData: TokenContributionData | null = useMemo(() => {
-    if (!data || data.contributions.length === 0) return null;
+  const [selectedDevice, setSelectedDevice] = useState<string>("total");
 
-    const contributions = data.contributions;
-    const totalCost = data.stats.totalCost;
-    const totalTokens = data.stats.totalTokens;
-    const maxCost = Math.max(...contributions.map((c) => c.totals.cost), 0);
+  const deviceContributions: DeviceContributionGroup[] = useMemo(
+    () => data.deviceContributions ?? [],
+    [data]
+  );
+  const hasDeviceBreakdown = deviceContributions.length > 1;
 
-    const yearMap = new Map<string, { totalTokens: number; totalCost: number; start: string; end: string }>();
-    for (const day of contributions) {
-      const year = day.date.split("-")[0];
-      const existing = yearMap.get(year);
-      if (existing) {
-        existing.totalTokens += day.totals.tokens;
-        existing.totalCost += day.totals.cost;
-        if (day.date < existing.start) existing.start = day.date;
-        if (day.date > existing.end) existing.end = day.date;
-      } else {
-        yearMap.set(year, {
-          totalTokens: day.totals.tokens,
-          totalCost: day.totals.cost,
-          start: day.date,
-          end: day.date,
-        });
-      }
-    }
+  const favoriteModel = useMemo(
+    () =>
+      data.modelUsage && data.modelUsage.length > 0
+        ? data.modelUsage.reduce(
+            (max, cur) => (cur.cost > max.cost ? cur : max),
+            data.modelUsage[0]
+          ).model
+        : undefined,
+    [data]
+  );
 
-    const years = Array.from(yearMap.entries())
-      .sort((a, b) => a[0].localeCompare(b[0]))
-      .map(([year, stats]) => ({
-        year,
-        totalTokens: stats.totalTokens,
-        totalCost: stats.totalCost,
-        range: { start: stats.start, end: stats.end },
-      }));
-
-    return {
-      meta: {
-        generatedAt: new Date().toISOString(),
-        version: "1.0.0",
-        dateRange: {
-          start: data.dateRange.start || contributions[0]?.date || "",
-          end: data.dateRange.end || contributions[contributions.length - 1]?.date || "",
+  const activeGraphData: TokenContributionData | null = useMemo(() => {
+    if (selectedDevice === "total") {
+      return buildGraphData(
+        data.contributions,
+        {
+          totalTokens: data.stats.totalTokens,
+          totalCost: data.stats.totalCost,
+          activeDays: data.stats.activeDays,
+          clients: data.clients,
+          models: data.models,
         },
+        data.dateRange
+      );
+    }
+    const device = deviceContributions.find((d) => d.id === selectedDevice);
+    if (!device) return null;
+    const derived = deriveStatsFromContributions(device.contributions);
+    const clients = Array.from(
+      new Set(
+        device.contributions.flatMap((c) => c.clients.map((cl) => cl.client))
+      )
+    );
+    const models = Array.from(
+      new Set(
+        device.contributions.flatMap((c) =>
+          c.clients.flatMap((cl) => Object.keys(cl.models ?? {}))
+        )
+      )
+    );
+    return buildGraphData(
+      device.contributions,
+      {
+        totalTokens: derived.totalTokens,
+        totalCost: derived.totalCost,
+        activeDays: derived.activeDays,
+        clients,
+        models,
       },
-      summary: {
-        totalTokens,
-        totalCost,
-        totalDays: contributions.length,
-        activeDays: data.stats.activeDays,
-        averagePerDay: data.stats.activeDays > 0 ? totalCost / data.stats.activeDays : 0,
-        maxCostInSingleDay: maxCost,
-        clients: data.clients as ClientType[],
-        models: data.models,
-      },
-      years,
-      contributions: contributions as DailyContribution[],
-    };
-  }, [data]);
+      { start: null, end: null }
+    );
+  }, [selectedDevice, data, deviceContributions]);
 
   const user: ProfileUser = useMemo(() => ({
     username: data.user.username,
@@ -135,6 +328,32 @@ export default function ProfilePageClient({ initialData, username }: ProfilePage
     activeDays: data.stats.activeDays,
     submissionCount: data.stats.submissionCount,
   }), [data]);
+
+  const activeStats: ProfileStatsData = useMemo(() => {
+    if (selectedDevice === "total") return stats;
+    const device = deviceContributions.find((d) => d.id === selectedDevice);
+    const derived = device
+      ? deriveStatsFromContributions(device.contributions)
+      : {
+          totalTokens: 0,
+          totalCost: 0,
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          activeDays: 0,
+        };
+    return { ...derived, submissionCount: data.stats.submissionCount };
+  }, [selectedDevice, deviceContributions, stats, data]);
+
+  const activeModelData = useMemo<{ models: string[]; modelUsage: ModelUsage[] }>(() => {
+    if (selectedDevice === "total") {
+      return { models: data.models, modelUsage: data.modelUsage ?? [] };
+    }
+    const device = deviceContributions.find((d) => d.id === selectedDevice);
+    if (!device) return { models: [], modelUsage: [] };
+    return deriveModelUsage(device.contributions);
+  }, [selectedDevice, data, deviceContributions]);
 
 const EARLY_ADOPTERS = ["code-yeongyu", "gtg7784", "qodot"];
   const showResubmitBanner = EARLY_ADOPTERS.includes(data.user.username) && data.stats.submissionCount === 1;
@@ -172,17 +391,35 @@ const EARLY_ADOPTERS = ["code-yeongyu", "gtg7784", "qodot"];
               id="tabpanel-activity"
               aria-labelledby="tab-activity"
             >
-              {graphData ? (
+              {data.contributions.length === 0 ? (
+                <ProfileEmptyActivity />
+              ) : (
                 <ActivitySection>
-                  <ProfileActivity data={graphData} />
-                  <ProfileStats
-                    stats={stats}
-                    favoriteModel={
-                      data.modelUsage?.reduce((max, current) => current.cost > max.cost ? current : max, data.modelUsage[0])?.model
-                    }
-                  />
+                  {hasDeviceBreakdown && (
+                    <DeviceFilterBar
+                      devices={deviceContributions}
+                      selected={selectedDevice}
+                      onSelect={setSelectedDevice}
+                    />
+                  )}
+                  {activeGraphData ? (
+                    <>
+                      <ProfileActivity
+                        key={selectedDevice}
+                        data={activeGraphData}
+                      />
+                      <ProfileStats
+                        stats={activeStats}
+                        favoriteModel={
+                          selectedDevice === "total" ? favoriteModel : undefined
+                        }
+                      />
+                    </>
+                  ) : (
+                    <ProfileEmptyActivity />
+                  )}
                 </ActivitySection>
-              ) : <ProfileEmptyActivity />}
+              )}
             </div>
           )}
           {activeTab === "breakdown" && (
@@ -191,7 +428,12 @@ const EARLY_ADOPTERS = ["code-yeongyu", "gtg7784", "qodot"];
               id="tabpanel-breakdown"
               aria-labelledby="tab-breakdown"
             >
-              <TokenBreakdown stats={stats} />
+              <BreakdownSection>
+                <TokenBreakdown stats={stats} />
+                {data.devices && data.devices.length > 0 && (
+                  <ProfileDevices devices={data.devices} />
+                )}
+              </BreakdownSection>
             </div>
           )}
           {activeTab === "models" && (
@@ -200,7 +442,19 @@ const EARLY_ADOPTERS = ["code-yeongyu", "gtg7784", "qodot"];
               id="tabpanel-models"
               aria-labelledby="tab-models"
             >
-              <ProfileModels models={data.models} modelUsage={data.modelUsage} />
+              <ModelsSection>
+                {hasDeviceBreakdown && (
+                  <DeviceFilterBar
+                    devices={deviceContributions}
+                    selected={selectedDevice}
+                    onSelect={setSelectedDevice}
+                  />
+                )}
+                <ProfileModels
+                  models={activeModelData.models}
+                  modelUsage={activeModelData.modelUsage}
+                />
+              </ModelsSection>
             </div>
           )}
         </ContentWrapper>
@@ -285,6 +539,48 @@ const ContentWrapper = styled.div`
 `;
 
 const ActivitySection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+`;
+
+const DeviceSelector = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+`;
+
+const DeviceSelectorButton = styled.button`
+  padding: 6px 14px;
+  border-radius: 9999px;
+  border: 1px solid var(--color-border-default);
+  background-color: transparent;
+  color: var(--color-fg-muted);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+
+  &[data-active="true"] {
+    background-color: #006edb;
+    border-color: #006edb;
+    color: #ffffff;
+  }
+
+  &:hover[data-active="false"] {
+    color: var(--color-fg-default);
+    border-color: var(--color-fg-muted);
+  }
+`;
+
+const BreakdownSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+`;
+
+const ModelsSection = styled.div`
   display: flex;
   flex-direction: column;
   gap: 24px;

--- a/packages/frontend/src/components/GraphContainer.tsx
+++ b/packages/frontend/src/components/GraphContainer.tsx
@@ -71,7 +71,7 @@ export function GraphContainer({ data }: GraphContainerProps) {
   const [selectedYear, setSelectedYear] = useState<string>(() => data.years.length > 0 ? data.years[data.years.length - 1].year : "");
   const [hoveredDay, setHoveredDay] = useState<DailyContribution | null>(null);
   const [tooltipPosition, setTooltipPosition] = useState<TooltipPosition | null>(null);
-  const [selectedDay, setSelectedDay] = useState<DailyContribution | null>(null);
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [clientFilter, setClientFilter] = useState<ClientType[]>([]);
   const initializedRef = useRef(false);
 
@@ -88,6 +88,16 @@ export function GraphContainer({ data }: GraphContainerProps) {
     const filtered = filterByYear(filteredByClient.contributions, selectedYear);
     return recalculateIntensity(filtered);
   }, [filteredByClient.contributions, selectedYear]);
+
+  // Derived from selectedDate so switching device or year refreshes the
+  // detailed breakdown instead of leaving a stale day on screen.
+  const selectedDay = useMemo(
+    () =>
+      selectedDate
+        ? yearContributions.find((c) => c.date === selectedDate) ?? null
+        : null,
+    [yearContributions, selectedDate]
+  );
 
   const maxTokens = useMemo(() => Math.max(...yearContributions.map((c) => c.totals.tokens), 0), [yearContributions]);
   const totalCost = useMemo(() => yearContributions.reduce((sum, c) => sum + c.totals.cost, 0), [yearContributions]);
@@ -114,7 +124,7 @@ export function GraphContainer({ data }: GraphContainerProps) {
         const latestDay = activeDaysWithTokens[activeDaysWithTokens.length - 1];
         // Intentional one-time initialization on first data load
         // eslint-disable-next-line react-hooks/set-state-in-effect
-        setSelectedDay(latestDay);
+        setSelectedDate(latestDay.date);
         initializedRef.current = true;
       }
     }
@@ -126,7 +136,7 @@ export function GraphContainer({ data }: GraphContainerProps) {
   }, []);
 
   const handleDayClick = useCallback((day: DailyContribution | null) => {
-    setSelectedDay((prev) => (prev?.date === day?.date ? null : day));
+    setSelectedDate((prev) => (prev === day?.date ? null : day?.date ?? null));
   }, []);
 
   return (
@@ -178,7 +188,7 @@ export function GraphContainer({ data }: GraphContainerProps) {
         </GraphWrapper>
       </GraphCard>
 
-      {selectedDay && <BreakdownPanel day={selectedDay} onClose={() => setSelectedDay(null)} palette={palette} />}
+      {selectedDay && <BreakdownPanel day={selectedDay} onClose={() => setSelectedDate(null)} palette={palette} />}
       {view === "2d" && <StatsPanel data={filteredByClient} palette={palette} />}
       <Tooltip day={hoveredDay} position={tooltipPosition} visible={hoveredDay !== null} palette={palette} />
     </Container>

--- a/packages/frontend/src/components/profile/ProfileDevices.tsx
+++ b/packages/frontend/src/components/profile/ProfileDevices.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import styled from "styled-components";
+import { formatNumber, formatCurrency } from "@/lib/utils";
+
+export interface ProfileDevice {
+  id: string;
+  name: string;
+  os: string | null;
+  totalTokens: number;
+  totalCost: number;
+  activeDays: number;
+  lastActiveDate: string | null;
+}
+
+interface ProfileDevicesProps {
+  devices: ProfileDevice[];
+}
+
+// Distinct hues for the per-device share bar; cycles when there are more
+// devices than colors.
+const DEVICE_COLORS = [
+  "#006edb",
+  "#894ceb",
+  "#30a147",
+  "#eb670f",
+  "#d6336c",
+  "#0ca678",
+  "#f59f00",
+  "#4263eb",
+];
+
+const OS_LABELS: Record<string, string> = {
+  linux: "Linux",
+  macos: "macOS",
+  windows: "Windows",
+};
+
+/** Per-device usage breakdown shown on the profile breakdown tab. */
+export function ProfileDevices({ devices }: ProfileDevicesProps) {
+  if (devices.length === 0) {
+    return null;
+  }
+
+  const totalTokens = devices.reduce((sum, d) => sum + d.totalTokens, 0);
+
+  const ranked = [...devices]
+    .sort((a, b) => b.totalTokens - a.totalTokens)
+    .map((device, index) => ({
+      ...device,
+      color: DEVICE_COLORS[index % DEVICE_COLORS.length],
+      percentage: totalTokens > 0 ? (device.totalTokens / totalTokens) * 100 : 0,
+    }));
+
+  return (
+    <Container
+      style={{
+        backgroundColor: "var(--color-bg-default)",
+        borderColor: "var(--color-border-default)",
+      }}
+    >
+      <Header>
+        <Title style={{ color: "var(--color-fg-default)" }}>
+          {devices.length === 1 ? "1 device" : `${devices.length} devices`}
+        </Title>
+        <Subtitle style={{ color: "var(--color-fg-subtle)" }}>
+          Usage aggregated across every machine
+        </Subtitle>
+      </Header>
+
+      {totalTokens > 0 && (
+        <ProgressBar style={{ backgroundColor: "var(--color-bg-subtle)" }}>
+          {ranked.map((device) => (
+            <div
+              key={device.id}
+              style={{
+                width: `${device.percentage}%`,
+                backgroundColor: device.color,
+              }}
+              title={`${device.name}: ${formatNumber(device.totalTokens)}`}
+            />
+          ))}
+        </ProgressBar>
+      )}
+
+      <DeviceList>
+        {ranked.map((device) => (
+          <DeviceRow key={device.id}>
+            <DeviceLeft>
+              <Dot style={{ backgroundColor: device.color }} />
+              <DeviceMeta>
+                <DeviceName style={{ color: "var(--color-fg-default)" }}>
+                  {device.name}
+                </DeviceName>
+                <DeviceSub style={{ color: "var(--color-fg-muted)" }}>
+                  {device.os ? OS_LABELS[device.os] ?? device.os : "Unknown OS"}
+                  {device.activeDays > 0 && ` · ${device.activeDays} active days`}
+                </DeviceSub>
+              </DeviceMeta>
+            </DeviceLeft>
+            <DeviceRight>
+              <DeviceTokens style={{ color: "var(--color-fg-default)" }}>
+                {formatNumber(device.totalTokens)}
+              </DeviceTokens>
+              <DeviceSub style={{ color: "var(--color-fg-subtle)" }}>
+                {formatCurrency(device.totalCost)} · {device.percentage.toFixed(1)}%
+              </DeviceSub>
+            </DeviceRight>
+          </DeviceRow>
+        ))}
+      </DeviceList>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  border-radius: 1rem;
+  border-width: 1px;
+  border-style: solid;
+  padding: 1rem;
+
+  @media (min-width: 640px) {
+    padding: 1.5rem;
+  }
+`;
+
+const Header = styled.div`
+  margin-bottom: 1rem;
+`;
+
+const Title = styled.h3`
+  font-size: 1rem;
+  font-weight: 600;
+
+  @media (min-width: 640px) {
+    font-size: 1.125rem;
+  }
+`;
+
+const Subtitle = styled.p`
+  font-size: 0.75rem;
+  margin-top: 0.125rem;
+`;
+
+const ProgressBar = styled.div`
+  height: 0.75rem;
+  border-radius: 9999px;
+  overflow: hidden;
+  display: flex;
+  margin-bottom: 1.25rem;
+`;
+
+const DeviceList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+`;
+
+const DeviceRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+`;
+
+const DeviceLeft = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+`;
+
+const Dot = styled.div`
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 9999px;
+  flex-shrink: 0;
+`;
+
+const DeviceMeta = styled.div`
+  min-width: 0;
+`;
+
+const DeviceName = styled.p`
+  font-size: 0.875rem;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const DeviceSub = styled.p`
+  font-size: 0.75rem;
+`;
+
+const DeviceRight = styled.div`
+  text-align: right;
+  flex-shrink: 0;
+`;
+
+const DeviceTokens = styled.p`
+  font-size: 0.875rem;
+  font-weight: 600;
+
+  @media (min-width: 640px) {
+    font-size: 1rem;
+  }
+`;

--- a/packages/frontend/src/components/profile/index.tsx
+++ b/packages/frontend/src/components/profile/index.tsx
@@ -1211,3 +1211,8 @@ export function ProfileEmptyActivity() {
     </EmptyActivityContainer>
   );
 }
+
+// Re-export the device breakdown widget so it is available alongside the
+// other profile components from "@/components/profile".
+export { ProfileDevices } from "./ProfileDevices";
+export type { ProfileDevice } from "./ProfileDevices";

--- a/packages/frontend/src/lib/db/devices.ts
+++ b/packages/frontend/src/lib/db/devices.ts
@@ -1,0 +1,165 @@
+/** Device queries for multi-device usage aggregation. */
+import { db, devices, dailyBreakdown, submissions } from "@/lib/db";
+import { and, eq, sql, desc } from "drizzle-orm";
+import type { ClientBreakdownData } from "@/lib/db/helpers";
+
+/** A drizzle transaction handle, as passed to `db.transaction(async (tx) => ...)`. */
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+export interface DeviceUsageStats {
+  id: string;
+  deviceId: string;
+  name: string;
+  hostname: string | null;
+  os: string | null;
+  cliVersion: string | null;
+  lastSeenAt: string | null;
+  createdAt: string;
+  totalTokens: number;
+  totalCost: number;
+  lastActiveDate: string | null;
+  activeDays: number;
+}
+
+function toIso(value: Date | string | null): string | null {
+  if (value == null) return null;
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+/** Lists a user's devices with summed usage, ordered by tokens descending. */
+export async function getUserDeviceStats(userId: string): Promise<DeviceUsageStats[]> {
+  const rows = await db
+    .select({
+      id: devices.id,
+      deviceId: devices.deviceId,
+      name: devices.name,
+      hostname: devices.hostname,
+      os: devices.os,
+      cliVersion: devices.cliVersion,
+      lastSeenAt: devices.lastSeenAt,
+      createdAt: devices.createdAt,
+      totalTokens: sql<number>`COALESCE(SUM(${dailyBreakdown.tokens}), 0)::bigint`,
+      totalCost: sql<string>`COALESCE(SUM(CAST(${dailyBreakdown.cost} AS DECIMAL(14,4))), 0)::text`,
+      lastActiveDate: sql<string | null>`MAX(${dailyBreakdown.date})`,
+      activeDays: sql<number>`COUNT(CASE WHEN ${dailyBreakdown.tokens} > 0 THEN 1 END)::int`,
+    })
+    .from(devices)
+    .leftJoin(dailyBreakdown, eq(dailyBreakdown.deviceId, devices.id))
+    .where(eq(devices.userId, userId))
+    .groupBy(devices.id)
+    .orderBy(desc(sql`COALESCE(SUM(${dailyBreakdown.tokens}), 0)`));
+
+  return rows.map((r) => ({
+    id: r.id,
+    deviceId: r.deviceId,
+    name: r.name,
+    hostname: r.hostname,
+    os: r.os,
+    cliVersion: r.cliVersion,
+    lastSeenAt: toIso(r.lastSeenAt),
+    createdAt: toIso(r.createdAt) ?? new Date(0).toISOString(),
+    totalTokens: Number(r.totalTokens) || 0,
+    totalCost: Number(r.totalCost) || 0,
+    lastActiveDate: r.lastActiveDate ?? null,
+    activeDays: Number(r.activeDays) || 0,
+  }));
+}
+
+/** Recompute a submission's totals from the SUM of its daily_breakdown rows. */
+async function recomputeSubmissionTotals(tx: Tx, submissionId: string): Promise<void> {
+  const [aggregates] = await tx
+    .select({
+      totalTokens: sql<number>`COALESCE(SUM(${dailyBreakdown.tokens}), 0)::bigint`,
+      totalCost: sql<string>`COALESCE(SUM(CAST(${dailyBreakdown.cost} AS DECIMAL(12,4))), 0)::text`,
+      inputTokens: sql<number>`COALESCE(SUM(${dailyBreakdown.inputTokens}), 0)::bigint`,
+      outputTokens: sql<number>`COALESCE(SUM(${dailyBreakdown.outputTokens}), 0)::bigint`,
+      dateStart: sql<string | null>`MIN(${dailyBreakdown.date})`,
+      dateEnd: sql<string | null>`MAX(${dailyBreakdown.date})`,
+      rowCount: sql<number>`COUNT(*)::int`,
+    })
+    .from(dailyBreakdown)
+    .where(eq(dailyBreakdown.submissionId, submissionId));
+
+  const allDays = await tx
+    .select({ sourceBreakdown: dailyBreakdown.sourceBreakdown })
+    .from(dailyBreakdown)
+    .where(eq(dailyBreakdown.submissionId, submissionId));
+
+  const allClients = new Set<string>();
+  const allModels = new Set<string>();
+  let totalCacheRead = 0;
+  let totalCacheCreation = 0;
+  let totalReasoning = 0;
+
+  for (const day of allDays) {
+    if (!day.sourceBreakdown) continue;
+    for (const [rawClientName, clientData] of Object.entries(day.sourceBreakdown)) {
+      allClients.add(rawClientName === "kilocode" ? "kilo" : rawClientName);
+      const cd = clientData as ClientBreakdownData;
+      if (cd.models) {
+        for (const modelId of Object.keys(cd.models)) allModels.add(modelId);
+      } else if (cd.modelId) {
+        allModels.add(cd.modelId);
+      }
+      totalCacheRead += cd.cacheRead || 0;
+      totalCacheCreation += cd.cacheWrite || 0;
+      totalReasoning += cd.reasoning || 0;
+    }
+  }
+
+  await tx
+    .update(submissions)
+    .set({
+      totalTokens: aggregates.totalTokens,
+      totalCost: aggregates.totalCost,
+      inputTokens: aggregates.inputTokens,
+      outputTokens: aggregates.outputTokens,
+      cacheReadTokens: totalCacheRead,
+      cacheCreationTokens: totalCacheCreation,
+      reasoningTokens: totalReasoning,
+      sourcesUsed: Array.from(allClients),
+      modelsUsed: Array.from(allModels),
+      // Keep the existing date range when no rows remain (columns are NOT NULL).
+      ...(aggregates.rowCount > 0 && aggregates.dateStart && aggregates.dateEnd
+        ? { dateStart: aggregates.dateStart, dateEnd: aggregates.dateEnd }
+        : {}),
+      updatedAt: new Date(),
+    })
+    .where(eq(submissions.id, submissionId));
+}
+
+/**
+ * Delete one of a user's devices and its usage rows, then recompute the user's
+ * submission totals. Returns false if the device is not found for the user.
+ */
+export async function deleteUserDevice(
+  userId: string,
+  deviceUuid: string
+): Promise<boolean> {
+  return db.transaction(async (tx) => {
+    const [device] = await tx
+      .select({ id: devices.id })
+      .from(devices)
+      .where(and(eq(devices.id, deviceUuid), eq(devices.userId, userId)))
+      .limit(1);
+
+    if (!device) return false;
+
+    // Lock the submission row so totals stay consistent with concurrent submits.
+    const [submission] = await tx
+      .select({ id: submissions.id })
+      .from(submissions)
+      .where(eq(submissions.userId, userId))
+      .for("update")
+      .limit(1);
+
+    // FK onDelete: cascade removes this device's daily_breakdown rows.
+    await tx.delete(devices).where(eq(devices.id, device.id));
+
+    if (submission) {
+      await recomputeSubmissionTotals(tx, submission.id);
+    }
+
+    return true;
+  });
+}

--- a/packages/frontend/src/lib/db/migrations/0007_add_devices_and_device_breakdown.sql
+++ b/packages/frontend/src/lib/db/migrations/0007_add_devices_and_device_breakdown.sql
@@ -1,0 +1,68 @@
+-- Multi-device usage aggregation: a `devices` table plus a `device_id`
+-- dimension on daily_breakdown. Existing rows are backfilled into a per-user
+-- "legacy" device, which is also the fallback for pre-device-aware CLIs.
+
+-- 1. Devices table -----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS "devices" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"device_id" varchar(64) NOT NULL,
+	"name" varchar(100) NOT NULL,
+	"hostname" varchar(255),
+	"os" varchar(32),
+	"cli_version" varchar(20),
+	"last_seen_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "devices_user_device_unique" UNIQUE("user_id","device_id")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+	ALTER TABLE "devices" ADD CONSTRAINT "devices_user_id_users_id_fk"
+		FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+	WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_devices_user_id" ON "devices" USING btree ("user_id");
+--> statement-breakpoint
+
+-- 2. Add device_id to daily_breakdown (nullable during backfill) -------------
+ALTER TABLE "daily_breakdown" ADD COLUMN IF NOT EXISTS "device_id" uuid;
+--> statement-breakpoint
+
+-- 3. One "legacy" device per user that already has a submission --------------
+INSERT INTO "devices" ("user_id", "device_id", "name", "created_at", "updated_at")
+SELECT DISTINCT s."user_id", 'legacy', 'Legacy device', now(), now()
+FROM "submissions" s
+ON CONFLICT ("user_id","device_id") DO NOTHING;
+--> statement-breakpoint
+
+-- 4. Backfill daily_breakdown.device_id from the owner's legacy device -------
+UPDATE "daily_breakdown" d
+SET "device_id" = dev."id"
+FROM "submissions" s
+JOIN "devices" dev ON dev."user_id" = s."user_id" AND dev."device_id" = 'legacy'
+WHERE d."submission_id" = s."id" AND d."device_id" IS NULL;
+--> statement-breakpoint
+
+-- 5. Enforce NOT NULL now that every row is backfilled ----------------------
+ALTER TABLE "daily_breakdown" ALTER COLUMN "device_id" SET NOT NULL;
+--> statement-breakpoint
+DO $$ BEGIN
+	ALTER TABLE "daily_breakdown" ADD CONSTRAINT "daily_breakdown_device_id_devices_id_fk"
+		FOREIGN KEY ("device_id") REFERENCES "public"."devices"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+	WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+
+-- 6. Replace (submission_id, date) unique with (submission_id, device_id, date)
+ALTER TABLE "daily_breakdown" DROP CONSTRAINT IF EXISTS "daily_breakdown_submission_date_unique";
+--> statement-breakpoint
+ALTER TABLE "daily_breakdown" ADD CONSTRAINT "daily_breakdown_submission_device_date_unique"
+	UNIQUE("submission_id","device_id","date");
+--> statement-breakpoint
+
+-- 7. Index for device-scoped queries ---------------------------------------
+CREATE INDEX IF NOT EXISTS "idx_daily_breakdown_device_id" ON "daily_breakdown" USING btree ("device_id");

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1778025600000,
       "tag": "0006_rehash_plaintext_personal_tokens",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1779321600000,
+      "tag": "0007_add_devices_and_device_breakdown",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -53,6 +53,7 @@ export const usersRelations = relations(users, ({ many }) => ({
   sessions: many(sessions),
   apiTokens: many(apiTokens),
   submissions: many(submissions),
+  devices: many(devices),
 }));
 
 // ============================================================================
@@ -143,6 +144,44 @@ export const deviceCodes = pgTable(
 );
 
 // ============================================================================
+// DEVICES
+// ============================================================================
+export const devices = pgTable(
+  "devices",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    /** CLI-generated stable UUID, or the sentinel "legacy". */
+    deviceId: varchar("device_id", { length: 64 }).notNull(),
+    name: varchar("name", { length: 100 }).notNull(),
+    hostname: varchar("hostname", { length: 255 }),
+    os: varchar("os", { length: 32 }),
+    cliVersion: varchar("cli_version", { length: 20 }),
+    lastSeenAt: timestamp("last_seen_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_devices_user_id").on(table.userId),
+    unique("devices_user_device_unique").on(table.userId, table.deviceId),
+  ]
+);
+
+export const devicesRelations = relations(devices, ({ one, many }) => ({
+  user: one(users, {
+    fields: [devices.userId],
+    references: [users.id],
+  }),
+  dailyBreakdown: many(dailyBreakdown),
+}));
+
+// ============================================================================
 // SUBMISSIONS
 // ============================================================================
 export const submissions = pgTable(
@@ -218,6 +257,9 @@ export const dailyBreakdown = pgTable(
     submissionId: uuid("submission_id")
       .notNull()
       .references(() => submissions.id, { onDelete: "cascade" }),
+    deviceId: uuid("device_id")
+      .notNull()
+      .references(() => devices.id, { onDelete: "cascade" }),
 
     date: date("date").notNull(),
     tokens: bigint("tokens", { mode: "number" }).notNull(),
@@ -260,9 +302,11 @@ export const dailyBreakdown = pgTable(
   },
   (table) => [
     index("idx_daily_breakdown_submission_id").on(table.submissionId),
+    index("idx_daily_breakdown_device_id").on(table.deviceId),
     index("idx_daily_breakdown_date").on(table.date),
-    unique("daily_breakdown_submission_date_unique").on(
+    unique("daily_breakdown_submission_device_date_unique").on(
       table.submissionId,
+      table.deviceId,
       table.date
     ),
   ]
@@ -272,6 +316,10 @@ export const dailyBreakdownRelations = relations(dailyBreakdown, ({ one }) => ({
   submission: one(submissions, {
     fields: [dailyBreakdown.submissionId],
     references: [submissions.id],
+  }),
+  device: one(devices, {
+    fields: [dailyBreakdown.deviceId],
+    references: [devices.id],
   }),
 }));
 
@@ -286,6 +334,8 @@ export type ApiToken = typeof apiTokens.$inferSelect;
 export type NewApiToken = typeof apiTokens.$inferInsert;
 export type DeviceCode = typeof deviceCodes.$inferSelect;
 export type NewDeviceCode = typeof deviceCodes.$inferInsert;
+export type Device = typeof devices.$inferSelect;
+export type NewDevice = typeof devices.$inferInsert;
 export type Submission = typeof submissions.$inferSelect;
 export type NewSubmission = typeof submissions.$inferInsert;
 export type DailyBreakdown = typeof dailyBreakdown.$inferSelect;

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -98,6 +98,28 @@ const ExportMetaSchema = z.object({
   }),
 });
 
+// The machine a submission came from. Optional: pre-device-aware CLIs omit it
+// and the server buckets them into a per-user "legacy" device.
+const DeviceInfoSchema = z.object({
+  // "legacy" is reserved for the server's fallback device.
+  deviceId: z
+    .string()
+    .trim()
+    .min(1)
+    .max(64)
+    .refine((id) => id.toLowerCase() !== "legacy", {
+      message: '"legacy" is a reserved device id',
+    }),
+  name: z.string().trim().min(1).max(100),
+  hostname: z.string().trim().max(255).optional(),
+  os: z.string().trim().max(32).optional(),
+  // Set by `--device-name`; the server only overwrites an existing device's
+  // name when true, so routine submits never clobber a chosen name.
+  nameExplicit: z.boolean().optional(),
+});
+
+export type DeviceInfo = z.infer<typeof DeviceInfoSchema>;
+
 const LEGACY_CLIENT_ALIASES: Record<string, string> = {
   kilocode: "kilo",
 };
@@ -166,6 +188,7 @@ const SubmissionDataSchema = z.preprocess(normalizeLegacySources, z.object({
   summary: DataSummarySchema,
   years: z.array(YearSummarySchema),
   contributions: z.array(DailyContributionSchema),
+  device: DeviceInfoSchema.optional(),
 }));
 
 export type SubmissionData = z.infer<typeof SubmissionDataSchema>;


### PR DESCRIPTION
## Summary

People often run AI coding tools across more than one machine — a work desktop, a laptop, remote dev servers — and want to see their *total* token usage across all of them. Today tokscale only scans the machine it runs on, and because every submission overwrote the previous one per `(submission, date)`, a multi-machine user could never see that total: each `tokscale submit` from a second machine replaced the first machine's numbers instead of adding to them.

This PR introduces a device dimension so usage from every machine a user submits from is stored separately and summed — in the API and on the profile. Users who do not log in are unaffected, and the CLI still works fully offline.

## What changed

**Database** — A `devices` table and a `device_id` column on `daily_breakdown`, with the uniqueness constraint widened from `(submission, date)` to `(submission, device, date)`. Migration `0007` backfills existing rows into a per-user `legacy` device.

**Submit API** — `POST /api/submit` accepts an optional `device` field and merges within that device; the per-user submission total is recomputed as the sum across all of a user's devices. Submissions without a `device` field (older CLIs) fall back to the `legacy` device, and the first device-aware submission promotes that device to the new identity so upgrading a single-machine CLI does not double-count a re-scan. Adds `GET` and `DELETE /api/settings/devices`, and the data-wipe endpoint now also removes the user's devices.

**CLI** — The CLI generates a stable device id once, persisted in `~/.config/tokscale/device.json`, and sends it with each submission so the server can aggregate usage per machine. A corrupt or unreadable identity file is treated as a hard error rather than silently regenerated, since minting a fresh id would re-upload the machine's history under a new device. New `tokscale submit --device-name <name>` sets the machine's display name.

**Profile** — `GET /api/users/[username]` returns per-device totals and daily contributions. The profile page gains a device breakdown widget and a Total / per-device selector on the Activity and Models tabs.

## Backward compatibility

Pre-device-aware CLIs keep working unchanged: their submissions have no `device` field and are bucketed into the per-user `legacy` device. Existing data is migrated into that same `legacy` device by migration `0007`, so nobody's totals change on deploy. A user who ran multiple machines before upgrading has that combined history attributed to whichever machine upgrades first; it self-corrects as each machine re-submits.

## Testing

`cargo test -p tokscale-cli` and the frontend `vitest` suite pass, including new coverage for device payload validation. Manually verified end to end against a local Postgres: submitting from two device identities aggregates correctly, `--device-name` updates the stored name, and the profile shows the per-device breakdown.

## Notes

This PR adds a database migration (`0007_add_devices_and_device_breakdown.sql`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aggregate token usage across multiple machines by tracking per-device data, so totals sum across devices instead of overwriting. Adds device-aware submit in the CLI and API, and shows per‑device breakdowns on profiles.

- **New Features**
  - Database: added `devices` table and `device_id` on `daily_breakdown`; uniqueness now `(submission_id, device_id, date)`.
  - API: `POST /api/submit` accepts optional `device` and merges within that device; totals are recomputed as the sum across devices. Added `GET /api/settings/devices` and `DELETE /api/settings/devices/:deviceId`; data wipe also deletes devices.
  - CLI (`tokscale-cli`): persists a stable device id in `~/.config/tokscale/device.json`; sends device info with each submit; `tokscale submit --device-name <name>` sets the display name; corrupt identity file is a hard error.
  - Profile: `GET /api/users/[username]` returns per-device totals and daily contributions; UI adds a device breakdown widget and a Total/per-device selector on Activity and Models.
  - Validation: submission schema rejects the reserved `deviceId` "legacy"; supports optional `nameExplicit` to update stored device names.

- **Migration**
  - Adds `0007_add_devices_and_device_breakdown.sql`: creates `devices`, backfills existing rows into a per-user `legacy` device, adds FKs, and replaces the unique key with `(submission_id, device_id, date)`.
  - Backward compatible: submissions without a `device` are bucketed into `legacy`.
  - Upgrade path: the first device-aware submit promotes the user’s `legacy` device to the new id to avoid double-counting.
  - No action required from users.

<sup>Written for commit c6b8c8e696fda67a419b42347d11124659a43919. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/583?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

