### PR TITLE
fix(db): widen total_cost and daily cost columns to avoid numeric overflow

### DIFF
--- a/packages/frontend/src/lib/db/migrations/0014_widen_cost_columns.sql
+++ b/packages/frontend/src/lib/db/migrations/0014_widen_cost_columns.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "submissions" ALTER COLUMN "total_cost" SET DATA TYPE numeric(18, 4);--> statement-breakpoint
+ALTER TABLE "daily_breakdown" ALTER COLUMN "cost" SET DATA TYPE numeric(14, 4);

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1780172800000,
       "tag": "0013_add_mcp_servers",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1780915651573,
+      "tag": "0014_widen_cost_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -168,7 +168,7 @@ export const submissions = pgTable(
       .references(() => users.id, { onDelete: "cascade" }),
 
     totalTokens: bigint("total_tokens", { mode: "number" }).notNull(),
-    totalCost: decimal("total_cost", { precision: 12, scale: 4 }).notNull(),
+    totalCost: decimal("total_cost", { precision: 18, scale: 4 }).notNull(),
     inputTokens: bigint("input_tokens", { mode: "number" }).notNull(),
     outputTokens: bigint("output_tokens", { mode: "number" }).notNull(),
     cacheCreationTokens: bigint("cache_creation_tokens", { mode: "number" })
@@ -275,7 +275,7 @@ export const dailyBreakdown = pgTable(
 
     date: date("date").notNull(),
     tokens: bigint("tokens", { mode: "number" }).notNull(),
-    cost: decimal("cost", { precision: 10, scale: 4 }).notNull(),
+    cost: decimal("cost", { precision: 14, scale: 4 }).notNull(),
     inputTokens: bigint("input_tokens", { mode: "number" }).notNull(),
     outputTokens: bigint("output_tokens", { mode: "number" }).notNull(),
     /** Unix ms timestamp of earliest message in this UTC day bucket. NULL for legacy data. */


### PR DESCRIPTION
## Why

#691 removed the application-layer `MAX_DAILY_COST = $10,000` cap. With it gone, two `decimal` columns have ceilings well below where heavy users will land:

| Column | Type | Ceiling |
|---|---|---|
| `submissions.total_cost` | `decimal(12, 4)` | ~$100M lifetime per user |
| `daily_breakdown.cost` | `decimal(10, 4)` | ~$1M per **single day** |

A day above $1M would now throw Postgres `numeric_value_out_of_range`, rolling back the entire `/api/submit` transaction with a generic 500. We're not bleeding right now (top user is $512k lifetime, $23k single-day max), but the window will close as soon as someone with serious cache usage submits.

cubic and the Codex review bot both flagged this on #691; this PR closes the loop.

## What

Widened both columns. Migration `0014_widen_cost_columns.sql` runs:

```sql
ALTER TABLE "submissions" ALTER COLUMN "total_cost" SET DATA TYPE numeric(18, 4);
ALTER TABLE "daily_breakdown" ALTER COLUMN "cost" SET DATA TYPE numeric(14, 4);
```

| Column | Before | After | New ceiling |
|---|---|---|---|
| `submissions.total_cost` | `decimal(12, 4)` | `decimal(18, 4)` | ~$100T |
| `daily_breakdown.cost` | `decimal(10, 4)` | `decimal(14, 4)` | ~$10M / day |

Schema.ts updated to match. Journal entry added at `idx = 14`, `when = 1780915651573` (real `Date.now()` from this work session — monotonic above 0013's `1780172800000`).

## Hand-rolled timestamp note

The journal `when` was hand-set because `drizzle-kit generate` prompts interactively about historic `provider_breakdown` / `model_breakdown` column-rename ambiguity and can't complete in a non-TTY session. AGENTS.md "Migration journal hygiene" warns against hand-rolling — calling it out so future migrations prefer `drizzle-kit generate`. This is the second hand-rolled exception (after 0010/0011).

## Deploy

`ALTER COLUMN TYPE` on `daily_breakdown` rewrites the table. At current dataset size (~100k rows) this is sub-second. **Vercel does not auto-migrate**, so after this PR merges, run manually:

```bash
vercel env pull /tmp/tokscale-prod.env --environment=production --yes
cd packages/frontend && set -a && source /tmp/tokscale-prod.env && set +a && bun run db:migrate
rm /tmp/tokscale-prod.env
```

## Test plan

- [x] Frontend Vitest green locally
- [x] tsc --noEmit clean (excluding pre-existing groupMemberRoleRoute test errors on main)
- [ ] After merge: manual `db:migrate` against prod
- [ ] Verify with parity check that all 15 migration hashes match between local files and `__drizzle_migrations`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widened database cost columns to prevent Postgres overflow on high-cost days. `submissions.total_cost` is now decimal(18,4) and `daily_breakdown.cost` is now decimal(14,4) to safely support heavy usage.

- **Migration**
  - Run manually in production (Vercel doesn't auto-migrate).
  - Pull prod env: `vercel env pull /tmp/tokscale-prod.env --environment=production --yes`
  - Apply migration and clean up: `cd packages/frontend && set -a && source /tmp/tokscale-prod.env && set +a && bun run db:migrate && rm /tmp/tokscale-prod.env`

<sup>Written for commit 33977071cbdfa1a3690f513e38bf24abd8f6f72a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

