### PR TITLE
fix(cli): honor explicit home diagnostics

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -415,7 +415,7 @@ fn main() -> Result<()> {
             let month = date.month;
             let (since, until) = build_date_filter(today, week, month, date.since, date.until);
             let year = normalize_year_filter(today, week, month, date.year);
-            let clients = build_client_filter(clients);
+            let clients = build_client_filter(clients, &cli.home);
             if json || light || !can_use_tui {
                 run_models_report(
                     json,
@@ -461,7 +461,7 @@ fn main() -> Result<()> {
             let month = date.month;
             let (since, until) = build_date_filter(today, week, month, date.since, date.until);
             let year = normalize_year_filter(today, week, month, date.year);
-            let clients = build_client_filter(clients);
+            let clients = build_client_filter(clients, &cli.home);
             if json || light || !can_use_tui {
                 run_monthly_report(
                     json,
@@ -504,7 +504,7 @@ fn main() -> Result<()> {
             let month = date.month;
             let (since, until) = build_date_filter(today, week, month, date.since, date.until);
             let year = normalize_year_filter(today, week, month, date.year);
-            let clients = build_client_filter(clients);
+            let clients = build_client_filter(clients, &cli.home);
             if json || light || !can_use_tui {
                 run_hourly_report(
                     json,
@@ -543,10 +543,7 @@ fn main() -> Result<()> {
             reject_unsupported_home_override(&cli.home, "pricing")?;
             run_pricing_lookup(&model_id, json, provider.as_deref(), no_spinner)
         }
-        Some(Commands::Clients { json }) => {
-            reject_unsupported_home_override(&cli.home, "clients")?;
-            run_clients_command(json)
-        }
+        Some(Commands::Clients { json }) => run_clients_command(json, cli.home.clone()),
         Some(Commands::Login { token }) => {
             reject_unsupported_home_override(&cli.home, "login")?;
             run_login_command(token)
@@ -575,7 +572,7 @@ fn main() -> Result<()> {
             let month = date.month;
             let (since, until) = build_date_filter(today, week, month, date.since, date.until);
             let year = normalize_year_filter(today, week, month, date.year);
-            let clients = build_client_filter(clients);
+            let clients = build_client_filter(clients, &cli.home);
             run_graph_command(
                 output,
                 cli.home.clone(),
@@ -594,7 +591,7 @@ fn main() -> Result<()> {
             let month = date.month;
             let (since, until) = build_date_filter(today, week, month, date.since, date.until);
             let year = normalize_year_filter(today, week, month, date.year);
-            let clients = build_client_filter(clients);
+            let clients = build_client_filter(clients, &cli.home);
             auto_sync_cursor_before_tui(&cli.home, &clients)?;
             tui::run(
                 &cli.theme,
@@ -647,7 +644,7 @@ fn main() -> Result<()> {
             no_spinner: _,
         }) => {
             reject_unsupported_home_override(&cli.home, "wrapped")?;
-            let client_filter = build_client_filter(client_flags);
+            let client_filter = build_client_filter(client_flags, &cli.home);
             run_wrapped_command(
                 output,
                 year,
@@ -689,7 +686,7 @@ fn main() -> Result<()> {
             let month = date.month;
             let (since, until) = build_date_filter(today, week, month, date.since, date.until);
             let year = normalize_year_filter(today, week, month, date.year);
-            let clients = build_client_filter(clients);
+            let clients = build_client_filter(clients, &cli.home);
             run_time_metrics_report(
                 json,
                 cli.home.clone(),
@@ -705,7 +702,7 @@ fn main() -> Result<()> {
             let today = cli.date.today;
             let week = cli.date.week;
             let month = cli.date.month;
-            let clients = build_client_filter(cli.clients);
+            let clients = build_client_filter(cli.clients, &cli.home);
             let (since, until) =
                 build_date_filter(today, week, month, cli.date.since, cli.date.until);
             let year = normalize_year_filter(today, week, month, cli.date.year);
@@ -1041,8 +1038,8 @@ pub struct DateRangeFlags {
 ///
 /// Returns `None` when no filters are active *and* no defaults configured
 /// so the caller can scan all clients.
-fn build_client_filter(flags: ClientFlags) -> Option<Vec<String>> {
-    let defaults = tui::settings::load_default_clients();
+fn build_client_filter(flags: ClientFlags, home_dir: &Option<String>) -> Option<Vec<String>> {
+    let defaults = tui::settings::load_default_clients_for_home(home_dir);
     build_client_filter_with_defaults(flags, &defaults)
 }
 
@@ -1551,7 +1548,7 @@ fn run_models_report(
                 until: until.clone(),
                 year: year.clone(),
                 group_by: group_by.clone(),
-                scanner_settings: tui::settings::load_scanner_settings(),
+                scanner_settings: tui::settings::load_scanner_settings_for_home(&home_dir),
             })
             .await
         })
@@ -2312,14 +2309,14 @@ fn run_monthly_report(
     let report = rt
         .block_on(async {
             get_monthly_report(ReportOptions {
-                home_dir,
+                home_dir: home_dir.clone(),
                 use_env_roots,
                 clients,
                 since,
                 until,
                 year,
                 group_by: GroupBy::default(),
-                scanner_settings: tui::settings::load_scanner_settings(),
+                scanner_settings: tui::settings::load_scanner_settings_for_home(&home_dir),
             })
             .await
         })
@@ -2606,14 +2603,14 @@ fn run_hourly_report(
     let report = rt
         .block_on(async {
             get_hourly_report(ReportOptions {
-                home_dir,
+                home_dir: home_dir.clone(),
                 use_env_roots,
                 clients,
                 since,
                 until,
                 year,
                 group_by: GroupBy::default(),
-                scanner_settings: tui::settings::load_scanner_settings(),
+                scanner_settings: tui::settings::load_scanner_settings_for_home(&home_dir),
             })
             .await
         })
@@ -3292,19 +3289,24 @@ fn capitalize_client(client: &str) -> String {
     }
 }
 
-fn run_clients_command(json: bool) -> Result<()> {
+fn run_clients_command(json: bool, home_dir: Option<String>) -> Result<()> {
     use tokscale_core::{
         built_in_extra_scan_paths_for, extra_scan_paths_for, parse_local_clients, ClientId,
         LocalParseOptions,
     };
 
-    let home_dir =
-        dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
-    let scanner_settings = tui::settings::load_scanner_settings();
+    let explicit_home_dir = home_dir;
+    let use_env_roots = use_env_roots(&explicit_home_dir);
+    let scanner_settings = tui::settings::load_scanner_settings_for_home(&explicit_home_dir);
+    let home_dir = explicit_home_dir
+        .map(PathBuf::from)
+        .or_else(dirs::home_dir)
+        .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+    let home_dir_str = home_dir.to_string_lossy().to_string();
 
     let parsed = parse_local_clients(LocalParseOptions {
-        home_dir: Some(home_dir.to_string_lossy().to_string()),
-        use_env_roots: true,
+        home_dir: Some(home_dir_str.clone()),
+        use_env_roots,
         clients: Some(
             ClientId::iter()
                 .filter(|client| client.parse_local())
@@ -3318,7 +3320,8 @@ fn run_clients_command(json: bool) -> Result<()> {
     })
     .map_err(|e| anyhow::anyhow!(e))?;
 
-    let headless_roots = get_headless_roots(&home_dir);
+    let headless_roots =
+        tokscale_core::scanner::headless_roots_with_env_strategy(&home_dir_str, use_env_roots);
     let headless_codex_count = parsed
         .messages
         .iter()
@@ -3376,20 +3379,23 @@ fn run_clients_command(json: bool) -> Result<()> {
         source: String,
     }
 
-    // Collect extra dirs from TOKSCALE_EXTRA_DIRS for display (reuse core parser)
-    let extra_dirs_val = std::env::var("TOKSCALE_EXTRA_DIRS").unwrap_or_default();
     let all_clients: std::collections::HashSet<ClientId> = ClientId::iter().collect();
-    let extra_dirs: Vec<(ClientId, String)> =
-        tokscale_core::parse_extra_dirs(&extra_dirs_val, &all_clients);
-    let built_in_extra_paths =
-        built_in_extra_scan_paths_for(&home_dir.to_string_lossy(), &all_clients);
+    let extra_dirs: Vec<(ClientId, String)> = if use_env_roots {
+        let extra_dirs_val = std::env::var("TOKSCALE_EXTRA_DIRS").unwrap_or_default();
+        tokscale_core::parse_extra_dirs(&extra_dirs_val, &all_clients)
+    } else {
+        Vec::new()
+    };
+    let built_in_extra_paths = built_in_extra_scan_paths_for(&home_dir_str, &all_clients);
     let settings_extra_dirs = extra_scan_paths_for(&scanner_settings, &all_clients);
     let copilot_exporter_path = tokscale_core::copilot_exporter_path();
 
     let clients: Vec<ClientRow> =
         ClientId::iter()
             .map(|client| {
-                let sessions_path = client.data().resolve_path(&home_dir.to_string_lossy());
+                let sessions_path = client
+                    .data()
+                    .resolve_path_with_env_strategy(&home_dir_str, use_env_roots);
                 let sessions_path_exists = Path::new(&sessions_path).exists();
                 let additional_paths: Vec<AdditionalPath> = built_in_extra_paths
                     .iter()
@@ -3536,7 +3542,7 @@ fn run_clients_command(json: bool) -> Result<()> {
                 "  {}",
                 format!(
                     "sessions: {}",
-                    describe_path(&row.sessions_path, row.sessions_path_exists)
+                    describe_path_for_home(&row.sessions_path, row.sessions_path_exists, &home_dir)
                 )
                 .bright_black()
             );
@@ -3545,7 +3551,7 @@ fn run_clients_command(json: bool) -> Result<()> {
                 let additional_desc: Vec<String> = row
                     .additional_paths
                     .iter()
-                    .map(|ap| describe_path(&ap.path, ap.exists))
+                    .map(|ap| describe_path_for_home(&ap.path, ap.exists, &home_dir))
                     .collect();
                 println!(
                     "  {}",
@@ -3557,7 +3563,7 @@ fn run_clients_command(json: bool) -> Result<()> {
                 let legacy_desc: Vec<String> = row
                     .legacy_paths
                     .iter()
-                    .map(|lp| describe_path(&lp.path, lp.exists))
+                    .map(|lp| describe_path_for_home(&lp.path, lp.exists, &home_dir))
                     .collect();
                 println!(
                     "  {}",
@@ -3570,7 +3576,7 @@ fn run_clients_command(json: bool) -> Result<()> {
                     .extra_paths
                     .iter()
                     .filter(|ep| ep.source == "settings")
-                    .map(|ep| describe_path(&ep.path, ep.exists))
+                    .map(|ep| describe_path_for_home(&ep.path, ep.exists, &home_dir))
                     .collect();
                 if !settings_desc.is_empty() {
                     println!(
@@ -3583,7 +3589,7 @@ fn run_clients_command(json: bool) -> Result<()> {
                     .extra_paths
                     .iter()
                     .filter(|ep| ep.source == "env")
-                    .map(|ep| describe_path(&ep.path, ep.exists))
+                    .map(|ep| describe_path_for_home(&ep.path, ep.exists, &home_dir))
                     .collect();
                 if !env_desc.is_empty() {
                     println!(
@@ -3604,7 +3610,7 @@ fn run_clients_command(json: bool) -> Result<()> {
                 let headless_desc: Vec<String> = row
                     .headless_paths
                     .iter()
-                    .map(|hp| describe_path(&hp.path, hp.exists))
+                    .map(|hp| describe_path_for_home(&hp.path, hp.exists, &home_dir))
                     .collect();
                 println!(
                     "  {}",
@@ -3656,12 +3662,8 @@ fn get_headless_roots(home_dir: &Path) -> Vec<PathBuf> {
     roots
 }
 
-fn describe_path(path: &str, exists: bool) -> String {
-    let path_display = if let Some(home) = dirs::home_dir() {
-        path.replace(&home.to_string_lossy().to_string(), "~")
-    } else {
-        path.to_string()
-    };
+fn describe_path_for_home(path: &str, exists: bool, home: &Path) -> String {
+    let path_display = path.replace(&home.to_string_lossy().to_string(), "~");
     if exists {
         format!("{} ✓", path_display)
     } else {
@@ -4227,14 +4229,14 @@ fn run_time_metrics_report(
     let report = rt
         .block_on(async {
             get_time_metrics_report(ReportOptions {
-                home_dir,
+                home_dir: home_dir.clone(),
                 use_env_roots,
                 clients,
                 since,
                 until,
                 year,
                 group_by: GroupBy::default(),
-                scanner_settings: tui::settings::load_scanner_settings(),
+                scanner_settings: tui::settings::load_scanner_settings_for_home(&home_dir),
             })
             .await
         })
@@ -4331,14 +4333,14 @@ fn run_graph_command(
     let graph_result = rt
         .block_on(async {
             generate_local_graph_report(ReportOptions {
-                home_dir,
+                home_dir: home_dir.clone(),
                 use_env_roots,
                 clients,
                 since,
                 until,
                 year,
                 group_by: GroupBy::default(),
-                scanner_settings: tui::settings::load_scanner_settings(),
+                scanner_settings: tui::settings::load_scanner_settings_for_home(&home_dir),
             })
             .await
         })

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -3388,7 +3388,8 @@ fn run_clients_command(json: bool, home_dir: Option<String>) -> Result<()> {
     };
     let built_in_extra_paths = built_in_extra_scan_paths_for(&home_dir_str, &all_clients);
     let settings_extra_dirs = extra_scan_paths_for(&scanner_settings, &all_clients);
-    let copilot_exporter_path = tokscale_core::copilot_exporter_path();
+    let copilot_exporter_path =
+        tokscale_core::copilot_exporter_path_with_env_strategy(use_env_roots);
 
     let clients: Vec<ClientRow> =
         ClientId::iter()

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::Result;
@@ -128,6 +128,10 @@ pub fn load_scanner_settings() -> ScannerSettings {
     Settings::load().scanner
 }
 
+pub fn load_scanner_settings_for_home(home_dir: &Option<String>) -> ScannerSettings {
+    Settings::load_for_home_override(home_dir.as_deref().map(Path::new)).scanner
+}
+
 /// Returns the user's configured `defaultClients` list as raw lowercase
 /// ids. Validation against the live `ClientFilter` enum happens at the
 /// CLI boundary so this module stays independent of the CLI types.
@@ -138,7 +142,21 @@ pub fn load_default_clients() -> Vec<String> {
     Settings::load().default_clients
 }
 
+pub fn load_default_clients_for_home(home_dir: &Option<String>) -> Vec<String> {
+    Settings::load_for_home_override(home_dir.as_deref().map(Path::new)).default_clients
+}
+
 impl Settings {
+    fn normalize(mut self) -> Self {
+        self.auto_refresh_ms = self
+            .auto_refresh_ms
+            .clamp(MIN_AUTO_REFRESH_MS, MAX_AUTO_REFRESH_MS);
+        self.native_timeout_ms = self
+            .native_timeout_ms
+            .clamp(MIN_NATIVE_TIMEOUT_MS, MAX_NATIVE_TIMEOUT_MS);
+        self
+    }
+
     fn config_path() -> Result<PathBuf> {
         let config_dir = crate::paths::get_config_dir();
 
@@ -147,6 +165,14 @@ impl Settings {
         }
 
         Ok(config_dir.join("settings.json"))
+    }
+
+    fn explicit_home_config_path(home_dir: &Path) -> PathBuf {
+        home_dir.join(".config/tokscale/settings.json")
+    }
+
+    fn explicit_home_legacy_macos_path(home_dir: &Path) -> PathBuf {
+        home_dir.join("Library/Application Support/tokscale/settings.json")
     }
 
     /// Returns the legacy `~/Library/Application Support/tokscale/settings.json`
@@ -177,15 +203,21 @@ impl Settings {
         });
 
         raw.and_then(|content| serde_json::from_str(&content).ok())
-            .map(|mut s: Settings| {
-                s.auto_refresh_ms = s
-                    .auto_refresh_ms
-                    .clamp(MIN_AUTO_REFRESH_MS, MAX_AUTO_REFRESH_MS);
-                s.native_timeout_ms = s
-                    .native_timeout_ms
-                    .clamp(MIN_NATIVE_TIMEOUT_MS, MAX_NATIVE_TIMEOUT_MS);
-                s
-            })
+            .map(Settings::normalize)
+            .unwrap_or_default()
+    }
+
+    pub fn load_for_home_override(home_dir: Option<&Path>) -> Self {
+        let Some(home_dir) = home_dir else {
+            return Self::load();
+        };
+
+        let raw = fs::read_to_string(Self::explicit_home_config_path(home_dir))
+            .ok()
+            .or_else(|| fs::read_to_string(Self::explicit_home_legacy_macos_path(home_dir)).ok());
+
+        raw.and_then(|content| serde_json::from_str(&content).ok())
+            .map(Settings::normalize)
             .unwrap_or_default()
     }
 

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -16,6 +16,22 @@ const DEFAULT_NATIVE_TIMEOUT_MS: u64 = 300_000;
 const MIN_NATIVE_TIMEOUT_MS: u64 = 5_000;
 const MAX_NATIVE_TIMEOUT_MS: u64 = 3_600_000;
 
+#[derive(Debug, Clone, Copy)]
+enum ExplicitHomeConfigLayout {
+    UnixDotConfig,
+    WindowsRoaming,
+}
+
+impl ExplicitHomeConfigLayout {
+    fn current() -> Self {
+        if cfg!(target_os = "windows") {
+            Self::WindowsRoaming
+        } else {
+            Self::UnixDotConfig
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LightSettings {
@@ -167,8 +183,25 @@ impl Settings {
         Ok(config_dir.join("settings.json"))
     }
 
+    fn explicit_home_config_path_for_layout(
+        home_dir: &Path,
+        layout: ExplicitHomeConfigLayout,
+    ) -> PathBuf {
+        match layout {
+            ExplicitHomeConfigLayout::UnixDotConfig => home_dir
+                .join(".config")
+                .join("tokscale")
+                .join("settings.json"),
+            ExplicitHomeConfigLayout::WindowsRoaming => home_dir
+                .join("AppData")
+                .join("Roaming")
+                .join("tokscale")
+                .join("settings.json"),
+        }
+    }
+
     fn explicit_home_config_path(home_dir: &Path) -> PathBuf {
-        home_dir.join(".config/tokscale/settings.json")
+        Self::explicit_home_config_path_for_layout(home_dir, ExplicitHomeConfigLayout::current())
     }
 
     fn explicit_home_legacy_macos_path(home_dir: &Path) -> PathBuf {
@@ -285,6 +318,44 @@ impl Settings {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    #[test]
+    fn explicit_home_config_path_uses_unix_dot_config_layout() {
+        assert_eq!(
+            Settings::explicit_home_config_path_for_layout(
+                Path::new("/home/alice"),
+                ExplicitHomeConfigLayout::UnixDotConfig,
+            ),
+            PathBuf::from("/home/alice/.config/tokscale/settings.json")
+        );
+    }
+
+    #[test]
+    fn explicit_home_config_path_uses_windows_roaming_layout() {
+        assert_eq!(
+            Settings::explicit_home_config_path_for_layout(
+                Path::new("C:/Users/Alice"),
+                ExplicitHomeConfigLayout::WindowsRoaming,
+            ),
+            PathBuf::from("C:/Users/Alice/AppData/Roaming/tokscale/settings.json")
+        );
+    }
+
+    #[test]
+    fn load_for_home_override_reads_current_platform_config_path() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let path = Settings::explicit_home_config_path(temp.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            r#"{"colorPalette":"halloween","defaultClients":["codex"]}"#,
+        )
+        .unwrap();
+
+        let loaded = Settings::load_for_home_override(Some(temp.path()));
+        assert_eq!(loaded.color_palette, "halloween");
+        assert_eq!(loaded.default_clients, vec!["codex".to_string()]);
+    }
 
     #[test]
     #[cfg(target_os = "macos")]

--- a/crates/tokscale-cli/src/tui/ui/header.rs
+++ b/crates/tokscale-cli/src/tui/ui/header.rs
@@ -154,12 +154,29 @@ mod tests {
         app
     }
 
-    fn render_header(app: &mut App, width: u16) {
+    fn render_header(app: &mut App, width: u16) -> Vec<Vec<String>> {
         let backend = TestBackend::new(width, 3);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|frame| render(frame, app, Rect::new(0, 0, width, 3)))
             .unwrap();
+
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .chunks(width as usize)
+            .map(|row| row.iter().map(|cell| cell.symbol().to_string()).collect())
+            .collect()
+    }
+
+    fn rendered_label_column(rows: &[Vec<String>], label: &str) -> u16 {
+        let target: Vec<String> = label.chars().map(|ch| ch.to_string()).collect();
+
+        rows[1]
+            .windows(target.len())
+            .position(|window| window == target.as_slice())
+            .expect("expected label to be rendered") as u16
     }
 
     fn click_header(app: &mut App, column: u16) {
@@ -175,8 +192,8 @@ mod tests {
     fn daily_label_click_uses_rendered_normal_tab_position() {
         let mut app = make_app(80);
 
-        render_header(&mut app, 80);
-        click_header(&mut app, 38);
+        let rows = render_header(&mut app, 80);
+        click_header(&mut app, rendered_label_column(&rows, "Daily"));
 
         assert_eq!(app.current_tab, Tab::Daily);
     }
@@ -185,8 +202,8 @@ mod tests {
     fn daily_short_label_click_uses_rendered_very_narrow_tab_position() {
         let mut app = make_app(59);
 
-        render_header(&mut app, 59);
-        click_header(&mut app, 27);
+        let rows = render_header(&mut app, 59);
+        click_header(&mut app, rendered_label_column(&rows, "Day"));
 
         assert_eq!(app.current_tab, Tab::Daily);
     }

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -905,6 +905,43 @@ fn test_clients_home_override_uses_explicit_home_for_json() {
 }
 
 #[test]
+fn test_clients_home_override_ignores_copilot_exporter_env() {
+    let real_home = create_empty_fixture_dir();
+    let conflicting_home = create_empty_fixture_dir();
+    let exporter_file = conflicting_home.path().join("copilot-host.jsonl");
+    fs::write(&exporter_file, "{}").unwrap();
+
+    let output = cmd_with_conflicting_env(conflicting_home.path())
+        .env("COPILOT_OTEL_FILE_EXPORTER_PATH", &exporter_file)
+        .args([
+            "--home",
+            real_home.path().to_str().unwrap(),
+            "clients",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let copilot = json["clients"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["client"] == "copilot")
+        .unwrap();
+    assert!(
+        copilot.get("exporterStatus").is_none(),
+        "explicit --home diagnostics must not report host COPILOT_OTEL_FILE_EXPORTER_PATH: {copilot:#?}"
+    );
+}
+
+#[test]
 fn test_models_with_since_only() {
     let tmp = create_temp_fixture_dir();
     cmd_with_home(tmp.path())

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -444,6 +444,35 @@ fn write_settings_json(base: &Path, body: &str) {
     }
 }
 
+fn write_codex_token_session(dir: &Path, name: &str, model: &str, input: i64, output: i64) {
+    fs::create_dir_all(dir).unwrap();
+    let turn_context = serde_json::json!({
+        "type": "turn_context",
+        "payload": {
+            "model": model
+        }
+    });
+    let token_count = serde_json::json!({
+        "timestamp": "2026-01-01T00:00:01Z",
+        "type": "event_msg",
+        "payload": {
+            "type": "token_count",
+            "info": {
+                "last_token_usage": {
+                    "input_tokens": input,
+                    "cached_input_tokens": 0,
+                    "output_tokens": output
+                }
+            }
+        }
+    });
+    fs::write(
+        dir.join(name),
+        format!("{}\n{}\n", turn_context, token_count),
+    )
+    .unwrap();
+}
+
 // ── Existing tests ─────────────────────────────────────────────────────────
 
 #[test]
@@ -826,16 +855,46 @@ fn test_tui_rejects_home_override() {
 }
 
 #[test]
-fn test_clients_rejects_home_override() {
-    let tmp = TempDir::new().unwrap();
+fn test_clients_home_override_uses_explicit_home_for_json() {
+    let real_home = create_codex_fixture_dir();
+    let conflicting_home = create_conflicting_codex_fixture_dir();
+    write_codex_token_session(
+        &real_home.path().join(".codex/sessions"),
+        "session-2.jsonl",
+        "gpt-4o-mini",
+        80,
+        20,
+    );
 
-    cargo_bin_cmd!("tokscale")
-        .args(["--home", tmp.path().to_str().unwrap(), "clients"])
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains(
-            "It is not supported for `clients`",
-        ));
+    let output = cmd_with_conflicting_env(conflicting_home.path())
+        .env("CODEX_HOME", conflicting_home.path().join(".codex"))
+        .args([
+            "--home",
+            real_home.path().to_str().unwrap(),
+            "clients",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let codex = json["clients"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["client"] == "codex")
+        .unwrap();
+    assert_eq!(
+        codex["sessionsPath"],
+        serde_json::json!(real_home.path().join(".codex/sessions"))
+    );
+    assert_eq!(codex["messageCount"].as_i64().unwrap(), 2);
 }
 
 #[test]
@@ -1245,6 +1304,60 @@ fn test_monthly_json_output() {
     assert!(first.get("cacheWrite").is_some());
     assert!(first.get("messageCount").is_some());
     assert!(first.get("cost").is_some());
+}
+
+#[test]
+fn test_hourly_home_override_uses_explicit_home_scanner_settings() {
+    let real_home = create_empty_fixture_dir();
+    let conflicting_home = create_conflicting_codex_fixture_dir();
+    let extra_home = TempDir::new().unwrap();
+    let extra_sessions = extra_home.path().join("portable-codex/sessions");
+    write_codex_token_session(
+        &extra_sessions,
+        "settings-session.jsonl",
+        "gpt-4o-mini",
+        210,
+        40,
+    );
+    write_settings_json(
+        real_home.path(),
+        &format!(
+            r#"{{
+                "scanner": {{
+                    "extraScanPaths": {{
+                        "codex": [{}]
+                    }}
+                }}
+            }}"#,
+            serde_json::to_string(extra_sessions.to_str().unwrap()).unwrap()
+        ),
+    );
+
+    let output = cmd_with_conflicting_env(conflicting_home.path())
+        .env("TOKSCALE_PRICING_CACHE_ONLY", "1")
+        .env("CODEX_HOME", conflicting_home.path().join(".codex"))
+        .args([
+            "hourly",
+            "--json",
+            "--codex",
+            "--no-spinner",
+            "--home",
+            real_home.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["entries"].as_array().unwrap().len(), 1);
+    assert_eq!(json["entries"][0]["input"].as_i64().unwrap(), 210);
+    assert_eq!(json["entries"][0]["output"].as_i64().unwrap(), 40);
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("gpt-5"));
 }
 
 #[test]

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -435,12 +435,19 @@ fn write_fake_credentials(base: &Path) {
 }
 
 fn write_settings_json(base: &Path, body: &str) {
-    for dir in [
-        base.join(".config/tokscale"),
-        base.join("Library/Application Support/tokscale"),
-    ] {
-        fs::create_dir_all(&dir).unwrap();
-        fs::write(dir.join("settings.json"), body).unwrap();
+    let path = settings_json_path(base);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, body).unwrap();
+}
+
+fn settings_json_path(base: &Path) -> std::path::PathBuf {
+    if cfg!(target_os = "windows") {
+        base.join("AppData")
+            .join("Roaming")
+            .join("tokscale")
+            .join("settings.json")
+    } else {
+        base.join(".config").join("tokscale").join("settings.json")
     }
 }
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1670,7 +1670,13 @@ pub async fn get_hourly_report(options: ReportOptions) -> Result<HourlyReport, S
     });
 
     let pricing = pricing::PricingService::get_or_init().await?;
-    let all_messages = parse_all_messages_with_pricing(&home_dir, &clients, Some(&pricing));
+    let all_messages = parse_all_messages_with_pricing_with_env_strategy(
+        &home_dir,
+        &clients,
+        Some(&pricing),
+        options.use_env_roots,
+        &options.scanner_settings,
+    );
 
     let filtered = filter_messages_for_report(all_messages, &options);
 


### PR DESCRIPTION
## Summary

This PR makes local diagnostics honor explicit `--home` overrides consistently. `tokscale clients --home ...` now works, and `tokscale hourly --home ...` uses the same explicit-home scanner settings and env-root isolation as the other local report paths.

## Why

`--home` is used to inspect an alternate sandbox or user profile without leaking data from the current machine. Some diagnostic paths were still inconsistent: `clients` rejected the override, while `hourly` accepted it but could still miss explicit-home scanner settings or read env-provided roots. That made diagnostics disagree with the source the user intended to scan.

## Diff Scope

- Allows `clients --home` and disables env-root expansion when an explicit home is provided.
- Loads `settings.json` from the explicit home for scanner paths and default client filters.
- Routes `hourly` through the env-strategy/scanner-settings parsing path.
- Adds CLI regression coverage for `clients --home` JSON output and `hourly --home` scanner `extraScanPaths` behavior with conflicting env roots.

## Branch Integrity

- Base: `junhoyeo/tokscale:main`
- Validated base SHA: `8e73312f05f603d5184d36059e4ce2604322d492`
- Head: `IvGolovach:codex/cli-home-diagnostics`
- Head SHA: `fd7618a5f3bf56fa1b0414706665fd2d0264624f`
- Ahead/behind: `0 behind / 1 ahead`

## Commit Integrity

- `fd7618a5f3bf56fa1b0414706665fd2d0264624f fix(cli): honor explicit home diagnostics`
- Final diff is limited to CLI dispatch/settings, the core hourly parser path, and targeted CLI tests.

## Diff Hygiene

- `git diff --check origin/main...HEAD`: PASS, no output
- Forbidden/local artifact files: not present
- DB migrations: not applicable; no schema changed
- Ledger: not applicable; not required for this change family
- Version: not applicable; not required for this change family

## Validation

Validation mode: Mode 2 — narrow CLI/core diagnostics runtime change.

- `cargo test -p tokscale-cli test_clients_home_override_uses_explicit_home_for_json`: PASS
- `cargo test -p tokscale-cli test_hourly_home_override_uses_explicit_home_scanner_settings`: PASS
- `cargo test -p tokscale-cli home_override`: PASS
- `cargo test -p tokscale-cli clients`: PASS
- `rustfmt --edition 2021 --check --config skip_children=true crates/tokscale-cli/src/main.rs crates/tokscale-cli/src/tui/settings.rs crates/tokscale-cli/tests/cli_tests.rs crates/tokscale-core/src/lib.rs`: PASS
- `rustup run stable cargo clippy -p tokscale-core --all-features -- -D warnings`: PASS
- `git diff --check origin/main...HEAD`: PASS

Not used as proof: `cargo fmt --all --check` and full CLI clippy currently report unrelated existing formatting/clippy issues outside this diff, so this PR relies on targeted formatting, targeted CLI tests, and core clippy.

## CI Context

Pending — required remote checks will run after the PR is opened.

## Runtime Safety

The change is scoped to local diagnostic/report parsing behavior. It does not alter submit/auth behavior, persisted data, pricing logic, or remote API behavior. No invariant regression introduced.

## Documentation Integrity

No public docs were changed. The CLI behavior now matches the existing `--home` intent for local diagnostics.

## Rollback Plan

Rollback: revert this PR.

DB downgrade: not applicable.

Data repair: not applicable.

Operational caveats: reverting would make `clients --home` unsupported again and would restore the inconsistent `hourly --home` scanner-settings behavior.

## Known Residual Risks

None known for the scoped diagnostics fix.
