### PR TITLE
fix(submit): recover first-write races

### DIFF
--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -642,6 +642,215 @@ describe("POST /api/submit auth path", () => {
     }));
   });
 
+  it("merges after a concurrent first submit creates the submission first", async () => {
+    mockState.authenticatePersonalToken.mockResolvedValue({
+      status: "valid",
+      tokenId: "token-1",
+      userId: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      expiresAt: null,
+    });
+
+    mockState.validateSubmission.mockReturnValue({
+      valid: true,
+      data: {
+        device: {
+          id: "dev_laptop",
+        },
+        meta: {
+          version: "2.0.0",
+          dateRange: { start: "2026-04-30", end: "2026-04-30" },
+        },
+        summary: {
+          clients: ["codex"],
+        },
+        contributions: [
+          {
+            date: "2026-04-30",
+            timestampMs: 456,
+            clients: [
+              {
+                client: "codex",
+                modelId: "gpt-5.5",
+                tokens: 15,
+                cost: 0.75,
+                input: 10,
+                output: 5,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+                messages: 1,
+              },
+            ],
+          },
+        ],
+      },
+      errors: [],
+      warnings: [],
+    });
+
+    const incomingBreakdown = {
+      tokens: 15,
+      cost: 0.75,
+      input: 10,
+      output: 5,
+      cacheRead: 0,
+      cacheWrite: 0,
+      reasoning: 0,
+      messages: 1,
+    };
+    const existingBreakdown = {
+      codex: {
+        tokens: 12,
+        cost: 0.5,
+        input: 7,
+        output: 5,
+        cacheRead: 0,
+        cacheWrite: 0,
+        reasoning: 0,
+        messages: 1,
+        models: { "gpt-5.5": { tokens: 12 } },
+      },
+    };
+    const mergedBreakdown = {
+      codex: {
+        ...incomingBreakdown,
+        models: { "gpt-5.5": incomingBreakdown },
+      },
+    };
+
+    mockState.clientContributionToBreakdownData.mockReturnValue(incomingBreakdown);
+    mockState.mergeClientBreakdownsWithRegressionGuard.mockReturnValue({
+      merged: mergedBreakdown,
+      warnings: [],
+    });
+    mockState.recalculateDayTotals.mockReturnValue({
+      tokens: 15,
+      cost: 0.75,
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+    mockState.mergeTimestampMs.mockReturnValue(456);
+
+    const selectResults = [
+      [],
+      [{ id: "submission-1" }],
+      [{
+        id: "daily-1",
+        date: "2026-04-30",
+        timestampMs: 123,
+        activeTimeMs: null,
+        sourceBreakdown: existingBreakdown,
+      }],
+      [{
+        totalTokens: 15,
+        totalCost: "0.7500",
+        inputTokens: 10,
+        outputTokens: 5,
+        dateStart: "2026-04-30",
+        dateEnd: "2026-04-30",
+        activeDays: 1,
+        rowCount: 1,
+      }],
+      [{ sourceBreakdown: mergedBreakdown }],
+    ];
+
+    let insertCall = 0;
+    let dailyInsertValues: unknown;
+    const uniqueSubmissionRace = Object.assign(
+      new Error("duplicate key value violates unique constraint"),
+      {
+        code: "23505",
+        constraint: "submissions_user_id_unique",
+      }
+    );
+    const tx = {
+      update: vi.fn(() => {
+        const builder = {
+          set: vi.fn(() => builder),
+          where: vi.fn(() => Promise.resolve()),
+        };
+        return builder;
+      }),
+      select: vi.fn(() => makeAwaitableBuilder(selectResults.shift() ?? [])),
+      insert: vi.fn(() => {
+        insertCall += 1;
+        if (insertCall === 1) {
+          const builder = {
+            values: vi.fn(() => builder),
+            returning: vi.fn(() => Promise.reject(uniqueSubmissionRace)),
+          };
+          return builder;
+        }
+
+        if (insertCall === 2) {
+          const builder = {
+            values: vi.fn(() => builder),
+            onConflictDoUpdate: vi.fn(() => builder),
+            returning: vi.fn(() => Promise.resolve([{ id: "submitted-device-1" }])),
+          };
+          return builder;
+        }
+
+        const builder = {
+          values: vi.fn((values: unknown) => {
+            dailyInsertValues = values;
+            return Promise.resolve();
+          }),
+        };
+        return builder;
+      }),
+      execute: vi.fn(() => Promise.resolve()),
+      transaction: vi.fn(async (callback: (sp: typeof tx) => Promise<unknown>) =>
+        callback(tx)
+      ),
+    };
+    type MockTransaction = typeof tx;
+
+    mockState.db.transaction.mockImplementation(async (callback: (tx: MockTransaction) => Promise<unknown>) =>
+      callback(tx)
+    );
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ meta: {}, contributions: [] }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(dailyInsertValues).toBeUndefined();
+    expect(tx.execute).toHaveBeenCalledTimes(1);
+    expect(mockState.mergeClientBreakdownsWithRegressionGuard).toHaveBeenCalledWith(
+      existingBreakdown,
+      {
+        codex: {
+          ...mergedBreakdown.codex,
+          provenance: {
+            schemaVersion: 1,
+            messageCount: 1,
+            modelCount: 1,
+          },
+        },
+      },
+      expect.any(Set)
+    );
+    expect(await response.json()).toEqual(expect.objectContaining({
+      success: true,
+      metrics: expect.objectContaining({
+        totalTokens: 15,
+        activeDays: 1,
+      }),
+      mode: "merge",
+    }));
+  });
+
   it("adopts legacy daily rows into the first modern device instead of duplicating totals", async () => {
     mockState.authenticatePersonalToken.mockResolvedValue({
       status: "valid",

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -75,6 +75,14 @@ function getSubmitDevice(data: SubmissionData): { key: string; name: string | nu
   };
 }
 
+function isUniqueConstraintViolation(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const maybeError = error as { code?: unknown; cause?: unknown };
+  if (maybeError.code === "23505") return true;
+  const cause = maybeError.cause;
+  return Boolean(cause && typeof cause === "object" && (cause as { code?: unknown }).code === "23505");
+}
+
 /**
  * POST /api/submit
  * Submit token usage data from CLI
@@ -189,27 +197,48 @@ export async function POST(request: Request) {
       if (existingSubmission) {
         submissionId = existingSubmission.id;
       } else {
-        isNewSubmission = true;
-        const [newSubmission] = await tx
-          .insert(submissions)
-          .values({
-            userId: tokenRecord.userId,
-            totalTokens: 0,
-            totalCost: "0",
-            inputTokens: 0,
-            outputTokens: 0,
-            cacheCreationTokens: 0,
-            cacheReadTokens: 0,
-            dateStart: data.meta.dateRange.start,
-            dateEnd: data.meta.dateRange.end,
-            sourcesUsed: [],
-            modelsUsed: [],
-            cliVersion: data.meta.version,
-            submissionHash: generateSubmissionHash(hashData),
-          })
-          .returning({ id: submissions.id });
+        try {
+          const [newSubmission] = await tx.transaction(async (sp) =>
+            sp
+              .insert(submissions)
+              .values({
+                userId: tokenRecord.userId,
+                totalTokens: 0,
+                totalCost: "0",
+                inputTokens: 0,
+                outputTokens: 0,
+                cacheCreationTokens: 0,
+                cacheReadTokens: 0,
+                dateStart: data.meta.dateRange.start,
+                dateEnd: data.meta.dateRange.end,
+                sourcesUsed: [],
+                modelsUsed: [],
+                cliVersion: data.meta.version,
+                submissionHash: generateSubmissionHash(hashData),
+              })
+              .returning({ id: submissions.id })
+          );
 
-        submissionId = newSubmission.id;
+          submissionId = newSubmission.id;
+          isNewSubmission = true;
+        } catch (creationErr) {
+          if (!isUniqueConstraintViolation(creationErr)) {
+            throw creationErr;
+          }
+
+          const [racedSubmission] = await tx
+            .select({ id: submissions.id })
+            .from(submissions)
+            .where(eq(submissions.userId, tokenRecord.userId))
+            .for('update')
+            .limit(1);
+
+          if (!racedSubmission) {
+            throw creationErr;
+          }
+
+          submissionId = racedSubmission.id;
+        }
       }
 
       const submitDevice = getSubmitDevice(data);


### PR DESCRIPTION
## Summary
- Recover cleanly when two first-time `/api/submit` requests for the same user race to create the initial `submissions` row.
- Use a nested transaction savepoint around the first-write insert so a duplicate-key error does not poison the outer transaction.
- Re-select the raced submission row with `FOR UPDATE` and continue through the existing device/day merge flow.

## Why
The first submit path selected the user's submission row with `FOR UPDATE`, but when the row did not exist there was nothing to lock. Two concurrent first submits could both observe no row, then the losing insert would hit the `submissions_user_id_unique` constraint and abort the outer transaction. That produced a failed submit instead of merging into the row created by the winning request.

## Diff scope
- `packages/frontend/src/app/api/submit/route.ts`: detects Postgres unique-constraint failures during first submission creation, rolls the failed insert back to a savepoint, locks the raced row, and continues as a merge.
- `packages/frontend/__tests__/api/submitAuth.test.ts`: adds regression coverage for the first-write race path and extends transaction mocks to support nested savepoint behavior.

## Branch integrity
- Base branch: `main`
- Validated base SHA: `2505a9fd933f217f3b5da7b30411351a8ea39052`
- Ahead/behind: `0 behind / 1 ahead`
- Merge-base: `2505a9fd933f217f3b5da7b30411351a8ea39052`
- Branch was rebased onto the fetched base before push.

## Commit integrity
- Introduced commit: `d78bc05905e81b57957774909255b5a05a0e1d62 fix(submit): recover first-write races`
- One logical change: make concurrent first submits recover into the normal merge path instead of returning a duplicate-key failure.
- Final diff contains only intended submit API and focused test changes.
- Ledger: not applicable — not required for selected validation mode/change family.
- Version: not applicable — not required for selected validation mode/change family.

## Diff hygiene
- `git diff --name-status origin/main...HEAD`: expected submit route and submit auth test files only.
- `git diff --check origin/main...HEAD`: PASS, no output.
- DB migration: not applicable — no DB migration changed.

## Validation mode and proof
- Validation mode: Mode 3 — shared submit API data-integrity behavior.
- `bun --cwd packages/frontend test __tests__/api/submitAuth.test.ts __tests__/api/submit.test.ts`: PASS, 58 tests passed.
- `git diff --check origin/main...HEAD`: PASS, no output.
- Not run: full frontend suite — not required locally because targeted submit API tests cover the changed first-write race and existing submit merge behavior; required remote CI should validate the final PR SHA before merge.

## CI context confirmation
- Pending — required CI has not run because the PR has not been opened yet.
- CI workflow/context names unchanged.

## Runtime safety
- No new migrations, background jobs, queues, or external service calls.
- The savepoint is scoped to the initial insert only; normal submit transaction semantics remain unchanged after the raced row is locked.
- No invariant regression introduced.

## Documentation integrity
- Not applicable — no docs, runbooks, commands, or operational procedures changed.

## Rollback plan
- Rollback: revert this PR.
- DB downgrade: not applicable.
- Data repair: not applicable.
- Operational caveats: none known.

## Known residual risks
- Remote CI is still pending until the PR is opened.
