### PR TITLE
feat(claude): discover cc-mirror variants

### DIFF
--- a/crates/tokscale-core/src/cc_mirror.rs
+++ b/crates/tokscale-core/src/cc_mirror.rs
@@ -1,0 +1,135 @@
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct VariantFile {
+    pub(crate) name: Option<String>,
+    pub(crate) provider: Option<String>,
+    pub(crate) provider_id: Option<String>,
+    pub(crate) config_dir: Option<String>,
+}
+
+pub(crate) fn read_variant_file(variant_path: &Path) -> Option<VariantFile> {
+    let contents = std::fs::read_to_string(variant_path).ok()?;
+    serde_json::from_str(&contents).ok()
+}
+
+pub(crate) fn variant_file_path(variant_dir: &Path) -> PathBuf {
+    variant_dir.join("variant.json")
+}
+
+pub(crate) fn discover_claude_project_roots(home_dir: &Path) -> Vec<PathBuf> {
+    let root = home_dir.join(".cc-mirror");
+    let entries = match std::fs::read_dir(root) {
+        Ok(entries) => entries,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut roots: Vec<PathBuf> = entries
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| {
+            let variant_path = variant_file_path(&entry.path());
+            let config_dir = config_dir_from_variant_file(&variant_path, home_dir)?;
+            let projects_dir = config_dir.join("projects");
+            projects_dir.is_dir().then_some(projects_dir)
+        })
+        .collect();
+    roots.sort_unstable();
+    roots
+}
+
+pub(crate) fn variant_file_for_session_path(
+    path: &Path,
+    home_dir: Option<&Path>,
+) -> Option<PathBuf> {
+    variant_dir_from_session_path(path, home_dir).map(|variant_dir| variant_file_path(&variant_dir))
+}
+
+pub(crate) fn variant_dir_from_session_path(
+    path: &Path,
+    home_dir: Option<&Path>,
+) -> Option<PathBuf> {
+    default_layout_variant_dir_from_session_path(path)
+        .or_else(|| configured_variant_dir_from_session_path(path, home_dir?))
+}
+
+fn default_layout_variant_dir_from_session_path(path: &Path) -> Option<PathBuf> {
+    for ancestor in path.ancestors() {
+        if ancestor.file_name().and_then(|name| name.to_str()) != Some("config") {
+            continue;
+        }
+        if !path.starts_with(ancestor.join("projects")) {
+            continue;
+        }
+        let variant_dir = ancestor.parent()?;
+        if variant_dir
+            .parent()
+            .and_then(|parent| parent.file_name())
+            .and_then(|name| name.to_str())
+            == Some(".cc-mirror")
+        {
+            return Some(variant_dir.to_path_buf());
+        }
+    }
+
+    None
+}
+
+fn configured_variant_dir_from_session_path(path: &Path, home_dir: &Path) -> Option<PathBuf> {
+    let root = home_dir.join(".cc-mirror");
+    let entries = std::fs::read_dir(root).ok()?;
+    let normal_claude_projects = home_dir.join(".claude").join("projects");
+    let mut candidates: Vec<(usize, PathBuf)> = entries
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| {
+            let variant_dir = entry.path();
+            if !variant_dir.is_dir() {
+                return None;
+            }
+            let variant_path = variant_file_path(&variant_dir);
+            let config_dir = config_dir_from_variant_file(&variant_path, home_dir)?;
+            let projects_dir = config_dir.join("projects");
+
+            if projects_dir == normal_claude_projects || !path.starts_with(&projects_dir) {
+                return None;
+            }
+
+            Some((projects_dir.components().count(), variant_dir))
+        })
+        .collect();
+
+    candidates.sort_by(|left, right| right.0.cmp(&left.0).then_with(|| left.1.cmp(&right.1)));
+    candidates
+        .into_iter()
+        .map(|(_, variant_dir)| variant_dir)
+        .next()
+}
+
+fn config_dir_from_variant_file(variant_path: &Path, home_dir: &Path) -> Option<PathBuf> {
+    let variant_dir = variant_path.parent()?;
+    let metadata = read_variant_file(variant_path)?;
+    metadata
+        .config_dir
+        .as_deref()
+        .and_then(|raw| expand_config_dir(raw, home_dir, variant_dir))
+        .or_else(|| Some(variant_dir.join("config")))
+}
+
+fn expand_config_dir(raw: &str, home_dir: &Path, variant_dir: &Path) -> Option<PathBuf> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Some(rest) = trimmed.strip_prefix("~/") {
+        return Some(home_dir.join(rest));
+    }
+
+    let path = PathBuf::from(trimmed);
+    if path.is_absolute() {
+        Some(path)
+    } else {
+        Some(variant_dir.join(path))
+    }
+}

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::all)]
 
 mod aggregator;
+mod cc_mirror;
 pub mod clients;
 pub mod fs_atomic;
 mod message_cache;
@@ -118,6 +119,7 @@ fn retain_for_requested_clients(
     requested: &HashSet<&str>,
 ) -> bool {
     requested.contains(client)
+        || (requested.contains("claude") && client.starts_with("cc-mirror/"))
         || (requested.contains("synthetic")
             && sessions::synthetic::matches_synthetic_filter(client, model_id, provider_id))
 }
@@ -627,15 +629,16 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         ))
     }
 
