### PR TITLE
feat(tui): add Cost/1M column to Models, Daily, Hourly tabs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-cli"
-version = "2.1.3"
+version = "3.0.0"
 dependencies = [
  "ab_glyph",
  "aes",
@@ -3473,7 +3473,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-core"
-version = "2.1.3"
+version = "3.0.0"
 dependencies = [
  "bincode",
  "chrono",

--- a/crates/tokscale-cli/src/tui/ui/daily.rs
+++ b/crates/tokscale-cli/src/tui/ui/daily.rs
@@ -5,8 +5,8 @@ use ratatui::widgets::{
 };
 
 use super::widgets::{
-    format_cache_hit_rate, format_cost, format_tokens, get_client_display_name,
-    get_provider_display_name,
+    format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens,
+    get_client_display_name, get_provider_display_name,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 
@@ -64,11 +64,12 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     } else if has_turn_data {
         vec![
             "Date", "Turn", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache×", "Total",
-            "Cost",
+            "Cost", "Cost/1M",
         ]
     } else {
         vec![
             "Date", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache×", "Total", "Cost",
+            "Cost/1M",
         ]
     };
 
@@ -199,6 +200,8 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                         .style(Style::default().fg(Color::Cyan)),
                         Cell::from(format_tokens(day.tokens.total())),
                         Cell::from(format_cost(day.cost)).style(Style::default().fg(Color::Green)),
+                        Cell::from(format_cost_per_million(day.cost, day.tokens.total()))
+                            .style(Style::default().fg(Color::Rgb(150, 200, 150))),
                     ]);
                     cells
                 };
@@ -246,6 +249,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             Constraint::Length(8),
             Constraint::Length(10),
             Constraint::Length(10),
+            Constraint::Length(10),
         ]
     } else {
         vec![
@@ -256,6 +260,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             Constraint::Length(10),
             Constraint::Length(10),
             Constraint::Length(8),
+            Constraint::Length(10),
             Constraint::Length(10),
             Constraint::Length(10),
         ]

--- a/crates/tokscale-cli/src/tui/ui/hourly.rs
+++ b/crates/tokscale-cli/src/tui/ui/hourly.rs
@@ -5,7 +5,7 @@ use ratatui::widgets::{
 };
 
 use super::hourly_profile;
-use super::widgets::{format_cache_hit_rate, format_cost, format_tokens};
+use super::widgets::{format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens};
 use crate::tui::app::{App, HourlyViewMode, SortDirection, SortField};
 
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
@@ -65,12 +65,12 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
     } else if has_turn_data {
         vec![
             "Hour", "Source", "Turn", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache×",
-            "Total", "Cost",
+            "Total", "Cost", "Cost/1M",
         ]
     } else {
         vec![
             "Hour", "Source", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache×", "Total",
-            "Cost",
+            "Cost", "Cost/1M",
         ]
     };
 
@@ -216,6 +216,8 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
                     .style(Style::default().fg(Color::Cyan)),
                     Cell::from(format_tokens(hour.tokens.total())),
                     Cell::from(format_cost(hour.cost)).style(Style::default().fg(Color::Green)),
+                    Cell::from(format_cost_per_million(hour.cost, hour.tokens.total()))
+                        .style(Style::default().fg(Color::Rgb(150, 200, 150))),
                 ]);
                 cells
             };
@@ -266,6 +268,7 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
             Constraint::Length(8),
             Constraint::Length(10),
             Constraint::Length(10),
+            Constraint::Length(10),
         ]
     } else {
         vec![
@@ -277,6 +280,7 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
             Constraint::Length(10),
             Constraint::Length(10),
             Constraint::Length(8),
+            Constraint::Length(10),
             Constraint::Length(10),
             Constraint::Length(10),
         ]

--- a/crates/tokscale-cli/src/tui/ui/models.rs
+++ b/crates/tokscale-cli/src/tui/ui/models.rs
@@ -4,8 +4,8 @@ use ratatui::widgets::{
 };
 
 use super::widgets::{
-    format_cache_hit_rate, format_cost, format_ms_per_1k, format_tokens, get_client_display_name,
-    get_provider_display_name,
+    format_cache_hit_rate, format_cost, format_cost_per_million, format_ms_per_1k, format_tokens,
+    get_client_display_name, get_provider_display_name,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 use tokscale_core::GroupBy;
@@ -83,11 +83,12 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             "Total",
             "ms/1K",
             "Cost",
+            "Cost/1M",
         ]
     } else {
         vec![
             "#", "Model", "Provider", "Source", "Input", "Output", "Cache R", "Cache W", "Cache×",
-            "Total", "ms/1K", "Cost",
+            "Total", "ms/1K", "Cost", "Cost/1M",
         ]
     };
 
