### PR TITLE
fix(claude): preserve cc-mirror tool result attribution

### DIFF
--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -426,6 +426,8 @@ pub fn parse_claude_file_with_cache_and_home(
                         entry: &entry,
                         last_model: last_model.as_deref(),
                         last_provider_hint: last_provider_hint.as_deref(),
+                        client_id: &client_id,
+                        default_provider_hint: metadata_provider_hint,
                         session_id: &session_id,
                         fallback_timestamp,
                         workspace_key: workspace_key.clone(),
@@ -813,6 +815,8 @@ struct ClaudeToolResultContext<'a> {
     entry: &'a ClaudeEntry,
     last_model: Option<&'a str>,
     last_provider_hint: Option<&'a str>,
+    client_id: &'a str,
+    default_provider_hint: Option<&'a str>,
     session_id: &'a str,
     fallback_timestamp: i64,
     workspace_key: Option<String>,
@@ -846,7 +850,8 @@ fn extract_claude_tool_result_message(
                 .and_then(|message| message.provider_id.clone())
         })
         .or_else(|| context.entry.provider_id.clone())
-        .or_else(|| context.last_provider_hint.map(str::to_string));
+        .or_else(|| context.last_provider_hint.map(str::to_string))
+        .or_else(|| context.default_provider_hint.map(str::to_string));
 
     let provider_choice = claude_provider_choice(&raw_model, provider_hint.as_deref());
     let model = canonicalize_claude_model(&raw_model);
@@ -855,7 +860,7 @@ fn extract_claude_tool_result_message(
         .unwrap_or(context.fallback_timestamp);
 
     let mut message = UnifiedMessage::new_with_dedup(
-        "claude",
+        context.client_id,
         model,
         provider_choice.id,
         context.session_id.to_string(),
@@ -868,9 +873,12 @@ fn extract_claude_tool_result_message(
             reasoning: 0,
         },
         0.0,
-        usage
-            .dedup_key
-            .map(|key| format!("claude:tool_result:{}:{key}", context.session_id)),
+        usage.dedup_key.map(|key| {
+            format!(
+                "{}:tool_result:{}:{key}",
+                context.client_id, context.session_id
+            )
+        }),
     );
     message.message_count = 0;
     message.agent = context.sidechain_agent;
@@ -1922,6 +1930,27 @@ mod tests {
             messages[0].dedup_key.as_deref(),
             Some(expected_dedup_key.as_str())
         );
+        assert_eq!(messages[0].message_count, 0);
+    }
+
+    #[test]
+    fn test_cc_mirror_tool_result_keeps_variant_client_and_provider() {
+        let content = r#"{"type":"user","timestamp":"2026-05-27T10:00:00.000Z","message":{"model":"sonnet","content":[{"type":"tool_result","tool_use_id":"toolu_cc_mirror","tool_output":{"input_tokens":7,"output":"tool output"}}]}}"#;
+
+        let (_temp_dir, path) = create_cc_mirror_project_file(
+            content,
+            "zai-worker",
+            "zai",
+            "project-one",
+            "session.jsonl",
+        );
+        let messages = parse_claude_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, "cc-mirror/zai-worker");
+        assert_eq!(messages[0].provider_id, "zai");
+        assert_eq!(messages[0].model_id, "sonnet");
+        assert_eq!(messages[0].tokens.input, 7);
         assert_eq!(messages[0].message_count, 0);
     }
 


### PR DESCRIPTION
## Summary

- Preserve cc-mirror variant client attribution for Claude `tool_result` usage rows.
- Carry the cc-mirror variant provider fallback into tool-result parsing, so pricing and diagnostics stay provider-aware.
- Add regression coverage for cc-mirror tool-result records using a variant client id and non-Anthropic provider.

## Why

Tokscale can discover cc-mirror Claude-compatible variants, but Claude `tool_result` usage rows had a separate parsing path that could fall back to plain `claude` attribution. That makes variant-scoped usage harder to understand and can lose the provider context needed for accurate pricing when a cc-mirror variant points at a non-Anthropic backend.

Related issue: #610.

## Diff scope

- `crates/tokscale-core/src/sessions/claudecode.rs`: threads the active client and provider context through Claude tool-result usage parsing.
- `crates/tokscale-core/src/sessions/claudecode.rs`: adds a regression fixture proving a cc-mirror variant keeps `cc-mirror/<variant>` client attribution and the variant provider fallback on tool-result usage.

## Branch integrity

- Base branch: `main`.
- Validated base SHA: `a86e688d620939d2c973c6d5625baa815ea223d7`.
- Ahead/behind: `0 behind / 1 ahead` against `origin/main`.
- Merge base: `a86e688d620939d2c973c6d5625baa815ea223d7`.
- Fast-forward safety: `origin/main` is an ancestor of this branch.

## Commit integrity

- Introduced commit: `75b321952d6858d8551be8794426c0829f3c333f fix(claude): preserve cc-mirror tool result attribution`.
- The PR contains one logical change scoped to Claude parser attribution for cc-mirror tool-result usage.
- Ledger: not applicable — not required for this change family.
- Version: PASS, `scripts/check-version-coherence.sh`.

## Diff hygiene

- `git diff --name-status origin/main...HEAD`: only `crates/tokscale-core/src/sessions/claudecode.rs` changed.
- `git diff --check origin/main...HEAD`: PASS, no output.

## Validation mode and proof

Mode 2 — narrow runtime change, because the diff changes localized Claude parser attribution behavior and focused tests without touching migrations, auth, deployment tooling, or external service contracts.

- TDD red proof: `cargo test -p tokscale-core sessions::claudecode::tests::test_cc_mirror_tool_result_keeps_variant_client_and_provider` failed before the implementation with plain `claude` attribution instead of the cc-mirror variant client.
- `cargo test -p tokscale-core sessions::claudecode::tests::test_cc_mirror_tool_result_keeps_variant_client_and_provider`: PASS.
- `cargo test -p tokscale-core sessions::claudecode`: PASS.
- `cargo test -p tokscale-core cc_mirror`: PASS, 9 tests.
- `cargo fmt --all -- --check`: PASS, no output.
- `scripts/check-version-coherence.sh`: PASS, `Version coherence OK: 3.0.0`.
- `git diff --check origin/main...HEAD`: PASS, no output.
- Not run: frontend validation tests — frontend files were not touched.

## Required remote gates

Pending — GitHub Actions and mergeability checks will run after the PR is opened.

## Migration notes

Not applicable — no database migration changed.

## Runtime safety

The change only passes existing parser context into an existing Claude usage branch. It does not add external I/O, persistent state, concurrency, or new scan paths. No invariant regression introduced.

## Documentation integrity

Not applicable — no docs, commands, or runbooks changed.

## Rollback plan

Rollback: revert this PR. DB downgrade: not applicable. Data repair: not applicable. Operational caveats: reverting would restore plain Claude attribution for cc-mirror tool-result usage rows.

## Known residual risks

Remote CI and GitHub mergeability are pending until the PR is opened. This PR is intentionally scoped to preserving attribution for cc-mirror tool-result rows; it does not expand cc-mirror discovery beyond the support already present on `main`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves `cc-mirror/<variant>` client and provider attribution when parsing Claude `tool_result` rows. This keeps pricing and diagnostics provider-aware, including for non-Anthropic backends.

- **Bug Fixes**
  - Threaded `client_id` and provider hints through Claude tool-result parsing.
  - Used the variant client in message metadata and dedup keys.
  - Added a regression test to validate variant client and provider are retained.

<sup>Written for commit 75b321952d6858d8551be8794426c0829f3c333f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

