### PR TITLE
fix(scanner): scan Hermes profile databases from extra paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,10 @@ Tokscale stores settings in `~/.config/tokscale/settings.json`:
       "codex": [
         "/Users/me/workspace/project-a/.codex/sessions",
         "/Users/me/workspace/project-b/.codex/archived_sessions"
+      ],
+      "hermes": [
+        "/Users/me/.hermes/profiles/director_planning",
+        "/Users/me/.hermes/profiles/research/state.db"
       ]
     }
   }
@@ -694,7 +698,7 @@ Tokscale stores settings in `~/.config/tokscale/settings.json`:
 | `minutelyTabEnabled` | boolean | `false` | Show the per-minute Minutely tab in the TUI and aggregate per-minute usage during data loading. Default-off because minute-granularity is a niche/diagnostic view for most users and the per-minute bucketing has a non-trivial cost on large datasets. |
 | `scanner.extraScanPaths` | object | `{}` | Additional per-client scan roots for sessions outside Tokscale's default home-root locations |
 
-Use `scanner.extraScanPaths` for persistent extra roots such as project-level `.codex` directories or imported Gemini/OpenClaw histories. Tokscale merges these paths with the default scan roots on every run and deduplicates overlapping roots by canonical path.
+Use `scanner.extraScanPaths` for persistent extra roots such as project-level `.codex` directories, imported Gemini/OpenClaw histories, or Hermes profile databases. Hermes entries may point at a profile directory containing `state.db` or directly at a `state.db` file. Tokscale merges these paths with the default scan roots on every run and deduplicates overlapping roots by canonical path.
 
 Use `defaultClients` to pin a personal default — for example, set it to `["opencode", "claude"]` if those are the only clients you use, and `tokscale` (with no flags) will scope every report to them automatically. Pass `--client` on the command line to override for a single run.
 
@@ -1270,13 +1274,17 @@ If you keep sessions outside Tokscale's default home-root locations, you can als
         "/Users/me/workspace/project-b/.codex/archived_sessions"
       ],
       "gemini": ["/Users/me/imports/imac/gemini/tmp"],
+      "hermes": [
+        "/Users/me/.hermes/profiles/director_planning",
+        "/Users/me/.hermes/profiles/research/state.db"
+      ],
       "openclaw": ["/Users/me/imports/imac/openclaw/agents"]
     }
   }
 }
 ```
 
-This is useful for project-level `.codex` directories and imported histories. Tokscale still scans its default roots, then merges `scanner.extraScanPaths` and `TOKSCALE_EXTRA_DIRS` on top with canonical-path deduplication. It does not auto-discover your whole workspace.
+This is useful for project-level `.codex` directories, imported histories, and Hermes profile databases outside the default `$HERMES_HOME/state.db` or `~/.hermes/state.db` location. Tokscale still scans its default roots, then merges `scanner.extraScanPaths` and `TOKSCALE_EXTRA_DIRS` on top with canonical-path deduplication. It does not auto-discover your whole workspace.
 
 Each message contains:
 ```json

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -1816,6 +1816,50 @@ fn test_clients_json_includes_settings_extra_paths() {
 }
 
 #[test]
