### PR TITLE
fix(cursor): clarify explicit setup diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ tokscale --client opencode,claude
 # Repeated: same effect, useful with shell aliases
 tokscale -c opencode -c claude
 
-# Cursor IDE uses Tokscale's API cache; run login + sync first
+# Cursor IDE uses Tokscale's API cache; run login + sync --json first
 tokscale --client cursor
 
 # Synthetic (synthetic.new) is detected from other agent sessions
@@ -514,7 +514,7 @@ Setup:
    - Network tab: make any request to `cursor.com/api/*`, then copy the value after `WorkosCursorSessionToken=` from the `Cookie` request header.
    - Application tab: open Cookies -> `https://www.cursor.com`, then copy the `WorkosCursorSessionToken` value.
 3. Run `tokscale cursor login --name work` and paste the token.
-4. Run `tokscale cursor sync` to populate `~/.config/tokscale/cursor-cache/usage.csv`.
+4. Run `tokscale cursor sync --json` to populate `~/.config/tokscale/cursor-cache/usage.csv`.
 5. Run `tokscale --client cursor` or any report command.
 
 Treat the session token like a password. It is stored locally in `~/.config/tokscale/cursor-credentials.json`.
@@ -531,7 +531,7 @@ tokscale cursor status
 tokscale cursor accounts
 
 # Manually refresh cached Cursor usage
-tokscale cursor sync
+tokscale cursor sync --json
 
 # Switch active account (controls which account syncs to cursor-cache/usage.csv)
 tokscale cursor switch work

