### PR TITLE
feat(cline): add Cline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 | Warp/Oz | [Warp](https://www.warp.dev/) / Oz | Cached via `tokscale warp sync` to `~/.config/tokscale/warp-cache/usage.json` (aggregate requests and spend only; no token transcripts) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-zed.webp" alt="Zed Agent" /> | [Zed Agent](https://zed.dev/docs/ai/agent-panel) | `~/.local/share/zed/threads/threads.db` (macOS: `~/Library/Application Support/Zed/threads/threads.db`; Windows: `%LOCALAPPDATA%/Zed/threads/threads.db`; hosted Zed models only, not external ACP agents) | ✅ Yes |
 | Kiro | Kiro | `~/.kiro/sessions/cli/*.json` (+ `*.jsonl`) and `~/.local/share/kiro-cli/data.sqlite3` (macOS: `~/Library/Application Support/kiro-cli/data.sqlite3`) | ✅ Yes |
+| <img width="48px" src=".github/assets/client-cline.png" alt="Cline" /> | [Cline](https://github.com/cline/cline) | `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/` (+ server: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/`) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | Re-attributed from other sources via `hf:` model prefix or `synthetic` provider (+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`) | ✅ Yes |
 
 Get real-time pricing calculations using [🚅 LiteLLM's pricing data](https://github.com/BerriAI/litellm), with support for tiered pricing models and cache token discounts.
@@ -149,7 +150,7 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
   - GitHub-style contribution graph with 9 color themes
   - Real-time filtering and sorting
   - Zero flicker rendering
-- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Zed, Kiro, Trae, and Synthetic
+- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Zed, Kiro, Trae, Cline, and Synthetic
 - **Real-time pricing** - Fetches current pricing from LiteLLM with 1-hour disk cache; automatic OpenRouter fallback and Cursor model pricing for newly released models
 - **Detailed breakdowns** - Input, output, cache read/write, and reasoning token tracking
 - **Native Rust core** - All parsing and aggregation done in Rust for 10x faster processing
@@ -359,7 +360,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-Possible values: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `zed`, `kiro`, `trae`, `synthetic`.
+Possible values: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `zed`, `kiro`, `trae`, `cline`, `synthetic`.
 
 > **Deprecation notice**: The legacy single-client flags (`--opencode`, `--claude`, `--codex`, etc.) still work for backward compatibility but are hidden from `--help` and will be removed in the next major release. Migrate to `--client` whenever possible. Running tokscale in an interactive terminal will print a one-line warning when a legacy flag is used.
 
@@ -852,7 +853,7 @@ The frontend provides a GitHub-style contribution graph visualization:
 - **Interactive tooltips**: Hover for detailed daily breakdowns
 - **Day breakdown panel**: Click to see per-source and per-model details
 - **Year filtering**: Navigate between years
-- **Source filtering**: Filter by platform (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Zed, Kiro, Trae, Synthetic)
+- **Source filtering**: Filter by platform (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Zed, Kiro, Trae, Cline, Synthetic)
 - **Stats panel**: Total cost, tokens, active days, streaks
 - **FOUC prevention**: Theme applied before React hydrates (no flash)
 
@@ -1172,6 +1173,7 @@ AI coding tools store their session data in cross-platform locations. Most tools
 | Qwen CLI | `~/.qwen/` | `%USERPROFILE%\.qwen\` | Same path on all platforms |
 | Roo Code | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks\` | VS Code globalStorage task logs |
 | Kilo | `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\kilocode.kilo-code\tasks\` | VS Code globalStorage task logs |
+| Cline | `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\saoudrizwan.claude-dev\tasks\` | VS Code globalStorage task logs |
 | Mux | `~/.mux/sessions/` | `%USERPROFILE%\.mux\sessions\` | Same path on all platforms |
 | Codebuff | `~/.config/manicode/projects/` (+ `manicode-dev`, `manicode-staging`) | `%USERPROFILE%\.config\manicode\projects\` | Override via `CODEBUFF_DATA_DIR` env var |
 | Kilo CLI | `~/.local/share/kilo/` | `%USERPROFILE%\.local\share\kilo\` | Uses `xdg-basedir` like OpenCode |
@@ -1510,6 +1512,17 @@ Location:
 - Server (best-effort): `~/.vscode-server/data/User/globalStorage/kilocode.kilo-code/tasks/{TASK_ID}/ui_messages.json`
 
 Kilo uses the same task log shape as Roo Code. Tokscale applies the same rules:
+- count only `say/api_req_started` events from `ui_messages.json`
+- parse `tokensIn`, `tokensOut`, `cacheReads`, `cacheWrites`, `cost`, and `apiProtocol` from `text` JSON
+- enrich model/agent metadata from sibling `api_conversation_history.json` when available
+
+### Cline
+
+Location:
+- Local: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/{TASK_ID}/ui_messages.json`
+- Server (best-effort): `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/{TASK_ID}/ui_messages.json`
+
+Cline is the upstream project that Roo Code and Kilo forked from, so it uses the same VS Code globalStorage task log shape. Tokscale applies the same rules:
 - count only `say/api_req_started` events from `ui_messages.json`
 - parse `tokensIn`, `tokensOut`, `cacheReads`, `cacheWrites`, `cost`, and `apiProtocol` from `text` JSON
 - enrich model/agent metadata from sibling `api_conversation_history.json` when available

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@
 | Warp/Oz | [Warp](https://www.warp.dev/) / Oz | Cached via `tokscale warp sync` to `~/.config/tokscale/warp-cache/usage.json` (aggregate requests and spend only; no token transcripts) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-zed.webp" alt="Zed Agent" /> | [Zed Agent](https://zed.dev/docs/ai/agent-panel) | `~/.local/share/zed/threads/threads.db` (macOS: `~/Library/Application Support/Zed/threads/threads.db`; Windows: `%LOCALAPPDATA%/Zed/threads/threads.db`; hosted Zed models only, not external ACP agents) | ✅ Yes |
 | Kiro | Kiro | `~/.kiro/sessions/cli/*.json` (+ `*.jsonl`) and `~/.local/share/kiro-cli/data.sqlite3` (macOS: `~/Library/Application Support/kiro-cli/data.sqlite3`) | ✅ Yes |
-| <img width="48px" src=".github/assets/client-cline.png" alt="Cline" /> | [Cline](https://github.com/cline/cline) | `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/` (+ server: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/`) | ✅ Yes |
+| <img width="48px" src=".github/assets/client-cline.png" alt="Cline" /> | [Cline](https://github.com/cline/cline) | VS Code globalStorage tasks (Linux: `~/.config/Code/...`; macOS: `~/Library/Application Support/Code/...`; Windows: `%APPDATA%\Code\...`; server: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/`) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | Re-attributed from other sources via `hf:` model prefix or `synthetic` provider (+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`) | ✅ Yes |
 
 Get real-time pricing calculations using [🚅 LiteLLM's pricing data](https://github.com/BerriAI/litellm), with support for tiered pricing models and cache token discounts.
@@ -1173,7 +1173,7 @@ AI coding tools store their session data in cross-platform locations. Most tools
 | Qwen CLI | `~/.qwen/` | `%USERPROFILE%\.qwen\` | Same path on all platforms |
 | Roo Code | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks\` | VS Code globalStorage task logs |
 | Kilo | `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\kilocode.kilo-code\tasks\` | VS Code globalStorage task logs |
-| Cline | `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\saoudrizwan.claude-dev\tasks\` | VS Code globalStorage task logs |
+| Cline | Linux: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`; macOS: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`; server: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/` | `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\tasks\` | VS Code globalStorage task logs |
 | Mux | `~/.mux/sessions/` | `%USERPROFILE%\.mux\sessions\` | Same path on all platforms |
 | Codebuff | `~/.config/manicode/projects/` (+ `manicode-dev`, `manicode-staging`) | `%USERPROFILE%\.config\manicode\projects\` | Override via `CODEBUFF_DATA_DIR` env var |
 | Kilo CLI | `~/.local/share/kilo/` | `%USERPROFILE%\.local\share\kilo\` | Uses `xdg-basedir` like OpenCode |
@@ -1519,7 +1519,9 @@ Kilo uses the same task log shape as Roo Code. Tokscale applies the same rules:
 ### Cline
 
 Location:
-- Local: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/{TASK_ID}/ui_messages.json`
+- Linux desktop VS Code: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/{TASK_ID}/ui_messages.json`
+- macOS desktop VS Code: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/{TASK_ID}/ui_messages.json`
+- Windows desktop VS Code: `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\tasks\{TASK_ID}\ui_messages.json`
 - Server (best-effort): `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/{TASK_ID}/ui_messages.json`
 
 Cline is the upstream project that Roo Code and Kilo forked from, so it uses the same VS Code globalStorage task log shape. Tokscale applies the same rules:

--- a/crates/tokscale-cli/src/commands/wrapped.rs
+++ b/crates/tokscale-cli/src/commands/wrapped.rs
@@ -1453,6 +1453,7 @@ fn client_display_name(client: &str) -> Option<&'static str> {
         "antigravity" => Some("Antigravity"),
         "zed" => Some("Zed Agent"),
         "warp" => Some("Warp"),
+        "cline" => Some("Cline"),
         "synthetic" => Some("Synthetic"),
         _ => None,
     }

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -845,6 +845,7 @@ pub enum ClientFilter {
     #[value(name = "trae")]
     Trae,
     Warp,
+    Cline,
     Synthetic,
 }
 
@@ -879,6 +880,7 @@ impl ClientFilter {
             Self::Kiro => "kiro",
             Self::Trae => "trae",
             Self::Warp => "warp",
+            Self::Cline => "cline",
             Self::Synthetic => "synthetic",
         }
     }
@@ -916,6 +918,7 @@ impl ClientFilter {
             Self::Kiro => Some(ClientId::Kiro),
             Self::Trae => Some(ClientId::Trae),
             Self::Warp => Some(ClientId::Warp),
+            Self::Cline => Some(ClientId::Cline),
             Self::Synthetic => None,
         }
     }
@@ -950,6 +953,7 @@ impl ClientFilter {
             ClientId::Kiro => Self::Kiro,
             ClientId::Trae => Self::Trae,
             ClientId::Warp => Self::Warp,
+            ClientId::Cline => Self::Cline,
         }
     }
 
@@ -1053,6 +1057,8 @@ pub struct ClientFlags {
     #[arg(long, hide = true)]
     pub warp: bool,
     #[arg(long, hide = true)]
+    pub cline: bool,
+    #[arg(long, hide = true)]
     pub synthetic: bool,
 }
 
@@ -1106,7 +1112,7 @@ fn build_client_filter_with_defaults(
         }
     }
 
-    let legacy: [(bool, ClientFilter); 26] = [
+    let legacy: [(bool, ClientFilter); 27] = [
         (flags.opencode, ClientFilter::Opencode),
         (flags.claude, ClientFilter::Claude),
         (flags.codex, ClientFilter::Codex),
@@ -1132,6 +1138,7 @@ fn build_client_filter_with_defaults(
         (flags.kiro, ClientFilter::Kiro),
         (flags.trae, ClientFilter::Trae),
         (flags.warp, ClientFilter::Warp),
+        (flags.cline, ClientFilter::Cline),
         (flags.synthetic, ClientFilter::Synthetic),
     ];
 
@@ -5930,6 +5937,7 @@ mod tests {
             kiro: true,
             trae: true,
             warp: true,
+            cline: true,
             synthetic: true,
             ..ClientFlags::default()
         };
@@ -5965,6 +5973,7 @@ mod tests {
             "kiro",
             "trae",
             "warp",
+            "cline",
             "synthetic",
         ] {
             assert!(

--- a/crates/tokscale-cli/src/tui/client_ui.rs
+++ b/crates/tokscale-cli/src/tui/client_ui.rs
@@ -106,6 +106,10 @@ pub const CLIENT_UI: [ClientUi; ClientId::COUNT] = [
         display_name: "Warp",
         hotkey: 'v',
     },
+    ClientUi {
+        display_name: "Cline",
+        hotkey: 'n',
+    },
 ];
 
 pub fn display_name(client: ClientId) -> &'static str {

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -1337,7 +1337,7 @@ mod tests {
     #[test]
     fn test_client_all() {
         let clients = ClientId::ALL;
-        assert_eq!(clients.len(), 25);
+        assert_eq!(clients.len(), 26);
         assert_eq!(clients[0], ClientId::OpenCode);
         assert_eq!(clients[1], ClientId::Claude);
         assert_eq!(clients[2], ClientId::Codex);
@@ -1363,6 +1363,7 @@ mod tests {
         assert_eq!(clients[22], ClientId::Kiro);
         assert_eq!(clients[23], ClientId::Trae);
         assert_eq!(clients[24], ClientId::Warp);
+        assert_eq!(clients[25], ClientId::Cline);
     }
 
     #[test]
@@ -1438,6 +1439,10 @@ mod tests {
         );
         assert_eq!(crate::tui::client_ui::display_name(ClientId::Kiro), "Kiro");
         assert_eq!(crate::tui::client_ui::display_name(ClientId::Trae), "Trae");
+        assert_eq!(
+            crate::tui::client_ui::display_name(ClientId::Cline),
+            "Cline"
+        );
     }
 
     #[test]
@@ -1465,6 +1470,7 @@ mod tests {
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Zed), 'z');
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Kiro), 'i');
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Trae), 'y');
+        assert_eq!(crate::tui::client_ui::hotkey(ClientId::Cline), 'n');
     }
 
     #[test]

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -466,7 +466,7 @@ mod tests {
 
     #[test]
     fn test_client_id_count() {
-        assert_eq!(ClientId::COUNT, 25);
+        assert_eq!(ClientId::COUNT, 26);
     }
 
     #[test]

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -405,6 +405,15 @@ define_clients!(
         headless: false,
         parse_local: true,
         submit_default: false
+    },
+    Cline = 25 => {
+        id: "cline",
+        root: PathRoot::Home,
+        relative: ".config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks",
+        pattern: "ui_messages.json",
+        headless: false,
+        parse_local: true,
+        submit_default: true
     }
 );
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1174,6 +1174,22 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         }
     }
 
