### PR TITLE
fix(frontend): allow the deployment's own origin in the CSRF allowlist

### DIFF
--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -13,10 +13,20 @@ DATABASE_URL=postgresql://user:password@localhost:5432/tokscale
 GITHUB_CLIENT_ID=your_github_client_id
 GITHUB_CLIENT_SECRET=your_github_client_secret
 
-# Public URL (used for OAuth redirects)
+# Public URL (used for OAuth redirects and CSRF origin checks)
 # For local development: http://localhost:3000
 # For production: https://your-domain.com
+# The origin of this URL is automatically allowed for cookie-authenticated
+# mutating requests (creating API tokens, managing groups, etc.).
 NEXT_PUBLIC_URL=http://localhost:3000
+
+# Optional: Extra origins allowed for cookie-authenticated mutating requests.
+# Comma-separated. Only needed when the app is served from origins other than
+# NEXT_PUBLIC_URL (e.g. multiple domains in front of one deployment).
+# When set, this REPLACES the default allowlist (https://tokscale.ai,
+# https://tokscale.dev, http://localhost:3000) — but the NEXT_PUBLIC_URL
+# origin is always allowed.
+# CSRF_ALLOWED_ORIGINS=https://your-domain.com,https://alt.your-domain.com
 
 # Optional: Session secret (auto-generated if not set)
 # AUTH_SECRET=your_random_secret_string

--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -24,8 +24,7 @@ NEXT_PUBLIC_URL=http://localhost:3000
 # Comma-separated. Only needed when the app is served from origins other than
 # NEXT_PUBLIC_URL (e.g. multiple domains in front of one deployment).
 # When set, this REPLACES the default allowlist (https://tokscale.ai,
-# https://tokscale.dev, http://localhost:3000) — but the NEXT_PUBLIC_URL
-# origin is always allowed.
+# http://localhost:3000) — but the NEXT_PUBLIC_URL origin is always allowed.
 # CSRF_ALLOWED_ORIGINS=https://your-domain.com,https://alt.your-domain.com
 
 # Optional: Session secret (auto-generated if not set)

--- a/packages/frontend/__tests__/lib/requestSessionCsrf.test.ts
+++ b/packages/frontend/__tests__/lib/requestSessionCsrf.test.ts
@@ -1,10 +1,11 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
  * B6: CSRF origin allowlist for cookie-based sessions.
  * - Mutating requests (POST/PATCH/PUT/DELETE) with a mismatched Origin are rejected.
  * - Requests with a valid Bearer token bypass the origin check.
  * - Requests without an Origin header are rejected on mutating cookie sessions (non-browser clients should use Bearer).
