### PR TITLE
fix(core): use local pricing fallback for hourly reports

### DIFF
--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -1457,6 +1457,43 @@ fn test_graph_offline_without_pricing_cache_still_succeeds() {
 }
 
 #[test]
+fn test_hourly_json_offline_without_pricing_cache_still_succeeds() {
+    let tmp = create_temp_fixture_dir_without_pricing_cache();
+    let output = offline_cmd_with_home(tmp.path())
+        .args(["hourly", "--json", "--opencode", "--no-spinner"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let entries = json["entries"].as_array().unwrap();
+    assert_eq!(entries.len(), 3);
+    assert_eq!(
+        entries
+            .iter()
+            .map(|entry| entry["input"].as_i64().unwrap())
+            .sum::<i64>(),
+        2400
+    );
+    assert_eq!(
+        entries
+            .iter()
+            .map(|entry| entry["output"].as_i64().unwrap())
+            .sum::<i64>(),
+        1000
+    );
+    let total_cost = json["totalCost"].as_f64().unwrap();
+    assert!(
+        (total_cost - 0.10).abs() < 1e-9,
+        "unexpected totalCost without pricing: {total_cost}"
+    );
+}
+
+#[test]
 fn test_models_json_offline_uses_stale_pricing_cache_when_available() {
     let tmp = create_temp_fixture_dir_without_pricing_cache();
     write_pricing_cache(tmp.path(), 1);
@@ -1519,6 +1556,45 @@ fn test_graph_offline_uses_stale_pricing_cache_when_available() {
 
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let total_cost = json["summary"]["totalCost"].as_f64().unwrap();
+    assert!(
+        (total_cost - 0.0209).abs() < 1e-9,
+        "unexpected totalCost: {total_cost}"
+    );
+}
+
+#[test]
+fn test_hourly_json_offline_uses_stale_pricing_cache_when_available() {
+    let tmp = create_temp_fixture_dir_without_pricing_cache();
+    write_pricing_cache(tmp.path(), 1);
+
+    let output = offline_cmd_with_home(tmp.path())
+        .args(["hourly", "--json", "--opencode", "--no-spinner"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let entries = json["entries"].as_array().unwrap();
+    assert_eq!(entries.len(), 3);
+    assert_eq!(
+        entries
+            .iter()
+            .map(|entry| entry["input"].as_i64().unwrap())
+            .sum::<i64>(),
+        2400
+    );
+    assert_eq!(
+        entries
+            .iter()
+            .map(|entry| entry["output"].as_i64().unwrap())
+            .sum::<i64>(),
+        1000
+    );
+    let total_cost = json["totalCost"].as_f64().unwrap();
     assert!(
         (total_cost - 0.0209).abs() < 1e-9,
         "unexpected totalCost: {total_cost}"

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1666,11 +1666,11 @@ pub async fn get_hourly_report(options: ReportOptions) -> Result<HourlyReport, S
         clients
     });
 
-    let pricing = pricing::PricingService::get_or_init().await?;
+    let pricing = load_pricing_for_local_parse().await;
     let all_messages = parse_all_messages_with_pricing_with_env_strategy(
         &home_dir,
         &clients,
-        Some(&pricing),
+        pricing.as_deref(),
         options.use_env_roots,
         &options.scanner_settings,
     );


### PR DESCRIPTION
## Summary
* Let hourly reports use the same local pricing fallback path as the other local parse/report flows.
* Keep hourly JSON output available when live LiteLLM/OpenRouter pricing fetches fail and no pricing cache exists.
* Reuse stale local pricing cache data for hourly reports when it is available.
* Add offline CLI regression coverage for both no-cache and stale-cache hourly scenarios.

## Why
Hourly reports should not fail just because the pricing services are temporarily unavailable. Other local parse paths already tolerate pricing fetch failures by falling back to cached or missing pricing data; this PR brings the hourly report path into that same behavior so users can still inspect local usage offline.

## Diff scope
* Updates `crates/tokscale-core/src/lib.rs` so `get_hourly_report` uses the local parse pricing loader instead of requiring strict live pricing initialization.
* Adds hourly offline regression tests in `crates/tokscale-cli/tests/cli_tests.rs`.
* Leaves the broader pricing resolver and non-hourly report behavior unchanged.

## Validation
* `cargo test -p tokscale-cli --test cli_tests test_hourly_json_offline_without_pricing_cache_still_succeeds -- --nocapture`: FAIL before the fix on strict LiteLLM/OpenRouter pricing fetch.
* `cargo test -p tokscale-cli --test cli_tests test_hourly_json_offline_uses_stale_pricing_cache_when_available -- --nocapture`: FAIL before the fix on strict LiteLLM/OpenRouter pricing fetch.
* `cargo test -p tokscale-cli --test cli_tests test_hourly_json_offline -- --nocapture`: PASS.
* `cargo test -p tokscale-cli --test cli_tests offline -- --nocapture`: PASS.
* `cargo fmt --all -- --check`: PASS.
* `git diff --check origin/main...HEAD`: PASS, no output.

## Runtime safety
* This change only relaxes pricing availability for local hourly reporting; it does not change token parsing or usage totals.
* When pricing cannot be loaded, hourly report generation continues with missing pricing rather than aborting.
* When stale pricing cache exists, hourly report generation uses it consistently with the other local parse flows.
* No invariant regression introduced.

## Rollback plan
Rollback: revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: reverting restores the previous strict hourly behavior where live pricing fetch failures can abort the report.

## Known residual risks
* If no live pricing and no stale pricing cache are available, cost fields may remain unavailable for models that require dynamic pricing data, but hourly usage output still renders.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes hourly reports use the same local pricing fallback as other local parse flows. Hourly JSON now works offline and during pricing outages, reusing stale cache when available.

- **Bug Fixes**
  - In `tokscale-core`, `get_hourly_report` now loads pricing via the local parse path and proceeds if pricing is missing.
  - Reuses stale local pricing cache for hourly costs; if none, usage renders and cost fields may be absent.
  - Adds offline hourly JSON tests in `tokscale-cli` for no-cache and stale-cache scenarios.
  - Non-hourly report behavior is unchanged.

<sup>Written for commit 607bd3de5890e63cec5d5795abfbf659cb38df52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

