### PR TITLE
fix(copilot): populate Agents tab from gen_ai.agent.id in OTEL spans

### DIFF
--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -507,6 +507,8 @@ impl DataLoader {
             if let Some(agent) = msg.agent.as_ref() {
                 let normalized_agent = if msg.client == "opencode" {
                     sessions::normalize_opencode_agent_name(agent)
+                } else if msg.client == "copilot" {
+                    sessions::normalize_copilot_agent_name(agent)
                 } else {
                     sessions::normalize_agent_name(agent)
                 };

--- a/crates/tokscale-cli/src/tui/ui/agents.rs
+++ b/crates/tokscale-cli/src/tui/ui/agents.rs
@@ -122,7 +122,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             } else {
                 vec![
                     Cell::from(format!("{}", idx + 1)).style(Style::default().fg(theme_muted)),
-                    Cell::from(truncate(&agent.agent, 22)).style(
+                    Cell::from(truncate(&agent.agent, 32)).style(
                         Style::default()
                             .fg(app.theme.foreground)
                             .add_modifier(Modifier::BOLD),
@@ -159,7 +159,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     } else {
         vec![
             Constraint::Length(3),
-            Constraint::Min(16),
+            Constraint::Min(24),
             Constraint::Length(24),
             Constraint::Length(10),
             Constraint::Length(10),

--- a/crates/tokscale-core/src/sessions/copilot.rs
+++ b/crates/tokscale-core/src/sessions/copilot.rs
@@ -84,6 +84,7 @@ struct TraceContext {
     model: Option<String>,
     session_id: Option<String>,
     session_id_priority: SessionIdPriority,
+    agent_id: Option<String>,
 }
 
 struct CopilotUsageCandidate {
@@ -97,6 +98,7 @@ struct CopilotUsageCandidate {
     duration_ms: Option<i64>,
     tokens: TokenBreakdown,
     dedup_key: String,
+    agent: Option<String>,
 }
 
 #[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
@@ -120,6 +122,7 @@ impl CopilotUsageCandidate {
             Some(self.dedup_key),
         );
         message.duration_ms = self.duration_ms;
+        message.agent = self.agent;
         message
     }
 }
@@ -142,6 +145,7 @@ fn collect_trace_contexts(records: &[Value]) -> HashMap<String, TraceContext> {
                 model: None,
                 session_id: None,
                 session_id_priority: SessionIdPriority::Missing,
+                agent_id: None,
             });
 
         if context.model.is_none() {
@@ -152,6 +156,12 @@ fn collect_trace_contexts(records: &[Value]) -> HashMap<String, TraceContext> {
             if priority > context.session_id_priority {
                 context.session_id = Some(session_id.to_string());
                 context.session_id_priority = priority;
+            }
+        }
+
+        if context.agent_id.is_none() {
+            if let Some(agent_id) = attr_str(attributes, "gen_ai.agent.id") {
+                context.agent_id = Some(agent_id.to_string());
             }
         }
     }
@@ -305,6 +315,7 @@ fn candidate_from_attributes(
         duration_ms,
         tokens,
         dedup_key,
+        agent: trace_context.and_then(|tc| tc.agent_id.clone()),
     })
 }
 
@@ -823,6 +834,32 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].tokens.cache_read, 21881);
         assert_eq!(messages[0].tokens.cache_write, 1397);
