### PR TITLE
fix(warp): scan aggregate usage cache files

### DIFF
--- a/crates/tokscale-core/src/aggregator.rs
+++ b/crates/tokscale-core/src/aggregator.rs
@@ -104,7 +104,10 @@ pub fn aggregate_by_session(messages: Vec<UnifiedMessage>) -> Vec<SessionContrib
 pub fn calculate_summary(contributions: &[DailyContribution]) -> DataSummary {
     let total_tokens: i64 = contributions.iter().map(|c| c.totals.tokens).sum();
     let total_cost: f64 = contributions.iter().map(|c| c.totals.cost).sum();
-    let active_days = contributions.iter().filter(|c| c.totals.tokens > 0).count() as i32;
+    let active_days = contributions
+        .iter()
+        .filter(|c| c.totals.tokens > 0 || c.totals.cost > 0.0 || c.totals.messages > 0)
+        .count() as i32;
     let max_cost = contributions
         .iter()
         .map(|c| c.totals.cost)
@@ -936,6 +939,53 @@ mod tests {
         assert_eq!(summary.total_days, 2);
         assert_eq!(summary.active_days, 1);
         assert!((summary.average_per_day - 0.05).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_calculate_summary_counts_cost_only_days_as_active() {
+        let contributions = vec![
+            DailyContribution {
+                date: "2024-01-01".to_string(),
+                totals: DailyTotals {
+                    tokens: 1000,
+                    cost: 0.05,
+                    messages: 1,
+                },
+                intensity: 0,
+                token_breakdown: TokenBreakdown::default(),
+                clients: Vec::new(),
+                active_time_ms: None,
+            },
+            DailyContribution {
+                date: "2024-01-02".to_string(),
+                totals: DailyTotals {
+                    tokens: 0,
+                    cost: 1.25,
+                    messages: 0,
+                },
+                intensity: 0,
+                token_breakdown: TokenBreakdown::default(),
+                clients: Vec::new(),
+                active_time_ms: None,
+            },
+            DailyContribution {
+                date: "2024-01-03".to_string(),
+                totals: DailyTotals {
+                    tokens: 0,
+                    cost: 0.0,
+                    messages: 0,
+                },
+                intensity: 0,
+                token_breakdown: TokenBreakdown::default(),
+                clients: Vec::new(),
+                active_time_ms: None,
+            },
+        ];
+
+        let summary = calculate_summary(&contributions);
+        assert_eq!(summary.total_days, 3);
+        assert_eq!(summary.active_days, 2);
+        assert!((summary.average_per_day - 0.65).abs() < 0.0001);
     }
 
     #[test]

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -403,7 +403,7 @@ define_clients!(
         relative: "warp-cache",
         pattern: "usage*.json",
         headless: false,
-        parse_local: false,
+        parse_local: true,
         submit_default: false
     }
 );
@@ -478,7 +478,7 @@ mod tests {
         let client = ClientId::from_str("warp").expect("warp client should be registered");
         assert_eq!(client.data().relative_path, "warp-cache");
         assert_eq!(client.data().pattern, "usage*.json");
-        assert!(!client.data().parse_local);
+        assert!(client.data().parse_local);
         assert!(!client.data().submit_default);
     }
 

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -290,6 +290,25 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
 
                     true
                 }
+                "usage*.json" => {
+                    if is_in_archive_dir {
+                        return false;
+                    }
+
+                    if file_name == "usage.json" {
+                        return true;
+                    }
+
+                    if !file_name.starts_with("usage.") || !file_name.ends_with(".json") {
+                        return false;
+                    }
+
+                    if file_name.starts_with("usage.backup") {
+                        return false;
+                    }
+
+                    true
+                }
                 "session-*.json" => {
                     file_name.starts_with("session-") && file_name.ends_with(".json")
                 }
@@ -1287,6 +1306,28 @@ mod tests {
         let csv_files = scan_directory(path.to_str().unwrap(), "*.csv");
         assert_eq!(csv_files.len(), 2);
         assert!(csv_files.iter().all(|p| p.extension().unwrap() == "csv"));
+    }
+
+    #[test]
+    fn test_scan_directory_usage_json_pattern() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path();
+        let archive = path.join("archive");
+        fs::create_dir_all(&archive).unwrap();
+
+        File::create(path.join("usage.json")).unwrap();
+        File::create(path.join("usage.account.json")).unwrap();
+        File::create(path.join("usage.backup-20240601.json")).unwrap();
+        File::create(path.join("other.json")).unwrap();
+        File::create(archive.join("usage.json")).unwrap();
+
+        let usage_files = scan_directory(path.to_str().unwrap(), "usage*.json");
+        let names: Vec<_> = usage_files
+            .iter()
+            .map(|path| path.file_name().unwrap().to_str().unwrap())
+            .collect();
+
+        assert_eq!(names, vec!["usage.account.json", "usage.json"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Enable Warp's aggregate cache files to be discovered by the local scanner.
- Count cost-only or message-only contribution days as active days in summary statistics.
- Keep Warp out of default submit while still making local report/graph paths able to parse the cache when selected.

## Why
Warp records aggregate usage in `usage*.json` cache files, but the scanner only understood the CSV variant of that pattern. As a result, Warp cache files could be declared in the client registry but still never be found. Warp rows can also carry spend and request counts without token totals, so the summary active-day calculation should treat those rows as activity instead of dropping them from the active-day denominator.

## Diff scope
- `crates/tokscale-core/src/clients.rs`: marks Warp as locally parseable while keeping `submit_default: false`.
- `crates/tokscale-core/src/scanner.rs`: adds deterministic `usage*.json` matching for `usage.json` and per-account `usage.<account>.json`, excluding archive and backup files.
- `crates/tokscale-core/src/aggregator.rs`: counts days with tokens, cost, or messages as active and adds regression coverage.

## Branch integrity
- Base branch: `main`
- Validated base SHA: `a86e688d620939d2c973c6d5625baa815ea223d7`
- Ahead/behind against fetched `origin/main`: `0 behind / 1 ahead`
- Merge base: `a86e688d620939d2c973c6d5625baa815ea223d7`
- Diff proof was computed against the fetched base.

## Commit integrity
- Introduced commit: `31f3711 fix(warp): scan aggregate usage cache files`
- Final PR diff contains only the intended core scanner, client registry, and summary changes.
- Ledger: not applicable — not required for selected validation mode/change family.
- Version: not applicable — not required for selected validation mode/change family.

## Diff hygiene
- `git diff --name-status origin/main...HEAD`: `M crates/tokscale-core/src/aggregator.rs`, `M crates/tokscale-core/src/clients.rs`, `M crates/tokscale-core/src/scanner.rs`
- `git diff --check origin/main...HEAD`: PASS, no output


## Validation mode and proof
- Validation mode: Mode 2 — narrow runtime change in core local scanning and summary aggregation.
- `cargo test -p tokscale-core test_warp_client_registered_as_aggregate_cache_source`: PASS
- `cargo test -p tokscale-core test_scan_directory`: PASS, 11 tests
- `cargo test -p tokscale-core test_calculate_summary`: PASS, 5 tests
- `cargo test -p tokscale-core warp`: PASS, 2 tests
- `cargo fmt --check`: PASS
- Full workspace suite not run locally because targeted core tests cover the changed scanner, client registry, parser, and summary behavior; remote PR CI should provide final full-suite proof after the PR is opened.

## CI context confirmation
- Pending — required GitHub Actions checks will run after the PR is created.
- CI workflow context names unchanged.

## Runtime safety
- Reviewed changed runtime paths: client registry lookup, `scan_directory`, and `calculate_summary`.
- No new blocking locks, unbounded queues, network calls, or cache writes were introduced.
- No invariant regression introduced.

## Migration notes
Not applicable — no DB migration changed.

## Documentation integrity
Not applicable — no docs, commands, or user-facing CLI behavior changed.

## Rollback plan
Rollback: revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks
- Remote CI has not run yet because the PR has not been opened.
- This change intentionally makes Warp locally parseable but does not add Warp to default submit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables local scanning of Warp aggregate cache files (`usage*.json`) and counts cost-only or message-only days as active in summary stats. Warp stays out of default submit, but local reports/graphs can read its cache.

- **Bug Fixes**
  - Scanner now matches `usage.json` and `usage.<account>.json`, skipping `archive/` and `usage.backup*`.
  - Warp is `parse_local: true` while keeping `submit_default: false`.
  - Summary counts a day as active if tokens, cost, or messages > 0 (with new regression test).

<sup>Written for commit 3be1542ee083ee8cd27f0f69e3f428388cc05f0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

