### PR TITLE
fix(codex): skip replayed fork token counts

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -4016,7 +4016,9 @@ mod tests {
                 "\n",
                 r#"{"timestamp":"2026-04-30T10:00:01Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#,
                 "\n",
-                r#"{"timestamp":"2026-04-30T10:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30},"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30}}}}"#,
+                r#"{"timestamp":"2026-04-30T10:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":50,"cached_input_tokens":10,"output_tokens":15,"total_tokens":65},"last_token_usage":{"input_tokens":50,"cached_input_tokens":10,"output_tokens":15,"total_tokens":65}}}}"#,
+                "\n",
+                r#"{"timestamp":"2026-04-30T10:00:03Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"total_tokens":130},"last_token_usage":{"input_tokens":50,"cached_input_tokens":10,"output_tokens":15,"total_tokens":65}}}}"#,
                 "\n"
             ),
         )
@@ -4024,13 +4026,17 @@ mod tests {
         std::fs::write(
             codex_dir.join("fork.jsonl"),
             concat!(
-                r#"{"timestamp":"2026-04-30T10:01:00Z","type":"session_meta","payload":{"id":"fork-session","forked_from_id":"parent-session","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent-session","depth":1}}},"model_provider":"openai","cwd":"/Users/alice/root-worktree"}}"#,
+                r#"{"timestamp":"2026-04-30T10:01:00Z","type":"session_meta","payload":{"id":"fork-session","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent-session","depth":1}}},"model_provider":"openai","cwd":"/Users/alice/root-worktree"}}"#,
                 "\n",
-                r#"{"timestamp":"2026-04-30T10:01:01Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#,
+                r#"{"timestamp":"2026-04-30T10:01:01Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"total_tokens":130},"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"total_tokens":130}}}}"#,
                 "\n",
-                r#"{"timestamp":"2026-04-30T10:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30},"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30}}}}"#,
+                r#"{"timestamp":"2026-04-30T10:01:02Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#,
                 "\n",
-                r#"{"timestamp":"2026-04-30T10:01:03Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":110,"cached_input_tokens":22,"output_tokens":33},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3}}}}"#,
+                r#"{"timestamp":"2026-04-30T10:01:03Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":50,"cached_input_tokens":10,"output_tokens":15,"total_tokens":65},"last_token_usage":{"input_tokens":50,"cached_input_tokens":10,"output_tokens":15,"total_tokens":65}}}}"#,
+                "\n",
+                r#"{"timestamp":"2026-04-30T10:01:04Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"total_tokens":130},"last_token_usage":{"input_tokens":50,"cached_input_tokens":10,"output_tokens":15,"total_tokens":65}}}}"#,
+                "\n",
+                r#"{"timestamp":"2026-04-30T10:01:05Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":110,"cached_input_tokens":22,"output_tokens":33,"total_tokens":143},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"total_tokens":13}}}}"#,
                 "\n"
             ),
         )
@@ -4054,7 +4060,7 @@ mod tests {
                 None,
             );
 
-            assert_eq!(messages.len(), 2);
+            assert_eq!(messages.len(), 3);
             assert_eq!(
                 messages
                     .iter()
@@ -4182,8 +4188,8 @@ mod tests {
             })
             .unwrap();
 
-            assert_eq!(parsed.counts.get(ClientId::Codex), 2);
-            assert_eq!(parsed.messages.len(), 2);
+            assert_eq!(parsed.counts.get(ClientId::Codex), 3);
+            assert_eq!(parsed.messages.len(), 3);
             assert_eq!(
                 parsed
                     .messages

--- a/crates/tokscale-core/src/sessions/codex.rs
+++ b/crates/tokscale-core/src/sessions/codex.rs
@@ -119,6 +119,13 @@ impl CodexTotals {
             .saturating_add(self.reasoning)
     }
 
+    fn is_within(self, baseline: Self) -> bool {
+        self.input <= baseline.input
+            && self.output <= baseline.output
+            && self.cached <= baseline.cached
+            && self.reasoning <= baseline.reasoning
+    }
+
     fn looks_like_stale_regression(self, previous: Self, last: Self) -> bool {
         let previous_total = previous.total();
         let current_total = self.total();
@@ -302,8 +309,13 @@ fn parse_codex_reader<R: BufRead>(
                     if let Some(ref id) = payload.id {
                         state.session_id_from_meta = Some(id.clone());
                     }
-                    if let Some(ref forked_from_id) = payload.forked_from_id {
-                        state.session_forked_from_id = Some(forked_from_id.clone());
+                    let forked_from_id = payload
+                        .forked_from_id
+                        .as_deref()
+                        .filter(|id| !id.is_empty())
+                        .or_else(|| forked_from_id_from_source(payload.source.as_ref()));
+                    if let Some(forked_from_id) = forked_from_id {
+                        state.session_forked_from_id = Some(forked_from_id.to_string());
                         state.forked_child_waiting_for_turn_context = true;
                         state.forked_child_inherited_baseline = None;
                         state.forked_child_inherited_reported_total = None;
@@ -363,16 +375,15 @@ fn parse_codex_reader<R: BufRead>(
                     let total_usage = info.total_token_usage.as_ref().map(CodexTotals::from_usage);
                     let last_usage = info.last_token_usage.as_ref().map(CodexTotals::from_usage);
 
-                    if forked_child_matches_inherited_baseline(
+                    // Forked child logs can replay more than one parent
+                    // token_count row after the first child turn_context,
+                    // often with child-local timestamps. Keep the inherited
+                    // baseline active until totals move beyond it.
+                    if forked_child_should_skip_inherited_snapshot(
                         &state,
                         info.total_token_usage.as_ref(),
                         total_usage,
                     ) {
-                        if let Some(total) = total_usage {
-                            state.previous_totals = Some(total);
-                        }
-                        state.forked_child_inherited_baseline = None;
-                        state.forked_child_inherited_reported_total = None;
                         continue;
                     }
                     state.forked_child_inherited_baseline = None;
@@ -561,6 +572,15 @@ fn codex_source_is_exec(source: Option<&Value>) -> bool {
     source.and_then(Value::as_str) == Some("exec")
 }
 
+fn forked_from_id_from_source(source: Option<&Value>) -> Option<&str> {
+    source?
+        .get("subagent")?
+        .get("thread_spawn")?
+        .get("parent_thread_id")?
+        .as_str()
+        .filter(|id| !id.is_empty())
+}
+
 fn parse_codex_entry_timestamp(timestamp: Option<&str>) -> Option<i64> {
     timestamp
         .and_then(|ts| chrono::DateTime::parse_from_rfc3339(ts).ok())
@@ -664,7 +684,7 @@ fn remember_forked_child_inherited_baseline(state: &mut CodexParseState, info: &
     state.forked_child_inherited_reported_total = reported_total_tokens(total_usage);
 }
 
-fn forked_child_matches_inherited_baseline(
+fn forked_child_should_skip_inherited_snapshot(
     state: &CodexParseState,
     total_usage: Option<&CodexTokenUsage>,
     totals: Option<CodexTotals>,
@@ -672,13 +692,13 @@ fn forked_child_matches_inherited_baseline(
     if let (Some(usage), Some(baseline)) =
         (total_usage, state.forked_child_inherited_reported_total)
     {
-        if reported_total_tokens(usage) == Some(baseline) {
+        if reported_total_tokens(usage).is_some_and(|total| total <= baseline) {
             return true;
         }
     }
 
     if let (Some(totals), Some(baseline)) = (totals, state.forked_child_inherited_baseline) {
-        return totals == baseline;
+        return totals.is_within(baseline);
     }
 
     false
@@ -1517,6 +1537,54 @@ mod tests {
         assert_eq!(messages[0].tokens.cache_read, 1000);
         assert_eq!(messages[0].tokens.output, 200);
         assert_eq!(messages[0].tokens.reasoning, 50);
+    }
+
+    #[test]
+    fn test_forked_child_ignores_replayed_parent_rows_after_turn_context() {
+        let file = create_test_file(concat!(
+            r#"{"timestamp":"2026-05-05T21:51:57.991Z","type":"session_meta","payload":{"id":"child-session","forked_from_id":"parent-session","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent-session","depth":1}}},"model_provider":"openai","agent_nickname":"worker","cwd":"/repo-child"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:57.994Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":300,"output_tokens":30,"total_tokens":330},"last_token_usage":{"input_tokens":300,"output_tokens":30,"total_tokens":330}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:58.947Z","type":"turn_context","payload":{"model":"gpt-5.5","cwd":"/repo-child"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:58.948Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":50,"output_tokens":5,"total_tokens":55},"last_token_usage":{"input_tokens":50,"output_tokens":5,"total_tokens":55}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:58.949Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":300,"output_tokens":30,"total_tokens":330},"last_token_usage":{"input_tokens":250,"output_tokens":25,"total_tokens":275}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:59.253Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":310,"output_tokens":32,"total_tokens":342},"last_token_usage":{"input_tokens":10,"output_tokens":2,"total_tokens":12}}}}"#,
+            "\n"
+        ));
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gpt-5.5");
+        assert_eq!(messages[0].tokens.input, 10);
+        assert_eq!(messages[0].tokens.output, 2);
+    }
+
+    #[test]
+    fn test_forked_child_detects_thread_spawn_source_without_top_level_fork_id() {
+        let file = create_test_file(concat!(
+            r#"{"timestamp":"2026-05-05T21:51:57.991Z","type":"session_meta","payload":{"id":"child-session","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent-session","depth":1}}},"model_provider":"openai","agent_nickname":"worker","cwd":"/repo-child"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:57.994Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":300,"output_tokens":30,"total_tokens":330},"last_token_usage":{"input_tokens":300,"output_tokens":30,"total_tokens":330}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:58.947Z","type":"turn_context","payload":{"model":"gpt-5.5","cwd":"/repo-child"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:58.948Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":50,"output_tokens":5,"total_tokens":55},"last_token_usage":{"input_tokens":50,"output_tokens":5,"total_tokens":55}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:59.253Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":310,"output_tokens":32,"total_tokens":342},"last_token_usage":{"input_tokens":10,"output_tokens":2,"total_tokens":12}}}}"#,
+            "\n"
+        ));
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gpt-5.5");
+        assert_eq!(messages[0].tokens.input, 10);
+        assert_eq!(messages[0].tokens.output, 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Follow-up to #601. This fixes Codex fork/subagent JSONL replay so inherited parent `token_count` rows are not counted again as fresh child usage.

## Why
The previous submit-validation fix was reverted back to the 10B/day guardrail, which means the latest #601 report still fails when Codex totals are inflated before submission. The root cause is parser-side: current Codex fork/subagent logs can replay parent `token_count` snapshots after the child `turn_context`, sometimes with child-local timestamps, so timestamp-based dedup alone cannot distinguish inherited history from real child deltas.

## Diff Scope
* Teach the Codex parser to detect forked subagent sessions from either top-level `forked_from_id` or nested `payload.source.subagent.thread_spawn.parent_thread_id`.
* Keep the inherited fork baseline active until cumulative totals move beyond it, so multiple replayed parent snapshots after `turn_context` are skipped.
* Strengthen Codex fork replay tests with rebased timestamps and nested thread-spawn metadata.
* Bump the source message cache schema to avoid reusing cached parses produced by the old fork replay behavior.

## Branch Integrity
* Base branch: `main`
* Validated base SHA: `c21f0f533205ad63e9154666c294bb789d2415c9`
* Ahead/behind: `0` behind, `1` ahead
* Merge-base: `c21f0f533205ad63e9154666c294bb789d2415c9`
* Diff proof computed against freshly fetched `origin/main`.

## Commit Integrity
* Introduced commit: `83db63467a4a39e00d0f2d42641bc70728cbc001 fix(codex): skip replayed fork token counts`
* Final PR diff contains only the intended Codex parser, cache schema, and regression test changes.
* Ledger: not applicable — not required for selected validation mode/change family.
* Version: PASS — `bash scripts/check-version-coherence.sh`

## Diff Hygiene
```text
git diff --name-status origin/main...HEAD
M crates/tokscale-core/src/lib.rs
M crates/tokscale-core/src/message_cache.rs
M crates/tokscale-core/src/sessions/codex.rs
```

`git diff --check`: PASS, no output.

## Validation Mode And Proof
Selected mode: Mode 3 — shared parser/data-integrity change that affects local Codex usage totals before `tokscale submit`.

Local proof:
* `cargo test -p tokscale-core forked_child`: PASS
* `cargo test -p tokscale-core test_parse_all_messages_with_pricing_codex_deduplicates_forked_history`: PASS
* `cargo test -p tokscale-core`: PASS
* `cargo clippy -p tokscale-core --all-features -- -D warnings`: PASS
* `cargo fmt --all -- --check`: PASS
* `git diff --check`: PASS
* `git diff --cached --check`: PASS
* `bash scripts/check-version-coherence.sh`: PASS

Not run locally: full workspace `cargo test` — not required because the changed package was fully tested locally and mandatory remote CI will cover final SHA breadth. Frontend tests are not applicable because the final diff does not touch frontend code.

## CI Context Confirmation
Pending — required remote checks will start only after the PR is opened.

## Runtime Safety
This changes only Codex JSONL parsing state and cache invalidation. It does not add blocking locks, unbounded queues, network calls, database writes, or submit API behavior. No invariant regression introduced.

## Migration Notes
Not applicable — no DB migration changed.

## Rollback Plan
Rollback: revert this PR. DB downgrade: not applicable. Data repair: not applicable. Operational caveats: users with already-cached Codex parses will refresh automatically because the source message cache schema is bumped.

## Known Residual Risks
This prevents future local parses from double-counting replayed Codex fork history. It does not retroactively repair already-submitted server rows; affected users may need to rerun `tokscale submit` after a release containing this fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex fork/subagent replay to stop double-counting parent token_count snapshots in child sessions. Prevents inflated usage totals before submit and keeps us within the 10B/day guardrail.

- **Bug Fixes**
  - Detect forked sessions via `forked_from_id` or `payload.source.subagent.thread_spawn.parent_thread_id`.
  - Keep the inherited baseline active after the child `turn_context`; skip replayed parent snapshots while totals stay within the baseline (not just equal) and handle multiple replays.
  - Added tests for repeated replay after `turn_context` and for thread-spawn-only fork detection.

<sup>Written for commit 21266d19d8ab8100989304db86990d98663b02ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

