### PR TITLE
fix(release): validate publish inputs before version bump

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -42,63 +42,35 @@ jobs:
 
       - name: Calculate version
         id: bump
+        env:
+          RELEASE_BUMP: ${{ inputs.bump }}
+          RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_RECOVERY: ${{ inputs.recovery }}
         run: |
           # Read current version from packages/cli/package.json (source of truth)
           CURRENT_VERSION=$(jq -r '.version' packages/cli/package.json)
           echo "📦 Current version: $CURRENT_VERSION"
-          echo "base_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
 
-          if [ "${{ inputs.recovery }}" = "true" ] && [ -z "${{ inputs.version }}" ]; then
-            echo "Recovery publishes must provide the existing release version." >&2
-            exit 1
-          fi
-          
-          # Calculate new version
-          if [ -n "${{ inputs.version }}" ]; then
-            NEW_VERSION="${{ inputs.version }}"
+          VERSION_FILE="$(mktemp)"
+          RELEASE_VERSION_FILE="$VERSION_FILE" bash scripts/calculate-release-version.sh
+          NEW_VERSION="$(cat "$VERSION_FILE")"
+          rm -f "$VERSION_FILE"
+
+          if [ -n "$RELEASE_VERSION" ]; then
             echo "📌 Using override version: $NEW_VERSION"
           else
-            # Strip any prerelease suffix for calculation
-            BASE="${CURRENT_VERSION%%-*}"
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
-            
-            case "${{ inputs.bump }}" in
-              "major (X.0.0)")
-                NEW_VERSION="$((MAJOR + 1)).0.0"
-                ;;
-              "minor (x.X.0)")
-                NEW_VERSION="${MAJOR}.$((MINOR + 1)).0"
-                ;;
-              *)
-                NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
-                ;;
-            esac
-            echo "🎯 Bump type: ${{ inputs.bump }}"
+            echo "🎯 Bump type: $RELEASE_BUMP"
           fi
           echo "🚀 New version: $NEW_VERSION"
           
           # Update packages/cli/package.json (version + platform optionalDependencies)
           jq --arg v "$NEW_VERSION" '.version = $v
