### PR TITLE
feat(claude): parse Cowork local agent sessions

### DIFF
--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -854,6 +854,25 @@ fn scan_all_clients_with_env_strategy_inner(
         }
     }
 
+    if enabled.contains(&ClientId::Claude) {
+        // Claude Desktop Cowork local-agent-mode sessions:
+        // ~/Library/Application Support/Claude/local-agent-mode-sessions/**/local_*/audit.jsonl
+        //
+        // These audit files use the Claude Code transcript shape but live outside
+        // ~/.claude/projects, so include the root as another Claude scan source.
+        let cowork_path = PathBuf::from(home_dir)
+            .join("Library")
+            .join("Application Support")
+            .join("Claude")
+            .join("local-agent-mode-sessions");
+        push_unique_scan_task(
+            &mut tasks,
+            &mut seen_scan_roots,
+            ClientId::Claude,
+            cowork_path,
+        );
+    }
+
     if enabled.contains(&ClientId::OpenClaw) {
         // OpenClaw transcripts: ~/.openclaw/agents/**/*.jsonl
         let openclaw_path = ClientId::OpenClaw
@@ -1530,6 +1549,20 @@ mod tests {
         let mut file = File::create(&file_path).unwrap();
         file.write_all(b"").unwrap();
         file_path
+    }
+
+    fn setup_mock_claude_cowork_dir(base: &std::path::Path) {
+        let cowork_path = base
+            .join("Library")
+            .join("Application Support")
+            .join("Claude")
+            .join("local-agent-mode-sessions")
+            .join("host-session")
+            .join("task-session")
+            .join("local_bcf5462f-09ac-468b-ace7-0b4b01edc1dc");
+        fs::create_dir_all(&cowork_path).unwrap();
+        let mut file = File::create(cowork_path.join("audit.jsonl")).unwrap();
+        file.write_all(b"").unwrap();
     }
 
     fn setup_mock_codex_dir(base: &std::path::Path) {
@@ -2471,6 +2504,21 @@ mod tests {
             1,
             "cc-mirror variants pointing at ~/.claude must not duplicate normal Claude files"
         );
+    }
+
+    #[test]
+    fn test_scan_all_clients_claude_includes_cowork_local_agent_audits() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_claude_dir(home);
+        setup_mock_claude_cowork_dir(home);
+
+        let result = scan_all_clients(home.to_str().unwrap(), &["claude".to_string()]);
+        assert_eq!(result.get(ClientId::Claude).len(), 2);
+        assert!(result
+            .get(ClientId::Claude)
+            .iter()
+            .any(|path| path.file_name().and_then(|name| name.to_str()) == Some("audit.jsonl")));
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -23,10 +23,11 @@ type ParentSubagentTypeCache = HashMap<PathBuf, HashMap<String, String>>;
 pub struct ClaudeEntry {
     #[serde(rename = "type")]
     pub entry_type: String,
+    #[serde(alias = "_audit_timestamp")]
     pub timestamp: Option<String>,
     pub message: Option<ClaudeMessage>,
     /// Request ID for deduplication (used with message.id)
-    #[serde(rename = "requestId")]
+    #[serde(rename = "requestId", alias = "request_id")]
     pub request_id: Option<String>,
     /// True for subagent (sidechain) transcript lines
     #[serde(rename = "isSidechain", default)]
@@ -35,7 +36,7 @@ pub struct ClaudeEntry {
     #[serde(rename = "agentId")]
     pub agent_id: Option<String>,
     /// Parent session UUID (present on every sidechain line)
-    #[serde(rename = "sessionId")]
+    #[serde(rename = "sessionId", alias = "session_id")]
     pub session_id: Option<String>,
     /// Optional billing or routing provider emitted by wrappers around Claude Code.
     #[serde(rename = "providerId", alias = "provider_id", alias = "provider")]
@@ -60,6 +61,13 @@ impl CcMirrorVariantMetadata {
     fn client_id(&self) -> String {
         format!("cc-mirror/{}", sanitize_cc_mirror_segment(&self.name))
     }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CoworkMetadataFile {
+    session_id: Option<String>,
+    user_selected_folders: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -337,11 +345,27 @@ pub fn parse_claude_file_with_cache_and_home(
     let metadata_provider_hint = cc_mirror_metadata
         .as_ref()
         .and_then(|metadata| metadata.provider_id.as_deref());
+    let cowork_metadata = claude_cowork_metadata_from_path(path);
+    let workspace_key = cowork_metadata
+        .as_ref()
+        .and_then(|metadata| metadata.workspace_key.clone())
+        .or(workspace_key);
+    let workspace_label = cowork_metadata
+        .as_ref()
+        .and_then(|metadata| metadata.workspace_label.clone())
+        .or(workspace_label);
     let mut session_id = path
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("unknown")
         .to_string();
+    if let Some(metadata_session_id) = cowork_metadata
+        .as_ref()
+        .and_then(|metadata| metadata.session_id.as_ref())
+        .filter(|session_id| !session_id.trim().is_empty())
+    {
+        session_id = metadata_session_id.clone();
+    }
 
     let fallback_timestamp = file_modified_timestamp_ms(path);
 
@@ -556,6 +580,22 @@ pub fn parse_claude_file_with_cache_and_home(
                 );
                 let provider_confidence = provider_choice.confidence;
                 let model = canonicalize_claude_model(&raw_model);
+                let tokens = TokenBreakdown {
+                    input: usage.input_tokens.unwrap_or(0).max(0),
+                    output: usage.output_tokens.unwrap_or(0).max(0),
+                    cache_read: usage.cache_read_input_tokens.unwrap_or(0).max(0),
+                    cache_write: usage.cache_creation_input_tokens.unwrap_or(0).max(0),
+                    reasoning: 0,
+                };
+                if model == "<synthetic>"
+                    && tokens.input == 0
+                    && tokens.output == 0
+                    && tokens.cache_read == 0
+                    && tokens.cache_write == 0
+                    && tokens.reasoning == 0
+                {
+                    continue;
+                }
 
                 let parsed_timestamp = parse_claude_entry_timestamp(entry.timestamp.as_deref());
                 let timestamp = parsed_timestamp.unwrap_or(fallback_timestamp);
@@ -573,13 +613,7 @@ pub fn parse_claude_file_with_cache_and_home(
                     provider_choice.id,
                     session_id.clone(),
                     timestamp,
-                    TokenBreakdown {
-                        input: usage.input_tokens.unwrap_or(0).max(0),
-                        output: usage.output_tokens.unwrap_or(0).max(0),
-                        cache_read: usage.cache_read_input_tokens.unwrap_or(0).max(0),
-                        cache_write: usage.cache_creation_input_tokens.unwrap_or(0).max(0),
-                        reasoning: 0,
-                    },
+                    tokens,
                     0.0,
                     dedup_key,
                 );
@@ -1064,6 +1098,69 @@ fn canonicalize_claude_model(model: &str) -> String {
         .to_string()
 }
 
+#[derive(Debug, Clone)]
+struct CoworkMetadata {
+    session_id: Option<String>,
+    workspace_key: Option<String>,
+    workspace_label: Option<String>,
+}
+
+fn claude_cowork_metadata_from_path(path: &Path) -> Option<CoworkMetadata> {
+    if path.file_name().and_then(|name| name.to_str()) != Some("audit.jsonl") {
+        return None;
+    }
+
+    let local_session_dir = path.parent()?;
+    let local_session_id = local_session_dir.file_name()?.to_str()?;
+    if !local_session_id.starts_with("local_") {
+        return None;
+    }
+
+    let session_root = local_session_dir.parent()?;
+    if !path_has_component(session_root, "local-agent-mode-sessions") {
+        return None;
+    }
+
+    let metadata_path = session_root.join(format!("{local_session_id}.json"));
+    let metadata = std::fs::read_to_string(metadata_path).ok()?;
+    let metadata: CoworkMetadataFile = serde_json::from_str(&metadata).ok()?;
+    let (workspace_key, workspace_label) = metadata
+        .user_selected_folders
+        .as_deref()
+        .and_then(cowork_workspace_from_selected_folders)
+        .unwrap_or((None, None));
+
+    Some(CoworkMetadata {
+        session_id: metadata.session_id,
+        workspace_key,
+        workspace_label,
+    })
+}
+
+fn path_has_component(path: &Path, component: &str) -> bool {
+    path.components().any(|path_component| {
+        path_component
+            .as_os_str()
+            .to_string_lossy()
+            .eq_ignore_ascii_case(component)
+    })
+}
+
+fn cowork_workspace_from_selected_folders(
+    folders: &[String],
+) -> Option<(Option<String>, Option<String>)> {
+    let folder = folders.iter().find(|folder| !folder.trim().is_empty())?;
+    let key = normalize_workspace_key(&claude_project_key_from_abs_path(folder));
+    let label = key.as_deref().and_then(workspace_label_from_key);
+    Some((key, label))
+}
+
+fn claude_project_key_from_abs_path(path: &str) -> String {
+    path.chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
+        .collect()
+}
+
 #[derive(Default)]
 struct ClaudeHeadlessState {
     model: Option<String>,
@@ -1533,6 +1630,32 @@ mod tests {
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(&path, content).unwrap();
         (temp_dir, path)
+    }
+
+    fn create_cowork_audit_file(
+        audit_content: &str,
+        metadata_content: &str,
+        local_session_id: &str,
+    ) -> (TempDir, std::path::PathBuf) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let root = temp_dir
+            .path()
+            .join("Library")
+            .join("Application Support")
+            .join("Claude")
+            .join("local-agent-mode-sessions")
+            .join("host-session")
+            .join("task-session");
+        let audit_dir = root.join(local_session_id);
+        std::fs::create_dir_all(&audit_dir).unwrap();
+        std::fs::write(
+            root.join(format!("{local_session_id}.json")),
+            metadata_content,
+        )
+        .unwrap();
+        let audit_path = audit_dir.join("audit.jsonl");
+        std::fs::write(&audit_path, audit_content).unwrap();
+        (temp_dir, audit_path)
     }
 
     #[test]
@@ -2188,6 +2311,53 @@ mod tests {
             messages.is_empty(),
             "wrapper transcripts without usage metadata must not be estimated"
         );
+    }
+
+    #[test]
+    fn test_workspace_metadata_from_cowork_local_agent_sidecar() {
+        let audit = r#"{"type":"assistant","session_id":"cli-session-001","request_id":"req_001","_audit_timestamp":"2026-06-10T01:11:33.761Z","message":{"id":"msg_001","model":"claude-fable-5","usage":{"input_tokens":2,"output_tokens":60,"cache_read_input_tokens":54804,"cache_creation_input_tokens":202}}}"#;
+        let metadata = r#"{"sessionId":"local_bcf5462f-09ac-468b-ace7-0b4b01edc1dc","title":"Flip level resale pricing engine","model":"claude-fable-5[1m]","userSelectedFolders":["/Users/will.wang/projects/code","/Users/will.wang/projects/second-brain"]}"#;
+        let (_dir, path) = create_cowork_audit_file(
+            audit,
+            metadata,
+            "local_bcf5462f-09ac-468b-ace7-0b4b01edc1dc",
+        );
+
+        let messages = parse_claude_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "claude-fable-5");
+        assert_eq!(messages[0].tokens.input, 2);
+        assert_eq!(messages[0].tokens.output, 60);
+        assert_eq!(messages[0].tokens.cache_read, 54804);
+        assert_eq!(messages[0].tokens.cache_write, 202);
+        assert_eq!(
+            messages[0].session_id,
+            "local_bcf5462f-09ac-468b-ace7-0b4b01edc1dc"
+        );
+        assert_eq!(
+            messages[0].workspace_key,
+            Some("-Users-will-wang-projects-code".to_string())
+        );
+        assert_eq!(
+            messages[0].workspace_label,
+            Some("-Users-will-wang-projects-code".to_string())
+        );
+    }
+
+    #[test]
+    fn test_zero_token_synthetic_cowork_error_is_skipped() {
+        let audit = r#"{"type":"assistant","session_id":"cli-session-001","request_id":"req_001","_audit_timestamp":"2026-06-10T01:11:33.761Z","message":{"id":"msg_001","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"content":[{"type":"text","text":"API Error: Unable to connect to API"}]}}"#;
+        let metadata = r#"{"sessionId":"local_bcf5462f-09ac-468b-ace7-0b4b01edc1dc","userSelectedFolders":["/Users/will.wang/projects/code"]}"#;
+        let (_dir, path) = create_cowork_audit_file(
+            audit,
+            metadata,
+            "local_bcf5462f-09ac-468b-ace7-0b4b01edc1dc",
+        );
+
+        let messages = parse_claude_file(&path);
+
+        assert!(messages.is_empty());
     }
 
     // --- Sidechain / Agent tracking tests ---


### PR DESCRIPTION
## Context
- Add Claude Desktop Cowork local-agent-mode audit logs to Tokscale’s Claude client scan path.
- Parse Cowork audit metadata (`session_id`, `request_id`, `_audit_timestamp`, and `userSelectedFolders`) so `claude-fable-5` and other Cowork model usage appears in local Tokscale reports.
- Skip zero-token `<synthetic>` Cowork API-error placeholder rows so model reports do not show non-usage artifacts.

## Test Plan
- `cargo test -p tokscale-core cowork`
- `cargo test -p tokscale-core claudecode`
- `cargo test -p tokscale-core scanner::tests::test_scan_all_clients_claude`
- `cargo test -p tokscale-core -- --test-threads=1`
- `cargo test -p tokscale-cli test_clients_json`
- `cargo run -p tokscale-cli -- models --claude --json --group-by client,model --no-spinner`
- Verified against local Cowork data that `claude-fable-5` appears in the patched report and the zero-token `<synthetic>` row is not emitted.
- Riskiest part is over-counting or mislabeling non-Claude-Code Cowork audit rows; coverage exercises discovery, sidecar metadata parsing, snake-case audit fields, and zero-token placeholder filtering.

## Mitigation
- The change is additive to the existing Claude client scanner and only adds another local scan root plus parser handling for Cowork audit metadata.
- If unexpected over-counting appears, rollback is straightforward by reverting this PR; users can also temporarily filter date ranges or avoid `--claude` reports until patched.
- No database, Terraform, or production service changes.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to external documentation if necessary (READMEs, Confluence, etc.)
- [x] I have checked that other PRs this PR depends on have already been deployed.
- [x] I can confirm that if this PR introduces a DB schema change, I have read and followed all the steps outlined in the [Data Contract](https://docs.google.com/document/d/1g_ZZ8TU58Dh2Fn_6aNHktBUNdnBtYNuOyu3GY-kGHnk/edit#heading=h.o2ce6n1q3gpb).
<!-- This PR template is inherited from https://github.com/opendoor-labs/.github -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for Claude Desktop Cowork local-agent-mode audit logs to Tokscale’s Claude scanner so Cowork usage (e.g., `claude-fable-5`) shows up in local reports with correct session/workspace context. Also skips zero‑token `<synthetic>` error rows to reduce noise.

- **New Features**
  - Scans `~/Library/Application Support/Claude/local-agent-mode-sessions/**/local_*/audit.jsonl` as a Claude source in `tokscale-core`.
  - Parses `_audit_timestamp`, `request_id`, and `session_id`; reads sidecar `local_*.json` to map `userSelectedFolders` into workspace key/label.
  - Filters zero‑token `<synthetic>` entries so API-error placeholders don’t appear in model usage.

<sup>Written for commit b5d3c123a0e85f06f9d8a41a4033d180852026db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

