### PR TITLE
fix(submit): preserve same-device totals on parser regressions

### DIFF
--- a/packages/frontend/__tests__/api/submit.test.ts
+++ b/packages/frontend/__tests__/api/submit.test.ts
@@ -4,6 +4,11 @@ import {
   generateSubmissionHash,
   validateSubmission,
 } from "../../src/lib/validation/submission";
+import {
+  deriveClientBreakdownProvenance,
+  mergeClientBreakdownsWithRegressionGuard,
+  type ClientBreakdownData,
+} from "../../src/lib/db/helpers";
 
 /**
  * Test suite for POST /api/submit - Client-Level Merge
@@ -220,6 +225,27 @@ describe('POST /api/submit - Client-Level Merge', () => {
 
       expect(result.valid).toBe(false);
       expect(result.errors.some((error) => error.includes('device.id'))).toBe(true);
+    });
+
+    it('accepts per-client submit provenance metadata', () => {
+      const payload = createMockSubmissionData({ clients: ['codex'] });
+      const client = payload.contributions[0].clients[0] as {
+        provenance?: { schemaVersion: number; messageCount: number; modelCount: number };
+      };
+      client.provenance = {
+        schemaVersion: 1,
+        messageCount: 7,
+        modelCount: 1,
+      };
+
+      const result = validateSubmission(payload);
+
+      expect(result.valid).toBe(true);
+      expect(result.data?.contributions[0].clients[0].provenance).toEqual({
+        schemaVersion: 1,
+        messageCount: 7,
+        modelCount: 1,
+      });
     });
   });
 
@@ -513,6 +539,124 @@ describe('POST /api/submit - Client-Level Merge', () => {
   });
 
   describe('Client-Level Merge Logic', () => {
+    const breakdown = (
+      tokens: number,
+      messages: number,
+      modelId = 'gpt-5.5'
+    ): ClientBreakdownData => ({
+      tokens,
+      cost: tokens / 1000,
+      input: tokens,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      reasoning: 0,
+      messages,
+      models: {
+        [modelId]: {
+          tokens,
+          cost: tokens / 1000,
+          input: tokens,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          reasoning: 0,
+          messages,
+        },
+      },
+      provenance: {
+        schemaVersion: 1,
+        messageCount: messages,
+        modelCount: 1,
+      },
+    });
+
+    it('preserves lower same-client resubmits when coverage also drops', () => {
+      const existing = { codex: breakdown(5_000, 30) };
+      const incoming = { codex: breakdown(3_600, 20) };
+
+      const result = mergeClientBreakdownsWithRegressionGuard(
+        existing,
+        incoming,
+        new Set(['codex'])
+      );
+
+      expect(result.merged.codex).toEqual(existing.codex);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toContain('codex');
+      expect(result.warnings[0]).toContain('5,000');
+      expect(result.warnings[0]).toContain('3,600');
+    });
+
+    it('allows lower token resubmits when coverage does not regress', () => {
+      const existing = { codex: breakdown(5_000, 30) };
+      const incoming = { codex: breakdown(4_800, 32) };
+
+      const result = mergeClientBreakdownsWithRegressionGuard(
+        existing,
+        incoming,
+        new Set(['codex'])
+      );
+
+      expect(result.merged.codex).toEqual(incoming.codex);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('preserves a submitted client that disappears from a same-device resubmit', () => {
+      const existing = {
+        codex: breakdown(5_000, 30),
+        claude: breakdown(2_000, 10, 'claude-sonnet-4'),
+      };
+
+      const result = mergeClientBreakdownsWithRegressionGuard(
+        existing,
+        {},
+        new Set(['codex'])
+      );
+
+      expect(result.merged.codex).toEqual(existing.codex);
+      expect(result.merged.claude).toEqual(existing.claude);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toContain('disappeared');
+    });
+
+    it('adds new clients without warning', () => {
+      const existing = { claude: breakdown(2_000, 10, 'claude-sonnet-4') };
+      const incoming = { codex: breakdown(3_000, 15) };
+
+      const result = mergeClientBreakdownsWithRegressionGuard(
+        existing,
+        incoming,
+        new Set(['codex'])
+      );
+
+      expect(result.merged.claude).toEqual(existing.claude);
+      expect(result.merged.codex).toEqual(incoming.codex);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('derives provenance from aggregate messages and model keys', () => {
+      const aggregate = {
+        ...breakdown(5_000, 30),
+        messages: 35,
+        models: {
+          'gpt-5.5': breakdown(3_000, 20).models['gpt-5.5'],
+          'gpt-5.5-mini': breakdown(2_000, 15, 'gpt-5.5-mini').models['gpt-5.5-mini'],
+        },
+        provenance: {
+          schemaVersion: 1,
+          messageCount: 30,
+          modelCount: 1,
+        },
+      };
+
+      expect(deriveClientBreakdownProvenance(aggregate)).toEqual({
+        schemaVersion: 1,
+        messageCount: 35,
+        modelCount: 2,
+      });
+    });
+
     it('should preserve clients NOT in submission but delete clients with no day activity', () => {
       const existingClientBreakdown = {
         claude: { tokens: 1000, cost: 10, modelId: 'claude-sonnet-4', input: 600, output: 400, cacheRead: 0, cacheWrite: 0, messages: 5 },

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -8,7 +8,13 @@ const mockState = vi.hoisted(() => {
   const revalidateUsernamePaths = vi.fn();
   const revalidateUserGroupLeaderboards = vi.fn();
   const mergeClientBreakdowns = vi.fn();
+  const mergeClientBreakdownsWithRegressionGuard = vi.fn();
   const recalculateDayTotals = vi.fn();
+  const deriveClientBreakdownProvenance = vi.fn((breakdown) => ({
+    schemaVersion: 1,
+    messageCount: breakdown.messages ?? 0,
+    modelCount: breakdown.models ? Object.keys(breakdown.models).length : 0,
+  }));
   const buildModelBreakdown = vi.fn();
   const clientContributionToBreakdownData = vi.fn();
   const mergeTimestampMs = vi.fn();
@@ -25,7 +31,9 @@ const mockState = vi.hoisted(() => {
     revalidateUsernamePaths,
     revalidateUserGroupLeaderboards,
     mergeClientBreakdowns,
+    mergeClientBreakdownsWithRegressionGuard,
     recalculateDayTotals,
+    deriveClientBreakdownProvenance,
     buildModelBreakdown,
     clientContributionToBreakdownData,
     mergeTimestampMs,
@@ -38,7 +46,9 @@ const mockState = vi.hoisted(() => {
       revalidateUsernamePaths.mockReset();
       revalidateUserGroupLeaderboards.mockReset();
       mergeClientBreakdowns.mockReset();
+      mergeClientBreakdownsWithRegressionGuard.mockReset();
       recalculateDayTotals.mockReset();
+      deriveClientBreakdownProvenance.mockClear();
       buildModelBreakdown.mockReset();
       clientContributionToBreakdownData.mockReset();
       mergeTimestampMs.mockReset();
@@ -107,7 +117,9 @@ vi.mock("@/lib/validation/submission", () => ({
 
 vi.mock("@/lib/db/helpers", () => ({
   mergeClientBreakdowns: mockState.mergeClientBreakdowns,
+  mergeClientBreakdownsWithRegressionGuard: mockState.mergeClientBreakdownsWithRegressionGuard,
   recalculateDayTotals: mockState.recalculateDayTotals,
+  deriveClientBreakdownProvenance: mockState.deriveClientBreakdownProvenance,
   buildModelBreakdown: mockState.buildModelBreakdown,
   clientContributionToBreakdownData: mockState.clientContributionToBreakdownData,
   mergeTimestampMs: mockState.mergeTimestampMs,
@@ -524,7 +536,10 @@ describe("POST /api/submit auth path", () => {
     };
 
     mockState.clientContributionToBreakdownData.mockReturnValue(incomingBreakdown);
-    mockState.mergeClientBreakdowns.mockReturnValue(mergedBreakdown);
+    mockState.mergeClientBreakdownsWithRegressionGuard.mockReturnValue({
+      merged: mergedBreakdown,
+      warnings: [],
+    });
     mockState.recalculateDayTotals.mockReturnValue({
       tokens: 15,
       cost: 0.75,
@@ -597,9 +612,18 @@ describe("POST /api/submit auth path", () => {
       id: "submittedDevices.id",
     }));
     expect(tx.execute).toHaveBeenCalledTimes(1);
-    expect(mockState.mergeClientBreakdowns).toHaveBeenCalledWith(
+    expect(mockState.mergeClientBreakdownsWithRegressionGuard).toHaveBeenCalledWith(
       existingBreakdown,
-      { codex: mergedBreakdown.codex },
+      {
+        codex: {
+          ...mergedBreakdown.codex,
+          provenance: {
+            schemaVersion: 1,
+            messageCount: 1,
+            modelCount: 1,
+          },
+        },
+      },
       expect.any(Set)
     );
     expect(await response.json()).toEqual(expect.objectContaining({

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -715,9 +715,22 @@ describe("POST /api/submit auth path", () => {
         models: { "gpt-5.5": incomingBreakdown },
       },
     };
+    const incomingBreakdownWithProvenance = {
+      codex: {
+        ...mergedBreakdown.codex,
+        provenance: {
+          schemaVersion: 1,
+          messageCount: 1,
+          modelCount: 1,
+        },
+      },
+    };
 
     mockState.clientContributionToBreakdownData.mockReturnValue(incomingBreakdown);
-    mockState.mergeClientBreakdowns.mockReturnValue(mergedBreakdown);
+    mockState.mergeClientBreakdownsWithRegressionGuard.mockReturnValue({
+      merged: mergedBreakdown,
+      warnings: [],
+    });
     mockState.recalculateDayTotals.mockReturnValue({
       tokens: 15,
       cost: 0.75,
@@ -802,9 +815,9 @@ describe("POST /api/submit auth path", () => {
     expect(tx.insert).toHaveBeenCalledTimes(1);
     expect(dailyInsertValues).toBeUndefined();
     expect(tx.execute).toHaveBeenCalledTimes(2);
-    expect(mockState.mergeClientBreakdowns).toHaveBeenCalledWith(
+    expect(mockState.mergeClientBreakdownsWithRegressionGuard).toHaveBeenCalledWith(
       legacyBreakdown,
-      { codex: mergedBreakdown.codex },
+      incomingBreakdownWithProvenance,
       expect.any(Set)
     );
     expect(await response.json()).toEqual(expect.objectContaining({
@@ -881,6 +894,11 @@ describe("POST /api/submit auth path", () => {
       codex: {
         ...incomingBreakdown,
         models: { "gpt-5.5": incomingBreakdown },
+        provenance: {
+          schemaVersion: 1,
+          messageCount: 1,
+          modelCount: 1,
+        },
       },
     };
 
@@ -967,7 +985,7 @@ describe("POST /api/submit auth path", () => {
       tokens: 15,
       sourceBreakdown: insertedBreakdown,
     })]);
-    expect(mockState.mergeClientBreakdowns).not.toHaveBeenCalled();
+    expect(mockState.mergeClientBreakdownsWithRegressionGuard).not.toHaveBeenCalled();
     expect(await response.json()).toEqual(expect.objectContaining({
       success: true,
       metrics: expect.objectContaining({

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -10,9 +10,10 @@ import {
 import { authenticatePersonalToken } from "@/lib/auth/personalTokens";
 import { getBearerToken } from "../../../lib/auth/bearerToken";
 import {
-  mergeClientBreakdowns,
+  mergeClientBreakdownsWithRegressionGuard,
   recalculateDayTotals,
   clientContributionToBreakdownData,
+  deriveClientBreakdownProvenance,
   mergeTimestampMs,
   type ClientBreakdownData,
 } from "@/lib/db/helpers";
@@ -136,6 +137,7 @@ export async function POST(request: Request) {
     }
 
     const data = validation.data;
+    const warnings = [...validation.warnings];
 
     if (data.contributions.length === 0) {
       return NextResponse.json(
@@ -345,10 +347,15 @@ export async function POST(request: Request) {
             } else {
               existing.models[client_contrib.modelId] = modelData;
             }
+            existing.provenance = deriveClientBreakdownProvenance(existing);
           } else {
-            incomingClientBreakdown[client_contrib.client] = {
+            const clientBreakdown = {
               ...modelData,
               models: { [client_contrib.modelId]: modelData },
+            };
+            incomingClientBreakdown[client_contrib.client] = {
+              ...clientBreakdown,
+              provenance: deriveClientBreakdownProvenance(clientBreakdown),
             };
           }
         }
@@ -356,12 +363,19 @@ export async function POST(request: Request) {
         const existingDay = existingDaysMap.get(incomingDay.date);
 
         if (existingDay) {
-           const existingClientBreakdown = (existingDay.sourceBreakdown || {}) as Record<string, ClientBreakdownData>;
-           const mergedClientBreakdown = mergeClientBreakdowns(
-             existingClientBreakdown,
-             incomingClientBreakdown,
-             submittedClients
-           );
+          const existingClientBreakdown = (existingDay.sourceBreakdown || {}) as Record<
+            string,
+            ClientBreakdownData
+          >;
+          const mergeResult = mergeClientBreakdownsWithRegressionGuard(
+            existingClientBreakdown,
+            incomingClientBreakdown,
+            submittedClients
+          );
+          warnings.push(
+            ...mergeResult.warnings.map((warning) => `Day ${incomingDay.date}: ${warning}`)
+          );
+          const mergedClientBreakdown = mergeResult.merged;
           const dayTotals = recalculateDayTotals(mergedClientBreakdown);
 
           toUpdate.push({
@@ -546,7 +560,7 @@ export async function POST(request: Request) {
       username: tokenRecord.username,
       metrics: result.metrics,
       mode: result.isNewSubmission ? "create" : "merge",
-      warnings: validation.warnings.length > 0 ? validation.warnings : undefined,
+      warnings: warnings.length > 0 ? warnings : undefined,
     });
   } catch (error) {
     console.error("Submit error:", error);

--- a/packages/frontend/src/lib/db/helpers.ts
+++ b/packages/frontend/src/lib/db/helpers.ts
@@ -13,6 +13,12 @@ export interface ModelBreakdownData {
   messages: number;
 }
 
+export interface ClientBreakdownProvenanceData {
+  schemaVersion: number;
+  messageCount: number;
+  modelCount: number;
+}
+
 export interface ClientBreakdownData {
   tokens: number;
   cost: number;
@@ -23,8 +29,14 @@ export interface ClientBreakdownData {
   reasoning: number;
   messages: number;
   models: Record<string, ModelBreakdownData>;
+  provenance?: ClientBreakdownProvenanceData;
   /** @deprecated Legacy field for backward compat - use models instead */
   modelId?: string;
