### PR TITLE
fix(cli): detect musl correctly under Bun and Alpine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1173,6 +1173,8 @@ cd packages/core && bun run bench
 | Windows | x86_64 | ✅ Supported |
 | Windows | aarch64 | ✅ Supported |
 
+On Linux, the launcher detects glibc vs musl automatically (via `process.report`, the musl dynamic loader at `/lib/ld-musl-*.so.1`, and `ldd`). If detection ever picks the wrong flavor — e.g. in minimal containers — set `TOKSCALE_LIBC=musl` (or `TOKSCALE_LIBC=gnu`) to force it.
+
 ### Windows Support
 
 Tokscale fully supports Windows. The TUI and CLI work the same as on macOS/Linux.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -56,28 +56,44 @@ function detectLibcKind(): LibcKind {
     return "musl";
   }
 
-  // musl distros (Alpine, Void-musl, ...) ship the loader as /lib/ld-musl-<arch>.so.1.
-  try {
-    if (readdirSync("/lib").some((entry) => entry.startsWith("ld-musl-"))) {
-      return "musl";
-    }
-  } catch {
-    // /lib unreadable or missing; fall through to ldd probing.
-  }
-
   try {
     const output = execSync("ldd --version", {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "pipe"],
     }).toLowerCase();
-    return output.includes("musl") ? "musl" : "gnu";
+    if (output.includes("musl")) return "musl";
+    if (output.includes("glibc") || output.includes("gnu")) return "gnu";
   } catch (error) {
     // musl's ldd rejects --version: it prints "musl libc" to stderr and
     // exits non-zero, so the answer is in the error, not the output.
     const { stdout, stderr } = (error ?? {}) as { stdout?: unknown; stderr?: unknown };
     const combined = `${stdout ?? ""}\n${stderr ?? ""}`.toLowerCase();
-    return combined.includes("musl") ? "musl" : "gnu";
+    if (combined.includes("musl")) return "musl";
+    if (combined.includes("glibc") || combined.includes("gnu")) return "gnu";
   }
+
+  // ldd missing or inconclusive: look for dynamic loaders. The glibc loader
+  // wins when both exist - a musl loader can coexist on glibc hosts (e.g.
+  // Debian with the musl package installed), but not the reverse.
+  if (loaderPresent("ld-linux-")) return "gnu";
+  if (loaderPresent("ld-musl-")) return "musl";
+
+  return "gnu";
+}
+
+// Glibc ships ld-linux-*.so.* in /lib64 (or /lib on some arches); musl
+// distros (Alpine, Void-musl, ...) ship /lib/ld-musl-<arch>.so.1.
+function loaderPresent(prefix: string): boolean {
+  for (const dir of ["/lib", "/lib64"]) {
+    try {
+      if (readdirSync(dir).some((entry) => entry.startsWith(prefix))) {
+        return true;
+      }
+    } catch {
+      // Directory unreadable or missing; try the next one.
+    }
+  }
+  return false;
 }
 
 function resolveTargetPackageName(): string | null {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -72,11 +72,16 @@ function detectLibcKind(): LibcKind {
     if (combined.includes("glibc") || combined.includes("gnu")) return "gnu";
   }
 
-  // ldd missing or inconclusive: look for dynamic loaders. The glibc loader
-  // wins when both exist - a musl loader can coexist on glibc hosts (e.g.
-  // Debian with the musl package installed), but not the reverse.
-  if (loaderPresent("ld-linux-")) return "gnu";
-  if (loaderPresent("ld-musl-")) return "musl";
+  // ldd missing or inconclusive: look for dynamic loaders. Either loader
+  // can coexist with the other's libc (Debian's musl package installs
+  // ld-musl-*; Alpine's gcompat installs ld-linux-*), so when both are
+  // present, let the distro break the tie.
+  const hasGnuLoader = loaderPresent("ld-linux-");
+  const hasMuslLoader = loaderPresent("ld-musl-");
+  if (hasGnuLoader !== hasMuslLoader) return hasMuslLoader ? "musl" : "gnu";
+  if (hasGnuLoader && hasMuslLoader) {
+    return existsSync("/etc/alpine-release") ? "musl" : "gnu";
+  }
 
   return "gnu";
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync, execSync } from "node:child_process";
-import { existsSync, realpathSync } from "node:fs";
+import { existsSync, readdirSync, realpathSync } from "node:fs";
 import { resolve, join, basename } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -25,9 +25,16 @@ const workspaceRoot = resolve(scopeDir, "..");
 type LibcKind = "gnu" | "musl";
 
 function detectLibcKind(): LibcKind {
+  const override = process.env.TOKSCALE_LIBC?.trim().toLowerCase();
+  if (override === "musl") return "musl";
+  if (override === "gnu" || override === "glibc") return "gnu";
+
   const report = process.report?.getReport?.() as
     | {
-        header?: { glibcVersionRuntime?: string };
+        header?: {
+          glibcVersionRuntime?: string;
+          release?: { sourceUrl?: string };
+        };
         sharedObjects?: string[];
       }
     | undefined;
@@ -43,14 +50,33 @@ function detectLibcKind(): LibcKind {
     return "musl";
   }
 
+  // Bun reports neither glibcVersionRuntime nor sharedObjects, but its
+  // release.sourceUrl names the build flavor (e.g. bun-linux-x64-musl-baseline.zip).
+  if (report?.header?.release?.sourceUrl?.toLowerCase().includes("musl")) {
+    return "musl";
+  }
+
+  // musl distros (Alpine, Void-musl, ...) ship the loader as /lib/ld-musl-<arch>.so.1.
+  try {
+    if (readdirSync("/lib").some((entry) => entry.startsWith("ld-musl-"))) {
+      return "musl";
+    }
+  } catch {
+    // /lib unreadable or missing; fall through to ldd probing.
+  }
+
   try {
     const output = execSync("ldd --version", {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "pipe"],
     }).toLowerCase();
     return output.includes("musl") ? "musl" : "gnu";
-  } catch {
-    return "gnu";
+  } catch (error) {
+    // musl's ldd rejects --version: it prints "musl libc" to stderr and
+    // exits non-zero, so the answer is in the error, not the output.
+    const { stdout, stderr } = (error ?? {}) as { stdout?: unknown; stderr?: unknown };
+    const combined = `${stdout ?? ""}\n${stderr ?? ""}`.toLowerCase();
+    return combined.includes("musl") ? "musl" : "gnu";
   }
 }
 

