### PR TITLE
fix(submit): adopt legacy rows for first device submit

### DIFF
--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -792,4 +792,165 @@ describe("POST /api/submit auth path", () => {
       mode: "merge",
     }));
   });
+
+  it("keeps legacy daily rows separate when another modern device already submitted", async () => {
+    mockState.authenticatePersonalToken.mockResolvedValue({
+      status: "valid",
+      tokenId: "token-1",
+      userId: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      expiresAt: null,
+    });
+
+    mockState.validateSubmission.mockReturnValue({
+      valid: true,
+      data: {
+        device: {
+          id: "dev_phone",
+          name: "Phone",
+        },
+        meta: {
+          version: "2.0.0",
+          dateRange: { start: "2026-04-30", end: "2026-04-30" },
+        },
+        summary: {
+          clients: ["codex"],
+        },
+        contributions: [
+          {
+            date: "2026-04-30",
+            timestampMs: 789,
+            clients: [
+              {
+                client: "codex",
+                modelId: "gpt-5.5",
+                tokens: 15,
+                cost: 0.75,
+                input: 10,
+                output: 5,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+                messages: 1,
+              },
+            ],
+          },
+        ],
+      },
+      errors: [],
+      warnings: [],
+    });
+
+    const incomingBreakdown = {
+      tokens: 15,
+      cost: 0.75,
+      input: 10,
+      output: 5,
+      cacheRead: 0,
+      cacheWrite: 0,
+      reasoning: 0,
+      messages: 1,
+    };
+    const insertedBreakdown = {
+      codex: {
+        ...incomingBreakdown,
+        models: { "gpt-5.5": incomingBreakdown },
+      },
+    };
+
+    mockState.clientContributionToBreakdownData.mockReturnValue(incomingBreakdown);
+    mockState.recalculateDayTotals.mockReturnValue({
+      tokens: 15,
+      cost: 0.75,
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+
+    const selectResults = [
+      [{ id: "submission-1" }],
+      [],
+      [],
+      [{
+        totalTokens: 42,
+        totalCost: "1.7500",
+        inputTokens: 27,
+        outputTokens: 15,
+        dateStart: "2026-04-30",
+        dateEnd: "2026-04-30",
+        activeDays: 1,
+        rowCount: 3,
+      }],
+      [{ sourceBreakdown: insertedBreakdown }],
+    ];
+
+    let insertCall = 0;
+    let dailyInsertValues: unknown;
+    const tx = {
+      update: vi.fn(() => {
+        const builder = {
+          set: vi.fn(() => builder),
+          where: vi.fn(() => Promise.resolve()),
+        };
+        return builder;
+      }),
+      select: vi.fn(() => makeAwaitableBuilder(selectResults.shift() ?? [])),
+      insert: vi.fn(() => {
+        insertCall += 1;
+        if (insertCall === 1) {
+          const builder = {
+            values: vi.fn(() => builder),
+            onConflictDoUpdate: vi.fn(() => builder),
+            returning: vi.fn(() => Promise.resolve([{ id: "submitted-device-2" }])),
+          };
+          return builder;
+        }
+
+        const builder = {
+          values: vi.fn((values: unknown) => {
+            dailyInsertValues = values;
+            return Promise.resolve();
+          }),
+        };
+        return builder;
+      }),
+      execute: vi.fn(() => Promise.resolve()),
+    };
+    type MockTransaction = typeof tx;
+
+    mockState.db.transaction.mockImplementation(async (callback: (tx: MockTransaction) => Promise<unknown>) =>
+      callback(tx)
+    );
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ meta: {}, contributions: [] }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(tx.insert).toHaveBeenCalledTimes(2);
+    expect(tx.execute).toHaveBeenCalledTimes(1);
+    expect(dailyInsertValues).toEqual([expect.objectContaining({
+      submittedDeviceId: "submitted-device-2",
+      date: "2026-04-30",
+      tokens: 15,
+      sourceBreakdown: insertedBreakdown,
+    })]);
+    expect(mockState.mergeClientBreakdowns).not.toHaveBeenCalled();
+    expect(await response.json()).toEqual(expect.objectContaining({
+      success: true,
+      metrics: expect.objectContaining({
+        totalTokens: 42,
+        activeDays: 1,
+      }),
+      mode: "merge",
+    }));
+  });
 });

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -611,4 +611,185 @@ describe("POST /api/submit auth path", () => {
       mode: "merge",
     }));
   });
