### PR TITLE
feat(devices): add per-device read+rename APIs and fix submit_count drift

### DIFF
--- a/packages/frontend/scripts/seed-dev.ts
+++ b/packages/frontend/scripts/seed-dev.ts
@@ -1,0 +1,230 @@
+// Synthetic seed data for local development.
+//
+// Usage:
+//   DATABASE_URL=postgresql://tokscale:tokscale@localhost:5432/tokscale \
+//     bun run packages/frontend/scripts/seed-dev.ts
+//
+// Idempotent: re-running clears anything inserted with the seed marker
+// `seed-dev@*` (devices, submissions) before re-creating it. Other rows
+// (real users, real submissions) are left untouched, so it is safe to point
+// at a DB that already has data.
+//
+// What it creates:
+//   - 3 demo users (alice, bob, carol)
+//   - 2 devices per user (laptop + desktop)
+//   - 1 submissions row per user
+//   - 14 daily_breakdown rows per device (~2 weeks of activity)
+//   - 1 public group "Engineering Leaderboard" with all three users
+//
+// No PII: usernames are fictional, github_id values are negative so they
+// cannot collide with any real GitHub user.
+
+import {
+  db,
+  users,
+  submittedDevices,
+  submissions,
+  dailyBreakdown,
+  groups,
+  groupMembers,
+} from "../src/lib/db";
+import { eq, or } from "drizzle-orm";
+import { randomUUID } from "node:crypto";
+
+const SEED_USERNAMES = ["seed-dev-alice", "seed-dev-bob", "seed-dev-carol"] as const;
+const SEED_GROUP_SLUG = "seed-dev-engineering";
+
+async function clearSeedData() {
+  const existing = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(or(...SEED_USERNAMES.map((u) => eq(users.username, u))));
+
+  if (existing.length > 0) {
+    // FK cascades from users → submissions → daily_breakdown and
+    // users → submitted_devices handle most of the graph automatically.
+    for (const u of existing) {
+      await db.delete(users).where(eq(users.id, u.id));
+    }
+  }
+
+  await db.delete(groups).where(eq(groups.slug, SEED_GROUP_SLUG));
+}
+
+async function seedUser(
+  username: string,
+  displayName: string,
+  githubId: number
+): Promise<{ userId: string }> {
+  const [created] = await db
+    .insert(users)
+    .values({
+      username,
+      displayName,
+      githubId,
+      avatarUrl: null,
+      email: `${username}@example.com`,
+    })
+    .returning({ id: users.id });
+
+  const userId = created.id;
+  const now = new Date();
+
+  const deviceKeys = ["laptop", "desktop"] as const;
+  const deviceRows = await db
+    .insert(submittedDevices)
+    .values(
+      deviceKeys.map((k) => ({
+        userId,
+        deviceKey: `seed-dev@${username}@${k}`,
+        displayName: `${displayName}'s ${k}`,
+        createdAt: now,
+        updatedAt: now,
+        lastSubmittedAt: now,
+      }))
+    )
+    .returning({ id: submittedDevices.id, deviceKey: submittedDevices.deviceKey });
+
+  const [submission] = await db
+    .insert(submissions)
+    .values({
+      userId,
+      totalTokens: 0,
+      totalCost: "0",
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheCreationTokens: 0,
+      cacheReadTokens: 0,
+      reasoningTokens: 0,
+      dateStart: "2026-05-01",
+      dateEnd: "2026-05-14",
+      sourcesUsed: ["claude", "codex"],
+      modelsUsed: ["claude-sonnet-4", "codex-mini"],
+      cliVersion: "2.1.3",
+      submissionHash: randomUUID().replace(/-/g, "").slice(0, 32),
+      schemaVersion: 2,
+    })
+    .returning({ id: submissions.id });
+
+  // 14 days of activity split across both devices
+  const dailyRows: Array<typeof dailyBreakdown.$inferInsert> = [];
+  let totalTokens = 0;
+  let totalCost = 0;
+  for (let day = 0; day < 14; day++) {
+    const date = `2026-05-${String(day + 1).padStart(2, "0")}`;
+    for (const device of deviceRows) {
+      const tokens = 50_000 + day * 5_000 + (device.deviceKey.endsWith("laptop") ? 0 : 15_000);
+      const cost = (tokens / 1_000_000) * 3.0;
+      const input = Math.floor(tokens * 0.7);
+      const output = Math.floor(tokens * 0.3);
+      dailyRows.push({
+        submissionId: submission.id,
+        submittedDeviceId: device.id,
+        date,
+        tokens,
+        cost: cost.toFixed(4),
+        inputTokens: input,
+        outputTokens: output,
+        timestampMs: new Date(`${date}T12:00:00Z`).getTime(),
+        // modelBreakdown is keyed by modelId → tokens-only number.
+        modelBreakdown: { "claude-sonnet-4": tokens },
+        // sourceBreakdown is keyed by clientId → full client metrics blob.
+        sourceBreakdown: {
+          claude: {
+            tokens,
+            cost,
+            input,
+            output,
+            cacheRead: 0,
+            cacheWrite: 0,
+            reasoning: 0,
+            messages: 1,
+          },
+        },
+      });
+      totalTokens += tokens;
+      totalCost += cost;
+    }
+  }
+  if (dailyRows.length > 0) {
+    await db.insert(dailyBreakdown).values(dailyRows);
+  }
+
+  // Reflect the rolled-up totals on the submissions row so reads match.
+  await db
+    .update(submissions)
+    .set({
+      totalTokens,
+      totalCost: totalCost.toFixed(4),
+      inputTokens: Math.floor(totalTokens * 0.7),
+      outputTokens: Math.floor(totalTokens * 0.3),
+    })
+    .where(eq(submissions.id, submission.id));
+
+  return { userId };
+}
+
+async function seedGroup(memberUserIds: string[]) {
+  if (memberUserIds.length === 0) return;
+  const [group] = await db
+    .insert(groups)
+    .values({
+      name: "Engineering Leaderboard",
+      slug: SEED_GROUP_SLUG,
+      description: "Seed group for local dev",
+      isPublic: true,
+      createdBy: memberUserIds[0],
+    })
+    .returning({ id: groups.id });
+
+  await db.insert(groupMembers).values(
+    memberUserIds.map((userId, idx) => ({
+      groupId: group.id,
+      userId,
+      role: idx === 0 ? ("owner" as const) : ("member" as const),
+      invitedBy: memberUserIds[0],
+    }))
+  );
+}
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    console.error("DATABASE_URL must be set");
+    process.exit(1);
+  }
+  // Refuse to run against anything that doesn't look local. Production
+  // database connection strings should not be passed to this seeder.
+  const url = process.env.DATABASE_URL;
+  if (!/localhost|127\.0\.0\.1|::1/.test(url)) {
+    console.error(
+      `seed-dev refuses to run against DATABASE_URL=${url}: only local hosts are allowed`
+    );
+    process.exit(1);
+  }
+
+  console.log("Clearing previous seed data...");
+  await clearSeedData();
+
+  console.log("Inserting users + devices + submissions + daily_breakdown...");
+  const seeded: string[] = [];
+  let githubId = -1000;
+  for (const username of SEED_USERNAMES) {
+    const displayName = username
+      .replace("seed-dev-", "")
+      .replace(/^[a-z]/, (c) => c.toUpperCase());
+    const { userId } = await seedUser(username, displayName, githubId);
+    seeded.push(userId);
+    githubId -= 1;
+  }
+
+  console.log("Inserting demo group...");
+  await seedGroup(seeded);
+
+  console.log(`Done. Seeded ${seeded.length} users + 1 group.`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/frontend/src/app/api/settings/devices/[deviceId]/route.ts
+++ b/packages/frontend/src/app/api/settings/devices/[deviceId]/route.ts
@@ -1,0 +1,127 @@
+import { NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { db, submittedDevices } from "@/lib/db";
+import { getSession } from "@/lib/auth/session";
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// 120 chars matches submitted_devices.display_name varchar(120).
+// Reject Unicode control characters so the label can't smuggle newlines /
+// terminal escape sequences into rendered UI.
+const RenameBodySchema = z.object({
+  name: z
+    .union([z.string(), z.null()])
+    .transform((value) => {
+      if (value == null) return null;
+      const trimmed = value.trim();
+      return trimmed === "" ? null : trimmed;
+    })
+    .refine(
+      (value) => value == null || value.length <= 120,
+      { message: "name must be 120 characters or fewer" }
+    )
+    .refine(
+      (value) => value == null || !/\p{C}/u.test(value),
+      { message: "name must not contain control characters" }
+    ),
+});
+
+interface RouteParams {
+  params: Promise<{ deviceId: string }>;
+}
+
+/**
+ * PATCH /api/settings/devices/[deviceId]
+ *
+ * Rename (or clear, with `name: null` / `name: ""`) the display label of a
+ * device the caller owns. Ownership is enforced via the session user id +
+ * `submitted_devices.user_id` in a single WHERE so a cross-user rename
+ * silently 404s without leaking existence.
+ */
+export async function PATCH(request: Request, { params }: RouteParams) {
+  try {
+    const session = await getSession();
+    if (!session) {
+      return NextResponse.json(
+        { error: "Not authenticated" },
+        { status: 401 }
+      );
+    }
+
+    const { deviceId } = await params;
+    if (!UUID_REGEX.test(deviceId)) {
+      return NextResponse.json(
+        { error: "Invalid device id" },
+        { status: 400 }
+      );
+    }
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid JSON body" },
+        { status: 400 }
+      );
+    }
+
+    const parsed = RenameBodySchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: "Invalid request body",
+          details: parsed.error.issues.map((issue) => issue.message),
+        },
+        { status: 400 }
+      );
+    }
+
+    const { name } = parsed.data;
+    const updatedAt = new Date();
+
+    const [updated] = await db
+      .update(submittedDevices)
+      .set({ displayName: name, updatedAt })
+      .where(
+        and(
+          eq(submittedDevices.id, deviceId),
+          eq(submittedDevices.userId, session.id)
+        )
+      )
+      .returning({
+        id: submittedDevices.id,
+        deviceKey: submittedDevices.deviceKey,
+        displayName: submittedDevices.displayName,
+      });
+
+    if (!updated) {
+      return NextResponse.json(
+        { error: "Device not found" },
+        { status: 404 }
+      );
+    }
+
+    try {
+      // Second arg "max" matches the rest of the codebase
+      // (settings/submitted-data/route.ts, submit/route.ts).
+      revalidateTag(`user:${session.username}`, "max");
+    } catch (e) {
+      console.error("Cache invalidation failed after device rename:", e);
+    }
+
+    return NextResponse.json({
+      success: true,
+      device: updated,
+    });
+  } catch (error) {
+    console.error("Device rename error:", error);
+    return NextResponse.json(
+      { error: "Failed to rename device" },
+      { status: 500 }
+    );
+  }
+}