-            | .optionalDependencies["@tokscale/cli-darwin-arm64"] = $v
-            | .optionalDependencies["@tokscale/cli-darwin-x64"] = $v
-            | .optionalDependencies["@tokscale/cli-linux-x64-gnu"] = $v
-            | .optionalDependencies["@tokscale/cli-linux-x64-musl"] = $v
-            | .optionalDependencies["@tokscale/cli-linux-arm64-gnu"] = $v
-            | .optionalDependencies["@tokscale/cli-linux-arm64-musl"] = $v
-            | .optionalDependencies["@tokscale/cli-win32-x64-msvc"] = $v
-            | .optionalDependencies["@tokscale/cli-win32-arm64-msvc"] = $v' packages/cli/package.json > tmp.json && mv tmp.json packages/cli/package.json
+            | .optionalDependencies = ((.optionalDependencies // {}) | with_entries(.value = $v))' packages/cli/package.json > tmp.json && mv tmp.json packages/cli/package.json
           echo "✅ Updated packages/cli/package.json"
 
           # Update platform package versions
-          for pkg in \
-            cli-darwin-arm64 \
-            cli-darwin-x64 \
-            cli-linux-x64-gnu \
-            cli-linux-x64-musl \
-            cli-linux-arm64-gnu \
-            cli-linux-arm64-musl \
-            cli-win32-x64-msvc \
-            cli-win32-arm64-msvc; do
+          mapfile -t PLATFORM_PACKAGES < <(jq -r '.optionalDependencies | keys[] | sub("^@tokscale/"; "")' packages/cli/package.json | sort)
+          for pkg in "${PLATFORM_PACKAGES[@]}"; do
             jq --arg v "$NEW_VERSION" '.version = $v' "packages/$pkg/package.json" > tmp.json && mv tmp.json "packages/$pkg/package.json"
             echo "✅ Updated packages/$pkg/package.json"
           done
@@ -147,13 +119,11 @@ jobs:
           echo "  cli -> darwin arm64: $(jq -r '.optionalDependencies["@tokscale/cli-darwin-arm64"]' packages/cli/package.json)"
           echo "  tokscale -> cli: $(jq -r '.dependencies["@tokscale/cli"]' packages/tokscale/package.json)"
           echo "  Platform packages:"
-          for pkg in cli-darwin-arm64 cli-darwin-x64 cli-linux-x64-gnu cli-linux-x64-musl cli-linux-arm64-gnu cli-linux-arm64-musl cli-win32-x64-msvc cli-win32-arm64-msvc; do
+          for pkg in "${PLATFORM_PACKAGES[@]}"; do
             echo "    $pkg: $(jq -r '.version' "packages/$pkg/package.json")"
           done
 
           bash scripts/check-version-coherence.sh --expect-version "$NEW_VERSION"
-          
-          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "📝 Version bump prepared (will commit after successful publish)"
 
       - name: Upload bumped manifest files
@@ -164,14 +134,7 @@ jobs:
             Cargo.toml
             Cargo.lock
             packages/cli/package.json
-            packages/cli-darwin-arm64/package.json
-            packages/cli-darwin-x64/package.json
-            packages/cli-linux-x64-gnu/package.json
-            packages/cli-linux-x64-musl/package.json
-            packages/cli-linux-arm64-gnu/package.json
-            packages/cli-linux-arm64-musl/package.json
-            packages/cli-win32-x64-msvc/package.json
-            packages/cli-win32-arm64-msvc/package.json
+            packages/cli-*/package.json
             packages/tokscale/package.json
           retention-days: 1
 

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -11,7 +11,7 @@ on:
       - 'packages/cli/package.json'
       - 'packages/tokscale/package.json'
       - 'packages/cli-*/package.json'
-      - 'scripts/check-version-coherence.sh'
+      - 'scripts/*.sh'
       - '.github/workflows/publish-cli.yml'
       - '.github/workflows/test_coverage.yml'
   pull_request:
@@ -23,7 +23,7 @@ on:
       - 'packages/cli/package.json'
       - 'packages/tokscale/package.json'
       - 'packages/cli-*/package.json'
-      - 'scripts/check-version-coherence.sh'
+      - 'scripts/*.sh'
       - '.github/workflows/publish-cli.yml'
       - '.github/workflows/test_coverage.yml'
 
@@ -45,6 +45,12 @@ jobs:
           components: clippy, rustfmt
       - name: Verify version coherence
         run: bash scripts/check-version-coherence.sh
+      - name: Run release helper tests
+        run: |
+          bash scripts/test-calculate-release-version.sh
+          bash scripts/test-check-version-coherence.sh
+          bash scripts/test-npm-release-state.sh
+          bash scripts/test-prepare-release-provenance.sh
       - name: Cache cargo registry
         uses: actions/cache@v5
         with:

--- a/scripts/calculate-release-version.sh
+++ b/scripts/calculate-release-version.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+RELEASE_BUMP="${RELEASE_BUMP:-patch (x.x.X)}"
+RELEASE_VERSION="${RELEASE_VERSION:-}"
+RELEASE_RECOVERY="${RELEASE_RECOVERY:-false}"
+RELEASE_VERSION_FILE="${RELEASE_VERSION_FILE:-}"
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+validate_semver() {
+  local label="$1"
+  local value="$2"
+  python3 - "${label}" "${value}" <<'PY'
+import re
+import sys
+
+label, value = sys.argv[1:]
+identifier = r"(?:0|[1-9A-Za-z-][0-9A-Za-z-]*)"
+pattern = re.compile(
+    r"^(0|[1-9][0-9]*)\."
+    r"(0|[1-9][0-9]*)\."
+    r"(0|[1-9][0-9]*)"
+    rf"(?:-({identifier}(?:\.{identifier})*))?"
+    rf"(?:\+({identifier}(?:\.{identifier})*))?$"
+)
+if not pattern.match(value):
+    raise SystemExit(f"{label}: {value}")
+PY
+}
+
+write_output() {
+  local key="$1"
+  local value="$2"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "${key}=${value}" >> "${GITHUB_OUTPUT}"
+  fi
+}
+
+CURRENT_VERSION="$(jq -r '.version' packages/cli/package.json)"
+[[ -n "${CURRENT_VERSION}" && "${CURRENT_VERSION}" != "null" ]] ||
+  fail "Could not read packages/cli/package.json version"
+validate_semver "Invalid current version" "${CURRENT_VERSION}" ||
+  fail "Invalid current version: ${CURRENT_VERSION}"
+
+if [[ "${RELEASE_RECOVERY}" == "true" && -z "${RELEASE_VERSION}" ]]; then
+  fail "Recovery publishes must provide the existing release version."
+fi
+
+if [[ -n "${RELEASE_VERSION}" ]]; then
+  validate_semver "Invalid release version override" "${RELEASE_VERSION}" ||
+    fail "Invalid release version override: ${RELEASE_VERSION}"
+  NEW_VERSION="${RELEASE_VERSION}"
+else
+  BASE="${CURRENT_VERSION%%-*}"
+  BASE="${BASE%%+*}"
+  IFS='.' read -r MAJOR MINOR PATCH <<< "${BASE}"
+
+  case "${RELEASE_BUMP}" in
+    "major (X.0.0)")
+      NEW_VERSION="$((MAJOR + 1)).0.0"
+      ;;
+    "minor (x.X.0)")
+      NEW_VERSION="${MAJOR}.$((MINOR + 1)).0"
+      ;;
+    "patch (x.x.X)")
+      NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+      ;;
+    *)
+      fail "Unsupported release bump value: ${RELEASE_BUMP}"
+      ;;
+  esac
+fi
+
+write_output "base_version" "${CURRENT_VERSION}"
+write_output "version" "${NEW_VERSION}"
+if [[ -n "${RELEASE_VERSION_FILE}" ]]; then
+  printf '%s\n' "${NEW_VERSION}" > "${RELEASE_VERSION_FILE}"
+fi
+echo "release version: ${NEW_VERSION}"