+fn test_clients_json_includes_hermes_settings_extra_profile_path() {
+    let tmp = create_empty_fixture_dir();
+    let hermes_profile = tmp.path().join(".hermes/profiles/director_planning");
+    fs::create_dir_all(&hermes_profile).unwrap();
+    let hermes_profile_json = serde_json::to_string(&hermes_profile).unwrap();
+    write_settings_json(
+        tmp.path(),
+        &format!(
+            r#"{{
+            "scanner": {{
+                "extraScanPaths": {{
+                    "hermes": [{hermes_profile_json}]
+                }}
+            }}
+        }}"#
+        ),
+    );
+
+    let output = cmd_with_home(tmp.path())
+        .args(["clients", "--json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let hermes = json["clients"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["client"] == "hermes")
+        .unwrap();
+
+    assert_eq!(
+        hermes["extraPaths"][0]["path"],
+        serde_json::json!(hermes_profile)
+    );
+    assert_eq!(
+        hermes["extraPaths"][0]["source"],
+        serde_json::json!("settings")
+    );
+    assert_eq!(hermes["extraPaths"][0]["exists"], true);
+}
+
+#[test]
 fn test_clients_command_includes_settings_extra_paths_text() {
     let tmp = create_empty_fixture_dir();
     write_settings_json(

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1176,17 +1176,14 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         all_messages.extend(kilo_messages);
     }
 
-    if let Some(db_path) = &scan_result.hermes_db {
-        let hermes_messages: Vec<UnifiedMessage> = sessions::hermes::parse_hermes_sqlite(db_path)
-            .into_iter()
-            .map(|mut msg| {
-                if msg.cost <= 0.0 {
-                    apply_pricing_if_available(&mut msg, pricing);
-                }
-                msg
-            })
-            .collect();
-        all_messages.extend(hermes_messages);
+    let mut hermes_seen: HashSet<String> = HashSet::new();
+    for db_path in scan_result.hermes_db_paths() {
+        let hermes_messages = parse_hermes_sqlite_with_pricing(&db_path, pricing);
+        all_messages.extend(
+            hermes_messages
+                .into_iter()
+                .filter(|message| should_keep_deduped_message(&mut hermes_seen, message)),
+        );
     }
 
     if let Some(db_path) = &scan_result.goose_db {
@@ -1910,6 +1907,21 @@ fn apply_pricing_if_available(
     }
 }
 
+fn parse_hermes_sqlite_with_pricing(
+    db_path: &Path,
+    pricing: Option<&pricing::PricingService>,
+) -> Vec<UnifiedMessage> {
+    sessions::hermes::parse_hermes_sqlite(db_path)
+        .into_iter()
+        .map(|mut msg| {
+            if msg.cost <= 0.0 {
+                apply_pricing_if_available(&mut msg, pricing);
+            }
+            msg
+        })
+        .collect()
+}
+
 fn select_local_parse_pricing<F>(
     fresh: Result<Arc<pricing::PricingService>, String>,
     stale: F,
@@ -2278,9 +2290,13 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
         0
     };
 
-    if let Some(db_path) = &scan_result.hermes_db {
-        let hermes_msgs: Vec<ParsedMessage> = sessions::hermes::parse_hermes_sqlite(db_path)
-            .into_iter()
+    let hermes_db_paths = scan_result.hermes_db_paths();
+    if !hermes_db_paths.is_empty() {
+        let mut hermes_seen: HashSet<String> = HashSet::new();
+        let hermes_msgs: Vec<ParsedMessage> = hermes_db_paths
+            .iter()
+            .flat_map(|db_path| sessions::hermes::parse_hermes_sqlite(db_path))
+            .filter(|msg| should_keep_deduped_message(&mut hermes_seen, msg))
             .map(|msg| unified_to_parsed(&msg))
             .collect();
         let count = summed_parsed_message_count(&hermes_msgs);
@@ -2626,6 +2642,56 @@ mod tests {
         )
         .unwrap();
         conn
+    }
+
+    fn create_hermes_sqlite_db(db_path: &std::path::Path) -> rusqlite::Connection {
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT NOT NULL,
+                model TEXT,
+                started_at REAL NOT NULL,
+                message_count INTEGER DEFAULT 0,
+                input_tokens INTEGER DEFAULT 0,
+                output_tokens INTEGER DEFAULT 0,
+                cache_read_tokens INTEGER DEFAULT 0,
+                cache_write_tokens INTEGER DEFAULT 0,
+                reasoning_tokens INTEGER DEFAULT 0,
+                billing_provider TEXT,
+                estimated_cost_usd REAL,
+                actual_cost_usd REAL
+            );",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn insert_hermes_session(
+        conn: &rusqlite::Connection,
+        id: &str,
+        model: &str,
+        message_count: i64,
+        input_tokens: i64,
+        output_tokens: i64,
+        actual_cost_usd: f64,
+    ) {
+        conn.execute(
+            "INSERT INTO sessions (
+                id, source, model, started_at, message_count,
+                input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
+                billing_provider, estimated_cost_usd, actual_cost_usd
+            ) VALUES (?1, 'cli', ?2, 1775001102.0, ?3, ?4, ?5, 0, 0, 0, 'anthropic', NULL, ?6)",
+            rusqlite::params![
+                id,
+                model,
+                message_count,
+                input_tokens,
+                output_tokens,
+                actual_cost_usd
+            ],
+        )
+        .unwrap();
     }
 
     #[test]
@@ -5526,6 +5592,126 @@ mod tests {
         assert_eq!(parsed_with_settings.messages.len(), 1);
         assert_eq!(parsed_with_settings.messages[0].client, "opencode");
         assert_eq!(parsed_with_settings.messages[0].model_id, "claude-sonnet-4");
+    }
+
+    #[test]
+    fn test_parse_local_clients_honors_scanner_extra_scan_paths_for_hermes_profile_db() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let profile_dir = temp_dir.path().join(".hermes/profiles/director_planning");
+        std::fs::create_dir_all(&profile_dir).unwrap();
+        let profile_db = profile_dir.join("state.db");
+        let conn = create_hermes_sqlite_db(&profile_db);
+        insert_hermes_session(
+            &conn,
+            "hermes-extra-session",
+            "claude-sonnet-4",
+            2,
+            100,
+            25,
+            0.07,
+        );
+        drop(conn);
+
+        let parsed_default = parse_local_clients(LocalParseOptions {
+            home_dir: Some(temp_dir.path().to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(vec!["hermes".to_string()]),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner::ScannerSettings::default(),
+        })
+        .unwrap();
+        assert_eq!(parsed_default.counts.get(ClientId::Hermes), 0);
+        assert!(parsed_default.messages.is_empty());
+
+        let mut extra_scan_paths = std::collections::BTreeMap::new();
+        extra_scan_paths.insert("hermes".to_string(), vec![profile_dir]);
+        let parsed_with_settings = parse_local_clients(LocalParseOptions {
+            home_dir: Some(temp_dir.path().to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(vec!["hermes".to_string()]),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner::ScannerSettings {
+                extra_scan_paths,
+                ..Default::default()
+            },
+        })
+        .unwrap();
+
+        assert_eq!(parsed_with_settings.counts.get(ClientId::Hermes), 2);
+        assert_eq!(parsed_with_settings.messages.len(), 1);
+        assert_eq!(parsed_with_settings.messages[0].client, "hermes");
+        assert_eq!(
+            parsed_with_settings.messages[0].agent.as_deref(),
+            Some("Hermes Agent")
+        );
+        assert_eq!(
+            parsed_with_settings.messages[0].session_id,
+            "hermes-extra-session"
+        );
+        assert_eq!(parsed_with_settings.messages[0].model_id, "claude-sonnet-4");
+        assert_eq!(parsed_with_settings.messages[0].input, 100);
+        assert_eq!(parsed_with_settings.messages[0].output, 25);
+    }
+
+    #[test]
+    fn test_parse_local_clients_dedups_hermes_sessions_across_default_and_extra_dbs() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+
+        let default_dir = temp_dir.path().join(".hermes");
+        std::fs::create_dir_all(&default_dir).unwrap();
+        let default_db = default_dir.join("state.db");
+        let default_conn = create_hermes_sqlite_db(&default_db);
+        insert_hermes_session(
+            &default_conn,
+            "shared-hermes-session",
+            "claude-sonnet-4",
+            2,
+            100,
+            25,
+            0.07,
+        );
+        drop(default_conn);
+
+        let profile_dir = temp_dir.path().join(".hermes/profiles/director_planning");
+        std::fs::create_dir_all(&profile_dir).unwrap();
+        let profile_db = profile_dir.join("state.db");
+        let profile_conn = create_hermes_sqlite_db(&profile_db);
+        insert_hermes_session(
+            &profile_conn,
+            "shared-hermes-session",
+            "claude-sonnet-4",
+            9,
+            999,
+            999,
+            9.99,
+        );
+        drop(profile_conn);
+
+        let mut extra_scan_paths = std::collections::BTreeMap::new();
+        extra_scan_paths.insert("hermes".to_string(), vec![profile_db]);
+        let parsed = parse_local_clients(LocalParseOptions {
+            home_dir: Some(temp_dir.path().to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(vec!["hermes".to_string()]),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner::ScannerSettings {
+                extra_scan_paths,
+                ..Default::default()
+            },
+        })
+        .unwrap();
+
+        assert_eq!(parsed.counts.get(ClientId::Hermes), 2);
+        assert_eq!(parsed.messages.len(), 1);
+        assert_eq!(parsed.messages[0].session_id, "shared-hermes-session");
+        assert_eq!(parsed.messages[0].input, 100);
+        assert_eq!(parsed.messages[0].output, 25);
     }
 
     #[test]

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -120,6 +120,35 @@ impl ScanResult {
 
         result
     }
+
+    /// Return every Hermes SQLite database that should be parsed.
+    ///
+    /// Hermes has a default `state.db` path plus optional profile databases
+    /// discovered through `scanner.extraScanPaths.hermes`. The generic
+    /// `files` bucket carries the extra profile DBs, so this helper gives
+    /// callers a single deduped view without changing older `hermes_db`
+    /// consumers that only expect the default path.
+    pub fn hermes_db_paths(&self) -> Vec<PathBuf> {
+        let mut paths = Vec::new();
+        let mut seen: HashSet<PathBuf> = HashSet::new();
+
+        let mut push = |path: &Path| {
+            let key = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+            if seen.insert(key) {
+                paths.push(path.to_path_buf());
+            }
+        };
+
+        if let Some(path) = &self.hermes_db {
+            push(path);
+        }
+
+        for path in self.get(ClientId::Hermes) {
+            push(path);
+        }
+
+        paths
+    }
 }
 
 pub fn headless_roots_with_env_strategy(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
@@ -233,6 +262,7 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
                 "ui_messages.json" => file_name == "ui_messages.json",
                 "session-usage.json" => file_name == "session-usage.json",
                 "chat-messages.json" => file_name == "chat-messages.json",
+                "state.db" => file_name == "state.db",
                 _ => false,
             }
         })
