### PR TITLE
fix(tui): honor compatible colors in Apple Terminal

### DIFF
--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -390,19 +390,23 @@ impl App {
             provider
         };
         let lookup_key = super::colors::model_shade_key(provider, model);
-        self.model_shade_map
+        let color = self
+            .model_shade_map
             .get(&lookup_key)
             .copied()
-            .unwrap_or_else(|| get_provider_shade(provider, 0))
+            .unwrap_or_else(|| get_provider_shade(provider, 0));
+        self.theme.color(color)
     }
 
     pub fn model_color(&self, model: &str) -> Color {
         let provider = get_provider_from_model(model);
         let lookup_key = super::colors::model_shade_key(provider, model);
-        self.model_shade_map
+        let color = self
+            .model_shade_map
             .get(&lookup_key)
             .copied()
-            .unwrap_or_else(|| get_model_color(model))
+            .unwrap_or_else(|| get_model_color(model));
+        self.theme.color(color)
     }
 
     pub fn has_visible_data(&self) -> bool {
@@ -3227,11 +3231,11 @@ mod tests {
 
         assert_eq!(
             app.model_color_for("anthropic", "sonnet-shared"),
-            get_provider_shade("anthropic", 0)
+            app.theme.color(get_provider_shade("anthropic", 0))
         );
         assert_eq!(
             app.model_color_for("openai", "sonnet-shared"),
-            get_provider_shade("openai", 0)
+            app.theme.color(get_provider_shade("openai", 0))
         );
         assert_ne!(
             app.model_color_for("anthropic", "sonnet-shared"),

--- a/crates/tokscale-cli/src/tui/themes.rs
+++ b/crates/tokscale-cli/src/tui/themes.rs
@@ -1,4 +1,4 @@
-use ratatui::style::Color;
+use ratatui::style::{Color, Style};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TerminalColorMode {
@@ -124,6 +124,7 @@ pub struct Theme {
     pub muted: Color,
     pub accent: Color,
     pub selection: Color,
+    color_mode: TerminalColorMode,
 }
 
 impl Theme {
@@ -212,6 +213,7 @@ impl Theme {
             muted: Color::Rgb(139, 148, 158),
             accent: Color::Cyan,
             selection: Color::Rgb(48, 54, 61),
+            color_mode,
         };
 
         if color_mode == TerminalColorMode::Compatible {
@@ -232,6 +234,92 @@ impl Theme {
         }
 
         theme
+    }
+
+    pub(crate) fn color(&self, color: Color) -> Color {
+        match (self.color_mode, color) {
+            (TerminalColorMode::Compatible, Color::Rgb(r, g, b)) => compatible_rgb(r, g, b),
+            _ => color,
+        }
+    }
+
+    pub(crate) fn metric_input_style(&self) -> Style {
+        Style::default().fg(self.color(Color::Rgb(100, 200, 100)))
+    }
+
+    pub(crate) fn metric_output_style(&self) -> Style {
+        Style::default().fg(self.color(Color::Rgb(200, 100, 100)))
+    }
+
+    pub(crate) fn metric_cache_read_style(&self) -> Style {
+        Style::default().fg(self.color(Color::Rgb(100, 150, 200)))
+    }
+
+    pub(crate) fn metric_cache_write_style(&self) -> Style {
+        Style::default().fg(self.color(Color::Rgb(200, 150, 100)))
+    }
+
+    pub(crate) fn secondary_text_style(&self) -> Style {
+        Style::default().fg(self.color(Color::Rgb(170, 170, 170)))
+    }
+
+    pub(crate) fn subtle_text_style(&self) -> Style {
+        Style::default().fg(self.color(Color::Rgb(102, 102, 102)))
+    }
+
+    pub(crate) fn striped_row_style(&self) -> Style {
+        if self.color_mode == TerminalColorMode::Compatible {
+            Style::default()
+        } else {
+            Style::default().bg(Color::Rgb(20, 24, 30))
+        }
+    }
+
+    pub(crate) fn current_row_style(&self) -> Style {
+        if self.color_mode == TerminalColorMode::Compatible {
+            Style::default().bg(self.selection)
+        } else {
+            Style::default().bg(Color::Rgb(28, 42, 34))
+        }
+    }
+}
+
+fn compatible_rgb(r: u8, g: u8, b: u8) -> Color {
+    let max = r.max(g).max(b);
+    let min = r.min(g).min(b);
+
+    if max < 64 {
+        return Color::Black;
+    }
+
+    if max.saturating_sub(min) < 40 {
+        return if max < 160 {
+            Color::DarkGray
+        } else {
+            Color::Gray
+        };
+    }
+
+    if r >= g && r >= b {
+        if g >= 150 {
+            Color::Yellow
+        } else if b >= 150 {
+            Color::Magenta
+        } else {
+            Color::Red
+        }
+    } else if g >= r && g >= b {
+        if b >= 150 {
+            Color::Cyan
+        } else {
+            Color::Green
+        }
+    } else if r >= 150 {
+        Color::Magenta
+    } else if g >= 150 {
+        Color::Cyan
+    } else {
+        Color::Blue
     }
 }
 
@@ -289,5 +377,46 @@ mod tests {
         assert_ne!(theme.background, Color::Reset);
         assert!(!matches!(theme.foreground, Color::Rgb(..)));
         assert!(!matches!(theme.selection, Color::Rgb(..)));
+    }
+
+    #[test]
+    fn full_color_theme_preserves_rgb_accent_styles() {
+        let theme = Theme::from_name_with_color_mode(ThemeName::Blue, TerminalColorMode::FullColor);
+
+        assert_eq!(
+            theme.metric_input_style().fg,
+            Some(Color::Rgb(100, 200, 100))
+        );
+        assert_eq!(theme.striped_row_style().bg, Some(Color::Rgb(20, 24, 30)));
+    }
+
+    #[test]
+    fn compatible_theme_downgrades_rgb_accent_styles() {
+        let theme =
+            Theme::from_name_with_color_mode(ThemeName::Blue, TerminalColorMode::Compatible);
+
+        let styles = [
+            theme.metric_input_style(),
+            theme.metric_output_style(),
+            theme.metric_cache_read_style(),
+            theme.metric_cache_write_style(),
+            theme.secondary_text_style(),
+            theme.subtle_text_style(),
+            theme.striped_row_style(),
+            theme.current_row_style(),
+        ];
+
+        for style in styles {
+            assert!(
+                !matches!(style.fg, Some(Color::Rgb(..))),
+                "compatible foreground should not use RGB: {:?}",
+                style.fg
+            );
+            assert!(
+                !matches!(style.bg, Some(Color::Rgb(..))),
+                "compatible background should not use RGB: {:?}",
+                style.bg
+            );
+        }
     }
 }

--- a/crates/tokscale-cli/src/tui/ui/agents.rs
+++ b/crates/tokscale-cli/src/tui/ui/agents.rs
@@ -34,6 +34,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let theme_accent = app.theme.accent;
     let theme_muted = app.theme.muted;
     let theme_selection = app.theme.selection;
+    let striped_row_style = app.theme.striped_row_style();
 
     let agents = app.get_sorted_agents();
     if agents.is_empty() {
@@ -136,7 +137,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             let row_style = if is_selected {
                 Style::default().bg(theme_selection)
             } else if is_striped {
-                Style::default().bg(Color::Rgb(20, 24, 30))
+                striped_row_style
             } else {
                 Style::default()
             };

--- a/crates/tokscale-cli/src/tui/ui/daily.rs
+++ b/crates/tokscale-cli/src/tui/ui/daily.rs
@@ -51,6 +51,12 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let selected_index = app.selected_index;
     let theme_accent = app.theme.accent;
     let theme_selection = app.theme.selection;
+    let metric_input_style = app.theme.metric_input_style();
+    let metric_output_style = app.theme.metric_output_style();
+    let metric_cache_read_style = app.theme.metric_cache_read_style();
+    let metric_cache_write_style = app.theme.metric_cache_write_style();
+    let current_row_style = app.theme.current_row_style();
+    let striped_row_style = app.theme.striped_row_style();
     let today = Local::now().date_naive();
 
     let header_cells = if is_very_narrow {
@@ -183,14 +189,12 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                     }
                     cells.extend([
                         Cell::from(day.message_count.to_string()),
-                        Cell::from(format_tokens(day.tokens.input))
-                            .style(Style::default().fg(Color::Rgb(100, 200, 100))),
-                        Cell::from(format_tokens(day.tokens.output))
-                            .style(Style::default().fg(Color::Rgb(200, 100, 100))),
+                        Cell::from(format_tokens(day.tokens.input)).style(metric_input_style),
+                        Cell::from(format_tokens(day.tokens.output)).style(metric_output_style),
                         Cell::from(format_tokens(day.tokens.cache_read))
-                            .style(Style::default().fg(Color::Rgb(100, 150, 200))),
+                            .style(metric_cache_read_style),
                         Cell::from(format_tokens(day.tokens.cache_write))
-                            .style(Style::default().fg(Color::Rgb(200, 150, 100))),
+                            .style(metric_cache_write_style),
                         Cell::from(format_cache_hit_rate(
                             day.tokens.cache_read,
                             day.tokens.input,
@@ -206,9 +210,9 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             let row_style = if is_selected {
                 Style::default().bg(theme_selection)
             } else if is_today {
-                Style::default().bg(Color::Rgb(28, 42, 34))
+                current_row_style
             } else if is_striped {
-                Style::default().bg(Color::Rgb(20, 24, 30))
+                striped_row_style
             } else {
                 Style::default()
             };
@@ -327,6 +331,11 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
     let theme_accent = app.theme.accent;
     let theme_muted = app.theme.muted;
     let theme_selection = app.theme.selection;
+    let metric_input_style = app.theme.metric_input_style();
+    let metric_output_style = app.theme.metric_output_style();
+    let metric_cache_read_style = app.theme.metric_cache_read_style();
+    let metric_cache_write_style = app.theme.metric_cache_write_style();
+    let striped_row_style = app.theme.striped_row_style();
 
     let header_cells = if is_very_narrow {
         vec!["Model", "Cost"]
@@ -425,14 +434,11 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
                     Cell::from(get_client_display_name(row.source))
                         .style(Style::default().fg(theme_muted)),
                     Cell::from(row.messages.to_string()),
-                    Cell::from(format_tokens(row.tokens.input))
-                        .style(Style::default().fg(Color::Rgb(100, 200, 100))),
-                    Cell::from(format_tokens(row.tokens.output))
-                        .style(Style::default().fg(Color::Rgb(200, 100, 100))),
-                    Cell::from(format_tokens(row.tokens.cache_read))
-                        .style(Style::default().fg(Color::Rgb(100, 150, 200))),
+                    Cell::from(format_tokens(row.tokens.input)).style(metric_input_style),
+                    Cell::from(format_tokens(row.tokens.output)).style(metric_output_style),
+                    Cell::from(format_tokens(row.tokens.cache_read)).style(metric_cache_read_style),
                     Cell::from(format_tokens(row.tokens.cache_write))
-                        .style(Style::default().fg(Color::Rgb(200, 150, 100))),
+                        .style(metric_cache_write_style),
                     Cell::from(format_cache_hit_rate(
                         row.tokens.cache_read,
                         row.tokens.input,
@@ -447,7 +453,7 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
             let row_style = if is_selected {
                 Style::default().bg(theme_selection)
             } else if is_striped {
-                Style::default().bg(Color::Rgb(20, 24, 30))
+                striped_row_style
             } else {
                 Style::default()
             };

--- a/crates/tokscale-cli/src/tui/ui/dialog/overlay.rs
+++ b/crates/tokscale-cli/src/tui/ui/dialog/overlay.rs
@@ -1,6 +1,6 @@
 use ratatui::{
     layout::Rect,
-    style::{Color, Style},
+    style::Style,
     widgets::{Block, Clear},
     Frame,
 };
@@ -17,11 +17,11 @@ pub fn centered_rect(viewport: Rect, width: u16, height: u16) -> Rect {
 }
 
 /// Render a semi-transparent dark backdrop over the viewport
-pub fn render_backdrop(frame: &mut Frame, viewport: Rect) {
+pub fn render_backdrop(frame: &mut Frame, viewport: Rect, theme: &Theme) {
     // Clear the area first
     frame.render_widget(Clear, viewport);
     // Render dark backdrop
-    let backdrop = Block::default().style(Style::default().bg(Color::Rgb(0, 0, 0)));
+    let backdrop = Block::default().style(Style::default().bg(theme.background));
     frame.render_widget(backdrop, viewport);
 }
 

--- a/crates/tokscale-cli/src/tui/ui/dialog/stack.rs
+++ b/crates/tokscale-cli/src/tui/ui/dialog/stack.rs
@@ -73,7 +73,7 @@ impl DialogStack {
         };
 
         // Render backdrop
-        overlay::render_backdrop(frame, viewport);
+        overlay::render_backdrop(frame, viewport, &self.theme);
 
         // Calculate centered position
         let (width, height) = top.desired_size(viewport);

--- a/crates/tokscale-cli/src/tui/ui/footer.rs
+++ b/crates/tokscale-cli/src/tui/ui/footer.rs
@@ -281,7 +281,7 @@ fn render_status_row(frame: &mut Frame, app: &App, area: Rect) {
     let mut spans: Vec<Span> = Vec::new();
 
     if app.data.loading {
-        let scanner_spans = get_scanner_spans(app.spinner_frame);
+        let scanner_spans = get_scanner_spans(app.spinner_frame, &app.theme);
         spans.extend(scanner_spans);
         spans.push(Span::raw(" "));
         spans.push(Span::styled(
@@ -295,7 +295,7 @@ fn render_status_row(frame: &mut Frame, app: &App, area: Rect) {
                 Style::default().fg(app.theme.muted),
             ));
         } else {
-            let scanner_spans = get_scanner_spans(app.spinner_frame);
+            let scanner_spans = get_scanner_spans(app.spinner_frame, &app.theme);
             spans.extend(scanner_spans);
             spans.push(Span::raw(" "));
             spans.push(Span::styled(

--- a/crates/tokscale-cli/src/tui/ui/header.rs
+++ b/crates/tokscale-cli/src/tui/ui/header.rs
@@ -53,8 +53,8 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     if !is_narrow {
         block = block.title_top(
             Line::from(vec![
-                Span::styled(" | ", Style::default().fg(Color::Rgb(102, 102, 102))),
-                Span::styled("GitHub ", Style::default().fg(Color::Rgb(102, 102, 102))),
+                Span::styled(" | ", app.theme.subtle_text_style()),
+                Span::styled("GitHub ", app.theme.subtle_text_style()),
             ])
             .right_aligned(),
         );

--- a/crates/tokscale-cli/src/tui/ui/hourly.rs
+++ b/crates/tokscale-cli/src/tui/ui/hourly.rs
@@ -51,6 +51,12 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
     let selected_index = app.selected_index;
     let theme_accent = app.theme.accent;
     let theme_selection = app.theme.selection;
+    let metric_input_style = app.theme.metric_input_style();
+    let metric_output_style = app.theme.metric_output_style();
+    let metric_cache_read_style = app.theme.metric_cache_read_style();
+    let metric_cache_write_style = app.theme.metric_cache_write_style();
+    let current_row_style = app.theme.current_row_style();
+    let striped_row_style = app.theme.striped_row_style();
     let now = Local::now().naive_local();
     let current_hour = now.date().and_hms_opt(now.hour(), 0, 0).unwrap_or(now);
 
@@ -200,14 +206,12 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
                 }
                 cells.extend([
                     Cell::from(hour.message_count.to_string()),
-                    Cell::from(format_tokens(hour.tokens.input))
-                        .style(Style::default().fg(Color::Rgb(100, 200, 100))),
-                    Cell::from(format_tokens(hour.tokens.output))
-                        .style(Style::default().fg(Color::Rgb(200, 100, 100))),
+                    Cell::from(format_tokens(hour.tokens.input)).style(metric_input_style),
+                    Cell::from(format_tokens(hour.tokens.output)).style(metric_output_style),
                     Cell::from(format_tokens(hour.tokens.cache_read))
-                        .style(Style::default().fg(Color::Rgb(100, 150, 200))),
+                        .style(metric_cache_read_style),
                     Cell::from(format_tokens(hour.tokens.cache_write))
-                        .style(Style::default().fg(Color::Rgb(200, 150, 100))),
+                        .style(metric_cache_write_style),
                     Cell::from(format_cache_hit_rate(
                         hour.tokens.cache_read,
                         hour.tokens.input,
@@ -223,9 +227,9 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
             let row_style = if is_selected {
                 Style::default().bg(theme_selection)
             } else if is_current {
-                Style::default().bg(Color::Rgb(28, 42, 34))
+                current_row_style
             } else if is_striped {
-                Style::default().bg(Color::Rgb(20, 24, 30))
+                striped_row_style
             } else {
                 Style::default()
             };

--- a/crates/tokscale-cli/src/tui/ui/minutely.rs
+++ b/crates/tokscale-cli/src/tui/ui/minutely.rs
@@ -43,6 +43,12 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let selected_index = app.selected_index;
     let theme_accent = app.theme.accent;
     let theme_selection = app.theme.selection;
+    let metric_input_style = app.theme.metric_input_style();
+    let metric_output_style = app.theme.metric_output_style();
+    let metric_cache_read_style = app.theme.metric_cache_read_style();
+    let metric_cache_write_style = app.theme.metric_cache_write_style();
+    let current_row_style = app.theme.current_row_style();
+    let striped_row_style = app.theme.striped_row_style();
     let now = Local::now().naive_local();
     let current_minute = now
         .date()
@@ -195,14 +201,12 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                 }
                 cells.extend([
                     Cell::from(minute.message_count.to_string()),
-                    Cell::from(format_tokens(minute.tokens.input))
-                        .style(Style::default().fg(Color::Rgb(100, 200, 100))),
-                    Cell::from(format_tokens(minute.tokens.output))
-                        .style(Style::default().fg(Color::Rgb(200, 100, 100))),
+                    Cell::from(format_tokens(minute.tokens.input)).style(metric_input_style),
+                    Cell::from(format_tokens(minute.tokens.output)).style(metric_output_style),
                     Cell::from(format_tokens(minute.tokens.cache_read))
-                        .style(Style::default().fg(Color::Rgb(100, 150, 200))),
+                        .style(metric_cache_read_style),
                     Cell::from(format_tokens(minute.tokens.cache_write))
-                        .style(Style::default().fg(Color::Rgb(200, 150, 100))),
+                        .style(metric_cache_write_style),
                     Cell::from(format_cache_hit_rate(
                         minute.tokens.cache_read,
                         minute.tokens.input,
@@ -218,9 +222,9 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             let row_style = if is_selected {
                 Style::default().bg(theme_selection)
             } else if is_current {
-                Style::default().bg(Color::Rgb(28, 42, 34))
+                current_row_style
             } else if is_striped {
-                Style::default().bg(Color::Rgb(20, 24, 30))
+                striped_row_style
             } else {
                 Style::default()
             };

--- a/crates/tokscale-cli/src/tui/ui/mod.rs
+++ b/crates/tokscale-cli/src/tui/ui/mod.rs
@@ -81,7 +81,7 @@ fn render_loading(frame: &mut Frame, app: &App, area: Rect) {
         ])
         .split(inner)[1];
 
-    let mut spans = spinner::get_scanner_spans(app.spinner_frame);
+    let mut spans = spinner::get_scanner_spans(app.spinner_frame, &app.theme);
     spans.push(Span::raw("  "));
     spans.push(Span::styled(
         spinner::get_phase_message("parsing-sources"),

--- a/crates/tokscale-cli/src/tui/ui/models.rs
+++ b/crates/tokscale-cli/src/tui/ui/models.rs
@@ -53,6 +53,11 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let theme_accent = app.theme.accent;
     let theme_muted = app.theme.muted;
     let theme_selection = app.theme.selection;
+    let metric_input_style = app.theme.metric_input_style();
+    let metric_output_style = app.theme.metric_output_style();
+    let metric_cache_read_style = app.theme.metric_cache_read_style();
+    let metric_cache_write_style = app.theme.metric_cache_write_style();
+    let striped_row_style = app.theme.striped_row_style();
 
     let models = app.get_sorted_models();
     if models.is_empty() {
@@ -172,14 +177,12 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                     Cell::from(get_provider_display_name(&model.provider)),
                     Cell::from(get_client_display_name(&model.client))
                         .style(Style::default().fg(theme_muted)),
-                    Cell::from(format_tokens(model.tokens.input))
-                        .style(Style::default().fg(Color::Rgb(100, 200, 100))),
-                    Cell::from(format_tokens(model.tokens.output))
-                        .style(Style::default().fg(Color::Rgb(200, 100, 100))),
+                    Cell::from(format_tokens(model.tokens.input)).style(metric_input_style),
+                    Cell::from(format_tokens(model.tokens.output)).style(metric_output_style),
                     Cell::from(format_tokens(model.tokens.cache_read))
-                        .style(Style::default().fg(Color::Rgb(100, 150, 200))),
+                        .style(metric_cache_read_style),
                     Cell::from(format_tokens(model.tokens.cache_write))
-                        .style(Style::default().fg(Color::Rgb(200, 150, 100))),
+                        .style(metric_cache_write_style),
                     Cell::from(format_tokens(model.tokens.total())),
                     Cell::from(format_ms_per_1k(model.performance.ms_per_1k_tokens))
                         .style(Style::default().fg(Color::Yellow)),
@@ -196,14 +199,12 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                     Cell::from(get_provider_display_name(&model.provider)),
                     Cell::from(get_client_display_name(&model.client))
                         .style(Style::default().fg(theme_muted)),
-                    Cell::from(format_tokens(model.tokens.input))
-                        .style(Style::default().fg(Color::Rgb(100, 200, 100))),
-                    Cell::from(format_tokens(model.tokens.output))
-                        .style(Style::default().fg(Color::Rgb(200, 100, 100))),
+                    Cell::from(format_tokens(model.tokens.input)).style(metric_input_style),
+                    Cell::from(format_tokens(model.tokens.output)).style(metric_output_style),
                     Cell::from(format_tokens(model.tokens.cache_read))
-                        .style(Style::default().fg(Color::Rgb(100, 150, 200))),
+                        .style(metric_cache_read_style),
                     Cell::from(format_tokens(model.tokens.cache_write))
-                        .style(Style::default().fg(Color::Rgb(200, 150, 100))),
+                        .style(metric_cache_write_style),
                     Cell::from(format_cache_hit_rate(
                         model.tokens.cache_read,
                         model.tokens.input,
@@ -220,7 +221,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             let row_style = if is_selected {
                 Style::default().bg(theme_selection)
             } else if is_striped {
-                Style::default().bg(Color::Rgb(20, 24, 30))
+                striped_row_style
             } else {
                 Style::default()
             };

--- a/crates/tokscale-cli/src/tui/ui/overview.rs
+++ b/crates/tokscale-cli/src/tui/ui/overview.rs
@@ -192,6 +192,8 @@ fn render_top_models(frame: &mut Frame, app: &mut App, area: Rect, items_per_pag
     let theme_muted = app.theme.muted;
     let theme_foreground = app.theme.foreground;
     let theme_selection = app.theme.selection;
+    let secondary_text_style = app.theme.secondary_text_style();
+    let subtle_text_style = app.theme.subtle_text_style();
     let scroll_offset = app.scroll_offset;
     let selected_index = app.selected_index;
     let is_narrow = app.is_narrow();
@@ -332,47 +334,29 @@ fn render_top_models(frame: &mut Frame, app: &mut App, area: Rect, items_per_pag
         let line2_spans = if is_narrow {
             vec![
                 Span::raw("  "),
-                Span::styled(
-                    format_tokens(model.tokens_input),
-                    Style::default().fg(Color::Rgb(170, 170, 170)),
-                ),
-                Span::styled("/", Style::default().fg(Color::Rgb(102, 102, 102))),
-                Span::styled(
-                    format_tokens(model.tokens_output),
-                    Style::default().fg(Color::Rgb(170, 170, 170)),
-                ),
-                Span::styled("/", Style::default().fg(Color::Rgb(102, 102, 102))),
-                Span::styled(
-                    format_tokens(model.tokens_cache_read),
-                    Style::default().fg(Color::Rgb(170, 170, 170)),
-                ),
-                Span::styled("/", Style::default().fg(Color::Rgb(102, 102, 102))),
+                Span::styled(format_tokens(model.tokens_input), secondary_text_style),
+                Span::styled("/", subtle_text_style),
+                Span::styled(format_tokens(model.tokens_output), secondary_text_style),
+                Span::styled("/", subtle_text_style),
+                Span::styled(format_tokens(model.tokens_cache_read), secondary_text_style),
+                Span::styled("/", subtle_text_style),
                 Span::styled(
                     format_tokens(model.tokens_cache_write),
-                    Style::default().fg(Color::Rgb(170, 170, 170)),
+                    secondary_text_style,
                 ),
             ]
         } else {
             vec![
-                Span::styled("  In: ", Style::default().fg(Color::Rgb(102, 102, 102))),
-                Span::styled(
-                    format_tokens(model.tokens_input),
-                    Style::default().fg(Color::Rgb(170, 170, 170)),
-                ),
-                Span::styled(" · Out: ", Style::default().fg(Color::Rgb(102, 102, 102))),
-                Span::styled(
-                    format_tokens(model.tokens_output),
-                    Style::default().fg(Color::Rgb(170, 170, 170)),
-                ),
-                Span::styled(" · CR: ", Style::default().fg(Color::Rgb(102, 102, 102))),
-                Span::styled(
-                    format_tokens(model.tokens_cache_read),
-                    Style::default().fg(Color::Rgb(170, 170, 170)),
-                ),
-                Span::styled(" · CW: ", Style::default().fg(Color::Rgb(102, 102, 102))),
+                Span::styled("  In: ", subtle_text_style),
+                Span::styled(format_tokens(model.tokens_input), secondary_text_style),
+                Span::styled(" · Out: ", subtle_text_style),
+                Span::styled(format_tokens(model.tokens_output), secondary_text_style),
+                Span::styled(" · CR: ", subtle_text_style),
+                Span::styled(format_tokens(model.tokens_cache_read), secondary_text_style),
+                Span::styled(" · CW: ", subtle_text_style),
                 Span::styled(
                     format_tokens(model.tokens_cache_write),
-                    Style::default().fg(Color::Rgb(170, 170, 170)),
+                    secondary_text_style,
                 ),
             ]
         };

--- a/crates/tokscale-cli/src/tui/ui/spinner.rs
+++ b/crates/tokscale-cli/src/tui/ui/spinner.rs
@@ -1,5 +1,7 @@
 use ratatui::prelude::*;
 
+use crate::tui::themes::Theme;
+
 const WIDTH: usize = 8;
 const HOLD_START: usize = 30;
 const HOLD_END: usize = 9;
@@ -47,7 +49,7 @@ pub fn get_scanner_state(frame: usize) -> ScannerState {
     }
 }
 
-pub fn get_scanner_spans(frame: usize) -> Vec<Span<'static>> {
+pub fn get_scanner_spans(frame: usize, theme: &Theme) -> Vec<Span<'static>> {
     let state = get_scanner_state(frame);
     let mut spans = Vec::with_capacity(WIDTH);
 
@@ -70,7 +72,10 @@ pub fn get_scanner_spans(frame: usize) -> Vec<Span<'static>> {
             ('⬝', INACTIVE_COLOR)
         };
 
-        spans.push(Span::styled(ch.to_string(), Style::default().fg(color)));
+        spans.push(Span::styled(
+            ch.to_string(),
+            Style::default().fg(theme.color(color)),
+        ));
     }
 
     spans

--- a/crates/tokscale-cli/src/tui/ui/stats.rs
+++ b/crates/tokscale-cli/src/tui/ui/stats.rs
@@ -65,6 +65,7 @@ fn render_graph(frame: &mut Frame, app: &mut App, area: Rect) {
     let theme_background = app.theme.background;
     let theme_muted = app.theme.muted;
     let theme_colors = app.theme.colors;
+    let subtle_text_style = app.theme.subtle_text_style();
     let selected_cell = app.selected_graph_cell;
     let is_narrow = app.is_narrow();
 
@@ -150,7 +151,7 @@ fn render_graph(frame: &mut Frame, app: &mut App, area: Rect) {
                     if is_selected {
                         ("▓▓", Style::default().fg(Color::White).bg(theme_colors[0]))
                     } else {
-                        ("· ", Style::default().fg(Color::Rgb(102, 102, 102)))
+                        ("· ", subtle_text_style)
                     }
                 }
             };
@@ -398,7 +399,7 @@ fn render_stats_panel(frame: &mut Frame, app: &App, area: Rect) {
 
     let legend_spans = vec![
         Span::styled("Less ", Style::default().fg(app.theme.muted)),
-        Span::styled("· ", Style::default().fg(Color::Rgb(102, 102, 102))),
+        Span::styled("· ", app.theme.subtle_text_style()),
         Span::styled("██", Style::default().fg(app.theme.colors[1])),
         Span::raw(" "),
         Span::styled("██", Style::default().fg(app.theme.colors[2])),
@@ -520,7 +521,7 @@ fn render_breakdown_panel(frame: &mut Frame, app: &mut App, area: Rect) {
                         .then_with(|| a.display_name.cmp(&b.display_name))
                 });
 
-                let client_color = get_client_color(client);
+                let client_color = app.theme.color(get_client_color(client));
                 let client_name = get_client_display_name(client);
                 let model_count = models.len();
                 let plural = if model_count > 1 { "s" } else { "" };
@@ -559,55 +560,53 @@ fn render_breakdown_panel(frame: &mut Frame, app: &mut App, area: Rect) {
 
                     let is_narrow = app.is_narrow();
                     if is_narrow {
+                        let secondary_text_style = app.theme.secondary_text_style();
+                        let subtle_text_style = app.theme.subtle_text_style();
                         lines.push(Line::from(vec![
                             Span::styled("    ", Style::default()),
                             Span::styled(
                                 format_tokens(model_info.tokens.input),
-                                Style::default().fg(Color::Rgb(170, 170, 170)),
+                                secondary_text_style,
                             ),
-                            Span::styled("/", Style::default().fg(Color::Rgb(102, 102, 102))),
+                            Span::styled("/", subtle_text_style),
                             Span::styled(
                                 format_tokens(model_info.tokens.output),
-                                Style::default().fg(Color::Rgb(170, 170, 170)),
+                                secondary_text_style,
                             ),
-                            Span::styled("/", Style::default().fg(Color::Rgb(102, 102, 102))),
+                            Span::styled("/", subtle_text_style),
                             Span::styled(
                                 format_tokens(model_info.tokens.cache_read),
-                                Style::default().fg(Color::Rgb(170, 170, 170)),
+                                secondary_text_style,
                             ),
-                            Span::styled("/", Style::default().fg(Color::Rgb(102, 102, 102))),
+                            Span::styled("/", subtle_text_style),
                             Span::styled(
                                 format_tokens(model_info.tokens.cache_write),
-                                Style::default().fg(Color::Rgb(170, 170, 170)),
+                                secondary_text_style,
                             ),
                         ]));
                     } else {
+                        let secondary_text_style = app.theme.secondary_text_style();
+                        let subtle_text_style = app.theme.subtle_text_style();
                         lines.push(Line::from(vec![
-                            Span::styled(
-                                "    In: ",
-                                Style::default().fg(Color::Rgb(102, 102, 102)),
-                            ),
+                            Span::styled("    In: ", subtle_text_style),
                             Span::styled(
                                 format_tokens(model_info.tokens.input),
-                                Style::default().fg(Color::Rgb(170, 170, 170)),
+                                secondary_text_style,
                             ),
-                            Span::styled(
-                                " · Out: ",
-                                Style::default().fg(Color::Rgb(102, 102, 102)),
-                            ),
+                            Span::styled(" · Out: ", subtle_text_style),
                             Span::styled(
                                 format_tokens(model_info.tokens.output),
-                                Style::default().fg(Color::Rgb(170, 170, 170)),
+                                secondary_text_style,
                             ),
-                            Span::styled(" · CR: ", Style::default().fg(Color::Rgb(102, 102, 102))),
+                            Span::styled(" · CR: ", subtle_text_style),
                             Span::styled(
                                 format_tokens(model_info.tokens.cache_read),
-                                Style::default().fg(Color::Rgb(170, 170, 170)),
+                                secondary_text_style,
                             ),
-                            Span::styled(" · CW: ", Style::default().fg(Color::Rgb(102, 102, 102))),
+                            Span::styled(" · CW: ", subtle_text_style),
                             Span::styled(
                                 format_tokens(model_info.tokens.cache_write),
-                                Style::default().fg(Color::Rgb(170, 170, 170)),
+                                secondary_text_style,
                             ),
                         ]));
                     }


### PR DESCRIPTION
## Summary
- Keep full RGB palettes for truecolor terminals while mapping RGB colors to terminal-compatible colors for Apple Terminal, `NO_COLOR`, and `TERM=dumb` environments.
- Route TUI semantic colors, model colors, provider shades, chart colors, dialog surfaces, and spinner colors through the active `Theme` before rendering.
- Preserve the selected theme name in compatible mode so user settings still round-trip, while the rendered colors avoid RGB output where the terminal is known to be unreliable.
- Add focused regressions for Apple Terminal detection, compatible palette conversion, truecolor preservation, and downgraded RGB foreground/background styles.

## Why
The TUI already had terminal color-mode detection, but several rendering paths still used raw RGB values directly. In Apple Terminal and other compatible-color environments, that could leave parts of the UI with unreadable or inconsistent colors even when the app selected a compatible mode. This PR centralizes color normalization through the active theme so the whole TUI follows the same terminal capability decision.

## Diff scope
- `crates/tokscale-cli/src/tui/themes.rs`
- `crates/tokscale-cli/src/tui/app.rs`
- `crates/tokscale-cli/src/tui/ui/**`

## Branch integrity
- Base branch: `main`
- Validated base SHA: `c21f0f533205ad63e9154666c294bb789d2415c9`
- Head branch: `IvGolovach:codex/tui-apple-terminal-colors-20260528`
- Head SHA: `69ff1778848119d6ff9311d4297f455876369bed`
- Ahead/behind vs fetched `origin/main`: `1 ahead / 0 behind`
- Commit: `69ff1778848119d6ff9311d4297f455876369bed fix(tui): honor compatible colors in Apple Terminal`

## Validation
- `cargo test -p tokscale-cli tui`: PASS, 183 tests passed and 1 ignored.
- `cargo fmt --all -- --check`: PASS, no output.
- `git diff --check origin/main...HEAD`: PASS, no output.
- `git status --short --untracked-files=all`: PASS, clean worktree.

## Runtime safety
- No API, database, auth, scanner, submit, pricing, or background job behavior changed.
- The change is limited to TUI color selection and style construction.
- Existing full-color terminal behavior remains available through the existing truecolor detection path.
- No invariant regression introduced.

## Migration notes
Not applicable - no database migration or schema change.

## Rollback plan
Rollback: revert this PR. DB downgrade: not applicable. Data repair: not applicable. Operational caveats: reverting restores the previous raw-RGB rendering behavior in Apple Terminal and compatible-color environments.

## Known residual risks
- This is validated with deterministic color-mode and style tests; final visual confirmation in a real Apple Terminal window is still useful before release.
- Remote CI should provide the final full-suite proof for the PR SHA.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unreadable colors in Apple Terminal by routing all TUI colors through the active theme and downgrading RGB to compatible colors when needed, while preserving truecolor on capable terminals. This makes tables, charts, dialogs, and the spinner render consistently in Apple Terminal, `NO_COLOR`, and `TERM=dumb`.

- **Bug Fixes**
  - Detect Apple Terminal and compatible modes, then map RGB to nearest 16-color via `Theme.color`; keep full RGB for truecolor terminals.
  - Normalize all UI paths (semantic colors, model/provider shades, charts, dialogs, spinner) through the active `Theme`.
  - Keep the selected theme name even in compatible mode so settings round-trip.
  - Added tests for detection, palette conversion, style downgrade, and truecolor preservation.

- **Refactors**
  - Introduced `Theme` `color_mode` and helpers for metric styles, subtle/secondary text, striped/current rows, and backdrop usage; updated tables, headers, footer, spinner, and dialogs to use them.
  - Centralized model/provider color lookups to flow through the theme for consistent rendering.

<sup>Written for commit 69ff1778848119d6ff9311d4297f455876369bed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/629?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