--- a/scripts/check-version-coherence.sh
+++ b/scripts/check-version-coherence.sh
@@ -56,6 +56,17 @@ if not platform_packages:
 
 errors: list[str] = []
 
+required_platform_names = {
+    "@tokscale/cli-darwin-arm64",
+    "@tokscale/cli-darwin-x64",
+    "@tokscale/cli-linux-arm64-gnu",
+    "@tokscale/cli-linux-arm64-musl",
+    "@tokscale/cli-linux-x64-gnu",
+    "@tokscale/cli-linux-x64-musl",
+    "@tokscale/cli-win32-arm64-msvc",
+    "@tokscale/cli-win32-x64-msvc",
+}
+
 def expect_equal(label: str, actual: str, expected: str) -> None:
     if actual != expected:
         errors.append(f"{label}: expected {expected}, found {actual}")
@@ -75,20 +86,28 @@ for path in platform_packages:
     if not name:
         errors.append(f"{path} missing package name")
         continue
+    if not name.startswith("@tokscale/cli-"):
+        errors.append(f"{path} package name must start with @tokscale/cli-")
+        continue
     platform_names.add(name)
     expect_equal(f"{path} version", manifest["version"], workspace_version)
 
-expected_optional = {
-    "@tokscale/cli-darwin-arm64",
-    "@tokscale/cli-darwin-x64",
-    "@tokscale/cli-linux-x64-gnu",
-    "@tokscale/cli-linux-x64-musl",
-    "@tokscale/cli-linux-arm64-gnu",
-    "@tokscale/cli-linux-arm64-musl",
-    "@tokscale/cli-win32-x64-msvc",
-    "@tokscale/cli-win32-arm64-msvc",
-}
+expected_optional = platform_names
 actual_optional = set(cli_package["optionalDependencies"].keys())
