### PR TITLE
fix(cache): preserve recreated source entries

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -419,7 +419,9 @@ impl SourceMessageCache {
                 .unwrap_or_default();
 
         for path in &self.deleted_paths {
-            merged_entries.remove(path);
+            if !path.to_path_buf().exists() {
+                merged_entries.remove(path);
+            }
         }
         for path in &self.dirty_keys {
             if let Some(entry) = self.entries.get(path) {
@@ -720,20 +722,24 @@ mod tests {
         Option<std::ffi::OsString>,
         Option<std::ffi::OsString>,
         Option<std::ffi::OsString>,
+        Option<std::ffi::OsString>,
     ) {
         let prev_home = std::env::var_os("HOME");
         let prev_xdg_config = std::env::var_os("XDG_CONFIG_HOME");
         let prev_xdg_cache = std::env::var_os("XDG_CACHE_HOME");
+        let prev_override = std::env::var_os("TOKSCALE_CONFIG_DIR");
         unsafe {
             std::env::set_var("HOME", temp_home);
             std::env::set_var("XDG_CONFIG_HOME", temp_home.join(".config"));
             std::env::set_var("XDG_CACHE_HOME", temp_home.join(".cache"));
+            std::env::remove_var("TOKSCALE_CONFIG_DIR");
         }
-        (prev_home, prev_xdg_config, prev_xdg_cache)
+        (prev_home, prev_xdg_config, prev_xdg_cache, prev_override)
     }
 
     fn restore_cache_env(
         prev: (
+            Option<std::ffi::OsString>,
             Option<std::ffi::OsString>,
             Option<std::ffi::OsString>,
             Option<std::ffi::OsString>,
@@ -742,6 +748,7 @@ mod tests {
         restore_env_var("HOME", prev.0);
         restore_env_var("XDG_CONFIG_HOME", prev.1);
         restore_env_var("XDG_CACHE_HOME", prev.2);
+        restore_env_var("TOKSCALE_CONFIG_DIR", prev.3);
     }
 
     fn write_temp_file(content: &[u8]) -> NamedTempFile {
@@ -1100,6 +1107,82 @@ mod tests {
         }
 
         restore_env_var("HOME", original_home);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_save_if_dirty_preserves_recreated_path_from_concurrent_writer() {
+        let temp_home = TempDir::new().unwrap();
+        let prev_env = sandbox_cache_env(temp_home.path());
+
+        {
+            let source_dir = TempDir::new().unwrap();
+            let path = source_dir.path().join("session.jsonl");
+            std::fs::write(&path, b"{\"id\":\"old\"}\n").unwrap();
+
+            let mut seed = SourceMessageCache::default();
+            seed.insert(CachedSourceEntry::new(
+                &path,
+                SourceFingerprint::from_path(&path).unwrap(),
+                vec![UnifiedMessage::new(
+                    "client",
+                    "gpt-5",
+                    "provider",
+                    "old-session",
+                    1,
+                    TokenBreakdown {
+                        input: 1,
+                        output: 0,
+                        cache_read: 0,
+                        cache_write: 0,
+                        reasoning: 0,
+                    },
+                    0.0,
+                )],
+                Vec::new(),
+                None,
+            ));
+            seed.save_if_dirty();
+
+            let mut stale_deleter = SourceMessageCache::load();
+            std::fs::remove_file(&path).unwrap();
+            stale_deleter.prune_missing_files();
+
+            std::fs::write(&path, b"{\"id\":\"fresh\"}\n").unwrap();
+            let mut fresh_writer = SourceMessageCache::load();
+            fresh_writer.insert(CachedSourceEntry::new(
+                &path,
+                SourceFingerprint::from_path(&path).unwrap(),
+                vec![UnifiedMessage::new(
+                    "client",
+                    "gpt-5",
+                    "provider",
+                    "fresh-session",
+                    2,
+                    TokenBreakdown {
+                        input: 2,
+                        output: 0,
+                        cache_read: 0,
+                        cache_write: 0,
+                        reasoning: 0,
+                    },
+                    0.0,
+                )],
+                Vec::new(),
+                None,
+            ));
+            fresh_writer.save_if_dirty();
+
+            stale_deleter.save_if_dirty();
+
+            let loaded = SourceMessageCache::load();
+            let entry = loaded
+                .get(&path)
+                .expect("recreated source cache entry should survive stale delete");
+            assert_eq!(entry.messages[0].session_id, "fresh-session");
+        }
+
+        restore_cache_env(prev_env);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Prevents a stale source-cache deleter from removing a cache entry that another writer recreated before the stale save acquired the cache lock.

## Why

`SourceMessageCache::save_if_dirty` merges local dirty entries with the on-disk cache under an exclusive lock. Before this change, a cache instance that had observed a source path as deleted could later acquire the lock and remove that path from the merged store even if another process had already recreated the source file and saved a fresh cache entry. That can drop valid cache data during concurrent scans or quick delete/recreate cycles.

## Diff scope

* `crates/tokscale-core/src/message_cache.rs`: revalidates deleted paths while holding the exclusive cache lock before removing them from the merged cache store.
* Adds regression coverage for a stale deleter racing with a fresh writer for the same source path.
* Extends test environment sandboxing to clear and restore `TOKSCALE_CONFIG_DIR`, so cache tests remain isolated from local overrides.

## Branch integrity

Base branch: `main`

Validated base SHA: `715fddf6db88258c50eb20a5cc8d698e442f35b9`

Ahead/behind: `0 behind / 1 ahead`

Merge base: `715fddf6db88258c50eb20a5cc8d698e442f35b9`

Fast-forward safety: `origin/main` is an ancestor of this branch.

## Commit integrity

Introduced commit:

```text
f5149523da973735b835f9ed398aafe9382e6fae fix(cache): preserve recreated source entries
```

The commit is one logical source-cache data-integrity fix and the final PR diff is limited to `message_cache.rs`.

## Ledger and version proof

Ledger: not applicable — not required for this change family.

Version: not applicable — no release/versioned package metadata changed.

## Diff hygiene

Changed files:

```text
M	crates/tokscale-core/src/message_cache.rs
```

`git diff --check origin/main...HEAD`: PASS, no output.

## Validation mode and proof

Validation mode: Mode 3 — shared source-cache data integrity and concurrent writer behavior.

Local validation:

```text
cargo test -p tokscale-core message_cache: PASS, 19 tests passed.
cargo fmt --all --check: PASS
git diff --check: PASS
git diff --cached --check: PASS
```

Not run locally: full workspace test suite — targeted cache tests cover the changed data-integrity path, and required remote CI will run on the PR SHA.

## CI context confirmation

Pending — required PR checks will run after the PR is opened. This PR does not rename PR check contexts.

## Runtime safety

The change adds one existence recheck for deleted paths while the cache save lock is held. It does not add new locks, queues, background work, migrations, or external calls. Existing atomic temp-file rename behavior is unchanged.

No invariant regression introduced.

## Documentation integrity

Not applicable — no user-facing commands, setup instructions, or operational runbooks changed.

## Rollback plan

Rollback: revert this PR.

DB downgrade: not applicable.

Data repair: not applicable.

Operational caveats: reverting restores the previous behavior where a stale cache save can remove a recreated source entry.

## Known residual risks

This protects the delete/recreate race for the source path itself. If a file is recreated after the stale save performs the lock-time existence recheck, a later parse/save cycle will repopulate the cache as before. This PR is ready for review after local validation, but it is not merge-ready until required remote PR checks pass.