--- a/packages/frontend/src/app/api/users/[username]/devices/[deviceId]/route.ts
+++ b/packages/frontend/src/app/api/users/[username]/devices/[deviceId]/route.ts
@@ -1,0 +1,144 @@
+import { NextResponse } from "next/server";
+import { and, desc, eq } from "drizzle-orm";
+// `and` is used to enforce ownership and id match in a single WHERE.
+import { db, dailyBreakdown, submittedDevices, users } from "@/lib/db";
+import {
+  USERNAME_LOOKUP_LIMIT,
+  getSingleUsernameMatch,
+  usernameEqualsIgnoreCase,
+} from "@/lib/db/usernameLookup";
+import { deviceDisplayLabel, toIsoString } from "@/lib/devices/shared";
+
+export const revalidate = 60;
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface RouteParams {
+  params: Promise<{ username: string; deviceId: string }>;
+}
+
+/**
+ * GET /api/users/[username]/devices/[deviceId]
+ *
+ * Per-device detail: device metadata + ordered list of daily contributions
+ * for that one device. Public read — matches the rest of the user-profile
+ * read APIs (auth is only required for mutating actions).
+ *
+ * `deviceId` must be a valid uuid. Reject other shapes early so we don't even
+ * touch the DB for obviously bogus input.
+ */
+export async function GET(_request: Request, { params }: RouteParams) {
+  try {
+    const { username, deviceId } = await params;
+
+    if (!UUID_REGEX.test(deviceId)) {
+      return NextResponse.json(
+        { error: "Invalid device id" },
+        { status: 400 }
+      );
+    }
+
+    const matchingUsers = await db
+      .select({
+        id: users.id,
+        username: users.username,
+        displayName: users.displayName,
+        avatarUrl: users.avatarUrl,
+      })
+      .from(users)
+      .where(usernameEqualsIgnoreCase(username))
+      .limit(USERNAME_LOOKUP_LIMIT);
+
+    const user = getSingleUsernameMatch(matchingUsers, username);
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    // Resolve device but check user ownership in the same WHERE so we never
+    // leak another user's device id via 404-vs-403 timing.
+    const [device] = await db
+      .select({
+        id: submittedDevices.id,
+        deviceKey: submittedDevices.deviceKey,
+        displayName: submittedDevices.displayName,
+        createdAt: submittedDevices.createdAt,
+        lastSubmittedAt: submittedDevices.lastSubmittedAt,
+      })
+      .from(submittedDevices)
+      .where(
+        and(
+          eq(submittedDevices.id, deviceId),
+          eq(submittedDevices.userId, user.id)
+        )
+      )
+      .limit(1);
+
+    if (!device) {
+      return NextResponse.json({ error: "Device not found" }, { status: 404 });
+    }
+
+    const dailyRows = await db
+      .select({
+        date: dailyBreakdown.date,
+        tokens: dailyBreakdown.tokens,
+        cost: dailyBreakdown.cost,
+        inputTokens: dailyBreakdown.inputTokens,
+        outputTokens: dailyBreakdown.outputTokens,
+        timestampMs: dailyBreakdown.timestampMs,
+      })
+      .from(dailyBreakdown)
+      .where(eq(dailyBreakdown.submittedDeviceId, device.id))
+      .orderBy(desc(dailyBreakdown.date));
+
+    let totalTokens = 0;
+    let totalCost = 0;
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let activeDays = 0;
+    for (const row of dailyRows) {
+      const tokens = Number(row.tokens) || 0;
+      totalTokens += tokens;
+      totalCost += Number(row.cost) || 0;
+      inputTokens += Number(row.inputTokens) || 0;
+      outputTokens += Number(row.outputTokens) || 0;
+      if (tokens > 0) activeDays += 1;
+    }
+
+    return NextResponse.json({
+      user: {
+        username: user.username,
+        displayName: user.displayName,
+        avatarUrl: user.avatarUrl,
+      },
+      device: {
+        id: device.id,
+        deviceKey: device.deviceKey,
+        displayName: deviceDisplayLabel(device.deviceKey, device.displayName),
+        createdAt: toIsoString(device.createdAt),
+        lastSubmittedAt: toIsoString(device.lastSubmittedAt),
+      },
+      totals: {
+        totalTokens,
+        totalCost,
+        inputTokens,
+        outputTokens,
+        activeDays,
+      },
+      contributions: dailyRows.map((row) => ({
+        date: row.date,
+        tokens: Number(row.tokens) || 0,
+        cost: Number(row.cost) || 0,
+        inputTokens: Number(row.inputTokens) || 0,
+        outputTokens: Number(row.outputTokens) || 0,
+        timestampMs: row.timestampMs == null ? null : Number(row.timestampMs),
+      })),
+    });
+  } catch (error) {
+    console.error("Get user device detail error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch device" },
+      { status: 500 }
+    );
+  }
+}