+missing_required_manifests = required_platform_names - platform_names
+if missing_required_manifests:
+    errors.append(
+        "Missing required platform package manifests: "
+        f"{sorted(missing_required_manifests)}"
+    )
+
+missing_required_optional = required_platform_names - actual_optional
+if missing_required_optional:
+    errors.append(
+        "Missing required platform optionalDependencies: "
+        f"{sorted(missing_required_optional)}"
+    )
+
 if actual_optional != expected_optional:
     errors.append(
         "packages/cli optionalDependencies keys mismatch: "

--- a/scripts/prepare-release-provenance.sh
+++ b/scripts/prepare-release-provenance.sh
@@ -11,24 +11,31 @@ EXPECTED_RELEASE_BASE_SHA="${EXPECTED_RELEASE_BASE_SHA:-}"
 GITHUB_OUTPUT="${GITHUB_OUTPUT:-}"
 RELEASE_RECOVERY="${RELEASE_RECOVERY:-false}"
 
-MANIFEST_PATHS=(
-  Cargo.toml
-  Cargo.lock
-  packages/cli/package.json
-  packages/cli-darwin-arm64/package.json
-  packages/cli-darwin-x64/package.json
-  packages/cli-linux-x64-gnu/package.json
-  packages/cli-linux-x64-musl/package.json
-  packages/cli-linux-arm64-gnu/package.json
-  packages/cli-linux-arm64-musl/package.json
-  packages/cli-win32-x64-msvc/package.json
-  packages/cli-win32-arm64-msvc/package.json
-  packages/tokscale/package.json
-)
-
 fail() {
   echo "ERROR: $*" >&2
   exit 1
+}
+
+release_manifest_paths() {
+  python3 - <<'PY'
+import json
+import pathlib
+
+root = pathlib.Path(".")
+paths = [
+    pathlib.Path("Cargo.toml"),
+    pathlib.Path("Cargo.lock"),
+    pathlib.Path("packages/cli/package.json"),
+]
+cli = json.loads((root / paths[-1]).read_text())
+for package_name in sorted(cli.get("optionalDependencies", {})):
+    if not package_name.startswith("@tokscale/cli-"):
+        raise SystemExit(f"Unexpected optional dependency package name: {package_name}")
+    paths.append(pathlib.Path("packages") / package_name.removeprefix("@tokscale/") / "package.json")
+paths.append(pathlib.Path("packages/tokscale/package.json"))
+for path in paths:
+    print(path.as_posix())
+PY
 }
 
 [[ -n "${NEW_VERSION}" ]] || fail "NEW_VERSION is required"
@@ -66,6 +73,7 @@ fi
 
 bash scripts/check-version-coherence.sh --expect-version "${NEW_VERSION}"
 
+mapfile -t MANIFEST_PATHS < <(release_manifest_paths)
 git add -- "${MANIFEST_PATHS[@]}"
 if git diff --cached --quiet; then
   if [[ "${RELEASE_RECOVERY}" == "true" ]]; then

--- a/scripts/test-calculate-release-version.sh
+++ b/scripts/test-calculate-release-version.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_UNDER_TEST="${ROOT_DIR}/scripts/calculate-release-version.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+write_cli_manifest() {
+  local work="$1"
+  local version="$2"
+  mkdir -p "${work}/packages/cli"
+  cat > "${work}/packages/cli/package.json" <<EOF_MANIFEST
+{
+  "name": "@tokscale/cli",
+  "version": "${version}"
+}
+EOF_MANIFEST
+}
+
+run_calculate() {
+  local work="$1"
+  local output_file="$2"
+  (
+    cd "${work}"
+    GITHUB_OUTPUT="${output_file}" bash scripts/calculate-release-version.sh
+  )
+}
+
+test_rejects_invalid_override_version() {
+  local work="${TMP_DIR}/invalid-override"
+  mkdir -p "${work}/scripts"
+  cp "${SCRIPT_UNDER_TEST}" "${work}/scripts/calculate-release-version.sh"
+  write_cli_manifest "${work}" "3.0.0"
+
+  local output="${TMP_DIR}/invalid-override-output.txt"
+  local gh_output="${TMP_DIR}/invalid-override-github-output.txt"
+  if RELEASE_VERSION='3.0.1$(echo injected)' RELEASE_BUMP='patch (x.x.X)' run_calculate "${work}" "${gh_output}" >"${output}" 2>&1; then
+    echo "Expected invalid version override to fail" >&2
+    return 1
+  fi
+
+  grep -q "Invalid release version override" "${output}"
+  test ! -s "${gh_output}"
+}
+
+test_recovery_requires_override_version() {
+  local work="${TMP_DIR}/recovery-without-version"
+  mkdir -p "${work}/scripts"
+  cp "${SCRIPT_UNDER_TEST}" "${work}/scripts/calculate-release-version.sh"
+  write_cli_manifest "${work}" "3.0.0"
+
+  local output="${TMP_DIR}/recovery-without-version-output.txt"
+  local gh_output="${TMP_DIR}/recovery-without-version-github-output.txt"
+  if RELEASE_RECOVERY=true RELEASE_BUMP='patch (x.x.X)' run_calculate "${work}" "${gh_output}" >"${output}" 2>&1; then
+    echo "Expected recovery without override version to fail" >&2
+    return 1
+  fi
+
+  grep -q "Recovery publishes must provide the existing release version" "${output}"
+  test ! -s "${gh_output}"
+}
+
+test_calculates_patch_bump_and_sets_outputs() {
+  local work="${TMP_DIR}/patch-bump"
+  mkdir -p "${work}/scripts"
+  cp "${SCRIPT_UNDER_TEST}" "${work}/scripts/calculate-release-version.sh"
+  write_cli_manifest "${work}" "3.0.0-beta.1"
+
+  local gh_output="${TMP_DIR}/patch-bump-github-output.txt"
+  RELEASE_BUMP='patch (x.x.X)' run_calculate "${work}" "${gh_output}" >"${TMP_DIR}/patch-bump-output.txt" 2>&1
+
+  grep -q '^base_version=3.0.0-beta.1$' "${gh_output}"
+  grep -q '^version=3.0.1$' "${gh_output}"
+}
+
+test_rejects_unknown_bump_choice() {
+  local work="${TMP_DIR}/unknown-bump"
+  mkdir -p "${work}/scripts"
+  cp "${SCRIPT_UNDER_TEST}" "${work}/scripts/calculate-release-version.sh"
+  write_cli_manifest "${work}" "3.0.0"
+
+  local output="${TMP_DIR}/unknown-bump-output.txt"
+  local gh_output="${TMP_DIR}/unknown-bump-github-output.txt"
+  if RELEASE_BUMP='patch; echo injected' run_calculate "${work}" "${gh_output}" >"${output}" 2>&1; then
+    echo "Expected unknown bump choice to fail" >&2
+    return 1
+  fi
+
+  grep -q "Unsupported release bump value" "${output}"
+  test ! -s "${gh_output}"
+}
+
+test_publish_workflow_does_not_interpolate_inputs_inside_shell_blocks() {
+  python3 - "${ROOT_DIR}/.github/workflows/publish-cli.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+lines = path.read_text().splitlines()
+errors = []
+in_run_block = False
+run_indent = -1
+
+for number, line in enumerate(lines, start=1):
+    stripped = line.lstrip(" ")
+    indent = len(line) - len(stripped)
+    if stripped.startswith("run: |"):
+        in_run_block = True
+        run_indent = indent
+        continue
+    if in_run_block and stripped and indent <= run_indent:
+        in_run_block = False
+    if in_run_block and "${{ inputs." in line:
+        errors.append(f"{path}:{number}: {line.strip()}")
+
+if errors:
+    raise SystemExit("Workflow inputs are interpolated inside shell run blocks:\n" + "\n".join(errors))
+PY
+}
+
+test_rejects_invalid_override_version
+test_recovery_requires_override_version
+test_calculates_patch_bump_and_sets_outputs
+test_rejects_unknown_bump_choice
+test_publish_workflow_does_not_interpolate_inputs_inside_shell_blocks
+
+echo "calculate-release-version tests passed"

