### PR TITLE
feat(warp): add aggregate usage sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@
 | <img width="48px" src=".github/assets/client-goose.png" alt="Goose" /> | [Goose](https://github.com/aaif-goose/goose) | `~/.local/share/goose/sessions/sessions.db` (+ macOS Application Support, legacy Block/goose paths; override via `GOOSE_PATH_ROOT`) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-antigravity.png" alt="Antigravity" /> | [Google Antigravity](https://antigravity.google/) | Cached via `tokscale antigravity sync` to `~/.config/tokscale/antigravity-cache/sessions/*.jsonl` (live RPC against the local language server) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-trae.png" alt="Trae" /> | [Trae IDE](https://www.trae.ai/) / [Trae Solo](https://www.trae.ai/solo) (international) | Cached via `tokscale trae sync` to `~/.config/tokscale/trae-cache/sessions/*.json` (account-level usage from the official API) | ✅ Yes |
+| Warp/Oz | [Warp](https://www.warp.dev/) / Oz | Cached via `tokscale warp sync` to `~/.config/tokscale/warp-cache/usage.json` (aggregate requests and spend only; no token transcripts) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-zed.webp" alt="Zed Agent" /> | [Zed Agent](https://zed.dev/docs/ai/agent-panel) | `~/.local/share/zed/threads/threads.db` (macOS: `~/Library/Application Support/Zed/threads/threads.db`; Windows: `%LOCALAPPDATA%/Zed/threads/threads.db`; hosted Zed models only, not external ACP agents) | ✅ Yes |
 | Kiro | Kiro | `~/.kiro/sessions/cli/*.json` (+ `*.jsonl`) and `~/.local/share/kiro-cli/data.sqlite3` (macOS: `~/Library/Application Support/kiro-cli/data.sqlite3`) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | Re-attributed from other sources via `hf:` model prefix or `synthetic` provider (+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`) | ✅ Yes |
@@ -111,6 +112,7 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
   - [Cursor IDE Commands](#cursor-ide-commands)
   - [Antigravity Commands](#antigravity-commands)
   - [Trae Commands](#trae-commands)
+  - [Warp/Oz Commands](#warpoz-commands)
   - [Subscription Usage](#subscription-usage)
   - [Example Output](#example-output---light-version)
   - [Configuration](#configuration)
@@ -610,6 +612,28 @@ tokscale trae logout --variant solo
 > **Note on pricing**: Trae cost figures are **vendor-reported** — tokscale surfaces the `dollar_float` value returned by Trae's own API rather than recomputing cost from token counts through tokscale's pricing engine. Numbers will match what you see on `trae.ai/account-setting#usage`, not what tokscale would otherwise calculate for the same usage.
 
 > **China variants**: The China editions (`trae.com.cn`) are intentionally **not** supported. The CN backend does not expose a session-level usage query API. Trae CN / Trae Solo CN support will be added once an official endpoint becomes available upstream.
+
+### Warp/Oz Commands
+
+Warp/Oz does not expose local token transcripts. Tokscale only syncs the aggregate request and spend counters returned by Warp's GraphQL API, then reports them as `warp` / `aggregate-requests` rows with zero token buckets.
+
+```bash
+# Save a bearer token or Cookie header copied from an authenticated Warp request
+tokscale warp login
+
+# Inspect credential/cache state and diagnostics
+tokscale warp status
+
+# Sync aggregate requests and spend into tokscale's local cache
+tokscale warp sync
+
+# Remove saved credentials; add --purge-cache to delete synced usage too
+tokscale warp logout --purge-cache
+```
+
+**Cache location**: `~/.config/tokscale/warp-cache/usage.json`
+
+**How it works**: `tokscale warp sync` calls Warp's authenticated GraphQL API for account and workspace aggregate counters. Tokscale preserves request counts as message counts and vendor-reported spend as cost, but it never converts requests into synthetic tokens. Warp is excluded from default `submit` data because the public leaderboard accepts token-attributed usage, not aggregate request counters.
 
 ### Subscription Usage
 
@@ -1157,6 +1181,7 @@ AI coding tools store their session data in cross-platform locations. Most tools
 | Zed Agent | `~/.local/share/zed/threads/threads.db` | `%LOCALAPPDATA%\Zed\threads\threads.db` | Hosted Zed model usage only; external ACP agents are not included |
 | Kiro | `~/.kiro/sessions/cli/` and `~/.local/share/kiro-cli/data.sqlite3` | `%USERPROFILE%\.kiro\sessions\cli\` and `%USERPROFILE%\.local\share\kiro-cli\data.sqlite3` | Parses Kiro session files plus the Kiro CLI SQLite database when present |
 | Trae | `~/.config/tokscale/trae-cache/sessions/` | `%APPDATA%\tokscale\trae-cache\sessions\` | Synced once via `tokscale trae sync`; credentials are auto-discovered from any installed Trae IDE or Trae Solo desktop app |
+| Warp/Oz | `~/.config/tokscale/warp-cache/usage.json` | `%APPDATA%\tokscale\warp-cache\usage.json` | Synced via `tokscale warp sync`; aggregate requests and spend only, no token transcripts |
 | Synthetic | Re-attributed from other sources | Re-attributed from other sources | Detects `hf:` model prefix + `synthetic` provider |
 
 > **Note**: On Windows, `~` expands to `%USERPROFILE%` (e.g., `C:\Users\YourName`). These tools intentionally use Unix-style paths (like `.local/share`) even on Windows for cross-platform consistency, rather than Windows-native paths like `%APPDATA%`.
@@ -1389,6 +1414,12 @@ Antigravity data is not fetched automatically by the root command. Run `tokscale
 Location: `~/.config/tokscale/trae-cache/sessions/*.json` (synced via official usage API)
 
 Trae data is not fetched automatically by the root command. Run `tokscale trae login` once, then `tokscale trae sync` before reports. Tokscale parses the synced API dumps as session-level records and preserves the cost totals reported by Trae.
+
+### Warp/Oz
+
+Location: `~/.config/tokscale/warp-cache/usage.json` (synced via authenticated GraphQL API)
+
+Warp/Oz data is not fetched automatically by the root command. Run `tokscale warp login`, then `tokscale warp sync` before reports. Tokscale records only aggregate request counts and spend because Warp does not expose token-attributed local transcripts.
 
 ### OpenClaw
 

--- a/crates/tokscale-cli/src/commands/usage/mod.rs
+++ b/crates/tokscale-cli/src/commands/usage/mod.rs
@@ -5,6 +5,7 @@ mod copilot;
 pub mod helpers;
 mod kimi;
 mod minimax;
+mod warp;
 mod zai;
 
 use anyhow::Result;
@@ -88,6 +89,7 @@ pub fn fetch_all() -> Vec<UsageOutput> {
         ("Copilot", copilot::has_credentials, copilot::fetch),
         ("Kimi", kimi::has_credentials, kimi::fetch),
         ("MiniMax", minimax::has_credentials, minimax::fetch),
+        ("Warp/Oz", warp::has_credentials, warp::fetch),
     ];
 
     let active: Vec<_> = providers.into_iter().filter(|(_, has, _)| has()).collect();

--- a/crates/tokscale-cli/src/commands/usage/warp.rs
+++ b/crates/tokscale-cli/src/commands/usage/warp.rs
@@ -1,0 +1,51 @@
+use super::{UsageMetric, UsageOutput};
+use anyhow::Result;
+
+pub fn has_credentials() -> bool {
+    crate::warp::load_usage_cache().is_some()
+}
+
+pub fn fetch() -> Result<UsageOutput> {
+    let cache = crate::warp::load_usage_cache()
+        .ok_or_else(|| anyhow::anyhow!("Warp aggregate usage cache not found"))?;
+    let mut metrics = Vec::new();
+
+    if let Some(used) = cache.usage.requests_used {
+        let (used_percent, remaining_percent, remaining_label) =
+            if let Some(limit) = cache.usage.request_limit.filter(|limit| *limit > 0) {
+                let used_percent = (used as f64 / limit as f64 * 100.0).clamp(0.0, 100.0);
+                let remaining = limit.saturating_sub(used);
+                (
+                    used_percent,
+                    100.0 - used_percent,
+                    Some(format!("{remaining} requests left")),
+                )
+            } else {
+                (0.0, 0.0, Some(format!("{used} requests used")))
+            };
+        metrics.push(UsageMetric {
+            label: "Requests".to_string(),
+            used_percent,
+            remaining_percent,
+            remaining_label,
+            resets_at: cache.usage.next_refresh_time.clone(),
+        });
+    }
+
+    if let Some(spend_cents) = cache.usage.spend_cents {
+        metrics.push(UsageMetric {
+            label: "Spend".to_string(),
+            used_percent: 0.0,
+            remaining_percent: 0.0,
+            remaining_label: Some(format!("${:.2}", spend_cents as f64 / 100.0)),
+            resets_at: cache.usage.next_refresh_time.clone(),
+        });
+    }
+
+    Ok(UsageOutput {
+        provider: "Warp/Oz".to_string(),
+        plan: Some("Aggregate API cache".to_string()),
+        email: None,
+        metrics,
+    })
+}

--- a/crates/tokscale-cli/src/commands/wrapped.rs
+++ b/crates/tokscale-cli/src/commands/wrapped.rs
@@ -1452,6 +1452,7 @@ fn client_display_name(client: &str) -> Option<&'static str> {
         "goose" => Some("Goose"),
         "antigravity" => Some("Antigravity"),
         "zed" => Some("Zed Agent"),
+        "warp" => Some("Warp"),
         "synthetic" => Some("Synthetic"),
         _ => None,
     }

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -6,6 +6,7 @@ mod device;
 mod paths;
 mod trae;
 mod tui;
+mod warp;
 
 use crate::tui::client_ui;
 use anyhow::Result;
@@ -284,6 +285,11 @@ enum Commands {
         #[command(subcommand)]
         subcommand: TraeSubcommand,
     },
+    #[command(about = "Warp/Oz aggregate usage integration commands")]
+    Warp {
+        #[command(subcommand)]
+        subcommand: WarpSubcommand,
+    },
     #[command(about = "Delete all submitted usage data from the server")]
     DeleteSubmittedData,
     #[command(
@@ -379,6 +385,35 @@ enum TraeSubcommand {
         since: Option<i64>,
         #[arg(long, help = "Include auxiliary usage types (not just main chat)")]
         include_aux: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum WarpSubcommand {
+    #[command(about = "Save Warp GraphQL authentication for aggregate usage sync")]
+    Login {
+        #[arg(long, help = "Warp bearer token or cookie header value")]
+        token: Option<String>,
+        #[arg(
+            long,
+            help = "Treat token as a Cookie header instead of a bearer token"
+        )]
+        cookie: bool,
+    },
+    #[command(about = "Remove cached Warp credentials")]
+    Logout {
+        #[arg(long, help = "Also delete cached Warp aggregate usage")]
+        purge_cache: bool,
+    },
+    #[command(about = "Show Warp aggregate sync status")]
+    Status {
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
+    },
+    #[command(about = "Sync Warp aggregate usage into local cache")]
+    Sync {
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
     },
 }
 
@@ -671,6 +706,10 @@ fn main() -> Result<()> {
             reject_unsupported_home_override(&cli.home, "trae")?;
             run_trae_command(subcommand)
         }
+        Some(Commands::Warp { subcommand }) => {
+            reject_unsupported_home_override(&cli.home, "warp")?;
+            run_warp_command(subcommand)
+        }
         Some(Commands::DeleteSubmittedData) => {
             reject_unsupported_home_override(&cli.home, "delete-submitted-data")?;
             run_delete_data_command()
@@ -804,6 +843,7 @@ pub enum ClientFilter {
     Kiro,
     #[value(name = "trae")]
     Trae,
+    Warp,
     Synthetic,
 }
 
@@ -837,6 +877,7 @@ impl ClientFilter {
             Self::Zed => "zed",
             Self::Kiro => "kiro",
             Self::Trae => "trae",
+            Self::Warp => "warp",
             Self::Synthetic => "synthetic",
         }
     }
@@ -873,6 +914,7 @@ impl ClientFilter {
             Self::Zed => Some(ClientId::Zed),
             Self::Kiro => Some(ClientId::Kiro),
             Self::Trae => Some(ClientId::Trae),
+            Self::Warp => Some(ClientId::Warp),
             Self::Synthetic => None,
         }
     }