+}
+
+export interface MergeClientBreakdownsResult {
+  merged: Record<string, ClientBreakdownData>;
+  warnings: string[];
 }
 
 export interface DayTotals {
@@ -69,6 +81,50 @@ export function recalculateDayTotals(
   };
 }
 
+function formatTokens(value: number): string {
+  return Math.round(value).toLocaleString("en-US");
+}
+
+export function deriveClientBreakdownProvenance(
+  breakdown: ClientBreakdownData
+): ClientBreakdownProvenanceData {
+  const modelCount = breakdown.models
+    ? Object.keys(breakdown.models).length
+    : breakdown.modelId
+    ? 1
+    : 0;
+
+  return {
+    schemaVersion: Math.max(1, breakdown.provenance?.schemaVersion ?? 1),
+    messageCount: Math.max(
+      0,
+      breakdown.provenance?.messageCount ?? 0,
+      breakdown.messages ?? 0
+    ),
+    modelCount: Math.max(0, breakdown.provenance?.modelCount ?? 0, modelCount),
+  };
+}
+
+function withDerivedProvenance(breakdown: ClientBreakdownData): ClientBreakdownData {
+  return {
+    ...breakdown,
+    provenance: deriveClientBreakdownProvenance(breakdown),
+  };
+}
+
+function hasLowerCoverage(
+  existing: ClientBreakdownData,
+  incoming: ClientBreakdownData
+): boolean {
+  const existingProvenance = deriveClientBreakdownProvenance(existing);
+  const incomingProvenance = deriveClientBreakdownProvenance(incoming);
+
+  return (
+    incomingProvenance.messageCount < existingProvenance.messageCount ||
+    incomingProvenance.modelCount < existingProvenance.modelCount
+  );
+}
+
 export function mergeClientBreakdowns(
   existing: Record<string, ClientBreakdownData> | null | undefined,
   incoming: Record<string, ClientBreakdownData>,
@@ -85,6 +141,51 @@ export function mergeClientBreakdowns(
   }
 
   return merged;
+}
+
+export function mergeClientBreakdownsWithRegressionGuard(
+  existing: Record<string, ClientBreakdownData> | null | undefined,
+  incoming: Record<string, ClientBreakdownData>,
+  incomingClients: Set<string>
+): MergeClientBreakdownsResult {
+  const merged: Record<string, ClientBreakdownData> = { ...(existing || {}) };
+  const warnings: string[] = [];
+
+  for (const clientName of incomingClients) {
+    const existingClient = existing?.[clientName];
+    const incomingClient = incoming[clientName];
+
+    if (!incomingClient) {
+      if (existingClient && existingClient.tokens > 0) {
+        merged[clientName] = withDerivedProvenance(existingClient);
+        warnings.push(
+          `Preserved ${clientName} because it disappeared from this same-device resubmit; kept ${formatTokens(existingClient.tokens)} tokens.`
+        );
+      } else {
+        delete merged[clientName];
+      }
+      continue;
+    }
+
+    const nextClient = withDerivedProvenance(incomingClient);
+    if (
+      existingClient &&
+      nextClient.tokens < existingClient.tokens &&
+      hasLowerCoverage(existingClient, nextClient)
+    ) {
+      merged[clientName] = withDerivedProvenance(existingClient);
+      const existingTokens = formatTokens(existingClient.tokens);
+      const nextTokens = formatTokens(nextClient.tokens);
+      warnings.push(
+        `Preserved ${clientName} because this same-device resubmit would reduce ${existingTokens} tokens to ${nextTokens} with lower coverage.`
+      );
+      continue;
+    }
+
+    merged[clientName] = nextClient;
+  }
+
+  return { merged, warnings };
 }
 
 export function clientContributionToBreakdownData(

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -303,6 +303,11 @@ export const dailyBreakdown = pgTable(
             reasoning: number;
             messages: number;
           }>;
+          provenance?: {
+            schemaVersion: number;
+            messageCount: number;
+            modelCount: number;
+          };
           modelId?: string;
         }
       >

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -34,6 +34,12 @@ const TokenBreakdownSchema = z.object({
   reasoning: NonNegativeIntegerSchema,
 });
 
