### PR TITLE
fix(pricing): resolve suffixed opus-4-8 ids instead of degrading to legacy opus-4

### DIFF
--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -1535,8 +1535,12 @@ where
 }
 
 fn strips_claude_numeric_minor(candidate: &str, first_stripped_segment: &str) -> bool {
-    !first_stripped_segment.is_empty()
-        && first_stripped_segment.chars().all(|c| c.is_ascii_digit())
+    // Only block stripping when the segment is a single-digit minor version
+    // (e.g. "8" from "claude-opus-4-8"). Multi-digit segments like dates
+    // ("20260601") or brackets ("1m") should not block suffix stripping.
+    first_stripped_segment.len() == 1
+        && first_stripped_segment.as_bytes()[0].is_ascii_digit()
+        && first_stripped_segment.as_bytes()[0] != b'0'
         && (candidate.contains("claude")
             || candidate.contains("opus")
             || candidate.contains("sonnet")
@@ -1550,12 +1554,22 @@ fn has_unrecognized_claude_four_minor(model_id: &str) -> bool {
         || model_id.contains("sonnet")
         || model_id.contains("haiku"))
         && contains_delimited_major_minor(model_id, '4')
-        && !contains_delimited_fragment(model_id, "4.5")
-        && !contains_delimited_fragment(model_id, "4-5")
-        && !contains_delimited_fragment(model_id, "4.6")
-        && !contains_delimited_fragment(model_id, "4-6")
-        && !contains_delimited_fragment(model_id, "4.7")
-        && !contains_delimited_fragment(model_id, "4-7")
+        && !has_known_claude_four_minor(model_id)
+}
+
+/// Returns true if `model_id` contains a recognized Claude 4.x minor version
+/// (single digit 1–9, e.g. `4-5`, `4.8`).
+fn has_known_claude_four_minor(model_id: &str) -> bool {
+    let parts: Vec<&str> = model_id
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|p| !p.is_empty())
+        .collect();
+    for window in parts.windows(2) {
+        if window[0] == "4" && is_single_digit_minor(window[1]) {
+            return true;
+        }
+    }
+    false
 }
 
 /// Attempts to find a model by progressively stripping leading segments.
@@ -4492,5 +4506,117 @@ mod tests {
             r_unknown.matched_key, r_none.matched_key,
             "unknown hint via source_and_provider should behave like None"
         );
+    }
+
+    /// Suffixed opus-4-8 ids (dated snapshot, bracket tag) should resolve to
+    /// `claude-opus-4-8` when the dataset carries that key, NOT degrade to
+    /// legacy `claude-opus-4` ($15/$75 per M).
+    /// Regression test for https://github.com/junhoyeo/tokscale/issues/631
+    #[test]
+    fn test_opus_4_8_dated_snapshot_resolves_to_4_8() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-opus-4-8".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000_005),
+                output_cost_per_token: Some(0.000_025),
+                ..Default::default()
+            },
+        );
+        // Legacy entry that should NOT be matched
+        litellm.insert(
+            "claude-opus-4".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000_015),
+                output_cost_per_token: Some(0.000_075),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        // Dated snapshot
+        let r = lookup.lookup("claude-opus-4-8-20260601").unwrap();
+        assert_eq!(r.matched_key, "claude-opus-4-8");
+        assert!((r.pricing.input_cost_per_token.unwrap() - 0.000_005).abs() < 1e-10);
+
+        // Bracket tag
+        let r = lookup.lookup("claude-opus-4-8[1m]").unwrap();
+        assert_eq!(r.matched_key, "claude-opus-4-8");
+        assert!((r.pricing.input_cost_per_token.unwrap() - 0.000_005).abs() < 1e-10);
+
+        // Bare id still works
+        let r = lookup.lookup("claude-opus-4-8").unwrap();
+        assert_eq!(r.matched_key, "claude-opus-4-8");
+    }
+
+    /// Suffixed opus-4-9 (not yet in any dataset) should return None rather
+    /// than silently degrading to legacy claude-opus-4.
+    #[test]
+    fn test_opus_4_9_unknown_suffix_returns_none() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-opus-4".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000_015),
+                output_cost_per_token: Some(0.000_075),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        // No 4-9 key in dataset → should not silently fall back to 4
+        assert!(lookup.lookup("claude-opus-4-9-20270101").is_none());
+        assert!(lookup.lookup("claude-opus-4-9").is_none());
+    }
+
+    /// Existing 4-5 / 4-6 / 4-7 suffix handling must keep working.
+    #[test]
+    fn test_opus_4_7_dated_snapshot_still_works() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-opus-4-7".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000_01),
+                output_cost_per_token: Some(0.000_05),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        let r = lookup.lookup("claude-opus-4-7-20260301").unwrap();
+        assert_eq!(r.matched_key, "claude-opus-4-7");
+    }
+
+    /// `strips_claude_numeric_minor` must allow date suffixes (multi-digit) to
+    /// be stripped while still protecting single-digit minor versions.
+    #[test]
+    fn test_strip_suffix_allows_date_not_minor() {
+        let mut do_lookup = |id: &str| -> Option<()> {
+            if id == "claude-opus-4-8" { Some(()) } else { None }
+        };
+
+        // Date suffix should be strippable
+        let result = try_strip_unknown_suffix("claude-opus-4-8-20260601", |id| {
+            do_lookup(id).map(|_| LookupResult {
+                pricing: ModelPricing::default(),
+                source: "test".into(),
+                matched_key: id.into(),
+            })
+        });
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().matched_key, "claude-opus-4-8");
+
+        // Single-digit minor must NOT be stripped from a bare id
+        let result = try_strip_unknown_suffix("claude-opus-4-8", |id| {
+            do_lookup(id).map(|_| LookupResult {
+                pricing: ModelPricing::default(),
+                source: "test".into(),
+                matched_key: id.into(),
+            })
+        });
+        assert!(result.is_none());
     }
 }


