### PR TITLE
fix: render usage reset times locally

### DIFF
--- a/crates/tokscale-cli/src/commands/usage/helpers.rs
+++ b/crates/tokscale-cli/src/commands/usage/helpers.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Duration, Local, TimeZone, Utc};
 
 pub fn capitalize(s: &str) -> String {
     let mut c = s.chars();
@@ -23,11 +23,19 @@ pub fn read_keychain(service: &str) -> Result<String> {
 }
 
 pub fn format_reset_time(resets_at: &str) -> String {
-    let dt = match DateTime::parse_from_rfc3339(resets_at) {
+    format_reset_time_at(resets_at, Utc::now(), &Local)
+}
+
+fn format_reset_time_at<Tz>(resets_at: &str, now_utc: DateTime<Utc>, display_tz: &Tz) -> String
+where
+    Tz: TimeZone,
+    Tz::Offset: std::fmt::Display,
+{
+    let dt_utc = match DateTime::parse_from_rfc3339(resets_at) {
         Ok(d) => d.with_timezone(&Utc),
         Err(_) => return resets_at.into(),
     };
-    let diff = dt - Utc::now();
+    let diff = dt_utc - now_utc;
     if diff <= Duration::zero() {
         return "resets now".into();
     }
@@ -43,9 +51,11 @@ pub fn format_reset_time(resets_at: &str) -> String {
             format!("resets in {h}h")
         }
     } else if diff.num_days() < 7 {
-        format!("resets {} {}", dt.format("%a"), dt.format("%-I%P"))
+        let dt_local = dt_utc.with_timezone(display_tz);
+        format!("resets {}", dt_local.format("%a %-I:%M%P"))
     } else {
-        format!("resets {}", dt.format("%b %-d"))
+        let dt_local = dt_utc.with_timezone(display_tz);
+        format!("resets {}", dt_local.format("%b %-d %-I:%M%P"))
     }
 }
 
@@ -90,4 +100,43 @@ pub fn atomic_write_secret(path: &std::path::Path, data: &[u8]) -> std::io::Resu
         return Err(e);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{FixedOffset, TimeZone};
+
+    #[test]
+    fn reset_time_uses_display_timezone_not_utc() {
+        let now = Utc.with_ymd_and_hms(2026, 6, 19, 0, 0, 0).unwrap();
+        let pacific_daylight = FixedOffset::west_opt(7 * 60 * 60).unwrap();
+
+        let shown = format_reset_time_at("2026-06-25T11:45:00Z", now, &pacific_daylight);
+
+        assert_eq!(shown, "resets Thu 4:45am");
+    }
+
+    #[test]
+    fn reset_time_keeps_minutes_for_local_absolute_times() {
+        let now = Utc.with_ymd_and_hms(2026, 6, 1, 0, 0, 0).unwrap();
+        let pacific_daylight = FixedOffset::west_opt(7 * 60 * 60).unwrap();
+
+        let shown = format_reset_time_at("2026-06-10T18:59:00Z", now, &pacific_daylight);
+
+        assert_eq!(shown, "resets Jun 10 11:59am");
+    }
+
+    #[test]
+    fn reset_time_rolls_back_to_previous_local_day() {
+        let now = Utc.with_ymd_and_hms(2026, 6, 19, 0, 0, 0).unwrap();
+        let pacific_daylight = FixedOffset::west_opt(7 * 60 * 60).unwrap();
+
+        // 2026-06-25 03:00 UTC -> 2026-06-24 20:00 PDT: the local day (Wed)
+        // is the day before the UTC day (Thu), so the weekday must come from
+        // the converted time, not the UTC timestamp.
+        let shown = format_reset_time_at("2026-06-25T03:00:00Z", now, &pacific_daylight);
+
+        assert_eq!(shown, "resets Wed 8:00pm");
+    }
 }


### PR DESCRIPTION
## Problem

Subscription reset labels in `tokscale usage` are rendered as UTC wall time instead of the user's local timezone. For users in Pacific time, this can make provider resets appear several hours late, such as showing `Thu 11am` for a Codex reset that happens locally at `Thu 4:45am`.

## Root Cause

`format_reset_time()` parses RFC3339 timestamps and normalizes them to UTC for duration math, but then formats that UTC value directly for human-facing output. The absolute-time formatter also omitted minutes, which made reset labels less precise.

## Fix

- Keep UTC normalization for parsing and reset countdown math.
- Convert reset timestamps to the machine's local timezone only when rendering absolute reset labels.
- Include minutes in absolute reset labels.
- Add deterministic formatter coverage by injecting `now_utc` and a display timezone in tests.

## Tests

- `cargo fmt --check`
- `cargo test -p tokscale-cli reset_time`
- `cargo test -p tokscale-cli`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect UTC display of subscription reset times in `tokscale usage` by rendering absolute times in the local timezone and showing minutes for clarity. Relative countdowns are unchanged.

- **Bug Fixes**
  - Convert parsed UTC timestamps to the local timezone only for absolute labels; keep UTC for countdown math.
  - Include minutes in absolute labels (e.g., "Thu 4:45am", "Jun 10 11:59am").
  - Add `format_reset_time_at` to inject `now_utc` and display timezone for deterministic tests.

<sup>Written for commit ba08a5685135a53a4c2dd5d9edbd46be5040b5c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

