### PR TITLE
fix(auth): hash browser session tokens at rest

### DIFF
--- a/packages/frontend/__tests__/lib/session.test.ts
+++ b/packages/frontend/__tests__/lib/session.test.ts
@@ -1,0 +1,243 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const selectResults: Array<Array<Record<string, unknown>>> = [];
+  const insertValues: Array<Record<string, unknown>> = [];
+  const cookieStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  const tables = {
+    sessions: {
+      id: "sessions.id",
+      userId: "sessions.userId",
+      tokenHash: "sessions.tokenHash",
+      expiresAt: "sessions.expiresAt",
+      source: "sessions.source",
+      userAgent: "sessions.userAgent",
+    },
+    users: {
+      id: "users.id",
+      username: "users.username",
+      displayName: "users.displayName",
+      avatarUrl: "users.avatarUrl",
+    },
+  };
+
+  const eq = vi.fn(() => "eq");
+  const and = vi.fn(() => "and");
+  const gt = vi.fn(() => "gt");
+
+  function nextResult<T>(queue: T[][]): T[] {
+    return queue.shift() ?? [];
+  }
+
+  const db = {
+    select: vi.fn(() => {
+      const builder = {
+        from: vi.fn(() => builder),
+        innerJoin: vi.fn(() => builder),
+        where: vi.fn(() => builder),
+        limit: vi.fn(async () => nextResult(selectResults)),
+      };
+
+      return builder;
+    }),
+    insert: vi.fn(() => {
+      const builder = {
+        values: vi.fn((value: Record<string, unknown>) => {
+          insertValues.push(value);
+          return builder;
+        }),
+      };
+
+      return builder;
+    }),
+    delete: vi.fn(() => {
+      const builder = {
+        where: vi.fn(() => builder),
+      };
+
+      return builder;
+    }),
+  };
+
+  return {
+    db,
+    tables,
+    eq,
+    and,
+    gt,
+    cookieStore,
+    insertValues,
+    reset() {
+      selectResults.length = 0;
+      insertValues.length = 0;
+      db.select.mockClear();
+      db.insert.mockClear();
+      db.delete.mockClear();
+      eq.mockClear();
+      and.mockClear();
+      gt.mockClear();
+      cookieStore.get.mockReset();
+      cookieStore.set.mockReset();
+      cookieStore.delete.mockReset();
+    },
+    pushSelectResult(rows: Array<Record<string, unknown>>) {
+      selectResults.push(rows);
+    },
+  };
+});
+
+const generateRandomString = vi.fn(() => "plain_session_token");
+const hashToken = vi.fn((token: string) => `hashed_${token}`);
+const authenticatePersonalToken = vi.fn();
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => mockState.cookieStore),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockState.db,
+  sessions: mockState.tables.sessions,
+  users: mockState.tables.users,
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: mockState.eq,
+  and: mockState.and,
+  gt: mockState.gt,
+}));
+
+vi.mock("@/lib/auth/utils", () => ({
+  generateRandomString,
+  hashToken,
+}));
+
+vi.mock("@/lib/auth/personalTokens", () => ({
+  authenticatePersonalToken,
+}));
+
+type ModuleExports = typeof import("../../src/lib/auth/session");
+
+let createSession: ModuleExports["createSession"];
+let getSession: ModuleExports["getSession"];
+let clearSession: ModuleExports["clearSession"];
+let getSessionFromHeader: ModuleExports["getSessionFromHeader"];
+
+beforeAll(async () => {
+  const sessionModule = await import("../../src/lib/auth/session");
+  createSession = sessionModule.createSession;
+  getSession = sessionModule.getSession;
+  clearSession = sessionModule.clearSession;
+  getSessionFromHeader = sessionModule.getSessionFromHeader;
+});
+
+beforeEach(() => {
+  mockState.reset();
+  generateRandomString.mockClear();
+  generateRandomString.mockReturnValue("plain_session_token");
+  hashToken.mockClear();
+  hashToken.mockImplementation((token: string) => `hashed_${token}`);
+  authenticatePersonalToken.mockReset();
+});
+
+describe("browser sessions", () => {
+  it("stores a hash while returning the plaintext session token", async () => {
+    const token = await createSession("user-1", {
+      source: "web",
+      userAgent: "Vitest",
+    });
+
+    expect(token).toBe("plain_session_token");
+    expect(mockState.insertValues[0]).toMatchObject({
+      userId: "user-1",
+      tokenHash: "hashed_plain_session_token",
+      source: "web",
+      userAgent: "Vitest",
+    });
+    expect(mockState.insertValues[0]).not.toHaveProperty("token", "plain_session_token");
+    expect(hashToken).toHaveBeenCalledWith("plain_session_token");
+  });
+
+  it("looks up cookie sessions by hashing the plaintext cookie value", async () => {
+    mockState.cookieStore.get.mockReturnValue({ value: "plain_cookie_token" });
+    mockState.pushSelectResult([
+      {
+        user: {
+          id: "user-1",
+          username: "alice",
+          displayName: "Alice",
+          avatarUrl: null,
+        },
+      },
+    ]);
+
+    const session = await getSession();
+
+    expect(session).toEqual({
+      id: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+    });
+    expect(hashToken).toHaveBeenCalledWith("plain_cookie_token");
+    expect(mockState.eq).toHaveBeenCalledWith(
+      mockState.tables.sessions.tokenHash,
+      "hashed_plain_cookie_token"
+    );
+  });
+
+  it("deletes sessions by hashing the plaintext cookie value", async () => {
+    mockState.cookieStore.get.mockReturnValue({ value: "plain_cookie_token" });
+
+    await clearSession();
+
+    expect(hashToken).toHaveBeenCalledWith("plain_cookie_token");
+    expect(mockState.eq).toHaveBeenCalledWith(
+      mockState.tables.sessions.tokenHash,
+      "hashed_plain_cookie_token"
+    );
+    expect(mockState.cookieStore.delete).toHaveBeenCalledWith("tt_session");
+  });
+
+  it("rejects raw web session tokens sent through Authorization", async () => {
+    const session = await getSessionFromHeader(
+      new Request("http://localhost.test/api", {
+        headers: { Authorization: "Bearer plain_session_token" },
+      })
+    );
+
+    expect(session).toBeNull();
+    expect(mockState.db.select).not.toHaveBeenCalled();
+    expect(authenticatePersonalToken).not.toHaveBeenCalled();
+  });
+
+  it("still authenticates personal tokens from Authorization", async () => {
+    authenticatePersonalToken.mockResolvedValue({
+      status: "valid",
+      tokenId: "token-1",
+      userId: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      expiresAt: null,
+    });
+
+    const session = await getSessionFromHeader(
+      new Request("http://localhost.test/api", {
+        headers: { Authorization: "Bearer tt_personal_token" },
+      })
+    );
+
+    expect(session).toEqual({
+      id: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+    });
+    expect(authenticatePersonalToken).toHaveBeenCalledWith("tt_personal_token");
+  });
+});

