### PR TITLE
fix(release): guard publish dist-tags and matrices

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -65,6 +65,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Check release workflow safety
+        run: python3 scripts/check-release-workflow-safety.py
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -27,6 +27,11 @@ permissions:
   contents: write
   pull-requests: read
 
+env:
+  MACOSX_DEPLOYMENT_TARGET: "10.13"
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
 jobs:
   bump-versions:
     name: Bump versions
@@ -36,6 +41,9 @@ jobs:
       base_version: ${{ steps.bump.outputs.base_version }}
     steps:
       - uses: actions/checkout@v5
+
+      - name: Check release workflow safety
+        run: python3 scripts/check-release-workflow-safety.py
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -180,14 +188,14 @@ jobs:
             artifact_name: cli-binary-aarch64-unknown-linux-gnu
             bin_name: tokscale
             build: cargo zigbuild --release -p tokscale-cli --target aarch64-unknown-linux-gnu
-            strip: aarch64-linux-gnu-strip target/aarch64-unknown-linux-gnu/release/tokscale
+            strip: ""
           - host: ubuntu-latest
             target: aarch64-unknown-linux-musl
             package_dir: cli-linux-arm64-musl
             artifact_name: cli-binary-aarch64-unknown-linux-musl
             bin_name: tokscale
             build: cargo zigbuild --release -p tokscale-cli --target aarch64-unknown-linux-musl
-            strip: aarch64-linux-gnu-strip target/aarch64-unknown-linux-musl/release/tokscale
+            strip: ""
           - host: windows-latest
             target: x86_64-pc-windows-msvc
             package_dir: cli-win32-x64-msvc

