### PR TITLE
feat: display MCP servers in profile Statistics panel

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -4075,6 +4075,8 @@ struct TsTokenContributionData {
     contributions: Vec<TsDailyContribution>,
     #[serde(skip_serializing_if = "Option::is_none")]
     time_metrics: Option<TsTimeMetrics>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mcp_servers: Option<Vec<String>>,
 }
 
 fn to_ts_token_contribution_data(
@@ -4166,6 +4168,14 @@ fn to_ts_token_contribution_data(
             max_concurrent_sessions: tm.max_concurrent_sessions,
             session_count: tm.session_count,
         }),
+        mcp_servers: {
+            let servers = tokscale_core::mcp::discover_mcp_server_names(None);
+            if servers.is_empty() {
+                None
+            } else {
+                Some(servers)
+            }
+        },
     }
 }
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -4,6 +4,7 @@ mod aggregator;
 mod cc_mirror;
 pub mod clients;
 pub mod fs_atomic;
+pub mod mcp;
 mod message_cache;
 mod parser;
 pub mod paths;

--- a/crates/tokscale-core/src/mcp.rs
+++ b/crates/tokscale-core/src/mcp.rs
@@ -1,0 +1,326 @@
+//! MCP server discovery — collects configured server *names* only (no secrets/paths).
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+pub struct McpServerEntry {
+    pub name: String,
+    pub source: McpSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum McpSource {
+    ClaudeCode,
+    ClaudeDesktop,
+    Cursor,
+    Kiro,
+    OpenCodeSkill,
+}
+
+pub fn discover_mcp_server_names(home_dir: Option<&Path>) -> Vec<String> {
+    let home = match home_dir.map(PathBuf::from).or_else(dirs::home_dir) {
+        Some(h) => h,
+        None => return Vec::new(),
+    };
+
+    let mut names: BTreeSet<String> = BTreeSet::new();
+
+    collect_mcp_server_keys(&home.join(".claude").join(".mcp.json"), &mut names);
+
+    #[cfg(target_os = "macos")]
+    {
+        collect_mcp_server_keys(
+            &home
+                .join("Library")
+                .join("Application Support")
+                .join("Claude")
+                .join("claude_desktop_config.json"),
+            &mut names,
+        );
+    }
+
+    collect_mcp_server_keys(&home.join(".cursor").join("mcp.json"), &mut names);
+
+    collect_mcp_server_keys(
+        &home.join(".kiro").join("settings").join("mcp.json"),
+        &mut names,
+    );
+
+    collect_skill_mcp_names(
+        &home.join(".config").join("opencode").join("skills"),
+        &mut names,
+    );
+    collect_skill_mcp_names(&home.join(".opencode").join("skills"), &mut names);
+
+    names.into_iter().collect()
+}
+
+fn collect_mcp_server_keys(path: &Path, names: &mut BTreeSet<String>) {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    let value: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+
+    if let Some(servers) = value.get("mcpServers").and_then(|v| v.as_object()) {
+        for key in servers.keys() {
+            if !key.is_empty() {
+                names.insert(key.clone());
+            }
+        }
+    }
+}
+
+fn collect_skill_mcp_names(skills_dir: &Path, names: &mut BTreeSet<String>) {
+    let dir = match std::fs::read_dir(skills_dir) {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+
+    for entry in dir.flatten() {
+        let path = entry.path();
+
+        if path.is_dir() {
+            let skill_file = path.join("SKILL.md");
+            if skill_file.is_file() {
+                extract_mcp_names_from_skill_md(&skill_file, names);
+            }
+        } else if path.extension().is_some_and(|ext| ext == "md") {
+            extract_mcp_names_from_skill_md(&path, names);
+        }
+    }
+}
+
+/// Line-based YAML frontmatter `mcp:` key extractor (avoids a full YAML dependency).
+fn extract_mcp_names_from_skill_md(path: &Path, names: &mut BTreeSet<String>) {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    let frontmatter = match extract_yaml_frontmatter(&content) {
+        Some(fm) => fm,
+        None => return,
+    };
+
+    let mut in_mcp_section = false;
+    let mut mcp_indent: usize = 0;
+
+    for line in frontmatter.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        let indent = line.len() - line.trim_start().len();
+
+        if !in_mcp_section {
+            if trimmed == "mcp:" || trimmed.starts_with("mcp:") {
+                in_mcp_section = true;
+                mcp_indent = indent;
+            }
+        } else {
+            if indent <= mcp_indent && !trimmed.is_empty() {
+                break;
+            }
+
+            if indent == mcp_indent + 2 || (mcp_indent == 0 && indent == 2) {
+                if let Some(key) = trimmed
+                    .strip_suffix(':')
+                    .or_else(|| trimmed.split(':').next())
+                {
+                    let key = key.trim();
+                    if !key.is_empty() && !key.starts_with('-') {
+                        names.insert(key.to_string());
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn extract_yaml_frontmatter(content: &str) -> Option<&str> {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return None;
+    }
+
+    let after_first = &trimmed[3..];
+    let after_first = after_first.trim_start_matches(['\r', '\n']);
+
+    let end = after_first.find("\n---")?;
+    Some(&after_first[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_collect_mcp_server_keys() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("mcp.json");
+        fs::write(
+            &path,
+            r#"{"mcpServers":{"slack":{"command":"npx"},"github":{"command":"npx"}}}"#,
+        )
+        .unwrap();
+
+        let mut names = BTreeSet::new();
+        collect_mcp_server_keys(&path, &mut names);
+        assert_eq!(
+            names.into_iter().collect::<Vec<_>>(),
+            vec!["github", "slack"]
+        );
+    }
+
+    #[test]
+    fn test_collect_mcp_server_keys_missing_file() {
+        let mut names = BTreeSet::new();
+        collect_mcp_server_keys(Path::new("/nonexistent/mcp.json"), &mut names);
+        assert!(names.is_empty());
+    }
+
+    #[test]
+    fn test_extract_mcp_names_from_skill_md() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("test.md");
+        fs::write(
+            &path,
+            r#"---
+name: playwright
+description: "Browser automation"
+mcp:
+  playwright:
+    command: npx
+    args:
+      - "@playwright/mcp@latest"
+---
+
+# Content here
+"#,
+        )
+        .unwrap();
+
+        let mut names = BTreeSet::new();
+        extract_mcp_names_from_skill_md(&path, &mut names);
+        assert_eq!(names.into_iter().collect::<Vec<_>>(), vec!["playwright"]);
+    }
+
+    #[test]
+    fn test_extract_mcp_names_from_skill_md_multiple() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("multi.md");
+        fs::write(
+            &path,
+            r#"---
+mcp:
+  server-a:
+    command: npx
+    args: ["-y", "server-a"]
+  server-b:
+    command: bunx
+    args: ["server-b"]
+---
+"#,
+        )
+        .unwrap();
+
+        let mut names = BTreeSet::new();
+        extract_mcp_names_from_skill_md(&path, &mut names);
+        assert_eq!(
+            names.into_iter().collect::<Vec<_>>(),
+            vec!["server-a", "server-b"]
+        );
+    }
+
+    #[test]
+    fn test_skill_directory_layout() {
+        let tmp = TempDir::new().unwrap();
+        let skills_dir = tmp.path().join("skills");
+
+        // Subdirectory layout
+        let tmap_dir = skills_dir.join("tmap");
+        fs::create_dir_all(&tmap_dir).unwrap();
+        fs::write(
+            tmap_dir.join("SKILL.md"),
+            "---\ndescription: \"TMAP\"\n---\n# TMAP MCP\n",
+        )
+        .unwrap();
+
+        // Flat file with mcp section
+        fs::write(
+            skills_dir.join("playwright.md"),
+            "---\nmcp:\n  playwright:\n    command: npx\n---\n# PW\n",
+        )
+        .unwrap();
+
+        let mut names = BTreeSet::new();
+        collect_skill_mcp_names(&skills_dir, &mut names);
+        // tmap SKILL.md has no mcp: section, so only playwright is found
+        assert_eq!(names.into_iter().collect::<Vec<_>>(), vec!["playwright"]);
+    }
+
+    #[test]
+    fn test_discover_mcp_server_names_integration() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path();
+
+        // Create Claude .mcp.json
+        let claude_dir = home.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+        fs::write(
+            claude_dir.join(".mcp.json"),
+            r#"{"mcpServers":{"slack":{},"tmap":{}}}"#,
+        )
+        .unwrap();
+
+        // Create Cursor mcp.json
+        let cursor_dir = home.join(".cursor");
+        fs::create_dir_all(&cursor_dir).unwrap();
+        fs::write(
+            cursor_dir.join("mcp.json"),
+            r#"{"mcpServers":{"github":{},"slack":{}}}"#,
+        )
+        .unwrap();
+
+        // Create Kiro mcp.json
+        let kiro_dir = home.join(".kiro").join("settings");
+        fs::create_dir_all(&kiro_dir).unwrap();
+        fs::write(kiro_dir.join("mcp.json"), r#"{"mcpServers":{"tmap":{}}}"#).unwrap();
+
+        // Create skill
+        let skills_dir = home.join(".opencode").join("skills");
+        fs::create_dir_all(&skills_dir).unwrap();
+        fs::write(
+            skills_dir.join("apple-mcp.md"),
+            "---\nmcp:\n  apple-mcp:\n    command: bunx\n---\n",
+        )
+        .unwrap();
+
+        let result = discover_mcp_server_names(Some(home));
+        // Deduplicated and sorted
+        assert_eq!(result, vec!["apple-mcp", "github", "slack", "tmap"]);
+    }
+
+    #[test]
+    fn test_extract_yaml_frontmatter() {
+        let content = "---\nname: test\nmcp:\n  foo:\n    cmd: x\n---\n# Body";
+        let fm = extract_yaml_frontmatter(content).unwrap();
+        assert!(fm.contains("mcp:"));
+        assert!(!fm.contains("# Body"));
+    }
+
+    #[test]
+    fn test_no_frontmatter() {
+        assert_eq!(extract_yaml_frontmatter("# Just a heading"), None);
+    }
+}

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -270,6 +270,42 @@ describe("POST /api/submit auth path", () => {
     });
   });
 
+  it("returns validation errors for a null JSON body without entering the transaction path", async () => {
+    mockState.authenticatePersonalToken.mockResolvedValue({
+      status: "valid",
+      tokenId: "token-1",
+      userId: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      expiresAt: null,
+    });
+    mockState.validateSubmission.mockReturnValue({
+      valid: false,
+      data: null,
+      errors: ["Submission data must be an object"],
+    });
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: "null",
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockState.validateSubmission).toHaveBeenCalledWith(null);
+    expect(mockState.db.transaction).not.toHaveBeenCalled();
+    expect(await response.json()).toEqual({
+      error: "Validation failed",
+      details: ["Submission data must be an object"],
+    });
+  });
+
   it("revalidates username ISR paths after a successful submit", async () => {
     mockState.authenticatePersonalToken.mockResolvedValue({
       status: "valid",
@@ -370,10 +406,20 @@ describe("POST /api/submit auth path", () => {
     let insertCall = 0;
     let submittedDeviceValues: unknown;
     let dailyInsertValues: unknown;
+    let submissionUpdateValues: unknown;
     const tx = {
-      update: vi.fn(() => {
+      update: vi.fn((table: unknown) => {
         const builder = {
-          set: vi.fn(() => builder),
+          set: vi.fn((values: unknown) => {
+            if (
+              table &&
+              typeof table === "object" &&
+              (table as { userId?: unknown }).userId === "submissions.userId"
+            ) {
+              submissionUpdateValues = values;
+            }
+            return builder;
+          }),
           where: vi.fn(() => Promise.resolve()),
         };
         return builder;
@@ -429,7 +475,11 @@ describe("POST /api/submit auth path", () => {
           Authorization: "Bearer tt_valid",
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ meta: {}, contributions: [] }),
+        body: JSON.stringify({
+          meta: {},
+          contributions: [],
+          mcpServers: ["github", "", "slack", 123, null],
+        }),
       })
     );
 
@@ -449,6 +499,11 @@ describe("POST /api/submit auth path", () => {
         date: "2026-04-30",
       }),
     ]);
+    expect(submissionUpdateValues).toEqual(
+      expect.objectContaining({
+        mcpServers: ["github", "slack"],
+      })
+    );
     expect(mockState.revalidateTag).toHaveBeenNthCalledWith(1, "leaderboard", "max");
     expect(mockState.revalidateTag).toHaveBeenNthCalledWith(2, "user:alice", "max");
     expect(mockState.revalidateTag).toHaveBeenNthCalledWith(3, "user-rank", "max");

--- a/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
@@ -1104,7 +1104,8 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
     const qs = params.toString();
     const url = qs ? `${pathname}?${qs}` : pathname;
     window.history.replaceState(null, "", url);
-  }, [period, requestedPage, effectiveSortBy, appliedFrom, appliedTo, pathname, debouncedSearch, searchParams]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [period, requestedPage, effectiveSortBy, appliedFrom, appliedTo, pathname, debouncedSearch]);
 
   // Debounce search input so URL/search sync updates after typing stops.
   const isSearchMounted = useRef(false);
@@ -1546,7 +1547,7 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
         <CTATitle>Join the Leaderboard</CTATitle>
         <CTADescription>Install Tokscale CLI and submit your usage data:</CTADescription>
         <CodeBlock>
-          {typeof window !== "undefined" && window.location.hostname !== "tokscale.ai" && (
+          {mounted && typeof window !== "undefined" && window.location.hostname !== "tokscale.ai" && (
             <CodeLine>
               <CommandPrompt>$</CommandPrompt>
               <CommandPrefix>export</CommandPrefix>

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -136,6 +136,14 @@ export async function POST(request: Request) {
 
     normalizeSubmissionData(rawData);
 
+    const mcpServers: string[] | null =
+      rawData != null && typeof rawData === "object" &&
+      Array.isArray((rawData as Record<string, unknown>).mcpServers)
+        ? ((rawData as Record<string, unknown>).mcpServers as unknown[]).filter(
+            (s): s is string => typeof s === "string" && s.length > 0
+          )
+        : null;
+
     const validation = validateSubmission(rawData);
 
     if (!validation.valid || !validation.data) {
@@ -576,6 +584,7 @@ export async function POST(request: Request) {
             maxConcurrentSessions: data.timeMetrics.maxConcurrentSessions,
             sessionCount: data.timeMetrics.sessionCount,
           } : {}),
+          mcpServers: mcpServers && mcpServers.length > 0 ? mcpServers : null,
           updatedAt: new Date(),
         })
         .where(eq(submissions.id, submissionId));

--- a/packages/frontend/src/app/api/users/[username]/route.ts
+++ b/packages/frontend/src/app/api/users/[username]/route.ts
@@ -75,6 +75,7 @@ export async function GET(_request: Request, { params }: RouteParams) {
           updatedAt: submissions.updatedAt,
           cliVersion: submissions.cliVersion,
           schemaVersion: submissions.schemaVersion,
+          mcpServers: submissions.mcpServers,
         })
         .from(submissions)
         .where(eq(submissions.userId, user.id))
@@ -459,6 +460,7 @@ export async function GET(_request: Request, { params }: RouteParams) {
       }),
       clients: latestSubmission?.sourcesUsed || [],
       models: latestSubmission?.modelsUsed || [],
+      mcpServers: latestSubmission?.mcpServers || [],
       modelUsage,
       contributions: graphContributions,
     });

--- a/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
+++ b/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
@@ -47,6 +47,7 @@ interface ProfileData {
   updatedAt: string | null;
   clients: string[];
   models: string[];
+  mcpServers?: string[];
   modelUsage?: ModelUsage[];
   contributions: DailyContribution[];
 }
@@ -182,6 +183,7 @@ const EARLY_ADOPTERS = ["code-yeongyu", "gtg7784", "qodot"];
                     data={graphData}
                     totalActiveTimeMs={data.stats.totalActiveTimeMs}
                     sessionCount={data.stats.sessionCount}
+                    mcpServers={data.mcpServers}
                   />
                   <ProfileStats
                     stats={stats}

--- a/packages/frontend/src/components/GraphContainer.tsx
+++ b/packages/frontend/src/components/GraphContainer.tsx
@@ -64,9 +64,10 @@ interface GraphContainerProps {
   data: TokenContributionData;
   totalActiveTimeMs?: number | null;
   sessionCount?: number | null;
+  mcpServers?: string[];
 }
 
-export function GraphContainer({ data, totalActiveTimeMs, sessionCount }: GraphContainerProps) {
+export function GraphContainer({ data, totalActiveTimeMs, sessionCount, mcpServers }: GraphContainerProps) {
   const { paletteName, setPalette } = useSettings();
 
   const [view, setView] = useState<ViewMode>("2d");
@@ -181,7 +182,7 @@ export function GraphContainer({ data, totalActiveTimeMs, sessionCount }: GraphC
       </GraphCard>
 
       {selectedDay && <BreakdownPanel day={selectedDay} onClose={() => setSelectedDay(null)} palette={palette} />}
-      {view === "2d" && <StatsPanel data={filteredByClient} palette={palette} totalActiveTimeMs={clientFilter.length === 0 ? totalActiveTimeMs : null} sessionCount={clientFilter.length === 0 ? sessionCount : null} />}
+      {view === "2d" && <StatsPanel data={filteredByClient} palette={palette} totalActiveTimeMs={clientFilter.length === 0 ? totalActiveTimeMs : null} sessionCount={clientFilter.length === 0 ? sessionCount : null} mcpServers={mcpServers} />}
       <Tooltip day={hoveredDay} position={tooltipPosition} visible={hoveredDay !== null} palette={palette} />
     </Container>
   );

--- a/packages/frontend/src/components/StatsPanel.tsx
+++ b/packages/frontend/src/components/StatsPanel.tsx
@@ -17,6 +17,7 @@ interface StatsPanelProps {
   palette: GraphColorPalette;
   totalActiveTimeMs?: number | null;
   sessionCount?: number | null;
+  mcpServers?: string[];
 }
 
 const Container = styled.div`
@@ -143,7 +144,20 @@ const StatItemSubValue = styled.div`
   color: var(--color-fg-muted);
 `;
 
-export function StatsPanel({ data, palette, totalActiveTimeMs, sessionCount }: StatsPanelProps) {
+function BadgeList({ label, items, palette }: { label: string; items: string[]; palette: GraphColorPalette }) {
+  return (
+    <SourcesContainer>
+      <SourcesLabel>{label}:</SourcesLabel>
+      {items.map((item) => (
+        <SourceBadge key={item} $backgroundColor={`${palette.grade3}20`}>
+          {item}
+        </SourceBadge>
+      ))}
+    </SourcesContainer>
+  );
+}
+
+export function StatsPanel({ data, palette, totalActiveTimeMs, sessionCount, mcpServers }: StatsPanelProps) {
   const { summary, contributions } = data;
   const currentStreak = calculateCurrentStreak(contributions);
   const longestStreak = calculateLongestStreak(contributions);
@@ -172,17 +186,10 @@ export function StatsPanel({ data, palette, totalActiveTimeMs, sessionCount }: S
         )}
       </Grid>
 
-      <SourcesContainer>
-        <SourcesLabel>Clients:</SourcesLabel>
-        {summary.clients.map((client) => (
-          <SourceBadge
-            key={client}
-            $backgroundColor={`${palette.grade3}20`}
-          >
-            {client}
-          </SourceBadge>
-        ))}
-      </SourcesContainer>
+      <BadgeList label="Clients" items={summary.clients} palette={palette} />
+      {mcpServers && mcpServers.length > 0 && (
+        <BadgeList label="MCPs" items={mcpServers} palette={palette} />
+      )}
     </Container>
   );
 }

--- a/packages/frontend/src/components/profile/index.tsx
+++ b/packages/frontend/src/components/profile/index.tsx
@@ -458,7 +458,7 @@ export function ProfileHeader({ user, stats, lastUpdated }: ProfileHeaderProps) 
           <LastUpdatedText
             style={{ color: "var(--color-fg-muted)" }}
           >
-            Last Updated: {new Date(lastUpdated).toLocaleString()}
+            Last Updated: {new Date(lastUpdated).toLocaleString("en-US", { timeZone: "UTC" })}
           </LastUpdatedText>
         )}
 
@@ -1155,6 +1155,7 @@ export interface ProfileActivityProps {
   data: TokenContributionData;
   totalActiveTimeMs?: number | null;
   sessionCount?: number | null;
+  mcpServers?: string[];
 }
 
 const ActivityContainer = styled.div`
@@ -1180,11 +1181,11 @@ const ActivityInner = styled.div`
   }
 `;
 
-export function ProfileActivity({ data, totalActiveTimeMs, sessionCount }: ProfileActivityProps) {
+export function ProfileActivity({ data, totalActiveTimeMs, sessionCount, mcpServers }: ProfileActivityProps) {
   return (
     <ActivityContainer>
       <ActivityInner>
-        <GraphContainer data={data} totalActiveTimeMs={totalActiveTimeMs} sessionCount={sessionCount} />
+        <GraphContainer data={data} totalActiveTimeMs={totalActiveTimeMs} sessionCount={sessionCount} mcpServers={mcpServers} />
       </ActivityInner>
     </ActivityContainer>
   );

--- a/packages/frontend/src/lib/db/migrations/0013_add_mcp_servers.sql
+++ b/packages/frontend/src/lib/db/migrations/0013_add_mcp_servers.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "submissions" ADD COLUMN "mcp_servers" jsonb;

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1779948193133,
       "tag": "0012_hash_browser_session_tokens",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1780172800000,
+      "tag": "0013_add_mcp_servers",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -198,6 +198,8 @@ export const submissions = pgTable(
     maxConcurrentSessions: integer("max_concurrent_sessions"),
     sessionCount: integer("session_count"),
 
+    mcpServers: jsonb("mcp_servers").$type<string[]>(),
+
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),


### PR DESCRIPTION
## Summary

Collect MCP server names from local config during CLI submit and display them as badges in the Statistics panel on user profile pages, below the existing Clients section.

## Changes

### CLI (Rust)
- Add `mcp` module to `tokscale-core` that discovers MCP server names from Claude, Cursor, and OpenCode configs
- Include `mcp_servers` field in the submit payload

### Backend (Next.js API)
- Add `mcp_servers` JSONB column to submissions table (migration 0013)
- Parse and store MCP servers on submit (always updates column so stale data can be cleared)
- Return `mcpServers` in the user profile API response

### Frontend
- Display MCPs as badges in the Statistics panel (below Clients)
- Thread `mcpServers` prop through ProfileActivity → GraphContainer → StatsPanel

### Misc
- Fix leaderboard hydration issue (mounted check)
- Fix profile Last Updated timezone to UTC

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show MCP servers on profile pages by collecting server names during CLI submit and storing them on the backend. Users see MCP badges under Clients in the Statistics panel.

- New Features
  - CLI: Discover MCP server names (names only) from Claude (incl. Desktop on macOS), Cursor, Kiro, and OpenCode skills via new `mcp` module in `@tokscale-core`; send `mcp_servers` in submit payload using `@tokscale-cli`.
  - Backend: Add `mcp_servers` JSONB column on `submissions`; persist on submit with null-safe extraction and array sanitization; return `mcpServers` in profile API.
  - Frontend: Thread `mcpServers` through ProfileActivity → GraphContainer → StatsPanel and render MCP badges below Clients via shared BadgeList. Also fixes leaderboard hydration and sets profile “Last Updated” to UTC.

- Migration
  - Run DB migration 0013 to add the `mcp_servers` column.
  - Update to the latest `@tokscale-cli`; existing profiles will show MCPs after the next submit.

<sup>Written for commit 875d8f873f13c12524de65a93fa8db848cadabaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

