### PR TITLE
feat(cli): add yesterday date filter

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -336,6 +336,7 @@ tokscale --client opencode,claude --week --json
 ```bash
 # クイック日付ショートカット
 tokscale --today              # 今日のみ
+tokscale --yesterday          # 昨日のみ
 tokscale --week               # 過去7日間
 tokscale --month              # 今月
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -335,6 +335,7 @@ tokscale --client opencode,claude --week --json
 ```bash
 # 빠른 날짜 단축키
 tokscale --today              # 오늘만
+tokscale --yesterday          # 어제만
 tokscale --week               # 최근 7일
 tokscale --month              # 이번 달
 

--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ Date filters work across all commands that generate reports (`tokscale`, `toksca
 ```bash
 # Quick date shortcuts
 tokscale --today              # Today only
+tokscale --yesterday          # Yesterday only
 tokscale --week               # Last 7 days
 tokscale --month              # Current calendar month
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -336,6 +336,7 @@ tokscale --client opencode,claude --week --json
 ```bash
 # 快速日期快捷方式
 tokscale --today              # 仅今天
+tokscale --yesterday          # 仅昨天
 tokscale --week               # 最近 7 天
 tokscale --month              # 本月
 

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -447,10 +447,11 @@ fn main() -> Result<()> {
                 std::process::exit(1);
             });
             let today = date.today;
+            let yesterday = date.yesterday;
             let week = date.week;
             let month = date.month;
-            let (since, until) = build_date_filter(today, week, month, date.since, date.until);
-            let year = normalize_year_filter(today, week, month, date.year);
+            let (since, until) = build_date_filter(today, yesterday, week, month, date.since, date.until);
+            let year = normalize_year_filter(today, yesterday, week, month, date.year);
             let clients = build_client_filter(clients, &cli.home);
             if json || light || !can_use_tui {
                 run_models_report(
@@ -463,6 +464,7 @@ fn main() -> Result<()> {
                     benchmark,
                     no_spinner || !can_use_tui,
                     today,
+                    yesterday,
                     week,
                     month,
                     group_by,
@@ -493,10 +495,11 @@ fn main() -> Result<()> {
             no_spinner,
         }) => {
             let today = date.today;
+            let yesterday = date.yesterday;
             let week = date.week;
             let month = date.month;
-            let (since, until) = build_date_filter(today, week, month, date.since, date.until);
-            let year = normalize_year_filter(today, week, month, date.year);
+            let (since, until) = build_date_filter(today, yesterday, week, month, date.since, date.until);
+            let year = normalize_year_filter(today, yesterday, week, month, date.year);
             let clients = build_client_filter(clients, &cli.home);
             if json || light || !can_use_tui {
                 run_monthly_report(
@@ -509,6 +512,7 @@ fn main() -> Result<()> {
                     benchmark,
                     no_spinner || !can_use_tui,
                     today,
+                    yesterday,
                     week,
                     month,
                 )
@@ -536,10 +540,11 @@ fn main() -> Result<()> {
             no_spinner,
         }) => {
             let today = date.today;
+            let yesterday = date.yesterday;
             let week = date.week;
             let month = date.month;
-            let (since, until) = build_date_filter(today, week, month, date.since, date.until);
-            let year = normalize_year_filter(today, week, month, date.year);
+            let (since, until) = build_date_filter(today, yesterday, week, month, date.since, date.until);
+            let year = normalize_year_filter(today, yesterday, week, month, date.year);
             let clients = build_client_filter(clients, &cli.home);
             if json || light || !can_use_tui {
                 run_hourly_report(
@@ -552,6 +557,7 @@ fn main() -> Result<()> {
                     benchmark,
                     no_spinner || !can_use_tui,
                     today,
+                    yesterday,
                     week,
                     month,
                 )
@@ -604,10 +610,11 @@ fn main() -> Result<()> {
             no_spinner,
         }) => {
             let today = date.today;
+            let yesterday = date.yesterday;
             let week = date.week;
             let month = date.month;
-            let (since, until) = build_date_filter(today, week, month, date.since, date.until);
-            let year = normalize_year_filter(today, week, month, date.year);
+            let (since, until) = build_date_filter(today, yesterday, week, month, date.since, date.until);
+            let year = normalize_year_filter(today, yesterday, week, month, date.year);
             let clients = build_client_filter(clients, &cli.home);
             run_graph_command(
                 output,
@@ -623,10 +630,11 @@ fn main() -> Result<()> {
         Some(Commands::Tui { clients, date }) => {
             ensure_home_supported_for_tui(&cli.home)?;
             let today = date.today;
+            let yesterday = date.yesterday;
             let week = date.week;
             let month = date.month;
-            let (since, until) = build_date_filter(today, week, month, date.since, date.until);
-            let year = normalize_year_filter(today, week, month, date.year);
+            let (since, until) = build_date_filter(today, yesterday, week, month, date.since, date.until);
+            let year = normalize_year_filter(today, yesterday, week, month, date.year);
             let clients = build_client_filter(clients, &cli.home);
             auto_sync_cursor_before_tui(&cli.home, &clients)?;
             tui::run(
@@ -647,10 +655,11 @@ fn main() -> Result<()> {
         }) => {
             reject_unsupported_home_override(&cli.home, "submit")?;
             let today = date.today;
+            let yesterday = date.yesterday;
             let week = date.week;
             let month = date.month;
-            let (since, until) = build_date_filter(today, week, month, date.since, date.until);
-            let year = normalize_year_filter(today, week, month, date.year);
+            let (since, until) = build_date_filter(today, yesterday, week, month, date.since, date.until);
+            let year = normalize_year_filter(today, yesterday, week, month, date.year);
             // Bypass settings.json defaultClients for the submit path: we want the
             // submit-specific default_submit_clients() fallback (in run_submit_command)
             // to fire when the user passes no client flags, not the user's general
@@ -722,10 +731,11 @@ fn main() -> Result<()> {
             no_spinner,
         }) => {
             let today = date.today;
+            let yesterday = date.yesterday;
             let week = date.week;
             let month = date.month;
-            let (since, until) = build_date_filter(today, week, month, date.since, date.until);
-            let year = normalize_year_filter(today, week, month, date.year);
+            let (since, until) = build_date_filter(today, yesterday, week, month, date.since, date.until);
+            let year = normalize_year_filter(today, yesterday, week, month, date.year);
             let clients = build_client_filter(clients, &cli.home);
             run_time_metrics_report(
                 json,
@@ -740,12 +750,13 @@ fn main() -> Result<()> {
         Some(Commands::WarmTuiCache) => run_warm_tui_cache(),
         None => {
             let today = cli.date.today;
+            let yesterday = cli.date.yesterday;
             let week = cli.date.week;
             let month = cli.date.month;
             let clients = build_client_filter(cli.clients, &cli.home);
             let (since, until) =
-                build_date_filter(today, week, month, cli.date.since, cli.date.until);
-            let year = normalize_year_filter(today, week, month, cli.date.year);
+                build_date_filter(today, yesterday, week, month, cli.date.since, cli.date.until);
+            let year = normalize_year_filter(today, yesterday, week, month, cli.date.year);
             let group_by: tokscale_core::GroupBy = cli.group_by.parse().unwrap_or_else(|e| {
                 eprintln!("Error: {}", e);
                 std::process::exit(1);
@@ -762,6 +773,7 @@ fn main() -> Result<()> {
                     cli.benchmark,
                     cli.no_spinner || cli.json,
                     today,
+                    yesterday,
                     week,
                     month,
                     group_by,
@@ -779,6 +791,7 @@ fn main() -> Result<()> {
                     cli.benchmark,
                     cli.no_spinner || !can_use_tui,
                     today,
+                    yesterday,
                     week,
                     month,
                     group_by,
@@ -1072,6 +1085,8 @@ pub struct ClientFlags {
 pub struct DateRangeFlags {
     #[arg(long, help = "Show only today's usage")]
     pub today: bool,
+    #[arg(long, help = "Show only yesterday's usage")]
+    pub yesterday: bool,
     #[arg(long, help = "Show last 7 days")]
     pub week: bool,
     #[arg(long, help = "Show current month")]
@@ -1516,6 +1531,7 @@ fn ensure_home_supported_for_tui(home_dir: &Option<String>) -> Result<()> {
 
 fn build_date_filter(
     today: bool,
+    yesterday: bool,
     week: bool,
     month: bool,
     since: Option<String>,
@@ -1523,6 +1539,7 @@ fn build_date_filter(
 ) -> (Option<String>, Option<String>) {
     build_date_filter_for_date(
         today,
+        yesterday,
         week,
         month,
         since,
@@ -1533,6 +1550,7 @@ fn build_date_filter(
 
 fn build_date_filter_for_date(
     today: bool,
+    yesterday: bool,
     week: bool,
     month: bool,
     since: Option<String>,
@@ -1543,6 +1561,11 @@ fn build_date_filter_for_date(
 
     if today {
         let date = current_date.format("%Y-%m-%d").to_string();
+        return (Some(date.clone()), Some(date));
+    }
+
+    if yesterday {
+        let date = (current_date - Duration::days(1)).format("%Y-%m-%d").to_string();
         return (Some(date.clone()), Some(date));
     }
 
@@ -1567,11 +1590,12 @@ fn build_date_filter_for_date(
 
 fn normalize_year_filter(
     today: bool,
+    yesterday: bool,
     week: bool,
     month: bool,
     year: Option<String>,
 ) -> Option<String> {
-    if today || week || month {
+    if today || yesterday || week || month {
         None
     } else {
         year
@@ -1580,6 +1604,7 @@ fn normalize_year_filter(
 
 fn get_date_range_label(
     today: bool,
+    yesterday: bool,
     week: bool,
     month: bool,
     since: &Option<String>,
@@ -1588,6 +1613,7 @@ fn get_date_range_label(
 ) -> Option<String> {
     get_date_range_label_for_date(
         today,
+        yesterday,
         week,
         month,
         since,
@@ -1599,6 +1625,7 @@ fn get_date_range_label(
 
 fn get_date_range_label_for_date(
     today: bool,
+    yesterday: bool,
     week: bool,
     month: bool,
     since: &Option<String>,
@@ -1608,6 +1635,9 @@ fn get_date_range_label_for_date(
 ) -> Option<String> {
     if today {
         return Some("Today".to_string());
+    }
+    if yesterday {
+        return Some("Yesterday".to_string());
     }
     if week {
         return Some("Last 7 days".to_string());
@@ -1755,6 +1785,7 @@ fn run_models_report(
     benchmark: bool,
     no_spinner: bool,
     today: bool,
+    yesterday: bool,
     week: bool,
     month_flag: bool,
     group_by: tokscale_core::GroupBy,
@@ -1765,7 +1796,7 @@ fn run_models_report(
     use tokio::runtime::Runtime;
     use tokscale_core::{get_model_report, GroupBy, ReportOptions};
 
-    let date_range = get_date_range_label(today, week, month_flag, &since, &until, &year);
+    let date_range = get_date_range_label(today, yesterday, week, month_flag, &since, &until, &year);
     let effective_home_dir = resolve_effective_home_dir(&home_dir);
 
     let had_cursor_cache = has_cursor_usage_cache_for_report(&home_dir);
@@ -2551,6 +2582,7 @@ fn run_monthly_report(
     benchmark: bool,
     no_spinner: bool,
     today: bool,
+    yesterday: bool,
     week: bool,
     month_flag: bool,
 ) -> Result<()> {
@@ -2558,7 +2590,7 @@ fn run_monthly_report(
     use tokio::runtime::Runtime;
     use tokscale_core::{get_monthly_report, GroupBy, ReportOptions};
 
-    let date_range = get_date_range_label(today, week, month_flag, &since, &until, &year);
+    let date_range = get_date_range_label(today, yesterday, week, month_flag, &since, &until, &year);
 
     let had_cursor_cache = has_cursor_usage_cache_for_report(&home_dir);
     let explicit_cursor_filter = client_filter_explicitly_requests_cursor(&clients);
@@ -2850,6 +2882,7 @@ fn run_hourly_report(
     benchmark: bool,
     no_spinner: bool,
     today: bool,
+    yesterday: bool,
     week: bool,
     month_flag: bool,
 ) -> Result<()> {
@@ -2857,7 +2890,7 @@ fn run_hourly_report(
     use tokio::runtime::Runtime;
     use tokscale_core::{get_hourly_report, GroupBy, ReportOptions};
 
-    let date_range = get_date_range_label(today, week, month_flag, &since, &until, &year);
+    let date_range = get_date_range_label(today, yesterday, week, month_flag, &since, &until, &year);
 
     let had_cursor_cache = has_cursor_usage_cache_for_report(&home_dir);
     let explicit_cursor_filter = client_filter_explicitly_requests_cursor(&clients);
@@ -6548,6 +6581,7 @@ mod tests {
             false,
             false,
             false,
+            false,
             Some("2024-01-01".to_string()),
             Some("2024-12-31".to_string()),
         );
@@ -6557,7 +6591,7 @@ mod tests {
 
     #[test]
     fn test_build_date_filter_no_filters() {
-        let (since, until) = build_date_filter(false, false, false, None, None);
+        let (since, until) = build_date_filter(false, false, false, false, None, None);
         assert_eq!(since, None);
         assert_eq!(until, None);
     }
@@ -6565,15 +6599,23 @@ mod tests {
     #[test]
     fn test_build_date_filter_today_uses_provided_local_date() {
         let today = chrono::NaiveDate::from_ymd_opt(2026, 3, 8).unwrap();
-        let (since, until) = build_date_filter_for_date(true, false, false, None, None, today);
+        let (since, until) = build_date_filter_for_date(true, false, false, false, None, None, today);
         assert_eq!(since, Some("2026-03-08".to_string()));
         assert_eq!(until, Some("2026-03-08".to_string()));
     }
 
     #[test]
+    fn test_build_date_filter_yesterday_uses_provided_local_date() {
+        let today = chrono::NaiveDate::from_ymd_opt(2026, 3, 8).unwrap();
+        let (since, until) = build_date_filter_for_date(false, true, false, false, None, None, today);
+        assert_eq!(since, Some("2026-03-07".to_string()));
+        assert_eq!(until, Some("2026-03-07".to_string()));
+    }
+
+    #[test]
     fn test_build_date_filter_week_uses_provided_local_date() {
         let today = chrono::NaiveDate::from_ymd_opt(2026, 3, 8).unwrap();
-        let (since, until) = build_date_filter_for_date(false, true, false, None, None, today);
+        let (since, until) = build_date_filter_for_date(false, false, true, false, None, None, today);
         assert_eq!(since, Some("2026-03-02".to_string()));
         assert_eq!(until, Some("2026-03-08".to_string()));
     }
@@ -6581,38 +6623,44 @@ mod tests {
     #[test]
     fn test_build_date_filter_month_uses_provided_local_date() {
         let today = chrono::NaiveDate::from_ymd_opt(2026, 3, 8).unwrap();
-        let (since, until) = build_date_filter_for_date(false, false, true, None, None, today);
+        let (since, until) = build_date_filter_for_date(false, false, false, true, None, None, today);
         assert_eq!(since, Some("2026-03-01".to_string()));
         assert_eq!(until, Some("2026-03-08".to_string()));
     }
 
     #[test]
     fn test_normalize_year_filter_with_year() {
-        let year = normalize_year_filter(false, false, false, Some("2024".to_string()));
+        let year = normalize_year_filter(false, false, false, false, Some("2024".to_string()));
         assert_eq!(year, Some("2024".to_string()));
     }
 
     #[test]
     fn test_normalize_year_filter_with_today() {
-        let year = normalize_year_filter(true, false, false, Some("2024".to_string()));
+        let year = normalize_year_filter(true, false, false, false, Some("2024".to_string()));
+        assert_eq!(year, None);
+    }
+
+    #[test]
+    fn test_normalize_year_filter_with_yesterday() {
+        let year = normalize_year_filter(false, true, false, false, Some("2024".to_string()));
         assert_eq!(year, None);
     }
 
     #[test]
     fn test_normalize_year_filter_with_week() {
-        let year = normalize_year_filter(false, true, false, Some("2024".to_string()));
+        let year = normalize_year_filter(false, false, true, false, Some("2024".to_string()));
         assert_eq!(year, None);
     }
 
     #[test]
     fn test_normalize_year_filter_with_month() {
-        let year = normalize_year_filter(false, false, true, Some("2024".to_string()));
+        let year = normalize_year_filter(false, false, false, true, Some("2024".to_string()));
         assert_eq!(year, None);
     }
 
     #[test]
     fn test_normalize_year_filter_no_year() {
-        let year = normalize_year_filter(false, false, false, None);
+        let year = normalize_year_filter(false, false, false, false, None);
         assert_eq!(year, None);
     }
 
@@ -6734,33 +6782,40 @@ mod tests {
 
     #[test]
     fn test_get_date_range_label_today() {
-        let label = get_date_range_label(true, false, false, &None, &None, &None);
+        let label = get_date_range_label(true, false, false, false, &None, &None, &None);
         assert_eq!(label, Some("Today".to_string()));
     }
 
     #[test]
+    fn test_get_date_range_label_yesterday() {
+        let label = get_date_range_label(false, true, false, false, &None, &None, &None);
+        assert_eq!(label, Some("Yesterday".to_string()));
+    }
+
+    #[test]
     fn test_get_date_range_label_week() {
-        let label = get_date_range_label(false, true, false, &None, &None, &None);
+        let label = get_date_range_label(false, false, true, false, &None, &None, &None);
         assert_eq!(label, Some("Last 7 days".to_string()));
     }
 
     #[test]
     fn test_get_date_range_label_month_uses_provided_local_date() {
         let today = chrono::NaiveDate::from_ymd_opt(2026, 3, 1).unwrap();
-        let label = get_date_range_label_for_date(false, false, true, &None, &None, &None, today);
+        let label = get_date_range_label_for_date(false, false, false, true, &None, &None, &None, today);
         assert_eq!(label, Some("March 2026".to_string()));
     }
 
     #[test]
     fn test_get_date_range_label_year() {
         let label =
-            get_date_range_label(false, false, false, &None, &None, &Some("2024".to_string()));
+            get_date_range_label(false, false, false, false, &None, &None, &Some("2024".to_string()));
         assert_eq!(label, Some("2024".to_string()));
     }
 
     #[test]
     fn test_get_date_range_label_custom_since() {
         let label = get_date_range_label(
+            false,
             false,
             false,
             false,
@@ -6777,6 +6832,7 @@ mod tests {
             false,
             false,
             false,
+            false,
             &None,
             &Some("2024-12-31".to_string()),
             &None,
@@ -6790,6 +6846,7 @@ mod tests {
             false,
             false,
             false,
+            false,
             &Some("2024-01-01".to_string()),
             &Some("2024-12-31".to_string()),
             &None,
@@ -6799,7 +6856,7 @@ mod tests {
 
     #[test]
     fn test_get_date_range_label_none() {
-        let label = get_date_range_label(false, false, false, &None, &None, &None);
+        let label = get_date_range_label(false, false, false, false, &None, &None, &None);
         assert_eq!(label, None);
     }
 

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -450,7 +450,8 @@ fn main() -> Result<()> {
             let yesterday = date.yesterday;
             let week = date.week;
             let month = date.month;
-            let (since, until) = build_date_filter(today, yesterday, week, month, date.since, date.until);
+            let (since, until) =
+                build_date_filter(today, yesterday, week, month, date.since, date.until);
             let year = normalize_year_filter(today, yesterday, week, month, date.year);
             let clients = build_client_filter(clients, &cli.home);
             if json || light || !can_use_tui {
@@ -498,7 +499,8 @@ fn main() -> Result<()> {
             let yesterday = date.yesterday;
             let week = date.week;
             let month = date.month;
-            let (since, until) = build_date_filter(today, yesterday, week, month, date.since, date.until);
+            let (since, until) =
+                build_date_filter(today, yesterday, week, month, date.since, date.until);
             let year = normalize_year_filter(today, yesterday, week, month, date.year);
             let clients = build_client_filter(clients, &cli.home);
             if json || light || !can_use_tui {
@@ -543,7 +545,8 @@ fn main() -> Result<()> {
             let yesterday = date.yesterday;
             let week = date.week;
             let month = date.month;
-            let (since, until) = build_date_filter(today, yesterday, week, month, date.since, date.until);
+            let (since, until) =
+                build_date_filter(today, yesterday, week, month, date.since, date.until);
             let year = normalize_year_filter(today, yesterday, week, month, date.year);
             let clients = build_client_filter(clients, &cli.home);
             if json || light || !can_use_tui {
@@ -613,7 +616,8 @@ fn main() -> Result<()> {
             let yesterday = date.yesterday;
             let week = date.week;
             let month = date.month;
-            let (since, until) = build_date_filter(today, yesterday, week, month, date.since, date.until);
+            let (since, until) =
+                build_date_filter(today, yesterday, week, month, date.since, date.until);
             let year = normalize_year_filter(today, yesterday, week, month, date.year);
             let clients = build_client_filter(clients, &cli.home);
             run_graph_command(
@@ -633,7 +637,8 @@ fn main() -> Result<()> {
             let yesterday = date.yesterday;
             let week = date.week;
             let month = date.month;
-            let (since, until) = build_date_filter(today, yesterday, week, month, date.since, date.until);
+            let (since, until) =
+                build_date_filter(today, yesterday, week, month, date.since, date.until);
             let year = normalize_year_filter(today, yesterday, week, month, date.year);
             let clients = build_client_filter(clients, &cli.home);
             auto_sync_cursor_before_tui(&cli.home, &clients)?;
@@ -658,7 +663,8 @@ fn main() -> Result<()> {
             let yesterday = date.yesterday;
             let week = date.week;
             let month = date.month;
-            let (since, until) = build_date_filter(today, yesterday, week, month, date.since, date.until);
+            let (since, until) =
+                build_date_filter(today, yesterday, week, month, date.since, date.until);
             let year = normalize_year_filter(today, yesterday, week, month, date.year);
             // Bypass settings.json defaultClients for the submit path: we want the
             // submit-specific default_submit_clients() fallback (in run_submit_command)
@@ -734,7 +740,8 @@ fn main() -> Result<()> {
             let yesterday = date.yesterday;
             let week = date.week;
             let month = date.month;
-            let (since, until) = build_date_filter(today, yesterday, week, month, date.since, date.until);
+            let (since, until) =
+                build_date_filter(today, yesterday, week, month, date.since, date.until);
             let year = normalize_year_filter(today, yesterday, week, month, date.year);
             let clients = build_client_filter(clients, &cli.home);
             run_time_metrics_report(
@@ -754,8 +761,14 @@ fn main() -> Result<()> {
             let week = cli.date.week;
             let month = cli.date.month;
             let clients = build_client_filter(cli.clients, &cli.home);
-            let (since, until) =
-                build_date_filter(today, yesterday, week, month, cli.date.since, cli.date.until);
+            let (since, until) = build_date_filter(
+                today,
+                yesterday,
+                week,
+                month,
+                cli.date.since,
+                cli.date.until,
+            );
             let year = normalize_year_filter(today, yesterday, week, month, cli.date.year);
             let group_by: tokscale_core::GroupBy = cli.group_by.parse().unwrap_or_else(|e| {
                 eprintln!("Error: {}", e);
@@ -1565,7 +1578,9 @@ fn build_date_filter_for_date(
     }
 
     if yesterday {
-        let date = (current_date - Duration::days(1)).format("%Y-%m-%d").to_string();
+        let date = (current_date - Duration::days(1))
+            .format("%Y-%m-%d")
+            .to_string();
         return (Some(date.clone()), Some(date));
     }
 
@@ -1623,6 +1638,7 @@ fn get_date_range_label(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn get_date_range_label_for_date(
     today: bool,
     yesterday: bool,
@@ -1796,7 +1812,8 @@ fn run_models_report(
     use tokio::runtime::Runtime;
     use tokscale_core::{get_model_report, GroupBy, ReportOptions};
 
-    let date_range = get_date_range_label(today, yesterday, week, month_flag, &since, &until, &year);
+    let date_range =
+        get_date_range_label(today, yesterday, week, month_flag, &since, &until, &year);
     let effective_home_dir = resolve_effective_home_dir(&home_dir);
 
     let had_cursor_cache = has_cursor_usage_cache_for_report(&home_dir);
@@ -2590,7 +2607,8 @@ fn run_monthly_report(
     use tokio::runtime::Runtime;
     use tokscale_core::{get_monthly_report, GroupBy, ReportOptions};
 
-    let date_range = get_date_range_label(today, yesterday, week, month_flag, &since, &until, &year);
+    let date_range =
+        get_date_range_label(today, yesterday, week, month_flag, &since, &until, &year);
 
     let had_cursor_cache = has_cursor_usage_cache_for_report(&home_dir);
     let explicit_cursor_filter = client_filter_explicitly_requests_cursor(&clients);
@@ -2890,7 +2908,8 @@ fn run_hourly_report(
     use tokio::runtime::Runtime;
     use tokscale_core::{get_hourly_report, GroupBy, ReportOptions};
 
-    let date_range = get_date_range_label(today, yesterday, week, month_flag, &since, &until, &year);
+    let date_range =
+        get_date_range_label(today, yesterday, week, month_flag, &since, &until, &year);
 
     let had_cursor_cache = has_cursor_usage_cache_for_report(&home_dir);
     let explicit_cursor_filter = client_filter_explicitly_requests_cursor(&clients);
@@ -6599,7 +6618,8 @@ mod tests {
     #[test]
     fn test_build_date_filter_today_uses_provided_local_date() {
         let today = chrono::NaiveDate::from_ymd_opt(2026, 3, 8).unwrap();
-        let (since, until) = build_date_filter_for_date(true, false, false, false, None, None, today);
+        let (since, until) =
+            build_date_filter_for_date(true, false, false, false, None, None, today);
         assert_eq!(since, Some("2026-03-08".to_string()));
         assert_eq!(until, Some("2026-03-08".to_string()));
     }
@@ -6607,7 +6627,8 @@ mod tests {
     #[test]
     fn test_build_date_filter_yesterday_uses_provided_local_date() {
         let today = chrono::NaiveDate::from_ymd_opt(2026, 3, 8).unwrap();
-        let (since, until) = build_date_filter_for_date(false, true, false, false, None, None, today);
+        let (since, until) =
+            build_date_filter_for_date(false, true, false, false, None, None, today);
         assert_eq!(since, Some("2026-03-07".to_string()));
         assert_eq!(until, Some("2026-03-07".to_string()));
     }
@@ -6615,7 +6636,8 @@ mod tests {
     #[test]
     fn test_build_date_filter_week_uses_provided_local_date() {
         let today = chrono::NaiveDate::from_ymd_opt(2026, 3, 8).unwrap();
-        let (since, until) = build_date_filter_for_date(false, false, true, false, None, None, today);
+        let (since, until) =
+            build_date_filter_for_date(false, false, true, false, None, None, today);
         assert_eq!(since, Some("2026-03-02".to_string()));
         assert_eq!(until, Some("2026-03-08".to_string()));
     }
@@ -6623,7 +6645,8 @@ mod tests {
     #[test]
     fn test_build_date_filter_month_uses_provided_local_date() {
         let today = chrono::NaiveDate::from_ymd_opt(2026, 3, 8).unwrap();
-        let (since, until) = build_date_filter_for_date(false, false, false, true, None, None, today);
+        let (since, until) =
+            build_date_filter_for_date(false, false, false, true, None, None, today);
         assert_eq!(since, Some("2026-03-01".to_string()));
         assert_eq!(until, Some("2026-03-08".to_string()));
     }
@@ -6801,14 +6824,22 @@ mod tests {
     #[test]
     fn test_get_date_range_label_month_uses_provided_local_date() {
         let today = chrono::NaiveDate::from_ymd_opt(2026, 3, 1).unwrap();
-        let label = get_date_range_label_for_date(false, false, false, true, &None, &None, &None, today);
+        let label =
+            get_date_range_label_for_date(false, false, false, true, &None, &None, &None, today);
         assert_eq!(label, Some("March 2026".to_string()));
     }
 
     #[test]
     fn test_get_date_range_label_year() {
-        let label =
-            get_date_range_label(false, false, false, false, &None, &None, &Some("2024".to_string()));
+        let label = get_date_range_label(
+            false,
+            false,
+            false,
+            false,
+            &None,
+            &None,
+            &Some("2024".to_string()),
+        );
         assert_eq!(label, Some("2024".to_string()));
     }
 

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -3245,7 +3245,7 @@ mod tests {
 
         let result = scan_all_clients(home_dir.path().to_str().unwrap(), &["gjc".to_string()]);
         assert!(
-            result.get(ClientId::Gjc).len() >= 1,
+            !result.get(ClientId::Gjc).is_empty(),
             "expected at least 1 file from GJC_CONFIG_DIR root, got {:?}",
             result.get(ClientId::Gjc)
         );
@@ -3290,7 +3290,7 @@ mod tests {
 
         let result = scan_all_clients(home_dir.path().to_str().unwrap(), &["gjc".to_string()]);
         assert!(
-            result.get(ClientId::Gjc).len() >= 1,
+            !result.get(ClientId::Gjc).is_empty(),
             "expected at least 1 file from PI_CONFIG_DIR root, got {:?}",
             result.get(ClientId::Gjc)
         );
@@ -3337,7 +3337,7 @@ mod tests {
 
         let result = scan_all_clients(home_dir.path().to_str().unwrap(), &["gjc".to_string()]);
         assert!(
-            result.get(ClientId::Gjc).len() >= 1,
+            !result.get(ClientId::Gjc).is_empty(),
             "expected at least 1 file from XDG_DATA_HOME/gjc/sessions, got {:?}",
             result.get(ClientId::Gjc)
         );


### PR DESCRIPTION
## Summary

Adds a `--yesterday` date shortcut to the shared CLI date range flags. It resolves to yesterday's local date for both `since` and `until`, matching the existing `--today` behavior but shifted back one day.

The flag is available anywhere `DateRangeFlags` is used, including the default/models, monthly, hourly, graph, TUI, submit, and time-metrics paths.

## Test Plan

- `cargo check -p tokscale-cli`
- `cargo test -p tokscale-cli yesterday -- --nocapture`
- `cargo test -p tokscale-cli test_build_date_filter -- --nocapture`
- `cargo test -p tokscale-cli test_get_date_range_label -- --nocapture`
- `cargo run -p tokscale-cli -- --help | grep -F -- '--yesterday'`
- `cargo run -p tokscale-cli -- models --help | grep -F -- '--yesterday'`
- `target/debug/tokscale models --light --opencode --yesterday --no-spinner`

Note: `cargo fmt` was not available in my local environment because the Rust toolchain does not have the `fmt` subcommand installed there.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--yesterday` date filter to the CLI that sets both `since` and `until` to yesterday’s local date. Works anywhere shared date range flags are used and mirrors `--today`.

- **New Features**
  - New `--yesterday` flag in `DateRangeFlags`.
  - Supported across all date-range commands (models, monthly, hourly, graph, TUI, submit, time-metrics, default).
  - Date range label now includes "Yesterday".
  - `--year` is ignored when `--yesterday` is set.
  - Tests added for filter building, year normalization, and labeling.

- **Refactors**
  - Documented `--yesterday` in README and translations.
  - Ran `cargo fmt` and fixed Clippy warnings (added `#[allow(clippy::too_many_arguments)]`, replaced `len() >= 1` with `!is_empty()` in `tokscale-core` tests) so `clippy --all-targets -D warnings` passes.

<sup>Written for commit 8ce067e1cf689cfbf2a1816d52bdc912d231d124. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