--- a/scripts/test-check-version-coherence.sh
+++ b/scripts/test-check-version-coherence.sh
@@ -143,8 +143,67 @@ EOF_LOCK
   )
 }
 
+test_accepts_new_platform_package_when_manifest_and_optional_dependency_match() {
+  local work="${TMP_DIR}/new-platform-package"
+  mkdir -p "${work}/scripts"
+  cp "${SCRIPT_UNDER_TEST}" "${work}/scripts/check-version-coherence.sh"
+  (
+    cd "${work}"
+    write_release_manifests "3.0.0"
+    mkdir -p packages/cli-linux-riscv64-gnu
+    cat > packages/cli-linux-riscv64-gnu/package.json <<'EOF_MANIFEST'
+{
+  "name": "@tokscale/cli-linux-riscv64-gnu",
+  "version": "3.0.0"
+}
+EOF_MANIFEST
+    python3 - <<'PY'
+import json
+import pathlib
+
+path = pathlib.Path("packages/cli/package.json")
+manifest = json.loads(path.read_text())
+manifest["optionalDependencies"]["@tokscale/cli-linux-riscv64-gnu"] = "3.0.0"
+path.write_text(json.dumps(manifest, indent=2) + "\n")
+PY
+
+    bash scripts/check-version-coherence.sh --expect-version "3.0.0" >"${TMP_DIR}/new-platform-package-output.txt" 2>&1
+  )
+}
+
+test_rejects_missing_canonical_platform_when_manifest_and_optional_dependency_are_removed() {
+  local work="${TMP_DIR}/missing-canonical-platform"
+  mkdir -p "${work}/scripts"
+  cp "${SCRIPT_UNDER_TEST}" "${work}/scripts/check-version-coherence.sh"
+  (
+    cd "${work}"
+    write_release_manifests "3.0.0"
+    rm -rf packages/cli-win32-arm64-msvc
+    python3 - <<'PY'
+import json
+import pathlib
+
+path = pathlib.Path("packages/cli/package.json")
+manifest = json.loads(path.read_text())
+manifest["optionalDependencies"].pop("@tokscale/cli-win32-arm64-msvc")
+path.write_text(json.dumps(manifest, indent=2) + "\n")
+PY
+
+    local output="${TMP_DIR}/missing-canonical-platform-output.txt"
+    if bash scripts/check-version-coherence.sh --expect-version "3.0.0" >"${output}" 2>&1; then
+      echo "Expected missing canonical platform to fail" >&2
+      return 1
+    fi
+
+    grep -q "Missing required platform package manifests: \\['@tokscale/cli-win32-arm64-msvc'\\]" "${output}"
+    grep -q "Missing required platform optionalDependencies: \\['@tokscale/cli-win32-arm64-msvc'\\]" "${output}"
+  )
+}
+
 test_rejects_stale_workspace_versions_in_cargo_lock
 test_accepts_matching_workspace_versions_in_cargo_lock
 test_ignores_registry_duplicate_names_in_cargo_lock
