### PR TITLE
fix(tui): scope cache by report filters

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -4947,19 +4947,15 @@ fn write_light_cache(
     year: &Option<String>,
     group_by: &tokscale_core::GroupBy,
 ) {
-    use crate::tui::{save_cached_data, DataLoader};
+    use crate::tui::{save_cached_data, CacheReportScope, DataLoader};
 
-    // The TUI cache key is `(enabled_clients, group_by)` only — it does
-    // NOT include `--since`, `--until`, `--year`, or `--home`. Writing
-    // date-filtered or home-scoped data under that key would silently
-    // poison subsequent TUI launches: the next `tokscale tui` would
-    // hit the cache and render the date-filtered slice as if it were
-    // the full report. Refuse the write when any of those filters is
-    // present and tell the user; their CLI report still prints fine.
-    if since.is_some() || until.is_some() || year.is_some() || home_dir.is_some() {
+    // The TUI cache key includes date filters, but not `--home`. Writing
+    // home-scoped data would still poison the default cache, so keep that
+    // guard until home is part of the cache key.
+    if home_dir.is_some() {
         eprintln!(
-            "tokscale: --write-cache skipped because --since/--until/--year/--home are set; \
-             the TUI cache key does not include those filters and writing would poison future TUI launches."
+            "tokscale: --write-cache skipped because --home is set; \
+             the TUI cache key does not include that filter and writing would poison future TUI launches."
         );
         return;
     }
@@ -4971,23 +4967,20 @@ fn write_light_cache(
         .collect();
     let include_synthetic = enabled_set.contains(&ClientFilter::Synthetic);
 
-    // No date/home filters at this point (guarded above), so passing
-    // None into `with_filters` matches what the TUI itself does on
-    // launch — keeps the cache key derivation byte-identical.
-    //
     // Cache writes are best-effort: the report has already been flushed
     // to stdout by the time we reach here, so a scan failure from the
     // background loader must NOT propagate up and turn a successful
     // user-visible report into a non-zero exit code. Mirrors the
     // pattern in `run_warm_tui_cache` below.
-    let loader = DataLoader::with_filters(None, None, None, None);
+    let loader = DataLoader::with_filters(None, since.clone(), until.clone(), year.clone());
+    let report_scope = CacheReportScope::new(since.clone(), until.clone(), year.clone());
     if let Ok(data) = loader.load(&scan_clients, group_by, include_synthetic) {
-        save_cached_data(&data, &enabled_set, group_by);
+        save_cached_data(&data, &enabled_set, group_by, &report_scope);
     }
 }
 
 fn run_warm_tui_cache() -> Result<()> {
-    use crate::tui::{save_cached_data, DataLoader, TUI_DEFAULT_GROUP_BY};
+    use crate::tui::{save_cached_data, CacheReportScope, DataLoader, TUI_DEFAULT_GROUP_BY};
     use tokscale_core::ClientId;
 
     // Warm the cache using the same default filter set the TUI uses on
@@ -5013,7 +5006,12 @@ fn run_warm_tui_cache() -> Result<()> {
     let include_synthetic = enabled_set.contains(&ClientFilter::Synthetic);
     let loader = DataLoader::with_filters(None, None, None, None);
     if let Ok(data) = loader.load(&scan_clients, &TUI_DEFAULT_GROUP_BY, include_synthetic) {
-        save_cached_data(&data, &enabled_set, &TUI_DEFAULT_GROUP_BY);
+        save_cached_data(
+            &data,
+            &enabled_set,
+            &TUI_DEFAULT_GROUP_BY,
+            &CacheReportScope::default(),
+        );
     }
     Ok(())
 }
@@ -6789,51 +6787,6 @@ mod tests {
             .error
             .as_deref()
             .is_some_and(|error| error.contains("runtime unavailable")));
-    }
-
-    #[test]
-    fn write_light_cache_refuses_when_since_filter_set() {
-        // Date/home filters are NOT part of the TUI cache key. Writing
-        // the filtered slice would silently poison subsequent TUI launches
-        // (next `tokscale tui` would render the filtered slice as if it
-        // were the default report). The function returns `()` and prints
-        // an eprintln; reaching this assertion line proves the function
-        // returned normally without panicking or attempting the write.
-        let group_by = tokscale_core::GroupBy::default();
-        write_light_cache(
-            &None,
-            &None,
-            &Some("2025-01-01".to_string()),
-            &None,
-            &None,
-            &group_by,
-        );
-    }
-
-    #[test]
-    fn write_light_cache_refuses_when_until_filter_set() {
-        let group_by = tokscale_core::GroupBy::default();
-        write_light_cache(
-            &None,
-            &None,
-            &None,
-            &Some("2025-12-31".to_string()),
-            &None,
-            &group_by,
-        );
-    }
-
-    #[test]
-    fn write_light_cache_refuses_when_year_filter_set() {
-        let group_by = tokscale_core::GroupBy::default();
-        write_light_cache(
-            &None,
-            &None,
-            &None,
-            &None,
-            &Some("2025".to_string()),
-            &group_by,
-        );
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/cache.rs
+++ b/crates/tokscale-cli/src/tui/cache.rs
@@ -21,7 +21,24 @@ use super::data::{
 
 /// Cache staleness threshold: 5 minutes (matches TS implementation)
 const CACHE_STALE_THRESHOLD_MS: u64 = 5 * 60 * 1000;
-const CACHE_SCHEMA_VERSION: u32 = 8;
+const CACHE_SCHEMA_VERSION: u32 = 9;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CacheReportScope {
+    #[serde(default)]
+    pub since: Option<String>,
+    #[serde(default)]
+    pub until: Option<String>,
+    #[serde(default)]
+    pub year: Option<String>,
+}
+
+impl CacheReportScope {
+    pub fn new(since: Option<String>, until: Option<String>, year: Option<String>) -> Self {
+        Self { since, until, year }
+    }
+}
 
 /// Single source of truth for the `group_by` value used to key the TUI
 /// cache. The cache file's `groupBy` field is compared verbatim against
@@ -75,6 +92,8 @@ struct CachedTUIData {
     include_synthetic: bool,
     #[serde(default)]
     group_by: Option<String>,
+    #[serde(default)]
+    report_scope: CacheReportScope,
     data: CachedUsageData,
 }
 
@@ -710,7 +729,11 @@ enum ClientMatch {
 /// `(enabled_clients: Vec<String>, include_synthetic: bool)` shape so
 /// existing user caches keep working across upgrades — projection
 /// happens here.
-pub fn load_cache(enabled_clients: &HashSet<ClientFilter>, group_by: &GroupBy) -> CacheResult {
+pub fn load_cache(
+    enabled_clients: &HashSet<ClientFilter>,
+    group_by: &GroupBy,
+    report_scope: &CacheReportScope,
+) -> CacheResult {
     let Some(cache_path) = cache_file() else {
         return CacheResult::Miss;
     };
@@ -744,6 +767,10 @@ pub fn load_cache(enabled_clients: &HashSet<ClientFilter>, group_by: &GroupBy) -
     }
 
     if cached_group_by.as_ref() != Some(group_by) {
+        return CacheResult::Miss;
+    }
+
+    if &cached.report_scope != report_scope {
         return CacheResult::Miss;
     }
 
@@ -838,6 +865,7 @@ pub fn save_cached_data(
     data: &UsageData,
     enabled_clients: &HashSet<ClientFilter>,
     group_by: &GroupBy,
+    report_scope: &CacheReportScope,
 ) {
     let Some(cache_path) = cache_file() else {
         return;
@@ -873,6 +901,7 @@ pub fn save_cached_data(
         enabled_clients: clients_vec,
         include_synthetic,
         group_by: Some(group_by.to_string()),
+        report_scope: report_scope.clone(),
         data: data.into(),
     };
 
@@ -1076,6 +1105,162 @@ mod tests {
 
     #[test]
     #[serial]
+    fn load_cache_misses_when_report_scope_differs() {
+        let temp_dir = TempDir::new().unwrap();
+        let previous_home = env::var_os("HOME");
+        unsafe {
+            env::set_var("HOME", temp_dir.path());
+        }
+
+        let cache_path = cache_file().unwrap();
+        fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
+        fs::write(
+            &cache_path,
+            r#"{
+  "schemaVersion": 9,
+  "timestamp": 9999999999999,
+  "enabledClients": ["claude"],
+  "includeSynthetic": false,
+  "groupBy": "model",
+  "reportScope": {
+    "since": "2026-05-01",
+    "until": "2026-05-07",
+    "year": null
+  },
+  "data": {
+    "models": [],
+    "agents": [],
+    "daily": [],
+    "hourly": [],
+    "graph": null,
+    "totalTokens": 0,
+    "totalCost": 0.0,
+    "currentStreak": 0,
+    "longestStreak": 0
+  }
+}"#,
+        )
+        .unwrap();
+
+        let clients = make_filters(&[ClientFilter::Claude], false);
+        let unfiltered_scope = CacheReportScope::default();
+        assert!(matches!(
+            load_cache(&clients, &GroupBy::Model, &unfiltered_scope),
+            CacheResult::Miss
+        ));
+
+        let filtered_scope = CacheReportScope::new(
+            Some("2026-05-01".to_string()),
+            Some("2026-05-07".to_string()),
+            None,
+        );
+        assert!(matches!(
+            load_cache(&clients, &GroupBy::Model, &filtered_scope),
+            CacheResult::Fresh(_)
+        ));
+
+        match previous_home {
+            Some(home) => unsafe { env::set_var("HOME", home) },
+            None => unsafe { env::remove_var("HOME") },
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn save_cached_data_writes_report_scope() {
+        let temp_dir = TempDir::new().unwrap();
+        let previous_home = env::var_os("HOME");
+        let previous_override = env::var_os("TOKSCALE_CONFIG_DIR");
+        unsafe {
+            env::set_var("HOME", temp_dir.path());
+            env::remove_var("TOKSCALE_CONFIG_DIR");
+        }
+
+        let clients = make_filters(&[ClientFilter::Claude], false);
+        let scope = CacheReportScope::new(
+            Some("2026-05-01".to_string()),
+            Some("2026-05-07".to_string()),
+            Some("2026".to_string()),
+        );
+
+        save_cached_data(&UsageData::default(), &clients, &GroupBy::Model, &scope);
+
+        let cache_path = cache_file().unwrap();
+        let saved: CachedTUIData = serde_json::from_slice(&fs::read(&cache_path).unwrap()).unwrap();
+        assert_eq!(saved.report_scope, scope);
+        assert!(matches!(
+            load_cache(&clients, &GroupBy::Model, &scope),
+            CacheResult::Fresh(_)
+        ));
+        assert!(matches!(
+            load_cache(&clients, &GroupBy::Model, &CacheReportScope::default()),
+            CacheResult::Miss
+        ));
+
+        match previous_home {
+            Some(home) => unsafe { env::set_var("HOME", home) },
+            None => unsafe { env::remove_var("HOME") },
+        }
+        match previous_override {
+            Some(value) => unsafe { env::set_var("TOKSCALE_CONFIG_DIR", value) },
+            None => unsafe { env::remove_var("TOKSCALE_CONFIG_DIR") },
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn old_cache_without_report_scope_is_stale_for_unfiltered_scope() {
+        let temp_dir = TempDir::new().unwrap();
+        let previous_home = env::var_os("HOME");
+        unsafe {
+            env::set_var("HOME", temp_dir.path());
+        }
+
+        let cache_path = cache_file().unwrap();
+        fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
+        fs::write(
+            &cache_path,
+            r#"{
+  "schemaVersion": 8,
+  "timestamp": 9999999999999,
+  "enabledClients": ["claude"],
+  "includeSynthetic": false,
+  "groupBy": "model",
+  "data": {
+    "models": [],
+    "agents": [],
+    "daily": [],
+    "hourly": [],
+    "graph": null,
+    "totalTokens": 0,
+    "totalCost": 0.0,
+    "currentStreak": 0,
+    "longestStreak": 0
+  }
+}"#,
+        )
+        .unwrap();
+
+        let clients = make_filters(&[ClientFilter::Claude], false);
+        assert!(matches!(
+            load_cache(&clients, &GroupBy::Model, &CacheReportScope::default()),
+            CacheResult::Stale(_)
+        ));
+
+        let filtered_scope = CacheReportScope::new(Some("2026-05-01".to_string()), None, None);
+        assert!(matches!(
+            load_cache(&clients, &GroupBy::Model, &filtered_scope),
+            CacheResult::Miss
+        ));
+
+        match previous_home {
+            Some(home) => unsafe { env::set_var("HOME", home) },
+            None => unsafe { env::remove_var("HOME") },
+        }
+    }
+
+    #[test]
+    #[serial]
     fn test_load_cache_misses_for_legacy_schema_without_group_by() {
         let temp_dir = TempDir::new().unwrap();
         let previous_home = env::var_os("HOME");
@@ -1106,7 +1291,7 @@ mod tests {
 
         let clients = make_filters(&[ClientFilter::Claude], false);
         assert!(matches!(
-            load_cache(&clients, &GroupBy::Model),
+            load_cache(&clients, &GroupBy::Model, &CacheReportScope::default()),
             CacheResult::Miss
         ));
 
@@ -1150,7 +1335,11 @@ mod tests {
 
         let clients = make_filters(&[ClientFilter::Claude], false);
         assert!(matches!(
-            load_cache(&clients, &GroupBy::WorkspaceModel),
+            load_cache(
+                &clients,
+                &GroupBy::WorkspaceModel,
+                &CacheReportScope::default()
+            ),
             CacheResult::Miss
         ));
 
@@ -1218,7 +1407,7 @@ mod tests {
         .unwrap();
 
         let clients = make_filters(&[ClientFilter::Claude], false);
-        match load_cache(&clients, &GroupBy::Model) {
+        match load_cache(&clients, &GroupBy::Model, &CacheReportScope::default()) {
             CacheResult::Stale(data) => {
                 let source = data.daily[0].source_breakdown.get("claude").unwrap();
                 let daily_model = source.models.get("claude-sonnet-4-5").unwrap();
@@ -1251,7 +1440,7 @@ mod tests {
         fs::write(
             &cache_path,
             r#"{
-  "schemaVersion": 8,
+  "schemaVersion": 9,
   "timestamp": 9999999999999,
   "enabledClients": ["claude", "cursor"],
   "includeSynthetic": false,
@@ -1338,7 +1527,7 @@ mod tests {
         .unwrap();
 
         let clients = make_filters(&[ClientFilter::Claude, ClientFilter::Cursor], false);
-        match load_cache(&clients, &GroupBy::Model) {
+        match load_cache(&clients, &GroupBy::Model, &CacheReportScope::default()) {
             CacheResult::Fresh(data) => {
                 assert_eq!(data.daily[0].source_breakdown.len(), 2);
                 let cursor = data.daily[0].source_breakdown.get("cursor").unwrap();
@@ -1419,7 +1608,7 @@ mod tests {
         .unwrap();
 
         let clients = make_filters(&[ClientFilter::Claude], false);
-        match load_cache(&clients, &GroupBy::Model) {
+        match load_cache(&clients, &GroupBy::Model, &CacheReportScope::default()) {
             CacheResult::Fresh(data) | CacheResult::Stale(data) => {
                 let hourly_model = data.hourly[0].models.get("claude-sonnet-4-5").unwrap();
                 assert_eq!(hourly_model.display_name, "claude-sonnet-4-5");
@@ -1492,7 +1681,7 @@ mod tests {
         .unwrap();
 
         let clients = make_filters(&[ClientFilter::Claude], false);
-        match load_cache(&clients, &GroupBy::Model) {
+        match load_cache(&clients, &GroupBy::Model, &CacheReportScope::default()) {
             CacheResult::Stale(data) => {
                 assert!(
                     data.daily[0].source_breakdown.contains_key("unknown"),
@@ -1533,7 +1722,7 @@ mod tests {
         fs::write(
             &legacy_path,
             r#"{
-  "schemaVersion": 8,
+  "schemaVersion": 9,
   "timestamp": 9999999999999,
   "enabledClients": ["claude"],
   "includeSynthetic": false,
@@ -1555,7 +1744,7 @@ mod tests {
 
         let clients = make_filters(&[ClientFilter::Claude], false);
         assert!(matches!(
-            load_cache(&clients, &GroupBy::Model),
+            load_cache(&clients, &GroupBy::Model, &CacheReportScope::default()),
             CacheResult::Fresh(_)
         ));
 
@@ -1612,7 +1801,7 @@ mod tests {
 
         let clients = make_filters(&[ClientFilter::Claude], false);
         assert!(matches!(
-            load_cache(&clients, &GroupBy::Model),
+            load_cache(&clients, &GroupBy::Model, &CacheReportScope::default()),
             CacheResult::Miss
         ));
 
@@ -1670,7 +1859,12 @@ mod tests {
         assert!(fs::metadata(&cache_path).is_ok());
 
         let clients = make_filters(&[ClientFilter::Claude], false);
-        save_cached_data(&UsageData::default(), &clients, &GroupBy::Model);
+        save_cached_data(
+            &UsageData::default(),
+            &clients,
+            &GroupBy::Model,
+            &CacheReportScope::default(),
+        );
 
         let metadata = fs::metadata(&cache_path).unwrap();
         assert!(metadata.is_file());
@@ -1727,16 +1921,22 @@ mod tests {
         }
 
         let enabled = ClientFilter::default_set();
+        let scope = CacheReportScope::default();
 
         // Write with the canonical key (mirrors what `run_warm_tui_cache`
         // does after the fix).
-        save_cached_data(&UsageData::default(), &enabled, &TUI_DEFAULT_GROUP_BY);
+        save_cached_data(
+            &UsageData::default(),
+            &enabled,
+            &TUI_DEFAULT_GROUP_BY,
+            &scope,
+        );
 
         // Read with the canonical key (mirrors what `tui::run` does on
         // launch). The bug would have returned `Miss` here because the
         // historical writer used `GroupBy::default()` (= ClientModel)
         // while the reader used `GroupBy::Model`.
-        let result = load_cache(&enabled, &TUI_DEFAULT_GROUP_BY);
+        let result = load_cache(&enabled, &TUI_DEFAULT_GROUP_BY, &scope);
         assert!(
             matches!(result, CacheResult::Fresh(_)),
             "expected Fresh after writing with TUI_DEFAULT_GROUP_BY, got {}",
@@ -1770,9 +1970,10 @@ mod tests {
         }
 
         let enabled = ClientFilter::default_set();
+        let scope = CacheReportScope::default();
 
         // Pre-fix: writer used `GroupBy::default()`.
-        save_cached_data(&UsageData::default(), &enabled, &GroupBy::default());
+        save_cached_data(&UsageData::default(), &enabled, &GroupBy::default(), &scope);
 
         // Reader uses the canonical key. If `GroupBy::default()` and
         // `TUI_DEFAULT_GROUP_BY` ever coincide (e.g. someone changes
@@ -1780,7 +1981,7 @@ mod tests {
         // will start failing — at which point the divergent-write site
         // in `run_warm_tui_cache` is no longer dangerous and the test
         // should be updated accordingly.
-        let result = load_cache(&enabled, &TUI_DEFAULT_GROUP_BY);
+        let result = load_cache(&enabled, &TUI_DEFAULT_GROUP_BY, &scope);
         assert!(
             matches!(result, CacheResult::Miss),
             "expected Miss when reader uses TUI_DEFAULT_GROUP_BY and writer used GroupBy::default(), got {}",

--- a/crates/tokscale-cli/src/tui/mod.rs
+++ b/crates/tokscale-cli/src/tui/mod.rs
@@ -11,7 +11,9 @@ mod themes;
 mod ui;
 
 pub use app::{App, Tab, TuiConfig};
-pub use cache::{load_cache, save_cached_data, CacheResult, TUI_DEFAULT_GROUP_BY};
+pub use cache::{
+    load_cache, save_cached_data, CacheReportScope, CacheResult, TUI_DEFAULT_GROUP_BY,
+};
 pub use data::{DataLoader, UsageData};
 pub use event::{Event, EventHandler};
 
@@ -58,6 +60,14 @@ fn background_data_loader(
     minutely_enabled: bool,
 ) -> DataLoader {
     DataLoader::with_filters(None, since, until, year).with_minutely_enabled(minutely_enabled)
+}
+
+fn background_cache_scope(
+    since: &Option<String>,
+    until: &Option<String>,
+    year: &Option<String>,
+) -> CacheReportScope {
+    CacheReportScope::new(since.clone(), until.clone(), year.clone())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -108,8 +118,12 @@ pub fn run(
     // on the same constant. Hard-coding a different value here would
     // silently invalidate the cache on every launch after `submit`.
     let initial_group_by = TUI_DEFAULT_GROUP_BY;
-    let (cached_data, needs_background_load) =
-        decide_initial_data(load_cache(&enabled_clients, &initial_group_by));
+    let initial_report_scope = background_cache_scope(&since, &until, &year);
+    let (cached_data, needs_background_load) = decide_initial_data(load_cache(
+        &enabled_clients,
+        &initial_group_by,
+        &initial_report_scope,
+    ));
 
     let original_hook = panic::take_hook();
     panic::set_hook(Box::new(move |info| {
@@ -166,6 +180,7 @@ pub fn run(
         let bg_year = year.clone();
         let bg_enabled_clients = enabled_clients.clone();
         let bg_group_by = app.group_by.borrow().clone();
+        let bg_report_scope = background_cache_scope(&since, &until, &year);
         let bg_minutely_enabled = app.settings.minutely_tab_enabled;
 
         thread::spawn(move || {
@@ -173,7 +188,7 @@ pub fn run(
             let result = loader.load(&bg_clients, &bg_group_by, bg_include_synthetic);
 
             if let Ok(ref data) = result {
-                save_cached_data(data, &bg_enabled_clients, &bg_group_by);
+                save_cached_data(data, &bg_enabled_clients, &bg_group_by, &bg_report_scope);
             }
 
             let _ = tx.send(result);
@@ -284,13 +299,14 @@ fn run_loop_with_background(
             let year = app.data_loader.year.clone();
             let enabled_clients = app.enabled_clients.borrow().clone();
             let group_by = app.group_by.borrow().clone();
+            let report_scope = background_cache_scope(&since, &until, &year);
             let minutely_enabled = app.settings.minutely_tab_enabled;
 
             thread::spawn(move || {
                 let loader = background_data_loader(since, until, year, minutely_enabled);
                 let result = loader.load(&clients, &group_by, include_synthetic);
                 if let Ok(ref data) = result {
-                    save_cached_data(data, &enabled_clients, &group_by);
+                    save_cached_data(data, &enabled_clients, &group_by, &report_scope);
                 }
                 let _ = tx.send(result);
             });
@@ -395,5 +411,23 @@ mod tests {
 
         let disabled = background_data_loader(None, None, None, false);
         assert!(!disabled.minutely_enabled);
+    }
+
+    #[test]
+    fn background_cache_scope_uses_date_filters() {
+        let scope = background_cache_scope(
+            &Some("2026-05-01".to_string()),
+            &Some("2026-05-07".to_string()),
+            &Some("2026".to_string()),
+        );
+
+        assert_eq!(
+            scope,
+            crate::tui::cache::CacheReportScope::new(
+                Some("2026-05-01".to_string()),
+                Some("2026-05-07".to_string()),
+                Some("2026".to_string()),
+            )
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Include report filters (`since`, `until`, and `year`) in the TUI cache key so filtered reports cannot reuse stale all-time cache data.
- Persist the report scope in the cache payload and miss when the requested scope differs from the cached scope.
- Keep the warmed TUI cache aligned with the TUI default grouping while allowing scoped light-cache writes for date-filtered reports.

## Why
The TUI cache already keyed on enabled clients and grouping, but it did not distinguish all-time data from date-filtered reports. That meant a cache file written for one report scope could be reused by another scope, causing the TUI to show incorrect cached totals while the background refresh was still running. This change makes the cache key explicit for report scope and preserves the existing stale/fresh behavior for compatible cache files.

## Diff scope
- `crates/tokscale-cli/src/tui/cache.rs`: adds `CacheReportScope`, bumps the cache schema, stores report scope in `tui-data-cache.json`, and treats mismatched scopes as cache misses.
- `crates/tokscale-cli/src/tui/mod.rs`: threads the active TUI report scope into initial cache loads and background cache saves.
- `crates/tokscale-cli/src/main.rs`: writes scoped light-cache data for `--since`, `--until`, and `--year` reports while keeping `--home` guarded because home is not part of the cache key.
- Tests cover scope mismatch, old cache behavior, persisted scope round-trips, background scope construction, and the remaining `--home --write-cache` guard.

## Branch integrity
- Base branch: `main`
- Validated base SHA: `715fddf6db88258c50eb20a5cc8d698e442f35b9`
- Ahead/behind: `0 behind / 1 ahead`
- Merge-base: `715fddf6db88258c50eb20a5cc8d698e442f35b9`
- Branch was rebased onto the fetched base before push.

## Commit integrity
- Introduced commit: `f5e3a75d3e14b9d32538ef49de0ecf05e91febab fix(tui): scope cache by report filters`
- One logical change: make TUI cache entries scoped to the report filters that produced them.
- Final diff contains only intended CLI TUI cache/load/write changes.
- Ledger: not applicable — not required for selected validation mode/change family.
- Version: not applicable — not required for selected validation mode/change family.

## Diff hygiene
- `git diff --name-status origin/main...HEAD`: expected CLI TUI cache files only.
- `git diff --check origin/main...HEAD`: PASS, no output.
- DB migration: not applicable — no DB migration changed.

## Validation mode and proof
- Validation mode: Mode 2 — narrow CLI cache behavior.
- `cargo test -p tokscale-cli tui::cache -- --nocapture`: PASS, 24 tests passed.
- `cargo test -p tokscale-cli background_cache_scope_uses_date_filters -- --nocapture`: PASS, 1 test passed.
- `cargo test -p tokscale-cli write_light_cache_refuses_when_home_dir_set -- --nocapture`: PASS, 1 test passed.
- `cargo fmt --all --check`: PASS.
- `git diff --check origin/main...HEAD`: PASS, no output.
- Not run: full CLI test suite — not required locally because targeted cache and write-cache tests cover the changed behavior; required remote CI should validate the final PR SHA before merge.

## CI context confirmation
- Pending — required CI has not run because the PR has not been opened yet.
- CI workflow/context names unchanged.

## Runtime safety
- No new migrations, external service calls, queues, or blocking locks.
- Cache reads and writes remain best-effort; incompatible scope data is ignored rather than transformed.
- No invariant regression introduced.

## Documentation integrity
- Not applicable — no docs, runbooks, commands, or operational procedures changed.

## Rollback plan
- Rollback: revert this PR.
- DB downgrade: not applicable.
- Data repair: not applicable.
- Operational caveats: after rollback, any cache files written with the scoped schema may be ignored by older cache readers and regenerated on the next TUI refresh.

## Known residual risks
- Remote CI is still pending until the PR is opened.

