### PR TITLE
feat(frontend): per-device usage breakdown on profile and settings

### DIFF
--- a/packages/frontend/__tests__/api/settingsDeviceRenameCsrf.test.ts
+++ b/packages/frontend/__tests__/api/settingsDeviceRenameCsrf.test.ts
@@ -4,6 +4,7 @@ const mockState = vi.hoisted(() => {
   const getSession = vi.fn();
   const getSessionFromHeader = vi.fn();
   const revalidateTag = vi.fn();
+  const revalidateUsernamePaths = vi.fn();
   const eq = vi.fn((left: unknown, right: unknown) => ({ op: "eq", left, right }));
   const and = vi.fn((...conditions: unknown[]) => ({ op: "and", conditions }));
   const returning = vi.fn(async () => updatedRows);
@@ -24,6 +25,7 @@ const mockState = vi.hoisted(() => {
     getSession,
     getSessionFromHeader,
     revalidateTag,
+    revalidateUsernamePaths,
     eq,
     and,
     db: { update },
@@ -35,6 +37,7 @@ const mockState = vi.hoisted(() => {
       getSession.mockReset();
       getSessionFromHeader.mockReset();
       revalidateTag.mockReset();
+      revalidateUsernamePaths.mockReset();
       eq.mockClear();
       and.mockClear();
       returning.mockClear();
@@ -67,6 +70,7 @@ vi.mock("@/lib/db", () => ({
 
 vi.mock("@/lib/db/usernameLookup", () => ({
   normalizeUsernameCacheKey: (username: string) => username.toLowerCase(),
+  revalidateUsernamePaths: mockState.revalidateUsernamePaths,
 }));
 
 type ModuleExports = typeof import("../../src/app/api/settings/devices/[deviceId]/route");
@@ -148,5 +152,6 @@ describe("PATCH /api/settings/devices/[deviceId] CSRF origin checks", () => {
     });
     expect(mockState.db.update).toHaveBeenCalledWith(mockState.submittedDevices);
     expect(mockState.revalidateTag).toHaveBeenCalledWith("user:alice", "max");
+    expect(mockState.revalidateUsernamePaths).toHaveBeenCalledWith("Alice");
   });
 });

--- a/packages/frontend/__tests__/api/usersDevicesRoute.test.ts
+++ b/packages/frontend/__tests__/api/usersDevicesRoute.test.ts
@@ -1,0 +1,225 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// GET /api/users/[username]/devices response-shape tests. The settings page
+// edits the raw `customName` while public profiles render the resolved
+// `displayName`, so both must be present and must not be conflated.
+
+interface DeviceRow {
+  id: string;
+  deviceKey: string;
+  displayName: string | null;
+  createdAt: Date | null;
+  lastSubmittedAt: Date | null;
+  totalTokens: string;
+  totalCost: string;
+  inputTokens: string;
+  outputTokens: string;
+  activeDays: string;
+  firstDay: string | null;
+  lastDay: string | null;
+}
+
+const mockState = vi.hoisted(() => {
+  let userRows: unknown[] = [];
+  let deviceRows: unknown[] = [];
+
+  // The route issues two select chains: the username lookup
+  // (.from().where().limit()) and the device aggregation
+  // (.from().leftJoin().where().groupBy().orderBy()).
+  const select = vi.fn(() => ({
+    from: () => ({
+      where: () => ({
+        limit: async () => userRows,
+      }),
+      leftJoin: () => ({
+        where: () => ({
+          groupBy: () => ({
+            orderBy: async () => deviceRows,
+          }),
+        }),
+      }),
+    }),
+  }));
+
+  return {
+    select,
+    setUserRows(rows: unknown[]) {
+      userRows = rows;
+    },
+    setDeviceRows(rows: DeviceRow[]) {
+      deviceRows = rows;
+    },
+    reset() {
+      select.mockClear();
+      userRows = [];
+      deviceRows = [];
+    },
+  };
+});
+
+vi.mock("@/lib/db", () => ({
+  db: { select: mockState.select },
+  users: {
+    id: "users.id",
+    username: "users.username",
+    displayName: "users.displayName",
+    avatarUrl: "users.avatarUrl",
+  },
+  submittedDevices: {
+    id: "submittedDevices.id",
+    deviceKey: "submittedDevices.deviceKey",
+    displayName: "submittedDevices.displayName",
+    userId: "submittedDevices.userId",
+    createdAt: "submittedDevices.createdAt",
+    lastSubmittedAt: "submittedDevices.lastSubmittedAt",
+  },
+  dailyBreakdown: {
+    tokens: "dailyBreakdown.tokens",
+    cost: "dailyBreakdown.cost",
+    inputTokens: "dailyBreakdown.inputTokens",
+    outputTokens: "dailyBreakdown.outputTokens",
+    date: "dailyBreakdown.date",
+    submittedDeviceId: "dailyBreakdown.submittedDeviceId",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  sql: Object.assign(
+    (strings: TemplateStringsArray, ...values: unknown[]) => ({
+      strings: Array.from(strings),
+      values,
+    }),
+    { raw: (value: string) => value }
+  ),
+  desc: (column: unknown) => ({ op: "desc", column }),
+  eq: (left: unknown, right: unknown) => ({ op: "eq", left, right }),
+}));
+
+// Mocked (matching usersProfile.test.ts) so the route does not pull in the
+// real drizzle schema through usernameLookup's `./schema` import.
+vi.mock("@/lib/db/usernameLookup", () => ({
+  USERNAME_LOOKUP_LIMIT: 2,
+  usernameEqualsIgnoreCase: (username: string) => ({
+    op: "usernameEqualsIgnoreCase",
+    username,
+  }),
+  getSingleUsernameMatch: (rows: unknown[]) => {
+    if (rows.length > 1) {
+      throw new Error("ambiguous username");
+    }
+    return rows[0] ?? null;
+  },
+}));
+
+type ModuleExports = typeof import("../../src/app/api/users/[username]/devices/route");
+
+let GET: ModuleExports["GET"];
+
+beforeAll(async () => {
+  const routeModule = await import(
+    "../../src/app/api/users/[username]/devices/route"
+  );
+  GET = routeModule.GET;
+});
+
+beforeEach(() => {
+  mockState.reset();
+});
+
+function deviceRow(overrides: Partial<DeviceRow> = {}): DeviceRow {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    deviceKey: "machine-aaaa",
+    displayName: null,
+    createdAt: new Date("2026-06-01T00:00:00.000Z"),
+    lastSubmittedAt: new Date("2026-06-09T12:00:00.000Z"),
+    totalTokens: "1000",
+    totalCost: "12.5",
+    inputTokens: "600",
+    outputTokens: "400",
+    activeDays: "3",
+    firstDay: "2026-06-01",
+    lastDay: "2026-06-09",
+    ...overrides,
+  };
+}
+
+function request(): Request {
+  return new Request("https://tokscale.ai/api/users/alice/devices");
+}
+
+const params = { params: Promise.resolve({ username: "alice" }) };
+
+describe("GET /api/users/[username]/devices", () => {
+  it("returns 404 when the user does not exist", async () => {
+    mockState.setUserRows([]);
+
+    const response = await GET(request(), params);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "User not found" });
+  });
+
+  it("exposes both the resolved displayName and the raw customName", async () => {
+    mockState.setUserRows([
+      { id: "u1", username: "alice", displayName: "Alice", avatarUrl: null },
+    ]);
+    mockState.setDeviceRows([
+      deviceRow({ id: "d1", deviceKey: "machine-aaaa", displayName: null }),
+      deviceRow({ id: "d2", deviceKey: "machine-bbbb", displayName: "Work laptop" }),
+      // A custom name that happens to equal the fallback label must round-trip
+      // as a real customName, not be treated as "never renamed".
+      deviceRow({ id: "d3", deviceKey: "machine-cccc", displayName: "Unnamed device" }),
+    ]);
+
+    const response = await GET(request(), params);
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.user).toEqual({
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+    });
+
+    const [unnamed, named, fallbackNamed] = body.devices;
+
+    expect(unnamed).toMatchObject({
+      id: "d1",
+      displayName: "Unnamed device",
+      customName: null,
+    });
+    expect(named).toMatchObject({
+      id: "d2",
+      displayName: "Work laptop",
+      customName: "Work laptop",
+    });
+    expect(fallbackNamed).toMatchObject({
+      id: "d3",
+      displayName: "Unnamed device",
+      customName: "Unnamed device",
+    });
+  });
+
+  it("coerces SQL aggregate strings to numbers and timestamps to ISO strings", async () => {
+    mockState.setUserRows([
+      { id: "u1", username: "alice", displayName: null, avatarUrl: null },
+    ]);
+    mockState.setDeviceRows([deviceRow()]);
+
+    const response = await GET(request(), params);
+    const body = await response.json();
+
+    expect(body.devices[0]).toMatchObject({
+      totalTokens: 1000,
+      totalCost: 12.5,
+      inputTokens: 600,
+      outputTokens: 400,
+      activeDays: 3,
+      createdAt: "2026-06-01T00:00:00.000Z",
+      lastSubmittedAt: "2026-06-09T12:00:00.000Z",
+      firstDay: "2026-06-01",
+      lastDay: "2026-06-09",
+    });
+  });
+});

--- a/packages/frontend/__tests__/lib/formatRelativeTime.test.ts
+++ b/packages/frontend/__tests__/lib/formatRelativeTime.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { formatRelativeTime } from "../../src/lib/format";
+
+const NOW = new Date("2026-06-10T12:00:00.000Z");
+
+describe("formatRelativeTime", () => {
+  it("returns 'never' for null, undefined, and invalid input", () => {
+    expect(formatRelativeTime(null, NOW)).toBe("never");
+    expect(formatRelativeTime(undefined, NOW)).toBe("never");
+    expect(formatRelativeTime("not-a-date", NOW)).toBe("never");
+  });
+
+  it("returns 'just now' for timestamps under a minute old", () => {
+    expect(formatRelativeTime("2026-06-10T11:59:30.000Z", NOW)).toBe("just now");
+    expect(formatRelativeTime("2026-06-10T12:00:00.000Z", NOW)).toBe("just now");
+  });
+
+  it("clamps future timestamps to 'just now'", () => {
+    expect(formatRelativeTime("2026-06-10T13:00:00.000Z", NOW)).toBe("just now");
+  });
+
+  it("formats minutes", () => {
+    expect(formatRelativeTime("2026-06-10T11:55:00.000Z", NOW)).toBe("5m ago");
+    expect(formatRelativeTime("2026-06-10T11:01:00.000Z", NOW)).toBe("59m ago");
+  });
+
+  it("formats hours", () => {
+    expect(formatRelativeTime("2026-06-10T09:00:00.000Z", NOW)).toBe("3h ago");
+    expect(formatRelativeTime("2026-06-09T12:30:00.000Z", NOW)).toBe("23h ago");
+  });
+
+  it("formats days", () => {
+    expect(formatRelativeTime("2026-06-09T11:00:00.000Z", NOW)).toBe("1d ago");
+    expect(formatRelativeTime("2026-05-12T12:00:00.000Z", NOW)).toBe("29d ago");
+  });
+
+  it("formats months", () => {
+    expect(formatRelativeTime("2026-05-11T12:00:00.000Z", NOW)).toBe("1mo ago");
+    expect(formatRelativeTime("2025-06-12T12:00:00.000Z", NOW)).toBe("12mo ago");
+  });
+
+  it("formats years", () => {
+    expect(formatRelativeTime("2025-06-10T12:00:00.000Z", NOW)).toBe("1y ago");
+    expect(formatRelativeTime("2023-06-01T12:00:00.000Z", NOW)).toBe("3y ago");
+  });
+});

--- a/packages/frontend/src/app/api/settings/devices/[deviceId]/route.ts
+++ b/packages/frontend/src/app/api/settings/devices/[deviceId]/route.ts
@@ -4,7 +4,10 @@ import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { db, submittedDevices } from "@/lib/db";
 import { getSessionFromRequest } from "@/lib/auth/requestSession";
-import { normalizeUsernameCacheKey } from "@/lib/db/usernameLookup";
+import {
+  normalizeUsernameCacheKey,
+  revalidateUsernamePaths,
+} from "@/lib/db/usernameLookup";
 
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -112,6 +115,10 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       // Normalize before building the cache key, matching submit/route.ts:535-540
       // which also calls normalizeUsernameCacheKey before revalidateTag.
       revalidateTag(`user:${normalizeUsernameCacheKey(session.username)}`, "max");
+      // Also flush the ISR-cached public endpoints (notably
+      // /api/users/[username]/devices, which feeds the profile page) so a
+      // rename is visible immediately, matching the submit route idiom.
+      revalidateUsernamePaths(session.username);
     } catch (e) {
       console.error("Cache invalidation failed after device rename:", e);
     }

--- a/packages/frontend/src/app/api/users/[username]/devices/route.ts
+++ b/packages/frontend/src/app/api/users/[username]/devices/route.ts
@@ -83,9 +83,11 @@ export async function GET(_request: Request, { params }: RouteParams) {
       devices: rows.map((row) => ({
         id: row.id,
         deviceKey: row.deviceKey,
-        // Public consumers see the fallback label, not the underlying null.
-        // Owners get the raw value via /api/settings/devices/[id] for editing.
+        // Public consumers render the resolved fallback label; `customName`
+        // carries the raw nullable value so owners (settings UI) can
+        // distinguish "user typed this" from "fallback label".
         displayName: deviceDisplayLabel(row.deviceKey, row.displayName),
+        customName: row.displayName,
         createdAt: toIsoString(row.createdAt),
         lastSubmittedAt: toIsoString(row.lastSubmittedAt),
         totalTokens: Number(row.totalTokens) || 0,

--- a/packages/frontend/src/app/settings/SettingsClient.tsx
+++ b/packages/frontend/src/app/settings/SettingsClient.tsx
@@ -35,7 +35,10 @@ interface CreatedApiToken extends ApiToken {
 interface SettingsDevice {
   id: string;
   deviceKey: string;
+  /** Resolved label (custom name or fallback) — what we render. */
   displayName: string;
+  /** Raw user-set name (null = never renamed) — what we edit. */
+  customName: string | null;
   lastSubmittedAt: string | null;
   totalTokens: number;
   totalCost: number;
@@ -440,11 +443,10 @@ export default function SettingsClient() {
   const startEditingDevice = (device: SettingsDevice) => {
     setEditingDeviceId(device.id);
     setDeviceError(null);
-    // The public devices endpoint returns the fallback label ("Unnamed
-    // device" / "Legacy submissions") instead of the raw null name. Don't
-    // pre-fill the input with a fallback the user never typed.
-    const fallback = deviceDisplayLabel(device.deviceKey, null);
-    setEditingDeviceName(device.displayName === fallback ? "" : device.displayName);
+    // Pre-fill from the raw custom name, not the resolved display label, so
+    // an unnamed device starts empty and a custom name that happens to equal
+    // the fallback label ("Unnamed device" etc.) is preserved.
+    setEditingDeviceName(device.customName ?? "");
   };
 
   const cancelEditingDevice = () => {
@@ -487,6 +489,7 @@ export default function SettingsClient() {
                   data.device.deviceKey,
                   data.device.displayName
                 ),
+                customName: data.device.displayName ?? null,
               }
             : item
         )

--- a/packages/frontend/src/app/settings/SettingsClient.tsx
+++ b/packages/frontend/src/app/settings/SettingsClient.tsx
@@ -6,6 +6,9 @@ import styled from "styled-components";
 import { KeyIcon } from "@/components/ui/Icons";
 import { Navigation } from "@/components/layout/Navigation";
 import { Footer } from "@/components/layout/Footer";
+import { deviceDisplayLabel } from "@/lib/devices/shared";
+import { formatNumber, formatCurrency } from "@/lib/utils";
+import { formatRelativeTime } from "@/lib/format";
 
 interface User {
   id: string;
@@ -24,6 +27,34 @@ interface ApiToken {
 
 interface CreatedApiToken extends ApiToken {
   token: string;
+}
+
+// Subset of GET /api/users/[username]/devices we render here. That public
+// endpoint already aggregates usage per device, so settings reuses it with
+// the session user's username instead of adding a private listing route.
+interface SettingsDevice {
+  id: string;
+  deviceKey: string;
+  displayName: string;
+  lastSubmittedAt: string | null;
+  totalTokens: number;
+  totalCost: number;
+  activeDays: number;
+}
+
+// Mirror the server-side RenameBodySchema in
+// /api/settings/devices/[deviceId]/route.ts (varchar(120), no control chars).
+const DEVICE_NAME_MAX_LENGTH = 120;
+const DEVICE_NAME_CONTROL_CHARS = /\p{C}/u;
+
+function validateDeviceName(name: string): string | null {
+  if (name.length > DEVICE_NAME_MAX_LENGTH) {
+    return `Device name must be ${DEVICE_NAME_MAX_LENGTH} characters or fewer`;
+  }
+  if (DEVICE_NAME_CONTROL_CHARS.test(name)) {
+    return "Device name must not contain control characters";
+  }
+  return null;
 }
 
 const PageWrapper = styled.div`
@@ -223,6 +254,18 @@ const IconWrapper = styled.div`
   color: #737373;
 `;
 
+const DeviceEditRow = styled.div`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 8px;
+  align-items: center;
+  width: 100%;
+
+  @media (max-width: 560px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
 
 const DangerButton = styled.button`
   padding: 4px 12px;
@@ -287,6 +330,15 @@ async function fetchApiTokens(): Promise<ApiToken[]> {
   return Array.isArray(tokensData.tokens) ? tokensData.tokens : [];
 }
 
+async function fetchDevices(username: string): Promise<SettingsDevice[]> {
+  const devicesResponse = await fetch(
+    `/api/users/${encodeURIComponent(username)}/devices`
+  );
+  if (!devicesResponse.ok) return [];
+  const devicesData = await devicesResponse.json();
+  return Array.isArray(devicesData.devices) ? devicesData.devices : [];
+}
+
 export default function SettingsClient() {
   const router = useRouter();
   const [user, setUser] = useState<User | null>(null);
@@ -296,6 +348,11 @@ export default function SettingsClient() {
   const [createdToken, setCreatedToken] = useState<CreatedApiToken | null>(null);
   const [isCreatingToken, setIsCreatingToken] = useState(false);
   const [createTokenError, setCreateTokenError] = useState<string | null>(null);
+  const [devices, setDevices] = useState<SettingsDevice[]>([]);
+  const [editingDeviceId, setEditingDeviceId] = useState<string | null>(null);
+  const [editingDeviceName, setEditingDeviceName] = useState("");
+  const [isSavingDeviceName, setIsSavingDeviceName] = useState(false);
+  const [deviceError, setDeviceError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -311,11 +368,17 @@ export default function SettingsClient() {
           return;
         }
 
-        const loadedTokens = await fetchApiTokens().catch(() => []);
+        const [loadedTokens, loadedDevices] = await Promise.all([
+          fetchApiTokens().catch(() => []),
+          fetchDevices(sessionData.user.username).catch(
+            () => [] as SettingsDevice[]
+          ),
+        ]);
 
         if (!cancelled) {
           setUser(sessionData.user);
           setTokens((current) => mergeApiTokenList(loadedTokens, current));
+          setDevices(loadedDevices);
           setIsLoading(false);
         }
       } catch {
@@ -371,6 +434,71 @@ export default function SettingsClient() {
       setCreateTokenError(error instanceof Error ? error.message : "Failed to create token");
     } finally {
       setIsCreatingToken(false);
+    }
+  };
+
+  const startEditingDevice = (device: SettingsDevice) => {
+    setEditingDeviceId(device.id);
+    setDeviceError(null);
+    // The public devices endpoint returns the fallback label ("Unnamed
+    // device" / "Legacy submissions") instead of the raw null name. Don't
+    // pre-fill the input with a fallback the user never typed.
+    const fallback = deviceDisplayLabel(device.deviceKey, null);
+    setEditingDeviceName(device.displayName === fallback ? "" : device.displayName);
+  };
+
+  const cancelEditingDevice = () => {
+    setEditingDeviceId(null);
+    setEditingDeviceName("");
+    setDeviceError(null);
+  };
+
+  const handleSaveDeviceName = async (device: SettingsDevice) => {
+    const trimmed = editingDeviceName.trim();
+    const validationError = validateDeviceName(trimmed);
+    if (validationError) {
+      setDeviceError(validationError);
+      return;
+    }
+
+    setIsSavingDeviceName(true);
+    setDeviceError(null);
+
+    try {
+      const response = await fetch(`/api/settings/devices/${device.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        // Empty input clears the custom name; server stores null and the
+        // display label falls back via deviceDisplayLabel.
+        body: JSON.stringify({ name: trimmed === "" ? null : trimmed }),
+      });
+
+      const data = await response.json();
+      if (!response.ok || !data.device) {
+        throw new Error(data.error || "Failed to rename device");
+      }
+
+      setDevices((current) =>
+        current.map((item) =>
+          item.id === device.id
+            ? {
+                ...item,
+                displayName: deviceDisplayLabel(
+                  data.device.deviceKey,
+                  data.device.displayName
+                ),
+              }
+            : item
+        )
+      );
+      setEditingDeviceId(null);
+      setEditingDeviceName("");
+    } catch (error) {
+      setDeviceError(
+        error instanceof Error ? error.message : "Failed to rename device"
+      );
+    } finally {
+      setIsSavingDeviceName(false);
     }
   };
 
@@ -548,6 +676,107 @@ export default function SettingsClient() {
           )}
         </Section>
 
+        <Section
+          style={{ backgroundColor: "var(--color-bg-default)", borderColor: "var(--color-border-default)" }}
+        >
+          <SectionTitle style={{ color: "var(--color-fg-default)" }}>
+            Devices
+          </SectionTitle>
+          <Description style={{ color: "var(--color-fg-muted)" }}>
+            Machines that have submitted usage data. Rename a device to tell
+            your machines apart — the name is shown on your public profile.
+          </Description>
+
+          {deviceError && <ErrorText>{deviceError}</ErrorText>}
+
+          {devices.length === 0 ? (
+            <EmptyState style={{ color: "var(--color-fg-muted)" }}>
+              <p>No devices yet.</p>
+              <EmptyText>
+                Run{" "}
+                <CodeText
+                  style={{ backgroundColor: "var(--color-bg-subtle)" }}
+                >
+                  bunx tokscale submit
+                </CodeText>{" "}
+                to register this machine.
+              </EmptyText>
+            </EmptyState>
+          ) : (
+            <TokenList>
+              {devices.map((device) => (
+                <TokenItem
+                  key={device.id}
+                  style={{ backgroundColor: "var(--color-bg-elevated)" }}
+                >
+                  {editingDeviceId === device.id ? (
+                    <DeviceEditRow>
+                      <TextInput
+                        aria-label="Device name"
+                        value={editingDeviceName}
+                        maxLength={DEVICE_NAME_MAX_LENGTH}
+                        placeholder="Device name (empty to reset)"
+                        autoFocus
+                        disabled={isSavingDeviceName}
+                        onChange={(event) =>
+                          setEditingDeviceName(event.target.value)
+                        }
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter") {
+                            event.preventDefault();
+                            handleSaveDeviceName(device);
+                          } else if (event.key === "Escape") {
+                            cancelEditingDevice();
+                          }
+                        }}
+                      />
+                      <PrimaryButton
+                        type="button"
+                        disabled={isSavingDeviceName}
+                        onClick={() => handleSaveDeviceName(device)}
+                      >
+                        {isSavingDeviceName ? "Saving..." : "Save"}
+                      </PrimaryButton>
+                      <SecondaryButton
+                        type="button"
+                        disabled={isSavingDeviceName}
+                        onClick={cancelEditingDevice}
+                      >
+                        Cancel
+                      </SecondaryButton>
+                    </DeviceEditRow>
+                  ) : (
+                    <>
+                      <TokenInfo>
+                        <div>
+                          <TokenName style={{ color: "var(--color-fg-default)" }}>
+                            {device.displayName}
+                          </TokenName>
+                          <SmallText style={{ color: "var(--color-fg-muted)" }}>
+                            {formatNumber(device.totalTokens)} tokens
+                            {" · "}
+                            {formatCurrency(device.totalCost)}
+                            {" · "}
+                            {device.activeDays} active{" "}
+                            {device.activeDays === 1 ? "day" : "days"}
+                            {" · "}
+                            Last submit {formatRelativeTime(device.lastSubmittedAt)}
+                          </SmallText>
+                        </div>
+                      </TokenInfo>
+                      <SecondaryButton
+                        type="button"
+                        onClick={() => startEditingDevice(device)}
+                      >
+                        Rename
+                      </SecondaryButton>
+                    </>
+                  )}
+                </TokenItem>
+              ))}
+            </TokenList>
+          )}
+        </Section>
 
       </MainContent>
 

--- a/packages/frontend/src/app/settings/SettingsClient.tsx
+++ b/packages/frontend/src/app/settings/SettingsClient.tsx
@@ -251,7 +251,7 @@ const TokenInfo = styled.div`
 `;
 
 const IconWrapper = styled.div`
-  color: #737373;
+  color: var(--color-fg-muted);
 `;
 
 const DeviceEditRow = styled.div`

--- a/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
+++ b/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
@@ -12,6 +12,8 @@ import {
   ProfileActivity,
   ProfileEmptyActivity,
   ProfileStats,
+  ProfileDevices,
+  type ProfileDevice,
   type ProfileUser,
   type ProfileStatsData,
   type ProfileTab,
@@ -54,10 +56,11 @@ interface ProfileData {
 
 interface ProfilePageClientProps {
   initialData: ProfileData;
+  initialDevices?: ProfileDevice[];
   username: string;
 }
 
-export default function ProfilePageClient({ initialData, username }: ProfilePageClientProps) {
+export default function ProfilePageClient({ initialData, initialDevices, username }: ProfilePageClientProps) {
   const [activeTab, setActiveTab] = useState<ProfileTab>("activity");
   const data = initialData;
 
@@ -213,6 +216,8 @@ const EARLY_ADOPTERS = ["code-yeongyu", "gtg7784", "qodot"];
               <ProfileModels models={data.models} modelUsage={data.modelUsage} />
             </div>
           )}
+
+          <ProfileDevices devices={initialDevices ?? []} />
         </ContentWrapper>
       </MainContent>
 

--- a/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
+++ b/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
@@ -148,7 +148,7 @@ const EARLY_ADOPTERS = ["code-yeongyu", "gtg7784", "qodot"];
   const showResubmitBanner = EARLY_ADOPTERS.includes(data.user.username) && data.stats.submissionCount === 1;
 
   return (
-    <PageContainer style={{ backgroundColor: "#10121C" }}>
+    <PageContainer style={{ backgroundColor: "var(--color-bg-default)" }}>
       <Navigation />
 
       {showResubmitBanner && (

--- a/packages/frontend/src/app/u/[username]/page.tsx
+++ b/packages/frontend/src/app/u/[username]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, permanentRedirect } from 'next/navigation';
+import { normalizeUsernameCacheKey } from '@/lib/db/usernameLookup';
 import ProfilePageClient from './ProfilePageClient';
 
 export const revalidate = 60;
@@ -29,7 +30,13 @@ async function getProfileData(username: string) {
 async function getProfileDevices(username: string) {
   try {
     const res = await fetch(`${getBaseUrl()}/api/users/${username}/devices`, {
-      next: { revalidate: 60 },
+      // Tagged so PATCH /api/settings/devices/[deviceId] (rename) can
+      // invalidate this immediately via revalidateTag(`user:...`) instead of
+      // waiting out the 60s revalidate window.
+      next: {
+        revalidate: 60,
+        tags: [`user:${normalizeUsernameCacheKey(username)}`],
+      },
     });
 
     if (!res.ok) {

--- a/packages/frontend/src/app/u/[username]/page.tsx
+++ b/packages/frontend/src/app/u/[username]/page.tsx
@@ -4,22 +4,43 @@ import ProfilePageClient from './ProfilePageClient';
 
 export const revalidate = 60;
 
-async function getProfileData(username: string) {
-  // In production: use explicit URL or Vercel auto-URL.
-  // In dev: use 127.0.0.1 to avoid ECONNREFUSED from localhost dual-stack DNS.
-  const baseUrl = process.env.NEXT_PUBLIC_URL
+// In production: use explicit URL or Vercel auto-URL.
+// In dev: use 127.0.0.1 to avoid ECONNREFUSED from localhost dual-stack DNS.
+function getBaseUrl(): string {
+  return process.env.NEXT_PUBLIC_URL
     || (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null)
     || 'http://127.0.0.1:3000';
-  
-  const res = await fetch(`${baseUrl}/api/users/${username}`, {
+}
+
+async function getProfileData(username: string) {
+  const res = await fetch(`${getBaseUrl()}/api/users/${username}`, {
     next: { revalidate: 60 },
   });
-  
+
   if (!res.ok) {
     return null;
   }
-  
+
   return res.json();
+}
+
+// Devices are an enrichment on top of the core profile: if this fetch fails
+// we still render the profile, just without the Devices section.
+async function getProfileDevices(username: string) {
+  try {
+    const res = await fetch(`${getBaseUrl()}/api/users/${username}/devices`, {
+      next: { revalidate: 60 },
+    });
+
+    if (!res.ok) {
+      return [];
+    }
+
+    const data = await res.json();
+    return Array.isArray(data.devices) ? data.devices : [];
+  } catch {
+    return [];
+  }
 }
 
 export async function generateMetadata({ params }: { params: Promise<{ username: string }> }): Promise<Metadata> {
@@ -52,8 +73,11 @@ export async function generateMetadata({ params }: { params: Promise<{ username:
 
 export default async function ProfilePage({ params }: { params: Promise<{ username: string }> }) {
   const { username } = await params;
-  const data = await getProfileData(username);
-  
+  const [data, devices] = await Promise.all([
+    getProfileData(username),
+    getProfileDevices(username),
+  ]);
+
   if (!data) {
     notFound();
   }
@@ -61,6 +85,6 @@ export default async function ProfilePage({ params }: { params: Promise<{ userna
   if (data.user?.username && data.user.username !== username) {
     permanentRedirect(`/u/${data.user.username}`);
   }
-  
-  return <ProfilePageClient initialData={data} username={username} />;
+
+  return <ProfilePageClient initialData={data} initialDevices={devices} username={username} />;
 }

--- a/packages/frontend/src/components/profile/ProfileDevices.tsx
+++ b/packages/frontend/src/components/profile/ProfileDevices.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import styled from "styled-components";
+import { formatNumber, formatCurrency } from "@/lib/utils";
+import { formatRelativeTime } from "@/lib/format";
+
+/**
+ * Shape returned by GET /api/users/[username]/devices (route already coerces
+ * the SQL SUM strings to numbers and applies the display-name fallback).
+ */
+export interface ProfileDevice {
+  id: string;
+  deviceKey: string;
+  displayName: string;
+  createdAt: string | null;
+  lastSubmittedAt: string | null;
+  totalTokens: number;
+  totalCost: number;
+  inputTokens: number;
+  outputTokens: number;
+  activeDays: number;
+  firstDay: string | null;
+  lastDay: string | null;
+}
+
+export interface ProfileDevicesProps {
+  devices: ProfileDevice[];
+}
+
+const SectionHeading = styled.h2`
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+`;
+
+const DevicesContainer = styled.div`
+  border-radius: 1rem;
+  border-width: 1px;
+  border-style: solid;
+  overflow: hidden;
+`;
+
+const DevicesHeader = styled.div`
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
+
+  @media (min-width: 480px) {
+    grid-template-columns: 1fr auto auto auto;
+    gap: 1rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  @media (min-width: 640px) {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+`;
+
+const DeviceRow = styled.div`
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  align-items: center;
+
+  @media (min-width: 480px) {
+    grid-template-columns: 1fr auto auto auto;
+    gap: 1rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  @media (min-width: 640px) {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+`;
+
+const DeviceNameCell = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+`;
+
+const DeviceNameText = styled.span`
+  font-size: 0.8125rem;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  @media (min-width: 480px) {
+    font-size: 0.875rem;
+  }
+`;
+
+const DeviceSubText = styled.span`
+  font-size: 0.75rem;
+`;
+
+const DeviceMetricCell = styled.div<{ $hideOnMobile?: boolean }>`
+  text-align: right;
+  width: 4.5rem;
+
+  ${(props) =>
+    props.$hideOnMobile &&
+    `
+    @media (max-width: 479px) {
+      display: none;
+    }
+  `}
+
+  @media (min-width: 640px) {
+    width: 5.5rem;
+  }
+`;
+
+const MetricText = styled.span`
+  font-size: 0.8125rem;
+
+  @media (min-width: 480px) {
+    font-size: 0.875rem;
+  }
+`;
+
+const CostText = styled.span`
+  font-size: 0.8125rem;
+  font-weight: 500;
+
+  @media (min-width: 480px) {
+    font-size: 0.875rem;
+  }
+`;
+
+/**
+ * Per-device usage breakdown for the public profile page. Hidden entirely
+ * when the user has no recorded devices (pre-device legacy profiles).
+ */
+export function ProfileDevices({ devices }: ProfileDevicesProps) {
+  if (devices.length === 0) return null;
+
+  return (
+    <section aria-label="Devices">
+      <SectionHeading style={{ color: "var(--color-fg-default)" }}>
+        Devices
+      </SectionHeading>
+
+      <DevicesContainer
+        style={{
+          backgroundColor: "var(--color-bg-default)",
+          borderColor: "var(--color-border-default)",
+        }}
+      >
+        <DevicesHeader
+          style={{
+            backgroundColor: "var(--color-bg-elevated)",
+            borderColor: "var(--color-border-default)",
+            color: "var(--color-fg-muted)",
+          }}
+        >
+          <div>Device</div>
+          <DeviceMetricCell>Tokens</DeviceMetricCell>
+          <DeviceMetricCell>Cost</DeviceMetricCell>
+          <DeviceMetricCell $hideOnMobile>Active Days</DeviceMetricCell>
+        </DevicesHeader>
+
+        <div>
+          {devices.map((device, index) => (
+            <DeviceRow
+              key={device.id}
+              style={{
+                backgroundColor:
+                  index % 2 === 1 ? "var(--color-bg-elevated)" : "transparent",
+                borderTop:
+                  index > 0 ? "1px solid var(--color-border-default)" : undefined,
+              }}
+            >
+              <DeviceNameCell>
+                <DeviceNameText style={{ color: "var(--color-fg-default)" }}>
+                  {device.displayName}
+                </DeviceNameText>
+                <DeviceSubText
+                  style={{ color: "var(--color-fg-muted)" }}
+                  suppressHydrationWarning
+                >
+                  Last submit {formatRelativeTime(device.lastSubmittedAt)}
+                </DeviceSubText>
+              </DeviceNameCell>
+              <DeviceMetricCell>
+                <MetricText
+                  style={{ color: "var(--color-fg-default)" }}
+                  title={device.totalTokens.toLocaleString("en-US")}
+                >
+                  {formatNumber(device.totalTokens)}
+                </MetricText>
+              </DeviceMetricCell>
+              <DeviceMetricCell>
+                <CostText style={{ color: "var(--color-primary)" }}>
+                  {formatCurrency(device.totalCost)}
+                </CostText>
+              </DeviceMetricCell>
+              <DeviceMetricCell $hideOnMobile>
+                <MetricText style={{ color: "var(--color-fg-muted)" }}>
+                  {device.activeDays}
+                </MetricText>
+              </DeviceMetricCell>
+            </DeviceRow>
+          ))}
+        </div>
+      </DevicesContainer>
+    </section>
+  );
+}

--- a/packages/frontend/src/components/profile/ProfileDevices.tsx
+++ b/packages/frontend/src/components/profile/ProfileDevices.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import type { ReactNode } from "react";
 import styled from "styled-components";
 import { formatNumber, formatCurrency } from "@/lib/utils";
 import { formatRelativeTime } from "@/lib/format";
+import { ListCard, ListHeader, ListMetricCell, ListRow } from "./listStyles";
 
 /**
  * Shape returned by GET /api/users/[username]/devices (route already coerces
@@ -11,7 +13,10 @@ import { formatRelativeTime } from "@/lib/format";
 export interface ProfileDevice {
   id: string;
   deviceKey: string;
+  /** Resolved label (custom name or fallback) — what public UIs render. */
   displayName: string;
+  /** Raw user-set name, null when the device has never been renamed. */
+  customName: string | null;
   createdAt: string | null;
   lastSubmittedAt: string | null;
   totalTokens: number;
@@ -33,57 +38,11 @@ const SectionHeading = styled.h2`
   margin-bottom: 0.75rem;
 `;
 
-const DevicesContainer = styled.div`
-  border-radius: 1rem;
-  border-width: 1px;
-  border-style: solid;
-  overflow: hidden;
-`;
-
-const DevicesHeader = styled.div`
-  display: grid;
-  grid-template-columns: 1fr auto auto;
-  gap: 0.75rem;
-  padding: 0.75rem;
-  font-size: 0.75rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  border-bottom-width: 1px;
-  border-bottom-style: solid;
-
-  @media (min-width: 480px) {
-    grid-template-columns: 1fr auto auto auto;
-    gap: 1rem;
-    padding-left: 1rem;
-    padding-right: 1rem;
-  }
-
-  @media (min-width: 640px) {
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
-  }
-`;
-
-const DeviceRow = styled.div`
-  display: grid;
-  grid-template-columns: 1fr auto auto;
-  gap: 0.75rem;
-  padding: 0.75rem;
-  align-items: center;
-
-  @media (min-width: 480px) {
-    grid-template-columns: 1fr auto auto auto;
-    gap: 1rem;
-    padding-left: 1rem;
-    padding-right: 1rem;
-  }
-
-  @media (min-width: 640px) {
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
-  }
-`;
+// Card/header/row/metric-cell primitives are shared with ProfileModels via
+// ./listStyles so the two profile tables stay visually in sync.
+const DevicesContainer = ListCard;
+const DevicesHeader = ListHeader;
+const DeviceRow = ListRow;
 
 const DeviceNameCell = styled.div`
   display: flex;
@@ -108,22 +67,14 @@ const DeviceSubText = styled.span`
   font-size: 0.75rem;
 `;
 
-const DeviceMetricCell = styled.div<{ $hideOnMobile?: boolean }>`
-  text-align: right;
-  width: 4.5rem;
-
-  ${(props) =>
-    props.$hideOnMobile &&
-    `
-    @media (max-width: 479px) {
-      display: none;
-    }
-  `}
-
-  @media (min-width: 640px) {
-    width: 5.5rem;
-  }
-`;
+// All device metric columns share the same fixed width, unlike the per-column
+// widths in ProfileModels, so bake them in here.
+function DeviceMetricCell(props: {
+  $hideOnMobile?: boolean;
+  children?: ReactNode;
+}) {
+  return <ListMetricCell $width="4.5rem" $smWidth="5.5rem" {...props} />;
+}
 
 const MetricText = styled.span`
   font-size: 0.8125rem;

--- a/packages/frontend/src/components/profile/index.tsx
+++ b/packages/frontend/src/components/profile/index.tsx
@@ -10,6 +10,9 @@ import { formatNumber, formatCurrency, formatDuration } from "@/lib/utils";
 import { legacy } from "@/lib/responsive";
 import { ProfileEmbedDialog } from "./ProfileEmbedDialog";
 
+export { ProfileDevices } from "./ProfileDevices";
+export type { ProfileDevice } from "./ProfileDevices";
+
 export interface ProfileUser {
   username: string;
   displayName: string | null;

--- a/packages/frontend/src/components/profile/index.tsx
+++ b/packages/frontend/src/components/profile/index.tsx
@@ -9,6 +9,7 @@ import type { TokenContributionData } from "@/lib/types";
 import { formatNumber, formatCurrency, formatDuration } from "@/lib/utils";
 import { legacy } from "@/lib/responsive";
 import { ProfileEmbedDialog } from "./ProfileEmbedDialog";
+import { ListCard, ListHeader, ListMetricCell, ListRow } from "./listStyles";
 
 export { ProfileDevices } from "./ProfileDevices";
 export type { ProfileDevice } from "./ProfileDevices";
@@ -928,63 +929,11 @@ export interface ProfileModelsProps {
   modelUsage?: ModelUsage[];
 }
 
-const ModelsListContainer = styled.div`
-  border-radius: 1rem;
-  border-width: 1px;
-  border-style: solid;
-  overflow: hidden;
-`;
-
-const ModelsListHeader = styled.div`
-  display: grid;
-  grid-template-columns: 1fr auto auto;
-  gap: 0.75rem;
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
-  font-size: 0.75rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  border-bottom-width: 1px;
-  border-bottom-style: solid;
-
-  @media (min-width: 480px) {
-    grid-template-columns: 1fr auto auto auto;
-    gap: 1rem;
-    padding-left: 1rem;
-    padding-right: 1rem;
-  }
-
-  @media (min-width: 640px) {
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
-  }
-`;
-
-const ModelsListRow = styled.div`
-  display: grid;
-  grid-template-columns: 1fr auto auto;
-  gap: 0.75rem;
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
-  align-items: center;
-
-  @media (min-width: 480px) {
-    grid-template-columns: 1fr auto auto auto;
-    gap: 1rem;
-    padding-left: 1rem;
-    padding-right: 1rem;
-  }
-
-  @media (min-width: 640px) {
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
-  }
-`;
+// Card/header/row/metric-cell primitives are shared with ProfileDevices via
+// ./listStyles so the two profile tables stay visually in sync.
+const ModelsListContainer = ListCard;
+const ModelsListHeader = ListHeader;
+const ModelsListRow = ListRow;
 
 const ModelNameCell = styled.div`
   display: flex;
@@ -1016,20 +965,7 @@ const ModelNameText = styled.span`
   }
 `;
 
-const ModelMetricCell = styled.div<{ $width: string; $smWidth: string; $hideOnMobile?: boolean }>`
-  text-align: right;
-  width: ${props => props.$width};
-
-  ${props => props.$hideOnMobile && css`
-    @media (max-width: 479px) {
-      display: none;
-    }
-  `}
-
-  @media (min-width: 640px) {
-    width: ${props => props.$smWidth};
-  }
-`;
+const ModelMetricCell = ListMetricCell;
 
 const MetricText = styled.span`
   font-size: 0.8125rem;

--- a/packages/frontend/src/components/profile/listStyles.ts
+++ b/packages/frontend/src/components/profile/listStyles.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import styled, { css } from "styled-components";
+
+/**
+ * Shared primitives for the profile page's "list table" cards (Models,
+ * Devices). Colors are applied inline by consumers via CSS variables; these
+ * only own layout/typography so the two tables can't drift apart.
+ *
+ * Grid columns are intentionally part of the shared header/row because both
+ * tables use the same `1fr auto auto` (+1 metric column at 480px) layout. If
+ * a future table needs a different column count, override
+ * `grid-template-columns` locally via `styled(ListHeader)` / `styled(ListRow)`.
+ */
+
+export const ListCard = styled.div`
+  border-radius: 1rem;
+  border-width: 1px;
+  border-style: solid;
+  overflow: hidden;
+`;
+
+export const ListHeader = styled.div`
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
+
+  @media (min-width: 480px) {
+    grid-template-columns: 1fr auto auto auto;
+    gap: 1rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  @media (min-width: 640px) {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+`;
+
+export const ListRow = styled.div`
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  align-items: center;
+
+  @media (min-width: 480px) {
+    grid-template-columns: 1fr auto auto auto;
+    gap: 1rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  @media (min-width: 640px) {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+`;
+
+export const ListMetricCell = styled.div<{
+  $width: string;
+  $smWidth: string;
+  $hideOnMobile?: boolean;
+}>`
+  text-align: right;
+  width: ${(props) => props.$width};
+
+  ${(props) =>
+    props.$hideOnMobile &&
+    css`
+      @media (max-width: 479px) {
+        display: none;
+      }
+    `}
+
+  @media (min-width: 640px) {
+    width: ${(props) => props.$smWidth};
+  }
+`;

--- a/packages/frontend/src/lib/db/usernameLookup.ts
+++ b/packages/frontend/src/lib/db/usernameLookup.ts
@@ -45,6 +45,7 @@ export function revalidateUsernamePaths(username: string): void {
   for (const variant of variants) {
     revalidatePath(`/u/${variant}`);
     revalidatePath(`/api/users/${variant}`);
+    revalidatePath(`/api/users/${variant}/devices`);
     revalidatePath(`/api/embed/${variant}/svg`);
   }
 }

--- a/packages/frontend/src/lib/format.ts
+++ b/packages/frontend/src/lib/format.ts
@@ -44,6 +44,37 @@ export function formatCurrency(value: number, compact = false): string {
 }
 
 /**
+ * Format an ISO timestamp as a short relative time, e.g. "just now",
+ * "5m ago", "3h ago", "12d ago", "2mo ago", "1y ago". Returns "never"
+ * for null/invalid input so callers can render it directly.
+ *
+ * `now` is injectable for tests; future timestamps clamp to "just now".
+ */
+export function formatRelativeTime(
+  iso: string | null | undefined,
+  now: Date = new Date()
+): string {
+  if (!iso) return "never";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "never";
+
+  const diffMs = now.getTime() - date.getTime();
+  if (diffMs < 60_000) return "just now";
+
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  if (days < 365) return `${Math.floor(days / 30)}mo ago`;
+
+  return `${Math.floor(days / 365)}y ago`;
+}
+
+/**
  * Format milliseconds into a human-readable duration string.
  * e.g. 3661000 → "1h 1m", 90000 → "1m 30s", 500 → "<1s"
  */


### PR DESCRIPTION
## Summary

Surfaces the per-device usage data that already exists server-side on two pages:

### Profile (`/u/[username]`)
- New **Devices** section below the tab panels, rendered from `GET /api/users/[username]/devices`.
- Fetched **server-side in `page.tsx`** (internal fetch with `revalidate: 60`, in `Promise.all` with the existing profile fetch) — same pattern the page already uses for its core data. A devices fetch failure omits the section instead of failing the page.
- New `ProfileDevices` component (`src/components/profile/ProfileDevices.tsx`) styled to match the existing `ProfileModels` table card (same radius/border/header tokens). Shows device name, total tokens (`formatNumber`), cost (`formatCurrency`), active days, and relative last-submit time.
- 0 devices → section hidden entirely; 1 device still renders; `legacy-default` naming handled by the API via `deviceDisplayLabel`.

### Settings (`/settings`)
- New **Devices** section in `SettingsClient` listing each device with a usage summary and an inline rename flow (Rename → input + Save/Cancel, Enter/Escape shortcuts) wired to `PATCH /api/settings/devices/[deviceId]`.
- **Data source:** reuses the public `GET /api/users/[username]/devices` with the session user's username — no new API routes. `/api/me/stats` was considered but is bearer-token-only (CLI), unusable from a cookie session, and lacks per-device usage totals.
- Client-side validation mirrors the server's `RenameBodySchema`: ≤120 chars, no Unicode control characters; empty input clears the name back to the fallback label. Since the public endpoint returns the fallback label (not the raw `null`), the edit input detects fallback labels and pre-fills empty.
- On success the list updates locally from the PATCH response via `deviceDisplayLabel`; errors render through the section's existing `ErrorText` pattern.

### Shared
- New `formatRelativeTime` in `src/lib/format.ts` (injectable clock, "just now" / "5m ago" / "3h ago" / "12d ago" / "2mo ago" / "1y ago", "never" for null) + unit tests following the `formatTokenCount.test.ts` pattern.

## Palette consistency check (vs landing)

- The landing page (`src/components/landing/`) uses its own **bespoke hardcoded navy palette** (`#01070f` bg, `#10233e` borders, `#0073ff` accent) and does not consume the `globals.css` design tokens. Profile and settings consistently use the token system (`--color-bg-default`, `--color-border-default`, `--color-fg-*`, etc.), and the new device sections use those same tokens from the start.
- Surgical fixes in this PR (separate commit): profile page's hardcoded `#10121C` background → `var(--color-bg-default)` (same value, token form); settings key-icon `#737373` stale neutral gray → `var(--color-fg-muted)`.
- **Deliberately not fixed** (reported instead): retheming profile/settings onto the landing's bespoke navy would be a site-wide restructure; `ProfileHeader` uses a one-off `#141A21` card background that matches no token; settings danger red `#F85149` has no danger token in `globals.css`.

## Screenshots

N/A — authored in a headless environment; no DB/session available for a live render.

## Test evidence

- `bun run test`: **52 files, 425 tests passed** (includes 8 new `formatRelativeTime` tests).
- `bunx tsc --noEmit`: only the 3 pre-existing errors (`groupMemberRoleRoute.test.ts` ×2, `BlackholeHero.tsx`) — zero new.
- `bun run build`: compiles; route table includes `/u/[username]` and `/settings`.
- `bun run lint`: identical findings to clean `origin/main` (1 pre-existing error in `ViewSelector.tsx`, 9 pre-existing warnings) — zero new.

Refs #593 (devices API), #329 (/api/me/stats)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per‑device usage breakdown to the public profile and settings pages, plus an inline device rename flow. Renames now update the profile immediately via tagged fetches and path revalidation.

- **New Features**
  - Profile: new Devices section under the tabs from `GET /api/users/[username]/devices`, fetched server‑side in `page.tsx` with `revalidate: 60` and cache tag `user:<normalized-username>`. Shows name, tokens, cost, active days, and last submit; hidden on 0 devices; fetch failures omit the section.
  - Settings: Devices list with usage summary and Rename via `PATCH /api/settings/devices/[deviceId]`. Reuses the public devices endpoint; client validation: ≤120 chars, no control chars; empty clears the name. Prefills from `customName` and updates from the PATCH response.
  - Shared: `formatRelativeTime` helper (“just now”, “5m ago”, … “1y ago”) with tests.

- **Refactors**
  - Devices API: returns both `displayName` (fallback‑resolved) and `customName` (raw nullable) to support correct rename prefill. Profile devices fetch is tagged and `revalidateUsernamePaths` now also flushes `/api/users/[username]/devices` so renames appear instantly.
  - Profile tables: extracted shared card/header/row primitives to `components/profile/listStyles.ts` and adopted in both Models and Devices. Also replaced stray hardcoded colors with tokens.

<sup>Written for commit 17bb5341baff9b238503a590ab80ee99850f556e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

