### PR TITLE
refactor(leaderboard): fold Groups into Leaderboard view selector

### DIFF
--- a/packages/frontend/src/app/(main)/groups/page.tsx
+++ b/packages/frontend/src/app/(main)/groups/page.tsx
@@ -1,62 +1,9 @@
-import { Suspense } from "react";
-import { Navigation } from "@/components/layout/Navigation";
-import { Footer } from "@/components/layout/Footer";
-import { getSession } from "@/lib/auth/session";
-import { listPublicGroups, listUserGroups } from "@/lib/groups/queries";
-import GroupsClient from "./GroupsClient";
+import { redirect } from "next/navigation";
 
-function isMissingDatabaseUrl(error: unknown): boolean {
-  return error instanceof Error && error.message === "DATABASE_URL environment variable is not set";
-}
-
-export default function GroupsPage() {
-  return (
-    <div
-      style={{
-        minHeight: "100vh",
-        display: "flex",
-        flexDirection: "column",
-        backgroundColor: "var(--color-bg-default)",
-      }}
-    >
-      <Navigation />
-      <main className="main-container">
-        <Suspense fallback={null}>
-          <GroupsContent />
-        </Suspense>
-      </main>
-      <Footer />
-    </div>
-  );
-}
-
-async function GroupsContent() {
-  const session = await getSession().catch((error) => {
-    if (isMissingDatabaseUrl(error)) return null;
-    throw error;
-  });
-  const [publicGroups, myGroups] = await Promise.all([
-    listPublicGroups(1, 20).catch((error) => {
-      if (isMissingDatabaseUrl(error)) {
-        return { groups: [], pagination: { page: 1, limit: 20, total: 0, totalPages: 0, hasNext: false, hasPrev: false } };
-      }
-      throw error;
-    }),
-    session
-      ? listUserGroups(session.id, 1, 20).catch((error) => {
-          if (isMissingDatabaseUrl(error)) {
-            return { groups: [], pagination: { page: 1, limit: 20, total: 0, totalPages: 0, hasNext: false, hasPrev: false } };
-          }
-          throw error;
-        })
-      : Promise.resolve(null),
-  ]);
-
-  return (
-    <GroupsClient
-      currentUser={session}
-      initialPublicGroups={publicGroups.groups}
-      initialMyGroups={myGroups?.groups ?? []}
-    />
-  );
+// The old /groups listing page was consolidated into /leaderboard?view=groups
+// so groups stops appearing as a separate top-level nav tab. Per-group detail
+// (/groups/[slug]), creation (/groups/new), and invite acceptance
+// (/groups/join/[token]) still live under /groups and are unaffected.
+export default function GroupsRedirect() {
+  redirect("/leaderboard?view=groups");
 }

--- a/packages/frontend/src/app/(main)/leaderboard/GroupsBrowser.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/GroupsBrowser.tsx
@@ -4,6 +4,11 @@ import Link from "next/link";
 import { useCallback, useState } from "react";
 import styled from "styled-components";
 
+// Inlined view of the groups list that lives under the /leaderboard ?view=groups
+// segmented control. The /groups/[slug], /groups/new, and /groups/join/[token]
+// subpages still exist as standalone routes; this component just replaces the
+// old /groups top-level listing page so groups is no longer a separate nav tab.
+
 type GroupRole = "owner" | "admin" | "member";
 
 interface SessionUser {
@@ -13,7 +18,7 @@ interface SessionUser {
   avatarUrl: string | null;
 }
 
-interface GroupCardData {
+export interface GroupCardData {
   id: string;
   name: string;
   slug: string;
@@ -24,7 +29,7 @@ interface GroupCardData {
   role?: GroupRole;
 }
 
-interface GroupsClientProps {
+interface GroupsBrowserProps {
   currentUser: SessionUser | null;
   initialPublicGroups: GroupCardData[];
   initialMyGroups: GroupCardData[];
@@ -32,8 +37,8 @@ interface GroupsClientProps {
 
 type ActiveTab = "public" | "mine";
 
-const PageHeader = styled.section`
-  margin: 32px 0 24px;
+const Header = styled.section`
+  margin: 16px 0 20px;
   display: flex;
   justify-content: space-between;
   gap: 16px;
@@ -42,13 +47,6 @@ const PageHeader = styled.section`
   @media (max-width: 640px) {
     flex-direction: column;
   }
-`;
-
-const Title = styled.h1`
-  margin: 0 0 8px;
-  font-size: 30px;
-  font-weight: 700;
-  color: var(--color-fg-default);
 `;
 
 const Description = styled.p`
@@ -131,8 +129,8 @@ const Avatar = styled.div<{ $image?: string | null }>`
   border-radius: 8px;
   flex: 0 0 auto;
   border: 1px solid var(--color-border-default);
-  background:
-    ${({ $image }) => $image ? `url(${$image}) center/cover` : "linear-gradient(135deg, #0073ff, #13a10e)"};
+  background: ${({ $image }) =>
+    $image ? `url(${$image}) center/cover` : "linear-gradient(135deg, #0073ff, #13a10e)"};
 `;
 
 const CardTitle = styled.h2`
@@ -188,11 +186,11 @@ function GroupCard({ group }: { group: GroupCardData }) {
   );
 }
 
-export default function GroupsClient({
+export default function GroupsBrowser({
   currentUser,
   initialPublicGroups,
   initialMyGroups,
-}: GroupsClientProps) {
+}: GroupsBrowserProps) {
   const [activeTab, setActiveTab] = useState<ActiveTab>(currentUser ? "mine" : "public");
   const [publicGroups, setPublicGroups] = useState(initialPublicGroups);
   const [myGroups, setMyGroups] = useState(initialMyGroups);
@@ -237,27 +235,33 @@ export default function GroupsClient({
     loadGroups(tab);
   };
 
+  // Send unauthenticated users back to /leaderboard?view=groups so they land
+  // on the groups view after sign-in (was /groups before the consolidation).
+  const signInHref = "/api/auth/github?returnTo=/leaderboard?view=groups";
+
   return (
     <>
-      <PageHeader>
-        <div>
-          <Title>Groups</Title>
-          <Description>
-            Create private or public leaderboards for teams, friends, and workspaces without changing the global Tokscale rankings.
-          </Description>
-        </div>
+      <Header>
+        <Description>
+          Create private or public leaderboards for teams, friends, and workspaces without changing
+          the global Tokscale rankings.
+        </Description>
         {currentUser ? (
           <PrimaryLink href="/groups/new">New group</PrimaryLink>
         ) : (
-          <PrimaryLink href="/api/auth/github?returnTo=/groups">Sign in</PrimaryLink>
+          <PrimaryLink href={signInHref}>Sign in</PrimaryLink>
         )}
-      </PageHeader>
+      </Header>
 
       <Tabs aria-label="Group filters">
         <TabButton $active={activeTab === "public"} onClick={() => handleTabChange("public")}>
           Public
         </TabButton>
-        <TabButton $active={activeTab === "mine"} onClick={() => handleTabChange("mine")} disabled={!currentUser}>
+        <TabButton
+          $active={activeTab === "mine"}
+          onClick={() => handleTabChange("mine")}
+          disabled={!currentUser}
+        >
           My groups
         </TabButton>
       </Tabs>

--- a/packages/frontend/src/app/(main)/leaderboard/ViewSelector.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/ViewSelector.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import Link from "next/link";
+import styled from "styled-components";
+
+// Top-of-page segmented control that swaps between the global user leaderboard
+// and the group browser. Pure-link nav (no client state), so SSR + back/forward
+// behave naturally and the URL is shareable.
+
+export type LeaderboardView = "users" | "groups";
+
+const Bar = styled.nav`
+  margin: 24px 0 0;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+`;
+
+const Group = styled.div`
+  display: inline-flex;
+  padding: 4px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 10px;
+  background: var(--color-bg-subtle);
+`;
+
+const Item = styled(Link)<{ $active: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 32px;
+  padding: 0 14px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  color: ${({ $active }) => ($active ? "var(--color-fg-default)" : "var(--color-fg-muted)")};
+  background: ${({ $active }) => ($active ? "var(--color-bg-default)" : "transparent")};
+  transition: background 0.12s, color 0.12s;
+
+  &:hover {
+    color: var(--color-fg-default);
+  }
+`;
+
+const Title = styled.h1`
+  margin: 0;
+  font-size: 30px;
+  font-weight: 700;
+  color: var(--color-fg-default);
+`;
+
+interface ViewSelectorProps {
+  current: LeaderboardView;
+}
+
+export default function ViewSelector({ current }: ViewSelectorProps) {
+  return (
+    <Bar aria-label="Leaderboard view">
+      <Title>{current === "groups" ? "Groups" : "Leaderboard"}</Title>
+      <Group role="tablist">
+        <Item href="/leaderboard?view=users" $active={current === "users"} role="tab" aria-selected={current === "users"}>
+          Users
+        </Item>
+        <Item href="/leaderboard?view=groups" $active={current === "groups"} role="tab" aria-selected={current === "groups"}>
+          Groups
+        </Item>
+      </Group>
+    </Bar>
+  );
+}

--- a/packages/frontend/src/app/(main)/leaderboard/page.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/page.tsx
@@ -8,11 +8,14 @@ import { getLeaderboardData, getUserRank } from "@/lib/leaderboard/getLeaderboar
 import type { LeaderboardData, Period, SortBy } from "@/lib/leaderboard/types";
 import { getSession } from "@/lib/auth/session";
 import { SORT_BY_COOKIE_NAME, isValidSortBy } from "@/lib/leaderboard/constants";
+import { listPublicGroups, listUserGroups } from "@/lib/groups/queries";
+import LeaderboardClient from "./LeaderboardClient";
+import GroupsBrowser from "./GroupsBrowser";
+import ViewSelector, { type LeaderboardView } from "./ViewSelector";
 
 function isMissingDatabaseUrl(error: unknown): boolean {
   return error instanceof Error && error.message === "DATABASE_URL environment variable is not set";
 }
-import LeaderboardClient from "./LeaderboardClient";
 
 const VALID_PERIODS: Period[] = ["all", "month", "last-month", "week", "custom"];
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
@@ -38,6 +41,10 @@ function createEmptyLeaderboardData(sortBy: SortBy): LeaderboardData {
     period: "all",
     sortBy,
   };
+}
+
+function resolveView(raw: string | string[] | undefined): LeaderboardView {
+  return raw === "groups" ? "groups" : "users";
 }
 
 interface PageProps {
@@ -68,23 +75,42 @@ export default function LeaderboardPage({ searchParams }: PageProps) {
   );
 }
 
-async function LeaderboardWithPreferences({ searchParams: searchParamsPromise }: { searchParams: Promise<{ [key: string]: string | string[] | undefined }> }) {
+async function LeaderboardWithPreferences({
+  searchParams: searchParamsPromise,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
   const [cookieStore, searchParams] = await Promise.all([cookies(), searchParamsPromise]);
-  const sortByCookie = cookieStore.get(SORT_BY_COOKIE_NAME)?.value;
+  const view = resolveView(searchParams.view);
 
+  if (view === "groups") {
+    return (
+      <>
+        <ViewSelector current="groups" />
+        <GroupsView />
+      </>
+    );
+  }
+
+  const sortByCookie = cookieStore.get(SORT_BY_COOKIE_NAME)?.value;
   const periodParam = typeof searchParams.period === "string" ? searchParams.period : null;
-  const pageParam = typeof searchParams.page === "string" ? Math.max(1, Number(searchParams.page) || 1) : 1;
+  const pageParam =
+    typeof searchParams.page === "string" ? Math.max(1, Number(searchParams.page) || 1) : 1;
   const sortByParam = typeof searchParams.sortBy === "string" ? searchParams.sortBy : null;
   const fromParam = typeof searchParams.from === "string" ? searchParams.from : null;
   const toParam = typeof searchParams.to === "string" ? searchParams.to : null;
 
-  const sortBy: SortBy = sortByParam && (sortByParam === "tokens" || sortByParam === "cost")
-    ? sortByParam
-    : isValidSortBy(sortByCookie) ? sortByCookie : "tokens";
+  const sortBy: SortBy =
+    sortByParam && (sortByParam === "tokens" || sortByParam === "cost")
+      ? sortByParam
+      : isValidSortBy(sortByCookie)
+      ? sortByCookie
+      : "tokens";
 
-  let period: Period = periodParam && VALID_PERIODS.includes(periodParam as Period)
-    ? (periodParam as Period)
-    : "all";
+  let period: Period =
+    periodParam && VALID_PERIODS.includes(periodParam as Period)
+      ? (periodParam as Period)
+      : "all";
 
   let customFrom: string | undefined;
   let customTo: string | undefined;
@@ -122,11 +148,55 @@ async function LeaderboardWithPreferences({ searchParams: searchParamsPromise }:
     : null;
 
   return (
-    <LeaderboardClient
-      initialData={initialData}
+    <>
+      <ViewSelector current="users" />
+      <LeaderboardClient
+        initialData={initialData}
+        currentUser={session}
+        initialSortBy={sortBy}
+        initialUserRank={initialUserRank}
+      />
+    </>
+  );
+}
+
+async function GroupsView() {
+  const emptyPagination = {
+    page: 1,
+    limit: 20,
+    total: 0,
+    totalPages: 0,
+    hasNext: false,
+    hasPrev: false,
+  } as const;
+
+  const session = await getSession().catch((error) => {
+    if (isMissingDatabaseUrl(error)) return null;
+    throw error;
+  });
+
+  const [publicGroups, myGroups] = await Promise.all([
+    listPublicGroups(1, 20).catch((error) => {
+      if (isMissingDatabaseUrl(error)) {
+        return { groups: [], pagination: emptyPagination };
+      }
+      throw error;
+    }),
+    session
+      ? listUserGroups(session.id, 1, 20).catch((error) => {
+          if (isMissingDatabaseUrl(error)) {
+            return { groups: [], pagination: emptyPagination };
+          }
+          throw error;
+        })
+      : Promise.resolve(null),
+  ]);
+
+  return (
+    <GroupsBrowser
       currentUser={session}
-      initialSortBy={sortBy}
-      initialUserRank={initialUserRank}
+      initialPublicGroups={publicGroups.groups}
+      initialMyGroups={myGroups?.groups ?? []}
     />
   );
 }

--- a/packages/frontend/src/components/layout/Navigation.tsx
+++ b/packages/frontend/src/components/layout/Navigation.tsx
@@ -629,10 +629,6 @@ function UserMenu({ user, onSignOut }: { user: User; onSignOut: () => void }) {
               <MenuIconSlot><PersonIcon /></MenuIconSlot>
               Your Profile
             </MenuItem>
-            <MenuItem href="/groups" onClick={handleClose}>
-              <MenuIconSlot><PersonIcon /></MenuIconSlot>
-              Groups
-            </MenuItem>
             <MenuItem href="/settings" onClick={handleClose}>
               <MenuIconSlot><GearIcon /></MenuIconSlot>
               Settings
@@ -695,11 +691,8 @@ export function Navigation() {
           <NavItemLink href="/" $isActive={pathname === "/"}>
             About
           </NavItemLink>
-          <NavItemLink href="/leaderboard" $isActive={pathname === "/leaderboard"}>
+          <NavItemLink href="/leaderboard" $isActive={pathname === "/leaderboard" || pathname.startsWith("/groups")}>
             Leaderboard
-          </NavItemLink>
-          <NavItemLink href="/groups" $isActive={pathname.startsWith("/groups")}>
-            Groups
           </NavItemLink>
           <NavItemLink href="/profile" $isActive={pathname === "/profile" || pathname.startsWith("/u/")}>
             Profile
@@ -742,11 +735,8 @@ export function Navigation() {
           <DropdownNavLink href="/" $isActive={pathname === "/"} onClick={closeMobileMenu}>
             About
           </DropdownNavLink>
-          <DropdownNavLink href="/leaderboard" $isActive={pathname === "/leaderboard"} onClick={closeMobileMenu}>
+          <DropdownNavLink href="/leaderboard" $isActive={pathname === "/leaderboard" || pathname.startsWith("/groups")} onClick={closeMobileMenu}>
             Leaderboard
-          </DropdownNavLink>
-          <DropdownNavLink href="/groups" $isActive={pathname.startsWith("/groups")} onClick={closeMobileMenu}>
-            Groups
           </DropdownNavLink>
           <DropdownNavLink href="/profile" $isActive={pathname === "/profile" || pathname.startsWith("/u/")} onClick={closeMobileMenu}>
             Profile
@@ -781,10 +771,6 @@ export function Navigation() {
               <DropdownUserAction href={`/u/${user.username}`} onClick={closeMobileMenu}>
                 <PersonIcon size={16} />
                 Your Profile
-              </DropdownUserAction>
-              <DropdownUserAction href="/groups" onClick={closeMobileMenu}>
-                <PersonIcon size={16} />
-                Groups
               </DropdownUserAction>
               <DropdownUserAction href="/settings" onClick={closeMobileMenu}>
                 <GearIcon size={16} />


### PR DESCRIPTION
Groups had its own top-nav tab even though it's just a scoped leaderboard. `/leaderboard?view=users|groups` segmented control replaces the standalone `/groups` listing. `/groups` redirects to `/leaderboard?view=groups`. Per-group routes (`/groups/[slug]`, `/groups/new`, `/groups/join/[token]`) untouched. Navigation no longer exposes a standalone Groups item.

## Verification
- `tsc --noEmit` → 0 errors
- `vitest run __tests__` → 251/251 pass
- Live HTTP smoke: `/leaderboard` 200, `/leaderboard?view=groups` 200, `/groups` 307→`/leaderboard?view=groups` 200

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the Groups list into the Leaderboard via a simple view toggle. /groups now redirects to /leaderboard?view=groups, and all per‑group routes still work as before.

- **Refactors**
  - Added a segmented `ViewSelector` on /leaderboard with users | groups.
  - Replaced the old Groups page with `GroupsBrowser` under the leaderboard, preserving existing UI and behavior.
  - Redirected /groups to /leaderboard?view=groups; kept /groups/[slug], /groups/new, and /groups/join/[token] unchanged.
  - Removed the Groups item from desktop, mobile, and user menus; the Leaderboard tab now stays active on /groups/*.

<sup>Written for commit aa6863df3c91616232c48958da373d9650afc292. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/599?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