+    }
+
+    #[test]
+    fn test_parse_copilot_cli_sets_agent_from_invoke_agent_span() {
+        // invoke_agent and chat spans share a traceId; gen_ai.agent.id from
+        // invoke_agent should propagate to chat messages via TraceContext so
+        // the Agents tab is populated for Copilot CLI sessions.
+        let content = r#"{"type":"span","traceId":"trace-agent","spanId":"invoke-1","name":"invoke_agent","endTime":[1775934260,0],"attributes":{"gen_ai.operation.name":"invoke_agent","gen_ai.provider.name":"github","gen_ai.conversation.id":"conv-agent","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.agent.id":"github.copilot.default","gen_ai.agent.version":"1.0.62"}}
+{"type":"span","traceId":"trace-agent","spanId":"chat-1","name":"chat claude-sonnet-4.6","endTime":[1775934264,967317833],"attributes":{"gen_ai.operation.name":"chat","gen_ai.provider.name":"github","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.response.model":"claude-sonnet-4.6","gen_ai.conversation.id":"conv-agent","gen_ai.usage.input_tokens":5000,"gen_ai.usage.output_tokens":100}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].agent.as_deref(), Some("github.copilot.default"));
+    }
+
+    #[test]
+    fn test_parse_copilot_cli_no_agent_when_invoke_agent_absent() {
+        let content = r#"{"type":"span","traceId":"trace-noagent","spanId":"chat-1","name":"chat claude-sonnet-4.6","endTime":[1775934264,967317833],"attributes":{"gen_ai.operation.name":"chat","gen_ai.provider.name":"github","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.response.model":"claude-sonnet-4.6","gen_ai.conversation.id":"conv-noagent","gen_ai.usage.input_tokens":1000,"gen_ai.usage.output_tokens":50}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].agent, None);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/copilot.rs
+++ b/crates/tokscale-core/src/sessions/copilot.rs
@@ -160,7 +160,7 @@ fn collect_trace_contexts(records: &[Value]) -> HashMap<String, TraceContext> {
         }
 
         if context.agent_id.is_none() {
-            if let Some(agent_id) = attr_str(attributes, "gen_ai.agent.id") {
+            if let Some(agent_id) = first_non_empty_attr(attributes, &["gen_ai.agent.id"]) {
                 context.agent_id = Some(agent_id.to_string());
             }
         }

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -106,6 +106,40 @@ pub fn normalize_opencode_agent_name(agent: &str) -> String {
     normalize_agent_name(&canonical)
 }
 
+pub fn normalize_copilot_agent_name(agent: &str) -> String {
+    // Hardcoded brand name for the default native agent
+    if agent.eq_ignore_ascii_case("github.copilot.default") {
+        return "GitHub Copilot".to_string();
+    }
+
+    // Native github.copilot.* agents: strip prefix, titlecase remainder
+    const GITHUB_COPILOT_PREFIX: &str = "github.copilot.";
+    if agent.len() > GITHUB_COPILOT_PREFIX.len()
+        && agent[..GITHUB_COPILOT_PREFIX.len()].eq_ignore_ascii_case(GITHUB_COPILOT_PREFIX)
+    {
+        let remainder = &agent[GITHUB_COPILOT_PREFIX.len()..];
+        let hyphenated = remainder.replace('.', "-");
+        return titlecase_agent(&hyphenated);
+    }
+
+    // Plugin:team:slug format — titlecase each colon-separated part, join with ": "
+    const PLUGIN_PREFIX: &str = "Plugin:";
+    if agent.len() > PLUGIN_PREFIX.len()
+        && agent[..PLUGIN_PREFIX.len()].eq_ignore_ascii_case(PLUGIN_PREFIX)
+    {
+        let rest = &agent[PLUGIN_PREFIX.len()..];
+        let parts: Vec<&str> = rest.splitn(2, ':').collect();
+        if parts.len() == 2 {
+            let team = titlecase_agent(parts[0]);
+            let slug = titlecase_agent(parts[1]);
+            return format!("{}: {}", team, slug);
+        }
+        return titlecase_agent(rest);
+    }
+
+    normalize_agent_name(agent)
+}
+
 fn normalize_oh_my_opencode_agent_name(agent_lower: &str) -> Option<String> {
     let normalized = match agent_lower {
         // Parenthesized format and dash format
@@ -625,6 +659,35 @@ mod tests {
         assert_eq!(
             normalize_agent_name("oh-my-claudecode:code-reviewer"),
             "Code Reviewer"
+        );
+    }
+
+    #[test]
+    fn test_normalize_copilot_agent_name() {
+        assert_eq!(
+            normalize_copilot_agent_name("github.copilot.default"),
+            "GitHub Copilot"
+        );
+        assert_eq!(
+            normalize_copilot_agent_name("GITHUB.COPILOT.DEFAULT"),
+            "GitHub Copilot"
+        );
+        assert_eq!(normalize_copilot_agent_name("github.copilot.chat"), "Chat");
+        assert_eq!(
+            normalize_copilot_agent_name("Plugin:software-engineering-team:se-ux-ui-designer"),
+            "Software Engineering Team: Se UX UI Designer"
+        );
+        assert_eq!(
+            normalize_copilot_agent_name("plugin:my-team:my-agent"),
+            "My Team: My Agent"
+        );
+        assert_eq!(
+            normalize_copilot_agent_name("Plugin:code-review-team:api-reviewer"),
+            "Code Review Team: API Reviewer"
+        );
+        assert_eq!(
+            normalize_copilot_agent_name("some-custom-agent"),
+            "Some Custom Agent"
         );
         assert_eq!(normalize_agent_name("oh-my-codex:librarian"), "Librarian");
         assert_eq!(normalize_agent_name("astrape:executor"), "Executor");

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -114,8 +114,9 @@ pub fn normalize_copilot_agent_name(agent: &str) -> String {
 
     // Native github.copilot.* agents: strip prefix, titlecase remainder
     const GITHUB_COPILOT_PREFIX: &str = "github.copilot.";
-    if agent.len() > GITHUB_COPILOT_PREFIX.len()
-        && agent[..GITHUB_COPILOT_PREFIX.len()].eq_ignore_ascii_case(GITHUB_COPILOT_PREFIX)
+    if agent
+        .get(..GITHUB_COPILOT_PREFIX.len())
+        .is_some_and(|head| head.eq_ignore_ascii_case(GITHUB_COPILOT_PREFIX))
     {
         let remainder = &agent[GITHUB_COPILOT_PREFIX.len()..];
         let hyphenated = remainder.replace('.', "-");
@@ -124,8 +125,9 @@ pub fn normalize_copilot_agent_name(agent: &str) -> String {
 
     // Plugin:team:slug format — titlecase each colon-separated part, join with ": "
     const PLUGIN_PREFIX: &str = "Plugin:";
-    if agent.len() > PLUGIN_PREFIX.len()
-        && agent[..PLUGIN_PREFIX.len()].eq_ignore_ascii_case(PLUGIN_PREFIX)
+    if agent
+        .get(..PLUGIN_PREFIX.len())
+        .is_some_and(|head| head.eq_ignore_ascii_case(PLUGIN_PREFIX))
     {
         let rest = &agent[PLUGIN_PREFIX.len()..];
         let parts: Vec<&str> = rest.splitn(2, ':').collect();


### PR DESCRIPTION
## Problem

The Agents tab shows nothing for GitHub Copilot CLI sessions. 

## Changes

### 1. Populate Agents tab from `gen_ai.agent.id` in OTEL spans

Copilot CLI emits one `invoke_agent` span per agent turn carrying `gen_ai.agent.id`. The subsequent `chat` spans in the same trace do not carry this attribute:

```
invoke_agent span  { traceId: "X", gen_ai.agent.id: "github.copilot.default" }
chat span          { traceId: "X", gen_ai.usage.input_tokens: 5000, ... }
```

Fix: store `agent_id` in `TraceContext` when processing any span in the trace, propagate it to `CopilotUsageCandidate`, then to `UnifiedMessage.agent`. Uses `first_non_empty_attr` (consistent with how `model` and `session_id` are guarded) to prevent blank strings from reaching the Agents tab.

### 2. Pretty-print Copilot CLI agent IDs

Copilot CLI agent IDs are technical reverse-DNS / namespaced strings. Added `normalize_copilot_agent_name()` with these rules:

| Raw `gen_ai.agent.id` | Display |
|---|---|
| `github.copilot.default` | `GitHub Copilot` (hardcoded brand name) |
| `github.copilot.chat` | `Chat` (strip prefix, titlecase) |
| `Plugin:software-engineering-team:se-ux-ui-designer` | `Software Engineering Team: Se UX UI Designer` |
| `Plugin:my-team:my-agent` | `My Team: My Agent` |
| anything else | existing `normalize_agent_name()` fallback |

The `Plugin:team:slug` format is handled generically — no plugin names are hardcoded. Team and slug are each split on `-`, titlecased with existing acronym exceptions (`UI`, `UX`, `API`), joined with `": "`.

### 3. Widen the Agents tab agent name column

Truncation limit increased from 22 → 32 chars and the minimum column width from 16 → 24 to accommodate longer Copilot CLI agent names.

## Tests

- `test_parse_copilot_cli_sets_agent_from_invoke_agent_span` — `invoke_agent` + `chat` in same trace yields `message.agent = Some("github.copilot.default")`
- `test_parse_copilot_cli_no_agent_when_invoke_agent_absent` — plain chat-only traces leave `message.agent = None`
- `test_normalize_copilot_agent_name` — covers hardcoded mapping, `github.copilot.*` prefix stripping, `Plugin:team:slug` generic parsing, and fallback