@@ -453,12 +483,13 @@ fn discover_crush_dbs(home_dir: &str, use_env_roots: bool) -> Vec<CrushDbSource>
 
 fn supports_extra_dir_scanning(client_id: ClientId) -> bool {
     // Kilo CLI currently loads a single SQLite DB via `scan_result.kilo_db`
-    // Kilo CLI and Hermes use SQLite database paths, Roo/KiloCode require local + remote
-    // and server task roots, and Crush discovers SQLite DBs via the project
-    // registry rather than scanned file paths.
+    // Roo/KiloCode require local + remote and server task roots, and Crush
+    // discovers SQLite DBs via the project registry rather than scanned file
+    // paths. Hermes profile databases are named `state.db`, so they can use
+    // `extraScanPaths` once `scan_directory` knows that exact filename.
     !matches!(
         client_id,
-        ClientId::Kilo | ClientId::Crush | ClientId::Hermes | ClientId::Goose | ClientId::Zed
+        ClientId::Kilo | ClientId::Crush | ClientId::Goose | ClientId::Zed
     )
 }
 
@@ -1730,6 +1761,78 @@ mod tests {
         );
 
         assert_eq!(result.get(ClientId::Codex).len(), 2);
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_with_scanner_settings_merges_hermes_extra_profile_db() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+
+        let default_dir = home.join(".hermes");
+        fs::create_dir_all(&default_dir).unwrap();
+        let default_db = default_dir.join("state.db");
+        File::create(&default_db).unwrap();
+
+        let profile_dir = home.join(".hermes/profiles/director_planning");
+        fs::create_dir_all(&profile_dir).unwrap();
+        let profile_db = profile_dir.join("state.db");
+        File::create(&profile_db).unwrap();
+
+        let settings: ScannerSettings = serde_json::from_value(serde_json::json!({
+            "extraScanPaths": {
+                "hermes": [
+                    profile_dir,
+                    profile_db
+                ]
+            }
+        }))
+        .unwrap();
+
+        let result = scan_all_clients_with_scanner_settings(
+            home.to_str().unwrap(),
+            &["hermes".to_string()],
+            true,
+            &settings,
+        );
+
+        assert_eq!(result.hermes_db.as_ref(), Some(&default_db));
+        assert_eq!(result.hermes_db_paths(), vec![default_db, profile_db]);
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_with_scanner_settings_respects_hermes_client_filter() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+
+        let profile_dir = home.join(".hermes/profiles/director_planning");
+        fs::create_dir_all(&profile_dir).unwrap();
+        let profile_db = profile_dir.join("state.db");
+        File::create(&profile_db).unwrap();
+
+        let settings: ScannerSettings = serde_json::from_value(serde_json::json!({
+            "extraScanPaths": {
+                "hermes": [profile_dir]
+            }
+        }))
+        .unwrap();
+
+        let claude_only = scan_all_clients_with_scanner_settings(
+            home.to_str().unwrap(),
+            &["claude".to_string()],
+            true,
+            &settings,
+        );
+        assert!(claude_only.hermes_db_paths().is_empty());
+
+        let hermes_only = scan_all_clients_with_scanner_settings(
+            home.to_str().unwrap(),
+            &["hermes".to_string()],
+            true,
+            &settings,
+        );
+        assert_eq!(hermes_only.hermes_db_paths(), vec![profile_db]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add Hermes `state.db` discovery from `scanner.extraScanPaths.hermes`, accepting both profile directories and direct DB paths.
- Parse all discovered Hermes databases with canonical path and session-level dedupe, so profile DBs add usage without double-counting the default DB.
- Surface Hermes settings paths in `tokscale clients --json` and document the profile DB configuration.

## Why
Hermes profiles can store usage in profile-local `state.db` files outside `$HERMES_HOME/state.db` or `~/.hermes/state.db`. Before this change, `scanner.extraScanPaths` did not participate in Hermes parsing, so configured profile paths could be missed by local reports.

## Diff scope
- `crates/tokscale-core/src/scanner.rs`: allow Hermes extra scan roots, scan exact `state.db` files, and expose a deduped `hermes_db_paths()` view.
- `crates/tokscale-core/src/lib.rs`: parse all discovered Hermes DBs with pricing fallback and session-level dedupe.
- `crates/tokscale-cli/tests/cli_tests.rs`: cover Hermes extra paths in `clients --json`.
- `README.md`: document Hermes profile directory and direct `state.db` examples.

## Branch integrity
Base branch: `main`. Validated base SHA: `1fa26f571b6f6f0affd1c84796f0d032e3e9ee33`. Branch status: `0 behind / 1 ahead`. Head SHA: `ba6c7c08ac7019033cac34549572d7eee63129b2`.

## Validation mode and proof
Mode 3 - shared scanner and local parser data ingestion behavior.
- `git diff --check origin/main...HEAD`: PASS, no output
- `cargo test -p tokscale-core scanner -- --nocapture`: PASS, 75 tests
- `cargo test -p tokscale-core hermes -- --nocapture`: PASS, 5 core tests plus 3 Hermes integration tests
- `cargo test -p tokscale-core scanner_settings -- --nocapture`: PASS, 10 tests
- `cargo test -p tokscale-core parse_local_clients -- --nocapture`: PASS, 10 tests
- `cargo test -p tokscale-cli test_clients_json_includes_hermes_settings_extra_profile_path -- --nocapture`: PASS, 1 test; existing `load_cache` warning only
- `cargo clippy -p tokscale-core --all-features -- -D warnings`: PASS
- `rustfmt --check crates/tokscale-core/src/scanner.rs crates/tokscale-cli/tests/cli_tests.rs`: PASS
- `bash scripts/check-version-coherence.sh`: PASS, `Version coherence OK: 2.1.3`

## Migration notes
Not applicable - no DB migration changed.

## CI context confirmation
Not applicable - no workflow or CI context names changed. Required remote checks are pending until the PR is opened.

## Runtime safety
Hermes DB parsing remains read-only. The new aggregation path adds bounded canonical path and session-id dedupe before messages are merged, without new blocking locks, unbounded queues, or global state. No invariant regression introduced.

## Rollback plan
Rollback: revert this PR. DB downgrade: not applicable. Data repair: not applicable. Operational caveats: none known.

## Known residual risks
This does not auto-enable workspace-wide discovery. Users still need to configure `scanner.extraScanPaths.hermes` for profile DBs outside the default Hermes home.

Closes #579.