--- a/scripts/test-package-launchers.sh
+++ b/scripts/test-package-launchers.sh
@@ -65,22 +65,35 @@ function detectLibcKind() {
   }
 
   try {
-    if (readdirSync("/lib").some((entry) => entry.startsWith("ld-musl-"))) {
-      return "musl";
-    }
-  } catch {}
-
-  try {
     const output = execSync("ldd --version", {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "pipe"],
     }).toLowerCase();
-    return output.includes("musl") ? "musl" : "gnu";
+    if (output.includes("musl")) return "musl";
+    if (output.includes("glibc") || output.includes("gnu")) return "gnu";
   } catch (error) {
     // musl's ldd prints "musl libc" to stderr and exits non-zero on --version.
     const combined = `${error?.stdout ?? ""}\n${error?.stderr ?? ""}`.toLowerCase();
-    return combined.includes("musl") ? "musl" : "gnu";
+    if (combined.includes("musl")) return "musl";
+    if (combined.includes("glibc") || combined.includes("gnu")) return "gnu";
   }
+
+  // ldd missing or inconclusive: look for dynamic loaders. The glibc loader
+  // wins when both exist (e.g. Debian with the musl package installed).
+  const loaderPresent = (prefix) => {
+    for (const dir of ["/lib", "/lib64"]) {
+      try {
+        if (readdirSync(dir).some((entry) => entry.startsWith(prefix))) {
+          return true;
+        }
+      } catch {}
+    }
+    return false;
+  };
+  if (loaderPresent("ld-linux-")) return "gnu";
+  if (loaderPresent("ld-musl-")) return "musl";
+
+  return "gnu";
 }
 
 const arch = process.arch;

--- a/scripts/test-package-launchers.sh
+++ b/scripts/test-package-launchers.sh
@@ -36,7 +36,7 @@ esac
 
 PLATFORM_PACKAGE="$(node --input-type=module <<'NODE'
 import { execSync } from "node:child_process";