--- a/crates/tokscale-cli/src/commands/wrapped.rs
+++ b/crates/tokscale-cli/src/commands/wrapped.rs
@@ -3002,9 +3002,9 @@ fn cursor_setup_warning_for_wrapped(
     }
 
     let action = if cursor_logged_in {
-        "run `tokscale cursor sync`"
+        "run `tokscale cursor sync --json`"
     } else {
-        "run `tokscale cursor login` and `tokscale cursor sync`"
+        "run `tokscale cursor login` and `tokscale cursor sync --json`"
     };
 
     Some(format!(
@@ -3020,14 +3020,14 @@ mod cursor_setup_warning_tests {
     fn wrapped_cursor_warning_suggests_login_when_not_authenticated() {
         let warning = cursor_setup_warning_for_wrapped(true, false, false).unwrap();
         assert!(warning.contains("tokscale cursor login"));
-        assert!(warning.contains("tokscale cursor sync"));
+        assert!(warning.contains("tokscale cursor sync --json"));
     }
 
     #[test]
     fn wrapped_cursor_warning_suggests_sync_only_when_authenticated() {
         let warning = cursor_setup_warning_for_wrapped(true, false, true).unwrap();
         assert!(!warning.contains("tokscale cursor login"));
-        assert!(warning.contains("tokscale cursor sync"));
+        assert!(warning.contains("tokscale cursor sync --json"));
     }
 
     #[test]

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1204,7 +1204,7 @@ fn cursor_setup_warnings_for_report(
 
     let Some(state) = cursor_setup_state(home_dir) else {
         return vec![
-            "Cursor usage requires Tokscale's Cursor API cache, but the home directory could not be resolved. Tokscale does not parse local ~/.cursor session data.".to_string(),
+            "Cursor usage requires Tokscale's Cursor API cache, but the home directory could not be resolved. Run `tokscale cursor login` and `tokscale cursor sync --json`. Tokscale does not parse local `~/.cursor` session data.".to_string(),
         ];
     };
     if state.has_cache {
@@ -1212,11 +1212,11 @@ fn cursor_setup_warnings_for_report(
     }
 
     let action = if state.home_override {
-        "populate that cache before running a report with --home"
+        "run `tokscale cursor login` and `tokscale cursor sync --json`, or populate that cache before running a report with --home"
     } else if state.has_credentials {
-        "run `tokscale cursor sync`"
+        "run `tokscale cursor sync --json`"
     } else {
-        "run `tokscale cursor login` and `tokscale cursor sync`"
+        "run `tokscale cursor login` and `tokscale cursor sync --json`"
     };
 
     vec![format!(

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -1089,10 +1089,13 @@ fn assert_cursor_setup_warning(json: &serde_json::Value) {
         .as_array()
         .expect("explicit Cursor report should expose setup warnings");
     assert!(
-        warnings.iter().any(|warning| warning
-            .as_str()
-            .is_some_and(|text| text.contains("tokscale cursor login")
-                && text.contains("cursor-cache/usage*.csv"))),
+        warnings
+            .iter()
+            .any(|warning| warning.as_str().is_some_and(|text| text
+                .contains("tokscale cursor login")
+                && text.contains("tokscale cursor sync --json")
+                && text.contains("cursor-cache/usage*.csv")
+                && text.contains("Tokscale does not parse local `~/.cursor`"))),
         "warnings did not explain Cursor setup: {warnings:?}"
     );
 }
@@ -1100,6 +1103,31 @@ fn assert_cursor_setup_warning(json: &serde_json::Value) {
 #[test]
 fn test_models_cursor_explicit_missing_cache_reports_setup_warning_json() {
     let tmp = create_empty_fixture_dir();
+    let output = cmd_with_home(tmp.path())
+        .args(["models", "--json", "--client", "cursor", "--no-spinner"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_cursor_setup_warning(&json);
+}
+
+#[test]
+fn test_models_cursor_explicit_local_cursor_state_still_reports_setup_warning_json() {
+    let tmp = create_empty_fixture_dir();
+    fs::create_dir_all(
+        tmp.path()
+            .join(".cursor/projects/demo/agent-transcripts/session"),
+    )
+    .unwrap();
+    fs::write(
+        tmp.path()
+            .join(".cursor/projects/demo/agent-transcripts/session/session.jsonl"),
+        r#"{"role":"user","content":"hello"}"#,
+    )
+    .unwrap();
+
     let output = cmd_with_home(tmp.path())
         .args(["models", "--json", "--client", "cursor", "--no-spinner"])
         .output()
@@ -1158,10 +1186,12 @@ fn test_models_cursor_explicit_home_override_reports_fixture_cache_path() {
         .as_array()
         .expect("explicit Cursor --home report should expose setup warnings");
     assert!(
-        warnings.iter().any(|warning| warning
-            .as_str()
-            .is_some_and(|text| text.contains(tmp.path().to_str().unwrap())
-                && text.contains("populate that cache")
+        warnings
+            .iter()
+            .any(|warning| warning.as_str().is_some_and(|text| text
+                .contains(tmp.path().to_str().unwrap())
+                && text.contains("tokscale cursor login")
+                && text.contains("tokscale cursor sync --json")
                 && text.contains("cursor-cache/usage*.csv"))),
         "warnings did not explain Cursor --home setup: {warnings:?}"
     );
@@ -1175,7 +1205,11 @@ fn test_models_cursor_explicit_missing_cache_reports_setup_warning_text() {
         .assert()
         .success()
         .stderr(predicate::str::contains("Cursor usage requires"))
-        .stderr(predicate::str::contains("tokscale cursor login"));
+        .stderr(predicate::str::contains("tokscale cursor login"))
+        .stderr(predicate::str::contains("tokscale cursor sync --json"))
+        .stderr(predicate::str::contains(
+            "Tokscale does not parse local `~/.cursor`",
+        ));
 }
 
 #[test]
@@ -1237,7 +1271,7 @@ fn test_models_cursor_logged_in_missing_cache_suggests_sync_only_json() {
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let warnings = json["warnings"].as_array().unwrap();
     let warning = warnings[0].as_str().unwrap();
-    assert!(warning.contains("tokscale cursor sync"));
+    assert!(warning.contains("tokscale cursor sync --json"));
     assert!(
         !warning.contains("tokscale cursor login"),
         "logged-in users with no cache should be told to sync, not log in again: {warning}"


### PR DESCRIPTION
## Summary

Clarifies Cursor setup diagnostics so explicit Cursor reports tell users to use Tokscale's Cursor API cache flow instead of implying that local `~/.cursor` session data can be parsed.

## Why

Cursor usage support depends on `tokscale cursor login` plus `tokscale cursor sync --json`, which populates `~/.config/tokscale/cursor-cache/usage*.csv`. When a user requests Cursor explicitly and the cache is missing, the warning should name the exact setup path and make it clear that local Cursor agent state under `~/.cursor` is not a supported source.

## Diff scope

* `crates/tokscale-cli/src/main.rs`: updates explicit Cursor report warnings to recommend `tokscale cursor login` and `tokscale cursor sync --json`, including the `--home` case.
* `crates/tokscale-cli/src/commands/wrapped.rs`: aligns Wrapped Cursor setup warnings with the same `sync --json` guidance.
* `README.md`: updates Cursor setup examples to use `tokscale cursor sync --json`.
* `crates/tokscale-cli/tests/cli_tests.rs`: adds coverage proving local `~/.cursor` data does not suppress the setup warning and updates assertions around the clearer warning text.

## Branch integrity

Base branch: `main`

Validated base SHA: `715fddf6db88258c50eb20a5cc8d698e442f35b9`

Ahead/behind: `0 behind / 1 ahead`

Merge base: `715fddf6db88258c50eb20a5cc8d698e442f35b9`

Fast-forward safety: `origin/main` is an ancestor of this branch.

## Commit integrity

Introduced commit:

```text
fa86f3f87121534adcb298d0ade8151c90db17cc fix(cursor): clarify explicit setup diagnostics
```

The commit is one logical Cursor diagnostics/docs change and the final PR diff contains only Cursor warning text, README setup examples, and focused CLI tests.

## Ledger and version proof

Ledger: not applicable — not required for this change family.

Version: not applicable — no release/versioned package metadata changed.

## Diff hygiene

Changed files:

```text
M	README.md
M	crates/tokscale-cli/src/commands/wrapped.rs
M	crates/tokscale-cli/src/main.rs
M	crates/tokscale-cli/tests/cli_tests.rs
```

`git diff --check origin/main...HEAD`: PASS, no output.

## Validation mode and proof

Validation mode: Mode 2 — narrow CLI diagnostics and documentation behavior.

Local validation:

```text
cargo test -p tokscale-cli setup_warning: PASS, 3 wrapped unit tests and 10 CLI tests passed.
cargo fmt --all --check: PASS
git diff --check: PASS
git diff --cached --check: PASS
```

Not run locally: full CLI suite — targeted diagnostics tests cover the changed behavior, and required remote CI will run on the PR SHA.

## CI context confirmation

Pending — required PR checks will run after the PR is opened. This PR does not rename PR check contexts.

## Runtime safety

The change affects warning text and setup-state reporting only. It does not change Cursor sync semantics, credentials storage, cache parsing, network behavior, background jobs, or aggregation logic.

No invariant regression introduced.

## Documentation integrity

README Cursor setup commands were updated to match the diagnostic guidance and current API-cache flow.

## Rollback plan

Rollback: revert this PR.

DB downgrade: not applicable.

Data repair: not applicable.

Operational caveats: reverting restores the previous less-explicit Cursor setup guidance.

## Known residual risks

This PR does not add local `~/.cursor` transcript parsing; it intentionally makes that boundary clearer. It is ready for review after local validation, but it is not merge-ready until required remote PR checks pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies Cursor setup diagnostics for explicit Cursor reports. Guidance now directs users to `tokscale cursor login` and `tokscale cursor sync --json`; local `~/.cursor` data is not used.

- **Bug Fixes**
  - Updated CLI warnings in `crates/tokscale-cli/src/main.rs` and `crates/tokscale-cli/src/commands/wrapped.rs`, including `--home` guidance.
  - Adjusted tests to assert the new messages and ensure local `~/.cursor` state does not suppress warnings.
  - Updated README examples to use `tokscale cursor sync --json`.

<sup>Written for commit fa86f3f87121534adcb298d0ade8151c90db17cc. Summary will update on new commits. <a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/623?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

