### PR TITLE
feat(grok): add Grok Build subscription usage

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -76,6 +76,7 @@
 | <img width="48px" src=".github/assets/client-goose.png" alt="Goose" /> | [Goose](https://github.com/aaif-goose/goose) | `~/.local/share/goose/sessions/sessions.db` (+ macOS Application Support、レガシー Block/goose パス; `GOOSE_PATH_ROOT` でオーバーライド可能) | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-antigravity.png" alt="Antigravity" /> | [Google Antigravity](https://antigravity.google/) | `tokscale antigravity sync` で `~/.config/tokscale/antigravity-cache/sessions/*.jsonl` にキャッシュ（ローカル言語サーバ RPC を使用） | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-trae.png" alt="Trae" /> | [Trae IDE](https://www.trae.ai/) / [Trae Solo](https://www.trae.ai/solo)（国際版） | `tokscale trae sync` で `~/.config/tokscale/trae-cache/sessions/*.json` にキャッシュ（公式 API のアカウント単位使用量） | ✅ 対応 |
+| Grok Build | Grok Build | `$GROK_HOME/sessions/*/*/updates.jsonl`（フォールバック: `~/.grok/sessions/*/*/updates.jsonl`） | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-zed.webp" alt="Zed Agent" /> | [Zed Agent](https://zed.dev/docs/ai/agent-panel) | `~/.local/share/zed/threads/threads.db`（macOS: `~/Library/Application Support/Zed/threads/threads.db`; Windows: `%LOCALAPPDATA%/Zed/threads/threads.db`; ホスティング済み Zed モデル専用、外部 ACP エージェントは対象外） | ✅ 対応 |
 | Kiro | Kiro | `~/.kiro/sessions/cli/*.json`（+ `*.jsonl`）と `~/.local/share/kiro-cli/data.sqlite3`（macOS: `~/Library/Application Support/kiro-cli/data.sqlite3`） | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | `hf:`モデルや`synthetic`プロバイダを検出して他ソースから再帰属（+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`） | ✅ 対応 |
@@ -145,7 +146,7 @@ AI支援開発の時代において、**トークンは新しいエネルギー*
   - 9色テーマのGitHubスタイル貢献グラフ
   - リアルタイムフィルタリングとソート
   - ゼロフリッカーレンダリング
-- **マルチプラットフォームサポート** - OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Zed、Kiro、Trae、Synthetic全体の使用量追跡
+- **マルチプラットフォームサポート** - OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Zed、Kiro、Trae、Grok Build、Synthetic全体の使用量追跡
 - **リアルタイム価格** - 1時間ディスクキャッシュ付きでLiteLLMから現在の価格を取得；OpenRouter自動フォールバックと新規モデル向けCursor価格サポート
 - **詳細な内訳** - 入力、出力、キャッシュ読み書き、推論トークン追跡
 - **ネイティブRustコア** - 10倍高速な処理のため、すべての解析と集計をRustで実行
@@ -656,7 +657,7 @@ tokscale sources --json
 - **インタラクティブツールチップ**: ホバーで詳細な日別内訳を表示
 - **日別内訳パネル**: クリックでソース別、モデル別の詳細を確認
 - **年別フィルタリング**: 年間を移動
-- **ソースフィルタリング**: プラットフォーム別フィルター（OpenCode、Claude、Codex、Copilot、Cursor、Gemini、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi、Qwen、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Zed、Kiro、Trae、Synthetic）
+- **ソースフィルタリング**: プラットフォーム別フィルター（OpenCode、Claude、Codex、Copilot、Cursor、Gemini、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi、Qwen、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Zed、Kiro、Trae、Grok Build、Synthetic）
 - **統計パネル**: 総コスト、トークン、活動日数、連続記録
 - **FOUC防止**: Reactハイドレーション前にテーマを適用（フラッシュなし）
 
@@ -967,6 +968,7 @@ AIコーディングツールはクロスプラットフォームの場所にセ
 | Goose | `~/.local/share/goose/sessions/` (+ macOS Application Support、レガシー Block パス) | `%USERPROFILE%\.local\share\goose\sessions\` | `GOOSE_PATH_ROOT` 環境変数で設定可能 |
 | Antigravity | `~/.config/tokscale/antigravity-cache/sessions/` | — | `tokscale antigravity sync` は現在 macOS / Linux でのみサポート |
 | Trae | `~/.config/tokscale/trae-cache/sessions/` | `%APPDATA%\tokscale\trae-cache\sessions\` | `tokscale trae sync` で 1 回だけ同期。インストール済みの Trae IDE または Trae Solo デスクトップアプリから資格情報を自動検出 |
+| Grok Build | `~/.grok/sessions/` | `%USERPROFILE%\.grok\sessions\` | `GROK_HOME` 環境変数で設定可能。`updates.jsonl` セッション更新を解析 |
 | Synthetic | 他ソースから再帰属 | 他ソースから再帰属 | `hf:`モデル + `synthetic`プロバイダを検出 |
 
 > **注**: Windowsでは`~`は`%USERPROFILE%`に展開されます（例：`C:\Users\ユーザー名`）。これらのツールは`%APPDATA%`のようなWindowsネイティブパスではなく、クロスプラットフォームの一貫性のためにUnixスタイルのパス（`.local/share`など）を意図的に使用しています。
@@ -1159,6 +1161,12 @@ Antigravity データはルートコマンドでは自動取得されません�
 場所: `~/.config/tokscale/trae-cache/sessions/*.json`（公式使用量 API 経由で同期）
 
 Trae データはルートコマンドでは自動取得されません。最初に `tokscale trae login` を実行し、レポート前に `tokscale trae sync` または `tokscale trae sync --since 30` を実行してください。Tokscale は同期された API dump をセッション単位のレコードとして解析し、Trae が返すコスト合計を保持します。
+
+### Grok Build
+
+場所: `$GROK_HOME/sessions/*/*/updates.jsonl`（フォールバック: `~/.grok/sessions/*/*/updates.jsonl`）
+
+Grok Build データはローカルのセッション更新から直接解析されます。現在のログは安定した input/output 分割なしで累積 `totalTokens` カウンターを公開するため、Tokscale はターンごとの正の増分を input トークンとして記録します。`grok-composer-2.5-fast` は専用の公開価格が利用可能になるまで Composer 2.5 Fast 価格 override に一時的にマップされます。
 
 ### OpenClaw
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -76,6 +76,7 @@
 | <img width="48px" src=".github/assets/client-goose.png" alt="Goose" /> | [Goose](https://github.com/aaif-goose/goose) | `~/.local/share/goose/sessions/sessions.db` (+ macOS Application Support, 레거시 Block/goose 경로; `GOOSE_PATH_ROOT`로 오버라이드 가능) | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-antigravity.png" alt="Antigravity" /> | [Google Antigravity](https://antigravity.google/) | `tokscale antigravity sync`로 `~/.config/tokscale/antigravity-cache/sessions/*.jsonl`에 캐싱 (로컬 언어 서버 RPC 사용) | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-trae.png" alt="Trae" /> | [Trae IDE](https://www.trae.ai/) / [Trae Solo](https://www.trae.ai/solo) (국제판) | `tokscale trae sync`로 `~/.config/tokscale/trae-cache/sessions/*.json`에 캐싱 (공식 API의 계정 단위 사용량) | ✅ 지원 |
+| Grok Build | Grok Build | `$GROK_HOME/sessions/*/*/updates.jsonl` (폴백: `~/.grok/sessions/*/*/updates.jsonl`) | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-zed.webp" alt="Zed Agent" /> | [Zed Agent](https://zed.dev/docs/ai/agent-panel) | `~/.local/share/zed/threads/threads.db` (macOS: `~/Library/Application Support/Zed/threads/threads.db`; Windows: `%LOCALAPPDATA%/Zed/threads/threads.db`; 호스팅된 Zed 모델 전용, 외부 ACP 에이전트 제외) | ✅ 지원 |
 | Kiro | Kiro | `~/.kiro/sessions/cli/*.json` (+ `*.jsonl`) 및 `~/.local/share/kiro-cli/data.sqlite3` (macOS: `~/Library/Application Support/kiro-cli/data.sqlite3`) | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | `hf:` 모델/`synthetic` provider 감지로 다른 소스에서 재귀속 (+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`) | ✅ 지원 |
@@ -145,7 +146,7 @@ AI 지원 개발 시대에 **토큰은 새로운 에너지**입니다. 토큰은
   - 9가지 테마의 GitHub 스타일 기여 그래프
   - 실시간 필터링 및 정렬
   - 깜빡임 없는 렌더링
-- **멀티 플랫폼 지원** - OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Zed, Kiro, Trae, Synthetic 사용량 통합 추적
+- **멀티 플랫폼 지원** - OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Zed, Kiro, Trae, Grok Build, Synthetic 사용량 통합 추적
 - **실시간 가격 반영** - LiteLLM에서 최신 가격을 가져와(디스크 캐시 1시간) 비용 계산; OpenRouter 자동 폴백 및 신규 모델용 Cursor 가격 지원
 - **상세 분석** - 입력, 출력, 캐시 읽기/쓰기, 추론 토큰까지 추적
 - **네이티브 Rust 코어** - 모든 파싱과 집계를 Rust로 처리해 최대 10배 빠른 성능
@@ -655,7 +656,7 @@ tokscale sources --json
 - **인터랙티브 툴팁**: 호버 시 상세 일별 분석 표시
 - **일별 분석 패널**: 클릭하여 소스별, 모델별 세부사항 확인
 - **연도 필터링**: 연도 간 탐색
-- **소스 필터링**: 플랫폼별 필터 (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Zed, Kiro, Trae, Synthetic)
+- **소스 필터링**: 플랫폼별 필터 (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Zed, Kiro, Trae, Grok Build, Synthetic)
 - **통계 패널**: 총 비용, 토큰, 활동 일수, 연속 기록
 - **FOUC 방지**: React 하이드레이션 전 테마 적용 (깜빡임 없음)
 
@@ -966,6 +967,7 @@ AI 코딩 도구들은 크로스 플랫폼 위치에 세션 데이터를 저장�
 | Goose | `~/.local/share/goose/sessions/` (+ macOS Application Support, 레거시 Block 경로) | `%USERPROFILE%\.local\share\goose\sessions\` | `GOOSE_PATH_ROOT` 환경변수로 설정 가능 |
 | Antigravity | `~/.config/tokscale/antigravity-cache/sessions/` | — | `tokscale antigravity sync`는 현재 macOS/Linux에서만 지원 |
 | Trae | `~/.config/tokscale/trae-cache/sessions/` | `%APPDATA%\tokscale\trae-cache\sessions\` | `tokscale trae sync`로 한 번 동기화; 설치된 Trae IDE 또는 Trae Solo 데스크톱 앱에서 자격 증명 자동 발견 |
+| Grok Build | `~/.grok/sessions/` | `%USERPROFILE%\.grok\sessions\` | `GROK_HOME` 환경변수로 설정 가능; `updates.jsonl` 세션 업데이트 파싱 |
 | Synthetic | 다른 소스에서 재귀속 | 다른 소스에서 재귀속 | `hf:` 모델 접두사 + `synthetic` provider 감지 |
 
 > **참고**: Windows에서 `~`는 `%USERPROFILE%`로 확장됩니다 (예: `C:\Users\사용자이름`). 이러한 도구들은 `%APPDATA%`와 같은 Windows 기본 경로 대신 크로스 플랫폼 일관성을 위해 의도적으로 Unix 스타일 경로(`.local/share` 등)를 사용합니다.
@@ -1158,6 +1160,12 @@ Antigravity 데이터는 루트 명령에서 자동으로 가져오지 않습니
 위치: `~/.config/tokscale/trae-cache/sessions/*.json` (공식 사용량 API를 통해 동기화)
 
 Trae 데이터는 루트 명령에서 자동으로 가져오지 않습니다. 먼저 `tokscale trae login`을 실행한 뒤, 리포트 전에 `tokscale trae sync` 또는 `tokscale trae sync --since 30`을 실행하세요. Tokscale은 동기화된 API dump를 세션 수준 레코드로 파싱하고 Trae가 반환한 비용 합계를 보존합니다.
+
+### Grok Build
+
+위치: `$GROK_HOME/sessions/*/*/updates.jsonl` (폴백: `~/.grok/sessions/*/*/updates.jsonl`)
+
+Grok Build 데이터는 로컬 세션 업데이트에서 직접 파싱됩니다. 현재 로그는 안정적인 input/output 분리 없이 누적 `totalTokens` 카운터를 노출하므로, Tokscale은 턴별 양수 증가분을 input 토큰으로 기록합니다. `grok-composer-2.5-fast`는 전용 공개 가격이 생길 때까지 Composer 2.5 Fast 가격 override에 임시 매핑됩니다.
 
 ### OpenClaw
 

--- a/README.md
+++ b/README.md
@@ -664,6 +664,7 @@ In the TUI, navigate to the **Usage** tab to see subscription data. Press `u` or
 | **Z.ai** | API key (env var) | Token limits, Web Searches | Set `ZAI_API_KEY` or `GLM_API_KEY` |
 | **Amp** | API key (`~/.local/share/amp/secrets.json`) | Free tier balance, Credits | Run `amp` to log in |
 | **GitHub Copilot** | GitHub token (keychain or `~/.config/gh/hosts.yml`) | Premium interactions, Chat quotas | Run `gh auth login` |
+| **Grok Build** | OAuth (`~/.grok/auth.json`) | Credits, subscription plan | Run `grok login` |
 | **Kimi** | OAuth (`~/.kimi/credentials/kimi-code.json`) | Session, Weekly quotas | Run `kimi` to log in |
 | **MiniMax** | API key (env var) | Prompt quotas per model | Set `MINIMAX_API_KEY` or `MINIMAX_API_TOKEN` |
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 | <img width="48px" src=".github/assets/client-antigravity.png" alt="Antigravity" /> | [Google Antigravity](https://antigravity.google/) | Cached via `tokscale antigravity sync` to `~/.config/tokscale/antigravity-cache/sessions/*.jsonl` (live RPC against the local language server) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-trae.png" alt="Trae" /> | [Trae IDE](https://www.trae.ai/) / [Trae Solo](https://www.trae.ai/solo) (international) | Cached via `tokscale trae sync` to `~/.config/tokscale/trae-cache/sessions/*.json` (account-level usage from the official API) | ✅ Yes |
 | Warp/Oz | [Warp](https://www.warp.dev/) / Oz | Cached via `tokscale warp sync` to `~/.config/tokscale/warp-cache/usage.json` (aggregate requests and spend only; no token transcripts) | ✅ Yes |
+| Grok Build | Grok Build | `$GROK_HOME/sessions/*/*/updates.jsonl` (fallback: `~/.grok/sessions/*/*/updates.jsonl`) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-zed.webp" alt="Zed Agent" /> | [Zed Agent](https://zed.dev/docs/ai/agent-panel) | `~/.local/share/zed/threads/threads.db` (macOS: `~/Library/Application Support/Zed/threads/threads.db`; Windows: `%LOCALAPPDATA%/Zed/threads/threads.db`; hosted Zed models only, not external ACP agents) | ✅ Yes |
 | Kiro | Kiro | `~/.kiro/sessions/cli/*.json` (+ `*.jsonl`) and `~/.local/share/kiro-cli/data.sqlite3` (macOS: `~/Library/Application Support/kiro-cli/data.sqlite3`) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | Re-attributed from other sources via `hf:` model prefix or `synthetic` provider (+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`) | ✅ Yes |
@@ -149,7 +150,7 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
   - GitHub-style contribution graph with 9 color themes
   - Real-time filtering and sorting
   - Zero flicker rendering
-- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Zed, Kiro, Trae, and Synthetic
+- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Zed, Kiro, Trae, Warp/Oz, Grok Build, and Synthetic
 - **Real-time pricing** - Fetches current pricing from LiteLLM with 1-hour disk cache; automatic OpenRouter fallback and Cursor model pricing for newly released models
 - **Detailed breakdowns** - Input, output, cache read/write, and reasoning token tracking
 - **Native Rust core** - All parsing and aggregation done in Rust for 10x faster processing
@@ -852,7 +853,7 @@ The frontend provides a GitHub-style contribution graph visualization:
 - **Interactive tooltips**: Hover for detailed daily breakdowns
 - **Day breakdown panel**: Click to see per-source and per-model details
 - **Year filtering**: Navigate between years
-- **Source filtering**: Filter by platform (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Zed, Kiro, Trae, Synthetic)
+- **Source filtering**: Filter by platform (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Zed, Kiro, Trae, Warp, Grok Build, Synthetic)
 - **Stats panel**: Total cost, tokens, active days, streaks
 - **FOUC prevention**: Theme applied before React hydrates (no flash)
 
@@ -1182,6 +1183,7 @@ AI coding tools store their session data in cross-platform locations. Most tools
 | Kiro | `~/.kiro/sessions/cli/` and `~/.local/share/kiro-cli/data.sqlite3` | `%USERPROFILE%\.kiro\sessions\cli\` and `%USERPROFILE%\.local\share\kiro-cli\data.sqlite3` | Parses Kiro session files plus the Kiro CLI SQLite database when present |
 | Trae | `~/.config/tokscale/trae-cache/sessions/` | `%APPDATA%\tokscale\trae-cache\sessions\` | Synced once via `tokscale trae sync`; credentials are auto-discovered from any installed Trae IDE or Trae Solo desktop app |
 | Warp/Oz | `~/.config/tokscale/warp-cache/usage.json` | `%APPDATA%\tokscale\warp-cache\usage.json` | Synced via `tokscale warp sync`; aggregate requests and spend only, no token transcripts |
+| Grok Build | `~/.grok/sessions/` | `%USERPROFILE%\.grok\sessions\` | Configurable via `GROK_HOME` env var; parses `updates.jsonl` session updates |
 | Synthetic | Re-attributed from other sources | Re-attributed from other sources | Detects `hf:` model prefix + `synthetic` provider |
 
 > **Note**: On Windows, `~` expands to `%USERPROFILE%` (e.g., `C:\Users\YourName`). These tools intentionally use Unix-style paths (like `.local/share`) even on Windows for cross-platform consistency, rather than Windows-native paths like `%APPDATA%`.
@@ -1420,6 +1422,12 @@ Trae data is not fetched automatically by the root command. Run `tokscale trae l
 Location: `~/.config/tokscale/warp-cache/usage.json` (synced via authenticated GraphQL API)
 
 Warp/Oz data is not fetched automatically by the root command. Run `tokscale warp login`, then `tokscale warp sync` before reports. Tokscale records only aggregate request counts and spend because Warp does not expose token-attributed local transcripts.
+
+### Grok Build
+
+Location: `$GROK_HOME/sessions/*/*/updates.jsonl` (fallback: `~/.grok/sessions/*/*/updates.jsonl`)
+
+Grok Build data is parsed directly from local session updates. Current logs expose cumulative `totalTokens` counters without a stable input/output split, so Tokscale records positive per-turn deltas as input tokens. `grok-composer-2.5-fast` is temporarily mapped to the Composer 2.5 Fast pricing override until a dedicated public price is available.
 
 ### OpenClaw
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -76,6 +76,7 @@
 | <img width="48px" src=".github/assets/client-goose.png" alt="Goose" /> | [Goose](https://github.com/aaif-goose/goose) | `~/.local/share/goose/sessions/sessions.db`（+ macOS Application Support、旧版 Block/goose 路径；可通过 `GOOSE_PATH_ROOT` 覆盖） | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-antigravity.png" alt="Antigravity" /> | [Google Antigravity](https://antigravity.google/) | 通过 `tokscale antigravity sync` 缓存到 `~/.config/tokscale/antigravity-cache/sessions/*.jsonl`（使用本地语言服务器 RPC） | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-trae.png" alt="Trae" /> | [Trae IDE](https://www.trae.ai/) / [Trae Solo](https://www.trae.ai/solo)（国际版） | 通过 `tokscale trae sync` 缓存到 `~/.config/tokscale/trae-cache/sessions/*.json`（来自官方 API 的账号级使用量） | ✅ 支持 |
+| Grok Build | Grok Build | `$GROK_HOME/sessions/*/*/updates.jsonl`（回退：`~/.grok/sessions/*/*/updates.jsonl`） | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-zed.webp" alt="Zed Agent" /> | [Zed Agent](https://zed.dev/docs/ai/agent-panel) | `~/.local/share/zed/threads/threads.db`（macOS: `~/Library/Application Support/Zed/threads/threads.db`；Windows: `%LOCALAPPDATA%/Zed/threads/threads.db`；仅限托管 Zed 模型，不含外部 ACP 代理） | ✅ 支持 |
 | Kiro | Kiro | `~/.kiro/sessions/cli/*.json`（+ `*.jsonl`）和 `~/.local/share/kiro-cli/data.sqlite3`（macOS: `~/Library/Application Support/kiro-cli/data.sqlite3`） | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | 通过 `hf:` 模型前缀或 `synthetic` provider 从其他来源重归属（+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`） | ✅ 支持 |
@@ -145,7 +146,7 @@
   - 9 种颜色主题的 GitHub 风格贡献图
   - 实时筛选和排序
   - 零闪烁渲染
-- **多平台支持** - 跟踪 OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Zed、Kiro、Trae 和 Synthetic 的使用情况
+- **多平台支持** - 跟踪 OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Zed、Kiro、Trae、Grok Build 和 Synthetic 的使用情况
 - **实时定价** - 从 LiteLLM 获取当前价格，带 1 小时磁盘缓存；OpenRouter 自动回退和新模型的 Cursor 定价支持
 - **详细分解** - 输入、输出、缓存读写和推理 Token 跟踪
 - **原生 Rust 核心** - 所有解析和聚合在 Rust 中完成，处理速度提升 10 倍
@@ -661,7 +662,7 @@ tokscale sources --json
 - **交互式提示**：悬停查看详细的每日分解
 - **每日分解面板**：点击查看每个来源和模型的详情
 - **年份筛选**：在年份之间导航
-- **来源筛选**：按平台筛选（OpenCode、Claude、Codex、Copilot、Cursor、Gemini、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi、Qwen、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Zed、Kiro、Trae、Synthetic）
+- **来源筛选**：按平台筛选（OpenCode、Claude、Codex、Copilot、Cursor、Gemini、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi、Qwen、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Zed、Kiro、Trae、Grok Build、Synthetic）
 - **统计面板**：总成本、Token、活跃天数、连续记录
 - **FOUC 防护**：在 React 水合前应用主题（无闪烁）
 
@@ -972,6 +973,7 @@ AI 编程工具将会话数据存储在跨平台位置。大多数工具在所�
 | Goose | `~/.local/share/goose/sessions/`（+ macOS Application Support、旧版 Block 路径） | `%USERPROFILE%\.local\share\goose\sessions\` | 可通过 `GOOSE_PATH_ROOT` 环境变量配置 |
 | Antigravity | `~/.config/tokscale/antigravity-cache/sessions/` | — | `tokscale antigravity sync` 目前仅支持 macOS / Linux |
 | Trae | `~/.config/tokscale/trae-cache/sessions/` | `%APPDATA%\tokscale\trae-cache\sessions\` | 通过 `tokscale trae sync` 同步一次；凭据会从已安装的任意 Trae IDE 或 Trae Solo 桌面端自动发现 |
+| Grok Build | `~/.grok/sessions/` | `%USERPROFILE%\.grok\sessions\` | 可通过 `GROK_HOME` 环境变量配置；解析 `updates.jsonl` 会话更新 |
 | Synthetic | 从其他来源重归属 | 从其他来源重归属 | 检测 `hf:` 模型前缀 + `synthetic` provider |
 
 > **注意**：在 Windows 上，`~` 扩展为 `%USERPROFILE%`（例如 `C:\Users\用户名`）。这些工具故意使用 Unix 风格的路径（如 `.local/share`）而不是 Windows 原生路径（如 `%APPDATA%`），以实现跨平台一致性。
@@ -1164,6 +1166,12 @@ Antigravity 数据不会被根命令自动获取。请在启用了 Antigravity �
 位置：`~/.config/tokscale/trae-cache/sessions/*.json`（通过官方使用量 API 同步）
 
 Trae 数据不会被根命令自动获取。先运行一次 `tokscale trae login`，然后在生成报告前运行 `tokscale trae sync`。Tokscale 会将同步得到的 API dump 解析为会话级记录，并保留 Trae 返回的成本总额。
+
+### Grok Build
+
+位置：`$GROK_HOME/sessions/*/*/updates.jsonl`（回退：`~/.grok/sessions/*/*/updates.jsonl`）
+
+Grok Build 数据直接从本地会话更新解析。当前日志只公开累积 `totalTokens` 计数器，没有稳定的 input/output 拆分，因此 Tokscale 将每个 turn 的正向增量记录为 input token。`grok-composer-2.5-fast` 会临时映射到 Composer 2.5 Fast 价格 override，直到专用公开价格可用。
 
 ### OpenClaw
 

--- a/crates/tokscale-cli/src/commands/usage/grok.rs
+++ b/crates/tokscale-cli/src/commands/usage/grok.rs
@@ -583,17 +583,15 @@ fn fetch_network_usage(credentials: &Credentials) -> Result<UsageOutput> {
             .timeout(Duration::from_secs(12))
             .build()?;
 
-        if metrics.is_empty() {
-            match fetch_billing_grpc(&client, &credentials.token).await {
-                Ok(body) => {
-                    if let Some(metric) = parse_grpc_billing_metric(&body) {
-                        metrics.push(metric);
-                    } else {
-                        errors.push("Grok billing response was not recognized".to_string());
-                    }
+        match fetch_billing_grpc(&client, &credentials.token).await {
+            Ok(body) => {
+                if let Some(metric) = parse_grpc_billing_metric(&body) {
+                    metrics.push(metric);
+                } else {
+                    errors.push("Grok billing response was not recognized".to_string());
                 }
-                Err(error) => errors.push(format!("Grok billing request failed: {error}")),
             }
+            Err(error) => errors.push(format!("Grok billing request failed: {error}")),
         }
 
         if metrics.is_empty() {
@@ -662,7 +660,14 @@ pub fn fetch() -> Result<UsageOutput> {
         }
     }
 
-    if let Some(billing) = fetch_agent_billing(Duration::from_secs(4)) {
+    // The `grok agent --no-leader stdio` billing fallback runs without
+    // credential context, so its metrics cannot be attributed to a specific
+    // account. Skip it when auth.json holds multiple credentials to avoid
+    // merging metrics with a plan/email that belongs to a different account.
+    if credentials.len() > 1 {
+        errors
+            .push("Grok agent billing fallback skipped: multiple credentials present".to_string());
+    } else if let Some(billing) = fetch_agent_billing(Duration::from_secs(4)) {
         let mut metrics = Vec::new();
         if let Some(metric) = parse_billing_json_metric(&billing) {
             metrics.push(metric);

--- a/crates/tokscale-cli/src/commands/usage/grok.rs
+++ b/crates/tokscale-cli/src/commands/usage/grok.rs
@@ -43,38 +43,46 @@ pub fn has_credentials() -> bool {
     auth_path().exists()
 }
 
-fn read_credentials() -> Result<Credentials> {
+fn read_credentials() -> Result<Vec<Credentials>> {
     let content = std::fs::read_to_string(auth_path())?;
     let doc: Value = serde_json::from_str(&content)?;
+    credential_candidates_from_value(&doc)
+}
+
+fn credential_candidates_from_value(doc: &Value) -> Result<Vec<Credentials>> {
     let entries = doc
         .as_object()
         .ok_or_else(|| anyhow::anyhow!("Grok auth.json must contain an object."))?;
 
     let mut candidates: Vec<_> = entries
         .iter()
-        .filter_map(|(scope, value)| value.as_object().map(|entry| (scope.as_str(), entry)))
-        .filter(|(_, entry)| entry.get("key").and_then(Value::as_str).is_some())
+        .filter_map(|(scope, value)| {
+            let entry = value.as_object()?;
+            let token = entry
+                .get("key")
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())?
+                .to_string();
+            let email = entry
+                .get("email")
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())
+                .map(ToString::to_string);
+            let priority = if scope.contains("auth.x.ai") { 0 } else { 1 };
+            Some((priority, Credentials { token, email }))
+        })
         .collect();
 
-    candidates.sort_by_key(|(scope, _)| if scope.contains("auth.x.ai") { 0 } else { 1 });
-
-    let (_, entry) = candidates
+    candidates.sort_by_key(|(priority, _)| *priority);
+    let credentials: Vec<_> = candidates
         .into_iter()
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("No Grok token found. Run 'grok login'."))?;
+        .map(|(_, credentials)| credentials)
+        .collect();
 
-    let token = entry
-        .get("key")
-        .and_then(Value::as_str)
-        .ok_or_else(|| anyhow::anyhow!("No Grok token found. Run 'grok login'."))?
-        .to_string();
-    let email = entry
-        .get("email")
-        .and_then(Value::as_str)
-        .filter(|value| !value.is_empty())
-        .map(ToString::to_string);
-
-    Ok(Credentials { token, email })
+    if credentials.is_empty() {
+        anyhow::bail!("No Grok token found. Run 'grok login'.");
+    }
+    Ok(credentials)
 }
 
 fn bearer_request(client: &reqwest::Client, token: &str, url: &str) -> reqwest::RequestBuilder {
@@ -244,10 +252,10 @@ fn parse_subscription_plan(value: &Value) -> Option<String> {
 
 fn numeric_value(value: &Value) -> Option<f64> {
     if let Some(number) = value.as_f64() {
-        return Some(number);
+        return number.is_finite().then_some(number);
     }
     if let Some(text) = value.as_str() {
-        return text.parse().ok();
+        return text.parse::<f64>().ok().filter(|number| number.is_finite());
     }
     value
         .as_object()
@@ -330,6 +338,7 @@ fn parse_billing_json_object(value: &Value) -> Option<UsageMetric> {
             .or_else(|| number_at(value, &["usagePercent"]))
             .or_else(|| number_at(value, &["creditUsagePercent"]))
     }?;
+    let percent = percent.is_finite().then(|| percent.clamp(0.0, 100.0))?;
 
     let start = string_at(value, &["billingCycle", "billingPeriodStart"])
         .or_else(|| string_at(value, &["billingPeriodStart"]))
@@ -561,8 +570,7 @@ fn parse_grpc_billing_metric(body: &[u8]) -> Option<UsageMetric> {
     None
 }
 
-pub fn fetch() -> Result<UsageOutput> {
-    let credentials = read_credentials()?;
+fn fetch_network_usage(credentials: &Credentials) -> Result<UsageOutput> {
     let mut plan: Option<String> = None;
     let mut metrics = Vec::new();
     let mut errors = Vec::new();
@@ -605,17 +613,6 @@ pub fn fetch() -> Result<UsageOutput> {
         Ok::<_, anyhow::Error>(())
     })?;
 
-    if metrics.is_empty() {
-        if let Some(billing) = fetch_agent_billing(Duration::from_secs(4)) {
-            if let Some(metric) = parse_billing_json_metric(&billing) {
-                metrics.push(metric);
-            }
-            collect_task_usage_metrics(&billing, &mut metrics);
-        } else {
-            errors.push("Grok agent billing RPC unavailable".to_string());
-        }
-    }
-
     if metrics.is_empty() && plan.is_none() {
         let detail = if errors.is_empty() {
             "no usage or active subscription data returned".to_string()
@@ -628,9 +625,75 @@ pub fn fetch() -> Result<UsageOutput> {
     Ok(UsageOutput {
         provider: "Grok Build".into(),
         plan,
-        email: credentials.email,
+        email: credentials.email.clone(),
         metrics,
     })
+}
+
+fn usage_output(
+    plan: Option<String>,
+    email: Option<String>,
+    metrics: Vec<UsageMetric>,
+) -> UsageOutput {
+    UsageOutput {
+        provider: "Grok Build".into(),
+        plan,
+        email,
+        metrics,
+    }
+}
+
+pub fn fetch() -> Result<UsageOutput> {
+    let credentials = read_credentials()?;
+    let mut errors = Vec::new();
+    let mut plan_only: Option<UsageOutput> = None;
+
+    for (index, credential) in credentials.iter().enumerate() {
+        match fetch_network_usage(credential) {
+            Ok(output) if !output.metrics.is_empty() => return Ok(output),
+            Ok(output) => {
+                if plan_only.is_none() {
+                    plan_only = Some(output);
+                }
+            }
+            Err(error) => errors.push(format!("Grok credential #{} failed: {error}", index + 1)),
+        }
+    }
+
+    if let Some(billing) = fetch_agent_billing(Duration::from_secs(4)) {
+        let mut metrics = Vec::new();
+        if let Some(metric) = parse_billing_json_metric(&billing) {
+            metrics.push(metric);
+        }
+        collect_task_usage_metrics(&billing, &mut metrics);
+        if !metrics.is_empty() {
+            return Ok(usage_output(
+                plan_only.as_ref().and_then(|output| output.plan.clone()),
+                plan_only
+                    .as_ref()
+                    .and_then(|output| output.email.clone())
+                    .or_else(|| {
+                        credentials
+                            .first()
+                            .and_then(|credential| credential.email.clone())
+                    }),
+                metrics,
+            ));
+        }
+    } else {
+        errors.push("Grok agent billing RPC unavailable".to_string());
+    }
+
+    if let Some(output) = plan_only {
+        return Ok(output);
+    }
+
+    let detail = if errors.is_empty() {
+        "no usage or active subscription data returned".to_string()
+    } else {
+        errors.join("; ")
+    };
+    anyhow::bail!("Grok usage unavailable: {detail}");
 }
 
 #[cfg(test)]
@@ -686,6 +749,44 @@ mod tests {
             Some("$87.50/$100.00 left")
         );
         assert_eq!(metric.resets_at.as_deref(), Some("2026-07-01T00:00:00Z"));
+    }
+
+    #[test]
+    fn rejects_non_finite_billing_json_percentages() {
+        for value in [
+            serde_json::json!({ "usedPercent": "NaN" }),
+            serde_json::json!({ "usedPercent": "inf" }),
+            serde_json::json!({
+                "monthlyLimit": "NaN",
+                "usage": { "totalUsed": 10 }
+            }),
+        ] {
+            assert!(parse_billing_json_metric(&value).is_none());
+        }
+    }
+
+    #[test]
+    fn reads_multiple_credential_candidates_with_auth_scope_first() {
+        let value = serde_json::json!({
+            "https://example.com": {
+                "key": "secondary-token",
+                "email": "secondary@example.com"
+            },
+            "https://auth.x.ai": {
+                "key": "primary-token",
+                "email": "primary@example.com"
+            }
+        });
+
+        let credentials = credential_candidates_from_value(&value).expect("credential candidates");
+        assert_eq!(credentials.len(), 2);
+        assert_eq!(credentials[0].token, "primary-token");
+        assert_eq!(credentials[0].email.as_deref(), Some("primary@example.com"));
+        assert_eq!(credentials[1].token, "secondary-token");
+        assert_eq!(
+            credentials[1].email.as_deref(),
+            Some("secondary@example.com")
+        );
     }
 
     #[test]

--- a/crates/tokscale-cli/src/commands/usage/grok.rs
+++ b/crates/tokscale-cli/src/commands/usage/grok.rs
@@ -1,0 +1,783 @@
+use std::io::{BufRead, Write};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use chrono::{TimeZone, Utc};
+use serde_json::Value;
+
+use super::{UsageMetric, UsageOutput};
+
+const SUBSCRIPTIONS_URL: &str = "https://grok.com/rest/subscriptions";
+const TASK_USAGE_URL: &str = "https://grok.com/rest/tasks/usage";
+const BILLING_GRPC_URL: &str = "https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig";
+const GROK_USER_AGENT: &str = "Grok Build";
+
+#[derive(Debug, Clone)]
+struct Credentials {
+    token: String,
+    email: Option<String>,
+}
+
+#[derive(Debug)]
+enum ProtoValue<'a> {
+    Varint(u64),
+    Fixed32(u32),
+    Fixed64,
+    Bytes(&'a [u8]),
+}
+
+fn grok_home() -> std::path::PathBuf {
+    std::env::var_os("GROK_HOME")
+        .map(std::path::PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".grok")))
+        .unwrap_or_else(|| std::path::PathBuf::from(".grok"))
+}
+
+fn auth_path() -> std::path::PathBuf {
+    grok_home().join("auth.json")
+}
+
+pub fn has_credentials() -> bool {
+    auth_path().exists()
+}
+
+fn read_credentials() -> Result<Credentials> {
+    let content = std::fs::read_to_string(auth_path())?;
+    let doc: Value = serde_json::from_str(&content)?;
+    let entries = doc
+        .as_object()
+        .ok_or_else(|| anyhow::anyhow!("Grok auth.json must contain an object."))?;
+
+    let mut candidates: Vec<_> = entries
+        .iter()
+        .filter_map(|(scope, value)| value.as_object().map(|entry| (scope.as_str(), entry)))
+        .filter(|(_, entry)| entry.get("key").and_then(Value::as_str).is_some())
+        .collect();
+
+    candidates.sort_by_key(|(scope, _)| if scope.contains("auth.x.ai") { 0 } else { 1 });
+
+    let (_, entry) = candidates
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("No Grok token found. Run 'grok login'."))?;
+
+    let token = entry
+        .get("key")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("No Grok token found. Run 'grok login'."))?
+        .to_string();
+    let email = entry
+        .get("email")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string);
+
+    Ok(Credentials { token, email })
+}
+
+fn bearer_request(client: &reqwest::Client, token: &str, url: &str) -> reqwest::RequestBuilder {
+    client
+        .get(url)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("X-XAI-Token-Auth", "xai-grok-cli")
+        .header("Accept", "application/json")
+        .header("User-Agent", GROK_USER_AGENT)
+}
+
+async fn fetch_subscriptions(client: &reqwest::Client, token: &str) -> Result<Value> {
+    let resp = bearer_request(client, token, SUBSCRIPTIONS_URL)
+        .send()
+        .await?;
+    let status = resp.status();
+    if !status.is_success() {
+        anyhow::bail!("Grok subscriptions request failed (HTTP {status})");
+    }
+    let text = resp.text().await?;
+    if text.trim_start().starts_with('<') {
+        anyhow::bail!("Grok subscriptions returned HTML");
+    }
+    Ok(serde_json::from_str(&text)?)
+}
+
+async fn fetch_task_usage(client: &reqwest::Client, token: &str) -> Result<Value> {
+    let resp = bearer_request(client, token, TASK_USAGE_URL).send().await?;
+    let status = resp.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        anyhow::bail!("NEEDS_AUTH");
+    }
+    if !status.is_success() {
+        anyhow::bail!("Grok task usage request failed (HTTP {status})");
+    }
+    Ok(resp.json().await?)
+}
+
+async fn fetch_billing_grpc(client: &reqwest::Client, token: &str) -> Result<Vec<u8>> {
+    let resp = client
+        .post(BILLING_GRPC_URL)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("X-XAI-Token-Auth", "xai-grok-cli")
+        .header("Accept", "application/grpc-web+proto")
+        .header("Content-Type", "application/grpc-web+proto")
+        .header("User-Agent", GROK_USER_AGENT)
+        .body(vec![0, 0, 0, 0, 0])
+        .send()
+        .await?;
+    let status = resp.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        anyhow::bail!("NEEDS_AUTH");
+    }
+    if !status.is_success() {
+        anyhow::bail!("Grok billing request failed (HTTP {status})");
+    }
+    Ok(resp.bytes().await?.to_vec())
+}
+
+fn fetch_agent_billing(timeout: Duration) -> Option<Value> {
+    let mut child = Command::new("grok")
+        .args(["agent", "--no-leader", "stdio"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+
+    let stdout = child.stdout.take()?;
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let reader = std::io::BufReader::new(stdout);
+        for line in reader.lines().map_while(std::result::Result::ok) {
+            let _ = tx.send(line);
+        }
+    });
+
+    let result = (|| {
+        let stdin = child.stdin.as_mut()?;
+        let initialize = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "1",
+                "clientCapabilities": {
+                    "fs": { "readTextFile": false, "writeTextFile": false },
+                    "terminal": false
+                }
+            }
+        });
+        let billing = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "x.ai/billing",
+            "params": {}
+        });
+        writeln!(stdin, "{}", serde_json::to_string(&initialize).ok()?).ok()?;
+        writeln!(stdin, "{}", serde_json::to_string(&billing).ok()?).ok()?;
+        stdin.flush().ok()?;
+
+        let response = wait_for_rpc_response(&rx, 2, timeout)?;
+        if response.get("error").is_some() {
+            return None;
+        }
+        response.get("result").cloned()
+    })();
+
+    let _ = child.kill();
+    let _ = child.wait();
+
+    result
+}
+
+fn wait_for_rpc_response(
+    rx: &mpsc::Receiver<String>,
+    expected_id: i64,
+    timeout: Duration,
+) -> Option<Value> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let remaining = deadline.checked_duration_since(Instant::now())?;
+        let line = rx.recv_timeout(remaining).ok()?;
+        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        if value.get("id").and_then(Value::as_i64) == Some(expected_id) {
+            return Some(value);
+        }
+    }
+}
+
+fn title_words(raw: &str) -> String {
+    raw.replace(['_', '-'], " ")
+        .split_whitespace()
+        .map(|word| {
+            let lower = word.to_lowercase();
+            let mut chars = lower.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn normalize_subscription_tier(raw: &str) -> String {
+    let trimmed = raw
+        .trim_start_matches("SUBSCRIPTION_TIER_")
+        .trim_start_matches("TIER_");
+    title_words(trimmed)
+}
+
+fn parse_subscription_plan(value: &Value) -> Option<String> {
+    let subscriptions = value.get("subscriptions")?.as_array()?;
+    let chosen = subscriptions.iter().find(|sub| {
+        sub.get("status")
+            .and_then(Value::as_str)
+            .map(|status| status.eq_ignore_ascii_case("active"))
+            .unwrap_or(false)
+    })?;
+
+    let tier = chosen.get("tier").and_then(Value::as_str)?;
+    Some(normalize_subscription_tier(tier))
+}
+
+fn numeric_value(value: &Value) -> Option<f64> {
+    if let Some(number) = value.as_f64() {
+        return Some(number);
+    }
+    if let Some(text) = value.as_str() {
+        return text.parse().ok();
+    }
+    value
+        .as_object()
+        .and_then(|object| object.get("val").or_else(|| object.get("value")))
+        .and_then(numeric_value)
+}
+
+fn number_at<'a>(value: &'a Value, path: &[&str]) -> Option<f64> {
+    let mut current = value;
+    for segment in path {
+        current = current.get(*segment)?;
+    }
+    numeric_value(current)
+}
+
+fn string_at(value: &Value, path: &[&str]) -> Option<String> {
+    let mut current = value;
+    for segment in path {
+        current = current.get(*segment)?;
+    }
+    current.as_str().map(ToString::to_string)
+}
+
+fn epoch_at(value: &Value, path: &[&str]) -> Option<String> {
+    number_at(value, path).and_then(|ts| epoch_to_rfc3339(ts as i64))
+}
+
+fn format_cents(cents: f64) -> String {
+    format!("${:.2}", cents / 100.0)
+}
+
+fn cycle_label(start: Option<&str>, end: Option<&str>) -> String {
+    let Some(start) = start else {
+        return "Credits".into();
+    };
+    let Some(end) = end else {
+        return "Credits".into();
+    };
+    let Ok(start) = chrono::DateTime::parse_from_rfc3339(start) else {
+        return "Credits".into();
+    };
+    let Ok(end) = chrono::DateTime::parse_from_rfc3339(end) else {
+        return "Credits".into();
+    };
+    let days = (end - start).num_days();
+    if (6..=8).contains(&days) {
+        "Weekly".into()
+    } else if (27..=33).contains(&days) {
+        "Monthly".into()
+    } else {
+        "Credits".into()
+    }
+}
+
+fn parse_billing_json_metric(value: &Value) -> Option<UsageMetric> {
+    if let Some(metric) = parse_billing_json_object(value) {
+        return Some(metric);
+    }
+    match value {
+        Value::Array(items) => items.iter().find_map(parse_billing_json_metric),
+        Value::Object(object) => object.values().find_map(parse_billing_json_metric),
+        _ => None,
+    }
+}
+
+fn parse_billing_json_object(value: &Value) -> Option<UsageMetric> {
+    let monthly_limit = number_at(value, &["monthlyLimit"])
+        .or_else(|| number_at(value, &["config", "monthlyLimit"]));
+    let total_used = number_at(value, &["usage", "totalUsed"])
+        .or_else(|| number_at(value, &["totalUsed"]))
+        .or_else(|| number_at(value, &["config", "usage", "totalUsed"]));
+    let percent = if let (Some(limit), Some(used)) = (monthly_limit, total_used) {
+        if limit > 0.0 {
+            Some((used / limit * 100.0).clamp(0.0, 100.0))
+        } else {
+            None
+        }
+    } else {
+        number_at(value, &["usedPercent"])
+            .or_else(|| number_at(value, &["usagePercent"]))
+            .or_else(|| number_at(value, &["creditUsagePercent"]))
+    }?;
+
+    let start = string_at(value, &["billingCycle", "billingPeriodStart"])
+        .or_else(|| string_at(value, &["billingPeriodStart"]))
+        .or_else(|| epoch_at(value, &["billingPeriodStart"]));
+    let end = string_at(value, &["billingCycle", "billingPeriodEnd"])
+        .or_else(|| string_at(value, &["billingPeriodEnd"]))
+        .or_else(|| epoch_at(value, &["billingPeriodEnd"]));
+
+    let remaining_label = if let (Some(limit), Some(used)) = (monthly_limit, total_used) {
+        let remaining = (limit - used).max(0.0);
+        Some(format!(
+            "{}/{} left",
+            format_cents(remaining),
+            format_cents(limit)
+        ))
+    } else {
+        None
+    };
+
+    Some(UsageMetric {
+        label: cycle_label(start.as_deref(), end.as_deref()),
+        used_percent: percent,
+        remaining_percent: 100.0 - percent,
+        remaining_label,
+        resets_at: end,
+    })
+}
+
+fn push_limit_metric(
+    metrics: &mut Vec<UsageMetric>,
+    label: &str,
+    used: Option<f64>,
+    limit: Option<f64>,
+    reset: Option<String>,
+) {
+    let Some(limit) = limit.filter(|limit| *limit > 0.0) else {
+        return;
+    };
+    let used = used.unwrap_or(0.0).clamp(0.0, limit);
+    let used_percent = (used / limit * 100.0).clamp(0.0, 100.0);
+    let remaining_label = format!("{:.0}/{:.0} left", limit - used, limit);
+    if metrics.iter().any(|metric| {
+        metric.label == label
+            && (metric.used_percent - used_percent).abs() < 0.0001
+            && metric.remaining_label.as_deref() == Some(remaining_label.as_str())
+    }) {
+        return;
+    }
+    metrics.push(UsageMetric {
+        label: label.into(),
+        used_percent,
+        remaining_percent: 100.0 - used_percent,
+        remaining_label: Some(remaining_label),
+        resets_at: reset,
+    });
+}
+
+fn collect_task_usage_metrics(value: &Value, metrics: &mut Vec<UsageMetric>) {
+    if let Value::Object(object) = value {
+        let reset = object
+            .get("resetTime")
+            .or_else(|| object.get("resetsAt"))
+            .or_else(|| object.get("resetAt"))
+            .and_then(Value::as_str)
+            .map(ToString::to_string);
+        push_limit_metric(
+            metrics,
+            "Tasks",
+            object.get("usage").and_then(numeric_value),
+            object.get("limit").and_then(numeric_value),
+            reset.clone(),
+        );
+        push_limit_metric(
+            metrics,
+            "Frequent",
+            object.get("frequentUsage").and_then(numeric_value),
+            object.get("frequentLimit").and_then(numeric_value),
+            reset.clone(),
+        );
+        push_limit_metric(
+            metrics,
+            "Occasional",
+            object.get("occasionalUsage").and_then(numeric_value),
+            object.get("occasionalLimit").and_then(numeric_value),
+            reset,
+        );
+        for child in object.values() {
+            collect_task_usage_metrics(child, metrics);
+        }
+    } else if let Value::Array(items) = value {
+        for child in items {
+            collect_task_usage_metrics(child, metrics);
+        }
+    }
+}
+
+fn read_varint(data: &[u8], pos: &mut usize) -> Option<u64> {
+    let mut result = 0_u64;
+    let mut shift = 0_u32;
+    while *pos < data.len() && shift <= 63 {
+        let byte = data[*pos];
+        *pos += 1;
+        result |= u64::from(byte & 0x7f) << shift;
+        if byte & 0x80 == 0 {
+            return Some(result);
+        }
+        shift += 7;
+    }
+    None
+}
+
+fn next_proto_field<'a>(data: &'a [u8], pos: &mut usize) -> Option<(u32, ProtoValue<'a>)> {
+    let key = read_varint(data, pos)?;
+    let field = u32::try_from(key >> 3).ok()?;
+    let wire = key & 0x07;
+    match wire {
+        0 => read_varint(data, pos).map(|value| (field, ProtoValue::Varint(value))),
+        1 => {
+            if *pos + 8 > data.len() {
+                return None;
+            }
+            *pos += 8;
+            Some((field, ProtoValue::Fixed64))
+        }
+        2 => {
+            let len = usize::try_from(read_varint(data, pos)?).ok()?;
+            if *pos + len > data.len() {
+                return None;
+            }
+            let bytes = &data[*pos..*pos + len];
+            *pos += len;
+            Some((field, ProtoValue::Bytes(bytes)))
+        }
+        5 => {
+            if *pos + 4 > data.len() {
+                return None;
+            }
+            let value =
+                u32::from_le_bytes([data[*pos], data[*pos + 1], data[*pos + 2], data[*pos + 3]]);
+            *pos += 4;
+            Some((field, ProtoValue::Fixed32(value)))
+        }
+        _ => None,
+    }
+}
+
+fn timestamp_message_to_rfc3339(data: &[u8]) -> Option<String> {
+    let mut pos = 0;
+    while pos < data.len() {
+        let (field, value) = next_proto_field(data, &mut pos)?;
+        if field == 1 {
+            if let ProtoValue::Varint(seconds) = value {
+                return epoch_to_rfc3339(i64::try_from(seconds).ok()?);
+            }
+        }
+    }
+    None
+}
+
+fn epoch_to_rfc3339(seconds: i64) -> Option<String> {
+    Utc.timestamp_opt(seconds, 0)
+        .single()
+        .map(|dt| dt.to_rfc3339())
+}
+
+fn parse_billing_config_proto(data: &[u8]) -> Option<UsageMetric> {
+    let mut pos = 0;
+    let mut used_percent: Option<f64> = None;
+    let mut start: Option<String> = None;
+    let mut end: Option<String> = None;
+
+    while pos < data.len() {
+        let (field, value) = next_proto_field(data, &mut pos)?;
+        match (field, value) {
+            (1, ProtoValue::Fixed32(bits)) => {
+                let percent = f32::from_bits(bits) as f64;
+                if percent.is_finite() {
+                    used_percent = Some(percent.clamp(0.0, 100.0));
+                }
+            }
+            (4, ProtoValue::Bytes(bytes)) => {
+                start = timestamp_message_to_rfc3339(bytes);
+            }
+            (5, ProtoValue::Bytes(bytes)) => {
+                end = timestamp_message_to_rfc3339(bytes);
+            }
+            _ => {}
+        }
+    }
+
+    let percent = used_percent?;
+    Some(UsageMetric {
+        label: cycle_label(start.as_deref(), end.as_deref()),
+        used_percent: percent,
+        remaining_percent: 100.0 - percent,
+        remaining_label: None,
+        resets_at: end,
+    })
+}
+
+fn parse_grpc_billing_metric(body: &[u8]) -> Option<UsageMetric> {
+    let mut pos = 0;
+    while pos + 5 <= body.len() {
+        let flag = body[pos];
+        let len = u32::from_be_bytes([body[pos + 1], body[pos + 2], body[pos + 3], body[pos + 4]])
+            as usize;
+        pos += 5;
+        if pos + len > body.len() {
+            return None;
+        }
+        let payload = &body[pos..pos + len];
+        pos += len;
+        if flag & 0x80 != 0 {
+            continue;
+        }
+
+        let mut payload_pos = 0;
+        while payload_pos < payload.len() {
+            let (field, value) = next_proto_field(payload, &mut payload_pos)?;
+            if field == 1 {
+                if let ProtoValue::Bytes(config) = value {
+                    if let Some(metric) = parse_billing_config_proto(config) {
+                        return Some(metric);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+pub fn fetch() -> Result<UsageOutput> {
+    let credentials = read_credentials()?;
+    let mut plan: Option<String> = None;
+    let mut metrics = Vec::new();
+    let mut errors = Vec::new();
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(async {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(12))
+            .build()?;
+
+        if metrics.is_empty() {
+            match fetch_billing_grpc(&client, &credentials.token).await {
+                Ok(body) => {
+                    if let Some(metric) = parse_grpc_billing_metric(&body) {
+                        metrics.push(metric);
+                    } else {
+                        errors.push("Grok billing response was not recognized".to_string());
+                    }
+                }
+                Err(error) => errors.push(format!("Grok billing request failed: {error}")),
+            }
+        }
+
+        if metrics.is_empty() {
+            match fetch_task_usage(&client, &credentials.token).await {
+                Ok(task_usage) => collect_task_usage_metrics(&task_usage, &mut metrics),
+                Err(error) => errors.push(format!("Grok task usage request failed: {error}")),
+            }
+        }
+
+        match fetch_subscriptions(&client, &credentials.token).await {
+            Ok(subscriptions) => {
+                plan = parse_subscription_plan(&subscriptions);
+            }
+            Err(error) => errors.push(format!("Grok subscriptions request failed: {error}")),
+        }
+
+        Ok::<_, anyhow::Error>(())
+    })?;
+
+    if metrics.is_empty() {
+        if let Some(billing) = fetch_agent_billing(Duration::from_secs(4)) {
+            if let Some(metric) = parse_billing_json_metric(&billing) {
+                metrics.push(metric);
+            }
+            collect_task_usage_metrics(&billing, &mut metrics);
+        } else {
+            errors.push("Grok agent billing RPC unavailable".to_string());
+        }
+    }
+
+    if metrics.is_empty() && plan.is_none() {
+        let detail = if errors.is_empty() {
+            "no usage or active subscription data returned".to_string()
+        } else {
+            errors.join("; ")
+        };
+        anyhow::bail!("Grok usage unavailable: {detail}");
+    }
+
+    Ok(UsageOutput {
+        provider: "Grok Build".into(),
+        plan,
+        email: credentials.email,
+        metrics,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn push_varint(mut value: u64, out: &mut Vec<u8>) {
+        while value >= 0x80 {
+            out.push((value as u8 & 0x7f) | 0x80);
+            value >>= 7;
+        }
+        out.push(value as u8);
+    }
+
+    fn push_len_field(field: u64, payload: &[u8], out: &mut Vec<u8>) {
+        push_varint((field << 3) | 2, out);
+        push_varint(payload.len() as u64, out);
+        out.extend_from_slice(payload);
+    }
+
+    fn push_fixed32_field(field: u64, value: u32, out: &mut Vec<u8>) {
+        push_varint((field << 3) | 5, out);
+        out.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn timestamp_message(seconds: u64) -> Vec<u8> {
+        let mut out = Vec::new();
+        push_varint(1 << 3, &mut out);
+        push_varint(seconds, &mut out);
+        out
+    }
+
+    #[test]
+    fn parses_billing_json_metric() {
+        let value = serde_json::json!({
+            "billingCycle": {
+                "billingPeriodStart": "2026-06-01T00:00:00Z",
+                "billingPeriodEnd": "2026-07-01T00:00:00Z"
+            },
+            "monthlyLimit": { "val": 10000 },
+            "usage": {
+                "includedUsed": { "val": 1250 },
+                "onDemandUsed": { "val": 0 },
+                "totalUsed": { "val": 1250 }
+            }
+        });
+
+        let metric = parse_billing_json_metric(&value).expect("billing metric");
+        assert_eq!(metric.label, "Monthly");
+        assert_eq!(metric.used_percent, 12.5);
+        assert_eq!(
+            metric.remaining_label.as_deref(),
+            Some("$87.50/$100.00 left")
+        );
+        assert_eq!(metric.resets_at.as_deref(), Some("2026-07-01T00:00:00Z"));
+    }
+
+    #[test]
+    fn parses_grpc_billing_percent_frame() {
+        let mut config = Vec::new();
+        push_fixed32_field(1, 25.0_f32.to_bits(), &mut config);
+        push_len_field(4, &timestamp_message(1_780_272_000), &mut config);
+        push_len_field(5, &timestamp_message(1_782_864_000), &mut config);
+
+        let mut message = Vec::new();
+        push_len_field(1, &config, &mut message);
+
+        let mut frame = Vec::new();
+        frame.push(0);
+        frame.extend_from_slice(&(message.len() as u32).to_be_bytes());
+        frame.extend_from_slice(&message);
+
+        let metric = parse_grpc_billing_metric(&frame).expect("billing metric");
+        assert_eq!(metric.label, "Monthly");
+        assert_eq!(metric.used_percent, 25.0);
+        assert_eq!(
+            metric.resets_at.as_deref(),
+            Some("2026-07-01T00:00:00+00:00")
+        );
+    }
+
+    #[test]
+    fn parses_task_usage_metrics() {
+        let value = serde_json::json!({
+            "frequentUsage": 3,
+            "frequentLimit": 10,
+            "occasionalUsage": 1,
+            "occasionalLimit": 5
+        });
+        let mut metrics = Vec::new();
+        collect_task_usage_metrics(&value, &mut metrics);
+
+        assert_eq!(metrics.len(), 2);
+        assert_eq!(metrics[0].label, "Frequent");
+        assert_eq!(metrics[0].used_percent, 30.0);
+        assert_eq!(metrics[1].label, "Occasional");
+        assert_eq!(metrics[1].used_percent, 20.0);
+    }
+
+    #[test]
+    fn normalizes_grok_subscription_plan() {
+        let value = serde_json::json!({
+            "subscriptions": [
+                {
+                    "tier": "SUBSCRIPTION_TIER_SUPER_GROK_PRO",
+                    "status": "active"
+                }
+            ]
+        });
+        assert_eq!(
+            parse_subscription_plan(&value).as_deref(),
+            Some("Super Grok Pro")
+        );
+    }
+
+    #[test]
+    fn ignores_inactive_subscription_plan() {
+        let value = serde_json::json!({
+            "subscriptions": [
+                {
+                    "tier": "SUBSCRIPTION_TIER_GROK_PRO",
+                    "status": "inactive"
+                }
+            ]
+        });
+
+        assert_eq!(parse_subscription_plan(&value), None);
+    }
+
+    #[test]
+    fn prefers_active_subscription_plan() {
+        let value = serde_json::json!({
+            "subscriptions": [
+                {
+                    "tier": "SUBSCRIPTION_TIER_GROK_PRO",
+                    "status": "inactive"
+                },
+                {
+                    "tier": "SUBSCRIPTION_TIER_SUPER_GROK_PRO",
+                    "status": "active"
+                }
+            ]
+        });
+
+        assert_eq!(
+            parse_subscription_plan(&value).as_deref(),
+            Some("Super Grok Pro")
+        );
+    }
+}

--- a/crates/tokscale-cli/src/commands/usage/mod.rs
+++ b/crates/tokscale-cli/src/commands/usage/mod.rs
@@ -2,6 +2,7 @@ mod amp;
 mod claude;
 mod codex;
 mod copilot;
+mod grok;
 pub mod helpers;
 mod kimi;
 mod minimax;
@@ -87,6 +88,7 @@ pub fn fetch_all() -> Vec<UsageOutput> {
         ("Z.ai", zai::has_credentials, zai::fetch),
         ("Amp", amp::has_credentials, amp::fetch),
         ("Copilot", copilot::has_credentials, copilot::fetch),
+        ("Grok Build", grok::has_credentials, grok::fetch),
         ("Kimi", kimi::has_credentials, kimi::fetch),
         ("MiniMax", minimax::has_credentials, minimax::fetch),
         ("Warp/Oz", warp::has_credentials, warp::fetch),

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -844,6 +844,7 @@ pub enum ClientFilter {
     #[value(name = "trae")]
     Trae,
     Warp,
+    Grok,
     Synthetic,
 }
 
@@ -878,6 +879,7 @@ impl ClientFilter {
             Self::Kiro => "kiro",
             Self::Trae => "trae",
             Self::Warp => "warp",
+            Self::Grok => "grok",
             Self::Synthetic => "synthetic",
         }
     }
@@ -915,6 +917,7 @@ impl ClientFilter {
             Self::Kiro => Some(ClientId::Kiro),
             Self::Trae => Some(ClientId::Trae),
             Self::Warp => Some(ClientId::Warp),
+            Self::Grok => Some(ClientId::Grok),
             Self::Synthetic => None,
         }
     }
@@ -949,6 +952,7 @@ impl ClientFilter {
             ClientId::Kiro => Self::Kiro,
             ClientId::Trae => Self::Trae,
             ClientId::Warp => Self::Warp,
+            ClientId::Grok => Self::Grok,
         }
     }
 
@@ -1052,6 +1056,8 @@ pub struct ClientFlags {
     #[arg(long, hide = true)]
     pub warp: bool,
     #[arg(long, hide = true)]
+    pub grok: bool,
+    #[arg(long, hide = true)]
     pub synthetic: bool,
 }
 
@@ -1105,7 +1111,7 @@ fn build_client_filter_with_defaults(
         }
     }
 
-    let legacy: [(bool, ClientFilter); 26] = [
+    let legacy: [(bool, ClientFilter); 27] = [
         (flags.opencode, ClientFilter::Opencode),
         (flags.claude, ClientFilter::Claude),
         (flags.codex, ClientFilter::Codex),
@@ -1131,6 +1137,7 @@ fn build_client_filter_with_defaults(
         (flags.kiro, ClientFilter::Kiro),
         (flags.trae, ClientFilter::Trae),
         (flags.warp, ClientFilter::Warp),
+        (flags.grok, ClientFilter::Grok),
         (flags.synthetic, ClientFilter::Synthetic),
     ];
 
@@ -3494,6 +3501,7 @@ fn capitalize_client(client: &str) -> String {
         "hermes" => "Hermes Agent".to_string(),
         "goose" => "Goose".to_string(),
         "warp" => "Warp".to_string(),
+        "grok" => "Grok Build".to_string(),
         "pi" => "Pi".to_string(),
         other => other.to_string(),
     }
@@ -5851,6 +5859,7 @@ mod tests {
             kiro: true,
             trae: true,
             warp: true,
+            grok: true,
             synthetic: true,
             ..ClientFlags::default()
         };
@@ -5886,6 +5895,7 @@ mod tests {
             "kiro",
             "trae",
             "warp",
+            "grok",
             "synthetic",
         ] {
             assert!(
@@ -7189,6 +7199,23 @@ mod tests {
         assert_eq!(
             ClientFilter::from_client_id(tokscale_core::ClientId::Warp),
             ClientFilter::Warp
+        );
+    }
+
+    #[test]
+    fn client_filter_round_trips_grok() {
+        assert_eq!(
+            ClientFilter::from_filter_str("grok"),
+            Some(ClientFilter::Grok)
+        );
+        assert_eq!(ClientFilter::Grok.as_filter_str(), "grok");
+        assert_eq!(
+            ClientFilter::Grok.to_client_id(),
+            Some(tokscale_core::ClientId::Grok)
+        );
+        assert_eq!(
+            ClientFilter::from_client_id(tokscale_core::ClientId::Grok),
+            ClientFilter::Grok
         );
     }
 

--- a/crates/tokscale-cli/src/tui/client_ui.rs
+++ b/crates/tokscale-cli/src/tui/client_ui.rs
@@ -106,6 +106,10 @@ pub const CLIENT_UI: [ClientUi; ClientId::COUNT] = [
         display_name: "Warp",
         hotkey: 'v',
     },
+    ClientUi {
+        display_name: "Grok Build",
+        hotkey: 'g',
+    },
 ];
 
 pub fn display_name(client: ClientId) -> &'static str {

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -1337,7 +1337,7 @@ mod tests {
     #[test]
     fn test_client_all() {
         let clients = ClientId::ALL;
-        assert_eq!(clients.len(), 25);
+        assert_eq!(clients.len(), 26);
         assert_eq!(clients[0], ClientId::OpenCode);
         assert_eq!(clients[1], ClientId::Claude);
         assert_eq!(clients[2], ClientId::Codex);
@@ -1363,6 +1363,7 @@ mod tests {
         assert_eq!(clients[22], ClientId::Kiro);
         assert_eq!(clients[23], ClientId::Trae);
         assert_eq!(clients[24], ClientId::Warp);
+        assert_eq!(clients[25], ClientId::Grok);
     }
 
     #[test]
@@ -1438,6 +1439,10 @@ mod tests {
         );
         assert_eq!(crate::tui::client_ui::display_name(ClientId::Kiro), "Kiro");
         assert_eq!(crate::tui::client_ui::display_name(ClientId::Trae), "Trae");
+        assert_eq!(
+            crate::tui::client_ui::display_name(ClientId::Grok),
+            "Grok Build"
+        );
     }
 
     #[test]
@@ -1465,6 +1470,7 @@ mod tests {
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Zed), 'z');
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Kiro), 'i');
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Trae), 'y');
+        assert_eq!(crate::tui::client_ui::hotkey(ClientId::Grok), 'g');
     }
 
     #[test]
@@ -1548,6 +1554,10 @@ mod tests {
         assert_eq!(
             crate::tui::client_ui::from_hotkey('y'),
             Some(ClientId::Trae)
+        );
+        assert_eq!(
+            crate::tui::client_ui::from_hotkey('g'),
+            Some(ClientId::Grok)
         );
     }
 

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -405,6 +405,18 @@ define_clients!(
         headless: false,
         parse_local: false,
         submit_default: false
+    },
+    Grok = 25 => {
+        id: "grok",
+        root: PathRoot::EnvVar {
+            var: "GROK_HOME",
+            fallback_relative: ".grok",
+        },
+        relative: "sessions",
+        pattern: "updates.jsonl",
+        headless: false,
+        parse_local: true,
+        submit_default: true
     }
 );
 
@@ -457,7 +469,7 @@ mod tests {
 
     #[test]
     fn test_client_id_count() {
-        assert_eq!(ClientId::COUNT, 25);
+        assert_eq!(ClientId::COUNT, 26);
     }
 
     #[test]
@@ -480,6 +492,15 @@ mod tests {
         assert_eq!(client.data().pattern, "usage*.json");
         assert!(!client.data().parse_local);
         assert!(!client.data().submit_default);
+    }
+
+    #[test]
+    fn test_grok_client_registered_as_local_session_source() {
+        let client = ClientId::from_str("grok").expect("grok client should be registered");
+        assert_eq!(client.data().relative_path, "sessions");
+        assert_eq!(client.data().pattern, "updates.jsonl");
+        assert!(client.data().parse_local);
+        assert!(client.data().submit_default);
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1029,6 +1029,22 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         }
     }
 
+    let grok_outcomes: Vec<CachedParseOutcome> = scan_result
+        .get(ClientId::Grok)
+        .par_iter()
+        .map(|path| {
+            load_or_parse_source(path, &source_cache, pricing, |path| {
+                sessions::grok::parse_grok_updates_file(path)
+            })
+        })
+        .collect();
+    for outcome in grok_outcomes {
+        all_messages.extend(outcome.messages);
+        if let Some(entry) = outcome.cache_entry {
+            source_cache.insert(entry);
+        }
+    }
+
     let amp_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::Amp)
         .par_iter()
@@ -2448,6 +2464,20 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     let warp_count = summed_parsed_message_count(&warp_msgs);
     counts.set(ClientId::Warp, warp_count);
     messages.extend(warp_msgs);
+
+    let grok_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::Grok)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::grok::parse_grok_updates_file(path)
+                .into_iter()
+                .map(|msg| unified_to_parsed(&msg))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let grok_count = summed_parsed_message_count(&grok_msgs);
+    counts.set(ClientId::Grok, grok_count);
+    messages.extend(grok_msgs);
 
     if include_synthetic {
         if let Some(db_path) = &scan_result.synthetic_db {

--- a/crates/tokscale-core/src/pricing/aliases.rs
+++ b/crates/tokscale-core/src/pricing/aliases.rs
@@ -42,6 +42,8 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     m.insert("gemini-3-pro-low", "gemini-3-pro");
     m.insert("gemini-3-flash", "gemini-3-flash-preview");
     m.insert("gemini-3-flash-c", "gemini-3-flash-preview");
+    m.insert("grok-composer-2.5", "composer-2.5");
+    m.insert("grok-composer-2.5-fast", "composer-2.5-fast");
 
     // Synthetic model variants (only where resolver needs help)
     m.insert("kimi-k2.5-nvfp4", "kimi-k2.5"); // Quantization variant → base model pricing
@@ -98,5 +100,14 @@ mod tests {
 
         assert_eq!(resolve_alias("k2p5"), Some("kimi-k2-thinking"));
         assert_eq!(resolve_alias("k2-p5"), Some("kimi-k2-thinking"));
+    }
+
+    #[test]
+    fn resolves_grok_composer_aliases_to_cursor_composer_prices() {
+        assert_eq!(resolve_alias("grok-composer-2.5"), Some("composer-2.5"));
+        assert_eq!(
+            resolve_alias("GROK-COMPOSER-2.5-FAST"),
+            Some("composer-2.5-fast")
+        );
     }
 }

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -563,6 +563,24 @@ mod tests {
     }
 
     #[test]
+    fn test_grok_composer_2_5_fast_uses_composer_2_5_fast_override() {
+        let service = PricingService::new(HashMap::new(), HashMap::new());
+        let result = service
+            .lookup_with_source("grok-composer-2.5-fast", None)
+            .unwrap();
+        assert_eq!(result.source, "Cursor");
+        assert_eq!(result.matched_key, "composer-2.5-fast");
+        assert_eq!(result.pricing.input_cost_per_token, Some(1.5e-6));
+        assert_eq!(result.pricing.output_cost_per_token, Some(7.5e-6));
+        assert_eq!(result.pricing.cache_read_input_token_cost, Some(3.5e-7));
+
+        let cost =
+            service.calculate_cost("grok-composer-2.5-fast", 1_000_000, 100_000, 50_000, 0, 0);
+        let expected = 1_000_000.0 * 1.5e-6 + 100_000.0 * 7.5e-6 + 50_000.0 * 3.5e-7;
+        assert!((cost - expected).abs() < 1e-10);
+    }
+
+    #[test]
     fn test_cursor_calculate_cost_for_composer_2_5() {
         let service = PricingService::new(HashMap::new(), HashMap::new());
         let cost = service.calculate_cost("composer-2.5", 1_000_000, 100_000, 50_000, 0, 0);

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -297,6 +297,7 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
                 "*.settings.json" => file_name.ends_with(".settings.json"),
                 "sessions.json" => file_name == "sessions.json",
                 "wire.jsonl" => file_name == "wire.jsonl",
+                "updates.jsonl" => file_name == "updates.jsonl",
                 "ui_messages.json" => file_name == "ui_messages.json",
                 "session-usage.json" => file_name == "session-usage.json",
                 "chat-messages.json" => file_name == "chat-messages.json",
@@ -1215,6 +1216,22 @@ mod tests {
     }
 
     #[test]
+    fn test_scan_directory_updates_jsonl_pattern() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path();
+        let session_dir = path.join("workspace/session-1");
+        fs::create_dir_all(&session_dir).unwrap();
+
+        File::create(session_dir.join("updates.jsonl")).unwrap();
+        File::create(session_dir.join("events.jsonl")).unwrap();
+        File::create(session_dir.join("updates.json")).unwrap();
+
+        let updates_files = scan_directory(path.to_str().unwrap(), "updates.jsonl");
+        assert_eq!(updates_files.len(), 1);
+        assert!(updates_files[0].ends_with("updates.jsonl"));
+    }
+
+    #[test]
     fn test_scan_directory_session_pattern() {
         let dir = TempDir::new().unwrap();
         let path = dir.path();
@@ -1408,6 +1425,14 @@ mod tests {
         fs::create_dir_all(&kimi_session).unwrap();
         let mut file = File::create(kimi_session.join("wire.jsonl")).unwrap();
         file.write_all(b"{\"type\": \"metadata\", \"protocol_version\": \"1.3\"}\n")
+            .unwrap();
+    }
+
+    fn setup_mock_grok_dir(base: &std::path::Path) {
+        let grok_session = base.join(".grok/sessions/%2Ftmp%2Fproject/session-uuid-1");
+        fs::create_dir_all(&grok_session).unwrap();
+        let mut file = File::create(grok_session.join("updates.jsonl")).unwrap();
+        file.write_all(b"{\"method\":\"session/update\"}\n")
             .unwrap();
     }
 
@@ -2656,6 +2681,23 @@ mod tests {
         let result = scan_all_clients(home.to_str().unwrap(), &["kimi".to_string()]);
         assert_eq!(result.get(ClientId::Kimi).len(), 1);
         assert!(result.get(ClientId::Kimi)[0].ends_with("wire.jsonl"));
+        assert!(result.get(ClientId::OpenCode).is_empty());
+        assert!(result.get(ClientId::Claude).is_empty());
+    }
+
+    #[test]
+    fn test_scan_all_clients_grok() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_grok_dir(home);
+
+        let result = scan_all_clients_with_env_strategy(
+            home.to_str().unwrap(),
+            &["grok".to_string()],
+            false,
+        );
+        assert_eq!(result.get(ClientId::Grok).len(), 1);
+        assert!(result.get(ClientId::Grok)[0].ends_with("updates.jsonl"));
         assert!(result.get(ClientId::OpenCode).is_empty());
         assert!(result.get(ClientId::Claude).is_empty());
     }

--- a/crates/tokscale-core/src/sessions/grok.rs
+++ b/crates/tokscale-core/src/sessions/grok.rs
@@ -1,0 +1,481 @@
+//! Grok Build session parser.
+//!
+//! Grok Build writes JSON-RPC session updates under
+//! `~/.grok/sessions/<urlencoded-workspace>/<session-id>/updates.jsonl`.
+//! Current logs expose cumulative `totalTokens` counters without a stable
+//! input/output split, so this parser records per-turn positive total-token
+//! deltas as input tokens.
+
+use super::utils::{
+    extract_i64, extract_string, file_modified_timestamp_ms, parse_timestamp_value,
+    read_file_or_none,
+};
+use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
+use crate::TokenBreakdown;
+use serde_json::Value;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+const CLIENT_ID: &str = "grok";
+const PROVIDER_ID: &str = "xai";
+const UNKNOWN_MODEL: &str = "grok-unknown";
+
+#[derive(Debug, Clone)]
+struct GrokMetadata {
+    session_id: String,
+    model_id: Option<String>,
+    timestamp: i64,
+    workspace_key: Option<String>,
+    workspace_label: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ActiveTurn {
+    baseline_total: i64,
+    max_total: i64,
+    timestamp: i64,
+    model_id: String,
+    turn_index: usize,
+}
+
+impl ActiveTurn {
+    fn new(baseline_total: i64, timestamp: i64, model_id: String, turn_index: usize) -> Self {
+        Self {
+            baseline_total,
+            max_total: baseline_total,
+            timestamp,
+            model_id,
+            turn_index,
+        }
+    }
+
+    fn observe_total(&mut self, total: i64, timestamp: i64) {
+        if total > self.max_total {
+            self.max_total = total;
+            self.timestamp = timestamp;
+        }
+    }
+
+    fn into_message(self, metadata: &GrokMetadata) -> Option<UnifiedMessage> {
+        let token_delta = self.max_total.saturating_sub(self.baseline_total);
+        if token_delta <= 0 {
+            return None;
+        }
+
+        let model_id = if self.model_id.trim().is_empty() {
+            UNKNOWN_MODEL.to_string()
+        } else {
+            self.model_id
+        };
+
+        let mut message = UnifiedMessage::new_with_dedup(
+            CLIENT_ID,
+            model_id,
+            PROVIDER_ID,
+            metadata.session_id.clone(),
+            self.timestamp,
+            TokenBreakdown {
+                input: token_delta,
+                output: 0,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            0.0,
+            Some(format!("grok:{}:{}", metadata.session_id, self.turn_index)),
+        );
+        message.set_workspace(
+            metadata.workspace_key.clone(),
+            metadata.workspace_label.clone(),
+        );
+        message.is_turn_start = true;
+        Some(message)
+    }
+}
+
+pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
+    if path.file_name().and_then(|name| name.to_str()) != Some("updates.jsonl") {
+        return Vec::new();
+    }
+
+    let metadata = read_metadata(path);
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut messages = Vec::new();
+    let mut current_model = metadata
+        .model_id
+        .clone()
+        .unwrap_or_else(|| UNKNOWN_MODEL.to_string());
+    let mut last_total: Option<i64> = None;
+    let mut active_turn: Option<ActiveTurn> = None;
+    let mut turn_index = 0usize;
+    let mut observed_model = metadata.model_id.is_some();
+
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+
+        if let Some(model_id) = extract_model_id(&value) {
+            current_model = model_id;
+            observed_model = true;
+            if let Some(turn) = active_turn.as_mut() {
+                if turn.model_id == UNKNOWN_MODEL {
+                    turn.model_id = current_model.clone();
+                }
+            }
+        }
+
+        let timestamp = extract_timestamp_ms(&value).unwrap_or(metadata.timestamp);
+        if is_user_message_chunk(&value) {
+            if let Some(turn) = active_turn.take() {
+                if let Some(message) = turn.into_message(&metadata) {
+                    messages.push(message);
+                }
+            }
+
+            active_turn = Some(ActiveTurn::new(
+                last_total.unwrap_or(0),
+                timestamp,
+                current_model.clone(),
+                turn_index,
+            ));
+            turn_index = turn_index.saturating_add(1);
+        }
+
+        let Some(total_tokens) = extract_total_tokens(&value) else {
+            continue;
+        };
+        if total_tokens < 0 {
+            continue;
+        }
+
+        match last_total {
+            Some(previous) if total_tokens < previous => {
+                // Grok sometimes repeats or rewinds intermediate counters while
+                // streaming tool updates. Treat cumulative totals as monotonic.
+                continue;
+            }
+            Some(previous) if total_tokens == previous => {}
+            Some(previous) => {
+                if active_turn.is_none() && observed_model {
+                    active_turn = Some(ActiveTurn::new(
+                        previous,
+                        timestamp,
+                        current_model.clone(),
+                        turn_index,
+                    ));
+                    turn_index = turn_index.saturating_add(1);
+                }
+                if let Some(turn) = active_turn.as_mut() {
+                    turn.observe_total(total_tokens, timestamp);
+                }
+                last_total = Some(total_tokens);
+            }
+            None => {
+                if let Some(turn) = active_turn.as_mut() {
+                    turn.observe_total(total_tokens, timestamp);
+                }
+                last_total = Some(total_tokens);
+            }
+        }
+    }
+
+    if let Some(turn) = active_turn {
+        if let Some(message) = turn.into_message(&metadata) {
+            messages.push(message);
+        }
+    }
+
+    if messages.is_empty() && observed_model {
+        if let Some(total_tokens) = last_total.filter(|tokens| *tokens > 0) {
+            let aggregate_turn = ActiveTurn {
+                baseline_total: 0,
+                max_total: total_tokens,
+                timestamp: metadata.timestamp,
+                model_id: current_model,
+                turn_index: 0,
+            };
+            if let Some(message) = aggregate_turn.into_message(&metadata) {
+                messages.push(message);
+            }
+        }
+    }
+
+    messages
+}
+
+fn read_metadata(path: &Path) -> GrokMetadata {
+    let session_dir = path.parent();
+    let session_id = session_dir
+        .and_then(|dir| dir.file_name())
+        .and_then(|name| name.to_str())
+        .filter(|id| !id.trim().is_empty())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let workspace_key = session_dir
+        .and_then(|dir| dir.parent())
+        .and_then(|workspace_dir| workspace_dir.file_name())
+        .and_then(|name| name.to_str())
+        .map(percent_decode_lossy)
+        .and_then(|decoded| normalize_workspace_key(&decoded));
+    let workspace_label = workspace_key.as_deref().and_then(workspace_label_from_key);
+
+    let fallback_timestamp = file_modified_timestamp_ms(path);
+    let mut metadata = GrokMetadata {
+        session_id,
+        model_id: None,
+        timestamp: fallback_timestamp,
+        workspace_key,
+        workspace_label,
+    };
+
+    if let Some(summary_path) = sibling(path, "summary.json") {
+        read_summary_metadata(&summary_path, &mut metadata);
+    }
+    if let Some(events_path) = sibling(path, "events.jsonl") {
+        read_events_metadata(&events_path, &mut metadata);
+    }
+
+    metadata
+}
+
+fn read_summary_metadata(path: &Path, metadata: &mut GrokMetadata) {
+    let Some(data) = read_file_or_none(path) else {
+        return;
+    };
+    let Ok(value) = serde_json::from_slice::<Value>(&data) else {
+        return;
+    };
+
+    if metadata.model_id.is_none() {
+        metadata.model_id = extract_string(value.get("current_model_id"))
+            .or_else(|| extract_string(value.get("model_id")));
+    }
+
+    if let Some(timestamp) = value
+        .get("updated_at")
+        .or_else(|| value.get("created_at"))
+        .and_then(parse_timestamp_value)
+    {
+        metadata.timestamp = timestamp;
+    }
+}
+
+fn read_events_metadata(path: &Path, metadata: &mut GrokMetadata) {
+    let Ok(file) = std::fs::File::open(path) else {
+        return;
+    };
+
+    for line in BufReader::new(file).lines().map_while(Result::ok).take(500) {
+        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+
+        if metadata.model_id.is_none() {
+            metadata.model_id = extract_string(value.get("model_id"));
+        }
+        if metadata.session_id == "unknown" {
+            if let Some(session_id) = extract_string(value.get("session_id")) {
+                metadata.session_id = session_id;
+            }
+        }
+        if let Some(timestamp) = value.get("ts").and_then(parse_timestamp_value) {
+            metadata.timestamp = timestamp;
+        }
+
+        if metadata.model_id.is_some() && metadata.session_id != "unknown" {
+            break;
+        }
+    }
+}
+
+fn sibling(path: &Path, file_name: &str) -> Option<PathBuf> {
+    Some(path.parent()?.join(file_name))
+}
+
+fn extract_model_id(value: &Value) -> Option<String> {
+    for path in [
+        &["params", "update", "_meta", "modelId"][..],
+        &["params", "_meta", "modelId"][..],
+        &["params", "modelId"][..],
+        &["model_id"][..],
+        &["modelId"][..],
+        &["model"][..],
+    ] {
+        if let Some(model_id) = get_path(value, path).and_then(|value| extract_string(Some(value)))
+        {
+            if !model_id.trim().is_empty() {
+                return Some(model_id);
+            }
+        }
+    }
+    None
+}
+
+fn extract_total_tokens(value: &Value) -> Option<i64> {
+    for path in [
+        &["params", "_meta", "totalTokens"][..],
+        &["params", "update", "_meta", "totalTokens"][..],
+        &["params", "update", "totalTokens"][..],
+        &["params", "totalTokens"][..],
+        &["usage", "totalTokens"][..],
+        &["totalTokens"][..],
+    ] {
+        if let Some(total) = get_path(value, path).and_then(|value| extract_i64(Some(value))) {
+            return Some(total);
+        }
+    }
+    None
+}
+
+fn extract_timestamp_ms(value: &Value) -> Option<i64> {
+    for path in [
+        &["params", "_meta", "agentTimestampMs"][..],
+        &["params", "update", "_meta", "agentTimestampMs"][..],
+        &["params", "timestamp"][..],
+        &["timestamp"][..],
+        &["ts"][..],
+    ] {
+        if let Some(timestamp) = get_path(value, path).and_then(parse_timestamp_value) {
+            return Some(timestamp);
+        }
+    }
+    None
+}
+
+fn is_user_message_chunk(value: &Value) -> bool {
+    get_path(value, &["params", "update", "sessionUpdate"]).and_then(|value| value.as_str())
+        == Some("user_message_chunk")
+}
+
+fn get_path<'a>(value: &'a Value, path: &[&str]) -> Option<&'a Value> {
+    path.iter()
+        .try_fold(value, |current, key| current.get(*key))
+}
+
+fn percent_decode_lossy(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut i = 0usize;
+
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let (Some(high), Some(low)) = (hex_value(bytes[i + 1]), hex_value(bytes[i + 2])) {
+                decoded.push((high << 4) | low);
+                i += 3;
+                continue;
+            }
+        }
+
+        decoded.push(bytes[i]);
+        i += 1;
+    }
+
+    String::from_utf8_lossy(&decoded).into_owned()
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_fixture(
+        updates_jsonl: &str,
+        summary_json: Option<&str>,
+    ) -> (tempfile::TempDir, PathBuf) {
+        let temp = tempfile::TempDir::new().unwrap();
+        let session_dir = temp
+            .path()
+            .join(".grok")
+            .join("sessions")
+            .join("%2Ftmp%2Fproject")
+            .join("session-1");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        let updates_path = session_dir.join("updates.jsonl");
+        std::fs::write(&updates_path, updates_jsonl).unwrap();
+        if let Some(summary_json) = summary_json {
+            std::fs::write(session_dir.join("summary.json"), summary_json).unwrap();
+        }
+        (temp, updates_path)
+    }
+
+    #[test]
+    fn parses_grok_total_token_deltas_by_turn() {
+        let (_temp, path) = write_fixture(
+            r#"{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"available_commands_update"},"_meta":{"totalTokens":100,"agentTimestampMs":1700000000000}}}
+{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"user_message_chunk","_meta":{"modelId":"grok-composer-2.5-fast"}},"_meta":{"agentTimestampMs":1700000001000}}}
+{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"agent_thought_chunk"},"_meta":{"totalTokens":250,"agentTimestampMs":1700000002000}}}
+{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"agent_message_chunk"},"_meta":{"totalTokens":300,"agentTimestampMs":1700000003000}}}
+{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"user_message_chunk","_meta":{"modelId":"grok-composer-2.5-fast"}},"_meta":{"agentTimestampMs":1700000004000}}}
+{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"agent_message_chunk"},"_meta":{"totalTokens":450,"agentTimestampMs":1700000005000}}}"#,
+            Some(
+                r#"{"current_model_id":"grok-composer-2.5-fast","updated_at":"2023-11-14T22:13:20Z"}"#,
+            ),
+        );
+
+        let messages = parse_grok_updates_file(&path);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].client, "grok");
+        assert_eq!(messages[0].model_id, "grok-composer-2.5-fast");
+        assert_eq!(messages[0].provider_id, "xai");
+        assert_eq!(messages[0].session_id, "session-1");
+        assert_eq!(messages[0].tokens.input, 200);
+        assert_eq!(messages[0].tokens.output, 0);
+        assert_eq!(messages[0].timestamp, 1700000003000);
+        assert_eq!(messages[0].workspace_key.as_deref(), Some("/tmp/project"));
+        assert_eq!(messages[0].workspace_label.as_deref(), Some("project"));
+        assert_eq!(messages[1].tokens.input, 150);
+        assert_eq!(messages[1].timestamp, 1700000005000);
+    }
+
+    #[test]
+    fn uses_summary_model_when_update_model_is_missing() {
+        let (_temp, path) = write_fixture(
+            r#"{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"user_message_chunk"},"_meta":{"agentTimestampMs":1700000000000}}}
+{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"agent_message_chunk"},"_meta":{"totalTokens":220,"agentTimestampMs":1700000001000}}}"#,
+            Some(
+                r#"{"current_model_id":"grok-composer-2.5-fast","updated_at":"2023-11-14T22:13:20Z"}"#,
+            ),
+        );
+
+        let messages = parse_grok_updates_file(&path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "grok-composer-2.5-fast");
+        assert_eq!(messages[0].tokens.input, 220);
+    }
+
+    #[test]
+    fn ignores_repeated_and_decreasing_total_tokens() {
+        let (_temp, path) = write_fixture(
+            r#"{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"available_commands_update"},"_meta":{"totalTokens":100,"agentTimestampMs":1700000000000}}}
+{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"user_message_chunk","_meta":{"modelId":"grok-composer-2.5-fast"}},"_meta":{"agentTimestampMs":1700000001000}}}
+{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"agent_message_chunk"},"_meta":{"totalTokens":150,"agentTimestampMs":1700000002000}}}
+{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"agent_message_chunk"},"_meta":{"totalTokens":150,"agentTimestampMs":1700000003000}}}
+{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"agent_message_chunk"},"_meta":{"totalTokens":120,"agentTimestampMs":1700000004000}}}
+{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"agent_message_chunk"},"_meta":{"totalTokens":200,"agentTimestampMs":1700000005000}}}"#,
+            None,
+        );
+
+        let messages = parse_grok_updates_file(&path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 100);
+        assert_eq!(messages[0].timestamp, 1700000005000);
+    }
+}

--- a/crates/tokscale-core/src/sessions/grok.rs
+++ b/crates/tokscale-core/src/sessions/grok.rs
@@ -110,9 +110,9 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
         .clone()
         .unwrap_or_else(|| UNKNOWN_MODEL.to_string());
     let mut last_total: Option<i64> = None;
+    let mut last_total_timestamp = metadata.timestamp;
     let mut active_turn: Option<ActiveTurn> = None;
     let mut turn_index = 0usize;
-    let mut observed_model = metadata.model_id.is_some();
 
     for line in BufReader::new(file).lines().map_while(Result::ok) {
         if line.trim().is_empty() {
@@ -125,7 +125,6 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
 
         if let Some(model_id) = extract_model_id(&value) {
             current_model = model_id;
-            observed_model = true;
             if let Some(turn) = active_turn.as_mut() {
                 if turn.model_id == UNKNOWN_MODEL {
                     turn.model_id = current_model.clone();
@@ -163,9 +162,11 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
                 // streaming tool updates. Treat cumulative totals as monotonic.
                 continue;
             }
-            Some(previous) if total_tokens == previous => {}
+            Some(previous) if total_tokens == previous => {
+                last_total_timestamp = timestamp;
+            }
             Some(previous) => {
-                if active_turn.is_none() && observed_model {
+                if active_turn.is_none() {
                     active_turn = Some(ActiveTurn::new(
                         previous,
                         timestamp,
@@ -177,12 +178,14 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
                 if let Some(turn) = active_turn.as_mut() {
                     turn.observe_total(total_tokens, timestamp);
                 }
+                last_total_timestamp = timestamp;
                 last_total = Some(total_tokens);
             }
             None => {
                 if let Some(turn) = active_turn.as_mut() {
                     turn.observe_total(total_tokens, timestamp);
                 }
+                last_total_timestamp = timestamp;
                 last_total = Some(total_tokens);
             }
         }
@@ -194,12 +197,12 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
         }
     }
 
-    if messages.is_empty() && observed_model {
+    if messages.is_empty() {
         if let Some(total_tokens) = last_total.filter(|tokens| *tokens > 0) {
             let aggregate_turn = ActiveTurn {
                 baseline_total: 0,
                 max_total: total_tokens,
-                timestamp: metadata.timestamp,
+                timestamp: last_total_timestamp,
                 model_id: current_model,
                 turn_index: 0,
             };
@@ -477,5 +480,34 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].tokens.input, 100);
         assert_eq!(messages[0].timestamp, 1700000005000);
+    }
+
+    #[test]
+    fn preserves_total_tokens_without_model_metadata() {
+        let (_temp, path) = write_fixture(
+            r#"{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"available_commands_update"},"_meta":{"totalTokens":120,"agentTimestampMs":1700000000000}}}"#,
+            None,
+        );
+
+        let messages = parse_grok_updates_file(&path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, UNKNOWN_MODEL);
+        assert_eq!(messages[0].tokens.input, 120);
+        assert_eq!(messages[0].timestamp, 1700000000000);
+    }
+
+    #[test]
+    fn creates_unknown_model_turn_without_model_metadata() {
+        let (_temp, path) = write_fixture(
+            r#"{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"available_commands_update"},"_meta":{"totalTokens":100,"agentTimestampMs":1700000000000}}}
+{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"agent_message_chunk"},"_meta":{"totalTokens":250,"agentTimestampMs":1700000002000}}}"#,
+            None,
+        );
+
+        let messages = parse_grok_updates_file(&path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, UNKNOWN_MODEL);
+        assert_eq!(messages[0].tokens.input, 150);
+        assert_eq!(messages[0].timestamp, 1700000002000);
     }
 }

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -13,6 +13,7 @@ pub mod cursor;
 pub mod droid;
 pub mod gemini;
 pub mod goose;
+pub mod grok;
 pub mod hermes;
 pub mod kilo;
 pub mod kilocode;

--- a/packages/frontend/src/components/SourceLogo.tsx
+++ b/packages/frontend/src/components/SourceLogo.tsx
@@ -63,6 +63,8 @@ export function SourceLogo({ sourceId, height = 14, className = "" }: SourceLogo
         return "/assets/logos/kiro.ico";
       case "zed":
         return "https://raw.githubusercontent.com/junhoyeo/tokscale/main/.github/assets/client-zed.webp";
+      case "grok":
+        return "/assets/logos/grok.jpg";
       case "synthetic":
         return "/assets/logos/synthetic.png";
       default:

--- a/packages/frontend/src/lib/constants.ts
+++ b/packages/frontend/src/lib/constants.ts
@@ -52,6 +52,7 @@ export const SOURCE_DISPLAY_NAMES: Record<ClientType, string> = {
   zed: "Zed Agent",
   trae: "Trae",
   warp: "Warp",
+  grok: "Grok Build",
   synthetic: "Synthetic",
 };
 
@@ -83,6 +84,7 @@ export const SOURCE_LOGOS: Record<ClientType, string> = {
   zed: `${GITHUB_CDN_BASE}/client-zed.webp`,
   trae: `${GITHUB_CDN_BASE}/client-trae.png`,
   warp: `${GITHUB_CDN_BASE}/client-warp.png`,
+  grok: "/assets/logos/grok.jpg",
   synthetic: `${GITHUB_CDN_BASE}/client-synthetic.png`,
 };
 
@@ -112,6 +114,7 @@ export const SOURCE_COLORS: Record<ClientType, string> = {
   zed: "#084CCF",
   trae: "#00BFA5",
   warp: "#01A4A4",
+  grok: "#1D9BF0",
   synthetic: "#4ADE80",
 };
 

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -24,6 +24,7 @@ export const SUPPORTED_CLIENT_TYPES = [
   "zed",
   "trae",
   "warp",
+  "grok",
   "synthetic",
 ] as const;
 


### PR DESCRIPTION
## Summary
- Add Grok Build to the usage provider list with OAuth credentials from `~/.grok/auth.json`.
- Fetch Grok Build subscription usage from the billing endpoint, fall back to task usage and agent billing data, and avoid showing inactive subscription tiers as the current plan.
- Document Grok Build usage support and add focused parser tests for billing, task limits, and subscription selection.

## Validation
- `cargo fmt --check`
- `cargo test -p tokscale-cli grok`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Grok Build usage and subscription support across the CLI, core parser, and UI. Tokscale now reads local Grok sessions and fetches account credits with OAuth to show your plan and limits.

- **New Features**
  - Usage provider: reads OAuth from `~/.grok/auth.json`, fetches credits via billing gRPC/REST; falls back to task usage and uses the agent billing RPC only when a single credential exists; ignores inactive tiers; shows Weekly/Monthly cycle labels with remaining credits.
  - Local parsing: scans `$GROK_HOME/sessions/*/*/updates.jsonl` (fallback `~/.grok/...`) and records positive per‑turn `totalTokens` deltas as input; maps `grok-composer-2.5(-fast)` to Composer 2.5 pricing overrides.
  - CLI/UI: adds `grok` to filters and default submit clients in `tokscale-cli`, TUI hotkey `u`, and frontend logo/color in `packages/frontend`.
  - Docs/tests: updated READMEs and focused tests for billing proto/JSON, task limits, subscription selection, and pricing aliases.

- **Bug Fixes**
  - Billing: handle 401/403 auth errors, HTML responses, non‑finite percentages, and gRPC frames; skip agent billing fallback when multiple credentials exist to avoid cross‑account merges.
  - Parser: tolerate missing `modelId`/timestamps via `summary.json`/`events.jsonl` and file mtime; enforce monotonic `totalTokens`, aggregate last deltas when needed, and percent‑decode workspace keys.

<sup>Written for commit e46574cbd0d96edf992ec72f383eec9b4024ba34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

