### PR TITLE
fix(submit): bypass cost-without-tokens check for Cursor legacy `premium-tool-call` 

### DIFF
--- a/packages/frontend/__tests__/api/submit.test.ts
+++ b/packages/frontend/__tests__/api/submit.test.ts
@@ -658,6 +658,87 @@ describe('POST /api/submit - Client-Level Merge', () => {
       expect(errorBlob).toContain("cost=$0.0400");
     });
 
+    it("tolerates floating-point residue when subtracting cursor legacy cost", () => {
+      // Regression for PR #612 review (cubic P2): strict `> 0` float
+      // comparison can falsely reject an all-legacy submission when IEEE
+      // 754 summation leaves a tiny positive remainder.
+      //
+      // Concretely: `0.1 + 0.2 === 0.30000000000000004` while the literal
+      // `0.3` is IEEE `0.299999999999999988…`, so `(0.1+0.2) - 0.3 ≈ 5.5e-17`
+      // — a non-zero positive number even though the user truly has $0.30 of
+      // legacy cost and nothing else. Without an epsilon, the
+      // cost-without-tokens check fires on noise.
+      const totalCostWithFpResidue = 0.1 + 0.2; // 0.30000000000000004
+      const legacyClientCost = 0.3; // 0.299999999999999988…
+      expect(totalCostWithFpResidue - legacyClientCost).toBeGreaterThan(0);
+      expect(totalCostWithFpResidue - legacyClientCost).toBeLessThan(1e-10);
+
+      const payload = {
+        meta: {
+          generatedAt: "2026-05-27T00:00:00.000Z",
+          version: "2.1.3",
+          dateRange: { start: "2025-04-29", end: "2025-04-29" },
+        },
+        summary: {
+          totalTokens: 0,
+          totalCost: totalCostWithFpResidue,
+          totalDays: 1,
+          activeDays: 0,
+          averagePerDay: totalCostWithFpResidue,
+          maxCostInSingleDay: totalCostWithFpResidue,
+          clients: ["cursor" as const],
+          models: ["premium-tool-call"],
+        },
+        years: [
+          {
+            year: "2025",
+            totalTokens: 0,
+            totalCost: totalCostWithFpResidue,
+            range: { start: "2025-04-29", end: "2025-04-29" },
+          },
+        ],
+        contributions: [
+          {
+            date: "2025-04-29",
+            totals: {
+              tokens: 0,
+              cost: totalCostWithFpResidue,
+              messages: 6,
+            },
+            intensity: 0 as const,
+            tokenBreakdown: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              reasoning: 0,
+            },
+            clients: [
+              {
+                client: "cursor" as const,
+                modelId: "premium-tool-call",
+                providerId: "cursor",
+                tokens: {
+                  input: 0,
+                  output: 0,
+                  cacheRead: 0,
+                  cacheWrite: 0,
+                  reasoning: 0,
+                },
+                cost: legacyClientCost,
+                messages: 6,
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = validateSubmission(payload);
+
+      expect(result.errors).toEqual([]);
+      expect(result.valid).toBe(true);
+    });
+
     it("excludes cursor legacy cost from the cost-per-million sanity cap", () => {
       // Regression for PR #612 review (codex P1): when a legacy
       // `premium-tool-call` row shares a day with a small amount of

--- a/packages/frontend/__tests__/api/submit.test.ts
+++ b/packages/frontend/__tests__/api/submit.test.ts
@@ -658,6 +658,96 @@ describe('POST /api/submit - Client-Level Merge', () => {
       expect(errorBlob).toContain("cost=$0.0400");
     });
 
+    it("excludes cursor legacy cost from the cost-per-million sanity cap", () => {
+      // Regression for PR #612 review (codex P1): when a legacy
+      // `premium-tool-call` row shares a day with a small amount of
+      // token-bearing usage, the day-level branch falls through to the
+      // cost-per-million check because `day.totals.tokens > 0`. If the full
+      // day cost (including the legacy charge) is used as the numerator,
+      // tiny token counts trip the $10k/M ceiling even though the legacy
+      // row is meant to be skipped. The legacy cost must be subtracted
+      // before computing cost-per-million as well.
+      const payload = {
+        meta: {
+          generatedAt: "2026-05-27T00:00:00.000Z",
+          version: "2.1.3",
+          dateRange: { start: "2025-04-29", end: "2025-04-29" },
+        },
+        summary: {
+          totalTokens: 100,
+          totalCost: 2.06,
+          totalDays: 1,
+          activeDays: 1,
+          averagePerDay: 2.06,
+          maxCostInSingleDay: 2.06,
+          clients: ["cursor" as const],
+          models: ["premium-tool-call", "claude-3.5-sonnet"],
+        },
+        years: [
+          {
+            year: "2025",
+            totalTokens: 100,
+            totalCost: 2.06,
+            range: { start: "2025-04-29", end: "2025-04-29" },
+          },
+        ],
+        contributions: [
+          {
+            date: "2025-04-29",
+            totals: { tokens: 100, cost: 2.06, messages: 45 },
+            intensity: 1 as const,
+            tokenBreakdown: {
+              input: 100,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              reasoning: 0,
+            },
+            clients: [
+              {
+                client: "cursor" as const,
+                modelId: "premium-tool-call",
+                providerId: "cursor",
+                tokens: {
+                  input: 0,
+                  output: 0,
+                  cacheRead: 0,
+                  cacheWrite: 0,
+                  reasoning: 0,
+                },
+                cost: 2.05,
+                messages: 44,
+              },
+              {
+                client: "cursor" as const,
+                modelId: "claude-3.5-sonnet",
+                providerId: "anthropic",
+                tokens: {
+                  input: 100,
+                  output: 0,
+                  cacheRead: 0,
+                  cacheWrite: 0,
+                  reasoning: 0,
+                },
+                cost: 0.01,
+                messages: 1,
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = validateSubmission(payload);
+
+      // Without the legacy-cost subtraction the day-level cost-per-million
+      // would be ($2.06 / 100 tokens) * 1e6 = $20,600/M, well above the
+      // $10,000/M ceiling. After subtracting the legacy $2.05, the
+      // checkable cost is $0.01, which is below the $1 floor in
+      // pushCostPerMillionError and the check is skipped entirely.
+      expect(result.errors).toEqual([]);
+      expect(result.valid).toBe(true);
+    });
+
     it("allows cursor legacy rows mixed with normal token-bearing rows", () => {
       // Same day, two clients: a legacy premium-tool-call entry (cost only)
       // and a regular cursor call that has both tokens and cost. The day

--- a/packages/frontend/__tests__/api/submit.test.ts
+++ b/packages/frontend/__tests__/api/submit.test.ts
@@ -485,6 +485,261 @@ describe('POST /api/submit - Client-Level Merge', () => {
       expect(result.errors.join("\n")).toContain("Cost submitted without tokens");
     });
 
+    it("includes client/provider/model/cost/tokens detail in tokenless-cost errors", () => {
+      const payload = createValidationPayload({
+        totalTokens: 0,
+        totalCost: 25,
+        tokenBreakdown: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          reasoning: 0,
+        },
+      });
+
+      const result = validateSubmission(payload);
+      const errorBlob = result.errors.join("\n");
+
+      expect(result.valid).toBe(false);
+      // Client-level error must name client, provider, modelId, full cost,
+      // and the full token breakdown so an operator can read the failed row
+      // straight from the error output without re-running the CLI in debug mode.
+      expect(errorBlob).toContain("Client claude/claude-sonnet-4-20250514");
+      expect(errorBlob).toContain("(provider=anthropic)");
+      expect(errorBlob).toContain("Cost submitted without tokens");
+      expect(errorBlob).toContain("cost=$25.0000");
+      expect(errorBlob).toContain("tokens={input=0");
+      expect(errorBlob).toContain("output=0");
+      expect(errorBlob).toContain("reasoning=0");
+
+      // Day-level error must include the date, day total cost, and which
+      // clients on that day were responsible (so multi-client days are still
+      // actionable).
+      expect(errorBlob).toContain("Day 2024-12-01: Cost submitted without tokens");
+      expect(errorBlob).toContain("offending clients:");
+    });
+
+    it("allows cursor legacy premium-tool-call rows that lack token attribution", () => {
+      // Cursor's pre-2025-05 usage exports include `premium-tool-call` rows
+      // that are billed per tool invocation and carry no token counts. They
+      // legitimately have cost > 0 and tokens = 0 and must bypass the
+      // cost-without-tokens sanity check; otherwise any user with historical
+      // Cursor data is permanently locked out of `tokscale submit`.
+      const payload = {
+        meta: {
+          generatedAt: "2026-05-27T00:00:00.000Z",
+          version: "2.1.3",
+          dateRange: { start: "2025-04-29", end: "2025-04-29" },
+        },
+        summary: {
+          totalTokens: 0,
+          totalCost: 2.05,
+          totalDays: 1,
+          activeDays: 0,
+          averagePerDay: 2.05,
+          maxCostInSingleDay: 2.05,
+          clients: ["cursor" as const],
+          models: ["premium-tool-call"],
+        },
+        years: [
+          {
+            year: "2025",
+            totalTokens: 0,
+            totalCost: 2.05,
+            range: { start: "2025-04-29", end: "2025-04-29" },
+          },
+        ],
+        contributions: [
+          {
+            date: "2025-04-29",
+            totals: { tokens: 0, cost: 2.05, messages: 44 },
+            intensity: 0 as const,
+            tokenBreakdown: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              reasoning: 0,
+            },
+            clients: [
+              {
+                client: "cursor" as const,
+                modelId: "premium-tool-call",
+                providerId: "cursor",
+                tokens: {
+                  input: 0,
+                  output: 0,
+                  cacheRead: 0,
+                  cacheWrite: 0,
+                  reasoning: 0,
+                },
+                cost: 2.05,
+                messages: 44,
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = validateSubmission(payload);
+
+      expect(result.errors).toEqual([]);
+      expect(result.valid).toBe(true);
+    });
+
+    it("does not extend the cursor legacy bypass to other cursor models", () => {
+      // Only `premium-tool-call` is grandfathered. Any other cursor model with
+      // cost > 0 and tokens = 0 should still be flagged so legitimate parser
+      // regressions remain visible.
+      const payload = {
+        meta: {
+          generatedAt: "2026-05-27T00:00:00.000Z",
+          version: "2.1.3",
+          dateRange: { start: "2025-05-18", end: "2025-05-18" },
+        },
+        summary: {
+          totalTokens: 0,
+          totalCost: 0.04,
+          totalDays: 1,
+          activeDays: 0,
+          averagePerDay: 0.04,
+          maxCostInSingleDay: 0.04,
+          clients: ["cursor" as const],
+          models: ["claude-3.5-sonnet"],
+        },
+        years: [
+          {
+            year: "2025",
+            totalTokens: 0,
+            totalCost: 0.04,
+            range: { start: "2025-05-18", end: "2025-05-18" },
+          },
+        ],
+        contributions: [
+          {
+            date: "2025-05-18",
+            totals: { tokens: 0, cost: 0.04, messages: 1 },
+            intensity: 0 as const,
+            tokenBreakdown: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              reasoning: 0,
+            },
+            clients: [
+              {
+                client: "cursor" as const,
+                modelId: "claude-3.5-sonnet",
+                providerId: "anthropic",
+                tokens: {
+                  input: 0,
+                  output: 0,
+                  cacheRead: 0,
+                  cacheWrite: 0,
+                  reasoning: 0,
+                },
+                cost: 0.04,
+                messages: 1,
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = validateSubmission(payload);
+      const errorBlob = result.errors.join("\n");
+
+      expect(result.valid).toBe(false);
+      expect(errorBlob).toContain("Client cursor/claude-3.5-sonnet");
+      expect(errorBlob).toContain("(provider=anthropic)");
+      expect(errorBlob).toContain("Cost submitted without tokens");
+      expect(errorBlob).toContain("cost=$0.0400");
+    });
+
+    it("allows cursor legacy rows mixed with normal token-bearing rows", () => {
+      // Same day, two clients: a legacy premium-tool-call entry (cost only)
+      // and a regular cursor call that has both tokens and cost. The day
+      // total has nonzero tokens, so the day-level check does not fire; the
+      // per-client legacy carve-out keeps the premium-tool-call row from
+      // tripping the client-level check.
+      const payload = {
+        meta: {
+          generatedAt: "2026-05-27T00:00:00.000Z",
+          version: "2.1.3",
+          dateRange: { start: "2025-04-29", end: "2025-04-29" },
+        },
+        summary: {
+          totalTokens: 1500,
+          totalCost: 3.55,
+          totalDays: 1,
+          activeDays: 1,
+          averagePerDay: 3.55,
+          maxCostInSingleDay: 3.55,
+          clients: ["cursor" as const],
+          models: ["premium-tool-call", "claude-3.5-sonnet"],
+        },
+        years: [
+          {
+            year: "2025",
+            totalTokens: 1500,
+            totalCost: 3.55,
+            range: { start: "2025-04-29", end: "2025-04-29" },
+          },
+        ],
+        contributions: [
+          {
+            date: "2025-04-29",
+            totals: { tokens: 1500, cost: 3.55, messages: 50 },
+            intensity: 2 as const,
+            tokenBreakdown: {
+              input: 1000,
+              output: 500,
+              cacheRead: 0,
+              cacheWrite: 0,
+              reasoning: 0,
+            },
+            clients: [
+              {
+                client: "cursor" as const,
+                modelId: "premium-tool-call",
+                providerId: "cursor",
+                tokens: {
+                  input: 0,
+                  output: 0,
+                  cacheRead: 0,
+                  cacheWrite: 0,
+                  reasoning: 0,
+                },
+                cost: 2.05,
+                messages: 44,
+              },
+              {
+                client: "cursor" as const,
+                modelId: "claude-3.5-sonnet",
+                providerId: "anthropic",
+                tokens: {
+                  input: 1000,
+                  output: 500,
+                  cacheRead: 0,
+                  cacheWrite: 0,
+                  reasoning: 0,
+                },
+                cost: 1.5,
+                messages: 6,
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = validateSubmission(payload);
+
+      expect(result.errors).toEqual([]);
+      expect(result.valid).toBe(true);
+    });
+
     it("rejects day cost totals that do not match client costs", () => {
       const payload = createValidationPayload({
         totalTokens: 1000,

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -233,17 +233,61 @@ function exceedsTolerance(
   return Math.abs(actual - expected) > Math.max(Math.abs(expected) * relativeTolerance, absoluteTolerance);
 }
 
-function pushCostSanityErrors(
+// Cursor legacy carve-out: Cursor's pre-2025-05 usage exports include rows
+// whose model id is `premium-tool-call`. These rows are billed per tool
+// invocation and carry no token attribution at all (input/output/cache
+// columns are empty in the CSV). They legitimately have cost > 0 with every
+// token field equal to 0, so the "Cost submitted without tokens" sanity
+// check must skip them — otherwise any user with historical Cursor data
+// (even a few cents' worth) is permanently locked out of submitting.
+const CURSOR_LEGACY_TOKENLESS_MODELS: ReadonlySet<string> = new Set([
+  "premium-tool-call",
+]);
+
+type ClientLike = {
+  client: string;
+  modelId: string;
+  providerId?: string;
+  tokens: TokenBreakdown;
+  cost: number;
+};
+
+function isLegacyTokenlessCursorClient(client: ClientLike): boolean {
+  return (
+    client.client === "cursor" &&
+    CURSOR_LEGACY_TOKENLESS_MODELS.has(client.modelId) &&
+    tokenTotal(client.tokens) === 0
+  );
+}
+
+function formatTokenBreakdown(tokens: TokenBreakdown): string {
+  return (
+    `input=${tokens.input}, output=${tokens.output}, ` +
+    `cacheRead=${tokens.cacheRead}, cacheWrite=${tokens.cacheWrite}, ` +
+    `reasoning=${tokens.reasoning}`
+  );
+}
+
+function formatCost(cost: number): string {
+  return `$${cost.toFixed(4)}`;
+}
+
+function describeTokenlessOffenders(clients: ClientLike[]): string {
+  return clients
+    .filter((c) => c.cost > 0 && tokenTotal(c.tokens) === 0)
+    .map((c) => {
+      const provider = c.providerId ? ` (provider=${c.providerId})` : "";
+      return `${c.client}/${c.modelId}${provider} cost=${formatCost(c.cost)}`;
+    })
+    .join("; ");
+}
+
+function pushCostPerMillionError(
   errors: string[],
   label: string,
   cost: number,
   tokens: number
 ): void {
-  if (cost > 0 && tokens === 0) {
-    errors.push(`${label}: Cost submitted without tokens`);
-    return;
-  }
-
   if (cost <= 1 || tokens === 0) {
     return;
   }
@@ -351,12 +395,30 @@ export function validateSubmission(data: unknown): ValidationResult {
     );
   }
 
-  pushCostSanityErrors(
-    errors,
-    "Submission summary",
-    submission.summary.totalCost,
-    submission.summary.totalTokens
-  );
+  if (submission.summary.totalCost > 0 && submission.summary.totalTokens === 0) {
+    const allClients: ClientLike[] = submission.contributions.flatMap(
+      (d) => d.clients
+    );
+    const legacyCost = allClients
+      .filter(isLegacyTokenlessCursorClient)
+      .reduce((sum, c) => sum + c.cost, 0);
+    if (submission.summary.totalCost - legacyCost > 0) {
+      const offenders = describeTokenlessOffenders(
+        allClients.filter((c) => !isLegacyTokenlessCursorClient(c))
+      );
+      const detail =
+        `cost=${formatCost(submission.summary.totalCost)}, total tokens=0` +
+        (offenders ? `; offending clients: ${offenders}` : "");
+      errors.push(`Submission summary: Cost submitted without tokens (${detail})`);
+    }
+  } else {
+    pushCostPerMillionError(
+      errors,
+      "Submission summary",
+      submission.summary.totalCost,
+      submission.summary.totalTokens
+    );
+  }
 
   // 3b. Active days should match
   const activeDays = submission.contributions.filter((d) => d.totals.tokens > 0).length;
@@ -380,7 +442,27 @@ export function validateSubmission(data: unknown): ValidationResult {
       );
     }
 
-    pushCostSanityErrors(errors, `Day ${day.date}`, day.totals.cost, day.totals.tokens);
+    if (day.totals.cost > 0 && day.totals.tokens === 0) {
+      const legacyCost = day.clients
+        .filter(isLegacyTokenlessCursorClient)
+        .reduce((sum, c) => sum + c.cost, 0);
+      if (day.totals.cost - legacyCost > 0) {
+        const offenders = describeTokenlessOffenders(
+          day.clients.filter((c) => !isLegacyTokenlessCursorClient(c))
+        );
+        const detail =
+          `cost=${formatCost(day.totals.cost)}, total tokens=0` +
+          (offenders ? `; offending clients: ${offenders}` : "");
+        errors.push(`Day ${day.date}: Cost submitted without tokens (${detail})`);
+      }
+    } else {
+      pushCostPerMillionError(
+        errors,
+        `Day ${day.date}`,
+        day.totals.cost,
+        day.totals.tokens
+      );
+    }
 
     const dayBreakdownTokens = tokenTotal(day.tokenBreakdown);
     if (exceedsTolerance(dayBreakdownTokens, day.totals.tokens, TOKEN_RELATIVE_TOLERANCE, TOKEN_ABSOLUTE_TOLERANCE)) {
@@ -425,12 +507,25 @@ export function validateSubmission(data: unknown): ValidationResult {
         );
       }
 
-      pushCostSanityErrors(
-        errors,
-        `Client ${client.client}/${client.modelId} on ${day.date}`,
-        client.cost,
-        clientTokens
-      );
+      if (client.cost > 0 && clientTokens === 0) {
+        if (!isLegacyTokenlessCursorClient(client)) {
+          const provider = client.providerId
+            ? ` (provider=${client.providerId})`
+            : "";
+          errors.push(
+            `Client ${client.client}/${client.modelId}${provider} on ${day.date}: ` +
+              `Cost submitted without tokens ` +
+              `(cost=${formatCost(client.cost)}, tokens={${formatTokenBreakdown(client.tokens)}})`
+          );
+        }
+      } else {
+        pushCostPerMillionError(
+          errors,
+          `Client ${client.client}/${client.modelId} on ${day.date}`,
+          client.cost,
+          clientTokens
+        );
+      }
     }
   }
 

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -20,6 +20,13 @@ const MAX_DAILY_COST = 10_000;
 const MAX_COST_PER_MILLION_TOKENS = 10_000;
 const COST_RELATIVE_TOLERANCE = 0.01;
 const COST_ABSOLUTE_TOLERANCE = 0.1;
+// Sub-cent epsilon for "is there real cost left after subtracting the
+// Cursor-legacy carve-out?" comparisons. Strict `> 0` would falsely reject
+// an all-legacy submission when floating-point summation leaves a tiny
+// residue (e.g. 0.1 + 0.2 === 0.30000000000000004, IEEE 0.3 ≈
+// 0.299999999999999988, diff ≈ 5.5e-17). 1e-6 is well below any real LLM
+// charge, so legitimate non-legacy cost will still trip the check.
+const LEGACY_COST_FLOAT_EPSILON = 1e-6;
 const TOKEN_RELATIVE_TOLERANCE = 0.01;
 const TOKEN_ABSOLUTE_TOLERANCE = 100;
 
@@ -408,7 +415,7 @@ export function validateSubmission(data: unknown): ValidationResult {
     const checkableCost = Math.max(0, submission.summary.totalCost - legacyCost);
 
     if (submission.summary.totalCost > 0 && submission.summary.totalTokens === 0) {
-      if (checkableCost > 0) {
+      if (checkableCost > LEGACY_COST_FLOAT_EPSILON) {
         const offenders = describeTokenlessOffenders(
           allClients.filter((c) => !isLegacyTokenlessCursorClient(c))
         );
@@ -459,7 +466,7 @@ export function validateSubmission(data: unknown): ValidationResult {
       const checkableCost = Math.max(0, day.totals.cost - legacyCost);
 
       if (day.totals.cost > 0 && day.totals.tokens === 0) {
-        if (checkableCost > 0) {
+        if (checkableCost > LEGACY_COST_FLOAT_EPSILON) {
           const offenders = describeTokenlessOffenders(
             day.clients.filter((c) => !isLegacyTokenlessCursorClient(c))
           );

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -395,29 +395,36 @@ export function validateSubmission(data: unknown): ValidationResult {
     );
   }
 
-  if (submission.summary.totalCost > 0 && submission.summary.totalTokens === 0) {
+  {
     const allClients: ClientLike[] = submission.contributions.flatMap(
       (d) => d.clients
     );
+    // Cursor legacy: subtract premium-tool-call cost before both sanity caps
+    // so a legacy charge cannot inflate the cost-per-million ratio either,
+    // not just the tokenless-cost error.
     const legacyCost = allClients
       .filter(isLegacyTokenlessCursorClient)
       .reduce((sum, c) => sum + c.cost, 0);
-    if (submission.summary.totalCost - legacyCost > 0) {
-      const offenders = describeTokenlessOffenders(
-        allClients.filter((c) => !isLegacyTokenlessCursorClient(c))
+    const checkableCost = Math.max(0, submission.summary.totalCost - legacyCost);
+
+    if (submission.summary.totalCost > 0 && submission.summary.totalTokens === 0) {
+      if (checkableCost > 0) {
+        const offenders = describeTokenlessOffenders(
+          allClients.filter((c) => !isLegacyTokenlessCursorClient(c))
+        );
+        const detail =
+          `cost=${formatCost(submission.summary.totalCost)}, total tokens=0` +
+          (offenders ? `; offending clients: ${offenders}` : "");
+        errors.push(`Submission summary: Cost submitted without tokens (${detail})`);
+      }
+    } else {
+      pushCostPerMillionError(
+        errors,
+        "Submission summary",
+        checkableCost,
+        submission.summary.totalTokens
       );
-      const detail =
-        `cost=${formatCost(submission.summary.totalCost)}, total tokens=0` +
-        (offenders ? `; offending clients: ${offenders}` : "");
-      errors.push(`Submission summary: Cost submitted without tokens (${detail})`);
     }
-  } else {
-    pushCostPerMillionError(
-      errors,
-      "Submission summary",
-      submission.summary.totalCost,
-      submission.summary.totalTokens
-    );
   }
 
   // 3b. Active days should match
@@ -442,26 +449,33 @@ export function validateSubmission(data: unknown): ValidationResult {
       );
     }
 
-    if (day.totals.cost > 0 && day.totals.tokens === 0) {
+    {
+      // Cursor legacy: subtract premium-tool-call cost before both sanity
+      // caps so legacy charges that share a day with normal token-bearing
+      // usage cannot inflate the cost-per-million ratio either.
       const legacyCost = day.clients
         .filter(isLegacyTokenlessCursorClient)
         .reduce((sum, c) => sum + c.cost, 0);
-      if (day.totals.cost - legacyCost > 0) {
-        const offenders = describeTokenlessOffenders(
-          day.clients.filter((c) => !isLegacyTokenlessCursorClient(c))
+      const checkableCost = Math.max(0, day.totals.cost - legacyCost);
+
+      if (day.totals.cost > 0 && day.totals.tokens === 0) {
+        if (checkableCost > 0) {
+          const offenders = describeTokenlessOffenders(
+            day.clients.filter((c) => !isLegacyTokenlessCursorClient(c))
+          );
+          const detail =
+            `cost=${formatCost(day.totals.cost)}, total tokens=0` +
+            (offenders ? `; offending clients: ${offenders}` : "");
+          errors.push(`Day ${day.date}: Cost submitted without tokens (${detail})`);
+        }
+      } else {
+        pushCostPerMillionError(
+          errors,
+          `Day ${day.date}`,
+          checkableCost,
+          day.totals.tokens
         );
-        const detail =
-          `cost=${formatCost(day.totals.cost)}, total tokens=0` +
-          (offenders ? `; offending clients: ${offenders}` : "");
-        errors.push(`Day ${day.date}: Cost submitted without tokens (${detail})`);
       }
-    } else {
-      pushCostPerMillionError(
-        errors,
-        `Day ${day.date}`,
-        day.totals.cost,
-        day.totals.tokens
-      );
     }
 
     const dayBreakdownTokens = tokenTotal(day.tokenBreakdown);


### PR DESCRIPTION
## What I hit

Running `npx tokscale@latest submit` against a freshly synced local payload (5,038 Cursor CSV rows, 230 active days, 59.07B tokens across 10 clients) failed at server-side validation with a long list of `Cost submitted without tokens` errors. The full failure mode looks like this:

```
Tokscale - Submit Usage Data
  Syncing Cursor usage data...
  Cursor sync failed; using cached data: <…>
  Scanning local session data...
  Data to submit:
    Date range: 2024-06-06 to 2026-05-27
    Active days: 230
    Total tokens: 59,067,653,128
    Total cost: $45618.04
    Clients: amp, claude, codex, copilot, cursor, droid, gemini, openclaw, opencode, pi
    Models: 83 models

  Submitting to server...

  Error: Validation failed
    - Day 2025-04-29: Cost submitted without tokens
    - Client cursor/premium-tool-call on 2025-04-29: Cost submitted without tokens
    - Day 2025-05-01: Cost submitted without tokens
    - Client cursor/premium-tool-call on 2025-05-01: Cost submitted without tokens
    ...
    - Client cursor/claude-3-5-sonnet on 2025-05-18: Cost submitted without tokens
    - Client cursor/auto on 2025-05-28: Cost submitted without tokens
    - Day 2025-06-03: Cost submitted without tokens
    - Client cursor/claude-4-sonnet-thinking on 2025-06-03: Cost submitted without tokens
    - Client cursor/o3 on 2025-06-13: Cost submitted without tokens
    ...
```

The entire 230-day submission was rejected.

## Root cause

`pushCostSanityErrors` in `packages/frontend/src/lib/validation/submission.ts` (introduced by PR #557 — `fix(submit): reject implausible submitted totals`) treats any `(date, client, modelId)` aggregate with `cost > 0 && tokens === 0` as fatal:

```ts
if (cost > 0 && tokens === 0) {
  errors.push(`${label}: Cost submitted without tokens`);
  return;
}
```

The check fires at three levels: per-client, per-day total, and overall summary total. **Any single offending row fails the whole submission.**

Cursor's CSV usage exports have legitimate cost-only rows whose token columns are blank:

| Source | What it is | Token columns |
|---|---|---|
| `cursor/premium-tool-call` | pre-2025-05 per-tool-call billing event | always empty |
| `cursor/auto`, `cursor/claude-3.5-sonnet`, `cursor/claude-4-sonnet-thinking`, `cursor/o3` | individual model calls Cursor records with `Cost` but no `Total Tokens` (sporadic) | sometimes empty |

`crates/tokscale-core/src/sessions/cursor.rs` (the Rust CSV parser) preserves these rows verbatim, so they reach the server as `cost > 0, tokens = 0` aggregates.

### Forensic count from my local cache

I crawled `~/.config/tokscale/cursor-cache/usage.csv` (the same file the CLI submits) and summed every `(date, model)` aggregate where `cost > 0 && totalTokens === 0`:

| Model | Affected days | Rows | Total cost |
|---|---:|---:|---:|
| `premium-tool-call` | 14 | 871 | **$40.55** |
| `claude-4-sonnet-thinking` | 11 | 132 | $4.44 |
| `auto` | 4 | 20 | $0.68 |
| `claude-3.5-sonnet` | 2 | 2 | $0.08 |
| `o3` | 1 | 2 | $0.04 |
| **Total** | | **1,027** | **$45.79** |

- `premium-tool-call` accounts for **89% of the rejected cost** and is the only model that is *always* tokenless by design (it disappeared from Cursor's schema in May 2025).
- The other models are sporadic and far smaller (~$5.20 combined across 26 days).
- **$45.79 of legacy data blocked submission of $45,618 of valid totals — 0.1% of the payload locked out the other 99.9%.**

## The fix

Two parts, both inside `packages/frontend/src/lib/validation/submission.ts`:

### 1. Cursor legacy carve-out (the actual unblock)

Add a narrow allowlist for the one model that legitimately and consistently has no token attribution:

```ts
// Cursor legacy: pre-2025-05 Cursor usage exports include `premium-tool-call`
// rows that are billed per tool invocation and carry no token attribution.
// They legitimately have cost > 0 with all token fields = 0 and must bypass
// the "Cost submitted without tokens" sanity check — otherwise any user with
// historical Cursor data is permanently locked out of `tokscale submit`.
const CURSOR_LEGACY_TOKENLESS_MODELS: ReadonlySet<string> = new Set([
  "premium-tool-call",
]);

function isLegacyTokenlessCursorClient(client: ClientLike): boolean {
  return (
    client.client === "cursor" &&
    CURSOR_LEGACY_TOKENLESS_MODELS.has(client.modelId) &&
    tokenTotal(client.tokens) === 0
  );
}
```

This carve-out is applied at **all three check sites**:

- **Client level** — skip the check entirely for legacy rows.
- **Day level** — subtract legacy cost from `day.totals.cost` before testing. If the day has *only* legacy rows the check no longer fires; if the day has a mix of legacy + a real tokenless regression, the remaining (non-legacy) cost still trips the check.
- **Submission summary level** — same subtraction logic across all contributions.

Other cursor models (`auto`, `claude-3.5-sonnet`, `claude-4-sonnet-thinking`, `o3`) are **explicitly not** included in the allowlist. They sometimes have tokenless rows, but unlike `premium-tool-call` those tokenless rows look like genuine parser/API regressions that we want to keep surfacing. Hiding them under a blanket cursor allowlist would mask real bugs.

### 2. Detailed English error messages

The old `Cost submitted without tokens` line was unactionable — operators had to re-run the CLI in debug mode to figure out which row failed. The new messages embed the full row context:

```text
Client cursor/claude-3.5-sonnet (provider=anthropic) on 2025-05-18: Cost submitted without tokens (cost=$0.0400, tokens={input=0, output=0, cacheRead=0, cacheWrite=0, reasoning=0})

Day 2025-04-29: Cost submitted without tokens (cost=$2.0500, total tokens=0; offending clients: cursor/auto (provider=cursor) cost=$1.5000; cursor/claude-4-sonnet-thinking (provider=anthropic) cost=$0.5500)

Submission summary: Cost submitted without tokens (cost=$45.7900, total tokens=0; offending clients: cursor/claude-3.5-sonnet (provider=anthropic) cost=$0.0400; ...)
```

All three levels now report client, providerId, modelId, full cost, and the full token breakdown. Day- and summary-level errors also enumerate which clients on that scope were responsible.

The legacy `pushCostSanityErrors` helper was split into:
- A pure cost-per-million check (`pushCostPerMillionError`), unchanged in behavior.
- Inline cost-without-tokens checks at each site, which is the only way to include the per-site context (offender list, token breakdown) in the error string.

## Why not the alternatives

| Option | Why rejected |
|---|---|
| Drop tokenless Cursor rows in the Rust parser | Loses real cost attribution that the leaderboard depends on — the user paid for it, it should count. |
| Loosen `cost > 0 && tokens === 0` to a warning globally | Re-opens the original PR #557 vulnerability (implausible cost-only submissions). |
| Estimate tokens from cost | Fabricates data; downstream cost-per-million sanity checks would fight the estimate. |
| Allow all cursor models with cost-only rows | Hides parser bugs in non-`premium-tool-call` paths. |

## Test plan

- [x] `npx vitest run __tests__/api/submit.test.ts` — 47/47 pass (was 44 before, +3 new tests).
- [x] `npx vitest run` (full frontend suite) — 283/283 pass.
- [x] `npx eslint src/lib/validation/submission.ts __tests__/api/submit.test.ts` — clean.
- [x] Existing `rejects submitted cost without corresponding tokens` test still passes (the new message still starts with the same prefix).
- [x] New `allows cursor legacy premium-tool-call rows that lack token attribution` test verifies the unblock works for the exact shape I hit locally (date `2025-04-29`, cost `$2.05`, all-zero tokens).
- [x] New `does not extend the cursor legacy bypass to other cursor models` test pins the carve-out to `premium-tool-call` only — `cursor/claude-3.5-sonnet` with cost-only still fails.
- [x] New `allows cursor legacy rows mixed with normal token-bearing rows` test covers the realistic mixed-day case.
- [x] New `includes client/provider/model/cost/tokens detail in tokenless-cost errors` test pins the new English error format so it doesn't silently regress.

## Files changed

- `packages/frontend/src/lib/validation/submission.ts` — carve-out + richer error messages.
- `packages/frontend/__tests__/api/submit.test.ts` — 4 new tests, existing assertions intact.

## Rollback

`git revert HEAD` — single commit, isolated to the validation module.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks submissions with historical Cursor data by bypassing the “cost without tokens” check for legacy `cursor/premium-tool-call` rows and excluding their cost from cost-per-million checks. Real tokenless-cost regressions still fail and are easier to debug.

- **Bug Fixes**
  - Allowlisted legacy `cursor/premium-tool-call` rows (cost > 0, tokens = 0) at client/day/summary levels; other Cursor models remain strict.
  - Day/summary checks subtract legacy cost before validating and before the cost-per-million cap to avoid false positives on mixed days.
  - Use a small float epsilon when comparing post-subtraction cost to avoid rounding-noise rejections on all-legacy submissions.
  - Error messages now include client/provider/model, cost, and token breakdown; day/summary errors list offending clients.

<sup>Written for commit 8eb7bfa60fcf6c5591a968c5e1b23f314b01ebb8. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/612?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

