### PR TITLE
fix(frontend): accept trae client submissions

### DIFF
--- a/packages/frontend/__tests__/lib/clientRegistry.test.ts
+++ b/packages/frontend/__tests__/lib/clientRegistry.test.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  SOURCE_COLORS,
+  SOURCE_DISPLAY_NAMES,
+  SOURCE_LOGOS,
+} from "../../src/lib/constants";
+import { validateSubmission } from "../../src/lib/validation/submission";
+
+const coreClientsPath = fileURLToPath(
+  new URL("../../../../crates/tokscale-core/src/clients.rs", import.meta.url)
+);
+
+function coreClientIds(): string[] {
+  const source = readFileSync(coreClientsPath, "utf8");
+  const registry = source.match(/define_clients!\(([\s\S]*?)\n\);/);
+  expect(registry).not.toBeNull();
+  return Array.from(registry![1].matchAll(/\bid:\s*"([^"]+)"/g), (match) => match[1]);
+}
+
+function payloadForClient(client: string) {
+  return {
+    meta: {
+      generatedAt: "2024-12-02T00:00:00.000Z",
+      version: "2.1.1",
+      dateRange: { start: "2024-12-01", end: "2024-12-01" },
+    },
+    summary: {
+      totalTokens: 1500,
+      totalCost: 1.5,
+      totalDays: 1,
+      activeDays: 1,
+      averagePerDay: 1.5,
+      maxCostInSingleDay: 1.5,
+      clients: [client],
+      models: ["claude-sonnet-4"],
+    },
+    years: [
+      {
+        year: "2024",
+        totalTokens: 1500,
+        totalCost: 1.5,
+        range: { start: "2024-12-01", end: "2024-12-01" },
+      },
+    ],
+    contributions: [
+      {
+        date: "2024-12-01",
+        totals: { tokens: 1500, cost: 1.5, messages: 5 },
+        intensity: 2,
+        tokenBreakdown: {
+          input: 1000,
+          output: 500,
+          cacheRead: 0,
+          cacheWrite: 0,
+          reasoning: 0,
+        },
+        clients: [
+          {
+            client,
+            modelId: "claude-sonnet-4",
+            tokens: {
+              input: 1000,
+              output: 500,
+              cacheRead: 0,
+              cacheWrite: 0,
+              reasoning: 0,
+            },
+            cost: 1.5,
+            messages: 5,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("frontend client registry", () => {
+  it("accepts trae submissions", () => {
+    const result = validateSubmission(payloadForClient("trae"));
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("accepts every core client id in submission validation", () => {
+    const rejected = coreClientIds().filter((client) => {
+      const result = validateSubmission(payloadForClient(client));
+      return !result.valid;
+    });
+
+    expect(rejected).toEqual([]);
+  });
+
+  it("has labels, logos, and colors for every core client id", () => {
+    const displayNames: Record<string, string> = SOURCE_DISPLAY_NAMES;
+    const logos: Record<string, string> = SOURCE_LOGOS;
+    const colors: Record<string, string> = SOURCE_COLORS;
+    const missing = coreClientIds().flatMap((client) => {
+      const fields = [];
+      if (!displayNames[client]) fields.push(`${client}:display`);
+      if (!logos[client]) fields.push(`${client}:logo`);
+      if (!colors[client]) fields.push(`${client}:color`);
+      return fields;
+    });
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/packages/frontend/src/lib/constants.ts
+++ b/packages/frontend/src/lib/constants.ts
@@ -1,3 +1,5 @@
+import type { ClientType } from "./types";
+
 // 2D Canvas
 export const BOX_WIDTH = 10;
 export const BOX_MARGIN = 2;
@@ -24,7 +26,7 @@ export const DAY_LABELS_SHORT = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
 export const MONTH_LABELS_SHORT = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
 // Source configuration
-export const SOURCE_DISPLAY_NAMES: Record<string, string> = {
+export const SOURCE_DISPLAY_NAMES: Record<ClientType, string> = {
   opencode: "OpenCode",
   claude: "Claude Code",
   codex: "Codex CLI",
@@ -48,12 +50,13 @@ export const SOURCE_DISPLAY_NAMES: Record<string, string> = {
   goose: "Goose",
   antigravity: "Antigravity",
   zed: "Zed Agent",
+  trae: "Trae",
   synthetic: "Synthetic",
 };
 
 // Client logos from GitHub CDN (public repo)
 const GITHUB_CDN_BASE = "https://raw.githubusercontent.com/junhoyeo/tokscale/main/.github/assets";
-export const SOURCE_LOGOS: Record<string, string> = {
+export const SOURCE_LOGOS: Record<ClientType, string> = {
   opencode: `${GITHUB_CDN_BASE}/client-opencode.png`,
   claude: `${GITHUB_CDN_BASE}/client-claude.jpg`,
   codex: `${GITHUB_CDN_BASE}/client-openai.jpg`,
@@ -77,10 +80,11 @@ export const SOURCE_LOGOS: Record<string, string> = {
   goose: `${GITHUB_CDN_BASE}/client-goose.png`,
   antigravity: `${GITHUB_CDN_BASE}/client-antigravity.png`,
   zed: `${GITHUB_CDN_BASE}/client-zed.webp`,
+  trae: `${GITHUB_CDN_BASE}/client-trae.png`,
   synthetic: `${GITHUB_CDN_BASE}/client-synthetic.png`,
 };
 
-export const SOURCE_COLORS: Record<string, string> = {
+export const SOURCE_COLORS: Record<ClientType, string> = {
   opencode: "#00A8E8",
   claude: "#f97316",
   codex: "#3b82f6",
@@ -104,10 +108,11 @@ export const SOURCE_COLORS: Record<string, string> = {
   goose: "#64B4DC",
   antigravity: "#6366F1",
   zed: "#084CCF",
+  trae: "#00BFA5",
   synthetic: "#4ADE80",
 };
 
-export const SOURCE_TEXT_COLORS: Record<string, string> = {
+export const SOURCE_TEXT_COLORS: Partial<Record<ClientType, string>> = {
   droid: "#FFFFFF",
 };
 

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -1,4 +1,32 @@
-export type ClientType = "opencode" | "claude" | "codex" | "copilot" | "gemini" | "cursor" | "amp" | "codebuff" | "droid" | "openclaw" | "hermes" | "pi" | "kimi" | "qwen" | "roocode" | "kilocode" | "kilo" | "mux" | "crush" | "goose" | "antigravity" | "kiro" | "zed" | "synthetic";
+export const SUPPORTED_CLIENT_TYPES = [
+  "opencode",
+  "claude",
+  "codex",
+  "copilot",
+  "gemini",
+  "cursor",
+  "amp",
+  "codebuff",
+  "droid",
+  "openclaw",
+  "hermes",
+  "pi",
+  "kimi",
+  "qwen",
+  "roocode",
+  "kilocode",
+  "kilo",
+  "mux",
+  "crush",
+  "goose",
+  "antigravity",
+  "kiro",
+  "zed",
+  "trae",
+  "synthetic",
+] as const;
+
+export type ClientType = typeof SUPPORTED_CLIENT_TYPES[number];
 
 export interface TokenBreakdown {
   input: number;

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -8,6 +8,7 @@
 
 import { createHash } from "node:crypto";
 import { z } from "zod";
+import { SUPPORTED_CLIENT_TYPES } from "../types";
 
 // ============================================================================
 // SCHEMAS
@@ -50,32 +51,7 @@ const ClientContributionProvenanceSchema = z.object({
   modelCount: NonNegativeIntegerSchema,
 });
 
-const SUPPORTED_SOURCES = [
-  "opencode",
-  "claude",
-  "codex",
-  "copilot",
-  "gemini",
-  "cursor",
-  "amp",
-  "codebuff",
-  "droid",
-  "openclaw",
-  "hermes",
-  "pi",
-  "kimi",
-  "qwen",
-  "roocode",
-  "kilo",
-  "mux",
-  "crush",
-  "goose",
-  "antigravity",
-  "kiro",
-  "zed",
-  "synthetic",
-] as const;
-const SourceSchema = z.enum(SUPPORTED_SOURCES);
+const SourceSchema = z.enum(SUPPORTED_CLIENT_TYPES);
 
 const ClientContributionSchema = z.object({
   client: SourceSchema,


### PR DESCRIPTION
## Summary
* Add `trae` to the frontend-supported client type list used by API submission validation.
* Add Trae display metadata so frontend views can render Trae usage consistently with other registered clients.
* Add a parity test that compares frontend validation/metadata coverage against the core Rust client registry.

## Why
The CLI/core already emits Trae usage, but the frontend validation and metadata layer did not include `trae`. That creates a real integration gap: valid Trae submissions can be rejected or rendered without matching client metadata. This PR keeps the frontend contract aligned with the source registry and adds a guard so newly registered core clients do not silently drift from frontend handling again.

## Diff scope
* Updates `packages/frontend/src/lib/types.ts` with a shared `SUPPORTED_CLIENT_TYPES` tuple that includes `trae`.
* Updates `packages/frontend/src/lib/validation/submission.ts` to validate clients from the shared tuple.
* Updates `packages/frontend/src/lib/constants.ts` with Trae display name, color, and logo metadata.
* Adds `packages/frontend/__tests__/lib/clientRegistry.test.ts` coverage for Trae acceptance and core/frontend registry parity.

## Validation
* `bun x vitest run __tests__/lib/clientRegistry.test.ts`: FAIL before the fix on missing `trae`, PASS after implementation.
* `bun x vitest run __tests__/lib/clientRegistry.test.ts __tests__/api/submit.test.ts`: PASS.
* `bun x eslint src/lib/types.ts src/lib/constants.ts src/lib/validation/submission.ts __tests__/lib/clientRegistry.test.ts`: PASS.
* `cargo test -p tokscale-core clients`: PASS.
* `bash scripts/check-version-coherence.sh`: PASS.
* `git diff --check origin/main...HEAD`: PASS, no output.

## Runtime safety
* The submission validator still rejects unsupported client IDs; this only adds an already-registered core client to the frontend allowlist.
* The new parity test checks validation and metadata coverage against `crates/tokscale-core/src/clients.rs`.
* No database, auth, or API shape changes are included.
* No invariant regression introduced.

## Rollback plan
Rollback: revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: reverting restores the previous behavior where frontend validation/metadata does not recognize Trae submissions.

## Known residual risks
* `bun x tsc --noEmit` is not used as local proof here because the current tree has an unrelated pre-existing `src/components/BlackholeHero.tsx` missing `hero-bg.png` import. The targeted Vitest and ESLint checks for this diff pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept `trae` client submissions in the frontend and render them with the correct name, color, and logo. This keeps the frontend in sync with the core client registry so valid Trae usage isn’t rejected.

- **Bug Fixes**
  - Added `trae` to `SUPPORTED_CLIENT_TYPES` and wired it into submission validation.
  - Added Trae metadata in `SOURCE_DISPLAY_NAMES`, `SOURCE_LOGOS`, and `SOURCE_COLORS`.
  - Added a parity test to ensure frontend validation/metadata matches `tokscale-core`’s client registry.

<sup>Written for commit 3298b16f5c87c9cfde04374f06355ec352a6c093. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

