### PR TITLE
fix(db): reorder 0012 timestamp after 0011 so drizzle-kit applies it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,8 @@ Migrations 0010 and 0011 have round-number hand-edited timestamps (`"when": 1780
 
 If two branches generate migrations with the same index, resolve the conflict by re-running `drizzle-kit generate` on the branch that was merged later — do not manually renumber files or edit `_journal.json`.
 
+**Never edit the SQL of a migration file after it has been applied to any database.** drizzle stores the SHA256 of the migration content in `drizzle.__drizzle_migrations` on first apply. If the local file content changes (even just a comment), the local hash diverges from the stored hash and drizzle-kit migrate will treat the migration as missing and attempt to re-apply it — which fails on idempotent-unsafe DDL. If you need to document a migration after the fact (lock-window risk, rollback notes, anything), put the commentary in a sidecar `0NNN_*.md` next to the .sql, in `schema.ts`, or in this file — never as comments inside the applied .sql.
+
 ## Agent Command Execution
 
 - When running `tokscale` CLI commands from an automated agent (tests, CI, or tool-driven shells), always pass `--no-spinner` unless spinner behavior is the thing being tested.

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -89,7 +89,7 @@
     {
       "idx": 12,
       "version": "7",
-      "when": 1779948193133,
+      "when": 1780150000000,
       "tag": "0012_hash_browser_session_tokens",
       "breakpoints": true
     },


### PR DESCRIPTION
## Why prod was 500'ing

After merging #675, every `/api/auth/session` and `/leaderboard` SSR request started failing with `column sessions.token_hash does not exist`. Migration `0012_hash_browser_session_tokens.sql` (from #625) renames `sessions.token → token_hash`, but it never ran on production even though `drizzle-kit migrate` claimed success.

## Root cause

The 2026-05-25 schema audit hand-rolled `when=1780000000000` (0010) and `1780086400000` (0011). When 0012 was generated by `drizzle-kit generate` later, it got the real-clock value `when=1779948193133` (Feb 24, 2026), which is **earlier** than the hand-rolled 0010/0011 timestamps (Feb 25).

`drizzle-kit migrate` sorts the journal by `when` before applying. On any DB where 0010/0011 had already been applied, drizzle considered the prefix-through-0011 already-applied and silently skipped 0012. Then 0013 (mcp_servers) applied cleanly because its `when` is the latest. Result: prod's `sessions` table never got renamed.

## Fix

Bump `0012.when` to `1780150000000` so it sits between `0011.when=1780086400000` and `0013.when=1780172800000`, restoring monotonic ordering.

## Already done on production

- Migration `0012` SQL applied by hand against prod (sessions table now has `token_hash`)
- `drizzle.__drizzle_migrations` row inserted for `0012` with the matching SHA256 (`782891d5...`) and the new `when=1780150000000`, so `drizzle-kit migrate` will not try to re-apply

## Test plan
- [x] `/api/auth/session` → 200 on prod (was 500)
- [x] `/leaderboard` SSR → renders 50 ranked users, no console errors (was Server Components render error)
- [ ] On next preview deploy: confirm `drizzle-kit migrate` reports zero migrations to apply (the matching journal row should already be in `__drizzle_migrations`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered migration 0012 by bumping its `when` so `drizzle-kit` applies it after 0011 and before 0013, fixing the `sessions.token → token_hash` rename and the 500s. Added a docs rule: never edit applied migration SQL; use a sidecar note to avoid hash mismatches that make `drizzle-kit` try to re-apply.

<sup>Written for commit 38de12eac21f1b365d5f3341b64619f8a0601427. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

