### PR TITLE
test(auth): align device authorize tests with guarded claims

### DIFF
--- a/packages/frontend/__tests__/api/deviceAuthorize.test.ts
+++ b/packages/frontend/__tests__/api/deviceAuthorize.test.ts
@@ -1,7 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockState = vi.hoisted(() => {
-  const selectResults: Array<Array<Record<string, unknown>>> = [];
   const updateResults: Array<Array<Record<string, unknown>>> = [];
   const updateSets: Array<Record<string, unknown>> = [];
   const updateWhereConditions: unknown[] = [];
@@ -21,8 +20,8 @@ const mockState = vi.hoisted(() => {
   const gt = vi.fn((left: unknown, right: unknown) => ({ kind: "gt", left, right }));
   const isNull = vi.fn((left: unknown) => ({ kind: "isNull", left }));
 
-  function nextResult(queue: Array<Array<Record<string, unknown>>>) {
-    return queue.shift() ?? [];
+  function nextUpdateResult() {
+    return updateResults.shift() ?? [];
   }
 
   const db = {
@@ -30,7 +29,7 @@ const mockState = vi.hoisted(() => {
       const builder = {
         from: vi.fn(() => builder),
         where: vi.fn(() => builder),
-        limit: vi.fn(async () => nextResult(selectResults)),
+        limit: vi.fn(async () => []),
       };
 
       return builder;
@@ -45,7 +44,7 @@ const mockState = vi.hoisted(() => {
           updateWhereConditions.push(condition);
           return builder;
         }),
-        returning: vi.fn(async () => nextResult(updateResults)),
+        returning: vi.fn(async () => nextUpdateResult()),
       };
 
       return builder;
@@ -63,7 +62,6 @@ const mockState = vi.hoisted(() => {
     updateSets,
     updateWhereConditions,
     reset() {
-      selectResults.length = 0;
       updateResults.length = 0;
       updateSets.length = 0;
       updateWhereConditions.length = 0;
@@ -74,9 +72,6 @@ const mockState = vi.hoisted(() => {
       and.mockClear();
       gt.mockClear();
       isNull.mockClear();
-    },
-    pushSelectResult(rows: Array<Record<string, unknown>>) {
-      selectResults.push(rows);
     },
     pushUpdateResult(rows: Array<Record<string, unknown>>) {
       updateResults.push(rows);
@@ -126,6 +121,14 @@ function flattenedTerms(condition: unknown): Array<Record<string, unknown>> {
   return [record];
 }
 
+function createAuthorizeRequest(userCode: string) {
+  return new Request("http://localhost:3000/api/auth/device/authorize", {
+    method: "POST",
+    headers: { Origin: "http://localhost:3000" },
+    body: JSON.stringify({ userCode }),
+  });
+}
+
 describe("POST /api/auth/device/authorize", () => {
   it("claims a valid device code with a guarded update", async () => {
     mockState.getSession.mockResolvedValue({
@@ -136,12 +139,7 @@ describe("POST /api/auth/device/authorize", () => {
     });
     mockState.pushUpdateResult([{ id: "device-1" }]);
 
-    const response = await POST(
-      new Request("http://localhost:3000/api/auth/device/authorize", {
-        method: "POST",
-        body: JSON.stringify({ userCode: "ABCD-1234" }),
-      })
-    );
+    const response = await POST(createAuthorizeRequest("ABCD-1234"));
     const body = await response.json();
 
     expect(response.status).toBe(200);
@@ -158,22 +156,9 @@ describe("POST /api/auth/device/authorize", () => {
       displayName: "Alice",
       avatarUrl: null,
     });
-    mockState.pushSelectResult([
-      {
-        id: "device-1",
-        userCode: "ABCD-1234",
-        expiresAt: new Date("2026-03-08T05:00:00.000Z"),
-        userId: null,
-      },
-    ]);
     mockState.pushUpdateResult([]);
 
-    const response = await POST(
-      new Request("http://localhost:3000/api/auth/device/authorize", {
-        method: "POST",
-        body: JSON.stringify({ userCode: "abcd1234" }),
-      })
-    );
+    const response = await POST(createAuthorizeRequest("abcd1234"));
     const body = await response.json();
     const updateTerms = flattenedTerms(mockState.updateWhereConditions[0]);
 

--- a/packages/frontend/__tests__/api/deviceAuthorizeCsrf.test.ts
+++ b/packages/frontend/__tests__/api/deviceAuthorizeCsrf.test.ts
@@ -11,7 +11,8 @@ const mockState = vi.hoisted(() => {
   const whereSelect = vi.fn(() => ({ limit }));
   const from = vi.fn(() => ({ where: whereSelect }));
   const select = vi.fn(() => ({ from }));
-  const whereUpdate = vi.fn(async () => undefined);
+  const returning = vi.fn(async () => records);
+  const whereUpdate = vi.fn(() => ({ returning }));
   const set = vi.fn(() => ({ where: whereUpdate }));
   const update = vi.fn(() => ({ set }));
   let records: Array<{ id: string }> = [];
@@ -46,6 +47,7 @@ const mockState = vi.hoisted(() => {
       whereSelect.mockClear();
       from.mockClear();
       select.mockClear();
+      returning.mockClear();
       whereUpdate.mockClear();
       set.mockClear();
       update.mockClear();


### PR DESCRIPTION
## Summary

Updates the device authorization route tests so they match the current guarded-claim implementation after #654.

## Why

The latest `Frontend CI` runs on `main` started failing in `Frontend Vitest` after `fix(auth): claim device codes atomically (#654)`. The route now authenticates through `getSessionFromRequest`, which rejects cookie-authenticated mutating requests without an allowed `Origin`, and claims device codes through `db.update(...).set(...).where(...).returning(...)`. The affected tests were still exercising the old request shape and one CSRF test mock did not expose `.returning()`, so CI failed even though the runtime route path was intentionally changed.

## Diff scope

* `packages/frontend/__tests__/api/deviceAuthorize.test.ts` now sends an allowed `Origin` for successful cookie-authenticated mutation tests and removes the stale pre-select fixture from the atomic claim race test.
* `packages/frontend/__tests__/api/deviceAuthorizeCsrf.test.ts` now models the Drizzle update builder with `.where(...).returning(...)`.
* No production runtime code changed.

## Branch integrity

* Base branch: `main`.
* Validated base SHA: `b48af31e8c119dbc82d8b2e0da2e72a5f9e4d63f`.
* Ahead/behind against fetched `origin/main`: `1 ahead / 0 behind`.
* Merge base: `b48af31e8c119dbc82d8b2e0da2e72a5f9e4d63f`.
* Diff proof was computed against the fetched base.

## Commit integrity

* `f20af788a48154d272c23dca6a33045a65d54503 test(auth): align device authorize mocks with guarded claims`
* One logical test-only correction.
* Final PR diff contains only the intended device authorization test files.

## Ledger/version proof

* Ledger: not applicable — not required for selected validation mode/change family.
* Version: not applicable — no release manifests changed.

## Diff hygiene

* `git diff --name-status origin/main...HEAD`: only `packages/frontend/__tests__/api/deviceAuthorize.test.ts` and `packages/frontend/__tests__/api/deviceAuthorizeCsrf.test.ts`.
* `git diff --check origin/main...HEAD`: PASS, no output.
* No `.env` files, secrets, credentials, build output, caches, or unrelated generated files are included.

## Validation mode and proof

* Validation mode: Mode 2 — Narrow Runtime-adjacent Test Correction. The change is test-only, but it covers a security-sensitive auth route and directly addresses a failing CI test path.
* TDD red: `bun --cwd packages/frontend test __tests__/api/deviceAuthorize.test.ts __tests__/api/deviceAuthorizeCsrf.test.ts`: FAIL before fix, 3 failed and 2 passed, matching the `Frontend CI` device authorize failures.
* `bun --cwd packages/frontend test __tests__/api/deviceAuthorize.test.ts __tests__/api/deviceAuthorizeCsrf.test.ts`: PASS, 5 tests.
* `bun --cwd packages/frontend test`: PASS, 48 test files and 391 tests.
* `bun run lint -- __tests__/api/deviceAuthorize.test.ts __tests__/api/deviceAuthorizeCsrf.test.ts` from `packages/frontend`: PASS.
* `git diff --check`: PASS.
* `git diff --cached --check`: PASS.
* Not run: `Frontend Migration Replay` locally — not required because no migration files changed and the failing GitHub job was `Frontend Vitest`.

## CI context confirmation

* Pending — required GitHub checks will run after PR creation.
* CI workflow definitions and context names are unchanged.

## Runtime safety

* Not applicable — no production runtime path changed.

## Documentation integrity

* Not applicable — no docs, runbooks, commands, or user-facing behavior changed.

## Rollback plan

Rollback: revert this PR.

DB downgrade: not applicable.

Data repair: not applicable.

Operational caveats: none known.

## Known residual risks

* Remote GitHub checks are pending until this PR is opened and CI completes on the pushed branch.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns device authorization tests with the guarded-claim flow from #654 to fix failing Frontend Vitest runs on `main`. Adds an allowed `Origin` header and updates Drizzle mocks to use `.returning(...)`; no runtime code changed.

- **Bug Fixes**
  - `packages/frontend/__tests__/api/deviceAuthorize.test.ts`: add allowed `Origin` for cookie-auth POSTs; remove stale pre-select fixture; add a small request helper.
  - `packages/frontend/__tests__/api/deviceAuthorizeCsrf.test.ts`: model update builder with `.where(...).returning(...)` to match Drizzle.
  - Test-only changes; production behavior unchanged.

<sup>Written for commit f20af788a48154d272c23dca6a33045a65d54503. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

