### PR TITLE
fix(submit): adopt legacy daily rows into device buckets

### DIFF
--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -615,4 +615,187 @@ describe("POST /api/submit auth path", () => {
       mode: "merge",
     }));
   });
+
+  it("adopts lone legacy daily rows into the first modern submit device instead of duplicating totals", async () => {
+    mockState.authenticatePersonalToken.mockResolvedValue({
+      status: "valid",
+      tokenId: "token-1",
+      userId: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      isAdmin: false,
+      expiresAt: null,
+    });
+
+    mockState.validateSubmission.mockReturnValue({
+      valid: true,
+      data: {
+        device: {
+          id: "dev_laptop",
+          name: "Laptop",
+        },
+        meta: {
+          version: "2.0.0",
+          dateRange: { start: "2026-04-30", end: "2026-04-30" },
+        },
+        summary: {
+          clients: ["codex"],
+        },
+        contributions: [
+          {
+            date: "2026-04-30",
+            timestampMs: 456,
+            clients: [
+              {
+                client: "codex",
+                modelId: "gpt-5.5",
+                tokens: 15,
+                cost: 0.75,
+                input: 10,
+                output: 5,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+                messages: 1,
+              },
+            ],
+          },
+        ],
+      },
+      errors: [],
+      warnings: [],
+    });
+
+    const incomingBreakdown = {
+      tokens: 15,
+      cost: 0.75,
+      input: 10,
+      output: 5,
+      cacheRead: 0,
+      cacheWrite: 0,
+      reasoning: 0,
+      messages: 1,
+    };
+    const legacyBreakdown = {
+      codex: {
+        tokens: 12,
+        cost: 0.5,
+        input: 7,
+        output: 5,
+        cacheRead: 0,
+        cacheWrite: 0,
+        reasoning: 0,
+        messages: 1,
+        models: { "gpt-5.5": { tokens: 12 } },
+      },
+    };
+    const mergedBreakdown = {
+      codex: {
+        ...incomingBreakdown,
+        models: { "gpt-5.5": incomingBreakdown },
+      },
+    };
+
+    mockState.clientContributionToBreakdownData.mockReturnValue(incomingBreakdown);
+    mockState.mergeClientBreakdowns.mockReturnValue(mergedBreakdown);
+    mockState.recalculateDayTotals.mockReturnValue({
+      tokens: 15,
+      cost: 0.75,
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+    mockState.buildModelBreakdown.mockReturnValue({ "gpt-5.5": 15 });
+    mockState.mergeTimestampMs.mockReturnValue(123);
+
+    const selectResults = [
+      [{ id: "submission-1" }],
+      [],
+      [{
+        id: "daily-legacy",
+        date: "2026-04-30",
+        timestampMs: 123,
+        activeTimeMs: null,
+        sourceBreakdown: legacyBreakdown,
+      }],
+      [{
+        totalTokens: 15,
+        totalCost: "0.7500",
+        inputTokens: 10,
+        outputTokens: 5,
+        dateStart: "2026-04-30",
+        dateEnd: "2026-04-30",
+        activeDays: 1,
+        rowCount: 1,
+      }],
+      [{ sourceBreakdown: mergedBreakdown }],
+    ];
+
+    let insertCall = 0;
+    let dailyInsertValues: unknown;
+    const tx = {
+      update: vi.fn(() => {
+        const builder = {
+          set: vi.fn(() => builder),
+          where: vi.fn(() => Promise.resolve()),
+        };
+        return builder;
+      }),
+      select: vi.fn(() => makeAwaitableBuilder(selectResults.shift() ?? [])),
+      insert: vi.fn(() => {
+        insertCall += 1;
+        if (insertCall === 1) {
+          const builder = {
+            values: vi.fn(() => builder),
+            onConflictDoUpdate: vi.fn(() => builder),
+            returning: vi.fn(() => Promise.resolve([{ id: "submitted-device-1" }])),
+          };
+          return builder;
+        }
+
+        const builder = {
+          values: vi.fn((values: unknown) => {
+            dailyInsertValues = values;
+            return builder;
+          }),
+        };
+        return builder;
+      }),
+      execute: vi.fn(() => Promise.resolve()),
+    };
+    type MockTransaction = typeof tx;
+
+    mockState.db.transaction.mockImplementation(async (callback: (tx: MockTransaction) => Promise<unknown>) =>
+      callback(tx)
+    );
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ meta: {}, contributions: [] }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(tx.insert).toHaveBeenCalledTimes(1);
+    expect(dailyInsertValues).toBeUndefined();
+    expect(tx.execute).toHaveBeenCalledTimes(2);
+    expect(mockState.mergeClientBreakdowns).toHaveBeenCalledWith(
+      legacyBreakdown,
+      { codex: mergedBreakdown.codex },
+      expect.any(Set)
+    );
+    expect(await response.json()).toEqual(expect.objectContaining({
+      success: true,
+      metrics: expect.objectContaining({
+        totalTokens: 15,
+        activeDays: 1,
+      }),
+      mode: "merge",
+    }));
+  });
 });

