### PR TITLE
fix(scanner): support zed extra scan paths

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1197,8 +1197,8 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         all_messages.extend(goose_messages);
     }
 
-    if let Some(db_path) = &scan_result.zed_db {
-        let outcome = load_or_parse_sqlite_source(db_path, &source_cache, pricing, |path| {
+    for db_path in scan_result.zed_db_paths() {
+        let outcome = load_or_parse_sqlite_source(&db_path, &source_cache, pricing, |path| {
             sessions::zed::parse_zed_sqlite(path)
         });
         all_messages.extend(outcome.messages);
@@ -2320,9 +2320,11 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
         messages.extend(goose_msgs);
     }
 
-    if let Some(db_path) = &scan_result.zed_db {
-        let zed_msgs: Vec<ParsedMessage> = sessions::zed::parse_zed_sqlite(db_path)
-            .into_iter()
+    let zed_db_paths = scan_result.zed_db_paths();
+    if !zed_db_paths.is_empty() {
+        let zed_msgs: Vec<ParsedMessage> = zed_db_paths
+            .iter()
+            .flat_map(|db_path| sessions::zed::parse_zed_sqlite(db_path))
             .map(|msg| unified_to_parsed(&msg))
             .collect();
         let count = summed_parsed_message_count(&zed_msgs);
@@ -2671,6 +2673,49 @@ mod tests {
         )
         .unwrap();
         conn
+    }
+
+    fn create_zed_sqlite_db(db_path: &std::path::Path) -> rusqlite::Connection {
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE threads (
+                id TEXT PRIMARY KEY,
+                summary TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                data_type TEXT NOT NULL,
+                data BLOB NOT NULL
+            );",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn insert_zed_thread(conn: &rusqlite::Connection, id: &str, model: &str) {
+        let payload = format!(
+            r#"{{
+                "version": "0.3.0",
+                "title": "Test thread",
+                "updated_at": "2026-05-01T12:30:00Z",
+                "request_token_usage": {{
+                    "turn-1": {{
+                        "input_tokens": 42,
+                        "output_tokens": 7,
+                        "cache_creation_input_tokens": 3,
+                        "cache_read_input_tokens": 5
+                    }}
+                }},
+                "model": {{
+                    "provider": "zed.dev",
+                    "model": "{model}"
+                }},
+                "imported": false
+            }}"#
+        );
+        conn.execute(
+            "INSERT INTO threads (id, summary, updated_at, data_type, data) VALUES (?1, ?2, ?3, ?4, ?5)",
+            rusqlite::params![id, "Test thread", "2026-05-01T12:30:00Z", "json", payload.as_bytes()],
+        )
+        .unwrap();
     }
 
     fn insert_hermes_session(
@@ -5774,6 +5819,124 @@ mod tests {
         assert_eq!(parsed_with_settings.messages[0].model_id, "claude-sonnet-4");
         assert_eq!(parsed_with_settings.messages[0].input, 100);
         assert_eq!(parsed_with_settings.messages[0].output, 25);
+    }
+
+    #[test]
+    fn test_parse_local_clients_honors_scanner_extra_scan_paths_for_zed_threads_db() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let windows_threads_dir = temp_dir.path().join("AppData/Local/Zed/threads");
+        std::fs::create_dir_all(&windows_threads_dir).unwrap();
+        let threads_db = windows_threads_dir.join("threads.db");
+        let conn = create_zed_sqlite_db(&threads_db);
+        insert_zed_thread(&conn, "zed-extra-thread", "claude-sonnet-4-5");
+        drop(conn);
+
+        let parsed_default = parse_local_clients(LocalParseOptions {
+            home_dir: Some(temp_dir.path().to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(vec!["zed".to_string()]),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner::ScannerSettings::default(),
+        })
+        .unwrap();
+        assert_eq!(parsed_default.counts.get(ClientId::Zed), 0);
+        assert!(parsed_default.messages.is_empty());
+
+        let mut extra_scan_paths = std::collections::BTreeMap::new();
+        extra_scan_paths.insert("zed".to_string(), vec![windows_threads_dir]);
+        let parsed_with_settings = parse_local_clients(LocalParseOptions {
+            home_dir: Some(temp_dir.path().to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(vec!["zed".to_string()]),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner::ScannerSettings {
+                extra_scan_paths,
+                ..Default::default()
+            },
+        })
+        .unwrap();
+
+        assert_eq!(parsed_with_settings.counts.get(ClientId::Zed), 1);
+        assert_eq!(parsed_with_settings.messages.len(), 1);
+        assert_eq!(parsed_with_settings.messages[0].client, "zed");
+        assert_eq!(
+            parsed_with_settings.messages[0].session_id,
+            "zed-extra-thread"
+        );
+        assert_eq!(
+            parsed_with_settings.messages[0].model_id,
+            "claude-sonnet-4-5"
+        );
+        assert_eq!(parsed_with_settings.messages[0].input, 42);
+        assert_eq!(parsed_with_settings.messages[0].output, 7);
+    }
+
+    #[test]
+    fn test_parse_local_clients_dedups_zed_threads_across_default_and_extra_dbs() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+
+        // Place threads.db at the default platform path so the scanner finds it
+        // as `zed_db` AND we also pass it via extraScanPaths.
+        let default_threads_dir = temp_dir.path().join(".local/share/zed/threads");
+        std::fs::create_dir_all(&default_threads_dir).unwrap();
+        let default_db = default_threads_dir.join("threads.db");
+        let conn = create_zed_sqlite_db(&default_db);
+        insert_zed_thread(&conn, "shared-zed-thread", "claude-sonnet-4-5");
+        drop(conn);
+
+        // Point extraScanPaths.zed at the same directory — dedup should prevent
+        // the thread from appearing twice.
+        let mut extra_scan_paths = std::collections::BTreeMap::new();
+        extra_scan_paths.insert("zed".to_string(), vec![default_threads_dir.clone()]);
+        let parsed = parse_local_clients(LocalParseOptions {
+            home_dir: Some(temp_dir.path().to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(vec!["zed".to_string()]),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner::ScannerSettings {
+                extra_scan_paths,
+                ..Default::default()
+            },
+        })
+        .unwrap();
+
+        // Should see exactly 1 message, not 2 (deduped by canonicalize).
+        assert_eq!(parsed.counts.get(ClientId::Zed), 1);
+        assert_eq!(parsed.messages.len(), 1);
+        assert_eq!(parsed.messages[0].session_id, "shared-zed-thread");
+    }
+
+    #[test]
+    fn test_parse_local_clients_zed_extra_scan_paths_nonexistent_dir_is_silent() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+
+        let mut extra_scan_paths = std::collections::BTreeMap::new();
+        extra_scan_paths.insert(
+            "zed".to_string(),
+            vec![temp_dir.path().join("does/not/exist")],
+        );
+        let parsed = parse_local_clients(LocalParseOptions {
+            home_dir: Some(temp_dir.path().to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(vec!["zed".to_string()]),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner::ScannerSettings {
+                extra_scan_paths,
+                ..Default::default()
+            },
+        })
+        .unwrap();
+
+        assert_eq!(parsed.counts.get(ClientId::Zed), 0);
+        assert!(parsed.messages.is_empty());
     }
 
     #[test]

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -164,6 +164,29 @@ impl ScanResult {
 
         paths
     }
+
+    /// Return every Zed threads SQLite database that should be parsed.
+    pub fn zed_db_paths(&self) -> Vec<PathBuf> {
+        let mut paths = Vec::new();
+        let mut seen: HashSet<PathBuf> = HashSet::new();
+
+        let mut push = |path: &Path| {
+            let key = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+            if seen.insert(key) {
+                paths.push(path.to_path_buf());
+            }
+        };
+
+        if let Some(path) = &self.zed_db {
+            push(path);
+        }
+
+        for path in self.get(ClientId::Zed) {
+            push(path);
+        }
+
+        paths
+    }
 }
 
 pub fn headless_roots_with_env_strategy(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
@@ -278,6 +301,7 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
                 "session-usage.json" => file_name == "session-usage.json",
                 "chat-messages.json" => file_name == "chat-messages.json",
                 "state.db" => file_name == "state.db",
+                "threads.db" => file_name == "threads.db",
                 _ => false,
             }
         })
@@ -500,11 +524,11 @@ fn supports_extra_dir_scanning(client_id: ClientId) -> bool {
     // Kilo CLI currently loads a single SQLite DB via `scan_result.kilo_db`
     // Roo/KiloCode require local + remote and server task roots, and Crush
     // discovers SQLite DBs via the project registry rather than scanned file
-    // paths. Hermes profile databases are named `state.db`, so they can use
-    // `extraScanPaths` once `scan_directory` knows that exact filename.
+    // paths. Hermes/Zed profile databases are named consistently enough for
+    // `scan_directory` to find them from user-provided roots.
     !matches!(
         client_id,
-        ClientId::Kilo | ClientId::Crush | ClientId::Goose | ClientId::Zed
+        ClientId::Kilo | ClientId::Crush | ClientId::Goose
     )
 }
 
@@ -1815,6 +1839,33 @@ mod tests {
 
         assert_eq!(result.hermes_db.as_ref(), Some(&default_db));
         assert_eq!(result.hermes_db_paths(), vec![default_db, profile_db]);
+    }
+
+    #[test]
+    fn test_scan_all_clients_with_scanner_settings_merges_zed_extra_threads_db() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+
+        let windows_threads_dir = home.join("AppData/Local/Zed/threads");
+        fs::create_dir_all(&windows_threads_dir).unwrap();
+        let threads_db = windows_threads_dir.join("threads.db");
+        File::create(&threads_db).unwrap();
+
+        let settings: ScannerSettings = serde_json::from_value(serde_json::json!({
+            "extraScanPaths": {
+                "zed": [windows_threads_dir]
+            }
+        }))
+        .unwrap();
+
+        let result = scan_all_clients_with_scanner_settings(
+            home.to_str().unwrap(),
+            &["zed".to_string()],
+            false,
+            &settings,
+        );
+
+        assert_eq!(result.zed_db_paths(), vec![threads_db]);
     }
 
     #[test]