-import { readdirSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 
 // Keep in sync with detectLibcKind() in packages/cli/src/index.ts.
 function detectLibcKind() {
@@ -78,8 +78,9 @@ function detectLibcKind() {
     if (combined.includes("glibc") || combined.includes("gnu")) return "gnu";
   }
 
-  // ldd missing or inconclusive: look for dynamic loaders. The glibc loader
-  // wins when both exist (e.g. Debian with the musl package installed).
+  // ldd missing or inconclusive: look for dynamic loaders. Either loader can
+  // coexist with the other's libc (Debian's musl package installs ld-musl-*;
+  // Alpine's gcompat installs ld-linux-*), so the distro breaks ties.
   const loaderPresent = (prefix) => {
     for (const dir of ["/lib", "/lib64"]) {
       try {
@@ -90,8 +91,12 @@ function detectLibcKind() {
     }
     return false;
   };
-  if (loaderPresent("ld-linux-")) return "gnu";
-  if (loaderPresent("ld-musl-")) return "musl";
+  const hasGnuLoader = loaderPresent("ld-linux-");
+  const hasMuslLoader = loaderPresent("ld-musl-");
+  if (hasGnuLoader !== hasMuslLoader) return hasMuslLoader ? "musl" : "gnu";
+  if (hasGnuLoader && hasMuslLoader) {
+    return existsSync("/etc/alpine-release") ? "musl" : "gnu";
+  }
 
   return "gnu";
 }

--- a/scripts/test-package-launchers.sh
+++ b/scripts/test-package-launchers.sh
@@ -36,11 +36,17 @@ esac
 
 PLATFORM_PACKAGE="$(node --input-type=module <<'NODE'
 import { execSync } from "node:child_process";
+import { readdirSync } from "node:fs";
 
+// Keep in sync with detectLibcKind() in packages/cli/src/index.ts.
 function detectLibcKind() {
   if (process.platform !== "linux") {
     return null;
   }
+
+  const override = process.env.TOKSCALE_LIBC?.trim().toLowerCase();
+  if (override === "musl") return "musl";
+  if (override === "gnu" || override === "glibc") return "gnu";
 
   const report = process.report?.getReport?.();
   if (report?.header?.glibcVersionRuntime) {
@@ -54,14 +60,26 @@ function detectLibcKind() {
     return "musl";
   }
 
+  if (report?.header?.release?.sourceUrl?.toLowerCase().includes("musl")) {
+    return "musl";
+  }
+
+  try {
+    if (readdirSync("/lib").some((entry) => entry.startsWith("ld-musl-"))) {
+      return "musl";
+    }
+  } catch {}
+
   try {
     const output = execSync("ldd --version", {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "pipe"],
     }).toLowerCase();
     return output.includes("musl") ? "musl" : "gnu";
-  } catch {
-    throw new Error("Unable to determine Linux libc kind for launcher smoke tests");
+  } catch (error) {
+    // musl's ldd prints "musl libc" to stderr and exits non-zero on --version.
+    const combined = `${error?.stdout ?? ""}\n${error?.stderr ?? ""}`.toLowerCase();
+    return combined.includes("musl") ? "musl" : "gnu";
   }
 }
 


### PR DESCRIPTION
Fixes #697

## Problem

On `oven/bun:1-alpine` the launcher selected the **gnu** binary instead of musl. Two gaps compounded (thanks @scrocquesel-ml150 for the precise report):

1. Bun's `process.report.getReport()` has no `header.glibcVersionRuntime` and an **empty** `sharedObjects` array, so both report-based checks were inconclusive.
2. The `ldd --version` fallback throws on musl — musl's `ldd` rejects `--version`, prints `musl libc` to **stderr**, and exits non-zero — and the `catch` block defaulted to `"gnu"`.

## Fix

`detectLibcKind()` now resolves in this order:

1. **`TOKSCALE_LIBC=musl|gnu|glibc`** — explicit env override (requested in the issue)
2. `header.glibcVersionRuntime` → gnu (unchanged)
3. `sharedObjects` containing musl → musl (unchanged)
4. **Bun's `header.release.sourceUrl`** names the build flavor (e.g. `bun-linux-x64-musl-baseline.zip`) → musl
5. **musl dynamic loader** present at `/lib/ld-musl-<arch>.so.1` (Alpine, Void-musl, …) → musl
6. `ldd --version`, now **parsing stdout/stderr of the failed probe** instead of blindly defaulting to gnu

The same logic is mirrored in `scripts/test-package-launchers.sh`, and the override is documented in the README's Supported Platforms section.

## Verification

Ran the detection function across Docker images (including the exact digest from the issue):

| Image | Runtime | Before | After |
|---|---|---|---|
| `oven/bun:1-alpine` (issue repro, same digest) | bun | gnu ❌ | **musl** ✅ |
| `oven/bun:1-alpine` via node shim | bun | gnu ❌ | **musl** ✅ |
| `node:20-alpine` | node | musl | musl ✅ |
| `node:20-slim` | node | gnu | gnu ✅ |
| `oven/bun:1` (Debian) | bun | gnu | gnu ✅ |
| `node:20-slim` + `TOKSCALE_LIBC=musl` | node | n/a | **musl** ✅ |

Also: `tsc` build passes, `bash -n` on the smoke-test script passes, and the embedded snippet still resolves `cli-darwin-arm64` on macOS.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix libc detection in the CLI launcher so musl is selected on Bun/Alpine and glibc isn’t misdetected on hosts with musl tools. Adds a `TOKSCALE_LIBC` override.

- **Bug Fixes**
  - Detect musl via Bun’s `header.release.sourceUrl`, the musl loader at `/lib/ld-musl-*.so.1`, and by parsing stdout/stderr from `ldd --version`.
  - Run the `ldd --version` probe first; if inconclusive, scan loaders; when both loaders exist, use `/etc/alpine-release` to break ties (Alpine → musl), otherwise prefer the single present loader.
  - Add `TOKSCALE_LIBC=musl|gnu` to force selection; mirror the logic in `scripts/test-package-launchers.sh`; document the override in README.

<sup>Written for commit 570c851a9a6df96212e6c48bd897668286d5c612. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

