### PR TITLE
fix(docs): remove hard-coded maintainer Git identity from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ This applies to all GitHub-content authoring through the CLI — PR bodies, issu
 
 ## Git Identity & Merge Discipline
 
-- Before making any commit, verify the local git identity is exactly `Junho Yeo <i@junho.io>`. If it is not, set `git config user.name "Junho Yeo"` and `git config user.email "i@junho.io"` before committing.
+- Before any commit, inspect the effective Git identity (`git config user.name` / `user.email`) and remotes. If the identity does not match the contributor or expected automation account for the current branch, stop and ask for confirmation.
 - Never commit as worker/agent identities such as `worker1`, `worker2`, `worker3`, or `*@example.invalid`.
 - When merging pull requests through `gh`, use squash merge (`gh pr merge --squash ...`) unless the user explicitly requests another merge strategy.
 - Before merging, verify the squash commit title is the intended conventional PR title and does not contain worker/agent/internal review jargon.


### PR DESCRIPTION
Closes #644

## Problem

`AGENTS.md` previously instructed agents to hard-code the maintainer identity (`Junho Yeo <i@junho.io>`) before every commit. This is risky as a repository-level instruction — external contributors or coding agents working from forks may follow this rule and accidentally author commits as the maintainer instead of the actual contributor, causing incorrect attribution, confusing audit history, and apparent impersonation.

## Fix

Replaced the hard-coded identity instruction with a safer rule that inspects the effective Git identity and asks for confirmation when it doesn't match the current contributor, without forcing any specific maintainer identity.

**Before:**
> Before making any commit, verify the local git identity is exactly `Junho Yeo <i@junho.io>`. If it is not, set `git config user.name "Junho Yeo"` and `git config user.email "i@junho.io"` before committing.

**After:**
> Before any commit, inspect the effective Git identity (`git config user.name` / `user.email`) and remotes. If the identity does not match the contributor or expected automation account for the current branch, stop and ask for confirmation. Do not hard-code a maintainer identity in repository-level instructions.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the hard-coded maintainer Git identity from `AGENTS.md` and replaced it with guidance to check the effective Git user and confirm if it doesn’t match the contributor or automation account. This prevents accidental impersonation and keeps commit attribution accurate, especially for forks and external contributors.

<sup>Written for commit a456fcec3de0ff6946d447c8d6eba1db75bea8f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

