### PR TITLE
fix(graph): reuse local Cursor auto-sync path

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -4542,18 +4542,9 @@ fn run_graph_command(
     use tokscale_core::{generate_local_graph_report, GroupBy, ReportOptions};
 
     let show_progress = output.is_some() && !no_spinner;
-    let include_cursor = home_dir.is_none()
-        && clients
-            .as_ref()
-            .is_none_or(|s| s.iter().any(|src| src == "cursor"));
+    let had_cursor_cache = has_cursor_usage_cache_for_report(&home_dir);
     let explicit_cursor_filter = client_filter_explicitly_requests_cursor(&clients);
-    let has_cursor_cache = include_cursor && has_cursor_usage_cache_for_report(&home_dir);
-    let mut cursor_sync_result: Option<cursor::SyncCursorResult> = None;
-
-    if include_cursor && cursor::is_cursor_logged_in() {
-        let rt_sync = tokio::runtime::Runtime::new()?;
-        cursor_sync_result = Some(rt_sync.block_on(async { cursor::sync_cursor_cache().await }));
-    }
+    let cursor_sync_result = auto_sync_cursor_for_local_report(&home_dir, &clients);
     let cursor_setup_warnings = setup_warnings_for_report(&home_dir, &clients);
 
     if show_progress {
@@ -4583,7 +4574,7 @@ fn run_graph_command(
         .map_err(|e| anyhow::anyhow!(e))?;
     emit_cursor_sync_warning(
         cursor_sync_result.as_ref(),
-        has_cursor_cache,
+        had_cursor_cache,
         explicit_cursor_filter,
     );
     emit_cursor_setup_warnings(&cursor_setup_warnings);
@@ -4634,7 +4625,7 @@ fn run_graph_command(
                         .bright_black()
                     );
                 } else if let Some(err) = sync.error {
-                    if has_cursor_cache {
+                    if had_cursor_cache {
                         eprintln!("{}", format!("  Cursor: sync failed - {}", err).yellow());
                     }
                 }

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -1336,6 +1336,32 @@ fn test_graph_cursor_explicit_missing_cache_reports_setup_warning_text() {
 }
 
 #[test]
+fn test_graph_fresh_cursor_cache_skips_auto_sync_warning() {
+    let tmp = create_empty_fixture_dir();
+    write_cursor_credentials(tmp.path());
+    write_cursor_usage_cache(tmp.path());
+
+    let output = cmd_with_home(tmp.path())
+        .env("HTTPS_PROXY", "http://127.0.0.1:9")
+        .env("HTTP_PROXY", "http://127.0.0.1:9")
+        .env("ALL_PROXY", "http://127.0.0.1:9")
+        .args(["graph", "--client", "cursor", "--no-spinner"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Cursor sync failed") && !stderr.contains("Cursor sync warning"),
+        "fresh Cursor cache should skip implicit graph sync; stderr: {stderr}"
+    );
+}
+
+#[test]
 fn test_submit_cursor_explicit_missing_cache_reports_setup_warning_text() {
     let tmp = create_empty_fixture_dir();
     cmd_with_home(tmp.path())


### PR DESCRIPTION
## Summary

- Make `tokscale graph` reuse the same best-effort Cursor auto-sync helper used by the other local reports.
- Preserve the existing Cursor setup warnings while avoiding a hard failure when the implicit sync runtime cannot be created.
- Add a CLI regression test proving a fresh Cursor cache does not emit a failed-sync warning for graph output.

## Why

`tokscale graph` had its own Cursor sync path instead of using the shared local-report helper. That made graph behavior drift from models/hourly/time reports: a fresh cache could still trigger a sync attempt and a runtime initialization failure could escape the best-effort path. Reusing the shared helper keeps graph consistent with the rest of the CLI and avoids turning optional Cursor refresh into a blocker for local graph generation.

## Diff scope

- `crates/tokscale-cli/src/main.rs`: replaces the graph-specific Cursor sync block with `auto_sync_cursor_for_local_report`, preserving setup warnings and benchmark output semantics.
- `crates/tokscale-cli/tests/cli_tests.rs`: adds a graph regression for fresh Cursor cache behavior using an explicit Cursor client filter to keep the test focused on the sync path.

## Branch integrity

- Base branch: `main`.
- Validated base SHA: `a86e688d620939d2c973c6d5625baa815ea223d7`.
- Ahead/behind: `0 behind / 1 ahead` against `origin/main`.
- Merge base: `a86e688d620939d2c973c6d5625baa815ea223d7`.
- Fast-forward safety: `origin/main` is an ancestor of this branch.

## Commit integrity

- Introduced commit: `8e0aecc2cc96e3a9e5369d335543829701c11b8b fix(graph): reuse local Cursor auto-sync path`.
- The PR contains one logical change scoped to graph Cursor auto-sync behavior and regression coverage.
- Ledger: not applicable - not required for this change family.
- Version: not applicable - no release manifest changed; version coherence was verified.

## Diff hygiene

- `git diff --name-status origin/main...HEAD`: only `crates/tokscale-cli/src/main.rs` and `crates/tokscale-cli/tests/cli_tests.rs` changed.
- `git diff --check origin/main...HEAD`: PASS, no output.


## Validation mode and proof

Mode 2 - narrow runtime change, because the diff changes one CLI report path and focused CLI tests without touching migrations, auth, deployment tooling, or external contracts.

- TDD red proof: `cargo test -p tokscale-cli test_graph_fresh_cursor_cache_skips_auto_sync_warning` failed before the implementation by exposing `Cursor sync failed; using cached data` despite a fresh cache.
- `cargo test -p tokscale-cli test_graph_fresh_cursor_cache_skips_auto_sync_warning`: PASS, 1 test.
- `cargo test -p tokscale-cli cursor_auto_sync`: PASS, 5 tests.
- `cargo test -p tokscale-cli graph_cursor`: PASS, 1 test.
- `cargo fmt --all -- --check`: PASS, no output.
- `bash scripts/check-version-coherence.sh`: PASS, `Version coherence OK: 3.0.0`.
- `git diff --check origin/main...HEAD`: PASS, no output.
- Additional lint: `cargo clippy -p tokscale-cli -- -D warnings` could not run in this local environment because installed rustc is `1.86.0` while resolved dependencies require rustc `1.88.0+`.
- Not run: full workspace test suite - not required for selected validation mode; required remote CI will run after the PR is opened.

## Required remote gates

Pending - GitHub Actions and mergeability checks will run after the PR is opened. Remote CI is expected to provide the final lint/build proof on its configured Rust toolchain.

## Migration notes

Not applicable - no database migration changed.

## Runtime safety

The change reuses an existing best-effort helper rather than introducing a new sync mechanism. Cursor sync remains optional, fresh caches short-circuit refresh, setup warnings are preserved, and graph generation still proceeds from local/cached data when sync is unavailable. No invariant regression introduced.

## Documentation integrity

Not applicable - no docs, commands, or runbooks changed.

## Rollback plan

Rollback: revert this PR. DB downgrade: not applicable. Data repair: not applicable. Operational caveats: reverting would restore graph-specific Cursor sync behavior that can warn or fail differently from other local reports.

## Known residual risks

Remote CI and GitHub mergeability are pending until the PR is opened. Local clippy for `tokscale-cli` could not run on this machine because the installed Rust compiler is older than the resolved dependency MSRV; targeted tests and formatting passed locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `tokscale graph` reuse the shared best-effort Cursor auto-sync helper used by other local reports. This keeps behavior consistent, avoids unnecessary sync warnings on a fresh cache, and ensures graph generation never blocks on auto-sync.

- **Bug Fixes**
  - Switched to `auto_sync_cursor_for_local_report` for graph.
  - Preserved setup warnings; no hard failure if the implicit runtime can’t start.
  - Added CLI regression test to confirm fresh Cursor cache doesn’t emit a failed-sync warning.

<sup>Written for commit 8e0aecc2cc96e3a9e5369d335543829701c11b8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

