### PR TITLE
test(core): isolate Zed path test from XDG_DATA_HOME

### DIFF
--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -744,10 +744,16 @@ mod tests {
 
     #[test]
     fn test_zed_data_dir_path() {
+        let _guard = env_lock().lock().unwrap();
+        let previous = std::env::var("XDG_DATA_HOME").ok();
+        unsafe { std::env::remove_var("XDG_DATA_HOME") };
+
         assert_eq!(
             ClientId::Zed.data().resolve_path("/tmp/home"),
             "/tmp/home/.local/share/zed/threads/threads.db"
         );
+
+        restore_env("XDG_DATA_HOME", previous);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Isolate `test_zed_data_dir_path` from process-global `XDG_DATA_HOME` before asserting the fallback Linux Zed data path.
- Keep production Zed path resolution unchanged; this is a test-only fix for the coverage failure seen on `main` after #660.

## Why

GitHub `Test & Coverage` failed because tarpaulin can run `clients::tests::test_zed_data_dir_path` while another env-sensitive test has temporarily set `XDG_DATA_HOME=/tmp/xdg-data-home`. The Zed test expected `/tmp/home/.local/share/zed/threads/threads.db`, but `ClientId::Zed.data().resolve_path("/tmp/home")` correctly honored the inherited process-global XDG override and returned `/tmp/xdg-data-home/zed/threads/threads.db`. This PR removes that fixture race by taking the existing env lock, clearing `XDG_DATA_HOME` for the fallback assertion, and restoring the previous value afterward.

## Diff Scope

- Test-only update in `crates/tokscale-core/src/clients.rs`.
- No runtime parser, pricing, submit, frontend, migration, workflow, or release files changed.

## Branch Integrity

- Base branch: `main`
- Validated base SHA: `c3f8d0937841189fd32e7e5454ac80d55f30d5d6`
- Ahead/behind: `0 behind / 1 ahead`
- Merge base: `c3f8d0937841189fd32e7e5454ac80d55f30d5d6`
- Fast-forward safety: `origin/main` is an ancestor of this branch.

## Commit Integrity

- Introduced commit: `fbdb509d2a5387a3f11b83297d17bd0b6446643e test(core): isolate Zed path test from XDG_DATA_HOME`
- One logical test-isolation commit.
- Final PR diff contains only the intended test fixture change.
- Ledger: not applicable - not required for selected validation mode/change family.
- Version: not applicable - no release manifests changed.

## Diff Hygiene

- `git diff --name-status origin/main...HEAD`: `M crates/tokscale-core/src/clients.rs`
- `git diff --check origin/main...HEAD`: PASS, no output.


## Validation Mode and Proof

- Validation mode: Mode 2R - post-merge test-only CI correction for a process-global env race in a single core test fixture; no runtime files changed.
- TDD red: `XDG_DATA_HOME=/tmp/xdg-data-home cargo test -p tokscale-core clients::tests::test_zed_data_dir_path -- --exact --nocapture`: FAIL before fix, reproduced the GitHub coverage failure with `/tmp/xdg-data-home/zed/threads/threads.db` instead of `/tmp/home/.local/share/zed/threads/threads.db`.
- `XDG_DATA_HOME=/tmp/xdg-data-home cargo test -p tokscale-core clients::tests::test_zed_data_dir_path -- --exact --nocapture`: PASS, 1 test.
- `cargo test -p tokscale-core clients::tests -- --test-threads=4`: PASS, 26 tests.
- `cargo test -p tokscale-core`: PASS, 838 lib tests passed, 1 ignored; codebuff/hermes integration tests passed; doc-tests passed.
- `cargo fmt --check`: PASS.
- `git diff --check`: PASS.
- `git diff --cached --check`: PASS.
- Local `cargo tarpaulin`: not run - not required for this test-only correction because the targeted red/green reproduction covers the failing branch and mandatory remote `Test & Coverage` will run tarpaulin on the final PR SHA.

## CI Context Confirmation

- CI context names unchanged.
- Required remote gates: pending until GitHub Actions completes on this PR SHA.

## Runtime Safety

- Not applicable - no runtime path changed.
- No invariant regression introduced.

## Documentation Integrity

- Not applicable - no docs, commands, runbooks, or user-facing documented behavior changed.

## Rollback Plan

- Rollback: revert this PR.
- DB downgrade: not applicable.
- Data repair: not applicable.
- Operational caveats: none known.

## Known Residual Risks

- The local fix is intentionally scoped to the failing fixture race; final coverage proof is expected from mandatory remote `Test & Coverage` on the PR SHA.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated the Zed data path test from `XDG_DATA_HOME` to prevent env leakage and flaky coverage. Test-only; no runtime behavior changed.

- **Bug Fixes**
  - Lock env, temporarily unset `XDG_DATA_HOME` for the fallback assertion, then restore it.
  - Stabilizes `test_zed_data_dir_path` when other tests set `XDG_DATA_HOME`.

<sup>Written for commit fbdb509d2a5387a3f11b83297d17bd0b6446643e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