--- a/packages/frontend/__tests__/api/usersProfile.test.ts
+++ b/packages/frontend/__tests__/api/usersProfile.test.ts
@@ -346,6 +346,134 @@ describe("GET /api/users/[username]", () => {
     expect(body.models).toEqual(["claude-3-7-sonnet"]);
   });
 
+  it("aggregates same-date rows from multiple submitted devices into one profile contribution", async () => {
+    mockState.pushSelectResult([
+      {
+        id: "user-1",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        totalTokens: 150,
+        totalCost: 1.5,
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        reasoningTokens: 0,
+        submissionCount: 2,
+        earliestDate: "2026-04-30",
+        latestDate: "2026-04-30",
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        sourcesUsed: ["codex", "claude"],
+        modelsUsed: ["gpt-5.5", "claude-sonnet-4"],
+        updatedAt: new Date("2026-04-30T10:00:00.000Z"),
+        cliVersion: "2.0.0",
+        schemaVersion: 2,
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        date: "2026-04-30",
+        timestampMs: 1_776_000_000_000,
+        tokens: 100,
+        cost: "1.0000",
+        inputTokens: 70,
+        outputTokens: 30,
+        sourceBreakdown: {
+          codex: {
+            tokens: 100,
+            cost: 1,
+            input: 70,
+            output: 30,
+            cacheRead: 0,
+            cacheWrite: 0,
+            reasoning: 0,
+            messages: 2,
+            models: {
+              "gpt-5.5": {
+                tokens: 100,
+                cost: 1,
+                input: 70,
+                output: 30,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+                messages: 2,
+              },
+            },
+          },
+        },
+      },
+      {
+        date: "2026-04-30",
+        timestampMs: 1_775_999_000_000,
+        tokens: 50,
+        cost: "0.5000",
+        inputTokens: 30,
+        outputTokens: 20,
+        sourceBreakdown: {
+          claude: {
+            tokens: 50,
+            cost: 0.5,
+            input: 30,
+            output: 20,
+            cacheRead: 0,
+            cacheWrite: 0,
+            reasoning: 0,
+            messages: 1,
+            models: {
+              "claude-sonnet-4": {
+                tokens: 50,
+                cost: 0.5,
+                input: 30,
+                output: 20,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+                messages: 1,
+              },
+            },
+          },
+        },
+      },
+    ]);
+    mockState.pushExecuteResult([{ rank: 1 }]);
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/users/alice"),
+      { params: Promise.resolve({ username: "alice" }) }
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.contributions).toHaveLength(1);
+    expect(body.contributions[0]).toMatchObject({
+      date: "2026-04-30",
+      timestampMs: 1_775_999_000_000,
+      totals: {
+        tokens: 150,
+        cost: 1.5,
+      },
+      tokenBreakdown: {
+        input: 100,
+        output: 50,
+      },
+    });
+    expect(body.contributions[0].clients.map((client: { client: string }) => client.client).sort()).toEqual([
+      "claude",
+      "codex",
+    ]);
+    expect(body.stats.activeDays).toBe(1);
+  });
+
   it("returns null freshness metadata when the user has no submission yet", async () => {
     mockState.pushSelectResult([
       {

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -228,22 +228,59 @@ export async function POST(request: Request) {
       // ------------------------------------------
       // STEP 3b: Fetch existing daily breakdown for merge
       // ------------------------------------------
-      const existingDays = await tx
-        .select({
-          id: dailyBreakdown.id,
-          date: dailyBreakdown.date,
-          timestampMs: dailyBreakdown.timestampMs,
-          activeTimeMs: dailyBreakdown.activeTimeMs,
-          sourceBreakdown: dailyBreakdown.sourceBreakdown,
-        })
-        .from(dailyBreakdown)
-        .where(
-          and(
-            eq(dailyBreakdown.submissionId, submissionId),
-            eq(dailyBreakdown.submittedDeviceId, submittedDevice.id)
+      const fetchExistingDeviceDays = () =>
+        tx
+          .select({
+            id: dailyBreakdown.id,
+            date: dailyBreakdown.date,
+            timestampMs: dailyBreakdown.timestampMs,
+            activeTimeMs: dailyBreakdown.activeTimeMs,
+            sourceBreakdown: dailyBreakdown.sourceBreakdown,
+          })
+          .from(dailyBreakdown)
+          .where(
+            and(
+              eq(dailyBreakdown.submissionId, submissionId),
+              eq(dailyBreakdown.submittedDeviceId, submittedDevice.id)
+            )
           )
-        )
-        .for('update');
+          .for('update');
+
+      let existingDays = await fetchExistingDeviceDays();
+
+      if (
+        existingDays.length === 0 &&
+        !isNewSubmission &&
+        submitDevice.key !== LEGACY_SUBMIT_DEVICE_KEY
+      ) {
+        // First modern CLI submit after the submitted_devices migration should
+        // adopt the user's lone legacy bucket instead of duplicating those days.
+        // If any modern device rows already exist, attribution is ambiguous and
+        // the legacy bucket is preserved rather than reassigned.
+        await tx.execute(sql`
+          UPDATE daily_breakdown AS db
+          SET submitted_device_id = ${submittedDevice.id}
+          WHERE db.submission_id = ${submissionId}
+            AND db.submitted_device_id IN (
+              SELECT sd.id
+              FROM submitted_devices AS sd
+              WHERE sd.user_id = ${tokenRecord.userId}
+                AND sd.device_key = ${LEGACY_SUBMIT_DEVICE_KEY}
+            )
+            AND NOT EXISTS (
+              SELECT 1
+              FROM daily_breakdown AS modern
+              WHERE modern.submission_id = db.submission_id
+                AND modern.submitted_device_id NOT IN (
+                  SELECT sd2.id
+                  FROM submitted_devices AS sd2
+                  WHERE sd2.user_id = ${tokenRecord.userId}
+                    AND sd2.device_key = ${LEGACY_SUBMIT_DEVICE_KEY}
+                )
+            )
+        `);
+        existingDays = await fetchExistingDeviceDays();
+      }
 
       const existingDaysMap = new Map(
         existingDays.map((d) => [d.date, d])

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -84,11 +84,25 @@ export interface ExportMeta {
   };
 }
 
+export interface SubmitDevice {
+  id: string;
+  name?: string;
+}
+
+export interface TimeMetrics {
+  totalActiveTimeMs: number;
+  longestContinuousMs: number;
+  maxConcurrentSessions: number;
+  sessionCount: number;
+}
+
 export interface TokenContributionData {
   meta: ExportMeta;
+  device?: SubmitDevice;
   summary: DataSummary;
   years: YearSummary[];
   contributions: DailyContribution[];
+  timeMetrics?: TimeMetrics;
 }
 
 export type ColorPaletteName =


### PR DESCRIPTION
## Summary
- Adopt a user's lone legacy `daily_breakdown` bucket into the first modern submitted device during `/api/submit`, so post-migration device-aware submissions do not duplicate historical totals.
- Keep the current `submitted_devices` architecture instead of reintroducing the older `submissions.source_id` design from #389.
- Add regression coverage for legacy-device adoption and same-date profile aggregation across submitted devices.

## Why
#560 reports cross-machine submissions clobbering or undercounting totals. Current `main` already stores daily rows by submitted device, but migrated historical rows live under the `legacy-default` device bucket. Without a guarded cutover path, the first device-aware submit for an existing user can create a second row for the same day and inflate totals instead of treating the legacy row as that user's initial device bucket.

This PR rescues the still-relevant part of #389 for the current schema: it fixes the legacy-to-device transition without adding a new source-scoped `submissions` model, without dropping `submission_hash`, and without changing the CLI payload shape.

## Diff scope
- `POST /api/submit`: when a non-legacy device submits to an existing account with no rows for that device, move the user's legacy daily rows into that device only if no modern device rows already exist for the submission.
- `TokenContributionData`: expose optional `device` and `timeMetrics` fields so the frontend type matches accepted submit payloads.
- Tests: add targeted API/profile regressions for no-duplication cutover and read-path aggregation across submitted devices.

## Branch integrity
- Base: `origin/main`
- Validated base SHA: `1fa26f571b6f6f0affd1c84796f0d032e3e9ee33`
- Head SHA: `c406ddcbae1a627e6ce02ef70913e3a85e7e1809`
- Ahead/behind: `0 behind / 1 ahead`
- Merge base: `1fa26f571b6f6f0affd1c84796f0d032e3e9ee33`

## Validation
- `git diff --check origin/main...HEAD`: PASS, no output
- `bun x vitest run __tests__/api/submitAuth.test.ts __tests__/api/submit.test.ts __tests__/api/usersProfile.test.ts __tests__/lib/getLeaderboard.test.ts __tests__/lib/getGroupLeaderboard.test.ts`: PASS, 5 files and 58 tests
- `bun x eslint src/app/api/submit/route.ts src/lib/types.ts __tests__/api/submitAuth.test.ts __tests__/api/usersProfile.test.ts`: PASS, no output
- `bash scripts/check-version-coherence.sh`: PASS (`Version coherence OK: 2.1.3`)

## Diagnostics
- `bun x tsc --noEmit --pretty false`: not selected as a merge gate for this PR. It currently fails on unrelated pre-existing frontend fixture/asset typing issues outside this diff: missing `totalTokens` / `totalCost` in render SVG test fixtures, and the `BlackholeHero` asset import typing.

## Migration notes
No DB migration changed. The fix uses the existing `submitted_devices` and `daily_breakdown.submitted_device_id` schema.

## Runtime safety
The adoption query is guarded so it only moves legacy rows when no modern submitted-device rows exist for that submission. Ambiguous mixed legacy/modern accounts are preserved rather than reassigned. No invariant regression introduced.

## Rollback plan
Rollback: revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks
- Remote CI has not run until the PR is opened.
- The legacy adoption path intentionally does not attempt to infer ownership when modern device rows already exist, because that attribution would be ambiguous.