--- a/scripts/check-release-workflow-safety.py
+++ b/scripts/check-release-workflow-safety.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+import json
+import pathlib
+import re
+import sys
+
+
+ROOT = pathlib.Path.cwd()
+PUBLISH_WORKFLOW = ROOT / ".github/workflows/publish-cli.yml"
+BUILD_NATIVE_WORKFLOW = ROOT / ".github/workflows/build-native.yml"
+REQUIRED_ENV_KEYS = ("MACOSX_DEPLOYMENT_TARGET", "CARGO_TERM_COLOR", "CARGO_INCREMENTAL")
+COMMON_BUILD_FIELDS = ("host", "target", "build", "strip", "bin_name")
+TARGET_PACKAGES = {
+    "x86_64-apple-darwin": "cli-darwin-x64",
+    "aarch64-apple-darwin": "cli-darwin-arm64",
+    "x86_64-unknown-linux-gnu": "cli-linux-x64-gnu",
+    "x86_64-unknown-linux-musl": "cli-linux-x64-musl",
+    "aarch64-unknown-linux-gnu": "cli-linux-arm64-gnu",
+    "aarch64-unknown-linux-musl": "cli-linux-arm64-musl",
+    "x86_64-pc-windows-msvc": "cli-win32-x64-msvc",
+    "aarch64-pc-windows-msvc": "cli-win32-arm64-msvc",
+}
+
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def read_lines(path: pathlib.Path) -> list[str]:
+    if not path.exists():
+        fail(f"Missing workflow: {path}")
+    return path.read_text().splitlines()
+
+
+def strip_yaml_scalar(value: str) -> str:
+    value = value.strip()
+    if value in {'""', "''"}:
+        return ""
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+    return value
+
+
+def top_level_env(lines: list[str]) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for index, line in enumerate(lines):
+        if line == "env:":
+            for env_line in lines[index + 1 :]:
+                if not env_line.startswith("  "):
+                    break
+                match = re.match(r"\s{2}([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$", env_line)
+                if match:
+                    env[match.group(1)] = strip_yaml_scalar(match.group(2))
+            return env
+    return env
+
+
+def job_block(lines: list[str], job_name: str) -> list[str]:
+    start = None
+    for index, line in enumerate(lines):
+        if re.match(rf"\s{{2}}{re.escape(job_name)}:\s*$", line):
+            start = index + 1
+            break
+    if start is None:
+        fail(f"Missing workflow job: {job_name}")
+
+    end = len(lines)
+    for index in range(start, len(lines)):
+        if re.match(r"\s{2}[A-Za-z0-9_-]+:\s*$", lines[index]):
+            end = index
+            break
+    return lines[start:end]
+
+
+def matrix_settings(lines: list[str], job_name: str) -> list[dict[str, str]]:
+    block = job_block(lines, job_name)
+    settings_start = None
+    settings_indent = 0
+    for index, line in enumerate(block):
+        match = re.match(r"(\s*)settings:\s*$", line)
+        if match:
+            settings_start = index + 1
+            settings_indent = len(match.group(1))
+            break
+    if settings_start is None:
+        fail(f"Missing matrix.settings for job: {job_name}")
+
+    entries: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    current_indent = 0
+    for line in block[settings_start:]:
+        if not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        if indent <= settings_indent:
+            break
+
+        entry_match = re.match(r"(\s*)-\s+([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$", line)
+        if entry_match:
+            current = {entry_match.group(2): strip_yaml_scalar(entry_match.group(3))}
+            current_indent = len(entry_match.group(1))
+            entries.append(current)
+            continue
+
+        field_match = re.match(r"\s*([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$", line)
+        if current is not None and field_match and indent > current_indent:
+            current[field_match.group(1)] = strip_yaml_scalar(field_match.group(2))
+
+    if not entries:
+        fail(f"No matrix settings found for job: {job_name}")
+    return entries
+
+
+def by_target(entries: list[dict[str, str]], label: str) -> dict[str, dict[str, str]]:
+    result: dict[str, dict[str, str]] = {}
+    for entry in entries:
+        target = entry.get("target")
+        if not target:
+            fail(f"{label} matrix entry is missing target: {entry}")
+        if target in result:
+            fail(f"{label} matrix target is duplicated: {target}")
+        result[target] = entry
+    return result
+
+
+def package_manifest_name(package_dir: str) -> str:
+    manifest_path = ROOT / "packages" / package_dir / "package.json"
+    if not manifest_path.exists():
+        fail(f"Missing platform package manifest: {manifest_path}")
+    manifest = json.loads(manifest_path.read_text())
+    name = manifest.get("name")
+    if not isinstance(name, str) or not name:
+        fail(f"{manifest_path} missing package name")
+    return name
+
+
+def main() -> None:
+    publish_lines = read_lines(PUBLISH_WORKFLOW)
+    native_lines = read_lines(BUILD_NATIVE_WORKFLOW)
+    errors: list[str] = []
+
+    publish_env = top_level_env(publish_lines)
+    native_env = top_level_env(native_lines)
+    for key in REQUIRED_ENV_KEYS:
+        publish_has_key = key in publish_env
+        native_has_key = key in native_env
+        if not publish_has_key:
+            errors.append(f"publish workflow missing required env {key}")
+        if not native_has_key:
+            errors.append(f"build-native workflow missing required env {key}")
+        if (
+            publish_has_key
+            and native_has_key
+            and publish_env.get(key) != native_env.get(key)
+        ):
+            errors.append(
+                f"env {key} differs: publish={publish_env.get(key)!r}, build-native={native_env.get(key)!r}"
+            )
+
+    publish_build = by_target(matrix_settings(publish_lines, "build-cli-binary"), "publish build")
+    native_build = by_target(matrix_settings(native_lines, "build"), "build-native")
+
+    if list(publish_build) != list(native_build):
+        errors.append(
+            f"build matrix targets differ: publish={list(publish_build)}, build-native={list(native_build)}"
+        )
+
+    for target, publish_entry in publish_build.items():
+        native_entry = native_build.get(target)
+        if native_entry is None:
+            continue
+        for field in COMMON_BUILD_FIELDS:
+            if publish_entry.get(field, "") != native_entry.get(field, ""):
+                errors.append(
+                    f"build matrix {target} field {field} differs: publish={publish_entry.get(field)!r}, build-native={native_entry.get(field)!r}"
+                )
+
+        expected_package_dir = TARGET_PACKAGES.get(target)
+        if publish_entry.get("package_dir") != expected_package_dir:
+            errors.append(
+                f"build matrix {target} package_dir drift: expected {expected_package_dir}, found {publish_entry.get('package_dir')}"
+            )
+        expected_artifact = f"cli-binary-{target}"
+        if publish_entry.get("artifact_name") != expected_artifact:
+            errors.append(
+                f"build matrix {target} artifact drift: expected {expected_artifact}, found {publish_entry.get('artifact_name')}"
+            )
+
+    publish_platform = matrix_settings(publish_lines, "publish-platform-packages")
+    platform_by_dir: dict[str, dict[str, str]] = {}
+    for entry in publish_platform:
+        package_dir = entry.get("package_dir")
+        if not package_dir:
+            errors.append(f"publish platform entry missing package_dir: {entry}")
+            continue
+        if package_dir in platform_by_dir:
+            errors.append(f"publish platform package_dir is duplicated: {package_dir}")
+            continue
+        platform_by_dir[package_dir] = entry
+
+    expected_package_dirs = {
+        entry["package_dir"] for entry in publish_build.values() if entry.get("package_dir")
+    }
+    if set(platform_by_dir) != expected_package_dirs:
+        errors.append(
+            f"publish platform package_dirs differ from build matrix: publish={sorted(platform_by_dir)}, build={sorted(expected_package_dirs)}"
+        )
+
+    build_by_package_dir = {
+        entry["package_dir"]: entry for entry in publish_build.values() if entry.get("package_dir")
+    }
+    for package_dir, platform_entry in platform_by_dir.items():
+        build_entry = build_by_package_dir.get(package_dir)
+        if build_entry is None:
+            continue
+        expected_package_name = package_manifest_name(package_dir)
+        if platform_entry.get("package_name") != expected_package_name:
+            errors.append(
+                f"publish platform package name drift for {package_dir}: expected {expected_package_name}, found {platform_entry.get('package_name')}"
+            )
+        if platform_entry.get("artifact_name") != build_entry.get("artifact_name"):
+            errors.append(
+                f"publish platform artifact drift for {package_dir}: expected {build_entry.get('artifact_name')}, found {platform_entry.get('artifact_name')}"
+            )
+        if platform_entry.get("binary_name") != build_entry.get("bin_name"):
+            errors.append(
+                f"publish platform binary drift for {package_dir}: expected {build_entry.get('bin_name')}, found {platform_entry.get('binary_name')}"
+            )
+
+    if errors:
+        raise SystemExit("Release workflow safety check failed:\n- " + "\n- ".join(errors))
+
+    print("Release workflow safety OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/publish-npm-package.sh
+++ b/scripts/publish-npm-package.sh
@@ -93,6 +93,42 @@ package_name="$(read_manifest_field name)"
 package_version="$(read_manifest_field version)"
 package_spec="${package_name}@${package_version}"
 
+semver_prerelease() {
+  python3 - "$1" <<'PY'
+import re
+import sys
+
+version = sys.argv[1]
+match = re.fullmatch(r"\d+\.\d+\.\d+(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?", version)
+if not match:
+    raise SystemExit(f"Unsupported semver value: {version}")
+print(match.group(1) or "")
+PY
+}
+
+derive_dist_tag() {
+  python3 - "$1" <<'PY'
+import re
+import sys
+
+prerelease = sys.argv[1]
+if not prerelease:
+    print("latest")
+    raise SystemExit(0)
+
+identifier = prerelease.split(".", 1)[0].lower()
+if not re.fullmatch(r"[a-z][a-z0-9_-]*", identifier):
+    identifier = "next"
+print(identifier)
+PY
+}
+
+package_prerelease="$(semver_prerelease "${package_version}")"
+npm_dist_tag="${NPM_DIST_TAG:-$(derive_dist_tag "${package_prerelease}")}"
+if [[ -n "${package_prerelease}" && "${npm_dist_tag}" == "latest" ]]; then
+  fail "Refusing to publish prerelease ${package_spec} with npm dist-tag latest"
+fi
+
 package_exists=false
 if npm_view_version_status published_version "${package_spec}"; then
   package_exists=true
@@ -111,8 +147,8 @@ if [[ "${package_exists}" == "true" ]]; then
   fail "${package_spec} already exists on npm; set RELEASE_RECOVERY=true to skip already-published packages"
 fi
 
-echo "Publishing ${package_spec}"
+echo "Publishing ${package_spec} with npm dist-tag ${npm_dist_tag}"
 (
   cd "${PACKAGE_DIR}"
-  "${NPM_CMD}" publish --access public
+  "${NPM_CMD}" publish --access public --tag "${npm_dist_tag}"
 )

--- a/scripts/test-npm-release-state.sh
+++ b/scripts/test-npm-release-state.sh
@@ -92,6 +92,10 @@ if [[ "${1:-}" == "view" ]]; then
     exit 1
   fi
   case "${spec}" in
+    *@3.1.0|*@3.1.0-beta.1|*@3.1.0+build-1|*@3.1.0+build-2)
+      echo "npm ERR! code E404" >&2
+      exit 1
+      ;;
     *@3.0.0)
       case "${spec}" in
         @tokscale/cli-darwin-x64@3.0.0|@tokscale/cli@3.0.0)
