### PR TITLE
fix(cli): prevent self-spawn fork bomb in which fallback

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync, execSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { resolve, join, basename } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -143,7 +143,30 @@ searchPaths.push(
   join(cliDir, "bin", binaryName),
 );
 
-let binary = searchPaths.find((p) => existsSync(p));
+function tryRealpath(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
+}
+
+// Paths that would re-enter this wrapper if executed - using any of these as
+// the "real" binary causes infinite recursion (a fork bomb). We compare by
+// realpath so symlinks (e.g. npm/bun bin shims) are dereferenced.
+const selfPaths = new Set<string>([
+  tryRealpath(fileURLToPath(import.meta.url)),
+  tryRealpath(join(cliDir, "bin.js")),
+]);
+if (process.argv[1]) {
+  selfPaths.add(tryRealpath(process.argv[1]));
+}
+
+function isSelfReference(p: string): boolean {
+  return selfPaths.has(tryRealpath(p));
+}
+
+let binary = searchPaths.find((p) => existsSync(p) && !isSelfReference(p));
 
 if (!binary) {
   try {
@@ -154,7 +177,7 @@ if (!binary) {
     })
       .trim()
       .split("\n")[0];
-    if (found && existsSync(found)) {
+    if (found && existsSync(found) && !isSelfReference(found)) {
       binary = found;
     }
   } catch {}


### PR DESCRIPTION
## Summary

When the platform-specific optional package (e.g. `@tokscale/cli-darwin-arm64`) is missing from a user's install, the launcher in `packages/cli/src/index.ts` falls back to `which`/`where` to locate a `tokscale` binary on `PATH`. That lookup resolves to the npm/bun bin shim, which symlinks back to this same `bin.js` wrapper. `spawnSync` then re-enters the launcher, which repeats the lookup, and the process forks itself recursively until the machine grinds to a halt.

I hit this on macOS arm64 with `bun add -g tokscale@2.1.1`: bun installed `@tokscale/cli` but skipped the platform optional dep, and a single \`tokscale --version\` invocation spawned ~70,000 node processes before I killed them all.

## Fix

- Track the wrapper's own realpath (plus \`process.argv[1]\` and \`packages/cli/bin.js\`) in a Set.
- Skip any candidate from the search paths or from the \`which\`/\`where\` fallback whose realpath matches.
- If nothing else resolves, fall through to the existing \`tokscale binary not found\` error - which is the correct UX when the platform package is missing.

The check uses \`realpathSync\` so symlinks (npm/bun/pnpm bin shims) are dereferenced before comparison.

## Repro (before the fix)

1. \`bun add -g tokscale@2.1.1\` on darwin-arm64 (bun does not install \`@tokscale/cli-darwin-arm64\`).
2. Run \`tokscale --version\`.
3. \`pgrep -fl tokscale | wc -l\` climbs into the tens of thousands within seconds.

## Verification

Reproduced the missing-platform-package scenario locally by copying the built \`dist/\` into a temp dir, symlinking a fake \`tokscale\` shim to \`bin.js\`, and running it with that shim on \`PATH\`:

\`\`\`
$ tokscale --version
Error: tokscale binary not found
Build from source: cargo build --release -p tokscale-cli
Expected optional package: @tokscale/cli-darwin-arm64
exit=1
\`\`\`

No runaway processes - the wrapper exits cleanly with the existing error message.

## Test plan

- [x] \`bun run --cwd packages/cli build\` passes
- [x] Local repro: missing platform package no longer fork-bombs; exits 1 with the existing not-found message
- [ ] Maintainer-side: confirm \`scripts/test-package-launchers.sh\` still passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a recursive self-spawn when the `which`/`where` fallback resolves to the npm/bun bin shim, stopping a fork bomb when a platform package like `@tokscale/cli-darwin-arm64` is missing. The launcher now skips paths that point back to itself and falls back to the existing not-found error.

- **Bug Fixes**
  - Compare candidate binaries by realpath and ignore any that resolve to the wrapper (`import.meta.url`, `process.argv[1]`, `packages/cli/bin.js`), covering npm/bun/pnpm shims.
  - If no valid binary is found, exit with the current “tokscale binary not found” message, preserving correct UX when `@tokscale/cli-<platform>` isn’t installed.

<sup>Written for commit 83c214b69a45d7d19fa23b74a849eb92475fc24f. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/585?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