@@ -906,6 +948,7 @@ impl ClientFilter {
             ClientId::Zed => Self::Zed,
             ClientId::Kiro => Self::Kiro,
             ClientId::Trae => Self::Trae,
+            ClientId::Warp => Self::Warp,
         }
     }
 
@@ -1007,6 +1050,8 @@ pub struct ClientFlags {
     #[arg(long, hide = true)]
     pub trae: bool,
     #[arg(long, hide = true)]
+    pub warp: bool,
+    #[arg(long, hide = true)]
     pub synthetic: bool,
 }
 
@@ -1060,7 +1105,7 @@ fn build_client_filter_with_defaults(
         }
     }
 
-    let legacy: [(bool, ClientFilter); 25] = [
+    let legacy: [(bool, ClientFilter); 26] = [
         (flags.opencode, ClientFilter::Opencode),
         (flags.claude, ClientFilter::Claude),
         (flags.codex, ClientFilter::Codex),
@@ -1085,6 +1130,7 @@ fn build_client_filter_with_defaults(
         (flags.zed, ClientFilter::Zed),
         (flags.kiro, ClientFilter::Kiro),
         (flags.trae, ClientFilter::Trae),
+        (flags.warp, ClientFilter::Warp),
         (flags.synthetic, ClientFilter::Synthetic),
     ];
 
@@ -1152,6 +1198,12 @@ fn client_filter_explicitly_requests_cursor(clients: &Option<Vec<String>>) -> bo
     clients
         .as_ref()
         .is_some_and(|sources| sources.iter().any(|source| source == "cursor"))
+}
+
+fn client_filter_explicitly_requests_warp(clients: &Option<Vec<String>>) -> bool {
+    clients
+        .as_ref()
+        .is_some_and(|sources| sources.iter().any(|source| source == "warp"))
 }
 
 #[derive(Debug)]
@@ -1236,6 +1288,65 @@ fn emit_cursor_setup_warnings(warnings: &[String]) {
     }
 }
 
