### PR TITLE
fix(leaderboard): use competition ranks for all-time ties

### DIFF
--- a/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
@@ -170,6 +170,162 @@ afterEach(() => {
 });
 
 describe("all-time leaderboard freshness queries", () => {
+  it("uses competition-rank SQL for all-time list and search ranks", async () => {
+    mockState.pushAwaitedResult([]);
+    mockState.pushAwaitedResult([{ totalTokens: 0, totalCost: 0, totalSubmissions: 0, uniqueUsers: 0 }]);
+
+    await getLeaderboardData("all", 1, 50, "tokens");
+    const listSqlTexts = serializeSqlCalls();
+
+    expect(listSqlTexts.some((text) => text.includes("RANK() OVER (ORDER BY"))).toBe(true);
+    expect(listSqlTexts.some((text) => text.includes("ROW_NUMBER() OVER"))).toBe(false);
+
+    mockState.reset();
+    mockState.pushAwaitedResult([]);
+    mockState.pushAwaitedResult([{ count: 0 }]);
+    mockState.pushAwaitedResult([{ totalTokens: 0, totalCost: 0, totalSubmissions: 0, uniqueUsers: 0 }]);
+
+    await getLeaderboardData("all", 1, 50, "tokens", "ali");
+    const searchSqlTexts = serializeSqlCalls();
+
+    expect(searchSqlTexts.some((text) => text.includes("RANK() OVER (ORDER BY"))).toBe(true);
+    expect(searchSqlTexts.some((text) => text.includes("ROW_NUMBER() OVER"))).toBe(false);
+  });
+
+  it("keeps tied all-time users at the same rank across list, search, and user rank", async () => {
+    mockState.pushAwaitedResult([
+      {
+        rank: 1,
+        userId: "user-bob",
+        username: "bob",
+        displayName: "Bob",
+        avatarUrl: null,
+        totalTokens: 5000,
+        totalCost: 50,
+        totalActiveTimeMs: 500,
+        submissionCount: 1,
+        lastSubmission: "2026-03-12T10:00:00.000Z",
+        cliVersion: "1.9.0",
+        schemaVersion: 1,
+      },
+      {
+        rank: 2,
+        userId: "user-alice",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        totalTokens: 3000,
+        totalCost: 40,
+        totalActiveTimeMs: 400,
+        submissionCount: 1,
+        lastSubmission: "2026-03-12T09:00:00.000Z",
+        cliVersion: "1.9.0",
+        schemaVersion: 1,
+      },
+      {
+        rank: 2,
+        userId: "user-alicia",
+        username: "alicia",
+        displayName: "Alicia",
+        avatarUrl: null,
+        totalTokens: 3000,
+        totalCost: 30,
+        totalActiveTimeMs: 300,
+        submissionCount: 1,
+        lastSubmission: "2026-03-12T08:00:00.000Z",
+        cliVersion: "1.9.0",
+        schemaVersion: 1,
+      },
+    ]);
+    mockState.pushAwaitedResult([
+      {
+        totalTokens: 11000,
+        totalCost: 120,
+        totalSubmissions: 3,
+        uniqueUsers: 3,
+      },
+    ]);
+
+    const leaderboard = await getLeaderboardData("all", 1, 50, "tokens");
+    const aliceListRank = leaderboard.users.find((user) => user.username === "alice")?.rank;
+    const aliciaListRank = leaderboard.users.find((user) => user.username === "alicia")?.rank;
+
+    mockState.reset();
+    mockState.pushAwaitedResult([
+      {
+        rank: 2,
+        userId: "user-alice",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        totalTokens: 3000,
+        totalCost: 40,
+        totalActiveTimeMs: 400,
+        submissionCount: 1,
+        lastSubmission: "2026-03-12T09:00:00.000Z",
+        cliVersion: "1.9.0",
+        schemaVersion: 1,
+      },
+      {
+        rank: 2,
+        userId: "user-alicia",
+        username: "alicia",
+        displayName: "Alicia",
+        avatarUrl: null,
+        totalTokens: 3000,
+        totalCost: 30,
+        totalActiveTimeMs: 300,
+        submissionCount: 1,
+        lastSubmission: "2026-03-12T08:00:00.000Z",
+        cliVersion: "1.9.0",
+        schemaVersion: 1,
+      },
+    ]);
+    mockState.pushAwaitedResult([{ count: 2 }]);
+    mockState.pushAwaitedResult([
+      {
+        totalTokens: 11000,
+        totalCost: 120,
+        totalSubmissions: 3,
+        uniqueUsers: 3,
+      },
+    ]);
+
+    const searchLeaderboard = await getLeaderboardData("all", 1, 50, "tokens", "ali");
+    const aliceSearchRank = searchLeaderboard.users.find((user) => user.username === "alice")?.rank;
+    const aliciaSearchRank = searchLeaderboard.users.find((user) => user.username === "alicia")?.rank;
+
+    mockState.reset();
+    mockState.pushAwaitedResult([
+      {
+        id: "user-alice",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+      },
+    ]);
+    mockState.pushAwaitedResult([
+      {
+        totalTokens: 3000,
+        totalCost: 40,
+        totalActiveTimeMs: 400,
+        submissionCount: 1,
+        lastSubmission: "2026-03-12T09:00:00.000Z",
+        cliVersion: "1.9.0",
+        schemaVersion: 1,
+      },
+    ]);
+    mockState.pushAwaitedResult([{ count: 1 }]);
+
+    const aliceUserRank = await getUserRank("alice", "all", "tokens");
+
+    expect(aliceListRank).toBe(2);
+    expect(aliciaListRank).toBe(2);
+    expect(aliceSearchRank).toBe(2);
+    expect(aliciaSearchRank).toBe(2);
+    expect(aliceUserRank?.rank).toBe(2);
+  });
+
   it("uses latest-row scalar subqueries instead of MAX(cliVersion/schemaVersion)", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-12T18:45:00Z"));

--- a/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
+++ b/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
@@ -157,6 +157,53 @@ beforeEach(() => {
 });
 
 describe("user embed data", () => {
+  it("keeps embed tie-breakers out of the rank window", async () => {
+    mockState.pushAwaitedResult([
+      {
+        id: "user-alice",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        totalTokens: 3000,
+        totalCost: 40,
+        submissionCount: 1,
+        updatedAt: new Date("2026-03-12T09:00:00.000Z"),
+      },
+    ]);
+    mockState.pushExecuteResult([{ rank: 2, total: 3 }]);
+
+    await getUserEmbedStats("alice", "tokens");
+    const tokenSqlTexts = serializeSqlCalls();
+
+    expect(tokenSqlTexts.some((text) => text.includes("RANK() OVER"))).toBe(true);
+    expect(tokenSqlTexts.some((text) =>
+      text.includes("total_tokens DESC, CAST(total_cost AS DECIMAL(12,4)) DESC")
+    )).toBe(false);
+
+    mockState.reset();
+    mockState.pushAwaitedResult([
+      {
+        id: "user-alice",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        totalTokens: 3000,
+        totalCost: 40,
+        submissionCount: 1,
+        updatedAt: new Date("2026-03-12T09:00:00.000Z"),
+      },
+    ]);
+    mockState.pushExecuteResult([{ rank: 2, total: 3 }]);
+
+    await getUserEmbedStats("alice", "cost");
+    const costSqlTexts = serializeSqlCalls();
+
+    expect(costSqlTexts.some((text) => text.includes("RANK() OVER"))).toBe(true);
+    expect(costSqlTexts.some((text) =>
+      text.includes("CAST(total_cost AS DECIMAL(12,4)) DESC, total_tokens DESC")
+    )).toBe(false);
+  });
+
   it("looks up embed stats usernames case-insensitively and returns the canonical username", async () => {
     mockState.pushAwaitedResult([
       {

--- a/packages/frontend/src/lib/embed/getUserEmbedStats.ts
+++ b/packages/frontend/src/lib/embed/getUserEmbedStats.ts
@@ -70,8 +70,8 @@ async function fetchUserEmbedStats(username: string, sortBy: EmbedSortBy): Promi
           RANK() OVER (
             ORDER BY
               ${sortBy === "cost"
-                ? sql`CAST(total_cost AS DECIMAL(12,4)) DESC, total_tokens DESC`
-                : sql`total_tokens DESC, CAST(total_cost AS DECIMAL(12,4)) DESC`}
+                ? sql`CAST(total_cost AS DECIMAL(12,4)) DESC`
+                : sql`total_tokens DESC`}
           ) AS rank
         FROM submissions
       )

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -347,13 +347,18 @@ async function fetchLeaderboardData(
     : sortBy === "time"
     ? sql`COALESCE(SUM(${submissions.totalActiveTimeMs}), 0)`
     : sql`SUM(${submissions.totalTokens})`;
+  const secondaryOrderByColumn = sortBy === "cost"
+    ? sql`SUM(${submissions.totalTokens})`
+    : sortBy === "time"
+    ? sql`SUM(${submissions.totalTokens})`
+    : sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`;
 
   if (search) {
     // When searching, use a subquery to compute global ranks for ALL users,
     // then filter by username. This preserves each user's true rank.
     const rankedSubquery = db
       .select({
-        rank: sql<number>`ROW_NUMBER() OVER (ORDER BY ${orderByColumn} DESC)`.as("rank"),
+        rank: sql<number>`RANK() OVER (ORDER BY ${orderByColumn} DESC)`.as("rank"),
         userId: users.id,
         username: users.username,
         displayName: users.displayName,
@@ -378,6 +383,11 @@ async function fetchLeaderboardData(
       .innerJoin(users, eq(submissions.userId, users.id))
       .groupBy(users.id, users.username, users.displayName, users.avatarUrl)
       .as("ranked");
+    const rankedSecondaryOrderByColumn = sortBy === "cost"
+      ? rankedSubquery.totalTokens
+      : sortBy === "time"
+      ? rankedSubquery.totalTokens
+      : rankedSubquery.totalCost;
 
     const escapedSearch = search.toLowerCase().replace(/[%_\\]/g, "\\$&");
     const searchPattern = `%${escapedSearch}%`;
@@ -385,7 +395,11 @@ async function fetchLeaderboardData(
       .select()
       .from(rankedSubquery)
       .where(sql`(LOWER(${rankedSubquery.username}) LIKE ${searchPattern} OR LOWER(COALESCE(${rankedSubquery.displayName}, '')) LIKE ${searchPattern})`)
-      .orderBy(sql`${rankedSubquery.rank} ASC`)
+      .orderBy(
+        sql`${rankedSubquery.rank} ASC`,
+        sql`${rankedSecondaryOrderByColumn} DESC`,
+        sql`LOWER(${rankedSubquery.username}) ASC`
+      )
       .limit(limit)
       .offset(offset);
 
@@ -446,10 +460,10 @@ async function fetchLeaderboardData(
     };
   }
 
-  // Non-search path: original query with sequential rank
+  // Non-search path: competition rank with deterministic row ordering for ties.
   const leaderboardQuery = db
     .select({
-      rank: sql<number>`ROW_NUMBER() OVER (ORDER BY ${orderByColumn} DESC)`.as("rank"),
+      rank: sql<number>`RANK() OVER (ORDER BY ${orderByColumn} DESC)`.as("rank"),
       userId: users.id,
       username: users.username,
       displayName: users.displayName,
@@ -473,7 +487,11 @@ async function fetchLeaderboardData(
     .from(submissions)
     .innerJoin(users, eq(submissions.userId, users.id))
     .groupBy(users.id, users.username, users.displayName, users.avatarUrl)
-    .orderBy(desc(orderByColumn))
+    .orderBy(
+      desc(orderByColumn),
+      desc(secondaryOrderByColumn),
+      sql`LOWER(${users.username}) ASC`
+    )
     .limit(limit)
     .offset(offset);
 
@@ -493,8 +511,8 @@ async function fetchLeaderboardData(
   const totalPages = Math.ceil(totalUsers / limit);
 
   return {
-    users: (results as AllTimeLeaderboardDbRow[]).map((row, index) => ({
-      rank: offset + index + 1,
+    users: (results as RankedLeaderboardDbRow[]).map((row) => ({
+      rank: Number(row.rank),
       userId: row.userId,
       username: row.username,
       displayName: row.displayName,


### PR DESCRIPTION
## Summary

- Preserve database-computed all-time ranks in leaderboard list responses instead of recalculating rank from page offset.
- Use competition ranking for all-time ties across list, search, and embed rank queries.
- Keep deterministic tie ordering for display while ensuring equal metric totals receive equal ranks.

## Why

All-time leaderboard ties could display inconsistent ranks depending on whether the user was looking at the paginated list, search results, or embed/profile-adjacent rank data. The SQL already has the right place to compute stable rank semantics, so this change makes ranking authoritative at the query layer and avoids client-side offset recalculation that breaks ties.

## Diff scope

- `packages/frontend/src/lib/leaderboard/getLeaderboard.ts`: computes all-time ranks with SQL `RANK()` and preserves those ranks in list/search responses while keeping deterministic secondary ordering outside the rank expression.
- `packages/frontend/src/lib/embed/getUserEmbedStats.ts`: computes embed rank windows on the selected metric only, so tied totals share a rank consistently.
- `packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts`: adds coverage for competition ranks and tied list/search behavior.
- `packages/frontend/__tests__/lib/getUserEmbedStats.test.ts`: adds coverage proving embed rank SQL does not include deterministic display tie-breakers inside the rank window.

## Branch integrity

- Base branch: `main`.
- Validated base SHA: `a86e688d620939d2c973c6d5625baa815ea223d7`.
- Ahead/behind: `0 behind / 1 ahead` against `origin/main`.
- Merge base: `a86e688d620939d2c973c6d5625baa815ea223d7`.
- Fast-forward safety: `origin/main` is an ancestor of this branch.

## Commit integrity

- Introduced commit: `85bbd9767d87c7095852f6fe8448b691bb2a7d97 fix(leaderboard): use competition ranks for all-time ties`.
- The PR contains one logical change scoped to all-time leaderboard/embed tie rank semantics and regression coverage.
- Ledger: not applicable - not required for this change family.
- Version: not applicable - not required for this frontend runtime change.

## Diff hygiene

- `git diff --name-status origin/main...HEAD`: only leaderboard/embed rank logic and focused tests changed.
- `git diff --check origin/main...HEAD`: PASS, no output.


## Validation mode and proof

Mode 2 - narrow runtime change, because the diff changes focused frontend leaderboard/embed query semantics without touching auth, migrations, deployment tooling, or broader API contracts.

- TDD red proof: `bun x vitest run __tests__/lib/getLeaderboardAllTime.test.ts` failed before the implementation because all-time list/search SQL lacked authoritative competition ranks and tied rows could receive offset-derived ranks.
- TDD red proof: `bun x vitest run __tests__/lib/getUserEmbedStats.test.ts` failed before the implementation because embed rank windows included secondary tie-breakers in the rank expression.
- `bun x vitest run __tests__/lib/getLeaderboardAllTime.test.ts __tests__/lib/getLeaderboard.test.ts __tests__/lib/getUserEmbedStats.test.ts __tests__/api/usersProfile.test.ts`: PASS, 4 files and 22 tests.
- `bun x eslint src/lib/leaderboard/getLeaderboard.ts src/lib/embed/getUserEmbedStats.ts __tests__/lib/getLeaderboardAllTime.test.ts __tests__/lib/getUserEmbedStats.test.ts`: PASS, no output.
- `git diff --check origin/main...HEAD`: PASS, no output.
- Not run: full frontend test suite - not required for selected validation mode because targeted leaderboard, profile, and embed tests cover the changed rank semantics; required remote CI will run after the PR is opened.

## Required remote gates

Pending - GitHub Actions, Vercel, and mergeability checks will run after the PR is opened.

## Migration notes

Not applicable - no database migration changed.

## Runtime safety

The change only alters rank calculation semantics for existing leaderboard/embed reads. It does not change stored usage data, submission totals, auth behavior, or write paths. Deterministic ordering remains in place for display stability, but it no longer changes the rank assigned to tied totals. No invariant regression introduced.

## Documentation integrity

Not applicable - no docs, commands, or runbooks changed.

## Rollback plan

Rollback: revert this PR. DB downgrade: not applicable. Data repair: not applicable. Operational caveats: reverting would restore inconsistent all-time tie ranks across leaderboard views.

## Known residual risks

Remote CI and GitHub mergeability are pending until the PR is opened. This PR intentionally keeps existing deterministic display ordering, so users with tied totals can still appear in a stable order while sharing the same competition rank.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistent all-time leaderboard ranks for ties by using competition ranking (`RANK()`) and returning the DB-computed rank. Ranks now match across list, search, and embeds while keeping stable display order.

- **Bug Fixes**
  - Use SQL `RANK()` for all-time ranks in `packages/frontend/src/lib/leaderboard/getLeaderboard.ts`; keep secondary deterministic ordering outside the rank and return the DB rank instead of offset.
  - Compute embed ranks by the selected metric only in `packages/frontend/src/lib/embed/getUserEmbedStats.ts` so tied totals share the same rank.
  - Add tests for consistent competition ranks across list, search, and embed in `packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts` and `packages/frontend/__tests__/lib/getUserEmbedStats.test.ts`.

<sup>Written for commit 85bbd9767d87c7095852f6fe8448b691bb2a7d97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

