### PR TITLE
fix(claude): surface desktop usage diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1341,6 +1341,8 @@ JSONL format with assistant messages containing usage data:
 
 Wrapper transcript files under `~/.claude/transcripts/` are counted only when they contain real Claude usage metadata. Files with user/tool events but no `usage` block are skipped rather than estimated.
 
+Tokscale's `claude` client is Claude Code token accounting, not Claude Desktop chat accounting. Claude Desktop stores app data under locations such as `~/Library/Application Support/Claude`, but Anthropic does not document a stable local per-message token ledger for consumer desktop chat or chat-history exports. Run `tokscale clients` to see a diagnostic when Claude Desktop data is present but only Claude Code JSONL roots are scannable. `tokscale usage` can show best-effort Claude subscription quota bars from Claude Code credentials, while organization/API usage belongs to Anthropic's Admin Usage and Cost APIs and is intentionally separate from local transcript scanning.
+
 ### Codex CLI
 
 Location: `~/.codex/sessions/*.jsonl`

--- a/crates/tokscale-cli/src/claude_diagnostics.rs
+++ b/crates/tokscale-cli/src/claude_diagnostics.rs
@@ -1,0 +1,125 @@
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticPath {
+    pub label: &'static str,
+    pub path: String,
+    pub exists: bool,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientDiagnostic {
+    pub code: &'static str,
+    pub severity: &'static str,
+    pub message: &'static str,
+    pub help: &'static str,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub paths: Vec<DiagnosticPath>,
+}
+
+const CLAUDE_DESKTOP_MESSAGE: &str =
+    "Claude Desktop app data was detected, but Tokscale counts Claude Code JSONL transcripts only.";
+
+const CLAUDE_DESKTOP_HELP: &str = "Claude Desktop chat storage and Claude data exports do not expose a documented per-message token ledger. Use `tokscale usage` for Claude subscription quota bars; organization/API billing requires Anthropic Admin Usage/Cost API outside local scanning.";
+
+pub fn diagnostics_for_clients_row(home_dir: &Path) -> Vec<ClientDiagnostic> {
+    claude_diagnostics(home_dir, true)
+}
+
+pub fn diagnostics_for_empty_explicit_report(
+    home_dir: &Path,
+    clients: &Option<Vec<String>>,
+    claude_message_count: i32,
+) -> Vec<ClientDiagnostic> {
+    if !explicitly_requests_claude(clients) || claude_message_count > 0 {
+        return Vec::new();
+    }
+
+    claude_diagnostics(home_dir, false)
+}
+
+fn explicitly_requests_claude(clients: &Option<Vec<String>>) -> bool {
+    clients
+        .as_ref()
+        .is_some_and(|ids| ids.iter().any(|id| id == "claude"))
+}
+
+fn claude_diagnostics(home_dir: &Path, include_info: bool) -> Vec<ClientDiagnostic> {
+    let mut diagnostics = Vec::new();
+
+    let desktop_paths: Vec<PathBuf> = claude_desktop_storage_paths(home_dir)
+        .into_iter()
+        .filter(|path| path.exists())
+        .collect();
+
+    if !desktop_paths.is_empty() {
+        diagnostics.push(ClientDiagnostic {
+            code: "claude_desktop_not_scanned",
+            severity: "warning",
+            message: CLAUDE_DESKTOP_MESSAGE,
+            help: CLAUDE_DESKTOP_HELP,
+            paths: diagnostic_paths(home_dir, desktop_paths),
+        });
+    }
+
+    let stats_cache = home_dir.join(".claude").join("stats-cache.json");
+    if include_info && stats_cache.exists() {
+        diagnostics.push(ClientDiagnostic {
+            code: "claude_stats_cache_not_imported",
+            severity: "info",
+            message: "Claude Code stats-cache.json was detected, but Tokscale does not import aggregate cache totals as session usage.",
+            help: "stats-cache.json contains aggregate /usage data without stable per-message/session attribution, so importing it would risk double counting or fabricated model/session totals.",
+            paths: vec![DiagnosticPath {
+                label: "statsCache",
+                path: stats_cache.to_string_lossy().to_string(),
+                exists: true,
+            }],
+        });
+    }
+
+    diagnostics
+}
+
+fn claude_desktop_storage_paths(home_dir: &Path) -> Vec<PathBuf> {
+    vec![
+        home_dir
+            .join("Library")
+            .join("Application Support")
+            .join("Claude"),
+        home_dir.join("AppData").join("Roaming").join("Claude"),
+        home_dir.join(".config").join("Claude"),
+    ]
+}
+
+fn diagnostic_paths(home_dir: &Path, desktop_paths: Vec<PathBuf>) -> Vec<DiagnosticPath> {
+    let mut paths: Vec<DiagnosticPath> = desktop_paths
+        .into_iter()
+        .map(|path| DiagnosticPath {
+            label: "desktopStorage",
+            path: path.to_string_lossy().to_string(),
+            exists: true,
+        })
+        .collect();
+
+    for (label, path) in [
+        (
+            "claudeCodeProjects",
+            home_dir.join(".claude").join("projects"),
+        ),
+        (
+            "claudeCodeTranscripts",
+            home_dir.join(".claude").join("transcripts"),
+        ),
+    ] {
+        let exists = path.exists();
+        paths.push(DiagnosticPath {
+            label,
+            path: path.to_string_lossy().to_string(),
+            exists,
+        });
+    }
+
+    paths
+}

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1,5 +1,6 @@
 mod antigravity;
 mod auth;
+mod claude_diagnostics;
 mod commands;
 mod cursor;
 mod device;
@@ -1459,6 +1460,36 @@ fn use_env_roots(home_dir: &Option<String>) -> bool {
     home_dir.is_none()
 }
 
+fn resolve_effective_home_dir(home_dir: &Option<String>) -> Option<PathBuf> {
+    home_dir.as_ref().map(PathBuf::from).or_else(dirs::home_dir)
+}
+
+fn model_usage_includes_client(entry: &tokscale_core::ModelUsage, client: &str) -> bool {
+    if entry.client == client {
+        return true;
+    }
+
+    entry
+        .merged_clients
+        .as_deref()
+        .is_some_and(|clients| clients.split(", ").any(|id| id == client))
+}
+
+fn emit_client_diagnostics(diagnostics: &[claude_diagnostics::ClientDiagnostic]) {
+    if diagnostics.is_empty() {
+        return;
+    }
+
+    use colored::Colorize;
+    for diagnostic in diagnostics {
+        eprintln!(
+            "{}",
+            format!("  {}: {}", diagnostic.severity, diagnostic.message).yellow()
+        );
+        eprintln!("{}", format!("  {}", diagnostic.help).bright_black());
+    }
+}
+
 fn ensure_home_supported_for_tui(home_dir: &Option<String>) -> Result<()> {
     if home_dir.is_some() {
         return Err(anyhow::anyhow!(
@@ -1721,6 +1752,7 @@ fn run_models_report(
     use tokscale_core::{get_model_report, GroupBy, ReportOptions};
 
     let date_range = get_date_range_label(today, week, month_flag, &since, &until, &year);
+    let effective_home_dir = resolve_effective_home_dir(&home_dir);
 
     let had_cursor_cache = has_cursor_usage_cache_for_report(&home_dir);
     let explicit_cursor_filter = client_filter_explicitly_requests_cursor(&clients);
@@ -1759,6 +1791,22 @@ fn run_models_report(
         explicit_cursor_filter,
     );
     let processing_time_ms = start.elapsed().as_millis();
+    let claude_message_count = report
+        .entries
+        .iter()
+        .filter(|entry| model_usage_includes_client(entry, "claude"))
+        .map(|entry| entry.message_count)
+        .sum();
+    let diagnostics = effective_home_dir
+        .as_deref()
+        .map(|home| {
+            claude_diagnostics::diagnostics_for_empty_explicit_report(
+                home,
+                &clients,
+                claude_message_count,
+            )
+        })
+        .unwrap_or_default();
 
     if json {
         #[derive(serde::Serialize)]
@@ -1798,6 +1846,8 @@ fn run_models_report(
             processing_time_ms: u32,
             #[serde(skip_serializing_if = "Vec::is_empty")]
             warnings: Vec<String>,
+            #[serde(skip_serializing_if = "Vec::is_empty")]
+            diagnostics: Vec<claude_diagnostics::ClientDiagnostic>,
         }
 
         let output = ModelReportJson {
@@ -1847,10 +1897,12 @@ fn run_models_report(
             total_cost: report.total_cost,
             processing_time_ms: report.processing_time_ms,
             warnings: cursor_setup_warnings,
+            diagnostics,
         };
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
         use comfy_table::{Attribute, Cell, CellAlignment, Color, ContentArrangement, Table};
+        emit_client_diagnostics(&diagnostics);
 
         emit_cursor_setup_warnings(&cursor_setup_warnings);
         let total_performance = aggregate_model_report_performance(&report.entries);
@@ -3558,6 +3610,8 @@ fn run_clients_command(json: bool, home_dir: Option<String>) -> Result<()> {
         exporter_status: Option<String>,
         #[serde(skip_serializing_if = "Vec::is_empty")]
         extra_paths: Vec<ExtraPath>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        diagnostics: Vec<claude_diagnostics::ClientDiagnostic>,
     }
 
     #[derive(serde::Serialize)]
@@ -3691,6 +3745,12 @@ fn run_clients_command(json: bool, home_dir: Option<String>) -> Result<()> {
                     },
                 ));
 
+                let diagnostics = if client == ClientId::Claude {
+                    claude_diagnostics::diagnostics_for_clients_row(&home_dir)
+                } else {
+                    Vec::new()
+                };
+
                 ClientRow {
                     client: client.as_str().to_string(),
                     label,
@@ -3706,6 +3766,7 @@ fn run_clients_command(json: bool, home_dir: Option<String>) -> Result<()> {
                         && copilot_exporter_path.is_some())
                     .then(|| "configured".to_string()),
                     extra_paths,
+                    diagnostics,
                 }
             })
             .collect();
@@ -3841,6 +3902,14 @@ fn run_clients_command(json: bool, home_dir: Option<String>) -> Result<()> {
                     "  {}",
                     format!("messages: {}", format_number(row.message_count)).bright_black()
                 );
+            }
+
+            for diagnostic in &row.diagnostics {
+                println!(
+                    "  {}",
+                    format!("{}: {}", diagnostic.severity, diagnostic.message).yellow()
+                );
+                println!("  {}", diagnostic.help.bright_black());
             }
 
             println!();

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -2302,6 +2302,76 @@ fn test_clients_command_includes_claude_transcripts_text() {
 }
 
 #[test]
+fn test_clients_json_includes_claude_desktop_diagnostic() {
+    let tmp = create_empty_fixture_dir();
+    fs::create_dir_all(tmp.path().join("Library/Application Support/Claude")).unwrap();
+
+    let output = cmd_with_home(tmp.path())
+        .args(["clients", "--json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let claude = json["clients"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["client"] == "claude")
+        .unwrap();
+    let diagnostics = claude["diagnostics"].as_array().unwrap();
+
+    assert!(diagnostics.iter().any(|item| {
+        item["code"] == "claude_desktop_not_scanned"
+            && item["severity"] == "warning"
+            && item["message"]
+                .as_str()
+                .unwrap()
+                .contains("Claude Desktop app data was detected")
+    }));
+}
+
+#[test]
+fn test_clients_command_includes_claude_desktop_diagnostic_text() {
+    let tmp = create_empty_fixture_dir();
+    fs::create_dir_all(tmp.path().join("Library/Application Support/Claude")).unwrap();
+
+    cmd_with_home(tmp.path())
+        .arg("clients")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Claude Desktop app data was detected",
+        ))
+        .stdout(predicate::str::contains(
+            "Claude Code JSONL transcripts only",
+        ));
+}
+
+#[test]
+fn test_models_json_includes_claude_desktop_diagnostic_for_empty_explicit_claude_report() {
+    let tmp = create_empty_fixture_dir();
+    fs::create_dir_all(tmp.path().join("Library/Application Support/Claude")).unwrap();
+
+    let output = cmd_with_home(tmp.path())
+        .args(["models", "--client", "claude", "--json", "--no-spinner"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let diagnostics = json["diagnostics"].as_array().unwrap();
+
+    assert!(diagnostics.iter().any(|item| {
+        item["code"] == "claude_desktop_not_scanned"
+            && item["message"]
+                .as_str()
+                .unwrap()
+                .contains("Tokscale counts Claude Code JSONL transcripts")
+    }));
+}
+
+#[test]
 fn test_clients_json_includes_settings_extra_paths() {
     let tmp = create_empty_fixture_dir();
     write_settings_json(

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -269,9 +269,16 @@ impl PricingLookup {
             Some("openrouter") => self.lookup_openrouter_only(id, provider_id),
             _ => self.lookup_auto(id, provider_id),
         };
+        let requested_opus_minor = normalize_claude_opus_4_minor(lower_ref);
+        let unsafe_opus_minor_resolution = |result: &LookupResult| {
+            resolves_different_claude_opus_4_minor(requested_opus_minor.as_deref(), result)
+        };
 
         // 1. Try direct lookup
         if let Some(result) = do_lookup(lower_ref) {
+            if unsafe_opus_minor_resolution(&result) {
+                return None;
+            }
             return Some(result);
         }
 
@@ -279,14 +286,18 @@ impl PricingLookup {
             return None;
         }
 
+        let guarded_lookup = |candidate: &str| {
+            do_lookup(candidate).filter(|result| !unsafe_opus_minor_resolution(result))
+        };
+
         // 2. Try stripping unknown suffixes (e.g., -thinking, -high, -codex)
-        if let Some(result) = try_strip_unknown_suffix(lower_ref, do_lookup) {
+        if let Some(result) = try_strip_unknown_suffix(lower_ref, guarded_lookup) {
             return Some(result);
         }
 
         // 3. Try stripping unknown prefixes (e.g., antigravity-, myplugin-)
         //    For each prefix candidate, also try suffix stripping
-        if let Some(result) = try_strip_unknown_prefix(lower_ref, do_lookup) {
+        if let Some(result) = try_strip_unknown_prefix(lower_ref, guarded_lookup) {
             return Some(result);
         }
 
@@ -1064,17 +1075,8 @@ fn normalize_model_name(model_id: &str) -> Option<String> {
     let lower = model_id.to_lowercase();
 
     if lower.contains("opus") {
-        if contains_delimited_fragment(&lower, "4.7") || contains_delimited_fragment(&lower, "4-7")
-        {
-            return Some("claude-opus-4-7".into());
-        } else if contains_delimited_fragment(&lower, "4.6")
-            || contains_delimited_fragment(&lower, "4-6")
-        {
-            return Some("claude-opus-4-6".into());
-        } else if contains_delimited_fragment(&lower, "4.5")
-            || contains_delimited_fragment(&lower, "4-5")
-        {
-            return Some("claude-opus-4-5".into());
+        if let Some(model) = normalize_claude_opus_4_minor(&lower) {
+            return Some(model);
         } else if contains_delimited_fragment(&lower, "4") {
             return Some("claude-opus-4".into());
         }
@@ -1107,6 +1109,41 @@ fn normalize_model_name(model_id: &str) -> Option<String> {
     }
 
     None
+}
+
+fn normalize_claude_opus_4_minor(lower: &str) -> Option<String> {
+    let parts: Vec<&str> = lower
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|part| !part.is_empty())
+        .collect();
+
+    for window in parts.windows(3) {
+        if window[0] == "opus" && window[1] == "4" && is_single_digit_minor(window[2]) {
+            return Some(format!("claude-opus-4-{}", window[2]));
+        }
+        if window[0] == "4" && is_single_digit_minor(window[1]) && window[2] == "opus" {
+            return Some(format!("claude-opus-4-{}", window[1]));
+        }
+    }
+
+    None
+}
+
+fn resolves_different_claude_opus_4_minor(
+    requested_minor: Option<&str>,
+    result: &LookupResult,
+) -> bool {
+    let Some(requested_minor) = requested_minor else {
+        return false;
+    };
+
+    normalize_model_name(&result.matched_key).is_some_and(|resolved| {
+        resolved.starts_with("claude-opus-4") && resolved != requested_minor
+    })
+}
+
+fn is_single_digit_minor(value: &str) -> bool {
+    value.len() == 1 && value.as_bytes()[0].is_ascii_digit() && value.as_bytes()[0] != b'0'
 }
 
 fn normalize_version_separator(model_id: &str) -> Option<String> {
@@ -2827,6 +2864,27 @@ mod tests {
         assert!(
             (140.0..=180.0).contains(&cost),
             "expected opus-4-7 priced cost around $160, got ${cost:.2}"
+        );
+    }
+
+    #[test]
+    fn test_future_opus_4_minor_does_not_degrade_to_legacy_opus_4() {
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "anthropic/claude-opus-4".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000015),
+                output_cost_per_token: Some(0.000075),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(HashMap::new(), openrouter, HashMap::new());
+        let result = lookup.lookup("aws.claude-opus-4-8");
+        assert!(
+            result.is_none(),
+            "unknown future opus minor versions must not price as legacy claude-opus-4; got {:?}",
+            result.map(|result| result.matched_key)
         );
     }
 

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -1901,6 +1901,22 @@ mod tests {
     }
 
     #[test]
+    fn test_opus_4_7_usage_is_parsed_when_usage_metadata_exists() {
+        let content = r#"{"type":"assistant","timestamp":"2026-04-16T10:00:00.000Z","requestId":"req_opus47","message":{"id":"msg_opus47","model":"claude-opus-4-7","usage":{"input_tokens":321,"output_tokens":654,"cache_read_input_tokens":987,"cache_creation_input_tokens":111}}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "claude-opus-4-7");
+        assert_eq!(messages[0].provider_id, "anthropic");
+        assert_eq!(messages[0].tokens.input, 321);
+        assert_eq!(messages[0].tokens.output, 654);
+        assert_eq!(messages[0].tokens.cache_read, 987);
+        assert_eq!(messages[0].tokens.cache_write, 111);
+    }
+
+    #[test]
     fn test_tool_result_output_counts_as_input() {
         let content = r#"{"type":"user","timestamp":"2026-05-27T10:00:00.000Z","message":{"model":"anthropic/claude-4-6-sonnet","content":[{"type":"tool_result","tool_use_id":"toolu_input","tool_output":{"output":"abcdefghijklmnop"}}]}}"#;
 


### PR DESCRIPTION
## Summary

Closes #558 by making Claude Desktop detection explicit without fabricating token totals from undocumented local app storage.

This PR adds Claude diagnostics to `tokscale clients` and to explicit empty `tokscale models --client claude --json` reports when Claude Desktop app data is present but only Claude Code JSONL usage roots are scannable. It also documents the boundary between Claude Code local usage, Claude Desktop consumer chat data, `tokscale usage` quota bars, and Anthropic Admin Usage/Cost APIs.

## Why

Claude Code usage is countable when local JSONL assistant messages include structured `message.usage` metadata. Claude Desktop consumer chat storage and Claude data exports do not expose a documented stable per-message token ledger, so importing Desktop app data as usage would risk silently fabricated totals. The better behavior is to tell users what Tokscale found, what it scanned, and why Desktop chat usage is not counted as a local transcript source.

Docs checked: [Claude Code costs](https://docs.anthropic.com/en/docs/claude-code/costs), [Claude data export](https://support.claude.com/en/articles/9450526-how-can-i-export-my-claude-data), [Usage and Cost Admin API](https://docs.anthropic.com/en/api/data-usage-cost-api), and [Claude pricing](https://platform.claude.com/docs/en/about-claude/pricing?hsLang=en).

## Diff scope

- Add a Claude diagnostics module that detects known Claude Desktop storage locations on macOS, Windows-style home directories, and Linux-style config directories.
- Surface `claude_desktop_not_scanned` diagnostics in `tokscale clients` JSON/text output and in explicit empty Claude model reports.
- Keep `stats-cache.json` out of session imports and report it as informational because it is aggregate data without stable per-message/session attribution.
- Add an Opus 4.7 Claude parser regression proving usage-bearing JSONL still counts tokens and provider attribution correctly.
- Guard future Claude Opus 4.x minor model IDs from degrading to legacy `claude-opus-4` pricing while preserving valid same-minor fuzzy/date fallback behavior.
- Update README to document the Claude Code versus Claude Desktop versus Anthropic Admin API boundary.

## Branch integrity

Base branch: `main`.

Validated base SHA: `fcab5fbda431dfe6efd76660e6bb44c45d2d32e1`.

Ahead/behind against fetched `origin/main`: `0 behind / 1 ahead`.

Merge-base SHA: `fcab5fbda431dfe6efd76660e6bb44c45d2d32e1`.

Fast-forward safety: `origin/main` is an ancestor of this branch, and the PR diff was computed against the fetched base.

## Commit integrity

Introduced commit: `6f0480ed9d898a30d2575ef904dcadabb3af7563 fix(claude): surface desktop usage diagnostics`.

The PR contains one logical change. The final diff contains only Claude diagnostics, Claude README notes, Claude parser regression coverage, and pricing resolver coverage needed for the same Claude usage-reporting issue.

## Diff hygiene

Changed files:

```text
M README.md
A crates/tokscale-cli/src/claude_diagnostics.rs
M crates/tokscale-cli/src/main.rs
M crates/tokscale-cli/tests/cli_tests.rs
M crates/tokscale-core/src/pricing/lookup.rs
M crates/tokscale-core/src/sessions/claudecode.rs
```

`git diff --check origin/main...HEAD`: PASS, no output.


## Validation mode and proof

Validation mode: Mode 3 — shared runtime pricing resolver plus CLI report diagnostics.

Local validation:

```text
cargo fmt --all -- --check: PASS
cargo test -p tokscale-cli claude_desktop_diagnostic: PASS, 3 tests
cargo test -p tokscale-cli models: PASS, 44 tests
cargo test -p tokscale-cli clients: PASS, 24 tests
cargo test -p tokscale-core opus_4: PASS, 12 tests
cargo test -p tokscale-core claude: PASS, 70 tests
cargo test -p tokscale-core pricing::lookup::tests: PASS, 137 tests
/opt/homebrew/Cellar/rust/1.94.0/bin/cargo-clippy clippy -p tokscale-cli --all-targets -- -D warnings: PASS
/opt/homebrew/Cellar/rust/1.94.0/bin/cargo-clippy clippy -p tokscale-core --all-targets -- -D warnings: PASS
git diff --check origin/main...HEAD: PASS
```

Full workspace test suite: not run locally because targeted CLI/core tests cover the changed surfaces and required remote CI will validate the final PR SHA.

## Ledger and version proof

Ledger: not applicable — not required for this change family.

Version: not applicable — no release manifests changed; repository release workflow owns version bumps.

## Migration notes

Not applicable — no database migration changed.

## CI context confirmation

Pending — required GitHub Actions checks will run after the PR is opened.

CI context names unchanged.

## Runtime safety

No database writes, auth changes, network sync behavior, queues, migrations, or submission semantics changed.

No invariant regression introduced.

## Documentation integrity

README now documents that `claude` is Claude Code token accounting, not consumer Claude Desktop chat accounting, and explains where `tokscale usage` and Anthropic Admin Usage/Cost APIs fit.

## Rollback plan

Rollback: revert this PR.

DB downgrade: not applicable.

Data repair: not applicable.

Operational caveats: none known.

## Known residual risks

This PR does not claim to count Claude Desktop consumer chat tokens. It intentionally avoids doing so until Anthropic exposes a stable, documented per-message token ledger or official personal usage export/API for that surface.
