### PR TITLE
fix(groups): enforce invite role hierarchy

### DIFF
--- a/packages/frontend/__tests__/api/groupInviteRoute.test.ts
+++ b/packages/frontend/__tests__/api/groupInviteRoute.test.ts
@@ -1,0 +1,184 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const getSessionFromRequest = vi.fn();
+  const getGroupBySlug = vi.fn();
+  const getGroupMembership = vi.fn();
+  const createGroupInvite = vi.fn();
+  const revalidateGroupCaches = vi.fn();
+
+  return {
+    getSessionFromRequest,
+    getGroupBySlug,
+    getGroupMembership,
+    createGroupInvite,
+    revalidateGroupCaches,
+    reset() {
+      getSessionFromRequest.mockReset();
+      getGroupBySlug.mockReset();
+      getGroupMembership.mockReset();
+      createGroupInvite.mockReset();
+      revalidateGroupCaches.mockReset();
+    },
+  };
+});
+
+vi.mock("@/lib/auth/requestSession", () => ({
+  getSessionFromRequest: mockState.getSessionFromRequest,
+}));
+
+vi.mock("@/lib/groups/cache", () => ({
+  revalidateGroupCaches: mockState.revalidateGroupCaches,
+}));
+
+vi.mock("@/lib/groups/invites", () => {
+  class GroupInviteError extends Error {
+    constructor(
+      public readonly code: "not_found" | "forbidden" | "invalid",
+      message: string
+    ) {
+      super(message);
+    }
+  }
+
+  return {
+    createGroupInvite: mockState.createGroupInvite,
+    GroupInviteError,
+  };
+});
+
+vi.mock("@/lib/groups/permissions", () => ({
+  getGroupMembership: mockState.getGroupMembership,
+}));
+
+vi.mock("@/lib/groups/queries", () => ({
+  getGroupBySlug: mockState.getGroupBySlug,
+}));
+
+vi.mock("../../src/lib/db/schema", () => ({
+  groupRoles: ["owner", "admin", "member"],
+}));
+
+type ModuleExports = typeof import("../../src/app/api/groups/[slug]/invite/route");
+
+let POST: ModuleExports["POST"];
+
+beforeAll(async () => {
+  const routeModule = await import("../../src/app/api/groups/[slug]/invite/route");
+  POST = routeModule.POST;
+});
+
+beforeEach(() => {
+  mockState.reset();
+  mockState.getSessionFromRequest.mockResolvedValue({
+    id: "actor-1",
+    username: "actor",
+    displayName: null,
+    avatarUrl: null,
+  });
+  mockState.getGroupBySlug.mockResolvedValue({
+    id: "group-1",
+    slug: "team",
+    name: "Team",
+    isPublic: false,
+  });
+  mockState.createGroupInvite.mockResolvedValue({
+    id: "invite-1",
+    token: "tg_token",
+    role: "member",
+    invitedUsername: null,
+    expiresAt: new Date("2026-06-01T00:00:00Z"),
+  });
+});
+
+function requestWithRole(role: string) {
+  return new Request("http://localhost:3000/api/groups/team/invite", {
+    method: "POST",
+    body: JSON.stringify({ role }),
+  });
+}
+
+describe("POST /api/groups/[slug]/invite", () => {
+  it("forbids admins from creating admin invites", async () => {
+    mockState.getGroupMembership.mockResolvedValue({ role: "admin" });
+
+    const response = await POST(requestWithRole("admin"), {
+      params: Promise.resolve({ slug: "team" }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "Forbidden" });
+    expect(mockState.createGroupInvite).not.toHaveBeenCalled();
+    expect(mockState.revalidateGroupCaches).not.toHaveBeenCalled();
+  });
+
+  it("forbids owner invites", async () => {
+    mockState.getGroupMembership.mockResolvedValue({ role: "owner" });
+
+    const response = await POST(requestWithRole("owner"), {
+      params: Promise.resolve({ slug: "team" }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "Forbidden" });
+    expect(mockState.createGroupInvite).not.toHaveBeenCalled();
+    expect(mockState.revalidateGroupCaches).not.toHaveBeenCalled();
+  });
+
+  it("allows owners to create admin invites", async () => {
+    mockState.getGroupMembership.mockResolvedValue({ role: "owner" });
+    mockState.createGroupInvite.mockResolvedValue({
+      id: "invite-1",
+      token: "tg_token",
+      role: "admin",
+      invitedUsername: null,
+      expiresAt: new Date("2026-06-01T00:00:00Z"),
+    });
+
+    const response = await POST(requestWithRole("admin"), {
+      params: Promise.resolve({ slug: "team" }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(mockState.createGroupInvite).toHaveBeenCalledWith({
+      groupId: "group-1",
+      invitedBy: "actor-1",
+      role: "admin",
+      invitedUsername: null,
+    });
+    expect(mockState.revalidateGroupCaches).toHaveBeenCalledWith("group-1", "team");
+  });
+
+  it("allows admins to create member invites", async () => {
+    mockState.getGroupMembership.mockResolvedValue({ role: "admin" });
+
+    const response = await POST(requestWithRole("member"), {
+      params: Promise.resolve({ slug: "team" }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(mockState.createGroupInvite).toHaveBeenCalledWith({
+      groupId: "group-1",
+      invitedBy: "actor-1",
+      role: "member",
+      invitedUsername: null,
+    });
+    expect(mockState.revalidateGroupCaches).toHaveBeenCalledWith("group-1", "team");
+  });
+
+  it("defaults invalid requested roles to member invites", async () => {
+    mockState.getGroupMembership.mockResolvedValue({ role: "admin" });
+
+    const response = await POST(requestWithRole("invalid"), {
+      params: Promise.resolve({ slug: "team" }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(mockState.createGroupInvite).toHaveBeenCalledWith({
+      groupId: "group-1",
+      invitedBy: "actor-1",
+      role: "member",
+      invitedUsername: null,
+    });
+  });
+});

--- a/packages/frontend/src/app/api/groups/[slug]/invite/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/invite/route.ts
@@ -4,7 +4,7 @@ import { revalidateGroupCaches } from "@/lib/groups/cache";
 import { createGroupInvite, GroupInviteError } from "@/lib/groups/invites";
 import { getGroupMembership } from "@/lib/groups/permissions";
 import { getGroupBySlug } from "@/lib/groups/queries";
-import { isGroupRole } from "@/lib/groups/utils";
+import { canManageGroupRole, isGroupRole } from "@/lib/groups/utils";
 import type { GroupRole } from "@/lib/db";
 
 export async function POST(
@@ -43,6 +43,10 @@ export async function POST(
     const invitedUsername = typeof body.invitedUsername === "string"
       ? body.invitedUsername
       : null;
+
+    if (!canManageGroupRole(membership.role, role)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
 
     const invite = await createGroupInvite({
       groupId: group.id,


### PR DESCRIPTION
## Summary

This PR enforces the existing group role hierarchy when creating group invites. Admins can still invite regular members, and owners can still invite admins, but invites can no longer bypass the direct role-management restrictions.

## Why

Direct member role changes already require the actor to outrank the target role. The invite route did not apply the same rule before creating an invite, so an admin could create an `admin` invite and grant peer-level permissions through the join flow.

## Diff Scope

- Applies `canManageGroupRole` in `POST /api/groups/[slug]/invite` before creating an invite.
- Adds route coverage for admin-created admin invites, owner-created admin invites, admin-created member invites, owner-role invite rejection, and invalid-role fallback behavior.

## Branch Integrity

- Base: `junhoyeo/tokscale:main`
- Validated base SHA: `8e73312f05f603d5184d36059e4ce2604322d492`
- Head: `IvGolovach:codex/groups-invite-role-hierarchy`
- Head SHA: `ae01b4648e7746bc0fe25d04cb00ae473324e46a`
- Ahead/behind: `0 behind / 1 ahead`

## Commit Integrity

- `ae01b4648e7746bc0fe25d04cb00ae473324e46a fix(groups): enforce invite role hierarchy`
- Final diff only touches the group invite route and targeted route test coverage.

## Diff Hygiene

- `git diff --check origin/main...HEAD`: PASS, no output
- Forbidden/local artifact files: not present
- DB migrations: not applicable; no schema changed
- Ledger: not applicable; not required for this change family
- Version: not applicable; not required for this change family

## Validation

Validation mode: Mode 2 — narrow frontend route permission change.

- `bun x vitest run __tests__/api/groupInviteRoute.test.ts`: PASS
- `bun x vitest run __tests__/api/groupInviteRoute.test.ts __tests__/api/groupInviteJoinRoute.test.ts __tests__/lib/groupInvites.test.ts __tests__/lib/groupHelpers.test.ts`: PASS, 14 tests
- `bun x vitest run __tests__/api/group*.test.ts __tests__/lib/group*.test.ts`: PASS, 20 tests
- `bun x eslint __tests__/api/groupInviteRoute.test.ts 'src/app/api/groups/[slug]/invite/route.ts'`: PASS
- `git diff --check origin/main...HEAD`: PASS

Not used as proof: full frontend lint/typecheck currently report unrelated existing issues outside this diff, so this PR relies on targeted route coverage and targeted ESLint.

## CI Context

Pending — required remote checks will run after the PR is opened.

## Runtime Safety

This only tightens an existing permission check on invite creation. It does not change invite token format, invite acceptance persistence, group membership schema, or cache invalidation behavior. No invariant regression introduced.

## Rollback Plan

Rollback: revert this PR.

DB downgrade: not applicable.

Data repair: not applicable.

Operational caveats: reverting would restore the invite-based role escalation path for group admins.

## Known Residual Risks

None known for the scoped permission fix.