@@ -309,6 +313,135 @@ EOF_MANIFEST
   )
 }
 
+test_prerelease_publish_uses_prerelease_dist_tag() {
+  local work="${TMP_DIR}/publish-prerelease-tag"
+  mkdir -p "${work}/scripts" "${work}/packages/cli"
+  cp "${PUBLISH_SCRIPT}" "${work}/scripts/publish-npm-package.sh"
+  (
+    cd "${work}"
+    cat > packages/cli/package.json <<'EOF_MANIFEST'
+{
+  "name": "@tokscale/cli",
+  "version": "3.1.0-beta.1"
+}
+EOF_MANIFEST
+    local fake_npm="${TMP_DIR}/fake-npm-publish-prerelease-tag"
+    write_fake_npm "${fake_npm}"
+
+    FAKE_NPM_LOG="${TMP_DIR}/publish-prerelease-tag-npm.log" \
+      FAKE_NPM_PUBLISH_LOG="${TMP_DIR}/publish-prerelease-tag-publish.log" \
+      NPM_CMD="${fake_npm}" \
+      bash scripts/publish-npm-package.sh packages/cli >"${TMP_DIR}/publish-prerelease-tag-output.txt" 2>&1
+
+    grep -q '^publish --access public --tag beta$' "${TMP_DIR}/publish-prerelease-tag-npm.log"
+  )
+}
+
+test_prerelease_publish_rejects_explicit_latest_dist_tag() {
+  local work="${TMP_DIR}/publish-prerelease-latest-tag"
+  mkdir -p "${work}/scripts" "${work}/packages/cli"
+  cp "${PUBLISH_SCRIPT}" "${work}/scripts/publish-npm-package.sh"
+  (
+    cd "${work}"
+    cat > packages/cli/package.json <<'EOF_MANIFEST'
+{
+  "name": "@tokscale/cli",
+  "version": "3.1.0-beta.1"
+}
+EOF_MANIFEST
+    local fake_npm="${TMP_DIR}/fake-npm-publish-prerelease-latest-tag"
+    write_fake_npm "${fake_npm}"
+
+    local output="${TMP_DIR}/publish-prerelease-latest-tag-output.txt"
+    if FAKE_NPM_LOG="${TMP_DIR}/publish-prerelease-latest-tag-npm.log" \
+      FAKE_NPM_PUBLISH_LOG="${TMP_DIR}/publish-prerelease-latest-tag-publish.log" \
+      NPM_CMD="${fake_npm}" \
+      NPM_DIST_TAG="latest" \
+      bash scripts/publish-npm-package.sh packages/cli >"${output}" 2>&1; then
+      echo "Expected publish helper to reject prerelease latest dist-tag" >&2
+      return 1
+    fi
+
+    grep -q "Refusing to publish prerelease @tokscale/cli@3.1.0-beta.1 with npm dist-tag latest" "${output}"
+    if [[ -s "${TMP_DIR}/publish-prerelease-latest-tag-npm.log" ]]; then
+      ! grep -q '^publish ' "${TMP_DIR}/publish-prerelease-latest-tag-npm.log"
+    fi
+  )
+}
+
+test_stable_publish_uses_latest_dist_tag() {
+  local work="${TMP_DIR}/publish-stable-tag"
+  mkdir -p "${work}/scripts" "${work}/packages/cli"
+  cp "${PUBLISH_SCRIPT}" "${work}/scripts/publish-npm-package.sh"
+  (
+    cd "${work}"
+    cat > packages/cli/package.json <<'EOF_MANIFEST'
+{
+  "name": "@tokscale/cli",
+  "version": "3.1.0"
+}
+EOF_MANIFEST
+    local fake_npm="${TMP_DIR}/fake-npm-publish-stable-tag"
+    write_fake_npm "${fake_npm}"
+
+    FAKE_NPM_LOG="${TMP_DIR}/publish-stable-tag-npm.log" \
+      FAKE_NPM_PUBLISH_LOG="${TMP_DIR}/publish-stable-tag-publish.log" \
+      NPM_CMD="${fake_npm}" \
+      bash scripts/publish-npm-package.sh packages/cli >"${TMP_DIR}/publish-stable-tag-output.txt" 2>&1
+
+    grep -q '^publish --access public --tag latest$' "${TMP_DIR}/publish-stable-tag-npm.log"
+  )
+}
+
+test_stable_build_metadata_publish_uses_latest_dist_tag() {
+  local work="${TMP_DIR}/publish-stable-build-metadata-tag"
+  mkdir -p "${work}/scripts" "${work}/packages/cli"
+  cp "${PUBLISH_SCRIPT}" "${work}/scripts/publish-npm-package.sh"
+  (
+    cd "${work}"
+    cat > packages/cli/package.json <<'EOF_MANIFEST'
+{
+  "name": "@tokscale/cli",
+  "version": "3.1.0+build-1"
+}
+EOF_MANIFEST
+    local fake_npm="${TMP_DIR}/fake-npm-publish-stable-build-metadata-tag"
+    write_fake_npm "${fake_npm}"
+
+    FAKE_NPM_LOG="${TMP_DIR}/publish-stable-build-metadata-tag-npm.log" \
+      FAKE_NPM_PUBLISH_LOG="${TMP_DIR}/publish-stable-build-metadata-tag-publish.log" \
+      NPM_CMD="${fake_npm}" \
+      bash scripts/publish-npm-package.sh packages/cli >"${TMP_DIR}/publish-stable-build-metadata-tag-output.txt" 2>&1
+
+    grep -q '^publish --access public --tag latest$' "${TMP_DIR}/publish-stable-build-metadata-tag-npm.log"
+  )
+}
+
+test_stable_build_metadata_allows_explicit_latest_dist_tag() {
+  local work="${TMP_DIR}/publish-stable-build-metadata-explicit-latest"
+  mkdir -p "${work}/scripts" "${work}/packages/cli"
+  cp "${PUBLISH_SCRIPT}" "${work}/scripts/publish-npm-package.sh"
+  (
+    cd "${work}"
+    cat > packages/cli/package.json <<'EOF_MANIFEST'
+{
+  "name": "@tokscale/cli",
+  "version": "3.1.0+build-2"
+}
+EOF_MANIFEST
+    local fake_npm="${TMP_DIR}/fake-npm-publish-stable-build-metadata-explicit-latest"
+    write_fake_npm "${fake_npm}"
+
+    FAKE_NPM_LOG="${TMP_DIR}/publish-stable-build-metadata-explicit-latest-npm.log" \
+      FAKE_NPM_PUBLISH_LOG="${TMP_DIR}/publish-stable-build-metadata-explicit-latest-publish.log" \
+      NPM_CMD="${fake_npm}" \
+      NPM_DIST_TAG="latest" \
+      bash scripts/publish-npm-package.sh packages/cli >"${TMP_DIR}/publish-stable-build-metadata-explicit-latest-output.txt" 2>&1
+
+    grep -q '^publish --access public --tag latest$' "${TMP_DIR}/publish-stable-build-metadata-explicit-latest-npm.log"
+  )
+}
+
 test_refuses_repo_version_ahead_of_npm_without_recovery
 test_recovery_allows_existing_target_versions_for_partial_retry
 test_recovery_requires_base_version
