### PR TITLE
ci(workflows): make Rust lint read-only

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -35,14 +35,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
-        with:
-          # Check out the PR branch for same-repo PRs so we can push auto-fixes back
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || '' }}
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -61,33 +57,10 @@ jobs:
           key: lint-${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             lint-${{ runner.os }}-cargo-
-
-      - name: Auto-fix lint issues
-        id: autofix
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        run: |
-          # Apply machine-fixable clippy lints
-          cargo clippy --fix --workspace --all-features --allow-dirty --allow-staged 2>&1 || true
-          # Apply formatting
-          cargo fmt --all
-          # Check if anything changed
-          if ! git diff --quiet; then
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Commit auto-fixes
-        if: steps.autofix.outputs.has_changes == 'true'
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git add -A
-          git diff --staged --quiet || git commit -m "style: auto-fix lint issues"
-          git pull --rebase origin "${{ github.head_ref }}"
-          git push origin "HEAD:${{ github.head_ref }}"
-      - name: Run Clippy (strict)
-        run: cargo clippy --workspace --all-features -- -D warnings
       - name: Check formatting (strict)
         run: cargo fmt --all -- --check
+      - name: Run Clippy (strict)
+        run: cargo clippy --locked --workspace --all-features -- -D warnings
 
   coverage:
     name: Code Coverage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-cli"
-version = "2.1.3"
+version = "3.0.0"
 dependencies = [
  "ab_glyph",
  "aes",
@@ -3473,7 +3473,7 @@ dependencies = [
 
 [[package]]
 name = "tokscale-core"
-version = "2.1.3"
+version = "3.0.0"
 dependencies = [
  "bincode",
  "chrono",


### PR DESCRIPTION
## Summary
* Make the Rust lint job in `test_coverage.yml` read-only for pull requests.
* Replace workflow-side auto-fix, commit, rebase, and push behavior with explicit `cargo fmt --all -- --check` and `cargo clippy --locked --workspace --all-features -- -D warnings` checks.
* Sync the lockfile's internal Tokscale crate versions with the workspace version so `--locked` validation can run without mutating `Cargo.lock`.

## Why
PR CI should validate proposed code without rewriting contributor branches. The previous lint job had write permission and could push formatting fixes back to the PR head. This makes linting deterministic, easier to reason about, and safer for forks by turning formatting and clippy into normal read-only gates.

## Diff scope
* Updates `.github/workflows/test_coverage.yml` so the `lint` job uses `contents: read`.
* Removes checkout credentials, auto-format commit, rebase, and push steps from the lint path.
* Keeps the existing coverage job behavior unchanged.
* Updates `Cargo.lock` only for the workspace crate version metadata required by locked Rust validation.

## Validation
* `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "YAML OK"' .github/workflows/test_coverage.yml`: PASS.
* Ruby lint-job read-only invariant check: PASS.
* `bash scripts/check-version-coherence.sh`: PASS.
* `rustup run stable cargo fmt --all -- --check`: PASS.
* `rustup run stable cargo clippy --locked --workspace --all-features -- -D warnings`: PASS.
* `git diff --check origin/main...HEAD`: PASS, no output.

## CI safety
* The lint job no longer receives a write-scoped token.
* The lint job no longer checks out the PR head with write credentials.
* The lint job no longer commits, rebases, or pushes to contributor branches.
* The coverage job is intentionally unchanged because it still owns the existing coverage badge publishing behavior.

## Rollback plan
Rollback: revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: contributors will need to run formatting locally when the read-only format check fails.

## Known residual risks
* Required GitHub Actions are pending until the PR is opened.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Rust lint job read-only and deterministic for PRs. Replace auto-fix/push behavior with strict `cargo fmt --check` and `cargo clippy --locked` checks; sync lockfile crate versions to support locked validation.

- **Refactors**
  - Set lint workflow permission to `contents: read` and remove auto-fix/commit/rebase/push steps.
  - Run `cargo fmt --all -- --check` and `cargo clippy --locked --workspace --all-features -- -D warnings`.
  - Coverage job remains unchanged.

- **Dependencies**
  - Sync `tokscale-cli` and `tokscale-core` versions in `Cargo.lock` to `3.0.0` to match the workspace for `--locked` checks.

<sup>Written for commit 399a5a471f0b1b6033f2541a7e1b4fc871f3164f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

