### PR TITLE
fix(codex): skip replayed parent usage in fork logs

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -4133,6 +4133,68 @@ mod tests {
         .unwrap();
     }
 
+    fn write_codex_parent_replay_fixture(source_home: &std::path::Path) {
+        let codex_dir = source_home.join(".codex/sessions");
+        std::fs::create_dir_all(&codex_dir).unwrap();
+        std::fs::write(
+            codex_dir.join("parent.jsonl"),
+            concat!(
+                r#"{"timestamp":"2026-05-24T20:00:00Z","type":"session_meta","payload":{"id":"019e5b00-0000-7000-8000-000000000001","source":"vscode","model_provider":"openai","cwd":"/repo"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-05-24T20:00:01Z","type":"turn_context","payload":{"turn_id":"019e5b00-0001-7000-8000-000000000001","model":"gpt-5.5","cwd":"/repo"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-05-24T20:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"output_tokens":10,"total_tokens":110},"last_token_usage":{"input_tokens":100,"output_tokens":10,"total_tokens":110}}}}"#,
+                "\n",
+                r#"{"timestamp":"2026-05-24T20:00:03Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":130,"output_tokens":13,"total_tokens":143},"last_token_usage":{"input_tokens":30,"output_tokens":3,"total_tokens":33}}}}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+
+        for (filename, child_id, child_turn_id, timestamp) in [
+            (
+                "child-a.jsonl",
+                "019e5c03-1e99-7000-8000-000000000001",
+                "019e5c03-6425-7000-8000-000000000001",
+                "2026-05-24T21:00:00Z",
+            ),
+            (
+                "child-b.jsonl",
+                "019e5c04-1e99-7000-8000-000000000001",
+                "019e5c04-6425-7000-8000-000000000001",
+                "2026-05-24T22:00:00Z",
+            ),
+        ] {
+            std::fs::write(
+                codex_dir.join(filename),
+                format!(
+                    concat!(
+                        r#"{{"timestamp":"{timestamp}","type":"session_meta","payload":{{"id":"{child_id}","forked_from_id":"019e5b00-0000-7000-8000-000000000001","source":{{"subagent":{{"thread_spawn":{{"parent_thread_id":"019e5b00-0000-7000-8000-000000000001","depth":1}}}}}},"model_provider":"openai","agent_nickname":"worker","cwd":"/repo"}}}}"#,
+                        "\n",
+                        r#"{{"timestamp":"{timestamp}","type":"session_meta","payload":{{"id":"019e5b00-0000-7000-8000-000000000001","source":"vscode","model_provider":"openai","cwd":"/repo"}}}}"#,
+                        "\n",
+                        r#"{{"timestamp":"{timestamp}","type":"turn_context","payload":{{"turn_id":"019e5b00-0001-7000-8000-000000000001","model":"gpt-5.5","cwd":"/repo"}}}}"#,
+                        "\n",
+                        r#"{{"timestamp":"{timestamp}","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":100,"output_tokens":10,"total_tokens":110}},"last_token_usage":{{"input_tokens":100,"output_tokens":10,"total_tokens":110}}}}}}}}"#,
+                        "\n",
+                        r#"{{"timestamp":"{timestamp}","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":130,"output_tokens":13,"total_tokens":143}},"last_token_usage":{{"input_tokens":30,"output_tokens":3,"total_tokens":33}}}}}}}}"#,
+                        "\n",
+                        r#"{{"timestamp":"{timestamp}","type":"event_msg","payload":{{"type":"task_started","turn_id":"{child_turn_id}"}}}}"#,
+                        "\n",
+                        r#"{{"timestamp":"{timestamp}","type":"turn_context","payload":{{"turn_id":"{child_turn_id}","model":"gpt-5.5","cwd":"/repo"}}}}"#,
+                        "\n",
+                        r#"{{"timestamp":"{timestamp}","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":140,"output_tokens":14,"total_tokens":154}},"last_token_usage":{{"input_tokens":10,"output_tokens":1,"total_tokens":11}}}}}}}}"#,
+                        "\n",
+                    ),
+                    timestamp = timestamp,
+                    child_id = child_id,
+                    child_turn_id = child_turn_id,
+                ),
+            )
+            .unwrap();
+        }
+    }
+
     #[test]
     #[serial_test::serial]
     fn test_parse_all_messages_with_pricing_codex_deduplicates_forked_history() {
@@ -4180,12 +4242,40 @@ mod tests {
         }
     }
 
+    #[test]
+    #[serial_test::serial]
+    fn test_parse_all_messages_with_pricing_codex_deduplicates_parent_replay_across_forks() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            write_codex_parent_replay_fixture(source_home.path());
+
+            let messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["codex".to_string()],
+                None,
+            );
+
+            assert_eq!(messages.len(), 4);
+            assert_eq!(messages.iter().map(|m| m.tokens.input).sum::<i64>(), 150);
+            assert_eq!(messages.iter().map(|m| m.tokens.output).sum::<i64>(), 15);
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
     fn write_codex_twin_token_count_fixture(source_home: &std::path::Path) {
         // Single session with two turns whose `last_token_usage` deltas are
         // byte-identical but emitted at different timestamps. The fork-dedup
-        // key includes timestamp, so both turns must survive — collapsing
-        // them would erase legitimate usage when a user happens to send two
-        // turns producing the same per-turn delta.
+        // key includes the cumulative total, so both turns must survive even
+        // when a user happens to send two turns producing the same per-turn
+        // delta.
         let codex_dir = source_home.join(".codex/sessions");
         std::fs::create_dir_all(&codex_dir).unwrap();
         std::fs::write(

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -10,7 +10,7 @@ use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
-const CACHE_SCHEMA_VERSION: u32 = 16;
+const CACHE_SCHEMA_VERSION: u32 = 17;
 const CACHE_FILENAME: &str = "source-message-cache.bin";
 const CACHE_LOCK_FILENAME: &str = "source-message-cache.lock";
 const MAX_CACHE_FILE_BYTES: u64 = 256 * 1024 * 1024;

--- a/crates/tokscale-core/src/sessions/codex.rs
+++ b/crates/tokscale-core/src/sessions/codex.rs
@@ -32,6 +32,7 @@ pub struct CodexPayload {
     pub model_name: Option<String>,
     pub model_info: Option<CodexModelInfo>,
     pub info: Option<CodexInfo>,
+    pub turn_id: Option<String>,
     pub source: Option<Value>,
     /// Current working directory from session_meta.
     pub cwd: Option<String>,
@@ -171,6 +172,8 @@ pub(crate) struct CodexParseState {
     pub session_is_headless: bool,
     pub session_id_from_meta: Option<String>,
     pub session_forked_from_id: Option<String>,
+    pub forked_child_session_id: Option<String>,
+    pub forked_child_replay_session_id: Option<String>,
     pub session_provider: Option<String>,
     pub session_agent: Option<String>,
     pub session_workspace_key: Option<String>,
@@ -285,11 +288,33 @@ fn parse_codex_reader<R: BufRead>(
                 let event_model = payload_model.clone().or(info_model.clone());
 
                 if state.forked_child_waiting_for_turn_context {
-                    if entry.entry_type == "turn_context" {
+                    if entry.entry_type == "turn_context"
+                        && forked_child_turn_starts_own_session(&state, payload.turn_id.as_deref())
+                    {
                         state.forked_child_waiting_for_turn_context = false;
+                        state.forked_child_replay_session_id = None;
+                        if let Some(ref id) = state.forked_child_session_id {
+                            state.session_id_from_meta = Some(id.clone());
+                        }
                         state.current_model = payload_model.clone();
                         handled = true;
                     } else {
+                        if entry.entry_type == "session_meta" {
+                            if let Some(ref id) = payload.id {
+                                if state
+                                    .forked_child_session_id
+                                    .as_deref()
+                                    .is_some_and(|child_id| child_id != id)
+                                {
+                                    // Newer Codex fork logs can embed the
+                                    // parent session metadata before replaying
+                                    // parent token_count history. Keep
+                                    // skipping while that copied upstream
+                                    // transcript is active.
+                                    state.forked_child_replay_session_id = Some(id.clone());
+                                }
+                            }
+                        }
                         if is_token_count {
                             if let Some(info) = payload.info.as_ref() {
                                 remember_forked_child_inherited_baseline(&mut state, info);
@@ -326,7 +351,9 @@ fn parse_codex_reader<R: BufRead>(
                         .or_else(|| forked_from_id_from_source(payload.source.as_ref()));
                     if let Some(forked_from_id) = forked_from_id {
                         state.session_forked_from_id = Some(forked_from_id.to_string());
+                        state.forked_child_session_id = payload.id.clone();
                         state.forked_child_waiting_for_turn_context = true;
+                        state.forked_child_replay_session_id = None;
                         state.forked_child_inherited_baseline = None;
                         state.forked_child_inherited_reported_total = None;
                     }
@@ -504,10 +531,13 @@ fn parse_codex_reader<R: BufRead>(
                         message.is_turn_start = true;
                         state.pending_turn_start = false;
                     }
-                    if parsed_timestamp.is_some() {
-                        if let Some(model) = model.as_deref() {
-                            set_codex_dedup_key(&mut message, model);
-                        }
+                    if parsed_timestamp.is_some() || total_usage.is_some() {
+                        set_codex_dedup_key(
+                            &mut message,
+                            model.as_deref().unwrap_or("unknown"),
+                            state.session_id_from_meta.as_deref().unwrap_or(session_id),
+                            total_usage,
+                        );
                     }
                     message.set_workspace(
                         state.session_workspace_key.clone(),
@@ -618,6 +648,52 @@ fn forked_from_id_from_source(source: Option<&Value>) -> Option<&str> {
         .filter(|id| !id.is_empty())
 }
 
+fn forked_child_turn_starts_own_session(state: &CodexParseState, turn_id: Option<&str>) -> bool {
+    if state.forked_child_replay_session_id.is_none() {
+        return true;
+    }
+
+    let Some(child_session_id) = state.forked_child_session_id.as_deref() else {
+        return true;
+    };
+
+    match (turn_id, codex_uuid_v7_order_key(child_session_id)) {
+        (Some(turn_id), Some(child_key)) => {
+            codex_uuid_v7_order_key(turn_id).is_none_or(|turn_key| turn_key >= child_key)
+        }
+        _ => true,
+    }
+}
+
+fn codex_uuid_v7_order_key(id: &str) -> Option<String> {
+    let mut parts = id.split('-');
+    let first = parts.next()?;
+    let second = parts.next()?;
+    let third = parts.next()?;
+    let fourth = parts.next()?;
+    let fifth = parts.next()?;
+
+    if parts.next().is_some()
+        || first.len() != 8
+        || second.len() != 4
+        || third.len() != 4
+        || fourth.len() != 4
+        || fifth.len() != 12
+        || !third.starts_with('7')
+    {
+        return None;
+    }
+
+    let mut key = String::with_capacity(32);
+    for part in [first, second, third, fourth, fifth] {
+        if !part.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return None;
+        }
+        key.push_str(&part.to_ascii_lowercase());
+    }
+    Some(key)
+}
+
 fn parse_codex_entry_timestamp(timestamp: Option<&str>) -> Option<i64> {
     timestamp
         .and_then(|ts| chrono::DateTime::parse_from_rfc3339(ts).ok())
@@ -629,7 +705,29 @@ fn duration_between_ms(start_ms: Option<i64>, end_ms: Option<i64>) -> Option<i64
     (duration > 0).then_some(duration)
 }
 
-fn codex_token_count_dedup_key(message: &UnifiedMessage, model: &str) -> String {
+fn codex_token_count_dedup_key(
+    message: &UnifiedMessage,
+    model: &str,
+    upstream_session_id: &str,
+    total_usage: Option<CodexTotals>,
+) -> String {
+    if let Some(total) = total_usage {
+        // Codex fork/subagent logs can replay the same upstream token_count
+        // history into many child files with child-local timestamps. The
+        // cumulative total is the stable upstream identity; timestamp is only
+        // a fallback when older rows do not carry totals.
+        return format!(
+            "codex:token_count-total:{}:{}:{}:{}:{}:{}:{}",
+            upstream_session_id,
+            message.provider_id,
+            model,
+            total.input,
+            total.output,
+            total.cached,
+            total.reasoning
+        );
+    }
+
     format!(
         "codex:token_count:{}:{}:{}:{}:{}:{}:{}:{}",
         message.timestamp,
@@ -643,9 +741,19 @@ fn codex_token_count_dedup_key(message: &UnifiedMessage, model: &str) -> String 
     )
 }
 
-fn set_codex_dedup_key(message: &mut UnifiedMessage, model: &str) {
+fn set_codex_dedup_key(
+    message: &mut UnifiedMessage,
+    model: &str,
+    upstream_session_id: &str,
+    total_usage: Option<CodexTotals>,
+) {
     if message.dedup_key.is_none() {
-        message.dedup_key = Some(codex_token_count_dedup_key(message, model));
+        message.dedup_key = Some(codex_token_count_dedup_key(
+            message,
+            model,
+            upstream_session_id,
+            total_usage,
+        ));
     }
 }
 
@@ -657,7 +765,8 @@ fn flush_pending_model_messages(
 ) {
     for (mut message, used_fallback_timestamp) in pending_model_messages.drain(..) {
         if !used_fallback_timestamp {
-            set_codex_dedup_key(&mut message, model);
+            let upstream_session_id = message.session_id.clone();
+            set_codex_dedup_key(&mut message, model, &upstream_session_id, None);
         }
         message.model_id = model.to_string();
         messages.push(message);
@@ -1673,6 +1782,43 @@ mod tests {
         assert_eq!(messages[0].model_id, "gpt-5.5");
         assert_eq!(messages[0].tokens.input, 10);
         assert_eq!(messages[0].tokens.output, 2);
+    }
+
+    #[test]
+    fn test_forked_child_skips_nested_parent_replay_until_own_turn() {
+        let parent = create_test_file(concat!(
+            r#"{"timestamp":"2026-05-05T21:51:57.991Z","type":"session_meta","payload":{"id":"019e5b00-0000-7000-8000-000000000001","source":"vscode","model_provider":"openai","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:58.000Z","type":"turn_context","payload":{"turn_id":"019e5b00-0001-7000-8000-000000000001","model":"gpt-5.5","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:58.100Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":300,"output_tokens":30,"total_tokens":330},"last_token_usage":{"input_tokens":300,"output_tokens":30,"total_tokens":330}}}}"#,
+            "\n"
+        ));
+        let child = create_test_file(concat!(
+            r#"{"timestamp":"2026-05-05T21:52:10.000Z","type":"session_meta","payload":{"id":"019e5c03-1e99-7000-8000-000000000001","forked_from_id":"019e5b00-0000-7000-8000-000000000001","source":{"subagent":{"thread_spawn":{"parent_thread_id":"019e5b00-0000-7000-8000-000000000001","depth":1}}},"model_provider":"openai","agent_nickname":"worker","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:52:10.000Z","type":"session_meta","payload":{"id":"019e5b00-0000-7000-8000-000000000001","source":"vscode","model_provider":"openai","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:52:10.100Z","type":"turn_context","payload":{"turn_id":"019e5b00-0001-7000-8000-000000000001","model":"gpt-5.5","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:52:10.200Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":300,"output_tokens":30,"total_tokens":330},"last_token_usage":{"input_tokens":300,"output_tokens":30,"total_tokens":330}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:52:20.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"019e5c03-6425-7000-8000-000000000001"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:52:20.100Z","type":"turn_context","payload":{"turn_id":"019e5c03-6425-7000-8000-000000000001","model":"gpt-5.5","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:52:20.200Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":320,"output_tokens":32,"total_tokens":352},"last_token_usage":{"input_tokens":20,"output_tokens":2,"total_tokens":22}}}}"#,
+            "\n"
+        ));
+
+        let parent_messages = parse_codex_file(parent.path());
+        let child_messages = parse_codex_file(child.path());
+
+        assert_eq!(parent_messages.len(), 1);
+        assert_eq!(child_messages.len(), 1);
+        assert_ne!(parent_messages[0].dedup_key, child_messages[0].dedup_key);
+        assert_eq!(child_messages[0].tokens.input, 20);
+        assert_eq!(child_messages[0].tokens.output, 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes #601.

This updates the Codex session parser so forked subagent logs no longer count replayed parent `token_count` history as fresh usage. It also bumps the source message cache schema so previously cached inflated Codex parse results are not reused.

## Why
Codex fork/subagent JSONL logs can embed the parent session metadata and replay the parent transcript before the child session reaches its own turn. Those replayed rows can carry child-local timestamps, so timestamp-based deduplication treats them as distinct usage and `tokscale submit` can produce impossible daily totals such as tens of billions of Codex tokens and five-figure daily costs. The server-side validation failure is correct; the local parser was overcounting inherited replay history.

## Diff scope
* `crates/tokscale-core/src/sessions/codex.rs`: tracks fork child session identity, skips nested parent replay until the first child-owned turn, and uses cumulative `total_token_usage` plus upstream session identity for Codex token_count dedup keys.
* `crates/tokscale-core/src/lib.rs`: adds end-to-end parser/accounting regressions for parent replay across forked child logs while preserving real child usage and repeated legitimate turns.
* `crates/tokscale-core/src/message_cache.rs`: bumps the source message cache schema from 16 to 17 to force reparsing with the corrected Codex semantics.

## Branch integrity
* Base branch: `main`
* Validated base SHA: `a86e688d620939d2c973c6d5625baa815ea223d7`
* Ahead/behind before PR open: `0 behind / 1 ahead`
* Merge base: `a86e688d620939d2c973c6d5625baa815ea223d7`
* Diff proof was computed against freshly fetched `origin/main`.

## Commit integrity
* Introduced commit: `c732360818e8f7a151101592243f624a0aa05118 fix(codex): skip replayed parent usage in fork logs`
* One logical parser/accounting fix.
* Final diff contains only Codex parser tests, Codex parser logic, and the required cache schema bump.

## Ledger and version proof
* Ledger: not applicable - not required for selected validation mode/change family.
* Version: not applicable - not required for selected validation mode/change family.

## Diff hygiene
* `git diff --check origin/main...HEAD`: PASS, no output.
* Changed files:
  * `crates/tokscale-core/src/lib.rs`
  * `crates/tokscale-core/src/message_cache.rs`
  * `crates/tokscale-core/src/sessions/codex.rs`


## Validation mode and proof
* Selected mode: Mode 3 - shared parser/accounting behavior that directly affects local reports and submitted totals.
* `cargo fmt --all -- --check`: PASS
* `cargo test -p tokscale-core codex`: PASS, 72 passed.
* `cargo test -p tokscale-core`: PASS, 817 passed, 1 ignored.
* `cargo clippy -p tokscale-core --all-targets -- -D warnings`: PASS
* Focused local verifier over real `~/.codex/sessions/2026/05/24/*.jsonl`: PASS, corrected total was `177,833,822` tokens after skipping `614,239` inherited replay `token_count` rows from the local Codex corpus.
* Full CLI cold parse over the entire local Codex corpus was not completed locally because it is dominated by multi-month, multi-GB JSONL I/O; the focused verifier used the real failing day and the Rust test suite covers the parser behavior.

## Migration notes
* DB migration: not applicable - no database migration changed.
* Cache migration: source message cache schema bumps from 16 to 17 so old inflated Codex cache entries are ignored and rebuilt.

## CI context confirmation
Pending - required CI will run after this PR is opened. CI workflow/context names are unchanged.

## Runtime safety
The change is limited to local Codex source parsing and cache invalidation. It does not add network calls, blocking locks, unbounded queues, or submit API contract changes. No invariant regression introduced.

## Documentation integrity
Not applicable - no user-facing command, runbook, or documented workflow changed.

## Rollback plan
Rollback: revert this PR. DB downgrade: not applicable. Data repair: not applicable. Operational caveats: users may need to rerun local scan/submit after rollback if they want cache contents regenerated under the previous parser behavior.

## Known residual risks
Remote CI is pending until the PR is opened. The parser intentionally relies on Codex v7-style turn/session ordering only while a forked child is replaying embedded parent metadata; if a future Codex format removes that ordering signal, the fallback is conservative and stops applying the replay skip rather than silently dropping child-owned usage.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips replayed parent `token_count` entries in Codex fork/subagent logs and deduplicates by cumulative totals to fix inflated usage and invalid submit totals. Also bumps the cache schema to force correct re-parsing.

- **Bug Fixes**
  - Track the forked child session and ignore the embedded parent transcript until the child’s first turn.
  - Dedup `token_count` using cumulative `total_token_usage` plus upstream session id (fall back to timestamp only if totals are missing).
  - Add tests for parent replay across multiple forks and preserve real child turns.

- **Migration**
  - Cache schema bumped to 17; Codex entries will reparse automatically.

<sup>Written for commit c732360818e8f7a151101592243f624a0aa05118. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