+fn warp_setup_warnings_for_report(
+    home_dir: &Option<String>,
+    clients: &Option<Vec<String>>,
+) -> Vec<String> {
+    if !client_filter_explicitly_requests_warp(clients) {
+        return Vec::new();
+    }
+
+    let (home_path, home_override) = match home_dir {
+        Some(home) => (PathBuf::from(home), true),
+        None => match dirs::home_dir() {
+            Some(home) => (home, false),
+            None => {
+                return vec![
+                    "Warp usage requires Tokscale's Warp aggregate cache, but the home directory could not be resolved. Tokscale does not parse local Warp transcripts.".to_string(),
+                ];
+            }
+        },
+    };
+    let has_cache = if home_override {
+        warp::has_usage_cache_in_home(&home_path)
+    } else {
+        warp::load_usage_cache().is_some()
+    };
+    if has_cache {
+        return Vec::new();
+    }
+
+    let cache_glob = if home_override {
+        home_path
+            .join(".config/tokscale/warp-cache/usage*.json")
+            .to_string_lossy()
+            .to_string()
+    } else {
+        "~/.config/tokscale/warp-cache/usage*.json".to_string()
+    };
+    let action = if home_override {
+        "run `tokscale warp sync` for the default profile or populate that cache before running a report with --home"
+    } else if warp::has_credentials() {
+        "run `tokscale warp sync`"
+    } else {
+        "run `tokscale warp login` and `tokscale warp sync`"
+    };
+
+    vec![format!(
+        "Warp usage requires Tokscale's aggregate API cache at `{}`; {}. Tokscale does not parse local Warp/Oz session transcripts and does not infer tokens from request counts.",
+        cache_glob, action
+    )]
+}
+
+fn setup_warnings_for_report(
+    home_dir: &Option<String>,
+    clients: &Option<Vec<String>>,
+) -> Vec<String> {
+    let mut warnings = cursor_setup_warnings_for_report(home_dir, clients);
+    warnings.extend(warp_setup_warnings_for_report(home_dir, clients));
+    warnings
+}
+
 fn should_auto_sync_cursor_for_local_report(
     home_dir: &Option<String>,
     clients: &Option<Vec<String>>,
@@ -1295,7 +1406,7 @@ fn auto_sync_cursor_before_tui(
         had_cursor_cache,
         explicit_cursor_filter,
     );
-    let cursor_setup_warnings = cursor_setup_warnings_for_report(home_dir, clients);
+    let cursor_setup_warnings = setup_warnings_for_report(home_dir, clients);
     emit_cursor_setup_warnings(&cursor_setup_warnings);
     Ok(())
 }
@@ -1619,7 +1730,7 @@ fn run_models_report(
         Some(LightSpinner::start("Scanning session data..."))
     };
     let cursor_sync_result = auto_sync_cursor_for_local_report(&home_dir, &clients);
-    let cursor_setup_warnings = cursor_setup_warnings_for_report(&home_dir, &clients);
+    let cursor_setup_warnings = setup_warnings_for_report(&home_dir, &clients);
     let use_env_roots = use_env_roots(&home_dir);
     let start = Instant::now();
     let rt = Runtime::new()?;
@@ -2391,7 +2502,7 @@ fn run_monthly_report(
         Some(LightSpinner::start("Scanning session data..."))
     };
     let cursor_sync_result = auto_sync_cursor_for_local_report(&home_dir, &clients);
-    let cursor_setup_warnings = cursor_setup_warnings_for_report(&home_dir, &clients);
+    let cursor_setup_warnings = setup_warnings_for_report(&home_dir, &clients);
     let use_env_roots = use_env_roots(&home_dir);
     let start = Instant::now();
     let rt = Runtime::new()?;
@@ -2690,7 +2801,7 @@ fn run_hourly_report(
         Some(LightSpinner::start("Scanning session data..."))
     };
     let cursor_sync_result = auto_sync_cursor_for_local_report(&home_dir, &clients);
-    let cursor_setup_warnings = cursor_setup_warnings_for_report(&home_dir, &clients);
+    let cursor_setup_warnings = setup_warnings_for_report(&home_dir, &clients);
     let use_env_roots = use_env_roots(&home_dir);
     let start = Instant::now();
     let rt = Runtime::new()?;
@@ -3382,6 +3493,7 @@ fn capitalize_client(client: &str) -> String {
         "openclaw" => "openclaw".to_string(),
         "hermes" => "Hermes Agent".to_string(),
         "goose" => "Goose".to_string(),
+        "warp" => "Warp".to_string(),
         "pi" => "Pi".to_string(),
         other => other.to_string(),
     }
@@ -4326,7 +4438,7 @@ fn run_time_metrics_report(
         Some(LightSpinner::start("Computing time metrics..."))
     };
     let cursor_sync_result = auto_sync_cursor_for_local_report(&home_dir, &clients);
-    let cursor_setup_warnings = cursor_setup_warnings_for_report(&home_dir, &clients);
+    let cursor_setup_warnings = setup_warnings_for_report(&home_dir, &clients);
     let use_env_roots = use_env_roots(&home_dir);
     let rt = Runtime::new()?;
     let report = rt
@@ -4442,7 +4554,7 @@ fn run_graph_command(
         let rt_sync = tokio::runtime::Runtime::new()?;
         cursor_sync_result = Some(rt_sync.block_on(async { cursor::sync_cursor_cache().await }));
     }
-    let cursor_setup_warnings = cursor_setup_warnings_for_report(&home_dir, &clients);
+    let cursor_setup_warnings = setup_warnings_for_report(&home_dir, &clients);
 
     if show_progress {
         eprintln!("  Scanning session data...");
@@ -4614,11 +4726,17 @@ fn is_legacy_tokenless_cursor_row(client: &tokscale_core::ClientContribution) ->
         && client_token_total(&client.tokens) == 0
 }
 
+fn is_aggregate_only_warp_row(client: &tokscale_core::ClientContribution) -> bool {
+    client.client == "warp"
+        && client.model_id == "aggregate-requests"
+        && client_token_total(&client.tokens) == 0
+}
+
 /// A row the server's "Cost submitted without tokens" sanity check would
 /// reject: real cost with every token bucket at zero, excluding the Cursor
 /// `premium-tool-call` carve-out above.
 fn is_tokenless_costed_row(client: &tokscale_core::ClientContribution) -> bool {
-    client.cost > 0.0
+    (is_aggregate_only_warp_row(client) || client.cost > 0.0)
         && client_token_total(&client.tokens) == 0
         && !is_legacy_tokenless_cursor_row(client)
 }
