### PR TITLE
fix(auth): claim device codes atomically

### DIFF
--- a/packages/frontend/__tests__/api/deviceAuthorize.test.ts
+++ b/packages/frontend/__tests__/api/deviceAuthorize.test.ts
@@ -1,0 +1,193 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const selectResults: Array<Array<Record<string, unknown>>> = [];
+  const updateResults: Array<Array<Record<string, unknown>>> = [];
+  const updateSets: Array<Record<string, unknown>> = [];
+  const updateWhereConditions: unknown[] = [];
+  const getSession = vi.fn();
+
+  const tables = {
+    deviceCodes: {
+      id: "deviceCodes.id",
+      userCode: "deviceCodes.userCode",
+      expiresAt: "deviceCodes.expiresAt",
+      userId: "deviceCodes.userId",
+    },
+  };
+
+  const eq = vi.fn((left: unknown, right: unknown) => ({ kind: "eq", left, right }));
+  const and = vi.fn((...terms: unknown[]) => ({ kind: "and", terms }));
+  const gt = vi.fn((left: unknown, right: unknown) => ({ kind: "gt", left, right }));
+  const isNull = vi.fn((left: unknown) => ({ kind: "isNull", left }));
+
+  function nextResult(queue: Array<Array<Record<string, unknown>>>) {
+    return queue.shift() ?? [];
+  }
+
+  const db = {
+    select: vi.fn(() => {
+      const builder = {
+        from: vi.fn(() => builder),
+        where: vi.fn(() => builder),
+        limit: vi.fn(async () => nextResult(selectResults)),
+      };
+
+      return builder;
+    }),
+    update: vi.fn(() => {
+      const builder = {
+        set: vi.fn((values: Record<string, unknown>) => {
+          updateSets.push(values);
+          return builder;
+        }),
+        where: vi.fn((condition: unknown) => {
+          updateWhereConditions.push(condition);
+          return builder;
+        }),
+        returning: vi.fn(async () => nextResult(updateResults)),
+      };
+
+      return builder;
+    }),
+  };
+
+  return {
+    db,
+    tables,
+    eq,
+    and,
+    gt,
+    isNull,
+    getSession,
+    updateSets,
+    updateWhereConditions,
+    reset() {
+      selectResults.length = 0;
+      updateResults.length = 0;
+      updateSets.length = 0;
+      updateWhereConditions.length = 0;
+      db.select.mockClear();
+      db.update.mockClear();
+      getSession.mockReset();
+      eq.mockClear();
+      and.mockClear();
+      gt.mockClear();
+      isNull.mockClear();
+    },
+    pushSelectResult(rows: Array<Record<string, unknown>>) {
+      selectResults.push(rows);
+    },
+    pushUpdateResult(rows: Array<Record<string, unknown>>) {
+      updateResults.push(rows);
+    },
+  };
+});
+
+vi.mock("@/lib/db", () => ({
+  db: mockState.db,
+  deviceCodes: mockState.tables.deviceCodes,
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: mockState.eq,
+  and: mockState.and,
+  gt: mockState.gt,
+  isNull: mockState.isNull,
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  getSession: mockState.getSession,
+}));
+
+type ModuleExports = typeof import("../../src/app/api/auth/device/authorize/route");
+
+let POST: ModuleExports["POST"];
+
+beforeAll(async () => {
+  const routeModule = await import("../../src/app/api/auth/device/authorize/route");
+  POST = routeModule.POST;
+});
+
+beforeEach(() => {
+  mockState.reset();
+});
+
+function flattenedTerms(condition: unknown): Array<Record<string, unknown>> {
+  if (!condition || typeof condition !== "object") {
+    return [];
+  }
+
+  const record = condition as Record<string, unknown>;
+  if (record.kind === "and" && Array.isArray(record.terms)) {
+    return record.terms.flatMap((term) => flattenedTerms(term));
+  }
+
+  return [record];
+}
+
+describe("POST /api/auth/device/authorize", () => {
+  it("claims a valid device code with a guarded update", async () => {
+    mockState.getSession.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+    });
+    mockState.pushUpdateResult([{ id: "device-1" }]);
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/auth/device/authorize", {
+        method: "POST",
+        body: JSON.stringify({ userCode: "ABCD-1234" }),
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ success: true });
+    expect(mockState.db.select).not.toHaveBeenCalled();
+    expect(mockState.db.update).toHaveBeenCalledWith(mockState.tables.deviceCodes);
+    expect(mockState.updateSets).toEqual([{ userId: "user-1" }]);
+  });
+
+  it("returns invalid or expired when the atomic device-code claim loses the race", async () => {
+    mockState.getSession.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+    });
+    mockState.pushSelectResult([
+      {
+        id: "device-1",
+        userCode: "ABCD-1234",
+        expiresAt: new Date("2026-03-08T05:00:00.000Z"),
+        userId: null,
+      },
+    ]);
+    mockState.pushUpdateResult([]);
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/auth/device/authorize", {
+        method: "POST",
+        body: JSON.stringify({ userCode: "abcd1234" }),
+      })
+    );
+    const body = await response.json();
+    const updateTerms = flattenedTerms(mockState.updateWhereConditions[0]);
+
+    expect(mockState.db.update).toHaveBeenCalledWith(mockState.tables.deviceCodes);
+    expect(mockState.updateSets).toEqual([{ userId: "user-1" }]);
+    expect(updateTerms).toEqual(
+      expect.arrayContaining([
+        { kind: "eq", left: mockState.tables.deviceCodes.userCode, right: "ABCD-1234" },
+        expect.objectContaining({ kind: "gt", left: mockState.tables.deviceCodes.expiresAt }),
+        { kind: "isNull", left: mockState.tables.deviceCodes.userId },
+      ])
+    );
+    expect(response.status).toBe(400);
+    expect(body).toEqual({ error: "Invalid or expired code" });
+    expect(mockState.db.select).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/src/app/api/auth/device/authorize/route.ts
+++ b/packages/frontend/src/app/api/auth/device/authorize/route.ts
@@ -31,10 +31,9 @@ export async function POST(request: Request) {
         ? `${normalizedCode.slice(0, 4)}-${normalizedCode.slice(4)}`
         : userCode.toUpperCase();
 
-    // Find the device code record
     const [record] = await db
-      .select()
-      .from(deviceCodes)
+      .update(deviceCodes)
+      .set({ userId: session.id })
       .where(
         and(
           eq(deviceCodes.userCode, formattedCode),
@@ -42,7 +41,7 @@ export async function POST(request: Request) {
           isNull(deviceCodes.userId)
         )
       )
-      .limit(1);
+      .returning({ id: deviceCodes.id });
 
     if (!record) {
       return NextResponse.json(
@@ -50,12 +49,6 @@ export async function POST(request: Request) {
         { status: 400 }
       );
     }
-
-    // Link user to device code
-    await db
-      .update(deviceCodes)
-      .set({ userId: session.id })
-      .where(eq(deviceCodes.id, record.id));
 
     return NextResponse.json({ success: true });
   } catch (error) {


### PR DESCRIPTION
## Summary

- Make device-code authorization claim the code in one guarded database update instead of selecting first and updating later.
- Reject already-claimed, expired, or missing user codes through the same atomic predicate.
- Add regression coverage proving the authorize route uses guarded update predicates and does not reintroduce the stale select-before-update path.

## Why

The previous authorize flow checked device-code eligibility before the update, then updated by row id. Concurrent requests could both observe an eligible code and race to claim it, which risks binding one device code to the wrong user or overwriting an existing claim. The route now lets the database perform the eligibility check and claim together, so only one request can win.

## Diff scope

- `packages/frontend/src/app/api/auth/device/authorize/route.ts`: replaces the select-before-update flow with a single guarded `UPDATE ... WHERE user_code AND expires_at > now AND user_id IS NULL RETURNING id`.
- `packages/frontend/__tests__/api/deviceAuthorize.test.ts`: adds route coverage for the atomic claim behavior and the stale/invalid-code rejection path.

## Branch integrity

- Base branch: `main`.
- Validated base SHA: `a86e688d620939d2c973c6d5625baa815ea223d7`.
- Ahead/behind: `0 behind / 1 ahead` against `origin/main`.
- Merge base: `a86e688d620939d2c973c6d5625baa815ea223d7`.
- Fast-forward safety: `origin/main` is an ancestor of this branch.

## Commit integrity

- Introduced commit: `8df5fe3af173d91d2e946318608c6fc6e191996c fix(auth): claim device codes atomically`.
- The PR contains one logical change scoped to device-code authorization correctness and regression coverage.
- Ledger: not applicable - not required for this change family.
- Version: not applicable - no CLI package or release manifest changed.

## Diff hygiene

- `git diff --name-status origin/main...HEAD`: only the device authorize route and its focused API test changed.
- `git diff --check origin/main...HEAD`: PASS, no output.


## Validation mode and proof

Mode 3 - auth-route runtime change, because this changes device-code authorization semantics and relies on database predicate correctness for race safety.

- TDD red proof: `bun run test __tests__/api/deviceAuthorize.test.ts` failed before the implementation because the update predicate only targeted `deviceCodes.id` instead of guarding `userCode`, `expiresAt`, and `userId`.
- `bun run test __tests__/api/deviceAuthorize.test.ts __tests__/api/devicePoll.test.ts`: PASS, 2 files and 7 tests.
- `bun run lint src/app/api/auth/device/authorize/route.ts __tests__/api/deviceAuthorize.test.ts`: PASS, no output.
- `git diff --check origin/main...HEAD`: PASS, no output.
- Not run: full frontend test suite - not required for selected validation mode because targeted authorize and poll route tests cover the changed auth path; required remote CI will run after the PR is opened.

## Required remote gates

Pending - GitHub Actions, Vercel, and mergeability checks will run after the PR is opened.

## Migration notes

Not applicable - no database migration changed.

## Runtime safety

The route keeps the same request/response contract and error status while moving the eligibility check into the database write. It does not change polling behavior, token issuance, session lookup, expiry duration, or device-code generation. No invariant regression introduced.

## Documentation integrity

Not applicable - no docs, commands, or runbooks changed.

## Rollback plan

Rollback: revert this PR. DB downgrade: not applicable. Data repair: not applicable. Operational caveats: reverting would restore the select-before-update race in device-code authorization.

## Known residual risks

Remote CI and GitHub mergeability are pending until the PR is opened. This relies on the existing database update semantics and does not add schema-level uniqueness or locking because the guarded single-row update is sufficient for the current device-code table contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make device-code authorization atomic to remove race conditions. The `POST /api/auth/device/authorize` route now claims codes in a single guarded update and returns clear errors for invalid, expired, or already-claimed codes.

- **Bug Fixes**
  - Replaced select-before-update with one guarded `UPDATE ... WHERE user_code AND expires_at > now AND user_id IS NULL RETURNING id`.
  - Added focused tests for atomic claim success and invalid/expired/already-claimed paths to prevent regressions.

<sup>Written for commit 8df5fe3af173d91d2e946318608c6fc6e191996c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

