### PR TITLE
chore(db): drop dead columns + redundant indexes + unique constraint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ crates/tokscale-cli/tokscale-export-*.json
 self-host/tokscale-key.pem
 self-host/
 .next/
+.vercel
+.env*.local

--- a/packages/frontend/__tests__/api/authToken.test.ts
+++ b/packages/frontend/__tests__/api/authToken.test.ts
@@ -81,7 +81,6 @@ describe("GET /api/auth/token", () => {
       username: "alice",
       displayName: null,
       avatarUrl: null,
-      isAdmin: false,
       expiresAt: null,
     });
 
@@ -105,7 +104,6 @@ describe("GET /api/auth/token", () => {
       username: "alice",
       displayName: "Alice",
       avatarUrl: "https://example.com/alice.png",
-      isAdmin: false,
       expiresAt: null,
     });
 

--- a/packages/frontend/__tests__/api/groupInviteJoinRoute.test.ts
+++ b/packages/frontend/__tests__/api/groupInviteJoinRoute.test.ts
@@ -86,7 +86,6 @@ describe("/api/groups/join/[token]", () => {
       username: "Alice",
       displayName: null,
       avatarUrl: null,
-      isAdmin: false,
     });
     mockState.acceptGroupInvite.mockResolvedValue({
       group: { id: "group-1", name: "Team", slug: "team" },
@@ -104,7 +103,6 @@ describe("/api/groups/join/[token]", () => {
       username: "Alice",
       displayName: null,
       avatarUrl: null,
-      isAdmin: false,
     });
     expect(await response.json()).toEqual({
       group: { id: "group-1", name: "Team", slug: "team" },

--- a/packages/frontend/__tests__/api/groupLeaderboardRoute.test.ts
+++ b/packages/frontend/__tests__/api/groupLeaderboardRoute.test.ts
@@ -62,7 +62,6 @@ describe("GET /api/groups/[slug]/leaderboard", () => {
       username: "outsider",
       displayName: null,
       avatarUrl: null,
-      isAdmin: false,
     });
     mockState.getGroupMembership.mockResolvedValue(null);
 
@@ -87,7 +86,6 @@ describe("GET /api/groups/[slug]/leaderboard", () => {
       username: "member",
       displayName: null,
       avatarUrl: null,
-      isAdmin: false,
     });
     mockState.getGroupMembership.mockResolvedValue({ role: "member" });
     mockState.getGroupLeaderboardData.mockResolvedValue({

--- a/packages/frontend/__tests__/api/groupLeaveRoute.test.ts
+++ b/packages/frontend/__tests__/api/groupLeaveRoute.test.ts
@@ -84,7 +84,6 @@ describe("POST /api/groups/[slug]/leave", () => {
       username: "alice",
       displayName: null,
       avatarUrl: null,
-      isAdmin: false,
     });
     mockState.getGroupBySlug.mockResolvedValue({
       id: "group-1",

--- a/packages/frontend/__tests__/api/groupRoute.test.ts
+++ b/packages/frontend/__tests__/api/groupRoute.test.ts
@@ -150,7 +150,6 @@ describe("/api/groups/[slug]", () => {
       username: "admin",
       displayName: null,
       avatarUrl: null,
-      isAdmin: false,
     });
     mockState.getGroupBySlug.mockResolvedValue(group());
     mockState.getGroupMembership.mockResolvedValue({ role: "admin" });
@@ -176,7 +175,6 @@ describe("/api/groups/[slug]", () => {
       username: "admin",
       displayName: null,
       avatarUrl: null,
-      isAdmin: false,
     });
     mockState.getGroupBySlug.mockResolvedValue(group());
     mockState.getGroupMembership.mockResolvedValue({ role: "admin" });

--- a/packages/frontend/__tests__/api/leaderboard.test.ts
+++ b/packages/frontend/__tests__/api/leaderboard.test.ts
@@ -65,7 +65,17 @@ describe("GET /api/leaderboard", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(getLeaderboardData).toHaveBeenCalledWith("all", 1, 10, "tokens", "");
+    // #522 added customFrom/customTo as the 6th and 7th positional args; this
+    // request doesn't pass them, so they arrive as `undefined`.
+    expect(getLeaderboardData).toHaveBeenCalledWith(
+      "all",
+      1,
+      10,
+      "tokens",
+      "",
+      undefined,
+      undefined,
+    );
     expect(body.users[0].submissionFreshness).toEqual({
       lastUpdated: "2026-01-10T10:00:00.000Z",
       cliVersion: "1.4.2",

--- a/packages/frontend/__tests__/api/settingsSubmittedDataDelete.test.ts
+++ b/packages/frontend/__tests__/api/settingsSubmittedDataDelete.test.ts
@@ -161,7 +161,6 @@ describe("DELETE /api/settings/submitted-data", () => {
       username: "Alice",
       displayName: "Alice",
       avatarUrl: null,
-      isAdmin: false,
     });
     mockState.setDeletedRows([{ id: "submission-1" }]);
     mockState.revalidateUserGroupLeaderboards.mockRejectedValueOnce(
@@ -215,7 +214,6 @@ describe("DELETE /api/settings/submitted-data", () => {
       username: "alice",
       displayName: "Alice",
       avatarUrl: null,
-      isAdmin: false,
     });
     mockState.setDeletedRows([]);
 
@@ -243,7 +241,6 @@ describe("DELETE /api/settings/submitted-data", () => {
       username: "alice",
       displayName: "Alice",
       avatarUrl: null,
-      isAdmin: false,
     });
     mockState.setDeleteError(new Error("db unavailable"));
 

--- a/packages/frontend/__tests__/api/settingsTokensDelete.test.ts
+++ b/packages/frontend/__tests__/api/settingsTokensDelete.test.ts
@@ -56,7 +56,6 @@ describe("DELETE /api/settings/tokens/[tokenId]", () => {
       username: "alice",
       displayName: "Alice",
       avatarUrl: null,
-      isAdmin: false,
     });
     mockState.revokePersonalToken.mockResolvedValue(true);
 
@@ -78,7 +77,6 @@ describe("DELETE /api/settings/tokens/[tokenId]", () => {
       username: "alice",
       displayName: "Alice",
       avatarUrl: null,
-      isAdmin: false,
     });
     mockState.revokePersonalToken.mockResolvedValue(false);
 

--- a/packages/frontend/__tests__/api/settingsTokensList.test.ts
+++ b/packages/frontend/__tests__/api/settingsTokensList.test.ts
@@ -57,7 +57,6 @@ describe("GET /api/settings/tokens", () => {
       username: "alice",
       displayName: "Alice",
       avatarUrl: null,
-      isAdmin: false,
     });
     mockState.listPersonalTokens.mockResolvedValue([]);
 
@@ -74,7 +73,6 @@ describe("GET /api/settings/tokens", () => {
       username: "alice",
       displayName: "Alice",
       avatarUrl: null,
-      isAdmin: false,
     });
     mockState.listPersonalTokens.mockResolvedValue([
       {
@@ -130,7 +128,6 @@ describe("GET /api/settings/tokens", () => {
       username: "alice",
       displayName: "Alice",
       avatarUrl: null,
-      isAdmin: false,
     });
     mockState.listPersonalTokens.mockRejectedValue(
       new Error("Database error")
@@ -165,7 +162,6 @@ describe("POST /api/settings/tokens", () => {
       username: "alice",
       displayName: "Alice",
       avatarUrl: null,
-      isAdmin: false,
     });
     mockState.issuePersonalToken.mockResolvedValue({
       id: "token-1",
@@ -207,7 +203,6 @@ describe("POST /api/settings/tokens", () => {
       username: "alice",
       displayName: "Alice",
       avatarUrl: null,
-      isAdmin: false,
     });
     mockState.issuePersonalToken.mockResolvedValue({
       id: "token-1",

--- a/packages/frontend/__tests__/api/submit.test.ts
+++ b/packages/frontend/__tests__/api/submit.test.ts
@@ -706,46 +706,6 @@ describe('POST /api/submit - Client-Level Merge', () => {
       expect(Object.keys(result.cursor.models)).toEqual(['gpt-4o']);
     });
 
-    it('should build modelBreakdown from clients with multiple models', () => {
-      const clientBreakdown = {
-        claude: {
-          tokens: 2550,
-          cost: 30,
-          input: 1300,
-          output: 800,
-          cacheRead: 300,
-          cacheWrite: 150,
-          messages: 13,
-          models: {
-            'claude-sonnet-4': { tokens: 950, cost: 10, input: 500, output: 300, cacheRead: 100, cacheWrite: 50, messages: 5 },
-            'claude-opus-4': { tokens: 1600, cost: 20, input: 800, output: 500, cacheRead: 200, cacheWrite: 100, messages: 8 },
-          },
-        },
-        cursor: {
-          tokens: 375,
-          cost: 5,
-          input: 200,
-          output: 100,
-          cacheRead: 50,
-          cacheWrite: 25,
-          messages: 3,
-          models: {
-            'gpt-4o': { tokens: 375, cost: 5, input: 200, output: 100, cacheRead: 50, cacheWrite: 25, messages: 3 },
-          },
-        },
-      };
-
-      const modelBreakdown: Record<string, number> = {};
-      for (const client of Object.values(clientBreakdown)) {
-        for (const [modelId, modelData] of Object.entries(client.models)) {
-          modelBreakdown[modelId] = (modelBreakdown[modelId] || 0) + modelData.tokens;
-        }
-      }
-
-      expect(modelBreakdown['claude-sonnet-4']).toBe(950);
-      expect(modelBreakdown['claude-opus-4']).toBe(1600);
-      expect(modelBreakdown['gpt-4o']).toBe(375);
-    });
   });
 
   describe('Response Format', () => {

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -196,7 +196,6 @@ describe("POST /api/submit auth path", () => {
       username: "alice",
       displayName: "Alice",
       avatarUrl: null,
-      isAdmin: false,
       expiresAt: null,
     });
     mockState.validateSubmission.mockReturnValue({
@@ -238,7 +237,6 @@ describe("POST /api/submit auth path", () => {
       username: "alice",
       displayName: "Alice",
       avatarUrl: null,
-      isAdmin: false,
       expiresAt: null,
     });
     mockState.validateSubmission.mockReturnValue({
@@ -272,7 +270,6 @@ describe("POST /api/submit auth path", () => {
       username: "Alice",
       displayName: "Alice",
       avatarUrl: null,
-      isAdmin: false,
       expiresAt: null,
     });
 
@@ -455,7 +452,6 @@ describe("POST /api/submit auth path", () => {
       username: "alice",
       displayName: "Alice",
       avatarUrl: null,
-      isAdmin: false,
       expiresAt: null,
     });
 

--- a/packages/frontend/__tests__/api/usersProfile.test.ts
+++ b/packages/frontend/__tests__/api/usersProfile.test.ts
@@ -40,7 +40,6 @@ const mockState = vi.hoisted(() => {
       inputTokens: "dailyBreakdown.inputTokens",
       outputTokens: "dailyBreakdown.outputTokens",
       sourceBreakdown: "dailyBreakdown.sourceBreakdown",
-      modelBreakdown: "dailyBreakdown.modelBreakdown",
     },
   };
 

--- a/packages/frontend/__tests__/lib/groupInvites.test.ts
+++ b/packages/frontend/__tests__/lib/groupInvites.test.ts
@@ -168,7 +168,6 @@ describe("group invites", () => {
       username: "alice",
       displayName: null,
       avatarUrl: null,
-      isAdmin: false,
     });
 
     expect(accepted).toEqual({
@@ -197,7 +196,6 @@ describe("group invites", () => {
         username: "bob",
         displayName: null,
         avatarUrl: null,
-        isAdmin: false,
       })
     ).rejects.toMatchObject({
       code: "not_found",

--- a/packages/frontend/__tests__/lib/personalTokens.test.ts
+++ b/packages/frontend/__tests__/lib/personalTokens.test.ts
@@ -24,7 +24,6 @@ const mockState = vi.hoisted(() => {
       username: "users.username",
       displayName: "users.displayName",
       avatarUrl: "users.avatarUrl",
-      isAdmin: "users.isAdmin",
     },
   };
 
@@ -331,7 +330,6 @@ describe("personal token service", () => {
         username: "alice",
         displayName: "Alice",
         avatarUrl: null,
-        isAdmin: false,
         expiresAt: new Date("2026-03-01T00:00:00.000Z"),
       },
     ]);
@@ -355,7 +353,6 @@ describe("personal token service", () => {
         username: "alice",
         displayName: "Alice",
         avatarUrl: null,
-        isAdmin: false,
         expiresAt: now,
       },
     ]);
@@ -375,7 +372,6 @@ describe("personal token service", () => {
         username: "alice",
         displayName: "Alice",
         avatarUrl: null,
-        isAdmin: false,
         expiresAt: null,
       },
     ]);
@@ -402,7 +398,6 @@ describe("personal token service", () => {
         username: "alice",
         displayName: "Alice",
         avatarUrl: null,
-        isAdmin: false,
         expiresAt: null,
       },
     ]);

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -12,7 +12,6 @@ import { getBearerToken } from "../../../lib/auth/bearerToken";
 import {
   mergeClientBreakdowns,
   recalculateDayTotals,
-  buildModelBreakdown,
   clientContributionToBreakdownData,
   mergeTimestampMs,
   type ClientBreakdownData,
@@ -202,7 +201,6 @@ export async function POST(request: Request) {
             dateEnd: data.meta.dateRange.end,
             sourcesUsed: [],
             modelsUsed: [],
-            status: "verified",
             cliVersion: data.meta.version,
             submissionHash: generateSubmissionHash(hashData),
           })
@@ -270,7 +268,6 @@ export async function POST(request: Request) {
         timestampMs: number | null;
         activeTimeMs: number | null;
         sourceBreakdown: Record<string, ClientBreakdownData>;
-        modelBreakdown: Record<string, number>;
       }> = [];
 
       const toUpdate: Array<{
@@ -282,7 +279,6 @@ export async function POST(request: Request) {
         timestampMs: number | null;
         activeTimeMs: number | null;
         sourceBreakdown: Record<string, ClientBreakdownData>;
-        modelBreakdown: Record<string, number>;
       }> = [];
 
       for (const incomingDay of data.contributions) {
@@ -330,7 +326,6 @@ export async function POST(request: Request) {
              submittedClients
            );
           const dayTotals = recalculateDayTotals(mergedClientBreakdown);
-          const modelBreakdown = buildModelBreakdown(mergedClientBreakdown);
 
           toUpdate.push({
             id: existingDay.id,
@@ -341,11 +336,9 @@ export async function POST(request: Request) {
             timestampMs: mergeTimestampMs(existingDay.timestampMs, incomingDay.timestampMs ?? null),
             activeTimeMs: incomingDay.activeTimeMs ?? existingDay.activeTimeMs ?? null,
             sourceBreakdown: mergedClientBreakdown,
-            modelBreakdown,
           });
         } else {
           const dayTotals = recalculateDayTotals(incomingClientBreakdown);
-          const modelBreakdown = buildModelBreakdown(incomingClientBreakdown);
 
           toInsert.push({
             submissionId,
@@ -358,7 +351,6 @@ export async function POST(request: Request) {
             timestampMs: incomingDay.timestampMs ?? null,
             activeTimeMs: incomingDay.activeTimeMs ?? null,
             sourceBreakdown: incomingClientBreakdown,
-            modelBreakdown,
           });
         }
       }
@@ -372,7 +364,7 @@ export async function POST(request: Request) {
       if (toUpdate.length > 0) {
         const valuesClauses = toUpdate.map(
           (row) =>
-            sql`(${row.id}::uuid, ${row.tokens}::bigint, ${row.cost}::numeric(10,4), ${row.inputTokens}::bigint, ${row.outputTokens}::bigint, ${row.timestampMs}::bigint, ${row.activeTimeMs}::bigint, ${JSON.stringify(row.sourceBreakdown)}::jsonb, ${JSON.stringify(row.modelBreakdown)}::jsonb)`
+            sql`(${row.id}::uuid, ${row.tokens}::bigint, ${row.cost}::numeric(10,4), ${row.inputTokens}::bigint, ${row.outputTokens}::bigint, ${row.timestampMs}::bigint, ${row.activeTimeMs}::bigint, ${JSON.stringify(row.sourceBreakdown)}::jsonb)`
         );
 
         const valuesList = sql.join(valuesClauses, sql`, `);
@@ -385,10 +377,9 @@ export async function POST(request: Request) {
             output_tokens = batch.output_tokens,
             timestamp_ms = batch.timestamp_ms,
             active_time_ms = batch.active_time_ms,
-            source_breakdown = batch.source_breakdown,
-            model_breakdown = batch.model_breakdown
+            source_breakdown = batch.source_breakdown
           FROM (VALUES ${valuesList})
-            AS batch(id, tokens, cost, input_tokens, output_tokens, timestamp_ms, active_time_ms, source_breakdown, model_breakdown)
+            AS batch(id, tokens, cost, input_tokens, output_tokens, timestamp_ms, active_time_ms, source_breakdown)
           WHERE d.id = batch.id
         `);
       }

--- a/packages/frontend/src/app/api/users/[username]/route.ts
+++ b/packages/frontend/src/app/api/users/[username]/route.ts
@@ -107,7 +107,6 @@ export async function GET(_request: Request, { params }: RouteParams) {
           inputTokens: dailyBreakdown.inputTokens,
           outputTokens: dailyBreakdown.outputTokens,
           sourceBreakdown: dailyBreakdown.sourceBreakdown,
-          modelBreakdown: dailyBreakdown.modelBreakdown,
         })
         .from(dailyBreakdown)
         .innerJoin(submissions, eq(dailyBreakdown.submissionId, submissions.id))

--- a/packages/frontend/src/lib/auth/personalTokens.ts
+++ b/packages/frontend/src/lib/auth/personalTokens.ts
@@ -28,7 +28,6 @@ export interface AuthenticatedPersonalToken {
   username: string;
   displayName: string | null;
   avatarUrl: string | null;
-  isAdmin: boolean;
   expiresAt: Date | null;
 }
 
@@ -204,7 +203,6 @@ export async function authenticatePersonalToken(
       username: users.username,
       displayName: users.displayName,
       avatarUrl: users.avatarUrl,
-      isAdmin: users.isAdmin,
       expiresAt: apiTokens.expiresAt,
     })
     .from(apiTokens)
@@ -236,7 +234,6 @@ export async function authenticatePersonalToken(
     username: record.username,
     displayName: record.displayName,
     avatarUrl: record.avatarUrl,
-    isAdmin: record.isAdmin,
     expiresAt: record.expiresAt,
   };
 }

--- a/packages/frontend/src/lib/auth/session.ts
+++ b/packages/frontend/src/lib/auth/session.ts
@@ -12,7 +12,6 @@ export interface SessionUser {
   username: string;
   displayName: string | null;
   avatarUrl: string | null;
-  isAdmin: boolean;
 }
 
 /**
@@ -48,7 +47,6 @@ export async function getSession(): Promise<SessionUser | null> {
     username: user.username,
     displayName: user.displayName,
     avatarUrl: user.avatarUrl,
-    isAdmin: user.isAdmin,
   };
 }
 
@@ -120,7 +118,6 @@ export async function validateApiToken(
     username: result.username,
     displayName: result.displayName,
     avatarUrl: result.avatarUrl,
-    isAdmin: result.isAdmin,
   };
 }
 
@@ -168,6 +165,5 @@ export async function getSessionFromHeader(
     username: user.username,
     displayName: user.displayName,
     avatarUrl: user.avatarUrl,
-    isAdmin: user.isAdmin,
   };
 }

--- a/packages/frontend/src/lib/db/helpers.ts
+++ b/packages/frontend/src/lib/db/helpers.ts
@@ -87,24 +87,6 @@ export function mergeClientBreakdowns(
   return merged;
 }
 
-export function buildModelBreakdown(
-  clientBreakdown: Record<string, ClientBreakdownData>
-): Record<string, number> {
-  const result: Record<string, number> = {};
-
-  for (const client of Object.values(clientBreakdown)) {
-    if (client.models) {
-      for (const [modelId, modelData] of Object.entries(client.models)) {
-        result[modelId] = (result[modelId] || 0) + modelData.tokens;
-      }
-    } else if (client.modelId) {
-      result[client.modelId] = (result[client.modelId] || 0) + client.tokens;
-    }
-  }
-
-  return result;
-}
-
 export function clientContributionToBreakdownData(
   client_contrib: {
     tokens: { input: number; output: number; cacheRead: number; cacheWrite: number; reasoning?: number };

--- a/packages/frontend/src/lib/db/migrations/0011_drop_dead_columns.sql
+++ b/packages/frontend/src/lib/db/migrations/0011_drop_dead_columns.sql
@@ -1,0 +1,30 @@
+-- Drop columns and indexes confirmed dead by full-codebase audit on 2026-05-25.
+--
+-- daily_breakdown.provider_breakdown: declared in schema.ts but never read
+--   or written anywhere in src/. Pure dead JSONB column allocated on every
+--   daily row.
+--
+-- daily_breakdown.model_breakdown: written on every submit, but the only
+--   SELECT (users/[username]/route.ts:110) places it in the result row and
+--   never references the value. Net result: storage + JSON serialization
+--   churn with no consumer.
+--
+-- submissions.status + idx_submissions_status: column is only ever written
+--   as 'verified' on insert (submit/route.ts:205); zero WHERE filters exist
+--   anywhere in the codebase. The index serves no query. Status semantics
+--   were planned ("pending"/"rejected"?) but never implemented.
+--
+-- users.is_admin: column is set/fetched into SessionUser, but no admin
+--   gate exists in the codebase. A user with is_admin=true had zero
+--   additional privileges. The column lied about what it did; if admin
+--   features ever ship, reintroduce the column WITH an actual gate.
+--
+-- All DROPs use IF EXISTS so the migration is safe to replay against any
+-- environment regardless of whether the column was already removed
+-- out-of-band.
+
+DROP INDEX IF EXISTS "idx_submissions_status";--> statement-breakpoint
+ALTER TABLE "submissions" DROP COLUMN IF EXISTS "status";--> statement-breakpoint
+ALTER TABLE "daily_breakdown" DROP COLUMN IF EXISTS "provider_breakdown";--> statement-breakpoint
+ALTER TABLE "daily_breakdown" DROP COLUMN IF EXISTS "model_breakdown";--> statement-breakpoint
+ALTER TABLE "users" DROP COLUMN IF EXISTS "is_admin";

--- a/packages/frontend/src/lib/db/migrations/0011_drop_dead_columns.sql
+++ b/packages/frontend/src/lib/db/migrations/0011_drop_dead_columns.sql
@@ -56,23 +56,20 @@ ALTER TABLE "users" DROP COLUMN IF EXISTS "is_admin";--> statement-breakpoint
 --   actually used by leaderboard period filters is on daily_breakdown.date
 --   (which has its own index).
 --
+-- HOLD on the duplicate-of-unique-constraint indexes:
 -- idx_users_username, idx_sessions_token, idx_api_tokens_token,
--- idx_device_codes_device_code, idx_device_codes_user_code:
---   Postgres auto-creates a btree for every UNIQUE constraint. These
---   explicit btrees duplicate the existing *_unique indexes 1:1 and
---   only add write-amplification on every INSERT/UPDATE. The
---   case-insensitive users_username_lower_unique is a DIFFERENT index
---   (on lower(username)) and stays.
+-- idx_device_codes_device_code, idx_device_codes_user_code.
+-- The 2026-05-25 prod pg_stat_user_indexes audit showed these are HOT
+-- (sessions_token 89k scans, users_username 30k, api_tokens_token 27k)
+-- while their unique-constraint siblings show 0 scans — the planner
+-- consistently picks the explicit non-unique index. Dropping would
+-- invalidate cached plans; keep them until a controlled re-plan can
+-- be scheduled.
 
 DROP INDEX IF EXISTS "idx_submissions_status";--> statement-breakpoint
 DROP INDEX IF EXISTS "idx_submissions_user_id";--> statement-breakpoint
 DROP INDEX IF EXISTS "idx_submissions_total_tokens";--> statement-breakpoint
 DROP INDEX IF EXISTS "idx_submissions_date_range";--> statement-breakpoint
-DROP INDEX IF EXISTS "idx_users_username";--> statement-breakpoint
-DROP INDEX IF EXISTS "idx_sessions_token";--> statement-breakpoint
-DROP INDEX IF EXISTS "idx_api_tokens_token";--> statement-breakpoint
-DROP INDEX IF EXISTS "idx_device_codes_device_code";--> statement-breakpoint
-DROP INDEX IF EXISTS "idx_device_codes_user_code";--> statement-breakpoint
 
 -- FK coverage gap: three FK columns were lacking covering indexes.
 -- Cascade-delete of a user did a seq scan of device_codes / group_members

--- a/packages/frontend/src/lib/db/migrations/0011_drop_dead_columns.sql
+++ b/packages/frontend/src/lib/db/migrations/0011_drop_dead_columns.sql
@@ -1,30 +1,95 @@
--- Drop columns and indexes confirmed dead by full-codebase audit on 2026-05-25.
+-- Drop dead schema surface confirmed by full-codebase audit on 2026-05-25.
+-- Combines three cleanup categories surfaced by the audit:
+--   (A) dead columns (no reads anywhere in src/)
+--   (B) dead and redundant indexes
+--   (C) redundant unique constraint
+-- Plus one positive add: covering index for device_codes.user_id FK.
+--
+-- All DROPs are gated with IF EXISTS so the migration is safe to replay
+-- against any environment regardless of out-of-band schema changes.
+
+-- =============================================================================
+-- (A) Dead columns
+-- =============================================================================
 --
 -- daily_breakdown.provider_breakdown: declared in schema.ts but never read
---   or written anywhere in src/. Pure dead JSONB column allocated on every
---   daily row.
+--   or written anywhere in src/. Pure dead JSONB allocated on every daily row.
 --
 -- daily_breakdown.model_breakdown: written on every submit, but the only
 --   SELECT (users/[username]/route.ts:110) places it in the result row and
---   never references the value. Net result: storage + JSON serialization
---   churn with no consumer.
+--   never references the value. Net result: storage + serialization churn
+--   with no consumer.
 --
--- submissions.status + idx_submissions_status: column is only ever written
---   as 'verified' on insert (submit/route.ts:205); zero WHERE filters exist
---   anywhere in the codebase. The index serves no query. Status semantics
---   were planned ("pending"/"rejected"?) but never implemented.
+-- submissions.status: only ever written as 'verified' on insert
+--   (submit/route.ts:205); zero WHERE filters exist anywhere in the codebase.
+--   The accompanying idx_submissions_status (dropped below) served no query.
+--   Status semantics were planned ("pending"/"rejected"?) but never wired.
 --
 -- users.is_admin: column is set/fetched into SessionUser, but no admin
 --   gate exists in the codebase. A user with is_admin=true had zero
 --   additional privileges. The column lied about what it did; if admin
---   features ever ship, reintroduce the column WITH an actual gate.
---
--- All DROPs use IF EXISTS so the migration is safe to replay against any
--- environment regardless of whether the column was already removed
--- out-of-band.
+--   features ever ship, reintroduce WITH an actual gate.
 
-DROP INDEX IF EXISTS "idx_submissions_status";--> statement-breakpoint
 ALTER TABLE "submissions" DROP COLUMN IF EXISTS "status";--> statement-breakpoint
 ALTER TABLE "daily_breakdown" DROP COLUMN IF EXISTS "provider_breakdown";--> statement-breakpoint
 ALTER TABLE "daily_breakdown" DROP COLUMN IF EXISTS "model_breakdown";--> statement-breakpoint
-ALTER TABLE "users" DROP COLUMN IF EXISTS "is_admin";
+ALTER TABLE "users" DROP COLUMN IF EXISTS "is_admin";--> statement-breakpoint
+
+-- =============================================================================
+-- (B) Dead and redundant indexes
+-- =============================================================================
+--
+-- idx_submissions_status: column dropped above; index has nothing to point at.
+--
+-- idx_submissions_user_id: redundant left-prefix of idx_submissions_leaderboard
+--   (user_id, total_tokens, total_cost, created_at). Per #389's prod-stats
+--   audit, 214 scans on this vs 3.27M on the leaderboard composite — every
+--   plain user_id lookup is already served by the composite's left-prefix.
+--
+-- idx_submissions_total_tokens: per #389's audit, 0 production scans.
+--   Leaderboard reads use SUM() per-user GROUP BY which is served by the
+--   composite leaderboard index; no single-row WHERE/ORDER BY on total_tokens
+--   exists anywhere.
+--
+-- idx_submissions_date_range (date_start, date_end): per #389's audit, 0
+--   production scans. No filter ever queries these columns; the date range
+--   actually used by leaderboard period filters is on daily_breakdown.date
+--   (which has its own index).
+--
+-- idx_users_username, idx_sessions_token, idx_api_tokens_token,
+-- idx_device_codes_device_code, idx_device_codes_user_code:
+--   Postgres auto-creates a btree for every UNIQUE constraint. These
+--   explicit btrees duplicate the existing *_unique indexes 1:1 and
+--   only add write-amplification on every INSERT/UPDATE. The
+--   case-insensitive users_username_lower_unique is a DIFFERENT index
+--   (on lower(username)) and stays.
+
+DROP INDEX IF EXISTS "idx_submissions_status";--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_submissions_user_id";--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_submissions_total_tokens";--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_submissions_date_range";--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_users_username";--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_sessions_token";--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_api_tokens_token";--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_device_codes_device_code";--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_device_codes_user_code";--> statement-breakpoint
+
+-- FK coverage gap: three FK columns were lacking covering indexes.
+-- Cascade-delete of a user did a seq scan of device_codes / group_members
+-- / group_invites. Small tables today, free to fix once.
+CREATE INDEX IF NOT EXISTS "idx_device_codes_user_id" ON "device_codes" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_group_members_invited_by" ON "group_members" USING btree ("invited_by");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_group_invites_invited_by" ON "group_invites" USING btree ("invited_by");--> statement-breakpoint
+
+-- =============================================================================
+-- (C) Redundant unique constraint
+-- =============================================================================
+--
+-- submissions_user_hash_unique (user_id, submission_hash) is functionally
+-- subsumed by submissions_user_id_unique (user_id): the stronger constraint
+-- already enforces one row per user, so any (user_id, submission_hash) tuple
+-- collision would already be rejected at the user_id level. The submission_hash
+-- column itself stays — it's still read by /api/submit for idempotency
+-- comparison against the stored value. Only the redundant uniqueness goes.
+
+ALTER TABLE "submissions" DROP CONSTRAINT IF EXISTS "submissions_user_hash_unique";

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1780000000000,
       "tag": "0010_submit_count_safety",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1780086400000,
+      "tag": "0011_drop_dead_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -32,7 +32,6 @@ export const users = pgTable(
     displayName: varchar("display_name", { length: 255 }),
     avatarUrl: text("avatar_url"),
     email: varchar("email", { length: 255 }),
-    isAdmin: boolean("is_admin").notNull().default(false),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -177,8 +176,6 @@ export const submissions = pgTable(
     sourcesUsed: text("sources_used").array().notNull(),
     modelsUsed: text("models_used").array().notNull(),
 
-    status: varchar("status", { length: 20 }).notNull().default("verified"),
-
     cliVersion: varchar("cli_version", { length: 20 }),
     submissionHash: varchar("submission_hash", { length: 64 }),
     submitCount: integer("submit_count").notNull().default(1),
@@ -199,7 +196,6 @@ export const submissions = pgTable(
   },
   (table) => [
     index("idx_submissions_user_id").on(table.userId),
-    index("idx_submissions_status").on(table.status),
     index("idx_submissions_total_tokens").on(table.totalTokens),
     index("idx_submissions_created_at").on(table.createdAt),
     index("idx_submissions_date_range").on(table.dateStart, table.dateEnd),
@@ -273,9 +269,6 @@ export const dailyBreakdown = pgTable(
     /** Unix ms timestamp of earliest message in this UTC day bucket. NULL for legacy data. */
     timestampMs: bigint("timestamp_ms", { mode: "number" }),
 
-    providerBreakdown: jsonb("provider_breakdown").$type<
-      Record<string, number>
-    >(),
     sourceBreakdown: jsonb("source_breakdown").$type<
       Record<
         string,
@@ -302,7 +295,6 @@ export const dailyBreakdown = pgTable(
         }
       >
     >(),
-    modelBreakdown: jsonb("model_breakdown").$type<Record<string, number>>(),
     /** Total active coding time in this UTC day bucket (milliseconds). NULL for legacy data. */
     activeTimeMs: bigint("active_time_ms", { mode: "number" }),
   },

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -40,8 +40,11 @@ export const users = pgTable(
       .defaultNow(),
   },
   (table) => [
-    // The .unique() on username already creates a covering btree; an explicit
-    // idx_users_username would be a 1:1 duplicate.
+    // Both indexes on username are intentional: the prod planner consistently
+    // picks the explicit non-unique idx_users_username (30k scans) over the
+    // unique-constraint sibling (0 scans). Removing this is a real re-plan
+    // event; don't.
+    index("idx_users_username").on(table.username),
     uniqueIndex(USERS_USERNAME_LOWER_UNIQUE_INDEX).on(
       usernameLowerExpression(table.username)
     ),
@@ -78,7 +81,9 @@ export const sessions = pgTable(
       .defaultNow(),
   },
   (table) => [
-    // The .unique() on token already creates a covering btree.
+    // Planner picks the explicit non-unique idx over the unique-constraint
+    // sibling (~89k vs 0 scans on prod 2026-05-25); keep both.
+    index("idx_sessions_token").on(table.token),
     index("idx_sessions_user_id").on(table.userId),
     index("idx_sessions_expires_at").on(table.expiresAt),
   ]
@@ -110,7 +115,9 @@ export const apiTokens = pgTable(
       .defaultNow(),
   },
   (table) => [
-    // The .unique() on token already creates a covering btree.
+    // Planner picks the explicit non-unique idx (~27k scans) over the
+    // unique-constraint sibling (0 scans); keep both.
+    index("idx_api_tokens_token").on(table.token),
     index("idx_api_tokens_user_id").on(table.userId),
     unique("api_tokens_user_name_unique").on(table.userId, table.name),
   ]
@@ -140,7 +147,10 @@ export const deviceCodes = pgTable(
       .defaultNow(),
   },
   (table) => [
-    // The .unique() on device_code / user_code already creates covering btrees.
+    // The .unique() siblings exist for device_code / user_code but the
+    // planner picks the explicit non-unique indexes; keep them.
+    index("idx_device_codes_device_code").on(table.deviceCode),
+    index("idx_device_codes_user_code").on(table.userCode),
     // idx_device_codes_user_id covers the FK so cascade-delete of a user
     // doesn't seq scan this table.
     index("idx_device_codes_user_id").on(table.userId),

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -40,7 +40,8 @@ export const users = pgTable(
       .defaultNow(),
   },
   (table) => [
-    index("idx_users_username").on(table.username),
+    // The .unique() on username already creates a covering btree; an explicit
+    // idx_users_username would be a 1:1 duplicate.
     uniqueIndex(USERS_USERNAME_LOWER_UNIQUE_INDEX).on(
       usernameLowerExpression(table.username)
     ),
@@ -77,7 +78,7 @@ export const sessions = pgTable(
       .defaultNow(),
   },
   (table) => [
-    index("idx_sessions_token").on(table.token),
+    // The .unique() on token already creates a covering btree.
     index("idx_sessions_user_id").on(table.userId),
     index("idx_sessions_expires_at").on(table.expiresAt),
   ]
@@ -109,7 +110,7 @@ export const apiTokens = pgTable(
       .defaultNow(),
   },
   (table) => [
-    index("idx_api_tokens_token").on(table.token),
+    // The .unique() on token already creates a covering btree.
     index("idx_api_tokens_user_id").on(table.userId),
     unique("api_tokens_user_name_unique").on(table.userId, table.name),
   ]
@@ -139,8 +140,10 @@ export const deviceCodes = pgTable(
       .defaultNow(),
   },
   (table) => [
-    index("idx_device_codes_device_code").on(table.deviceCode),
-    index("idx_device_codes_user_code").on(table.userCode),
+    // The .unique() on device_code / user_code already creates covering btrees.
+    // idx_device_codes_user_id covers the FK so cascade-delete of a user
+    // doesn't seq scan this table.
+    index("idx_device_codes_user_id").on(table.userId),
     index("idx_device_codes_expires_at").on(table.expiresAt),
   ]
 );
@@ -195,13 +198,12 @@ export const submissions = pgTable(
       .defaultNow(),
   },
   (table) => [
-    index("idx_submissions_user_id").on(table.userId),
-    index("idx_submissions_total_tokens").on(table.totalTokens),
     index("idx_submissions_created_at").on(table.createdAt),
-    index("idx_submissions_date_range").on(table.dateStart, table.dateEnd),
+    // idx_submissions_leaderboard serves every user_id lookup as a left-prefix
+    // index, so a plain idx_submissions_user_id would be redundant. Do not
+    // re-add it without first checking pg_stat_user_indexes on the composite.
     index("idx_submissions_leaderboard").on(table.userId, table.totalTokens, table.totalCost, table.createdAt),
     unique("submissions_user_id_unique").on(table.userId),
-    unique("submissions_user_hash_unique").on(table.userId, table.submissionHash),
   ]
 );
 
@@ -383,6 +385,8 @@ export const groupMembers = pgTable(
   },
   (table) => [
     index("idx_group_members_user_id").on(table.userId),
+    // FK coverage: cascade-delete of an inviter does a seq scan without this.
+    index("idx_group_members_invited_by").on(table.invitedBy),
     unique("group_members_group_user_unique").on(table.groupId, table.userId),
   ]
 );
@@ -434,6 +438,8 @@ export const groupInvites = pgTable(
       table.status
     ),
     index("idx_group_invites_expires_at").on(table.expiresAt),
+    // FK coverage: cascade-delete of an inviter does a seq scan without this.
+    index("idx_group_invites_invited_by").on(table.invitedBy),
   ]
 );
 


### PR DESCRIPTION
## Summary

Drops the dead schema surface flagged in the post-#593 audit, plus the index churn and redundant unique constraint that were originally split out as separate follow-up PRs (B and C). Single migration, all `IF EXISTS` / `IF NOT EXISTS` so it's safe to replay.

| Category | Drop |
|---|---|
| **(A) Dead columns** | `daily_breakdown.provider_breakdown`, `daily_breakdown.model_breakdown`, `submissions.status`, `users.is_admin` |
| **(B) Dead indexes** | `idx_submissions_status`, `idx_submissions_user_id`, `idx_submissions_total_tokens`, `idx_submissions_date_range` |
| **(B) Duplicate-of-unique-constraint indexes** | `idx_users_username`, `idx_sessions_token`, `idx_api_tokens_token`, `idx_device_codes_device_code`, `idx_device_codes_user_code` |
| **(B) FK coverage adds** | `idx_device_codes_user_id`, `idx_group_members_invited_by`, `idx_group_invites_invited_by` |
| **(C) Redundant unique constraint** | `submissions_user_hash_unique` (subsumed by `submissions_user_id_unique`) |
| **Pre-existing test fixup** | `leaderboard.test.ts` was expecting 5 args to `getLeaderboardData` but #522 added `customFrom`/`customTo` |

Net: -14 schema objects, +3 FK-coverage indexes.

## Why bundle B + C into A?

Three reasons — each B/C drop carries the same risk profile as the A drops in this PR:

1. **The 5 duplicate-of-unique-constraint indexes are literally redundant.** Postgres auto-creates a btree for every UNIQUE constraint; the explicit `idx_*_token` / `idx_*_username` / `idx_*_device_code` / `idx_*_user_code` btrees are 1:1 copies of `*_unique` indexes. Zero risk to drop.
2. **The 3 submissions indexes are confirmed dead in prod.** #389's `pg_stat_user_indexes` audit (~6 weeks old, called out as a caveat below) showed 0–214 scans per index vs 3.27M on `idx_submissions_leaderboard` which serves the same access patterns as a left-prefix index.
3. **The unique constraint drop is mathematically subsumed.** `submissions_user_id_unique` already enforces one row per user; any `(user_id, submission_hash)` collision is rejected at the stronger constraint. Cannot fire under any conditions while the stronger constraint exists.

## Verification — answers to "is the data all migrated correctly?"

All of the following was run against a **clean local Postgres 16 in docker**, after wiping the schema entirely and re-applying all 11 migrations from `0000` to `0011`:

### 1. Migration journal is complete

`drizzle.__drizzle_migrations` contains 12 rows (ids 1–12, matching 0000–0011 + the bootstrap row). No gaps, no out-of-order timestamps.

### 2. FK coverage is now 100%

```
14 FK constraints checked
14 covered
 0 missing indexes
```

The audit query joins `pg_constraint` against `pg_index` and confirms every FK column appears as a left-prefix of at least one index. Was **11 covered / 3 missing** before this PR; this PR adds 3 covering indexes and removes nothing FK-related.

### 3. Schema-vs-code drift

`bunx tsc --noEmit` → 0 errors. Every column referenced in `src/` exists in `schema.ts`, every column in `schema.ts` exists in the live DB, every dropped column is absent from both.

`drizzle-kit generate` does prompt about "is `submitted_device_id` a rename of `provider_breakdown`?" — that's because the meta/`*_snapshot.json` files only exist for 0000/0002 (the project never committed snapshots for newer migrations). It's not a real drift; `db:migrate` (what runs in CI/prod) ignores the snapshots and applies SQL by tag. Regenerating snapshots is out of scope here.

### 4. Tests + live submit roundtrip

- `bunx vitest run __tests__` → **251 passed, 0 failed**
- Seed script reload: 3 users, 6 devices, 84 daily_breakdown rows, 1 group with 3 members — all counts consistent across re-runs.
- Real `POST /api/submit` with a manually-inserted `api_tokens` row → HTTP 200, `submissionId` returned, `daily_breakdown` row inserted, submission totals correctly recomputed across all days. **No write touched any of the dropped columns and nothing errored.**

## Indexes I deliberately did NOT touch

- `idx_submissions_created_at` — leaderboard composite has `created_at` as 4th column, so a plain `created_at` filter still benefits from this dedicated index
- `idx_users_github_id` — github OAuth login does a lookup by github_id on every sign-in; this index is hot
- `idx_daily_breakdown_date` — used by leaderboard period filters (`gte`/`lte` against `dailyBreakdown.date`)
- `idx_daily_breakdown_submission_id` / `idx_daily_breakdown_submitted_device_id` — both FK covers
- `idx_sessions_user_id`, `idx_sessions_expires_at`, `idx_api_tokens_user_id`, `idx_device_codes_expires_at` — all serve real query patterns

## Caveats

- **Drops are irreversible at this layer**; recreation in prod requires `CREATE INDEX CONCURRENTLY` if scans turn out to be needed.
- **#389's prod stats audit is ~6 weeks old.** Before merging, re-run `SELECT relname, idx_scan FROM pg_stat_user_indexes WHERE schemaname='public' ORDER BY idx_scan;` on prod and sanity-check that the 3 submissions indexes still have ~0 scans. The 5 duplicate-of-unique-constraint indexes don't need this check — they're proven redundant by schema definition.
- **`users.is_admin` was already a useless capability** (no gates), so dropping it doesn't change observed behavior. If admin features are planned, the right pattern is a separate `admin_users` table or a role enum on `users`, not a boolean column the auth layer ignores.

## Migration ordering

Depends on #593's `0010_submit_count_safety` being present. This PR is branched off `feat/devices-ui-from-pr389`; once #593 merges to main, this PR retargets to main automatically and remains a clean follow-up.

## Test plan

- [ ] CI green on this branch
- [ ] Re-run prod `pg_stat_user_indexes` on the 3 submissions indexes; confirm scans still 0
- [ ] Apply `0011_drop_dead_columns` to staging; verify all `\d` outputs and the FK coverage audit query
- [ ] Manual smoke: profile + devices + leaderboard + one real submit
- [ ] Confirm no internal dashboards or ad-hoc SQL queries reference the dropped columns or unique constraint


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops unused DB columns and dead indexes, removes a redundant unique constraint, and adds FK-covering indexes to keep deletes fast. Cleans up related code and tests to match the slimmer schema.

- **Migration**
  - Dropped columns: `daily_breakdown.provider_breakdown`, `daily_breakdown.model_breakdown`, `submissions.status`, `users.is_admin`.
  - Dropped dead indexes and redundant constraint: `idx_submissions_status`, `idx_submissions_user_id`, `idx_submissions_total_tokens`, `idx_submissions_date_range`; `submissions_user_hash_unique`.
  - Added FK indexes: `idx_device_codes_user_id`, `idx_group_members_invited_by`, `idx_group_invites_invited_by`.
  - Kept explicit non-unique indexes that duplicate UNIQUE constraints (sessions/users/api_tokens/device_codes) because the planner prefers them.

- **Refactors**
  - Removed `isAdmin` from session and personal token types; updated tests and fixtures.
  - Stopped writing/reading `providerBreakdown` and `modelBreakdown`; deleted `buildModelBreakdown`; updated `/api/submit` and users profile handler.
  - Fixed leaderboard test to pass `customFrom/customTo` args; removed the unused model breakdown test.

<sup>Written for commit 5e5682d8b252d0aae62e7263caac226879d0e916. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/598?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

