### PR TITLE
fix(auth): reject personal tokens on group mutations

### DIFF
--- a/packages/frontend/__tests__/api/groupInviteCreateRoute.test.ts
+++ b/packages/frontend/__tests__/api/groupInviteCreateRoute.test.ts
@@ -66,7 +66,61 @@ beforeEach(() => {
   mockState.reset();
 });
 
+function session() {
+  return { id: "user-1", username: "alice", displayName: null, avatarUrl: null };
+}
+
+function mockBrowserSessionOnly() {
+  mockState.getSessionFromRequest.mockImplementation(
+    async (
+      request: Request,
+      options?: { allowAuthorizationHeader?: boolean }
+    ) => {
+      if (
+        request.headers.has("Authorization") &&
+        options?.allowAuthorizationHeader === false
+      ) {
+        return null;
+      }
+
+      return session();
+    }
+  );
+}
+
 describe("POST /api/groups/[slug]/invite", () => {
+  it("rejects Authorization header sessions when creating invites", async () => {
+    mockBrowserSessionOnly();
+    mockState.getGroupBySlug.mockResolvedValue({
+      id: "group-1",
+      slug: "team",
+      name: "Team",
+      isPublic: true,
+      createdBy: "user-2",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      description: null,
+      avatarUrl: null,
+    });
+    mockState.getGroupMembership.mockResolvedValue({ role: "admin" });
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/groups/team/invite", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_personal",
+          Origin: "http://localhost:3000",
+        },
+      }),
+      { params: Promise.resolve({ slug: "team" }) }
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockState.getGroupBySlug).not.toHaveBeenCalled();
+    expect(mockState.createGroupInvite).not.toHaveBeenCalled();
+  });
+
   it("returns 400 when request body contains malformed JSON", async () => {
     mockState.getSessionFromRequest.mockResolvedValue({
       id: "user-1",

--- a/packages/frontend/__tests__/api/groupInviteJoinRoute.test.ts
+++ b/packages/frontend/__tests__/api/groupInviteJoinRoute.test.ts
@@ -45,6 +45,28 @@ beforeEach(() => {
   mockState.reset();
 });
 
+function session() {
+  return { id: "user-1", username: "Alice", displayName: null, avatarUrl: null };
+}
+
+function mockBrowserSessionOnly() {
+  mockState.getSessionFromRequest.mockImplementation(
+    async (
+      request: Request,
+      options?: { allowAuthorizationHeader?: boolean }
+    ) => {
+      if (
+        request.headers.has("Authorization") &&
+        options?.allowAuthorizationHeader === false
+      ) {
+        return null;
+      }
+
+      return session();
+    }
+  );
+}
+
 describe("/api/groups/join/[token]", () => {
   it("shows a safe invite preview without requiring authentication", async () => {
     mockState.getGroupInvitePreview.mockResolvedValue({
@@ -77,6 +99,29 @@ describe("/api/groups/join/[token]", () => {
     );
 
     expect(response.status).toBe(401);
+    expect(mockState.acceptGroupInvite).not.toHaveBeenCalled();
+  });
+
+  it("rejects Authorization header sessions when accepting an invite", async () => {
+    mockBrowserSessionOnly();
+    mockState.acceptGroupInvite.mockResolvedValue({
+      group: { id: "group-1", name: "Team", slug: "team" },
+      role: "member",
+    });
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/groups/join/tg_token", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_personal",
+          Origin: "http://localhost:3000",
+        },
+      }),
+      { params: Promise.resolve({ token: "tg_token" }) }
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
     expect(mockState.acceptGroupInvite).not.toHaveBeenCalled();
   });
 

--- a/packages/frontend/__tests__/api/groupRoute.test.ts
+++ b/packages/frontend/__tests__/api/groupRoute.test.ts
@@ -95,11 +95,13 @@ type ModuleExports = typeof import("../../src/app/api/groups/[slug]/route");
 
 let GET: ModuleExports["GET"];
 let PATCH: ModuleExports["PATCH"];
+let DELETE: ModuleExports["DELETE"];
 
 beforeAll(async () => {
   const routeModule = await import("../../src/app/api/groups/[slug]/route");
   GET = routeModule.GET;
   PATCH = routeModule.PATCH;
+  DELETE = routeModule.DELETE;
 });
 
 beforeEach(() => {
@@ -119,6 +121,34 @@ function group(overrides: Record<string, unknown> = {}) {
     updatedAt: new Date("2026-01-01T00:00:00Z"),
     ...overrides,
   };
+}
+
+function session(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "owner-1",
+    username: "owner",
+    displayName: null,
+    avatarUrl: null,
+    ...overrides,
+  };
+}
+
+function mockBrowserSessionOnly() {
+  mockState.getSessionFromRequest.mockImplementation(
+    async (
+      request: Request,
+      options?: { allowAuthorizationHeader?: boolean }
+    ) => {
+      if (
+        request.headers.has("Authorization") &&
+        options?.allowAuthorizationHeader === false
+      ) {
+        return null;
+      }
+
+      return session();
+    }
+  );
 }
 
 describe("/api/groups/[slug]", () => {
@@ -169,6 +199,30 @@ describe("/api/groups/[slug]", () => {
     expect(mockState.db.update).not.toHaveBeenCalled();
   });
 
+  it("rejects Authorization header sessions when updating a group", async () => {
+    mockBrowserSessionOnly();
+    mockState.getGroupBySlug.mockResolvedValue(group());
+    mockState.getGroupMembership.mockResolvedValue({ role: "admin" });
+
+    const response = await PATCH(
+      new Request("http://localhost:3000/api/groups/team", {
+        method: "PATCH",
+        body: JSON.stringify({ description: "Updated" }),
+        headers: {
+          Authorization: "Bearer tt_personal",
+          "Content-Type": "application/json",
+          Origin: "http://localhost:3000",
+        },
+      }),
+      { params: Promise.resolve({ slug: "team" }) }
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockState.getGroupBySlug).not.toHaveBeenCalled();
+    expect(mockState.db.update).not.toHaveBeenCalled();
+  });
+
   it("allows explicit null PATCH fields to clear optional group metadata", async () => {
     mockState.getSessionFromRequest.mockResolvedValue({
       id: "admin-1",
@@ -201,5 +255,27 @@ describe("/api/groups/[slug]", () => {
       })
     );
     expect(mockState.revalidateGroupCaches).toHaveBeenCalledWith("group-1", "team");
+  });
+
+  it("rejects Authorization header sessions when deleting a group", async () => {
+    mockBrowserSessionOnly();
+    mockState.getGroupBySlug.mockResolvedValue(group());
+    mockState.getGroupMembership.mockResolvedValue({ role: "owner" });
+
+    const response = await DELETE(
+      new Request("http://localhost:3000/api/groups/team", {
+        method: "DELETE",
+        headers: {
+          Authorization: "Bearer tt_personal",
+          Origin: "http://localhost:3000",
+        },
+      }),
+      { params: Promise.resolve({ slug: "team" }) }
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockState.getGroupBySlug).not.toHaveBeenCalled();
+    expect(mockState.db.delete).not.toHaveBeenCalled();
   });
 });

--- a/packages/frontend/__tests__/api/groupTransferOwnership.test.ts
+++ b/packages/frontend/__tests__/api/groupTransferOwnership.test.ts
@@ -128,6 +128,24 @@ function ownerSession() {
   return { id: "owner-1", username: "alice", displayName: null, avatarUrl: null };
 }
 
+function mockBrowserSessionOnly() {
+  mockState.getSessionFromRequest.mockImplementation(
+    async (
+      request: Request,
+      options?: { allowAuthorizationHeader?: boolean }
+    ) => {
+      if (
+        request.headers.has("Authorization") &&
+        options?.allowAuthorizationHeader === false
+      ) {
+        return null;
+      }
+
+      return ownerSession();
+    }
+  );
+}
+
 function makeRequest(body: unknown) {
   return new Request("http://localhost:3000/api/groups/team/transfer-ownership", {
     method: "POST",
@@ -137,6 +155,30 @@ function makeRequest(body: unknown) {
 }
 
 describe("POST /api/groups/[slug]/transfer-ownership", () => {
+  it("rejects Authorization header sessions when transferring ownership", async () => {
+    mockBrowserSessionOnly();
+    mockState.getGroupBySlug.mockResolvedValue(group());
+    mockState.getGroupMembership.mockResolvedValue({ role: "owner" });
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/groups/team/transfer-ownership", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_personal",
+          "Content-Type": "application/json",
+          Origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({ targetUserId: "bob" }),
+      }),
+      { params: Promise.resolve({ slug: "team" }) }
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockState.getGroupBySlug).not.toHaveBeenCalled();
+    expect(mockState.db.transaction).not.toHaveBeenCalled();
+  });
+
   it("returns 401 when not authenticated", async () => {
     mockState.getSessionFromRequest.mockResolvedValue(null);
     mockState.getGroupBySlug.mockResolvedValue(group());

--- a/packages/frontend/__tests__/api/groupsPayloadGuard.test.ts
+++ b/packages/frontend/__tests__/api/groupsPayloadGuard.test.ts
@@ -147,6 +147,24 @@ function session() {
   return { id: "user-1", username: "alice", displayName: null, avatarUrl: null };
 }
 
+function mockBrowserSessionOnly() {
+  mockGroups.getSessionFromRequest.mockImplementation(
+    async (
+      request: Request,
+      options?: { allowAuthorizationHeader?: boolean }
+    ) => {
+      if (
+        request.headers.has("Authorization") &&
+        options?.allowAuthorizationHeader === false
+      ) {
+        return null;
+      }
+
+      return session();
+    }
+  );
+}
+
 function group() {
   return {
     id: "group-1",
@@ -170,6 +188,26 @@ const BAD_BODIES = [
 // ─── POST /api/groups ─────────────────────────────────────────────────────────
 
 describe("POST /api/groups — payload guard (B2)", () => {
+  it("rejects Authorization header sessions when creating groups", async () => {
+    mockBrowserSessionOnly();
+
+    const response = await groupsPOST(
+      new Request("http://localhost:3000/api/groups", {
+        method: "POST",
+        body: JSON.stringify({ name: "Team" }),
+        headers: {
+          Authorization: "Bearer tt_personal",
+          "Content-Type": "application/json",
+          Origin: "http://localhost:3000",
+        },
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockGroups.db.transaction).not.toHaveBeenCalled();
+  });
+
   it.each(BAD_BODIES)("returns 400 for $label body", async ({ body }) => {
     mockGroups.getSessionFromRequest.mockResolvedValue(session());
 
@@ -190,6 +228,30 @@ describe("POST /api/groups — payload guard (B2)", () => {
 // ─── PATCH /api/groups/[slug] ─────────────────────────────────────────────────
 
 describe("PATCH /api/groups/[slug] — payload guard (B2)", () => {
+  it("rejects Authorization header sessions when updating groups", async () => {
+    mockBrowserSessionOnly();
+    mockGroups.getGroupBySlug.mockResolvedValue(group());
+    mockGroups.getGroupMembership.mockResolvedValue({ role: "admin" });
+
+    const response = await slugPATCH(
+      new Request("http://localhost:3000/api/groups/team", {
+        method: "PATCH",
+        body: JSON.stringify({ description: "Updated" }),
+        headers: {
+          Authorization: "Bearer tt_personal",
+          "Content-Type": "application/json",
+          Origin: "http://localhost:3000",
+        },
+      }),
+      { params: Promise.resolve({ slug: "team" }) }
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockGroups.getGroupBySlug).not.toHaveBeenCalled();
+    expect(mockGroups.db.update).not.toHaveBeenCalled();
+  });
+
   it.each(BAD_BODIES)("returns 400 for $label body", async ({ body }) => {
     mockGroups.getSessionFromRequest.mockResolvedValue(session());
     mockGroups.getGroupBySlug.mockResolvedValue(group());
@@ -213,6 +275,30 @@ describe("PATCH /api/groups/[slug] — payload guard (B2)", () => {
 // ─── PATCH /api/groups/[slug]/members/[userId]/role ───────────────────────────
 
 describe("PATCH /api/groups/[slug]/members/[userId]/role — payload guard (B2)", () => {
+  it("rejects Authorization header sessions when updating member roles", async () => {
+    mockBrowserSessionOnly();
+    mockGroups.getGroupBySlug.mockResolvedValue(group());
+    mockGroups.getGroupMembership.mockResolvedValue({ role: "owner" });
+
+    const response = await rolePATCH(
+      new Request("http://localhost:3000/api/groups/team/members/user-2/role", {
+        method: "PATCH",
+        body: JSON.stringify({ role: "admin" }),
+        headers: {
+          Authorization: "Bearer tt_personal",
+          "Content-Type": "application/json",
+          Origin: "http://localhost:3000",
+        },
+      }),
+      { params: Promise.resolve({ slug: "team", userId: "user-2" }) }
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Not authenticated" });
+    expect(mockGroups.getGroupBySlug).not.toHaveBeenCalled();
+    expect(mockGroups.db.update).not.toHaveBeenCalled();
+  });
+
   it.each(BAD_BODIES)("returns 400 for $label body", async ({ body }) => {
     mockGroups.getSessionFromRequest.mockResolvedValue(session());
     mockGroups.getGroupBySlug.mockResolvedValue(group());

--- a/packages/frontend/__tests__/lib/requestSessionCsrf.test.ts
+++ b/packages/frontend/__tests__/lib/requestSessionCsrf.test.ts
@@ -146,4 +146,56 @@ describe("getSessionFromRequest — CSRF origin check (B6)", () => {
     expect(mockState.getSessionFromHeader).toHaveBeenCalledTimes(1);
     expect(mockState.getSession).not.toHaveBeenCalled();
   });
+
+  it("does not resolve Authorization header sessions when bearer auth is disabled", async () => {
+    mockState.getSessionFromHeader.mockResolvedValue(validUser);
+    mockState.getSession.mockResolvedValue(null);
+
+    const result = await getSessionFromRequest(
+      makeRequest("POST", {
+        Origin: "http://localhost:3000",
+        Authorization: "Bearer tt_sometoken",
+      }),
+      { allowAuthorizationHeader: false }
+    );
+
+    expect(result).toBeNull();
+    expect(mockState.getSessionFromHeader).not.toHaveBeenCalled();
+    expect(mockState.getSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows cookie sessions when bearer auth is disabled and Origin is allowed", async () => {
+    mockState.getSession.mockResolvedValue(validUser);
+
+    const result = await getSessionFromRequest(
+      makeRequest("POST", { Origin: "http://localhost:3000" }),
+      { allowAuthorizationHeader: false }
+    );
+
+    expect(result).toEqual(validUser);
+    expect(mockState.getSessionFromHeader).not.toHaveBeenCalled();
+    expect(mockState.getSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores Authorization headers when bearer auth is disabled and still uses valid cookies", async () => {
+    mockState.getSessionFromHeader.mockResolvedValue({
+      id: "token-user",
+      username: "token-user",
+      displayName: null,
+      avatarUrl: null,
+    });
+    mockState.getSession.mockResolvedValue(validUser);
+
+    const result = await getSessionFromRequest(
+      makeRequest("POST", {
+        Origin: "http://localhost:3000",
+        Authorization: "Bearer tt_sometoken",
+      }),
+      { allowAuthorizationHeader: false }
+    );
+
+    expect(result).toEqual(validUser);
+    expect(mockState.getSessionFromHeader).not.toHaveBeenCalled();
+    expect(mockState.getSession).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/frontend/src/app/api/groups/[slug]/invite/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/invite/route.ts
@@ -7,12 +7,14 @@ import { getGroupBySlug } from "@/lib/groups/queries";
 import { canManageGroupRole, isGroupRole } from "@/lib/groups/utils";
 import type { GroupRole } from "@/lib/db";
 
+const BROWSER_SESSION_OPTIONS = { allowAuthorizationHeader: false } as const;
+
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ slug: string }> }
 ) {
   try {
-    const session = await getSessionFromRequest(request);
+    const session = await getSessionFromRequest(request, BROWSER_SESSION_OPTIONS);
     if (!session) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }

--- a/packages/frontend/src/app/api/groups/[slug]/leave/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/leave/route.ts
@@ -6,12 +6,14 @@ import { revalidateGroupCaches } from "@/lib/groups/cache";
 import { getGroupMembership } from "@/lib/groups/permissions";
 import { getGroupBySlug } from "@/lib/groups/queries";
 
+const BROWSER_SESSION_OPTIONS = { allowAuthorizationHeader: false } as const;
+
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ slug: string }> }
 ) {
   try {
-    const session = await getSessionFromRequest(request);
+    const session = await getSessionFromRequest(request, BROWSER_SESSION_OPTIONS);
     if (!session) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }

--- a/packages/frontend/src/app/api/groups/[slug]/members/[userId]/role/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/members/[userId]/role/route.ts
@@ -8,13 +8,15 @@ import { getGroupBySlug } from "@/lib/groups/queries";
 import { canManageGroupRole, isGroupRole } from "@/lib/groups/utils";
 import type { GroupRole } from "@/lib/db";
 
+const BROWSER_SESSION_OPTIONS = { allowAuthorizationHeader: false } as const;
+
 interface RouteParams {
   params: Promise<{ slug: string; userId: string }>;
 }
 
 export async function PATCH(request: Request, { params }: RouteParams) {
   try {
-    const session = await getSessionFromRequest(request);
+    const session = await getSessionFromRequest(request, BROWSER_SESSION_OPTIONS);
     if (!session) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }

--- a/packages/frontend/src/app/api/groups/[slug]/members/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/members/route.ts
@@ -6,6 +6,8 @@ import { revalidateGroupCaches } from "@/lib/groups/cache";
 import { canManageGroupMember, getGroupMembership } from "@/lib/groups/permissions";
 import { getGroupBySlug } from "@/lib/groups/queries";
 
+const BROWSER_SESSION_OPTIONS = { allowAuthorizationHeader: false } as const;
+
 interface RouteParams {
   params: Promise<{ slug: string }>;
 }
@@ -57,7 +59,7 @@ export async function GET(request: Request, { params }: RouteParams) {
 
 export async function DELETE(request: Request, { params }: RouteParams) {
   try {
-    const session = await getSessionFromRequest(request);
+    const session = await getSessionFromRequest(request, BROWSER_SESSION_OPTIONS);
     if (!session) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }

--- a/packages/frontend/src/app/api/groups/[slug]/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/route.ts
@@ -8,6 +8,8 @@ import { getGroupMembership } from "@/lib/groups/permissions";
 import { getGroupBySlug, getGroupMemberCount } from "@/lib/groups/queries";
 import { generateUniqueGroupSlug } from "@/lib/groups/slugs";
 
+const BROWSER_SESSION_OPTIONS = { allowAuthorizationHeader: false } as const;
+
 interface RouteParams {
   params: Promise<{ slug: string }>;
 }
@@ -79,7 +81,7 @@ export async function GET(request: Request, { params }: RouteParams) {
 
 export async function PATCH(request: Request, { params }: RouteParams) {
   try {
-    const session = await getSessionFromRequest(request);
+    const session = await getSessionFromRequest(request, BROWSER_SESSION_OPTIONS);
     if (!session) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }
@@ -174,7 +176,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
 
 export async function DELETE(request: Request, { params }: RouteParams) {
   try {
-    const session = await getSessionFromRequest(request);
+    const session = await getSessionFromRequest(request, BROWSER_SESSION_OPTIONS);
     if (!session) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }

--- a/packages/frontend/src/app/api/groups/[slug]/transfer-ownership/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/transfer-ownership/route.ts
@@ -7,12 +7,14 @@ import { getGroupMembership } from "@/lib/groups/permissions";
 import { getGroupBySlug } from "@/lib/groups/queries";
 import type { GroupRole } from "@/lib/db";
 
+const BROWSER_SESSION_OPTIONS = { allowAuthorizationHeader: false } as const;
+
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ slug: string }> }
 ) {
   try {
-    const session = await getSessionFromRequest(request);
+    const session = await getSessionFromRequest(request, BROWSER_SESSION_OPTIONS);
     if (!session) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }

--- a/packages/frontend/src/app/api/groups/join/[token]/route.ts
+++ b/packages/frontend/src/app/api/groups/join/[token]/route.ts
@@ -7,6 +7,8 @@ import {
   GroupInviteError,
 } from "@/lib/groups/invites";
 
+const BROWSER_SESSION_OPTIONS = { allowAuthorizationHeader: false } as const;
+
 interface RouteParams {
   params: Promise<{ token: string }>;
 }
@@ -34,7 +36,7 @@ export async function GET(_request: Request, { params }: RouteParams) {
 
 export async function POST(request: Request, { params }: RouteParams) {
   try {
-    const session = await getSessionFromRequest(request);
+    const session = await getSessionFromRequest(request, BROWSER_SESSION_OPTIONS);
     if (!session) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }

--- a/packages/frontend/src/app/api/groups/route.ts
+++ b/packages/frontend/src/app/api/groups/route.ts
@@ -5,6 +5,8 @@ import { getSessionFromRequest } from "@/lib/auth/requestSession";
 import { generateUniqueGroupSlug } from "@/lib/groups/slugs";
 import { listPublicGroups, listUserGroups } from "@/lib/groups/queries";
 
+const BROWSER_SESSION_OPTIONS = { allowAuthorizationHeader: false } as const;
+
 function parseIntSafe(value: string | null, defaultValue: number): number {
   if (!value) return defaultValue;
   const parsed = Number(value);
@@ -39,7 +41,7 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
-    const session = await getSessionFromRequest(request);
+    const session = await getSessionFromRequest(request, BROWSER_SESSION_OPTIONS);
     if (!session) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }

--- a/packages/frontend/src/lib/auth/requestSession.ts
+++ b/packages/frontend/src/lib/auth/requestSession.ts
@@ -2,6 +2,10 @@ import { getSession, getSessionFromHeader, type SessionUser } from "./session";
 
 const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
+interface GetSessionFromRequestOptions {
+  allowAuthorizationHeader?: boolean;
+}
+
 function getAllowedOrigins(): string[] {
   const env = process.env.CSRF_ALLOWED_ORIGINS;
   if (env) {
@@ -10,10 +14,13 @@ function getAllowedOrigins(): string[] {
   return ["https://tokscale.dev", "http://localhost:3000"];
 }
 
-export async function getSessionFromRequest(request: Request): Promise<SessionUser | null> {
+export async function getSessionFromRequest(
+  request: Request,
+  options: GetSessionFromRequestOptions = {}
+): Promise<SessionUser | null> {
   const authHeader = request.headers.get("Authorization");
 
-  if (authHeader) {
+  if (authHeader && options.allowAuthorizationHeader !== false) {
     return getSessionFromHeader(request);
   }
 


### PR DESCRIPTION
## Summary

Restricts group mutation endpoints to browser sessions by making those routes ignore `Authorization` header personal-token auth. Token auth remains available for API-oriented routes that already depend on it, such as submit and settings token flows.

## Why

Group creation, membership, invite, role, leave, ownership, update, and delete actions are browser workflows with CSRF protections. Allowing `Authorization` header sessions on those same mutation routes creates an unnecessary auth boundary overlap: a personal token can bypass the browser-session-only expectation for group administration.

## Diff scope

* `packages/frontend/src/lib/auth/requestSession.ts`: adds an explicit `allowAuthorizationHeader` option while preserving the existing default behavior.
* Group mutation routes: pass `{ allowAuthorizationHeader: false }` before performing write-side group operations.
* Group read routes: keep the default behavior so existing authenticated reads are not changed.
* Tests: add coverage proving `Authorization: Bearer ...` is rejected for representative group mutations, while cookie sessions and existing token-auth routes remain covered.

## Branch integrity

Base branch: `main`

Validated base SHA: `715fddf6db88258c50eb20a5cc8d698e442f35b9`

Ahead/behind: `0 behind / 1 ahead`

Merge base: `715fddf6db88258c50eb20a5cc8d698e442f35b9`

Fast-forward safety: `origin/main` is an ancestor of this branch.

## Commit integrity

Introduced commit:

```text
f556fb799e01432f0b3a86b59a086bcac2d595be fix(auth): reject personal tokens on group mutations
```

The commit is one logical auth-boundary change and the final PR diff contains only group auth routing and focused tests.

## Ledger and version proof

Ledger: not applicable — not required for this change family.

Version: not applicable — no release/versioned package metadata changed.

## Diff hygiene

Changed files:

```text
M	packages/frontend/__tests__/api/groupInviteCreateRoute.test.ts
M	packages/frontend/__tests__/api/groupInviteJoinRoute.test.ts
M	packages/frontend/__tests__/api/groupRoute.test.ts
M	packages/frontend/__tests__/api/groupTransferOwnership.test.ts
M	packages/frontend/__tests__/api/groupsPayloadGuard.test.ts
M	packages/frontend/__tests__/lib/requestSessionCsrf.test.ts
M	packages/frontend/src/app/api/groups/[slug]/invite/route.ts
M	packages/frontend/src/app/api/groups/[slug]/leave/route.ts
M	packages/frontend/src/app/api/groups/[slug]/members/[userId]/role/route.ts
M	packages/frontend/src/app/api/groups/[slug]/members/route.ts
M	packages/frontend/src/app/api/groups/[slug]/route.ts
M	packages/frontend/src/app/api/groups/[slug]/transfer-ownership/route.ts
M	packages/frontend/src/app/api/groups/join/[token]/route.ts
M	packages/frontend/src/app/api/groups/route.ts
M	packages/frontend/src/lib/auth/requestSession.ts
```

`git diff --check origin/main...HEAD`: PASS, no output.


## Validation mode and proof

Validation mode: Mode 3 — security-sensitive auth boundary for group mutation routes.

Local validation:

```text
bun run --cwd packages/frontend test __tests__/lib/requestSessionCsrf.test.ts __tests__/api/groupsPayloadGuard.test.ts __tests__/api/groupRoute.test.ts __tests__/api/groupInviteCreateRoute.test.ts __tests__/api/groupTransferOwnership.test.ts __tests__/api/groupInviteJoinRoute.test.ts __tests__/api/groupLeaveRoute.test.ts __tests__/api/submitAuth.test.ts __tests__/api/settingsSubmittedDataDelete.test.ts: PASS, 9 files and 62 tests passed.
git diff --check: PASS
git diff --cached --check: PASS
```

Not run locally: full frontend suite — targeted API/auth tests cover the changed boundary, and required remote CI will run on the PR SHA.

## CI context confirmation

Pending — required PR checks will run after the PR is opened. This PR does not rename PR check contexts.

## Runtime safety

The change is intentionally scoped to authentication selection before group mutation handlers run. It does not add background jobs, queues, locks, migrations, or new external service calls.

No invariant regression introduced.

## Documentation integrity

Not applicable — no user-facing commands, setup instructions, or operational runbooks changed.

## Rollback plan

Rollback: revert this PR.

DB downgrade: not applicable.

Data repair: not applicable.

Operational caveats: reverting restores the previous behavior where group mutation routes can resolve sessions from `Authorization` headers.

## Known residual risks

This PR is ready for review after local validation, but it is not merge-ready until required remote PR checks pass.
