### PR TITLE
fix(release): commit release provenance before npm publish

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -284,9 +284,45 @@ jobs:
           path: target/${{ matrix.settings.target }}/release/${{ matrix.settings.bin_name }}
           if-no-files-found: error
 
+  prepare-release-provenance:
+    name: Commit release provenance
+    needs: [bump-versions, build-cli-binary]
+    runs-on: ubuntu-latest
+    outputs:
+      release_commit: ${{ steps.prepare.outputs.release_commit }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Download bumped package.json files
+        uses: actions/download-artifact@v6
+        with:
+          name: bumped-manifests
+          path: .
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit and push release provenance
+        id: prepare
+        env:
+          NEW_VERSION: ${{ needs.bump-versions.outputs.version }}
+          RELEASE_REF_NAME: ${{ github.ref_name }}
+          RELEASE_REF_TYPE: ${{ github.ref_type }}
+          EXPECTED_RELEASE_BASE_SHA: ${{ github.sha }}
+        run: bash scripts/prepare-release-provenance.sh
+
   publish-platform-packages:
     name: Publish platform package - ${{ matrix.settings.package_name }}
-    needs: [bump-versions, build-cli-binary]
+    needs: [bump-versions, build-cli-binary, prepare-release-provenance]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -327,12 +363,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-
-      - name: Download bumped package.json files
-        uses: actions/download-artifact@v6
         with:
-          name: bumped-manifests
-          path: .
+          ref: ${{ needs.prepare-release-provenance.outputs.release_commit }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -365,17 +397,13 @@ jobs:
 
   publish-cli:
     name: Publish @tokscale/cli
-    needs: [bump-versions, publish-platform-packages]
+    needs: [prepare-release-provenance, publish-platform-packages]
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v5
-
-      - name: Download bumped package.json files
-        uses: actions/download-artifact@v6
         with:
-          name: bumped-manifests
-          path: .
+          ref: ${{ needs.prepare-release-provenance.outputs.release_commit }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -400,17 +428,13 @@ jobs:
 
   publish-alias:
     name: Publish tokscale (wrapper)
-    needs: [bump-versions, publish-cli]
+    needs: [prepare-release-provenance, publish-cli]
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v5
-
-      - name: Download bumped package.json files
-        uses: actions/download-artifact@v6
         with:
-          name: bumped-manifests
-          path: .
+          ref: ${{ needs.prepare-release-provenance.outputs.release_commit }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -426,39 +450,18 @@ jobs:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   finalize:
-    name: Commit version bump and create release
-    needs: [bump-versions, publish-alias]
+    name: Create release
+    needs: [bump-versions, prepare-release-provenance, publish-alias]
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v5
         with:
+          ref: ${{ needs.prepare-release-provenance.outputs.release_commit }}
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: true
           fetch-depth: 0
           fetch-tags: true
-
-      - name: Download bumped package.json files
-        uses: actions/download-artifact@v6
-        with:
-          name: bumped-manifests
-          path: .
-
-      - name: Configure Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Commit and push version bump
-        run: |
-          NEW_VERSION="${{ needs.bump-versions.outputs.version }}"
-          echo "📦 Committing version bump to $NEW_VERSION"
-          
-          git add Cargo.toml packages/cli/package.json packages/cli-darwin-arm64/package.json packages/cli-darwin-x64/package.json packages/cli-linux-x64-gnu/package.json packages/cli-linux-x64-musl/package.json packages/cli-linux-arm64-gnu/package.json packages/cli-linux-arm64-musl/package.json packages/cli-win32-x64-msvc/package.json packages/cli-win32-arm64-msvc/package.json packages/tokscale/package.json
-          git commit -m "chore: bump version to $NEW_VERSION"
-          git push
-          
-          echo "✅ Successfully published and committed version $NEW_VERSION"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -471,11 +474,17 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           NEW_VERSION="${{ needs.bump-versions.outputs.version }}"
+          RELEASE_COMMIT="${{ needs.prepare-release-provenance.outputs.release_commit }}"
           
           if git rev-parse "v$NEW_VERSION" >/dev/null 2>&1; then
-            echo "🏷️ Tag v$NEW_VERSION already exists"
+            TAG_COMMIT="$(git rev-list -n 1 "v$NEW_VERSION")"
+            if [ "$TAG_COMMIT" != "$RELEASE_COMMIT" ]; then
+              echo "Tag v$NEW_VERSION already points at $TAG_COMMIT, expected $RELEASE_COMMIT" >&2
+              exit 1
+            fi
+            echo "🏷️ Tag v$NEW_VERSION already points at release commit $RELEASE_COMMIT"
           else
-            git tag "v$NEW_VERSION"
+            git tag "v$NEW_VERSION" "$RELEASE_COMMIT"
             git push origin "v$NEW_VERSION"
             echo "🏷️ Created tag v$NEW_VERSION"
           fi

--- a/scripts/prepare-release-provenance.sh
+++ b/scripts/prepare-release-provenance.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+NEW_VERSION="${NEW_VERSION:-}"
+RELEASE_REF_NAME="${RELEASE_REF_NAME:-}"
+RELEASE_REF_TYPE="${RELEASE_REF_TYPE:-branch}"
+EXPECTED_RELEASE_BASE_SHA="${EXPECTED_RELEASE_BASE_SHA:-}"
+GITHUB_OUTPUT="${GITHUB_OUTPUT:-}"
+
+MANIFEST_PATHS=(
+  Cargo.toml
+  packages/cli/package.json
+  packages/cli-darwin-arm64/package.json
+  packages/cli-darwin-x64/package.json
+  packages/cli-linux-x64-gnu/package.json
+  packages/cli-linux-x64-musl/package.json
+  packages/cli-linux-arm64-gnu/package.json
+  packages/cli-linux-arm64-musl/package.json
+  packages/cli-win32-x64-msvc/package.json
+  packages/cli-win32-arm64-msvc/package.json
+  packages/tokscale/package.json
+)
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+[[ -n "${NEW_VERSION}" ]] || fail "NEW_VERSION is required"
+[[ -n "${RELEASE_REF_NAME}" ]] || fail "RELEASE_REF_NAME is required"
+[[ -n "${EXPECTED_RELEASE_BASE_SHA}" ]] || fail "EXPECTED_RELEASE_BASE_SHA is required"
+[[ "${RELEASE_REF_TYPE}" == "branch" ]] || fail "Release publishing must run from a branch ref"
+
+git check-ref-format --branch "${RELEASE_REF_NAME}" >/dev/null ||
+  fail "Invalid release branch name: ${RELEASE_REF_NAME}"
+git rev-parse --verify "${EXPECTED_RELEASE_BASE_SHA}^{commit}" >/dev/null ||
+  fail "Expected release base is not a commit: ${EXPECTED_RELEASE_BASE_SHA}"
+
+local_sha="$(git rev-parse HEAD)"
+if [[ "${local_sha}" != "${EXPECTED_RELEASE_BASE_SHA}" ]]; then
+  fail "Checked-out release base ${local_sha} does not match expected ${EXPECTED_RELEASE_BASE_SHA}"
+fi
+
+remote_tracking_ref="refs/remotes/origin/${RELEASE_REF_NAME}"
+git fetch --no-tags origin "+refs/heads/${RELEASE_REF_NAME}:${remote_tracking_ref}"
+remote_sha="$(git rev-parse "${remote_tracking_ref}^{commit}")"
+if [[ "${remote_sha}" != "${EXPECTED_RELEASE_BASE_SHA}" ]]; then
+  fail "Release base is stale: origin/${RELEASE_REF_NAME} is ${remote_sha}, expected ${EXPECTED_RELEASE_BASE_SHA}. Re-run the publish workflow from the updated branch before publishing npm packages."
+fi
+
+if git ls-remote --exit-code --tags origin "refs/tags/v${NEW_VERSION}" >/dev/null 2>&1; then
+  fail "Tag v${NEW_VERSION} already exists. Choose a new version before publishing npm packages."
+fi
+
+bash scripts/check-version-coherence.sh --expect-version "${NEW_VERSION}"
+
+git add -- "${MANIFEST_PATHS[@]}"
+if git diff --cached --quiet; then
+  fail "No release manifest changes staged for ${NEW_VERSION}"
+fi
+
+git commit -m "chore: bump version to ${NEW_VERSION}"
+release_commit="$(git rev-parse HEAD)"
+git push origin "HEAD:refs/heads/${RELEASE_REF_NAME}"
+
+echo "Release commit ${release_commit} pushed to ${RELEASE_REF_NAME}"
+if [[ -n "${GITHUB_OUTPUT}" ]]; then
+  echo "release_commit=${release_commit}" >> "${GITHUB_OUTPUT}"
+fi

--- a/scripts/test-prepare-release-provenance.sh
+++ b/scripts/test-prepare-release-provenance.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_UNDER_TEST="${ROOT_DIR}/scripts/prepare-release-provenance.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+git_config() {
+  git config user.name "Test Runner"
+  git config user.email "test@example.com"
+}
+
+git_add_release_files() {
+  git add -- \
+    Cargo.toml \
+    packages/cli/package.json \
+    packages/cli-darwin-arm64/package.json \
+    packages/cli-darwin-x64/package.json \
+    packages/cli-linux-x64-gnu/package.json \
+    packages/cli-linux-x64-musl/package.json \
+    packages/cli-linux-arm64-gnu/package.json \
+    packages/cli-linux-arm64-musl/package.json \
+    packages/cli-win32-x64-msvc/package.json \
+    packages/cli-win32-arm64-msvc/package.json \
+    packages/tokscale/package.json \
+    scripts/check-version-coherence.sh \
+    scripts/prepare-release-provenance.sh
+}
+
+write_manifests() {
+  local version="$1"
+  mkdir -p \
+    packages/cli \
+    packages/cli-darwin-arm64 \
+    packages/cli-darwin-x64 \
+    packages/cli-linux-x64-gnu \
+    packages/cli-linux-x64-musl \
+    packages/cli-linux-arm64-gnu \
+    packages/cli-linux-arm64-musl \
+    packages/cli-win32-x64-msvc \
+    packages/cli-win32-arm64-msvc \
+    packages/tokscale
+
+  cat > Cargo.toml <<EOF_MANIFEST
+[workspace.package]
+version = "${version}"
+EOF_MANIFEST
+
+  cat > packages/cli/package.json <<EOF_MANIFEST
+{
+  "name": "@tokscale/cli",
+  "version": "${version}",
+  "optionalDependencies": {
+    "@tokscale/cli-darwin-arm64": "${version}",
+    "@tokscale/cli-darwin-x64": "${version}",
+    "@tokscale/cli-linux-x64-gnu": "${version}",
+    "@tokscale/cli-linux-x64-musl": "${version}",
+    "@tokscale/cli-linux-arm64-gnu": "${version}",
+    "@tokscale/cli-linux-arm64-musl": "${version}",
+    "@tokscale/cli-win32-x64-msvc": "${version}",
+    "@tokscale/cli-win32-arm64-msvc": "${version}"
+  }
+}
+EOF_MANIFEST
+
+  for pkg in \
+    cli-darwin-arm64 \
+    cli-darwin-x64 \
+    cli-linux-x64-gnu \
+    cli-linux-x64-musl \
+    cli-linux-arm64-gnu \
+    cli-linux-arm64-musl \
+    cli-win32-x64-msvc \
+    cli-win32-arm64-msvc; do
+    cat > "packages/${pkg}/package.json" <<EOF_MANIFEST
+{
+  "name": "@tokscale/${pkg}",
+  "version": "${version}"
+}
+EOF_MANIFEST
+  done
+
+  cat > packages/tokscale/package.json <<EOF_MANIFEST
+{
+  "name": "tokscale",
+  "version": "${version}",
+  "dependencies": {
+    "@tokscale/cli": "${version}"
+  }
+}
+EOF_MANIFEST
+}
+
+copy_release_scripts() {
+  mkdir -p scripts
+  cp "${ROOT_DIR}/scripts/check-version-coherence.sh" scripts/check-version-coherence.sh
+  cp "${SCRIPT_UNDER_TEST}" scripts/prepare-release-provenance.sh
+  chmod +x scripts/*.sh
+}
+
+create_origin_with_initial_commit() {
+  local origin="$1"
+  local seed="$2"
+
+  git init --bare "${origin}" >/dev/null
+  git init "${seed}" >/dev/null
+  (
+    cd "${seed}"
+    git_config
+    git checkout -b main >/dev/null 2>&1
+    copy_release_scripts
+    write_manifests "1.2.3"
+    git_add_release_files
+    git commit -m "seed release files" >/dev/null
+    git remote add origin "${origin}"
+    git push origin main >/dev/null
+  )
+}
+
+run_prepare() {
+  local repo="$1"
+  local version="$2"
+  local expected_sha="$3"
+  local output_file="$4"
+
+  (
+    cd "${repo}"
+    NEW_VERSION="${version}" \
+      RELEASE_REF_NAME="main" \
+      EXPECTED_RELEASE_BASE_SHA="${expected_sha}" \
+      GITHUB_OUTPUT="${output_file}" \
+      bash scripts/prepare-release-provenance.sh
+  )
+}
+
+test_stale_base_refuses_to_push_release_commit() {
+  local origin="${TMP_DIR}/stale-origin.git"
+  local seed="${TMP_DIR}/stale-seed"
+  local work="${TMP_DIR}/stale-work"
+  local advancer="${TMP_DIR}/stale-advancer"
+  create_origin_with_initial_commit "${origin}" "${seed}"
+
+  git clone "${origin}" "${work}" >/dev/null
+  git -C "${work}" checkout main >/dev/null 2>&1
+  local dispatch_sha
+  dispatch_sha="$(git -C "${work}" rev-parse HEAD)"
+
+  git clone "${origin}" "${advancer}" >/dev/null
+  (
+    cd "${advancer}"
+    git_config
+    git checkout main >/dev/null 2>&1
+    echo "advance" > README.md
+    git add README.md
+    git commit -m "advance main" >/dev/null
+    git push origin main >/dev/null
+  )
+  local advanced_sha
+  advanced_sha="$(git --git-dir="${origin}" rev-parse refs/heads/main)"
+
+  (
+    cd "${work}"
+    git_config
+    write_manifests "1.2.4"
+  )
+
+  local output="${TMP_DIR}/stale-output.txt"
+  local gh_output="${TMP_DIR}/stale-github-output.txt"
+  if run_prepare "${work}" "1.2.4" "${dispatch_sha}" "${gh_output}" >"${output}" 2>&1; then
+    echo "Expected stale release base to fail" >&2
+    return 1
+  fi
+
+  grep -q "Release base is stale" "${output}"
+  test "$(git --git-dir="${origin}" rev-parse refs/heads/main)" = "${advanced_sha}"
+  test ! -s "${gh_output}"
+}
+
+test_current_base_pushes_release_commit_and_sets_output() {
+  local origin="${TMP_DIR}/current-origin.git"
+  local seed="${TMP_DIR}/current-seed"
+  local work="${TMP_DIR}/current-work"
+  create_origin_with_initial_commit "${origin}" "${seed}"
+
+  git clone "${origin}" "${work}" >/dev/null
+  git -C "${work}" checkout main >/dev/null 2>&1
+  local dispatch_sha
+  dispatch_sha="$(git -C "${work}" rev-parse HEAD)"
+
+  (
+    cd "${work}"
+    git_config
+    write_manifests "1.2.4"
+  )
+
+  local output="${TMP_DIR}/current-output.txt"
+  local gh_output="${TMP_DIR}/current-github-output.txt"
+  run_prepare "${work}" "1.2.4" "${dispatch_sha}" "${gh_output}" >"${output}" 2>&1
+
+  local release_sha
+  release_sha="$(git -C "${work}" rev-parse HEAD)"
+  test "$(git --git-dir="${origin}" rev-parse refs/heads/main)" = "${release_sha}"
+  grep -q "release_commit=${release_sha}" "${gh_output}"
+  git -C "${work}" log -1 --format=%s | grep -q '^chore: bump version to 1.2.4$'
+}
+
+test_stale_base_refuses_to_push_release_commit
+test_current_base_pushes_release_commit_and_sets_output
+
+echo "prepare-release-provenance tests passed"


### PR DESCRIPTION
## Summary

This PR moves release provenance creation ahead of immutable npm publishing. The publish workflow now creates and pushes the release commit before publishing platform packages, then every npm publish job checks out that exact release commit.

## Why

The previous workflow published the platform packages, `@tokscale/cli`, and `tokscale` before committing the bumped manifests and creating the tag/release. If `main` advanced during the release window, the final `git push` could fail as non-fast-forward after npm versions had already been published. That leaves package provenance, tags, and GitHub Releases out of sync with immutable npm artifacts.

## Diff Scope

- Adds `scripts/prepare-release-provenance.sh` to verify the dispatch branch is still at the expected SHA, reject stale releases before npm publish, preflight existing release tags, verify version coherence, commit bumped manifests, and push the release commit.
- Adds `scripts/test-prepare-release-provenance.sh` with isolated git remotes covering stale-base refusal and successful release commit publication.
- Updates `.github/workflows/publish-cli.yml` so npm jobs depend on the release provenance job and checkout the exact release commit; finalization now only verifies/creates the tag and GitHub Release after publish.

## Branch Integrity

- Base: `junhoyeo/tokscale:main`
- Validated base SHA: `8e73312f05f603d5184d36059e4ce2604322d492`
- Head: `IvGolovach:codex/release-finalization-race-safe`
- Head SHA: `1d477d65eb5c2f2404f7713ade28a3a21683a501`
- Ahead/behind: `0 behind / 1 ahead`

## Commit Integrity

- `1d477d65eb5c2f2404f7713ade28a3a21683a501 fix(release): commit release provenance before npm publish`
- Final diff is limited to the publish workflow and release-provenance test/script tooling.

## Diff Hygiene

- `git diff --check origin/main...HEAD`: PASS, no output
- Forbidden/local artifact files: not present
- DB migrations: not applicable; no schema changed
- Ledger: not applicable; not required for this change family
- Version: not applicable; release version files are not bumped by this PR

## Validation

Validation mode: Mode 4 — release workflow tooling.

- `bash scripts/test-prepare-release-provenance.sh`: PASS
- `bash -n scripts/prepare-release-provenance.sh scripts/test-prepare-release-provenance.sh scripts/check-version-coherence.sh`: PASS
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-cli.yml"); puts "workflow YAML syntax OK"'`: PASS
- `bash scripts/check-version-coherence.sh`: PASS
- `git diff --check origin/main...HEAD`: PASS

Not run locally: `actionlint` was unavailable in this environment, and the full publish workflow cannot be safely executed locally because it publishes immutable npm artifacts.

## CI Context

Pending — required remote checks will run after the PR is opened.

## Runtime Safety

Not applicable — no application runtime path changed. This only changes release workflow ordering and release-provenance scripts.

## Documentation Integrity

No user-facing command behavior changed. Release operator behavior changes are represented directly in the workflow and covered by the new release-provenance script tests.

## Rollback Plan

Rollback: revert this PR.

DB downgrade: not applicable.

Data repair: not applicable.

Operational caveats: after rollback, the publish workflow returns to committing release provenance after npm publish, so the original non-fast-forward finalization risk would return.

## Known Residual Risks

The real publish workflow still needs GitHub Actions validation before merge. This PR intentionally avoids local execution of any command that would publish to npm.
