### PR TITLE
fix(tui): align scrollbar position with viewport

### DIFF
--- a/crates/tokscale-cli/src/tui/ui/agents.rs
+++ b/crates/tokscale-cli/src/tui/ui/agents.rs
@@ -1,9 +1,9 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{
-    Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, ScrollbarState, Table,
+    Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, Table,
 };
 
-use super::widgets::{format_cost, format_tokens, get_client_display_name};
+use super::widgets::{format_cost, format_tokens, get_client_display_name, scrollbar_state};
 use crate::tui::app::{App, SortDirection, SortField};
 use crate::ClientFilter;
 
@@ -176,7 +176,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             .begin_symbol(Some("▲"))
             .end_symbol(Some("▼"));
 
-        let mut scrollbar_state = ScrollbarState::new(agents_len).position(scroll_offset);
+        let mut scrollbar_state = scrollbar_state(agents_len, scroll_offset, visible_height);
 
         frame.render_stateful_widget(
             scrollbar,

--- a/crates/tokscale-cli/src/tui/ui/daily.rs
+++ b/crates/tokscale-cli/src/tui/ui/daily.rs
@@ -1,12 +1,12 @@
 use chrono::Local;
 use ratatui::prelude::*;
 use ratatui::widgets::{
-    Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, ScrollbarState, Table,
+    Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, Table,
 };
 
 use super::widgets::{
     format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens,
-    get_client_display_name, get_provider_display_name,
+    get_client_display_name, get_provider_display_name, scrollbar_state,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 
@@ -301,7 +301,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             .begin_symbol(Some("▲"))
             .end_symbol(Some("▼"));
 
-        let mut scrollbar_state = ScrollbarState::new(daily_len).position(scroll_offset);
+        let mut scrollbar_state = scrollbar_state(daily_len, scroll_offset, visible_height);
 
         frame.render_stateful_widget(
             scrollbar,
@@ -525,7 +525,7 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
             .begin_symbol(Some("▲"))
             .end_symbol(Some("▼"));
 
-        let mut scrollbar_state = ScrollbarState::new(detail_len).position(scroll_offset);
+        let mut scrollbar_state = scrollbar_state(detail_len, scroll_offset, visible_height);
 
         frame.render_stateful_widget(
             scrollbar,

--- a/crates/tokscale-cli/src/tui/ui/hourly.rs
+++ b/crates/tokscale-cli/src/tui/ui/hourly.rs
@@ -1,11 +1,13 @@
 use chrono::{Local, NaiveDate, Timelike};
 use ratatui::prelude::*;
 use ratatui::widgets::{
-    Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, ScrollbarState, Table,
+    Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, Table,
 };
 
 use super::hourly_profile;
-use super::widgets::{format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens};
+use super::widgets::{
+    format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens, scrollbar_state,
+};
 use crate::tui::app::{App, HourlyViewMode, SortDirection, SortField};
 
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
@@ -336,7 +338,8 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
             .begin_symbol(Some("▲"))
             .end_symbol(Some("▼"));
 
-        let mut scrollbar_state = ScrollbarState::new(hourly_len).position(scroll_offset);
+        let mut scrollbar_state =
+            scrollbar_state(hourly_len, scroll_offset, data_rows_shown.max(1));
 
         frame.render_stateful_widget(
             scrollbar,

--- a/crates/tokscale-cli/src/tui/ui/minutely.rs
+++ b/crates/tokscale-cli/src/tui/ui/minutely.rs
@@ -1,10 +1,10 @@
 use chrono::{Local, Timelike};
 use ratatui::prelude::*;
 use ratatui::widgets::{
-    Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, ScrollbarState, Table,
+    Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, Table,
 };
 
-use super::widgets::{format_cache_hit_rate, format_cost, format_tokens};
+use super::widgets::{format_cache_hit_rate, format_cost, format_tokens, scrollbar_state};
 use crate::tui::app::{App, SortDirection, SortField};
 
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
@@ -292,7 +292,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             .begin_symbol(Some("▲"))
             .end_symbol(Some("▼"));
 
-        let mut scrollbar_state = ScrollbarState::new(minutely_len).position(scroll_offset);
+        let mut scrollbar_state = scrollbar_state(minutely_len, scroll_offset, visible_height);
 
         frame.render_stateful_widget(
             scrollbar,

--- a/crates/tokscale-cli/src/tui/ui/models.rs
+++ b/crates/tokscale-cli/src/tui/ui/models.rs
@@ -1,11 +1,11 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{
-    Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, ScrollbarState, Table,
+    Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, Table,
 };
 
 use super::widgets::{
     format_cache_hit_rate, format_cost, format_cost_per_million, format_ms_per_1k, format_tokens,
-    get_client_display_name, get_provider_display_name,
+    get_client_display_name, get_provider_display_name, scrollbar_state,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 use tokscale_core::GroupBy;
@@ -288,7 +288,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             .begin_symbol(Some("▲"))
             .end_symbol(Some("▼"));
 
-        let mut scrollbar_state = ScrollbarState::new(models_len).position(scroll_offset);
+        let mut scrollbar_state = scrollbar_state(models_len, scroll_offset, visible_height);
 
         frame.render_stateful_widget(
             scrollbar,

--- a/crates/tokscale-cli/src/tui/ui/overview.rs
+++ b/crates/tokscale-cli/src/tui/ui/overview.rs
@@ -1,10 +1,8 @@
 use ratatui::prelude::*;
-use ratatui::widgets::{
-    Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
-};
+use ratatui::widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation};
 
 use super::bar_chart::{render_stacked_bar_chart, ModelSegment, StackedBarData};
-use super::widgets::format_tokens;
+use super::widgets::{format_tokens, scrollbar_state};
 use crate::tui::app::{App, ChartGranularity};
 use tokscale_core::GroupBy;
 
@@ -375,7 +373,7 @@ fn render_top_models(frame: &mut Frame, app: &mut App, area: Rect, items_per_pag
             .track_symbol(Some("│"))
             .thumb_symbol("█");
 
-        let mut scrollbar_state = ScrollbarState::new(models_len).position(scroll_offset);
+        let mut scrollbar_state = scrollbar_state(models_len, scroll_offset, items_per_page);
 
         frame.render_stateful_widget(
             scrollbar,

--- a/crates/tokscale-cli/src/tui/ui/stats.rs
+++ b/crates/tokscale-cli/src/tui/ui/stats.rs
@@ -1,9 +1,9 @@
 use ratatui::prelude::*;
-use ratatui::widgets::{
-    Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
-};
+use ratatui::widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation};
 
-use super::widgets::{format_cost, format_tokens, get_client_color, get_client_display_name};
+use super::widgets::{
+    format_cost, format_tokens, get_client_color, get_client_display_name, scrollbar_state,
+};
 use crate::tui::app::{App, ClickAction};
 
 const CELL_WIDTH: u16 = 2;
@@ -641,8 +641,11 @@ fn render_breakdown_panel(frame: &mut Frame, app: &mut App, area: Rect) {
             .begin_symbol(Some("▲"))
             .end_symbol(Some("▼"));
 
-        let mut scrollbar_state =
-            ScrollbarState::new(app.stats_breakdown_total_lines).position(app.scroll_offset);
+        let mut scrollbar_state = scrollbar_state(
+            app.stats_breakdown_total_lines,
+            app.scroll_offset,
+            visible_height,
+        );
 
         frame.render_stateful_widget(
             scrollbar,

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -1,4 +1,5 @@
 use ratatui::prelude::*;
+use ratatui::widgets::ScrollbarState;
 use tokscale_core::ClientId;
 
 use crate::tui::client_ui;
@@ -79,6 +80,27 @@ pub fn format_ms_per_1k(ms_per_1k_tokens: Option<f64>) -> String {
         format!("{:.1}s", value / 1000.0)
     } else {
         format!("{:.0}ms", value)
+    }
+}
+
+pub fn scrollbar_state(
+    content_len: usize,
+    scroll_offset: usize,
+    viewport_len: usize,
+) -> ScrollbarState {
+    let viewport_len = viewport_len.max(1);
+    ScrollbarState::new(content_len)
+        .position(scrollbar_position(scroll_offset, content_len, viewport_len))
+        .viewport_content_length(viewport_len)
+}
+
+fn scrollbar_position(scroll_offset: usize, content_len: usize, viewport_len: usize) -> usize {
+    let max_scroll = content_len.saturating_sub(viewport_len);
+    if max_scroll == 0 {
+        0
+    } else {
+        ((scroll_offset.min(max_scroll) as u128) * (content_len.saturating_sub(1) as u128)
+            / (max_scroll as u128)) as usize
     }
 }
 
@@ -318,6 +340,42 @@ fn capitalize_first(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn scrollbar_state_maps_bottom_offset_to_last_position() {
+        assert_eq!(scrollbar_position(15, 20, 5), 19);
+    }
+
+    #[test]
+    fn scrollbar_state_keeps_top_at_zero() {
+        assert_eq!(scrollbar_position(0, 20, 5), 0);
+    }
+
+    #[test]
+    fn scrollbar_state_clamps_overscroll_to_bottom() {
+        assert_eq!(scrollbar_position(999, 20, 5), 19);
+    }
+
+    #[test]
+    fn scrollbar_state_single_page_stays_at_zero() {
+        assert_eq!(scrollbar_position(0, 5, 10), 0);
+    }
+
+    #[test]
+    fn scrollbar_state_uses_wide_math_for_large_lengths() {
+        let content_len = usize::MAX;
+        let viewport_len = 2;
+        let scroll_offset = content_len / 2;
+        let max_scroll = content_len.saturating_sub(viewport_len);
+        let expected = ((scroll_offset.min(max_scroll) as u128)
+            * (content_len.saturating_sub(1) as u128)
+            / (max_scroll as u128)) as usize;
+
+        assert_eq!(
+            scrollbar_position(scroll_offset, content_len, viewport_len),
+            expected
+        );
+    }
 
     #[test]
     fn shade_from_base_rank_0_equals_base() {


### PR DESCRIPTION
## Summary
- Add a shared TUI scrollbar state helper that maps list scroll offsets to Ratatui's full content-position range.
- Set viewport content length for scrollbars so thumbs reach the end of the track on the last visible page.
- Apply the helper across TUI list/detail scrollbars, including Overview and Hourly's effective data-row viewport.

## Tests
- `cargo test -p tokscale-cli scrollbar_state`
- `cargo test -p tokscale-cli test_overview_scroll_keeps_rendered_capacity_after_resize`
- `cargo test -p tokscale-cli`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TUI scrollbars so the thumb matches the visible viewport across all screens and edge cases. The thumb now reaches the end of the track on the last page and stays at zero on single-page lists.

- **Bug Fixes**
  - Added a shared scrollbar helper to map scroll offsets to `ratatui` content positions, set viewport content length, and clamp overscroll using wide math for large lists.
  - Applied across Agents, Daily (table and detail), Hourly (uses data-row viewport), Minutely, Models, Overview top models, and Stats breakdown.

<sup>Written for commit 52ee94ac3321d1bee6fb7db56b77df923cd46b24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

