### PR TITLE
feat(tui): compact date display in Hourly & Daily tabs (fix '2026-0…' truncation)

### DIFF
--- a/crates/tokscale-cli/src/tui/ui/daily.rs
+++ b/crates/tokscale-cli/src/tui/ui/daily.rs
@@ -59,6 +59,24 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let striped_row_style = app.theme.striped_row_style();
     let today = Local::now().date_naive();
 
+    // Date format adapts to *available* width, not just the narrow breakpoint.
+    // In full mode the table can still be wider than the terminal, so the year
+    // would otherwise get compressed to "2026-0". When the full layout doesn't
+    // fit we drop the year (near-constant in a by-day list) to "%m-%d" and
+    // shrink the date column, freeing 5 columns. `full_layout_width` is the
+    // ideal full-mode total (Length(12) date + spacing); keep it in sync with
+    // the `widths` block below.
+    let full_layout_width: u16 = if has_turn_data { 112 } else { 105 };
+    let compact_full_date = !is_narrow && !is_very_narrow && inner.width < full_layout_width;
+    let date_col_width: u16 = if compact_full_date { 7 } else { 12 };
+    let date_fmt: &str = if is_very_narrow {
+        "%m/%d"
+    } else if is_narrow || compact_full_date {
+        "%m-%d"
+    } else {
+        "%Y-%m-%d"
+    };
+
     let header_cells = if is_very_narrow {
         vec!["Date", "Cost"]
     } else if is_narrow {
@@ -136,79 +154,81 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             let is_striped = idx % 2 == 1;
             let is_today = day.date == today;
 
-            let cells: Vec<Cell> =
-                if is_very_narrow {
+            let cells: Vec<Cell> = if is_very_narrow {
+                vec![
+                    Cell::from(day.date.format(date_fmt).to_string()).style(if is_today {
+                        Style::default()
+                            .fg(Color::Yellow)
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default()
+                    }),
+                    Cell::from(format_cost(day.cost)).style(Style::default().fg(Color::Green)),
+                ]
+            } else if is_narrow {
+                let mut cells =
                     vec![
-                        Cell::from(day.date.format("%m/%d").to_string()).style(if is_today {
+                        Cell::from(day.date.format(date_fmt).to_string()).style(if is_today {
                             Style::default()
                                 .fg(Color::Yellow)
                                 .add_modifier(Modifier::BOLD)
                         } else {
                             Style::default()
                         }),
-                        Cell::from(format_cost(day.cost)).style(Style::default().fg(Color::Green)),
-                    ]
-                } else if is_narrow {
-                    let mut cells = vec![Cell::from(day.date.format("%Y-%m-%d").to_string())
-                        .style(if is_today {
-                            Style::default()
-                                .fg(Color::Yellow)
-                                .add_modifier(Modifier::BOLD)
-                        } else {
-                            Style::default()
-                        })];
-                    if has_turn_data {
-                        let turn_str = if day.turn_count > 0 {
-                            day.turn_count.to_string()
-                        } else {
-                            "\u{2014}".to_string()
-                        };
-                        cells.push(Cell::from(turn_str));
-                    }
-                    cells.extend([
-                        Cell::from(day.message_count.to_string()),
-                        Cell::from(format_tokens(day.tokens.total())),
-                        Cell::from(format_cost(day.cost)).style(Style::default().fg(Color::Green)),
-                    ]);
-                    cells
-                } else {
-                    let mut cells = vec![Cell::from(day.date.format("%Y-%m-%d").to_string())
-                        .style(if is_today {
+                    ];
+                if has_turn_data {
+                    let turn_str = if day.turn_count > 0 {
+                        day.turn_count.to_string()
+                    } else {
+                        "\u{2014}".to_string()
+                    };
+                    cells.push(Cell::from(turn_str));
+                }
+                cells.extend([
+                    Cell::from(day.message_count.to_string()),
+                    Cell::from(format_tokens(day.tokens.total())),
+                    Cell::from(format_cost(day.cost)).style(Style::default().fg(Color::Green)),
+                ]);
+                cells
+            } else {
+                let mut cells =
+                    vec![
+                        Cell::from(day.date.format(date_fmt).to_string()).style(if is_today {
                             Style::default()
                                 .fg(Color::Yellow)
                                 .add_modifier(Modifier::BOLD)
                         } else {
                             Style::default().add_modifier(Modifier::BOLD)
-                        })];
-                    if has_turn_data {
-                        let turn_str = if day.turn_count > 0 {
-                            day.turn_count.to_string()
-                        } else {
-                            "\u{2014}".to_string()
-                        };
-                        cells.push(Cell::from(turn_str));
-                    }
-                    cells.extend([
-                        Cell::from(day.message_count.to_string()),
-                        Cell::from(format_tokens(day.tokens.input)).style(metric_input_style),
-                        Cell::from(format_tokens(day.tokens.output)).style(metric_output_style),
-                        Cell::from(format_tokens(day.tokens.cache_read))
-                            .style(metric_cache_read_style),
-                        Cell::from(format_tokens(day.tokens.cache_write))
-                            .style(metric_cache_write_style),
-                        Cell::from(format_cache_hit_rate(
-                            day.tokens.cache_read,
-                            day.tokens.input,
-                            day.tokens.cache_write,
-                        ))
-                        .style(Style::default().fg(Color::Cyan)),
-                        Cell::from(format_tokens(day.tokens.total())),
-                        Cell::from(format_cost(day.cost)).style(Style::default().fg(Color::Green)),
-                        Cell::from(format_cost_per_million(day.cost, day.tokens.total()))
-                            .style(Style::default().fg(Color::Rgb(150, 200, 150))),
-                    ]);
-                    cells
-                };
+                        }),
+                    ];
+                if has_turn_data {
+                    let turn_str = if day.turn_count > 0 {
+                        day.turn_count.to_string()
+                    } else {
+                        "\u{2014}".to_string()
+                    };
+                    cells.push(Cell::from(turn_str));
+                }
+                cells.extend([
+                    Cell::from(day.message_count.to_string()),
+                    Cell::from(format_tokens(day.tokens.input)).style(metric_input_style),
+                    Cell::from(format_tokens(day.tokens.output)).style(metric_output_style),
+                    Cell::from(format_tokens(day.tokens.cache_read)).style(metric_cache_read_style),
+                    Cell::from(format_tokens(day.tokens.cache_write))
+                        .style(metric_cache_write_style),
+                    Cell::from(format_cache_hit_rate(
+                        day.tokens.cache_read,
+                        day.tokens.input,
+                        day.tokens.cache_write,
+                    ))
+                    .style(Style::default().fg(Color::Cyan)),
+                    Cell::from(format_tokens(day.tokens.total())),
+                    Cell::from(format_cost(day.cost)).style(Style::default().fg(Color::Green)),
+                    Cell::from(format_cost_per_million(day.cost, day.tokens.total()))
+                        .style(Style::default().fg(Color::Rgb(150, 200, 150))),
+                ]);
+                cells
+            };
 
             let row_style = if is_selected {
                 Style::default().bg(theme_selection)
@@ -243,7 +263,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         ]
     } else if has_turn_data {
         vec![
-            Constraint::Length(12),
+            Constraint::Length(date_col_width),
             Constraint::Length(6),
             Constraint::Length(6),
             Constraint::Length(10),
@@ -257,7 +277,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         ]
     } else {
         vec![
-            Constraint::Length(12),
+            Constraint::Length(date_col_width),
             Constraint::Length(6),
             Constraint::Length(10),
             Constraint::Length(10),
@@ -530,5 +550,93 @@ fn truncate(s: &str, max_chars: usize) -> String {
     } else {
         let head: String = s.chars().take(max_chars - 3).collect();
         format!("{}...", head)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::app::{Tab, TuiConfig};
+    use crate::tui::data::{DailyUsage, TokenBreakdown};
+    use chrono::NaiveDate;
+    use ratatui::{backend::TestBackend, Terminal};
+    use std::collections::BTreeMap;
+
+    fn day(date: NaiveDate, cost: f64) -> DailyUsage {
+        DailyUsage {
+            date,
+            tokens: TokenBreakdown::default(),
+            cost,
+            source_breakdown: BTreeMap::new(),
+            message_count: 10,
+            turn_count: 3,
+        }
+    }
+
+    fn make_app(width: u16) -> App {
+        let config = TuiConfig {
+            theme: "blue".to_string(),
+            refresh: 0,
+            sessions_path: None,
+            clients: None,
+            since: None,
+            until: None,
+            year: None,
+            initial_tab: None,
+        };
+        let mut app = App::new_with_cached_data(config, None).unwrap();
+        app.terminal_width = width;
+        app.current_tab = Tab::Daily;
+        app.sort_field = SortField::Date;
+        app.sort_direction = SortDirection::Descending;
+        app.data.daily = vec![
+            day(NaiveDate::from_ymd_opt(2026, 5, 29).unwrap(), 3.0),
+            day(NaiveDate::from_ymd_opt(2026, 5, 28).unwrap(), 2.0),
+        ];
+        app
+    }
+
+    fn render_body(app: &mut App, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render(frame, app, Rect::new(0, 0, width, height)))
+            .unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .chunks(width as usize)
+            .map(|row| {
+                row.iter()
+                    .map(|c| c.symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn wide_terminal_keeps_year() {
+        let mut app = make_app(130);
+        let body = render_body(&mut app, 130, 12);
+        assert!(
+            body.contains("2026-05-29"),
+            "a layout that fits should keep the full date\n{body}"
+        );
+    }
+
+    #[test]
+    fn full_mode_drops_year_when_layout_does_not_fit() {
+        // 110 cols is full mode (>= 100) but narrower than the ~112-col full
+        // layout, so the year is dropped — the date stays readable as "05-29"
+        // instead of being compressed to "2026-0".
+        let mut app = make_app(110);
+        let body = render_body(&mut app, 110, 12);
+        assert!(
+            !body.contains("2026-05-29"),
+            "year should be dropped when the full layout does not fit\n{body}"
+        );
+        assert!(body.contains("05-29"), "expected compact date\n{body}");
     }
 }

--- a/crates/tokscale-cli/src/tui/ui/hourly.rs
+++ b/crates/tokscale-cli/src/tui/ui/hourly.rs
@@ -438,6 +438,36 @@ mod tests {
     }
 
     #[test]
+    fn selected_row_visible_in_single_line_viewport() {
+        // Regression guard for the day-boundary separator bug both cubic and
+        // Codex flagged: when the selected row is the FIRST row of a new day and
+        // the viewport has room for only one line, the separator and the data
+        // row cannot share the budget. The fix drops the separator but still
+        // renders the data row, so the selected row never disappears. The old
+        // `break` form skipped the data row, leaving the highlight invisible
+        // until another keypress (max_visible_items is driven by data rows
+        // actually rendered, so the nav/scroll clamp would not advance).
+        //
+        // Data is newest-first: index 3 == 05/28 23:00 is the first row of the
+        // older day (it needs a separator). Pin the window to it.
+        let mut app = make_app(120);
+        app.scroll_offset = 3;
+        app.selected_index = 3;
+
+        // height 4 → inner height 2 → visible_height = 2 - 1 = 1 (single line):
+        // the separator and the data row cannot both fit on the one line left.
+        let body = render_lines(&mut app, 120, 4).join("\n");
+
+        // The old `break` form bailed here and rendered nothing, so the selected
+        // hour was invisible until another keypress. The fix drops the separator
+        // but still renders the data row.
+        assert!(
+            body.contains("23:00"),
+            "selected row (05/28 23:00) must stay visible in a one-line viewport\n{body}"
+        );
+    }
+
+    #[test]
     fn window_never_overflows_height_and_reports_data_rows() {
         let mut app = make_app(120);
         // Tight height forces the line budget to bite (separators + data rows).

--- a/crates/tokscale-cli/src/tui/ui/hourly.rs
+++ b/crates/tokscale-cli/src/tui/ui/hourly.rs
@@ -1,4 +1,4 @@
-use chrono::{Local, Timelike};
+use chrono::{Local, NaiveDate, Timelike};
 use ratatui::prelude::*;
 use ratatui::widgets::{
     Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, ScrollbarState, Table,
@@ -31,7 +31,13 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_widget(block, area);
 
     let visible_height = inner.height.saturating_sub(1) as usize;
-    app.set_max_visible_items(visible_height);
+    // NB: unlike the other tabs we do NOT seed max_visible_items with
+    // visible_height here. Separators make the effective page smaller than the
+    // raw height, so the real page size is set at the end of the render loop
+    // (data rows actually shown). Clamping with visible_height up front would
+    // over-restrict scroll and make the last rows unreachable. Scroll/selection
+    // are kept valid by the nav handlers and update_data(); a resize only ever
+    // shrinks the window from the same start, which stays in-bounds.
 
     let hourly = app.get_sorted_hourly();
     if hourly.is_empty() {
@@ -120,125 +126,154 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
     )
     .height(1);
 
+    // Day-boundary separators factor the date out of every data row: rows show
+    // only the hour bucket ("%H:00"), and a muted separator row carrying the
+    // "%m/%d" date is emitted at the top of the window and at each day change.
+    // This keeps the time column ~5 wide instead of repeating "2026-05-29 " on
+    // every line (which ratatui was compressing down to "2026-0").
+    //
+    // Separators consume vertical space and ratatui clips rows that overflow
+    // the area (`get_row_bounds`), so we budget by *rendered lines* (data rows
+    // + separators) rather than slicing a fixed data-row count, then report the
+    // actual data rows shown via `max_visible_items` so paging/scroll stay in
+    // sync.
     let hourly_len = hourly.len();
     let start = scroll_offset.min(hourly_len);
-    let end = (start + visible_height).min(hourly_len);
-
     if start >= hourly_len {
         return;
     }
 
-    let rows: Vec<Row> = hourly[start..end]
-        .iter()
-        .enumerate()
-        .map(|(i, hour)| {
-            let idx = i + start;
-            let is_selected = idx == selected_index;
-            let is_striped = idx % 2 == 1;
-            let is_current = hour.datetime == current_hour;
+    let sep_style = Style::default()
+        .fg(theme_accent)
+        .bg(Color::Rgb(24, 28, 36))
+        .add_modifier(Modifier::BOLD);
 
-            let clients_str: String = {
-                let mut c: Vec<&str> = hour.clients.iter().map(String::as_str).collect();
-                c.sort();
-                c.join(", ")
-            };
+    // Turn count → display string ("—" when the hour has no turn data).
+    let turn_cell = |count: u32| -> String {
+        if count > 0 {
+            count.to_string()
+        } else {
+            "\u{2014}".to_string()
+        }
+    };
 
-            let cells: Vec<Cell> = if is_very_narrow {
-                vec![
-                    Cell::from(hour.datetime.format("%m/%d %H:%M").to_string()).style(
-                        if is_current {
-                            Style::default()
-                                .fg(Color::Yellow)
-                                .add_modifier(Modifier::BOLD)
-                        } else {
-                            Style::default()
-                        },
-                    ),
-                    Cell::from(format_cost(hour.cost)).style(Style::default().fg(Color::Green)),
-                ]
-            } else if is_narrow {
-                let mut cells = vec![
-                    Cell::from(hour.datetime.format("%Y-%m-%d %H:%M").to_string()).style(
-                        if is_current {
-                            Style::default()
-                                .fg(Color::Yellow)
-                                .add_modifier(Modifier::BOLD)
-                        } else {
-                            Style::default()
-                        },
-                    ),
-                    Cell::from(clients_str),
-                ];
-                if has_turn_data {
-                    let turn_str = if hour.turn_count > 0 {
-                        hour.turn_count.to_string()
-                    } else {
-                        "\u{2014}".to_string()
-                    };
-                    cells.push(Cell::from(turn_str));
-                }
-                cells.extend([
-                    Cell::from(hour.message_count.to_string()),
-                    Cell::from(format_tokens(hour.tokens.total())),
-                    Cell::from(format_cost(hour.cost)).style(Style::default().fg(Color::Green)),
-                ]);
-                cells
-            } else {
-                let mut cells = vec![
-                    Cell::from(hour.datetime.format("%Y-%m-%d %H:%M").to_string()).style(
-                        if is_current {
-                            Style::default()
-                                .fg(Color::Yellow)
-                                .add_modifier(Modifier::BOLD)
-                        } else {
-                            Style::default().add_modifier(Modifier::BOLD)
-                        },
-                    ),
-                    Cell::from(clients_str),
-                ];
-                if has_turn_data {
-                    let turn_str = if hour.turn_count > 0 {
-                        hour.turn_count.to_string()
-                    } else {
-                        "\u{2014}".to_string()
-                    };
-                    cells.push(Cell::from(turn_str));
-                }
-                cells.extend([
-                    Cell::from(hour.message_count.to_string()),
-                    Cell::from(format_tokens(hour.tokens.input)).style(metric_input_style),
-                    Cell::from(format_tokens(hour.tokens.output)).style(metric_output_style),
-                    Cell::from(format_tokens(hour.tokens.cache_read))
-                        .style(metric_cache_read_style),
-                    Cell::from(format_tokens(hour.tokens.cache_write))
-                        .style(metric_cache_write_style),
-                    Cell::from(format_cache_hit_rate(
-                        hour.tokens.cache_read,
-                        hour.tokens.input,
-                        hour.tokens.cache_write,
-                    ))
-                    .style(Style::default().fg(Color::Cyan)),
-                    Cell::from(format_tokens(hour.tokens.total())),
-                    Cell::from(format_cost(hour.cost)).style(Style::default().fg(Color::Green)),
-                    Cell::from(format_cost_per_million(hour.cost, hour.tokens.total()))
-                        .style(Style::default().fg(Color::Rgb(150, 200, 150))),
-                ]);
-                cells
-            };
+    let mut rows: Vec<Row> = Vec::with_capacity(visible_height + 1);
+    let mut lines_used = 0usize;
+    let mut prev_date: Option<NaiveDate> = None;
+    let mut data_idx = start;
 
-            let row_style = if is_selected {
-                Style::default().bg(theme_selection)
-            } else if is_current {
-                current_row_style
-            } else if is_striped {
-                striped_row_style
-            } else {
-                Style::default()
-            };
+    while data_idx < hourly_len && lines_used < visible_height {
+        let hour = &hourly[data_idx];
+        let row_date = hour.datetime.date();
 
-            Row::new(cells).style(row_style).height(1)
-        })
-        .collect();
+        // Separator at the window top (prev_date == None) and at each day
+        // change. When only one line remains it cannot share the line budget
+        // with its data row, so we DROP THE SEPARATOR but still render the data
+        // row. This keeps the selected row visible even when it is the first
+        // row of a new day in a one-line viewport: skipping the data row here
+        // (the old behaviour) made the highlight disappear because
+        // `max_visible_items` is driven by data rows actually rendered, so the
+        // nav/scroll clamp would not advance the window to reveal it.
+        if prev_date != Some(row_date) && lines_used + 1 < visible_height {
+            rows.push(
+                Row::new(vec![
+                    Cell::from(row_date.format("%m/%d").to_string()).style(sep_style)
+                ])
+                .height(1),
+            );
+            lines_used += 1;
+        }
+        prev_date = Some(row_date);
+
+        let idx = data_idx;
+        let is_selected = idx == selected_index;
+        let is_striped = idx % 2 == 1;
+        let is_current = hour.datetime == current_hour;
+
+        let clients_str: String = {
+            let mut c: Vec<&str> = hour.clients.iter().map(String::as_str).collect();
+            c.sort();
+            c.join(", ")
+        };
+
+        let time_str = hour.datetime.format("%H:00").to_string();
+        let time_style = if is_current {
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD)
+        } else if !is_narrow && !is_very_narrow {
+            Style::default().add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+
+        let cells: Vec<Cell> = if is_very_narrow {
+            vec![
+                Cell::from(time_str).style(time_style),
+                Cell::from(format_cost(hour.cost)).style(Style::default().fg(Color::Green)),
+            ]
+        } else if is_narrow {
+            let mut cells = vec![
+                Cell::from(time_str).style(time_style),
+                Cell::from(clients_str),
+            ];
+            if has_turn_data {
+                cells.push(Cell::from(turn_cell(hour.turn_count)));
+            }
+            cells.extend([
+                Cell::from(hour.message_count.to_string()),
+                Cell::from(format_tokens(hour.tokens.total())),
+                Cell::from(format_cost(hour.cost)).style(Style::default().fg(Color::Green)),
+            ]);
+            cells
+        } else {
+            let mut cells = vec![
+                Cell::from(time_str).style(time_style),
+                Cell::from(clients_str),
+            ];
+            if has_turn_data {
+                cells.push(Cell::from(turn_cell(hour.turn_count)));
+            }
+            cells.extend([
+                Cell::from(hour.message_count.to_string()),
+                Cell::from(format_tokens(hour.tokens.input)).style(metric_input_style),
+                Cell::from(format_tokens(hour.tokens.output)).style(metric_output_style),
+                Cell::from(format_tokens(hour.tokens.cache_read)).style(metric_cache_read_style),
+                Cell::from(format_tokens(hour.tokens.cache_write)).style(metric_cache_write_style),
+                Cell::from(format_cache_hit_rate(
+                    hour.tokens.cache_read,
+                    hour.tokens.input,
+                    hour.tokens.cache_write,
+                ))
+                .style(Style::default().fg(Color::Cyan)),
+                Cell::from(format_tokens(hour.tokens.total())),
+                Cell::from(format_cost(hour.cost)).style(Style::default().fg(Color::Green)),
+                Cell::from(format_cost_per_million(hour.cost, hour.tokens.total()))
+                    .style(Style::default().fg(Color::Rgb(150, 200, 150))),
+            ]);
+            cells
+        };
+
+        let row_style = if is_selected {
+            Style::default().bg(theme_selection)
+        } else if is_current {
+            current_row_style
+        } else if is_striped {
+            striped_row_style
+        } else {
+            Style::default()
+        };
+
+        rows.push(Row::new(cells).style(row_style).height(1));
+        lines_used += 1;
+        data_idx += 1;
+    }
+
+    // Effective data rows shown (separators excluded) drives paging & scroll on
+    // the next frame. `hourly` is no longer borrowed past this point, so the
+    // mutable field write is sound.
+    let data_rows_shown = data_idx - start;
+    app.set_max_visible_items(data_rows_shown.max(1));
 
     let widths = if is_very_narrow {
         vec![Constraint::Percentage(60), Constraint::Percentage(40)]
@@ -261,7 +296,7 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
         ]
     } else if has_turn_data {
         vec![
-            Constraint::Length(18),
+            Constraint::Length(7),
             Constraint::Length(14),
             Constraint::Length(6),
             Constraint::Length(6),
@@ -276,7 +311,7 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
         ]
     } else {
         vec![
-            Constraint::Length(18),
+            Constraint::Length(7),
             Constraint::Length(14),
             Constraint::Length(6),
             Constraint::Length(10),
@@ -311,5 +346,109 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
             }),
             &mut scrollbar_state,
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::app::{Tab, TuiConfig};
+    use crate::tui::data::{HourlyUsage, TokenBreakdown};
+    use chrono::NaiveDate;
+    use ratatui::{backend::TestBackend, Terminal};
+    use std::collections::{BTreeMap, BTreeSet};
+
+    fn hour(date: NaiveDate, h: u32) -> HourlyUsage {
+        let mut clients = BTreeSet::new();
+        clients.insert("claude".to_string());
+        HourlyUsage {
+            datetime: date.and_hms_opt(h, 0, 0).unwrap(),
+            tokens: TokenBreakdown::default(),
+            cost: 1.0,
+            clients,
+            models: BTreeMap::new(),
+            message_count: 5,
+            turn_count: 2,
+        }
+    }
+
+    /// App with two days of hourly data (3 hours on 05-29, 2 on 05-28),
+    /// sorted newest-first like the live default.
+    fn make_app(width: u16) -> App {
+        let config = TuiConfig {
+            theme: "blue".to_string(),
+            refresh: 0,
+            sessions_path: None,
+            clients: None,
+            since: None,
+            until: None,
+            year: None,
+            initial_tab: None,
+        };
+        let mut app = App::new_with_cached_data(config, None).unwrap();
+        app.terminal_width = width;
+        app.current_tab = Tab::Hourly;
+        app.sort_field = SortField::Date;
+        app.sort_direction = SortDirection::Descending;
+        let d1 = NaiveDate::from_ymd_opt(2026, 5, 29).unwrap();
+        let d0 = NaiveDate::from_ymd_opt(2026, 5, 28).unwrap();
+        app.data.hourly = vec![
+            hour(d1, 14),
+            hour(d1, 13),
+            hour(d1, 12),
+            hour(d0, 23),
+            hour(d0, 22),
+        ];
+        app
+    }
+
+    fn render_lines(app: &mut App, width: u16, height: u16) -> Vec<String> {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render(frame, app, Rect::new(0, 0, width, height)))
+            .unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .chunks(width as usize)
+            .map(|row| {
+                row.iter()
+                    .map(|c| c.symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn compact_time_with_day_separators() {
+        let mut app = make_app(120);
+        let body = render_lines(&mut app, 120, 20).join("\n");
+
+        // Hour buckets are compact "%H:00", not the old per-row timestamp.
+        assert!(body.contains("14:00"), "expected HH:00 bucket\n{body}");
+        assert!(
+            !body.contains("2026-05-29 14"),
+            "the full date must not repeat on every row\n{body}"
+        );
+        // The date lives on muted day-boundary separator rows as "%m/%d".
+        assert!(body.contains("05/29"), "expected 05/29 separator\n{body}");
+        assert!(body.contains("05/28"), "expected 05/28 separator\n{body}");
+    }
+
+    #[test]
+    fn window_never_overflows_height_and_reports_data_rows() {
+        let mut app = make_app(120);
+        // Tight height forces the line budget to bite (separators + data rows).
+        let height = 6u16;
+        let lines = render_lines(&mut app, 120, height);
+
+        // Buffer is exactly `height` rows — nothing rendered past the area.
+        assert_eq!(lines.len(), height as usize);
+        // max_visible_items counts DATA rows shown (separators excluded), and
+        // can never exceed the rows area (height - borders - header).
+        assert!(app.max_visible_items >= 1);
+        assert!(app.max_visible_items <= (height as usize).saturating_sub(3));
     }
 }


### PR DESCRIPTION
## Problem

In both the **Hourly** and **Daily** tabs, the date/time column carries a long, mostly-redundant string (`2026-05-29 14:00` per hour row, `2026-05-29` per day row). When the full multi-column layout is wider than the terminal, ratatui distributes the deficit by compressing columns — and the date column, holding the longest content, gets crushed to unreadable garbage like `2026-0…`.

This is easy to hit on a normal ~110–120 col terminal once all the token/cache/cost columns are present.

## Changes

**Hourly — factor the date out of every row**
- Data rows now show only the compact `%H:00` bucket (~5 cols instead of 16).
- A muted **day-boundary separator row** carries the `%m/%d` date, emitted at the top of the window and whenever the day changes — so every visible hour always has a discoverable date above it.
- Hour column: `Length(18)` → `Length(7)`, reclaiming 11 columns.

**Daily — drop the year when the layout doesn't fit**
- The year is near-constant in a by-day list. When the full layout is wider than the terminal (`inner.width < full_layout_width`), the date drops to `%m-%d` and the date column shrinks `12 → 7`. Otherwise the full `%Y-%m-%d` is kept.
- Unifies the very-narrow / narrow / full date formatting behind a single width-driven `date_fmt`.

## Implementation notes

Separator rows consume vertical space, and ratatui clips rows that overflow the area (`Table::get_row_bounds`). So the Hourly render loop **budgets by rendered lines** (data rows + separators) rather than slicing a fixed data-row count, and reports the actual number of data rows shown via `max_visible_items` so paging/scroll stay in sync. (Known minor edge: at the very bottom a page spanning ≥2 days can leave the last row one line short until the next keypress; Hourly defaults to newest-first so the oldest tail is rarely visited.)

## Tests

Adds `TestBackend` render tests:
- Hourly: compact `%H:00` present, no per-row full date, `%m/%d` separators rendered, and the window never overflows the visible height.
- Daily: full date kept when it fits; year dropped to `%m-%d` when the layout doesn't fit.

`cargo test -p tokscale-cli` green; `cargo clippy --all-targets` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Hourly and Daily dates compact and readable to prevent the "2026-0…" truncation on narrow terminals. Also fixes a bug where the selected hour could disappear at a day break.

- **New Features**
  - Hourly: show only "%H:00"; add muted "%m/%d" separators at the top and on day changes; time column shrinks 18 → 7; render loop budgets by rendered lines (data rows + separators) and sets `max_visible_items` to data rows shown.
  - Daily: width-aware date; drop the year to "%m-%d" when the full layout doesn’t fit (keep "%Y-%m-%d" when it does); date column shrinks 12 → 7 in compact mode; column widths rebalanced.
  - Tests: render tests cover hourly separators/compact time, selected-row visibility in a 1-line viewport, daily year kept vs. dropped, and no overflow with correct data-row budgeting.

- **Bug Fixes**
  - Hourly: when only one line remains at a day boundary, drop the separator but still render the data row so the selected row stays visible.

<sup>Written for commit 27034c8183011cfc1716fd72d1a14b8b54b29661. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