+    let cline_outcomes: Vec<CachedParseOutcome> = scan_result
+        .get(ClientId::Cline)
+        .par_iter()
+        .map(|path| {
+            load_or_parse_source(path, &source_cache, pricing, |path| {
+                sessions::cline::parse_cline_file(path)
+            })
+        })
+        .collect();
+    for outcome in cline_outcomes {
+        all_messages.extend(outcome.messages);
+        if let Some(entry) = outcome.cache_entry {
+            source_cache.insert(entry);
+        }
+    }
+
     let mux_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::Mux)
         .par_iter()
@@ -2298,6 +2314,20 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     let kilocode_count = summed_parsed_message_count(&kilocode_msgs);
     counts.set(ClientId::KiloCode, kilocode_count);
     messages.extend(kilocode_msgs);
+
+    let cline_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::Cline)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::cline::parse_cline_file(path)
+                .into_iter()
+                .map(|msg| unified_to_parsed(&msg))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let cline_count = summed_parsed_message_count(&cline_msgs);
+    counts.set(ClientId::Cline, cline_count);
+    messages.extend(cline_msgs);
 
     let mux_msgs: Vec<ParsedMessage> = scan_result
         .get(ClientId::Mux)

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -544,6 +544,31 @@ fn discover_crush_dbs(home_dir: &str, use_env_roots: bool) -> Vec<CrushDbSource>
     dbs
 }
 