-    fn load_or_parse_source_with_fingerprint_and_policy<F>(
+    fn load_or_parse_source_with_fingerprint_and_policy<F, FingerprintFn>(
         path: &Path,
         source_cache: &message_cache::SourceMessageCache,
         pricing: Option<&pricing::PricingService>,
-        fingerprint_from_path: fn(&Path) -> Option<message_cache::SourceFingerprint>,
+        fingerprint_from_path: FingerprintFn,
         parse: F,
     ) -> CachedParseOutcome
     where
         F: Fn(&Path) -> (Vec<UnifiedMessage>, bool),
+        FingerprintFn: Fn(&Path) -> Option<message_cache::SourceFingerprint>,
     {
         let Some(fingerprint) = fingerprint_from_path(path) else {
             let (mut messages, _) = parse(path);
@@ -678,15 +681,16 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         }
     }
 
-    fn load_or_parse_source_with_fingerprint<F>(
+    fn load_or_parse_source_with_fingerprint<F, FingerprintFn>(
         path: &Path,
         source_cache: &message_cache::SourceMessageCache,
         pricing: Option<&pricing::PricingService>,
-        fingerprint_from_path: fn(&Path) -> Option<message_cache::SourceFingerprint>,
+        fingerprint_from_path: FingerprintFn,
         parse: F,
     ) -> CachedParseOutcome
     where
         F: Fn(&Path) -> Vec<UnifiedMessage>,
+        FingerprintFn: Fn(&Path) -> Option<message_cache::SourceFingerprint>,
     {
         load_or_parse_source_with_fingerprint_and_policy(
             path,
@@ -888,6 +892,7 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         }
     }
 
+    let claude_home = PathBuf::from(home_dir);
     let claude_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::Claude)
         .par_iter()
@@ -896,8 +901,13 @@ fn parse_all_messages_with_pricing_with_env_strategy(
                 path,
                 &source_cache,
                 pricing,
-                message_cache::SourceFingerprint::from_claude_code_path,
-                sessions::claudecode::parse_claude_file,
+                |path| {
+                    message_cache::SourceFingerprint::from_claude_code_path_with_home(
+                        path,
+                        Some(&claude_home),
+                    )
+                },
+                |path| sessions::claudecode::parse_claude_file_with_home(path, Some(&claude_home)),
             )
         })
         .collect();
@@ -2079,17 +2089,22 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     };
     counts.set(ClientId::OpenCode, opencode_count);
 
+    let claude_home = PathBuf::from(&home_dir);
     let claude_msgs_raw: Vec<(String, ParsedMessage)> = scan_result
         .get(ClientId::Claude)
         .par_iter()
         .map_init(std::collections::HashMap::new, |parent_cache, path| {
-            sessions::claudecode::parse_claude_file_with_cache(path, parent_cache)
-                .into_iter()
-                .map(|msg| {
-                    let dedup_key = msg.dedup_key.clone().unwrap_or_default();
-                    (dedup_key, unified_to_parsed(&msg))
-                })
-                .collect::<Vec<_>>()
+            sessions::claudecode::parse_claude_file_with_cache_and_home(
+                path,
+                parent_cache,
+                Some(&claude_home),
+            )
+            .into_iter()
+            .map(|msg| {
+                let dedup_key = msg.dedup_key.clone().unwrap_or_default();
+                (dedup_key, unified_to_parsed(&msg))
+            })
+            .collect::<Vec<_>>()
         })
         .flatten()
         .collect();
@@ -6003,6 +6018,117 @@ mod tests {
         assert_eq!(parsed.messages[0].output, 45);
         assert_eq!(parsed.messages[0].cache_read, 67);
         assert_eq!(parsed.messages[0].cache_write, 8);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parse_all_messages_refreshes_cc_mirror_provider_when_variant_metadata_changes() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            let variant_dir = source_home.path().join(".cc-mirror/kimi-code");
+            let config_dir = source_home.path().join("mirror-configs/kimi-code");
+            let project_dir = config_dir.join("projects/project-one");
+            std::fs::create_dir_all(&project_dir).unwrap();
+            std::fs::create_dir_all(&variant_dir).unwrap();
+            let variant_path = variant_dir.join("variant.json");
+            std::fs::write(
+                &variant_path,
+                format!(
+                    r#"{{"name":"kimi-code","provider":"kimi","configDir":"{}"}}"#,
+                    config_dir.display()
+                ),
+            )
+            .unwrap();
+            let session_path = project_dir.join("session.jsonl");
+            std::fs::write(
+                &session_path,
+                r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50}}}
+"#,
+            )
+            .unwrap();
+
+            let first_messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["claude".to_string()],
+                None,
+            );
+            assert_eq!(first_messages.len(), 1);
+            assert_eq!(first_messages[0].client, "cc-mirror/kimi-code");
+            assert_eq!(first_messages[0].provider_id, "kimi");
+
+            std::fs::write(
+                &variant_path,
+                format!(
+                    r#"{{"name":"kimi-code","provider":"minimax","configDir":"{}"}}"#,
+                    config_dir.display()
+                ),
+            )
+            .unwrap();
+
+            let refreshed_messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["claude".to_string()],
+                None,
+            );
+            assert_eq!(refreshed_messages.len(), 1);
+            assert_eq!(refreshed_messages[0].client, "cc-mirror/kimi-code");
+            assert_eq!(refreshed_messages[0].provider_id, "minimax");
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parse_all_messages_keeps_normal_claude_when_cc_mirror_points_at_claude_config() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            let claude_dir = source_home.path().join(".claude");
+            let project_dir = claude_dir.join("projects/project-one");
+            std::fs::create_dir_all(&project_dir).unwrap();
+            let session_path = project_dir.join("session.jsonl");
+            std::fs::write(
+                &session_path,
+                r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50}}}
+"#,
+            )
+            .unwrap();
+
+            let variant_dir = source_home.path().join(".cc-mirror/plain-mirror");
+            std::fs::create_dir_all(&variant_dir).unwrap();
+            std::fs::write(
+                variant_dir.join("variant.json"),
+                format!(
+                    r#"{{"name":"plain-mirror","provider":"mirror","configDir":"{}"}}"#,
+                    claude_dir.display()
+                ),
+            )
+            .unwrap();
+
+            let messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["claude".to_string()],
+                None,
+            );
+            assert_eq!(messages.len(), 1);
+            assert_eq!(messages[0].client, "claude");
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
     }
 
     #[test]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -133,12 +133,22 @@ impl SourceFingerprint {
     /// Fingerprint for a Claude Code JSONL file that may have a sibling `.meta.json`
     /// sidecar. When the sidecar appears or changes (e.g. after a Claude Code upgrade),
     /// the fingerprint changes and the cache invalidates.
