### PR TITLE
fix: update copyright year to use current year dynamically

### DIFF
--- a/packages/frontend/src/components/layout/Footer.tsx
+++ b/packages/frontend/src/components/layout/Footer.tsx
@@ -226,7 +226,7 @@ export function Footer() {
 
           <TextContainer>
             <CopyrightText>
-              © 2025 Tokscale. All rights reserved.
+              © {new Date().getFullYear()} Tokscale. All rights reserved.
             </CopyrightText>
             <GitHubLink 
               href="https://github.com/junhoyeo/tokscale" 

--- a/packages/frontend/src/components/layout/Footer.tsx
+++ b/packages/frontend/src/components/layout/Footer.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import styled from 'styled-components';
+
+const DEFAULT_COPYRIGHT_YEAR = 2026;
 
 const Container = styled.div`
   width: 100%;
@@ -197,6 +200,12 @@ const SpinningGlobe = styled(Image)`
 `;
 
 export function Footer() {
+  const [currentYear, setCurrentYear] = useState(DEFAULT_COPYRIGHT_YEAR);
+
+  useEffect(() => {
+    setCurrentYear(new Date().getFullYear());
+  }, []);
+
   return (
     <Container>
       <FooterElement>
@@ -226,7 +235,7 @@ export function Footer() {
 
           <TextContainer>
             <CopyrightText>
-              © {new Date().getFullYear()} Tokscale. All rights reserved.
+              © {currentYear} Tokscale. All rights reserved.
             </CopyrightText>
             <GitHubLink 
               href="https://github.com/junhoyeo/tokscale" 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use the current year in the footer so it stays up to date automatically.
The Footer now sets a currentYear state (default 2026) and updates it on mount with new Date().getFullYear(), replacing the hardcoded year in the copyright text.

<sup>Written for commit c6f548ddf222abfe8c716b9b1db6939043e1ec14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

