### PR TITLE
feat(codex): add multi-account usage controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ tokscale usage --json
 tokscale usage --light
 ```
 
-In the TUI, navigate to the **Usage** tab to see subscription data. Press `u` or `r` to refresh.
+In the TUI, navigate to the **Usage** tab to see subscription data. Use `[Refresh]` to refresh subscription quotas. The keyboard refresh shortcut `r` uses the same refresh path.
 
 > **Note**: Subscription quotas and balances are **vendor-reported** — tokscale calls each provider's own quota endpoint and surfaces the response verbatim. Numbers reflect what the provider reports (which is also what shows up in their official dashboards) and are not independently verified against tokscale's own usage tracking.
 
@@ -661,7 +661,7 @@ In the TUI, navigate to the **Usage** tab to see subscription data. Press `u` or
 | Provider | Auth Method | Metrics | Setup |
 |----------|-------------|---------|-------|
 | **Claude** | OAuth (credentials file or macOS Keychain) | Session (5hr), Weekly, Opus quotas | Run `claude` to log in |
-| **Codex** (OpenAI) | OAuth (`~/.config/codex/auth.json` or `~/.codex/auth.json`) | Session, Weekly quotas | Run `codex` to log in |
+| **Codex** (OpenAI) | OAuth (`~/.config/codex/auth.json`, `~/.codex/auth.json`, or saved Tokscale accounts) | Session, Weekly quotas | Use `[Add Codex]` in the TUI Usage tab, run `codex` to log in, or import an existing auth with `tokscale codex import --name work` |
 | **Z.ai** | API key (env var) | Token limits, Web Searches | Set `ZAI_API_KEY` or `GLM_API_KEY` |
 | **Amp** | API key (`~/.local/share/amp/secrets.json`) | Free tier balance, Credits | Run `amp` to log in |
 | **GitHub Copilot** | GitHub token (keychain or `~/.config/gh/hosts.yml`) | Premium interactions, Chat quotas | Run `gh auth login` |
@@ -669,6 +669,35 @@ In the TUI, navigate to the **Usage** tab to see subscription data. Press `u` or
 | **MiniMax** | API key (env var) | Prompt quotas per model | Set `MINIMAX_API_KEY` or `MINIMAX_API_TOKEN` |
 
 Providers are auto-detected — only those with valid credentials are shown. If a provider is missing, ensure you've logged in or set the required environment variable.
+
+#### Codex Multi-Account Usage
+
+Tokscale can save multiple Codex OAuth accounts for subscription usage display. The TUI Usage tab groups saved accounts under one **Codex** section. The active account is marked with `*`; inactive accounts can be selected with `[Use]`; account removal uses `[Remove]` followed by `[Confirm]`.
+
+To add an account without leaving the TUI, click `[Add Codex]` in the Usage tab. Tokscale starts `codex login` with a temporary `CODEX_HOME`, displays the login output in the Usage tab, imports the resulting auth into Tokscale's saved account store, and then refreshes usage. This keeps the login isolated and does not switch the current Codex auth; click `[Use]` on a saved account when you want Tokscale to write that account into the real Codex auth file.
+
+The CLI commands are still available for scripted or manual account management:
+
+```bash
+# Save the current Codex auth as a named Tokscale account
+tokscale codex import --name work
+
+# List saved Codex accounts
+tokscale codex accounts
+tokscale codex accounts --json
+
+# Switch the active Codex account and write Codex auth.json
+tokscale codex switch work
+
+# Remove a saved Codex account
+tokscale codex remove personal
+
+# Check subscription usage for the active or a named account
+tokscale codex status
+tokscale codex status --name personal --json
+```
+
+When saved Codex accounts exist, `tokscale usage --json` includes structured account metadata for each Codex entry and the TUI displays those entries under one Codex group. Without saved accounts, Tokscale falls back to the current Codex auth discovery path (`CODEX_HOME/auth.json`, `~/.config/codex/auth.json`, `~/.codex/auth.json`, then macOS Keychain).
 
 #### Example Output
 

--- a/crates/tokscale-cli/src/commands/usage/amp.rs
+++ b/crates/tokscale-cli/src/commands/usage/amp.rs
@@ -168,6 +168,7 @@ pub fn fetch() -> Result<UsageOutput> {
 
         Ok(UsageOutput {
             provider: "Amp".into(),
+            account: None,
             plan,
             email: None,
             metrics,

--- a/crates/tokscale-cli/src/commands/usage/claude.rs
+++ b/crates/tokscale-cli/src/commands/usage/claude.rs
@@ -219,6 +219,7 @@ pub fn fetch() -> Result<UsageOutput> {
 
         Ok(UsageOutput {
             provider: "Claude".into(),
+            account: None,
             plan,
             email: None,
             metrics,

--- a/crates/tokscale-cli/src/commands/usage/codex.rs
+++ b/crates/tokscale-cli/src/commands/usage/codex.rs
@@ -1,22 +1,29 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use chrono::{TimeZone, Utc};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 use super::helpers::capitalize;
-use super::{UsageMetric, UsageOutput};
+use super::{UsageAccount, UsageMetric, UsageOutput};
 
 const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct Auth {
     tokens: Option<Tokens>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct Tokens {
+    #[serde(skip_serializing_if = "Option::is_none")]
     access_token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     refresh_token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     account_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     id_token: Option<String>,
 }
 
@@ -50,41 +57,112 @@ struct Refresh {
     expires_in: Option<i64>,
 }
 
-#[derive(Debug, Clone)]
-enum CredentialSource {
-    File(std::path::PathBuf),
-    Keychain,
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodexAccount {
+    tokens: Tokens,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    label: Option<String>,
 }
 
-fn read_credentials() -> Result<(Auth, CredentialSource)> {
-    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
-    let mut paths: Vec<std::path::PathBuf> = Vec::new();
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CodexCredentialsStore {
+    version: i32,
+    #[serde(rename = "activeAccountId")]
+    active_account_id: String,
+    accounts: HashMap<String, CodexAccount>,
+}
 
-    // CODEX_HOME takes precedence
+#[derive(Debug, Clone, Serialize)]
+pub struct CodexAccountInfo {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(rename = "accountId", skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<String>,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "isActive")]
+    pub is_active: bool,
+}
+
+#[derive(Debug, Clone)]
+enum CredentialSource {
+    File(PathBuf),
+    Keychain,
+    Store(String),
+}
+
+fn home_dir() -> Result<PathBuf> {
+    dirs::home_dir().context("Could not determine home directory")
+}
+
+fn codex_store_path() -> PathBuf {
+    crate::paths::get_config_dir().join("codex-credentials.json")
+}
+
+#[cfg(test)]
+fn codex_store_path_in_home(home_dir: &Path) -> PathBuf {
+    home_dir
+        .join(".config")
+        .join("tokscale")
+        .join("codex-credentials.json")
+}
+
+fn current_auth_paths() -> Vec<PathBuf> {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    let mut paths = Vec::new();
+
     if let Ok(codex_home) = std::env::var("CODEX_HOME") {
-        paths.push(std::path::PathBuf::from(codex_home).join("auth.json"));
+        if !codex_home.trim().is_empty() {
+            paths.push(PathBuf::from(codex_home).join("auth.json"));
+        }
     }
+
     paths.push(home.join(".config").join("codex").join("auth.json"));
     paths.push(home.join(".codex").join("auth.json"));
+    paths
+}
 
-    for p in &paths {
+fn auth_write_path() -> Result<PathBuf> {
+    if let Ok(codex_home) = std::env::var("CODEX_HOME") {
+        if !codex_home.trim().is_empty() {
+            return Ok(PathBuf::from(codex_home).join("auth.json"));
+        }
+    }
+
+    let home = home_dir()?;
+    let config_path = home.join(".config").join("codex").join("auth.json");
+    if config_path.exists() {
+        return Ok(config_path);
+    }
+
+    let legacy_path = home.join(".codex").join("auth.json");
+    if legacy_path.exists() {
+        return Ok(legacy_path);
+    }
+
+    Ok(config_path)
+}
+
+fn read_current_credentials() -> Result<(Auth, CredentialSource)> {
+    for p in current_auth_paths() {
         if p.exists() {
-            let content = std::fs::read_to_string(p)?;
+            let content = std::fs::read_to_string(&p)?;
             if let Ok(auth) = serde_json::from_str::<Auth>(&content) {
-                // Only accept if tokens contains a usable access_token
                 if auth
                     .tokens
                     .as_ref()
                     .and_then(|t| t.access_token.as_ref())
                     .is_some()
                 {
-                    return Ok((auth, CredentialSource::File(p.clone())));
+                    return Ok((auth, CredentialSource::File(p)));
                 }
             }
         }
     }
 
-    // macOS keychain fallback
     if let Ok(raw) = super::helpers::read_keychain("Codex Auth") {
         if let Ok(auth) = serde_json::from_str::<Auth>(&raw) {
             if auth
@@ -101,61 +179,499 @@ fn read_credentials() -> Result<(Auth, CredentialSource)> {
     anyhow::bail!("No Codex credentials found. Run 'codex' to log in.")
 }
 
-fn save_credentials(
-    path: &std::path::Path,
-    access_token: &str,
-    refresh_token: &str,
-    account_id: Option<&str>,
-    id_token: Option<&str>,
-) {
-    let mut tokens = serde_json::json!({
-        "access_token": access_token,
-        "refresh_token": refresh_token,
-    });
-    if let Some(aid) = account_id {
-        tokens["account_id"] = serde_json::Value::String(aid.to_string());
-    }
-    if let Some(it) = id_token {
-        tokens["id_token"] = serde_json::Value::String(it.to_string());
-    }
-    let json = serde_json::json!({
+fn auth_document(tokens: &Tokens) -> serde_json::Value {
+    serde_json::json!({
         "tokens": tokens,
         "last_refresh": chrono::Utc::now().to_rfc3339(),
-    });
-    let content = match serde_json::to_string_pretty(&json) {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("warning: failed to serialize Codex credentials: {e}");
-            return;
-        }
+    })
+}
+
+fn save_auth_tokens(path: &Path, tokens: &Tokens) -> Result<()> {
+    let content = serde_json::to_string_pretty(&auth_document(tokens))?;
+    super::helpers::atomic_write_secret(path, content.as_bytes())
+        .with_context(|| format!("Failed to write Codex auth to {}", path.display()))
+}
+
+fn remove_auth_file_if_account_matches(
+    path: &Path,
+    account_id: &str,
+    account_tokens: &Tokens,
+) -> Result<()> {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return Ok(());
     };
-    if let Err(e) = super::helpers::atomic_write_secret(path, content.as_bytes()) {
-        eprintln!("warning: failed to save Codex credentials: {e}");
+    let Ok(auth) = serde_json::from_str::<Auth>(&content) else {
+        return Ok(());
+    };
+    let Some(tokens) = auth.tokens else {
+        return Ok(());
+    };
+
+    if derive_account_id(&tokens) == account_id || same_token_identity(&tokens, account_tokens) {
+        std::fs::remove_file(path)
+            .with_context(|| format!("Failed to remove Codex auth at {}", path.display()))?;
+    }
+
+    Ok(())
+}
+
+fn persist_tokens(source: &CredentialSource, tokens: &Tokens) {
+    match source {
+        CredentialSource::File(path) => {
+            if let Err(e) = save_auth_tokens(path, tokens) {
+                eprintln!("warning: failed to save Codex credentials: {e}");
+            }
+        }
+        CredentialSource::Store(account_id) => {
+            if let Err(e) = update_account_tokens(account_id, tokens.clone()) {
+                eprintln!("warning: failed to save Codex account credentials: {e}");
+            }
+        }
+        CredentialSource::Keychain => {}
+    }
+}
+
+fn hash_token(token: &str) -> String {
+    let digest = Sha256::digest(token.as_bytes());
+    digest
+        .iter()
+        .take(8)
+        .map(|b| format!("{b:02x}"))
+        .collect::<String>()
+}
+
+fn derive_account_id(tokens: &Tokens) -> String {
+    if let Some(account_id) = tokens.account_id.as_deref() {
+        let trimmed = account_id.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+
+    if let Some(id_token) = tokens.id_token.as_deref() {
+        let trimmed = id_token.trim();
+        if !trimmed.is_empty() {
+            return format!("id-{}", hash_token(trimmed));
+        }
+    }
+
+    tokens
+        .access_token
+        .as_deref()
+        .map(|token| format!("token-{}", hash_token(token)))
+        .unwrap_or_else(|| "account".to_string())
+}
+
+fn normalized_token_field(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn same_token_identity(a: &Tokens, b: &Tokens) -> bool {
+    match (
+        normalized_token_field(a.account_id.as_deref()),
+        normalized_token_field(b.account_id.as_deref()),
+    ) {
+        (Some(a_id), Some(b_id)) => return a_id == b_id,
+        (Some(_), None) | (None, Some(_)) => {}
+        (None, None) => {}
+    }
+
+    match (
+        normalized_token_field(a.id_token.as_deref()),
+        normalized_token_field(b.id_token.as_deref()),
+    ) {
+        (Some(a_id), Some(b_id)) => return a_id == b_id,
+        (Some(_), None) | (None, Some(_)) => {}
+        (None, None) => {}
+    }
+
+    match (
+        normalized_token_field(a.access_token.as_deref()),
+        normalized_token_field(b.access_token.as_deref()),
+    ) {
+        (Some(a_token), Some(b_token)) => a_token == b_token,
+        _ => false,
+    }
+}
+
+fn next_available_account_id(store: &CodexCredentialsStore, base_id: &str) -> String {
+    if !store.accounts.contains_key(base_id) {
+        return base_id.to_string();
+    }
+
+    for suffix in 2usize.. {
+        let candidate = format!("{base_id}-{suffix}");
+        if !store.accounts.contains_key(&candidate) {
+            return candidate;
+        }
+    }
+
+    unreachable!("unbounded suffix search must eventually find an unused Codex account id")
+}
+
+fn validate_label_available(
+    store: &CodexCredentialsStore,
+    account_id: &str,
+    label: Option<&str>,
+) -> Result<()> {
+    let Some(label) = label.map(str::trim).filter(|label| !label.is_empty()) else {
+        return Ok(());
+    };
+    let needle = label.to_lowercase();
+
+    for (id, account) in &store.accounts {
+        if id == account_id {
+            continue;
+        }
+        if account
+            .label
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_lowercase)
+            .as_deref()
+            == Some(needle.as_str())
+        {
+            anyhow::bail!("Codex account label already exists: {label}");
+        }
+    }
+
+    Ok(())
+}
+
+pub fn load_credentials_store() -> Option<CodexCredentialsStore> {
+    load_credentials_store_from_path(&codex_store_path())
+}
+
+#[cfg(test)]
+fn load_credentials_store_from_home(home_dir: &Path) -> Option<CodexCredentialsStore> {
+    load_credentials_store_from_path(&codex_store_path_in_home(home_dir))
+}
+
+fn load_credentials_store_from_path(path: &Path) -> Option<CodexCredentialsStore> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let mut store = serde_json::from_str::<CodexCredentialsStore>(&content).ok()?;
+
+    if store.version != 1 || store.accounts.is_empty() {
+        return None;
+    }
+
+    if !store.accounts.contains_key(&store.active_account_id) {
+        if let Some(first_id) = first_account_id(&store) {
+            store.active_account_id = first_id;
+            let _ = save_credentials_store_at_path(path, &store);
+        }
+    }
+
+    Some(store)
+}
+
+fn save_credentials_store(store: &CodexCredentialsStore) -> Result<()> {
+    save_credentials_store_at_path(&codex_store_path(), store)
+}
+
+#[cfg(test)]
+fn save_credentials_store_in_home(home_dir: &Path, store: &CodexCredentialsStore) -> Result<()> {
+    let path = codex_store_path_in_home(home_dir);
+    save_credentials_store_at_path(&path, store)
+}
+
+fn save_credentials_store_at_path(path: &Path, store: &CodexCredentialsStore) -> Result<()> {
+    let json = serde_json::to_string_pretty(store)?;
+    super::helpers::atomic_write_secret(path, json.as_bytes())
+        .with_context(|| format!("Failed to write Codex account store to {}", path.display()))
+}
+
+fn resolve_account_id(store: &CodexCredentialsStore, name_or_id: &str) -> Option<String> {
+    let needle = name_or_id.trim();
+    if needle.is_empty() {
+        return None;
+    }
+
+    if store.accounts.contains_key(needle) {
+        return Some(needle.to_string());
+    }
+
+    let needle_lower = needle.to_lowercase();
+    for (id, account) in &store.accounts {
+        if account
+            .label
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_lowercase)
+            .as_deref()
+            == Some(needle_lower.as_str())
+        {
+            return Some(id.clone());
+        }
+    }
+
+    None
+}
+
+fn account_info(
+    store: &CodexCredentialsStore,
+    account_id: &str,
+    account: &CodexAccount,
+) -> CodexAccountInfo {
+    CodexAccountInfo {
+        id: account_id.to_string(),
+        label: account.label.clone(),
+        account_id: account.tokens.account_id.clone(),
+        created_at: account.created_at.clone(),
+        is_active: account_id == store.active_account_id,
+    }
+}
+
+fn first_account_id(store: &CodexCredentialsStore) -> Option<String> {
+    store
+        .accounts
+        .iter()
+        .min_by(|(a_id, a), (b_id, b)| {
+            let a_name = a.label.as_deref().unwrap_or(a_id).to_lowercase();
+            let b_name = b.label.as_deref().unwrap_or(b_id).to_lowercase();
+            a_name.cmp(&b_name).then_with(|| a_id.cmp(b_id))
+        })
+        .map(|(id, _)| id.clone())
+}
+
+struct RemovedCodexAccount {
+    info: CodexAccountInfo,
+    tokens: Tokens,
+    next_active_tokens: Option<Tokens>,
+}
+
+fn remove_account_from_store(
+    store: &mut CodexCredentialsStore,
+    name_or_id: &str,
+) -> Result<RemovedCodexAccount> {
+    let resolved = resolve_account_id(store, name_or_id)
+        .ok_or_else(|| anyhow::anyhow!("Codex account not found: {name_or_id}"))?;
+    let removed_was_active = store.active_account_id == resolved;
+    let account = store
+        .accounts
+        .remove(&resolved)
+        .ok_or_else(|| anyhow::anyhow!("Codex account not found: {resolved}"))?;
+    let removed_tokens = account.tokens.clone();
+    let removed = CodexAccountInfo {
+        id: resolved,
+        label: account.label,
+        account_id: account.tokens.account_id.clone(),
+        created_at: account.created_at,
+        is_active: removed_was_active,
+    };
+
+    let next_active_tokens = if removed_was_active {
+        if let Some(next_id) = first_account_id(store) {
+            store.active_account_id = next_id.clone();
+            store.accounts.get(&next_id).map(|a| a.tokens.clone())
+        } else {
+            store.active_account_id.clear();
+            None
+        }
+    } else {
+        None
+    };
+
+    Ok(RemovedCodexAccount {
+        info: removed,
+        tokens: removed_tokens,
+        next_active_tokens,
+    })
+}
+
+pub fn list_accounts() -> Vec<CodexAccountInfo> {
+    let store = match load_credentials_store() {
+        Some(store) => store,
+        None => return Vec::new(),
+    };
+
+    let mut accounts: Vec<_> = store
+        .accounts
+        .iter()
+        .map(|(id, account)| account_info(&store, id, account))
+        .collect();
+
+    accounts.sort_by(|a, b| {
+        if a.is_active != b.is_active {
+            return if a.is_active {
+                std::cmp::Ordering::Less
+            } else {
+                std::cmp::Ordering::Greater
+            };
+        }
+        let la = a.label.as_deref().unwrap_or(&a.id).to_lowercase();
+        let lb = b.label.as_deref().unwrap_or(&b.id).to_lowercase();
+        la.cmp(&lb)
+    });
+
+    accounts
+}
+
+fn save_account_from_auth(auth: Auth, label: Option<&str>) -> Result<CodexAccountInfo> {
+    save_account_from_auth_at_path(&codex_store_path(), auth, label, true)
+}
+
+#[cfg(test)]
+fn save_account_from_auth_in_home(
+    home_dir: &Path,
+    auth: Auth,
+    label: Option<&str>,
+) -> Result<CodexAccountInfo> {
+    save_account_from_auth_at_path(&codex_store_path_in_home(home_dir), auth, label, true)
+}
+
+#[cfg(test)]
+fn save_account_from_auth_in_home_with_active(
+    home_dir: &Path,
+    auth: Auth,
+    label: Option<&str>,
+    make_active: bool,
+) -> Result<CodexAccountInfo> {
+    save_account_from_auth_at_path(
+        &codex_store_path_in_home(home_dir),
+        auth,
+        label,
+        make_active,
+    )
+}
+
+fn save_account_from_auth_at_path(
+    store_path: &Path,
+    auth: Auth,
+    label: Option<&str>,
+    make_active: bool,
+) -> Result<CodexAccountInfo> {
+    let tokens = auth
+        .tokens
+        .ok_or_else(|| anyhow::anyhow!("No Codex tokens."))?;
+    if tokens
+        .access_token
+        .as_deref()
+        .unwrap_or("")
+        .trim()
+        .is_empty()
+    {
+        anyhow::bail!("No Codex access token.");
+    }
+
+    let base_account_id = derive_account_id(&tokens);
+    let mut store =
+        load_credentials_store_from_path(store_path).unwrap_or_else(|| CodexCredentialsStore {
+            version: 1,
+            active_account_id: base_account_id.clone(),
+            accounts: HashMap::new(),
+        });
+
+    let existing_same_identity = store
+        .accounts
+        .get(&base_account_id)
+        .map(|existing| same_token_identity(&existing.tokens, &tokens))
+        .unwrap_or(false);
+
+    if existing_same_identity {
+        validate_label_available(&store, &base_account_id, label)?;
+        if let Some(existing) = store.accounts.get_mut(&base_account_id) {
+            existing.tokens = tokens;
+            if let Some(label) = label.map(str::trim).filter(|s| !s.is_empty()) {
+                existing.label = Some(label.to_string());
+            }
+        }
+        if make_active {
+            store.active_account_id = base_account_id.clone();
+        }
+        save_credentials_store_at_path(store_path, &store)?;
+
+        let account = store
+            .accounts
+            .get(&base_account_id)
+            .ok_or_else(|| anyhow::anyhow!("Failed to save Codex account"))?;
+        return Ok(account_info(&store, &base_account_id, account));
+    }
+
+    let account_id = if store.accounts.contains_key(&base_account_id) {
+        next_available_account_id(&store, &base_account_id)
+    } else {
+        base_account_id
+    };
+
+    validate_label_available(&store, &account_id, label)?;
+
+    let account = CodexAccount {
+        tokens,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        label: label
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string),
+    };
+
+    store.accounts.insert(account_id.clone(), account);
+    if make_active || store.active_account_id.trim().is_empty() {
+        store.active_account_id = account_id.clone();
+    }
+    save_credentials_store_at_path(store_path, &store)?;
+
+    let account = store
+        .accounts
+        .get(&account_id)
+        .ok_or_else(|| anyhow::anyhow!("Failed to save Codex account"))?;
+    Ok(account_info(&store, &account_id, account))
+}
+
+pub fn import_auth_file_without_activating(
+    path: &Path,
+    label: Option<&str>,
+) -> Result<CodexAccountInfo> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read Codex auth from {}", path.display()))?;
+    let auth = serde_json::from_str::<Auth>(&content)
+        .with_context(|| format!("Failed to parse Codex auth from {}", path.display()))?;
+    save_account_from_auth_at_path(&codex_store_path(), auth, label, false)
+}
+
+fn update_account_tokens(account_id: &str, tokens: Tokens) -> Result<()> {
+    let mut store =
+        load_credentials_store().ok_or_else(|| anyhow::anyhow!("No saved Codex accounts"))?;
+    let account = store
+        .accounts
+        .get_mut(account_id)
+        .ok_or_else(|| anyhow::anyhow!("Codex account not found: {account_id}"))?;
+    account.tokens = tokens;
+    save_credentials_store(&store)
+}
+
+fn load_account(name_or_id: Option<&str>) -> Result<(String, CodexAccount, CodexAccountInfo)> {
+    let store =
+        load_credentials_store().ok_or_else(|| anyhow::anyhow!("No saved Codex accounts"))?;
+    let resolved = match name_or_id {
+        Some(name) => resolve_account_id(&store, name)
+            .ok_or_else(|| anyhow::anyhow!("Codex account not found: {name}"))?,
+        None => store.active_account_id.clone(),
+    };
+    let account = store
+        .accounts
+        .get(&resolved)
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("Codex account not found: {resolved}"))?;
+    let info = account_info(&store, &resolved, &account);
+    Ok((resolved, account, info))
+}
+
+fn auth_from_account(account: &CodexAccount) -> Auth {
+    Auth {
+        tokens: Some(account.tokens.clone()),
     }
 }
 
 pub fn has_credentials() -> bool {
-    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
-    if let Ok(codex_home) = std::env::var("CODEX_HOME") {
-        if std::path::PathBuf::from(codex_home)
-            .join("auth.json")
-            .exists()
-        {
-            return true;
-        }
-    }
-    if home
-        .join(".config")
-        .join("codex")
-        .join("auth.json")
-        .exists()
+    if load_credentials_store()
+        .map(|store| !store.accounts.is_empty())
+        .unwrap_or(false)
     {
         return true;
     }
-    if home.join(".codex").join("auth.json").exists() {
-        return true;
-    }
-    super::helpers::read_keychain("Codex Auth").is_ok()
+
+    read_current_credentials().is_ok()
 }
 
 async fn refresh_token(client: &reqwest::Client, rt: &str) -> Result<Refresh> {
@@ -205,88 +721,738 @@ async fn fetch_usage(
     Ok(serde_json::from_str(&body)?)
 }
 
-pub fn fetch() -> Result<UsageOutput> {
+fn metric_from_window(label: &str, window: &Window) -> UsageMetric {
+    let pct = window.used_percent.unwrap_or(0).clamp(0, 100) as f64;
+    UsageMetric {
+        label: label.into(),
+        used_percent: pct,
+        remaining_percent: 100.0 - pct,
+        remaining_label: None,
+        resets_at: window
+            .reset_at
+            .and_then(|ts| Utc.timestamp_opt(ts, 0).single())
+            .map(|dt| dt.to_rfc3339()),
+    }
+}
+
+async fn fetch_with_auth_async(
+    auth: Auth,
+    source: CredentialSource,
+    provider_name: String,
+    account: Option<UsageAccount>,
+) -> Result<UsageOutput> {
+    let tokens = auth
+        .tokens
+        .ok_or_else(|| anyhow::anyhow!("No Codex tokens."))?;
+    let access_token = tokens
+        .access_token
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("No Codex access token."))?;
+
+    let client = reqwest::Client::new();
+    let resp = match fetch_usage(&client, &access_token, tokens.account_id.as_deref()).await {
+        Ok(r) => r,
+        Err(e) if e.to_string().contains("NEEDS_AUTH") => {
+            let rt_str = tokens
+                .refresh_token
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("No refresh token."))?;
+            let refreshed = refresh_token(&client, rt_str).await?;
+            let new = refreshed
+                .access_token
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("Refresh returned no token."))?;
+
+            let mut updated_tokens = tokens.clone();
+            updated_tokens.access_token = Some(new.clone());
+            if let Some(new_rt) = refreshed.refresh_token {
+                updated_tokens.refresh_token = Some(new_rt);
+            }
+            persist_tokens(&source, &updated_tokens);
+
+            fetch_usage(&client, &new, updated_tokens.account_id.as_deref()).await?
+        }
+        Err(e) => return Err(e),
+    };
+
+    let plan = resp.plan_type.as_deref().map(capitalize);
+    let mut metrics = Vec::new();
+    if let Some(ref rl) = resp.rate_limit {
+        if let Some(ref w) = rl.primary_window {
+            metrics.push(metric_from_window("Session", w));
+        }
+        if let Some(ref w) = rl.secondary_window {
+            metrics.push(metric_from_window("Weekly", w));
+        }
+    }
+
+    Ok(UsageOutput {
+        provider: provider_name,
+        account,
+        plan,
+        email: resp.email,
+        metrics,
+    })
+}
+
+fn fetch_with_auth(
+    auth: Auth,
+    source: CredentialSource,
+    provider_name: String,
+    account: Option<UsageAccount>,
+) -> Result<UsageOutput> {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
-    rt.block_on(async {
-        let (auth, source) = read_credentials()?;
-        let tokens = auth
-            .tokens
-            .ok_or_else(|| anyhow::anyhow!("No Codex tokens."))?;
-        let access_token = tokens
-            .access_token
-            .clone()
-            .ok_or_else(|| anyhow::anyhow!("No Codex access token."))?;
-        let account_id = tokens.account_id.as_deref();
+    rt.block_on(fetch_with_auth_async(auth, source, provider_name, account))
+}
 
-        let client = reqwest::Client::new();
-        let resp = match fetch_usage(&client, &access_token, account_id).await {
-            Ok(r) => r,
-            Err(e) if e.to_string().contains("NEEDS_AUTH") => {
-                let rt_str = tokens
-                    .refresh_token
-                    .as_ref()
-                    .ok_or_else(|| anyhow::anyhow!("No refresh token."))?;
-                let refreshed = refresh_token(&client, rt_str).await?;
-                let new = refreshed
-                    .access_token
-                    .clone()
-                    .ok_or_else(|| anyhow::anyhow!("Refresh returned no token."))?;
-                if let CredentialSource::File(ref path) = source {
-                    let new_rt = refreshed
-                        .refresh_token
-                        .as_deref()
-                        .unwrap_or_else(|| tokens.refresh_token.as_deref().unwrap_or(""));
-                    save_credentials(
-                        path,
-                        &new,
-                        new_rt,
-                        tokens.account_id.as_deref(),
-                        tokens.id_token.as_deref(),
+pub fn fetch() -> Result<UsageOutput> {
+    let (auth, source) = read_current_credentials()?;
+    fetch_with_auth(auth, source, "Codex".into(), None)
+}
+
+fn usage_account_from_saved(
+    store: &CodexCredentialsStore,
+    account_id: &str,
+    account: &CodexAccount,
+) -> UsageAccount {
+    UsageAccount {
+        id: account_id.to_string(),
+        label: account.label.clone(),
+        is_active: account_id == store.active_account_id,
+    }
+}
+
+pub fn fetch_all() -> Result<Vec<UsageOutput>> {
+    let Some(store) = load_credentials_store() else {
+        return fetch().map(|output| vec![output]);
+    };
+
+    if store.accounts.is_empty() {
+        return fetch().map(|output| vec![output]);
+    }
+
+    let mut account_ids: Vec<_> = store.accounts.keys().cloned().collect();
+    account_ids.sort_by(|a, b| {
+        if a == &store.active_account_id {
+            std::cmp::Ordering::Less
+        } else if b == &store.active_account_id {
+            std::cmp::Ordering::Greater
+        } else {
+            let la = store
+                .accounts
+                .get(a)
+                .and_then(|account| account.label.as_deref())
+                .unwrap_or(a)
+                .to_lowercase();
+            let lb = store
+                .accounts
+                .get(b)
+                .and_then(|account| account.label.as_deref())
+                .unwrap_or(b)
+                .to_lowercase();
+            la.cmp(&lb)
+        }
+    });
+
+    let mut outputs = Vec::new();
+    let mut first_error = None;
+    for account_id in account_ids {
+        let Some(account) = store.accounts.get(&account_id) else {
+            continue;
+        };
+        let usage_account = usage_account_from_saved(&store, &account_id, account);
+        match fetch_with_auth(
+            auth_from_account(account),
+            CredentialSource::Store(account_id.clone()),
+            "Codex".into(),
+            Some(usage_account),
+        ) {
+            Ok(output) => outputs.push(output),
+            Err(e) if first_error.is_none() => first_error = Some(e),
+            Err(_) => {}
+        }
+    }
+
+    if outputs.is_empty() {
+        if let Some(error) = first_error {
+            Err(error)
+        } else {
+            Ok(outputs)
+        }
+    } else {
+        Ok(outputs)
+    }
+}
+
+fn fetch_saved_account(name_or_id: Option<&str>) -> Result<(CodexAccountInfo, UsageOutput)> {
+    let (account_id, account, info) = load_account(name_or_id)?;
+    let usage_account = UsageAccount {
+        id: info.id.clone(),
+        label: info.label.clone(),
+        is_active: info.is_active,
+    };
+    let usage = fetch_with_auth(
+        auth_from_account(&account),
+        CredentialSource::Store(account_id),
+        "Codex".into(),
+        Some(usage_account),
+    )?;
+    Ok((info, usage))
+}
+
+pub fn import_current_account(label: Option<&str>) -> Result<CodexAccountInfo> {
+    let (auth, _) = read_current_credentials()?;
+    save_account_from_auth(auth, label)
+}
+
+pub fn save_current_account_as_active(label: Option<&str>) -> Result<CodexAccountInfo> {
+    let (auth, _) = read_current_credentials()?;
+    save_account_from_auth(auth, label)
+}
+
+pub fn switch_active_account(name_or_id: &str) -> Result<CodexAccountInfo> {
+    let mut store =
+        load_credentials_store().ok_or_else(|| anyhow::anyhow!("No saved Codex accounts"))?;
+    let resolved = resolve_account_id(&store, name_or_id)
+        .ok_or_else(|| anyhow::anyhow!("Codex account not found: {name_or_id}"))?;
+    let account = store
+        .accounts
+        .get(&resolved)
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("Codex account not found: {resolved}"))?;
+
+    let path = auth_write_path()?;
+    save_auth_tokens(&path, &account.tokens)?;
+
+    store.active_account_id = resolved.clone();
+    save_credentials_store(&store)?;
+
+    Ok(account_info(&store, &resolved, &account))
+}
+
+pub fn remove_account(name_or_id: &str) -> Result<CodexAccountInfo> {
+    let mut store =
+        load_credentials_store().ok_or_else(|| anyhow::anyhow!("No saved Codex accounts"))?;
+    let removal = remove_account_from_store(&mut store, name_or_id)?;
+
+    if let Some(tokens) = removal.next_active_tokens {
+        let path = auth_write_path()?;
+        save_auth_tokens(&path, &tokens)?;
+    } else if removal.info.is_active {
+        let path = auth_write_path()?;
+        remove_auth_file_if_account_matches(&path, &removal.info.id, &removal.tokens)?;
+    }
+
+    save_credentials_store(&store)?;
+    Ok(removal.info)
+}
+
+pub fn run_codex_import(name: Option<String>) -> Result<()> {
+    use colored::Colorize;
+
+    let info = import_current_account(name.as_deref())?;
+    let display = info.label.as_deref().unwrap_or(&info.id);
+
+    println!("\n  {}\n", "Codex - Import".cyan());
+    println!(
+        "  {}",
+        format!("Imported Codex account {}", display.bold()).green()
+    );
+    println!("{}", format!("  Account ID: {}", info.id).bright_black());
+    println!();
+
+    Ok(())
+}
+
+pub fn run_codex_accounts(json: bool) -> Result<()> {
+    use colored::Colorize;
+
+    let accounts = list_accounts();
+    if json {
+        #[derive(Serialize)]
+        struct Output {
+            accounts: Vec<CodexAccountInfo>,
+        }
+        println!("{}", serde_json::to_string_pretty(&Output { accounts })?);
+        return Ok(());
+    }
+
+    if accounts.is_empty() {
+        println!("\n  {}\n", "No saved Codex accounts.".yellow());
+        return Ok(());
+    }
+
+    println!("{}", "\n  Codex - Accounts\n".cyan());
+    for account in &accounts {
+        let name = if let Some(label) = &account.label {
+            format!("{} ({})", label, account.id)
+        } else {
+            account.id.clone()
+        };
+        let marker = if account.is_active { "*" } else { "-" };
+        let marker_colored = if account.is_active {
+            marker.green().to_string()
+        } else {
+            marker.bright_black().to_string()
+        };
+        println!("  {} {}", marker_colored, name);
+        if let Some(account_id) = &account.account_id {
+            println!(
+                "{}",
+                format!("    Account ID: {}", account_id).bright_black()
+            );
+        }
+    }
+    println!();
+
+    Ok(())
+}
+
+pub fn run_codex_switch(name: &str) -> Result<()> {
+    use colored::Colorize;
+
+    let info = switch_active_account(name)?;
+    let display = info.label.as_deref().unwrap_or(&info.id);
+
+    println!(
+        "\n  {}\n",
+        format!("Active Codex account set to {}", display.bold()).green()
+    );
+
+    Ok(())
+}
+
+pub fn run_codex_remove(name: &str) -> Result<()> {
+    use colored::Colorize;
+
+    let info = remove_account(name)?;
+    let display = info.label.as_deref().unwrap_or(&info.id);
+
+    println!(
+        "\n  {}\n",
+        format!("Removed Codex account {}", display.bold()).green()
+    );
+
+    Ok(())
+}
+
+pub fn run_codex_status(name: Option<String>, json: bool) -> Result<()> {
+    use colored::Colorize;
+
+    let result = if name.is_some() || load_credentials_store().is_some() {
+        fetch_saved_account(name.as_deref()).map(|(account, usage)| (Some(account), usage))
+    } else {
+        fetch().map(|usage| (None, usage))
+    };
+
+    if json {
+        #[derive(Serialize)]
+        struct Output {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            account: Option<CodexAccountInfo>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            usage: Option<UsageOutput>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            error: Option<String>,
+        }
+        let output = match result {
+            Ok((account, usage)) => Output {
+                account,
+                usage: Some(usage),
+                error: None,
+            },
+            Err(e) => Output {
+                account: None,
+                usage: None,
+                error: Some(e.to_string()),
+            },
+        };
+        println!("{}", serde_json::to_string_pretty(&output)?);
+        return Ok(());
+    }
+
+    println!("\n  {}\n", "Codex - Status".cyan());
+    match result {
+        Ok((account, usage)) => {
+            if let Some(account) = account {
+                let display = account.label.as_deref().unwrap_or(&account.id);
+                println!("{}", format!("  Account: {}", display).white());
+                if let Some(account_id) = account.account_id {
+                    println!("{}", format!("  Account ID: {}", account_id).bright_black());
+                }
+            }
+            if let Some(email) = usage.email {
+                println!("{}", format!("  Email: {}", email).white());
+            }
+            if let Some(plan) = usage.plan {
+                println!("{}", format!("  Plan: {}", plan).white());
+            }
+            if usage.metrics.is_empty() {
+                println!("{}", "  No quota metrics returned.".yellow());
+            } else {
+                for metric in usage.metrics {
+                    let remaining = metric
+                        .remaining_label
+                        .unwrap_or_else(|| format!("{:.0}% left", metric.remaining_percent));
+                    println!(
+                        "  {} {}",
+                        format!("{:<10}", metric.label).bright_black(),
+                        remaining
                     );
                 }
-                fetch_usage(&client, &new, account_id).await?
-            }
-            Err(e) => return Err(e),
-        };
-
-        let plan = resp.plan_type.as_deref().map(capitalize);
-        let mut metrics = Vec::new();
-        if let Some(ref rl) = resp.rate_limit {
-            if let Some(ref w) = rl.primary_window {
-                let pct = w.used_percent.unwrap_or(0).clamp(0, 100) as f64;
-                metrics.push(UsageMetric {
-                    label: "Session".into(),
-                    used_percent: pct,
-                    remaining_percent: 100.0 - pct,
-                    remaining_label: None,
-                    resets_at: w
-                        .reset_at
-                        .and_then(|ts| Utc.timestamp_opt(ts, 0).single())
-                        .map(|dt| dt.to_rfc3339()),
-                });
-            }
-            if let Some(ref w) = rl.secondary_window {
-                let pct = w.used_percent.unwrap_or(0).clamp(0, 100) as f64;
-                metrics.push(UsageMetric {
-                    label: "Weekly".into(),
-                    used_percent: pct,
-                    remaining_percent: 100.0 - pct,
-                    remaining_label: None,
-                    resets_at: w
-                        .reset_at
-                        .and_then(|ts| Utc.timestamp_opt(ts, 0).single())
-                        .map(|dt| dt.to_rfc3339()),
-                });
             }
         }
+        Err(e) => {
+            println!("  {}", format!("Status failed: {e}").red());
+        }
+    }
+    println!();
 
-        Ok(UsageOutput {
-            provider: "Codex".into(),
-            plan,
-            email: resp.email,
-            metrics,
-        })
-    })
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn tokens(access: &str, account_id: Option<&str>) -> Tokens {
+        Tokens {
+            access_token: Some(access.to_string()),
+            refresh_token: Some("refresh".to_string()),
+            account_id: account_id.map(str::to_string),
+            id_token: None,
+        }
+    }
+
+    fn tokens_with_id_token(access: &str, account_id: Option<&str>, id_token: &str) -> Tokens {
+        Tokens {
+            access_token: Some(access.to_string()),
+            refresh_token: Some("refresh".to_string()),
+            account_id: account_id.map(str::to_string),
+            id_token: Some(id_token.to_string()),
+        }
+    }
+
+    #[test]
+    fn derive_account_id_prefers_account_id() {
+        let tokens = tokens("access-token", Some("acct_work"));
+        assert_eq!(derive_account_id(&tokens), "acct_work");
+    }
+
+    #[test]
+    fn derive_account_id_falls_back_to_stable_token_hash() {
+        let id = derive_account_id(&tokens("access-token", None));
+        assert!(id.starts_with("token-"));
+        assert_eq!(id, derive_account_id(&tokens("access-token", None)));
+    }
+
+    #[test]
+    fn same_token_identity_prefers_account_id_over_rotating_id_token() {
+        let a = tokens_with_id_token("access-a", Some("acct_shared"), "id-token-a");
+        let b = tokens_with_id_token("access-b", Some("acct_shared"), "id-token-b");
+
+        assert!(same_token_identity(&a, &b));
+    }
+
+    #[test]
+    fn load_credentials_store_repairs_missing_active_account() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let mut accounts = HashMap::new();
+        accounts.insert(
+            "acct_a".to_string(),
+            CodexAccount {
+                tokens: tokens("access-a", Some("acct_a")),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                label: Some("zulu".to_string()),
+            },
+        );
+        accounts.insert(
+            "acct_b".to_string(),
+            CodexAccount {
+                tokens: tokens("access-b", Some("acct_b")),
+                created_at: "2026-01-02T00:00:00Z".to_string(),
+                label: Some("alpha".to_string()),
+            },
+        );
+        let store = CodexCredentialsStore {
+            version: 1,
+            active_account_id: "missing".to_string(),
+            accounts,
+        };
+        save_credentials_store_in_home(tmp.path(), &store)?;
+
+        let loaded = load_credentials_store_from_home(tmp.path()).unwrap();
+        assert_eq!(loaded.active_account_id, "acct_b");
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_account_id_matches_label_case_insensitively() {
+        let mut accounts = HashMap::new();
+        accounts.insert(
+            "acct_a".to_string(),
+            CodexAccount {
+                tokens: tokens("access-a", Some("acct_a")),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                label: Some("Work".to_string()),
+            },
+        );
+        let store = CodexCredentialsStore {
+            version: 1,
+            active_account_id: "acct_a".to_string(),
+            accounts,
+        };
+
+        assert_eq!(
+            resolve_account_id(&store, "work").as_deref(),
+            Some("acct_a")
+        );
+    }
+
+    #[test]
+    fn save_account_from_auth_in_home_imports_tokens_without_touching_real_home() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let info = save_account_from_auth_in_home(
+            tmp.path(),
+            Auth {
+                tokens: Some(tokens("access-a", Some("acct_a"))),
+            },
+            Some("work"),
+        )?;
+
+        assert_eq!(info.id, "acct_a");
+        assert_eq!(info.label.as_deref(), Some("work"));
+        assert!(info.is_active);
+
+        let loaded = load_credentials_store_from_home(tmp.path()).unwrap();
+        assert_eq!(loaded.active_account_id, "acct_a");
+        assert!(loaded.accounts.contains_key("acct_a"));
+        Ok(())
+    }
+
+    #[test]
+    fn save_account_from_auth_in_home_preserves_label_when_updating_same_account() -> Result<()> {
+        let tmp = TempDir::new()?;
+        save_account_from_auth_in_home(
+            tmp.path(),
+            Auth {
+                tokens: Some(tokens("access-a", Some("acct_a"))),
+            },
+            Some("work"),
+        )?;
+
+        let info = save_account_from_auth_in_home(
+            tmp.path(),
+            Auth {
+                tokens: Some(tokens("access-b", Some("acct_a"))),
+            },
+            None,
+        )?;
+
+        assert_eq!(info.id, "acct_a");
+        assert_eq!(info.label.as_deref(), Some("work"));
+
+        let loaded = load_credentials_store_from_home(tmp.path()).unwrap();
+        assert_eq!(loaded.accounts.len(), 1);
+        let account = loaded.accounts.get("acct_a").unwrap();
+        assert_eq!(account.label.as_deref(), Some("work"));
+        assert_eq!(account.tokens.access_token.as_deref(), Some("access-b"));
+        Ok(())
+    }
+
+    #[test]
+    fn save_account_from_auth_in_home_keeps_existing_account_on_identity_collision() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let mut accounts = HashMap::new();
+        accounts.insert(
+            "acct_shared".to_string(),
+            CodexAccount {
+                tokens: tokens_with_id_token("access-a", Some("acct_other"), "id-token-a"),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                label: Some("work".to_string()),
+            },
+        );
+        save_credentials_store_in_home(
+            tmp.path(),
+            &CodexCredentialsStore {
+                version: 1,
+                active_account_id: "acct_shared".to_string(),
+                accounts,
+            },
+        )?;
+
+        let info = save_account_from_auth_in_home(
+            tmp.path(),
+            Auth {
+                tokens: Some(tokens_with_id_token(
+                    "access-b",
+                    Some("acct_shared"),
+                    "id-token-b",
+                )),
+            },
+            None,
+        )?;
+
+        assert_eq!(info.id, "acct_shared-2");
+
+        let loaded = load_credentials_store_from_home(tmp.path()).unwrap();
+        assert_eq!(loaded.accounts.len(), 2);
+        assert_eq!(loaded.active_account_id, "acct_shared-2");
+        assert_eq!(
+            loaded
+                .accounts
+                .get("acct_shared")
+                .and_then(|account| account.label.as_deref()),
+            Some("work")
+        );
+        assert!(loaded.accounts.contains_key("acct_shared-2"));
+        Ok(())
+    }
+
+    #[test]
+    fn save_account_from_auth_in_home_can_add_without_changing_active_account() -> Result<()> {
+        let tmp = TempDir::new()?;
+        save_account_from_auth_in_home(
+            tmp.path(),
+            Auth {
+                tokens: Some(tokens("access-a", Some("acct_a"))),
+            },
+            Some("work"),
+        )?;
+
+        let info = save_account_from_auth_in_home_with_active(
+            tmp.path(),
+            Auth {
+                tokens: Some(tokens("access-b", Some("acct_b"))),
+            },
+            Some("personal"),
+            false,
+        )?;
+
+        assert_eq!(info.id, "acct_b");
+        assert!(!info.is_active);
+
+        let loaded = load_credentials_store_from_home(tmp.path()).unwrap();
+        assert_eq!(loaded.active_account_id, "acct_a");
+        assert!(loaded.accounts.contains_key("acct_a"));
+        assert!(loaded.accounts.contains_key("acct_b"));
+        Ok(())
+    }
+
+    #[test]
+    fn remove_auth_file_if_account_matches_deletes_matching_auth() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let path = tmp.path().join("auth.json");
+        save_auth_tokens(&path, &tokens("access-a", Some("acct_a")))?;
+
+        remove_auth_file_if_account_matches(&path, "acct_a", &tokens("access-a", Some("acct_a")))?;
+
+        assert!(!path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn remove_auth_file_if_account_matches_keeps_other_auth() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let path = tmp.path().join("auth.json");
+        save_auth_tokens(&path, &tokens("access-b", Some("acct_b")))?;
+
+        remove_auth_file_if_account_matches(&path, "acct_a", &tokens("access-a", Some("acct_a")))?;
+
+        assert!(path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn remove_auth_file_if_account_matches_deletes_collision_suffixed_account() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let path = tmp.path().join("auth.json");
+        let account_tokens = tokens("access-a", Some("acct_a"));
+        save_auth_tokens(&path, &account_tokens)?;
+
+        remove_auth_file_if_account_matches(&path, "acct_a-2", &account_tokens)?;
+
+        assert!(!path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn remove_account_from_store_keeps_active_when_removing_inactive() -> Result<()> {
+        let mut accounts = HashMap::new();
+        accounts.insert(
+            "acct_a".to_string(),
+            CodexAccount {
+                tokens: tokens("access-a", Some("acct_a")),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                label: Some("Work".to_string()),
+            },
+        );
+        accounts.insert(
+            "acct_b".to_string(),
+            CodexAccount {
+                tokens: tokens("access-b", Some("acct_b")),
+                created_at: "2026-01-02T00:00:00Z".to_string(),
+                label: Some("Personal".to_string()),
+            },
+        );
+        let mut store = CodexCredentialsStore {
+            version: 1,
+            active_account_id: "acct_a".to_string(),
+            accounts,
+        };
+
+        let removal = remove_account_from_store(&mut store, "personal")?;
+
+        assert_eq!(removal.info.id, "acct_b");
+        assert_eq!(removal.tokens.access_token.as_deref(), Some("access-b"));
+        assert!(!removal.info.is_active);
+        assert!(removal.next_active_tokens.is_none());
+        assert_eq!(store.active_account_id, "acct_a");
+        assert!(!store.accounts.contains_key("acct_b"));
+        Ok(())
+    }
+
+    #[test]
+    fn remove_account_from_store_selects_next_active_when_removing_active() -> Result<()> {
+        let mut accounts = HashMap::new();
+        accounts.insert(
+            "acct_a".to_string(),
+            CodexAccount {
+                tokens: tokens("access-a", Some("acct_a")),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                label: Some("Work".to_string()),
+            },
+        );
+        accounts.insert(
+            "acct_b".to_string(),
+            CodexAccount {
+                tokens: tokens("access-b", Some("acct_b")),
+                created_at: "2026-01-02T00:00:00Z".to_string(),
+                label: Some("Personal".to_string()),
+            },
+        );
+        let mut store = CodexCredentialsStore {
+            version: 1,
+            active_account_id: "acct_a".to_string(),
+            accounts,
+        };
+
+        let removal = remove_account_from_store(&mut store, "work")?;
+
+        assert_eq!(removal.info.id, "acct_a");
+        assert_eq!(removal.tokens.access_token.as_deref(), Some("access-a"));
+        assert!(removal.info.is_active);
+        assert_eq!(store.active_account_id, "acct_b");
+        assert_eq!(
+            removal
+                .next_active_tokens
+                .and_then(|tokens| tokens.access_token)
+                .as_deref(),
+            Some("access-b")
+        );
+        Ok(())
+    }
 }

--- a/crates/tokscale-cli/src/commands/usage/copilot.rs
+++ b/crates/tokscale-cli/src/commands/usage/copilot.rs
@@ -280,6 +280,7 @@ pub fn fetch() -> Result<UsageOutput> {
 
         Ok(UsageOutput {
             provider: "Copilot".into(),
+            account: None,
             plan,
             email: None,
             metrics,

--- a/crates/tokscale-cli/src/commands/usage/kimi.rs
+++ b/crates/tokscale-cli/src/commands/usage/kimi.rs
@@ -268,6 +268,7 @@ pub fn fetch() -> Result<UsageOutput> {
 
         Ok(UsageOutput {
             provider: "Kimi".into(),
+            account: None,
             plan,
             email: None,
             metrics,

--- a/crates/tokscale-cli/src/commands/usage/minimax.rs
+++ b/crates/tokscale-cli/src/commands/usage/minimax.rs
@@ -242,6 +242,7 @@ pub fn fetch() -> Result<UsageOutput> {
 
         Ok(UsageOutput {
             provider: "MiniMax".into(),
+            account: None,
             plan,
             email: None,
             metrics,

--- a/crates/tokscale-cli/src/commands/usage/mod.rs
+++ b/crates/tokscale-cli/src/commands/usage/mod.rs
@@ -1,6 +1,6 @@
 mod amp;
 mod claude;
-mod codex;
+pub mod codex;
 mod copilot;
 pub mod helpers;
 mod kimi;
@@ -24,9 +24,90 @@ pub struct UsageMetric {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct UsageOutput {
     pub provider: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account: Option<UsageAccount>,
     pub plan: Option<String>,
     pub email: Option<String>,
     pub metrics: Vec<UsageMetric>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct UsageAccount {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default)]
+    pub is_active: bool,
+}
+
+impl UsageAccount {
+    pub fn label_name(&self) -> Option<&str> {
+        self.label
+            .as_deref()
+            .map(str::trim)
+            .filter(|label| !label.is_empty())
+    }
+
+    pub fn short_id(&self) -> String {
+        let id = self.id.trim();
+        if id.is_empty() {
+            return "unknown".to_string();
+        }
+
+        let char_count = id.chars().count();
+        if char_count <= 12 {
+            return id.to_string();
+        }
+
+        let head: String = id.chars().take(6).collect();
+        let tail: String = id
+            .chars()
+            .rev()
+            .take(4)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect();
+        format!("{head}...{tail}")
+    }
+
+    pub fn display_name(&self) -> String {
+        self.label_name()
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("Account {}", self.short_id()))
+    }
+}
+
+impl UsageOutput {
+    pub fn account_display_name(&self) -> Option<String> {
+        let account = self.account.as_ref()?;
+
+        if let Some(label) = account.label_name() {
+            return Some(label.to_string());
+        }
+
+        if let Some(email) = self
+            .email
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            return Some(email.to_string());
+        }
+
+        Some(account.display_name())
+    }
+
+    pub fn display_name(&self) -> String {
+        match &self.account {
+            Some(_) => format!(
+                "{} ({})",
+                self.provider,
+                self.account_display_name().unwrap_or_default()
+            ),
+            None => self.provider.clone(),
+        }
+    }
 }
 
 // ── Cache ──
@@ -78,18 +159,46 @@ pub fn load_cache() -> Option<Vec<UsageOutput>> {
 
 // ── Public API ──
 
-type UsageProvider = (&'static str, fn() -> bool, fn() -> Result<UsageOutput>);
+type UsageProvider = (&'static str, fn() -> bool, fn() -> Result<Vec<UsageOutput>>);
+
+fn fetch_amp() -> Result<Vec<UsageOutput>> {
+    amp::fetch().map(|output| vec![output])
+}
+
+fn fetch_claude() -> Result<Vec<UsageOutput>> {
+    claude::fetch().map(|output| vec![output])
+}
+
+fn fetch_copilot() -> Result<Vec<UsageOutput>> {
+    copilot::fetch().map(|output| vec![output])
+}
+
+fn fetch_kimi() -> Result<Vec<UsageOutput>> {
+    kimi::fetch().map(|output| vec![output])
+}
+
+fn fetch_minimax() -> Result<Vec<UsageOutput>> {
+    minimax::fetch().map(|output| vec![output])
+}
+
+fn fetch_warp() -> Result<Vec<UsageOutput>> {
+    warp::fetch().map(|output| vec![output])
+}
+
+fn fetch_zai() -> Result<Vec<UsageOutput>> {
+    zai::fetch().map(|output| vec![output])
+}
 
 pub fn fetch_all() -> Vec<UsageOutput> {
     let providers: Vec<UsageProvider> = vec![
-        ("Claude", claude::has_credentials, claude::fetch),
-        ("Codex", codex::has_credentials, codex::fetch),
-        ("Z.ai", zai::has_credentials, zai::fetch),
-        ("Amp", amp::has_credentials, amp::fetch),
-        ("Copilot", copilot::has_credentials, copilot::fetch),
-        ("Kimi", kimi::has_credentials, kimi::fetch),
-        ("MiniMax", minimax::has_credentials, minimax::fetch),
-        ("Warp/Oz", warp::has_credentials, warp::fetch),
+        ("Claude", claude::has_credentials, fetch_claude),
+        ("Codex", codex::has_credentials, codex::fetch_all),
+        ("Z.ai", zai::has_credentials, fetch_zai),
+        ("Amp", amp::has_credentials, fetch_amp),
+        ("Copilot", copilot::has_credentials, fetch_copilot),
+        ("Kimi", kimi::has_credentials, fetch_kimi),
+        ("MiniMax", minimax::has_credentials, fetch_minimax),
+        ("Warp/Oz", warp::has_credentials, fetch_warp),
     ];
 
     let active: Vec<_> = providers.into_iter().filter(|(_, has, _)| has()).collect();
@@ -105,6 +214,7 @@ pub fn fetch_all() -> Vec<UsageOutput> {
             .collect::<Vec<_>>()
             .into_iter()
             .filter_map(|h| h.join().ok().flatten())
+            .flatten()
             .collect()
     })
 }
@@ -125,7 +235,11 @@ fn truncate(s: &str, max_len: usize) -> String {
 fn render_light(output: &UsageOutput) {
     println!("╭{}╮", "─".repeat(CARD_WIDTH));
     // Provider header
-    println!("│ {:<width$}│", output.provider, width = CARD_WIDTH - 1);
+    println!(
+        "│ {:<width$}│",
+        output.display_name(),
+        width = CARD_WIDTH - 1
+    );
     for m in &output.metrics {
         let rem = m
             .remaining_label
@@ -167,4 +281,76 @@ pub fn run(json: bool, _light: bool) -> Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn usage_output_display_name_includes_account_label() {
+        let output = UsageOutput {
+            provider: "Codex".to_string(),
+            account: Some(UsageAccount {
+                id: "acct_123".to_string(),
+                label: Some("work".to_string()),
+                is_active: true,
+            }),
+            plan: None,
+            email: None,
+            metrics: Vec::new(),
+        };
+
+        assert_eq!(output.display_name(), "Codex (work)");
+    }
+
+    #[test]
+    fn usage_output_display_name_prefers_email_over_account_id() {
+        let output = UsageOutput {
+            provider: "Codex".to_string(),
+            account: Some(UsageAccount {
+                id: "acct_123".to_string(),
+                label: Some("  ".to_string()),
+                is_active: false,
+            }),
+            plan: None,
+            email: Some("user@example.com".to_string()),
+            metrics: Vec::new(),
+        };
+
+        assert_eq!(output.display_name(), "Codex (user@example.com)");
+    }
+
+    #[test]
+    fn usage_output_display_name_masks_long_account_id() {
+        let output = UsageOutput {
+            provider: "Codex".to_string(),
+            account: Some(UsageAccount {
+                id: "123e4567-e89b-12d3-a456-426614174000".to_string(),
+                label: None,
+                is_active: false,
+            }),
+            plan: None,
+            email: None,
+            metrics: Vec::new(),
+        };
+
+        assert_eq!(output.display_name(), "Codex (Account 123e45...4000)");
+    }
+
+    #[test]
+    fn usage_output_deserializes_legacy_json_without_account() -> Result<()> {
+        let output: UsageOutput = serde_json::from_str(
+            r#"{
+                "provider": "Codex",
+                "plan": null,
+                "email": null,
+                "metrics": []
+            }"#,
+        )?;
+
+        assert!(output.account.is_none());
+        assert_eq!(output.display_name(), "Codex");
+        Ok(())
+    }
 }

--- a/crates/tokscale-cli/src/commands/usage/warp.rs
+++ b/crates/tokscale-cli/src/commands/usage/warp.rs
@@ -44,6 +44,7 @@ pub fn fetch() -> Result<UsageOutput> {
 
     Ok(UsageOutput {
         provider: "Warp/Oz".to_string(),
+        account: None,
         plan: Some("Aggregate API cache".to_string()),
         email: None,
         metrics,

--- a/crates/tokscale-cli/src/commands/usage/zai.rs
+++ b/crates/tokscale-cli/src/commands/usage/zai.rs
@@ -163,6 +163,7 @@ pub fn fetch() -> Result<UsageOutput> {
 
         Ok(UsageOutput {
             provider: "Z.ai".into(),
+            account: None,
             plan,
             email: None,
             metrics,

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -271,6 +271,11 @@ enum Commands {
         #[arg(long, help = "Light terminal output (no TUI)")]
         light: bool,
     },
+    #[command(about = "Codex account integration commands")]
+    Codex {
+        #[command(subcommand)]
+        subcommand: CodexSubcommand,
+    },
     #[command(about = "Cursor API cache integration commands")]
     Cursor {
         #[command(subcommand)]
@@ -345,6 +350,37 @@ enum CursorSubcommand {
     Switch {
         #[arg(help = "Account label or id")]
         name: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum CodexSubcommand {
+    #[command(about = "Import the current Codex OAuth credentials as a saved account")]
+    Import {
+        #[arg(long, help = "Label for this Codex account (e.g., work, personal)")]
+        name: Option<String>,
+    },
+    #[command(about = "List saved Codex accounts")]
+    Accounts {
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
+    },
+    #[command(about = "Switch active Codex account and write Codex auth.json")]
+    Switch {
+        #[arg(help = "Account label or id")]
+        name: String,
+    },
+    #[command(about = "Remove a saved Codex account")]
+    Remove {
+        #[arg(help = "Account label or id")]
+        name: String,
+    },
+    #[command(about = "Check Codex subscription usage for an account")]
+    Status {
+        #[arg(long, help = "Account label or id")]
+        name: Option<String>,
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
     },
 }
 
@@ -702,6 +738,10 @@ fn main() -> Result<()> {
         Some(Commands::Usage { json, light }) => {
             reject_unsupported_home_override(&cli.home, "usage")?;
             commands::usage::run(json, light)
+        }
+        Some(Commands::Codex { subcommand }) => {
+            reject_unsupported_home_override(&cli.home, "codex")?;
+            run_codex_command(subcommand)
         }
         Some(Commands::Trae { subcommand }) => {
             reject_unsupported_home_override(&cli.home, "trae")?;
@@ -5388,6 +5428,18 @@ fn run_cursor_command(subcommand: CursorSubcommand) -> Result<()> {
     }
 }
 
+fn run_codex_command(subcommand: CodexSubcommand) -> Result<()> {
+    match subcommand {
+        CodexSubcommand::Import { name } => commands::usage::codex::run_codex_import(name),
+        CodexSubcommand::Accounts { json } => commands::usage::codex::run_codex_accounts(json),
+        CodexSubcommand::Switch { name } => commands::usage::codex::run_codex_switch(&name),
+        CodexSubcommand::Remove { name } => commands::usage::codex::run_codex_remove(&name),
+        CodexSubcommand::Status { name, json } => {
+            commands::usage::codex::run_codex_status(name, json)
+        }
+    }
+}
+
 fn run_antigravity_command(subcommand: AntigravitySubcommand) -> Result<()> {
     match subcommand {
         AntigravitySubcommand::Sync => antigravity::run_antigravity_sync(),
@@ -7287,6 +7339,21 @@ mod tests {
     fn clap_accepts_cursor_sync_command() {
         assert!(Cli::try_parse_from(["tokscale", "cursor", "sync"]).is_ok());
         assert!(Cli::try_parse_from(["tokscale", "cursor", "sync", "--json"]).is_ok());
+    }
+
+    #[test]
+    fn clap_accepts_codex_account_commands() {
+        assert!(Cli::try_parse_from(["tokscale", "codex", "import", "--name", "work"]).is_ok());
+        assert!(Cli::try_parse_from(["tokscale", "codex", "accounts"]).is_ok());
+        assert!(Cli::try_parse_from(["tokscale", "codex", "accounts", "--json"]).is_ok());
+        assert!(Cli::try_parse_from(["tokscale", "codex", "switch", "work"]).is_ok());
+        assert!(Cli::try_parse_from(["tokscale", "codex", "remove", "work"]).is_ok());
+        assert!(Cli::try_parse_from(["tokscale", "codex", "status"]).is_ok());
+        assert!(Cli::try_parse_from(["tokscale", "codex", "status", "--name", "work"]).is_ok());
+        assert!(
+            Cli::try_parse_from(["tokscale", "codex", "status", "--name", "work", "--json"])
+                .is_ok()
+        );
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -161,6 +161,31 @@ pub enum ClickAction {
     Tab(Tab),
     Sort(SortField),
     GraphCell { week: usize, day: usize },
+    UsageRefresh,
+    CodexStartLogin,
+    CodexDismissLogin,
+    CodexUseAccount { account_id: String },
+    CodexRemoveAccount { account_id: String },
+}
+
+#[derive(Debug, Clone)]
+pub enum CodexLoginOutcome {
+    Imported(crate::commands::usage::codex::CodexAccountInfo),
+    Failed(String),
+}
+
+#[cfg(test)]
+type UsageFetcher = fn() -> Vec<crate::commands::usage::UsageOutput>;
+
+#[cfg(test)]
+fn test_usage_fetcher() -> Vec<crate::commands::usage::UsageOutput> {
+    Vec::new()
+}
+
+#[derive(Debug, Clone)]
+enum CodexLoginEvent {
+    Output(String),
+    Finished(CodexLoginOutcome),
 }
 
 struct MinutelySortCache {
@@ -229,9 +254,15 @@ pub struct App {
     pub model_shade_map: HashMap<String, Color>,
 
     pub subscription_usage: Vec<crate::commands::usage::UsageOutput>,
+    pub pending_codex_remove_account_id: Option<String>,
+    pub codex_login_lines: Vec<String>,
+    pub codex_login_outcome: Option<CodexLoginOutcome>,
 
     pub usage_fetch_attempted: bool,
     usage_rx: Option<std::sync::mpsc::Receiver<Vec<crate::commands::usage::UsageOutput>>>,
+    #[cfg(test)]
+    usage_fetcher: UsageFetcher,
+    codex_login_rx: Option<std::sync::mpsc::Receiver<CodexLoginEvent>>,
 
     data_version: u64,
     minutely_sort_cache: RefCell<Option<MinutelySortCache>>,
@@ -344,8 +375,14 @@ impl App {
                     Vec::new()
                 }
             },
+            pending_codex_remove_account_id: None,
+            codex_login_lines: Vec::new(),
+            codex_login_outcome: None,
             usage_fetch_attempted: false,
             usage_rx: None,
+            #[cfg(test)]
+            usage_fetcher: test_usage_fetcher,
+            codex_login_rx: None,
             data_version: 0,
             minutely_sort_cache: RefCell::new(None),
         };
@@ -467,6 +504,73 @@ impl App {
                 Err(std::sync::mpsc::TryRecvError::Empty) => {}
             }
         }
+
+        self.poll_codex_login();
+    }
+
+    fn poll_codex_login(&mut self) {
+        let mut events = Vec::new();
+        let mut disconnected = false;
+
+        if let Some(rx) = &self.codex_login_rx {
+            loop {
+                match rx.try_recv() {
+                    Ok(event) => events.push(event),
+                    Err(std::sync::mpsc::TryRecvError::Empty) => break,
+                    Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                        disconnected = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        let mut finished = false;
+        for event in events {
+            match event {
+                CodexLoginEvent::Output(line) => {
+                    self.codex_login_lines.push(line);
+                    const MAX_LOGIN_LINES: usize = 12;
+                    if self.codex_login_lines.len() > MAX_LOGIN_LINES {
+                        let drain_count = self.codex_login_lines.len() - MAX_LOGIN_LINES;
+                        self.codex_login_lines.drain(0..drain_count);
+                    }
+                }
+                CodexLoginEvent::Finished(outcome) => {
+                    finished = true;
+                    match &outcome {
+                        CodexLoginOutcome::Imported(info) => {
+                            let display = info.label.as_deref().unwrap_or(&info.id);
+                            self.set_status(&format!("Imported Codex account: {display}"));
+                        }
+                        CodexLoginOutcome::Failed(error) => {
+                            self.set_status(&format!("Codex login failed: {error}"));
+                        }
+                    }
+                    self.codex_login_outcome = Some(outcome);
+                }
+            }
+        }
+
+        if disconnected && !finished && self.codex_login_outcome.is_none() {
+            self.codex_login_outcome = Some(CodexLoginOutcome::Failed(
+                "login worker stopped".to_string(),
+            ));
+            self.set_status("Codex login failed: login worker stopped");
+            finished = true;
+        }
+
+        if finished {
+            self.codex_login_rx = None;
+            if matches!(
+                self.codex_login_outcome,
+                Some(CodexLoginOutcome::Imported(_))
+            ) {
+                self.codex_login_lines.clear();
+                self.codex_login_outcome = None;
+                self.refresh_usage();
+            }
+        }
     }
 
     pub fn handle_key_event(&mut self, key: KeyEvent) -> bool {
@@ -539,12 +643,7 @@ impl App {
                 self.cycle_theme();
             }
             KeyCode::Char('r') => {
-                if self.background_loading {
-                    self.set_status("Refresh already in progress");
-                } else {
-                    self.needs_reload = true;
-                    self.fetch_subscription_usage();
-                }
+                self.refresh_usage();
             }
             KeyCode::Char('R') if key.modifiers.contains(KeyModifiers::SHIFT) => {
                 self.toggle_auto_refresh();
@@ -614,14 +713,161 @@ impl App {
         self.status_message_time = Some(std::time::Instant::now());
         let (tx, rx) = std::sync::mpsc::channel();
         self.usage_rx = Some(rx);
+        #[cfg(test)]
+        let usage_fetcher = self.usage_fetcher;
         std::thread::spawn(move || {
+            #[cfg(test)]
+            let results = usage_fetcher();
+            #[cfg(not(test))]
             let results = crate::commands::usage::fetch_all();
             let _ = tx.send(results);
         });
     }
 
+    pub fn refresh_usage(&mut self) {
+        if self.usage_rx.is_some() {
+            self.set_status("Refresh already in progress");
+        } else {
+            if !self.background_loading {
+                self.needs_reload = true;
+            }
+            self.fetch_subscription_usage();
+        }
+    }
+
     pub fn is_fetching_usage(&self) -> bool {
         self.usage_rx.is_some()
+    }
+
+    fn handle_click_action(&mut self, action: ClickAction) {
+        match action {
+            ClickAction::Tab(tab) => {
+                self.switch_tab(tab);
+                self.reset_selection();
+            }
+            ClickAction::Sort(field) => {
+                self.set_sort(field);
+            }
+            ClickAction::GraphCell { week, day } => {
+                self.selected_graph_cell = Some((week, day));
+                self.stats_breakdown_total_lines = 0;
+                self.selected_index = 0;
+                self.scroll_offset = 0;
+            }
+            ClickAction::UsageRefresh => {
+                self.refresh_usage();
+            }
+            ClickAction::CodexStartLogin => {
+                self.start_codex_login();
+            }
+            ClickAction::CodexDismissLogin => {
+                self.dismiss_codex_login();
+            }
+            ClickAction::CodexUseAccount { account_id } => {
+                self.use_codex_account(&account_id);
+            }
+            ClickAction::CodexRemoveAccount { account_id } => {
+                self.remove_codex_account(&account_id);
+            }
+        }
+    }
+
+    pub fn is_codex_login_running(&self) -> bool {
+        self.codex_login_rx.is_some()
+    }
+
+    pub fn should_show_codex_login_panel(&self) -> bool {
+        self.is_codex_login_running()
+            || self.codex_login_outcome.is_some()
+            || !self.codex_login_lines.is_empty()
+    }
+
+    fn start_codex_login(&mut self) {
+        if self.codex_login_rx.is_some() {
+            self.set_status("Codex login already in progress");
+            return;
+        }
+
+        self.pending_codex_remove_account_id = None;
+        self.codex_login_lines.clear();
+        self.codex_login_outcome = None;
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.codex_login_rx = Some(rx);
+        self.set_status("Starting Codex login...");
+        std::thread::spawn(move || run_codex_login_worker(tx));
+    }
+
+    fn dismiss_codex_login(&mut self) {
+        if self.codex_login_rx.is_none() {
+            self.codex_login_lines.clear();
+            self.codex_login_outcome = None;
+            self.set_status("Codex login panel dismissed");
+        }
+    }
+
+    fn use_codex_account(&mut self, account_id: &str) {
+        self.pending_codex_remove_account_id = None;
+
+        match crate::commands::usage::codex::switch_active_account(account_id) {
+            Ok(info) => {
+                self.mark_active_codex_account(&info.id);
+                self.persist_subscription_usage_cache();
+                let display = info.label.as_deref().unwrap_or(&info.id);
+                self.set_status(&format!("Active Codex account: {display}"));
+            }
+            Err(e) => {
+                self.set_status(&format!("Codex account switch failed: {e}"));
+            }
+        }
+    }
+
+    fn remove_codex_account(&mut self, account_id: &str) {
+        if self.pending_codex_remove_account_id.as_deref() != Some(account_id) {
+            self.pending_codex_remove_account_id = Some(account_id.to_string());
+            self.set_status("Click Confirm to remove this Codex account");
+            return;
+        }
+
+        self.pending_codex_remove_account_id = None;
+        match crate::commands::usage::codex::remove_account(account_id) {
+            Ok(info) => {
+                self.subscription_usage.retain(|usage| {
+                    usage.account.as_ref().map(|account| account.id.as_str())
+                        != Some(info.id.as_str())
+                });
+                if let Some(active) = crate::commands::usage::codex::list_accounts()
+                    .into_iter()
+                    .find(|account| account.is_active)
+                {
+                    self.mark_active_codex_account(&active.id);
+                }
+                self.persist_subscription_usage_cache();
+                let display = info.label.as_deref().unwrap_or(&info.id);
+                self.set_status(&format!("Removed Codex account: {display}"));
+            }
+            Err(e) => {
+                self.set_status(&format!("Codex account removal failed: {e}"));
+            }
+        }
+    }
+
+    fn persist_subscription_usage_cache(&self) {
+        if self.subscription_usage.is_empty() {
+            crate::commands::usage::clear_cache();
+        } else {
+            crate::commands::usage::save_cache(&self.subscription_usage);
+        }
+    }
+
+    fn mark_active_codex_account(&mut self, active_account_id: &str) {
+        for usage in &mut self.subscription_usage {
+            if usage.provider == "Codex" {
+                if let Some(account) = &mut usage.account {
+                    account.is_active = account.id == active_account_id;
+                }
+            }
+        }
     }
 
     pub fn handle_mouse_event(&mut self, event: MouseEvent) {
@@ -635,29 +881,19 @@ impl App {
                 let x = event.column;
                 let y = event.row;
 
-                for area in &self.click_areas {
-                    if x >= area.rect.x
-                        && x < area.rect.x + area.rect.width
-                        && y >= area.rect.y
-                        && y < area.rect.y + area.rect.height
-                    {
-                        match &area.action {
-                            ClickAction::Tab(tab) => {
-                                self.switch_tab(*tab);
-                                self.reset_selection();
-                            }
-                            ClickAction::Sort(field) => {
-                                self.set_sort(*field);
-                            }
-                            ClickAction::GraphCell { week, day } => {
-                                self.selected_graph_cell = Some((*week, *day));
-                                self.stats_breakdown_total_lines = 0;
-                                self.selected_index = 0;
-                                self.scroll_offset = 0;
-                            }
-                        }
-                        break;
-                    }
+                let action = self
+                    .click_areas
+                    .iter()
+                    .find(|area| {
+                        x >= area.rect.x
+                            && x < area.rect.x + area.rect.width
+                            && y >= area.rect.y
+                            && y < area.rect.y + area.rect.height
+                    })
+                    .map(|area| area.action.clone());
+
+                if let Some(action) = action {
+                    self.handle_click_action(action);
                 }
             }
             MouseEventKind::ScrollUp => {
@@ -726,6 +962,9 @@ impl App {
         self.persist_current_sort();
 
         self.current_tab = target;
+        if target != Tab::Usage {
+            self.pending_codex_remove_account_id = None;
+        }
         if target != Tab::Daily {
             self.selected_daily_detail_date = None;
         }
@@ -1500,6 +1739,167 @@ impl App {
     pub fn is_very_narrow(&self) -> bool {
         self.terminal_width < 60
     }
+}
+
+fn run_codex_login_worker(tx: std::sync::mpsc::Sender<CodexLoginEvent>) {
+    let result = run_codex_login_worker_inner(tx.clone());
+    let outcome = match result {
+        Ok(info) => CodexLoginOutcome::Imported(info),
+        Err(e) => CodexLoginOutcome::Failed(e.to_string()),
+    };
+    let _ = tx.send(CodexLoginEvent::Finished(outcome));
+}
+
+fn run_codex_login_worker_inner(
+    tx: std::sync::mpsc::Sender<CodexLoginEvent>,
+) -> Result<crate::commands::usage::codex::CodexAccountInfo> {
+    let codex_home =
+        std::env::temp_dir().join(format!("tokscale-codex-login-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&codex_home)
+        .map_err(|e| anyhow::anyhow!("failed to create temporary Codex home: {e}"))?;
+
+    let result = run_codex_login_in_home(&codex_home, tx);
+    let _ = std::fs::remove_dir_all(&codex_home);
+    result
+}
+
+fn run_codex_login_in_home(
+    codex_home: &std::path::Path,
+    tx: std::sync::mpsc::Sender<CodexLoginEvent>,
+) -> Result<crate::commands::usage::codex::CodexAccountInfo> {
+    let _ = tx.send(CodexLoginEvent::Output(
+        "Starting Codex browser login".to_string(),
+    ));
+
+    let mut child = std::process::Command::new("codex")
+        .arg("login")
+        .env("CODEX_HOME", codex_home)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("failed to start codex login: {e}"))?;
+
+    let output_lines = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let mut readers = Vec::new();
+    if let Some(stdout) = child.stdout.take() {
+        readers.push(spawn_codex_login_output_reader(
+            stdout,
+            tx.clone(),
+            std::sync::Arc::clone(&output_lines),
+        ));
+    }
+    if let Some(stderr) = child.stderr.take() {
+        readers.push(spawn_codex_login_output_reader(
+            stderr,
+            tx.clone(),
+            std::sync::Arc::clone(&output_lines),
+        ));
+    }
+
+    let status = child
+        .wait()
+        .map_err(|e| anyhow::anyhow!("failed to wait for codex login: {e}"))?;
+    for reader in readers {
+        let _ = reader.join();
+    }
+
+    if !status.success() {
+        let output_lines = output_lines
+            .lock()
+            .map(|lines| lines.clone())
+            .unwrap_or_default();
+        anyhow::bail!("{}", codex_login_failure_message(&status, &output_lines));
+    }
+
+    let auth_path = codex_home.join("auth.json");
+    let _ = crate::commands::usage::codex::save_current_account_as_active(None);
+    crate::commands::usage::codex::import_auth_file_without_activating(&auth_path, None)
+}
+
+fn spawn_codex_login_output_reader<R>(
+    reader: R,
+    tx: std::sync::mpsc::Sender<CodexLoginEvent>,
+    output_lines: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+) -> std::thread::JoinHandle<()>
+where
+    R: std::io::Read + Send + 'static,
+{
+    std::thread::spawn(move || {
+        let reader = std::io::BufReader::new(reader);
+        for line in std::io::BufRead::lines(reader).map_while(std::result::Result::ok) {
+            let line = sanitize_codex_login_line(&line);
+            if !line.trim().is_empty() {
+                if let Ok(mut output_lines) = output_lines.lock() {
+                    output_lines.push(line.clone());
+                }
+                let _ = tx.send(CodexLoginEvent::Output(line));
+            }
+        }
+    })
+}
+
+fn codex_login_failure_message(
+    status: &std::process::ExitStatus,
+    output_lines: &[String],
+) -> String {
+    codex_login_failure_message_from_output(&status.to_string(), output_lines)
+}
+
+fn codex_login_failure_message_from_output(status: &str, output_lines: &[String]) -> String {
+    let output = output_lines.join("\n").to_lowercase();
+
+    if output.contains("429") || output.contains("too many requests") {
+        return "OpenAI login is rate-limited (429 Too Many Requests). Wait before trying Add Codex again.".to_string();
+    }
+
+    if output.contains("expired") {
+        return "Codex device code expired. Start Add Codex again to get a new code.".to_string();
+    }
+
+    if output.contains("device auth failed") {
+        return "Codex device login failed. Try Add Codex again later.".to_string();
+    }
+
+    format!("codex login exited with {status}")
+}
+
+fn sanitize_codex_login_line(line: &str) -> String {
+    let mut sanitized = String::with_capacity(line.len());
+    let mut chars = line.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '\x1b' {
+            match chars.next() {
+                Some('[') => {
+                    for ch in chars.by_ref() {
+                        if ('\u{40}'..='\u{7e}').contains(&ch) {
+                            break;
+                        }
+                    }
+                }
+                Some(']') => {
+                    while let Some(ch) = chars.next() {
+                        if ch == '\x07' {
+                            break;
+                        }
+                        if ch == '\x1b' && chars.peek() == Some(&'\\') {
+                            let _ = chars.next();
+                            break;
+                        }
+                    }
+                }
+                Some(_) | None => {}
+            }
+            continue;
+        }
+
+        if !ch.is_control() || ch == '\t' {
+            sanitized.push(ch);
+        }
+    }
+
+    sanitized
 }
 
 #[cfg(test)]
@@ -2663,9 +3063,10 @@ mod tests {
         app.handle_key_event(key(KeyCode::Char('r')));
 
         assert!(!app.needs_reload);
+        assert!(app.is_fetching_usage());
         assert_eq!(
             app.status_message.as_deref(),
-            Some("Refresh already in progress")
+            Some("Fetching usage data...")
         );
     }
 
@@ -2767,6 +3168,56 @@ mod tests {
         };
         app.handle_mouse_event(event);
         assert_eq!(app.selected_graph_cell, Some((2, 3)));
+    }
+
+    #[test]
+    fn test_handle_mouse_click_usage_refresh_uses_refresh_path() {
+        let mut app = make_app();
+        app.background_loading = true;
+        app.add_click_area(Rect::new(0, 0, 10, 2), ClickAction::UsageRefresh);
+
+        let event = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 5,
+            row: 1,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse_event(event);
+
+        assert!(!app.needs_reload);
+        assert!(app.is_fetching_usage());
+        assert_eq!(
+            app.status_message.as_deref(),
+            Some("Fetching usage data...")
+        );
+    }
+
+    #[test]
+    fn test_handle_mouse_click_codex_remove_requires_confirmation() {
+        let mut app = make_app();
+        app.add_click_area(
+            Rect::new(0, 0, 10, 2),
+            ClickAction::CodexRemoveAccount {
+                account_id: "acct_work".to_string(),
+            },
+        );
+
+        let event = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 5,
+            row: 1,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse_event(event);
+
+        assert_eq!(
+            app.pending_codex_remove_account_id.as_deref(),
+            Some("acct_work")
+        );
+        assert_eq!(
+            app.status_message.as_deref(),
+            Some("Click Confirm to remove this Codex account")
+        );
     }
 
     #[test]
@@ -2909,6 +3360,110 @@ mod tests {
         app.on_tick();
         assert!(app.status_message.is_some());
         assert_eq!(app.status_message.as_ref().unwrap(), "fresh message");
+    }
+
+    #[test]
+    fn test_on_tick_collects_codex_login_events() {
+        let mut app = make_app();
+        let (tx, rx) = std::sync::mpsc::channel();
+        app.codex_login_rx = Some(rx);
+        tx.send(CodexLoginEvent::Output(
+            "Open https://example.com/device".to_string(),
+        ))
+        .unwrap();
+        tx.send(CodexLoginEvent::Finished(CodexLoginOutcome::Failed(
+            "expired".to_string(),
+        )))
+        .unwrap();
+        drop(tx);
+
+        app.on_tick();
+
+        assert!(app.codex_login_rx.is_none());
+        assert_eq!(
+            app.codex_login_lines.last().map(String::as_str),
+            Some("Open https://example.com/device")
+        );
+        assert!(matches!(
+            app.codex_login_outcome,
+            Some(CodexLoginOutcome::Failed(ref error)) if error == "expired"
+        ));
+        assert_eq!(
+            app.status_message.as_deref(),
+            Some("Codex login failed: expired")
+        );
+    }
+
+    #[test]
+    fn test_on_tick_clears_codex_login_panel_after_import() {
+        let mut app = make_app();
+        app.background_loading = true;
+        let (tx, rx) = std::sync::mpsc::channel();
+        app.codex_login_rx = Some(rx);
+        tx.send(CodexLoginEvent::Output(
+            "Starting Codex browser login".to_string(),
+        ))
+        .unwrap();
+        tx.send(CodexLoginEvent::Finished(CodexLoginOutcome::Imported(
+            crate::commands::usage::codex::CodexAccountInfo {
+                id: "acct_work".to_string(),
+                label: Some("work".to_string()),
+                account_id: Some("acct_work".to_string()),
+                created_at: "2026-06-09T00:00:00Z".to_string(),
+                is_active: true,
+            },
+        )))
+        .unwrap();
+        drop(tx);
+
+        app.on_tick();
+
+        assert!(app.codex_login_rx.is_none());
+        assert!(app.codex_login_lines.is_empty());
+        assert!(app.codex_login_outcome.is_none());
+        assert!(!app.should_show_codex_login_panel());
+    }
+
+    #[test]
+    fn test_sanitize_codex_login_line_strips_ansi_sequences() {
+        assert_eq!(
+            sanitize_codex_login_line("\u{1b}[94mhttps://auth.openai.com/codex/device\u{1b}[0m"),
+            "https://auth.openai.com/codex/device"
+        );
+        assert_eq!(
+            sanitize_codex_login_line("\u{1b}[90mCAGW-LNUYX\u{1b}[0m"),
+            "CAGW-LNUYX"
+        );
+    }
+
+    #[test]
+    fn test_codex_login_failure_message_identifies_rate_limit() {
+        let message = codex_login_failure_message_from_output(
+            "exit status: 1",
+            &[
+                "Device codes are a common phishing target. Never share this code.".to_string(),
+                "Error logging in with device code: device auth failed with status 429 Too Many Requests"
+                    .to_string(),
+            ],
+        );
+
+        assert_eq!(
+            message,
+            "OpenAI login is rate-limited (429 Too Many Requests). Wait before trying Add Codex again."
+        );
+    }
+
+    #[test]
+    fn test_codex_login_failure_message_identifies_expired_code() {
+        let message = codex_login_failure_message_from_output(
+            "exit status: 1",
+            &["Error logging in with device code: expired".to_string()],
+        );
+
+        assert_eq!(
+            message,
+            "Codex device code expired. Start Add Codex again to get a new code."
+        );
     }
 
     // ── click area management ───────────────────────────────────────

--- a/crates/tokscale-cli/src/tui/ui/usage.rs
+++ b/crates/tokscale-cli/src/tui/ui/usage.rs
@@ -1,10 +1,16 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-use crate::commands::usage::helpers;
-use crate::tui::app::App;
+use crate::commands::usage::{helpers, UsageMetric, UsageOutput};
+use crate::tui::app::{App, ClickAction, CodexLoginOutcome};
 
 const BAR_WIDTH: usize = 20;
+
+struct ButtonSpec {
+    label: &'static str,
+    style: Style,
+    action: ClickAction,
+}
 
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default()
@@ -17,18 +23,218 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
+    let content = render_action_bar(frame, app, inner);
+    let content = render_codex_login_panel(frame, app, content);
+
     if app.subscription_usage.is_empty() {
         if app.is_fetching_usage() {
-            render_fetching(frame, app, inner);
+            render_fetching(frame, app, content);
         } else if app.usage_fetch_attempted {
-            render_empty(frame, app, inner);
+            render_empty(frame, app, content);
         } else {
-            render_loading(frame, app, inner);
+            render_loading(frame, app, content);
         }
     } else if app.subscription_usage.iter().all(|o| o.metrics.is_empty()) {
-        render_empty(frame, app, inner);
+        render_empty(frame, app, content);
     } else {
-        render_loaded(frame, app, inner, &app.subscription_usage);
+        let outputs = app.subscription_usage.clone();
+        render_loaded(frame, app, content, &outputs);
+    }
+}
+
+fn render_action_bar(frame: &mut Frame, app: &mut App, area: Rect) -> Rect {
+    if area.height == 0 {
+        return area;
+    }
+
+    let refresh_label = if app.is_fetching_usage() {
+        "Refreshing"
+    } else {
+        "Refresh"
+    };
+    let refresh_style = if app.is_fetching_usage() {
+        Style::default().fg(app.theme.muted)
+    } else {
+        Style::default()
+            .fg(app.theme.accent)
+            .add_modifier(Modifier::BOLD)
+    };
+
+    let add_label = if app.is_codex_login_running() {
+        "Adding Codex"
+    } else {
+        "Add Codex"
+    };
+    let add_style = if app.is_codex_login_running() {
+        Style::default().fg(app.theme.muted)
+    } else {
+        Style::default().fg(app.theme.accent)
+    };
+
+    let buttons = vec![
+        ButtonSpec {
+            label: refresh_label,
+            style: refresh_style,
+            action: ClickAction::UsageRefresh,
+        },
+        ButtonSpec {
+            label: add_label,
+            style: add_style,
+            action: ClickAction::CodexStartLogin,
+        },
+    ];
+
+    let mut spans = vec![Span::raw(" ")];
+    let right_edge = area.x.saturating_add(area.width);
+    push_click_buttons(
+        &mut spans,
+        app,
+        buttons,
+        area.x.saturating_add(1),
+        area.y,
+        right_edge,
+    );
+
+    frame.render_widget(
+        Paragraph::new(Line::from(spans)),
+        Rect::new(area.x, area.y, area.width, 1),
+    );
+
+    if area.height > 1 {
+        Rect::new(area.x, area.y + 1, area.width, area.height - 1)
+    } else {
+        Rect::new(area.x, area.y, area.width, 0)
+    }
+}
+
+fn button_render_width(label: &str) -> usize {
+    label.chars().count() + 2
+}
+
+fn click_buttons_width(buttons: &[ButtonSpec]) -> usize {
+    buttons
+        .iter()
+        .enumerate()
+        .map(|(index, button)| button_render_width(button.label) + usize::from(index > 0))
+        .sum()
+}
+
+fn push_click_buttons(
+    spans: &mut Vec<Span<'static>>,
+    app: &mut App,
+    buttons: Vec<ButtonSpec>,
+    start_x: u16,
+    y: u16,
+    right_edge: u16,
+) {
+    let mut x = start_x;
+    for (index, button) in buttons.into_iter().enumerate() {
+        if index > 0 {
+            spans.push(Span::raw(" "));
+            x = x.saturating_add(1);
+        }
+
+        let rendered = format!("[{}]", button.label);
+        let width = rendered.chars().count() as u16;
+        spans.push(Span::styled(rendered, button.style));
+
+        if x < right_edge {
+            app.add_click_area(Rect::new(x, y, width.min(right_edge - x), 1), button.action);
+        }
+        x = x.saturating_add(width);
+    }
+}
+
+fn render_codex_login_panel(frame: &mut Frame, app: &mut App, area: Rect) -> Rect {
+    if area.height == 0 || !app.should_show_codex_login_panel() {
+        return area;
+    }
+
+    let max_output_lines = 5usize;
+    let output_start = app.codex_login_lines.len().saturating_sub(max_output_lines);
+    let output_lines: Vec<String> = app.codex_login_lines[output_start..].to_vec();
+    let height = (2 + output_lines.len() as u16 + u16::from(app.codex_login_outcome.is_some()))
+        .min(area.height);
+    if height == 0 {
+        return area;
+    }
+
+    let mut lines: Vec<Line> = Vec::new();
+    let status = match &app.codex_login_outcome {
+        Some(CodexLoginOutcome::Imported(_)) => "Imported",
+        Some(CodexLoginOutcome::Failed(_)) => "Failed",
+        None if app.is_codex_login_running() => "Running",
+        None => "Idle",
+    };
+
+    let mut header_spans = vec![
+        Span::styled(
+            " Codex login ",
+            Style::default()
+                .fg(app.theme.foreground)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(status, Style::default().fg(app.theme.muted)),
+    ];
+    if app.codex_login_outcome.is_some() {
+        let dismiss = "[Dismiss]";
+        let used_width = 14usize + status.chars().count();
+        let dismiss_width = dismiss.chars().count();
+        let dismiss_click_width = (dismiss_width as u16).min(area.width);
+        let padding = (area.width as usize).saturating_sub(used_width + dismiss_width);
+        header_spans.push(Span::raw(" ".repeat(padding)));
+        header_spans.push(Span::styled(dismiss, Style::default().fg(app.theme.accent)));
+        let x = area
+            .x
+            .saturating_add(area.width.saturating_sub(dismiss_click_width));
+        if dismiss_click_width > 0 {
+            app.add_click_area(
+                Rect::new(x, area.y, dismiss_click_width, 1),
+                ClickAction::CodexDismissLogin,
+            );
+        }
+    }
+    lines.push(Line::from(header_spans));
+
+    if output_lines.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  Waiting for codex output...",
+            Style::default().fg(app.theme.muted),
+        )));
+    } else {
+        for line in output_lines {
+            lines.push(Line::from(Span::styled(
+                format!("  {line}"),
+                Style::default().fg(app.theme.muted),
+            )));
+        }
+    }
+
+    if let Some(outcome) = &app.codex_login_outcome {
+        let (label, style) = match outcome {
+            CodexLoginOutcome::Imported(info) => (
+                format!(
+                    "  Imported {}",
+                    info.label.as_deref().unwrap_or(info.id.as_str())
+                ),
+                Style::default().fg(app.theme.accent),
+            ),
+            CodexLoginOutcome::Failed(error) => {
+                (format!("  {error}"), Style::default().fg(Color::Red))
+            }
+        };
+        lines.push(Line::from(Span::styled(label, style)));
+    }
+
+    frame.render_widget(
+        Paragraph::new(lines),
+        Rect::new(area.x, area.y, area.width, height),
+    );
+
+    if area.height > height {
+        Rect::new(area.x, area.y + height, area.width, area.height - height)
+    } else {
+        Rect::new(area.x, area.y, area.width, 0)
     }
 }
 
@@ -62,7 +268,7 @@ fn render_loading(frame: &mut Frame, app: &App, area: Rect) {
     let msg = if app.data.loading {
         "Loading subscription data..."
     } else {
-        "Press 'u' to fetch subscription usage"
+        "Use Refresh to fetch subscription usage"
     };
     let paragraph = Paragraph::new(msg)
         .style(Style::default().fg(app.theme.muted))
@@ -86,75 +292,508 @@ fn render_empty(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(paragraph, center);
 }
 
-fn render_loaded(
-    frame: &mut Frame,
-    app: &App,
-    area: Rect,
-    outputs: &[crate::commands::usage::UsageOutput],
-) {
+fn render_loaded(frame: &mut Frame, app: &mut App, area: Rect, outputs: &[UsageOutput]) {
     let mut lines: Vec<Line> = Vec::new();
+    let groups = group_outputs_by_provider(outputs);
 
-    for (i, output) in outputs.iter().enumerate() {
-        if i > 0 {
+    for (group_index, group) in groups.iter().enumerate() {
+        if group_index > 0 {
             lines.push(Line::from(""));
         }
 
-        lines.push(Line::from(Span::styled(
-            format!(" {} ", output.provider),
-            Style::default()
-                .fg(app.theme.foreground)
-                .add_modifier(Modifier::BOLD),
-        )));
+        let account_group = group.outputs.iter().any(|output| output.account.is_some());
 
-        for m in &output.metrics {
-            let remaining = m
-                .remaining_label
-                .clone()
-                .unwrap_or_else(|| format!("{:.0}% left", m.remaining_percent));
-            let bar = helpers::render_ascii_bar(m.remaining_percent, BAR_WIDTH);
-            let reset = m
-                .resets_at
-                .as_ref()
-                .map(|r| helpers::format_reset_time(r))
-                .unwrap_or_default();
+        if account_group {
+            push_provider_header(&mut lines, app, group.provider);
 
-            let label = Span::styled(
-                format!(" {:<14}", m.label),
-                Style::default().fg(app.theme.foreground),
-            );
-            let value = Span::styled(
-                format!("{:<11}", remaining),
-                Style::default().fg(app.theme.foreground),
-            );
-            let bar_span = Span::styled(
-                format!("{:<24}", bar),
-                Style::default().fg(if m.remaining_percent < 10.0 {
-                    Color::Red
-                } else if m.remaining_percent < 25.0 {
-                    Color::Yellow
-                } else {
-                    app.theme.accent
-                }),
-            );
-            let reset_span = Span::styled(reset, Style::default().fg(app.theme.muted));
-
-            lines.push(Line::from(vec![label, value, bar_span, reset_span]));
-        }
-
-        if let Some(ref email) = output.email {
-            lines.push(Line::from(Span::styled(
-                format!(" {:<12}{email}", "Account"),
-                Style::default().fg(app.theme.muted),
-            )));
-        }
-        if let Some(ref plan) = output.plan {
-            lines.push(Line::from(Span::styled(
-                format!(" {:<12}{plan}", "Plan"),
-                Style::default().fg(app.theme.muted),
-            )));
+            for (output_index, output) in group.outputs.iter().enumerate() {
+                if output_index > 0 {
+                    lines.push(Line::from(""));
+                }
+                push_account_header(&mut lines, app, output, area);
+                push_output_details(
+                    &mut lines,
+                    app,
+                    output,
+                    "   ",
+                    "Email",
+                    account_header_uses_email(output),
+                );
+            }
+        } else {
+            for (output_index, output) in group.outputs.iter().enumerate() {
+                if output_index > 0 {
+                    lines.push(Line::from(""));
+                }
+                push_provider_header(&mut lines, app, &output.display_name());
+                push_output_details(&mut lines, app, output, " ", "Account", false);
+            }
         }
     }
 
     let paragraph = Paragraph::new(lines);
     frame.render_widget(paragraph, area);
+}
+
+struct UsageProviderGroup<'a> {
+    provider: &'a str,
+    outputs: Vec<&'a UsageOutput>,
+}
+
+fn group_outputs_by_provider(outputs: &[UsageOutput]) -> Vec<UsageProviderGroup<'_>> {
+    let mut groups: Vec<UsageProviderGroup<'_>> = Vec::new();
+
+    for output in outputs {
+        if let Some(group) = groups
+            .iter_mut()
+            .find(|group| group.provider == output.provider)
+        {
+            group.outputs.push(output);
+        } else {
+            groups.push(UsageProviderGroup {
+                provider: &output.provider,
+                outputs: vec![output],
+            });
+        }
+    }
+
+    groups
+}
+
+fn push_provider_header(lines: &mut Vec<Line>, app: &App, label: &str) {
+    lines.push(Line::from(Span::styled(
+        format!(" {label} "),
+        Style::default()
+            .fg(app.theme.foreground)
+            .add_modifier(Modifier::BOLD),
+    )));
+}
+
+fn push_account_header(lines: &mut Vec<Line>, app: &mut App, output: &UsageOutput, area: Rect) {
+    let (name, is_active) = match &output.account {
+        Some(account) => (
+            output.account_display_name().unwrap_or_default(),
+            account.is_active,
+        ),
+        None => (output.display_name(), false),
+    };
+    let name_width = name.chars().count();
+    let marker = if is_active { "*" } else { "-" };
+    let marker_style = if is_active {
+        Style::default()
+            .fg(app.theme.accent)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(app.theme.muted)
+    };
+    let name_style = if is_active {
+        Style::default()
+            .fg(app.theme.foreground)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(app.theme.foreground)
+    };
+
+    let mut spans = vec![
+        Span::raw(" "),
+        Span::styled(marker, marker_style),
+        Span::raw(" "),
+        Span::styled(name, name_style),
+    ];
+
+    if let Some(account) = &output.account {
+        let y = area.y.saturating_add(lines.len() as u16);
+        let left_width = 3usize.saturating_add(name_width);
+        let pending_remove =
+            app.pending_codex_remove_account_id.as_deref() == Some(account.id.as_str());
+
+        let mut buttons: Vec<ButtonSpec> = Vec::new();
+        if !account.is_active {
+            buttons.push(ButtonSpec {
+                label: "Use",
+                style: Style::default()
+                    .fg(app.theme.accent)
+                    .add_modifier(Modifier::BOLD),
+                action: ClickAction::CodexUseAccount {
+                    account_id: account.id.clone(),
+                },
+            });
+        }
+
+        buttons.push(ButtonSpec {
+            label: if pending_remove { "Confirm" } else { "Remove" },
+            style: Style::default().fg(if pending_remove {
+                Color::Red
+            } else {
+                app.theme.muted
+            }),
+            action: ClickAction::CodexRemoveAccount {
+                account_id: account.id.clone(),
+            },
+        });
+
+        let button_width = click_buttons_width(&buttons);
+        let padding = (area.width as usize).saturating_sub(left_width + button_width);
+        spans.push(Span::raw(" ".repeat(padding)));
+
+        let x = area
+            .x
+            .saturating_add(left_width as u16)
+            .saturating_add(padding as u16);
+        let right_edge = area.x.saturating_add(area.width);
+        push_click_buttons(&mut spans, app, buttons, x, y, right_edge);
+    }
+
+    lines.push(Line::from(spans));
+}
+
+fn push_output_details(
+    lines: &mut Vec<Line>,
+    app: &App,
+    output: &UsageOutput,
+    indent: &str,
+    email_label: &str,
+    skip_email: bool,
+) {
+    for metric in &output.metrics {
+        lines.push(metric_line(app, metric, indent));
+    }
+
+    if !skip_email {
+        if let Some(ref email) = output.email {
+            push_metadata_line(lines, app, indent, email_label, email);
+        }
+    }
+    if let Some(ref plan) = output.plan {
+        push_metadata_line(lines, app, indent, "Plan", plan);
+    }
+}
+
+fn account_header_uses_email(output: &UsageOutput) -> bool {
+    let Some(account) = &output.account else {
+        return false;
+    };
+    if account.label_name().is_some() {
+        return false;
+    }
+
+    output
+        .email
+        .as_deref()
+        .map(str::trim)
+        .filter(|email| !email.is_empty())
+        .is_some()
+}
+
+fn metric_line(app: &App, metric: &UsageMetric, indent: &str) -> Line<'static> {
+    let remaining = metric
+        .remaining_label
+        .clone()
+        .unwrap_or_else(|| format!("{:.0}% left", metric.remaining_percent));
+    let bar = helpers::render_ascii_bar(metric.remaining_percent, BAR_WIDTH);
+    let reset = metric
+        .resets_at
+        .as_ref()
+        .map(|r| helpers::format_reset_time(r))
+        .unwrap_or_default();
+
+    let label = Span::styled(
+        format!("{indent}{:<14}", metric.label),
+        Style::default().fg(app.theme.foreground),
+    );
+    let value = Span::styled(
+        format!("{:<11}", remaining),
+        Style::default().fg(app.theme.foreground),
+    );
+    let bar_span = Span::styled(
+        format!("{:<24}", bar),
+        Style::default().fg(if metric.remaining_percent < 10.0 {
+            Color::Red
+        } else if metric.remaining_percent < 25.0 {
+            Color::Yellow
+        } else {
+            app.theme.accent
+        }),
+    );
+    let reset_span = Span::styled(reset, Style::default().fg(app.theme.muted));
+
+    Line::from(vec![label, value, bar_span, reset_span])
+}
+
+fn push_metadata_line(lines: &mut Vec<Line>, app: &App, indent: &str, label: &str, value: &str) {
+    lines.push(Line::from(Span::styled(
+        format!("{indent}{:<12}{value}", label),
+        Style::default().fg(app.theme.muted),
+    )));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::usage::{UsageAccount, UsageMetric};
+    use crate::tui::app::TuiConfig;
+    use crate::tui::data::UsageData;
+    use ratatui::{backend::TestBackend, Terminal};
+
+    fn output(provider: &str, account: Option<UsageAccount>) -> UsageOutput {
+        UsageOutput {
+            provider: provider.to_string(),
+            account,
+            plan: None,
+            email: None,
+            metrics: vec![UsageMetric {
+                label: "Session".to_string(),
+                used_percent: 10.0,
+                remaining_percent: 90.0,
+                remaining_label: Some("90% left".to_string()),
+                resets_at: None,
+            }],
+        }
+    }
+
+    fn make_app() -> App {
+        let config = TuiConfig {
+            theme: "blue".to_string(),
+            refresh: 0,
+            sessions_path: None,
+            clients: None,
+            since: None,
+            until: None,
+            year: None,
+            initial_tab: None,
+        };
+        App::new_with_cached_data(config, Some(UsageData::default())).unwrap()
+    }
+
+    fn render_body(app: &mut App, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render(frame, app, Rect::new(0, 0, width, height)))
+            .unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .chunks(width as usize)
+            .map(|row| {
+                row.iter()
+                    .map(|cell| cell.symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn groups_usage_outputs_by_provider_preserving_first_seen_order() {
+        let outputs = vec![
+            output(
+                "Codex",
+                Some(UsageAccount {
+                    id: "acct_work".to_string(),
+                    label: Some("work".to_string()),
+                    is_active: true,
+                }),
+            ),
+            output("Claude", None),
+            output(
+                "Codex",
+                Some(UsageAccount {
+                    id: "acct_personal".to_string(),
+                    label: Some("personal".to_string()),
+                    is_active: false,
+                }),
+            ),
+        ];
+
+        let groups = group_outputs_by_provider(&outputs);
+
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].provider, "Codex");
+        assert_eq!(groups[0].outputs.len(), 2);
+        assert_eq!(groups[1].provider, "Claude");
+        assert_eq!(groups[1].outputs.len(), 1);
+    }
+
+    #[test]
+    fn renders_codex_accounts_under_one_provider_section() {
+        let mut app = make_app();
+        app.subscription_usage = vec![
+            output(
+                "Codex",
+                Some(UsageAccount {
+                    id: "acct_work".to_string(),
+                    label: Some("work".to_string()),
+                    is_active: true,
+                }),
+            ),
+            output(
+                "Codex",
+                Some(UsageAccount {
+                    id: "acct_personal".to_string(),
+                    label: Some("personal".to_string()),
+                    is_active: false,
+                }),
+            ),
+            output("Claude", None),
+        ];
+
+        let body = render_body(&mut app, 100, 18);
+
+        assert_eq!(
+            body.matches(" Codex ").count(),
+            1,
+            "Codex provider should render once for grouped accounts\n{body}"
+        );
+        assert!(body.contains("* work"), "active account missing\n{body}");
+        assert!(
+            body.contains("- personal"),
+            "inactive account missing\n{body}"
+        );
+        assert!(
+            body.contains(" Claude "),
+            "other providers still render\n{body}"
+        );
+    }
+
+    #[test]
+    fn renders_codex_account_email_instead_of_raw_account_id() {
+        let mut app = make_app();
+        let raw_id = "123e4567-e89b-12d3-a456-426614174000";
+        app.subscription_usage = vec![UsageOutput {
+            provider: "Codex".to_string(),
+            account: Some(UsageAccount {
+                id: raw_id.to_string(),
+                label: None,
+                is_active: true,
+            }),
+            plan: None,
+            email: Some("user@example.com".to_string()),
+            metrics: vec![UsageMetric {
+                label: "Session".to_string(),
+                used_percent: 10.0,
+                remaining_percent: 90.0,
+                remaining_label: Some("90% left".to_string()),
+                resets_at: None,
+            }],
+        }];
+
+        let body = render_body(&mut app, 100, 10);
+
+        assert!(body.contains("* user@example.com"), "email missing\n{body}");
+        assert!(!body.contains(raw_id), "raw id leaked\n{body}");
+    }
+
+    #[test]
+    fn registers_usage_refresh_and_codex_account_click_areas() {
+        let mut app = make_app();
+        app.subscription_usage = vec![
+            output(
+                "Codex",
+                Some(UsageAccount {
+                    id: "acct_work".to_string(),
+                    label: Some("work".to_string()),
+                    is_active: true,
+                }),
+            ),
+            output(
+                "Codex",
+                Some(UsageAccount {
+                    id: "acct_personal".to_string(),
+                    label: Some("personal".to_string()),
+                    is_active: false,
+                }),
+            ),
+        ];
+
+        let body = render_body(&mut app, 100, 18);
+
+        assert!(body.contains("[Refresh]"), "refresh button missing\n{body}");
+        assert!(body.contains("[Add Codex]"), "add button missing\n{body}");
+        assert!(body.contains("* work"), "active marker missing\n{body}");
+        assert!(body.contains("[Use]"), "use button missing\n{body}");
+        assert!(body.contains("[Remove]"), "remove button missing\n{body}");
+        assert!(app
+            .click_areas
+            .iter()
+            .any(|area| matches!(area.action, ClickAction::UsageRefresh)));
+        assert!(app
+            .click_areas
+            .iter()
+            .any(|area| matches!(area.action, ClickAction::CodexStartLogin)));
+        assert!(app.click_areas.iter().any(|area| matches!(
+            &area.action,
+            ClickAction::CodexUseAccount { account_id } if account_id == "acct_personal"
+        )));
+        assert!(app.click_areas.iter().any(|area| matches!(
+            &area.action,
+            ClickAction::CodexRemoveAccount { account_id } if account_id == "acct_work"
+        )));
+    }
+
+    #[test]
+    fn renders_confirm_for_pending_codex_removal() {
+        let mut app = make_app();
+        app.pending_codex_remove_account_id = Some("acct_work".to_string());
+        app.subscription_usage = vec![output(
+            "Codex",
+            Some(UsageAccount {
+                id: "acct_work".to_string(),
+                label: Some("work".to_string()),
+                is_active: true,
+            }),
+        )];
+
+        let body = render_body(&mut app, 100, 10);
+
+        assert!(body.contains("[Confirm]"), "confirm button missing\n{body}");
+        assert!(
+            !body.contains("[Remove]"),
+            "stale remove button shown\n{body}"
+        );
+    }
+
+    #[test]
+    fn renders_codex_login_panel_output_and_dismiss_action() {
+        let mut app = make_app();
+        app.codex_login_lines = vec![
+            "Open https://example.com/device".to_string(),
+            "Code ABCD-EFGH".to_string(),
+        ];
+        app.codex_login_outcome = Some(CodexLoginOutcome::Failed("expired".to_string()));
+
+        let body = render_body(&mut app, 100, 12);
+
+        assert!(body.contains("Codex login"), "login panel missing\n{body}");
+        assert!(
+            body.contains("Open https://example.com/device"),
+            "login output missing\n{body}"
+        );
+        assert!(body.contains("expired"), "login error missing\n{body}");
+        assert!(body.contains("[Dismiss]"), "dismiss button missing\n{body}");
+        assert!(app
+            .click_areas
+            .iter()
+            .any(|area| matches!(area.action, ClickAction::CodexDismissLogin)));
+    }
+
+    #[test]
+    fn codex_login_dismiss_click_area_stays_inside_narrow_panel() {
+        let mut app = make_app();
+        app.codex_login_outcome = Some(CodexLoginOutcome::Failed("expired".to_string()));
+
+        let _body = render_body(&mut app, 6, 8);
+
+        let dismiss_area = app
+            .click_areas
+            .iter()
+            .find(|area| matches!(area.action, ClickAction::CodexDismissLogin))
+            .expect("dismiss click area");
+        assert!(
+            dismiss_area.rect.x + dismiss_area.rect.width <= 6,
+            "dismiss click area exceeds panel: {:?}",
+            dismiss_area.rect
+        );
+    }
 }

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -720,6 +720,18 @@ fn test_clients_command_help() {
 }
 
 #[test]
+fn test_codex_command_help() {
+    let mut cmd = cargo_bin_cmd!("tokscale");
+    cmd.arg("codex")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Codex account integration commands",
+        ));
+}
+
+#[test]
 fn test_graph_command_help() {
     let mut cmd = cargo_bin_cmd!("tokscale");
     cmd.arg("graph")
@@ -789,6 +801,18 @@ fn test_invalid_command() {
 fn test_invalid_subcommand() {
     let mut cmd = cargo_bin_cmd!("tokscale");
     cmd.arg("models").arg("invalid-flag").assert().failure();
+}
+
+#[test]
+fn test_codex_accounts_empty_json() {
+    let tmp = TempDir::new().expect("failed to create temp home");
+    let mut cmd = cargo_bin_cmd!("tokscale");
+    cmd.env("HOME", tmp.path())
+        .env_remove("CODEX_HOME")
+        .args(["codex", "accounts", "--json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""accounts": []"#));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add saved Codex account metadata to subscription usage output while preserving legacy JSON compatibility.
- Group Codex accounts under one Usage section with mouse-driven Refresh, Add Codex, Use, Remove, and Confirm controls.
- Add TUI Codex login through an isolated temporary CODEX_HOME, then import the account without switching the active Codex auth until Use is clicked.
- Mask raw account identifiers in the TUI by preferring labels or email and falling back to shortened account ids.

## Validation
- cargo fmt -p tokscale-cli --check
- git diff --check
- cargo test -p tokscale-cli codex --no-default-features
- cargo test -p tokscale-cli usage --no-default-features
- cargo check -p tokscale-cli --no-default-features
- cargo build -p tokscale-cli --no-default-features

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds multi-account Codex management to the CLI and TUI, with import/switch/remove controls and account metadata in usage output, while keeping existing JSON output compatible.

- **New Features**
  - TUI: Group Codex accounts under Usage with [Refresh], [Add Codex], [Use], [Remove], and confirm remove. Adds a login panel that runs in a temporary `CODEX_HOME` and imports without switching until [Use]. Masks raw IDs by showing label/email or a shortened ID. Keyboard `r` uses the same refresh path.
  - CLI: New `codex` commands:
    - `codex import [--name <label>]` to save the current Codex OAuth as an account.
    - `codex accounts [--json]` to list saved accounts.
    - `codex switch <label|id>` to activate an account and write Codex `auth.json`.
    - `codex remove <label|id>` to delete an account.
  - JSON: `UsageOutput` adds `account` with `{ id, label, is_active }`; non-Codex providers set `account: null`. Legacy JSON stays compatible.

<sup>Written for commit 4c45dcc0035f6d97500ff2a5659c7b8c96268742. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