### PR DESCRIPTION
## Context

I run `tokscale` inside WSL, while my Zed Agent usage database lives on the Windows side because Zed is installed and running on Windows. In that setup, the Zed thread database is typically under a Windows path such as `/mnt/c/Users/<user>/AppData/Local/Zed/threads/threads.db`, not under the Linux `$XDG_DATA_HOME/zed/threads/threads.db` path that `tokscale` scans by default.

I expected this to work by adding a Zed extra scan path in config:

```json
{
  "scanner": {
    "extraScanPaths": {
      "zed": ["/mnt/c/Users/<user>/AppData/Local/Zed/threads"]
    }
  }
}
```

Before this PR, that setting could be read from config, but it did not actually make Zed usage count in this WSL scenario.

## What Was Broken

Zed was still treated like a single default database source. The scanner did not include Zed in the clients that can use extra scan roots, and the parser path only consumed the default `scan_result.zed_db` field. As a result, a user-provided Windows Zed `threads.db` path could be configured but still never contribute to parsed usage.

## What Changed

- Allow Zed to use configured extra scan roots.
- Teach the extra scanner to recognize `threads.db`.
- Add `ScanResult::zed_db_paths()` so the default Zed DB and configured extra Zed DBs are exposed as one deduped list.
- Parse all deduped Zed thread DB paths instead of only the default platform path.
- Add regression coverage for parsing Zed usage from `scanner.extraScanPaths.zed`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p tokscale-core zed -- --nocapture`
- `cargo test -p tokscale-cli zed -- --nocapture`
- `cargo clippy --locked --workspace --all-features -- -D warnings`
