### PR TITLE
fix(claude): count tool-result input usage

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -10,7 +10,7 @@ use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
-const CACHE_SCHEMA_VERSION: u32 = 14;
+const CACHE_SCHEMA_VERSION: u32 = 15;
 const CACHE_FILENAME: &str = "source-message-cache.bin";
 const CACHE_LOCK_FILENAME: &str = "source-message-cache.lock";
 const MAX_CACHE_FILE_BYTES: u64 = 256 * 1024 * 1024;

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -9,10 +9,10 @@ use super::utils::{
 use super::{
     normalize_agent_name, normalize_workspace_key, workspace_label_from_key, UnifiedMessage,
 };
-use crate::{provider_identity, TokenBreakdown};
+use crate::{pricing, provider_identity, TokenBreakdown};
 use serde::Deserialize;
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
@@ -344,6 +344,8 @@ pub fn parse_claude_file_with_cache(
     // so the next assistant message can be marked as a turn start.
     let mut pending_turn_start = false;
     let mut pending_request_start_timestamp_ms: Option<i64> = None;
+    let mut last_model: Option<String> = None;
+    let mut last_provider_hint: Option<String> = None;
     // Sidechain detection state (resolved lazily on first parseable entry)
     let mut sidechain_agent: Option<String> = None;
     let mut sidechain_detected = false;
@@ -381,17 +383,46 @@ pub fn parse_claude_file_with_cache(
                 }
             }
 
-            if entry.entry_type == "user" {
+            if entry.entry_type == "user" || entry.entry_type == "tool_result" {
+                let tool_result_message = extract_claude_tool_result_message(
+                    trimmed,
+                    ClaudeToolResultContext {
+                        entry: &entry,
+                        last_model: last_model.as_deref(),
+                        last_provider_hint: last_provider_hint.as_deref(),
+                        session_id: &session_id,
+                        fallback_timestamp,
+                        workspace_key: workspace_key.clone(),
+                        workspace_label: workspace_label.clone(),
+                        sidechain_agent: sidechain_agent.clone(),
+                    },
+                );
+
                 if let Some(timestamp_ms) = parse_claude_entry_timestamp(entry.timestamp.as_deref())
                 {
                     pending_request_start_timestamp_ms = Some(timestamp_ms);
                 }
-                // Distinguish real human input from tool results / system messages.
-                // Tool results have content as a JSON array (e.g. [{"type":"tool_result",...}]).
-                // System messages have XML-tagged content (e.g. <local-command-stdout>).
-                // Only plain text without XML tags counts as a genuine user turn.
-                if is_human_turn(trimmed) {
+
+                if entry.entry_type == "user" && is_human_turn(trimmed) {
                     pending_turn_start = true;
+                }
+
+                if let Some(tool_message) = tool_result_message {
+                    if let Some(ref dedup_key) = tool_message.dedup_key {
+                        if let Some(&existing_idx) = processed_hashes.get(dedup_key) {
+                            merge_claude_tool_result_duplicate(
+                                &mut messages[existing_idx],
+                                tool_message.tokens.input,
+                                tool_message.timestamp,
+                            );
+                            continue;
+                        }
+                        processed_hashes.insert(dedup_key.clone(), messages.len());
+                    }
+                    let provider_confidence =
+                        stored_claude_provider_confidence(&tool_message.provider_id);
+                    messages.push(tool_message);
+                    provider_confidences.push(provider_confidence);
                 }
                 continue;
             }
@@ -402,6 +433,15 @@ pub fn parse_claude_file_with_cache(
                     Some(m) => m,
                     None => continue,
                 };
+
+                if let Some(model) = message.model.as_deref() {
+                    last_model = Some(model.to_string());
+                    last_provider_hint = message
+                        .provider_id
+                        .as_deref()
+                        .or(entry.provider_id.as_deref())
+                        .map(str::to_string);
+                }
 
                 let usage = match message.usage {
                     Some(u) => u,
@@ -463,18 +503,19 @@ pub fn parse_claude_file_with_cache(
                     _ => None,
                 };
 
-                let model = match message.model {
+                let raw_model = match message.model {
                     Some(m) => m,
                     None => continue,
                 };
                 let provider_choice = claude_provider_choice(
-                    &model,
+                    &raw_model,
                     message
                         .provider_id
                         .as_deref()
                         .or(entry.provider_id.as_deref()),
                 );
                 let provider_confidence = provider_choice.confidence;
+                let model = canonicalize_claude_model(&raw_model);
 
                 let parsed_timestamp = parse_claude_entry_timestamp(entry.timestamp.as_deref());
                 let timestamp = parsed_timestamp.unwrap_or(fallback_timestamp);
@@ -621,6 +662,269 @@ fn merge_claude_duplicate(
     }
 }
 
+fn merge_claude_tool_result_duplicate(
+    existing: &mut UnifiedMessage,
+    input_tokens: i64,
+    timestamp_ms: i64,
+) {
+    existing.tokens.input = existing.tokens.input.max(input_tokens.max(0));
+    if timestamp_ms >= existing.timestamp {
+        existing.set_timestamp(timestamp_ms);
+    }
+}
+
+struct ClaudeToolResultUsage {
+    input_tokens: i64,
+    dedup_key: Option<String>,
+}
+
+struct ClaudeToolResultContext<'a> {
+    entry: &'a ClaudeEntry,
+    last_model: Option<&'a str>,
+    last_provider_hint: Option<&'a str>,
+    session_id: &'a str,
+    fallback_timestamp: i64,
+    workspace_key: Option<String>,
+    workspace_label: Option<String>,
+    sidechain_agent: Option<String>,
+}
+
+fn extract_claude_tool_result_message(
+    line: &str,
+    context: ClaudeToolResultContext<'_>,
+) -> Option<UnifiedMessage> {
+    let value: Value = serde_json::from_str(line).ok()?;
+    let usage = extract_claude_tool_result_usage(&value)?;
+
+    let raw_model = extract_claude_model(&value)
+        .or_else(|| {
+            context
+                .entry
+                .message
+                .as_ref()
+                .and_then(|message| message.model.clone())
+        })
+        .or_else(|| context.last_model.map(str::to_string))
+        .unwrap_or_else(|| "unknown".to_string());
+    let provider_hint = extract_claude_provider(&value)
+        .or_else(|| {
+            context
+                .entry
+                .message
+                .as_ref()
+                .and_then(|message| message.provider_id.clone())
+        })
+        .or_else(|| context.entry.provider_id.clone())
+        .or_else(|| context.last_provider_hint.map(str::to_string));
+
+    let provider_choice = claude_provider_choice(&raw_model, provider_hint.as_deref());
+    let model = canonicalize_claude_model(&raw_model);
+    let timestamp = parse_claude_entry_timestamp(context.entry.timestamp.as_deref())
+        .or_else(|| extract_claude_timestamp(&value))
+        .unwrap_or(context.fallback_timestamp);
+
+    let mut message = UnifiedMessage::new_with_dedup(
+        "claude",
+        model,
+        provider_choice.id,
+        context.session_id.to_string(),
+        timestamp,
+        TokenBreakdown {
+            input: usage.input_tokens,
+            output: 0,
+            cache_read: 0,
+            cache_write: 0,
+            reasoning: 0,
+        },
+        0.0,
+        usage
+            .dedup_key
+            .map(|key| format!("claude:tool_result:{}:{key}", context.session_id)),
+    );
+    message.message_count = 0;
+    message.agent = context.sidechain_agent;
+    message.set_workspace(context.workspace_key, context.workspace_label);
+    Some(message)
+}
+
+fn extract_claude_tool_result_usage(value: &Value) -> Option<ClaudeToolResultUsage> {
+    let mut total_tokens = 0;
+    let mut first_dedup_id: Option<String> = None;
+    let mut seen_ids = HashSet::new();
+
+    for tool_result in claude_tool_result_values(value) {
+        let tool_result_id = extract_tool_result_id(tool_result);
+        if let Some(id) = tool_result_id.as_ref() {
+            if !seen_ids.insert(id.clone()) {
+                continue;
+            }
+        }
+        if first_dedup_id.is_none() {
+            first_dedup_id = tool_result_id;
+        }
+        total_tokens += extract_tool_result_input_tokens(tool_result).unwrap_or(0);
+    }
+
+    if total_tokens <= 0 {
+        return None;
+    }
+
+    Some(ClaudeToolResultUsage {
+        input_tokens: total_tokens,
+        dedup_key: first_dedup_id.map(|id| format!("tool_result:{id}")),
+    })
+}
+
+fn claude_tool_result_values(value: &Value) -> Vec<&Value> {
+    let mut results = Vec::new();
+
+    if value
+        .get("type")
+        .and_then(|kind| kind.as_str())
+        .is_some_and(|kind| kind == "tool_result")
+    {
+        results.push(value);
+    }
+
+    if let Some(tool_result) = value.get("tool_result") {
+        results.push(tool_result);
+    }
+
+    if let Some(message_tool_result) = value
+        .get("message")
+        .and_then(|message| message.get("tool_result"))
+    {
+        results.push(message_tool_result);
+    }
+
+    if let Some(content) = value
+        .get("message")
+        .and_then(|message| message.get("content"))
+        .or_else(|| value.get("content"))
+    {
+        collect_tool_result_blocks(content, &mut results);
+    }
+
+    results
+}
+
+fn collect_tool_result_blocks<'a>(value: &'a Value, results: &mut Vec<&'a Value>) {
+    if let Some(blocks) = value.as_array() {
+        for block in blocks {
+            if block
+                .get("type")
+                .and_then(|kind| kind.as_str())
+                .is_some_and(|kind| kind == "tool_result")
+            {
+                results.push(block);
+            }
+        }
+    }
+}
+
+fn extract_tool_result_id(tool_result: &Value) -> Option<String> {
+    extract_string(tool_result.get("tool_use_id"))
+        .or_else(|| extract_string(tool_result.get("id")))
+        .or_else(|| extract_string(tool_result.get("tool_result_id")))
+}
+
+fn extract_tool_result_input_tokens(tool_result: &Value) -> Option<i64> {
+    explicit_tool_result_input_tokens(tool_result).or_else(|| {
+        let chars = tool_result_output_char_count(tool_result);
+        (chars > 0).then(|| estimate_tokens_from_chars(chars))
+    })
+}
+
+fn explicit_tool_result_input_tokens(tool_result: &Value) -> Option<i64> {
+    for candidate in [
+        tool_result.get("input_tokens"),
+        tool_result.get("token_count"),
+        tool_result.get("tokens"),
+        tool_result
+            .get("usage")
+            .and_then(|usage| usage.get("input_tokens")),
+        tool_result
+            .get("tool_output")
+            .and_then(|tool_output| tool_output.get("input_tokens")),
+        tool_result
+            .get("tool_output")
+            .and_then(|tool_output| tool_output.get("token_count")),
+        tool_result
+            .get("tool_output")
+            .and_then(|tool_output| tool_output.get("tokens")),
+        tool_result
+            .get("tool_output")
+            .and_then(|tool_output| tool_output.get("usage"))
+            .and_then(|usage| usage.get("input_tokens")),
+    ] {
+        if let Some(tokens) = extract_i64(candidate) {
+            return Some(tokens.max(0));
+        }
+    }
+    None
+}
+
+fn tool_result_output_char_count(tool_result: &Value) -> usize {
+    let mut chars = 0;
+
+    if let Some(output) = tool_result
+        .get("tool_output")
+        .and_then(|tool_output| tool_output.get("output"))
+        .and_then(|output| output.as_str())
+    {
+        chars += output.chars().count();
+    }
+
+    match tool_result.get("content") {
+        Some(content) if content.is_string() => {
+            chars += content
+                .as_str()
+                .map(str::chars)
+                .map(Iterator::count)
+                .unwrap_or(0);
+        }
+        Some(content) => {
+            chars += tool_result_content_output_chars(content);
+        }
+        None => {}
+    }
+
+    chars
+}
+
+fn tool_result_content_output_chars(content: &Value) -> usize {
+    content
+        .as_array()
+        .map(|blocks| {
+            blocks
+                .iter()
+                .map(|block| {
+                    block
+                        .get("tool_output")
+                        .and_then(|tool_output| tool_output.get("output"))
+                        .and_then(|output| output.as_str())
+                        .or_else(|| block.get("text").and_then(|text| text.as_str()))
+                        .map(str::chars)
+                        .map(Iterator::count)
+                        .unwrap_or(0)
+                })
+                .sum()
+        })
+        .unwrap_or(0)
+}
+
+fn estimate_tokens_from_chars(chars: usize) -> i64 {
+    // Claude Code tool outputs may not include token metadata. Match the
+    // existing Kiro fallback of one token per four characters, rounded up.
+    chars.div_ceil(4) as i64
+}
+
+fn canonicalize_claude_model(model: &str) -> String {
+    pricing::aliases::resolve_alias(model)
+        .unwrap_or(model)
+        .to_string()
+}
+
 #[derive(Default)]
 struct ClaudeHeadlessState {
     model: Option<String>,
@@ -717,8 +1021,9 @@ fn extract_claude_headless_message(
     let usage = value
         .get("usage")
         .or_else(|| value.get("message").and_then(|msg| msg.get("usage")))?;
-    let model = extract_claude_model(value)?;
-    let provider_id = claude_provider_id(&model, extract_claude_provider(value).as_deref());
+    let raw_model = extract_claude_model(value)?;
+    let provider_id = claude_provider_id(&raw_model, extract_claude_provider(value).as_deref());
+    let model = canonicalize_claude_model(&raw_model);
     let timestamp = extract_claude_timestamp(value).unwrap_or(fallback_timestamp);
 
     Some(UnifiedMessage::new(
@@ -935,8 +1240,9 @@ fn finalize_headless_state(
     session_id: &str,
     fallback_timestamp: i64,
 ) -> Option<UnifiedMessage> {
-    let model = state.model.clone()?;
-    let provider_id = claude_provider_id(&model, state.provider_id.as_deref());
+    let raw_model = state.model.clone()?;
+    let provider_id = claude_provider_id(&raw_model, state.provider_id.as_deref());
+    let model = canonicalize_claude_model(&raw_model);
     let timestamp = state.timestamp_ms.unwrap_or(fallback_timestamp);
     if state.input == 0 && state.output == 0 && state.cache_read == 0 && state.cache_write == 0 {
         *state = ClaudeHeadlessState::default();
@@ -1273,21 +1579,34 @@ mod tests {
         let file = create_test_file(content);
         let messages = parse_claude_file(file.path());
 
-        assert_eq!(messages.len(), 3, "Should have 3 assistant messages");
+        assert_eq!(
+            messages.len(),
+            4,
+            "Should include 3 assistant messages plus 1 tool-result input message"
+        );
+        let assistant_messages: Vec<_> = messages
+            .iter()
+            .filter(|message| message.tokens.output > 0)
+            .collect();
+        assert_eq!(
+            assistant_messages.len(),
+            3,
+            "Should have 3 assistant usage messages"
+        );
 
         // First assistant after first human user → turn start
         assert!(
-            messages[0].is_turn_start,
+            assistant_messages[0].is_turn_start,
             "First response should be turn start"
         );
         // Assistant after tool_result → NOT a new turn
         assert!(
-            !messages[1].is_turn_start,
+            !assistant_messages[1].is_turn_start,
             "Response after tool_result should NOT be turn start"
         );
         // First assistant after second human user → turn start
         assert!(
-            messages[2].is_turn_start,
+            assistant_messages[2].is_turn_start,
             "Response after real user input should be turn start"
         );
 
@@ -1347,6 +1666,91 @@ mod tests {
         assert_eq!(messages[0].tokens.cache_read, 200);
         assert_eq!(messages[0].tokens.cache_write, 100);
         assert_eq!(messages[0].tokens.reasoning, 0);
+    }
+
+    #[test]
+    fn test_tool_result_output_counts_as_input() {
+        let content = r#"{"type":"user","timestamp":"2026-05-27T10:00:00.000Z","message":{"model":"anthropic/claude-4-6-sonnet","content":[{"type":"tool_result","tool_use_id":"toolu_input","tool_output":{"output":"abcdefghijklmnop"}}]}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "claude-sonnet-4-6");
+        assert_eq!(messages[0].provider_id, "anthropic");
+        assert_eq!(messages[0].tokens.input, 4);
+        assert_eq!(messages[0].tokens.output, 0);
+        assert_eq!(messages[0].tokens.cache_read, 0);
+        assert_eq!(messages[0].tokens.cache_write, 0);
+        let expected_dedup_key = format!(
+            "claude:tool_result:{}:tool_result:toolu_input",
+            messages[0].session_id
+        );
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some(expected_dedup_key.as_str())
+        );
+        assert_eq!(messages[0].message_count, 0);
+    }
+
+    #[test]
+    fn test_tool_result_duplicate_uses_max_input_tokens() {
+        let content = r#"{"type":"tool_result","timestamp":"2026-05-27T10:00:00.000Z","model":"anthropic/claude-4-6-sonnet","tool_result":{"tool_use_id":"toolu_stream","tool_output":{"output":"abcdefghijklmnop"}}}
+{"type":"tool_result","timestamp":"2026-05-27T10:00:00.100Z","model":"anthropic/claude-4-6-sonnet","tool_result":{"tool_use_id":"toolu_stream","tool_output":{"output":"abcdefghijklmnopqrstuvwxyzabcd"}}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "claude-sonnet-4-6");
+        assert_eq!(messages[0].tokens.input, 8);
+        assert_eq!(messages[0].timestamp, 1_779_876_000_100);
+    }
+
+    #[test]
+    fn test_tool_result_repeated_in_same_record_is_not_counted_twice() {
+        let content = r#"{"type":"tool_result","timestamp":"2026-05-27T10:00:00.000Z","model":"anthropic/claude-4-6-sonnet","tool_result":{"tool_use_id":"toolu_same","tool_output":{"output":"abcdefghijklmnop"}},"message":{"content":[{"type":"tool_result","tool_use_id":"toolu_same","tool_output":{"output":"abcdefghijklmnop"}}]}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 4);
+    }
+
+    #[test]
+    fn test_tool_result_prefers_input_token_metadata_over_char_estimate() {
+        let content = r#"{"type":"user","timestamp":"2026-05-27T10:00:00.000Z","message":{"model":"claude-sonnet-4-6","content":[{"type":"tool_result","tool_use_id":"toolu_metadata","tool_output":{"output":"abcdefghijklmnopqrstuvwxyzabcd","input_tokens":3}}]}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 3);
+    }
+
+    #[test]
+    fn test_assistant_usage_with_tool_use_is_not_estimated_from_prompt_text() {
+        let content = r#"{"type":"assistant","timestamp":"2026-05-27T10:00:00.000Z","message":{"id":"msg_tool_use","model":"claude-sonnet-4-6","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"file_path":"/tmp/large.txt"}}],"usage":{"input_tokens":100,"output_tokens":50}}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 100);
+        assert_eq!(messages[0].tokens.output, 50);
+    }
+
+    #[test]
+    fn test_anthropic_prefixed_claude_model_is_canonicalized() {
+        let content = r#"{"type":"assistant","timestamp":"2026-05-27T10:00:00.000Z","message":{"model":"anthropic/claude-4-6-sonnet","usage":{"input_tokens":100,"output_tokens":50}}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "claude-sonnet-4-6");
+        assert_eq!(messages[0].provider_id, "anthropic");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Counts Claude Code `tool_result` output as input usage when transcripts expose tool-result payloads without normal assistant `usage` rows. The parser now attributes those rows to the surrounding Claude model/provider, deduplicates repeated tool-result streams, and invalidates the source-message cache schema so stale cached parses do not hide recovered usage.

## Why

Claude Code transcripts can include large tool outputs as `tool_result` content. Those payloads are part of the next model request context, but they were previously ignored when they appeared outside assistant usage rows. That made Claude usage totals undercount long tool-heavy sessions, especially when tool results carried no explicit token metadata.

## Diff scope

* `crates/tokscale-core/src/sessions/claudecode.rs`: extracts `tool_result` records from top-level, nested `tool_result`, and message content shapes.
* Adds explicit token metadata support for tool results and falls back to the existing one-token-per-four-characters estimate when metadata is missing.
* Attributes recovered tool-result input to the latest Claude model/provider context, with Anthropic-prefixed model aliases canonicalized before aggregation/pricing.
* Deduplicates streaming or repeated tool results by tool result id, keeping the maximum observed input count for the same tool result.
* Ensures synthetic tool-result usage rows do not increment message count.
* `crates/tokscale-core/src/message_cache.rs`: bumps the cache schema version so older cached Claude parses are rebuilt under the new parser behavior.

## Branch integrity

Base branch: `main`

Validated base SHA: `715fddf6db88258c50eb20a5cc8d698e442f35b9`

Ahead/behind: `0 behind / 1 ahead`

Merge base: `715fddf6db88258c50eb20a5cc8d698e442f35b9`

Fast-forward safety: `origin/main` is an ancestor of this branch.

## Commit integrity

Introduced commit:

```text
748f7a580e41de036a378d0622f619280f0ca67d fix(claude): count tool-result input usage
```

The commit is one logical Claude parser/cache change and the final PR diff contains only Claude parsing tests plus the cache schema bump needed to make the new parser behavior take effect.

## Ledger and version proof

Ledger: not applicable — not required for this change family.

Version: not applicable — no release/versioned package metadata changed.

## Diff hygiene

Changed files:

```text
M	crates/tokscale-core/src/message_cache.rs
M	crates/tokscale-core/src/sessions/claudecode.rs
```

`git diff --check origin/main...HEAD`: PASS, no output.


## Validation mode and proof

Validation mode: Mode 3 — shared parser and pricing-facing usage behavior.

Local validation:

```text
cargo test -p tokscale-core claudecode -- --nocapture: PASS, 55 tests passed.
cargo test -p tokscale-core pricing -- --nocapture: PASS, 224 tests passed.
cargo test -p tokscale-core test_normalize_model_for_grouping -- --nocapture: PASS, 1 test passed.
cargo fmt --all --check: PASS
git diff --check: PASS
git diff --cached --check: PASS
```

Not run locally: full workspace test suite — targeted parser, pricing, and grouping coverage exercises the changed paths, and required remote CI will run on the PR SHA.

## CI context confirmation

Pending — required PR checks will run after the PR is opened. This PR does not rename PR check contexts.

## Runtime safety

The parser still ignores rows with no usable token signal. Tool-result estimates are input-only, output/cache/reasoning buckets remain zero, duplicate tool-result ids are collapsed, and cache schema invalidation prevents mixing old and new parse semantics.

No invariant regression introduced.

## Documentation integrity

Not applicable — no user-facing commands, setup instructions, or operational runbooks changed.

## Rollback plan

Rollback: revert this PR.

DB downgrade: not applicable.

Data repair: not applicable.

Operational caveats: reverting restores the previous behavior where Claude tool-result payloads without assistant usage rows are not counted.

## Known residual risks

Tool-result rows without explicit token metadata use a character-count estimate, so recovered usage is intentionally approximate in those cases. This PR is ready for review after local validation, but it is not merge-ready until required remote PR checks pass.
