### PR TITLE
fix(pricing): skip unusable exact price entries

### DIFF
--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -587,11 +587,9 @@ impl PricingLookup {
             let key = format!("{}{}", prefix, model_id);
             if let Some(litellm_key) = self.litellm_lower.get(&key) {
                 if let Some(pricing) = self.litellm.get(litellm_key) {
-                    return Some(LookupResult {
-                        pricing: pricing.clone(),
-                        source: "LiteLLM".into(),
-                        matched_key: litellm_key.clone(),
-                    });
+                    if let Some(result) = lookup_result_if_usable(pricing, "LiteLLM", litellm_key) {
+                        return Some(result);
+                    }
                 }
             }
         }
@@ -657,30 +655,18 @@ impl PricingLookup {
     fn exact_match_litellm(&self, model_id: &str) -> Option<LookupResult> {
         let key = self.litellm_lower.get(model_id)?;
         let pricing = self.litellm.get(key)?;
-        Some(LookupResult {
-            pricing: pricing.clone(),
-            source: "LiteLLM".into(),
-            matched_key: key.clone(),
-        })
+        lookup_result_if_usable(pricing, "LiteLLM", key)
     }
 
     fn exact_match_openrouter(&self, model_id: &str) -> Option<LookupResult> {
         if let Some(key) = self.openrouter_lower.get(model_id) {
             if let Some(pricing) = self.openrouter.get(key) {
-                return Some(LookupResult {
-                    pricing: pricing.clone(),
-                    source: "OpenRouter".into(),
-                    matched_key: key.clone(),
-                });
+                return lookup_result_if_usable(pricing, "OpenRouter", key);
             }
         }
         if let Some(key) = self.openrouter_model_part.get(model_id) {
             if let Some(pricing) = self.openrouter.get(key) {
-                return Some(LookupResult {
-                    pricing: pricing.clone(),
-                    source: "OpenRouter".into(),
-                    matched_key: key.clone(),
-                });
+                return lookup_result_if_usable(pricing, "OpenRouter", key);
             }
         }
         None
@@ -688,20 +674,12 @@ impl PricingLookup {
 
     fn exact_match_cursor(&self, model_id: &str) -> Option<LookupResult> {
         if let Some(key) = self.cursor_lower.get(model_id) {
-            return Some(LookupResult {
-                pricing: self.cursor.get(key).unwrap().clone(),
-                source: "Cursor".into(),
-                matched_key: key.clone(),
-            });
+            return lookup_result_if_usable(self.cursor.get(key).unwrap(), "Cursor", key);
         }
         if let Some(model_part) = model_id.split('/').next_back() {
             if model_part != model_id {
                 if let Some(key) = self.cursor_lower.get(model_part) {
-                    return Some(LookupResult {
-                        pricing: self.cursor.get(key).unwrap().clone(),
-                        source: "Cursor".into(),
-                        matched_key: key.clone(),
-                    });
+                    return lookup_result_if_usable(self.cursor.get(key).unwrap(), "Cursor", key);
                 }
             }
         }
@@ -721,11 +699,9 @@ impl PricingLookup {
             let key = format!("{}{}", prefix, model_id);
             if let Some(litellm_key) = self.litellm_lower.get(&key) {
                 if let Some(pricing) = self.litellm.get(litellm_key) {
-                    return Some(LookupResult {
-                        pricing: pricing.clone(),
-                        source: "LiteLLM".into(),
-                        matched_key: litellm_key.clone(),
-                    });
+                    if let Some(result) = lookup_result_if_usable(pricing, "LiteLLM", litellm_key) {
+                        return Some(result);
+                    }
                 }
             }
         }
@@ -745,11 +721,9 @@ impl PricingLookup {
             let key = format!("{}{}", prefix, model_id);
             if let Some(or_key) = self.openrouter_lower.get(&key) {
                 if let Some(pricing) = self.openrouter.get(or_key) {
-                    return Some(LookupResult {
-                        pricing: pricing.clone(),
-                        source: "OpenRouter".into(),
-                        matched_key: or_key.clone(),
-                    });
+                    if let Some(result) = lookup_result_if_usable(pricing, "OpenRouter", or_key) {
+                        return Some(result);
+                    }
                 }
             }
         }
@@ -1077,6 +1051,8 @@ fn normalize_model_name(model_id: &str) -> Option<String> {
     if lower.contains("opus") {
         if let Some(model) = normalize_claude_opus_4_minor(&lower) {
             return Some(model);
+        } else if contains_delimited_major_minor(&lower, '4') {
+            return None;
         } else if contains_delimited_fragment(&lower, "4") {
             return Some("claude-opus-4".into());
         }
@@ -1085,6 +1061,8 @@ fn normalize_model_name(model_id: &str) -> Option<String> {
         if contains_delimited_fragment(&lower, "4.5") || contains_delimited_fragment(&lower, "4-5")
         {
             return Some("claude-sonnet-4-5".into());
+        } else if contains_delimited_major_minor(&lower, '4') {
+            return None;
         } else if contains_delimited_fragment(&lower, "4") {
             return Some("claude-sonnet-4".into());
         } else if contains_delimited_fragment(&lower, "3.7")
@@ -1101,6 +1079,8 @@ fn normalize_model_name(model_id: &str) -> Option<String> {
         if contains_delimited_fragment(&lower, "4.5") || contains_delimited_fragment(&lower, "4-5")
         {
             return Some("claude-haiku-4-5".into());
+        } else if contains_delimited_major_minor(&lower, '4') {
+            return None;
         } else if contains_delimited_fragment(&lower, "3.5")
             || contains_delimited_fragment(&lower, "3-5")
         {
@@ -1221,6 +1201,18 @@ fn has_any_usable_pricing(pricing: &ModelPricing) -> bool {
     .any(|opt| opt.is_some_and(is_valid_price_value))
 }
 
+fn lookup_result_if_usable(
+    pricing: &ModelPricing,
+    source: &str,
+    matched_key: &str,
+) -> Option<LookupResult> {
+    has_any_usable_pricing(pricing).then(|| LookupResult {
+        pricing: pricing.clone(),
+        source: source.into(),
+        matched_key: matched_key.into(),
+    })
+}
+
 fn has_any_valid_above_tier_value(pricing: &ModelPricing) -> bool {
     [
         pricing.input_cost_per_token_above_128k_tokens,
@@ -1305,6 +1297,26 @@ fn contains_delimited_fragment(haystack: &str, fragment: &str) -> bool {
     false
 }
 
+fn contains_delimited_major_minor(haystack: &str, major: char) -> bool {
+    for (pos, _) in haystack.match_indices(major) {
+        let before_ok = pos == 0 || !haystack[..pos].chars().last().unwrap().is_alphanumeric();
+        let after_pos = pos + major.len_utf8();
+        let mut after = haystack[after_pos..].chars();
+        let Some(separator) = after.next() else {
+            continue;
+        };
+        let Some(minor_start) = after.next() else {
+            continue;
+        };
+
+        if before_ok && matches!(separator, '.' | '-') && minor_start.is_ascii_digit() {
+            return true;
+        }
+    }
+
+    false
+}
+
 fn is_fuzzy_eligible(model_id: &str) -> bool {
     if model_id.len() < MIN_FUZZY_MATCH_LEN {
         return false;
@@ -1319,6 +1331,10 @@ fn try_strip_unknown_suffix<F>(model_id: &str, do_lookup: F) -> Option<LookupRes
 where
     F: Fn(&str) -> Option<LookupResult>,
 {
+    if has_unrecognized_claude_four_minor(model_id) {
+        return None;
+    }
+
     let parts: Vec<&str> = model_id.split('-').collect();
 
     if parts.len() < 2 {
@@ -1331,6 +1347,10 @@ where
         let candidate: String = parts[..parts.len() - strip].join("-");
 
         if candidate.len() >= MIN_MODEL_NAME_LEN {
+            if strips_claude_numeric_minor(&candidate, parts[parts.len() - strip]) {
+                continue;
+            }
+
             if let Some(result) = do_lookup(&candidate) {
                 return Some(result);
             }
@@ -1338,6 +1358,30 @@ where
     }
 
     None
+}
+
+fn strips_claude_numeric_minor(candidate: &str, first_stripped_segment: &str) -> bool {
+    !first_stripped_segment.is_empty()
+        && first_stripped_segment.chars().all(|c| c.is_ascii_digit())
+        && (candidate.contains("claude")
+            || candidate.contains("opus")
+            || candidate.contains("sonnet")
+            || candidate.contains("haiku"))
+        && contains_delimited_fragment(candidate, "4")
+}
+
+fn has_unrecognized_claude_four_minor(model_id: &str) -> bool {
+    (model_id.contains("claude")
+        || model_id.contains("opus")
+        || model_id.contains("sonnet")
+        || model_id.contains("haiku"))
+        && contains_delimited_major_minor(model_id, '4')
+        && !contains_delimited_fragment(model_id, "4.5")
+        && !contains_delimited_fragment(model_id, "4-5")
+        && !contains_delimited_fragment(model_id, "4.6")
+        && !contains_delimited_fragment(model_id, "4-6")
+        && !contains_delimited_fragment(model_id, "4.7")
+        && !contains_delimited_fragment(model_id, "4-7")
 }
 
 /// Attempts to find a model by progressively stripping leading segments.
@@ -2739,7 +2783,7 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_opus_4_60_does_not_map_to_4_6() {
+    fn test_normalize_opus_4_60_does_not_degrade_to_opus_4() {
         let mut litellm = HashMap::new();
         litellm.insert(
             "claude-opus-4".into(),
@@ -2759,9 +2803,7 @@ mod tests {
         );
 
         let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
-        let result = lookup.lookup("opus-4-60").unwrap();
-        assert_eq!(result.matched_key, "claude-opus-4");
-        assert_ne!(result.matched_key, "claude-opus-4-6");
+        assert!(lookup.lookup("opus-4-60").is_none());
     }
 
     #[test]
@@ -2868,7 +2910,7 @@ mod tests {
     }
 
     #[test]
-    fn test_future_opus_4_minor_does_not_degrade_to_legacy_opus_4() {
+    fn test_unknown_future_opus_minor_does_not_degrade_to_opus_4() {
         let mut openrouter = HashMap::new();
         openrouter.insert(
             "anthropic/claude-opus-4".into(),
@@ -2880,12 +2922,9 @@ mod tests {
         );
 
         let lookup = PricingLookup::new(HashMap::new(), openrouter, HashMap::new());
-        let result = lookup.lookup("aws.claude-opus-4-8");
-        assert!(
-            result.is_none(),
-            "unknown future opus minor versions must not price as legacy claude-opus-4; got {:?}",
-            result.map(|result| result.matched_key)
-        );
+
+        assert!(lookup.lookup("claude-opus-4-8").is_none());
+        assert!(lookup.lookup("aws.claude-opus-4-8").is_none());
     }
 
     #[test]
@@ -3833,6 +3872,79 @@ mod tests {
         assert_eq!(result.matched_key, "claude-opus-4-6-20250301");
         assert_eq!(result.source, "LiteLLM");
         assert!(result.pricing.input_cost_per_token.is_some());
+    }
+
+    #[test]
+    fn test_none_pricing_exact_litellm_does_not_shadow_openrouter_model_part() {
+        let mut litellm = HashMap::new();
+        litellm.insert("claude-opus-4-6".into(), ModelPricing::default());
+
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "anthropic/claude-opus-4-6".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000005),
+                output_cost_per_token: Some(0.000025),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, openrouter, HashMap::new());
+        let result = lookup.lookup("claude-opus-4-6").unwrap();
+
+        assert_eq!(result.source, "OpenRouter");
+        assert_eq!(result.matched_key, "anthropic/claude-opus-4-6");
+
+        let cost = lookup.calculate_cost("claude-opus-4-6", 100, 20, 0, 0, 0);
+        assert!(cost > 0.0, "cost should use priced fallback, got {cost}");
+    }
+
+    #[test]
+    fn test_none_pricing_provider_exact_does_not_shadow_stripped_priced_entry() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "anthropic/claude-sonnet-4-5".into(),
+            ModelPricing::default(),
+        );
+        litellm.insert(
+            "claude-sonnet-4-5".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000003),
+                output_cost_per_token: Some(0.000015),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+        let result = lookup.lookup("anthropic/claude-sonnet-4-5").unwrap();
+
+        assert_eq!(result.source, "LiteLLM");
+        assert_eq!(result.matched_key, "claude-sonnet-4-5");
+
+        let cost = lookup.calculate_cost("anthropic/claude-sonnet-4-5", 100, 20, 0, 0, 0);
+        assert!(
+            cost > 0.0,
+            "cost should use stripped priced entry, got {cost}"
+        );
+    }
+
+    #[test]
+    fn test_zero_pricing_exact_entry_is_usable() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "free-model".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0),
+                output_cost_per_token: Some(0.0),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+        let result = lookup.lookup("free-model").unwrap();
+
+        assert_eq!(result.matched_key, "free-model");
+        assert_eq!(lookup.calculate_cost("free-model", 100, 20, 0, 0, 0), 0.0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Ignore exact pricing matches whose pricing object has no usable price fields, allowing a priced fallback source to win.
- Keep explicit finite zero-price entries valid, so free or zero-base provider overrides are not accidentally rejected.
- Prevent unknown future Claude 4.x minor variants from degrading to older Claude 4 pricing.

## Why

Exact lookup paths could return a `ModelPricing` entry where every price field was `None`. That made the resolver stop early and report zero cost even when another pricing source had usable prices for the same model. The same resolver family also needed a guard against mapping unknown future Claude 4.x variants onto older lower-version Claude 4 rows, which can silently produce misleading cost estimates.

Related issues: #548, #631.

## Diff scope

- `crates/tokscale-core/src/pricing/lookup.rs`: filters exact and provider-prefixed direct matches through the existing usable-pricing rules before returning them.
- `crates/tokscale-core/src/pricing/lookup.rs`: adds Claude 4.x minor-version guards so unrecognized future minor variants stay unknown instead of falling through to legacy lower-version pricing.
- `crates/tokscale-core/src/pricing/lookup.rs`: adds regression coverage for unusable exact entries, provider-prefixed fallback behavior, valid zero-price entries, and unknown future Claude minor variants.

## Branch integrity

- Base branch: `main`.
- Validated base SHA: `a86e688d620939d2c973c6d5625baa815ea223d7`.
- Ahead/behind: `0 behind / 1 ahead` against `origin/main`.
- Merge base: `a86e688d620939d2c973c6d5625baa815ea223d7`.
- Fast-forward safety: `origin/main` is an ancestor of this branch.

## Commit integrity

- Introduced commit: `efcba6c32f1b7941f3b417e35a1eb5630431a5f0 fix(pricing): skip unusable exact price entries`.
- The PR contains one logical change scoped to pricing resolver safety and regression coverage.
- Ledger: not applicable — not required for this change family.
- Version: not applicable — release workflow owns package version bumps.

## Diff hygiene

- `git diff --name-status origin/main...HEAD`: only `crates/tokscale-core/src/pricing/lookup.rs` changed.
- `git diff --check origin/main...HEAD`: PASS, no output.

## Validation mode and proof

Mode 2 — narrow runtime change, because the diff changes localized pricing lookup behavior and focused tests without touching migrations, auth, deployment tooling, or external service contracts.

- TDD red proof: the all-`None` exact shadowing case and unknown Claude minor fallback tests failed before the implementation.
- `cargo test -p tokscale-core pricing::lookup::tests -- --nocapture`: PASS, 143 tests.
- `cargo fmt --all -- --check`: PASS, no output.
- `git diff --check origin/main...HEAD`: PASS, no output.
- Not run: full workspace test suite — not required for selected validation mode; targeted pricing lookup tests cover the changed resolver behavior.

## Required remote gates

Pending — GitHub Actions and mergeability checks will run after the PR is opened.

## Migration notes

Not applicable — no database migration changed.

## Runtime safety

The change narrows resolver acceptance for unusable exact rows and preserves the existing finite-price validation path. It does not add external I/O, persistent state, concurrency, or new pricing data sources. No invariant regression introduced.

## Documentation integrity

Not applicable — no docs, commands, or runbooks changed.

## Rollback plan

Rollback: revert this PR. DB downgrade: not applicable. Data repair: not applicable. Operational caveats: reverting would restore early returns for unusable exact pricing rows and the older Claude minor-version fallback behavior.

## Known residual risks

Remote CI and GitHub mergeability are pending until the PR is opened. The resolver intentionally treats unknown future Claude minor versions as unknown pricing rather than estimating from older lower-version rows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip exact and derived matches that have no usable price fields, so the resolver falls back to a priced source instead of reporting zero cost. Unknown Claude 4.x minor variants now stay unpriced instead of degrading to Claude 4; explicit 0.0 prices remain valid.

- **Bug Fixes**
  - Filter exact, provider-prefixed, and model-part matches across `LiteLLM`, `OpenRouter`, and `Cursor` to only return usable pricing; otherwise allow fallback.
  - Prefer stripped/priced entries when a provider-exact row exists but has no prices.
  - Keep unknown Claude 4.x minor variants unknown and block numeric-suffix stripping that would map them to 4; no degradation across prefixes.
  - Added tests for unusable exact/model-part entries, stripped fallbacks, valid zero-price entries, and future Claude 4 minor variants.

<sup>Written for commit 5d657da7db92b60d0b093383991de8408b5c9a32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