-    pub(crate) fn from_claude_code_path(path: &Path) -> Option<Self> {
-        let related = path.file_stem().and_then(|s| s.to_str()).map(|stem| {
+    pub(crate) fn from_claude_code_path_with_home(
+        path: &Path,
+        home_dir: Option<&Path>,
+    ) -> Option<Self> {
+        let mut related = Vec::new();
+
+        if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
             let meta_filename = format!("{}.meta.json", stem);
-            let meta_path = path.with_file_name(meta_filename);
-            (".meta.json".to_string(), meta_path)
-        });
+            related.push((".meta.json".to_string(), path.with_file_name(meta_filename)));
+        }
+
+        if let Some(variant_path) = crate::cc_mirror::variant_file_for_session_path(path, home_dir)
+        {
+            related.push(("cc-mirror/variant.json".to_string(), variant_path));
+        }
+
         Self::from_path_with_related(path, related)
     }
 
@@ -834,12 +844,13 @@ mod tests {
         std::fs::write(&jsonl_path, b"jsonl-content").unwrap();
 
         // No meta sidecar → baseline fingerprint
-        let base = SourceFingerprint::from_claude_code_path(&jsonl_path).unwrap();
+        let base = SourceFingerprint::from_claude_code_path_with_home(&jsonl_path, None).unwrap();
 
         // Add meta sidecar → fingerprint changes
         let meta_path = dir.path().join("agent-abc123.meta.json");
         std::fs::write(&meta_path, br#"{"agentType":"explore"}"#).unwrap();
-        let with_meta = SourceFingerprint::from_claude_code_path(&jsonl_path).unwrap();
+        let with_meta =
+            SourceFingerprint::from_claude_code_path_with_home(&jsonl_path, None).unwrap();
         assert_ne!(
             base, with_meta,
             "Adding meta sidecar should change fingerprint"
@@ -847,7 +858,8 @@ mod tests {
 
         // Update meta sidecar → fingerprint changes again
         std::fs::write(&meta_path, br#"{"agentType":"executor"}"#).unwrap();
-        let updated_meta = SourceFingerprint::from_claude_code_path(&jsonl_path).unwrap();
+        let updated_meta =
+            SourceFingerprint::from_claude_code_path_with_home(&jsonl_path, None).unwrap();
         assert_ne!(
             with_meta, updated_meta,
             "Updating meta sidecar should change fingerprint"
@@ -856,14 +868,97 @@ mod tests {
         // Main session file (no agent- prefix) → unaffected by unrelated meta files
         let main_path = dir.path().join("session-uuid.jsonl");
         std::fs::write(&main_path, b"main-session").unwrap();
-        let main_fp1 = SourceFingerprint::from_claude_code_path(&main_path).unwrap();
+        let main_fp1 =
+            SourceFingerprint::from_claude_code_path_with_home(&main_path, None).unwrap();
         // Create a meta file with the main session stem (unlikely in practice)
         let main_meta = dir.path().join("session-uuid.meta.json");
         std::fs::write(&main_meta, br#"{"agentType":"x"}"#).unwrap();
-        let main_fp2 = SourceFingerprint::from_claude_code_path(&main_path).unwrap();
+        let main_fp2 =
+            SourceFingerprint::from_claude_code_path_with_home(&main_path, None).unwrap();
         assert_ne!(
             main_fp1, main_fp2,
-            "from_claude_code_path always tracks .meta.json if it exists"
+            "Claude Code fingerprints always track .meta.json if it exists"
+        );
+    }
+
+    #[test]
+    fn test_claude_code_fingerprint_tracks_cc_mirror_variant_metadata_changes() {
+        let dir = TempDir::new().unwrap();
+        let variant_dir = dir.path().join(".cc-mirror/kimi-code");
+        let config_dir = variant_dir.join("config");
+        let project_dir = config_dir.join("projects/project-one");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let jsonl_path = project_dir.join("session.jsonl");
+        std::fs::write(&jsonl_path, b"jsonl-content").unwrap();
+
+        let variant_path = variant_dir.join("variant.json");
+        std::fs::write(
+            &variant_path,
+            format!(
+                r#"{{"name":"kimi-code","provider":"kimi","configDir":"{}"}}"#,
+                config_dir.display()
+            ),
+        )
+        .unwrap();
+        let with_kimi =
+            SourceFingerprint::from_claude_code_path_with_home(&jsonl_path, None).unwrap();
+
+        std::fs::write(
+            &variant_path,
+            format!(
+                r#"{{"name":"kimi-code","provider":"minimax","configDir":"{}"}}"#,
+                config_dir.display()
+            ),
+        )
+        .unwrap();
+        let with_minimax =
+            SourceFingerprint::from_claude_code_path_with_home(&jsonl_path, None).unwrap();
+
+        assert_ne!(
+            with_kimi, with_minimax,
+            "Changing cc-mirror provider metadata should invalidate parsed Claude cache entries"
+        );
+    }
+
+    #[test]
+    fn test_claude_code_fingerprint_tracks_cc_mirror_custom_config_dir_metadata_changes() {
+        let dir = TempDir::new().unwrap();
+        let variant_dir = dir.path().join(".cc-mirror/kimi-code");
+        let config_dir = dir.path().join("mirror-configs/kimi-code");
+        let project_dir = config_dir.join("projects/project-one");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let jsonl_path = project_dir.join("session.jsonl");
+        std::fs::write(&jsonl_path, b"jsonl-content").unwrap();
+
+        std::fs::create_dir_all(&variant_dir).unwrap();
+        let variant_path = variant_dir.join("variant.json");
+        std::fs::write(
+            &variant_path,
+            format!(
+                r#"{{"name":"kimi-code","provider":"kimi","configDir":"{}"}}"#,
+                config_dir.display()
+            ),
+        )
+        .unwrap();
+        let with_kimi =
+            SourceFingerprint::from_claude_code_path_with_home(&jsonl_path, Some(dir.path()))
+                .unwrap();
+
+        std::fs::write(
+            &variant_path,
+            format!(
+                r#"{{"name":"kimi-code","provider":"minimax","configDir":"{}"}}"#,
+                config_dir.display()
+            ),
+        )
+        .unwrap();
+        let with_minimax =
+            SourceFingerprint::from_claude_code_path_with_home(&jsonl_path, Some(dir.path()))
+                .unwrap();
+
+        assert_ne!(
+            with_kimi, with_minimax,
+            "Changing cc-mirror metadata should invalidate cache entries for custom configDir layouts"
         );
     }
 

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -356,6 +356,11 @@ pub fn built_in_extra_scan_paths_for(
             ClientId::Claude,
             PathBuf::from(format!("{}/.claude/transcripts", home_dir)),
         ));
+        paths.extend(
+            crate::cc_mirror::discover_claude_project_roots(Path::new(home_dir))
+                .into_iter()
+                .map(|path| (ClientId::Claude, path)),
+        );
     }
 
     paths
@@ -2142,6 +2147,69 @@ mod tests {
 
         assert_eq!(result.get(ClientId::Claude), &vec![transcript]);
         assert!(result.get(ClientId::OpenCode).is_empty());
+    }
+
+    #[test]
+    fn test_scan_all_clients_claude_discovers_cc_mirror_variant_projects() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_claude_dir(home);
+
+        let variant_dir = home.join(".cc-mirror/kimi-code");
+        let config_dir = variant_dir.join("config");
+        let project_dir = config_dir.join("projects/project-one");
+        fs::create_dir_all(&project_dir).unwrap();
+        let variant_file = variant_dir.join("variant.json");
+        fs::write(
+            &variant_file,
+            format!(
+                r#"{{"name":"kimi-code","provider":"kimi","configDir":"{}"}}"#,
+                config_dir.display()
+            ),
+        )
+        .unwrap();
+        let variant_session = project_dir.join("variant-session.jsonl");
+        File::create(&variant_session).unwrap();
+
+        let result = scan_all_clients(home.to_str().unwrap(), &["claude".to_string()]);
+
+        assert_eq!(result.get(ClientId::Claude).len(), 2);
+        assert!(
+            result
+                .get(ClientId::Claude)
+                .iter()
+                .any(|path| path == &variant_session),
+            "expected cc-mirror session {} in {:?}",
+            variant_session.display(),
+            result.get(ClientId::Claude)
+        );
+    }
+
+    #[test]
+    fn test_scan_all_clients_claude_dedups_cc_mirror_config_dir_pointing_at_normal_claude() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_claude_dir(home);
+
+        let normal_claude_dir = home.join(".claude");
+        let variant_dir = home.join(".cc-mirror/plain-mirror");
+        fs::create_dir_all(&variant_dir).unwrap();
+        fs::write(
+            variant_dir.join("variant.json"),
+            format!(
+                r#"{{"name":"plain-mirror","provider":"mirror","configDir":"{}"}}"#,
+                normal_claude_dir.display()
+            ),
+        )
+        .unwrap();
+
+        let result = scan_all_clients(home.to_str().unwrap(), &["claude".to_string()]);
+
+        assert_eq!(
+            result.get(ClientId::Claude).len(),
+            1,
+            "cc-mirror variants pointing at ~/.claude must not duplicate normal Claude files"
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -50,6 +50,18 @@ struct AgentMetaFile {
     agent_type: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+struct CcMirrorVariantMetadata {
+    name: String,
+    provider_id: Option<String>,
+}
+
+impl CcMirrorVariantMetadata {
+    fn client_id(&self) -> String {
+        format!("cc-mirror/{}", sanitize_cc_mirror_segment(&self.name))
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct ClaudeMessage {
     pub model: Option<String>,
@@ -294,15 +306,37 @@ fn extract_agent_id_from_text(text: &str) -> Option<String> {
 
 /// Parse a Claude Code JSONL file
 pub fn parse_claude_file(path: &Path) -> Vec<UnifiedMessage> {
+    let home_dir = dirs::home_dir();
+    parse_claude_file_with_home(path, home_dir.as_deref())
+}
+
+pub fn parse_claude_file_with_home(path: &Path, home_dir: Option<&Path>) -> Vec<UnifiedMessage> {
     let mut parent_cache = ParentSubagentTypeCache::new();
-    parse_claude_file_with_cache(path, &mut parent_cache)
+    parse_claude_file_with_cache_and_home(path, &mut parent_cache, home_dir)
 }
 
 pub fn parse_claude_file_with_cache(
     path: &Path,
     parent_cache: &mut ParentSubagentTypeCache,
 ) -> Vec<UnifiedMessage> {
+    let home_dir = dirs::home_dir();
+    parse_claude_file_with_cache_and_home(path, parent_cache, home_dir.as_deref())
+}
+
+pub fn parse_claude_file_with_cache_and_home(
+    path: &Path,
+    parent_cache: &mut ParentSubagentTypeCache,
+    home_dir: Option<&Path>,
+) -> Vec<UnifiedMessage> {
     let (workspace_key, workspace_label) = claude_workspace_from_path(path);
+    let cc_mirror_metadata = cc_mirror_variant_metadata_from_path(path, home_dir);
+    let client_id = cc_mirror_metadata
+        .as_ref()
+        .map(CcMirrorVariantMetadata::client_id)
+        .unwrap_or_else(|| "claude".to_string());
+    let metadata_provider_hint = cc_mirror_metadata
+        .as_ref()
+        .and_then(|metadata| metadata.provider_id.as_deref());
     let mut session_id = path
         .file_stem()
         .and_then(|s| s.to_str())
@@ -318,6 +352,8 @@ pub fn parse_claude_file_with_cache(
             fallback_timestamp,
             workspace_key.clone(),
             workspace_label.clone(),
+            &client_id,
+            metadata_provider_hint,
         );
         if !json_messages.is_empty() {
             return json_messages;
@@ -453,7 +489,8 @@ pub fn parse_claude_file_with_cache(
                     message
                         .provider_id
                         .as_deref()
-                        .or(entry.provider_id.as_deref()),
+                        .or(entry.provider_id.as_deref())
+                        .or(metadata_provider_hint),
                 );
 
                 // Build dedup key for global deduplication (messageId:requestId composite).
@@ -512,7 +549,8 @@ pub fn parse_claude_file_with_cache(
                     message
                         .provider_id
                         .as_deref()
-                        .or(entry.provider_id.as_deref()),
+                        .or(entry.provider_id.as_deref())
+                        .or(metadata_provider_hint),
                 );
                 let provider_confidence = provider_choice.confidence;
                 let model = canonicalize_claude_model(&raw_model);
@@ -528,7 +566,7 @@ pub fn parse_claude_file_with_cache(
                 });
 
                 let mut unified = UnifiedMessage::new_with_dedup(
-                    "claude",
+                    client_id.clone(),
                     model,
                     provider_choice.id,
                     session_id.clone(),
@@ -573,6 +611,8 @@ pub fn parse_claude_file_with_cache(
             &session_id,
             &mut headless_state,
             fallback_timestamp,
+            &client_id,
+            metadata_provider_hint,
         ) {
             let mut message = message;
             message.set_workspace(workspace_key.clone(), workspace_label.clone());
@@ -582,9 +622,13 @@ pub fn parse_claude_file_with_cache(
         }
     }
 
-    if let Some(message) =
-        finalize_headless_state(&mut headless_state, &session_id, fallback_timestamp)
-    {
+    if let Some(message) = finalize_headless_state(
+        &mut headless_state,
+        &session_id,
+        fallback_timestamp,
+        &client_id,
+        metadata_provider_hint,
+    ) {
         let mut message = message;
         message.set_workspace(workspace_key, workspace_label);
         let provider_confidence = stored_claude_provider_confidence(&message.provider_id);
@@ -609,7 +653,94 @@ fn claude_workspace_from_path(path: &Path) -> (Option<String>, Option<String>) {
         }
     }
 
+    for window in components.windows(5) {
+        if window[0] == ".cc-mirror" && window[2] == "config" && window[3] == "projects" {
+            let key = normalize_workspace_key(&window[4]);
+            let label = key.as_deref().and_then(workspace_label_from_key);
+            return (key, label);
+        }
+    }
+
+    for window in components.windows(2).rev() {
+        if window[0] == "projects" {
+            let key = normalize_workspace_key(&window[1]);
+            let label = key.as_deref().and_then(workspace_label_from_key);
+            return (key, label);
+        }
+    }
+
     (None, None)
+}
+
+fn sanitize_cc_mirror_segment(raw: &str) -> String {
+    let mut segment: String = raw
+        .trim()
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+                ch.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect();
+
+    while segment.contains("--") {
+        segment = segment.replace("--", "-");
+    }
+    let mut segment = segment
+        .trim_matches(|ch| matches!(ch, '-' | '_' | '.'))
+        .to_string();
+    if segment.len() > 96 {
+        segment.truncate(96);
+        segment = segment
+            .trim_matches(|ch| matches!(ch, '-' | '_' | '.'))
+            .to_string();
+    }
+    if segment.is_empty() {
+        "variant".to_string()
+    } else {
+        segment
+    }
+}
+
+fn cc_mirror_provider_id(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.eq_ignore_ascii_case("mirror") {
+        return Some("anthropic".to_string());
+    }
+    provider_identity::canonical_provider(trimmed)
+}
+
+fn cc_mirror_variant_metadata_from_path(
+    path: &Path,
+    home_dir: Option<&Path>,
+) -> Option<CcMirrorVariantMetadata> {
+    let variant_dir = crate::cc_mirror::variant_dir_from_session_path(path, home_dir)?;
+    let variant_name = variant_dir.file_name()?.to_string_lossy().to_string();
+    let variant_path = crate::cc_mirror::variant_file_path(&variant_dir);
+    let metadata = crate::cc_mirror::read_variant_file(&variant_path);
+
+    let name = metadata
+        .as_ref()
+        .and_then(|metadata| metadata.name.as_deref())
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or(&variant_name)
+        .to_string();
+    let provider_id = metadata
+        .as_ref()
+        .and_then(|metadata| {
+            metadata
+                .provider_id
+                .as_deref()
+                .or(metadata.provider.as_deref())
+        })
+        .and_then(cc_mirror_provider_id);
+
+    Some(CcMirrorVariantMetadata { name, provider_id })
 }
 
 fn parse_claude_entry_timestamp(timestamp: Option<&str>) -> Option<i64> {
@@ -942,6 +1073,8 @@ fn parse_claude_headless_json(
     fallback_timestamp: i64,
     workspace_key: Option<String>,
     workspace_label: Option<String>,
+    client_id: &str,
+    default_provider_hint: Option<&str>,
 ) -> Vec<UnifiedMessage> {
     let Some(data) = read_file_or_none(path) else {
         return Vec::new();
@@ -954,7 +1087,13 @@ fn parse_claude_headless_json(
     };
 
     let mut messages = Vec::with_capacity(1);
-    if let Some(message) = extract_claude_headless_message(&value, session_id, fallback_timestamp) {
+    if let Some(message) = extract_claude_headless_message(
+        &value,
+        session_id,
+        fallback_timestamp,
+        client_id,
+        default_provider_hint,
+    ) {
         let mut message = message;
         message.set_workspace(workspace_key, workspace_label);
         messages.push(message);
@@ -968,6 +1107,8 @@ fn process_claude_headless_line(
     session_id: &str,
     state: &mut ClaudeHeadlessState,
     fallback_timestamp: i64,
+    client_id: &str,
+    default_provider_hint: Option<&str>,
 ) -> Option<UnifiedMessage> {
     let mut bytes = line.as_bytes().to_vec();
     let value: Value = simd_json::from_slice(&mut bytes).ok()?;
@@ -977,7 +1118,13 @@ fn process_claude_headless_line(
 
     match event_type {
         "message_start" => {
-            completed_message = finalize_headless_state(state, session_id, fallback_timestamp);
+            completed_message = finalize_headless_state(
+                state,
+                session_id,
+                fallback_timestamp,
+                client_id,
+                default_provider_hint,
+            );
 
             state.model = extract_claude_model(&value);
             state.provider_id = extract_claude_provider(&value);
@@ -999,12 +1146,22 @@ fn process_claude_headless_line(
             }
         }
         "message_stop" => {
-            completed_message = finalize_headless_state(state, session_id, fallback_timestamp);
+            completed_message = finalize_headless_state(
+                state,
+                session_id,
+                fallback_timestamp,
+                client_id,
+                default_provider_hint,
+            );
         }
         _ => {
-            if let Some(message) =
-                extract_claude_headless_message(&value, session_id, fallback_timestamp)
-            {
+            if let Some(message) = extract_claude_headless_message(
+                &value,
+                session_id,
+                fallback_timestamp,
+                client_id,
+                default_provider_hint,
+            ) {
                 completed_message = Some(message);
             }
         }
@@ -1017,17 +1174,23 @@ fn extract_claude_headless_message(
     value: &Value,
     session_id: &str,
     fallback_timestamp: i64,
+    client_id: &str,
+    default_provider_hint: Option<&str>,
 ) -> Option<UnifiedMessage> {
     let usage = value
         .get("usage")
         .or_else(|| value.get("message").and_then(|msg| msg.get("usage")))?;
     let raw_model = extract_claude_model(value)?;
-    let provider_id = claude_provider_id(&raw_model, extract_claude_provider(value).as_deref());
+    let provider_hint = extract_claude_provider(value);
+    let provider_id = claude_provider_id(
+        &raw_model,
+        provider_hint.as_deref().or(default_provider_hint),
+    );
     let model = canonicalize_claude_model(&raw_model);
     let timestamp = extract_claude_timestamp(value).unwrap_or(fallback_timestamp);
 
     Some(UnifiedMessage::new(
-        "claude",
+        client_id,
         model,
         provider_id,
         session_id.to_string(),
@@ -1239,9 +1402,14 @@ fn finalize_headless_state(
     state: &mut ClaudeHeadlessState,
     session_id: &str,
     fallback_timestamp: i64,
+    client_id: &str,
+    default_provider_hint: Option<&str>,
 ) -> Option<UnifiedMessage> {
     let raw_model = state.model.clone()?;
-    let provider_id = claude_provider_id(&raw_model, state.provider_id.as_deref());
+    let provider_id = claude_provider_id(
+        &raw_model,
+        state.provider_id.as_deref().or(default_provider_hint),
+    );
     let model = canonicalize_claude_model(&raw_model);
     let timestamp = state.timestamp_ms.unwrap_or(fallback_timestamp);
     if state.input == 0 && state.output == 0 && state.cache_read == 0 && state.cache_write == 0 {
@@ -1250,7 +1418,7 @@ fn finalize_headless_state(
     }
 
     let message = UnifiedMessage::new(
-        "claude",
+        client_id,
         model,
         provider_id,
         session_id.to_string(),
@@ -1323,6 +1491,30 @@ mod tests {
         (temp_dir, path)
     }
 
+    fn create_cc_mirror_project_file(
+        content: &str,
+        variant: &str,
+        provider: &str,
+        project: &str,
+        filename: &str,
+    ) -> (TempDir, std::path::PathBuf) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let variant_dir = temp_dir.path().join(".cc-mirror").join(variant);
+        let config_dir = variant_dir.join("config");
+        let path = config_dir.join("projects").join(project).join(filename);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            variant_dir.join("variant.json"),
+            format!(
+                r#"{{"name":"{variant}","provider":"{provider}","configDir":"{}"}}"#,
+                config_dir.display()
+            ),
+        )
+        .unwrap();
+        std::fs::write(&path, content).unwrap();
+        (temp_dir, path)
+    }
+
     fn create_transcript_file(content: &str, filename: &str) -> (TempDir, std::path::PathBuf) {
         let temp_dir = tempfile::tempdir().unwrap();
         let path = temp_dir
@@ -1351,6 +1543,46 @@ mod tests {
         );
         assert_eq!(messages[0].tokens.input, 100);
         assert_eq!(messages[1].tokens.input, 200);
+    }
+
+    #[test]
+    fn test_parse_cc_mirror_claude_variant_attributes_client_provider_and_workspace() {
+        let content = r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":10,"cache_creation_input_tokens":5}}}"#;
+
+        let (_temp_dir, path) = create_cc_mirror_project_file(
+            content,
+            "zai-worker",
+            "zai",
+            "-Users-example-work",
+            "session.jsonl",
+        );
+
+        let messages = parse_claude_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, "cc-mirror/zai-worker");
+        assert_eq!(messages[0].provider_id, "zai");
+        assert_eq!(messages[0].model_id, "claude-3-5-sonnet");
+        assert_eq!(messages[0].tokens.input, 100);
+        assert_eq!(messages[0].tokens.output, 50);
+        assert_eq!(messages[0].tokens.cache_read, 10);
+        assert_eq!(messages[0].tokens.cache_write, 5);
+        assert_eq!(
+            messages[0].workspace_key.as_deref(),
+            Some("-Users-example-work")
+        );
+        assert_eq!(
+            messages[0].workspace_label.as_deref(),
+            Some("-Users-example-work")
+        );
+    }
+
+    #[test]
+    fn test_cc_mirror_variant_client_segment_is_submit_safe() {
+        assert_eq!(sanitize_cc_mirror_segment(" zaicc "), "zaicc");
+        assert_eq!(sanitize_cc_mirror_segment("../Zai CC!"), "zai-cc");
+        assert_eq!(sanitize_cc_mirror_segment("..."), "variant");
+        assert_eq!(sanitize_cc_mirror_segment(&"a".repeat(120)).len(), 96);
     }
 
     #[test]

--- a/packages/frontend/__tests__/api/submit.test.ts
+++ b/packages/frontend/__tests__/api/submit.test.ts
@@ -307,6 +307,58 @@ describe('POST /api/submit - Client-Level Merge', () => {
       expect(data.contributions[0].clients[0].client).toBe('zed');
     });
 
+    it('should pass validation for cc-mirror variant submissions', () => {
+      const data = createMockSubmissionData({
+        clients: ['cc-mirror/zaicc'],
+        contributions: [
+          {
+            date: '2024-12-01',
+            clients: [
+              {
+                client: 'cc-mirror/zaicc',
+                modelId: 'glm-5.1',
+                cost: 1.5,
+                tokens: { input: 1000, output: 500, cacheRead: 0, cacheWrite: 0 },
+                messages: 5,
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = validateSubmission(data);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      expect(result.data?.summary.clients).toEqual(['cc-mirror/zaicc']);
+      expect(result.data?.contributions[0].clients[0].client).toBe('cc-mirror/zaicc');
+    });
+
+    it('rejects malformed cc-mirror variant client ids', () => {
+      const data = createMockSubmissionData({
+        clients: ['cc-mirror/../zaicc' as ClientType],
+        contributions: [
+          {
+            date: '2024-12-01',
+            clients: [
+              {
+                client: 'cc-mirror/../zaicc' as ClientType,
+                modelId: 'glm-5.1',
+                cost: 1.5,
+                tokens: { input: 1000, output: 500, cacheRead: 0, cacheWrite: 0 },
+                messages: 5,
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = validateSubmission(data);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.join("\n")).toContain("Invalid cc-mirror variant client id");
+    });
+
     it('should pass validation for kilo client submissions', () => {
       const payload = {
         meta: { generatedAt: new Date().toISOString(), version: '1.0.0', dateRange: { start: '2024-12-01', end: '2024-12-01' } },

--- a/packages/frontend/src/lib/constants.ts
+++ b/packages/frontend/src/lib/constants.ts
@@ -51,6 +51,7 @@ export const SOURCE_DISPLAY_NAMES: Record<ClientType, string> = {
   antigravity: "Antigravity",
   zed: "Zed Agent",
   trae: "Trae",
+  warp: "Warp",
   synthetic: "Synthetic",
 };
 
@@ -81,6 +82,7 @@ export const SOURCE_LOGOS: Record<ClientType, string> = {
   antigravity: `${GITHUB_CDN_BASE}/client-antigravity.png`,
   zed: `${GITHUB_CDN_BASE}/client-zed.webp`,
   trae: `${GITHUB_CDN_BASE}/client-trae.png`,
+  warp: `${GITHUB_CDN_BASE}/client-warp.png`,
   synthetic: `${GITHUB_CDN_BASE}/client-synthetic.png`,
 };
 
@@ -109,6 +111,7 @@ export const SOURCE_COLORS: Record<ClientType, string> = {
   antigravity: "#6366F1",
   zed: "#084CCF",
   trae: "#00BFA5",
+  warp: "#01A4A4",
   synthetic: "#4ADE80",
 };
 

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -26,7 +26,8 @@ export const SUPPORTED_CLIENT_TYPES = [
   "synthetic",
 ] as const;
 
-export type ClientType = typeof SUPPORTED_CLIENT_TYPES[number];
+export type CcMirrorClientType = `cc-mirror/${string}`;
+export type ClientType = typeof SUPPORTED_CLIENT_TYPES[number] | CcMirrorClientType;
 
 export interface TokenBreakdown {
   input: number;

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -23,6 +23,7 @@ export const SUPPORTED_CLIENT_TYPES = [
   "kiro",
   "zed",
   "trae",
+  "warp",
   "synthetic",
 ] as const;
 

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -51,7 +51,11 @@ const ClientContributionProvenanceSchema = z.object({
   modelCount: NonNegativeIntegerSchema,
 });
 
-const SourceSchema = z.enum(SUPPORTED_CLIENT_TYPES);
+const CcMirrorSourceSchema = z.string().regex(
+  /^cc-mirror\/[a-z0-9][a-z0-9._-]{0,95}$/,
+  "Invalid cc-mirror variant client id"
+);
+const SourceSchema = z.union([z.enum(SUPPORTED_CLIENT_TYPES), CcMirrorSourceSchema]);
 
 const ClientContributionSchema = z.object({
   client: SourceSchema,


### PR DESCRIPTION
## Summary
- Discover cc-mirror Claude variants under `~/.cc-mirror/*/variant.json` and scan each variant's resolved `configDir/projects` transcript root.
- Attribute parsed Claude Code usage to stable dynamic client ids like `cc-mirror/kimi-code` while preserving provider hints from variant metadata.
- Share cc-mirror `configDir` resolution across scanner, parser, and cache fingerprinting so non-default config directories keep correct attribution and invalidate cache entries when `variant.json` changes.
- Allow submitted usage payloads to carry validated `cc-mirror/<variant>` source ids without opening arbitrary client strings.

## Why
cc-mirror stores Claude-compatible transcripts outside the normal `~/.claude/projects` tree, so Tokscale could miss real Claude usage generated through those variants. Treating each variant as plain `claude` would also hide which mirrored provider produced the usage. This change reuses the existing Claude parser where the transcript format is compatible, while keeping variant attribution and provider metadata visible through local parsing, cache invalidation, filtering, and frontend submit validation.

## Diff scope
- `crates/tokscale-core/src/cc_mirror.rs`: centralizes variant metadata parsing, `configDir` expansion, project-root discovery, and session-path to variant resolution.
- `crates/tokscale-core/src/scanner.rs`: discovers cc-mirror variant project roots through the shared resolver and keeps deduplication for variants pointing at the normal Claude project root.
- `crates/tokscale-core/src/sessions/claudecode.rs`: detects cc-mirror transcript paths with explicit home context, derives `cc-mirror/<variant>` client ids, preserves workspace metadata, and maps variant provider metadata into provider hints.
- `crates/tokscale-core/src/message_cache.rs`: includes the related cc-mirror `variant.json` file in Claude cache fingerprints, including custom `configDir` layouts.
- `crates/tokscale-core/src/lib.rs`: threads the explicit scan home through Claude parsing and fingerprinting so cache behavior matches scanner discovery.
- `packages/frontend/src/lib/validation/submission.ts`, `packages/frontend/src/lib/types.ts`, and `packages/frontend/__tests__/api/submit.test.ts`: accept validated dynamic cc-mirror source ids and reject malformed variants.

## Branch integrity
- Base branch: `main`
- Validated base SHA: `715fddf6db88258c50eb20a5cc8d698e442f35b9`
- Ahead/behind: `0 behind / 1 ahead`
- Merge-base: `715fddf6db88258c50eb20a5cc8d698e442f35b9`
- Branch was validated against the fetched base before push.

## Commit integrity
- Introduced commit: `dc17cdbbb6a5719af8b050d6dd2172a78e525fc7 feat(claude): discover cc-mirror variants`
- One logical change: add cc-mirror Claude variant discovery and preserve variant attribution through parsing, cache invalidation, filtering, and submit validation.
- Final diff contains only intended core scanner/parser/cache/reporting changes plus focused frontend submit validation updates.
- Ledger: not applicable — not required for selected validation mode/change family.
- Version: not applicable — not required for selected validation mode/change family.

## Diff hygiene
- `git diff --name-status origin/main...HEAD`: expected core cc-mirror integration files and frontend submit validation files only.
- `git diff --check origin/main...HEAD`: PASS, no output.
- DB migration: not applicable — no DB migration changed.

## Validation mode and proof
- Validation mode: Mode 3 — cross-module client discovery, parsing, cache, and submit validation behavior.
- `cargo fmt --check`: PASS.
- `cargo test -p tokscale-core test_claude_code_fingerprint_tracks_cc_mirror -- --nocapture`: PASS, 2 tests passed.
- `cargo test -p tokscale-core test_parse_all_messages_refreshes_cc_mirror_provider_when_variant_metadata_changes -- --nocapture`: PASS, 1 test passed.
- `cargo test -p tokscale-core test_parse_all_messages_keeps_normal_claude_when_cc_mirror_points_at_claude_config -- --nocapture`: PASS, 1 test passed.
- `cargo test -p tokscale-core cc_mirror -- --nocapture`: PASS, 8 tests passed.
- `cargo test -p tokscale-core sessions::claudecode -- --nocapture`: PASS, 51 tests passed.
- `cargo clippy -p tokscale-core --all-targets -- -D warnings`: PASS.
- `bun --cwd packages/frontend test __tests__/api/submit.test.ts`: PASS, 51 tests passed.
- `git diff --check origin/main...HEAD`: PASS, no output.
- Remote CI on final SHA `dc17cdbbb6a5719af8b050d6dd2172a78e525fc7`: PASS — Frontend Vitest, Frontend Migration Replay, Lint, Code Coverage, Vercel, WIP, and all 8 Build Native targets.
- Not run: full Rust workspace and full frontend suites locally — not required because targeted scanner, parser, cache, and submit tests cover the changed integration and required remote CI passed on the final PR SHA.

## CI context confirmation
- CI workflow/context names unchanged.
- Required visible PR checks are passing on the final SHA.

## Runtime safety
- No new migrations, background jobs, queues, network calls, or blocking locks.
- cc-mirror discovery is best-effort and only adds existing local transcript roots when variant metadata and project directories are present.
- Cache invalidation becomes stricter for affected Claude transcript files because related `variant.json` metadata is now part of the fingerprint.
- No invariant regression introduced.

## Documentation integrity
- Not applicable — no docs, runbooks, commands, or operational procedures changed.

## Rollback plan
- Rollback: revert this PR.
- DB downgrade: not applicable.
- Data repair: not applicable.
- Operational caveats: after rollback, previously submitted `cc-mirror/<variant>` source ids would no longer be accepted by the frontend validation layer.

## Known residual risks
- None known.