+test_accepts_new_platform_package_when_manifest_and_optional_dependency_match
+test_rejects_missing_canonical_platform_when_manifest_and_optional_dependency_are_removed
 
 echo "check-version-coherence tests passed"


### PR DESCRIPTION
## Summary

- Validate publish workflow version inputs before any release manifest rewrite or package publish step.
- Move release version calculation into a shared script used by the publish workflow and shell tests.
- Keep a canonical required platform-package baseline while still allowing additional platform packages when their manifests and optional dependencies match.
- Wire release helper tests into CI so publish/recovery/version-coherence regressions are caught before manual release runs.

## Why

The publish workflow accepted manual `version` and `bump` inputs directly inside shell steps before a dedicated validation boundary. A malformed override could fail late in the release path, after expensive setup or close to publish-time behavior. This PR adds a small, testable release-version calculator and uses it as the front door for publish version selection, while also keeping the release package matrix safe: new platform packages can be discovered dynamically, but the current canonical platform set cannot disappear silently if both a package manifest and matching `optionalDependencies` entry are removed.

## Diff scope

- `.github/workflows/publish-cli.yml`: calculates and validates the next release version through `scripts/calculate-release-version.sh` before bumping manifests, then passes validated values through environment/output plumbing instead of interpolating raw workflow inputs in the version bump logic.
- `.github/workflows/test_coverage.yml`: runs release helper shell tests when release workflow/scripts change.
- `scripts/calculate-release-version.sh`: adds a shared release version calculator for bump and explicit override inputs.
- `scripts/test-calculate-release-version.sh`: adds focused coverage for valid bumps, explicit versions, invalid overrides, and unsupported input combinations.
- `scripts/check-version-coherence.sh`: restores a canonical required platform-package baseline while preserving dynamic discovery for additional matched platform packages.
- `scripts/test-check-version-coherence.sh`: adds regression coverage for the missing canonical platform case where both the manifest and optional dependency are removed.
- `scripts/prepare-release-provenance.sh`: aligns release provenance behavior with the validated version flow.

