### PR TITLE
fix(submission): raise per-day token/cost ceilings and add warn bands

### DIFF
--- a/packages/frontend/__tests__/api/submit.test.ts
+++ b/packages/frontend/__tests__/api/submit.test.ts
@@ -441,8 +441,7 @@ describe('POST /api/submit - Client-Level Merge', () => {
 
   describe("Submission validation guardrails", () => {
     it("accepts internally consistent high-volume one-day token totals", () => {
-      // Cap is 10B (MAX_DAILY_TOKENS). Use a value just under to confirm the
-      // cap boundary is respected without triggering a rejection.
+      // Well under the warn band (10B). Confirms ordinary high days stay clean.
       const payload = createValidationPayload({
         totalTokens: 8_000_000_000,
         totalCost: 800,
@@ -461,7 +460,29 @@ describe('POST /api/submit - Client-Level Merge', () => {
       expect(result.errors).toHaveLength(0);
     });
 
-    it("rejects one-day fabricated token totals above the submission cap", () => {
+    it("accepts a real cache-read-heavy day above the prior 10B/$10k caps", () => {
+      // Single-client day that the old caps rejected: 12.9B tokens (mostly
+      // cacheRead) and $11,185.52, with a plausible ~$0.87/M blended rate. Sits
+      // in the warn band for both tokens and cost, so it logs but does not reject.
+      const payload = createValidationPayload({
+        totalTokens: 12_910_573_877,
+        totalCost: 11_185.52,
+        tokenBreakdown: {
+          input: 1_000_000_000,
+          output: 700_000_000,
+          cacheRead: 11_000_000_000,
+          cacheWrite: 200_000_000,
+          reasoning: 10_573_877,
+        },
+      });
+
+      const result = validateSubmission(payload);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("rejects one-day fabricated token totals above the hard ceiling", () => {
       const payload = createValidationPayload({
         totalTokens: 1_000_000_000_000,
         tokenBreakdown: {
@@ -477,8 +498,28 @@ describe('POST /api/submit - Client-Level Merge', () => {
 
       expect(result.valid).toBe(false);
       expect(result.errors.join("\n")).toContain("Daily token total exceeds");
-      expect(result.errors.join("\n")).toContain("10,000,000,000");
+      expect(result.errors.join("\n")).toContain("50,000,000,000");
       expect(result.errors.join("\n")).toContain("Client claude");
+    });
+
+    it("rejects one-day cost above the hard ceiling", () => {
+      const payload = createValidationPayload({
+        totalTokens: 1_000_000_000,
+        totalCost: 60_000,
+        tokenBreakdown: {
+          input: 600_000_000,
+          output: 200_000_000,
+          cacheRead: 150_000_000,
+          cacheWrite: 50_000_000,
+          reasoning: 0,
+        },
+      });
+
+      const result = validateSubmission(payload);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.join("\n")).toContain("Daily cost exceeds");
+      expect(result.errors.join("\n")).toContain("50,000");
     });
 
     it("keeps structural validation for high-volume payloads", () => {

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -14,13 +14,31 @@ import { SUPPORTED_CLIENT_TYPES } from "../types";
 // SCHEMAS
 // ============================================================================
 
-// Hard cap: 10B tokens per day. f6aeca7 raised this to 100B; reverting because
-// 100B/day is implausible for any single device and would hide data errors.
-// A warn band at 5B logs structured warnings for high-but-plausible volumes
-// without rejecting them (see warnIfHighDailyTokens below).
-const MAX_DAILY_TOKENS = 10_000_000_000;
-const WARN_DAILY_TOKENS = 5_000_000_000;
-const MAX_DAILY_COST = 10_000;
+// Per-day sanity ceilings for self-reported usage. These are anti-data-error
+// guards, not throughput models. Two things make the old 10B-token / $10k-cost
+// limits reachable in a single legitimate day:
+//   1. cacheRead dominates modern agentic usage. Tools re-read large contexts
+//      every turn, so cacheRead routinely runs 10-100x output tokens. A day's
+//      token total is mostly cache reads, which carry little to no cost.
+//   2. Heavy parallel multi-agent runs on high-end hardware fan out dozens of
+//      concurrent sessions, multiplying a single device's daily volume.
+//
+// Two-tier design (the token band already worked this way; cost now matches):
+//   - WARN_* : high-but-plausible. Logs a structured warning for visibility but
+//              does NOT reject, so real outliers still submit and anomalies stay
+//              greppable in server logs.
+//   - MAX_*  : hard reject. Still catches order-of-magnitude data errors (a
+//              stray 10x, a unit bug) instead of hiding them behind a silent pass.
+//
+// f6aeca7 raised the token cap to 100B with no warn band and was reverted for
+// hiding data errors. This keeps a hard ceiling (50B) AND a warn band, so the
+// visibility concern is answered rather than removed. The real fraud backstop is
+// MAX_COST_PER_MILLION_TOKENS below, left unchanged on purpose: it rejects
+// "huge tokens + huge cost" fabrications regardless of these per-day caps.
+const MAX_DAILY_TOKENS = 50_000_000_000;
+const WARN_DAILY_TOKENS = 10_000_000_000;
+const MAX_DAILY_COST = 50_000;
+const WARN_DAILY_COST = 10_000;
 const MAX_COST_PER_MILLION_TOKENS = 10_000;
 const COST_RELATIVE_TOLERANCE = 0.01;
 const COST_ABSOLUTE_TOLERANCE = 0.1;
@@ -444,6 +462,13 @@ export function validateSubmission(data: unknown): ValidationResult {
       errors.push(
         `Daily cost exceeds ${MAX_DAILY_COST.toLocaleString("en-US")} on ${day.date}: ${day.totals.cost.toFixed(2)}`
       );
+    } else if (day.totals.cost > WARN_DAILY_COST) {
+      console.warn("[submission] high daily cost", {
+        date: day.date,
+        cost: day.totals.cost,
+        warnThreshold: WARN_DAILY_COST,
+        cap: MAX_DAILY_COST,
+      });
     }
 
     {


### PR DESCRIPTION
## Problem

`validateSubmission` rejects legitimate single-day usage. The per-day caps (`MAX_DAILY_TOKENS = 10B`, `MAX_DAILY_COST = $10k`) are applied per day, per client, and to `maxCostInSingleDay`, so one heavy day fails with a wall of errors:

```
Summary maxCostInSingleDay exceeds 10,000: 11185.52
Daily token total exceeds 10,000,000,000 on 2026-06-05: 12,910,573,877
Daily cost exceeds 10,000 on 2026-06-05: 11185.52
Client codex on 2026-06-05: token total exceeds 10,000,000,000: 12,910,573,877
Client codex on 2026-06-05: cost exceeds 10,000: 11185.52
```

These run server-side, so the CLI just surfaces the rejection and the user is locked out of submitting. Two things make the old limits reachable in a single real day:

1. **cacheRead dominates agentic usage.** Tools re-read large contexts every turn, so `cacheRead` routinely runs 10-100x `output` while carrying little to no cost. A day's token total is mostly cache reads. The example above is 12.9B tokens at ~$0.87/M blended, which is a normal rate, not an inflated one.
2. **Parallel multi-agent runs.** Fanning out dozens of concurrent sessions on one high-end device multiplies a single device's daily volume.

## Changes

Extend the existing two-tier pattern (the token band already worked this way; cost now matches it):

- `MAX_DAILY_TOKENS` 10B -> 50B, `WARN_DAILY_TOKENS` 5B -> 10B
- `MAX_DAILY_COST` $10k -> $50k, plus a new `WARN_DAILY_COST` $10k warn band (logs `[submission] high daily cost`, mirroring the existing high-token warning)
- `MAX_COST_PER_MILLION_TOKENS` unchanged at $10k/M

`WARN_*` logs a structured warning for visibility but does not reject, so real outliers submit and anomalies stay greppable in logs. `MAX_*` still hard-rejects order-of-magnitude data errors. Unlike f6aeca7 (which raised the token cap to 100B with no warn band and was reverted for hiding data errors), this keeps a hard ceiling **and** a warn band. The real fraud backstop, `MAX_COST_PER_MILLION_TOKENS`, is left unchanged on purpose: it rejects "huge tokens + huge cost" fabrications regardless of these per-day caps.

## Test plan

`bun run --cwd packages/frontend test __tests__/api/submit.test.ts` -> 53 passed.

Added to the existing guardrail suite:

- accepts a real cache-read-heavy day (12.9B tokens / $11,185.52, single client) that the old caps rejected
- still rejects a day above the 50B token ceiling (assertion updated to the new value)
- still rejects a day above the $50k cost ceiling

Unchanged guardrails still pass: cost-per-million, tokenless-cost, structural/schema validation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relaxed daily submission caps and added warn bands to prevent legitimate high-volume single-day usage from being rejected while keeping hard ceilings and clear log visibility.

- **Bug Fixes**
  - Raised per-day ceilings: tokens 10B -> 50B (warn at 10B), cost $10k -> $50k (warn at $10k).
  - Added structured warning for high daily cost; still hard-reject above caps.
  - Kept `MAX_COST_PER_MILLION_TOKENS` at $10k/M.
  - Updated tests: accept a 12.9B tokens / $11,185 day; still reject >50B tokens and >$50k cost.

<sup>Written for commit 9ae3f6bfa9b41244ebd584bd131a45af018b7233. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

