### PR TITLE
fix(auth): require CSRF validation for cookie mutations

### DIFF
--- a/packages/frontend/__tests__/api/deviceAuthorizeCsrf.test.ts
+++ b/packages/frontend/__tests__/api/deviceAuthorizeCsrf.test.ts
@@ -1,0 +1,141 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const getSession = vi.fn();
+  const getSessionFromHeader = vi.fn();
+  const eq = vi.fn((left: unknown, right: unknown) => ({ op: "eq", left, right }));
+  const gt = vi.fn((left: unknown, right: unknown) => ({ op: "gt", left, right }));
+  const isNull = vi.fn((value: unknown) => ({ op: "isNull", value }));
+  const and = vi.fn((...conditions: unknown[]) => ({ op: "and", conditions }));
+  const limit = vi.fn(async () => records);
+  const whereSelect = vi.fn(() => ({ limit }));
+  const from = vi.fn(() => ({ where: whereSelect }));
+  const select = vi.fn(() => ({ from }));
+  const whereUpdate = vi.fn(async () => undefined);
+  const set = vi.fn(() => ({ where: whereUpdate }));
+  const update = vi.fn(() => ({ set }));
+  let records: Array<{ id: string }> = [];
+
+  const deviceCodes = {
+    id: "deviceCodes.id",
+    userCode: "deviceCodes.userCode",
+    expiresAt: "deviceCodes.expiresAt",
+    userId: "deviceCodes.userId",
+  };
+
+  return {
+    getSession,
+    getSessionFromHeader,
+    eq,
+    gt,
+    isNull,
+    and,
+    db: { select, update },
+    deviceCodes,
+    setRecords(value: Array<{ id: string }>) {
+      records = value;
+    },
+    reset() {
+      getSession.mockReset();
+      getSessionFromHeader.mockReset();
+      eq.mockClear();
+      gt.mockClear();
+      isNull.mockClear();
+      and.mockClear();
+      limit.mockClear();
+      whereSelect.mockClear();
+      from.mockClear();
+      select.mockClear();
+      whereUpdate.mockClear();
+      set.mockClear();
+      update.mockClear();
+      records = [];
+    },
+  };
+});
+
+vi.mock("drizzle-orm", () => ({
+  eq: mockState.eq,
+  gt: mockState.gt,
+  isNull: mockState.isNull,
+  and: mockState.and,
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  getSession: mockState.getSession,
+  getSessionFromHeader: mockState.getSessionFromHeader,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockState.db,
+  deviceCodes: mockState.deviceCodes,
+}));
+
+type ModuleExports = typeof import("../../src/app/api/auth/device/authorize/route");
+
+let POST: ModuleExports["POST"];
+
+beforeAll(async () => {
+  const routeModule = await import("../../src/app/api/auth/device/authorize/route");
+  POST = routeModule.POST;
+});
+
+beforeEach(() => {
+  mockState.reset();
+});
+
+function session() {
+  return {
+    id: "user-1",
+    username: "alice",
+    displayName: "Alice",
+    avatarUrl: null,
+  };
+}
+
+function createRequest(headers: Record<string, string> = { Origin: "http://localhost:3000" }) {
+  return new Request("http://localhost:3000/api/auth/device/authorize", {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ userCode: "ABCD-1234" }),
+  });
+}
+
+describe("POST /api/auth/device/authorize CSRF origin checks", () => {
+  it("returns 401 for cookie auth when Origin is missing", async () => {
+    mockState.getSession.mockResolvedValue(session());
+    mockState.setRecords([{ id: "device-code-1" }]);
+
+    const response = await POST(createRequest({}));
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockState.getSession).not.toHaveBeenCalled();
+    expect(mockState.db.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for cookie auth when Origin is not allowed", async () => {
+    mockState.getSession.mockResolvedValue(session());
+    mockState.setRecords([{ id: "device-code-1" }]);
+
+    const response = await POST(
+      createRequest({ Origin: "https://attacker.example" })
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockState.getSession).not.toHaveBeenCalled();
+    expect(mockState.db.update).not.toHaveBeenCalled();
+  });
+
+  it("authorizes device code when cookie Origin is allowed", async () => {
+    mockState.getSession.mockResolvedValue(session());
+    mockState.setRecords([{ id: "device-code-1" }]);
+
+    const response = await POST(createRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+    expect(mockState.db.update).toHaveBeenCalledWith(mockState.deviceCodes);
+  });
+});

--- a/packages/frontend/__tests__/api/settingsDeviceRenameCsrf.test.ts
+++ b/packages/frontend/__tests__/api/settingsDeviceRenameCsrf.test.ts
@@ -1,0 +1,152 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const getSession = vi.fn();
+  const getSessionFromHeader = vi.fn();
+  const revalidateTag = vi.fn();
+  const eq = vi.fn((left: unknown, right: unknown) => ({ op: "eq", left, right }));
+  const and = vi.fn((...conditions: unknown[]) => ({ op: "and", conditions }));
+  const returning = vi.fn(async () => updatedRows);
+  const where = vi.fn(() => ({ returning }));
+  const set = vi.fn(() => ({ where }));
+  const update = vi.fn(() => ({ set }));
+  let updatedRows: Array<{ id: string; deviceKey: string; displayName: string | null }> = [];
+
+  const submittedDevices = {
+    id: "submittedDevices.id",
+    deviceKey: "submittedDevices.deviceKey",
+    displayName: "submittedDevices.displayName",
+    userId: "submittedDevices.userId",
+    updatedAt: "submittedDevices.updatedAt",
+  };
+
+  return {
+    getSession,
+    getSessionFromHeader,
+    revalidateTag,
+    eq,
+    and,
+    db: { update },
+    submittedDevices,
+    setUpdatedRows(rows: Array<{ id: string; deviceKey: string; displayName: string | null }>) {
+      updatedRows = rows;
+    },
+    reset() {
+      getSession.mockReset();
+      getSessionFromHeader.mockReset();
+      revalidateTag.mockReset();
+      eq.mockClear();
+      and.mockClear();
+      returning.mockClear();
+      where.mockClear();
+      set.mockClear();
+      update.mockClear();
+      updatedRows = [];
+    },
+  };
+});
+
+vi.mock("next/cache", () => ({
+  revalidateTag: mockState.revalidateTag,
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: mockState.eq,
+  and: mockState.and,
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  getSession: mockState.getSession,
+  getSessionFromHeader: mockState.getSessionFromHeader,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockState.db,
+  submittedDevices: mockState.submittedDevices,
+}));
+
+vi.mock("@/lib/db/usernameLookup", () => ({
+  normalizeUsernameCacheKey: (username: string) => username.toLowerCase(),
+}));
+
+type ModuleExports = typeof import("../../src/app/api/settings/devices/[deviceId]/route");
+
+let PATCH: ModuleExports["PATCH"];
+
+const deviceId = "11111111-1111-4111-8111-111111111111";
+
+beforeAll(async () => {
+  const routeModule = await import("../../src/app/api/settings/devices/[deviceId]/route");
+  PATCH = routeModule.PATCH;
+});
+
+beforeEach(() => {
+  mockState.reset();
+});
+
+function session() {
+  return {
+    id: "user-1",
+    username: "Alice",
+    displayName: "Alice",
+    avatarUrl: null,
+  };
+}
+
+function createRequest(headers: Record<string, string> = { Origin: "http://localhost:3000" }) {
+  return new Request(`http://localhost:3000/api/settings/devices/${deviceId}`, {
+    method: "PATCH",
+    headers,
+    body: JSON.stringify({ name: "Laptop" }),
+  });
+}
+
+describe("PATCH /api/settings/devices/[deviceId] CSRF origin checks", () => {
+  it("returns 401 for cookie auth when Origin is missing", async () => {
+    mockState.getSession.mockResolvedValue(session());
+    mockState.setUpdatedRows([{ id: deviceId, deviceKey: "machine", displayName: "Laptop" }]);
+
+    const response = await PATCH(
+      createRequest({}),
+      { params: Promise.resolve({ deviceId }) }
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockState.getSession).not.toHaveBeenCalled();
+    expect(mockState.db.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for cookie auth when Origin is not allowed", async () => {
+    mockState.getSession.mockResolvedValue(session());
+    mockState.setUpdatedRows([{ id: deviceId, deviceKey: "machine", displayName: "Laptop" }]);
+
+    const response = await PATCH(
+      createRequest({ Origin: "https://attacker.example" }),
+      { params: Promise.resolve({ deviceId }) }
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockState.getSession).not.toHaveBeenCalled();
+    expect(mockState.db.update).not.toHaveBeenCalled();
+  });
+
+  it("renames a device when cookie Origin is allowed", async () => {
+    mockState.getSession.mockResolvedValue(session());
+    mockState.setUpdatedRows([{ id: deviceId, deviceKey: "machine", displayName: "Laptop" }]);
+
+    const response = await PATCH(
+      createRequest(),
+      { params: Promise.resolve({ deviceId }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: true,
+      device: { id: deviceId, deviceKey: "machine", displayName: "Laptop" },
+    });
+    expect(mockState.db.update).toHaveBeenCalledWith(mockState.submittedDevices);
+    expect(mockState.revalidateTag).toHaveBeenCalledWith("user:alice", "max");
+  });
+});

--- a/packages/frontend/__tests__/api/settingsSubmittedDataDelete.test.ts
+++ b/packages/frontend/__tests__/api/settingsSubmittedDataDelete.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockState = vi.hoisted(() => {
   const getSession = vi.fn();
+  const getSessionFromHeader = vi.fn();
   const authenticatePersonalToken = vi.fn();
   const revalidateTag = vi.fn();
   const revalidatePath = vi.fn();
@@ -54,6 +55,7 @@ const mockState = vi.hoisted(() => {
 
   return {
     getSession,
+    getSessionFromHeader,
     authenticatePersonalToken,
     revalidateTag,
     revalidatePath,
@@ -65,6 +67,7 @@ const mockState = vi.hoisted(() => {
     where,
     reset() {
       getSession.mockReset();
+      getSessionFromHeader.mockReset();
       authenticatePersonalToken.mockReset();
       revalidateTag.mockReset();
       revalidatePath.mockReset();
@@ -98,6 +101,7 @@ vi.mock("drizzle-orm", () => ({
 
 vi.mock("@/lib/auth/session", () => ({
   getSession: mockState.getSession,
+  getSessionFromHeader: mockState.getSessionFromHeader,
 }));
 
 vi.mock("@/lib/auth/personalTokens", () => ({
@@ -132,10 +136,13 @@ beforeEach(() => {
   mockState.reset();
 });
 
-function createRequest(token?: string) {
+function createRequest(options: { token?: string; origin?: string | null } = {}) {
   const headers = new Headers();
-  if (token) {
-    headers.set("Authorization", `Bearer ${token}`);
+  if (options.token) {
+    headers.set("Authorization", `Bearer ${options.token}`);
+  }
+  if (options.origin !== null) {
+    headers.set("Origin", options.origin ?? "http://localhost:3000");
   }
   return new Request("http://localhost/api/settings/submitted-data", {
     method: "DELETE",
@@ -151,6 +158,42 @@ describe("DELETE /api/settings/submitted-data", () => {
 
     expect(response.status).toBe(401);
     expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockState.db.delete).not.toHaveBeenCalled();
+    expect(mockState.db.transaction).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for cookie auth when Origin is missing", async () => {
+    mockState.getSession.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+    });
+
+    const response = await DELETE(createRequest({ origin: null }));
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockState.getSession).not.toHaveBeenCalled();
+    expect(mockState.db.delete).not.toHaveBeenCalled();
+    expect(mockState.db.transaction).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for cookie auth when Origin is not allowed", async () => {
+    mockState.getSession.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+    });
+
+    const response = await DELETE(
+      createRequest({ origin: "https://attacker.example" })
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockState.getSession).not.toHaveBeenCalled();
     expect(mockState.db.delete).not.toHaveBeenCalled();
     expect(mockState.db.transaction).not.toHaveBeenCalled();
   });
@@ -260,7 +303,12 @@ describe("DELETE /api/settings/submitted-data", () => {
     });
     mockState.setDeletedRows([{ id: "submission-2" }]);
 
-    const response = await DELETE(createRequest("tt_valid"));
+    const response = await DELETE(
+      createRequest({
+        token: "tt_valid",
+        origin: "https://attacker.example",
+      })
+    );
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({

--- a/packages/frontend/__tests__/api/settingsTokensDelete.test.ts
+++ b/packages/frontend/__tests__/api/settingsTokensDelete.test.ts
@@ -2,13 +2,16 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockState = vi.hoisted(() => {
   const getSession = vi.fn();
+  const getSessionFromHeader = vi.fn();
   const revokePersonalToken = vi.fn();
 
   return {
     getSession,
+    getSessionFromHeader,
     revokePersonalToken,
     reset() {
       getSession.mockReset();
+      getSessionFromHeader.mockReset();
       revokePersonalToken.mockReset();
     },
   };
@@ -16,6 +19,7 @@ const mockState = vi.hoisted(() => {
 
 vi.mock("@/lib/auth/session", () => ({
   getSession: mockState.getSession,
+  getSessionFromHeader: mockState.getSessionFromHeader,
 }));
 
 vi.mock("@/lib/auth/personalTokens", () => ({
@@ -35,19 +39,88 @@ beforeEach(() => {
   mockState.reset();
 });
 
+function createDeleteRequest(
+  tokenId: string,
+  headers: Record<string, string> = { Origin: "http://localhost:3000" }
+) {
+  return new Request(`http://localhost:3000/api/settings/tokens/${tokenId}`, {
+    method: "DELETE",
+    headers,
+  });
+}
+
 describe("DELETE /api/settings/tokens/[tokenId]", () => {
   it("returns 401 with 'Not authenticated' when session is null", async () => {
     mockState.getSession.mockResolvedValue(null);
 
     const response = await DELETE(
-      new Request("http://localhost:3000/api/settings/tokens/token-1", {
-        method: "DELETE",
+      createDeleteRequest("token-1"),
+      { params: Promise.resolve({ tokenId: "token-1" }) }
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+  });
+
+  it("returns 401 for cookie auth when Origin is missing", async () => {
+    mockState.getSession.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+    });
+
+    const response = await DELETE(
+      createDeleteRequest("token-1", {}),
+      { params: Promise.resolve({ tokenId: "token-1" }) }
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockState.getSession).not.toHaveBeenCalled();
+    expect(mockState.revokePersonalToken).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for cookie auth when Origin is not allowed", async () => {
+    mockState.getSession.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+    });
+
+    const response = await DELETE(
+      createDeleteRequest("token-1", { Origin: "https://attacker.example" }),
+      { params: Promise.resolve({ tokenId: "token-1" }) }
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockState.getSession).not.toHaveBeenCalled();
+    expect(mockState.revokePersonalToken).not.toHaveBeenCalled();
+  });
+
+  it("rejects Authorization-header session auth for token delete mutations", async () => {
+    mockState.getSession.mockResolvedValue(null);
+    mockState.getSessionFromHeader.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+    });
+
+    const response = await DELETE(
+      createDeleteRequest("token-1", {
+        Origin: "http://localhost:3000",
+        Authorization: "Bearer header-session",
       }),
       { params: Promise.resolve({ tokenId: "token-1" }) }
     );
 
     expect(response.status).toBe(401);
     expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockState.getSessionFromHeader).not.toHaveBeenCalled();
+    expect(mockState.revokePersonalToken).not.toHaveBeenCalled();
   });
 
   it("returns 200 with 'success: true' when token is successfully revoked", async () => {
@@ -60,9 +133,7 @@ describe("DELETE /api/settings/tokens/[tokenId]", () => {
     mockState.revokePersonalToken.mockResolvedValue(true);
 
     const response = await DELETE(
-      new Request("http://localhost:3000/api/settings/tokens/token-1", {
-        method: "DELETE",
-      }),
+      createDeleteRequest("token-1"),
       { params: Promise.resolve({ tokenId: "token-1" }) }
     );
 
@@ -81,9 +152,7 @@ describe("DELETE /api/settings/tokens/[tokenId]", () => {
     mockState.revokePersonalToken.mockResolvedValue(false);
 
     const response = await DELETE(
-      new Request("http://localhost:3000/api/settings/tokens/token-999", {
-        method: "DELETE",
-      }),
+      createDeleteRequest("token-999"),
       { params: Promise.resolve({ tokenId: "token-999" }) }
     );
 

--- a/packages/frontend/__tests__/api/settingsTokensList.test.ts
+++ b/packages/frontend/__tests__/api/settingsTokensList.test.ts
@@ -2,15 +2,18 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockState = vi.hoisted(() => {
   const getSession = vi.fn();
+  const getSessionFromHeader = vi.fn();
   const listPersonalTokens = vi.fn();
   const issuePersonalToken = vi.fn();
 
   return {
     getSession,
+    getSessionFromHeader,
     listPersonalTokens,
     issuePersonalToken,
     reset() {
       getSession.mockReset();
+      getSessionFromHeader.mockReset();
       listPersonalTokens.mockReset();
       issuePersonalToken.mockReset();
     },
@@ -19,6 +22,7 @@ const mockState = vi.hoisted(() => {
 
 vi.mock("@/lib/auth/session", () => ({
   getSession: mockState.getSession,
+  getSessionFromHeader: mockState.getSessionFromHeader,
 }));
 
 vi.mock("@/lib/auth/personalTokens", () => ({
@@ -40,6 +44,17 @@ beforeAll(async () => {
 beforeEach(() => {
   mockState.reset();
 });
+
+function createPostRequest(
+  body: unknown,
+  headers: Record<string, string> = { Origin: "http://localhost:3000" }
+) {
+  return new Request("http://localhost:3000/api/settings/tokens", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
 
 describe("GET /api/settings/tokens", () => {
   it("returns 401 when user is not authenticated", async () => {
@@ -144,15 +159,44 @@ describe("POST /api/settings/tokens", () => {
   it("returns 401 when user is not authenticated", async () => {
     mockState.getSession.mockResolvedValue(null);
 
+    const response = await POST(createPostRequest({ name: "CI" }));
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockState.issuePersonalToken).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for cookie auth when Origin is missing", async () => {
+    mockState.getSession.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+    });
+
+    const response = await POST(createPostRequest({ name: "CI" }, {}));
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockState.getSession).not.toHaveBeenCalled();
+    expect(mockState.issuePersonalToken).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for cookie auth when Origin is not allowed", async () => {
+    mockState.getSession.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+    });
+
     const response = await POST(
-      new Request("http://localhost:3000/api/settings/tokens", {
-        method: "POST",
-        body: JSON.stringify({ name: "CI" }),
-      })
+      createPostRequest({ name: "CI" }, { Origin: "https://attacker.example" })
     );
 
     expect(response.status).toBe(401);
     expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockState.getSession).not.toHaveBeenCalled();
     expect(mockState.issuePersonalToken).not.toHaveBeenCalled();
   });
 
@@ -173,12 +217,7 @@ describe("POST /api/settings/tokens", () => {
       expiresAt: null,
     });
 
-    const response = await POST(
-      new Request("http://localhost:3000/api/settings/tokens", {
-        method: "POST",
-        body: JSON.stringify({ name: "  GitHub Actions  " }),
-      })
-    );
+    const response = await POST(createPostRequest({ name: "  GitHub Actions  " }));
 
     expect(response.status).toBe(201);
     expect(mockState.issuePersonalToken).toHaveBeenCalledWith({
@@ -214,12 +253,7 @@ describe("POST /api/settings/tokens", () => {
       expiresAt: null,
     });
 
-    const response = await POST(
-      new Request("http://localhost:3000/api/settings/tokens", {
-        method: "POST",
-        body: JSON.stringify({ name: "   " }),
-      })
-    );
+    const response = await POST(createPostRequest({ name: "   " }));
 
     expect(response.status).toBe(201);
     expect(mockState.issuePersonalToken).toHaveBeenCalledWith({

--- a/packages/frontend/src/app/api/auth/device/authorize/route.ts
+++ b/packages/frontend/src/app/api/auth/device/authorize/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from "next/server";
 import { db, deviceCodes } from "@/lib/db";
 import { eq, and, gt, isNull } from "drizzle-orm";
-import { getSession } from "@/lib/auth/session";
+import { getSessionFromRequest } from "@/lib/auth/requestSession";
 
 export async function POST(request: Request) {
   try {
     // Check if user is authenticated
-    const session = await getSession();
+    const session = await getSessionFromRequest(request, {
+      allowAuthorizationHeader: false,
+    });
     if (!session) {
       return NextResponse.json(
         { error: "Not authenticated" },

--- a/packages/frontend/src/app/api/settings/devices/[deviceId]/route.ts
+++ b/packages/frontend/src/app/api/settings/devices/[deviceId]/route.ts
@@ -3,7 +3,7 @@ import { revalidateTag } from "next/cache";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { db, submittedDevices } from "@/lib/db";
-import { getSession } from "@/lib/auth/session";
+import { getSessionFromRequest } from "@/lib/auth/requestSession";
 import { normalizeUsernameCacheKey } from "@/lib/db/usernameLookup";
 
 const UUID_REGEX =
@@ -44,7 +44,9 @@ interface RouteParams {
  */
 export async function PATCH(request: Request, { params }: RouteParams) {
   try {
-    const session = await getSession();
+    const session = await getSessionFromRequest(request, {
+      allowAuthorizationHeader: false,
+    });
     if (!session) {
       return NextResponse.json(
         { error: "Not authenticated" },

--- a/packages/frontend/src/app/api/settings/submitted-data/route.ts
+++ b/packages/frontend/src/app/api/settings/submitted-data/route.ts
@@ -1,8 +1,8 @@
 import { revalidatePath, revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
-import { getSession } from "@/lib/auth/session";
 import { authenticatePersonalToken } from "@/lib/auth/personalTokens";
+import { getSessionFromRequest } from "@/lib/auth/requestSession";
 import { db, submissions, submittedDevices } from "@/lib/db";
 import { normalizeUsernameCacheKey, revalidateUsernamePaths } from "@/lib/db/usernameLookup";
 import { getBearerToken } from "../../../../lib/auth/bearerToken";
@@ -18,7 +18,7 @@ async function resolveUser(request: Request): Promise<{ id: string; username: st
     return null;
   }
 
-  const session = await getSession();
+  const session = await getSessionFromRequest(request);
   if (session) {
     return { id: session.id, username: session.username };
   }

--- a/packages/frontend/src/app/api/settings/tokens/[tokenId]/route.ts
+++ b/packages/frontend/src/app/api/settings/tokens/[tokenId]/route.ts
@@ -1,14 +1,16 @@
 import { NextResponse } from "next/server";
-import { getSession } from "@/lib/auth/session";
+import { getSessionFromRequest } from "@/lib/auth/requestSession";
 import { revokePersonalToken } from "@/lib/auth/personalTokens";
 
 interface RouteParams {
   params: Promise<{ tokenId: string }>;
 }
 
-export async function DELETE(_request: Request, { params }: RouteParams) {
+export async function DELETE(request: Request, { params }: RouteParams) {
   try {
-    const session = await getSession();
+    const session = await getSessionFromRequest(request, {
+      allowAuthorizationHeader: false,
+    });
     if (!session) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }

--- a/packages/frontend/src/app/api/settings/tokens/route.ts
+++ b/packages/frontend/src/app/api/settings/tokens/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
+import { getSessionFromRequest } from "@/lib/auth/requestSession";
 import { issuePersonalToken, listPersonalTokens } from "@/lib/auth/personalTokens";
 
 const DEFAULT_TOKEN_NAME = "CI token";
@@ -46,7 +47,9 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
-    const session = await getSession();
+    const session = await getSessionFromRequest(request, {
+      allowAuthorizationHeader: false,
+    });
     if (!session) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }


### PR DESCRIPTION
## Summary
- Require cookie-authenticated mutation routes to pass the shared `Origin` allowlist gate before using the browser session.
- Keep token-based clients on explicit Bearer-token paths instead of letting `Authorization` headers bypass browser CSRF checks on settings routes.
- Add focused regression coverage for device authorization, personal token management, submitted-data deletion, and device rename behavior.

## Why
Several browser-facing mutation routes were using cookie session helpers directly or accepted `Authorization` headers through the shared request-session helper. That made the CSRF boundary inconsistent across settings and device routes. This change centralizes request-session handling so cookie-authenticated mutations require a trusted `Origin`, while non-browser Bearer-token flows remain explicit and intentional.

## Diff scope
- `packages/frontend/src/lib/auth/requestSession.ts`: adds an option to disable `Authorization` header session resolution for routes that should only use cookie sessions behind the CSRF gate.
- Settings token and device mutation routes now use the request-aware session helper with Bearer headers disabled.
- Device authorization and submitted-data deletion now use the same request-aware CSRF session behavior while preserving the submitted-data Bearer token deletion path used by API clients.
- Tests cover missing, hostile, allowed `Origin`, and rejected `Authorization`-header session-auth cases for the changed mutation routes.

## Branch integrity
- Base branch: `main`
- Validated base SHA: `715fddf6db88258c50eb20a5cc8d698e442f35b9`
- Ahead/behind: `0 behind / 1 ahead`
- Merge-base: `715fddf6db88258c50eb20a5cc8d698e442f35b9`
- Branch was rebased onto the fetched base before push.

## Commit integrity
- Introduced commit: `c72e2859ba471055ef86e992cdb58bc71c204080 fix(auth): apply CSRF gate to cookie mutations`
- One logical change: align cookie-authenticated mutation routes with the shared CSRF request-session gate.
- Final diff contains only intended frontend auth route and API test changes.
- Ledger: not applicable - not required for selected validation mode/change family.
- Version: not applicable - not required for selected validation mode/change family.

## Diff hygiene
- `git diff --name-status origin/main...HEAD`: expected route/helper/test files only.
- `git diff --check origin/main...HEAD`: PASS, no output.
- No `.env` files, credentials, local environment files, caches, build outputs, or unrelated generated files are included.
- DB migration: not applicable - no DB migration changed.

## Validation mode and proof
- Validation mode: Mode 3 - security-sensitive auth mutation behavior.
- `bun --cwd packages/frontend test __tests__/api/settingsTokensDelete.test.ts`: PASS, 6 tests passed.
- `bun --cwd packages/frontend test __tests__/api/settingsTokensList.test.ts __tests__/api/settingsTokensDelete.test.ts __tests__/api/settingsSubmittedDataDelete.test.ts __tests__/api/deviceAuthorizeCsrf.test.ts __tests__/api/settingsDeviceRenameCsrf.test.ts __tests__/lib/requestSessionCsrf.test.ts`: PASS, 37 tests passed.
- `git diff --check origin/main...HEAD`: PASS, no output.
- Not run: full frontend suite - not required locally because targeted API and auth CSRF tests cover the changed security-sensitive routes; required remote CI should validate the final PR SHA before merge.

## CI context confirmation
- Pending - required CI has not completed on the updated PR SHA yet.
- CI workflow/context names unchanged.

## Runtime safety
- No new blocking locks, queues, migrations, or background jobs.
- Non-browser submitted-data deletion through personal Bearer tokens remains supported through the existing explicit token-auth path.
- No invariant regression introduced.

## Documentation integrity
- Not applicable - no docs, runbooks, commands, or operational procedures changed.

## Rollback plan
- Rollback: revert this PR.
- DB downgrade: not applicable.
- Data repair: not applicable.
- Operational caveats: none known.

## Known residual risks
- Remote CI is still pending on the updated SHA.