### PR DESCRIPTION
## Problem

`has_unrecognized_claude_four_minor()` hardcodes only `4-5`, `4-6`, `4-7` as recognized Claude 4.x minor versions. Any new minor (4-8, 4-9, 5.x ...) triggers this guard, which **blocks** `try_strip_unknown_suffix()` from ever running. Suffixed ids like `claude-opus-4-8-20260601` or `claude-opus-4-8[1m]` fall through to fuzzy matching, which resolves to the legacy `claude-opus-4` entry at **$15/$75 per M** — a 3× overcharge vs the correct $5/$25.

Every new Claude minor version will silently trigger this overcharge until a developer manually adds the version to the hardcoded allowlist.

## Root Cause

Two functions collaborate to produce the wrong result:

1. **`has_unrecognized_claude_four_minor`** (line 1551): returns `true` for any Claude model with `4.x` where x ∉ {5,6,7}. This causes `try_strip_unknown_suffix` to bail out at its first line (line 1508), so suffixes like `-20260601` or `[1m]` are never peeled.

2. **`strips_claude_numeric_minor`** (line 1537): treats **any all-digit segment** as a numeric minor version and blocks stripping. For `claude-opus-4-8-20260601`, stripping the date suffix produces candidate `claude-opus-4-8`, but the guard sees `"20260601"` is all-digits and blocks it — even though it's a date, not a minor version.

## Fix

### 1. Replace hardcoded allowlist with generic minor detection

```rust
// Before: hardcoded 4-5, 4-6, 4-7
&& !contains_delimited_fragment(model_id, "4-5")
&& !contains_delimited_fragment(model_id, "4-6")
&& !contains_delimited_fragment(model_id, "4-7")

// After: recognizes any single-digit minor 1–9
&& !has_known_claude_four_minor(model_id)
```

`has_known_claude_four_minor` reuses the existing `is_single_digit_minor` helper (already used by `normalize_claude_opus_4_minor`) to recognize `4-1` through `4-9`. New minors no longer need manual entries.

### 2. Tighten `strips_claude_numeric_minor` to single-digit segments only

```rust
// Before: any all-digit segment blocks stripping
first_stripped_segment.chars().all(|c| c.is_ascii_digit())

// After: only single-digit 1–9 blocks stripping
first_stripped_segment.len() == 1
    && first_stripped_segment.as_bytes()[0].is_ascii_digit()
    && first_stripped_segment.as_bytes()[0] != b'0'
```

Multi-digit segments like dates (`20260601`) now pass through, so suffix stripping can peel dated snapshots. Single-digit minors (`8`) still correctly block stripping of the minor version itself.

## Verification

The fix resolves all three failing repros from #631:

| Input | Before | After |
|---|---|---|
| `claude-opus-4-8` | ✅ $5/$25 (exact match) | ✅ $5/$25 (exact match) |
| `claude-opus-4-8[1m]` | ❌ $15/$75 (legacy) | ✅ $5/$25 |
| `claude-opus-4-8-20260601` | ❌ $15/$75 (legacy) | ✅ $5/$25 |

Existing tests for `4-5`, `4-6`, `4-7`, `opus-14-6`, and the bare `claude-opus-4-8` → None case are unaffected.

New tests added:
- `test_opus_4_8_dated_snapshot_resolves_to_4_8` — dated + bracket + bare
- `test_opus_4_9_unknown_suffix_returns_none` — future minor returns None, not legacy
- `test_opus_4_7_dated_snapshot_still_works` — existing minor still works
- `test_strip_suffix_allows_date_not_minor` — unit test for `strips_claude_numeric_minor`

Closes #631

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix pricing lookup for suffixed Claude 4.x IDs so `claude-opus-4-8-20260601` and `claude-opus-4-8[1m]` resolve to `claude-opus-4-8` instead of falling back to legacy `claude-opus-4`. Prevents a 3x overcharge and future‑proofs new 4.x minors.

- **Bug Fixes**
  - Replaced the hardcoded allowlist with `has_known_claude_four_minor`, which recognizes any single‑digit 4.x minor (1–9).
  - Tightened `strips_claude_numeric_minor` to block only single‑digit segments; multi‑digit dates and tags now strip correctly so suffixed IDs resolve.
  - Unknown minors (e.g., `4-9`) now return None instead of silently degrading to legacy; added tests to cover dated, bracketed, and existing minors.

<sup>Written for commit b8f876b1a6cf1dc5e583ac3771003a770d1ab7df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