@@ -316,5 +449,10 @@ test_precheck_fails_on_non_404_npm_lookup_errors
 test_publish_skips_existing_target_version_during_recovery
 test_refuses_to_publish_existing_target_without_recovery
 test_publish_fails_on_non_404_npm_lookup_errors
+test_prerelease_publish_uses_prerelease_dist_tag
+test_prerelease_publish_rejects_explicit_latest_dist_tag
+test_stable_publish_uses_latest_dist_tag
+test_stable_build_metadata_publish_uses_latest_dist_tag
+test_stable_build_metadata_allows_explicit_latest_dist_tag
 
 echo "npm release-state tests passed"

--- a/scripts/test-package-launchers.sh
+++ b/scripts/test-package-launchers.sh
@@ -18,6 +18,21 @@ BUN_BIN="${BUN_BIN:-$(command -v bun)}"
 NODE_BIN="${NODE_BIN:-$(command -v node)}"
 LDD_BIN="${LDD_BIN:-$(command -v ldd || true)}"
 WHICH_BIN="${WHICH_BIN:-$(command -v which || true)}"
+TOKSCALE_SMOKE_BUILD_PROFILE="${TOKSCALE_SMOKE_BUILD_PROFILE:-debug}"
+case "${TOKSCALE_SMOKE_BUILD_PROFILE}" in
+  debug)
+    CARGO_BUILD_ARGS=(-p tokscale-cli)
+    CARGO_BINARY_DIR="target/debug"
+    ;;
+  release)
+    CARGO_BUILD_ARGS=(--release -p tokscale-cli)
+    CARGO_BINARY_DIR="target/release"
+    ;;
+  *)
+    echo "Unsupported TOKSCALE_SMOKE_BUILD_PROFILE: ${TOKSCALE_SMOKE_BUILD_PROFILE}" >&2
+    exit 1
+    ;;
+esac
 
 PLATFORM_PACKAGE="$(node --input-type=module <<'NODE'
 import { execSync } from "node:child_process";