+const ClientContributionProvenanceSchema = z.object({
+  schemaVersion: NonNegativeIntegerSchema.min(1),
+  messageCount: NonNegativeIntegerSchema,
+  modelCount: NonNegativeIntegerSchema,
+});
+
 const SUPPORTED_SOURCES = [
   "opencode",
   "claude",
@@ -68,6 +74,7 @@ const ClientContributionSchema = z.object({
   tokens: TokenBreakdownSchema,
   cost: NonNegativeNumberSchema,
   messages: NonNegativeIntegerSchema,
+  provenance: ClientContributionProvenanceSchema.optional(),
 });
 
 const DailyContributionSchema = z.object({
@@ -528,6 +535,7 @@ export function generateSubmissionHash(data: SubmissionData): string {
             tokens: client.tokens,
             cost: client.cost,
             messages: client.messages,
+            provenance: client.provenance ?? null,
           }))
           .sort((a, b) =>
             `${a.client}\u0000${a.providerId ?? ""}\u0000${a.modelId}`.localeCompare(


### PR DESCRIPTION
## Summary
- Adds a same-device/day/client regression guard in `/api/submit` so a lower-coverage resubmit preserves the existing positive client bucket instead of reducing stored totals.
- Derives lightweight per-client provenance from aggregate messages and model keys, and accepts optional submitted client provenance for forward compatibility.
- Returns submit warnings when the guard preserves existing data, while still allowing lower token totals when coverage does not regress.

## Why
Fixes #483. A parser or CLI version change can report fewer local sessions than a previous submit. Because same-device submit merges replace that device/date/client slice, the server can otherwise overwrite previously stored usage with a lower, less complete scan. This keeps legitimate corrections possible, but blocks the specific no-regression failure mode when the new scan has weaker coverage signals.

## Diff scope
- `packages/frontend/src/lib/db/helpers.ts`: adds provenance derivation and guarded client-breakdown merge semantics.
- `packages/frontend/src/app/api/submit/route.ts`: uses the guarded merge result, recalculates totals from the preserved breakdown, and returns warning messages.
- `packages/frontend/src/lib/validation/submission.ts`: accepts optional per-client provenance and includes it in the submission hash.
- `packages/frontend/src/lib/db/schema.ts`: types the optional JSON provenance payload stored inside each client breakdown.
- `packages/frontend/__tests__/api/submit.test.ts` and `packages/frontend/__tests__/api/submitAuth.test.ts`: cover the regression guard, allowed lower-token corrections, missing-client preservation, new-client merge behavior, schema acceptance, and route wiring.

## Branch integrity
- Base branch: `main`
- Validated base SHA: `8e73312f05f603d5184d36059e4ce2604322d492`
- Head SHA: `464db28cdfc22c2e700bcc6f417c1edb744a3ca1`
- Ahead/behind: `0` behind, `1` ahead
- Merge base: `8e73312f05f603d5184d36059e4ce2604322d492`

## Commit integrity
- `464db28cdfc22c2e700bcc6f417c1edb744a3ca1 fix(submit): preserve same-device totals on parser regressions`
- One logical change: submit merge no-regression behavior plus focused tests.
- Ledger: not applicable — not required for this frontend submit runtime change.
- Version: not applicable — no released package metadata changed.

## Diff hygiene
- `git diff --name-status origin/main...HEAD`: only frontend submit route/helper/schema/validation/test files changed.
- `git diff --check origin/main...HEAD`: PASS, no output.
- No migrations, secrets, credentials, generated artifacts, build output, or unrelated files are included.

## Validation mode and proof
- Validation mode: Mode 2 — narrow runtime change limited to submit validation, submit merge helpers, route wiring, and targeted tests.
- `bun x vitest run __tests__/api/submit.test.ts __tests__/api/submitAuth.test.ts`: PASS, `47` tests.
- `bun run lint -- src/app/api/submit/route.ts src/lib/db/helpers.ts src/lib/validation/submission.ts src/lib/db/schema.ts __tests__/api/submit.test.ts __tests__/api/submitAuth.test.ts`: PASS.
- `git diff --check`: PASS.
- `git diff --cached --check`: PASS before commit.
- Not run: full frontend build — not required for the selected mode; targeted submit tests and targeted lint cover the changed runtime path.
- Not run: `bun x tsc --noEmit` — checked, but currently blocked by an existing unrelated static image module declaration issue in `packages/frontend/src/components/BlackholeHero.tsx` for `@/../public/assets/hero-bg.png`.

## Migration notes
Not applicable — no database migration changed. Provenance is stored as an optional field inside the existing `source_breakdown` JSON shape.

## CI context confirmation
Pending — required GitHub checks will run after the PR is opened.

## Runtime safety
- The guard only applies within the existing same-submission, same-device, same-date merge path.
- Other devices remain separate rows and continue to aggregate normally.
- Totals are still recalculated from the final merged `sourceBreakdown`, preserving the existing invariant between daily rows and submission totals.
- No new blocking locks, queues, external calls, or cache-invalidation behavior were introduced.

## Rollback plan
Rollback: revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks
- This does not repair missing local parser coverage by itself; it prevents a less complete same-device resubmit from lowering already stored server totals.
- Guard warnings are returned in the submit response, but there is no persistent audit table in this PR.