--- a/packages/frontend/src/app/api/users/[username]/devices/route.ts
+++ b/packages/frontend/src/app/api/users/[username]/devices/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from "next/server";
+import { desc, eq, sql } from "drizzle-orm";
+import { db, dailyBreakdown, submittedDevices, users } from "@/lib/db";
+import {
+  USERNAME_LOOKUP_LIMIT,
+  getSingleUsernameMatch,
+  usernameEqualsIgnoreCase,
+} from "@/lib/db/usernameLookup";
+import { deviceDisplayLabel, toIsoString } from "@/lib/devices/shared";
+
+export const revalidate = 60;
+
+interface RouteParams {
+  params: Promise<{ username: string }>;
+}
+
+/**
+ * GET /api/users/[username]/devices
+ *
+ * Returns the list of submission devices belonging to `username` with usage
+ * totals aggregated from `daily_breakdown`. Public — no auth required, mirrors
+ * the visibility model of GET /api/users/[username].
+ *
+ * Returned in `last_submitted_at DESC, created_at DESC` order so the device
+ * the user just submitted from is always first.
+ */
+export async function GET(_request: Request, { params }: RouteParams) {
+  try {
+    const { username } = await params;
+
+    const matchingUsers = await db
+      .select({
+        id: users.id,
+        username: users.username,
+        displayName: users.displayName,
+        avatarUrl: users.avatarUrl,
+      })
+      .from(users)
+      .where(usernameEqualsIgnoreCase(username))
+      .limit(USERNAME_LOOKUP_LIMIT);
+
+    const user = getSingleUsernameMatch(matchingUsers, username);
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const rows = await db
+      .select({
+        id: submittedDevices.id,
+        deviceKey: submittedDevices.deviceKey,
+        displayName: submittedDevices.displayName,
+        createdAt: submittedDevices.createdAt,
+        lastSubmittedAt: submittedDevices.lastSubmittedAt,
+        totalTokens: sql<string>`COALESCE(SUM(${dailyBreakdown.tokens}), 0)`,
+        totalCost: sql<string>`COALESCE(SUM(${dailyBreakdown.cost}), 0)`,
+        inputTokens: sql<string>`COALESCE(SUM(${dailyBreakdown.inputTokens}), 0)`,
+        outputTokens: sql<string>`COALESCE(SUM(${dailyBreakdown.outputTokens}), 0)`,
+        activeDays: sql<string>`COUNT(DISTINCT CASE WHEN ${dailyBreakdown.tokens} > 0 THEN ${dailyBreakdown.date} END)`,
+        firstDay: sql<string | null>`MIN(${dailyBreakdown.date})`,
+        lastDay: sql<string | null>`MAX(${dailyBreakdown.date})`,
+      })
+      .from(submittedDevices)
+      .leftJoin(dailyBreakdown, eq(dailyBreakdown.submittedDeviceId, submittedDevices.id))
+      .where(eq(submittedDevices.userId, user.id))
+      .groupBy(
+        submittedDevices.id,
+        submittedDevices.deviceKey,
+        submittedDevices.displayName,
+        submittedDevices.createdAt,
+        submittedDevices.lastSubmittedAt
+      )
+      .orderBy(
+        sql`${submittedDevices.lastSubmittedAt} DESC NULLS LAST`,
+        desc(submittedDevices.createdAt)
+      );
+
+    return NextResponse.json({
+      user: {
+        username: user.username,
+        displayName: user.displayName,
+        avatarUrl: user.avatarUrl,
+      },
+      devices: rows.map((row) => ({
+        id: row.id,
+        deviceKey: row.deviceKey,
+        // Public consumers see the fallback label, not the underlying null.
+        // Owners get the raw value via /api/settings/devices/[id] for editing.
+        displayName: deviceDisplayLabel(row.deviceKey, row.displayName),
+        createdAt: toIsoString(row.createdAt),
+        lastSubmittedAt: toIsoString(row.lastSubmittedAt),
+        totalTokens: Number(row.totalTokens) || 0,
+        totalCost: Number(row.totalCost) || 0,
+        inputTokens: Number(row.inputTokens) || 0,
+        outputTokens: Number(row.outputTokens) || 0,
+        activeDays: Number(row.activeDays) || 0,
+        firstDay: row.firstDay,
+        lastDay: row.lastDay,
+      })),
+    });
+  } catch (error) {
+    console.error("Get user devices error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch devices" },
+      { status: 500 }
+    );
+  }
+}

