### PR TITLE
fix(pricing): block brand-token fuzzy matches and prefer canonical pricing sources

### DIFF
--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -50,7 +50,23 @@ const RESELLER_PROVIDER_PREFIXES: &[&str] = &[
 // no model information: a fuzzy hit from them can land on any model of the
 // brand (e.g. retired `claude-2.1` eroding to `claude` and billing at an
 // opus-fast key), so such a match is never trustworthy.
-const FUZZY_BLOCKLIST: &[&str] = &["auto", "mini", "chat", "base", "claude", "anthropic"];
+//
+// Generic English words ("model", "router") are blocked for the same reason:
+// they carry no model identity, yet substring-match real priced keys
+// (`azure_ai/model_router`, `kilo/switchpoint/router`). Without this guard an
+// id whose only fuzzy-eligible remnant after suffix stripping is the word
+// `model` (e.g. `model-zero-usage-v1` -> stripped `model`) misprices at the
+// router key's rate. See `fuzzy_match_does_not_resolve_generic_model_token`.
+const FUZZY_BLOCKLIST: &[&str] = &[
+    "auto",
+    "mini",
+    "chat",
+    "base",
+    "claude",
+    "anthropic",
+    "model",
+    "router",
+];
 
 const MAX_LOOKUP_CACHE_ENTRIES: usize = 512;
 const TIERED_PRICING_THRESHOLD_128K_TOKENS: f64 = 128_000.0;
@@ -2795,6 +2811,49 @@ mod tests {
         let result = lookup.lookup_with_provider("gpt-4", Some("azure")).unwrap();
         assert_eq!(result.matched_key, "azure/openai/gpt-4");
         assert_eq!(result.source, "LiteLLM");
+    }
+
+    // Regression: a generic id whose only fuzzy-eligible remnant after suffix
+    // stripping is the bare word `model` (real example seen in local data:
+    // `model-zero-usage-v1`, `test-model`) must NOT fuzzy-match a real priced
+    // key like `azure_ai/model_router`. The word `model` carries no model
+    // identity and is on the FUZZY_BLOCKLIST.
+    #[test]
+    fn fuzzy_match_does_not_resolve_generic_model_token() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "azure_ai/model_router".into(),
+            ModelPricing {
+                input_cost_per_token: Some(1.4e-7),
+                output_cost_per_token: Some(0.0),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        // The bare token must not resolve.
+        assert!(lookup.lookup("model").is_none());
+        // Ids that strip down to the bare `model` token must not misresolve.
+        assert!(lookup.lookup("model-zero-usage-v1").is_none());
+        assert!(lookup.lookup("model-nonzero-usage-v1").is_none());
+        assert!(lookup.lookup("test-model").is_none());
+
+        // But an EXACT key match is still honored — `model-router` is a real
+        // model id, not a fuzzy remnant.
+        let mut litellm2 = HashMap::new();
+        litellm2.insert(
+            "azure/model-router".into(),
+            ModelPricing {
+                input_cost_per_token: Some(1.4e-7),
+                output_cost_per_token: Some(0.0),
+                ..Default::default()
+            },
+        );
+        let lookup2 = PricingLookup::new(litellm2, HashMap::new(), HashMap::new());
+        assert_eq!(
+            lookup2.lookup("model-router").unwrap().matched_key,
+            "azure/model-router"
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -161,6 +161,17 @@ impl PricingLookup {
         for key in &models_dev_keys {
             let lower = key.to_lowercase();
             models_dev_lower.insert(lower.clone(), key.clone());
+            // Only priced entries enter the model-part index: the
+            // deterministic anthropic-first preference must choose among
+            // keys that can actually price usage, otherwise an unpriced
+            // `anthropic/<model>` row would shadow a priced reseller row
+            // and bill the model at zero cost. (The models.dev loader only
+            // emits entries with input+output costs — see
+            // `models_dev::cost_to_pricing` — but this constructor is
+            // public, so the index guards itself too.)
+            if !models_dev.get(key).is_some_and(has_any_usable_pricing) {
+                continue;
+            }
             if let Some(model_part) = lower.split('/').next_back() {
                 if model_part != lower {
                     match models_dev_model_part.entry(model_part.to_string()) {
@@ -439,12 +450,26 @@ impl PricingLookup {
             return Some(result);
         }
 
+        // A provider hint pins the lookup to that provider's catalog: the
+        // provider-scoped models.dev pass must run before the unscoped
+        // separator-normalized fallback below, otherwise a hinted lookup
+        // (e.g. `venice` + `claude-opus-4-6-fast`) would take OpenRouter's
+        // `anthropic/claude-opus-4.6-fast` price instead of the hinted
+        // provider's own `venice/claude-opus-4-6-fast` key.
+        if provider_id.is_some() {
+            if let Some(result) = self.exact_match_models_dev_for_provider(model_id, provider_id) {
+                return Some(result);
+            }
+        }
+
         // Separator-normalized exact passes against the canonical sources
         // (LiteLLM + OpenRouter) run BEFORE the models.dev model-part pass so
         // ids like `claude-opus-4-6-fast` hit the canonical
         // `anthropic/claude-opus-4.6-fast` key instead of a reseller's
         // `venice/claude-opus-4-6-fast` markup. models.dev stays the
-        // long-tail fallback below.
+        // long-tail fallback below. This reorder only preempts models.dev
+        // for UNhinted lookups: the provider-scoped passes above and below
+        // keep provider-hinted resolutions pinned to the hinted provider.
         if let Some(version_normalized) = normalize_version_separator(model_id) {
             if let Some(result) = choose_best_source_result(
                 self.exact_match_litellm_for_provider(&version_normalized, provider_id),
@@ -452,6 +477,13 @@ impl PricingLookup {
                 provider_id,
             ) {
                 return Some(result);
+            }
+            if provider_id.is_some() {
+                if let Some(result) =
+                    self.exact_match_models_dev_for_provider(&version_normalized, provider_id)
+                {
+                    return Some(result);
+                }
             }
             if let Some(result) = self.exact_match_litellm(&version_normalized) {
                 return Some(result);
@@ -3650,7 +3682,7 @@ mod tests {
         );
         let lookup = PricingLookup::new(HashMap::new(), openrouter, HashMap::new());
 
-        for id in ["claude-2.1", "claude-2.0", "claude"] {
+        for id in ["claude-2.1", "claude-2.0", "claude", "anthropic"] {
             assert!(
                 lookup.lookup(id).is_none(),
                 "id {id} must resolve unpriced, never to another model's price"
@@ -3724,6 +3756,79 @@ mod tests {
         let result = lookup.lookup("claude-opus-4-6-fast").unwrap();
         assert_eq!(result.matched_key, "anthropic/claude-opus-4.6-fast");
         assert_eq!(result.pricing.input_cost_per_token, Some(30e-6));
+    }
+
+    /// Regression (#707 review): a provider hint pins the lookup to that
+    /// provider's catalog. The canonical-source reorder asserted by
+    /// `canonical_fast_price_beats_reseller_markup` only applies to unhinted
+    /// lookups; with `provider_id = Some("venice")` the provider-scoped
+    /// models.dev pass must win over OpenRouter's unscoped `anthropic/...`
+    /// row, so provider-aware callers get the hinted provider's price.
+    #[test]
+    fn provider_hint_keeps_models_dev_provider_key_over_unscoped_canonical() {
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "anthropic/claude-opus-4.6-fast".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(30e-6),
+                output_cost_per_token: Some(150e-6),
+                ..Default::default()
+            },
+        );
+        let mut models_dev = HashMap::new();
+        models_dev.insert(
+            "venice/claude-opus-4-6-fast".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(36e-6),
+                output_cost_per_token: Some(180e-6),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new_with_models_dev(
+            HashMap::new(),
+            openrouter,
+            HashMap::new(),
+            models_dev,
+        );
+
+        let hinted = lookup
+            .lookup_with_provider("claude-opus-4-6-fast", Some("venice"))
+            .unwrap();
+        assert_eq!(hinted.matched_key, "venice/claude-opus-4-6-fast");
+        assert_eq!(hinted.pricing.input_cost_per_token, Some(36e-6));
+
+        // Unhinted lookups keep the canonical resolution.
+        let unhinted = lookup.lookup("claude-opus-4-6-fast").unwrap();
+        assert_eq!(unhinted.matched_key, "anthropic/claude-opus-4.6-fast");
+        assert_eq!(unhinted.pricing.input_cost_per_token, Some(30e-6));
+    }
+
+    /// Regression (#707 review): the anthropic-first preference in the
+    /// models.dev model-part index must only choose among priced keys. An
+    /// unpriced (all-None) `anthropic/<model>` row must not shadow a priced
+    /// reseller row, which would bill the model at zero cost.
+    #[test]
+    fn unpriced_anthropic_models_dev_key_does_not_shadow_priced_reseller() {
+        let mut models_dev = HashMap::new();
+        models_dev.insert("anthropic/model-x".to_string(), ModelPricing::default());
+        models_dev.insert(
+            "reseller/model-x".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(36e-6),
+                output_cost_per_token: Some(180e-6),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new_with_models_dev(
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            models_dev,
+        );
+
+        let result = lookup.lookup("model-x").unwrap();
+        assert_eq!(result.matched_key, "reseller/model-x");
+        assert_eq!(result.pricing.input_cost_per_token, Some(36e-6));
     }
 
     /// After the lookup_auto reorder, models.dev must remain the long-tail

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -46,7 +46,11 @@ const RESELLER_PROVIDER_PREFIXES: &[&str] = &[
     "openrouter/",
 ];
 
-const FUZZY_BLOCKLIST: &[&str] = &["auto", "mini", "chat", "base"];
+// Bare brand tokens ("claude", "anthropic") are blocked because they contain
+// no model information: a fuzzy hit from them can land on any model of the
+// brand (e.g. retired `claude-2.1` eroding to `claude` and billing at an
+// opus-fast key), so such a match is never trustworthy.
+const FUZZY_BLOCKLIST: &[&str] = &["auto", "mini", "chat", "base", "claude", "anthropic"];
 
 const MAX_LOOKUP_CACHE_ENTRIES: usize = 512;
 const TIERED_PRICING_THRESHOLD_128K_TOKENS: f64 = 128_000.0;
@@ -152,13 +156,23 @@ impl PricingLookup {
         }
 
         let mut models_dev_lower = HashMap::with_capacity(models_dev.len());
-        let mut models_dev_model_part = HashMap::with_capacity(models_dev.len());
+        let mut models_dev_model_part: HashMap<String, String> =
+            HashMap::with_capacity(models_dev.len());
         for key in &models_dev_keys {
             let lower = key.to_lowercase();
             models_dev_lower.insert(lower.clone(), key.clone());
             if let Some(model_part) = lower.split('/').next_back() {
                 if model_part != lower {
-                    models_dev_model_part.insert(model_part.to_string(), key.clone());
+                    match models_dev_model_part.entry(model_part.to_string()) {
+                        std::collections::hash_map::Entry::Occupied(mut entry) => {
+                            if prefers_model_part_key(key, entry.get()) {
+                                entry.insert(key.clone());
+                            }
+                        }
+                        std::collections::hash_map::Entry::Vacant(entry) => {
+                            entry.insert(key.clone());
+                        }
+                    }
                 }
             }
         }
@@ -424,10 +438,13 @@ impl PricingLookup {
         if let Some(result) = self.exact_match_openrouter(model_id) {
             return Some(result);
         }
-        if let Some(result) = self.exact_match_models_dev_with_provider(model_id, provider_id) {
-            return Some(result);
-        }
 
+        // Separator-normalized exact passes against the canonical sources
+        // (LiteLLM + OpenRouter) run BEFORE the models.dev model-part pass so
+        // ids like `claude-opus-4-6-fast` hit the canonical
+        // `anthropic/claude-opus-4.6-fast` key instead of a reseller's
+        // `venice/claude-opus-4-6-fast` markup. models.dev stays the
+        // long-tail fallback below.
         if let Some(version_normalized) = normalize_version_separator(model_id) {
             if let Some(result) = choose_best_source_result(
                 self.exact_match_litellm_for_provider(&version_normalized, provider_id),
@@ -442,6 +459,12 @@ impl PricingLookup {
             if let Some(result) = self.exact_match_openrouter(&version_normalized) {
                 return Some(result);
             }
+        }
+
+        if let Some(result) = self.exact_match_models_dev_with_provider(model_id, provider_id) {
+            return Some(result);
+        }
+        if let Some(version_normalized) = normalize_version_separator(model_id) {
             if let Some(result) =
                 self.exact_match_models_dev_with_provider(&version_normalized, provider_id)
             {
@@ -1661,13 +1684,41 @@ where
 }
 
 fn strips_claude_numeric_minor(candidate: &str, first_stripped_segment: &str) -> bool {
-    !first_stripped_segment.is_empty()
-        && first_stripped_segment.chars().all(|c| c.is_ascii_digit())
-        && (candidate.contains("claude")
-            || candidate.contains("opus")
-            || candidate.contains("sonnet")
-            || candidate.contains("haiku"))
-        && contains_delimited_fragment(candidate, "4")
+    if !is_version_segment(first_stripped_segment) {
+        return false;
+    }
+    let claude_branded = candidate.contains("claude")
+        || candidate.contains("opus")
+        || candidate.contains("sonnet")
+        || candidate.contains("haiku");
+    if !claude_branded {
+        return false;
+    }
+    // Refuse to strip a version segment when it would either peel a minor off
+    // a still-versioned claude-4 candidate (claude-sonnet-4-5 -> claude-sonnet-4)
+    // or erode the id's only version, leaving a bare brand token
+    // (claude-2.1 -> claude). Both candidates would resolve to a different
+    // model's price. Dated forms (claude-3-5-sonnet-20241022) keep stripping:
+    // their candidate retains a version, so neither arm fires.
+    contains_delimited_fragment(candidate, "4") || !candidate.bytes().any(|b| b.is_ascii_digit())
+}
+
+/// True for a bare version segment produced by splitting an id on `-`:
+/// digits with at most one interior dot (`4`, `6`, `2.1`, `20241022`).
+fn is_version_segment(segment: &str) -> bool {
+    let bytes = segment.as_bytes();
+    if bytes.is_empty() || !bytes[0].is_ascii_digit() || !bytes[bytes.len() - 1].is_ascii_digit() {
+        return false;
+    }
+    let mut seen_dot = false;
+    for &byte in bytes {
+        match byte {
+            b'0'..=b'9' => {}
+            b'.' if !seen_dot => seen_dot = true,
+            _ => return false,
+        }
+    }
+    true
 }
 
 fn has_unrecognized_claude_four_minor(model_id: &str) -> bool {
@@ -1716,6 +1767,26 @@ where
     }
 
     None
+}
+
+/// Deterministic provider choice when multiple models.dev providers share a
+/// model part: the canonical `anthropic/` namespace wins outright; otherwise
+/// the shorter key is preferred (the historical winner of the insertion-order
+/// race, keeping existing resolutions stable), with lexicographic order
+/// breaking length ties so the result no longer depends on HashMap iteration
+/// order.
+fn prefers_model_part_key(candidate: &str, existing: &str) -> bool {
+    let candidate_lower = candidate.to_lowercase();
+    let existing_lower = existing.to_lowercase();
+    let is_anthropic = |key: &str| key.split('/').next() == Some("anthropic");
+    match (
+        is_anthropic(&candidate_lower),
+        is_anthropic(&existing_lower),
+    ) {
+        (true, false) => true,
+        (false, true) => false,
+        _ => (candidate_lower.len(), candidate_lower) < (existing_lower.len(), existing_lower),
+    }
 }
 
 fn is_original_provider(key: &str) -> bool {
@@ -3558,6 +3629,160 @@ mod tests {
         );
     }
 
+    /// Regression (post-#634 catalog audit, bug 1): retired `claude-2.x` ids
+    /// (present in historical usage logs, absent from every pricing dataset)
+    /// must resolve to None, not to a modern model's price. Previously
+    /// `try_strip_unknown_suffix` eroded `claude-2.1` to bare `claude`
+    /// (the "2.1" segment failed the all-digits version check), which then
+    /// fuzzy-matched `anthropic/claude-opus-4.7-fast` at $30/$150. The #634
+    /// family veto was bypassed because `claude-2.1` carries no
+    /// opus/sonnet/haiku/fable token.
+    #[test]
+    fn claude_2x_never_fuzzy_matches_modern_models() {
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "anthropic/claude-opus-4.7-fast".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(30e-6),
+                output_cost_per_token: Some(150e-6),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new(HashMap::new(), openrouter, HashMap::new());
+
+        for id in ["claude-2.1", "claude-2.0", "claude"] {
+            assert!(
+                lookup.lookup(id).is_none(),
+                "id {id} must resolve unpriced, never to another model's price"
+            );
+        }
+    }
+
+    /// Positive control for the claude-2.x guards: when a dataset actually
+    /// prices `claude-2.1`, it still resolves — the guards only block the
+    /// erosion-to-bare-brand path, not legitimate dataset hits.
+    #[test]
+    fn claude_2x_still_resolves_when_dataset_prices_it() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-2.1".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(8e-6),
+                output_cost_per_token: Some(24e-6),
+                ..Default::default()
+            },
+        );
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "anthropic/claude-opus-4.7-fast".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(30e-6),
+                output_cost_per_token: Some(150e-6),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new(litellm, openrouter, HashMap::new());
+
+        let result = lookup.lookup("claude-2.1").unwrap();
+        assert_eq!(result.matched_key, "claude-2.1");
+        assert_eq!(result.pricing.input_cost_per_token, Some(8e-6));
+    }
+
+    /// Regression (post-#634 catalog audit, bug 2): `claude-opus-4-6-fast`
+    /// must hit the canonical OpenRouter `anthropic/claude-opus-4.6-fast`
+    /// key ($30/$150) via separator normalization, not Models.dev's reseller
+    /// `venice/claude-opus-4-6-fast` markup ($36/$180). Previously the
+    /// models.dev model-part pass ran before the version-normalized
+    /// OpenRouter exact pass in `lookup_auto`.
+    #[test]
+    fn canonical_fast_price_beats_reseller_markup() {
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "anthropic/claude-opus-4.6-fast".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(30e-6),
+                output_cost_per_token: Some(150e-6),
+                ..Default::default()
+            },
+        );
+        let mut models_dev = HashMap::new();
+        models_dev.insert(
+            "venice/claude-opus-4-6-fast".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(36e-6),
+                output_cost_per_token: Some(180e-6),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new_with_models_dev(
+            HashMap::new(),
+            openrouter,
+            HashMap::new(),
+            models_dev,
+        );
+
+        let result = lookup.lookup("claude-opus-4-6-fast").unwrap();
+        assert_eq!(result.matched_key, "anthropic/claude-opus-4.6-fast");
+        assert_eq!(result.pricing.input_cost_per_token, Some(30e-6));
+    }
+
+    /// After the lookup_auto reorder, models.dev must remain the long-tail
+    /// fallback for ids no canonical source knows.
+    #[test]
+    fn models_dev_still_covers_long_tail_after_reorder() {
+        let mut models_dev = HashMap::new();
+        models_dev.insert(
+            "someprovider/exotic-model-9".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(2e-6),
+                output_cost_per_token: Some(6e-6),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new_with_models_dev(
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            models_dev,
+        );
+
+        let result = lookup.lookup("exotic-model-9").unwrap();
+        assert_eq!(result.matched_key, "someprovider/exotic-model-9");
+        assert_eq!(result.pricing.input_cost_per_token, Some(2e-6));
+    }
+
+    /// Regression (post-#634 catalog audit, bug 2b): when multiple models.dev
+    /// providers share a model part, the winner must be deterministic and
+    /// prefer the canonical `anthropic/` namespace. Previously the winner
+    /// depended on HashMap iteration order (with real data `302ai/` beat
+    /// `anthropic/` for claude-3-5-haiku-20241022 because shorter keys were
+    /// inserted last).
+    #[test]
+    fn models_dev_provider_choice_is_deterministic_and_prefers_anthropic() {
+        let price = ModelPricing {
+            input_cost_per_token: Some(0.8e-6),
+            output_cost_per_token: Some(4e-6),
+            ..Default::default()
+        };
+        // Adversarial insertion order: the non-canonical provider first.
+        let mut models_dev = HashMap::new();
+        models_dev.insert("302ai/claude-3-5-haiku-20241022".to_string(), price.clone());
+        models_dev.insert(
+            "anthropic/claude-3-5-haiku-20241022".to_string(),
+            price.clone(),
+        );
+        let lookup = PricingLookup::new_with_models_dev(
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            models_dev,
+        );
+
+        let result = lookup.lookup("claude-3-5-haiku-20241022").unwrap();
+        assert_eq!(result.matched_key, "anthropic/claude-3-5-haiku-20241022");
+        assert_eq!(result.pricing.input_cost_per_token, Some(0.8e-6));
+    }
+
     #[test]
     fn test_blocklist_auto() {
         let lookup = create_lookup();
@@ -3751,7 +3976,10 @@ mod tests {
         assert!(!is_fuzzy_eligible("base"));
         assert!(!is_fuzzy_eligible("abc"));
         assert!(is_fuzzy_eligible("gpt-4o"));
-        assert!(is_fuzzy_eligible("claude"));
+        // Bare brand tokens carry no model information: a fuzzy hit from them
+        // can land on any model of the brand, so they are blocklisted.
+        assert!(!is_fuzzy_eligible("claude"));
+        assert!(!is_fuzzy_eligible("anthropic"));
     }
 
     // =========================================================================

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -446,20 +446,29 @@ impl PricingLookup {
         if let Some(result) = self.exact_match_litellm(model_id) {
             return Some(result);
         }
-        if let Some(result) = self.exact_match_openrouter(model_id) {
+        // An unscoped OpenRouter FULL-KEY match is the id's own canonical key,
+        // so it wins even under a provider hint. The MODEL-PART fallback does
+        // not: it matches "some other provider's model whose model-part equals
+        // this id", which is exactly what a provider hint must override.
+        if let Some(result) = self.exact_match_openrouter_full_key(model_id) {
             return Some(result);
         }
 
         // A provider hint pins the lookup to that provider's catalog: the
-        // provider-scoped models.dev pass must run before the unscoped
-        // separator-normalized fallback below, otherwise a hinted lookup
-        // (e.g. `venice` + `claude-opus-4-6-fast`) would take OpenRouter's
-        // `anthropic/claude-opus-4.6-fast` price instead of the hinted
-        // provider's own `venice/claude-opus-4-6-fast` key.
+        // provider-scoped models.dev pass must run before BOTH the unscoped
+        // OpenRouter model-part fallback here and the separator-normalized
+        // fallback below. Otherwise a hinted lookup (e.g. `venice` + dotted
+        // `claude-opus-4.6-fast`, which already matches OpenRouter's
+        // `anthropic/claude-opus-4.6-fast` model-part) would take the canonical
+        // price instead of the hinted provider's own key. A hint with no
+        // matching key falls through to the canonical resolution below.
         if provider_id.is_some() {
             if let Some(result) = self.exact_match_models_dev_for_provider(model_id, provider_id) {
                 return Some(result);
             }
+        }
+        if let Some(result) = self.exact_match_openrouter_model_part(model_id) {
+            return Some(result);
         }
 
         // Separator-normalized exact passes against the canonical sources
@@ -851,17 +860,26 @@ impl PricingLookup {
     }
 
     fn exact_match_openrouter(&self, model_id: &str) -> Option<LookupResult> {
-        if let Some(key) = self.openrouter_lower.get(model_id) {
-            if let Some(pricing) = self.openrouter.get(key) {
-                return lookup_result_if_usable(pricing, "OpenRouter", key);
-            }
-        }
-        if let Some(key) = self.openrouter_model_part.get(model_id) {
-            if let Some(pricing) = self.openrouter.get(key) {
-                return lookup_result_if_usable(pricing, "OpenRouter", key);
-            }
-        }
-        None
+        self.exact_match_openrouter_full_key(model_id)
+            .or_else(|| self.exact_match_openrouter_model_part(model_id))
+    }
+
+    /// Full-key (`provider/model`) exact match against OpenRouter — the id's
+    /// own canonical key. This wins even under a provider hint.
+    fn exact_match_openrouter_full_key(&self, model_id: &str) -> Option<LookupResult> {
+        let key = self.openrouter_lower.get(model_id)?;
+        let pricing = self.openrouter.get(key)?;
+        lookup_result_if_usable(pricing, "OpenRouter", key)
+    }
+
+    /// Model-part exact match against OpenRouter — matches any provider whose
+    /// model-part equals `model_id`. A provider hint must take precedence over
+    /// this (see `lookup_auto`), otherwise a hinted lookup leaks to a different
+    /// provider's canonical key.
+    fn exact_match_openrouter_model_part(&self, model_id: &str) -> Option<LookupResult> {
+        let key = self.openrouter_model_part.get(model_id)?;
+        let pricing = self.openrouter.get(key)?;
+        lookup_result_if_usable(pricing, "OpenRouter", key)
     }
 
     fn exact_match_models_dev(&self, model_id: &str) -> Option<LookupResult> {
@@ -3801,6 +3819,64 @@ mod tests {
         let unhinted = lookup.lookup("claude-opus-4-6-fast").unwrap();
         assert_eq!(unhinted.matched_key, "anthropic/claude-opus-4.6-fast");
         assert_eq!(unhinted.pricing.input_cost_per_token, Some(30e-6));
+    }
+
+    /// Regression (#707 review, cubic follow-up): the provider-hint pin must
+    /// also beat the unscoped OpenRouter MODEL-PART fallback, not just the
+    /// separator-normalized passes. When the hinted provider's models.dev key
+    /// shares the dotted model-part spelling that OpenRouter already indexes
+    /// (here both `claude-opus-4.6-fast`), an unscoped model-part match would
+    /// otherwise return `anthropic/...` before the provider-scoped pass ran.
+    #[test]
+    fn provider_hint_beats_unscoped_openrouter_model_part_for_dotted_id() {
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "anthropic/claude-opus-4.6-fast".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(30e-6),
+                output_cost_per_token: Some(150e-6),
+                ..Default::default()
+            },
+        );
+        let mut models_dev = HashMap::new();
+        // Hinted provider's key uses the SAME dotted spelling OpenRouter
+        // indexes as a model-part — this is what makes the unscoped model-part
+        // pass fire first without the fix.
+        models_dev.insert(
+            "venice/claude-opus-4.6-fast".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(36e-6),
+                output_cost_per_token: Some(180e-6),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new_with_models_dev(
+            HashMap::new(),
+            openrouter,
+            HashMap::new(),
+            models_dev,
+        );
+
+        // Hinted dotted lookup must pin to venice, not the canonical OpenRouter
+        // model-part it also matches.
+        let hinted = lookup
+            .lookup_with_provider("claude-opus-4.6-fast", Some("venice"))
+            .unwrap();
+        assert_eq!(hinted.matched_key, "venice/claude-opus-4.6-fast");
+        assert_eq!(hinted.pricing.input_cost_per_token, Some(36e-6));
+
+        // Unhinted dotted lookup keeps the canonical OpenRouter resolution.
+        let unhinted = lookup.lookup("claude-opus-4.6-fast").unwrap();
+        assert_eq!(unhinted.matched_key, "anthropic/claude-opus-4.6-fast");
+        assert_eq!(unhinted.pricing.input_cost_per_token, Some(30e-6));
+
+        // A hint for a provider with no matching key must still fall through to
+        // the canonical resolution rather than returning None.
+        let no_match = lookup
+            .lookup_with_provider("claude-opus-4.6-fast", Some("groq"))
+            .unwrap();
+        assert_eq!(no_match.matched_key, "anthropic/claude-opus-4.6-fast");
+        assert_eq!(no_match.pricing.input_cost_per_token, Some(30e-6));
     }
 
     /// Regression (#707 review): the anthropic-first preference in the

--- a/crates/tokscale-core/tests/anthropic_catalog.rs
+++ b/crates/tokscale-core/tests/anthropic_catalog.rs
@@ -150,7 +150,7 @@ fn anthropic_catalog_resolves_to_correct_family_version_and_price() {
 
     // Retired models absent from all datasets, and bare brand tokens, must
     // resolve unpriced — never to another model's price.
-    for id in ["claude-2.1", "claude-2.0", "claude"] {
+    for id in ["claude-2.1", "claude-2.0", "claude", "anthropic"] {
         if let Some(result) = lookup.lookup(id) {
             failures.push(format!(
                 "{}: must be None, resolved to {} at {:?}",

--- a/crates/tokscale-core/tests/anthropic_catalog.rs
+++ b/crates/tokscale-core/tests/anthropic_catalog.rs
@@ -1,0 +1,167 @@
+//! Catalog invariant test against the real cached pricing datasets.
+//!
+//! `#[ignore]`d so CI (which has no `~/.config/tokscale/cache/`) skips it.
+//! Run manually when datasets are cached:
+//!
+//! ```sh
+//! cargo test -p tokscale-core --test anthropic_catalog -- --ignored
+//! ```
+//!
+//! Asserts INVARIANTS, not exact keys: every id in the official Anthropic
+//! catalog must resolve to a key carrying the same family token and the same
+//! major-minor version token (accepting both `4-8` and `4.8` spellings), at a
+//! price within ±25% of the official rate (band tolerates regional variants).
+//! Retired `claude-2.x` ids and bare brand tokens must resolve to None.
+
+use std::collections::HashMap;
+use tokscale_core::pricing::lookup::PricingLookup;
+use tokscale_core::pricing::{litellm, models_dev, openrouter, ModelPricing};
+
+struct CatalogEntry {
+    id: &'static str,
+    family: &'static str,
+    /// Major-minor version token in dashed spelling (e.g. "4-8"); the dotted
+    /// spelling is accepted too. Bare-major models (fable-5) use "5".
+    version: &'static str,
+    /// Official $/MTok.
+    input_per_mtok: f64,
+    output_per_mtok: f64,
+}
+
+const CATALOG: &[CatalogEntry] = &[
+    // Current models
+    e("claude-fable-5", "fable", "5", 10.0, 50.0),
+    e("claude-fable-5[1m]", "fable", "5", 10.0, 50.0),
+    e("claude-opus-4-8", "opus", "4-8", 5.0, 25.0),
+    e("claude-opus-4-7", "opus", "4-7", 5.0, 25.0),
+    e("claude-opus-4-6", "opus", "4-6", 5.0, 25.0),
+    e("claude-sonnet-4-6", "sonnet", "4-6", 3.0, 15.0),
+    e("claude-haiku-4-5", "haiku", "4-5", 1.0, 5.0),
+    // Legacy models
+    e("claude-opus-4-5", "opus", "4-5", 5.0, 25.0),
+    e("claude-opus-4-1", "opus", "4-1", 15.0, 75.0),
+    e("claude-sonnet-4-5", "sonnet", "4-5", 3.0, 15.0),
+    // Dated forms
+    e("claude-haiku-4-5-20251001", "haiku", "4-5", 1.0, 5.0),
+    e("claude-opus-4-5-20251101", "opus", "4-5", 5.0, 25.0),
+    e("claude-opus-4-1-20250805", "opus", "4-1", 15.0, 75.0),
+    e("claude-sonnet-4-5-20250929", "sonnet", "4-5", 3.0, 15.0),
+    // Provider forms
+    e("anthropic.claude-opus-4-8", "opus", "4-8", 5.0, 25.0),
+    e(
+        "us.anthropic.claude-sonnet-4-6-v1:0",
+        "sonnet",
+        "4-6",
+        3.0,
+        15.0,
+    ),
+];
+
+const fn e(
+    id: &'static str,
+    family: &'static str,
+    version: &'static str,
+    input_per_mtok: f64,
+    output_per_mtok: f64,
+) -> CatalogEntry {
+    CatalogEntry {
+        id,
+        family,
+        version,
+        input_per_mtok,
+        output_per_mtok,
+    }
+}
+
+/// Mirror of `PricingService::filter_litellm_data`: github_copilot/ entries
+/// use subscription pricing ($0.00) and are excluded from lookups.
+fn filter_litellm(mut data: HashMap<String, ModelPricing>) -> HashMap<String, ModelPricing> {
+    data.retain(|key, _| !key.to_lowercase().starts_with("github_copilot/"));
+    data
+}
+
+fn within_band(actual_per_token: f64, official_per_mtok: f64) -> bool {
+    let official_per_token = official_per_mtok / 1e6;
+    (actual_per_token - official_per_token).abs() <= official_per_token * 0.25
+}
+
+fn key_has_version(matched_lower: &str, version: &str) -> bool {
+    let dashed = version.to_string();
+    let dotted = version.replace('-', ".");
+    matched_lower.contains(&dashed) || matched_lower.contains(&dotted)
+}
+
+#[test]
+#[ignore]
+fn anthropic_catalog_resolves_to_correct_family_version_and_price() {
+    let (Some(litellm_data), Some(openrouter_data), Some(models_dev_data)) = (
+        litellm::load_cached_any_age(),
+        openrouter::load_cached_any_age(),
+        models_dev::load_cached_any_age(),
+    ) else {
+        eprintln!("pricing dataset cache absent; skipping catalog invariant test");
+        return;
+    };
+
+    let lookup = PricingLookup::new_with_models_dev(
+        filter_litellm(litellm_data),
+        openrouter_data,
+        HashMap::new(),
+        models_dev_data,
+    );
+
+    let mut failures = Vec::new();
+
+    for entry in CATALOG {
+        let Some(result) = lookup.lookup(entry.id) else {
+            failures.push(format!("{}: did not resolve", entry.id));
+            continue;
+        };
+        let matched_lower = result.matched_key.to_lowercase();
+
+        if !matched_lower.contains(entry.family) {
+            failures.push(format!(
+                "{}: resolved to {} (missing family token {:?})",
+                entry.id, result.matched_key, entry.family
+            ));
+        }
+        if !key_has_version(&matched_lower, entry.version) {
+            failures.push(format!(
+                "{}: resolved to {} (missing version token {:?})",
+                entry.id, result.matched_key, entry.version
+            ));
+        }
+
+        match result.pricing.input_cost_per_token {
+            Some(input) if within_band(input, entry.input_per_mtok) => {}
+            other => failures.push(format!(
+                "{}: input price {:?} outside ±25% of ${}/MTok (key {})",
+                entry.id, other, entry.input_per_mtok, result.matched_key
+            )),
+        }
+        match result.pricing.output_cost_per_token {
+            Some(output) if within_band(output, entry.output_per_mtok) => {}
+            other => failures.push(format!(
+                "{}: output price {:?} outside ±25% of ${}/MTok (key {})",
+                entry.id, other, entry.output_per_mtok, result.matched_key
+            )),
+        }
+    }
+
+    // Retired models absent from all datasets, and bare brand tokens, must
+    // resolve unpriced — never to another model's price.
+    for id in ["claude-2.1", "claude-2.0", "claude"] {
+        if let Some(result) = lookup.lookup(id) {
+            failures.push(format!(
+                "{}: must be None, resolved to {} at {:?}",
+                id, result.matched_key, result.pricing.input_cost_per_token
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "catalog invariant violations:\n{}",
+        failures.join("\n")
+    );
+}

--- a/crates/tokscale-core/tests/anthropic_catalog.rs
+++ b/crates/tokscale-core/tests/anthropic_catalog.rs
@@ -369,17 +369,20 @@ fn real_local_models_all_resolve_sanely() {
     for entry in parse_fixture() {
         let resolved = lookup_id(&lookup, &entry.id, entry.provider.as_deref());
 
-        // Documented acceptable-None: must stay unpriced.
+        // Documented acceptable-None: must stay unpriced. Flag ANY resolution
+        // (matching the sibling catalog test), not just an input-priced one —
+        // a key with `input: None` but `output: Some(..)` is still a wrong
+        // resolution and must not slip through.
         if entry.input_per_mtok.is_none() {
             if let Some((key, pricing)) = resolved {
-                if pricing.input_cost_per_token.is_some() {
-                    failures.push(format!(
-                        "{} [{}]: documented acceptable-None resolved to priced key {}",
-                        entry.id,
-                        entry.provider.as_deref().unwrap_or("-"),
-                        key
-                    ));
-                }
+                failures.push(format!(
+                    "{} [{}]: documented acceptable-None resolved to {} at in={:?} out={:?}",
+                    entry.id,
+                    entry.provider.as_deref().unwrap_or("-"),
+                    key,
+                    pricing.input_cost_per_token,
+                    pricing.output_cost_per_token
+                ));
             }
             continue;
         }

--- a/crates/tokscale-core/tests/anthropic_catalog.rs
+++ b/crates/tokscale-core/tests/anthropic_catalog.rs
@@ -1,52 +1,108 @@
-//! Catalog invariant test against the real cached pricing datasets.
+//! Catalog invariant tests against the real cached pricing datasets.
 //!
-//! `#[ignore]`d so CI (which has no `~/.config/tokscale/cache/`) skips it.
+//! `#[ignore]`d so CI (which has no `~/.config/tokscale/cache/`) skips them.
 //! Run manually when datasets are cached:
 //!
 //! ```sh
 //! cargo test -p tokscale-core --test anthropic_catalog -- --ignored
 //! ```
 //!
-//! Asserts INVARIANTS, not exact keys: every id in the official Anthropic
-//! catalog must resolve to a key carrying the same family token and the same
-//! major-minor version token (accepting both `4-8` and `4.8` spellings), at a
-//! price within ±25% of the official rate (band tolerates regional variants).
+//! These assert INVARIANTS, not exact keys:
+//!
+//! * [`anthropic_catalog_resolves_to_correct_family_version_and_price`] drives
+//!   the Anthropic-family catalog from the model ids ACTUALLY seen in local
+//!   session data (committed as `tests/fixtures/local_model_ids.txt`). Every
+//!   `claude-*` id must resolve to a key carrying the same family token and the
+//!   same major-minor version token (accepting both `4-8` and `4.8` spellings),
+//!   at a price within ±25% of the official rate (band tolerates regional
+//!   variants). A handful of additional hardcoded provider/regional forms guard
+//!   shapes that may not currently appear in local data.
+//! * [`real_local_models_all_resolve_sanely`] iterates the FULL harvested id
+//!   set (all vendors) and asserts each id either resolves to a key whose
+//!   matched family token matches the id's known vendor token, or is a
+//!   documented acceptable-None — and that NO id resolves to a cross-family key.
+//!
 //! Retired `claude-2.x` ids and bare brand tokens must resolve to None.
 
 use std::collections::HashMap;
 use tokscale_core::pricing::lookup::PricingLookup;
 use tokscale_core::pricing::{litellm, models_dev, openrouter, ModelPricing};
 
+const FIXTURE: &str = include_str!("fixtures/local_model_ids.txt");
+
+/// One harvested id row from the committed fixture.
+struct FixtureEntry {
+    id: String,
+    provider: Option<String>,
+    /// Vendor/family token the matched key must contain. `*` => generic.
+    family: String,
+    /// Dashed major-minor version token (e.g. "4-8"); dotted accepted too.
+    /// Empty => no version assertion.
+    version: String,
+    /// Official $/MTok, or `None` for a documented acceptable-None id.
+    input_per_mtok: Option<f64>,
+    output_per_mtok: Option<f64>,
+}
+
+fn parse_fixture() -> Vec<FixtureEntry> {
+    let mut entries = Vec::new();
+    for line in FIXTURE.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let cols: Vec<&str> = line.split('|').map(str::trim).collect();
+        assert_eq!(
+            cols.len(),
+            6,
+            "malformed fixture row (expected 6 pipe-separated columns): {line:?}"
+        );
+        let provider = if cols[1] == "-" {
+            None
+        } else {
+            Some(cols[1].to_string())
+        };
+        let version = if cols[3] == "-" {
+            String::new()
+        } else {
+            cols[3].to_string()
+        };
+        let parse_price = |s: &str| -> Option<f64> {
+            if s == "NONE" {
+                None
+            } else {
+                Some(
+                    s.parse()
+                        .unwrap_or_else(|_| panic!("bad price {s:?} in {line:?}")),
+                )
+            }
+        };
+        entries.push(FixtureEntry {
+            id: cols[0].to_string(),
+            provider,
+            family: cols[2].to_string(),
+            version,
+            input_per_mtok: parse_price(cols[4]),
+            output_per_mtok: parse_price(cols[5]),
+        });
+    }
+    entries
+}
+
+/// Hardcoded provider/regional/suffix forms that round out the harvested set.
+/// These guard shapes that may not currently appear in local data but must
+/// keep resolving correctly.
 struct CatalogEntry {
     id: &'static str,
     family: &'static str,
-    /// Major-minor version token in dashed spelling (e.g. "4-8"); the dotted
-    /// spelling is accepted too. Bare-major models (fable-5) use "5".
     version: &'static str,
-    /// Official $/MTok.
     input_per_mtok: f64,
     output_per_mtok: f64,
 }
 
-const CATALOG: &[CatalogEntry] = &[
-    // Current models
-    e("claude-fable-5", "fable", "5", 10.0, 50.0),
+const EXTRA_CATALOG: &[CatalogEntry] = &[
     e("claude-fable-5[1m]", "fable", "5", 10.0, 50.0),
-    e("claude-opus-4-8", "opus", "4-8", 5.0, 25.0),
-    e("claude-opus-4-7", "opus", "4-7", 5.0, 25.0),
-    e("claude-opus-4-6", "opus", "4-6", 5.0, 25.0),
-    e("claude-sonnet-4-6", "sonnet", "4-6", 3.0, 15.0),
-    e("claude-haiku-4-5", "haiku", "4-5", 1.0, 5.0),
-    // Legacy models
-    e("claude-opus-4-5", "opus", "4-5", 5.0, 25.0),
     e("claude-opus-4-1", "opus", "4-1", 15.0, 75.0),
-    e("claude-sonnet-4-5", "sonnet", "4-5", 3.0, 15.0),
-    // Dated forms
-    e("claude-haiku-4-5-20251001", "haiku", "4-5", 1.0, 5.0),
-    e("claude-opus-4-5-20251101", "opus", "4-5", 5.0, 25.0),
-    e("claude-opus-4-1-20250805", "opus", "4-1", 15.0, 75.0),
-    e("claude-sonnet-4-5-20250929", "sonnet", "4-5", 3.0, 15.0),
-    // Provider forms
     e("anthropic.claude-opus-4-8", "opus", "4-8", 5.0, 25.0),
     e(
         "us.anthropic.claude-sonnet-4-6-v1:0",
@@ -91,59 +147,136 @@ fn key_has_version(matched_lower: &str, version: &str) -> bool {
     matched_lower.contains(&dashed) || matched_lower.contains(&dotted)
 }
 
-#[test]
-#[ignore]
-fn anthropic_catalog_resolves_to_correct_family_version_and_price() {
+/// Build the lookup exactly as `PricingService` does for cached datasets
+/// (filter github_copilot, no cursor overrides needed for these ids, models.dev
+/// as the long-tail source), or `None` when the cache is absent.
+fn load_lookup() -> Option<PricingLookup> {
     let (Some(litellm_data), Some(openrouter_data), Some(models_dev_data)) = (
         litellm::load_cached_any_age(),
         openrouter::load_cached_any_age(),
         models_dev::load_cached_any_age(),
     ) else {
         eprintln!("pricing dataset cache absent; skipping catalog invariant test");
-        return;
+        return None;
     };
-
-    let lookup = PricingLookup::new_with_models_dev(
+    Some(PricingLookup::new_with_models_dev(
         filter_litellm(litellm_data),
         openrouter_data,
         HashMap::new(),
         models_dev_data,
-    );
+    ))
+}
+
+fn lookup_id(
+    lookup: &PricingLookup,
+    id: &str,
+    provider: Option<&str>,
+) -> Option<(String, ModelPricing)> {
+    lookup
+        .lookup_with_provider(id, provider)
+        .map(|r| (r.matched_key, r.pricing))
+}
+
+#[test]
+#[ignore]
+fn anthropic_catalog_resolves_to_correct_family_version_and_price() {
+    let Some(lookup) = load_lookup() else {
+        return;
+    };
 
     let mut failures = Vec::new();
 
-    for entry in CATALOG {
-        let Some(result) = lookup.lookup(entry.id) else {
+    // Drive the Anthropic family from the harvested real ids.
+    for entry in parse_fixture() {
+        let is_anthropic = entry.family == "opus"
+            || entry.family == "sonnet"
+            || entry.family == "haiku"
+            || entry.family == "fable"
+            || entry.id.contains("claude");
+        if !is_anthropic {
+            continue;
+        }
+
+        let resolved = lookup_id(&lookup, &entry.id, entry.provider.as_deref());
+
+        // Documented acceptable-None ids must stay unpriced.
+        if entry.input_per_mtok.is_none() {
+            if let Some((key, pricing)) = resolved {
+                failures.push(format!(
+                    "{}: documented acceptable-None resolved to {} at {:?}",
+                    entry.id, key, pricing.input_cost_per_token
+                ));
+            }
+            continue;
+        }
+
+        let Some((matched_key, pricing)) = resolved else {
             failures.push(format!("{}: did not resolve", entry.id));
             continue;
         };
-        let matched_lower = result.matched_key.to_lowercase();
+        let matched_lower = matched_key.to_lowercase();
 
+        if !matched_lower.contains(&entry.family) {
+            failures.push(format!(
+                "{}: resolved to {} (missing family token {:?})",
+                entry.id, matched_key, entry.family
+            ));
+        }
+        if !entry.version.is_empty() && !key_has_version(&matched_lower, &entry.version) {
+            failures.push(format!(
+                "{}: resolved to {} (missing version token {:?})",
+                entry.id, matched_key, entry.version
+            ));
+        }
+        match (pricing.input_cost_per_token, entry.input_per_mtok) {
+            (Some(input), Some(expected)) if within_band(input, expected) => {}
+            (other, Some(expected)) => failures.push(format!(
+                "{}: input price {:?} outside ±25% of ${}/MTok (key {})",
+                entry.id, other, expected, matched_key
+            )),
+            _ => {}
+        }
+        match (pricing.output_cost_per_token, entry.output_per_mtok) {
+            (Some(output), Some(expected)) if within_band(output, expected) => {}
+            (other, Some(expected)) => failures.push(format!(
+                "{}: output price {:?} outside ±25% of ${}/MTok (key {})",
+                entry.id, other, expected, matched_key
+            )),
+            _ => {}
+        }
+    }
+
+    // Hardcoded provider/regional/suffix forms.
+    for entry in EXTRA_CATALOG {
+        let Some((matched_key, pricing)) = lookup_id(&lookup, entry.id, None) else {
+            failures.push(format!("{}: did not resolve", entry.id));
+            continue;
+        };
+        let matched_lower = matched_key.to_lowercase();
         if !matched_lower.contains(entry.family) {
             failures.push(format!(
                 "{}: resolved to {} (missing family token {:?})",
-                entry.id, result.matched_key, entry.family
+                entry.id, matched_key, entry.family
             ));
         }
         if !key_has_version(&matched_lower, entry.version) {
             failures.push(format!(
                 "{}: resolved to {} (missing version token {:?})",
-                entry.id, result.matched_key, entry.version
+                entry.id, matched_key, entry.version
             ));
         }
-
-        match result.pricing.input_cost_per_token {
+        match pricing.input_cost_per_token {
             Some(input) if within_band(input, entry.input_per_mtok) => {}
             other => failures.push(format!(
                 "{}: input price {:?} outside ±25% of ${}/MTok (key {})",
-                entry.id, other, entry.input_per_mtok, result.matched_key
+                entry.id, other, entry.input_per_mtok, matched_key
             )),
         }
-        match result.pricing.output_cost_per_token {
+        match pricing.output_cost_per_token {
             Some(output) if within_band(output, entry.output_per_mtok) => {}
             other => failures.push(format!(
                 "{}: output price {:?} outside ±25% of ${}/MTok (key {})",
-                entry.id, other, entry.output_per_mtok, result.matched_key
+                entry.id, other, entry.output_per_mtok, matched_key
             )),
         }
     }
@@ -151,10 +284,10 @@ fn anthropic_catalog_resolves_to_correct_family_version_and_price() {
     // Retired models absent from all datasets, and bare brand tokens, must
     // resolve unpriced — never to another model's price.
     for id in ["claude-2.1", "claude-2.0", "claude", "anthropic"] {
-        if let Some(result) = lookup.lookup(id) {
+        if let Some((key, pricing)) = lookup_id(&lookup, id, None) {
             failures.push(format!(
                 "{}: must be None, resolved to {} at {:?}",
-                id, result.matched_key, result.pricing.input_cost_per_token
+                id, key, pricing.input_cost_per_token
             ));
         }
     }
@@ -162,6 +295,139 @@ fn anthropic_catalog_resolves_to_correct_family_version_and_price() {
     assert!(
         failures.is_empty(),
         "catalog invariant violations:\n{}",
+        failures.join("\n")
+    );
+}
+
+/// Map a fixture vendor/family token to the set of substrings that, if any
+/// appears in a matched key, would indicate a CROSS-FAMILY misresolution.
+/// Returns the list of foreign vendor tokens that must NOT appear.
+fn cross_family_tokens(family: &str) -> Vec<&'static str> {
+    // Mutually-exclusive vendor token groups. A key matched for one group must
+    // not carry a token from any other group.
+    const GROUPS: &[(&[&str], &[&str])] = &[
+        // (family tokens that map to this group, foreign tokens to reject)
+        (
+            &["opus", "sonnet", "haiku", "fable", "claude"],
+            &[
+                "gpt", "gemini", "grok", "glm", "kimi", "qwen", "deepseek", "mistral", "llama",
+            ],
+        ),
+        (
+            &["gpt"],
+            &[
+                "claude", "opus", "sonnet", "haiku", "gemini", "grok", "glm", "kimi", "qwen",
+                "deepseek", "mistral", "llama",
+            ],
+        ),
+        (
+            &["gemini"],
+            &[
+                "claude", "opus", "sonnet", "haiku", "gpt", "grok", "glm", "kimi", "qwen",
+                "deepseek", "mistral", "llama",
+            ],
+        ),
+        (
+            &["grok"],
+            &[
+                "claude", "opus", "sonnet", "haiku", "gpt", "gemini", "glm", "kimi", "qwen",
+                "deepseek", "mistral", "llama",
+            ],
+        ),
+        (
+            &["glm"],
+            &[
+                "claude", "opus", "sonnet", "haiku", "gpt", "gemini", "grok", "kimi", "qwen",
+                "deepseek", "mistral", "llama",
+            ],
+        ),
+        (
+            &["kimi"],
+            &[
+                "claude", "opus", "sonnet", "haiku", "gpt", "gemini", "grok", "glm", "qwen",
+                "deepseek", "mistral", "llama",
+            ],
+        ),
+    ];
+    for (members, foreign) in GROUPS {
+        if members.contains(&family) {
+            return foreign.to_vec();
+        }
+    }
+    Vec::new()
+}
+
+#[test]
+#[ignore]
+fn real_local_models_all_resolve_sanely() {
+    let Some(lookup) = load_lookup() else {
+        return;
+    };
+
+    let mut failures = Vec::new();
+
+    for entry in parse_fixture() {
+        let resolved = lookup_id(&lookup, &entry.id, entry.provider.as_deref());
+
+        // Documented acceptable-None: must stay unpriced.
+        if entry.input_per_mtok.is_none() {
+            if let Some((key, pricing)) = resolved {
+                if pricing.input_cost_per_token.is_some() {
+                    failures.push(format!(
+                        "{} [{}]: documented acceptable-None resolved to priced key {}",
+                        entry.id,
+                        entry.provider.as_deref().unwrap_or("-"),
+                        key
+                    ));
+                }
+            }
+            continue;
+        }
+
+        let Some((matched_key, _)) = resolved else {
+            failures.push(format!(
+                "{} [{}]: expected to resolve but returned None",
+                entry.id,
+                entry.provider.as_deref().unwrap_or("-")
+            ));
+            continue;
+        };
+        let lower = matched_key.to_lowercase();
+
+        // Generic family ("*") only checks that SOMETHING resolved (above).
+        if entry.family == "*" {
+            continue;
+        }
+
+        // Known vendor token must appear in the matched key.
+        if !lower.contains(&entry.family) {
+            failures.push(format!(
+                "{} [{}]: matched key {} is missing expected family token {:?}",
+                entry.id,
+                entry.provider.as_deref().unwrap_or("-"),
+                matched_key,
+                entry.family
+            ));
+        }
+
+        // And no FOREIGN vendor token may appear (cross-family misresolution).
+        for foreign in cross_family_tokens(&entry.family) {
+            if lower.contains(foreign) {
+                failures.push(format!(
+                    "{} [{}]: CROSS-FAMILY misresolution — key {} carries foreign token {:?} (expected {:?})",
+                    entry.id,
+                    entry.provider.as_deref().unwrap_or("-"),
+                    matched_key,
+                    foreign,
+                    entry.family
+                ));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "real-local-model sanity violations:\n{}",
         failures.join("\n")
     );
 }

--- a/crates/tokscale-core/tests/fixtures/local_model_ids.txt
+++ b/crates/tokscale-core/tests/fixtures/local_model_ids.txt
@@ -1,0 +1,119 @@
+# Harvested DISTINCT model-id strings actually seen in local tokscale session
+# data, used to drive the catalog regression in tests/anthropic_catalog.rs.
+#
+# PRIVACY: this file contains ONLY model-id strings, an optional provider hint,
+# and pricing-expectation metadata. It carries NO usage counts, token totals,
+# costs, session ids, timestamps, paths, or any user-identifying content.
+#
+# Format (pipe-separated):
+#   model_id | provider_hint | expected_family | expected_version | in_$/MTok | out_$/MTok
+#
+# Conventions:
+#   - provider_hint: "-" means no hint (looked up unscoped).
+#   - expected_family: the vendor/family token the matched key MUST contain.
+#     "*" means "no known vendor token / generic" (only cross-family is checked).
+#   - expected_version: dashed major-minor token the matched key must carry
+#     ("4-8"; dotted "4.8" is also accepted). "-" means no version assertion.
+#   - in/out: official $/MTok, asserted within +/-25%. "NONE" means this id is a
+#     documented acceptable-None (must NOT resolve to any priced key).
+#
+# Every Anthropic-family entry below was audited as resolving to the correct
+# family, version token, and price band. Entries marked NONE are malformed or
+# noise ids that must stay unpriced (never-degrade).
+
+# --- Anthropic / Claude family ---
+claude-3-5-sonnet-20241022 | anthropic | sonnet | 3-5 | 3.0 | 15.0
+claude-3.7-sonnet-thought | github-copilot | sonnet | 3-7 | 3.0 | 15.0
+claude-fable-5 | anthropic | fable | 5 | 10.0 | 50.0
+claude-haiku-4-5 | anthropic | haiku | 4-5 | 1.0 | 5.0
+claude-haiku-4-5 | ccapi | haiku | 4-5 | 1.0 | 5.0
+claude-haiku-4-5-20251001 | anthropic | haiku | 4-5 | 1.0 | 5.0
+claude-opus-4-0 | anthropic | opus | 4-0 | 15.0 | 75.0
+claude-opus-4-1-20250805 | anthropic | opus | 4-1 | 15.0 | 75.0
+claude-opus-4-20250514 | anthropic | opus | 4 | 15.0 | 75.0
+claude-opus-4-5 | anthropic | opus | 4-5 | 5.0 | 25.0
+claude-opus-4-5 | opencode | opus | 4-5 | 5.0 | 25.0
+claude-opus-4-5-20251101 | anthropic | opus | 4-5 | 5.0 | 25.0
+claude-opus-4-5-high | anthropic | opus | 4-5 | 5.0 | 25.0
+claude-opus-4-5-thinking-high | google | opus | 4-5 | 5.0 | 25.0
+claude-opus-4-5-thinking-low | google | opus | 4-5 | 5.0 | 25.0
+claude-opus-4-6 | anthropic | opus | 4-6 | 5.0 | 25.0
+claude-opus-4-6 | ccapi | opus | 4-6 | 5.0 | 25.0
+claude-opus-4-6 | opencode | opus | 4-6 | 5.0 | 25.0
+claude-opus-4-7 | anthropic | opus | 4-7 | 5.0 | 25.0
+claude-opus-4-7 | ccapi | opus | 4-7 | 5.0 | 25.0
+claude-opus-4-8 | anthropic | opus | 4-8 | 5.0 | 25.0
+claude-opus-4.5 | github-copilot | opus | 4-5 | 5.0 | 25.0
+claude-opus-4.6 | github-copilot | opus | 4-6 | 5.0 | 25.0
+claude-opus-4.7 | github-copilot | opus | 4-7 | 5.0 | 25.0
+claude-opus-41 | github-copilot | opus | - | NONE | NONE
+claude-sonnet-4 | github-copilot | sonnet | 4 | 3.0 | 15.0
+claude-sonnet-4-20250514 | anthropic | sonnet | 4 | 3.0 | 15.0
+claude-sonnet-4-5 | anthropic | sonnet | 4-5 | 3.0 | 15.0
+claude-sonnet-4-5 | ccapi | sonnet | 4-5 | 3.0 | 15.0
+claude-sonnet-4-5 | opencode | sonnet | 4-5 | 3.0 | 15.0
+claude-sonnet-4-5-20250929 | anthropic | sonnet | 4-5 | 3.0 | 15.0
+claude-sonnet-4-5-high | anthropic | sonnet | 4-5 | 3.0 | 15.0
+claude-sonnet-4-5-thinking-medium | google | sonnet | 4-5 | 3.0 | 15.0
+claude-sonnet-4-6 | anthropic | sonnet | 4-6 | 3.0 | 15.0
+claude-sonnet-4.5 | github-copilot | sonnet | 4-5 | 3.0 | 15.0
+claude-sonnet-4.6 | github-copilot | sonnet | 4-6 | 3.0 | 15.0
+
+# --- OpenAI / GPT family ---
+gpt-4o | openai | gpt | - | 2.5 | 10.0
+gpt-5-codex | openai | gpt | 5 | 1.25 | 10.0
+gpt-5-nano | opencode | gpt | 5 | 0.05 | 0.4
+gpt-5.1 | openai | gpt | 5.1 | 1.25 | 10.0
+gpt-5.1 | openai-codex | gpt | 5.1 | 1.25 | 10.0
+gpt-5.1-codex | openai | gpt | 5.1 | 1.25 | 10.0
+gpt-5.1-codex-low | openai | gpt | 5.1 | 1.25 | 10.0
+gpt-5.1-codex-max | openai | gpt | 5.1 | 1.25 | 10.0
+gpt-5.1-codex-max-high | openai | gpt | 5.1 | 1.25 | 10.0
+gpt-5.1-codex-max-xhigh | openai | gpt | 5.1 | 1.25 | 10.0
+gpt-5.2 | github-copilot | gpt | 5.2 | 1.75 | 14.0
+gpt-5.2 | openai | gpt | 5.2 | 1.75 | 14.0
+gpt-5.2 | openai-codex | gpt | 5.2 | 1.75 | 14.0
+gpt-5.2-codex | github-copilot | gpt | 5.2 | 1.75 | 14.0
+gpt-5.2-codex | openai | gpt | 5.2 | 1.75 | 14.0
+gpt-5.2-high | openai | gpt | 5.2 | 1.75 | 14.0
+gpt-5.2-xhigh | openai | gpt | 5.2 | 1.75 | 14.0
+gpt-5.3-codex | openai | gpt | 5.3 | 1.75 | 14.0
+gpt-5.3-codex | openai-codex | gpt | 5.3 | 1.75 | 14.0
+gpt-5.3-codex-spark | openai | gpt | 5.3 | 1.75 | 14.0
+gpt-5.4 | openai | gpt | 5.4 | 2.5 | 15.0
+gpt-5.4 | opencode | gpt | 5.4 | 2.5 | 15.0
+gpt-5.4-mini | openai | gpt | 5.4 | 0.75 | 4.5
+gpt-5.4-mini-fast | openai | gpt | 5.4 | 0.75 | 4.5
+gpt-5.4-pro | opencode | gpt | 5.4 | 30.0 | 180.0
+gpt-5.5 | github-copilot | gpt | 5.5 | 5.0 | 30.0
+gpt-5.5 | openai | gpt | 5.5 | 5.0 | 30.0
+gpt-5.5 | opencode | gpt | 5.5 | 5.0 | 30.0
+
+# --- Google / Gemini family ---
+gemini-2.5-flash | google | gemini | 2.5 | 0.3 | 2.5
+gemini-2.5-pro | google | gemini | 2.5 | 1.25 | 10.0
+gemini-3-flash | google | gemini | 3 | 0.5 | 3.0
+gemini-3-flash-preview | google | gemini | 3 | 0.5 | 3.0
+gemini-3-pro | google | gemini | 3 | 2.0 | 12.0
+gemini-3-pro | opencode | gemini | 3 | 2.0 | 12.0
+gemini-3-pro-high | google | gemini | 3 | 2.0 | 12.0
+gemini-3-pro-low | google | gemini | 3 | 2.0 | 12.0
+gemini-3-pro-preview | google | gemini | 3 | 2.0 | 12.0
+gemini-3-pro-preview | google-vertex | gemini | 3 | 2.0 | 12.0
+gemini-3.1-pro-preview | google | gemini | 3 | 2.0 | 12.0
+gemini-flash-latest | google | gemini | - | 0.3 | 2.5
+
+# --- Kimi / Moonshot family ---
+k2p6 | kimi-for-coding | kimi | - | 0.95 | 4.0
+kimi-k2-thinking | opencode | kimi | - | 0.4 | 2.5
+kimi-k2.5 | opencode | kimi | - | 0.6 | 3.0
+
+# --- GLM / zai family ---
+big-pickle | opencode | glm | 4.7 | 0.6 | 2.2
+glm-5 | opencode | glm | 5 | 1.0 | 3.2
+
+# --- Grok family ---
+grok-code-fast-1 | github-copilot | grok | - | 0.2 | 1.5
+
+# --- Documented acceptable-None (noise / malformed; must stay unpriced) ---
+unknown | unknown | * | - | NONE | NONE


### PR DESCRIPTION
Found by post-#634 catalog audit of `crates/tokscale-core/src/pricing/lookup.rs` against the real Anthropic model catalog.

## Bug 1 (severe): retired `claude-2.x` billed at `claude-opus-4.7-fast` rates

With the real cached datasets, before this PR:

```
claude-2.1 -> anthropic/claude-opus-4.7-fast  $30/$150 per MTok  (OpenRouter)
claude-2.0 -> anthropic/claude-opus-4.7-fast  $30/$150 per MTok  (OpenRouter)
claude     -> anthropic/claude-opus-4.7-fast  $30/$150 per MTok  (OpenRouter)
anthropic  -> vercel_ai_gateway/anthropic/claude-3-5-sonnet-20241022 (LiteLLM)
```

`claude-2.1`/`claude-2.0` are retired models that still appear in historical usage logs and are absent from every pricing dataset — they must resolve unpriced, never to another model's price.

Root cause chain: `try_strip_unknown_suffix` erodes `claude-2.1` to bare `claude` — the `strips_claude_numeric_minor` guard didn't fire because segment `"2.1"` contains a dot and failed the all-digits version check. Bare `claude` (len 6 ≥ `MIN_FUZZY_MATCH_LEN`, not blocklisted) then reached `fuzzy_match_openrouter` and matched the first claude key. The #634 family veto (`resolves_unsafe_claude_version`) was bypassed because `claude-2.1` carries no opus/sonnet/haiku/fable token, so `requested_family` is `None`.

**Fixes**
- `strips_claude_numeric_minor`: version-segment recognition generalized from all-digits to digits-with-optional-dot (new `is_version_segment`, plain char loop — file avoids regex), and the guard now also refuses strips that erode a claude-branded id to a bare brand token (candidate left with no digits). Dated forms (`claude-3-5-sonnet-20241022`) keep stripping — their candidate retains a version.
- `FUZZY_BLOCKLIST` (exact-token match in `is_fuzzy_eligible`) gains `"claude"` and `"anthropic"` — a bare brand token can match any model of the brand, so a fuzzy hit from it is never trustworthy.

## Bug 2 (minor): reseller markup beats canonical pricing for `-fast` ids

Before this PR:

```
claude-opus-4-6-fast -> venice/claude-opus-4-6-fast  $36/$180  (Models.dev reseller)
claude-opus-4-7-fast -> venice/claude-opus-4-7-fast  $36/$180  (Models.dev reseller)
```

instead of canonical `anthropic/claude-opus-4.6-fast` / `4.7-fast` at $30/$150 (OpenRouter).

Root cause: in `lookup_auto`, `exact_match_models_dev_with_provider(model_id)` ran before the `normalize_version_separator` pass that converts `4-6` → `4.6` and hits the canonical OpenRouter key.

**Fixes**
- `lookup_auto` reordered: separator-normalized exact passes (LiteLLM + OpenRouter) now run before the models.dev model-part pass; models.dev remains the long-tail fallback (covered by a regression test).
- `models_dev_model_part` index (new `prefers_model_part_key`): when multiple providers share a model part, the winner is now deterministic — exact `anthropic` provider first, then shorter key (the historical winner of the insertion-order race, keeping existing resolutions stable), then lexicographic tie-break. Previously HashMap iteration order decided (with real data `302ai/` beat `anthropic/` for `claude-3-5-haiku-20241022`).
  - Note: the audit prescription suggested anthropic-then-pure-lexicographic; a pre-change analysis showed pure lexicographic choice would silently move **161** model parts to different-priced providers, so the shorter-key preference was kept to preserve all historical unique-shortest winners and only make the flaky ties deterministic.

## Reorder safety diff (real cached datasets, 197 probed ids)

A temporary probe dumped `model_id → matched_key,input_price` for every distinct id in the lookup.rs test corpus + the Anthropic catalog + ~50 non-Anthropic ids exercising the models.dev model-part path (gpt/gemini/llama/qwen/deepseek/grok/kimi/glm/...), before and after. **10 ids changed, 187 unchanged**:

| id | before | after | class |
|---|---|---|---|
| `claude-2.1`, `claude-2.0`, `claude`, `anthropic` | opus-4.7-fast / 3.5-sonnet keys | **None** | intended (bug 1) |
| `claude-opus-4-6-fast`, `claude-opus-4-7-fast` | `venice/...` $36/$180 | `anthropic/claude-opus-4.x-fast` $30/$150 | intended (bug 2) |
| `claude-3-5-haiku-20241022` | `302ai/...` | `anthropic/...` | namespace change, identical price ($0.8/$4) |
| `claude-3-5-haiku` | `opencode/claude-3-5-haiku` (Models.dev) | `anthropic/claude-3.5-haiku` (OpenRouter) | canonical source, identical price ($0.8/$4) |
| `kimi-k2-5` | `venice/kimi-k2-5` $0.56/$3.5 | `moonshotai/kimi-k2.5` $0.6/$3.0 | same class as bug 2 fix: canonical original provider via separator normalization |
| `grok-4-0709` | `jiekou/grok-4-0709` | `abacus/grok-4-0709` | previously a nondeterministic equal-length (18-char) key tie between `jiekou/` and `abacus/`; now deterministic |

The probe was deleted before committing.

## Tests

In `lookup.rs mod tests` (fixture style matching `claude_family_fixture`, each fixture contains the tempting wrong candidate so the test is red without the fix):
1. `claude_2x_never_fuzzy_matches_modern_models` — openrouter fixture with only `anthropic/claude-opus-4.7-fast`; `claude-2.1`/`claude-2.0`/`claude` all None.
2. `claude_2x_still_resolves_when_dataset_prices_it` — positive control; matched_key `claude-2.1`, input 8e-6.
3. `canonical_fast_price_beats_reseller_markup` — venice (36e-6) vs canonical (30e-6); resolves to `anthropic/claude-opus-4.6-fast` at 30e-6.
4. `models_dev_still_covers_long_tail_after_reorder` — models.dev-only `someprovider/exotic-model-9` still resolves.
5. `models_dev_provider_choice_is_deterministic_and_prefers_anthropic` — `302ai/` + `anthropic/` same price; anthropic wins.

New `crates/tokscale-core/tests/anthropic_catalog.rs` (`#[ignore]`d, CI skips; run with `--ignored` when datasets are cached): asserts invariants over the real datasets for the official catalog (fable-5, opus-4-8/4-7/4-6/4-5/4-1, sonnet-4-6/4-5, haiku-4-5, dated and provider forms) — resolved key carries the same family + major-minor version token (both `4-8`/`4.8` spellings accepted), price within ±25% of official, and `claude-2.x`/bare `claude` are None. Passes locally.

## Verification

- `cargo fmt --all --check` clean; `cargo clippy --all-targets -- -D warnings` clean
- `cargo test -p tokscale-core`: 914 passed (909 pre-existing + 5 new), 0 failed. One pre-existing assertion changed: `test_is_fuzzy_eligible` asserted `is_fuzzy_eligible("claude")` — that line pinned the exact behavior bug 1 removes, so it now asserts the inverse (plus `anthropic`). No other existing test was touched.
- `cargo test -p tokscale-core --test anthropic_catalog -- --ignored`: passes against the local cache
- `cargo test -p tokscale-cli`: 778 passed, 0 failed

Found by post-#634 catalog audit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mispricing by blocking fuzzy matches on brand/generic tokens, preferring canonical `OpenRouter`/`LiteLLM` prices, and honoring provider hints. Tests now flag any resolution of acceptable-None ids.

- **Bug Fixes**
  - Fuzzy guard: recognize dotted version segments; blocklist `claude`, `anthropic`, and generic `model`/`router`; refuse strips that leave a bare brand. Stops `claude-2.x` mapping to modern models.
  - Canonical preference + hints: for unhinted ids, run separator-normalized exact passes (`LiteLLM`/`OpenRouter`) before `models.dev`; with a hint, run provider-scoped `models.dev` before unscoped `OpenRouter` model-part and normalized fallbacks. Split `OpenRouter` exact into full-key (wins even with a hint) vs model-part (hint overrides). No-match hints fall back to canonical.
  - `models.dev`: deterministic provider choice (`anthropic/` first, then shorter key, then lexicographic); skip unpriced rows so zero-cost keys don’t shadow priced ones.

- **Tests**
  - Added ignored catalog invariants driven by harvested local ids plus a fixture; checks family/version tokens and price bands, and that `claude-2.x`/`claude`/`anthropic` resolve to None.
  - New unit tests for generic-token fuzzy blocklist and provider-hint precedence over unscoped `OpenRouter` model-part; updated `is_fuzzy_eligible` to assert `claude`/`anthropic` are blocked.
  - Acceptable-None gate now fails on any resolution (input or output), with clearer failure messages showing both prices.

<sup>Written for commit 3a408b83e55ccd7d4e3099a8688b5f4937695d86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