+
+  it("adopts legacy daily rows into the first modern device instead of duplicating totals", async () => {
+    mockState.authenticatePersonalToken.mockResolvedValue({
+      status: "valid",
+      tokenId: "token-1",
+      userId: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      expiresAt: null,
+    });
+
+    mockState.validateSubmission.mockReturnValue({
+      valid: true,
+      data: {
+        device: {
+          id: "dev_laptop",
+          name: "Laptop",
+        },
+        meta: {
+          version: "2.0.0",
+          dateRange: { start: "2026-04-30", end: "2026-04-30" },
+        },
+        summary: {
+          clients: ["codex"],
+        },
+        contributions: [
+          {
+            date: "2026-04-30",
+            timestampMs: 456,
+            clients: [
+              {
+                client: "codex",
+                modelId: "gpt-5.5",
+                tokens: 15,
+                cost: 0.75,
+                input: 10,
+                output: 5,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+                messages: 1,
+              },
+            ],
+          },
+        ],
+      },
+      errors: [],
+      warnings: [],
+    });
+
+    const incomingBreakdown = {
+      tokens: 15,
+      cost: 0.75,
+      input: 10,
+      output: 5,
+      cacheRead: 0,
+      cacheWrite: 0,
+      reasoning: 0,
+      messages: 1,
+    };
+    const legacyBreakdown = {
+      codex: {
+        tokens: 12,
+        cost: 0.5,
+        input: 7,
+        output: 5,
+        cacheRead: 0,
+        cacheWrite: 0,
+        reasoning: 0,
+        messages: 1,
+        models: { "gpt-5.5": { tokens: 12 } },
+      },
+    };
+    const mergedBreakdown = {
+      codex: {
+        ...incomingBreakdown,
+        models: { "gpt-5.5": incomingBreakdown },
+      },
+    };
+
+    mockState.clientContributionToBreakdownData.mockReturnValue(incomingBreakdown);
+    mockState.mergeClientBreakdowns.mockReturnValue(mergedBreakdown);
+    mockState.recalculateDayTotals.mockReturnValue({
+      tokens: 15,
+      cost: 0.75,
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+    mockState.mergeTimestampMs.mockReturnValue(123);
+
+    const selectResults = [
+      [{ id: "submission-1" }],
+      [],
+      [{
+        id: "daily-legacy",
+        date: "2026-04-30",
+        timestampMs: 123,
+        activeTimeMs: null,
+        sourceBreakdown: legacyBreakdown,
+      }],
+      [{
+        totalTokens: 15,
+        totalCost: "0.7500",
+        inputTokens: 10,
+        outputTokens: 5,
+        dateStart: "2026-04-30",
+        dateEnd: "2026-04-30",
+        activeDays: 1,
+        rowCount: 1,
+      }],
+      [{ sourceBreakdown: mergedBreakdown }],
+    ];
+
+    let insertCall = 0;
+    let dailyInsertValues: unknown;
+    const tx = {
+      update: vi.fn(() => {
+        const builder = {
+          set: vi.fn(() => builder),
+          where: vi.fn(() => Promise.resolve()),
+        };
+        return builder;
+      }),
+      select: vi.fn(() => makeAwaitableBuilder(selectResults.shift() ?? [])),
+      insert: vi.fn(() => {
+        insertCall += 1;
+        if (insertCall === 1) {
+          const builder = {
+            values: vi.fn(() => builder),
+            onConflictDoUpdate: vi.fn(() => builder),
+            returning: vi.fn(() => Promise.resolve([{ id: "submitted-device-1" }])),
+          };
+          return builder;
+        }
+
+        const builder = {
+          values: vi.fn((values: unknown) => {
+            dailyInsertValues = values;
+            return Promise.resolve();
+          }),
+        };
+        return builder;
+      }),
+      execute: vi.fn(() => Promise.resolve()),
+    };
+    type MockTransaction = typeof tx;
+
+    mockState.db.transaction.mockImplementation(async (callback: (tx: MockTransaction) => Promise<unknown>) =>
+      callback(tx)
+    );
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ meta: {}, contributions: [] }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(tx.insert).toHaveBeenCalledTimes(1);
+    expect(dailyInsertValues).toBeUndefined();
+    expect(tx.execute).toHaveBeenCalledTimes(2);
+    expect(mockState.mergeClientBreakdowns).toHaveBeenCalledWith(
+      legacyBreakdown,
+      { codex: mergedBreakdown.codex },
+      expect.any(Set)
+    );
+    expect(await response.json()).toEqual(expect.objectContaining({
+      success: true,
+      metrics: expect.objectContaining({
+        totalTokens: 15,
+        activeDays: 1,
+      }),
+      mode: "merge",
+    }));
+  });
 });

