### PR TITLE
fix(pricing): resolve Kimi k2p6 aliases

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -5258,6 +5258,42 @@ mod tests {
     }
 
     #[test]
+    fn test_apply_pricing_if_available_prices_kimi_k2p6_alias() {
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "moonshotai/kimi-k2.6".into(),
+            pricing::ModelPricing {
+                input_cost_per_token: Some(9.5e-7),
+                output_cost_per_token: Some(0.000004),
+                ..Default::default()
+            },
+        );
+        let pricing = pricing::PricingService::new(HashMap::new(), openrouter);
+
+        let mut msg = UnifiedMessage::new(
+            "kimi",
+            "k2p6",
+            "kimi-for-coding",
+            "session-1",
+            1_776_000_000_000,
+            TokenBreakdown {
+                input: 1_000_000,
+                output: 250_000,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            0.0,
+        );
+
+        apply_pricing_if_available(&mut msg, Some(&pricing));
+
+        let expected = 1_000_000.0 * 9.5e-7 + 250_000.0 * 0.000004;
+        assert!((msg.cost - expected).abs() < 1e-12);
+        assert!(msg.cost > 0.0);
+    }
+
+    #[test]
     fn test_select_local_parse_pricing_prefers_fresh_service_for_new_models() {
         let mut fresh_litellm = HashMap::new();
         fresh_litellm.insert(

--- a/crates/tokscale-core/src/pricing/aliases.rs
+++ b/crates/tokscale-core/src/pricing/aliases.rs
@@ -8,6 +8,9 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     m.insert("bigpickle", "glm-4.7");
     m.insert("k2p5", "kimi-k2-thinking");
     m.insert("k2-p5", "kimi-k2-thinking");
+    m.insert("k2p6", "kimi-k2.6");
+    m.insert("k2-p6", "kimi-k2.6");
+    m.insert("kimi-k2p6", "kimi-k2.6");
     m.insert("kimi-k2.5-thinking", "kimi-k2-thinking");
     m.insert("kimi-for-coding", "kimi-k2.5");
 
@@ -84,5 +87,16 @@ mod tests {
             resolve_alias("anthropic/claude-4-6-sonnet"),
             Some("claude-sonnet-4-6")
         );
+    }
+
+    #[test]
+    fn resolves_kimi_k2p6_aliases_without_regressing_k2p5() {
+        assert_eq!(resolve_alias("k2p6"), Some("kimi-k2.6"));
+        assert_eq!(resolve_alias("k2-p6"), Some("kimi-k2.6"));
+        assert_eq!(resolve_alias("kimi-k2p6"), Some("kimi-k2.6"));
+        assert_eq!(resolve_alias("KIMI-K2P6"), Some("kimi-k2.6"));
+
+        assert_eq!(resolve_alias("k2p5"), Some("kimi-k2-thinking"));
+        assert_eq!(resolve_alias("k2-p5"), Some("kimi-k2-thinking"));
     }
 }

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -1942,6 +1942,16 @@ mod tests {
             },
         );
         m.insert(
+            "moonshotai/kimi-k2.6".into(),
+            ModelPricing {
+                input_cost_per_token: Some(9.5e-7),
+                output_cost_per_token: Some(0.000004),
+                cache_read_input_token_cost: None,
+                cache_creation_input_token_cost: None,
+                ..Default::default()
+            },
+        );
+        m.insert(
             "moonshotai/kimi-k2-thinking".into(),
             ModelPricing {
                 input_cost_per_token: Some(4e-7),
@@ -2190,6 +2200,39 @@ mod tests {
         let result = lookup.lookup("kimi-k2.5-free").unwrap();
         assert_eq!(result.matched_key, "moonshotai/kimi-k2.5");
         assert_eq!(result.source, "OpenRouter");
+    }
+
+    #[test]
+    fn test_opencode_zen_kimi_k2_6_aliases() {
+        let lookup = create_lookup();
+        for model_id in ["k2p6", "k2-p6", "kimi-k2p6", "Kimi-K2.6"] {
+            let result = lookup.lookup(model_id).unwrap();
+            assert_eq!(result.matched_key, "moonshotai/kimi-k2.6");
+            assert_eq!(result.source, "OpenRouter");
+            assert_eq!(result.pricing.input_cost_per_token, Some(9.5e-7));
+            assert_eq!(result.pricing.output_cost_per_token, Some(0.000004));
+        }
+    }
+
+    #[test]
+    fn test_opencode_zen_kimi_k2_6_provider_hint_from_kimi_for_coding() {
+        let lookup = create_lookup();
+        let result = lookup
+            .lookup_with_provider("k2p6", Some("kimi-for-coding"))
+            .unwrap();
+        assert_eq!(result.matched_key, "moonshotai/kimi-k2.6");
+        assert_eq!(result.source, "OpenRouter");
+    }
+
+    #[test]
+    fn test_opencode_zen_kimi_k2_5_aliases_unchanged() {
+        let lookup = create_lookup();
+
+        let raw_k2p5 = lookup.lookup("k2p5").unwrap();
+        assert_eq!(raw_k2p5.matched_key, "moonshotai/kimi-k2-thinking");
+
+        let dotted = lookup.lookup("kimi-k2.5").unwrap();
+        assert_eq!(dotted.matched_key, "moonshotai/kimi-k2.5");
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary
- Resolve raw Kimi K2.6 aliases such as `k2p6`, `k2-p6`, and `kimi-k2p6` to the canonical `kimi-k2.6` model id.
- Let provider-scoped lookup with `kimi-for-coding` reach OpenRouter's `moonshotai/kimi-k2.6` pricing entry.
- Add regression coverage so existing K2.5 aliases continue resolving to their existing canonical targets.

## Why
Some local clients can report Kimi K2.6 usage with short model ids rather than the canonical OpenRouter id. Without an alias, Tokscale can leave those rows unpriced even when upstream pricing data contains `moonshotai/kimi-k2.6`. This change only adds resolver aliases and tests; it does not hardcode production pricing values outside of test fixtures.

## Diff scope
- `crates/tokscale-core/src/pricing/aliases.rs`: adds exact Kimi K2.6 alias mappings and keeps K2.5 alias behavior pinned.
- `crates/tokscale-core/src/pricing/lookup.rs`: extends pricing fixtures and resolver tests for raw K2.6 variants, case handling, provider hints, and K2.5 non-regression.
- `crates/tokscale-core/src/lib.rs`: adds a report-level pricing regression proving a `k2p6` message with provider `kimi-for-coding` receives nonzero calculated cost when the canonical pricing entry is available.

## Branch integrity
- Base branch: `main`
- Validated base SHA: `715fddf6db88258c50eb20a5cc8d698e442f35b9`
- Ahead/behind: `0 behind / 1 ahead`
- Merge-base: `715fddf6db88258c50eb20a5cc8d698e442f35b9`
- Branch was rebased onto the fetched base before push.

## Commit integrity
- Introduced commit: `3f503eb082dd4080931dfba8654e09d3d7aab1d8 fix(pricing): resolve Kimi k2p6 aliases`
- One logical change: map Kimi K2.6 short/raw model ids to the canonical model key used by upstream pricing data.
- Final diff contains only intended core pricing alias, lookup, and report-level test changes.
- Ledger: not applicable - not required for selected validation mode/change family.
- Version: not applicable - not required for selected validation mode/change family.

## Diff hygiene
- `git diff --name-status origin/main...HEAD`: expected core pricing files only.
- `git diff --check origin/main...HEAD`: PASS, no output.
- DB migration: not applicable - no DB migration changed.

## Validation mode and proof
- Validation mode: Mode 2 - narrow pricing alias and resolver behavior.
- `cargo test -p tokscale-core pricing::`: PASS, 205 tests passed.
- `cargo test -p tokscale-core test_apply_pricing_if_available_prices_kimi_k2p6_alias`: PASS, 1 test passed.
- `cargo fmt --all --check`: PASS.
- `git diff --check origin/main...HEAD`: PASS, no output.
- `curl -fsSL https://openrouter.ai/api/v1/models | jq -r ".data[].id" | rg "^moonshotai/kimi-k2\\.6$"`: PASS, printed `moonshotai/kimi-k2.6`.
- Not run: full Rust workspace suite - not required locally because targeted pricing tests cover the changed resolver behavior; required remote CI should validate the final PR SHA before merge.

## CI context confirmation
- Pending - required CI has not run because the PR has not been opened yet.
- CI workflow/context names unchanged.

## Runtime safety
- No new migrations, external writes, queues, locks, or network calls in runtime code.
- The production pricing source remains upstream pricing data; this PR only routes additional reported model ids to an existing canonical key.
- No invariant regression introduced.

## Documentation integrity
- Not applicable - no docs, runbooks, commands, or operational procedures changed.

## Rollback plan
- Rollback: revert this PR.
- DB downgrade: not applicable.
- Data repair: not applicable.
- Operational caveats: after rollback, usage reported as `k2p6`, `k2-p6`, or `kimi-k2p6` may return to being unpriced unless another resolver path covers it.

## Known residual risks
- Remote CI is still pending until the PR is opened.

