### PR TITLE
feat(kiro): add globalStorage support

### DIFF
--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -637,12 +637,8 @@ fn kiro_global_storage_roots(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf
     if cfg!(target_os = "windows") {
         if use_env_roots {
             if let Some(app_data) = std::env::var_os("APPDATA").filter(|value| !value.is_empty()) {
-                roots.push(
-                    PathBuf::from(&app_data).join("Kiro/User/globalStorage/kiro.kiroagent"),
-                );
-                roots.push(
-                    PathBuf::from(&app_data).join("kiro/User/globalStorage/kiro.kiroagent"),
-                );
+                roots.push(PathBuf::from(&app_data).join("Kiro/User/globalStorage/kiro.kiroagent"));
+                roots.push(PathBuf::from(&app_data).join("kiro/User/globalStorage/kiro.kiroagent"));
             }
         }
 

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -637,8 +637,12 @@ fn kiro_global_storage_roots(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf
     if cfg!(target_os = "windows") {
         if use_env_roots {
             if let Some(app_data) = std::env::var_os("APPDATA").filter(|value| !value.is_empty()) {
-                roots.push(PathBuf::from(&app_data).join("Kiro/User/globalStorage/kiro.kiroagent"));
-                roots.push(PathBuf::from(&app_data).join("kiro/User/globalStorage/kiro.kiroagent"));
+                roots.push(
+                    PathBuf::from(&app_data).join("Kiro/User/globalStorage/kiro.kiroagent"),
+                );
+                roots.push(
+                    PathBuf::from(&app_data).join("kiro/User/globalStorage/kiro.kiroagent"),
+                );
             }
         }
 

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -314,6 +314,11 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
                 }
                 "T-*.json" => file_name.starts_with("T-") && file_name.ends_with(".json"),
                 "*.settings.json" => file_name.ends_with(".settings.json"),
+                "kiro-globalstorage" => {
+                    file_name.ends_with(".chat")
+                        || file_name.ends_with(".json")
+                        || path.extension().is_none()
+                }
                 "sessions.json" => file_name == "sessions.json",
                 "wire.jsonl" => file_name == "wire.jsonl",
                 "updates.jsonl" => file_name == "updates.jsonl",
@@ -588,6 +593,16 @@ fn push_unique_scan_task(
     client_id: ClientId,
     raw_path: impl Into<PathBuf>,
 ) {
+    push_unique_scan_task_with_pattern(tasks, seen, client_id, raw_path, client_id.data().pattern);
+}
+
+fn push_unique_scan_task_with_pattern(
+    tasks: &mut Vec<(ClientId, String, &'static str)>,
+    seen: &mut HashSet<(ClientId, PathBuf)>,
+    client_id: ClientId,
+    raw_path: impl Into<PathBuf>,
+    pattern: &'static str,
+) {
     let raw_path = raw_path.into();
     if raw_path.as_os_str().is_empty() {
         return;
@@ -595,9 +610,49 @@ fn push_unique_scan_task(
 
     let key = std::fs::canonicalize(&raw_path).unwrap_or_else(|_| raw_path.clone());
     if seen.insert((client_id, key)) {
-        let pattern = client_id.data().pattern;
         tasks.push((client_id, raw_path.to_string_lossy().to_string(), pattern));
     }
+}
+
+fn kiro_global_storage_roots(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
+    let mut roots = vec![
+        PathBuf::from(format!(
+            "{}/Library/Application Support/Kiro/User/globalStorage/kiro.kiroagent",
+            home_dir
+        )),
+        PathBuf::from(format!(
+            "{}/Library/Application Support/kiro/User/globalStorage/kiro.kiroagent",
+            home_dir
+        )),
+        PathBuf::from(format!(
+            "{}/.config/Kiro/User/globalStorage/kiro.kiroagent",
+            home_dir
+        )),
+        PathBuf::from(format!(
+            "{}/.config/kiro/User/globalStorage/kiro.kiroagent",
+            home_dir
+        )),
+    ];
+
+    if cfg!(target_os = "windows") {
+        if use_env_roots {
+            if let Some(app_data) = std::env::var_os("APPDATA").filter(|value| !value.is_empty()) {
+                roots.push(PathBuf::from(&app_data).join("Kiro/User/globalStorage/kiro.kiroagent"));
+                roots.push(PathBuf::from(&app_data).join("kiro/User/globalStorage/kiro.kiroagent"));
+            }
+        }
+
+        roots.push(PathBuf::from(format!(
+            "{}/AppData/Roaming/Kiro/User/globalStorage/kiro.kiroagent",
+            home_dir
+        )));
+        roots.push(PathBuf::from(format!(
+            "{}/AppData/Roaming/kiro/User/globalStorage/kiro.kiroagent",
+            home_dir
+        )));
+    }
+
+    roots
 }
 
 /// Merge user-configured OpenCode db paths from [`ScannerSettings`] into the
@@ -1074,6 +1129,27 @@ fn scan_all_clients_with_env_strategy_inner(
     }
 
     if enabled.contains(&ClientId::Kiro) {
+        let kiro_cli_path = ClientId::Kiro
+            .data()
+            .resolve_path_with_env_strategy(home_dir, use_env_roots);
+        push_unique_scan_task_with_pattern(
+            &mut tasks,
+            &mut seen_scan_roots,
+            ClientId::Kiro,
+            kiro_cli_path,
+            "*.json",
+        );
+
+        for root in kiro_global_storage_roots(home_dir, use_env_roots) {
+            push_unique_scan_task_with_pattern(
+                &mut tasks,
+                &mut seen_scan_roots,
+                ClientId::Kiro,
+                root,
+                "kiro-globalstorage",
+            );
+        }
+
         let xdg_path = PathBuf::from(format!("{}/.local/share/kiro-cli/data.sqlite3", home_dir));
         if xdg_path.is_file() {
             result.kiro_db = Some(xdg_path);
@@ -1470,6 +1546,28 @@ mod tests {
     }
 
     #[test]
+    fn test_scan_directory_kiro_globalstorage_pattern() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path();
+
+        let root = path.join("Library/Application Support/Kiro/User/globalStorage/kiro.kiroagent");
+        let workspace = root.join("workspace-a");
+        fs::create_dir_all(&workspace).unwrap();
+        File::create(workspace.join("execution.chat")).unwrap();
+        File::create(workspace.join("session.json")).unwrap();
+        File::create(workspace.join("execution")).unwrap();
+        File::create(workspace.join("index.sqlite")).unwrap();
+
+        let files = scan_directory(root.to_str().unwrap(), "kiro-globalstorage");
+        let names: Vec<_> = files
+            .iter()
+            .map(|path| path.file_name().unwrap().to_str().unwrap())
+            .collect();
+
+        assert_eq!(names, vec!["execution", "execution.chat", "session.json"]);
+    }
+
+    #[test]
     fn test_scan_directory_nonexistent() {
         let files = scan_directory("/nonexistent/path/that/does/not/exist", "*.json");
         assert!(files.is_empty());
@@ -1558,6 +1656,21 @@ mod tests {
         fs::create_dir_all(&pi_path).unwrap();
         let mut file = File::create(pi_path.join("1733011200000_pi_ses_001.jsonl")).unwrap();
         file.write_all(b"{}").unwrap();
+    }
+
+    fn setup_mock_kiro_dir(base: &std::path::Path) {
+        let kiro_path = base.join(".kiro/sessions/cli");
+        fs::create_dir_all(&kiro_path).unwrap();
+        File::create(kiro_path.join("session-001.json")).unwrap();
+    }
+
+    fn setup_mock_kiro_global_storage_dir(base: &std::path::Path) {
+        let root = base.join("Library/Application Support/Kiro/User/globalStorage/kiro.kiroagent");
+        let workspace = root.join("workspace-a");
+        fs::create_dir_all(&workspace).unwrap();
+        File::create(workspace.join("execution.chat")).unwrap();
+        File::create(workspace.join("session.json")).unwrap();
+        File::create(workspace.join("execution")).unwrap();
     }
 
     fn setup_mock_omp_dir(base: &std::path::Path) {
@@ -2592,6 +2705,29 @@ mod tests {
         assert_eq!(result.get(ClientId::Gemini).len(), 1);
         assert!(result.get(ClientId::OpenCode).is_empty());
         assert!(result.get(ClientId::Codex).is_empty());
+    }
+
+    #[test]
+    fn test_scan_all_clients_kiro_includes_cli_and_global_storage() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_kiro_dir(home);
+        setup_mock_kiro_global_storage_dir(home);
+
+        let result = scan_all_clients(home.to_str().unwrap(), &["kiro".to_string()]);
+        assert_eq!(result.get(ClientId::Kiro).len(), 4);
+        assert!(result
+            .get(ClientId::Kiro)
+            .iter()
+            .any(|p| p.ends_with("session-001.json")));
+        assert!(result
+            .get(ClientId::Kiro)
+            .iter()
+            .any(|p| p.ends_with("execution.chat")));
+        assert!(result
+            .get(ClientId::Kiro)
+            .iter()
+            .any(|p| p.ends_with("execution")));
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -328,6 +328,23 @@ fn is_kiro_global_storage_path(path: &Path) -> bool {
     path_str.contains("globalStorage") && path_str.contains("kiro.kiroagent")
 }
 
+/// Extract the workspace folder name from a Kiro globalStorage path.
+///
+/// Snapshots live under `.../globalStorage/kiro.kiroagent/<workspace>/...`,
+/// so the workspace folder is the path segment immediately following the
+/// `kiro.kiroagent` component. Returns `None` when no such segment exists.
+fn kiro_global_storage_workspace(path: &Path) -> Option<String> {
+    let mut components = path
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy().into_owned());
+    while let Some(component) = components.next() {
+        if component == "kiro.kiroagent" {
+            return components.next();
+        }
+    }
+    None
+}
+
 #[derive(Debug, Default)]
 struct KiroSnapshotTextCounts {
     prompt_chars: usize,
@@ -452,14 +469,24 @@ fn parse_kiro_global_storage_file(path: &Path) -> Vec<UnifiedMessage> {
         Err(_) => return Vec::new(),
     };
 
-    let session_id = path
+    let file_stem = path
         .file_stem()
         .and_then(|name| name.to_str())
-        .unwrap_or("unknown")
-        .to_string();
+        .unwrap_or("unknown");
+    // Attribute the snapshot to its IDE workspace folder, mirroring how the
+    // file/sqlite Kiro paths derive workspace identity from `cwd`.
+    let workspace = kiro_global_storage_workspace(path);
+    let workspace_key = workspace
+        .as_deref()
+        .and_then(normalize_workspace_key);
+    let workspace_label = workspace_key.as_deref().and_then(workspace_label_from_key);
+    // Namespace the session id by workspace so two workspaces that both contain
+    // e.g. `execution.chat` do not collapse into one session / dedup_key.
+    let session_id = match workspace.as_deref() {
+        Some(ws) => format!("{}/{}", ws, file_stem),
+        None => file_stem.to_string(),
+    };
     let model_id = find_kiro_snapshot_model_id(&value).unwrap_or_else(|| UNKNOWN_MODEL.to_string());
-    let workspace_key = None;
-    let workspace_label = None;
 
     let mut counts = KiroSnapshotTextCounts::default();
     collect_kiro_snapshot_text(&value, &mut counts, None);
@@ -484,6 +511,13 @@ fn parse_kiro_global_storage_file(path: &Path) -> Vec<UnifiedMessage> {
             reasoning: 0,
         },
         0.0,
+        // dedup_key is structurally disjoint from the sqlite (CLI) source: this
+        // key is `<workspace>/<file_stem>:globalstorage` (always the literal
+        // `:globalstorage` suffix), whereas `parse_kiro_sqlite` emits
+        // `<conversation_id>:<turn_index>` (always a numeric-index suffix).
+        // IDE globalStorage snapshots and the kiro-cli `data.sqlite3` are
+        // distinct surfaces, so the same conversation cannot appear in both and
+        // these keys can never collide — no cross-source dedup is needed.
         Some(format!("{}:globalstorage", session_id)),
     );
     message.message_count = 1;
@@ -779,6 +813,53 @@ not valid json at all
         assert_eq!(messages[0].model_id, "auto");
         assert!(messages[0].tokens.input > 0);
         assert!(messages[0].tokens.output > 0);
+        // (4a) Workspace attribution: the `<workspace>` segment after
+        // `kiro.kiroagent/` flows through the same workspace helpers.
+        assert_eq!(messages[0].workspace_key, Some("workspace-a".to_string()));
+        assert_eq!(messages[0].workspace_label, Some("workspace-a".to_string()));
+        assert_eq!(
+            messages[0].dedup_key,
+            Some("workspace-a/execution:globalstorage".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_kiro_global_storage_dedup_keys_differ_across_workspaces() {
+        let dir = TempDir::new().unwrap();
+        let payload = r#"{
+                "model": "auto",
+                "messages": [
+                    {"role": "user", "content": "hello world"},
+                    {"role": "assistant", "content": "response text"}
+                ]
+            }"#;
+
+        // Two `execution.chat` snapshots under DIFFERENT workspaces.
+        let path_a = dir.path().join(
+            "Library/Application Support/Kiro/User/globalStorage/kiro.kiroagent/workspace-a/execution.chat",
+        );
+        let path_b = dir.path().join(
+            "Library/Application Support/Kiro/User/globalStorage/kiro.kiroagent/workspace-b/execution.chat",
+        );
+        fs::create_dir_all(path_a.parent().unwrap()).unwrap();
+        fs::create_dir_all(path_b.parent().unwrap()).unwrap();
+        fs::write(&path_a, payload).unwrap();
+        fs::write(&path_b, payload).unwrap();
+
+        let messages_a = parse_kiro_file(&path_a);
+        let messages_b = parse_kiro_file(&path_b);
+
+        assert_eq!(messages_a.len(), 1);
+        assert_eq!(messages_b.len(), 1);
+        assert_ne!(messages_a[0].dedup_key, messages_b[0].dedup_key);
+        assert_eq!(
+            messages_a[0].dedup_key,
+            Some("workspace-a/execution:globalstorage".to_string())
+        );
+        assert_eq!(
+            messages_b[0].dedup_key,
+            Some("workspace-b/execution:globalstorage".to_string())
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -388,7 +388,7 @@ fn collect_kiro_snapshot_text(
         Value::String(text) => match role {
             Some(KiroSnapshotRole::Assistant) => counts.assistant_chars += text.chars().count(),
             Some(KiroSnapshotRole::Prompt) => counts.prompt_chars += text.chars().count(),
-            _ => counts.assistant_chars += text.chars().count(),
+            None => {}
         },
         _ => {}
     }
@@ -760,5 +760,30 @@ not valid json at all
         assert_eq!(messages[0].model_id, "auto");
         assert!(messages[0].tokens.input > 0);
         assert!(messages[0].tokens.output > 0);
+    }
+
+    #[test]
+    fn test_parse_kiro_global_storage_ignores_unknown_roles() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join(
+            "Library/Application Support/Kiro/User/globalStorage/kiro.kiroagent/workspace-a/execution.chat",
+        );
+        fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+        fs::write(
+            &file_path,
+            r#"{
+                "model": "auto",
+                "messages": [
+                    {"role": "mystery", "content": "mystery text"},
+                    {"role": "assistant", "content": "response text"}
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let messages = parse_kiro_file(&file_path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.output, 4);
     }
 }

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -1,8 +1,9 @@
 //! Kiro session parser
 //!
-//! Parses session data from two sources:
+//! Parses session data from three sources:
 //! 1. File-based: ~/.kiro/sessions/cli/*.json + *.jsonl
-//! 2. SQLite-based: ~/Library/Application Support/kiro-cli/data.sqlite3
+//! 2. Kiro IDE globalStorage snapshots
+//! 3. SQLite-based: ~/Library/Application Support/kiro-cli/data.sqlite3
 //!    (conversations_v2 table with history[*].request_metadata)
 //!
 //! Turn-level token counts are currently zero in both sources, so usage is
@@ -14,6 +15,7 @@ use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
 use rusqlite::Connection;
 use serde::Deserialize;
+use serde_json::Value;
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
@@ -94,6 +96,16 @@ struct KiroMessageContent {
 }
 
 pub fn parse_kiro_file(path: &Path) -> Vec<UnifiedMessage> {
+    if is_kiro_global_storage_path(path)
+        || path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| ext.eq_ignore_ascii_case("chat"))
+            .unwrap_or(false)
+    {
+        return parse_kiro_global_storage_file(path);
+    }
+
     let fallback_timestamp = file_modified_timestamp_ms(path);
 
     let mut json_bytes = match std::fs::read(path) {
@@ -311,6 +323,156 @@ fn session_id_from_path(path: &Path) -> String {
         .to_string()
 }
 
+fn is_kiro_global_storage_path(path: &Path) -> bool {
+    let path_str = path.to_string_lossy();
+    path_str.contains("globalStorage") && path_str.contains("kiro.kiroagent")
+}
+
+#[derive(Debug, Default)]
+struct KiroSnapshotTextCounts {
+    prompt_chars: usize,
+    assistant_chars: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KiroSnapshotRole {
+    Prompt,
+    Assistant,
+}
+
+fn collect_kiro_snapshot_text(
+    value: &Value,
+    counts: &mut KiroSnapshotTextCounts,
+    mut role: Option<KiroSnapshotRole>,
+) {
+    match value {
+        Value::Object(map) => {
+            if let Some(kind) = map.get("role").and_then(|v| v.as_str()) {
+                role = match kind {
+                    "user" | "prompt" => Some(KiroSnapshotRole::Prompt),
+                    "assistant" | "response" => Some(KiroSnapshotRole::Assistant),
+                    _ => role,
+                };
+            }
+            if let Some(kind) = map.get("type").and_then(|v| v.as_str()) {
+                role = match kind {
+                    "user" | "prompt" => Some(KiroSnapshotRole::Prompt),
+                    "assistant" | "response" => Some(KiroSnapshotRole::Assistant),
+                    _ => role,
+                };
+            }
+
+            for key in ["prompt", "response", "content", "text", "message"] {
+                if let Some(item) = map.get(key) {
+                    collect_kiro_snapshot_text(item, counts, role);
+                }
+            }
+
+            for key in ["messages", "conversation", "chat", "transcript", "entries", "events", "history"] {
+                if let Some(item) = map.get(key) {
+                    collect_kiro_snapshot_text(item, counts, role);
+                }
+            }
+
+            for key in ["parts", "items", "nodes"] {
+                if let Some(item) = map.get(key) {
+                    collect_kiro_snapshot_text(item, counts, role);
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_kiro_snapshot_text(item, counts, role);
+            }
+        }
+        Value::String(text) => match role {
+            Some(KiroSnapshotRole::Assistant) => counts.assistant_chars += text.chars().count(),
+            Some(KiroSnapshotRole::Prompt) => counts.prompt_chars += text.chars().count(),
+            _ => counts.assistant_chars += text.chars().count(),
+        },
+        _ => {}
+    }
+}
+
+fn find_kiro_snapshot_model_id(value: &Value) -> Option<String> {
+    match value {
+        Value::Object(map) => {
+            for key in ["model_id", "modelId", "model"] {
+                if let Some(model) = map.get(key).and_then(|v| v.as_str()) {
+                    let model = model.trim();
+                    if !model.is_empty() {
+                        return Some(model.to_string());
+                    }
+                }
+            }
+
+            for key in ["messages", "conversation", "chat", "transcript", "entries", "events", "history", "content", "text", "message"] {
+                if let Some(item) = map.get(key) {
+                    if let Some(model) = find_kiro_snapshot_model_id(item) {
+                        return Some(model);
+                    }
+                }
+            }
+
+            None
+        }
+        Value::Array(items) => items.iter().find_map(find_kiro_snapshot_model_id),
+        _ => None,
+    }
+}
+
+fn parse_kiro_global_storage_file(path: &Path) -> Vec<UnifiedMessage> {
+    let fallback_timestamp = file_modified_timestamp_ms(path);
+    let json = match std::fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(_) => return Vec::new(),
+    };
+
+    let value: Value = match serde_json::from_str(&json) {
+        Ok(value) => value,
+        Err(_) => return Vec::new(),
+    };
+
+    let session_id = path
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let model_id = find_kiro_snapshot_model_id(&value).unwrap_or_else(|| UNKNOWN_MODEL.to_string());
+    let workspace_key = None;
+    let workspace_label = None;
+
+    let mut counts = KiroSnapshotTextCounts::default();
+    collect_kiro_snapshot_text(&value, &mut counts, None);
+
+    let input = estimate_tokens(counts.prompt_chars);
+    let output = estimate_tokens(counts.assistant_chars);
+    if input + output == 0 {
+        return Vec::new();
+    }
+
+    let mut message = UnifiedMessage::new_with_dedup(
+        CLIENT_ID,
+        model_id,
+        PROVIDER_ID,
+        session_id.clone(),
+        fallback_timestamp,
+        TokenBreakdown {
+            input,
+            output,
+            cache_read: 0,
+            cache_write: 0,
+            reasoning: 0,
+        },
+        0.0,
+        Some(format!("{}:globalstorage", session_id)),
+    );
+    message.message_count = 1;
+    message.is_turn_start = true;
+    message.set_workspace(workspace_key, workspace_label);
+    vec![message]
+}
+
 pub fn parse_kiro_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
     let conn = match Connection::open_with_flags(
         db_path,
@@ -376,7 +538,7 @@ pub fn parse_kiro_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             .model_info
             .as_ref()
             .and_then(|info| info.model_id.as_deref())
-            .filter(|m| !m.trim().is_empty() && *m != "auto")
+            .filter(|m| !m.trim().is_empty())
             .unwrap_or(UNKNOWN_MODEL)
             .to_string();
         let workspace_key = normalize_workspace_key(&cwd);
@@ -460,6 +622,7 @@ struct KiroDbRequestMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
     use std::io::Write;
     use tempfile::TempDir;
 
@@ -542,7 +705,7 @@ not valid json at all
         .unwrap();
         let value = r#"{
             "model_info": {
-                "model_id": "claude-sonnet-4-5",
+                "model_id": "auto",
                 "context_window_tokens": 1000
             },
             "history": [{
@@ -564,9 +727,38 @@ not valid json at all
         let messages = parse_kiro_sqlite(&db_path);
 
         assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "auto");
         assert_eq!(messages[0].timestamp, 1770983426000);
         assert_eq!(messages[0].duration_ms, Some(1500));
         assert_eq!(messages[0].tokens.input, 100);
         assert_eq!(messages[0].tokens.output, 10);
+    }
+
+    #[test]
+    fn test_parse_kiro_global_storage_chat_file() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join(
+            "Library/Application Support/Kiro/User/globalStorage/kiro.kiroagent/workspace-a/execution.chat",
+        );
+        fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+        fs::write(
+            &file_path,
+            r#"{
+                "model": "auto",
+                "messages": [
+                    {"role": "user", "content": "hello world"},
+                    {"role": "assistant", "content": "response text"}
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let messages = parse_kiro_file(&file_path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, "kiro");
+        assert_eq!(messages[0].model_id, "auto");
+        assert!(messages[0].tokens.input > 0);
+        assert!(messages[0].tokens.output > 0);
     }
 }

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -476,9 +476,7 @@ fn parse_kiro_global_storage_file(path: &Path) -> Vec<UnifiedMessage> {
     // Attribute the snapshot to its IDE workspace folder, mirroring how the
     // file/sqlite Kiro paths derive workspace identity from `cwd`.
     let workspace = kiro_global_storage_workspace(path);
-    let workspace_key = workspace
-        .as_deref()
-        .and_then(normalize_workspace_key);
+    let workspace_key = workspace.as_deref().and_then(normalize_workspace_key);
     let workspace_label = workspace_key.as_deref().and_then(workspace_label_from_key);
     // Namespace the session id by workspace so two workspaces that both contain
     // e.g. `execution.chat` do not collapse into one session / dedup_key.

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -368,7 +368,15 @@ fn collect_kiro_snapshot_text(
                 }
             }
 
-            for key in ["messages", "conversation", "chat", "transcript", "entries", "events", "history"] {
+            for key in [
+                "messages",
+                "conversation",
+                "chat",
+                "transcript",
+                "entries",
+                "events",
+                "history",
+            ] {
                 if let Some(item) = map.get(key) {
                     collect_kiro_snapshot_text(item, counts, role);
                 }
@@ -406,7 +414,18 @@ fn find_kiro_snapshot_model_id(value: &Value) -> Option<String> {
                 }
             }
 
-            for key in ["messages", "conversation", "chat", "transcript", "entries", "events", "history", "content", "text", "message"] {
+            for key in [
+                "messages",
+                "conversation",
+                "chat",
+                "transcript",
+                "entries",
+                "events",
+                "history",
+                "content",
+                "text",
+                "message",
+            ] {
                 if let Some(item) = map.get(key) {
                     if let Some(model) = find_kiro_snapshot_model_id(item) {
                         return Some(model);


### PR DESCRIPTION
## Summary
- Add Kiro IDE `globalStorage` discovery alongside the existing Kiro CLI session paths.
- Preserve Kiro's `auto` model label instead of collapsing it to `unknown`.

## Verification
- `cargo test -p tokscale-core kiro -- --nocapture`
- `cargo test -p tokscale-core`
- `tokscale --no-spinner --today --client kiro --json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Kiro IDE `globalStorage` snapshot support and merge it with existing Kiro CLI sessions. Snapshots are attributed to IDE workspaces with dedup keys namespaced per workspace; Windows path discovery is more robust.

- **New Features**
  - Discover IDE snapshots under `globalStorage/kiro.kiroagent` on macOS/Linux/Windows, matching `.chat`, `.json`, and extensionless files; uses `APPDATA` on Windows with `~/AppData/Roaming` fallback.
  - Parse snapshots and SQLite: estimate tokens from prompt/assistant text, preserve `auto` model labels, ignore unknown roles, and keep IDE vs. CLI dedup keys disjoint to avoid collisions.

<sup>Written for commit 4cbc05e6d3569a4d7b54cbd985a4d038866058b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

