### PR TITLE
test(cli): isolate fixtures from inherited scan-path env vars

### DIFF
--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -335,7 +335,10 @@ fn cmd_with_home(tmp: &Path) -> Command {
         .env_remove("CODEX_HOME")
         .env_remove("COPILOT_OTEL_FILE_EXPORTER_PATH")
         .env_remove("GOOSE_PATH_ROOT")
-        .env_remove("CODEBUFF_DATA_DIR");
+        .env_remove("CODEBUFF_DATA_DIR")
+        .env_remove("GEMINI_CLI_HOME")
+        .env_remove("HERMES_HOME")
+        .env_remove("TOKSCALE_CONFIG_DIR");
     cmd
 }
 
@@ -368,7 +371,10 @@ fn offline_cmd_with_home(tmp: &Path) -> Command {
         .env_remove("CODEX_HOME")
         .env_remove("COPILOT_OTEL_FILE_EXPORTER_PATH")
         .env_remove("GOOSE_PATH_ROOT")
-        .env_remove("CODEBUFF_DATA_DIR");
+        .env_remove("CODEBUFF_DATA_DIR")
+        .env_remove("GEMINI_CLI_HOME")
+        .env_remove("HERMES_HOME")
+        .env_remove("TOKSCALE_CONFIG_DIR");
     cmd
 }
 

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -325,7 +325,17 @@ fn cmd_with_home(tmp: &Path) -> Command {
         .env("XDG_CONFIG_HOME", tmp.join(".config"))
         .env("XDG_DATA_HOME", tmp.join(".local/share"))
         .env("XDG_CACHE_HOME", tmp.join(".cache"))
-        .env("TOKSCALE_PRICING_CACHE_ONLY", "1");
+        .env("TOKSCALE_PRICING_CACHE_ONLY", "1")
+        // Clear scan-path overrides inherited from the dev's shell, otherwise a
+        // developer who exports e.g. TOKSCALE_EXTRA_DIRS=~/.codex/sessions (for
+        // codefuse mirror tracking) makes the scanner read real session data
+        // and breaks fixture-count assertions. Hermetic on CI either way.
+        .env_remove("TOKSCALE_EXTRA_DIRS")
+        .env_remove("TOKSCALE_HEADLESS_DIR")
+        .env_remove("CODEX_HOME")
+        .env_remove("COPILOT_OTEL_FILE_EXPORTER_PATH")
+        .env_remove("GOOSE_PATH_ROOT")
+        .env_remove("CODEBUFF_DATA_DIR");
     cmd
 }
 
@@ -351,7 +361,14 @@ fn offline_cmd_with_home(tmp: &Path) -> Command {
         .env("XDG_CACHE_HOME", tmp.join(".cache"))
         .env("HTTP_PROXY", "http://127.0.0.1:9")
         .env("HTTPS_PROXY", "http://127.0.0.1:9")
-        .env("ALL_PROXY", "http://127.0.0.1:9");
+        .env("ALL_PROXY", "http://127.0.0.1:9")
+        // Clear scan-path overrides (mirrors cmd_with_home)
+        .env_remove("TOKSCALE_EXTRA_DIRS")
+        .env_remove("TOKSCALE_HEADLESS_DIR")
+        .env_remove("CODEX_HOME")
+        .env_remove("COPILOT_OTEL_FILE_EXPORTER_PATH")
+        .env_remove("GOOSE_PATH_ROOT")
+        .env_remove("CODEBUFF_DATA_DIR");
     cmd
 }
 


### PR DESCRIPTION
## Problem

`cmd_with_home` sets `HOME` and the XDG dirs but leaves `TOKSCALE_EXTRA_DIRS`, `TOKSCALE_HEADLESS_DIR` and `CODEX_HOME` inherited from the developer's shell.

A contributor who uses tokscale to track their own usage — e.g. `export TOKSCALE_EXTRA_DIRS=...:~/.codex/sessions` — makes the codex scanner read **real** session data from inside the test fixtures. Fixture-count assertions then fail locally while passing on CI's clean env. Concretely:

```
test_models_group_by_workspace_model_surfaces_workspace_fields_for_codex
  left: 50   (real ~/.codex sessions leaked in)
 right: 1    (the lone fixture session)
```

Confirmed by toggling the var: with `TOKSCALE_EXTRA_DIRS` unset the test passes; with it set it fails — independent of any source change.

## Fix

Clear the three inherited scan-path overrides (`TOKSCALE_EXTRA_DIRS`, `TOKSCALE_HEADLESS_DIR`, `CODEX_HOME`) in `cmd_with_home` so tests are hermetic regardless of the dev's shell. Tests that need `CODEX_HOME` set it explicitly afterwards, so the removal is overridden where intended.

## Verification

- The previously-failing test now passes **with `TOKSCALE_EXTRA_DIRS` still exported** in the shell.
- Full `cargo test -p tokscale-cli` suite green (no regression in the `CODEX_HOME`-setting tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make CLI tests hermetic by clearing inherited scan-path and tool-home env vars in `cmd_with_home` and `offline_cmd_with_home`. Prevents real Codex session data and other artifacts from leaking into fixtures and fixes local count assertions.

- **Bug Fixes**
  - Remove these in both helpers: TOKSCALE_EXTRA_DIRS, TOKSCALE_HEADLESS_DIR, CODEX_HOME, COPILOT_OTEL_FILE_EXPORTER_PATH, GOOSE_PATH_ROOT, CODEBUFF_DATA_DIR, GEMINI_CLI_HOME, HERMES_HOME, TOKSCALE_CONFIG_DIR.
  - Tests that need CODEX_HOME set it explicitly; the previously failing fixture-count test now passes even with TOKSCALE_EXTRA_DIRS exported; full `cargo test -p tokscale-cli` remains green.

<sup>Written for commit 9a92278800b890a122f97e1c3f0bda1576ddc510. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

