### PR TITLE
feat(pricing): add models.dev fallback source

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -165,7 +165,7 @@ enum Commands {
         json: bool,
         #[arg(
             long,
-            help = "Force specific provider (custom, litellm, or openrouter)"
+            help = "Force specific pricing source (custom, litellm, openrouter, or models.dev)"
         )]
         provider: Option<String>,
         #[arg(long, help = "Disable spinner")]
@@ -3119,14 +3119,14 @@ fn run_pricing_lookup(
 
     let provider_normalized = provider.map(|p| p.to_lowercase());
     if let Some(ref p) = provider_normalized {
-        if p != "custom" && p != "litellm" && p != "openrouter" {
+        if p != "custom" && p != "litellm" && p != "openrouter" && p != "models.dev" {
             println!(
                 "\n  {}",
                 format!("Invalid provider: {}", provider.unwrap_or("")).red()
             );
             println!(
                 "{}\n",
-                "  Valid providers: custom, litellm, openrouter".bright_black()
+                "  Valid providers: custom, litellm, openrouter, models.dev".bright_black()
             );
             std::process::exit(1);
         }
@@ -3242,6 +3242,7 @@ fn run_pricing_lookup(
                     "custom" => "Custom",
                     "litellm" => "LiteLLM",
                     "openrouter" => "OpenRouter",
+                    "models.dev" => "Models.dev",
                     _ => pricing.source.as_str(),
                 };
                 println!("  Source: {}", source_label);

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -89,13 +89,17 @@ pub struct PricingLookup {
     litellm: HashMap<String, ModelPricing>,
     openrouter: HashMap<String, ModelPricing>,
     cursor: HashMap<String, ModelPricing>,
+    models_dev: HashMap<String, ModelPricing>,
     litellm_keys: Vec<String>,
     openrouter_keys: Vec<String>,
     litellm_key_parts: Vec<KeyModelPart>,
     openrouter_key_parts: Vec<KeyModelPart>,
+    models_dev_key_parts: Vec<KeyModelPart>,
     litellm_lower: HashMap<String, String>,
     openrouter_lower: HashMap<String, String>,
+    models_dev_lower: HashMap<String, String>,
     openrouter_model_part: HashMap<String, String>,
+    models_dev_model_part: HashMap<String, String>,
     cursor_lower: HashMap<String, String>,
     lookup_cache: RwLock<HashMap<String, Option<CachedResult>>>,
 }
@@ -112,11 +116,23 @@ impl PricingLookup {
         openrouter: HashMap<String, ModelPricing>,
         cursor: HashMap<String, ModelPricing>,
     ) -> Self {
+        Self::new_with_models_dev(litellm, openrouter, cursor, HashMap::new())
+    }
+
+    pub fn new_with_models_dev(
+        litellm: HashMap<String, ModelPricing>,
+        openrouter: HashMap<String, ModelPricing>,
+        cursor: HashMap<String, ModelPricing>,
+        models_dev: HashMap<String, ModelPricing>,
+    ) -> Self {
         let mut litellm_keys: Vec<String> = litellm.keys().cloned().collect();
         litellm_keys.sort_by_key(|k| std::cmp::Reverse(k.len()));
 
         let mut openrouter_keys: Vec<String> = openrouter.keys().cloned().collect();
         openrouter_keys.sort_by_key(|k| std::cmp::Reverse(k.len()));
+
+        let mut models_dev_keys: Vec<String> = models_dev.keys().cloned().collect();
+        models_dev_keys.sort_by_key(|k| std::cmp::Reverse(k.len()));
 
         let mut litellm_lower = HashMap::with_capacity(litellm.len());
         for key in &litellm_keys {
@@ -131,6 +147,18 @@ impl PricingLookup {
             if let Some(model_part) = lower.split('/').next_back() {
                 if model_part != lower {
                     openrouter_model_part.insert(model_part.to_string(), key.clone());
+                }
+            }
+        }
+
+        let mut models_dev_lower = HashMap::with_capacity(models_dev.len());
+        let mut models_dev_model_part = HashMap::with_capacity(models_dev.len());
+        for key in &models_dev_keys {
+            let lower = key.to_lowercase();
+            models_dev_lower.insert(lower.clone(), key.clone());
+            if let Some(model_part) = lower.split('/').next_back() {
+                if model_part != lower {
+                    models_dev_model_part.insert(model_part.to_string(), key.clone());
                 }
             }
         }
@@ -155,18 +183,23 @@ impl PricingLookup {
 
         let litellm_key_parts = build_key_parts(&litellm_keys);
         let openrouter_key_parts = build_key_parts(&openrouter_keys);
+        let models_dev_key_parts = build_key_parts(&models_dev_keys);
 
         Self {
             litellm,
             openrouter,
             cursor,
+            models_dev,
             litellm_keys,
             openrouter_keys,
             litellm_key_parts,
             openrouter_key_parts,
+            models_dev_key_parts,
             litellm_lower,
             openrouter_lower,
+            models_dev_lower,
             openrouter_model_part,
+            models_dev_model_part,
             cursor_lower,
             lookup_cache: RwLock::new(HashMap::with_capacity(64)),
         }
@@ -267,6 +300,9 @@ impl PricingLookup {
         let do_lookup = |id: &str| match force_source {
             Some("litellm") => self.lookup_litellm_only(id, provider_id),
             Some("openrouter") => self.lookup_openrouter_only(id, provider_id),
+            Some("models.dev") | Some("modelsdev") | Some("models_dev") => {
+                self.lookup_models_dev_only(id, provider_id)
+            }
             _ => self.lookup_auto(id, provider_id),
         };
 
@@ -327,6 +363,14 @@ impl PricingLookup {
                 if let Some(result) = stripped_litellm {
                     return Some(result);
                 }
+                if let Some(result) = self.exact_match_models_dev(model_id) {
+                    return Some(result);
+                }
+                if let Some(result) =
+                    self.exact_match_models_dev_with_provider(stripped, provider_id)
+                {
+                    return Some(result);
+                }
             } else {
                 if let Some(result) = choose_best_source_result(
                     self.exact_match_litellm_for_provider(stripped, provider_id),
@@ -336,6 +380,11 @@ impl PricingLookup {
                     return Some(result);
                 }
                 if let Some(result) = self.exact_or_normalized_litellm(stripped, provider_id) {
+                    return Some(result);
+                }
+                if let Some(result) =
+                    self.exact_match_models_dev_with_provider(stripped, provider_id)
+                {
                     return Some(result);
                 }
             }
@@ -355,6 +404,9 @@ impl PricingLookup {
         if let Some(result) = self.exact_match_openrouter(model_id) {
             return Some(result);
         }
+        if let Some(result) = self.exact_match_models_dev_with_provider(model_id, provider_id) {
+            return Some(result);
+        }
 
         if let Some(version_normalized) = normalize_version_separator(model_id) {
             if let Some(result) = choose_best_source_result(
@@ -368,6 +420,11 @@ impl PricingLookup {
                 return Some(result);
             }
             if let Some(result) = self.exact_match_openrouter(&version_normalized) {
+                return Some(result);
+            }
+            if let Some(result) =
+                self.exact_match_models_dev_with_provider(&version_normalized, provider_id)
+            {
                 return Some(result);
             }
         }
@@ -386,6 +443,11 @@ impl PricingLookup {
             if let Some(result) = self.exact_match_openrouter(&normalized) {
                 return Some(result);
             }
+            if let Some(result) =
+                self.exact_match_models_dev_with_provider(&normalized, provider_id)
+            {
+                return Some(result);
+            }
         }
 
         if let Some(result) = self.prefix_match_litellm(model_id, provider_id) {
@@ -394,12 +456,18 @@ impl PricingLookup {
         if let Some(result) = self.prefix_match_openrouter(model_id, provider_id) {
             return Some(result);
         }
+        if let Some(result) = self.prefix_match_models_dev(model_id, provider_id) {
+            return Some(result);
+        }
 
         if let Some(version_normalized) = normalize_version_separator(model_id) {
             if let Some(result) = self.prefix_match_litellm(&version_normalized, provider_id) {
                 return Some(result);
             }
             if let Some(result) = self.prefix_match_openrouter(&version_normalized, provider_id) {
+                return Some(result);
+            }
+            if let Some(result) = self.prefix_match_models_dev(&version_normalized, provider_id) {
                 return Some(result);
             }
         }
@@ -449,6 +517,43 @@ impl PricingLookup {
                 return Some(result);
             }
             if let Some(result) = self.exact_match_litellm(&normalized) {
+                return Some(result);
+            }
+        }
+        None
+    }
+
+    fn lookup_models_dev_only(
+        &self,
+        model_id: &str,
+        provider_id: Option<&str>,
+    ) -> Option<LookupResult> {
+        if parse_provider_scoped_model_path(model_id).is_some() {
+            return None;
+        }
+
+        if let Some(result) = self.exact_match_models_dev_with_provider(model_id, provider_id) {
+            return Some(result);
+        }
+        if let Some(version_normalized) = normalize_version_separator(model_id) {
+            if let Some(result) =
+                self.exact_match_models_dev_with_provider(&version_normalized, provider_id)
+            {
+                return Some(result);
+            }
+        }
+        if let Some(normalized) = normalize_model_name(model_id) {
+            if let Some(result) =
+                self.exact_match_models_dev_with_provider(&normalized, provider_id)
+            {
+                return Some(result);
+            }
+        }
+        if let Some(result) = self.prefix_match_models_dev(model_id, provider_id) {
+            return Some(result);
+        }
+        if let Some(version_normalized) = normalize_version_separator(model_id) {
+            if let Some(result) = self.prefix_match_models_dev(&version_normalized, provider_id) {
                 return Some(result);
             }
         }
@@ -643,6 +748,29 @@ impl PricingLookup {
             .or_else(|| self.exact_match_openrouter(model_id))
     }
 
+    fn exact_match_models_dev_for_provider(
+        &self,
+        model_id: &str,
+        provider_id: Option<&str>,
+    ) -> Option<LookupResult> {
+        exact_match_with_provider_prefixes(
+            model_id,
+            provider_id,
+            &self.models_dev_key_parts,
+            &self.models_dev,
+            "Models.dev",
+        )
+    }
+
+    fn exact_match_models_dev_with_provider(
+        &self,
+        model_id: &str,
+        provider_id: Option<&str>,
+    ) -> Option<LookupResult> {
+        self.exact_match_models_dev_for_provider(model_id, provider_id)
+            .or_else(|| self.exact_match_models_dev(model_id))
+    }
+
     fn exact_match_litellm(&self, model_id: &str) -> Option<LookupResult> {
         let key = self.litellm_lower.get(model_id)?;
         let pricing = self.litellm.get(key)?;
@@ -668,6 +796,28 @@ impl PricingLookup {
                 return Some(LookupResult {
                     pricing: pricing.clone(),
                     source: "OpenRouter".into(),
+                    matched_key: key.clone(),
+                });
+            }
+        }
+        None
+    }
+
+    fn exact_match_models_dev(&self, model_id: &str) -> Option<LookupResult> {
+        if let Some(key) = self.models_dev_lower.get(model_id) {
+            if let Some(pricing) = self.models_dev.get(key) {
+                return Some(LookupResult {
+                    pricing: pricing.clone(),
+                    source: "Models.dev".into(),
+                    matched_key: key.clone(),
+                });
+            }
+        }
+        if let Some(key) = self.models_dev_model_part.get(model_id) {
+            if let Some(pricing) = self.models_dev.get(key) {
+                return Some(LookupResult {
+                    pricing: pricing.clone(),
+                    source: "Models.dev".into(),
                     matched_key: key.clone(),
                 });
             }
@@ -738,6 +888,30 @@ impl PricingLookup {
                         pricing: pricing.clone(),
                         source: "OpenRouter".into(),
                         matched_key: or_key.clone(),
+                    });
+                }
+            }
+        }
+        None
+    }
+
+    fn prefix_match_models_dev(
+        &self,
+        model_id: &str,
+        provider_id: Option<&str>,
+    ) -> Option<LookupResult> {
+        if let Some(result) = self.exact_match_models_dev_for_provider(model_id, provider_id) {
+            return Some(result);
+        }
+
+        for prefix in PROVIDER_PREFIXES {
+            let key = format!("{}{}", prefix, model_id);
+            if let Some(models_dev_key) = self.models_dev_lower.get(&key) {
+                if let Some(pricing) = self.models_dev.get(models_dev_key) {
+                    return Some(LookupResult {
+                        pricing: pricing.clone(),
+                        source: "Models.dev".into(),
+                        matched_key: models_dev_key.clone(),
                     });
                 }
             }

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -3,6 +3,7 @@ pub mod cache;
 pub mod custom;
 pub mod litellm;
 pub mod lookup;
+pub mod models_dev;
 pub mod openrouter;
 
 use custom::CustomPricing;
@@ -41,12 +42,22 @@ impl PricingService {
         litellm_data: HashMap<String, ModelPricing>,
         openrouter_data: HashMap<String, ModelPricing>,
     ) -> Self {
+        Self::new_with_custom_and_models_dev(custom, litellm_data, openrouter_data, HashMap::new())
+    }
+
+    pub fn new_with_custom_and_models_dev(
+        custom: CustomPricing,
+        litellm_data: HashMap<String, ModelPricing>,
+        openrouter_data: HashMap<String, ModelPricing>,
+        models_dev_data: HashMap<String, ModelPricing>,
+    ) -> Self {
         Self {
             custom,
-            lookup: PricingLookup::new(
+            lookup: PricingLookup::new_with_models_dev(
                 litellm_data,
                 openrouter_data,
                 Self::build_cursor_overrides(),
+                models_dev_data,
             ),
         }
     }
@@ -117,31 +128,44 @@ impl PricingService {
     }
 
     async fn fetch_inner() -> Result<Self, String> {
-        let (litellm_result, openrouter_data) =
-            tokio::join!(litellm::fetch(), openrouter::fetch_all_mapped());
+        let (litellm_result, openrouter_data, models_dev_result) = tokio::join!(
+            litellm::fetch(),
+            openrouter::fetch_all_mapped(),
+            models_dev::fetch()
+        );
 
         let litellm_data = litellm_result.map_err(|e| e.to_string())?;
         let litellm_data = Self::filter_litellm_data(litellm_data);
+        let models_dev_data = match models_dev_result {
+            Ok(data) => data,
+            Err(e) => {
+                eprintln!("[tokscale] models.dev fetch failed: {}", e);
+                HashMap::new()
+            }
+        };
 
-        Ok(Self::new_with_custom(
+        Ok(Self::new_with_custom_and_models_dev(
             CustomPricing::load_from_default_path(),
             litellm_data,
             openrouter_data,
+            models_dev_data,
         ))
     }
 
     fn from_cached_datasets(
         litellm_data: Option<HashMap<String, ModelPricing>>,
         openrouter_data: Option<HashMap<String, ModelPricing>>,
+        models_dev_data: Option<HashMap<String, ModelPricing>>,
     ) -> Option<Self> {
-        if litellm_data.is_none() && openrouter_data.is_none() {
+        if litellm_data.is_none() && openrouter_data.is_none() && models_dev_data.is_none() {
             return None;
         }
 
-        Some(Self::new_with_custom(
+        Some(Self::new_with_custom_and_models_dev(
             CustomPricing::load_from_default_path(),
             Self::filter_litellm_data(litellm_data.unwrap_or_default()),
             openrouter_data.unwrap_or_default(),
+            models_dev_data.unwrap_or_default(),
         ))
     }
 
@@ -149,6 +173,7 @@ impl PricingService {
         Self::from_cached_datasets(
             litellm::load_cached_any_age(),
             openrouter::load_cached_any_age(),
+            models_dev::load_cached_any_age(),
         )
     }
 
@@ -270,6 +295,167 @@ mod tests {
         openrouter: HashMap<String, ModelPricing>,
     ) -> PricingService {
         PricingService::new_with_custom(CustomPricing::from_models(custom), litellm, openrouter)
+    }
+
+    fn fixture_models_dev() -> HashMap<String, ModelPricing> {
+        models_dev::parse_dataset(include_str!("../../tests/fixtures/models_dev_pricing.json"))
+            .unwrap()
+    }
+
+    fn custom_service_with_models_dev(
+        custom: HashMap<String, ModelPricing>,
+        litellm: HashMap<String, ModelPricing>,
+        openrouter: HashMap<String, ModelPricing>,
+        models_dev: HashMap<String, ModelPricing>,
+    ) -> PricingService {
+        PricingService::new_with_custom_and_models_dev(
+            CustomPricing::from_models(custom),
+            litellm,
+            openrouter,
+            models_dev,
+        )
+    }
+
+    #[test]
+    fn models_dev_parses_fixture_prices_per_token() {
+        let data = fixture_models_dev();
+        let pricing = data.get("openai/gpt-fixture-model").unwrap();
+
+        assert_eq!(pricing.input_cost_per_token, Some(0.00000125));
+        assert_eq!(pricing.output_cost_per_token, Some(0.00001));
+        assert_eq!(pricing.cache_read_input_token_cost, Some(0.000000125));
+        assert_eq!(pricing.cache_creation_input_token_cost, Some(0.000001875));
+        assert!(!data.contains_key("openai/missing-output-price"));
+    }
+
+    #[test]
+    fn models_dev_fills_provider_aware_fallback_prices() {
+        let service = custom_service_with_models_dev(
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            fixture_models_dev(),
+        );
+
+        let result = service
+            .lookup_with_source_and_provider("gpt-fixture-model", None, Some("openai"))
+            .unwrap();
+
+        assert_eq!(result.source, "Models.dev");
+        assert_eq!(result.matched_key, "openai/gpt-fixture-model");
+        assert_eq!(result.pricing.input_cost_per_token, Some(0.00000125));
+    }
+
+    #[test]
+    fn models_dev_cache_prices_are_used_for_cost_fallback() {
+        let service = custom_service_with_models_dev(
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            fixture_models_dev(),
+        );
+        let usage = TokenBreakdown {
+            input: 1_000_000,
+            output: 100_000,
+            cache_read: 50_000,
+            cache_write: 20_000,
+            reasoning: 0,
+        };
+
+        let cost =
+            service.calculate_cost_with_provider("gpt-fixture-model", Some("openai"), &usage);
+
+        let expected = 1.25 + 1.0 + 0.00625 + 0.0375;
+        assert!((cost - expected).abs() < 1e-10);
+    }
+
+    #[test]
+    fn existing_sources_beat_models_dev_fallback() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "gpt-fixture-model".into(),
+            model_pricing(0.000002, 0.000008),
+        );
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "anthropic/claude-fixture-sonnet".into(),
+            model_pricing(0.000004, 0.000016),
+        );
+
+        let service = custom_service_with_models_dev(
+            HashMap::new(),
+            litellm,
+            openrouter,
+            fixture_models_dev(),
+        );
+
+        let litellm_result = service
+            .lookup_with_source_and_provider("gpt-fixture-model", None, Some("openai"))
+            .unwrap();
+        assert_eq!(litellm_result.source, "LiteLLM");
+        assert_eq!(litellm_result.pricing.input_cost_per_token, Some(0.000002));
+
+        let openrouter_result = service
+            .lookup_with_source_and_provider("claude-fixture-sonnet", None, Some("anthropic"))
+            .unwrap();
+        assert_eq!(openrouter_result.source, "OpenRouter");
+        assert_eq!(
+            openrouter_result.pricing.input_cost_per_token,
+            Some(0.000004)
+        );
+    }
+
+    #[test]
+    fn models_dev_respects_forced_source_boundaries() {
+        let service = custom_service_with_models_dev(
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            fixture_models_dev(),
+        );
+
+        assert!(service
+            .lookup_with_source_and_provider("gpt-fixture-model", Some("litellm"), Some("openai"))
+            .is_none());
+        assert!(service
+            .lookup_with_source_and_provider(
+                "gpt-fixture-model",
+                Some("openrouter"),
+                Some("openai")
+            )
+            .is_none());
+
+        let result = service
+            .lookup_with_source_and_provider(
+                "gpt-fixture-model",
+                Some("models.dev"),
+                Some("openai"),
+            )
+            .unwrap();
+        assert_eq!(result.source, "Models.dev");
+    }
+
+    #[test]
+    fn custom_override_beats_models_dev_fallback() {
+        let mut custom = HashMap::new();
+        custom.insert(
+            "gpt-fixture-model".into(),
+            model_pricing(0.000009, 0.000018),
+        );
+
+        let service = custom_service_with_models_dev(
+            custom,
+            HashMap::new(),
+            HashMap::new(),
+            fixture_models_dev(),
+        );
+
+        let result = service
+            .lookup_with_source_and_provider("gpt-fixture-model", None, Some("openai"))
+            .unwrap();
+
+        assert_eq!(result.source, "Custom");
+        assert_eq!(result.pricing.input_cost_per_token, Some(0.000009));
     }
 
     #[test]
@@ -617,7 +803,7 @@ mod tests {
 
     #[test]
     fn test_from_cached_datasets_returns_none_when_both_sources_missing() {
-        assert!(PricingService::from_cached_datasets(None, None).is_none());
+        assert!(PricingService::from_cached_datasets(None, None, None).is_none());
     }
 
     #[test]
@@ -638,7 +824,7 @@ mod tests {
             },
         );
 
-        let service = PricingService::from_cached_datasets(Some(litellm), None).unwrap();
+        let service = PricingService::from_cached_datasets(Some(litellm), None, None).unwrap();
 
         assert!(service
             .lookup_with_source("github_copilot/gpt-5.3-codex", Some("litellm"))
@@ -646,6 +832,19 @@ mod tests {
         assert!(service
             .lookup_with_source("gpt-5.2", Some("litellm"))
             .is_some());
+    }
+
+    #[test]
+    fn test_from_cached_datasets_uses_models_dev_when_other_sources_missing() {
+        let service =
+            PricingService::from_cached_datasets(None, None, Some(fixture_models_dev())).unwrap();
+
+        let result = service
+            .lookup_with_source_and_provider("gpt-fixture-model", None, Some("openai"))
+            .unwrap();
+
+        assert_eq!(result.source, "Models.dev");
+        assert_eq!(result.matched_key, "openai/gpt-fixture-model");
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/models_dev.rs
+++ b/crates/tokscale-core/src/pricing/models_dev.rs
@@ -1,0 +1,207 @@
+use super::cache;
+use super::litellm::ModelPricing;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+const CACHE_FILENAME: &str = "pricing-models-dev.json";
+const MODELS_DEV_URL: &str = "https://models.dev/api.json";
+const MAX_RETRIES: u32 = 3;
+const INITIAL_BACKOFF_MS: u64 = 200;
+const PER_MILLION: f64 = 1_000_000.0;
+
+#[derive(Deserialize)]
+struct Provider {
+    #[serde(default)]
+    models: HashMap<String, Model>,
+}
+
+#[derive(Deserialize)]
+struct Model {
+    id: Option<String>,
+    cost: Option<ModelCost>,
+}
+
+#[derive(Deserialize)]
+struct ModelCost {
+    input: Option<f64>,
+    output: Option<f64>,
+    cache_read: Option<f64>,
+    cache_write: Option<f64>,
+}
+
+pub type PricingDataset = HashMap<String, ModelPricing>;
+
+pub fn load_cached() -> Option<PricingDataset> {
+    cache::load_cache(CACHE_FILENAME)
+}
+
+pub fn load_cached_any_age() -> Option<PricingDataset> {
+    cache::load_cache_any_age(CACHE_FILENAME)
+}
+
+pub(crate) fn parse_dataset(content: &str) -> Result<PricingDataset, serde_json::Error> {
+    let providers: HashMap<String, Provider> = serde_json::from_str(content)?;
+    Ok(map_providers(providers))
+}
+
+pub async fn fetch() -> Result<PricingDataset, reqwest::Error> {
+    fetch_inner(MODELS_DEV_URL, true).await
+}
+
+async fn fetch_inner(url: &str, use_cache: bool) -> Result<PricingDataset, reqwest::Error> {
+    if use_cache {
+        if let Some(cached) = load_cached() {
+            return Ok(cached);
+        }
+    }
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .build()?;
+
+    let mut last_error: Option<reqwest::Error> = None;
+
+    for attempt in 0..MAX_RETRIES {
+        match client.get(url).send().await {
+            Ok(response) => {
+                let status = response.status();
+
+                if status.is_server_error() || status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                    eprintln!(
+                        "[tokscale] models.dev HTTP {} (attempt {}/{})",
+                        status,
+                        attempt + 1,
+                        MAX_RETRIES
+                    );
+                    if attempt == MAX_RETRIES - 1 {
+                        return Err(response.error_for_status().unwrap_err());
+                    }
+                    let _ = response.bytes().await;
+                    tokio::time::sleep(std::time::Duration::from_millis(
+                        INITIAL_BACKOFF_MS * (1 << attempt),
+                    ))
+                    .await;
+                    continue;
+                }
+
+                if !status.is_success() {
+                    eprintln!("[tokscale] models.dev HTTP {}", status);
+                    return Err(response.error_for_status().unwrap_err());
+                }
+
+                let content = response.text().await?;
+                match parse_dataset(&content) {
+                    Ok(data) => {
+                        if let Err(e) = cache::save_cache(CACHE_FILENAME, &data) {
+                            eprintln!(
+                                "[tokscale] Warning: Failed to cache models.dev pricing at {}: {}",
+                                cache::get_cache_path(CACHE_FILENAME).display(),
+                                e
+                            );
+                        }
+                        return Ok(data);
+                    }
+                    Err(e) => {
+                        eprintln!("[tokscale] models.dev JSON parse failed: {}", e);
+                        return Ok(HashMap::new());
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!(
+                    "[tokscale] models.dev network error (attempt {}/{}): {}",
+                    attempt + 1,
+                    MAX_RETRIES,
+                    e
+                );
+                last_error = Some(e);
+                if attempt < MAX_RETRIES - 1 {
+                    tokio::time::sleep(std::time::Duration::from_millis(
+                        INITIAL_BACKOFF_MS * (1 << attempt),
+                    ))
+                    .await;
+                }
+            }
+        }
+    }
+
+    match last_error {
+        Some(e) => Err(e),
+        None => Ok(HashMap::new()),
+    }
+}
+
+fn map_providers(providers: HashMap<String, Provider>) -> PricingDataset {
+    let mut result = HashMap::new();
+
+    for (provider_id, provider) in providers {
+        for (model_key, model) in provider.models {
+            let model_id = model.id.as_deref().unwrap_or(&model_key);
+            let Some(pricing) = model.cost.and_then(cost_to_pricing) else {
+                continue;
+            };
+            result.insert(format!("{provider_id}/{model_id}").to_lowercase(), pricing);
+        }
+    }
+
+    result
+}
+
+fn cost_to_pricing(cost: ModelCost) -> Option<ModelPricing> {
+    let input = per_token(cost.input?)?;
+    let output = per_token(cost.output?)?;
+
+    Some(ModelPricing {
+        input_cost_per_token: Some(input),
+        output_cost_per_token: Some(output),
+        cache_read_input_token_cost: cost.cache_read.and_then(per_token),
+        cache_creation_input_token_cost: cost.cache_write.and_then(per_token),
+        ..Default::default()
+    })
+}
+
+fn per_token(value: f64) -> Option<f64> {
+    value
+        .is_finite()
+        .then_some(value)
+        .filter(|v| *v >= 0.0)
+        .map(|v| v / PER_MILLION)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    fn retryable_status_server(status_line: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+
+        thread::spawn(move || {
+            for _ in 0..MAX_RETRIES {
+                let Ok((mut stream, _)) = listener.accept() else {
+                    return;
+                };
+                let mut buffer = [0; 1024];
+                let _ = stream.read(&mut buffer);
+                let response =
+                    format!("{status_line}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+
+        url
+    }
+
+    #[tokio::test]
+    async fn fetch_returns_error_after_retryable_http_statuses() {
+        let url = retryable_status_server("HTTP/1.1 503 Service Unavailable");
+
+        let result = fetch_inner(&url, false).await;
+
+        assert!(result.is_err());
+    }
+}

--- a/crates/tokscale-core/tests/fixtures/models_dev_pricing.json
+++ b/crates/tokscale-core/tests/fixtures/models_dev_pricing.json
@@ -1,0 +1,41 @@
+{
+  "openai": {
+    "id": "openai",
+    "name": "OpenAI",
+    "models": {
+      "gpt-fixture-model": {
+        "id": "gpt-fixture-model",
+        "name": "GPT Fixture Model",
+        "cost": {
+          "input": 1.25,
+          "output": 10.0,
+          "cache_read": 0.125,
+          "cache_write": 1.875
+        }
+      },
+      "missing-output-price": {
+        "id": "missing-output-price",
+        "name": "Missing Output Price",
+        "cost": {
+          "input": 1.0
+        }
+      }
+    }
+  },
+  "anthropic": {
+    "id": "anthropic",
+    "name": "Anthropic",
+    "models": {
+      "claude-fixture-sonnet": {
+        "id": "claude-fixture-sonnet",
+        "name": "Claude Fixture Sonnet",
+        "cost": {
+          "input": 3.0,
+          "output": 15.0,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `models.dev` as a third upstream pricing dataset alongside LiteLLM and OpenRouter.
- Cache the parsed `models.dev` dataset in the existing pricing cache layer and reuse stale cached data when live fetches are unavailable.
- Use `models.dev` only as a provider-aware fallback so custom overrides, LiteLLM, OpenRouter, and existing Cursor overrides keep their current precedence.
- Expose `models.dev` through `tokscale pricing --provider models.dev` for direct pricing inspection.

## Why
Tokscale can miss cost estimates when a newer model appears in `models.dev` before it is represented in LiteLLM or OpenRouter. That creates avoidable zero-cost or unknown-cost reports even when a usable public pricing source already exists. This change expands coverage while keeping the existing source ordering intact: the new dataset fills gaps, but it does not shadow custom overrides or the established primary sources.

## Diff scope
- `crates/tokscale-core/src/pricing/models_dev.rs`: adds the fetch, cache, retry, parser, and per-million-to-per-token conversion for the `models.dev` API.
- `crates/tokscale-core/src/pricing/mod.rs`: loads `models.dev` in parallel with the existing pricing sources, includes stale-cache recovery, and adds fixture-backed coverage for fallback cost calculation.
- `crates/tokscale-core/src/pricing/lookup.rs`: wires `models.dev` into exact, normalized, provider-aware, and prefix lookup paths after the existing primary sources.
- `crates/tokscale-cli/src/main.rs`: allows `pricing --provider models.dev` and renders the source label consistently.
- `crates/tokscale-core/tests/fixtures/models_dev_pricing.json`: adds a focused fixture for parser and precedence tests.

## Branch integrity
- Base branch: `main`
- Validated base SHA: `a86e688d620939d2c973c6d5625baa815ea223d7`
- Ahead/behind against fetched `origin/main`: `0 behind / 1 ahead`
- Merge base: `a86e688d620939d2c973c6d5625baa815ea223d7`
- Diff proof was computed against the fetched base.

## Commit integrity
- Introduced commit: `b7226c82827c7b8532803c3fdeb30467510f39d0 feat(pricing): add models.dev fallback source`
- Final PR diff contains only the intended pricing-source integration, CLI provider option, and regression fixture changes.
- Ledger: not applicable - not required for selected validation mode/change family.
- Version: not applicable - not required for selected validation mode/change family.

## Diff hygiene
- `git diff --name-status origin/main...HEAD`: `M crates/tokscale-cli/src/main.rs`, `M crates/tokscale-core/src/pricing/lookup.rs`, `M crates/tokscale-core/src/pricing/mod.rs`, `A crates/tokscale-core/src/pricing/models_dev.rs`, `A crates/tokscale-core/tests/fixtures/models_dev_pricing.json`
- `git diff --check origin/main...HEAD`: PASS, no output


## Validation mode and proof
- Validation mode: Mode 3 - shared pricing behavior and user-visible cost calculation fallback.
- `cargo test -p tokscale-core pricing::`: PASS, 212 tests
- `cargo check -p tokscale-cli`: PASS
- `cargo fmt --check`: PASS
- `curl -fsSL -A 'tokscale-pr-validation/1.0' https://models.dev/api.json | python3 -c '...'`: PASS, provider map with model objects and optional cost fields
- Full workspace test suite not run locally because the targeted pricing suite plus CLI compile check cover this diff, and remote PR CI should provide final full-gate status after the PR is opened.

## CI context confirmation
- Pending - required GitHub Actions checks will run after the PR is created.
- CI workflow context names unchanged.

## Runtime safety
- Reviewed changed runtime paths: pricing service fetch path, pricing cache fallback path, lookup precedence, and CLI pricing provider validation.
- The new live fetch runs in the existing async pricing fetch phase and degrades to an empty dataset when `models.dev` fails, preserving LiteLLM/OpenRouter behavior.
- Existing custom overrides and primary pricing sources retain precedence over `models.dev`.
- No new blocking locks, unbounded queues, database writes, or auth-sensitive paths were introduced.
- No invariant regression introduced.

## Migration notes
Not applicable - no DB migration changed.

## Documentation integrity
Not applicable - no docs or runbooks changed. The CLI help text for `tokscale pricing --provider` was updated with the new valid source.

## Rollback plan
Rollback: revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: reverting restores the previous LiteLLM/OpenRouter/custom-only pricing source set.

## Known residual risks
- Remote CI has not run yet because the PR has not been opened.
- `models.dev` is an external best-effort data source; the implementation treats fetch or parse failures as non-fatal so existing pricing behavior remains available.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `models.dev` as a provider-aware fallback pricing source to fill gaps when `LiteLLM` or `OpenRouter` don’t have a model. Also adds CLI support to query it with `tokscale pricing --provider models.dev`.

- **New Features**
  - Integrates `models.dev` after custom overrides, `LiteLLM`, and `OpenRouter` (exact/normalized/prefix, provider-aware) without changing precedence.
  - Fetches with retry/backoff, parses per‑million to per‑token, caches results, and reuses stale cache on failures.
  - CLI: `tokscale pricing --provider models.dev` and updated provider validation/help.

- **Bug Fixes**
  - Corrected retry handling for `models.dev` to back off on 429/5xx and fail after max retries; still falls back to cached data when available.

<sup>Written for commit 37b5a06cb9124d3b816cef2d56d46bc22990bf79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