--- a/packages/frontend/src/lib/db/migrations/0010_submit_count_safety.sql
+++ b/packages/frontend/src/lib/db/migrations/0010_submit_count_safety.sql
@@ -1,0 +1,14 @@
+-- Schema-drift safety net.
+--
+-- `submissions.submit_count` is referenced by schema.ts and by every call to
+-- /api/submit (`COALESCE(submit_count, 0) + 1`), but no earlier .sql migration
+-- file actually adds the column. Production has it because somebody once ran
+-- `drizzle-kit push` against the live DB; any fresh `drizzle-kit migrate` run
+-- (CI, staging, a new local dev DB) ends up without the column and breaks
+-- `/api/submit` on the very first submission. Verified locally on
+-- 2026-05-25 against `postgres:16`.
+--
+-- Using `ADD COLUMN IF NOT EXISTS` so this migration is a no-op on prod (and
+-- on any environment that already received the column out-of-band) but
+-- repairs every other environment in a single step.
+ALTER TABLE "submissions" ADD COLUMN IF NOT EXISTS "submit_count" integer DEFAULT 1 NOT NULL;

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1778198400000,
       "tag": "0009_add_groups",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1780000000000,
+      "tag": "0010_submit_count_safety",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/devices/shared.ts
+++ b/packages/frontend/src/lib/devices/shared.ts
@@ -1,0 +1,28 @@
+// Shared helpers for the per-device read APIs under
+// /api/users/[username]/devices/...
+//
+// Why a dedicated module: the listing endpoint, the per-device detail
+// endpoint, and the rename endpoint all need the same display-name fallback
+// and update-time normalization. Keeping them here prevents a class of bugs
+// where one endpoint accepts an empty string and another doesn't.
+
+export const LEGACY_DEVICE_KEY = "legacy-default";
+
+/** Fallback label used when `submitted_devices.display_name` is null/empty. */
+export function deviceDisplayLabel(
+  deviceKey: string,
+  displayName: string | null | undefined
+): string {
+  const trimmed = displayName?.trim();
+  if (trimmed) return trimmed;
+  if (deviceKey === LEGACY_DEVICE_KEY) return "Legacy submissions";
+  return "Unnamed device";
+}
+
+/** Coerce any drizzle timestamp / Date / string into a stable ISO string. */
+export function toIsoString(value: Date | string | null | undefined): string | null {
+  if (!value) return null;
+  if (value instanceof Date) return value.toISOString();
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}