+fn cline_additional_vscode_task_roots(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
+    let mut roots = vec![PathBuf::from(home_dir)
+        .join("Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/tasks")];
+
+    if cfg!(target_os = "windows") && use_env_roots {
+        if let Some(app_data) = std::env::var_os("APPDATA").filter(|value| !value.is_empty()) {
+            roots.push(
+                PathBuf::from(app_data)
+                    .join("Code/User/globalStorage/saoudrizwan.claude-dev/tasks"),
+            );
+        }
+    }
+
+    roots.push(
+        PathBuf::from(home_dir)
+            .join("AppData/Roaming/Code/User/globalStorage/saoudrizwan.claude-dev/tasks"),
+    );
+    roots.push(
+        PathBuf::from(home_dir)
+            .join(".vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks"),
+    );
+
+    roots
+}
+
 fn supports_extra_dir_scanning(client_id: ClientId) -> bool {
     // Kilo CLI currently loads a single SQLite DB via `scan_result.kilo_db`
     // Roo/KiloCode require local + remote and server task roots, and Crush
@@ -910,18 +935,16 @@ fn scan_all_clients_with_env_strategy_inner(
         let local_path = ClientId::Cline
             .data()
             .resolve_path_with_env_strategy(home_dir, use_env_roots);
-        push_unique_scan_task(&mut tasks, &mut seen_scan_roots, ClientId::Cline, local_path);
-
-        let server_path = format!(
-            "{}/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks",
-            home_dir
-        );
         push_unique_scan_task(
             &mut tasks,
             &mut seen_scan_roots,
             ClientId::Cline,
-            server_path,
+            local_path,
         );
+
+        for root in cline_additional_vscode_task_roots(home_dir, use_env_roots) {
+            push_unique_scan_task(&mut tasks, &mut seen_scan_roots, ClientId::Cline, root);
+        }
     }
 
     if enabled.contains(&ClientId::Kilo) {
@@ -1518,11 +1541,22 @@ mod tests {
     fn setup_mock_cline_dir(base: &std::path::Path) {
         let local =
             base.join(".config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/task-local");
-        let server = base
-            .join(".vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/task-server");
+        let macos = base.join(
+            "Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/task-macos",
+        );
+        let windows = base.join(
+            "AppData/Roaming/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/task-windows",
+        );
+        let server = base.join(
+            ".vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/task-server",
+        );
         fs::create_dir_all(&local).unwrap();
+        fs::create_dir_all(&macos).unwrap();
+        fs::create_dir_all(&windows).unwrap();
         fs::create_dir_all(&server).unwrap();
         File::create(local.join("ui_messages.json")).unwrap();
+        File::create(macos.join("ui_messages.json")).unwrap();
+        File::create(windows.join("ui_messages.json")).unwrap();
         File::create(server.join("ui_messages.json")).unwrap();
     }
 
@@ -2766,7 +2800,7 @@ mod tests {
         setup_mock_cline_dir(home);
 
         let result = scan_all_clients(home.to_str().unwrap(), &["cline".to_string()]);
-        assert_eq!(result.get(ClientId::Cline).len(), 2);
+        assert_eq!(result.get(ClientId::Cline).len(), 4);
         assert!(result
             .get(ClientId::Cline)
             .iter()

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -687,6 +687,7 @@ fn scan_all_clients_with_env_strategy_inner(
                 | ClientId::OpenClaw
                 | ClientId::RooCode
                 | ClientId::KiloCode
+                | ClientId::Cline
                 | ClientId::Kilo
                 | ClientId::Hermes
                 | ClientId::Goose
@@ -901,6 +902,24 @@ fn scan_all_clients_with_env_strategy_inner(
             &mut tasks,
             &mut seen_scan_roots,
             ClientId::KiloCode,
+            server_path,
+        );
+    }
+
+    if enabled.contains(&ClientId::Cline) {
+        let local_path = ClientId::Cline
+            .data()
+            .resolve_path_with_env_strategy(home_dir, use_env_roots);
+        push_unique_scan_task(&mut tasks, &mut seen_scan_roots, ClientId::Cline, local_path);
+
+        let server_path = format!(
+            "{}/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks",
+            home_dir
+        );
+        push_unique_scan_task(
+            &mut tasks,
+            &mut seen_scan_roots,
+            ClientId::Cline,
             server_path,
         );
     }
@@ -1490,6 +1509,17 @@ mod tests {
             base.join(".config/Code/User/globalStorage/kilocode.kilo-code/tasks/task-local");
         let server = base
             .join(".vscode-server/data/User/globalStorage/kilocode.kilo-code/tasks/task-server");
+        fs::create_dir_all(&local).unwrap();
+        fs::create_dir_all(&server).unwrap();
+        File::create(local.join("ui_messages.json")).unwrap();
+        File::create(server.join("ui_messages.json")).unwrap();
+    }
+
+    fn setup_mock_cline_dir(base: &std::path::Path) {
+        let local =
+            base.join(".config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/task-local");
+        let server = base
+            .join(".vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/task-server");
         fs::create_dir_all(&local).unwrap();
         fs::create_dir_all(&server).unwrap();
         File::create(local.join("ui_messages.json")).unwrap();
@@ -2725,6 +2755,20 @@ mod tests {
         assert_eq!(result.get(ClientId::KiloCode).len(), 2);
         assert!(result
             .get(ClientId::KiloCode)
+            .iter()
+            .all(|p| p.ends_with("ui_messages.json")));
+    }
+
+    #[test]
+    fn test_scan_all_clients_cline() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_cline_dir(home);
+
+        let result = scan_all_clients(home.to_str().unwrap(), &["cline".to_string()]);
+        assert_eq!(result.get(ClientId::Cline).len(), 2);
+        assert!(result
+            .get(ClientId::Cline)
             .iter()
             .all(|p| p.ends_with("ui_messages.json")));
     }

--- a/crates/tokscale-core/src/sessions/cline.rs
+++ b/crates/tokscale-core/src/sessions/cline.rs
@@ -1,0 +1,84 @@
+//! Cline task parser
+//!
+//! Cline is the upstream project that Roo Code and Kilo forked from, so it
+//! shares the same VS Code globalStorage task-log format and reuses the same
+//! parser helper.
+
+use super::roocode::parse_roo_kilo_file;
+use super::UnifiedMessage;
+use std::path::Path;
+
+pub fn parse_cline_file(path: &Path) -> Vec<UnifiedMessage> {
+    parse_roo_kilo_file(path, "cline")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_parse_cline_valid_api_req_started() {
+        let dir = TempDir::new().unwrap();
+        let task_dir = dir.path().join("tasks").join("cline-task-1");
+        fs::create_dir_all(&task_dir).unwrap();
+        fs::write(
+            task_dir.join("ui_messages.json"),
+            r#"[
+  {
+    "type": "say",
+    "say": "api_req_started",
+    "ts": "2026-02-18T12:00:00Z",
+    "text": "{\"cost\":0.05,\"tokensIn\":40,\"tokensOut\":15,\"cacheReads\":7,\"cacheWrites\":3,\"apiProtocol\":\"anthropic\"}"
+  }
+]"#,
+        )
+        .unwrap();
+        fs::write(
+            task_dir.join("api_conversation_history.json"),
+            r#"
+<environment_details>
+<model>claude-sonnet-4</model>
+<name>ClineAgent</name>
+</environment_details>
+"#,
+        )
+        .unwrap();
+
+        let messages = parse_cline_file(&task_dir.join("ui_messages.json"));
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, "cline");
+        assert_eq!(messages[0].provider_id, "anthropic");
+        assert_eq!(messages[0].model_id, "claude-sonnet-4");
+        assert_eq!(messages[0].session_id, "cline-task-1");
+        assert_eq!(messages[0].agent.as_deref(), Some("ClineAgent"));
+        assert_eq!(messages[0].tokens.input, 40);
+        assert_eq!(messages[0].tokens.output, 15);
+        assert_eq!(messages[0].tokens.cache_read, 7);
+        assert_eq!(messages[0].tokens.cache_write, 3);
+        assert_eq!(messages[0].cost, 0.05);
+    }
+
+    #[test]
+    fn test_parse_cline_ignores_non_api_req_started_events() {
+        let dir = TempDir::new().unwrap();
+        let task_dir = dir.path().join("tasks").join("cline-task-2");
+        fs::create_dir_all(&task_dir).unwrap();
+        fs::write(
+            task_dir.join("ui_messages.json"),
+            r#"[
+  {
+    "type": "say",
+    "say": "assistant_message",
+    "ts": "2026-02-18T12:00:00Z",
+    "text": "{\"cost\":0.2,\"tokensIn\":10,\"tokensOut\":1,\"cacheReads\":0,\"cacheWrites\":0,\"apiProtocol\":\"anthropic\"}"
+  }
+]"#,
+        )
+        .unwrap();
+
+        let messages = parse_cline_file(&task_dir.join("ui_messages.json"));
+        assert!(messages.is_empty());
+    }
+}

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -5,6 +5,7 @@
 pub mod amp;
 pub mod antigravity;
 pub mod claudecode;
+pub mod cline;
 pub mod codebuff;
 pub mod codex;
 pub mod copilot;

--- a/packages/frontend/src/components/SourceLogo.tsx
+++ b/packages/frontend/src/components/SourceLogo.tsx
@@ -63,6 +63,8 @@ export function SourceLogo({ sourceId, height = 14, className = "" }: SourceLogo
         return "/assets/logos/kiro.ico";
       case "zed":
         return "https://raw.githubusercontent.com/junhoyeo/tokscale/main/.github/assets/client-zed.webp";
+      case "cline":
+        return "/assets/logos/cline.png";
       case "synthetic":
         return "/assets/logos/synthetic.png";
       default:

--- a/packages/frontend/src/lib/constants.ts
+++ b/packages/frontend/src/lib/constants.ts
@@ -52,6 +52,7 @@ export const SOURCE_DISPLAY_NAMES: Record<ClientType, string> = {
   zed: "Zed Agent",
   trae: "Trae",
   warp: "Warp",
+  cline: "Cline",
   synthetic: "Synthetic",
 };
 
@@ -83,6 +84,7 @@ export const SOURCE_LOGOS: Record<ClientType, string> = {
   zed: `${GITHUB_CDN_BASE}/client-zed.webp`,
   trae: `${GITHUB_CDN_BASE}/client-trae.png`,
   warp: `${GITHUB_CDN_BASE}/client-warp.png`,
+  cline: `${GITHUB_CDN_BASE}/client-cline.png`,
   synthetic: `${GITHUB_CDN_BASE}/client-synthetic.png`,
 };
 
@@ -112,6 +114,7 @@ export const SOURCE_COLORS: Record<ClientType, string> = {
   zed: "#084CCF",
   trae: "#00BFA5",
   warp: "#01A4A4",
+  cline: "#5B8DEF",
   synthetic: "#4ADE80",
 };
 

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -24,6 +24,7 @@ export const SUPPORTED_CLIENT_TYPES = [
   "zed",
   "trae",
   "warp",
+  "cline",
   "synthetic",
 ] as const;
 

--- a/scripts/check-release-workflow-safety.py
+++ b/scripts/check-release-workflow-safety.py
@@ -30,7 +30,7 @@ def fail(message: str) -> None:
 def read_lines(path: pathlib.Path) -> list[str]:
     if not path.exists():
         fail(f"Missing workflow: {path}")
-    return path.read_text().splitlines()
+    return path.read_text(encoding="utf-8").splitlines()
 
 
 def strip_yaml_scalar(value: str) -> str:
@@ -130,7 +130,7 @@ def package_manifest_name(package_dir: str) -> str:
     manifest_path = ROOT / "packages" / package_dir / "package.json"
     if not manifest_path.exists():
         fail(f"Missing platform package manifest: {manifest_path}")
-    manifest = json.loads(manifest_path.read_text())
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     name = manifest.get("name")
     if not isinstance(name, str) or not name:
         fail(f"{manifest_path} missing package name")

--- a/scripts/test-release-workflow-safety.sh
+++ b/scripts/test-release-workflow-safety.sh
@@ -77,6 +77,20 @@ test_accepts_matching_publish_and_native_workflows() {
   grep -q "Release workflow safety OK" "${TMP_DIR}/good-output.txt"
 }
 
+test_reads_workflows_as_utf8_when_locale_is_non_utf8() {
+  local work="${TMP_DIR}/utf8-locale"
+  write_good_workflows "${work}"
+  printf '# UTF-8 sentinel: 🧪\n' >> "${work}/.github/workflows/publish-cli.yml"
+  printf '# UTF-8 sentinel: 🧪\n' >> "${work}/.github/workflows/build-native.yml"
+
+  (
+    cd "${work}"
+    LC_ALL=C PYTHONUTF8=0 python3 "${SCRIPT_UNDER_TEST}" >"${TMP_DIR}/utf8-locale-output.txt" 2>&1
+  )
+
+  grep -q "Release workflow safety OK" "${TMP_DIR}/utf8-locale-output.txt"
+}
+
 test_rejects_build_matrix_target_drift() {
   local work="${TMP_DIR}/target-drift"
   write_good_workflows "${work}"
@@ -167,6 +181,7 @@ PY
 }
 
 test_accepts_matching_publish_and_native_workflows
+test_reads_workflows_as_utf8_when_locale_is_non_utf8
 test_rejects_build_matrix_target_drift
 test_rejects_release_env_drift
 test_rejects_missing_required_release_env


### PR DESCRIPTION
> [!WARNING]
> **Vibecoded PR.** This change was led by an AI model (Claude) and reviewed by a human before submission. Tests and lint were run locally and pass, but please review with that context in mind.

## What

Adds [Cline](https://github.com/cline/cline) as a first-class client. Cline is the upstream project that Roo Code and Kilo both forked from, so it stores task logs in the same VS Code `globalStorage` `ui_messages.json` format — just under its own extension id, `saoudrizwan.claude-dev`. This implementation reuses the existing shared Roo/Kilo parser rather than duplicating it.

## Locations scanned

- Local: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/{TASK_ID}/ui_messages.json`
- Server (best-effort): `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/{TASK_ID}/ui_messages.json`

Same counting rules as Roo Code / Kilo: only `say` / `api_req_started` events are counted, token/cost fields are read from the event `text` JSON, and model/agent metadata is enriched from the sibling `api_conversation_history.json` when present.

## Changes

- **core** — new `Cline` `ClientId` (`crates/tokscale-core/src/clients.rs`) and a `sessions::cline` parser delegating to the shared `parse_roo_kilo_file` helper; wired into both the cached and uncached scan paths in `lib.rs`.
- **scanner** — discovers both the local and `.vscode-server` task roots, mirroring the Roo/Kilo handling.
- **cli** — `ClientFilter::Cline` variant + `cline` filter id, hidden legacy `--cline` flag, and a TUI entry (display name "Cline", hotkey `n`).
- **frontend** — `cline` added to `SUPPORTED_CLIENT_TYPES`, display name, accent color, and logo mappings.
- **docs** — README supported-clients table, multi-platform / filter lists, possible filter values, Windows path table, and a parser-details section.

## Tests

- New unit tests for the Cline parser (`sessions::cline`) and scanner discovery (`test_scan_all_clients_cline`).
- Updated `ClientId::ALL` ordering, TUI display-name/hotkey, and `build_client_filter` exhaustiveness tests to include Cline.
- `cargo build`, `cargo clippy` (core + cli), the Rust suite, and the frontend `vitest` suite (352 tests) all pass locally. One pre-existing Rust test (`test_data_loader_keeps_synthetic_gateway_messages_under_original_client`) and one pre-existing frontend lint error (`LeaderboardClient.tsx`) fail on `main` as well, independent of this change.

## Follow-up

This PR references logo assets that still need to be added by a maintainer: `.github/assets/client-cline.png` and `packages/frontend/public/assets/logos/cline.png`. Until then the UI falls back to the source id text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class Cline support across core, scanner, CLI/TUI, and frontend with cross‑platform VS Code task discovery. Also fixes the release safety script to read workflows as UTF‑8 to avoid locale decoding errors.

- **New Features**
  - Core: new `ClientId::Cline` and `sessions::cline` reusing the shared Roo/Kilo `ui_messages.json` parser; wired into cached and uncached paths in `tokscale-core`.
  - Scanner: discovers Cline VS Code `globalStorage` tasks on Linux, macOS, Windows, and `.vscode-server`.
  - CLI/TUI: `ClientFilter::Cline` (`--client cline`), hidden legacy `--cline`, TUI “Cline” (hotkey `n`), and display-name mapping.
  - Frontend: `cline` added to `SUPPORTED_CLIENT_TYPES` with display name, color, and logo mapping; `SourceLogo` path added.
  - Docs: README updated with supported-client lists and OS-specific paths.

- **Bug Fixes**
  - CI: `scripts/check-release-workflow-safety.py` now reads files with UTF‑8, fixing failures under non‑UTF‑8 locales (with test coverage).

<sup>Written for commit ca1513de4b7ceb2b0d91474742ed315f70ede7db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