@@ -72,9 +87,9 @@ if [[ -z "${PLATFORM_PACKAGE}" ]]; then
   exit 1
 fi
 
-echo "Building CLI wrapper and native binary..."
+echo "Building CLI wrapper and native binary (${TOKSCALE_SMOKE_BUILD_PROFILE})..."
 bun run --cwd packages/cli build >/dev/null
-cargo build --release -p tokscale-cli >/dev/null
+cargo build "${CARGO_BUILD_ARGS[@]}" >/dev/null
 
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/tokscale-launcher-smoke.XXXXXX")"
 cleanup() {
@@ -103,7 +118,7 @@ mkdir -p \
   "${BUN_ONLY_DIR}" \
   "${NODE_ONLY_DIR}" \
   "${STALE_PATH_DIR}"
-cp target/release/tokscale "${PLATFORM_STAGE}/bin/tokscale"
+cp "${CARGO_BINARY_DIR}/tokscale" "${PLATFORM_STAGE}/bin/tokscale"
 
 chmod +x "${CLI_STAGE}/bin.js" "${WRAPPER_STAGE}/bin.js" "${PLATFORM_STAGE}/bin/tokscale"
 
@@ -149,13 +164,10 @@ fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 NODE
 WRAPPER_TGZ="$(cd "${WRAPPER_STAGE}" && NPM_CONFIG_CACHE="${NPM_CACHE}" npm pack --silent)"
 
-echo "Installing local tarballs with Bun..."
+echo "Installing local wrapper tarball with Bun..."
 (
   cd "${INSTALL_DIR}"
-  env PATH="${BUN_ONLY_PATH}" bun add \
-    "${CLI_STAGE}/${CLI_TGZ}" \
-    "${WRAPPER_STAGE}/${WRAPPER_TGZ}" \
-    "${PLATFORM_STAGE}/${PLATFORM_TGZ}" >/dev/null
+  env PATH="${BUN_ONLY_PATH}" bun add "${WRAPPER_STAGE}/${WRAPPER_TGZ}" >/dev/null
 )
 
 INSTALLED_BIN="${INSTALL_DIR}/node_modules/.bin/tokscale"
@@ -163,9 +175,41 @@ if [[ ! -e "${INSTALLED_BIN}" ]]; then
   echo "Installed tokscale launcher not found at ${INSTALLED_BIN}" >&2
   exit 1
 fi
+WRAPPER_PACKAGE_DIR="${INSTALL_DIR}/node_modules/tokscale"
+CLI_PACKAGE_DIR="${INSTALL_DIR}/node_modules/@tokscale/cli"
+PLATFORM_PACKAGE_DIR="${INSTALL_DIR}/node_modules/@tokscale/${PLATFORM_PACKAGE}"
+WRAPPER_BIN="${WRAPPER_PACKAGE_DIR}/bin.js"
+for expected in \
+  "${WRAPPER_BIN}" \
+  "${CLI_PACKAGE_DIR}/bin.js" \
+  "${PLATFORM_PACKAGE_DIR}/bin/tokscale"; do
+  if [[ ! -e "${expected}" ]]; then
+    echo "Expected installed package path missing: ${expected}" >&2
+    exit 1
+  fi
+done
+grep -q 'await import("@tokscale/cli")' "${WRAPPER_PACKAGE_DIR}/bin.js" || {
+  echo "Installed tokscale wrapper does not import @tokscale/cli" >&2
+  exit 1
+}
+if [[ -L "${INSTALLED_BIN}" ]]; then
+  INSTALLED_BIN_TARGET="$(readlink "${INSTALLED_BIN}")"
+  echo "Installed tokscale bin points at ${INSTALLED_BIN_TARGET}"
+fi
 
-echo "Checking source-tree wrapper with Node-only PATH..."
-env PATH="${NODE_ONLY_PATH}" "${ROOT_DIR}/packages/tokscale/bin.js" --version >/dev/null
+if [[ "${TOKSCALE_SMOKE_BUILD_PROFILE}" == "release" ]]; then
+  echo "Checking source-tree wrapper with Node-only PATH..."
+  env PATH="${NODE_ONLY_PATH}" "${ROOT_DIR}/packages/tokscale/bin.js" --version >/dev/null
+else
+  echo "Skipping source-tree wrapper check for debug smoke profile..."
+fi
+
+echo "Checking installed wrapper package with Node-only PATH..."
+INSTALLED_WRAPPER_VERSION_NODE="$(env PATH="${NODE_ONLY_PATH}" "${WRAPPER_BIN}" --version)"
+[[ "${INSTALLED_WRAPPER_VERSION_NODE}" == tokscale* ]] || {
+  echo "Unexpected installed wrapper output: ${INSTALLED_WRAPPER_VERSION_NODE}" >&2
+  exit 1
+}
 
 echo "Checking installed launcher via Bun runtime..."
 INSTALLED_VERSION_BUN="$(env PATH="${BUN_ONLY_PATH}" bun "${INSTALLED_BIN}" --version)"
@@ -190,7 +234,7 @@ rm -f "${INSTALL_DIR}/node_modules/packages/${PLATFORM_PACKAGE}/bin/tokscale"
 rm -f "${INSTALL_DIR}/node_modules/target/release/tokscale"
 rm -f "${INSTALL_DIR}/node_modules/@tokscale/cli/bin/tokscale"
 set +e
-STALE_OUTPUT="$(env PATH="${STALE_PATH_DIR}:${NODE_ONLY_PATH}" "${INSTALLED_BIN}" --version 2>&1)"
+STALE_OUTPUT="$(env PATH="${STALE_PATH_DIR}:${NODE_ONLY_PATH}" "${WRAPPER_BIN}" --version 2>&1)"
 STALE_CODE=$?
 set -e
 if [[ ${STALE_CODE} -eq 0 ]]; then

--- a/scripts/test-release-workflow-safety.sh
+++ b/scripts/test-release-workflow-safety.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_UNDER_TEST="${ROOT_DIR}/scripts/check-release-workflow-safety.py"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+write_good_workflows() {
+  local work="$1"
+  mkdir -p "${work}/.github/workflows" "${work}/packages/cli-linux-x64-gnu"
+  cat > "${work}/packages/cli-linux-x64-gnu/package.json" <<'EOF_MANIFEST'
+{
+  "name": "@tokscale/cli-linux-x64-gnu",
+  "version": "3.0.0"
+}
+EOF_MANIFEST
+  cat > "${work}/.github/workflows/build-native.yml" <<'EOF_YAML'
+name: Build Native (Test Only)
+
+env:
+  MACOSX_DEPLOYMENT_TARGET: "10.13"
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        settings:
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            build: cargo zigbuild --release -p tokscale-cli --target x86_64-unknown-linux-gnu
+            strip: strip target/x86_64-unknown-linux-gnu/release/tokscale
+            bin_name: tokscale
+EOF_YAML
+  cat > "${work}/.github/workflows/publish-cli.yml" <<'EOF_YAML'
+name: Publish
+
+env:
+  MACOSX_DEPLOYMENT_TARGET: "10.13"
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  build-cli-binary:
+    strategy:
+      matrix:
+        settings:
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            package_dir: cli-linux-x64-gnu
+            artifact_name: cli-binary-x86_64-unknown-linux-gnu
+            bin_name: tokscale
+            build: cargo zigbuild --release -p tokscale-cli --target x86_64-unknown-linux-gnu
+            strip: strip target/x86_64-unknown-linux-gnu/release/tokscale
+  publish-platform-packages:
+    strategy:
+      matrix:
+        settings:
+          - package_name: '@tokscale/cli-linux-x64-gnu'
+            package_dir: cli-linux-x64-gnu
+            artifact_name: cli-binary-x86_64-unknown-linux-gnu
+            binary_name: tokscale
+EOF_YAML
+}
+
+test_accepts_matching_publish_and_native_workflows() {
+  local work="${TMP_DIR}/good"
+  write_good_workflows "${work}"
+
+  (
+    cd "${work}"
+    python3 "${SCRIPT_UNDER_TEST}" >"${TMP_DIR}/good-output.txt" 2>&1
+  )
+
+  grep -q "Release workflow safety OK" "${TMP_DIR}/good-output.txt"
+}
+
+test_rejects_build_matrix_target_drift() {
+  local work="${TMP_DIR}/target-drift"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/publish-cli.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text()
+text = text.replace("target: x86_64-unknown-linux-gnu", "target: x86_64-unknown-linux-musl", 1)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/target-drift-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to reject target drift" >&2
+    return 1
+  fi
+
+  grep -q "build matrix targets differ" "${output}"
+}
+
+test_rejects_release_env_drift() {
+  local work="${TMP_DIR}/env-drift"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/publish-cli.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace('MACOSX_DEPLOYMENT_TARGET: "10.13"', 'MACOSX_DEPLOYMENT_TARGET: "11.0"')
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/env-drift-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to reject env drift" >&2
+    return 1
+  fi
+
+  grep -q "env MACOSX_DEPLOYMENT_TARGET differs" "${output}"
+}
+
+test_rejects_missing_required_release_env() {
+  local work="${TMP_DIR}/missing-env"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/publish-cli.yml" "${work}/.github/workflows/build-native.yml" <<'PY'
+import pathlib
+import sys
+
+for path_arg in sys.argv[1:]:
+    path = pathlib.Path(path_arg)
+    text = "\n".join(
+        line for line in path.read_text().splitlines() if "CARGO_INCREMENTAL:" not in line
+    )
+    path.write_text(text + "\n")
+PY
+
+  local output="${TMP_DIR}/missing-env-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to reject missing required env" >&2
+    return 1
+  fi
+
+  grep -q "publish workflow missing required env CARGO_INCREMENTAL" "${output}"
+  grep -q "build-native workflow missing required env CARGO_INCREMENTAL" "${output}"
+}
+
+test_rejects_platform_publish_matrix_drift() {
+  local work="${TMP_DIR}/publish-drift"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/publish-cli.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace("artifact_name: cli-binary-x86_64-unknown-linux-gnu", "artifact_name: cli-binary-x86_64-unknown-linux-musl", 1)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/publish-drift-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to reject platform publish drift" >&2
+    return 1
+  fi
+
+  grep -q "publish platform artifact drift" "${output}"
+}
+
+test_accepts_matching_publish_and_native_workflows
+test_rejects_build_matrix_target_drift
+test_rejects_release_env_drift
+test_rejects_missing_required_release_env
+test_rejects_platform_publish_matrix_drift
+
+echo "release workflow safety tests passed"


### PR DESCRIPTION
## Summary
- Add a release workflow safety checker that keeps the native-build and publish matrices aligned before build or publish jobs run.
- Guard npm publishing so prerelease versions derive a prerelease dist-tag and cannot accidentally publish to `latest`.
- Extend release-state and launcher smoke coverage to catch package metadata, installed wrapper, platform binary, and stale PATH fallback regressions.
- Align publish workflow environment settings with the native build workflow and remove unsupported ARM Linux strip commands from the publish matrix.

## Why
Tokscale publishes platform packages and wrapper packages directly to npm from a manual release workflow. Small drift between the test-only native build matrix, the publish build matrix, and the platform publish matrix can produce release-only failures that are hard to see in normal PR checks. The same is true for npm dist-tags: a prerelease should not be able to land on `latest` by accident. This PR adds deterministic local and CI checks for those release invariants before a release publish can proceed.

## Diff scope
- `.github/workflows/publish-cli.yml`: adds top-level release build environment parity, runs the release safety checker, and avoids unsupported ARM Linux strip commands in the publish matrix.
- `.github/workflows/build-native.yml`: runs the same release safety checker during native-build PR validation.
- `scripts/check-release-workflow-safety.py`: validates workflow env parity, build matrix parity, package directory mapping, artifact names, binary names, and platform package manifest names.
- `scripts/publish-npm-package.sh`: derives npm dist-tags from semver prerelease identifiers and refuses prerelease publishes with `latest`.
- `scripts/test-release-workflow-safety.sh`: covers accepted and rejected workflow drift cases.
- `scripts/test-npm-release-state.sh`: covers stable and prerelease npm dist-tag behavior.
- `scripts/test-package-launchers.sh`: supports debug smoke builds, verifies installed wrapper/package paths, and checks stale PATH fallback failure behavior.

## Branch integrity
- Base branch: `main`
- Validated base SHA: `a86e688d620939d2c973c6d5625baa815ea223d7`
- Ahead/behind against fetched `origin/main`: `0 behind / 1 ahead`
- Merge base: `a86e688d620939d2c973c6d5625baa815ea223d7`
- Diff proof was computed against the fetched base.

## Commit integrity
- Introduced commit: `5600a47776f7184d4c0db51ba59e2b716cb70928 fix(release): guard publish dist-tags and matrices`
- Final PR diff contains only the intended release workflow, publish script, and release verification test changes.
- Ledger: not applicable - not required for selected validation mode/change family.
- Version: not applicable - not required for selected validation mode/change family.

## Diff hygiene
- `git diff --name-status origin/main...HEAD`: `M .github/workflows/build-native.yml`, `M .github/workflows/publish-cli.yml`, `A scripts/check-release-workflow-safety.py`, `M scripts/publish-npm-package.sh`, `M scripts/test-npm-release-state.sh`, `M scripts/test-package-launchers.sh`, `A scripts/test-release-workflow-safety.sh`
- `git diff --check origin/main...HEAD`: PASS, no output


## Validation mode and proof
- Validation mode: Mode 4 - CI/release workflow and release verification tooling changed.
- `python3 scripts/check-release-workflow-safety.py`: PASS
- `bash scripts/test-release-workflow-safety.sh`: PASS
- `bash scripts/test-npm-release-state.sh`: PASS
- `TOKSCALE_SMOKE_BUILD_PROFILE=debug bash scripts/test-package-launchers.sh`: PASS
- `bash -n scripts/*.sh`: PASS
- `python3 -m py_compile scripts/check-release-workflow-safety.py`: PASS
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-cli.yml"); YAML.load_file(".github/workflows/build-native.yml"); puts "YAML parse OK"'`: PASS
- `git diff --check origin/main...HEAD`: PASS, no output
- `actionlint`: not run - not installed in this local environment.

## CI context confirmation
- Pending - required GitHub Actions checks will run after the PR is created.
- CI workflow context names unchanged; this PR adds checks inside existing workflows rather than renaming contexts.

## Runtime safety
Not applicable - no CLI runtime session parsing, frontend runtime, database, auth, or server API path changed.

## Release safety
- The publish and native build matrices are now checked for target, host, build command, strip command, binary name, artifact name, package directory, and platform package manifest drift.
- The publish script now uses `latest` only for stable versions and derives prerelease dist-tags such as `beta` for versions like `3.1.0-beta.1`.
- The publish script refuses prerelease packages when the effective npm dist-tag is `latest`.
- Launcher smoke coverage validates the installed wrapper and platform package layout and confirms missing platform binaries do not silently fall back to a stale `tokscale` on `PATH`.

## Migration notes
Not applicable - no DB migration changed.

## Documentation integrity
Not applicable - no docs or runbooks changed. This PR enforces existing release expectations through scripts and workflow checks.

## Rollback plan
Rollback: revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: reverting removes the new release safety checks and restores the previous npm publish dist-tag behavior.

## Known residual risks
- Remote CI has not run yet because the PR has not been opened.
- Local `actionlint` proof is unavailable because `actionlint` is not installed in this environment; workflow YAML was parsed locally and the release safety checker exercises the changed matrix invariants.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a release safety checker to keep native-build and publish matrices/env in sync, and prevents prerelease versions from publishing with the `latest` npm tag. Expands tests, aligns publish env with native build, and removes unsupported ARM Linux strip commands.

- **New Features**
  - Adds `scripts/check-release-workflow-safety.py` and runs it in build-native and publish workflows to enforce env/matrix/artifact/binary/package parity.
  - Updates `scripts/publish-npm-package.sh` to derive npm dist-tags from semver (stable -> `latest`, prerelease -> first identifier like `beta`) and reject prerelease publishes with `latest`.
  - Extends tests: workflow drift checks; npm dist-tag cases (prerelease, build metadata, explicit `NPM_DIST_TAG`); launcher smokes add debug/release profiles, verify installed wrapper/CLI/platform paths, and assert PATH fallback failures.

- **Bug Fixes**
  - Aligns publish workflow top-level env with native build.
  - Removes unsupported ARM Linux strip commands from the publish matrix.

<sup>Written for commit b030c90250beeeaf5a8db18ed2a0175ea9fd94df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