@@ -184,6 +185,8 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                     Cell::from(format_ms_per_1k(model.performance.ms_per_1k_tokens))
                         .style(Style::default().fg(Color::Yellow)),
                     Cell::from(format_cost(model.cost)).style(Style::default().fg(Color::Green)),
+                    Cell::from(format_cost_per_million(model.cost, model.tokens.total()))
+                        .style(Style::default().fg(Color::Rgb(150, 200, 150))),
                 ]
             } else {
                 vec![
@@ -214,6 +217,8 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                     Cell::from(format_ms_per_1k(model.performance.ms_per_1k_tokens))
                         .style(Style::default().fg(Color::Yellow)),
                     Cell::from(format_cost(model.cost)).style(Style::default().fg(Color::Green)),
+                    Cell::from(format_cost_per_million(model.cost, model.tokens.total()))
+                        .style(Style::default().fg(Color::Rgb(150, 200, 150))),
                 ]
             };
 
@@ -251,6 +256,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             Constraint::Length(10),
             Constraint::Length(10),
             Constraint::Length(10),
+            Constraint::Length(10),
         ]
     } else {
         vec![
@@ -263,6 +269,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             Constraint::Length(10),
             Constraint::Length(10),
             Constraint::Length(8),
+            Constraint::Length(10),
             Constraint::Length(10),
             Constraint::Length(10),
             Constraint::Length(10),

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -43,6 +43,16 @@ pub fn format_cost(cost: f64) -> String {
     }
 }
 
+/// Cost per million tokens: useful for comparing model efficiency across sessions.
+/// Returns "—" when there are no tokens to avoid division by zero.
+pub fn format_cost_per_million(cost: f64, total_tokens: u64) -> String {
+    if total_tokens == 0 || !cost.is_finite() || cost < 0.0 {
+        return "\u{2014}".to_string(); // —
+    }
+    let per_m = cost / (total_tokens as f64) * 1_000_000.0;
+    format!("${:.2}", per_m)
+}
+
 /// Cache reuse multiplier: cached reads per full-price input token.
 /// `cache_read / (input + cache_write)` — how many low-cost reads you
 /// got for every token you paid full price (fresh input or cache write).


### PR DESCRIPTION
## What

Adds a **Cost/1M** (cost per million tokens) column to the full-width layout of the **Models**, **Daily**, and **Hourly** TUI tabs.

## Why

Upstream already exposes a `Cost/1M` column (via `format_cost_per_million`) in the CLI light-table output (`main.rs`), but the interactive TUI tabs don't have it. This brings the TUI to parity with the CLI, so model/day/hour cost-efficiency can be compared without leaving the TUI.

## Details

- `widgets.rs`: add `format_cost_per_million(cost, total_tokens)` — returns `—` when `total_tokens == 0` to avoid division by zero.
- `models.rs` / `daily.rs` / `hourly.rs`: add the column to the **full-width** header, row cells, and width constraints only. Narrow / very-narrow layouts are untouched (column hidden on small terminals), matching the existing responsive behavior. Handles both the turn-data and no-turn-data variants.
- Also syncs `Cargo.lock` to 3.0.0 (c21f0f5 bumped `Cargo.toml` to 3.0.0 but left the lockfile at 2.1.3). Happy to drop this commit if you'd prefer it separate.

## Testing

- `cargo build` + `cargo clippy` clean, `cargo test` green (1454 tests).
- Verified header/cells/widths column counts stay consistent across all three tabs and both turn/no-turn variants.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Cost/1M column to the Models, Daily, and Hourly TUI tabs to show cost per million tokens and match the CLI. The column appears only in full-width layouts and stays hidden on narrow terminals.

- New Features
  - Added header, row cells, and width constraints for the new Cost/1M column on all three tabs.
  - Introduced `format_cost_per_million(cost, total_tokens)` that returns "—" when tokens are 0 to avoid division by zero.

- Dependencies
  - Synced `Cargo.lock` to 3.0.0 to match `Cargo.toml`.

<sup>Written for commit 329afb6461bde3a75cbb2916e4c15ed389d61363. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/632?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

