### PR TITLE
chore(ui): audit pass on Leaderboard ViewSelector + GroupsBrowser

### DIFF
--- a/packages/frontend/src/app/(main)/leaderboard/GroupsBrowser.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/GroupsBrowser.tsx
@@ -90,6 +90,16 @@ const TabButton = styled.button<{ $active: boolean }>`
   color: ${({ $active }) => ($active ? "var(--color-fg-default)" : "var(--color-fg-muted)")};
   font-weight: 600;
   cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
 `;
 
 const Grid = styled.div`
@@ -113,6 +123,40 @@ const Card = styled(Link)`
   &:hover {
     border-color: var(--color-primary);
     background: var(--color-bg-subtle);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+    border-color: var(--color-primary);
+  }
+`;
+
+const SkeletonGrid = styled(Grid)`
+  pointer-events: none;
+`;
+
+const SkeletonCard = styled.div`
+  min-height: 150px;
+  padding: 16px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  background: linear-gradient(
+    90deg,
+    var(--color-bg-default) 0%,
+    var(--color-bg-subtle) 50%,
+    var(--color-bg-default) 100%
+  );
+  background-size: 200% 100%;
+  animation: groups-skeleton-shimmer 1.6s ease-in-out infinite;
+
+  @keyframes groups-skeleton-shimmer {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
   }
 `;
 
@@ -266,9 +310,13 @@ export default function GroupsBrowser({
         </TabButton>
       </Tabs>
 
-      {error && <ErrorText>{error}</ErrorText>}
+      {error && <ErrorText role="alert">{error}</ErrorText>}
       {isLoading ? (
-        <EmptyState>Loading groups...</EmptyState>
+        <SkeletonGrid aria-busy="true" aria-live="polite" aria-label="Loading groups">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <SkeletonCard key={i} />
+          ))}
+        </SkeletonGrid>
       ) : groups.length === 0 ? (
         <EmptyState>
           {activeTab === "mine"

--- a/packages/frontend/src/app/(main)/leaderboard/ViewSelector.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/ViewSelector.tsx
@@ -6,6 +6,11 @@ import styled from "styled-components";
 // Top-of-page segmented control that swaps between the global user leaderboard
 // and the group browser. Pure-link nav (no client state), so SSR + back/forward
 // behave naturally and the URL is shareable.
+//
+// Uses aria-current="page" rather than role="tablist": these are full-page
+// navigations, not in-page tab panels, so the link semantics are the honest
+// thing and keep ArrowLeft/Right doing whatever the browser would normally do
+// for in-page focus.
 
 export type LeaderboardView = "users" | "groups";
 
@@ -14,13 +19,18 @@ const Bar = styled.nav`
   display: flex;
   align-items: center;
   gap: 16px;
+  flex-wrap: wrap;
+
+  @media (max-width: 480px) {
+    gap: 12px;
+  }
 `;
 
 const Group = styled.div`
   display: inline-flex;
   padding: 4px;
   border: 1px solid var(--color-border-default);
-  border-radius: 10px;
+  border-radius: 8px;
   background: var(--color-bg-subtle);
 `;
 
@@ -30,7 +40,7 @@ const Item = styled(Link)<{ $active: boolean }>`
   gap: 6px;
   min-height: 32px;
   padding: 0 14px;
-  border-radius: 8px;
+  border-radius: 6px;
   font-size: 13px;
   font-weight: 600;
   text-decoration: none;
@@ -41,6 +51,11 @@ const Item = styled(Link)<{ $active: boolean }>`
   &:hover {
     color: var(--color-fg-default);
   }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
 `;
 
 const Title = styled.h1`
@@ -48,6 +63,10 @@ const Title = styled.h1`
   font-size: 30px;
   font-weight: 700;
   color: var(--color-fg-default);
+
+  @media (max-width: 480px) {
+    font-size: 24px;
+  }
 `;
 
 interface ViewSelectorProps {
@@ -58,11 +77,19 @@ export default function ViewSelector({ current }: ViewSelectorProps) {
   return (
     <Bar aria-label="Leaderboard view">
       <Title>{current === "groups" ? "Groups" : "Leaderboard"}</Title>
-      <Group role="tablist">
-        <Item href="/leaderboard?view=users" $active={current === "users"} role="tab" aria-selected={current === "users"}>
+      <Group>
+        <Item
+          href="/leaderboard?view=users"
+          $active={current === "users"}
+          aria-current={current === "users" ? "page" : undefined}
+        >
           Users
         </Item>
-        <Item href="/leaderboard?view=groups" $active={current === "groups"} role="tab" aria-selected={current === "groups"}>
+        <Item
+          href="/leaderboard?view=groups"
+          $active={current === "groups"}
+          aria-current={current === "groups" ? "page" : undefined}
+        >
           Groups
         </Item>
       </Group>


### PR DESCRIPTION
Audit pass on the new components from PR #599. Adds keyboard `:focus-visible` rings, makes the selector responsive, swaps misleading `role=tablist` for `aria-current="page"`, harmonizes border-radius with the rest of the codebase, and replaces a plain loading string with a proper shimmering skeleton grid (respects `prefers-reduced-motion`).

## Verification
- `tsc --noEmit` -> 0 errors
- Live HTTP smoke against `bun run dev`: `/leaderboard` 200, `/leaderboard?view=groups` 200
- Markup grep confirms `aria-current="page"` and `aria-live` ship; CSS grep confirms multiple `:focus-visible` rules emit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accessibility and responsiveness audit for the leaderboard `ViewSelector` and `GroupsBrowser`. Improves keyboard focus, small-screen layout, and loading UX.

- New Features
  - Shimmer skeleton grid for group loading (6 cards); honors prefers-reduced-motion and uses aria-busy/aria-live.

- Refactors
  - Add :focus-visible outlines to `ViewSelector` items, tab buttons, and group cards.
  - Make `ViewSelector` responsive (wrap bar; title scales at ≤480px).
  - Replace role="tablist"/aria-selected with `aria-current="page"` on links for correct semantics.
  - Align border-radius with the app (group 10→8, item 8→6).
  - Use role="alert" for error text and disabled styling for the “My groups” tab when signed out.

<sup>Written for commit d4c8ac76d7b7960947f6abd48f08644e988f570e. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/600?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

