### PR TITLE
fix(submit): aggregate device time totals

### DIFF
--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -851,6 +851,355 @@ describe("POST /api/submit auth path", () => {
     }));
   });
 
+  it("sets all-time active time from all submitted device daily rows", async () => {
+    mockState.authenticatePersonalToken.mockResolvedValue({
+      status: "valid",
+      tokenId: "token-1",
+      userId: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      expiresAt: null,
+    });
+
+    mockState.validateSubmission.mockReturnValue({
+      valid: true,
+      data: {
+        device: {
+          id: "dev_desktop",
+          name: "Desktop",
+        },
+        meta: {
+          version: "2.0.0",
+          dateRange: { start: "2026-04-30", end: "2026-04-30" },
+        },
+        summary: {
+          clients: ["codex"],
+        },
+        contributions: [
+          {
+            date: "2026-04-30",
+            timestampMs: 456,
+            activeTimeMs: 4_000,
+            clients: [
+              {
+                client: "codex",
+                modelId: "gpt-5.5",
+                tokens: 15,
+                cost: 0.75,
+                input: 10,
+                output: 5,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+                messages: 1,
+              },
+            ],
+          },
+        ],
+        timeMetrics: {
+          totalActiveTimeMs: 4_000,
+          longestContinuousMs: 4_000,
+          maxConcurrentSessions: 1,
+          sessionCount: 1,
+        },
+      },
+      errors: [],
+      warnings: [],
+    });
+
+    const incomingBreakdown = {
+      tokens: 15,
+      cost: 0.75,
+      input: 10,
+      output: 5,
+      cacheRead: 0,
+      cacheWrite: 0,
+      reasoning: 0,
+      messages: 1,
+    };
+    const insertedBreakdown = {
+      codex: {
+        ...incomingBreakdown,
+        models: { "gpt-5.5": incomingBreakdown },
+        provenance: {
+          schemaVersion: 1,
+          messageCount: 1,
+          modelCount: 1,
+        },
+      },
+    };
+
+    mockState.clientContributionToBreakdownData.mockReturnValue(incomingBreakdown);
+    mockState.recalculateDayTotals.mockReturnValue({
+      tokens: 15,
+      cost: 0.75,
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+
+    const selectResults = [
+      [{ id: "submission-1" }],
+      [],
+      [],
+      [{
+        totalTokens: 42,
+        totalCost: "1.7500",
+        inputTokens: 27,
+        outputTokens: 15,
+        dateStart: "2026-04-30",
+        dateEnd: "2026-04-30",
+        activeDays: 1,
+        rowCount: 3,
+        totalActiveTimeMs: 10_000,
+      }],
+      [{ sourceBreakdown: insertedBreakdown }],
+    ];
+
+    const submissionUpdateSets: Array<Record<string, unknown>> = [];
+    let insertCall = 0;
+    let dailyInsertValues: unknown;
+    const tx = {
+      update: vi.fn((table: unknown) => {
+        const builder = {
+          set: vi.fn((values: Record<string, unknown>) => {
+            if ((table as { id?: unknown }).id === "submissions.id") {
+              submissionUpdateSets.push(values);
+            }
+            return builder;
+          }),
+          where: vi.fn(() => Promise.resolve()),
+        };
+        return builder;
+      }),
+      select: vi.fn(() => makeAwaitableBuilder(selectResults.shift() ?? [])),
+      insert: vi.fn(() => {
+        insertCall += 1;
+        if (insertCall === 1) {
+          const builder = {
+            values: vi.fn(() => builder),
+            onConflictDoUpdate: vi.fn(() => builder),
+            returning: vi.fn(() => Promise.resolve([{ id: "submitted-device-2" }])),
+          };
+          return builder;
+        }
+
+        const builder = {
+          values: vi.fn((values: unknown) => {
+            dailyInsertValues = values;
+            return Promise.resolve();
+          }),
+        };
+        return builder;
+      }),
+      execute: vi.fn(() => Promise.resolve()),
+      transaction: vi.fn(async (callback: (sp: typeof tx) => Promise<unknown>) =>
+        callback(tx)
+      ),
+    };
+    type MockTransaction = typeof tx;
+
+    mockState.db.transaction.mockImplementation(async (callback: (tx: MockTransaction) => Promise<unknown>) =>
+      callback(tx)
+    );
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ meta: {}, contributions: [] }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(dailyInsertValues).toEqual([expect.objectContaining({
+      activeTimeMs: 4_000,
+    })]);
+    expect(submissionUpdateSets.at(-1)).toEqual(expect.objectContaining({
+      totalActiveTimeMs: 10_000,
+      longestContinuousMs: 4_000,
+      maxConcurrentSessions: 1,
+      sessionCount: 1,
+    }));
+  });
+
+  it("updates same-device active time totals without double-counting the replaced row", async () => {
+    mockState.authenticatePersonalToken.mockResolvedValue({
+      status: "valid",
+      tokenId: "token-1",
+      userId: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      expiresAt: null,
+    });
+
+    mockState.validateSubmission.mockReturnValue({
+      valid: true,
+      data: {
+        device: {
+          id: "dev_laptop",
+        },
+        meta: {
+          version: "2.0.0",
+          dateRange: { start: "2026-04-30", end: "2026-04-30" },
+        },
+        summary: {
+          clients: ["codex"],
+        },
+        contributions: [
+          {
+            date: "2026-04-30",
+            timestampMs: 456,
+            activeTimeMs: 5_000,
+            clients: [
+              {
+                client: "codex",
+                modelId: "gpt-5.5",
+                tokens: 15,
+                cost: 0.75,
+                input: 10,
+                output: 5,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+                messages: 1,
+              },
+            ],
+          },
+        ],
+        timeMetrics: {
+          totalActiveTimeMs: 5_000,
+          longestContinuousMs: 5_000,
+          maxConcurrentSessions: 1,
+          sessionCount: 1,
+        },
+      },
+      errors: [],
+      warnings: [],
+    });
+
+    const incomingBreakdown = {
+      tokens: 15,
+      cost: 0.75,
+      input: 10,
+      output: 5,
+      cacheRead: 0,
+      cacheWrite: 0,
+      reasoning: 0,
+      messages: 1,
+    };
+    const existingBreakdown = {
+      codex: {
+        tokens: 12,
+        cost: 0.5,
+        input: 7,
+        output: 5,
+        cacheRead: 0,
+        cacheWrite: 0,
+        reasoning: 0,
+        messages: 1,
+        models: { "gpt-5.5": { tokens: 12 } },
+      },
+    };
+    const mergedBreakdown = {
+      codex: {
+        ...incomingBreakdown,
+        models: { "gpt-5.5": incomingBreakdown },
+      },
+    };
+
+    mockState.clientContributionToBreakdownData.mockReturnValue(incomingBreakdown);
+    mockState.mergeClientBreakdownsWithRegressionGuard.mockReturnValue({
+      merged: mergedBreakdown,
+      warnings: [],
+    });
+    mockState.recalculateDayTotals.mockReturnValue({
+      tokens: 15,
+      cost: 0.75,
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+    mockState.mergeTimestampMs.mockReturnValue(456);
+
+    const selectResults = [
+      [{ id: "submission-1" }],
+      [{
+        id: "daily-1",
+        date: "2026-04-30",
+        timestampMs: 123,
+        activeTimeMs: 2_000,
+        sourceBreakdown: existingBreakdown,
+      }],
+      [{
+        totalTokens: 27,
+        totalCost: "1.2500",
+        inputTokens: 17,
+        outputTokens: 10,
+        dateStart: "2026-04-30",
+        dateEnd: "2026-04-30",
+        activeDays: 1,
+        rowCount: 2,
+        totalActiveTimeMs: 13_000,
+      }],
+      [{ sourceBreakdown: mergedBreakdown }],
+    ];
+
+    const submissionUpdateSets: Array<Record<string, unknown>> = [];
+    const tx = {
+      update: vi.fn((table: unknown) => {
+        const builder = {
+          set: vi.fn((values: Record<string, unknown>) => {
+            if ((table as { id?: unknown }).id === "submissions.id") {
+              submissionUpdateSets.push(values);
+            }
+            return builder;
+          }),
+          where: vi.fn(() => Promise.resolve()),
+        };
+        return builder;
+      }),
+      select: vi.fn(() => makeAwaitableBuilder(selectResults.shift() ?? [])),
+      insert: vi.fn(() => {
+        const builder = {
+          values: vi.fn(() => builder),
+          onConflictDoUpdate: vi.fn(() => builder),
+          returning: vi.fn(() => Promise.resolve([{ id: "submitted-device-1" }])),
+        };
+        return builder;
+      }),
+      execute: vi.fn(() => Promise.resolve()),
+      transaction: vi.fn(async (callback: (sp: typeof tx) => Promise<unknown>) =>
+        callback(tx)
+      ),
+    };
+    type MockTransaction = typeof tx;
+
+    mockState.db.transaction.mockImplementation(async (callback: (tx: MockTransaction) => Promise<unknown>) =>
+      callback(tx)
+    );
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ meta: {}, contributions: [] }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(tx.insert).toHaveBeenCalledTimes(1);
+    expect(tx.execute).toHaveBeenCalledTimes(1);
+    expect(submissionUpdateSets.at(-1)).toEqual(expect.objectContaining({
+      totalActiveTimeMs: 13_000,
+    }));
+  });
   it("adopts legacy daily rows into the first modern device instead of duplicating totals", async () => {
     mockState.authenticatePersonalToken.mockResolvedValue({
       status: "valid",

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -509,6 +509,7 @@ export async function POST(request: Request) {
           dateStart: sql<string>`MIN(${dailyBreakdown.date})`,
           dateEnd: sql<string>`MAX(${dailyBreakdown.date})`,
           activeDays: sql<number>`COUNT(DISTINCT CASE WHEN ${dailyBreakdown.tokens} > 0 THEN ${dailyBreakdown.date} END)::int`,
+          totalActiveTimeMs: sql<number>`COALESCE(SUM(${dailyBreakdown.activeTimeMs}), 0)::bigint`,
           rowCount: sql<number>`COUNT(*)::int`,
         })
         .from(dailyBreakdown)
@@ -568,8 +569,9 @@ export async function POST(request: Request) {
           submissionHash: generateSubmissionHash(hashData),
           submitCount: sql`COALESCE(submit_count, 0) + 1`,
           schemaVersion: sql`GREATEST(COALESCE(${submissions.schemaVersion}, 0), ${submitDevice.schemaVersion})`,
+          totalActiveTimeMs: aggregates.totalActiveTimeMs,
+          // Session-shape metrics cannot be safely recomputed from daily active-time buckets.
           ...(data.timeMetrics ? {
-            totalActiveTimeMs: data.timeMetrics.totalActiveTimeMs,
             longestContinuousMs: data.timeMetrics.longestContinuousMs,
             maxConcurrentSessions: data.timeMetrics.maxConcurrentSessions,
             sessionCount: data.timeMetrics.sessionCount,


### PR DESCRIPTION
## Summary
- Derive `submissions.totalActiveTimeMs` from persisted `daily_breakdown.active_time_ms` rows across all submitted devices.
- Preserve per-device replace semantics so resubmitting one device updates that device's row without double-counting prior active time.
- Keep session-shape metrics (`longestContinuousMs`, `maxConcurrentSessions`, `sessionCount`) tied to incoming `timeMetrics` because they cannot be safely recomputed from daily active-time buckets.
- Add focused submit route regressions for multi-device active-time sums, same-device replacement, and submissions without incoming `timeMetrics`.

## Why
The submit path already recalculates token and cost totals from all persisted daily rows, but `totalActiveTimeMs` was still copied from the latest incoming payload. With multiple devices, all-time profile and leaderboard time totals could represent only the latest submitting device instead of the user's aggregate submitted history. This PR makes active-time totals follow the same persisted-row aggregate model as token totals.

## Diff scope
- `packages/frontend/src/app/api/submit/route.ts`
- `packages/frontend/__tests__/api/submitAuth.test.ts`

## Branch integrity
- Base branch: `main`
- Validated base SHA: `c21f0f533205ad63e9154666c294bb789d2415c9`
- Head branch: `IvGolovach:codex/submit-device-time-metrics-20260528`
- Head SHA: `fdd4e0f191b434e47601e089d8d59d3d2fa00b70`
- Ahead/behind vs fetched `origin/main`: `1 ahead / 0 behind`
- Commit: `fdd4e0f191b434e47601e089d8d59d3d2fa00b70 fix(submit): aggregate device time totals`

## Validation
- `bun run --cwd packages/frontend test __tests__/api/submitAuth.test.ts __tests__/api/submit.test.ts`: PASS, 60 tests passed.
- `bun run --cwd packages/frontend lint -- src/app/api/submit/route.ts __tests__/api/submitAuth.test.ts`: PASS, no output.
- `git diff --check origin/main...HEAD`: PASS, no output.
- `git status --short --untracked-files=all`: PASS, clean worktree.

## Runtime safety
- No new external services, queues, timers, or background jobs.
- The submit transaction already recalculates persisted totals after daily rows are inserted or updated; this PR extends that aggregate query to `active_time_ms`.
- Same-device replacement still updates the existing daily row before totals are recomputed.
- No invariant regression introduced.

## Migration notes
Not applicable - no database migration or schema change.

## Rollback plan
Rollback: revert this PR. DB downgrade: not applicable. Data repair: not applicable. Operational caveats: reverting restores latest-payload `totalActiveTimeMs` behavior.

## Known residual risks
- `longestContinuousMs`, `maxConcurrentSessions`, and `sessionCount` remain sourced from incoming `timeMetrics` when present because daily active-time buckets do not contain enough information to recompute those session-shape metrics correctly.
- Remote CI should provide the final full-suite proof for the PR SHA.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aggregates all-time active time from persisted daily device rows in the `api/submit` route so multi-device totals are correct. Preserves same-device replacement and keeps session metrics from incoming `timeMetrics`.

- **Bug Fixes**
  - Compute `submissions.totalActiveTimeMs` from SUM of `daily_breakdown.active_time_ms` across all submitted devices.
  - Recompute totals after same-device row replacement to avoid double-counting; session-shape metrics (`longestContinuousMs`, `maxConcurrentSessions`, `sessionCount`) use incoming `timeMetrics` when provided.

<sup>Written for commit 7d06744fffab7c45169827500338ae8670649c93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

