### PR TITLE
fix(tui): anchor warm-cache writer and TUI reader on a shared group_by constant

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -4987,8 +4987,8 @@ fn write_light_cache(
 }
 
 fn run_warm_tui_cache() -> Result<()> {
-    use crate::tui::{save_cached_data, DataLoader};
-    use tokscale_core::{ClientId, GroupBy};
+    use crate::tui::{save_cached_data, DataLoader, TUI_DEFAULT_GROUP_BY};
+    use tokscale_core::ClientId;
 
     // Warm the cache using the same default filter set the TUI uses on
     // a no-flag launch. Going through `resolve_default_tui_filter_set()`
@@ -4997,6 +4997,14 @@ fn run_warm_tui_cache() -> Result<()> {
     // `build_client_filter`. If they drift, every TUI launch after
     // `submit` becomes a cache miss instead of a fresh hit, defeating
     // the warming.
+    //
+    // The `group_by` MUST be `TUI_DEFAULT_GROUP_BY`, NOT
+    // `GroupBy::default()`. Using `GroupBy::default()` here is the bug
+    // that motivated this constant — the TUI's cache reader keys on
+    // `TUI_DEFAULT_GROUP_BY` (= `GroupBy::Model`) while
+    // `GroupBy::default()` is `GroupBy::ClientModel`, so the warm cache
+    // was written under a key the TUI never queried. Every submit
+    // silently invalidated the next TUI launch.
     let enabled_set = resolve_default_tui_filter_set();
     let scan_clients: Vec<ClientId> = enabled_set
         .iter()
@@ -5004,8 +5012,8 @@ fn run_warm_tui_cache() -> Result<()> {
         .collect();
     let include_synthetic = enabled_set.contains(&ClientFilter::Synthetic);
     let loader = DataLoader::with_filters(None, None, None, None);
-    if let Ok(data) = loader.load(&scan_clients, &GroupBy::default(), include_synthetic) {
-        save_cached_data(&data, &enabled_set, &GroupBy::default());
+    if let Ok(data) = loader.load(&scan_clients, &TUI_DEFAULT_GROUP_BY, include_synthetic) {
+        save_cached_data(&data, &enabled_set, &TUI_DEFAULT_GROUP_BY);
     }
     Ok(())
 }

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -302,7 +302,7 @@ impl App {
             data,
             data_loader,
             enabled_clients: Rc::new(RefCell::new(enabled_clients)),
-            group_by: Rc::new(RefCell::new(tokscale_core::GroupBy::Model)),
+            group_by: Rc::new(RefCell::new(super::cache::TUI_DEFAULT_GROUP_BY)),
             sort_field,
             sort_direction,
             tab_sort_state: HashMap::new(),

--- a/crates/tokscale-cli/src/tui/cache.rs
+++ b/crates/tokscale-cli/src/tui/cache.rs
@@ -23,6 +23,25 @@ use super::data::{
 const CACHE_STALE_THRESHOLD_MS: u64 = 5 * 60 * 1000;
 const CACHE_SCHEMA_VERSION: u32 = 8;
 
+/// Single source of truth for the `group_by` value used to key the TUI
+/// cache. The cache file's `groupBy` field is compared verbatim against
+/// this on load (`cache.rs::load_cache`), so any code path that writes
+/// the cache — most importantly the detached `warm-tui-cache` subprocess
+/// fired after `tokscale submit` — must use this exact value, NOT
+/// `GroupBy::default()`.
+///
+/// Historical bug: the warm-tui-cache writer keyed on `GroupBy::default()`
+/// (= `ClientModel`) while the TUI loaded with the hard-coded
+/// `GroupBy::Model`, so every submit silently invalidated the next TUI
+/// launch's cache and the "show cached data while refreshing" contract
+/// never triggered. Anchoring both ends on this constant prevents the
+/// two from drifting again — change here ⇒ change everywhere.
+///
+/// The value matches the TUI's runtime default (`App.group_by` in
+/// `app.rs`) so swapping `GroupBy::Model` → `TUI_DEFAULT_GROUP_BY` is
+/// purely a refactor with no user-visible presentation change.
+pub const TUI_DEFAULT_GROUP_BY: GroupBy = GroupBy::Model;
+
 /// Get the cache directory path
 /// Uses `~/.cache/tokscale/` to match TypeScript implementation for cache sharing
 fn cache_dir() -> Option<PathBuf> {
@@ -1673,6 +1692,108 @@ mod tests {
             CacheResult::Fresh(_) => "Fresh",
             CacheResult::Stale(_) => "Stale",
             CacheResult::Miss => "Miss",
+        }
+    }
+
+    /// Regression test for the TUI cache `group_by` mismatch bug.
+    ///
+    /// Symptom: `npx tokscale@latest` (TUI launch) silently dropped the
+    /// on-disk cache and showed an empty dashboard until the background
+    /// scan finished, even though `~/.config/tokscale/cache/tui-data-cache.json`
+    /// existed and was well-formed.
+    ///
+    /// Root cause: the warm-tui-cache writer (`run_warm_tui_cache` in
+    /// `main.rs`, spawned as a detached subprocess after every successful
+    /// `tokscale submit`) saved the cache with `GroupBy::default()`
+    /// (= `ClientModel`, serialized as `"client,model"`), while the TUI
+    /// reader (`tui::run`) loaded with the hard-coded `GroupBy::Model`
+    /// (serialized as `"model"`). `cache.rs::load_cache` does a strict
+    /// inequality check on the cached vs. requested `group_by`, so the
+    /// two never matched and every submit silently invalidated the next
+    /// TUI launch's cache.
+    ///
+    /// Fix: anchor both ends on `TUI_DEFAULT_GROUP_BY`. This test pins
+    /// the contract — round-tripping a save→load under the canonical key
+    /// must return `Fresh`, never `Miss`.
+    #[test]
+    #[serial]
+    fn warm_cache_round_trip_under_canonical_key_is_fresh() {
+        let temp_dir = TempDir::new().unwrap();
+        let previous_home = env::var_os("HOME");
+        let previous_override = env::var_os("TOKSCALE_CONFIG_DIR");
+        unsafe {
+            env::set_var("HOME", temp_dir.path());
+            env::remove_var("TOKSCALE_CONFIG_DIR");
+        }
+
+        let enabled = ClientFilter::default_set();
+
+        // Write with the canonical key (mirrors what `run_warm_tui_cache`
+        // does after the fix).
+        save_cached_data(&UsageData::default(), &enabled, &TUI_DEFAULT_GROUP_BY);
+
+        // Read with the canonical key (mirrors what `tui::run` does on
+        // launch). The bug would have returned `Miss` here because the
+        // historical writer used `GroupBy::default()` (= ClientModel)
+        // while the reader used `GroupBy::Model`.
+        let result = load_cache(&enabled, &TUI_DEFAULT_GROUP_BY);
+        assert!(
+            matches!(result, CacheResult::Fresh(_)),
+            "expected Fresh after writing with TUI_DEFAULT_GROUP_BY, got {}",
+            other_variant_name(&result)
+        );
+
+        match previous_home {
+            Some(home) => unsafe { env::set_var("HOME", home) },
+            None => unsafe { env::remove_var("HOME") },
+        }
+        match previous_override {
+            Some(value) => unsafe { env::set_var("TOKSCALE_CONFIG_DIR", value) },
+            None => unsafe { env::remove_var("TOKSCALE_CONFIG_DIR") },
+        }
+    }
+
+    /// Documents the historical bug as a frozen regression: writing with
+    /// `GroupBy::default()` (the pre-fix `run_warm_tui_cache` behavior)
+    /// and reading with `TUI_DEFAULT_GROUP_BY` returns `Miss`. If
+    /// anyone re-introduces `GroupBy::default()` at any TUI cache write
+    /// site, this assertion proves the cache breaks.
+    #[test]
+    #[serial]
+    fn pre_fix_writer_key_misses_under_canonical_reader_key() {
+        let temp_dir = TempDir::new().unwrap();
+        let previous_home = env::var_os("HOME");
+        let previous_override = env::var_os("TOKSCALE_CONFIG_DIR");
+        unsafe {
+            env::set_var("HOME", temp_dir.path());
+            env::remove_var("TOKSCALE_CONFIG_DIR");
+        }
+
+        let enabled = ClientFilter::default_set();
+
+        // Pre-fix: writer used `GroupBy::default()`.
+        save_cached_data(&UsageData::default(), &enabled, &GroupBy::default());
+
+        // Reader uses the canonical key. If `GroupBy::default()` and
+        // `TUI_DEFAULT_GROUP_BY` ever coincide (e.g. someone changes
+        // `impl Default for GroupBy` to return `Model`), this assertion
+        // will start failing — at which point the divergent-write site
+        // in `run_warm_tui_cache` is no longer dangerous and the test
+        // should be updated accordingly.
+        let result = load_cache(&enabled, &TUI_DEFAULT_GROUP_BY);
+        assert!(
+            matches!(result, CacheResult::Miss),
+            "expected Miss when reader uses TUI_DEFAULT_GROUP_BY and writer used GroupBy::default(), got {}",
+            other_variant_name(&result)
+        );
+
+        match previous_home {
+            Some(home) => unsafe { env::set_var("HOME", home) },
+            None => unsafe { env::remove_var("HOME") },
+        }
+        match previous_override {
+            Some(value) => unsafe { env::set_var("TOKSCALE_CONFIG_DIR", value) },
+            None => unsafe { env::remove_var("TOKSCALE_CONFIG_DIR") },
         }
     }
 }

--- a/crates/tokscale-cli/src/tui/mod.rs
+++ b/crates/tokscale-cli/src/tui/mod.rs
@@ -11,7 +11,7 @@ mod themes;
 mod ui;
 
 pub use app::{App, Tab, TuiConfig};
-pub use cache::{load_cache, save_cached_data, CacheResult};
+pub use cache::{load_cache, save_cached_data, CacheResult, TUI_DEFAULT_GROUP_BY};
 pub use data::{DataLoader, UsageData};
 pub use event::{Event, EventHandler};
 
@@ -103,7 +103,11 @@ pub fn run(
     };
 
     // Single file read: load cache and check freshness in one pass.
-    let initial_group_by = tokscale_core::GroupBy::Model;
+    // The key MUST be `cache::TUI_DEFAULT_GROUP_BY` — any code path that
+    // writes the TUI cache (notably `run_warm_tui_cache` in main.rs) keys
+    // on the same constant. Hard-coding a different value here would
+    // silently invalidate the cache on every launch after `submit`.
+    let initial_group_by = TUI_DEFAULT_GROUP_BY;
     let (cached_data, needs_background_load) =
         decide_initial_data(load_cache(&enabled_clients, &initial_group_by));
 


### PR DESCRIPTION
## Symptom

`npx tokscale@latest` (TUI launch) starts with an empty dashboard even though `~/.config/tokscale/cache/tui-data-cache.json` exists, is well-formed (2.4 MB on one user's machine — 117 models / 266 daily / 2,346 hourly / 154 agents), and the schema version matches the running binary. The contract the TUI was built around — *"if a local cache exists, render it instantly while the fresh load runs in the background"* — never triggers, so you see nothing until the full scan completes.

## Root cause: TUI cache writer and reader disagree on the `group_by` key

The cache key is the tuple `(enabled_clients, group_by)`. The two sides of that contract use **different** `group_by` values, so every comparison fails as long as both code paths are exercised.

### Writer (`run_warm_tui_cache` — `crates/tokscale-cli/src/main.rs:5007-5008` before this PR)

```rust
if let Ok(data) = loader.load(&scan_clients, &GroupBy::default(), include_synthetic) {
    save_cached_data(&data, &enabled_set, &GroupBy::default());
}
```

- `GroupBy::default() == GroupBy::ClientModel` (`crates/tokscale-core/src/lib.rs`), serialized as `"client,model"`.
- This function is fired as a **detached subprocess** after every successful `tokscale submit` (`main.rs:4849 spawn_warm_tui_cache_detached`), so the very first thing that touches the cache on a user's machine after a submit writes a `"client,model"` key.

### Reader (`tui::run` — `crates/tokscale-cli/src/tui/mod.rs:106` before this PR)

```rust
let initial_group_by = tokscale_core::GroupBy::Model;
let (cached_data, needs_background_load) =
    decide_initial_data(load_cache(&enabled_clients, &initial_group_by));
```

- Hard-coded to `GroupBy::Model`, serialized as `"model"`.

### Strict comparison kills the load (`cache.rs:727`)

```rust
if cached_group_by.as_ref() != Some(group_by) {
    return CacheResult::Miss;
}
```

`"client,model" != "model"` → `CacheResult::Miss` → the cached `UsageData` is dropped on the floor before the `Subset`/`Stale` paths are ever reached. The TUI then renders an empty state until the background loader finishes.

## Empirical confirmation against a real user cache

```
On-disk groupBy: 'client,model'
On-disk schemaVersion: 7
Loader compares: cached='client,model' vs initial='model' → match=False
If loader used default ('client,model'): match=True
```

Schema version is fine (cache `7`, v2.1.3 binary `7`). Client set is fine (cached 23 clients are all known to the binary; `check_client_match` would return `Subset` because the binary added `trae`, which on its own returns `Stale(data)` — still a render). Hourly/daily date parsing is fine (0 bad rows out of 2,346 + 266). **Only the group_by mismatch trips it.**

## Why the bug self-perpetuates

The TUI's own background-load path (`mod.rs:172`) writes the cache with `bg_group_by = app.group_by.borrow().clone()`, and the App's runtime default was `GroupBy::Model` (`app.rs:305`). So a clean TUI launch that completes its background load *should* overwrite the cache with `"model"` and self-heal on the next launch. That doesn't happen because:

1. **Every `submit` re-poisons the cache.** `spawn_warm_tui_cache_detached` runs after every successful submit and writes `"client,model"`. The cycle is:
   ```
   submit → warm-tui-cache writes "client,model"
   tokscale (TUI) → Miss → BG load → writes "model"
   submit → warm-tui-cache writes "client,model"   ← invalidates again
   tokscale (TUI) → Miss → BG load → writes "model"
   ...
   ```
   Every TUI launch immediately after a submit is a forced cold start, regardless of how recently the previous TUI launch was.
2. **Users often quit the TUI before the first BG load finishes.** On a 200 MB `source-message-cache.bin` and 5K+ session-day dataset the first scan takes a noticeable amount of time, and you see an empty screen the whole time — so the natural reaction is to ^C and re-run, which never lets the self-heal save fire.

## Deeper design split

The hard-coded `GroupBy::Model` on the TUI side is inconsistent with `GroupBy::default()` (= `ClientModel`):

| Site | group_by value (before) |
|---|---|
| `tui::mod.rs:106` initial cache lookup | `GroupBy::Model` |
| `tui::app.rs:305` runtime `App.group_by` | `GroupBy::Model` |
| `main.rs::run_warm_tui_cache` save | `GroupBy::default()` (ClientModel) |
| `main.rs::write_light_cache` save | passed-in (`--write-cache` flag default = ClientModel) |
| `main.rs::2407, 2706, 4341, 4466, 4668` various non-cache loaders | `GroupBy::default()` (ClientModel) |

The TUI is the lone holdout using `Model`. Two consistent worlds would work; the current mixed state cannot.

## Fix: single source of truth

This PR uses approach **"one source of truth, no breaking change"** (the choice you asked for): introduce a single named constant `tui::cache::TUI_DEFAULT_GROUP_BY` and route every TUI-cache-touching site through it.

```rust
// crates/tokscale-cli/src/tui/cache.rs
pub const TUI_DEFAULT_GROUP_BY: GroupBy = GroupBy::Model;
```

Wired into:
- **`tui::mod.rs`** — cache lookup uses `TUI_DEFAULT_GROUP_BY`.
- **`tui::app.rs`** — runtime `App.group_by` default uses `TUI_DEFAULT_GROUP_BY`.
- **`main.rs::run_warm_tui_cache`** — writer now uses `TUI_DEFAULT_GROUP_BY` instead of `GroupBy::default()`. This is the only behavioral change; the read sites already used `GroupBy::Model`.

The constant value matches the prior TUI runtime default (`Model`), so:
- **No user-visible presentation change** — the Models tab default grouping stays "by model".
- **No on-disk cache breakage** — existing users will see one final Miss on next launch (their cache file has `"client,model"`, the reader still wants `"model"`), then the BG load will write `"model"` and the cache self-heals from that launch forward.

Other `GroupBy::default()` sites in `main.rs` (CLI subcommand loaders at lines 2407, 2706, 4341, 4466, 4668) are intentionally **left alone**. They're report-computation defaults, not TUI cache writes, and changing them would alter unrelated user-visible CLI output.

## Why not the alternatives

| Approach | Why rejected |
|---|---|
| Flip TUI reader + App default to `GroupBy::default()` (= ClientModel) | User-visible presentation change — Models tab grouping flips from "by model" to "by client+model". Breaks existing user expectation. |
| Change `impl Default for GroupBy` to return `Model` | Broader blast radius — affects every `GroupBy::default()` call site across CLI subcommand loaders. |
| Delete the writer's `group_by` field from the cache (key only on clients) | Cache schema break; existing on-disk caches become unreadable across the upgrade. |
| Loosen `cache.rs:727` to ignore `group_by` mismatches | Re-opens the original PR #340 problem the strict check was added to prevent (workspace-grouping cache served to a user that wanted model grouping). |

## Test plan

Added two regression tests in `tui::cache::tests`:

1. **`warm_cache_round_trip_under_canonical_key_is_fresh`** — saves an empty `UsageData` with `TUI_DEFAULT_GROUP_BY`, then loads with the same key. Must return `Fresh`. This pins the contract: the warm-cache writer's output is readable by the TUI on the very next launch.

2. **`pre_fix_writer_key_misses_under_canonical_reader_key`** — saves with `GroupBy::default()` (the pre-fix `run_warm_tui_cache` behavior) and asserts the reader (using `TUI_DEFAULT_GROUP_BY`) returns `Miss`. Documents the historical bug as a frozen assertion: any future re-introduction of `GroupBy::default()` at a TUI cache write site is caught immediately. The test comment explains it will fail (in a good way) if `impl Default for GroupBy` ever changes to return `Model`.

Local verification:
- [x] `cargo build -p tokscale-cli` — clean.
- [x] `cargo test -p tokscale-cli --bin tokscale cache::` — 21/21 pass, including both new regression tests.
- [x] `cargo clippy -p tokscale-cli --bin tokscale --tests --no-deps` — clean.

## Files changed

- `crates/tokscale-cli/src/tui/cache.rs` — declare `TUI_DEFAULT_GROUP_BY`, add 2 regression tests.
- `crates/tokscale-cli/src/tui/mod.rs` — re-export + use in cache lookup.
- `crates/tokscale-cli/src/tui/app.rs` — use in runtime App default.
- `crates/tokscale-cli/src/main.rs` — `run_warm_tui_cache` uses the canonical constant (the actual bug fix).

## Rollback

`git revert HEAD` — single commit, narrow blast radius.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the empty TUI on launch by making the warm-cache writer and TUI reader use the same `group_by` key. Cached data now shows instantly after `tokscale submit` while the background scan runs.

- **Bug Fixes**
  - Added `tui::cache::TUI_DEFAULT_GROUP_BY = GroupBy::Model` and used it in `tui::run`, `App.group_by` default, and `run_warm_tui_cache`.
  - Added two regression tests to lock the writer/reader contract and prevent `GroupBy::default()` regressions.
  - No UI changes. Cache self-heals after one miss. Other `GroupBy::default()` sites (non-TUI) unchanged.

<sup>Written for commit 8414531d7893e8a9236c65d0d8cb641dfa683992. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/613?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