--- a/packages/frontend/__tests__/api/usersProfile.test.ts
+++ b/packages/frontend/__tests__/api/usersProfile.test.ts
@@ -288,6 +288,150 @@ describe("GET /api/users/[username]", () => {
     expect(mockState.limitCalls[0]).toBe(2);
   });
 
+  it("aggregates same-date rows from multiple submitted devices into one profile contribution", async () => {
+    mockState.pushSelectResult([
+      {
+        id: "user-1",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        totalTokens: 27,
+        totalCost: 1.25,
+        inputTokens: 17,
+        outputTokens: 10,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        reasoningTokens: 0,
+        submissionCount: 2,
+        earliestDate: "2026-04-30",
+        latestDate: "2026-04-30",
+        totalActiveTimeMs: 0,
+        sessionCount: 0,
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        sourcesUsed: ["codex"],
+        modelsUsed: ["gpt-5.5"],
+        updatedAt: new Date("2026-04-30T12:00:00.000Z"),
+        cliVersion: "2.0.0",
+        schemaVersion: 2,
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        date: "2026-04-30",
+        timestampMs: 100,
+        tokens: 12,
+        cost: "0.5000",
+        inputTokens: 7,
+        outputTokens: 5,
+        sourceBreakdown: {
+          codex: {
+            tokens: 12,
+            cost: 0.5,
+            input: 7,
+            output: 5,
+            cacheRead: 0,
+            cacheWrite: 0,
+            reasoning: 0,
+            messages: 1,
+            models: {
+              "gpt-5.5": {
+                tokens: 12,
+                cost: 0.5,
+                input: 7,
+                output: 5,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+                messages: 1,
+              },
+            },
+          },
+        },
+      },
+      {
+        date: "2026-04-30",
+        timestampMs: 200,
+        tokens: 15,
+        cost: "0.7500",
+        inputTokens: 10,
+        outputTokens: 5,
+        sourceBreakdown: {
+          codex: {
+            tokens: 15,
+            cost: 0.75,
+            input: 10,
+            output: 5,
+            cacheRead: 0,
+            cacheWrite: 0,
+            reasoning: 0,
+            messages: 1,
+            models: {
+              "gpt-5.5": {
+                tokens: 15,
+                cost: 0.75,
+                input: 10,
+                output: 5,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+                messages: 1,
+              },
+            },
+          },
+        },
+      },
+    ]);
+    mockState.pushExecuteResult([{ rank: 4 }]);
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/users/alice"),
+      { params: Promise.resolve({ username: "alice" }) }
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.stats.totalTokens).toBe(27);
+    expect(body.stats.activeDays).toBe(1);
+    expect(body.contributions).toHaveLength(1);
+    expect(body.contributions[0]).toEqual(expect.objectContaining({
+      date: "2026-04-30",
+      timestampMs: 100,
+      totals: expect.objectContaining({
+        tokens: 27,
+        cost: 1.25,
+      }),
+      tokenBreakdown: expect.objectContaining({
+        input: 17,
+        output: 10,
+      }),
+    }));
+    expect(body.contributions[0].clients[0]).toEqual(expect.objectContaining({
+      client: "codex",
+      cost: 1.25,
+      messages: 2,
+      tokens: expect.objectContaining({
+        input: 17,
+        output: 10,
+      }),
+    }));
+    expect(body.modelUsage).toEqual([
+      expect.objectContaining({
+        model: "gpt-5.5",
+        tokens: 27,
+        cost: 1.25,
+        percentage: 100,
+      }),
+    ]);
+  });
+
   it("returns submission freshness metadata for the latest submission", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-11T12:00:00.000Z"));

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -233,22 +233,59 @@ export async function POST(request: Request) {
       // ------------------------------------------
       // STEP 3b: Fetch existing daily breakdown for merge
       // ------------------------------------------
-      const existingDays = await tx
-        .select({
-          id: dailyBreakdown.id,
-          date: dailyBreakdown.date,
-          timestampMs: dailyBreakdown.timestampMs,
-          activeTimeMs: dailyBreakdown.activeTimeMs,
-          sourceBreakdown: dailyBreakdown.sourceBreakdown,
-        })
-        .from(dailyBreakdown)
-        .where(
-          and(
-            eq(dailyBreakdown.submissionId, submissionId),
-            eq(dailyBreakdown.submittedDeviceId, submittedDevice.id)
+      const fetchExistingDeviceDays = () =>
+        tx
+          .select({
+            id: dailyBreakdown.id,
+            date: dailyBreakdown.date,
+            timestampMs: dailyBreakdown.timestampMs,
+            activeTimeMs: dailyBreakdown.activeTimeMs,
+            sourceBreakdown: dailyBreakdown.sourceBreakdown,
+          })
+          .from(dailyBreakdown)
+          .where(
+            and(
+              eq(dailyBreakdown.submissionId, submissionId),
+              eq(dailyBreakdown.submittedDeviceId, submittedDevice.id)
+            )
           )
-        )
-        .for('update');
+          .for('update');
+
+      let existingDays = await fetchExistingDeviceDays();
+
+      if (
+        existingDays.length === 0 &&
+        !isNewSubmission &&
+        submitDevice.key !== LEGACY_SUBMIT_DEVICE_KEY
+      ) {
+        // The first device-aware submit after the migration should continue
+        // the user's legacy bucket instead of counting the same history twice.
+        // Once any modern device rows exist, attribution is ambiguous, so the
+        // legacy bucket stays separate.
+        await tx.execute(sql`
+          UPDATE daily_breakdown AS db
+          SET submitted_device_id = ${submittedDevice.id}
+          WHERE db.submission_id = ${submissionId}
+            AND db.submitted_device_id IN (
+              SELECT sd.id
+              FROM submitted_devices AS sd
+              WHERE sd.user_id = ${tokenRecord.userId}
+                AND sd.device_key = ${LEGACY_SUBMIT_DEVICE_KEY}
+            )
+            AND NOT EXISTS (
+              SELECT 1
+              FROM daily_breakdown AS modern
+              WHERE modern.submission_id = db.submission_id
+                AND modern.submitted_device_id NOT IN (
+                  SELECT sd2.id
+                  FROM submitted_devices AS sd2
+                  WHERE sd2.user_id = ${tokenRecord.userId}
+                    AND sd2.device_key = ${LEGACY_SUBMIT_DEVICE_KEY}
+                )
+            )
+        `);
+        existingDays = await fetchExistingDeviceDays();
+      }
 
       const existingDaysMap = new Map(
         existingDays.map((d) => [d.date, d])


### PR DESCRIPTION
## Summary
- Fixes #248 by completing the remaining legacy-to-device cutover for multi-machine submissions.
- Keeps the merged device-aware submit model from #517: modern devices still get separate daily buckets, and totals are still recalculated from all stored daily rows.
- Adds regression coverage for the legacy cutover write path and for profile aggregation when multiple submitted devices have same-date rows.

## Why
#517 fixed the normal modern case where multiple computers submit with stable device IDs, but migrated historical rows still live in the `legacy-default` device bucket. On current `main`, the first modern device-aware submit only looks for rows attached to the new device ID, so it can insert a new same-date row while the legacy row remains counted. That can double-count the same historical usage during the upgrade path and leave #248 reproducible for users with pre-device data.

## Diff scope
- `packages/frontend/src/app/api/submit/route.ts`: before writing incoming daily rows, the submit transaction now adopts a user's legacy daily rows into the first real device bucket when no modern device rows exist yet for that submission.
- `packages/frontend/__tests__/api/submitAuth.test.ts`: adds a regression test that fails on current `main` because the route inserts a duplicate daily row instead of adopting the legacy row.
- `packages/frontend/__tests__/api/usersProfile.test.ts`: adds read-path coverage proving same-date rows from multiple submitted devices render as one profile contribution with summed totals.

## Branch integrity
- Base branch: `main`
- Validated base SHA: `64e278cdc4f55544576f3b42010644cd8ba6aa9d`
- Head SHA: `49a01dd44d89dc88ce55cd209f33569e53b1f10a`
- Ahead/behind: `0 behind / 1 ahead`
- Merge base: `64e278cdc4f55544576f3b42010644cd8ba6aa9d`

## Commit integrity
- Introduced commit: `49a01dd44d89dc88ce55cd209f33569e53b1f10a fix(submit): adopt legacy rows for first device submit`
- The PR contains one logical data-integrity fix plus targeted regression tests.

## Diff hygiene
- `git diff --name-status origin/main...HEAD`: PASS, only the submit route and two targeted frontend test files changed.
- `git diff --check origin/main...HEAD`: PASS, no output.
- `git diff --cached --check`: PASS, no output before commit.

## Validation mode and proof
- Validation mode: Mode 3 - submit data-integrity change. The diff changes how legacy `daily_breakdown` rows are attributed during the device-aware submit transition, so targeted submit/profile/leaderboard coverage is required.
- `bun x vitest run __tests__/api/submitAuth.test.ts`: PASS, 7 tests.
- `bun x vitest run __tests__/api/submitAuth.test.ts __tests__/api/usersProfile.test.ts`: PASS, 13 tests.
- `bun x vitest run __tests__/api/submitAuth.test.ts __tests__/api/usersProfile.test.ts __tests__/lib/getLeaderboard.test.ts __tests__/lib/getGroupLeaderboard.test.ts`: PASS, 22 tests.
- `bun x vitest run __tests__/lib/getLeaderboardAllTime.test.ts`: PASS, 4 tests.
- `bun run lint -- src/app/api/submit/route.ts __tests__/api/submitAuth.test.ts __tests__/api/usersProfile.test.ts`: PASS.
- `bash scripts/check-version-coherence.sh`: PASS, `Version coherence OK: 2.1.3`.
- Full frontend suite and Rust suite: not run locally because they are not required for this selected validation mode; the local proof targets the changed submit write path, profile read path, and public leaderboard aggregation.

## Ledger and version proof
- Ledger: not applicable - not required for selected validation mode/change family.
- Version: PASS via `bash scripts/check-version-coherence.sh`.

## Migration notes
- Not applicable - no DB migration changed.
- The fix uses the existing `submitted_devices` table and existing `daily_breakdown.submitted_device_id` uniqueness model.

## Runtime safety
- The adoption runs inside the existing `/api/submit` transaction after the user submission row is selected with `FOR UPDATE`.
- Legacy rows are adopted only when the target modern device has no rows yet and the submission has no existing modern device rows, avoiding arbitrary reassignment for mixed/ambiguous accounts.
- No new background jobs, blocking locks outside the existing transaction, unbounded queues, or schema invariants are introduced.
- No invariant regression introduced.

## CI context confirmation
- Pending - remote CI has not run because this PR has not been opened yet.
- CI context names unchanged.

## Rollback plan
- Rollback: revert this PR.
- DB downgrade: not applicable.
- Data repair: not applicable.
- Operational caveats: none known.

## Known residual risks
- Existing accounts that already have both legacy rows and modern device rows are intentionally not auto-reassigned because the original device attribution is ambiguous.
- Remote CI remains pending until the PR is opened.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #248 by adopting legacy `daily_breakdown` rows into the first modern submitted device on the first device-aware submit, preventing duplicate same-date rows and double-counted totals. Keeps #517 behavior: modern devices still have separate daily buckets and totals are recalculated from all rows.

- Bug Fixes
  - In `packages/frontend/src/app/api/submit/route.ts`, inside the `/api/submit` transaction, when no modern-device rows exist for the submission and the incoming device is modern, reassign that submission’s legacy rows to the device; otherwise keep legacy rows separate.
  - Adds regression tests in `packages/frontend/__tests__/api/submitAuth.test.ts` and `packages/frontend/__tests__/api/usersProfile.test.ts` covering adoption (no duplicate insert), preserving legacy rows when another modern device already submitted, and profile aggregation into a single per-date contribution with summed totals.

<sup>Written for commit 1c8a21738e748d21712d67c44eac59c2b257e0c5. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/609?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