## Branch integrity

- Base branch: `main`.
- Validated base SHA: `a86e688d620939d2c973c6d5625baa815ea223d7`.
- Ahead/behind: `0 behind / 1 ahead` against `origin/main`.
- Merge base: `a86e688d620939d2c973c6d5625baa815ea223d7`.
- Fast-forward safety: `origin/main` is an ancestor of this branch.

## Commit integrity

- Introduced commit: `43564cc2bda23081204459e67ed6094e6a29f737 fix(release): validate publish inputs before version bump`.
- The PR contains one logical change scoped to release workflow input validation, platform-package coherence checks, and release helper CI coverage.
- Ledger: not applicable — not required for this change family.
- Version: not applicable — this PR does not change package versions.

## Diff hygiene

- `git diff --name-status origin/main...HEAD`: release workflow, test workflow, and release helper scripts only.
- `git diff --check origin/main...HEAD`: PASS, no output.

## Validation mode and proof

Mode 4 — CI/release tooling, because the diff changes GitHub Actions workflow behavior and release helper scripts.

- TDD red proof: release-version helper tests failed before `scripts/calculate-release-version.sh` existed, and the canonical platform regression test fails without the restored required-platform baseline.
- `bash scripts/test-calculate-release-version.sh && bash scripts/test-check-version-coherence.sh && bash scripts/test-npm-release-state.sh && bash scripts/test-prepare-release-provenance.sh`: PASS.
- `bash -n scripts/check-version-coherence.sh scripts/test-check-version-coherence.sh`: PASS.
- `bash scripts/check-version-coherence.sh`: PASS, `Version coherence OK: 3.0.0`.
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "#{path}: OK" }' .github/workflows/publish-cli.yml .github/workflows/test_coverage.yml`: PASS.
- `gh pr checks 660 --watch --interval 10`: PASS for Lint, Code Coverage, mergeability, Vercel, Vercel Preview Comments, and WIP on commit `43564cc2bda23081204459e67ed6094e6a29f737`.
- Not run: `scripts/test-package-launchers.sh` — not required for selected validation mode because launcher runtime code was unchanged.

## Migration notes

Not applicable — no database migration changed.

## CI context confirmation

Workflow context names for existing test jobs are unchanged. This PR adds release-helper coverage inside the existing test workflow rather than renaming required contexts.

## Runtime safety

Not applicable — no application runtime path changed.

## Documentation integrity

Not applicable — no docs, commands, or runbooks changed. The release behavior is covered by executable helper tests.

## Rollback plan

Rollback: revert this PR. DB downgrade: not applicable. Data repair: not applicable. Operational caveats: reverting would restore the previous publish workflow input handling and remove release-helper CI coverage added here.

## Known residual risks

The publish workflow itself is still manually triggered; this PR validates its input path and helper tests but does not perform a live npm publish dry run.
