### PR TITLE
fix(submit): allow consistent high-volume token reports

### DIFF
--- a/packages/frontend/__tests__/api/submit.test.ts
+++ b/packages/frontend/__tests__/api/submit.test.ts
@@ -362,6 +362,25 @@ describe('POST /api/submit - Client-Level Merge', () => {
   });
 
   describe("Submission validation guardrails", () => {
+    it("accepts internally consistent high-volume one-day token totals", () => {
+      const payload = createValidationPayload({
+        totalTokens: 20_000_000_000,
+        totalCost: 2_000,
+        tokenBreakdown: {
+          input: 12_000_000_000,
+          output: 5_000_000_000,
+          cacheRead: 2_000_000_000,
+          cacheWrite: 750_000_000,
+          reasoning: 250_000_000,
+        },
+      });
+
+      const result = validateSubmission(payload);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
     it("rejects one-day fabricated token totals above the submission cap", () => {
       const payload = createValidationPayload({
         totalTokens: 1_000_000_000_000,
@@ -378,6 +397,28 @@ describe('POST /api/submit - Client-Level Merge', () => {
 
       expect(result.valid).toBe(false);
       expect(result.errors.join("\n")).toContain("Daily token total exceeds");
+      expect(result.errors.join("\n")).toContain("100,000,000,000");
+      expect(result.errors.join("\n")).toContain("Client claude");
+    });
+
+    it("keeps structural validation for high-volume payloads", () => {
+      const payload = createValidationPayload({
+        totalTokens: 20_000_000_000,
+        totalCost: 2_000,
+        tokenBreakdown: {
+          input: 12_000_000_000,
+          output: 5_000_000_000,
+          cacheRead: 2_000_000_000,
+          cacheWrite: 750_000_000,
+          reasoning: 250_000_000,
+        },
+      });
+      payload.contributions[0].clients[0].modelId = "";
+
+      const result = validateSubmission(payload);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.join("\n")).toContain("modelId");
     });
 
     it("rejects submitted cost that is implausible for the reported tokens", () => {

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -13,7 +13,9 @@ import { z } from "zod";
 // SCHEMAS
 // ============================================================================
 
-const MAX_DAILY_TOKENS = 10_000_000_000;
+// Self-reported usage still needs a hard ceiling, but legitimate high-volume
+// local usage can exceed tens of billions of tokens in a day.
+const MAX_DAILY_TOKENS = 100_000_000_000;
 const MAX_DAILY_COST = 10_000;
 const MAX_COST_PER_MILLION_TOKENS = 10_000;
 const COST_RELATIVE_TOLERANCE = 0.01;


### PR DESCRIPTION
## Summary

Closes #601.

This PR recalibrates the submit validation guardrail for high-volume local usage. It keeps the server-side protection against impossible self-reported payloads, but no longer rejects internally consistent reports in the tens-of-billions token range.

## Why

The previous `10,000,000,000` per-day/per-client hard cap rejected legitimate high-volume Codex submissions such as the `20,735,354,861` token day reported in #601. The payload was blocked before the existing consistency checks could distinguish a large but coherent report from fabricated data.

## Diff Scope

- Raises the hard daily/client token ceiling to `100,000,000,000` while preserving schema validation, summary/day/client consistency checks, safe-integer validation, and cost sanity checks.
- Adds submit validation regressions for a consistent `20B` one-day report, a fabricated `1T` one-day report, and a malformed high-volume payload.

## Branch Integrity

- Base: `junhoyeo/tokscale:main`
- Validated base SHA: `8e73312f05f603d5184d36059e4ce2604322d492`
- Head: `IvGolovach:codex/submit-validation-high-volume`
- Head SHA: `47765bd705fd0ff6e56f2477131a2a4701bee107`
- Ahead/behind: `0 behind / 1 ahead`

## Commit Integrity

- `47765bd705fd0ff6e56f2477131a2a4701bee107 fix(submit): allow consistent high-volume token reports`
- Final diff only touches submit validation and its targeted API test coverage.

## Diff Hygiene

- `git diff --check origin/main...HEAD`: PASS, no output
- Forbidden/local artifact files: not present
- DB migrations: not applicable; no schema changed
- Ledger: not applicable; not required for this change family
- Version: not applicable; not required for this change family

## Validation

Validation mode: Mode 2 — narrow frontend submit validation runtime change.

- `bun x vitest run __tests__/api/submit.test.ts`: PASS, 37 tests
- `bun run --cwd packages/frontend lint -- src/lib/validation/submission.ts __tests__/api/submit.test.ts`: PASS
- `git diff --check origin/main...HEAD`: PASS

Additional note: `bun x tsc -p packages/frontend/tsconfig.json --noEmit` currently reports an unrelated pre-existing `packages/frontend/src/components/BlackholeHero.tsx` PNG module resolution error, so it is not used as proof for this focused fix.

## CI Context

Pending — required remote checks will run after the PR is opened.

## Runtime Safety

No persistence, auth, or merge semantics changed. The change only recalibrates the submit validator's hard token ceiling while leaving consistency and cost sanity checks in place. No invariant regression introduced.

## Rollback Plan

Rollback: revert this PR.

DB downgrade: not applicable.

Data repair: not applicable.

Operational caveats: none known.

## Known Residual Risks

This keeps a hard cap by design. If users later submit legitimate daily totals above `100B`, the cap may need another evidence-based adjustment rather than removal.