### PR DESCRIPTION
## Summary

Ports the user-facing "devices" surface from #389 onto main's already-merged `submitted_devices` schema (from #517), and ships the schema-drift fix that #389's audit surfaced for `submissions.submit_count`.

#249 and #389 themselves remain open — both are architecturally superseded by what's now on main (#524 groups; #517 device-aware merges). This PR extracts the parts that *are* new value: the read APIs for per-device usage, a rename endpoint, the seed script for local dev, and the migration that unbreaks fresh deploys.

## Why now

`packages/frontend/src/lib/db/schema.ts` declares `submissions.submit_count` and `src/app/api/submit/route.ts:465` writes to it on every submit, but **no migration file actually adds the column.** Production has it because somebody once ran `drizzle-kit push` against the live DB; any fresh `drizzle-kit migrate` run today (CI, staging, a new local dev DB) leaves the column missing and breaks `/api/submit` on the very first submission.

Verified on `2026-05-25` against `postgres:16` in docker: a clean `drizzle-kit migrate` run against an empty DB does not produce the column. #389's commit message audited prod and called this out a month ago; this PR is the first time the fix lands.

## Changes

### Migration

- `0010_submit_count_safety.sql` — `ALTER TABLE submissions ADD COLUMN IF NOT EXISTS submit_count integer DEFAULT 1 NOT NULL`. No-op on prod, repair on every other environment.

