### PR TITLE
fix(auth): constrain GitHub OAuth return paths

### DIFF
--- a/packages/frontend/__tests__/api/githubAuthReturnTo.test.ts
+++ b/packages/frontend/__tests__/api/githubAuthReturnTo.test.ts
@@ -1,0 +1,191 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const cookieStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+  };
+  const cookies = vi.fn(async () => cookieStore);
+  const getAuthorizationUrl = vi.fn(() => "https://github.com/login/oauth/authorize");
+  const exchangeCodeForToken = vi.fn(async () => "access-token");
+  const getGitHubUser = vi.fn(async () => ({
+    id: 123,
+    login: "alice",
+    name: "Alice",
+    avatar_url: "https://avatars.example/alice.png",
+    email: "alice@example.com",
+  }));
+  const getGitHubUserEmail = vi.fn(async () => "alice@example.com");
+  const createSession = vi.fn(async () => "session-token");
+  const setSessionCookie = vi.fn(async () => undefined);
+  const generateRandomString = vi.fn(() => "state-token");
+
+  const selectLimit = vi.fn(async () => [
+    {
+      id: "user-1",
+      githubId: 123,
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: "https://avatars.example/alice.png",
+      email: "alice@example.com",
+    },
+  ]);
+  const selectWhere = vi.fn(() => ({ limit: selectLimit }));
+  const selectFrom = vi.fn(() => ({ where: selectWhere }));
+  const updateWhere = vi.fn(async () => undefined);
+  const updateSet = vi.fn(() => ({ where: updateWhere }));
+  const insertReturning = vi.fn(async () => [{ id: "user-1" }]);
+  const insertValues = vi.fn(() => ({ returning: insertReturning }));
+  const db = {
+    select: vi.fn(() => ({ from: selectFrom })),
+    update: vi.fn(() => ({ set: updateSet })),
+    insert: vi.fn(() => ({ values: insertValues })),
+  };
+
+  return {
+    cookieStore,
+    cookies,
+    getAuthorizationUrl,
+    exchangeCodeForToken,
+    getGitHubUser,
+    getGitHubUserEmail,
+    createSession,
+    setSessionCookie,
+    generateRandomString,
+    db,
+    selectLimit,
+    reset() {
+      cookieStore.get.mockReset();
+      cookieStore.set.mockReset();
+      cookieStore.delete.mockReset();
+      cookies.mockClear();
+      getAuthorizationUrl.mockClear();
+      exchangeCodeForToken.mockClear();
+      getGitHubUser.mockClear();
+      getGitHubUserEmail.mockClear();
+      createSession.mockClear();
+      setSessionCookie.mockClear();
+      generateRandomString.mockClear();
+      db.select.mockClear();
+      db.update.mockClear();
+      db.insert.mockClear();
+      selectLimit.mockClear();
+    },
+  };
+});
+
+vi.mock("next/headers", () => ({
+  cookies: mockState.cookies,
+}));
+
+vi.mock("@/lib/auth/github", () => ({
+  getAuthorizationUrl: mockState.getAuthorizationUrl,
+  exchangeCodeForToken: mockState.exchangeCodeForToken,
+  getGitHubUser: mockState.getGitHubUser,
+  getGitHubUserEmail: mockState.getGitHubUserEmail,
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  createSession: mockState.createSession,
+  setSessionCookie: mockState.setSessionCookie,
+}));
+
+vi.mock("@/lib/auth/utils", () => ({
+  generateRandomString: mockState.generateRandomString,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockState.db,
+  users: {
+    id: "users.id",
+    githubId: "users.githubId",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn(() => "eq"),
+}));
+
+type StartRouteExports = typeof import("../../src/app/api/auth/github/route");
+type CallbackRouteExports = typeof import("../../src/app/api/auth/github/callback/route");
+
+let startGET: StartRouteExports["GET"];
+let callbackGET: CallbackRouteExports["GET"];
+
+beforeAll(async () => {
+  const [startRoute, callbackRoute] = await Promise.all([
+    import("../../src/app/api/auth/github/route"),
+    import("../../src/app/api/auth/github/callback/route"),
+  ]);
+  startGET = startRoute.GET;
+  callbackGET = callbackRoute.GET;
+});
+
+beforeEach(() => {
+  mockState.reset();
+  process.env.NEXT_PUBLIC_URL = "https://tokscale.ai";
+});
+
+describe("GitHub OAuth returnTo safety", () => {
+  it.each([
+    ["/settings", "/settings"],
+    ["/device?code=abc", "/device?code=abc"],
+    ["https://evil.test/path", "/leaderboard"],
+    ["//evil.test/path", "/leaderboard"],
+    ["@evil.test/path", "/leaderboard"],
+    ["\\evil.test\\path", "/leaderboard"],
+    ["%2f%2fevil.test/path", "/leaderboard"],
+    ["%5cevil.test%5cpath", "/leaderboard"],
+  ])("stores safe returnTo value for %s", async (returnTo, expected) => {
+    await startGET(
+      new Request(
+        `https://tokscale.ai/api/auth/github?returnTo=${encodeURIComponent(returnTo)}`
+      )
+    );
+
+    expect(mockState.cookieStore.set).toHaveBeenCalledTimes(1);
+    const [, rawValue] = mockState.cookieStore.set.mock.calls[0];
+    expect(JSON.parse(rawValue)).toMatchObject({
+      state: "state-token",
+      returnTo: expected,
+    });
+  });
+
+  it.each([
+    ["@evil.test/path"],
+    ["https://evil.test/path"],
+    ["//evil.test/path"],
+    ["\\evil.test\\path"],
+    ["%2f%2fevil.test/path"],
+    ["/%5cevil.test"],
+  ])("falls back when callback cookie returnTo is unsafe: %s", async (returnTo) => {
+    mockState.cookieStore.get.mockReturnValue({
+      value: JSON.stringify({ state: "state-token", returnTo }),
+    });
+
+    const response = await callbackGET(
+      new Request(
+        "https://tokscale.ai/api/auth/github/callback?code=ok&state=state-token"
+      )
+    );
+
+    expect(response.headers.get("location")).toBe("https://tokscale.ai/leaderboard");
+  });
+
+  it("redirects to a safe same-origin relative callback returnTo", async () => {
+    mockState.cookieStore.get.mockReturnValue({
+      value: JSON.stringify({ state: "state-token", returnTo: "/device?code=abc" }),
+    });
+
+    const response = await callbackGET(
+      new Request(
+        "https://tokscale.ai/api/auth/github/callback?code=ok&state=state-token"
+      )
+    );
+
+    expect(response.headers.get("location")).toBe(
+      "https://tokscale.ai/device?code=abc"
+    );
+  });
+});

--- a/packages/frontend/src/app/api/auth/github/callback/route.ts
+++ b/packages/frontend/src/app/api/auth/github/callback/route.ts
@@ -5,6 +5,7 @@ import {
   getGitHubUser,
   getGitHubUserEmail,
 } from "@/lib/auth/github";
+import { sanitizeAuthReturnTo } from "@/lib/auth/returnTo";
 import { createSession, setSessionCookie } from "@/lib/auth/session";
 import { db, users } from "@/lib/db";
 import { eq } from "drizzle-orm";
@@ -105,8 +106,8 @@ export async function GET(request: Request) {
     await setSessionCookie(sessionToken);
 
     // Redirect to return URL
-    const returnTo = storedState.returnTo || "/leaderboard";
-    return NextResponse.redirect(`${baseUrl}${returnTo}`);
+    const returnTo = sanitizeAuthReturnTo(storedState.returnTo);
+    return NextResponse.redirect(new URL(returnTo, baseUrl));
   } catch (err) {
     console.error("GitHub OAuth callback error:", err);
     return NextResponse.redirect(`${baseUrl}/leaderboard?error=auth_failed`);

--- a/packages/frontend/src/app/api/auth/github/route.ts
+++ b/packages/frontend/src/app/api/auth/github/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { getAuthorizationUrl } from "@/lib/auth/github";
+import { sanitizeAuthReturnTo } from "@/lib/auth/returnTo";
 import { generateRandomString } from "@/lib/auth/utils";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const returnTo = searchParams.get("returnTo") || "/leaderboard";
+  const returnTo = sanitizeAuthReturnTo(searchParams.get("returnTo"));
 
   // Generate CSRF state
   const state = generateRandomString(32);

--- a/packages/frontend/src/lib/auth/returnTo.ts
+++ b/packages/frontend/src/lib/auth/returnTo.ts
@@ -1,0 +1,55 @@
+const DEFAULT_AUTH_RETURN_TO = "/leaderboard";
+const RETURN_TO_BASE_URL = "https://tokscale.invalid";
+
+function hasUnsafeRelativeStart(value: string): boolean {
+  return !value.startsWith("/") || value.startsWith("//");
+}
+
+export function sanitizeAuthReturnTo(value: string | null | undefined): string {
+  if (!value) {
+    return DEFAULT_AUTH_RETURN_TO;
+  }
+
+  const raw = value.trim();
+  if (!raw || raw.includes("\\")) {
+    return DEFAULT_AUTH_RETURN_TO;
+  }
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    return DEFAULT_AUTH_RETURN_TO;
+  }
+
+  if (
+    decoded.includes("\\") ||
+    hasUnsafeRelativeStart(raw) ||
+    hasUnsafeRelativeStart(decoded)
+  ) {
+    return DEFAULT_AUTH_RETURN_TO;
+  }
+
+  const baseUrl = new URL(RETURN_TO_BASE_URL);
+  let parsed: URL;
+  let decodedParsed: URL;
+  try {
+    parsed = new URL(raw, baseUrl);
+    decodedParsed = new URL(decoded, baseUrl);
+  } catch {
+    return DEFAULT_AUTH_RETURN_TO;
+  }
+
+  if (
+    parsed.origin !== baseUrl.origin ||
+    decodedParsed.origin !== baseUrl.origin ||
+    parsed.username ||
+    parsed.password ||
+    decodedParsed.username ||
+    decodedParsed.password
+  ) {
+    return DEFAULT_AUTH_RETURN_TO;
+  }
+
+  return `${parsed.pathname}${parsed.search}${parsed.hash}` || DEFAULT_AUTH_RETURN_TO;
+}


### PR DESCRIPTION
## Summary
- Sanitize GitHub OAuth `returnTo` values before they are stored in the OAuth state cookie.
- Re-sanitize the cookie value in the callback before redirecting.
- Build the final redirect with `new URL(...)` so only same-origin relative app paths are used.

## Why
The OAuth start route accepted a raw `returnTo` query parameter and the callback later concatenated it with the site base URL. Values such as `@evil.test/path`, absolute URLs, protocol-relative URLs, backslashes, or encoded variants could produce unsafe redirect targets or confusing userinfo-style URLs. OAuth redirects should only return users to safe relative paths inside the app.

## Diff scope
- `packages/frontend/src/lib/auth/returnTo.ts`: adds a shared sanitizer with a safe `/leaderboard` fallback.
- `packages/frontend/src/app/api/auth/github/route.ts`: stores only sanitized `returnTo` values in the state cookie.
- `packages/frontend/src/app/api/auth/github/callback/route.ts`: sanitizes again at callback time and redirects via `new URL(returnTo, baseUrl)`.
- `packages/frontend/__tests__/api/githubAuthReturnTo.test.ts`: adds route-level regression coverage for safe relative paths and unsafe external/userinfo/backslash/encoded inputs.

## Branch integrity
- Base branch: `main`
- Validated base SHA: `a86e688d620939d2c973c6d5625baa815ea223d7`
- Ahead/behind against fetched `origin/main`: `0 behind / 1 ahead`
- Merge base: `a86e688d620939d2c973c6d5625baa815ea223d7`
- Diff proof was computed against the fetched base.

## Commit integrity
- Introduced commit: `ac9bbd6 fix(auth): constrain GitHub OAuth return paths`
- Final PR diff contains only the intended OAuth route, sanitizer, and regression test changes.
- Ledger: not applicable — not required for selected validation mode/change family.
- Version: not applicable — not required for selected validation mode/change family.

## Diff hygiene
- `git diff --name-status origin/main...HEAD`: `A packages/frontend/__tests__/api/githubAuthReturnTo.test.ts`, `M packages/frontend/src/app/api/auth/github/callback/route.ts`, `M packages/frontend/src/app/api/auth/github/route.ts`, `A packages/frontend/src/lib/auth/returnTo.ts`
- `git diff --check origin/main...HEAD`: PASS, no output


## Validation mode and proof
- Validation mode: Mode 3 — security-sensitive OAuth redirect behavior.
- `bun x vitest run __tests__/api/githubAuthReturnTo.test.ts`: PASS, 15 tests
- `bun x eslint src/app/api/auth/github/route.ts src/app/api/auth/github/callback/route.ts src/lib/auth/returnTo.ts __tests__/api/githubAuthReturnTo.test.ts`: PASS
- Full package TypeScript check not run as merge proof locally because the current project-wide check is blocked by unrelated existing frontend errors outside this diff; remote PR CI should provide final gate status after the PR is opened.

## CI context confirmation
- Pending — required GitHub Actions checks will run after the PR is created.
- CI workflow context names unchanged.

## Runtime safety
- Reviewed changed runtime paths: GitHub OAuth start route, callback route, and shared return-path sanitizer.
- No new blocking locks, unbounded queues, network calls, or database writes were introduced.
- Invalid, external, protocol-relative, backslash, and encoded unsafe values fall back to `/leaderboard`.
- No invariant regression introduced.

## Migration notes
Not applicable — no DB migration changed.

## Documentation integrity
Not applicable — no docs, commands, or user-facing option names changed.

## Rollback plan
Rollback: revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks
- Remote CI has not run yet because the PR has not been opened.
- Existing unrelated frontend TypeScript errors remain outside this diff.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitized GitHub OAuth `returnTo` values to prevent open redirects. Only same‑origin relative paths are allowed; unsafe inputs fall back to `/leaderboard`.

- **Bug Fixes**
  - Added `sanitizeAuthReturnTo` with a safe `/leaderboard` default in `packages/frontend/src/lib/auth/returnTo.ts`.
  - Start route stores only sanitized `returnTo`; callback re-sanitizes and redirects via `new URL(returnTo, baseUrl)`.
  - Blocked absolute, protocol-relative, backslash, userinfo-style, and encoded variants; added regression tests in `packages/frontend/__tests__/api/githubAuthReturnTo.test.ts`.

<sup>Written for commit ac9bbd6a29ac0886b18fb7dc852679de98ef14da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