+ * - The NEXT_PUBLIC_URL origin (self-hosted deployments) is always allowed.
  */
 
 const mockState = vi.hoisted(() => {
@@ -36,6 +37,8 @@ beforeAll(async () => {
 });
 
 beforeEach(() => mockState.reset());
+
+afterEach(() => vi.unstubAllEnvs());
 
 const validUser = { id: "user-1", username: "alice", displayName: null, avatarUrl: null };
 
@@ -194,6 +197,71 @@ describe("getSessionFromRequest — CSRF origin check (B6)", () => {
     expect(result).toEqual(validUser);
     expect(mockState.getSessionFromHeader).not.toHaveBeenCalled();
     expect(mockState.getSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows cookie session from the NEXT_PUBLIC_URL origin (self-hosted deployment)", async () => {
+    vi.stubEnv("NEXT_PUBLIC_URL", "https://tokscale.my-company.example");
+    mockState.getSession.mockResolvedValue(validUser);
+
+    const result = await getSessionFromRequest(
+      makeRequest("POST", { Origin: "https://tokscale.my-company.example" }),
+      { allowAuthorizationHeader: false }
+    );
+
+    expect(result).toEqual(validUser);
+    expect(mockState.getSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("derives the allowed origin from NEXT_PUBLIC_URL with a path or trailing slash", async () => {
+    vi.stubEnv("NEXT_PUBLIC_URL", "https://tokscale.my-company.example/app/");
+    mockState.getSession.mockResolvedValue(validUser);
+
+    const result = await getSessionFromRequest(
+      makeRequest("POST", { Origin: "https://tokscale.my-company.example" }),
+      { allowAuthorizationHeader: false }
+    );
+
+    expect(result).toEqual(validUser);
+  });
+
+  it("still allows the NEXT_PUBLIC_URL origin when CSRF_ALLOWED_ORIGINS is set to other origins", async () => {
+    vi.stubEnv("NEXT_PUBLIC_URL", "https://tokscale.my-company.example");
+    vi.stubEnv("CSRF_ALLOWED_ORIGINS", "https://other.example.com");
+    mockState.getSession.mockResolvedValue(validUser);
+
+    const result = await getSessionFromRequest(
+      makeRequest("POST", { Origin: "https://tokscale.my-company.example" }),
+      { allowAuthorizationHeader: false }
+    );
+
+    expect(result).toEqual(validUser);
+  });
+
+  it("keeps rejecting unknown origins when NEXT_PUBLIC_URL is set", async () => {
+    vi.stubEnv("NEXT_PUBLIC_URL", "https://tokscale.my-company.example");
+    mockState.getSession.mockResolvedValue(validUser);
+
+    const result = await getSessionFromRequest(
+      makeRequest("POST", { Origin: "https://evil.example.com" })
+    );
+
+    expect(result).toBeNull();
+    expect(mockState.getSession).not.toHaveBeenCalled();
+  });
+
+  it("ignores a malformed NEXT_PUBLIC_URL and keeps the explicit allowlist working", async () => {
+    vi.stubEnv("NEXT_PUBLIC_URL", "not-a-valid-url");
+    mockState.getSession.mockResolvedValue(validUser);
+
+    const allowed = await getSessionFromRequest(
+      makeRequest("POST", { Origin: "http://localhost:3000" })
+    );
+    expect(allowed).toEqual(validUser);
+
+    const rejected = await getSessionFromRequest(
+      makeRequest("POST", { Origin: "https://evil.example.com" })
+    );
+    expect(rejected).toBeNull();
   });
 
   it("ignores Authorization headers when bearer auth is disabled and still uses valid cookies", async () => {

--- a/packages/frontend/__tests__/lib/requestSessionCsrf.test.ts
+++ b/packages/frontend/__tests__/lib/requestSessionCsrf.test.ts
@@ -102,14 +102,15 @@ describe("getSessionFromRequest — CSRF origin check (B6)", () => {
     expect(mockState.getSession).toHaveBeenCalledTimes(1);
   });
 
-  it("allows cookie session when Origin is in the default allowlist (production)", async () => {
+  it("rejects the removed tokscale.dev origin (domain does not exist)", async () => {
     mockState.getSession.mockResolvedValue(validUser);
 
     const result = await getSessionFromRequest(
       makeRequest("POST", { Origin: "https://tokscale.dev" })
     );
 
-    expect(result).toEqual(validUser);
+    expect(result).toBeNull();
+    expect(mockState.getSession).not.toHaveBeenCalled();
   });
 
   it("allows cookie session from the production custom domain when bearer auth is disabled", async () => {

--- a/packages/frontend/__tests__/lib/requestSessionCsrf.test.ts
+++ b/packages/frontend/__tests__/lib/requestSessionCsrf.test.ts
@@ -250,6 +250,20 @@ describe("getSessionFromRequest — CSRF origin check (B6)", () => {
     expect(mockState.getSession).not.toHaveBeenCalled();
   });
 
+  it("does not allowlist the opaque 'null' origin from a non-HTTP NEXT_PUBLIC_URL", async () => {
+    vi.stubEnv("NEXT_PUBLIC_URL", "mailto:admin@example.com");
+    mockState.getSession.mockResolvedValue(validUser);
+
+    // new URL("mailto:...").origin === "null"; sandboxed iframes send
+    // Origin: null, so accepting it would reopen CSRF.
+    const result = await getSessionFromRequest(
+      makeRequest("POST", { Origin: "null" })
+    );
+
+    expect(result).toBeNull();
+    expect(mockState.getSession).not.toHaveBeenCalled();
+  });
+
   it("ignores a malformed NEXT_PUBLIC_URL and keeps the explicit allowlist working", async () => {
     vi.stubEnv("NEXT_PUBLIC_URL", "not-a-valid-url");
     mockState.getSession.mockResolvedValue(validUser);

--- a/packages/frontend/src/lib/auth/requestSession.ts
+++ b/packages/frontend/src/lib/auth/requestSession.ts
@@ -8,10 +8,26 @@ interface GetSessionFromRequestOptions {
 
 function getAllowedOrigins(): string[] {
   const env = process.env.CSRF_ALLOWED_ORIGINS;
-  if (env) {
-    return env.split(",").map((o) => o.trim()).filter(Boolean);
+  const origins = env
+    ? env.split(",").map((o) => o.trim()).filter(Boolean)
+    : ["https://tokscale.ai", "https://tokscale.dev", "http://localhost:3000"];
+
+  // Self-hosted deployments already set NEXT_PUBLIC_URL for OAuth redirects;
+  // the deployment's own origin is always a legitimate request source, so
+  // include it whether or not CSRF_ALLOWED_ORIGINS is configured.
+  const publicUrl = process.env.NEXT_PUBLIC_URL;
+  if (publicUrl) {
+    try {
+      const origin = new URL(publicUrl).origin;
+      if (!origins.includes(origin)) {
+        origins.push(origin);
+      }
+    } catch {
+      // Malformed NEXT_PUBLIC_URL; ignore and rely on the explicit list.
+    }
   }
-  return ["https://tokscale.ai", "https://tokscale.dev", "http://localhost:3000"];
+
+  return origins;
 }
 
 export async function getSessionFromRequest(

--- a/packages/frontend/src/lib/auth/requestSession.ts
+++ b/packages/frontend/src/lib/auth/requestSession.ts
@@ -10,7 +10,7 @@ function getAllowedOrigins(): string[] {
   const env = process.env.CSRF_ALLOWED_ORIGINS;
   const origins = env
     ? env.split(",").map((o) => o.trim()).filter(Boolean)
-    : ["https://tokscale.ai", "https://tokscale.dev", "http://localhost:3000"];
+    : ["https://tokscale.ai", "http://localhost:3000"];
 
   // Self-hosted deployments already set NEXT_PUBLIC_URL for OAuth redirects;
   // the deployment's own origin is always a legitimate request source, so

--- a/packages/frontend/src/lib/auth/requestSession.ts
+++ b/packages/frontend/src/lib/auth/requestSession.ts
@@ -18,9 +18,15 @@ function getAllowedOrigins(): string[] {
   const publicUrl = process.env.NEXT_PUBLIC_URL;
   if (publicUrl) {
     try {
-      const origin = new URL(publicUrl).origin;
-      if (!origins.includes(origin)) {
-        origins.push(origin);
+      const url = new URL(publicUrl);
+      // Only http(s) URLs have a real origin. Anything else (mailto:,
+      // file:, ...) yields the opaque origin "null", and allowlisting the
+      // literal string "null" would accept Origin: null requests from
+      // sandboxed iframes - a CSRF hole.
+      if (url.protocol === "http:" || url.protocol === "https:") {
+        if (!origins.includes(url.origin)) {
+          origins.push(url.origin);
+        }
       }
     } catch {
       // Malformed NEXT_PUBLIC_URL; ignore and rely on the explicit list.


### PR DESCRIPTION
Fixes #695

## Problem

Self-hosted deployments on custom domains get **401 "Not authenticated"** on every cookie-authenticated mutating request — creating API tokens, managing groups, renaming devices — even with a valid session (thanks @liyuerich for the report and for tracking it down to `CSRF_ALLOWED_ORIGINS`).

The CSRF origin allowlist in `getSessionFromRequest()` defaults to the hosted domains, so any other origin is rejected before the session cookie is even looked at. The `CSRF_ALLOWED_ORIGINS` escape hatch existed but was documented nowhere.

## Fix

- The origin derived from **`NEXT_PUBLIC_URL`** — which self-hosters already must set for OAuth redirects — is now always included in the allowlist. Setting up a custom domain no longer requires any extra configuration.
- It stays allowed even when `CSRF_ALLOWED_ORIGINS` overrides the defaults (the deployment's own origin is always a legitimate request source).
- Malformed `NEXT_PUBLIC_URL` values are ignored gracefully.
- Both `NEXT_PUBLIC_URL` and `CSRF_ALLOWED_ORIGINS` are now documented in `.env.example`.
- **`https://tokscale.dev` is removed from the default allowlist** — the domain doesn't exist and isn't ours, so allowlisting it would let whoever registers it mount CSRF attacks against cookie sessions. The default list is now `https://tokscale.ai` + `http://localhost:3000`.

Deliberately **not** done: comparing Origin against the request `Host` / `X-Forwarded-Host` headers — those are not operator-declared intent and can be wrong behind misconfigured proxies. `NEXT_PUBLIC_URL` is an explicit operator setting, so trusting its origin doesn't widen the CSRF surface.

## Verification

- 5 new tests in `requestSessionCsrf.test.ts`: custom-domain origin allowed, origin derived correctly from URL with path/trailing slash, still allowed alongside `CSRF_ALLOWED_ORIGINS`, unknown origins still rejected, malformed `NEXT_PUBLIC_URL` ignored. The former tokscale.dev allow-test now asserts rejection.
- Full frontend suite: **50 files / 408 tests pass**.
- ESLint: no new findings (the one existing error in `ViewSelector.tsx` predates this change).