### PR TITLE
fix(kimi): deduplicate repeated status updates

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -3388,6 +3388,83 @@ mod tests {
         assert!(messages[0].cost > 0.0);
     }
 
+    fn write_kimi_repeated_status_fixture(source_home: &std::path::Path) {
+        let session_dir = source_home.join(".kimi/sessions/group-1/session-1");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        std::fs::write(
+            session_dir.join("wire.jsonl"),
+            r#"{"type": "metadata", "protocol_version": "1.3"}
+{"timestamp": 1770983410.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 10, "output": 1, "input_cache_read": 0, "input_cache_creation": 0}, "message_id": "msg-progressive"}}}
+{"timestamp": 1770983420.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 20, "output": 2, "input_cache_read": 0, "input_cache_creation": 0}, "message_id": "msg-progressive"}}}
+{"timestamp": 1770983430.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 5, "output": 1, "input_cache_read": 0, "input_cache_creation": 0}, "message_id": "msg-distinct"}}}
+{"timestamp": 1770983440.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 7, "output": 1, "input_cache_read": 0, "input_cache_creation": 0}}}}
+{"timestamp": 1770983450.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 8, "output": 1, "input_cache_read": 0, "input_cache_creation": 0}}}}"#,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parse_all_messages_with_pricing_kimi_deduplicates_repeated_status_updates() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            write_kimi_repeated_status_fixture(source_home.path());
+
+            let messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["kimi".to_string()],
+                None,
+            );
+
+            assert_eq!(messages.len(), 4);
+            assert_eq!(messages.iter().map(|m| m.tokens.input).sum::<i64>(), 40);
+            assert_eq!(messages.iter().map(|m| m.tokens.output).sum::<i64>(), 5);
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parse_local_clients_kimi_deduplicates_repeated_status_updates() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            write_kimi_repeated_status_fixture(source_home.path());
+
+            let parsed = parse_local_clients(LocalParseOptions {
+                home_dir: Some(source_home.path().to_str().unwrap().to_string()),
+                use_env_roots: false,
+                clients: Some(vec!["kimi".to_string()]),
+                since: None,
+                until: None,
+                year: None,
+                scanner_settings: scanner::ScannerSettings::default(),
+            })
+            .unwrap();
+
+            assert_eq!(parsed.counts.get(ClientId::Kimi), 4);
+            assert_eq!(parsed.messages.len(), 4);
+            assert_eq!(parsed.messages.iter().map(|m| m.input).sum::<i64>(), 40);
+            assert_eq!(parsed.messages.iter().map(|m| m.output).sum::<i64>(), 5);
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
     #[test]
     #[serial_test::serial]
     fn test_source_cache_refreshes_stale_date_on_cache_hit() {

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -10,7 +10,7 @@ use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
-const CACHE_SCHEMA_VERSION: u32 = 14;
+const CACHE_SCHEMA_VERSION: u32 = 15;
 const CACHE_FILENAME: &str = "source-message-cache.bin";
 const CACHE_LOCK_FILENAME: &str = "source-message-cache.lock";
 const MAX_CACHE_FILE_BYTES: u64 = 256 * 1024 * 1024;

--- a/crates/tokscale-core/src/sessions/kimi.rs
+++ b/crates/tokscale-core/src/sessions/kimi.rs
@@ -7,6 +7,7 @@ use super::utils::file_modified_timestamp_ms;
 use super::UnifiedMessage;
 use crate::TokenBreakdown;
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 
@@ -92,6 +93,7 @@ pub fn parse_kimi_file(path: &Path) -> Vec<UnifiedMessage> {
 
     let reader = BufReader::new(file);
     let mut messages: Vec<UnifiedMessage> = Vec::new();
+    let mut keyed_indices: HashMap<String, usize> = HashMap::new();
 
     for line in reader.lines() {
         let line = match line {
@@ -153,7 +155,7 @@ pub fn parse_kimi_file(path: &Path) -> Vec<UnifiedMessage> {
 
         let dedup_key = payload.message_id;
 
-        messages.push(UnifiedMessage::new_with_dedup(
+        let message = UnifiedMessage::new_with_dedup(
             "kimi",
             model.clone(),
             DEFAULT_PROVIDER,
@@ -169,10 +171,47 @@ pub fn parse_kimi_file(path: &Path) -> Vec<UnifiedMessage> {
             },
             0.0,
             dedup_key,
-        ));
+        );
+        push_or_replace_status_update(&mut messages, &mut keyed_indices, message);
     }
 
     messages
+}
+
+fn should_replace_status_update(existing: &UnifiedMessage, candidate: &UnifiedMessage) -> bool {
+    let existing_total = existing.tokens.total();
+    let candidate_total = candidate.tokens.total();
+
+    candidate_total > existing_total
+        || (candidate_total == existing_total && candidate.timestamp >= existing.timestamp)
+}
+
+fn push_or_replace_status_update(
+    messages: &mut Vec<UnifiedMessage>,
+    keyed_indices: &mut HashMap<String, usize>,
+    message: UnifiedMessage,
+) {
+    let dedup_key = message
+        .dedup_key
+        .as_ref()
+        .filter(|key| !key.is_empty())
+        .cloned();
+
+    let Some(dedup_key) = dedup_key else {
+        messages.push(message);
+        return;
+    };
+
+    if let Some(index) = keyed_indices.get(&dedup_key).copied() {
+        if should_replace_status_update(&messages[index], &message) {
+            messages[index] = message;
+        }
+        return;
+    }
+
+    let index = messages.len();
+    messages.push(message);
+    keyed_indices.insert(dedup_key, index);
 }
 
 #[cfg(test)]
@@ -289,6 +328,41 @@ mod tests {
         assert_eq!(messages[0].tokens.output, 205);
         assert_eq!(messages[0].tokens.cache_read, 4864);
         assert_eq!(messages[0].tokens.cache_write, 0);
+    }
+
+    #[test]
+    fn test_parse_kimi_deduplicates_repeated_status_updates_by_message_id() {
+        let content = r#"{"type": "metadata", "protocol_version": "1.3"}
+{"timestamp": 1770983410.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 100, "output": 10, "input_cache_read": 0, "input_cache_creation": 0}, "message_id": "msg-progressive"}}}
+{"timestamp": 1770983420.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 120, "output": 30, "input_cache_read": 5, "input_cache_creation": 0}, "message_id": "msg-progressive"}}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_kimi_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].dedup_key.as_deref(), Some("msg-progressive"));
+        assert_eq!(messages[0].tokens.input, 120);
+        assert_eq!(messages[0].tokens.output, 30);
+        assert_eq!(messages[0].tokens.cache_read, 5);
+        assert_eq!(messages[0].timestamp, 1770983420000);
+    }
+
+    #[test]
+    fn test_parse_kimi_keeps_distinct_and_missing_message_ids_separate() {
+        let content = r#"{"type": "metadata", "protocol_version": "1.3"}
+{"timestamp": 1770983410.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 10, "output": 1, "input_cache_read": 0, "input_cache_creation": 0}, "message_id": "msg-1"}}}
+{"timestamp": 1770983420.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 20, "output": 2, "input_cache_read": 0, "input_cache_creation": 0}, "message_id": "msg-2"}}}
+{"timestamp": 1770983430.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 30, "output": 3, "input_cache_read": 0, "input_cache_creation": 0}}}}
+{"timestamp": 1770983440.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 40, "output": 4, "input_cache_read": 0, "input_cache_creation": 0}}}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_kimi_file(file.path());
+
+        assert_eq!(messages.len(), 4);
+        assert_eq!(messages[0].dedup_key.as_deref(), Some("msg-1"));
+        assert_eq!(messages[1].dedup_key.as_deref(), Some("msg-2"));
+        assert!(messages[2].dedup_key.is_none());
+        assert!(messages[3].dedup_key.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
* Deduplicate repeated Kimi `StatusUpdate` rows that carry the same non-empty `message_id`.
* Keep the most complete snapshot for each message by selecting the largest token total and using the later timestamp as the tie-breaker.
* Preserve distinct messages and status rows without a `message_id`, so unrelated or incomplete events are not collapsed accidentally.
* Bump the source-cache schema so previously cached duplicate Kimi rows are rebuilt with the corrected parser behavior.

Closes #229.

## Why
Kimi `wire.jsonl` logs can contain progressive or retry `StatusUpdate` events for the same completion. The previous parser emitted each update as a separate message, which inflated message counts, token totals, and downstream cost estimates. Deduplicating by `message_id` keeps the parser aligned with Kimi's event semantics while preserving rows that cannot be safely matched.

## Diff scope
* Updates `crates/tokscale-core/src/sessions/kimi.rs` to collapse repeated non-empty `message_id` snapshots.
* Adds focused parser tests for duplicate status updates, distinct IDs, and missing IDs.
* Adds priced parse and local parse regression coverage in `crates/tokscale-core/src/lib.rs`.
* Updates `CACHE_SCHEMA_VERSION` in `crates/tokscale-core/src/message_cache.rs` to invalidate stale cached Kimi parse results.

## Validation
* `cargo test -p tokscale-core kimi_deduplicates_repeated_status_updates -- --nocapture`: PASS.
* `cargo test -p tokscale-core test_parse_kimi_keeps_distinct_and_missing_message_ids_separate -- --nocapture`: PASS.
* `cargo test -p tokscale-core kimi -- --nocapture`: PASS.
* `cargo fmt --all --check`: PASS.
* `cargo clippy -p tokscale-core --all-features -- -D warnings`: PASS.
* `git diff --check origin/main...HEAD`: PASS, no output.

## Runtime safety
* Deduplication is scoped to Kimi status updates with a non-empty `message_id`.
* Rows without a stable ID remain separate because they cannot be safely matched.
* The cache schema bump prevents old duplicate parse results from being reused.
* No invariant regression introduced.

## Rollback plan
Rollback: revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: users may temporarily see old cached Kimi totals until this PR is merged and the bumped cache schema forces a reparse.

## Known residual risks
* If Kimi ever emits a smaller later snapshot for the same `message_id`, the parser keeps the larger token-total snapshot to avoid undercounting progressive updates.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates Kimi StatusUpdate rows by non-empty message_id to fix inflated message counts, token totals, and cost estimates. Keeps the most complete snapshot and refreshes old cached results via a cache schema bump.

- **Bug Fixes**
  - Collapse repeated `StatusUpdate` events with the same message_id; pick the highest token total, break ties by later timestamp.
  - Keep distinct message_ids and rows without a message_id separate.
  - Bump `CACHE_SCHEMA_VERSION` to rebuild stale Kimi parses; add focused parser tests and priced/local parse coverage. Closes #229.

<sup>Written for commit 5cc49224b6d1caf7d7e36f84319fa04a7d4e0a8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

