### PR TITLE
fix(auth): allow tokscale.ai CSRF origin

### DIFF
--- a/packages/frontend/__tests__/lib/requestSessionCsrf.test.ts
+++ b/packages/frontend/__tests__/lib/requestSessionCsrf.test.ts
@@ -109,6 +109,25 @@ describe("getSessionFromRequest — CSRF origin check (B6)", () => {
     expect(result).toEqual(validUser);
   });
 
+  it("allows cookie session from the production custom domain when bearer auth is disabled", async () => {
+    mockState.getSession.mockResolvedValue(validUser);
+
+    const result = await getSessionFromRequest(
+      new Request("https://tokscale.ai/api/groups", {
+        method: "POST",
+        headers: {
+          Cookie: "tt_session=session-token",
+          Origin: "https://tokscale.ai",
+        },
+      }),
+      { allowAuthorizationHeader: false }
+    );
+
+    expect(result).toEqual(validUser);
+    expect(mockState.getSession).toHaveBeenCalledTimes(1);
+    expect(mockState.getSessionFromHeader).not.toHaveBeenCalled();
+  });
+
   it("rejects cookie session on mutating method with no Origin header (non-browser clients must use Bearer)", async () => {
     mockState.getSession.mockResolvedValue(validUser);
 

--- a/packages/frontend/src/lib/auth/requestSession.ts
+++ b/packages/frontend/src/lib/auth/requestSession.ts
@@ -11,7 +11,7 @@ function getAllowedOrigins(): string[] {
   if (env) {
     return env.split(",").map((o) => o.trim()).filter(Boolean);
   }
-  return ["https://tokscale.dev", "http://localhost:3000"];
+  return ["https://tokscale.ai", "https://tokscale.dev", "http://localhost:3000"];
 }
 
 export async function getSessionFromRequest(


### PR DESCRIPTION
## Summary

- Add `https://tokscale.ai` to the default CSRF trusted-origin set for cookie-authenticated browser mutations.
- Keep localhost and configured deployment origins unchanged.
- Add regression coverage for production-origin group creation plus the existing group route path.

## Why

Production browser requests from `https://tokscale.ai` can carry a valid `tt_session` cookie but still be rejected by the CSRF origin gate if the app does not have an explicit environment override. Group creation is one of the affected mutating routes, so users can be signed in yet receive an authorization failure in production. The fix makes the canonical production origin part of the safe default instead of requiring every deployment to rediscover the same allowlist setting.

## Diff scope

- `packages/frontend/src/lib/auth/requestSession.ts`: includes `https://tokscale.ai` in the built-in trusted origins used by `getSessionFromRequest` for cookie-authenticated mutation requests.
- `packages/frontend/__tests__/lib/requestSessionCsrf.test.ts`: adds a production-origin regression case for `POST https://tokscale.ai/api/groups` with a valid `tt_session` cookie.

## Branch integrity

- Base branch: `main`.
- Validated base SHA: `a86e688d620939d2c973c6d5625baa815ea223d7`.
- Ahead/behind: `0 behind / 1 ahead` against `origin/main`.
- Merge base: `a86e688d620939d2c973c6d5625baa815ea223d7`.
- Fast-forward safety: `origin/main` is an ancestor of this branch.

## Commit integrity

- Introduced commit: `5a2eba5d2d8f3568fe7c45ae7e87e74c7a4c604e fix(auth): allow tokscale.ai CSRF origin`.
- The PR contains one logical change scoped to the production CSRF origin allowlist and its regression coverage.
- Ledger: not applicable - not required for this change family.
- Version: not applicable - no release/version manifests changed.

## Diff hygiene

- `git diff --name-status origin/main...HEAD`: only `packages/frontend/src/lib/auth/requestSession.ts` and `packages/frontend/__tests__/lib/requestSessionCsrf.test.ts` changed.
- `git diff --check origin/main...HEAD`: PASS, no output.


## Validation mode and proof

Mode 3 - security-sensitive runtime change, because the CSRF origin allowlist affects cookie-authenticated mutating requests. Local validation was targeted to the CSRF request-session helper and the group creation route that exercises this auth path.

- TDD red proof: `bun run test __tests__/lib/requestSessionCsrf.test.ts` failed before the implementation because the new `tokscale.ai` production-origin case returned `null`.
- `bun run test __tests__/lib/requestSessionCsrf.test.ts __tests__/api/groupRoute.test.ts`: PASS, 2 files and 18 tests.
- `git diff --check origin/main...HEAD`: PASS, no output.
- Not run: full frontend suite, full build, and full lint - not required for this scoped allowlist fix because targeted tests cover the changed auth helper and affected group route path, and required remote CI will run after the PR is opened.

## Required remote gates

Pending - GitHub Actions, Vercel, and mergeability checks will run after the PR is opened.

## Migration notes

Not applicable - no database migration changed.

## Runtime safety

The change is additive to the trusted-origin defaults and does not weaken same-origin/session requirements. It allows the canonical production site origin while preserving existing localhost and environment-configured origins. No token handling, session storage, role checks, or route mutation semantics changed. No invariant regression introduced.

## Documentation integrity

Not applicable - no docs, commands, or runbooks changed.

## Rollback plan

Rollback: revert this PR. DB downgrade: not applicable. Data repair: not applicable. Operational caveats: reverting would reintroduce the production-origin CSRF rejection unless the deployment provides an equivalent environment allowlist.

## Known residual risks

Remote CI and GitHub mergeability are pending until the PR is opened. If the production domain changes in the future, that new canonical origin will still need to be configured or added separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow `https://tokscale.ai` as a trusted CSRF origin for cookie-authenticated browser mutations so signed-in users aren’t blocked in production (e.g., group creation). Localhost and env-configured origins remain unchanged.

- **Bug Fixes**
  - Added `https://tokscale.ai` to the default CSRF trusted origins used by `getSessionFromRequest`.
  - Added a regression test for `POST https://tokscale.ai/api/groups` to confirm cookie sessions are accepted when bearer auth is disabled.

<sup>Written for commit 5a2eba5d2d8f3568fe7c45ae7e87e74c7a4c604e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