--- a/packages/frontend/src/lib/auth/session.ts
+++ b/packages/frontend/src/lib/auth/session.ts
@@ -1,7 +1,7 @@
 import { cookies } from "next/headers";
 import { db, sessions, users } from "@/lib/db";
 import { eq, and, gt } from "drizzle-orm";
-import { generateRandomString } from "./utils";
+import { generateRandomString, hashToken } from "./utils";
 import { authenticatePersonalToken } from "./personalTokens";
 
 const SESSION_COOKIE_NAME = "tt_session";
@@ -26,6 +26,8 @@ export async function getSession(): Promise<SessionUser | null> {
     return null;
   }
 
+  const sessionTokenHash = hashToken(sessionToken);
+
   const result = await db
     .select({
       session: sessions,
@@ -33,7 +35,9 @@ export async function getSession(): Promise<SessionUser | null> {
     })
     .from(sessions)
     .innerJoin(users, eq(sessions.userId, users.id))
-    .where(and(eq(sessions.token, sessionToken), gt(sessions.expiresAt, new Date())))
+    .where(
+      and(eq(sessions.tokenHash, sessionTokenHash), gt(sessions.expiresAt, new Date()))
+    )
     .limit(1);
 
   if (result.length === 0) {
@@ -58,11 +62,12 @@ export async function createSession(
   options: { source?: "web" | "cli"; userAgent?: string } = {}
 ): Promise<string> {
   const token = generateRandomString(64);
+  const tokenHash = hashToken(token);
   const expiresAt = new Date(Date.now() + SESSION_DURATION_MS);
 
   await db.insert(sessions).values({
     userId,
-    token,
+    tokenHash,
     expiresAt,
     source: options.source ?? "web",
     userAgent: options.userAgent,
@@ -94,7 +99,7 @@ export async function clearSession(): Promise<void> {
   const sessionToken = cookieStore.get(SESSION_COOKIE_NAME)?.value;
 
   if (sessionToken) {
-    await db.delete(sessions).where(eq(sessions.token, sessionToken));
+    await db.delete(sessions).where(eq(sessions.tokenHash, hashToken(sessionToken)));
   }
 
   cookieStore.delete(SESSION_COOKIE_NAME);
@@ -138,32 +143,9 @@ export async function getSessionFromHeader(
     ? authHeader.slice(7)
     : authHeader;
 
-  // Check if it's an API token (CLI)
   if (token.startsWith("tt_")) {
     return validateApiToken(token);
   }
 
-  // Otherwise treat as session token (web)
-  const result = await db
-    .select({
-      session: sessions,
-      user: users,
-    })
-    .from(sessions)
-    .innerJoin(users, eq(sessions.userId, users.id))
-    .where(and(eq(sessions.token, token), gt(sessions.expiresAt, new Date())))
-    .limit(1);
-
-  if (result.length === 0) {
-    return null;
-  }
-
-  const { user } = result[0];
-
-  return {
-    id: user.id,
-    username: user.username,
-    displayName: user.displayName,
-    avatarUrl: user.avatarUrl,
-  };
+  return null;
 }

--- a/packages/frontend/src/lib/db/migrations/0012_hash_browser_session_tokens.sql
+++ b/packages/frontend/src/lib/db/migrations/0012_hash_browser_session_tokens.sql
@@ -1,0 +1,15 @@
+-- Existing browser session rows contain raw random tokens. They cannot be
+-- converted into hashes after the fact, so expire them and require re-login.
+DELETE FROM "sessions";--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_sessions_token";--> statement-breakpoint
+ALTER TABLE "sessions" RENAME COLUMN "token" TO "token_hash";--> statement-breakpoint
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'sessions_token_unique'
+  ) THEN
+    ALTER TABLE "sessions" RENAME CONSTRAINT "sessions_token_unique" TO "sessions_token_hash_unique";
+  END IF;
+END $$;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_sessions_token_hash" ON "sessions" USING btree ("token_hash");--> statement-breakpoint

--- a/packages/frontend/src/lib/db/migrations/meta/0012_snapshot.json
+++ b/packages/frontend/src/lib/db/migrations/meta/0012_snapshot.json
@@ -1,0 +1,887 @@
+{
+  "id": "5118b95c-e5ac-4e8b-9497-1682ba15e667",
+  "prevId": "4342d7b5-5562-431f-afd1-0dd773563dff",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_api_tokens_token": {
+          "name": "idx_api_tokens_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_api_tokens_user_id": {
+          "name": "idx_api_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_unique": {
+          "name": "api_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
+        },
+        "api_tokens_user_name_unique": {
+          "name": "api_tokens_user_name_unique",
+          "columns": [
+            "user_id",
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_breakdown": {
+      "name": "daily_breakdown",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_breakdown": {
+          "name": "provider_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_breakdown": {
+          "name": "source_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_breakdown": {
+          "name": "model_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_daily_breakdown_submission_id": {
+          "name": "idx_daily_breakdown_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_daily_breakdown_date": {
+          "name": "idx_daily_breakdown_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "daily_breakdown_submission_id_submissions_id_fk": {
+          "name": "daily_breakdown_submission_id_submissions_id_fk",
+          "tableFrom": "daily_breakdown",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "tableTo": "submissions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_breakdown_submission_date_unique": {
+          "name": "daily_breakdown_submission_date_unique",
+          "columns": [
+            "submission_id",
+            "date"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_codes_device_code": {
+          "name": "idx_device_codes_device_code",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_device_codes_user_code": {
+          "name": "idx_device_codes_user_code",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_device_codes_expires_at": {
+          "name": "idx_device_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "device_codes_user_id_users_id_fk": {
+          "name": "device_codes_user_id_users_id_fk",
+          "tableFrom": "device_codes",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "columns": [
+            "device_code"
+          ],
+          "nullsNotDistinct": false
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "columns": [
+            "user_code"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_token_hash": {
+          "name": "idx_sessions_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sources_used": {
+          "name": "sources_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "models_used": {
+          "name": "models_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verified'"
+        },
+        "cli_version": {
+          "name": "cli_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_hash": {
+          "name": "submission_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submit_count": {
+          "name": "submit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_submissions_user_id": {
+          "name": "idx_submissions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_submissions_status": {
+          "name": "idx_submissions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_submissions_total_tokens": {
+          "name": "idx_submissions_total_tokens",
+          "columns": [
+            {
+              "expression": "total_tokens",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_submissions_created_at": {
+          "name": "idx_submissions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_submissions_date_range": {
+          "name": "idx_submissions_date_range",
+          "columns": [
+            {
+              "expression": "date_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submissions_user_id_unique": {
+          "name": "submissions_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "submissions_user_hash_unique": {
+          "name": "submissions_user_hash_unique",
+          "columns": [
+            "user_id",
+            "submission_hash"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_users_github_id": {
+          "name": "idx_users_github_id",
+          "columns": [
+            {
+              "expression": "github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "columns": [
+            "github_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1780086400000,
       "tag": "0011_drop_dead_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1779948193133,
+      "tag": "0012_hash_browser_session_tokens",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -72,7 +72,7 @@ export const sessions = pgTable(
     userId: uuid("user_id")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
-    token: varchar("token", { length: 64 }).notNull().unique(),
+    tokenHash: varchar("token_hash", { length: 64 }).notNull().unique(),
     expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
     source: varchar("source", { length: 10 }).notNull().default("web"),
     userAgent: text("user_agent"),
@@ -81,9 +81,7 @@ export const sessions = pgTable(
       .defaultNow(),
   },
   (table) => [
-    // Planner picks the explicit non-unique idx over the unique-constraint
-    // sibling (~89k vs 0 scans on prod 2026-05-25); keep both.
-    index("idx_sessions_token").on(table.token),
+    index("idx_sessions_token_hash").on(table.tokenHash),
     index("idx_sessions_user_id").on(table.userId),
     index("idx_sessions_expires_at").on(table.expiresAt),
   ]


### PR DESCRIPTION
## Summary
- Store browser session tokens as hashes in the database while continuing to return the plaintext secret only to the browser cookie.
- Reject raw browser session tokens in `Authorization` headers so bearer auth stays reserved for `tt_*` personal tokens.
- Add migration `0012_hash_browser_session_tokens` to expire legacy raw session rows, rename `sessions.token` to `sessions.token_hash`, and update the explicit session-token index/constraint metadata.
- Add focused auth/session regression coverage for creation, cookie lookup, logout cleanup, raw bearer rejection, and personal-token bearer auth.

## Why
Personal tokens are already hashed before storage, but browser session tokens were stored as raw bearer secrets and could also be replayed through the `Authorization` header. This PR makes browser sessions follow the same secret-storage boundary: plaintext stays client-side, the database stores only a deterministic hash, and API bearer auth is limited to personal tokens.

## Diff scope
- `packages/frontend/src/lib/auth/session.ts`
- `packages/frontend/src/lib/db/schema.ts`
- `packages/frontend/src/lib/db/migrations/0012_hash_browser_session_tokens.sql`
- `packages/frontend/src/lib/db/migrations/meta/_journal.json`
- `packages/frontend/src/lib/db/migrations/meta/0012_snapshot.json`
- `packages/frontend/__tests__/lib/session.test.ts`

## Branch integrity
- Base branch: `main`
- Validated base SHA: `c21f0f533205ad63e9154666c294bb789d2415c9`
- Head branch: `IvGolovach:codex/session-token-hash-20260528`
- Head SHA: `3693642b4159f1f9d728a8c2b4e28fceb3972718`
- Ahead/behind vs fetched `origin/main`: `1 ahead / 0 behind`
- Commit: `3693642b4159f1f9d728a8c2b4e28fceb3972718 fix(auth): hash browser session tokens at rest`

## Validation
- `bun run --cwd packages/frontend test __tests__/lib/session.test.ts __tests__/lib/personalTokens.test.ts __tests__/api/authToken.test.ts __tests__/lib/requestSessionCsrf.test.ts`: PASS, 30 tests passed.
- `bunx drizzle-kit check --config drizzle.config.ts` from `packages/frontend`: PASS.
- `git diff --check origin/main...HEAD`: PASS, no output.
- `git status --short --untracked-files=all`: PASS, clean worktree.

## Migration notes
- Migration: `0012_hash_browser_session_tokens`.
- Classification: destructive for existing browser session rows only; it deletes raw session rows because those secrets cannot be safely converted to hashes after the fact.
- User impact: users with existing browser sessions will need to sign in again after the migration. Personal tokens are unchanged.
- DB downgrade: revert the PR and manually rename `sessions.token_hash` back to `sessions.token` if the migration has already been applied. Deleted legacy session rows cannot be recovered and should remain invalidated.

## Runtime safety
- No new external services, queues, background jobs, or unbounded work.
- Session lookup remains an indexed equality lookup, now on `token_hash`.
- No invariant regression introduced.

## Rollback plan
Rollback: revert this PR. DB downgrade: rename `sessions.token_hash` back to `sessions.token` if migration `0012` has already run. Data repair: none for deleted legacy sessions; users can create fresh sessions by signing in again. Operational caveats: existing browser sessions are intentionally invalidated by the forward migration.

## Known residual risks
- Existing browser sessions are expired by design because raw session secrets cannot be recovered into hashes.
- Full migration replay against a live database was not run locally because no `DATABASE_URL` is configured in this worktree; `drizzle-kit check` passed and remote CI should provide the final database/migration gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hash browser session tokens at rest and restrict bearer auth to `tt_*` personal tokens to harden authentication. Migration renames `sessions.token` to `sessions.token_hash` and deletes legacy session rows.

- **New Features**
  - Store only hashed browser session tokens in the DB; the cookie keeps the plaintext.
  - Lookups and logout hash the cookie value and use the `token_hash` index.
  - Reject raw browser session tokens in `Authorization`; only `tt_*` tokens are accepted. Added tests for create, lookup, logout, header rejection, and personal-token auth.

- **Migration**
  - Apply `0012_hash_browser_session_tokens` in `packages/frontend`.
  - Existing browser sessions are deleted; users must sign in again.
  - Drops `idx_sessions_token`, renames the unique constraint, and creates `idx_sessions_token_hash`.

<sup>Written for commit 830cb732ec3851fceb185972841e436b067f6bc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

