### PR TITLE
feat(submit): remove all per-day token/cost size caps

### DIFF
--- a/packages/frontend/__tests__/api/submit.test.ts
+++ b/packages/frontend/__tests__/api/submit.test.ts
@@ -441,8 +441,9 @@ describe('POST /api/submit - Client-Level Merge', () => {
 
   describe("Submission validation guardrails", () => {
     it("accepts internally consistent high-volume one-day token totals", () => {
-      // Cap is 10B (MAX_DAILY_TOKENS). Use a value just under to confirm the
-      // cap boundary is respected without triggering a rejection.
+      // Size caps were removed in feat/remove-submission-size-caps; this test
+      // now confirms that an arbitrarily large but internally-consistent
+      // payload still validates.
       const payload = createValidationPayload({
         totalTokens: 8_000_000_000,
         totalCost: 800,
@@ -461,9 +462,10 @@ describe('POST /api/submit - Client-Level Merge', () => {
       expect(result.errors).toHaveLength(0);
     });
 
-    it("rejects one-day fabricated token totals above the submission cap", () => {
+    it("accepts trillion-token internally consistent payloads (no size cap)", () => {
       const payload = createValidationPayload({
         totalTokens: 1_000_000_000_000,
+        totalCost: 100_000,
         tokenBreakdown: {
           input: 1_000_000_000_000,
           output: 0,
@@ -475,10 +477,8 @@ describe('POST /api/submit - Client-Level Merge', () => {
 
       const result = validateSubmission(payload);
 
-      expect(result.valid).toBe(false);
-      expect(result.errors.join("\n")).toContain("Daily token total exceeds");
-      expect(result.errors.join("\n")).toContain("10,000,000,000");
-      expect(result.errors.join("\n")).toContain("Client claude");
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
     });
 
     it("keeps structural validation for high-volume payloads", () => {
@@ -499,25 +499,6 @@ describe('POST /api/submit - Client-Level Merge', () => {
 
       expect(result.valid).toBe(false);
       expect(result.errors.join("\n")).toContain("modelId");
-    });
-
-    it("rejects submitted cost that is implausible for the reported tokens", () => {
-      const payload = createValidationPayload({
-        totalTokens: 5,
-        totalCost: 1_000_000_000,
-        tokenBreakdown: {
-          input: 5,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          reasoning: 0,
-        },
-      });
-
-      const result = validateSubmission(payload);
-
-      expect(result.valid).toBe(false);
-      expect(result.errors.join("\n")).toContain("Cost per million tokens exceeds");
     });
 
     it("rejects submitted cost without corresponding tokens", () => {

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -14,14 +14,6 @@ import { SUPPORTED_CLIENT_TYPES } from "../types";
 // SCHEMAS
 // ============================================================================
 
-// Hard cap: 10B tokens per day. f6aeca7 raised this to 100B; reverting because
-// 100B/day is implausible for any single device and would hide data errors.
-// A warn band at 5B logs structured warnings for high-but-plausible volumes
-// without rejecting them (see warnIfHighDailyTokens below).
-const MAX_DAILY_TOKENS = 10_000_000_000;
-const WARN_DAILY_TOKENS = 5_000_000_000;
-const MAX_DAILY_COST = 10_000;
-const MAX_COST_PER_MILLION_TOKENS = 10_000;
 const COST_RELATIVE_TOLERANCE = 0.01;
 const COST_ABSOLUTE_TOLERANCE = 0.1;
 // Sub-cent epsilon for "is there real cost left after subtracting the
@@ -272,24 +264,6 @@ function describeTokenlessOffenders(clients: ClientLike[]): string {
     .join("; ");
 }
 
-function pushCostPerMillionError(
-  errors: string[],
-  label: string,
-  cost: number,
-  tokens: number
-): void {
-  if (cost <= 1 || tokens === 0) {
-    return;
-  }
-
-  const costPerMillion = (cost * 1_000_000) / tokens;
-  if (costPerMillion > MAX_COST_PER_MILLION_TOKENS) {
-    errors.push(
-      `${label}: Cost per million tokens exceeds ${MAX_COST_PER_MILLION_TOKENS.toLocaleString("en-US")}: ${costPerMillion.toFixed(2)}`
-    );
-  }
-}
-
 /**
  * Validate submission data (Level 1 validation)
  */
@@ -363,57 +337,25 @@ export function validateSubmission(data: unknown): ValidationResult {
     );
   }
 
-  const claimedDays = Math.max(submission.summary.totalDays, submission.contributions.length, 1);
-  const maxSubmissionTokens = MAX_DAILY_TOKENS * claimedDays;
-  const maxSubmissionCost = MAX_DAILY_COST * claimedDays;
-
-  if (submission.summary.totalTokens > maxSubmissionTokens) {
-    errors.push(
-      `Submission token total exceeds ${maxSubmissionTokens.toLocaleString("en-US")} for ${claimedDays} day(s): ${submission.summary.totalTokens.toLocaleString("en-US")}`
-    );
-  }
-
-  if (submission.summary.totalCost > maxSubmissionCost) {
-    errors.push(
-      `Submission cost exceeds ${maxSubmissionCost.toLocaleString("en-US")} for ${claimedDays} day(s): ${submission.summary.totalCost.toFixed(2)}`
-    );
-  }
-
-  if (submission.summary.maxCostInSingleDay > MAX_DAILY_COST) {
-    errors.push(
-      `Summary maxCostInSingleDay exceeds ${MAX_DAILY_COST.toLocaleString("en-US")}: ${submission.summary.maxCostInSingleDay.toFixed(2)}`
-    );
-  }
-
-  {
+  if (submission.summary.totalCost > 0 && submission.summary.totalTokens === 0) {
+    // Cursor legacy: subtract premium-tool-call cost before the tokenless-cost
+    // detection so a legacy charge cannot trip the error.
     const allClients: ClientLike[] = submission.contributions.flatMap(
       (d) => d.clients
     );
-    // Cursor legacy: subtract premium-tool-call cost before both sanity caps
-    // so a legacy charge cannot inflate the cost-per-million ratio either,
-    // not just the tokenless-cost error.
     const legacyCost = allClients
       .filter(isLegacyTokenlessCursorClient)
       .reduce((sum, c) => sum + c.cost, 0);
     const checkableCost = Math.max(0, submission.summary.totalCost - legacyCost);
 
-    if (submission.summary.totalCost > 0 && submission.summary.totalTokens === 0) {
-      if (checkableCost > LEGACY_COST_FLOAT_EPSILON) {
-        const offenders = describeTokenlessOffenders(
-          allClients.filter((c) => !isLegacyTokenlessCursorClient(c))
-        );
-        const detail =
-          `cost=${formatCost(submission.summary.totalCost)}, total tokens=0` +
-          (offenders ? `; offending clients: ${offenders}` : "");
-        errors.push(`Submission summary: Cost submitted without tokens (${detail})`);
-      }
-    } else {
-      pushCostPerMillionError(
-        errors,
-        "Submission summary",
-        checkableCost,
-        submission.summary.totalTokens
+    if (checkableCost > LEGACY_COST_FLOAT_EPSILON) {
+      const offenders = describeTokenlessOffenders(
+        allClients.filter((c) => !isLegacyTokenlessCursorClient(c))
       );
+      const detail =
+        `cost=${formatCost(submission.summary.totalCost)}, total tokens=0` +
+        (offenders ? `; offending clients: ${offenders}` : "");
+      errors.push(`Submission summary: Cost submitted without tokens (${detail})`);
     }
   }
 
@@ -427,25 +369,6 @@ export function validateSubmission(data: unknown): ValidationResult {
 
   // 3c. Day token breakdown should sum to totals
   for (const day of submission.contributions) {
-    if (day.totals.tokens > MAX_DAILY_TOKENS) {
-      errors.push(
-        `Daily token total exceeds ${MAX_DAILY_TOKENS.toLocaleString("en-US")} on ${day.date}: ${day.totals.tokens.toLocaleString("en-US")}`
-      );
-    } else if (day.totals.tokens > WARN_DAILY_TOKENS) {
-      console.warn("[submission] high daily token count", {
-        date: day.date,
-        tokens: day.totals.tokens,
-        warnThreshold: WARN_DAILY_TOKENS,
-        cap: MAX_DAILY_TOKENS,
-      });
-    }
-
-    if (day.totals.cost > MAX_DAILY_COST) {
-      errors.push(
-        `Daily cost exceeds ${MAX_DAILY_COST.toLocaleString("en-US")} on ${day.date}: ${day.totals.cost.toFixed(2)}`
-      );
-    }
-
     {
       // Cursor legacy: subtract premium-tool-call cost before both sanity
       // caps so legacy charges that share a day with normal token-bearing
@@ -465,13 +388,6 @@ export function validateSubmission(data: unknown): ValidationResult {
             (offenders ? `; offending clients: ${offenders}` : "");
           errors.push(`Day ${day.date}: Cost submitted without tokens (${detail})`);
         }
-      } else {
-        pushCostPerMillionError(
-          errors,
-          `Day ${day.date}`,
-          checkableCost,
-          day.totals.tokens
-        );
       }
     }
 
@@ -506,17 +422,6 @@ export function validateSubmission(data: unknown): ValidationResult {
 
     for (const client of day.clients) {
       const clientTokens = tokenTotal(client.tokens);
-      if (clientTokens > MAX_DAILY_TOKENS) {
-        errors.push(
-          `Client ${client.client} on ${day.date}: token total exceeds ${MAX_DAILY_TOKENS.toLocaleString("en-US")}: ${clientTokens.toLocaleString("en-US")}`
-        );
-      }
-
-      if (client.cost > MAX_DAILY_COST) {
-        errors.push(
-          `Client ${client.client} on ${day.date}: cost exceeds ${MAX_DAILY_COST.toLocaleString("en-US")}: ${client.cost.toFixed(2)}`
-        );
-      }
 
       if (client.cost > 0 && clientTokens === 0) {
         if (!isLegacyTokenlessCursorClient(client)) {
@@ -529,13 +434,6 @@ export function validateSubmission(data: unknown): ValidationResult {
               `(cost=${formatCost(client.cost)}, tokens={${formatTokenBreakdown(client.tokens)}})`
           );
         }
-      } else {
-        pushCostPerMillionError(
-          errors,
-          `Client ${client.client}/${client.modelId} on ${day.date}`,
-          client.cost,
-          clientTokens
-        );
       }
     }
   }


### PR DESCRIPTION
## Closes #684

@xsyetopz, @ramarivera, and @handsupmin all hit the daily-token / daily-cost / cost-per-million sanity caps with legitimate Codex usage (the kind of cache-heavy submission patterns that trip 10B tokens or $10k/day without anything being wrong). The fix per @junhoyeo's reply on the issue is to remove the restrictions.

## What this drops

All four size constants and the checks that reference them:

| Constant | Was | Where it fired |
|---|---|---|
| `MAX_DAILY_TOKENS` | 10B / day | summary, day-level, per-client |
| `MAX_DAILY_COST` | $10k / day | summary, day-level, per-client, plus `maxCostInSingleDay` |
| `MAX_COST_PER_MILLION_TOKENS` | $10k / M | summary, day, per-client (the "implausibly cheap" sanity cap) |
| `WARN_DAILY_TOKENS` | 5B / day | structured `console.warn` band |

## What stays

These are arithmetic consistency, not size limits — they catch corrupted/inconsistent submissions, not large ones:

- Day token breakdown sums to day total (`TOKEN_RELATIVE_TOLERANCE`)
- Client tokens/cost sum to day totals (`COST_RELATIVE_TOLERANCE`, `COST_ABSOLUTE_TOLERANCE`)
- **Tokenless-cost detection** (`cost > 0` with `tokens === 0`) — still rejects the data-corruption case where someone submits a cost figure without any token data
- Cursor legacy tokenless carve-out

## Test diff

- ✅ `accepts internally consistent high-volume one-day token totals` (kept, cap-boundary comment removed)
- ✅ `accepts trillion-token internally consistent payloads (no size cap)` (new — confirms a 1T-token submit validates)
- ❌ `rejects one-day fabricated token totals above the submission cap` (deleted — no cap to enforce)
- ❌ `rejects submitted cost that is implausible for the reported tokens` (deleted — no cost-per-million sanity cap)
- ✅ `rejects submitted cost without corresponding tokens` (kept — tokenless-cost branch is still gated)

`bunx tsc --noEmit` exit 0. Full `submit` test suite passes locally.

## Test plan

- [x] Frontend Vitest green on CI
- [ ] After merge: ask @xsyetopz, @ramarivera, @handsupmin to retry `bunx tokscale submit` against the new deploy
- [ ] Monitor `/api/submit` server logs for unexpected payload shapes now that the upper bound is gone (the arithmetic-consistency checks should still catch anything corrupted)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes all per-day token and cost caps in submission validation to unblock legitimate high-volume usage (e.g., Codex with deep cache). Addresses #684 while keeping arithmetic consistency and tokenless-cost checks.

- **New Features**
  - Dropped `MAX_DAILY_TOKENS`, `MAX_DAILY_COST`, `MAX_COST_PER_MILLION_TOKENS`, and `WARN_DAILY_TOKENS` with their checks.
  - Kept day/client sum consistency and tokenless-cost detection; preserved Cursor legacy carve-out.
  - Tests updated: added 1T-token acceptance; removed cap-based failures.

<sup>Written for commit b687d130eb466e221fa28f7e51e6e29db4dce2bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