@@ -4628,13 +4746,10 @@ fn is_tokenless_costed_row(client: &tokscale_core::ClientContribution) -> bool {
 /// rejected wholesale.
 ///
 /// Cursor's usage export lists historical request/On-Demand charges (e.g.
-/// `auto`, `claude-3.5-sonnet`, `o3`) with empty token columns, which the
-/// parser turns into cost > 0 / tokens = 0 rows. The server rejects the entire
-/// submission when it sees any such row (see
-/// packages/frontend/src/lib/validation/submission.ts), permanently blocking
-/// users with that historical data. Rather than weaken the server check (which
-/// still guards against genuine parser regressions), we exclude the offending
-/// rows here and report them to the user.
+/// `auto`, `claude-3.5-sonnet`, `o3`) with empty token columns, and Warp/Oz
+/// only exposes aggregate request/spend counters. The server rejects cost with
+/// no tokens, and request counts must not be submitted as fabricated tokens, so
+/// we exclude the offending rows here and report them to the user.
 ///
 /// Excluded rows always carry zero tokens, so only cost/messages change; token
 /// totals, breakdowns, and intensities are untouched. Summary and year rollups
@@ -4696,7 +4811,7 @@ fn report_excluded_tokenless_rows(excluded: &[ExcludedTokenlessRow]) {
     println!(
         "{}",
         format!(
-            "  Excluded {} cost-only row(s) with no token data (Cursor historical billing):",
+            "  Excluded {} aggregate/cost-only row(s) with no token data:",
             excluded.len()
         )
         .yellow()
@@ -4772,6 +4887,7 @@ fn run_submit_command(
     println!("\n  {}\n", "Tokscale - Submit Usage Data".cyan());
 
     let explicit_cursor_filter = client_filter_explicitly_requests_cursor(&clients);
+    let explicit_warp_filter = client_filter_explicitly_requests_warp(&clients);
     let clients = clients.or_else(|| Some(default_submit_clients()));
 
     let include_cursor = clients
@@ -4797,8 +4913,8 @@ fn run_submit_command(
             }
         }
     }
-    if explicit_cursor_filter {
-        let cursor_setup_warnings = cursor_setup_warnings_for_report(&report_home, &clients);
+    if explicit_cursor_filter || explicit_warp_filter {
+        let cursor_setup_warnings = setup_warnings_for_report(&report_home, &clients);
         emit_cursor_setup_warnings(&cursor_setup_warnings);
     }
 
@@ -5339,6 +5455,15 @@ fn run_trae_command(subcommand: TraeSubcommand) -> Result<()> {
     }
 }
 
+fn run_warp_command(subcommand: WarpSubcommand) -> Result<()> {
+    match subcommand {
+        WarpSubcommand::Login { token, cookie } => warp::run_warp_login(token, cookie),
+        WarpSubcommand::Logout { purge_cache } => warp::run_warp_logout(purge_cache),
+        WarpSubcommand::Status { json } => warp::run_warp_status(json),
+        WarpSubcommand::Sync { json } => warp::run_warp_sync(json),
+    }
+}
+
 fn format_tokens_with_commas(n: i64) -> String {
     let s = n.to_string();
     let bytes = s.as_bytes();
@@ -5727,6 +5852,7 @@ mod tests {
             zed: true,
             kiro: true,
             trae: true,
+            warp: true,
             synthetic: true,
             ..ClientFlags::default()
         };
@@ -5761,6 +5887,7 @@ mod tests {
             "zed",
             "kiro",
             "trae",
+            "warp",
             "synthetic",
         ] {
             assert!(
@@ -6827,6 +6954,31 @@ mod tests {
     }
 
     #[test]
+    fn test_exclude_tokenless_cost_drops_warp_aggregate_requests() {
+        let mut graph = graph_result_with_contributions(vec![day_with_clients(
+            "2026-01-02",
+            0,
+            vec![client_contribution(
+                "warp",
+                "aggregate-requests",
+                "warp",
+                0,
+                12.34,
+                42,
+            )],
+        )]);
+
+        let excluded = exclude_tokenless_cost_contributions(&mut graph);
+
+        assert_eq!(excluded.len(), 1);
+        assert_eq!(excluded[0].client, "warp");
+        assert_eq!(excluded[0].model_id, "aggregate-requests");
+        assert!(graph.contributions[0].clients.is_empty());
+        assert_eq!(graph.summary.total_tokens, 0);
+        assert_eq!(graph.summary.total_cost, 0.0);
+    }
+
+    #[test]
     fn test_submit_payload_includes_device_when_provided() {
         let graph = graph_result_with_contributions(vec![daily_contribution(
             "2026-12-31",
@@ -7015,6 +7167,50 @@ mod tests {
     fn clap_accepts_cursor_sync_command() {
         assert!(Cli::try_parse_from(["tokscale", "cursor", "sync"]).is_ok());
         assert!(Cli::try_parse_from(["tokscale", "cursor", "sync", "--json"]).is_ok());
+    }
+
+    #[test]
+    fn clap_accepts_warp_status_and_sync_commands() {
+        assert!(Cli::try_parse_from(["tokscale", "warp", "status"]).is_ok());
+        assert!(Cli::try_parse_from(["tokscale", "warp", "status", "--json"]).is_ok());
+        assert!(Cli::try_parse_from(["tokscale", "warp", "sync"]).is_ok());
+        assert!(Cli::try_parse_from(["tokscale", "warp", "sync", "--json"]).is_ok());
+    }
+
+    #[test]
+    fn client_filter_round_trips_warp() {
+        assert_eq!(
+            ClientFilter::from_filter_str("warp"),
+            Some(ClientFilter::Warp)
+        );
+        assert_eq!(ClientFilter::Warp.as_filter_str(), "warp");
+        assert_eq!(
+            ClientFilter::Warp.to_client_id(),
+            Some(tokscale_core::ClientId::Warp)
+        );
+        assert_eq!(
+            ClientFilter::from_client_id(tokscale_core::ClientId::Warp),
+            ClientFilter::Warp
+        );
+    }
+
+    #[test]
+    fn default_submit_clients_excludes_warp_aggregate_source() {
+        let clients = default_submit_clients();
+        assert!(!clients.contains(&"warp".to_string()));
+    }
+
+    #[test]
+    fn warp_setup_warning_explains_missing_aggregate_cache() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let warnings = warp_setup_warnings_for_report(
+            &Some(temp.path().to_string_lossy().to_string()),
+            &Some(vec!["warp".to_string()]),
+        );
+
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("tokscale warp"));
+        assert!(warnings[0].contains("does not infer tokens from request counts"));
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/client_ui.rs
+++ b/crates/tokscale-cli/src/tui/client_ui.rs
@@ -102,6 +102,10 @@ pub const CLIENT_UI: [ClientUi; ClientId::COUNT] = [
         display_name: "Trae",
         hotkey: 'y',
     },
+    ClientUi {
+        display_name: "Warp",
+        hotkey: 'v',
+    },
 ];
 
 pub fn display_name(client: ClientId) -> &'static str {

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -1337,7 +1337,7 @@ mod tests {
     #[test]
     fn test_client_all() {
         let clients = ClientId::ALL;
-        assert_eq!(clients.len(), 24);
+        assert_eq!(clients.len(), 25);
         assert_eq!(clients[0], ClientId::OpenCode);
         assert_eq!(clients[1], ClientId::Claude);
         assert_eq!(clients[2], ClientId::Codex);
@@ -1362,6 +1362,7 @@ mod tests {
         assert_eq!(clients[21], ClientId::Zed);
         assert_eq!(clients[22], ClientId::Kiro);
         assert_eq!(clients[23], ClientId::Trae);
+        assert_eq!(clients[24], ClientId::Warp);
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -255,6 +255,7 @@ pub fn get_client_color(client: &str) -> Color {
         "codebuff" => Color::Rgb(124, 58, 237),    // #7C3AED Codebuff brand purple
         "antigravity" => Color::Rgb(99, 102, 241), // #6366F1 Antigravity indigo
         "zed" => Color::Rgb(8, 76, 207),           // #084CCF Zed blue
+        "warp" => Color::Rgb(1, 155, 150),         // #019B96 Warp teal
         _ => Color::Rgb(136, 136, 136),            // #888888
     }
 }

--- a/crates/tokscale-cli/src/warp.rs
+++ b/crates/tokscale-cli/src/warp.rs
@@ -1,0 +1,591 @@
+use anyhow::{Context, Result};
+use colored::Colorize;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+const WARP_GRAPHQL_ENDPOINT: &str = "https://app.warp.dev/graphql/v2";
+const WARP_HTTP_TIMEOUT: Duration = Duration::from_secs(8);
+
+const REQUEST_LIMIT_QUERY: &str = r#"query GetRequestLimitInfo { requestLimitInfo { requestLimit requestsUsedSinceLastRefresh nextRefreshTime bonusGrantsInfo { spendingInfo { currentMonthSpendCents currentMonthCreditsPurchased } } } }"#;
+const WORKSPACES_QUERY: &str = r#"query GetWorkspacesMetadataForUser { workspacesMetadataForUser { id name totalRequestsUsedSinceLastRefresh aiOverages { currentMonthlyRequestCostCents currentMonthlyRequestsUsed } usageInfo { requestsUsedSinceLastRefresh } members { userId usageInfo { requestsUsedSinceLastRefresh } } } }"#;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WarpCredentials {
+    auth_value: String,
+    auth_kind: WarpAuthKind,
+    created_at: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum WarpAuthKind {
+    Bearer,
+    Cookie,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct WarpAggregateUsage {
+    pub requests_used: Option<i64>,
+    pub request_limit: Option<i64>,
+    pub spend_cents: Option<i64>,
+    pub credits_purchased_cents: Option<i64>,
+    pub next_refresh_time: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct WarpWorkspaceUsage {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub requests_used: Option<i64>,
+    pub spend_cents: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WarpUsageCache {
+    pub version: i32,
+    pub synced_at: String,
+    pub usage: WarpAggregateUsage,
+    pub workspaces: Vec<WarpWorkspaceUsage>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WarpStatus {
+    cache_dir: String,
+    credentials_path: String,
+    usage_path: String,
+    has_credentials: bool,
+    has_cache: bool,
+    requests_used: Option<i64>,
+    request_limit: Option<i64>,
+    spend_cents: Option<i64>,
+    workspace_count: usize,
+    diagnostics: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SyncWarpResult {
+    synced: bool,
+    requests_used: Option<i64>,
+    spend_cents: Option<i64>,
+    workspace_count: usize,
+    error: Option<String>,
+}
+
+pub fn get_warp_cache_dir() -> PathBuf {
+    crate::paths::get_config_dir().join("warp-cache")
+}
+
+fn credentials_path() -> PathBuf {
+    get_warp_cache_dir().join("credentials.json")
+}
+
+fn usage_path() -> PathBuf {
+    get_warp_cache_dir().join("usage.json")
+}
+
+fn ensure_cache_dir() -> Result<()> {
+    let dir = get_warp_cache_dir();
+    if !dir.exists() {
+        fs::create_dir_all(&dir)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&dir, fs::Permissions::from_mode(0o700))?;
+        }
+    }
+    Ok(())
+}
+
+fn atomic_write_secret(path: &Path, data: &[u8]) -> Result<()> {
+    crate::commands::usage::helpers::atomic_write_secret(path, data)?;
+    Ok(())
+}
+
+fn save_credentials(creds: &WarpCredentials) -> Result<()> {
+    ensure_cache_dir()?;
+    let json = serde_json::to_vec_pretty(creds)?;
+    atomic_write_secret(&credentials_path(), &json)?;
+    Ok(())
+}
+
+fn load_credentials() -> Option<WarpCredentials> {
+    let content = fs::read_to_string(credentials_path()).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+pub fn has_credentials() -> bool {
+    load_credentials().is_some()
+}
+
+pub(crate) fn load_usage_cache() -> Option<WarpUsageCache> {
+    let content = fs::read_to_string(usage_path()).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+pub fn has_usage_cache_in_home(home_dir: &Path) -> bool {
+    home_dir
+        .join(".config/tokscale/warp-cache/usage.json")
+        .exists()
+}
+
+pub fn run_warp_login(token: Option<String>, cookie: bool) -> Result<()> {
+    println!("\n  {}\n", "Warp/Oz - Login".cyan());
+    let auth_value = match token {
+        Some(token) => token,
+        None => {
+            print!("  Enter Warp bearer token or Cookie header value: ");
+            std::io::stdout().flush()?;
+            rpassword::read_password().context("Failed to read Warp credential")?
+        }
+    };
+    let auth_value = auth_value.trim().to_string();
+    if auth_value.is_empty() {
+        anyhow::bail!("Warp credential must not be empty");
+    }
+
+    save_credentials(&WarpCredentials {
+        auth_value,
+        auth_kind: if cookie {
+            WarpAuthKind::Cookie
+        } else {
+            WarpAuthKind::Bearer
+        },
+        created_at: chrono::Utc::now().to_rfc3339(),
+    })?;
+
+    println!("{}", "  Warp credentials saved.".green());
+    println!(
+        "{}",
+        "  Run `tokscale warp sync` to cache aggregate requests and spend.".bright_black()
+    );
+    Ok(())
+}
+
+pub fn run_warp_logout(purge_cache: bool) -> Result<()> {
+    let creds = credentials_path();
+    if creds.exists() {
+        fs::remove_file(creds)?;
+    }
+    if purge_cache {
+        let usage = usage_path();
+        if usage.exists() {
+            fs::remove_file(usage)?;
+        }
+    }
+    println!("{}", "  Warp credentials removed.".green());
+    Ok(())
+}
+
+pub fn run_warp_status(json: bool) -> Result<()> {
+    let status = build_status();
+    if json {
+        println!("{}", serde_json::to_string_pretty(&status)?);
+        return Ok(());
+    }
+
+    println!("\n  {}", "Warp/Oz aggregate usage".cyan());
+    println!(
+        "  {} {}",
+        "Credentials:".bright_black(),
+        if status.has_credentials {
+            "found".green()
+        } else {
+            "missing".yellow()
+        }
+    );
+    println!(
+        "  {} {}",
+        "Cache:".bright_black(),
+        if status.has_cache {
+            status.usage_path.green()
+        } else {
+            status.usage_path.yellow()
+        }
+    );
+    if let Some(requests) = status.requests_used {
+        println!("  {} {}", "Requests:".bright_black(), requests);
+    }
+    if let Some(limit) = status.request_limit {
+        println!("  {} {}", "Request limit:".bright_black(), limit);
+    }
+    if let Some(cents) = status.spend_cents {
+        println!(
+            "  {} ${:.2}",
+            "Current spend:".bright_black(),
+            cents as f64 / 100.0
+        );
+    }
+    for diagnostic in status.diagnostics {
+        println!("{}", format!("  Warning: {diagnostic}").yellow());
+    }
+    println!();
+    Ok(())
+}
+
+pub fn run_warp_sync(json: bool) -> Result<()> {
+    let rt = tokio::runtime::Runtime::new()?;
+    let result = rt.block_on(sync_warp_cache());
+    if json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        return Ok(());
+    }
+
+    if result.synced {
+        println!(
+            "{}",
+            format!(
+                "  Warp: synced aggregate usage (requests={}, spend=${:.2}, workspaces={})",
+                result.requests_used.unwrap_or(0),
+                result.spend_cents.unwrap_or(0) as f64 / 100.0,
+                result.workspace_count
+            )
+            .green()
+        );
+    } else if let Some(error) = result.error {
+        eprintln!("{}", format!("  Warp sync failed: {error}").yellow());
+    }
+    Ok(())
+}
+
+async fn sync_warp_cache() -> SyncWarpResult {
+    let credentials = match load_credentials() {
+        Some(credentials) => credentials,
+        None => {
+            return SyncWarpResult {
+                synced: false,
+                requests_used: None,
+                spend_cents: None,
+                workspace_count: 0,
+                error: Some(
+                    "Not authenticated. Run `tokscale warp login`, then `tokscale warp sync`."
+                        .to_string(),
+                ),
+            };
+        }
+    };
+
+    match fetch_warp_usage(&credentials).await {
+        Ok(cache) => {
+            if let Err(error) = write_usage_cache(&cache) {
+                return SyncWarpResult {
+                    synced: false,
+                    requests_used: cache.usage.requests_used,
+                    spend_cents: cache.usage.spend_cents,
+                    workspace_count: cache.workspaces.len(),
+                    error: Some(format!("Failed to write Warp cache: {error}")),
+                };
+            }
+            SyncWarpResult {
+                synced: true,
+                requests_used: cache.usage.requests_used,
+                spend_cents: cache.usage.spend_cents,
+                workspace_count: cache.workspaces.len(),
+                error: None,
+            }
+        }
+        Err(error) => SyncWarpResult {
+            synced: false,
+            requests_used: None,
+            spend_cents: None,
+            workspace_count: 0,
+            error: Some(error.to_string()),
+        },
+    }
+}
+
+async fn fetch_warp_usage(credentials: &WarpCredentials) -> Result<WarpUsageCache> {
+    let client = reqwest::Client::builder()
+        .timeout(WARP_HTTP_TIMEOUT)
+        .build()
+        .context("Failed to build Warp HTTP client")?;
+    let responses = vec![
+        send_graphql(
+            &client,
+            credentials,
+            "GetRequestLimitInfo",
+            REQUEST_LIMIT_QUERY,
+        )
+        .await?,
+        send_graphql(
+            &client,
+            credentials,
+            "GetWorkspacesMetadataForUser",
+            WORKSPACES_QUERY,
+        )
+        .await?,
+    ];
+    normalize_graphql_usage(&responses)
+}
+
+async fn send_graphql(
+    client: &reqwest::Client,
+    credentials: &WarpCredentials,
+    operation_name: &str,
+    query: &str,
+) -> Result<Value> {
+    let mut request = client
+        .post(WARP_GRAPHQL_ENDPOINT)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .json(&serde_json::json!({
+            "operationName": operation_name,
+            "query": query,
+            "variables": {}
+        }));
+    request = match credentials.auth_kind {
+        WarpAuthKind::Bearer => request.bearer_auth(&credentials.auth_value),
+        WarpAuthKind::Cookie => request.header("Cookie", &credentials.auth_value),
+    };
+
+    let response = request.send().await?;
+    if response.status() == reqwest::StatusCode::UNAUTHORIZED
+        || response.status() == reqwest::StatusCode::FORBIDDEN
+    {
+        anyhow::bail!(
+            "Warp authentication failed. Run `tokscale warp login` with a fresh credential."
+        );
+    }
+    if !response.status().is_success() {
+        anyhow::bail!("Warp GraphQL API returned status {}", response.status());
+    }
+    Ok(response.json().await?)
+}
+
+fn write_usage_cache(cache: &WarpUsageCache) -> Result<()> {
+    ensure_cache_dir()?;
+    let json = serde_json::to_vec_pretty(cache)?;
+    atomic_write_secret(&usage_path(), &json)?;
+    Ok(())
+}
+
+fn build_status() -> WarpStatus {
+    let cache = load_usage_cache();
+    let has_credentials = has_credentials();
+    let has_cache = cache.is_some();
+    let cache_dir = get_warp_cache_dir();
+    let credentials_path = credentials_path();
+    let usage_path = usage_path();
+    let mut diagnostics = Vec::new();
+    if !has_credentials {
+        diagnostics.push("missing credentials; run `tokscale warp login`".to_string());
+    }
+    if !has_cache {
+        diagnostics.push("missing aggregate usage cache; run `tokscale warp sync`".to_string());
+    }
+
+    let usage = cache.as_ref().map(|cache| &cache.usage);
+    WarpStatus {
+        cache_dir: cache_dir.to_string_lossy().to_string(),
+        credentials_path: credentials_path.to_string_lossy().to_string(),
+        usage_path: usage_path.to_string_lossy().to_string(),
+        has_credentials,
+        has_cache,
+        requests_used: usage.and_then(|usage| usage.requests_used),
+        request_limit: usage.and_then(|usage| usage.request_limit),
+        spend_cents: usage.and_then(|usage| usage.spend_cents),
+        workspace_count: cache.map(|cache| cache.workspaces.len()).unwrap_or(0),
+        diagnostics,
+    }
+}
+
+fn normalize_graphql_usage(responses: &[Value]) -> Result<WarpUsageCache> {
+    let mut usage = WarpAggregateUsage::default();
+    let mut workspaces = Vec::new();
+
+    for response in responses {
+        usage.requests_used = usage.requests_used.or_else(|| {
+            find_i64_by_keys(
+                response,
+                &[
+                    "requestsUsedSinceLastRefresh",
+                    "totalRequestsUsedSinceLastRefresh",
+                    "currentMonthlyRequestsUsed",
+                ],
+            )
+        });
+        usage.request_limit = usage
+            .request_limit
+            .or_else(|| find_i64_by_keys(response, &["requestLimit"]));
+        usage.spend_cents = usage.spend_cents.or_else(|| {
+            find_i64_by_keys(
+                response,
+                &["currentMonthSpendCents", "currentMonthlyRequestCostCents"],
+            )
+        });
+        usage.credits_purchased_cents = usage
+            .credits_purchased_cents
+            .or_else(|| find_i64_by_keys(response, &["currentMonthCreditsPurchased"]));
+        usage.next_refresh_time = usage
+            .next_refresh_time
+            .or_else(|| find_string_by_key(response, "nextRefreshTime"));
+        workspaces.extend(extract_workspace_usage(response));
+    }
+
+    if usage.requests_used.is_none() && usage.spend_cents.is_none() && workspaces.is_empty() {
+        anyhow::bail!("Warp GraphQL response did not contain aggregate usage fields");
+    }
+
+    Ok(WarpUsageCache {
+        version: 1,
+        synced_at: chrono::Utc::now().to_rfc3339(),
+        usage,
+        workspaces,
+    })
+}
+
+fn extract_workspace_usage(value: &Value) -> Vec<WarpWorkspaceUsage> {
+    let mut out = Vec::new();
+    collect_workspace_usage(value, &mut out);
+    out
+}
+
+fn collect_workspace_usage(value: &Value, out: &mut Vec<WarpWorkspaceUsage>) {
+    match value {
+        Value::Object(map) => {
+            let looks_like_workspace = map.contains_key("aiOverages")
+                || map.contains_key("totalRequestsUsedSinceLastRefresh");
+            if looks_like_workspace {
+                let workspace = WarpWorkspaceUsage {
+                    id: map
+                        .get("id")
+                        .and_then(Value::as_str)
+                        .map(ToString::to_string),
+                    name: map
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .map(ToString::to_string),
+                    requests_used: find_i64_by_keys(
+                        value,
+                        &[
+                            "currentMonthlyRequestsUsed",
+                            "totalRequestsUsedSinceLastRefresh",
+                            "requestsUsedSinceLastRefresh",
+                        ],
+                    ),
+                    spend_cents: find_i64_by_keys(
+                        value,
+                        &["currentMonthlyRequestCostCents", "currentMonthSpendCents"],
+                    ),
+                };
+                if workspace.requests_used.is_some() || workspace.spend_cents.is_some() {
+                    out.push(workspace);
+                    return;
+                }
+            }
+            for child in map.values() {
+                collect_workspace_usage(child, out);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_workspace_usage(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn find_i64_by_keys(value: &Value, keys: &[&str]) -> Option<i64> {
+    match value {
+        Value::Object(map) => {
+            for key in keys {
+                if let Some(found) = map.get(*key).and_then(value_to_i64) {
+                    return Some(found.max(0));
+                }
+            }
+            for child in map.values() {
+                if let Some(found) = find_i64_by_keys(child, keys) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        Value::Array(items) => items.iter().find_map(|item| find_i64_by_keys(item, keys)),
+        _ => None,
+    }
+}
+
+fn find_string_by_key(value: &Value, key: &str) -> Option<String> {
+    match value {
+        Value::Object(map) => {
+            if let Some(found) = map.get(key).and_then(Value::as_str) {
+                return Some(found.to_string());
+            }
+            map.values()
+                .find_map(|child| find_string_by_key(child, key))
+        }
+        Value::Array(items) => items.iter().find_map(|item| find_string_by_key(item, key)),
+        _ => None,
+    }
+}
+
+fn value_to_i64(value: &Value) -> Option<i64> {
+    value
+        .as_i64()
+        .or_else(|| value.as_u64().and_then(|number| i64::try_from(number).ok()))
+        .or_else(|| value.as_str().and_then(|text| text.parse::<i64>().ok()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_graphql_usage_extracts_request_limit_and_workspace_overage() {
+        let responses = vec![
+            serde_json::json!({
+                "data": {
+                    "requestLimitInfo": {
+                        "requestLimit": 100,
+                        "requestsUsedSinceLastRefresh": 42,
+                        "nextRefreshTime": "2026-06-01T00:00:00Z",
+                        "bonusGrantsInfo": {
+                            "spendingInfo": {
+                                "currentMonthSpendCents": 1234,
+                                "currentMonthCreditsPurchased": 500
+                            }
+                        }
+                    }
+                }
+            }),
+            serde_json::json!({
+                "data": {
+                    "workspacesMetadataForUser": [
+                        {
+                            "id": "workspace-1",
+                            "name": "Personal",
+                            "aiOverages": {
+                                "currentMonthlyRequestCostCents": 345,
+                                "currentMonthlyRequestsUsed": 12
+                            }
+                        }
+                    ]
+                }
+            }),
+        ];
+
+        let cache = normalize_graphql_usage(&responses).unwrap();
+
+        assert_eq!(cache.usage.requests_used, Some(42));
+        assert_eq!(cache.usage.request_limit, Some(100));
+        assert_eq!(cache.usage.spend_cents, Some(1234));
+        assert_eq!(cache.usage.credits_purchased_cents, Some(500));
+        assert_eq!(
+            cache.usage.next_refresh_time.as_deref(),
+            Some("2026-06-01T00:00:00Z")
+        );
+        assert_eq!(cache.workspaces.len(), 1);
+        assert_eq!(cache.workspaces[0].requests_used, Some(12));
+        assert_eq!(cache.workspaces[0].spend_cents, Some(345));
+    }
+}

--- a/crates/tokscale-cli/src/warp.rs
+++ b/crates/tokscale-cli/src/warp.rs
@@ -358,7 +358,29 @@ async fn send_graphql(
     if !response.status().is_success() {
         anyhow::bail!("Warp GraphQL API returned status {}", response.status());
     }
-    Ok(response.json().await?)
+    let value: Value = response.json().await?;
+    ensure_graphql_response_ok(&value)?;
+    Ok(value)
+}
+
+fn ensure_graphql_response_ok(response: &Value) -> Result<()> {
+    let Some(errors) = response.get("errors").and_then(Value::as_array) else {
+        return Ok(());
+    };
+    if errors.is_empty() {
+        return Ok(());
+    }
+
+    let message = errors
+        .iter()
+        .filter_map(|error| error.get("message").and_then(Value::as_str))
+        .take(3)
+        .collect::<Vec<_>>()
+        .join("; ");
+    if message.is_empty() {
+        anyhow::bail!("Warp GraphQL API returned errors");
+    }
+    anyhow::bail!("Warp GraphQL API returned errors: {message}");
 }
 
 fn write_usage_cache(cache: &WarpUsageCache) -> Result<()> {
@@ -539,6 +561,27 @@ fn value_to_i64(value: &Value) -> Option<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ensure_graphql_response_ok_rejects_semantic_errors() {
+        let response = serde_json::json!({
+            "data": {
+                "requestLimitInfo": null
+            },
+            "errors": [
+                { "message": "token expired" },
+                { "message": "workspace unavailable" }
+            ]
+        });
+
+        let err = ensure_graphql_response_ok(&response)
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("Warp GraphQL API returned errors"));
+        assert!(err.contains("token expired"));
+        assert!(err.contains("workspace unavailable"));
+    }
 
     #[test]
     fn normalize_graphql_usage_extracts_request_limit_and_workspace_overage() {

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -396,6 +396,15 @@ define_clients!(
         headless: false,
         parse_local: true,
         submit_default: false
+    },
+    Warp = 24 => {
+        id: "warp",
+        root: PathRoot::Config,
+        relative: "warp-cache",
+        pattern: "usage*.json",
+        headless: false,
+        parse_local: false,
+        submit_default: false
     }
 );
 
@@ -448,7 +457,7 @@ mod tests {
 
     #[test]
     fn test_client_id_count() {
-        assert_eq!(ClientId::COUNT, 24);
+        assert_eq!(ClientId::COUNT, 25);
     }
 
     #[test]
@@ -462,6 +471,15 @@ mod tests {
             let id = client.as_str();
             assert_eq!(ClientId::from_str(id), Some(client));
         }
+    }
+
+    #[test]
+    fn test_warp_client_registered_as_aggregate_cache_source() {
+        let client = ClientId::from_str("warp").expect("warp client should be registered");
+        assert_eq!(client.data().relative_path, "warp-cache");
+        assert_eq!(client.data().pattern, "usage*.json");
+        assert!(!client.data().parse_local);
+        assert!(!client.data().submit_default);
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1003,6 +1003,22 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         }
     }
 
+    let warp_outcomes: Vec<CachedParseOutcome> = scan_result
+        .get(ClientId::Warp)
+        .par_iter()
+        .map(|path| {
+            load_or_parse_source(path, &source_cache, pricing, |path| {
+                sessions::warp::parse_warp_file(path)
+            })
+        })
+        .collect();
+    for outcome in warp_outcomes {
+        all_messages.extend(outcome.messages);
+        if let Some(entry) = outcome.cache_entry {
+            source_cache.insert(entry);
+        }
+    }
+
     let amp_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::Amp)
         .par_iter()
@@ -2401,6 +2417,20 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     let trae_count = trae_msgs.len() as i32;
     counts.set(ClientId::Trae, trae_count);
     messages.extend(trae_msgs);
+
+    let warp_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::Warp)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::warp::parse_warp_file(path)
+                .into_iter()
+                .map(|msg| unified_to_parsed(&msg))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let warp_count = summed_parsed_message_count(&warp_msgs);
+    counts.set(ClientId::Warp, warp_count);
+    messages.extend(warp_msgs);
 
     if include_synthetic {
         if let Some(db_path) = &scan_result.synthetic_db {

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -27,6 +27,7 @@ pub mod roocode;
 pub mod synthetic;
 pub mod trae;
 pub(crate) mod utils;
+pub mod warp;
 pub mod zed;
 
 use crate::TokenBreakdown;
@@ -374,6 +375,72 @@ where
 mod tests {
     use super::*;
     use chrono::FixedOffset;
+
+    #[test]
+    fn warp_cache_parser_preserves_requests_and_spend_without_tokens() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            file.path(),
+            r#"{
+  "version": 1,
+  "syncedAt": "2026-05-29T12:00:00Z",
+  "usage": {
+    "requestsUsed": 42,
+    "requestLimit": 100,
+    "spendCents": 1234,
+    "nextRefreshTime": "2026-06-01T00:00:00Z"
+  },
+  "workspaces": [
+    {
+      "id": "workspace-1",
+      "name": "Personal",
+      "requestsUsed": 12,
+      "spendCents": 345
+    }
+  ]
+}"#,
+        )
+        .unwrap();
+
+        let messages = crate::sessions::warp::parse_warp_file(file.path());
+        assert_eq!(messages.len(), 1);
+
+        let workspace = messages
+            .iter()
+            .find(|message| message.session_id == "warp-aggregate-workspace-1")
+            .unwrap();
+        assert_eq!(workspace.client, "warp");
+        assert_eq!(workspace.model_id, "aggregate-requests");
+        assert_eq!(workspace.provider_id, "warp");
+        assert_eq!(workspace.workspace_label.as_deref(), Some("Personal"));
+        assert_eq!(workspace.message_count, 12);
+        assert_eq!(workspace.tokens, TokenBreakdown::default());
+        assert!((workspace.cost - 3.45).abs() < 1e-9);
+
+        std::fs::write(
+            file.path(),
+            r#"{
+  "version": 1,
+  "syncedAt": "2026-05-29T12:00:00Z",
+  "usage": {
+    "requestsUsed": 42,
+    "requestLimit": 100,
+    "spendCents": 1234,
+    "nextRefreshTime": "2026-06-01T00:00:00Z"
+  },
+  "workspaces": []
+}"#,
+        )
+        .unwrap();
+
+        let messages = crate::sessions::warp::parse_warp_file(file.path());
+        assert_eq!(messages.len(), 1);
+        let account = &messages[0];
+        assert_eq!(account.session_id, "warp-aggregate-account");
+        assert_eq!(account.message_count, 42);
+        assert_eq!(account.tokens, TokenBreakdown::default());
+        assert!((account.cost - 12.34).abs() < 1e-9);
+    }
 
     #[test]
     fn test_timestamp_to_date_with_positive_offset() {

--- a/crates/tokscale-core/src/sessions/warp.rs
+++ b/crates/tokscale-core/src/sessions/warp.rs
@@ -1,0 +1,153 @@
+use super::UnifiedMessage;
+use crate::TokenBreakdown;
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use std::path::Path;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WarpUsageCache {
+    synced_at: Option<String>,
+    usage: Option<WarpAggregateUsage>,
+    #[serde(default)]
+    workspaces: Vec<WarpWorkspaceUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WarpAggregateUsage {
+    requests_used: Option<i64>,
+    spend_cents: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WarpWorkspaceUsage {
+    id: Option<String>,
+    name: Option<String>,
+    requests_used: Option<i64>,
+    spend_cents: Option<i64>,
+}
+
+pub fn parse_warp_file(path: &Path) -> Vec<UnifiedMessage> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(_) => return Vec::new(),
+    };
+    let cache: WarpUsageCache = match serde_json::from_str(&content) {
+        Ok(cache) => cache,
+        Err(_) => return Vec::new(),
+    };
+    let timestamp = cache
+        .synced_at
+        .as_deref()
+        .and_then(parse_rfc3339_millis)
+        .unwrap_or(0);
+    if timestamp <= 0 {
+        return Vec::new();
+    }
+
+    let workspace_messages: Vec<UnifiedMessage> = cache
+        .workspaces
+        .iter()
+        .filter_map(|workspace| workspace_to_message(workspace, timestamp))
+        .collect();
+    if !workspace_messages.is_empty() {
+        return workspace_messages;
+    }
+
+    cache
+        .usage
+        .as_ref()
+        .and_then(|usage| usage_to_message(usage, timestamp))
+        .into_iter()
+        .collect()
+}
+
+fn usage_to_message(usage: &WarpAggregateUsage, timestamp: i64) -> Option<UnifiedMessage> {
+    let requests = non_negative_i32(usage.requests_used);
+    let spend_cents = non_negative_i64(usage.spend_cents);
+    if requests == 0 && spend_cents == 0 {
+        return None;
+    }
+
+    let mut message = UnifiedMessage::new(
+        "warp",
+        "aggregate-requests",
+        "warp",
+        "warp-aggregate-account",
+        timestamp,
+        TokenBreakdown::default(),
+        cents_to_dollars(spend_cents),
+    );
+    message.message_count = requests;
+    Some(message)
+}
+
+fn workspace_to_message(workspace: &WarpWorkspaceUsage, timestamp: i64) -> Option<UnifiedMessage> {
+    let requests = non_negative_i32(workspace.requests_used);
+    let spend_cents = non_negative_i64(workspace.spend_cents);
+    if requests == 0 && spend_cents == 0 {
+        return None;
+    }
+
+    let workspace_id = workspace
+        .id
+        .as_deref()
+        .map(sanitize_id)
+        .filter(|id| !id.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+    let mut message = UnifiedMessage::new(
+        "warp",
+        "aggregate-requests",
+        "warp",
+        format!("warp-aggregate-{workspace_id}"),
+        timestamp,
+        TokenBreakdown::default(),
+        cents_to_dollars(spend_cents),
+    );
+    message.message_count = requests;
+    message.set_workspace(
+        workspace.id.clone().filter(|id| !id.trim().is_empty()),
+        workspace
+            .name
+            .clone()
+            .filter(|name| !name.trim().is_empty()),
+    );
+    Some(message)
+}
+
+fn parse_rfc3339_millis(value: &str) -> Option<i64> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc).timestamp_millis())
+}
+
+fn non_negative_i64(value: Option<i64>) -> i64 {
+    value.unwrap_or(0).max(0)
+}
+
+fn non_negative_i32(value: Option<i64>) -> i32 {
+    non_negative_i64(value).min(i32::MAX as i64) as i32
+}
+
+fn cents_to_dollars(cents: i64) -> f64 {
+    cents as f64 / 100.0
+}
+
+fn sanitize_id(value: &str) -> String {
+    value
+        .trim()
+        .to_lowercase()
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '.' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string()
+}


### PR DESCRIPTION
## Summary
* Add a `warp` client backed by a local `~/.config/tokscale/warp-cache/usage.json` cache populated through `tokscale warp sync`.
* Add `tokscale warp login`, `status`, `sync`, and `logout` commands for authenticated Warp/Oz aggregate usage sync.
* Parse Warp/Oz as an aggregate-only source: request counts stay as message counts, vendor-reported spend stays as cost, and token buckets remain zero instead of being inferred.
* Exclude Warp/Oz aggregate rows from default `submit` data so token leaderboards are not populated with fabricated token totals.

Closes #571.
Closes #497.
Related #105.

## Why
Warp/Oz does not appear to expose local per-message token transcripts, but the desktop app does expose current-period aggregate request and spend counters through authenticated GraphQL calls. This PR adds a narrow integration that makes that available in local Tokscale reports without pretending that request counters are token counts.

## Diff scope
* Registers `warp` in the core client registry as a non-default aggregate cache source.
* Adds a Warp/Oz cache parser that preserves account/workspace request counts, spend, timestamps, and workspace labels.
* Adds CLI auth/cache/sync/status commands for Warp/Oz.
* Wires Warp/Oz into client filters, setup diagnostics, subscription usage output, wrapped display names, TUI client metadata, and README source documentation.
* Updates submit filtering so aggregate/cost-only Warp/Oz rows are reported locally but not submitted as token-attributed usage.

## Validation
* `rustup run stable cargo test -p tokscale-core warp -- --nocapture`: PASS.
* `rustup run stable cargo test -p tokscale-cli warp -- --nocapture`: PASS.
* `rustup run stable cargo test -p tokscale-core clients::tests -- --nocapture`: PASS.
* `rustup run stable cargo test -p tokscale-cli client_filter -- --nocapture`: PASS.
* `rustup run stable cargo test -p tokscale-cli test_client_all -- --nocapture`: PASS.
* `rustup run stable cargo test -p tokscale-cli default_submit_clients_excludes_warp_aggregate_source -- --nocapture`: PASS.
* `rustup run stable cargo fmt --all -- --check`: PASS.
* `rustup run stable cargo clippy -p tokscale-core -p tokscale-cli --all-features -- -D warnings`: PASS.
* `git diff --check origin/main...HEAD`: PASS, no output.

## Runtime safety
* Warp/Oz sync is explicit and opt-in; normal report generation does not call the Warp GraphQL API automatically.
* Saved credentials and synced usage are written through the existing secret-write helper under Tokscale's config directory.
* Warp/Oz is excluded from default submit clients, and aggregate rows with zero token buckets are stripped before submit when explicitly selected.
* No invariant regression introduced.

## Rollback plan
Rollback: revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: users who synced Warp/Oz usage may keep local cache files under `~/.config/tokscale/warp-cache/`; removing the PR only stops Tokscale from reading them.

## Known residual risks
* The GraphQL query shape is based on observed Warp desktop traffic rather than an official public API contract, so future Warp backend changes may require a parser/query update.
* Warp/Oz still cannot provide per-message input/output/cache/reasoning token attribution because those transcripts are not available locally.
* Required GitHub Actions are pending until the PR is opened.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Warp/Oz aggregate usage sync via authenticated GraphQL and a local cache, exposing request and spend totals in reports without fabricating tokens. Warp data is excluded from default submit to keep token leaderboards accurate.

- New Features
  - Added `tokscale warp login|status|sync|logout` commands and a local cache at `~/.config/tokscale/warp-cache/usage.json`.
  - Parse Warp/Oz as aggregate-only: requests -> message count, spend -> cost, all token buckets stay zero.
  - Excluded Warp from default `submit`; tokenless aggregate rows are stripped if Warp is explicitly included.
  - Integrated into client filters, TUI (name/color/hotkey), usage metrics (Requests/Spend), and README docs.

- Bug Fixes
  - `tokscale warp sync` now rejects GraphQL responses that include `errors`, returning a clear auth/message error instead of writing a bad cache.

<sup>Written for commit fb0f93ffe86e49b96f202d326ab8c3322e9547d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