### New read APIs (public, no auth — matches `/api/users/[username]`)

- `GET /api/users/[username]/devices` — list a user's submission devices with aggregated totals (tokens, cost, input/output, active-day count, first/last day). One query: `submitted_devices LEFT JOIN daily_breakdown GROUP BY device_id`. Ordered by `last_submitted_at DESC NULLS LAST`.
- `GET /api/users/[username]/devices/[deviceId]` — per-device detail: device metadata + day-by-day contributions. Cross-user device id silently 404s (no existence leak).

### New write API (session-authenticated)

- `PATCH /api/settings/devices/[deviceId]` — rename or clear a device's display label. Validates ≤120 chars (matches column), rejects Unicode control characters. Ownership enforced in the same `WHERE` so non-owner attempts 404.

### Helpers

- `src/lib/devices/shared.ts` — `deviceDisplayLabel()` (fallback to `"Legacy submissions"` / `"Unnamed device"`) and `toIsoString()` (stable timestamp serialization). Shared by all three routes so the public label format can't drift.

### Local dev tooling

- `scripts/seed-dev.ts` — idempotent synthetic seed: 3 users × 2 devices × 14 days + 1 group. Refuses any non-`localhost` `DATABASE_URL`. Use with `bun run packages/frontend/scripts/seed-dev.ts`.

