### PR TITLE
fix(ci): register gjc client registry entries and apply cargo fmt

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -6112,7 +6112,10 @@ mod tests {
         // both the ClientId<->ClientFilter conversions and the id string.
         assert_eq!(ClientFilter::Gjc.as_filter_str(), "gjc");
         assert_eq!(ClientFilter::Gjc.to_client_id(), Some(ClientId::Gjc));
-        assert_eq!(ClientFilter::from_client_id(ClientId::Gjc), ClientFilter::Gjc);
+        assert_eq!(
+            ClientFilter::from_client_id(ClientId::Gjc),
+            ClientFilter::Gjc
+        );
         assert_eq!(ClientFilter::Gjc.as_filter_str(), ClientId::Gjc.as_str());
     }
 

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -2923,7 +2923,9 @@ fn test_models_with_client_filter_gjc() {
     );
 
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    let entries = json["entries"].as_array().expect("entries must be an array");
+    let entries = json["entries"]
+        .as_array()
+        .expect("entries must be an array");
 
     assert!(
         !entries.is_empty(),
@@ -2940,9 +2942,12 @@ fn test_models_with_client_filter_gjc() {
     }
 
     // The fixture model claude-sonnet-4 must appear.
-    let has_sonnet = entries
-        .iter()
-        .any(|e| e["model"].as_str().unwrap_or("").contains("claude-sonnet-4"));
+    let has_sonnet = entries.iter().any(|e| {
+        e["model"]
+            .as_str()
+            .unwrap_or("")
+            .contains("claude-sonnet-4")
+    });
     assert!(
         has_sonnet,
         "expected claude-sonnet-4 in gjc entries; got: {entries:?}"
@@ -2968,7 +2973,9 @@ fn test_client_filter_gjc_empty_is_clean() {
     );
 
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    let entries = json["entries"].as_array().expect("entries must be an array");
+    let entries = json["entries"]
+        .as_array()
+        .expect("entries must be an array");
     assert!(
         entries.is_empty(),
         "expected zero entries for empty gjc fixture, got: {entries:?}"
@@ -2995,7 +3002,9 @@ fn test_client_filter_gjc_isolation() {
     );
 
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    let entries = json["entries"].as_array().expect("entries must be an array");
+    let entries = json["entries"]
+        .as_array()
+        .expect("entries must be an array");
 
     // No gjc entry should leak through when filtering for claude.
     for entry in entries {

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -3127,8 +3127,7 @@ mod tests {
         // depth 1: <slug>/<id>.jsonl
         setup_mock_gjc_session(home, "--work--proj--", "sess-001.jsonl");
         // depth 2: <slug>/<session>/N-Pass.jsonl
-        let depth2 = home
-            .join(".gjc/agent/sessions/--work--proj--/sess-001");
+        let depth2 = home.join(".gjc/agent/sessions/--work--proj--/sess-001");
         fs::create_dir_all(&depth2).unwrap();
         File::create(depth2.join("0-Pass.jsonl")).unwrap();
 
@@ -3146,18 +3145,18 @@ mod tests {
         // read only the home fallback.
         let other = TempDir::new().unwrap();
         unsafe {
-            std::env::set_var("GJC_CODING_AGENT_DIR", other.path().to_string_lossy().as_ref())
+            std::env::set_var(
+                "GJC_CODING_AGENT_DIR",
+                other.path().to_string_lossy().as_ref(),
+            )
         };
 
         let dir = TempDir::new().unwrap();
         let home = dir.path();
         setup_mock_gjc_session(home, "slug", "a.jsonl");
 
-        let result = scan_all_clients_with_env_strategy(
-            home.to_str().unwrap(),
-            &["gjc".to_string()],
-            false,
-        );
+        let result =
+            scan_all_clients_with_env_strategy(home.to_str().unwrap(), &["gjc".to_string()], false);
         assert_eq!(result.get(ClientId::Gjc).len(), 1);
 
         restore_env("GJC_CODING_AGENT_DIR", previous);
@@ -3176,9 +3175,7 @@ mod tests {
         fs::create_dir_all(&override_sessions).unwrap();
         File::create(override_sessions.join("o.jsonl")).unwrap();
 
-        unsafe {
-            std::env::set_var("GJC_CODING_AGENT_DIR", agent_dir.to_string_lossy().as_ref())
-        };
+        unsafe { std::env::set_var("GJC_CODING_AGENT_DIR", agent_dir.to_string_lossy().as_ref()) };
 
         let result = scan_all_clients(home.to_str().unwrap(), &["gjc".to_string()]);
         assert!(result
@@ -3203,9 +3200,7 @@ mod tests {
         // Point the env var at <home>/.gjc/agent so root (1) and root (4)
         // resolve to the same directory.
         let agent_dir = home.join(".gjc/agent");
-        unsafe {
-            std::env::set_var("GJC_CODING_AGENT_DIR", agent_dir.to_string_lossy().as_ref())
-        };
+        unsafe { std::env::set_var("GJC_CODING_AGENT_DIR", agent_dir.to_string_lossy().as_ref()) };
 
         let result = scan_all_clients(home.to_str().unwrap(), &["gjc".to_string()]);
         assert_eq!(result.get(ClientId::Gjc).len(), 1);
@@ -3242,7 +3237,10 @@ mod tests {
         File::create(sessions.join("x.jsonl")).unwrap();
 
         unsafe {
-            std::env::set_var("GJC_CONFIG_DIR", config_dir.path().to_string_lossy().as_ref())
+            std::env::set_var(
+                "GJC_CONFIG_DIR",
+                config_dir.path().to_string_lossy().as_ref(),
+            )
         };
 
         let result = scan_all_clients(home_dir.path().to_str().unwrap(), &["gjc".to_string()]);
@@ -3288,9 +3286,7 @@ mod tests {
         fs::create_dir_all(&sessions).unwrap();
         File::create(sessions.join("x.jsonl")).unwrap();
 
-        unsafe {
-            std::env::set_var("PI_CONFIG_DIR", pi_config.path().to_string_lossy().as_ref())
-        };
+        unsafe { std::env::set_var("PI_CONFIG_DIR", pi_config.path().to_string_lossy().as_ref()) };
 
         let result = scan_all_clients(home_dir.path().to_str().unwrap(), &["gjc".to_string()]);
         assert!(
@@ -3337,9 +3333,7 @@ mod tests {
         fs::create_dir_all(&sessions).unwrap();
         File::create(sessions.join("x.jsonl")).unwrap();
 
-        unsafe {
-            std::env::set_var("XDG_DATA_HOME", xdg_data.path().to_string_lossy().as_ref())
-        };
+        unsafe { std::env::set_var("XDG_DATA_HOME", xdg_data.path().to_string_lossy().as_ref()) };
 
         let result = scan_all_clients(home_dir.path().to_str().unwrap(), &["gjc".to_string()]);
         assert!(
@@ -3389,9 +3383,7 @@ mod tests {
         fs::create_dir_all(&xdg_sessions).unwrap();
         File::create(xdg_sessions.join("xdg.jsonl")).unwrap();
 
-        unsafe {
-            std::env::set_var("XDG_DATA_HOME", xdg_data.path().to_string_lossy().as_ref())
-        };
+        unsafe { std::env::set_var("XDG_DATA_HOME", xdg_data.path().to_string_lossy().as_ref()) };
 
         let result = scan_all_clients(home_dir.path().to_str().unwrap(), &["gjc".to_string()]);
         assert_eq!(
@@ -3436,7 +3428,10 @@ mod tests {
 
         unsafe {
             std::env::remove_var("GJC_CODING_AGENT_DIR");
-            std::env::set_var("GJC_CONFIG_DIR", config_dir.path().to_string_lossy().as_ref());
+            std::env::set_var(
+                "GJC_CONFIG_DIR",
+                config_dir.path().to_string_lossy().as_ref(),
+            );
             std::env::set_var("XDG_DATA_HOME", xdg_data.path().to_string_lossy().as_ref());
         }
 
@@ -3480,7 +3475,10 @@ mod tests {
 
         // Point GJC_CODING_AGENT_DIR at a path that does not exist.
         unsafe {
-            std::env::set_var("GJC_CODING_AGENT_DIR", "/nonexistent/path/that/does/not/exist");
+            std::env::set_var(
+                "GJC_CODING_AGENT_DIR",
+                "/nonexistent/path/that/does/not/exist",
+            );
             std::env::remove_var("GJC_CONFIG_DIR");
             std::env::remove_var("PI_CONFIG_DIR");
             std::env::remove_var("XDG_DATA_HOME");

--- a/crates/tokscale-core/src/sessions/gjc.rs
+++ b/crates/tokscale-core/src/sessions/gjc.rs
@@ -291,7 +291,10 @@ not valid json at all
         let file = create_test_file(content);
         let messages = parse_gjc_file(file.path());
         assert_eq!(messages.len(), 1);
-        assert_eq!(messages[0].dedup_key, Some("gjc_ses_005:msg_abc".to_string()));
+        assert_eq!(
+            messages[0].dedup_key,
+            Some("gjc_ses_005:msg_abc".to_string())
+        );
     }
 
     #[test]
@@ -302,7 +305,10 @@ not valid json at all
         let messages = parse_gjc_file(file.path());
         assert_eq!(messages.len(), 1);
         let key = messages[0].dedup_key.clone().unwrap();
-        assert!(key.starts_with("gjc:gjc_ses_006:1767225601000:gpt-4o:10-5:"), "key={key}");
+        assert!(
+            key.starts_with("gjc:gjc_ses_006:1767225601000:gpt-4o:10-5:"),
+            "key={key}"
+        );
     }
 
     #[test]
@@ -401,7 +407,11 @@ not valid json at all
 {"type":"message","id":"msg_neg","message":{"role":"assistant","model":"m","provider":"p","timestamp":1700000001000,"usage":{"input":-100,"output":-50,"cacheRead":-10,"cacheWrite":-5,"cost":{"total":0.0}}}}"#;
         let file = create_test_file(content);
         let messages = parse_gjc_file(file.path());
-        assert_eq!(messages.len(), 1, "message should be parsed despite negative tokens");
+        assert_eq!(
+            messages.len(),
+            1,
+            "message should be parsed despite negative tokens"
+        );
         let t = &messages[0].tokens;
         assert_eq!(t.input, 0, "negative input clamped to 0");
         assert_eq!(t.output, 0, "negative output clamped to 0");
@@ -417,7 +427,10 @@ not valid json at all
         let file = create_test_file(content);
         let messages = parse_gjc_file(file.path());
         assert_eq!(messages.len(), 1);
-        assert_eq!(messages[0].cost, 0.0, "negative cost.total must fall back to 0.0");
+        assert_eq!(
+            messages[0].cost, 0.0,
+            "negative cost.total must fall back to 0.0"
+        );
     }
 
     /// (g) cost.total absent entirely -> 0.0.
@@ -439,14 +452,16 @@ not valid json at all
         let line = r#"{"type":"message","id":"replay_msg","message":{"role":"assistant","model":"m","provider":"p","timestamp":1700000001000,"usage":{"input":10,"output":5,"cost":{"total":0.05}}}}"#;
         let content = format!(
             "{}\n{}\n{}",
-            r#"{"type":"session","id":"gjc_ses_replay","cwd":"/tmp"}"#,
-            line,
-            line
+            r#"{"type":"session","id":"gjc_ses_replay","cwd":"/tmp"}"#, line, line
         );
         let file = create_test_file(&content);
         let messages = parse_gjc_file(file.path());
         // Both lines parse successfully; it's the caller's job to dedup.
-        assert_eq!(messages.len(), 2, "parser emits both; dedup is caller's concern");
+        assert_eq!(
+            messages.len(),
+            2,
+            "parser emits both; dedup is caller's concern"
+        );
         assert_eq!(
             messages[0].dedup_key, messages[1].dedup_key,
             "identical id+session must produce the same dedup_key"
@@ -468,13 +483,21 @@ not valid json at all
         // Must not panic; workspace fields may or may not be populated depending
         // on normalize_workspace_key, but the parse result must be exactly 1 message.
         let messages = parse_gjc_file(file.path());
-        assert_eq!(messages.len(), 1, "unicode cwd must not cause a panic or skip");
+        assert_eq!(
+            messages.len(),
+            1,
+            "unicode cwd must not cause a panic or skip"
+        );
 
         // Path with percent-encoding (URL-style directories some tools emit)
         let content_pct = r#"{"type":"session","id":"gjc_adv_i2","cwd":"/home/user/my%20project"}
 {"type":"message","id":"msg_p","message":{"role":"assistant","model":"m","provider":"p","timestamp":1700000001000,"usage":{"input":1,"output":1,"cost":{"total":0.001}}}}"#;
         let file2 = create_test_file(content_pct);
         let messages2 = parse_gjc_file(file2.path());
-        assert_eq!(messages2.len(), 1, "percent-encoded cwd must not cause a panic or skip");
+        assert_eq!(
+            messages2.len(),
+            1,
+            "percent-encoded cwd must not cause a panic or skip"
+        );
     }
 }

--- a/crates/tokscale-core/tests/gjc.rs
+++ b/crates/tokscale-core/tests/gjc.rs
@@ -87,7 +87,8 @@ async fn test_gjc_cost_precedence_end_to_end() {
 
     {
         let mut f = std::fs::File::create(&session_file).expect("failed to create session file");
-        f.write_all(jsonl.as_bytes()).expect("failed to write JSONL");
+        f.write_all(jsonl.as_bytes())
+            .expect("failed to write JSONL");
         f.flush().expect("failed to flush");
     }
 
@@ -218,9 +219,10 @@ async fn test_gjc_workspace_key_from_dashed_slug() {
         year: None,
         scanner_settings: ScannerSettings::default(),
     };
-    let messages = parse_local_unified_messages_with_pricing(options, Some(&make_pricing_service()))
-        .await
-        .expect("parse failed");
+    let messages =
+        parse_local_unified_messages_with_pricing(options, Some(&make_pricing_service()))
+            .await
+            .expect("parse failed");
     assert_eq!(messages.len(), 1);
     assert_eq!(messages[0].workspace_key.as_deref(), Some("/work/pi"));
     assert_eq!(messages[0].workspace_label.as_deref(), Some("pi"));
@@ -279,17 +281,25 @@ async fn test_gjc_recursive_glob_depth1_and_depth2() {
         year: None,
         scanner_settings: ScannerSettings::default(),
     };
-    let messages = parse_local_unified_messages_with_pricing(options, Some(&make_pricing_service()))
-        .await
-        .expect("parse failed");
+    let messages =
+        parse_local_unified_messages_with_pricing(options, Some(&make_pricing_service()))
+            .await
+            .expect("parse failed");
     // Both the depth-1 and the distinct depth-2 message are discovered.
-    assert_eq!(messages.len(), 2, "expected depth1 + depth2 messages: {messages:#?}");
+    assert_eq!(
+        messages.len(),
+        2,
+        "expected depth1 + depth2 messages: {messages:#?}"
+    );
     let mut ids: Vec<String> = messages
         .iter()
         .map(|m| m.dedup_key.clone().unwrap_or_default())
         .collect();
     ids.sort();
-    assert_eq!(ids, vec!["s_depth1:d1_m1".to_string(), "s_depth2:d2_m1".to_string()]);
+    assert_eq!(
+        ids,
+        vec!["s_depth1:d1_m1".to_string(), "s_depth2:d2_m1".to_string()]
+    );
 }
 
 /// G9b: message-level dedup collapses a replayed parent message id across files.
@@ -312,7 +322,8 @@ async fn test_gjc_message_dedup_across_replayed_files() {
     // Same session id "S" and same message id "SHARED" in BOTH files → same
     // dedup_key "S:SHARED" → counted once.
     let shared_msg = r#"{"type":"message","id":"SHARED","timestamp":"2026-01-01T00:01:00.000Z","message":{"role":"assistant","model":"gjc-priceable-model","provider":"anthropic","timestamp":1767225661000,"usage":{"input":10,"output":5,"cost":{"total":0.01}}}}"#;
-    let header = r#"{"type":"session","id":"S","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/work/proj"}"#;
+    let header =
+        r#"{"type":"session","id":"S","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/work/proj"}"#;
     let content = format!("{header}\n{shared_msg}\n");
 
     {
@@ -338,9 +349,10 @@ async fn test_gjc_message_dedup_across_replayed_files() {
         year: None,
         scanner_settings: ScannerSettings::default(),
     };
-    let messages = parse_local_unified_messages_with_pricing(options, Some(&make_pricing_service()))
-        .await
-        .expect("parse failed");
+    let messages =
+        parse_local_unified_messages_with_pricing(options, Some(&make_pricing_service()))
+            .await
+            .expect("parse failed");
     assert_eq!(
         messages.len(),
         1,

--- a/packages/frontend/src/lib/constants.ts
+++ b/packages/frontend/src/lib/constants.ts
@@ -54,6 +54,7 @@ export const SOURCE_DISPLAY_NAMES: Record<ClientType, string> = {
   warp: "Warp",
   cline: "Cline",
   synthetic: "Synthetic",
+  gjc: "Gajae Code",
 };
 
 // Client logos from GitHub CDN (public repo)
@@ -86,6 +87,7 @@ export const SOURCE_LOGOS: Record<ClientType, string> = {
   warp: `${GITHUB_CDN_BASE}/client-warp.png`,
   cline: `${GITHUB_CDN_BASE}/client-cline.png`,
   synthetic: `${GITHUB_CDN_BASE}/client-synthetic.png`,
+  gjc: `${GITHUB_CDN_BASE}/client-gjc.png`,
 };
 
 export const SOURCE_COLORS: Record<ClientType, string> = {
@@ -116,6 +118,7 @@ export const SOURCE_COLORS: Record<ClientType, string> = {
   warp: "#01A4A4",
   cline: "#5B8DEF",
   synthetic: "#4ADE80",
+  gjc: "#FF6B6B",
 };
 
 export const SOURCE_TEXT_COLORS: Partial<Record<ClientType, string>> = {

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -26,6 +26,7 @@ export const SUPPORTED_CLIENT_TYPES = [
   "warp",
   "cline",
   "synthetic",
+  "gjc",
 ] as const;
 
 export type CcMirrorClientType = `cc-mirror/${string}`;


### PR DESCRIPTION
## Two unrelated failures on `main` HEAD

### 1. Frontend Vitest — `clientRegistry.test.ts` (broken since #675 deployed)

The test reads `crates/tokscale-core/src/clients.rs`, pulls every `id: "..."` from the `define_clients!` macro, and asserts each id:

- validates as a submission body (zod enum gate)
- has a `SOURCE_DISPLAY_NAMES` entry
- has a `SOURCE_LOGOS` entry
- has a `SOURCE_COLORS` entry

PR #685 added `gjc` (gajae-code) to the Rust macro but the frontend constants were never updated. Vitest started failing the moment that PR landed; the failure didn't surface on `main` until the next deploy.

Commit `5448b58` adds `gjc` to all four registries: `SUPPORTED_CLIENT_TYPES` (the zod enum), `SOURCE_DISPLAY_NAMES` ("Gajae Code"), `SOURCE_LOGOS` (CDN URL pointing at `client-gjc.png` — the actual asset is pending in `.github/assets/`), and `SOURCE_COLORS` (`#FF6B6B`, a coral that's distinct from the existing palette).

### 2. cargo fmt drift across the workspace (Test & Coverage / Lint failing since #685)

`Test & Coverage` job runs `cargo fmt --all --check`, which has been failing for three consecutive commits (`1492b96`, `b43dc5f`, `e644f96`). The drift accumulated across multiple PRs that touched `crates/tokscale-cli/src/main.rs`, `crates/tokscale-core/src/scanner.rs`, `crates/tokscale-core/src/sessions/gjc.rs`, and a couple of test files.

Commit `7af6e1d` is a single `cargo fmt --all` pass against rustfmt 1.8.0-stable. Pure whitespace/reflow, no behavioral change.

## Test plan

- [x] `bun run --cwd packages/frontend test clientRegistry` → 3/3 passed locally
- [x] `cargo fmt --all --check` → exit 0
- [ ] On this PR's CI: Frontend Vitest green AND Test & Coverage / Lint green

After both go green and this merges, `main` should be release-ready.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken CI by registering the `gjc` client in the frontend registries and formatting the Rust workspace. Frontend Vitest and `cargo fmt --check` should now pass.

- **Bug Fixes**
  - Added `gjc` to `SUPPORTED_CLIENT_TYPES`.
  - Added `gjc` entries to `SOURCE_DISPLAY_NAMES` ("Gajae Code"), `SOURCE_LOGOS` (`client-gjc.png`), and `SOURCE_COLORS` (`#FF6B6B`).

- **Refactors**
  - Ran `cargo fmt --all` to align the workspace with rustfmt 1.8.0 (no behavior changes).

<sup>Written for commit 7af6e1d2c9c9af7307af0f8f346488f186080515. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

