### PR TITLE
fix(antigravity): include cache rows in default submit

### DIFF
--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -368,7 +368,7 @@ define_clients!(
         pattern: "*.jsonl",
         headless: false,
         parse_local: true,
-        submit_default: false
+        submit_default: true
     },
     Zed = 21 => {
         id: "zed",
@@ -738,8 +738,8 @@ mod tests {
     }
 
     #[test]
-    fn test_antigravity_submit_default_is_false() {
-        assert!(!ClientId::Antigravity.submit_default());
+    fn test_antigravity_submit_default_is_true() {
+        assert!(ClientId::Antigravity.submit_default());
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -2590,10 +2590,11 @@ pub fn parsed_to_unified(msg: &ParsedMessage, cost: f64) -> UnifiedMessage {
 mod tests {
     use super::{
         aggregate_model_usage_entries, apply_pricing_if_available, dedupe_latest_trae_messages,
-        message_cache, normalize_model_for_grouping, parse_all_messages_with_pricing,
-        parse_local_clients, parsed_to_unified, pricing, retain_for_requested_clients, scanner,
-        select_local_parse_pricing, unified_to_parsed, ClientId, GroupBy, LocalParseOptions,
-        TokenBreakdown, UnifiedMessage, UNKNOWN_WORKSPACE_LABEL,
+        generate_graph_with_loaded_pricing, message_cache, normalize_model_for_grouping,
+        parse_all_messages_with_pricing, parse_local_clients, parsed_to_unified, pricing,
+        retain_for_requested_clients, scanner, select_local_parse_pricing, unified_to_parsed,
+        ClientId, GroupBy, LocalParseOptions, ReportOptions, TokenBreakdown, UnifiedMessage,
+        UNKNOWN_WORKSPACE_LABEL,
     };
     use std::collections::{HashMap, HashSet};
     use std::io::Write;
@@ -5924,6 +5925,54 @@ mod tests {
         );
         assert_eq!(parsed_with_settings.messages[0].input, 42);
         assert_eq!(parsed_with_settings.messages[0].output, 7);
+    }
+
+    #[test]
+    fn test_submit_default_graph_includes_antigravity_cache_rows() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let sessions_dir = temp_dir
+            .path()
+            .join(".config/tokscale/antigravity-cache/sessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        std::fs::write(
+            sessions_dir.join("ag-submit.jsonl"),
+            r#"{"type":"usage","sessionId":"ag-submit","modelId":"model_placeholder_m84","timestamp":1711200000000,"input":12,"output":4,"cacheRead":2,"cacheWrite":0,"reasoning":1,"responseId":"resp-ag"}
+"#,
+        )
+        .unwrap();
+
+        let mut clients: Vec<String> = ClientId::iter()
+            .filter(|client| client.submit_default())
+            .map(|client| client.as_str().to_string())
+            .collect();
+        clients.push("synthetic".to_string());
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let graph = rt
+            .block_on(generate_graph_with_loaded_pricing(
+                ReportOptions {
+                    home_dir: Some(temp_dir.path().to_string_lossy().to_string()),
+                    use_env_roots: false,
+                    clients: Some(clients),
+                    since: None,
+                    until: None,
+                    year: None,
+                    group_by: GroupBy::default(),
+                    scanner_settings: scanner::ScannerSettings::default(),
+                },
+                None,
+            ))
+            .unwrap();
+
+        assert_eq!(graph.summary.clients, vec!["antigravity"]);
+        assert_eq!(graph.summary.models, vec!["model_placeholder_m84"]);
+        assert_eq!(graph.summary.total_tokens, 19);
+        assert_eq!(graph.contributions.len(), 1);
+        assert_eq!(graph.contributions[0].clients[0].client, "antigravity");
+        assert_eq!(
+            graph.contributions[0].clients[0].model_id,
+            "model_placeholder_m84"
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/aliases.rs
+++ b/crates/tokscale-core/src/pricing/aliases.rs
@@ -87,6 +87,8 @@ mod tests {
             resolve_alias("anthropic/claude-4-6-sonnet"),
             Some("claude-sonnet-4-6")
         );
+        assert_eq!(resolve_alias("model_placeholder_m84"), None);
+        assert_eq!(resolve_alias("model_placeholder_m16"), None);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/antigravity.rs
+++ b/crates/tokscale-core/src/sessions/antigravity.rs
@@ -154,4 +154,21 @@ mod tests {
         assert_eq!(messages[0].model_id, "claude-opus-4-6");
         assert_eq!(messages[0].provider_id, "anthropic");
     }
+
+    #[test]
+    fn parse_usage_row_preserves_unmapped_placeholder_models() {
+        let input = r#"{"type":"usage","sessionId":"abc","modelId":"model_placeholder_m84","timestamp":1711200000000,"input":12,"output":4,"cacheRead":2,"cacheWrite":0,"reasoning":1}
+{"type":"usage","sessionId":"abc","modelId":"model_placeholder_m16","timestamp":1711200000001,"input":8,"output":3,"cacheRead":0,"cacheWrite":0,"reasoning":0}
+"#;
+
+        let path = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(path.path(), input).unwrap();
+
+        let messages = parse_antigravity_file(path.path());
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].model_id, "model_placeholder_m84");
+        assert_eq!(messages[0].provider_id, "antigravity");
+        assert_eq!(messages[1].model_id, "model_placeholder_m16");
+        assert_eq!(messages[1].provider_id, "antigravity");
+    }
 }


### PR DESCRIPTION
## Summary

- Include Antigravity cache rows in the default submit client set now that the local parser and frontend source registry support the client.
- Add a submit-shaped graph regression proving Antigravity cache rows are included when the CLI builds the default submit client list.
- Preserve unmapped Antigravity placeholder models as visible Antigravity rows instead of inventing unsafe model aliases.

## Why

Antigravity was parseable locally but still excluded from the default submit path, so users could see Antigravity data in local reports while `tokscale submit` silently omitted it unless they explicitly selected the client. This change closes that end-to-end gap: Antigravity rows now participate in default submit totals, while unknown placeholder model IDs remain honest and visible until there is reliable evidence for canonical pricing aliases.

## Diff scope

- `crates/tokscale-core/src/clients.rs`: flips `ClientId::Antigravity` to `submit_default: true` and updates the client registry test.
- `crates/tokscale-core/src/lib.rs`: adds a submit-shaped graph regression that builds the same default client list and verifies Antigravity cache rows flow into graph totals.
- `crates/tokscale-core/src/sessions/antigravity.rs`: adds parser coverage showing unmapped placeholder models are preserved with `antigravity` provider attribution.
- `crates/tokscale-core/src/pricing/aliases.rs`: documents the current no-alias behavior for `model_placeholder_m84` and `model_placeholder_m16` with tests, avoiding speculative pricing mappings.

## Branch integrity

- Base branch: `main`.
- Validated base SHA: `a86e688d620939d2c973c6d5625baa815ea223d7`.
- Ahead/behind: `0 behind / 1 ahead` against `origin/main`.
- Merge base: `a86e688d620939d2c973c6d5625baa815ea223d7`.
- Fast-forward safety: `origin/main` is an ancestor of this branch.

## Commit integrity

- Introduced commit: `d2ba22d7c1a6df272c0b7d1aa67af9870965dfff fix(antigravity): include cache rows in default submit`.
- The PR contains one logical change scoped to Antigravity default-submit inclusion and its regression coverage.
- Ledger: not applicable - `scripts/ledger` is absent and no ledger policy applies to this change family.
- Version: not applicable - no manifest version bump is required because release workflow owns package version updates.

## Diff hygiene

- `git diff --name-status origin/main...HEAD`: only Antigravity/core parser, client registry, pricing alias tests, and submit-shaped graph regression files changed.
- `git diff --check origin/main...HEAD`: PASS, no output.


## Validation mode and proof

Mode 2 - narrow runtime change, because the diff changes core client default selection and targeted parser/submit graph behavior without touching frontend, migrations, auth, or deployment tooling.

- TDD red proof: `cargo test -p tokscale-core antigravity` failed before the implementation with `test_antigravity_submit_default_is_true` and `test_submit_default_graph_includes_antigravity_cache_rows`.
- `cargo test -p tokscale-core antigravity`: PASS, 14 tests.
- `cargo test -p tokscale-cli default_submit_clients`: PASS, 2 tests.
- `cargo fmt --all -- --check`: PASS, no output.
- `cargo clippy -p tokscale-core --all-features -- -D warnings`: PASS.
- `bash scripts/check-version-coherence.sh`: PASS, `Version coherence OK: 3.0.0`.
- `git diff --check origin/main...HEAD`: PASS, no output.
- Not run: frontend tests - not required because no frontend files changed and the current frontend registry already accepts core client IDs.
- Not run: full workspace test suite - not required for selected validation mode; required remote CI will run after the PR is opened.

## Required remote gates

Pending - GitHub Actions and mergeability checks will run after the PR is opened.

## Migration notes

Not applicable - no database migration changed.

## Runtime safety

The change only adds an already-parseable local client to default submit selection. It does not alter token parsing semantics for existing clients, does not fabricate placeholder model aliases, and keeps unknown Antigravity placeholders visible with zero priced cost until a real canonical mapping exists. No invariant regression introduced.

## Documentation integrity

Not applicable - no documented commands or runbooks changed.

## Rollback plan

Rollback: revert this PR. DB downgrade: not applicable. Data repair: not applicable. Operational caveats: reverting would make Antigravity local rows disappear from default submit totals again unless users explicitly submit that client.

## Known residual risks

Remote CI and GitHub mergeability are pending until the PR is opened. `model_placeholder_m84` and `model_placeholder_m16` intentionally remain unmapped because there is no safe canonical model evidence in repo history or public code search; their tokens will be included, but pricing can remain zero until a verified alias is added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include `antigravity` cache rows in the default submit path so they appear in `tokscale submit` totals. Unmapped Antigravity placeholder models remain visible and unaliased.

- **Bug Fixes**
  - Set `ClientId::Antigravity` to `submit_default: true` and updated the registry test.
  - Added a submit-shaped graph test to verify Antigravity cache rows are included in totals.
  - Preserved unmapped models (`model_placeholder_m84`, `model_placeholder_m16`) as `antigravity` rows and added alias tests confirming no mapping.

<sup>Written for commit d2ba22d7c1a6df272c0b7d1aa67af9870965dfff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