## What is *not* in this PR

| From | Item | Why deferred |
|---|---|---|
| #389 | `submissions.source_id` / `source_name` schema rewrite | conflicts with #517's `submitted_devices` model on main; that decision is bigger than one PR |
| #389 | CLI source-id lockfile + `TOKSCALE_SOURCE_ID` env var | main's CLI already sends `device: { id, name }` in submit payload via #517 + #545 |
| #389 | Profile "Devices" tab UI | substantial styled-components surface; better as its own visual-review PR built on top of these endpoints |
| #389 | Index cleanup migration (`idx_submissions_user_id`, etc.) | drops based on prod `pg_stat_user_indexes` audit; wants a separate analysis-driven PR with the matching audit re-run, not bundled here |
| #249 | Groups feature | strictly superseded by #524 already on main (per-invite hashed tokens vs reusable invite code, targeted invites, last-owner protection). No cherry-picks identified |

The two source PRs (#389, #249) should be closed once this lands and you confirm nothing's missing.

## Verification

Local stack (docker `postgres:16` on `localhost:5432`, `bun run db:migrate` applied):

- `bunx tsc --noEmit` → 0 errors
- `bunx vitest run __tests__` → exit 0
- `bun run scripts/seed-dev.ts` against local DB → 3 users + 6 devices + 84 daily_breakdown rows + 1 group
- `curl /api/users/seed-dev-alice/devices` → 200 JSON, two devices with summed tokens 1,365,000 + 1,155,000 (matches raw `SUM(tokens)` query)
- `curl /api/users/seed-dev-alice/devices/<uuid>` → 200 JSON, 14 contributions
- `curl /api/users/seed-dev-alice/devices/not-a-uuid` → 400 JSON `{"error":"Invalid device id"}`
- `curl /api/users/nobody-here/devices/<uuid>` → 404 JSON `{"error":"User not found"}`
- `curl -X PATCH /api/settings/devices/<uuid>` without auth → 401 JSON

## Test plan

- [ ] CI green
- [ ] Migration `0010_submit_count_safety` applies cleanly on staging (no-op if column already there)
- [ ] Manual smoke: hit `/api/users/<your-username>/devices` after deploy; counts should match `/api/users/<your-username>` totals
- [ ] After this lands, close #389 and #249 with a pointer to this PR + #517 + #524


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds public per-device read APIs and a session-authenticated rename endpoint for devices. Also fixes schema drift by adding a safety migration for `submissions.submit_count` so fresh environments don't break.

- **New Features**
  - `GET /api/users/[username]/devices`: list devices with aggregated totals (tokens, cost, input/output, active days).
  - `GET /api/users/[username]/devices/[deviceId]`: per-device detail with daily contributions; cross-user ids 404; 60s revalidate.
  - `PATCH /api/settings/devices/[deviceId]`: rename or clear display label; ≤120 chars; rejects control chars; ownership enforced in a single WHERE.
  - Shared helpers: `deviceDisplayLabel()` and `toIsoString()` to keep labels and timestamps consistent.
  - Local dev: `scripts/seed-dev.ts` seeds 3 users × 2 devices × 14 days; idempotent; refuses non-`localhost` `DATABASE_URL`.

- **Migration**
  - `0010_submit_count_safety.sql`: `ALTER TABLE submissions ADD COLUMN IF NOT EXISTS submit_count integer DEFAULT 1 NOT NULL`.
  - Prevents failures on fresh `drizzle-kit migrate`; no-op on prod where the column already exists.

<sup>Written for commit d73b1372509c478fc64aa52242c6eacf422449a9. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/593?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

