### PR TITLE
fix(groups): guard member mutations against stale roles

### DIFF
--- a/packages/frontend/__tests__/api/groupMemberDeleteRoute.test.ts
+++ b/packages/frontend/__tests__/api/groupMemberDeleteRoute.test.ts
@@ -1,0 +1,191 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const getSessionFromRequest = vi.fn();
+  const getGroupBySlug = vi.fn();
+  const getGroupMembership = vi.fn();
+  const canManageGroupMember = vi.fn();
+  const revalidateGroupCaches = vi.fn();
+  const eq = vi.fn((left: unknown, right: unknown) => ({ kind: "eq", left, right }));
+  const and = vi.fn((...conditions: unknown[]) => ({ kind: "and", conditions }));
+
+  let selectRows: Array<Array<Record<string, unknown>>> = [];
+  let selectCall = 0;
+  let deletedRows: Array<Record<string, unknown>> = [];
+
+  const forUpdate = vi.fn(async () => selectRows[selectCall++] ?? []);
+  const limit = vi.fn(() => ({ for: forUpdate }));
+  const selectWhere = vi.fn(() => ({ limit }));
+  const from = vi.fn(() => ({ where: selectWhere }));
+  const select = vi.fn(() => ({ from }));
+
+  const returning = vi.fn(async () => deletedRows);
+  const deleteWhere = vi.fn(() => ({ returning }));
+  const deleteBuilder = vi.fn(() => ({ where: deleteWhere }));
+
+  const tx = {
+    select,
+    delete: deleteBuilder,
+  };
+
+  const db = {
+    transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(tx)),
+    delete: vi.fn(() => ({ where: deleteWhere })),
+  };
+
+  return {
+    getSessionFromRequest,
+    getGroupBySlug,
+    getGroupMembership,
+    canManageGroupMember,
+    revalidateGroupCaches,
+    eq,
+    and,
+    db,
+    tx,
+    forUpdate,
+    returning,
+    deleteBuilder,
+    reset() {
+      getSessionFromRequest.mockReset();
+      getGroupBySlug.mockReset();
+      getGroupMembership.mockReset();
+      canManageGroupMember.mockReset();
+      revalidateGroupCaches.mockReset();
+      eq.mockClear();
+      and.mockClear();
+      db.transaction.mockClear();
+      db.delete.mockClear();
+      select.mockClear();
+      from.mockClear();
+      selectWhere.mockClear();
+      limit.mockClear();
+      forUpdate.mockClear();
+      deleteBuilder.mockClear();
+      deleteWhere.mockClear();
+      returning.mockClear();
+      selectRows = [];
+      selectCall = 0;
+      deletedRows = [];
+    },
+    setLockedRows(actorRows: Array<Record<string, unknown>>, targetRows: Array<Record<string, unknown>>) {
+      selectRows = [actorRows, targetRows];
+      selectCall = 0;
+    },
+    setDeletedRows(rows: Array<Record<string, unknown>>) {
+      deletedRows = rows;
+    },
+  };
+});
+
+vi.mock("drizzle-orm", () => ({
+  and: mockState.and,
+  eq: mockState.eq,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockState.db,
+  groupMembers: {
+    id: "groupMembers.id",
+    groupId: "groupMembers.groupId",
+    userId: "groupMembers.userId",
+    role: "groupMembers.role",
+  },
+  users: {
+    id: "users.id",
+    username: "users.username",
+    displayName: "users.displayName",
+    avatarUrl: "users.avatarUrl",
+  },
+}));
+
+vi.mock("@/lib/auth/requestSession", () => ({
+  getSessionFromRequest: mockState.getSessionFromRequest,
+}));
+
+vi.mock("@/lib/groups/cache", () => ({
+  revalidateGroupCaches: mockState.revalidateGroupCaches,
+}));
+
+vi.mock("@/lib/groups/permissions", () => ({
+  getGroupMembership: mockState.getGroupMembership,
+  canManageGroupMember: mockState.canManageGroupMember,
+}));
+
+vi.mock("@/lib/groups/queries", () => ({
+  getGroupBySlug: mockState.getGroupBySlug,
+}));
+
+vi.mock("../../src/lib/db/schema", () => ({
+  groupRoles: ["owner", "admin", "member"],
+}));
+
+type ModuleExports = typeof import("../../src/app/api/groups/[slug]/members/route");
+
+let DELETE: ModuleExports["DELETE"];
+
+beforeAll(async () => {
+  const routeModule = await import("../../src/app/api/groups/[slug]/members/route");
+  DELETE = routeModule.DELETE;
+});
+
+beforeEach(() => {
+  mockState.reset();
+  mockState.getSessionFromRequest.mockResolvedValue({
+    id: "actor-1",
+    username: "actor",
+    displayName: null,
+    avatarUrl: null,
+  });
+  mockState.getGroupBySlug.mockResolvedValue({
+    id: "group-1",
+    slug: "team",
+    name: "Team",
+    isPublic: true,
+  });
+  mockState.getGroupMembership.mockResolvedValue({ role: "owner" });
+  mockState.canManageGroupMember.mockResolvedValue(true);
+  mockState.setDeletedRows([{ id: "membership-1" }]);
+});
+
+function deleteRequest(userId: string) {
+  return new Request(`http://localhost:3000/api/groups/team/members?userId=${userId}`, {
+    method: "DELETE",
+  });
+}
+
+describe("DELETE /api/groups/[slug]/members", () => {
+  it("rechecks the actor role inside the delete transaction", async () => {
+    mockState.setLockedRows(
+      [{ userId: "actor-1", role: "member" }],
+      [{ userId: "target-1", role: "member" }]
+    );
+
+    const response = await DELETE(deleteRequest("target-1"), {
+      params: Promise.resolve({ slug: "team" }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "Forbidden" });
+    expect(mockState.db.transaction).toHaveBeenCalledTimes(1);
+    expect(mockState.tx.delete).not.toHaveBeenCalled();
+    expect(mockState.revalidateGroupCaches).not.toHaveBeenCalled();
+  });
+
+  it("does not delete a member who became an owner before mutation", async () => {
+    mockState.setLockedRows(
+      [{ userId: "actor-1", role: "owner" }],
+      [{ userId: "target-1", role: "owner" }]
+    );
+
+    const response = await DELETE(deleteRequest("target-1"), {
+      params: Promise.resolve({ slug: "team" }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "Forbidden" });
+    expect(mockState.db.transaction).toHaveBeenCalledTimes(1);
+    expect(mockState.tx.delete).not.toHaveBeenCalled();
+    expect(mockState.revalidateGroupCaches).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/__tests__/api/groupMemberRoleRoute.test.ts
+++ b/packages/frontend/__tests__/api/groupMemberRoleRoute.test.ts
@@ -1,0 +1,263 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const getSessionFromRequest = vi.fn();
+  const getGroupBySlug = vi.fn();
+  const getGroupMembership = vi.fn();
+  const revalidateGroupCaches = vi.fn();
+  const eq = vi.fn((left: unknown, right: unknown) => ({ kind: "eq", left, right }));
+  const ne = vi.fn((left: unknown, right: unknown) => ({ kind: "ne", left, right }));
+  const and = vi.fn((...conditions: unknown[]) => ({ kind: "and", conditions }));
+
+  let selectRows: Array<Array<Record<string, unknown>>> = [];
+  let selectCall = 0;
+  let updatedRows: Array<Record<string, unknown>> = [];
+
+  const forUpdate = vi.fn(async () => selectRows[selectCall++] ?? []);
+  const limit = vi.fn(() => ({ for: forUpdate }));
+  const selectWhere = vi.fn(() => ({ limit, for: forUpdate }));
+  const from = vi.fn(() => ({ where: selectWhere }));
+  const select = vi.fn(() => ({ from }));
+
+  const returning = vi.fn(async () => updatedRows);
+  const updateWhere = vi.fn(() => ({ returning }));
+  const set = vi.fn(() => ({ where: updateWhere }));
+  const update = vi.fn(() => ({ set }));
+
+  const tx = {
+    select,
+    update,
+  };
+
+  const db = {
+    transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(tx)),
+    select,
+    update,
+  };
+
+  return {
+    getSessionFromRequest,
+    getGroupBySlug,
+    getGroupMembership,
+    revalidateGroupCaches,
+    eq,
+    ne,
+    and,
+    db,
+    tx,
+    forUpdate,
+    selectWhere,
+    update,
+    set,
+    returning,
+    reset() {
+      getSessionFromRequest.mockReset();
+      getGroupBySlug.mockReset();
+      getGroupMembership.mockReset();
+      revalidateGroupCaches.mockReset();
+      eq.mockClear();
+      ne.mockClear();
+      and.mockClear();
+      db.transaction.mockClear();
+      select.mockClear();
+      from.mockClear();
+      selectWhere.mockClear();
+      limit.mockClear();
+      forUpdate.mockClear();
+      update.mockClear();
+      set.mockClear();
+      updateWhere.mockClear();
+      returning.mockClear();
+      selectRows = [];
+      selectCall = 0;
+      updatedRows = [];
+    },
+    setLockedRows(...rows: Array<Array<Record<string, unknown>>>) {
+      selectRows = rows;
+      selectCall = 0;
+    },
+    setUpdatedRows(rows: Array<Record<string, unknown>>) {
+      updatedRows = rows;
+    },
+  };
+});
+
+vi.mock("drizzle-orm", () => ({
+  and: mockState.and,
+  eq: mockState.eq,
+  ne: mockState.ne,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockState.db,
+  groupMembers: {
+    id: "groupMembers.id",
+    groupId: "groupMembers.groupId",
+    userId: "groupMembers.userId",
+    role: "groupMembers.role",
+  },
+}));
+
+vi.mock("@/lib/auth/requestSession", () => ({
+  getSessionFromRequest: mockState.getSessionFromRequest,
+}));
+
+vi.mock("@/lib/groups/cache", () => ({
+  revalidateGroupCaches: mockState.revalidateGroupCaches,
+}));
+
+vi.mock("@/lib/groups/permissions", () => ({
+  getGroupMembership: mockState.getGroupMembership,
+}));
+
+vi.mock("@/lib/groups/queries", () => ({
+  getGroupBySlug: mockState.getGroupBySlug,
+}));
+
+vi.mock("../../src/lib/db/schema", () => ({
+  groupRoles: ["owner", "admin", "member"],
+}));
+
+type ModuleExports = typeof import("../../src/app/api/groups/[slug]/members/[userId]/role/route");
+
+let PATCH: ModuleExports["PATCH"];
+
+beforeAll(async () => {
+  const routeModule = await import("../../src/app/api/groups/[slug]/members/[userId]/role/route");
+  PATCH = routeModule.PATCH;
+});
+
+beforeEach(() => {
+  mockState.reset();
+  mockState.getSessionFromRequest.mockResolvedValue({
+    id: "actor-1",
+    username: "actor",
+    displayName: null,
+    avatarUrl: null,
+  });
+  mockState.getGroupBySlug.mockResolvedValue({
+    id: "group-1",
+    slug: "team",
+    name: "Team",
+    isPublic: true,
+  });
+  mockState.getGroupMembership
+    .mockResolvedValueOnce({ role: "owner" })
+    .mockResolvedValueOnce({ role: "member" });
+  mockState.setUpdatedRows([{ id: "membership-1", userId: "target-1", role: "admin" }]);
+});
+
+function roleRequest(role: string) {
+  return new Request("http://localhost:3000/api/groups/team/members/target-1/role", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ role }),
+  });
+}
+
+function selectLockedUserId(callIndex: number) {
+  const [condition] = mockState.selectWhere.mock.calls[callIndex] ?? [];
+  return condition?.conditions?.find(
+    (item: { kind?: string; left?: string }) => item.kind === "eq" && item.left === "groupMembers.userId"
+  )?.right;
+}
+
+describe("PATCH /api/groups/[slug]/members/[userId]/role", () => {
+  it("rechecks the actor role inside the role update transaction", async () => {
+    mockState.setLockedRows(
+      [{ userId: "actor-1", role: "member" }],
+      [{ userId: "target-1", role: "member" }]
+    );
+
+    const response = await PATCH(roleRequest("admin"), {
+      params: Promise.resolve({ slug: "team", userId: "target-1" }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "Forbidden" });
+    expect(mockState.db.transaction).toHaveBeenCalledTimes(1);
+    expect(mockState.tx.update).not.toHaveBeenCalled();
+    expect(mockState.revalidateGroupCaches).not.toHaveBeenCalled();
+  });
+
+  it("does not update a target who became an owner before mutation", async () => {
+    mockState.setLockedRows(
+      [{ userId: "actor-1", role: "owner" }],
+      [{ userId: "target-1", role: "owner" }],
+      [{ id: "other-owner" }]
+    );
+
+    const response = await PATCH(roleRequest("member"), {
+      params: Promise.resolve({ slug: "team", userId: "target-1" }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "Forbidden" });
+    expect(mockState.db.transaction).toHaveBeenCalledTimes(1);
+    expect(mockState.tx.update).not.toHaveBeenCalled();
+    expect(mockState.revalidateGroupCaches).not.toHaveBeenCalled();
+  });
+
+  it("rejects demoting the last owner inside the mutation boundary", async () => {
+    mockState.getGroupMembership.mockReset();
+    mockState.getGroupMembership
+      .mockResolvedValueOnce({ role: "owner" })
+      .mockResolvedValueOnce({ role: "owner" });
+    mockState.setLockedRows(
+      [{ userId: "actor-1", role: "owner" }],
+      [{ userId: "target-1", role: "owner" }],
+      []
+    );
+
+    const response = await PATCH(roleRequest("member"), {
+      params: Promise.resolve({ slug: "team", userId: "target-1" }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error:
+        "Cannot demote the last owner. Use POST /api/groups/:slug/transfer-ownership to assign a new owner first.",
+    });
+    expect(mockState.db.transaction).toHaveBeenCalledTimes(1);
+    expect(mockState.tx.update).not.toHaveBeenCalled();
+    expect(mockState.revalidateGroupCaches).not.toHaveBeenCalled();
+  });
+
+  it("updates a weaker target only after locking current actor and target roles", async () => {
+    mockState.setLockedRows(
+      [{ userId: "actor-1", role: "owner" }],
+      [{ userId: "target-1", role: "member" }]
+    );
+
+    const response = await PATCH(roleRequest("admin"), {
+      params: Promise.resolve({ slug: "team", userId: "target-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ id: "membership-1", userId: "target-1", role: "admin" });
+    expect(mockState.db.transaction).toHaveBeenCalledTimes(1);
+    expect(mockState.tx.update).toHaveBeenCalledTimes(1);
+    expect(mockState.revalidateGroupCaches).toHaveBeenCalledWith("group-1", "team");
+  });
+
+  it("locks actor and target memberships in deterministic user id order", async () => {
+    mockState.getSessionFromRequest.mockResolvedValue({
+      id: "z-actor",
+      username: "actor",
+      displayName: null,
+      avatarUrl: null,
+    });
+    mockState.setLockedRows([{ role: "member" }], [{ role: "owner" }]);
+    mockState.setUpdatedRows([{ id: "membership-1", userId: "a-target", role: "admin" }]);
+
+    const response = await PATCH(roleRequest("admin"), {
+      params: Promise.resolve({ slug: "team", userId: "a-target" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(selectLockedUserId(0)).toBe("a-target");
+    expect(selectLockedUserId(1)).toBe("z-actor");
+    expect(await response.json()).toEqual({ id: "membership-1", userId: "a-target", role: "admin" });
+    expect(mockState.tx.update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/frontend/src/app/api/groups/[slug]/members/[userId]/role/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/members/[userId]/role/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { and, eq, ne, sql } from "drizzle-orm";
+import { and, eq, ne } from "drizzle-orm";
 import { db, groupMembers } from "@/lib/db";
 import { getSessionFromRequest } from "@/lib/auth/requestSession";
 import { revalidateGroupCaches } from "@/lib/groups/cache";
@@ -35,63 +35,102 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       return NextResponse.json({ error: "Role must be member or admin" }, { status: 400 });
     }
 
-    const [actor, target] = await Promise.all([
-      getGroupMembership(group.id, session.id),
-      getGroupMembership(group.id, userId),
-    ]);
-
-    if (!group.isPublic && !actor) {
+    const membership = await getGroupMembership(group.id, session.id);
+    if (!group.isPublic && !membership) {
       return NextResponse.json({ error: "Group not found" }, { status: 404 });
     }
 
-    if (
-      !actor ||
-      !target ||
-      !canManageGroupRole(actor.role, target.role) ||
-      !canManageGroupRole(actor.role, nextRole)
-    ) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
+    const updateResult = await db.transaction(async (tx) => {
+      const lockedMembers = new Map<string, { role: GroupRole }>();
+      const lockUserIds = Array.from(new Set([session.id, userId])).sort();
 
-    // Demoting an owner would orphan the group if no other owners remain.
-    // The route already rejects nextRole === "owner" above, so reaching this
-    // branch with target.role === "owner" always means we're demoting.
-    if (target.role === "owner") {
-      const [{ count: otherOwnerCount }] = await db
-        .select({ count: sql<number>`COUNT(*)::int` })
-        .from(groupMembers)
+      for (const lockUserId of lockUserIds) {
+        const [member] = await tx
+          .select({ role: groupMembers.role })
+          .from(groupMembers)
+          .where(and(eq(groupMembers.groupId, group.id), eq(groupMembers.userId, lockUserId)))
+          .limit(1)
+          .for("update");
+
+        if (member) {
+          lockedMembers.set(lockUserId, member);
+        }
+      }
+
+      const actor = lockedMembers.get(session.id);
+
+      if (!actor) {
+        return { status: "forbidden" as const };
+      }
+
+      const target = lockedMembers.get(userId);
+
+      if (!target) {
+        return { status: "not_found" as const };
+      }
+
+      if (target.role === "owner") {
+        const otherOwners = await tx
+          .select({ id: groupMembers.id })
+          .from(groupMembers)
+          .where(
+            and(
+              eq(groupMembers.groupId, group.id),
+              eq(groupMembers.role, "owner"),
+              ne(groupMembers.userId, userId)
+            )
+          )
+          .for("update");
+
+        return otherOwners.length === 0
+          ? { status: "last_owner" as const }
+          : { status: "forbidden" as const };
+      }
+
+      if (!canManageGroupRole(actor.role, target.role) || !canManageGroupRole(actor.role, nextRole)) {
+        return { status: "forbidden" as const };
+      }
+
+      const [updated] = await tx
+        .update(groupMembers)
+        .set({ role: nextRole as GroupRole })
         .where(
           and(
             eq(groupMembers.groupId, group.id),
-            eq(groupMembers.role, "owner"),
-            ne(groupMembers.userId, userId),
-          ),
-        );
+            eq(groupMembers.userId, userId),
+            eq(groupMembers.role, target.role)
+          )
+        )
+        .returning({
+          id: groupMembers.id,
+          userId: groupMembers.userId,
+          role: groupMembers.role,
+        });
 
-      if (otherOwnerCount === 0) {
-        return NextResponse.json(
-          {
-            error:
-              "Cannot demote the last owner. Use POST /api/groups/:slug/transfer-ownership to assign a new owner first.",
-          },
-          { status: 400 }
-        );
-      }
+      return updated
+        ? { status: "updated" as const, member: updated }
+        : { status: "not_found" as const };
+    });
+
+    if (updateResult.status === "forbidden") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    const [updated] = await db
-      .update(groupMembers)
-      .set({ role: nextRole as GroupRole })
-      .where(and(eq(groupMembers.groupId, group.id), eq(groupMembers.userId, userId)))
-      .returning({
-        id: groupMembers.id,
-        userId: groupMembers.userId,
-        role: groupMembers.role,
-      });
+    if (updateResult.status === "last_owner") {
+      return NextResponse.json(
+        {
+          error:
+            "Cannot demote the last owner. Use POST /api/groups/:slug/transfer-ownership to assign a new owner first.",
+        },
+        { status: 400 }
+      );
+    }
 
-    if (!updated) {
+    if (updateResult.status === "not_found") {
       return NextResponse.json({ error: "Member not found" }, { status: 404 });
     }
+
+    const updated = updateResult.member;
 
     try {
       await revalidateGroupCaches(group.id, group.slug);

--- a/packages/frontend/src/app/api/groups/[slug]/members/route.ts
+++ b/packages/frontend/src/app/api/groups/[slug]/members/route.ts
@@ -3,8 +3,9 @@ import { and, eq } from "drizzle-orm";
 import { db, groupMembers, users } from "@/lib/db";
 import { getSessionFromRequest } from "@/lib/auth/requestSession";
 import { revalidateGroupCaches } from "@/lib/groups/cache";
-import { canManageGroupMember, getGroupMembership } from "@/lib/groups/permissions";
+import { getGroupMembership } from "@/lib/groups/permissions";
 import { getGroupBySlug } from "@/lib/groups/queries";
+import { canManageGroupRole } from "@/lib/groups/utils";
 
 interface RouteParams {
   params: Promise<{ slug: string }>;
@@ -83,16 +84,48 @@ export async function DELETE(request: Request, { params }: RouteParams) {
       return NextResponse.json({ error: "Group not found" }, { status: 404 });
     }
 
-    if (!membership || !(await canManageGroupMember(group.id, session.id, userId))) {
+    const deleteResult = await db.transaction(async (tx) => {
+      const [actor] = await tx
+        .select({ role: groupMembers.role })
+        .from(groupMembers)
+        .where(and(eq(groupMembers.groupId, group.id), eq(groupMembers.userId, session.id)))
+        .limit(1)
+        .for("update");
+
+      if (!actor) {
+        return { status: "forbidden" as const };
+      }
+
+      const [target] = await tx
+        .select({ role: groupMembers.role })
+        .from(groupMembers)
+        .where(and(eq(groupMembers.groupId, group.id), eq(groupMembers.userId, userId)))
+        .limit(1)
+        .for("update");
+
+      if (!target) {
+        return { status: "not_found" as const };
+      }
+
+      if (!canManageGroupRole(actor.role, target.role)) {
+        return { status: "forbidden" as const };
+      }
+
+      const deleted = await tx
+        .delete(groupMembers)
+        .where(and(eq(groupMembers.groupId, group.id), eq(groupMembers.userId, userId)))
+        .returning({ id: groupMembers.id });
+
+      return deleted.length === 0
+        ? { status: "not_found" as const }
+        : { status: "deleted" as const };
+    });
+
+    if (deleteResult.status === "forbidden") {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    const deleted = await db
-      .delete(groupMembers)
-      .where(and(eq(groupMembers.groupId, group.id), eq(groupMembers.userId, userId)))
-      .returning({ id: groupMembers.id });
-
-    if (deleted.length === 0) {
+    if (deleteResult.status === "not_found") {
       return NextResponse.json({ error: "Member not found" }, { status: 404 });
     }
 


### PR DESCRIPTION
## Summary
- Recheck and lock actor/target group membership rows inside the DELETE member transaction before removing a member.
- Recheck and lock actor/target roles inside the PATCH role transaction before changing a member role.
- Preserve private-group not-found behavior and best-effort cache revalidation while making stale authorization fail safely.
- Add focused regression tests for stale actor state, stale target state, owner protection, and last-owner role safety.

## Why
Group member mutations previously authorized from membership state loaded before the write. A concurrent demotion, removal, or target role change could make that authorization stale by the time the mutation executed. This PR moves the decisive actor/target role checks into the mutation boundary so group admins cannot accidentally act with stale privileges and owner invariants are preserved under concurrent changes.

## Diff scope
- `packages/frontend/src/app/api/groups/[slug]/members/route.ts`
- `packages/frontend/src/app/api/groups/[slug]/members/[userId]/role/route.ts`
- `packages/frontend/__tests__/api/groupMemberDeleteRoute.test.ts`
- `packages/frontend/__tests__/api/groupMemberRoleRoute.test.ts`

## Branch integrity
- Base branch: `main`
- Validated base SHA: `c21f0f533205ad63e9154666c294bb789d2415c9`
- Head branch: `IvGolovach:codex/group-member-race-safe-20260528`
- Head SHA: `657514bf3bc979826d24ce9607d8a2b4c8e3585a`
- Ahead/behind vs fetched `origin/main`: `1 ahead / 0 behind`
- Commit: `657514bf3bc979826d24ce9607d8a2b4c8e3585a fix(groups): guard member mutations against stale roles`

## Validation
- `bun run test __tests__/api/group*.test.ts __tests__/lib/groupHelpers.test.ts` from `packages/frontend`: PASS, 49 tests passed.
- `bun x eslint 'src/app/api/groups/[slug]/members/route.ts' 'src/app/api/groups/[slug]/members/[userId]/role/route.ts' __tests__/api/groupMemberDeleteRoute.test.ts __tests__/api/groupMemberRoleRoute.test.ts` from `packages/frontend`: PASS, no output.
- `git diff --check origin/main...HEAD`: PASS, no output.
- `git status --short --untracked-files=all`: PASS, clean worktree.

## Runtime safety
- No new external services, queues, timers, or background jobs.
- Mutations now perform the decisive role checks inside the transaction before delete/update.
- Cache invalidation remains best-effort and still cannot mask a successful database mutation.
- No invariant regression introduced.

## Migration notes
Not applicable - no database migration or schema change.

## Rollback plan
Rollback: revert this PR. DB downgrade: not applicable. Data repair: not applicable. Operational caveats: none known.

## Known residual risks
- Remote CI should provide the final full-suite proof for the PR SHA.
- The transaction-level behavior depends on the production database honoring row locks for the selected membership rows, matching the existing Postgres-backed route patterns.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale-role race conditions in group member delete and role update by rechecking and row-locking actor/target memberships inside the transaction with a deterministic lock order. This blocks actions with outdated privileges and preserves owner safety.

- **Bug Fixes**
  - DELETE members: lock actor/target rows, authorize via `canManageGroupRole`, return 403 on stale roles and 404 when missing; preserve private-group 404 behavior.
  - PATCH role: lock actor/target rows in sorted user-id order, forbid updates if target is now owner, reject demoting the last owner (400) after locking owners, guard updates by matching the current target role; return 403/404 as appropriate.
  - Keep cache revalidation best-effort post-mutation.
  - Add regression tests for stale actor/target state, deterministic lock ordering, owner protection, and last-owner safety.

<sup>Written for commit 899a602263d89dbe5f200abfe40c4a787e8678bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/626?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

