### PR TITLE
fix(frontend): render source logos from shared registry

### DIFF
--- a/packages/frontend/__tests__/components/sourceLogo.test.tsx
+++ b/packages/frontend/__tests__/components/sourceLogo.test.tsx
@@ -1,0 +1,48 @@
+import { isValidElement, type ReactElement } from "react";
+import { describe, expect, it } from "vitest";
+import { SourceLogo } from "../../src/components/SourceLogo";
+import { SOURCE_LOGOS } from "../../src/lib/constants";
+import { SUPPORTED_CLIENT_TYPES } from "../../src/lib/types";
+
+type SourceLogoElementProps = {
+  alt?: string;
+  children?: string;
+  className?: string;
+  src?: string;
+};
+
+function renderSourceLogo(sourceId: string): ReactElement<SourceLogoElementProps> {
+  const element = SourceLogo({ sourceId, height: 16, className: "source-logo" });
+
+  expect(isValidElement(element)).toBe(true);
+  return element as ReactElement<SourceLogoElementProps>;
+}
+
+describe("SourceLogo", () => {
+  it("uses the shared logo registry for every supported base client", () => {
+    for (const client of SUPPORTED_CLIENT_TYPES) {
+      const element = renderSourceLogo(client);
+
+      expect(element.type).not.toBe("span");
+      expect(element.props.src).toBe(SOURCE_LOGOS[client]);
+      expect(element.props.alt).toBe(client);
+      expect(element.props.className).toBe("source-logo");
+    }
+  });
+
+  it("normalizes source ids before registry lookup", () => {
+    const element = renderSourceLogo("CodeBuff");
+
+    expect(element.type).not.toBe("span");
+    expect(element.props.src).toBe(SOURCE_LOGOS.codebuff);
+    expect(element.props.alt).toBe("CodeBuff");
+  });
+
+  it("falls back to text for unsupported variant ids", () => {
+    const element = renderSourceLogo("cc-mirror/example");
+
+    expect(element.type).toBe("span");
+    expect(element.props.children).toBe("cc-mirror/example");
+    expect(element.props.className).toBe("source-logo");
+  });
+});

--- a/packages/frontend/src/components/SourceLogo.tsx
+++ b/packages/frontend/src/components/SourceLogo.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import styled from "styled-components";
+import { SOURCE_LOGOS } from "@/lib/constants";
+import type { ClientType } from "@/lib/types";
 
 interface SourceLogoProps {
   sourceId: string;
@@ -20,59 +22,10 @@ const StyledImg = styled.img<{ $height: number }>`
 `;
 
 export function SourceLogo({ sourceId, height = 14, className = "" }: SourceLogoProps) {
-  const normalizedId = sourceId.toLowerCase();
-
-  const getLogoSrc = (id: string) => {
-    switch (id) {
-      case "opencode":
-        return "/assets/logos/opencode.png";
-      case "claude":
-        return "/assets/logos/claude.jpg";
-      case "codex":
-        return "/assets/logos/openai.jpg";
-      case "copilot":
-        return "https://raw.githubusercontent.com/junhoyeo/tokscale/main/.github/assets/client-copilot.jpg";
-      case "gemini":
-        return "/assets/logos/gemini.png";
-      case "cursor":
-        return "/assets/logos/cursor.jpg";
-      case "amp":
-        return "/assets/logos/amp.png";
-      case "droid":
-        return "/assets/logos/droid.png";
-      case "openclaw":
-        return "/assets/logos/openclaw.jpg";
-      case "hermes":
-        return "/assets/logos/hermes.png";
-      case "pi":
-        return "/assets/logos/pi.png";
-      case "kimi":
-        return "/assets/logos/kimi.png";
-      case "qwen":
-        return "/assets/logos/qwen.png";
-      case "roocode":
-        return "/assets/logos/roocode.png";
-      case "kilocode":
-      case "kilo":
-        return "/assets/logos/kilocode.png";
-      case "mux":
-        return "/assets/logos/mux.png";
-      case "crush":
-        return "https://raw.githubusercontent.com/junhoyeo/tokscale/main/.github/assets/client-crush.png";
-      case "kiro":
-        return "/assets/logos/kiro.ico";
-      case "zed":
-        return "https://raw.githubusercontent.com/junhoyeo/tokscale/main/.github/assets/client-zed.webp";
-      case "cline":
-        return "/assets/logos/cline.png";
-      case "synthetic":
-        return "/assets/logos/synthetic.png";
-      default:
-        return null;
-    }
-  };
-
-  const src = getLogoSrc(normalizedId);
+  const normalizedId = sourceId.toLowerCase() as ClientType;
+  const src = Object.prototype.hasOwnProperty.call(SOURCE_LOGOS, normalizedId)
+    ? SOURCE_LOGOS[normalizedId]
+    : null;
 
   if (!src) {
     return <span className={className}>{sourceId}</span>;


### PR DESCRIPTION
## Summary
- Reuse the existing `SOURCE_LOGOS` registry inside `SourceLogo` instead of maintaining a component-local logo switch.
- Add focused coverage that renders every `SUPPORTED_CLIENT_TYPES` entry through `SourceLogo`.
- Keep the text fallback for unsupported variant client ids such as `cc-mirror/...`.

## Why
The frontend already has a shared source logo registry with entries for every supported base client, but `SourceLogo` duplicated only part of that mapping locally. As new clients were added, that second mapping drifted and several supported clients could render without their branded image even though the canonical registry was already correct.

## Diff scope
- `packages/frontend/src/components/SourceLogo.tsx`
- `packages/frontend/__tests__/components/sourceLogo.test.tsx`

## Branch integrity
- Base branch: `main`
- Validated base SHA: `d4a3bd3299ea52b9d8bb8ad25ed8cb419fd3c535`
- Ahead/behind versus fetched `origin/main`: `1` ahead, `0` behind
- Merge base: `d4a3bd3299ea52b9d8bb8ad25ed8cb419fd3c535`
- Diff proof was computed against the fetched base.

## Validation
- Validation mode: Mode 2 - narrow frontend runtime change, because the shared logo component behavior changes while staying localized to one component path.
- `bun install --frozen-lockfile`: PASS.
- `bun --cwd packages/frontend test __tests__/components/sourceLogo.test.tsx __tests__/lib/clientRegistry.test.ts`: PASS, 2 files and 6 tests.
- `bun --cwd packages/frontend test`: PASS, 49 files and 394 tests.
- `bun run lint -- src/components/SourceLogo.tsx __tests__/components/sourceLogo.test.tsx` from `packages/frontend`: PASS.
- `git diff --check`: PASS.
- `git diff --cached --check`: PASS.
- Ledger: not applicable - not required for selected validation mode/change family.
- Version: not applicable - not required for selected validation mode/change family.
- Not run: full frontend build - not required for selected validation mode; full frontend tests and targeted lint cover the changed component path.

## Remote gates
Pending - GitHub checks will run after the PR is created.

## Rollback
Rollback: revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks
Remote CI has not run yet because this page is prepared before PR creation.

