### PR TITLE
feat(tui): add subscription usage dashboard

### DIFF
--- a/crates/tokscale-cli/src/commands/usage/amp.rs
+++ b/crates/tokscale-cli/src/commands/usage/amp.rs
@@ -172,6 +172,9 @@ pub fn fetch() -> Result<UsageOutput> {
             plan,
             email: None,
             metrics,
+            reset_credits: None,
+            credit_status: None,
+            spend_control: None,
         })
     })
 }

--- a/crates/tokscale-cli/src/commands/usage/claude.rs
+++ b/crates/tokscale-cli/src/commands/usage/claude.rs
@@ -223,6 +223,9 @@ pub fn fetch() -> Result<UsageOutput> {
             plan,
             email: None,
             metrics,
+            reset_credits: None,
+            credit_status: None,
+            spend_control: None,
         })
     })
 }

--- a/crates/tokscale-cli/src/commands/usage/codex.rs
+++ b/crates/tokscale-cli/src/commands/usage/codex.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use chrono::{TimeZone, Utc};
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
@@ -735,6 +736,31 @@ async fn refresh_token(client: &reqwest::Client, rt: &str) -> Result<Refresh> {
     Ok(resp.json().await?)
 }
 
+fn parse_chatgpt_json_body<T>(body: &str) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    if body.trim_start().starts_with('<') {
+        anyhow::bail!("NEEDS_AUTH");
+    }
+    Ok(serde_json::from_str(body)?)
+}
+
+async fn parse_chatgpt_json_response<T>(resp: reqwest::Response, request_label: &str) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    let status = resp.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        anyhow::bail!("NEEDS_AUTH");
+    }
+    if !status.is_success() {
+        anyhow::bail!("{request_label} failed (HTTP {status})");
+    }
+    let body = resp.text().await?;
+    parse_chatgpt_json_body(&body)
+}
+
 async fn fetch_usage(
     client: &reqwest::Client,
     token: &str,
@@ -752,18 +778,7 @@ async fn fetch_usage(
         req = req.header("ChatGPT-Account-Id", id);
     }
     let resp = req.send().await?;
-    let status = resp.status();
-    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
-        anyhow::bail!("NEEDS_AUTH");
-    }
-    if !status.is_success() {
-        anyhow::bail!("Codex usage request failed (HTTP {status})");
-    }
-    let body = resp.text().await?;
-    if body.trim().starts_with('<') {
-        anyhow::bail!("NEEDS_AUTH");
-    }
-    Ok(serde_json::from_str(&body)?)
+    parse_chatgpt_json_response(resp, "Codex usage request").await
 }
 
 async fn fetch_reset_credits(
@@ -783,14 +798,7 @@ async fn fetch_reset_credits(
         req = req.header("ChatGPT-Account-Id", id);
     }
     let resp = req.send().await?;
-    let status = resp.status();
-    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
-        anyhow::bail!("NEEDS_AUTH");
-    }
-    if !status.is_success() {
-        anyhow::bail!("Codex reset credits request failed (HTTP {status})");
-    }
-    Ok(resp.json().await?)
+    parse_chatgpt_json_response(resp, "Codex reset credits request").await
 }
 
 async fn consume_reset_credit(
@@ -815,14 +823,7 @@ async fn consume_reset_credit(
         req = req.header("ChatGPT-Account-Id", id);
     }
     let resp = req.send().await?;
-    let status = resp.status();
-    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
-        anyhow::bail!("NEEDS_AUTH");
-    }
-    if !status.is_success() {
-        anyhow::bail!("Codex reset request failed (HTTP {status})");
-    }
-    Ok(resp.json().await?)
+    parse_chatgpt_json_response(resp, "Codex reset request").await
 }
 
 fn metric_from_window(label: &str, window: &Window) -> UsageMetric {
@@ -1482,6 +1483,28 @@ mod tests {
 
         assert_eq!(usage.email.as_deref(), Some("plus@example.com"));
         assert!(usage.additional_rate_limits.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn chatgpt_json_body_treats_html_as_auth_expiry() {
+        let error = parse_chatgpt_json_body::<ResetCreditsResponse>(
+            "<html><body>please sign in</body></html>",
+        )
+        .unwrap_err();
+
+        assert_eq!(error.to_string(), "NEEDS_AUTH");
+    }
+
+    #[test]
+    fn chatgpt_json_body_parses_reset_credit_response() -> Result<()> {
+        let response: ResetCreditsResponse = parse_chatgpt_json_body(
+            r#"{"available_count":1,"credits":[{"id":"credit_1","status":"available"}]}"#,
+        )?;
+
+        assert_eq!(response.available_count, Some(1));
+        assert_eq!(response.credits.len(), 1);
+        assert_eq!(response.credits[0].id.as_deref(), Some("credit_1"));
         Ok(())
     }
 

--- a/crates/tokscale-cli/src/commands/usage/codex.rs
+++ b/crates/tokscale-cli/src/commands/usage/codex.rs
@@ -6,7 +6,10 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use super::helpers::capitalize;
-use super::{UsageAccount, UsageMetric, UsageOutput};
+use super::{
+    UsageAccount, UsageCreditStatus, UsageMetric, UsageOutput, UsageResetCredit, UsageResetCredits,
+    UsageSpendControl,
+};
 
 const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 
@@ -33,6 +36,11 @@ struct Usage {
     email: Option<String>,
     plan_type: Option<String>,
     rate_limit: Option<RateLimit>,
+    #[serde(default, deserialize_with = "deserialize_null_default_vec")]
+    additional_rate_limits: Vec<AdditionalRateLimit>,
+    rate_limit_reset_credits: Option<ResetCreditsSummary>,
+    credits: Option<Credits>,
+    spend_control: Option<SpendControl>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -45,8 +53,74 @@ struct RateLimit {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
 struct Window {
-    used_percent: Option<i64>,
+    used_percent: Option<f64>,
+    #[serde(alias = "resets_at")]
     reset_at: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct AdditionalRateLimit {
+    metered_feature: Option<String>,
+    limit_name: Option<String>,
+    rate_limit: Option<RateLimit>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct ResetCreditsSummary {
+    available_count: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct ResetCreditsResponse {
+    available_count: Option<u32>,
+    #[serde(default)]
+    credits: Vec<ResetCredit>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct ResetCredit {
+    id: Option<String>,
+    status: Option<String>,
+    reset_type: Option<String>,
+    expires_at: Option<String>,
+    title: Option<String>,
+    description: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct Credits {
+    balance: Option<serde_json::Value>,
+    has_credits: Option<bool>,
+    unlimited: Option<bool>,
+    overage_limit_reached: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct SpendControl {
+    individual_limit: Option<serde_json::Value>,
+    reached: Option<bool>,
+}
+
+fn deserialize_null_default_vec<'de, D, T>(deserializer: D) -> std::result::Result<Vec<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Ok(Option::<Vec<T>>::deserialize(deserializer)?.unwrap_or_default())
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RateLimitResetConsumeResult {
+    #[serde(default)]
+    pub code: String,
+    pub windows_reset: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -317,7 +391,9 @@ fn load_credentials_store_for_update(path: &Path) -> Result<Option<CodexCredenti
         return Ok(None);
     }
 
-    if !store.accounts.contains_key(&store.active_account_id) {
+    if !store.active_account_id.trim().is_empty()
+        && !store.accounts.contains_key(&store.active_account_id)
+    {
         if let Some(first_id) = first_account_id(&store) {
             store.active_account_id = first_id;
             let _ = save_credentials_store_at_path(path, &store);
@@ -435,11 +511,7 @@ fn remove_account_from_store(
     };
 
     if removed_was_active {
-        if let Some(next_id) = first_account_id(store) {
-            store.active_account_id = next_id;
-        } else {
-            store.active_account_id.clear();
-        }
+        store.active_account_id.clear();
     }
 
     Ok(removed)
@@ -494,7 +566,11 @@ fn save_account_from_auth_at_path(
     let mut store =
         load_credentials_store_for_update(store_path)?.unwrap_or_else(|| CodexCredentialsStore {
             version: 1,
-            active_account_id: base_account_id.clone(),
+            active_account_id: if make_active {
+                base_account_id.clone()
+            } else {
+                String::new()
+            },
             accounts: HashMap::new(),
         });
 
@@ -545,7 +621,7 @@ fn save_account_from_auth_at_path(
     };
 
     store.accounts.insert(account_id.clone(), account);
-    if make_active || store.active_account_id.trim().is_empty() {
+    if make_active {
         store.active_account_id = account_id.clone();
     }
     save_credentials_store_at_path(store_path, &store)?;
@@ -612,6 +688,9 @@ fn load_account(name_or_id: Option<&str>) -> Result<(String, CodexAccount, Codex
     let resolved = match name_or_id {
         Some(name) => resolve_account_id(&store, name)
             .ok_or_else(|| anyhow::anyhow!("Codex account not found: {name}"))?,
+        None if store.active_account_id.trim().is_empty() => {
+            anyhow::bail!("No active Codex account; pass an account name or switch to one first")
+        }
         None => store.active_account_id.clone(),
     };
     let account = store
@@ -687,8 +766,67 @@ async fn fetch_usage(
     Ok(serde_json::from_str(&body)?)
 }
 
+async fn fetch_reset_credits(
+    client: &reqwest::Client,
+    token: &str,
+    account_id: Option<&str>,
+) -> Result<ResetCreditsResponse> {
+    let mut req = client
+        .get("https://chatgpt.com/backend-api/wham/rate-limit-reset-credits")
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Accept", "application/json")
+        .header(
+            "User-Agent",
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+        );
+    if let Some(id) = account_id {
+        req = req.header("ChatGPT-Account-Id", id);
+    }
+    let resp = req.send().await?;
+    let status = resp.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        anyhow::bail!("NEEDS_AUTH");
+    }
+    if !status.is_success() {
+        anyhow::bail!("Codex reset credits request failed (HTTP {status})");
+    }
+    Ok(resp.json().await?)
+}
+
+async fn consume_reset_credit(
+    client: &reqwest::Client,
+    token: &str,
+    account_id: Option<&str>,
+    redeem_request_id: &str,
+) -> Result<RateLimitResetConsumeResult> {
+    let mut req = client
+        .post("https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume")
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Accept", "application/json")
+        .header("Content-Type", "application/json")
+        .header(
+            "User-Agent",
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+        )
+        .json(&serde_json::json!({
+            "redeem_request_id": redeem_request_id,
+        }));
+    if let Some(id) = account_id {
+        req = req.header("ChatGPT-Account-Id", id);
+    }
+    let resp = req.send().await?;
+    let status = resp.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        anyhow::bail!("NEEDS_AUTH");
+    }
+    if !status.is_success() {
+        anyhow::bail!("Codex reset request failed (HTTP {status})");
+    }
+    Ok(resp.json().await?)
+}
+
 fn metric_from_window(label: &str, window: &Window) -> UsageMetric {
-    let pct = window.used_percent.unwrap_or(0).clamp(0, 100) as f64;
+    let pct = window.used_percent.unwrap_or(0.0).clamp(0.0, 100.0);
     UsageMetric {
         label: label.into(),
         used_percent: pct,
@@ -698,6 +836,67 @@ fn metric_from_window(label: &str, window: &Window) -> UsageMetric {
             .reset_at
             .and_then(|ts| Utc.timestamp_opt(ts, 0).single())
             .map(|dt| dt.to_rfc3339()),
+    }
+}
+
+fn push_rate_limit_metrics(
+    metrics: &mut Vec<UsageMetric>,
+    prefix: Option<&str>,
+    rate_limit: &RateLimit,
+) {
+    let label_prefix = prefix.map(str::trim).filter(|label| !label.is_empty());
+    if let Some(ref w) = rate_limit.primary_window {
+        let label = label_prefix
+            .map(|prefix| format!("{prefix} 5h"))
+            .unwrap_or_else(|| "5h".to_string());
+        metrics.push(metric_from_window(&label, w));
+    }
+    if let Some(ref w) = rate_limit.secondary_window {
+        let label = label_prefix
+            .map(|prefix| format!("{prefix} week"))
+            .unwrap_or_else(|| "Weekly".to_string());
+        metrics.push(metric_from_window(&label, w));
+    }
+}
+
+fn reset_credits_from_summary(summary: Option<&ResetCreditsSummary>) -> Option<UsageResetCredits> {
+    summary.and_then(|summary| {
+        summary
+            .available_count
+            .map(|available_count| UsageResetCredits {
+                available_count,
+                credits: Vec::new(),
+            })
+    })
+}
+
+fn reset_credits_from_response(response: ResetCreditsResponse) -> Option<UsageResetCredits> {
+    response
+        .available_count
+        .map(|available_count| UsageResetCredits {
+            available_count,
+            credits: response
+                .credits
+                .into_iter()
+                .map(|credit| UsageResetCredit {
+                    id: credit.id,
+                    status: credit.status,
+                    reset_type: credit.reset_type,
+                    expires_at: credit.expires_at,
+                    title: credit.title,
+                    description: credit.description,
+                })
+                .collect(),
+        })
+}
+
+fn json_scalar_string(value: Option<serde_json::Value>) -> Option<String> {
+    match value? {
+        serde_json::Value::Null => None,
+        serde_json::Value::String(value) => Some(value),
+        serde_json::Value::Number(value) => Some(value.to_string()),
+        serde_json::Value::Bool(value) => Some(value.to_string()),
+        _ => None,
     }
 }
 
@@ -716,6 +915,8 @@ async fn fetch_with_auth_async(
         .ok_or_else(|| anyhow::anyhow!("No Codex access token."))?;
 
     let client = reqwest::Client::new();
+    let mut effective_tokens = tokens.clone();
+    let mut effective_access_token = access_token.clone();
     let resp = match fetch_usage(&client, &access_token, tokens.account_id.as_deref()).await {
         Ok(r) => r,
         Err(e) if e.to_string().contains("NEEDS_AUTH") => {
@@ -735,6 +936,8 @@ async fn fetch_with_auth_async(
                 updated_tokens.refresh_token = Some(new_rt);
             }
             persist_tokens(&source, &updated_tokens);
+            effective_access_token = new.clone();
+            effective_tokens = updated_tokens.clone();
 
             fetch_usage(&client, &new, updated_tokens.account_id.as_deref()).await?
         }
@@ -744,13 +947,46 @@ async fn fetch_with_auth_async(
     let plan = resp.plan_type.as_deref().map(capitalize);
     let mut metrics = Vec::new();
     if let Some(ref rl) = resp.rate_limit {
-        if let Some(ref w) = rl.primary_window {
-            metrics.push(metric_from_window("Session", w));
-        }
-        if let Some(ref w) = rl.secondary_window {
-            metrics.push(metric_from_window("Weekly", w));
+        push_rate_limit_metrics(&mut metrics, None, rl);
+    }
+    for limit in &resp.additional_rate_limits {
+        if let Some(rate_limit) = &limit.rate_limit {
+            let label = limit
+                .limit_name
+                .as_deref()
+                .or(limit.metered_feature.as_deref())
+                .map(capitalize);
+            push_rate_limit_metrics(&mut metrics, label.as_deref(), rate_limit);
         }
     }
+
+    let mut reset_credits = reset_credits_from_summary(resp.rate_limit_reset_credits.as_ref());
+    let should_fetch_reset_details = reset_credits
+        .as_ref()
+        .map(|credits| credits.available_count > 0)
+        .unwrap_or(true);
+    if should_fetch_reset_details {
+        if let Ok(details) = fetch_reset_credits(
+            &client,
+            &effective_access_token,
+            effective_tokens.account_id.as_deref(),
+        )
+        .await
+        {
+            reset_credits = reset_credits_from_response(details);
+        }
+    }
+
+    let credit_status = resp.credits.map(|credits| UsageCreditStatus {
+        balance: json_scalar_string(credits.balance),
+        has_credits: credits.has_credits,
+        unlimited: credits.unlimited,
+        overage_limit_reached: credits.overage_limit_reached,
+    });
+    let spend_control = resp.spend_control.map(|control| UsageSpendControl {
+        individual_limit: json_scalar_string(control.individual_limit),
+        reached: control.reached,
+    });
 
     Ok(UsageOutput {
         provider: provider_name,
@@ -758,6 +994,9 @@ async fn fetch_with_auth_async(
         plan,
         email: resp.email,
         metrics,
+        reset_credits,
+        credit_status,
+        spend_control,
     })
 }
 
@@ -779,19 +1018,68 @@ pub fn fetch() -> Result<UsageOutput> {
 }
 
 fn usage_account_from_saved(
-    store: &CodexCredentialsStore,
     account_id: &str,
     account: &CodexAccount,
+    active_account_id: Option<&str>,
 ) -> UsageAccount {
     UsageAccount {
         id: account_id.to_string(),
         label: account.label.clone(),
-        is_active: account_id == store.active_account_id,
+        is_active: active_account_id == Some(account_id),
     }
 }
 
+fn matching_account_id_for_tokens(
+    store: &CodexCredentialsStore,
+    tokens: &Tokens,
+) -> Option<String> {
+    let derived = derive_account_id(tokens);
+    if store
+        .accounts
+        .get(&derived)
+        .is_some_and(|account| same_token_identity(tokens, &account.tokens))
+    {
+        return Some(derived);
+    }
+
+    store
+        .accounts
+        .iter()
+        .find(|(_, account)| same_token_identity(tokens, &account.tokens))
+        .map(|(account_id, _)| account_id.clone())
+        .or_else(|| store.accounts.contains_key(&derived).then_some(derived))
+}
+
+fn current_auth_account_id_in_store(store: &CodexCredentialsStore) -> Option<String> {
+    let (auth, _) = read_current_credentials().ok()?;
+    let tokens = auth.tokens.as_ref()?;
+    matching_account_id_for_tokens(store, tokens)
+}
+
+fn active_account_id_for_usage(store: &mut CodexCredentialsStore) -> Option<String> {
+    let active_account_id = current_auth_account_id_in_store(store).or_else(|| {
+        (!store.active_account_id.trim().is_empty()
+            && store.accounts.contains_key(&store.active_account_id))
+        .then(|| store.active_account_id.clone())
+    });
+
+    match active_account_id.as_ref() {
+        Some(active_account_id) if store.active_account_id != *active_account_id => {
+            store.active_account_id = active_account_id.clone();
+            let _ = save_credentials_store(store);
+        }
+        None if !store.active_account_id.trim().is_empty() => {
+            store.active_account_id.clear();
+            let _ = save_credentials_store(store);
+        }
+        _ => {}
+    }
+
+    active_account_id
+}
+
 pub fn fetch_all() -> Result<Vec<UsageOutput>> {
-    let Some(store) = load_credentials_store() else {
+    let Some(mut store) = load_credentials_store() else {
         return fetch().map(|output| vec![output]);
     };
 
@@ -799,18 +1087,28 @@ pub fn fetch_all() -> Result<Vec<UsageOutput>> {
         return fetch().map(|output| vec![output]);
     }
 
+    let active_account_id = active_account_id_for_usage(&mut store);
     let mut account_ids: Vec<_> = store.accounts.keys().cloned().collect();
-    account_ids.sort_by_key(|id| {
-        (
-            id != &store.active_account_id,
-            account_sort_key(
-                store
-                    .accounts
-                    .get(id)
-                    .and_then(|account| account.label.as_deref()),
-                id,
-            ),
-        )
+    account_ids.sort_by(|a, b| {
+        if active_account_id.as_deref() == Some(a.as_str()) {
+            std::cmp::Ordering::Less
+        } else if active_account_id.as_deref() == Some(b.as_str()) {
+            std::cmp::Ordering::Greater
+        } else {
+            let la = store
+                .accounts
+                .get(a)
+                .and_then(|account| account.label.as_deref())
+                .map(|label| account_sort_key(Some(label), a))
+                .unwrap_or_else(|| account_sort_key(None, a));
+            let lb = store
+                .accounts
+                .get(b)
+                .and_then(|account| account.label.as_deref())
+                .map(|label| account_sort_key(Some(label), b))
+                .unwrap_or_else(|| account_sort_key(None, b));
+            la.cmp(&lb).then_with(|| a.cmp(b))
+        }
     });
 
     let mut outputs = Vec::new();
@@ -819,7 +1117,8 @@ pub fn fetch_all() -> Result<Vec<UsageOutput>> {
         let Some(account) = store.accounts.get(&account_id) else {
             continue;
         };
-        let usage_account = usage_account_from_saved(&store, &account_id, account);
+        let usage_account =
+            usage_account_from_saved(&account_id, account, active_account_id.as_deref());
         match fetch_with_auth(
             auth_from_account(account),
             CredentialSource::Store(account_id.clone()),
@@ -841,6 +1140,79 @@ pub fn fetch_all() -> Result<Vec<UsageOutput>> {
     } else {
         Ok(outputs)
     }
+}
+
+async fn consume_reset_credit_with_auth_async(
+    auth: Auth,
+    source: CredentialSource,
+) -> Result<RateLimitResetConsumeResult> {
+    let tokens = auth
+        .tokens
+        .ok_or_else(|| anyhow::anyhow!("No Codex tokens."))?;
+    let access_token = tokens
+        .access_token
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("No Codex access token."))?;
+    let client = reqwest::Client::new();
+    let redeem_request_id = uuid::Uuid::new_v4().to_string();
+
+    match consume_reset_credit(
+        &client,
+        &access_token,
+        tokens.account_id.as_deref(),
+        &redeem_request_id,
+    )
+    .await
+    {
+        Ok(result) => Ok(result),
+        Err(e) if e.to_string().contains("NEEDS_AUTH") => {
+            let rt_str = tokens
+                .refresh_token
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("No refresh token."))?;
+            let refreshed = refresh_token(&client, rt_str).await?;
+            let new = refreshed
+                .access_token
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("Refresh returned no token."))?;
+
+            let mut updated_tokens = tokens.clone();
+            updated_tokens.access_token = Some(new.clone());
+            if let Some(new_rt) = refreshed.refresh_token {
+                updated_tokens.refresh_token = Some(new_rt);
+            }
+            persist_tokens(&source, &updated_tokens);
+
+            consume_reset_credit(
+                &client,
+                &new,
+                updated_tokens.account_id.as_deref(),
+                &redeem_request_id,
+            )
+            .await
+        }
+        Err(e) => Err(e),
+    }
+}
+
+pub fn consume_rate_limit_reset_credit(name_or_id: &str) -> Result<RateLimitResetConsumeResult> {
+    let store =
+        load_credentials_store().ok_or_else(|| anyhow::anyhow!("No saved Codex accounts"))?;
+    let resolved = resolve_account_id(&store, name_or_id)
+        .ok_or_else(|| anyhow::anyhow!("Codex account not found: {name_or_id}"))?;
+    let account = store
+        .accounts
+        .get(&resolved)
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("Codex account not found: {resolved}"))?;
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(consume_reset_credit_with_auth_async(
+        auth_from_account(&account),
+        CredentialSource::Store(resolved),
+    ))
 }
 
 fn fetch_saved_account(name_or_id: Option<&str>) -> Result<(CodexAccountInfo, UsageOutput)> {
@@ -1091,6 +1463,29 @@ mod tests {
     }
 
     #[test]
+    fn usage_response_treats_null_additional_rate_limits_as_empty() -> Result<()> {
+        let usage: Usage = serde_json::from_value(serde_json::json!({
+            "email": "plus@example.com",
+            "plan_type": "plus",
+            "rate_limit": {
+                "primary_window": {
+                    "used_percent": 1,
+                    "reset_at": 1781929382
+                },
+                "secondary_window": {
+                    "used_percent": 16,
+                    "reset_at": 1782413780
+                }
+            },
+            "additional_rate_limits": null
+        }))?;
+
+        assert_eq!(usage.email.as_deref(), Some("plus@example.com"));
+        assert!(usage.additional_rate_limits.is_empty());
+        Ok(())
+    }
+
+    #[test]
     fn derive_account_id_prefers_account_id() {
         let tokens = tokens("access-token", Some("acct_work"));
         assert_eq!(derive_account_id(&tokens), "acct_work");
@@ -1109,6 +1504,74 @@ mod tests {
         let b = tokens_with_id_token("access-b", Some("acct_shared"), "id-token-b");
 
         assert!(same_token_identity(&a, &b));
+    }
+
+    #[test]
+    fn usage_active_account_matches_current_token_identity() {
+        let mut accounts = HashMap::new();
+        accounts.insert(
+            "acct_a".to_string(),
+            CodexAccount {
+                tokens: tokens("access-a", Some("acct_a")),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                label: Some("work".to_string()),
+            },
+        );
+        accounts.insert(
+            "acct_b".to_string(),
+            CodexAccount {
+                tokens: tokens("access-b", Some("acct_b")),
+                created_at: "2026-01-02T00:00:00Z".to_string(),
+                label: Some("personal".to_string()),
+            },
+        );
+        let store = CodexCredentialsStore {
+            version: 1,
+            active_account_id: "acct_a".to_string(),
+            accounts,
+        };
+
+        let current_tokens = tokens("rotated-access-b", Some("acct_b"));
+        let active_id = matching_account_id_for_tokens(&store, &current_tokens);
+        assert_eq!(active_id.as_deref(), Some("acct_b"));
+
+        let account_a = store.accounts.get("acct_a").unwrap();
+        let account_b = store.accounts.get("acct_b").unwrap();
+        assert!(!usage_account_from_saved("acct_a", account_a, active_id.as_deref()).is_active);
+        assert!(usage_account_from_saved("acct_b", account_b, active_id.as_deref()).is_active);
+    }
+
+    #[test]
+    fn usage_active_account_handles_collision_suffixed_account_ids() {
+        let mut accounts = HashMap::new();
+        accounts.insert(
+            "acct_shared".to_string(),
+            CodexAccount {
+                tokens: tokens_with_id_token("access-a", Some("acct_other"), "id-token-a"),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                label: Some("old".to_string()),
+            },
+        );
+        accounts.insert(
+            "acct_shared-2".to_string(),
+            CodexAccount {
+                tokens: tokens_with_id_token("access-b", Some("acct_shared"), "id-token-b"),
+                created_at: "2026-01-02T00:00:00Z".to_string(),
+                label: Some("current".to_string()),
+            },
+        );
+        let store = CodexCredentialsStore {
+            version: 1,
+            active_account_id: "acct_shared".to_string(),
+            accounts,
+        };
+
+        let current_tokens =
+            tokens_with_id_token("rotated-access", Some("acct_shared"), "id-token-b");
+        assert_eq!(
+            matching_account_id_for_tokens(&store, &current_tokens).as_deref(),
+            Some("acct_shared-2")
+        );
     }
 
     #[test]
@@ -1141,6 +1604,33 @@ mod tests {
 
         let loaded = load_credentials_store_from_path(&store_path).unwrap();
         assert_eq!(loaded.active_account_id, "acct_b");
+        Ok(())
+    }
+
+    #[test]
+    fn load_credentials_store_preserves_empty_active_account() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let mut accounts = HashMap::new();
+        accounts.insert(
+            "acct_a".to_string(),
+            CodexAccount {
+                tokens: tokens("access-a", Some("acct_a")),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                label: Some("work".to_string()),
+            },
+        );
+        let store = CodexCredentialsStore {
+            version: 1,
+            active_account_id: String::new(),
+            accounts,
+        };
+        let store_path = test_store_path(&tmp);
+        save_credentials_store_at_path(&store_path, &store)?;
+
+        let loaded = load_credentials_store_from_path(&store_path).unwrap();
+        assert!(loaded.active_account_id.is_empty());
+        let account = loaded.accounts.get("acct_a").unwrap();
+        assert!(!account_info(&loaded, "acct_a", account).is_active);
         Ok(())
     }
 
@@ -1341,7 +1831,7 @@ mod tests {
     }
 
     #[test]
-    fn remove_account_from_store_selects_next_active_when_removing_active() -> Result<()> {
+    fn remove_account_from_store_clears_active_when_removing_active() -> Result<()> {
         let mut accounts = HashMap::new();
         accounts.insert(
             "acct_a".to_string(),
@@ -1369,7 +1859,9 @@ mod tests {
 
         assert_eq!(removed.id, "acct_a");
         assert!(removed.is_active);
-        assert_eq!(store.active_account_id, "acct_b");
+        assert!(store.active_account_id.is_empty());
+        let account_b = store.accounts.get("acct_b").unwrap();
+        assert!(!usage_account_from_saved("acct_b", account_b, None).is_active);
         Ok(())
     }
 

--- a/crates/tokscale-cli/src/commands/usage/copilot.rs
+++ b/crates/tokscale-cli/src/commands/usage/copilot.rs
@@ -284,6 +284,9 @@ pub fn fetch() -> Result<UsageOutput> {
             plan,
             email: None,
             metrics,
+            reset_credits: None,
+            credit_status: None,
+            spend_control: None,
         })
     })
 }

--- a/crates/tokscale-cli/src/commands/usage/grok.rs
+++ b/crates/tokscale-cli/src/commands/usage/grok.rs
@@ -626,6 +626,9 @@ fn fetch_network_usage(credentials: &Credentials) -> Result<UsageOutput> {
         plan,
         email: credentials.email.clone(),
         metrics,
+        reset_credits: None,
+        credit_status: None,
+        spend_control: None,
     })
 }
 
@@ -640,6 +643,9 @@ fn usage_output(
         plan,
         email,
         metrics,
+        reset_credits: None,
+        credit_status: None,
+        spend_control: None,
     }
 }
 

--- a/crates/tokscale-cli/src/commands/usage/kimi.rs
+++ b/crates/tokscale-cli/src/commands/usage/kimi.rs
@@ -290,6 +290,9 @@ pub fn fetch() -> Result<UsageOutput> {
             plan,
             email: None,
             metrics,
+            reset_credits: None,
+            credit_status: None,
+            spend_control: None,
         })
     })
 }

--- a/crates/tokscale-cli/src/commands/usage/minimax.rs
+++ b/crates/tokscale-cli/src/commands/usage/minimax.rs
@@ -246,6 +246,9 @@ pub fn fetch() -> Result<UsageOutput> {
             plan,
             email: None,
             metrics,
+            reset_credits: None,
+            credit_status: None,
+            spend_control: None,
         })
     })
 }

--- a/crates/tokscale-cli/src/commands/usage/mod.rs
+++ b/crates/tokscale-cli/src/commands/usage/mod.rs
@@ -23,6 +23,49 @@ pub struct UsageMetric {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct UsageResetCredits {
+    pub available_count: u32,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub credits: Vec<UsageResetCredit>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct UsageResetCredit {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reset_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct UsageCreditStatus {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub balance: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub has_credits: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unlimited: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub overage_limit_reached: Option<bool>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct UsageSpendControl {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub individual_limit: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reached: Option<bool>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct UsageOutput {
     pub provider: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -30,6 +73,12 @@ pub struct UsageOutput {
     pub plan: Option<String>,
     pub email: Option<String>,
     pub metrics: Vec<UsageMetric>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reset_credits: Option<UsageResetCredits>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credit_status: Option<UsageCreditStatus>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spend_control: Option<UsageSpendControl>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -277,6 +326,14 @@ fn render_light(output: &UsageOutput) {
         let plan = truncate(plan, CARD_WIDTH - 11);
         println!("│ {:<10}{:<width$}│", "Plan", plan, width = CARD_WIDTH - 11);
     }
+    if let Some(ref credits) = output.reset_credits {
+        println!(
+            "│ {:<10}{:<width$}│",
+            "Resets",
+            format!("{} available", credits.available_count),
+            width = CARD_WIDTH - 11
+        );
+    }
     println!("╰{}╯", "─".repeat(CARD_WIDTH));
 }
 
@@ -308,6 +365,9 @@ mod tests {
             plan: None,
             email: None,
             metrics: Vec::new(),
+            reset_credits: None,
+            credit_status: None,
+            spend_control: None,
         };
 
         assert_eq!(output.display_name(), "Codex (work)");
@@ -325,6 +385,9 @@ mod tests {
             plan: None,
             email: Some("user@example.com".to_string()),
             metrics: Vec::new(),
+            reset_credits: None,
+            credit_status: None,
+            spend_control: None,
         };
 
         assert_eq!(output.display_name(), "Codex (user@example.com)");
@@ -342,6 +405,9 @@ mod tests {
             plan: None,
             email: None,
             metrics: Vec::new(),
+            reset_credits: None,
+            credit_status: None,
+            spend_control: None,
         };
 
         assert_eq!(output.display_name(), "Codex (Account 123e45...4000)");

--- a/crates/tokscale-cli/src/commands/usage/warp.rs
+++ b/crates/tokscale-cli/src/commands/usage/warp.rs
@@ -48,5 +48,8 @@ pub fn fetch() -> Result<UsageOutput> {
         plan: Some("Aggregate API cache".to_string()),
         email: None,
         metrics,
+        reset_credits: None,
+        credit_status: None,
+        spend_control: None,
     })
 }

--- a/crates/tokscale-cli/src/commands/usage/zai.rs
+++ b/crates/tokscale-cli/src/commands/usage/zai.rs
@@ -167,6 +167,9 @@ pub fn fetch() -> Result<UsageOutput> {
             plan,
             email: None,
             metrics,
+            reset_credits: None,
+            credit_status: None,
+            spend_control: None,
         })
     })
 }

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -299,6 +299,7 @@ pub struct App {
 
     pub usage_fetch_attempted: bool,
     usage_rx: Option<std::sync::mpsc::Receiver<Vec<crate::commands::usage::UsageOutput>>>,
+    usage_fetch_preserve_status: bool,
     codex_reset_rx: Option<
         std::sync::mpsc::Receiver<
             Result<crate::commands::usage::codex::RateLimitResetConsumeResult, String>,
@@ -438,6 +439,7 @@ impl App {
             codex_login_outcome: None,
             usage_fetch_attempted: false,
             usage_rx: None,
+            usage_fetch_preserve_status: false,
             codex_reset_rx: None,
             codex_login_rx: None,
             codex_login_child: None,
@@ -547,21 +549,33 @@ impl App {
         if let Some(ref rx) = self.usage_rx {
             match rx.try_recv() {
                 Ok(results) => {
+                    let preserve_status = self.usage_fetch_preserve_status;
+                    self.usage_fetch_preserve_status = false;
                     self.usage_rx = None;
                     self.subscription_usage = results;
                     if !self.subscription_usage.is_empty() {
                         crate::commands::usage::save_cache(&self.subscription_usage);
-                        self.status_message = Some("Usage data loaded".into());
+                        if !preserve_status {
+                            self.status_message = Some("Usage data loaded".into());
+                        }
                     } else {
                         crate::commands::usage::clear_cache();
-                        self.status_message = Some("No usage data available".into());
+                        if !preserve_status {
+                            self.status_message = Some("No usage data available".into());
+                        }
                     }
-                    self.status_message_time = Some(std::time::Instant::now());
+                    if !preserve_status {
+                        self.status_message_time = Some(std::time::Instant::now());
+                    }
                 }
                 Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                    let preserve_status = self.usage_fetch_preserve_status;
+                    self.usage_fetch_preserve_status = false;
                     self.usage_rx = None;
-                    self.status_message = Some("Usage fetch failed".into());
-                    self.status_message_time = Some(std::time::Instant::now());
+                    if !preserve_status {
+                        self.status_message = Some("Usage fetch failed".into());
+                        self.status_message_time = Some(std::time::Instant::now());
+                    }
                 }
                 Err(std::sync::mpsc::TryRecvError::Empty) => {}
             }
@@ -576,7 +590,7 @@ impl App {
                         codex_reset_outcome_label(&result)
                     ));
                     self.status_message_time = Some(std::time::Instant::now());
-                    self.fetch_subscription_usage();
+                    self.fetch_subscription_usage_preserving_status();
                 }
                 Ok(Err(error)) => {
                     self.codex_reset_rx = None;
@@ -820,12 +834,26 @@ impl App {
     }
 
     pub fn fetch_subscription_usage(&mut self) {
+        self.fetch_subscription_usage_with_status(false);
+    }
+
+    fn fetch_subscription_usage_preserving_status(&mut self) {
+        self.fetch_subscription_usage_with_status(true);
+    }
+
+    fn fetch_subscription_usage_with_status(&mut self, preserve_status: bool) {
         if self.usage_rx.is_some() {
+            if preserve_status {
+                self.usage_fetch_preserve_status = true;
+            }
             return; // already fetching
         }
         self.usage_fetch_attempted = true;
-        self.status_message = Some("Fetching usage data...".into());
-        self.status_message_time = Some(std::time::Instant::now());
+        self.usage_fetch_preserve_status = preserve_status;
+        if !preserve_status {
+            self.status_message = Some("Fetching usage data...".into());
+            self.status_message_time = Some(std::time::Instant::now());
+        }
         let (tx, rx) = std::sync::mpsc::channel();
         self.usage_rx = Some(rx);
         std::thread::spawn(move || {
@@ -3552,6 +3580,43 @@ mod tests {
         assert_eq!(
             app.status_message.as_deref(),
             Some("Fetching usage data...")
+        );
+    }
+
+    #[test]
+    fn test_codex_reset_success_status_survives_follow_up_usage_refresh() {
+        let mut app = make_app();
+        let (tx, rx) = std::sync::mpsc::channel();
+        app.codex_reset_rx = Some(rx);
+        tx.send(Ok(
+            crate::commands::usage::codex::RateLimitResetConsumeResult {
+                code: "reset".to_string(),
+                windows_reset: Some(1),
+            },
+        ))
+        .unwrap();
+        drop(tx);
+
+        app.on_tick();
+
+        assert_eq!(
+            app.status_message.as_deref(),
+            Some("Codex reset credit: reset 1 window")
+        );
+        assert!(app.is_fetching_usage());
+
+        for _ in 0..20 {
+            app.on_tick();
+            if !app.is_fetching_usage() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(1));
+        }
+
+        assert!(!app.is_fetching_usage());
+        assert_eq!(
+            app.status_message.as_deref(),
+            Some("Codex reset credit: reset 1 window")
         );
     }
 

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -13,13 +13,15 @@ use crate::ClientFilter;
 
 use ratatui::style::Color;
 
+use super::codex_login::CodexLoginOutcome;
 use super::data::{
     AgentUsage, DailyUsage, DataLoader, HourlyUsage, MinutelyUsage, ModelUsage, TokenBreakdown,
     UsageData,
 };
+use super::privacy::looks_like_email;
 use super::settings::Settings;
 use super::themes::{Theme, ThemeName};
-use super::ui::dialog::{ClientPickerDialog, DialogStack};
+use super::ui::dialog::{ClientPickerDialog, ConfirmDialog, DialogStack};
 use super::ui::widgets::{get_model_color, get_provider_from_model, get_provider_shade};
 
 /// Configuration for TUI initialization
@@ -164,20 +166,57 @@ pub enum ClickAction {
     UsageRefresh,
     CodexStartLogin,
     CodexDismissLogin,
+    UsageSelect { index: usize },
+    UsageToggleEmailPrivacy,
     CodexUseAccount { account_id: String },
     CodexRemoveAccount { account_id: String },
-}
-
-#[derive(Debug, Clone)]
-pub enum CodexLoginOutcome {
-    Imported(crate::commands::usage::codex::CodexAccountInfo),
-    Failed(String),
+    CodexResetAccount { account_id: String },
 }
 
 #[derive(Debug, Clone)]
 enum CodexLoginEvent {
     Output(String),
     Finished(CodexLoginOutcome),
+}
+
+fn codex_reset_outcome_label(
+    result: &crate::commands::usage::codex::RateLimitResetConsumeResult,
+) -> String {
+    match result.code.as_str() {
+        "reset" => match result.windows_reset {
+            Some(1) => "reset 1 window".to_string(),
+            Some(count) => format!("reset {count} windows"),
+            None => "reset complete".to_string(),
+        },
+        "already_redeemed" => "credit already redeemed".to_string(),
+        "nothing_to_reset" => "nothing to reset".to_string(),
+        "no_credit" => "no credit available".to_string(),
+        "" => "unknown response".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn short_account_id(account_id: &str) -> String {
+    let id = account_id.trim();
+    if id.is_empty() {
+        return "Account unknown".to_string();
+    }
+
+    let char_count = id.chars().count();
+    if char_count <= 12 {
+        return format!("Account {id}");
+    }
+
+    let head: String = id.chars().take(6).collect();
+    let tail: String = id
+        .chars()
+        .rev()
+        .take(4)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect();
+    format!("Account {head}...{tail}")
 }
 
 /// Shared handle to the spawned `codex login` child process. The login worker
@@ -251,12 +290,20 @@ pub struct App {
     pub model_shade_map: HashMap<String, Color>,
 
     pub subscription_usage: Vec<crate::commands::usage::UsageOutput>,
-    pub pending_codex_remove_account_id: Option<String>,
+    confirmed_codex_use_account_id: Rc<RefCell<Option<String>>>,
+    confirmed_codex_remove_account_id: Rc<RefCell<Option<String>>>,
+    confirmed_codex_reset_account_id: Rc<RefCell<Option<String>>>,
+    pub hide_usage_emails: bool,
     pub codex_login_lines: Vec<String>,
-    pub codex_login_outcome: Option<CodexLoginOutcome>,
+    pub(crate) codex_login_outcome: Option<CodexLoginOutcome>,
 
     pub usage_fetch_attempted: bool,
     usage_rx: Option<std::sync::mpsc::Receiver<Vec<crate::commands::usage::UsageOutput>>>,
+    codex_reset_rx: Option<
+        std::sync::mpsc::Receiver<
+            Result<crate::commands::usage::codex::RateLimitResetConsumeResult, String>,
+        >,
+    >,
     codex_login_rx: Option<std::sync::mpsc::Receiver<CodexLoginEvent>>,
     codex_login_child: Option<CodexLoginChildSlot>,
 
@@ -322,6 +369,9 @@ impl App {
         let has_data = !data.models.is_empty();
         let dialog_stack = DialogStack::new(theme.clone());
         let dialog_needs_reload = Rc::new(RefCell::new(false));
+        let confirmed_codex_use_account_id = Rc::new(RefCell::new(None));
+        let confirmed_codex_remove_account_id = Rc::new(RefCell::new(None));
+        let confirmed_codex_reset_account_id = Rc::new(RefCell::new(None));
         let requested_tab = config.initial_tab.unwrap_or(Tab::Overview);
         let current_tab = if Self::tab_visible(&settings, requested_tab) {
             requested_tab
@@ -380,11 +430,15 @@ impl App {
                     Vec::new()
                 }
             },
-            pending_codex_remove_account_id: None,
+            confirmed_codex_use_account_id,
+            confirmed_codex_remove_account_id,
+            confirmed_codex_reset_account_id,
+            hide_usage_emails: true,
             codex_login_lines: Vec::new(),
             codex_login_outcome: None,
             usage_fetch_attempted: false,
             usage_rx: None,
+            codex_reset_rx: None,
             codex_login_rx: None,
             codex_login_child: None,
             remote_stats: None,
@@ -394,6 +448,7 @@ impl App {
             minutely_sort_cache: RefCell::new(None),
         };
         app.build_model_shade_map();
+        app.maybe_fetch_usage_on_entry();
         Ok(app)
     }
 
@@ -512,6 +567,31 @@ impl App {
             }
         }
 
+        if let Some(ref rx) = self.codex_reset_rx {
+            match rx.try_recv() {
+                Ok(Ok(result)) => {
+                    self.codex_reset_rx = None;
+                    self.status_message = Some(format!(
+                        "Codex reset credit: {}",
+                        codex_reset_outcome_label(&result)
+                    ));
+                    self.status_message_time = Some(std::time::Instant::now());
+                    self.fetch_subscription_usage();
+                }
+                Ok(Err(error)) => {
+                    self.codex_reset_rx = None;
+                    self.status_message = Some(format!("Codex reset failed: {error}"));
+                    self.status_message_time = Some(std::time::Instant::now());
+                }
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                    self.codex_reset_rx = None;
+                    self.status_message = Some("Codex reset failed".into());
+                    self.status_message_time = Some(std::time::Instant::now());
+                }
+                Err(std::sync::mpsc::TryRecvError::Empty) => {}
+            }
+        }
+
         self.poll_remote_stats();
         self.maybe_refresh_remote_stats();
 
@@ -592,6 +672,15 @@ impl App {
 
         if self.dialog_stack.is_active() {
             self.dialog_stack.handle_key(key.code);
+            self.consume_confirmed_codex_account_action();
+            return false;
+        }
+
+        if key.code == KeyCode::Esc
+            && self.current_tab == Tab::Usage
+            && self.should_show_codex_login_panel()
+        {
+            self.dismiss_codex_login();
             return false;
         }
 
@@ -654,7 +743,13 @@ impl App {
                 self.cycle_theme();
             }
             KeyCode::Char('r') => {
-                self.refresh_usage();
+                if self.current_tab == Tab::Usage {
+                    self.refresh_usage();
+                } else if self.background_loading {
+                    self.set_status("Refresh already in progress");
+                } else {
+                    self.needs_reload = true;
+                }
             }
             KeyCode::Char('R') if key.modifiers.contains(KeyModifiers::SHIFT) => {
                 self.toggle_auto_refresh();
@@ -689,6 +784,15 @@ impl App {
             }
             KeyCode::Char('g') => {
                 self.open_group_by_picker();
+            }
+            KeyCode::Char('a') if self.current_tab == Tab::Usage => {
+                self.start_codex_login();
+            }
+            KeyCode::Char('m') if self.current_tab == Tab::Usage => {
+                self.toggle_usage_email_privacy();
+            }
+            KeyCode::Char('x') if self.current_tab == Tab::Usage => {
+                self.confirm_selected_codex_rate_limit_reset();
             }
             KeyCode::Char('u') if self.current_tab == Tab::Usage => {
                 self.refresh_usage();
@@ -738,9 +842,13 @@ impl App {
         if self.usage_rx.is_some() {
             self.set_status("Refresh already in progress");
         } else {
-            if !self.background_loading {
-                self.needs_reload = true;
-            }
+            self.fetch_subscription_usage();
+        }
+    }
+
+    pub(crate) fn maybe_fetch_usage_on_entry(&mut self) {
+        if self.current_tab == Tab::Usage && !self.usage_fetch_attempted && self.usage_rx.is_none()
+        {
             self.fetch_subscription_usage();
         }
     }
@@ -856,11 +964,21 @@ impl App {
             ClickAction::CodexDismissLogin => {
                 self.dismiss_codex_login();
             }
+            ClickAction::UsageSelect { index } => {
+                self.selected_index = index;
+                self.clamp_selection();
+            }
+            ClickAction::UsageToggleEmailPrivacy => {
+                self.toggle_usage_email_privacy();
+            }
             ClickAction::CodexUseAccount { account_id } => {
-                self.use_codex_account(&account_id);
+                self.confirm_codex_account_switch(&account_id);
             }
             ClickAction::CodexRemoveAccount { account_id } => {
-                self.remove_codex_account(&account_id);
+                self.confirm_codex_account_removal(&account_id);
+            }
+            ClickAction::CodexResetAccount { account_id } => {
+                self.confirm_codex_rate_limit_reset(&account_id);
             }
         }
     }
@@ -881,7 +999,6 @@ impl App {
             return;
         }
 
-        self.pending_codex_remove_account_id = None;
         self.codex_login_lines.clear();
         self.codex_login_outcome = None;
 
@@ -921,12 +1038,97 @@ impl App {
         }
     }
 
-    fn use_codex_account(&mut self, account_id: &str) {
-        self.pending_codex_remove_account_id = None;
+    fn confirm_codex_account_switch(&mut self, account_id: &str) {
+        if self.subscription_usage.iter().any(|usage| {
+            usage
+                .account
+                .as_ref()
+                .is_some_and(|account| account.id == account_id && account.is_active)
+        }) {
+            self.set_status("Codex account already active");
+            return;
+        }
 
+        let account_label = self.codex_account_label(account_id);
+        let dialog = ConfirmDialog::codex_switch(
+            account_id.to_string(),
+            account_label,
+            self.confirmed_codex_use_account_id.clone(),
+        );
+        self.dialog_stack.show(Box::new(dialog));
+        self.set_status("Confirm Codex account switch");
+    }
+
+    fn confirm_codex_account_removal(&mut self, account_id: &str) {
+        let account_label = self.codex_account_label(account_id);
+        let dialog = ConfirmDialog::codex_remove(
+            account_id.to_string(),
+            account_label,
+            self.confirmed_codex_remove_account_id.clone(),
+        );
+        self.dialog_stack.show(Box::new(dialog));
+        self.set_status("Confirm Codex account removal");
+    }
+
+    fn consume_confirmed_codex_account_action(&mut self) {
+        let account_id = self.confirmed_codex_use_account_id.borrow_mut().take();
+        if let Some(account_id) = account_id {
+            self.use_codex_account(&account_id);
+            return;
+        }
+
+        let account_id = self.confirmed_codex_remove_account_id.borrow_mut().take();
+        if let Some(account_id) = account_id {
+            self.remove_codex_account(&account_id);
+            return;
+        }
+
+        let account_id = self.confirmed_codex_reset_account_id.borrow_mut().take();
+        if let Some(account_id) = account_id {
+            self.reset_codex_rate_limits(&account_id);
+        }
+    }
+
+    fn codex_account_label(&self, account_id: &str) -> String {
+        self.subscription_usage
+            .iter()
+            .find_map(|usage| {
+                let account = usage.account.as_ref()?;
+                if account.id != account_id {
+                    return None;
+                }
+
+                let label = usage
+                    .account_display_name()
+                    .unwrap_or_else(|| account.display_name());
+                if self.hide_usage_emails && looks_like_email(&label) {
+                    Some(format!("Account {}", account.short_id()))
+                } else {
+                    Some(label)
+                }
+            })
+            .unwrap_or_else(|| short_account_id(account_id))
+    }
+
+    fn use_codex_account(&mut self, account_id: &str) {
         match crate::commands::usage::codex::switch_active_account(account_id) {
             Ok(info) => {
                 self.mark_active_codex_account(&info.id);
+                if let Some(index) = self.subscription_usage.iter().position(|usage| {
+                    usage
+                        .account
+                        .as_ref()
+                        .is_some_and(|account| account.id == info.id)
+                }) {
+                    self.selected_index = index;
+                    if self.selected_index < self.scroll_offset {
+                        self.scroll_offset = self.selected_index;
+                    } else if self.selected_index >= self.scroll_offset + self.max_visible_items {
+                        self.scroll_offset = self
+                            .selected_index
+                            .saturating_sub(self.max_visible_items.saturating_sub(1));
+                    }
+                }
                 self.persist_subscription_usage_cache();
                 let display = info.label.as_deref().unwrap_or(&info.id);
                 self.set_status(&format!("Active Codex account: {display}"));
@@ -937,25 +1139,121 @@ impl App {
         }
     }
 
-    fn remove_codex_account(&mut self, account_id: &str) {
-        if self.pending_codex_remove_account_id.as_deref() != Some(account_id) {
-            self.pending_codex_remove_account_id = Some(account_id.to_string());
-            self.set_status("Click Confirm to remove this Codex account");
+    fn toggle_usage_email_privacy(&mut self) {
+        self.hide_usage_emails = !self.hide_usage_emails;
+        if self.hide_usage_emails {
+            self.set_status("Usage emails hidden");
+        } else {
+            self.set_status("Usage emails shown");
+        }
+    }
+
+    fn confirm_selected_codex_rate_limit_reset(&mut self) {
+        let Some(output) = self.subscription_usage.get(self.selected_index) else {
+            self.set_status("No usage account selected");
+            return;
+        };
+
+        if output.provider != "Codex" {
+            self.set_status("Codex reset only supports Codex accounts");
             return;
         }
 
-        self.pending_codex_remove_account_id = None;
+        let Some(account_id) = output.account.as_ref().map(|account| account.id.clone()) else {
+            self.set_status("Select a saved Codex account to reset");
+            return;
+        };
+
+        self.confirm_codex_rate_limit_reset(&account_id);
+    }
+
+    fn confirm_codex_rate_limit_reset(&mut self, account_id: &str) {
+        if self.codex_reset_rx.is_some() {
+            self.set_status("Codex reset already in progress");
+            return;
+        }
+
+        let Some(output) = self.subscription_usage.iter().find(|usage| {
+            usage.provider == "Codex"
+                && usage
+                    .account
+                    .as_ref()
+                    .is_some_and(|account| account.id == account_id)
+        }) else {
+            self.set_status("Codex account not found");
+            return;
+        };
+
+        let available = output
+            .reset_credits
+            .as_ref()
+            .map(|credits| credits.available_count)
+            .unwrap_or(0);
+        if available == 0 {
+            self.set_status("No Codex reset credits available");
+            return;
+        }
+
+        let mut account_label = self.codex_account_label(account_id);
+        account_label.push_str(&format!(" - {available} reset"));
+        if available != 1 {
+            account_label.push('s');
+        }
+        if let Some(expiry) = output.reset_credits.as_ref().and_then(|credits| {
+            credits
+                .credits
+                .iter()
+                .find_map(|credit| credit.expires_at.as_ref())
+        }) {
+            account_label.push_str(&format!(
+                " - {}",
+                crate::commands::usage::helpers::format_reset_time(expiry)
+                    .replace("resets", "expires")
+            ));
+        }
+
+        let dialog = ConfirmDialog::codex_reset(
+            account_id.to_string(),
+            account_label,
+            self.confirmed_codex_reset_account_id.clone(),
+        );
+        self.dialog_stack.show(Box::new(dialog));
+        self.set_status("Confirm Codex reset credit use");
+    }
+
+    fn reset_codex_rate_limits(&mut self, account_id: &str) {
+        if self.codex_reset_rx.is_some() {
+            self.set_status("Codex reset already in progress");
+            return;
+        }
+
+        let account_id = account_id.to_string();
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.codex_reset_rx = Some(rx);
+        self.set_status("Resetting Codex limits...");
+        std::thread::spawn(move || {
+            let result =
+                crate::commands::usage::codex::consume_rate_limit_reset_credit(&account_id)
+                    .map_err(|error| error.to_string());
+            let _ = tx.send(result);
+        });
+    }
+
+    fn remove_codex_account(&mut self, account_id: &str) {
         match crate::commands::usage::codex::remove_account(account_id) {
             Ok(info) => {
                 self.subscription_usage.retain(|usage| {
                     usage.account.as_ref().map(|account| account.id.as_str())
                         != Some(info.id.as_str())
                 });
+                self.clamp_selection();
                 if let Some(active) = crate::commands::usage::codex::list_accounts()
                     .into_iter()
                     .find(|account| account.is_active)
                 {
                     self.mark_active_codex_account(&active.id);
+                } else {
+                    self.clear_active_codex_accounts();
                 }
                 self.persist_subscription_usage_cache();
                 let display = info.label.as_deref().unwrap_or(&info.id);
@@ -987,9 +1285,20 @@ impl App {
         }
     }
 
+    fn clear_active_codex_accounts(&mut self) {
+        for usage in &mut self.subscription_usage {
+            if usage.provider == "Codex" {
+                if let Some(account) = &mut usage.account {
+                    account.is_active = false;
+                }
+            }
+        }
+    }
+
     pub fn handle_mouse_event(&mut self, event: MouseEvent) {
         if self.dialog_stack.is_active() {
             self.dialog_stack.handle_mouse(event);
+            self.consume_confirmed_codex_account_action();
             return;
         }
 
@@ -1079,9 +1388,6 @@ impl App {
         self.persist_current_sort();
 
         self.current_tab = target;
-        if target != Tab::Usage {
-            self.pending_codex_remove_account_id = None;
-        }
         if target != Tab::Daily {
             self.selected_daily_detail_date = None;
         }
@@ -1093,6 +1399,8 @@ impl App {
             .unwrap_or_else(|| Self::default_sort_for_tab(target));
         self.sort_field = field;
         self.sort_direction = dir;
+
+        self.maybe_fetch_usage_on_entry();
     }
 
     fn default_sort_for_tab(tab: Tab) -> (SortField, SortDirection) {
@@ -3225,6 +3533,21 @@ mod tests {
         app.handle_key_event(key(KeyCode::Char('r')));
 
         assert!(!app.needs_reload);
+        assert!(!app.is_fetching_usage());
+        assert_eq!(
+            app.status_message.as_deref(),
+            Some("Refresh already in progress")
+        );
+    }
+
+    #[test]
+    fn test_handle_key_refresh_usage_tab_fetches_usage() {
+        let mut app = make_app();
+        app.current_tab = Tab::Usage;
+
+        app.handle_key_event(key(KeyCode::Char('r')));
+
+        assert!(!app.needs_reload);
         assert!(app.is_fetching_usage());
         assert_eq!(
             app.status_message.as_deref(),
@@ -3355,7 +3678,7 @@ mod tests {
     }
 
     #[test]
-    fn test_handle_mouse_click_codex_remove_requires_confirmation() {
+    fn test_handle_mouse_click_codex_remove_opens_confirmation_dialog() {
         let mut app = make_app();
         app.add_click_area(
             Rect::new(0, 0, 10, 2),
@@ -3372,13 +3695,10 @@ mod tests {
         };
         app.handle_mouse_event(event);
 
-        assert_eq!(
-            app.pending_codex_remove_account_id.as_deref(),
-            Some("acct_work")
-        );
+        assert!(app.dialog_stack.is_active());
         assert_eq!(
             app.status_message.as_deref(),
-            Some("Click Confirm to remove this Codex account")
+            Some("Confirm Codex account removal")
         );
     }
 

--- a/crates/tokscale-cli/src/tui/codex_login.rs
+++ b/crates/tokscale-cli/src/tui/codex_login.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Clone)]
+pub(crate) enum CodexLoginOutcome {
+    Imported(crate::commands::usage::codex::CodexAccountInfo),
+    Failed(String),
+}

--- a/crates/tokscale-cli/src/tui/mod.rs
+++ b/crates/tokscale-cli/src/tui/mod.rs
@@ -1,11 +1,13 @@
 mod app;
 mod cache;
 pub mod client_ui;
+pub(crate) mod codex_login;
 mod colors;
 pub mod config;
 pub mod data;
 mod event;
 mod export;
+pub(crate) mod privacy;
 pub mod remote;
 pub mod settings;
 mod themes;

--- a/crates/tokscale-cli/src/tui/privacy.rs
+++ b/crates/tokscale-cli/src/tui/privacy.rs
@@ -1,0 +1,4 @@
+pub(crate) fn looks_like_email(value: &str) -> bool {
+    let trimmed = value.trim();
+    trimmed.contains('@') && trimmed.split('@').count() == 2
+}

--- a/crates/tokscale-cli/src/tui/ui/dialog/confirm.rs
+++ b/crates/tokscale-cli/src/tui/ui/dialog/confirm.rs
@@ -1,0 +1,363 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crossterm::event::{KeyCode, MouseButton, MouseEvent, MouseEventKind};
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use crate::tui::themes::Theme;
+use crate::tui::ui::widgets::truncate_ellipsis as truncate;
+
+use super::{DialogContent, DialogResult};
+
+#[derive(Clone, Copy)]
+enum ConfirmTone {
+    Accent,
+    Warning,
+    Danger,
+}
+
+pub struct ConfirmDialog {
+    value: String,
+    title: &'static str,
+    message: &'static str,
+    target_label: String,
+    effect: &'static str,
+    confirm_label: &'static str,
+    confirm_verb: &'static str,
+    tone: ConfirmTone,
+    confirmed_value: Rc<RefCell<Option<String>>>,
+}
+
+struct ButtonLayout {
+    confirm: Option<Rect>,
+    cancel: Option<Rect>,
+}
+
+impl ConfirmDialog {
+    pub fn codex_switch(
+        account_id: String,
+        account_label: String,
+        confirmed_value: Rc<RefCell<Option<String>>>,
+    ) -> Self {
+        Self {
+            value: account_id,
+            title: " Switch Codex Account ",
+            message: "This will replace the active Codex auth.json account.",
+            target_label: account_label,
+            effect: "New Codex requests use this account",
+            confirm_label: "Confirm",
+            confirm_verb: "confirm",
+            tone: ConfirmTone::Accent,
+            confirmed_value,
+        }
+    }
+
+    pub fn codex_remove(
+        account_id: String,
+        account_label: String,
+        confirmed_value: Rc<RefCell<Option<String>>>,
+    ) -> Self {
+        Self {
+            value: account_id,
+            title: " Remove Codex Account ",
+            message: "This will remove the saved Codex account from Tokscale.",
+            target_label: account_label,
+            effect: "Saved account is deleted; codex CLI login is unchanged",
+            confirm_label: "Remove",
+            confirm_verb: "remove",
+            tone: ConfirmTone::Danger,
+            confirmed_value,
+        }
+    }
+
+    pub fn codex_reset(
+        account_id: String,
+        account_label: String,
+        confirmed_value: Rc<RefCell<Option<String>>>,
+    ) -> Self {
+        Self {
+            value: account_id,
+            title: " Reset Codex Limits ",
+            message: "This will consume one available Codex reset credit.",
+            target_label: account_label,
+            effect: "Codex rate-limit windows reset for this account",
+            confirm_label: "Reset",
+            confirm_verb: "reset",
+            tone: ConfirmTone::Warning,
+            confirmed_value,
+        }
+    }
+
+    fn confirm(&self) {
+        *self.confirmed_value.borrow_mut() = Some(self.value.clone());
+    }
+
+    fn tone_color(&self, theme: &Theme) -> Color {
+        match self.tone {
+            ConfirmTone::Accent => theme.accent,
+            ConfirmTone::Warning => Color::Yellow,
+            ConfirmTone::Danger => Color::Red,
+        }
+    }
+
+    fn confirm_button_style(&self, theme: &Theme) -> Style {
+        match self.tone {
+            ConfirmTone::Accent => Style::default().fg(theme.background).bg(theme.accent),
+            ConfirmTone::Warning => Style::default().fg(Color::Black).bg(Color::Yellow),
+            ConfirmTone::Danger => Style::default().fg(Color::Black).bg(Color::Red),
+        }
+        .add_modifier(Modifier::BOLD)
+    }
+
+    fn content_area(area: Rect) -> Rect {
+        Rect::new(
+            area.x.saturating_add(1),
+            area.y.saturating_add(1),
+            area.width.saturating_sub(2),
+            area.height.saturating_sub(2),
+        )
+    }
+
+    fn button_y(inner: Rect) -> Option<u16> {
+        match inner.height {
+            0..=4 => None,
+            5 => Some(inner.y.saturating_add(4)),
+            _ => Some(inner.y.saturating_add(inner.height.saturating_sub(2))),
+        }
+    }
+
+    fn button_layout(&self, inner: Rect) -> ButtonLayout {
+        let Some(y) = Self::button_y(inner) else {
+            return ButtonLayout {
+                confirm: None,
+                cancel: None,
+            };
+        };
+
+        let confirm_width = self.confirm_button().chars().count() as u16;
+        if inner.width < confirm_width {
+            return ButtonLayout {
+                confirm: None,
+                cancel: None,
+            };
+        }
+
+        let cancel_width = 10u16;
+        let gap = 2u16;
+        let total = confirm_width
+            .saturating_add(gap)
+            .saturating_add(cancel_width);
+        if inner.width >= total {
+            let x = inner.x + inner.width.saturating_sub(total) / 2;
+            return ButtonLayout {
+                confirm: Some(Rect::new(x, y, confirm_width, 1)),
+                cancel: Some(Rect::new(x + confirm_width + gap, y, cancel_width, 1)),
+            };
+        }
+
+        let x = inner.x + inner.width.saturating_sub(confirm_width) / 2;
+        ButtonLayout {
+            confirm: Some(Rect::new(x, y, confirm_width, 1)),
+            cancel: None,
+        }
+    }
+
+    fn confirm_button(&self) -> String {
+        format!("[ {} ]", self.confirm_label)
+    }
+
+    fn button_line(
+        &self,
+        layout: &ButtonLayout,
+        inner: Rect,
+        theme: &Theme,
+    ) -> Option<Line<'static>> {
+        let confirm = layout.confirm?;
+        let mut spans = vec![
+            Span::raw(" ".repeat(confirm.x.saturating_sub(inner.x) as usize)),
+            Span::styled(self.confirm_button(), self.confirm_button_style(theme)),
+        ];
+        if let Some(cancel) = layout.cancel {
+            spans.push(Span::raw(
+                " ".repeat(cancel.x.saturating_sub(confirm.right()) as usize),
+            ));
+            spans.push(Span::styled("[ Cancel ]", Style::default().fg(theme.muted)));
+        }
+        Some(Line::from(spans))
+    }
+
+    fn contains(rect: Rect, column: u16, row: u16) -> bool {
+        column >= rect.x
+            && column < rect.x.saturating_add(rect.width)
+            && row >= rect.y
+            && row < rect.y.saturating_add(rect.height)
+    }
+}
+
+impl DialogContent for ConfirmDialog {
+    fn desired_size(&self, viewport: Rect) -> (u16, u16) {
+        (
+            68u16.min(viewport.width.saturating_sub(4)),
+            10u16.min(viewport.height.saturating_sub(4)),
+        )
+    }
+
+    fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let tone = self.tone_color(theme);
+        let block = Block::default()
+            .title(self.title)
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(tone));
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        if inner.width == 0 || inner.height == 0 {
+            return;
+        }
+
+        let mut lines = vec![
+            Line::from(Span::styled(
+                self.message,
+                Style::default().fg(theme.foreground),
+            )),
+            Line::from(""),
+            labeled_line(
+                "Target",
+                &self.target_label,
+                Style::default().fg(tone).add_modifier(Modifier::BOLD),
+                inner.width,
+                theme,
+            ),
+            labeled_line(
+                "Effect",
+                self.effect,
+                theme.secondary_text_style(),
+                inner.width,
+                theme,
+            ),
+        ];
+
+        let layout = self.button_layout(inner);
+        if let Some(button_line) = self.button_line(&layout, inner, theme) {
+            let button_row = layout
+                .confirm
+                .map(|rect| rect.y.saturating_sub(inner.y) as usize)
+                .unwrap_or(lines.len());
+            while lines.len() < button_row {
+                lines.push(Line::from(""));
+            }
+            lines.push(button_line);
+        }
+
+        let hint = Line::from(Span::styled(
+            format!("Enter/y {} - n/Esc cancel", self.confirm_verb),
+            Style::default().fg(theme.muted),
+        ))
+        .centered();
+        if lines.len() < inner.height as usize {
+            lines.push(hint);
+        }
+
+        frame.render_widget(Paragraph::new(lines), inner);
+    }
+
+    fn handle_key(&mut self, key: KeyCode) -> DialogResult {
+        match key {
+            KeyCode::Enter | KeyCode::Char('y') | KeyCode::Char('Y') => {
+                self.confirm();
+                DialogResult::Close
+            }
+            KeyCode::Char('n') | KeyCode::Char('N') => DialogResult::Close,
+            _ => DialogResult::None,
+        }
+    }
+
+    fn handle_mouse(&mut self, event: MouseEvent, area: Rect) -> DialogResult {
+        if !matches!(event.kind, MouseEventKind::Down(MouseButton::Left)) {
+            return DialogResult::None;
+        }
+
+        let layout = self.button_layout(Self::content_area(area));
+        if layout
+            .confirm
+            .is_some_and(|rect| Self::contains(rect, event.column, event.row))
+        {
+            self.confirm();
+            DialogResult::Close
+        } else if layout
+            .cancel
+            .is_some_and(|rect| Self::contains(rect, event.column, event.row))
+        {
+            DialogResult::Close
+        } else {
+            DialogResult::None
+        }
+    }
+}
+
+fn labeled_line(
+    label: &'static str,
+    value: &str,
+    value_style: Style,
+    width: u16,
+    theme: &Theme,
+) -> Line<'static> {
+    let width = width as usize;
+    let label_text = format!("{label:<8}");
+    let label_width = label_text.chars().count();
+    if width <= label_width {
+        return Line::from(Span::styled(
+            truncate(&label_text, width),
+            Style::default().fg(theme.muted),
+        ));
+    }
+
+    Line::from(vec![
+        Span::styled(label_text, Style::default().fg(theme.muted)),
+        Span::styled(truncate(value, width - label_width), value_style),
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::themes::ThemeName;
+    use ratatui::{backend::TestBackend, Terminal};
+
+    fn render_dialog(width: u16, height: u16) -> String {
+        let confirmed = Rc::new(RefCell::new(None));
+        let dialog = ConfirmDialog::codex_switch(
+            "acct_123".to_string(),
+            "very-long-account-label".to_string(),
+            confirmed,
+        );
+        let theme = Theme::from_name_for_current_terminal(ThemeName::Blue);
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| dialog.render(frame, Rect::new(0, 0, width, height), &theme))
+            .unwrap();
+
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .chunks(width as usize)
+            .map(|row| {
+                row.iter()
+                    .map(|cell| cell.symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn narrow_confirm_dialog_does_not_render_orphan_ellipsis_for_zero_target_width() {
+        let body = render_dialog(10, 8);
+
+        assert!(body.contains("Target"), "{body}");
+        assert!(!body.contains("..."), "{body}");
+    }
+}

--- a/crates/tokscale-cli/src/tui/ui/dialog/mod.rs
+++ b/crates/tokscale-cli/src/tui/ui/dialog/mod.rs
@@ -1,3 +1,4 @@
+pub mod confirm;
 pub mod group_by_picker;
 pub mod overlay;
 pub mod source_picker;
@@ -8,6 +9,7 @@ use ratatui::{layout::Rect, Frame};
 
 use crate::tui::themes::Theme;
 
+pub use confirm::ConfirmDialog;
 pub use group_by_picker::GroupByPickerDialog;
 pub use source_picker::ClientPickerDialog;
 pub use stack::DialogStack;

--- a/crates/tokscale-cli/src/tui/ui/usage.rs
+++ b/crates/tokscale-cli/src/tui/ui/usage.rs
@@ -1,47 +1,140 @@
+use ratatui::layout::Flex;
 use ratatui::prelude::*;
-use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::widgets::{Block, Borders, Cell, HighlightSpacing, Paragraph, Row, Table, TableState};
 
 use crate::commands::usage::{helpers, UsageMetric, UsageOutput};
-use crate::tui::app::{App, ClickAction, CodexLoginOutcome};
-
-const BAR_WIDTH: usize = 20;
+use crate::tui::app::{App, ClickAction};
+use crate::tui::codex_login::CodexLoginOutcome;
+use crate::tui::privacy::looks_like_email;
+use crate::tui::ui::widgets::{
+    get_provider_shade, light_ratio_bar_spans, truncate_ellipsis as truncate_string,
+};
 
 struct ButtonSpec {
-    label: &'static str,
-    style: Style,
+    label: String,
+    kind: ButtonKind,
     action: ClickAction,
+}
+
+#[derive(Clone, Copy)]
+enum ButtonKind {
+    Primary,
+    Secondary,
+    Warning,
+    Danger,
+    Disabled,
+}
+
+struct UsageProviderGroup<'a> {
+    provider: &'a str,
+    outputs: Vec<(usize, &'a UsageOutput)>,
+}
+
+struct UsageInventory {
+    providers: usize,
+    saved: usize,
+    managed: usize,
+}
+
+struct UsageRowView<'a> {
+    account: String,
+    account_summary: String,
+    plan: String,
+    limit: String,
+    reset: String,
+    readiness: UsageReadiness,
+    metric: Option<&'a UsageMetric>,
 }
 
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(app.theme.border))
-        .title(" Subscription Usage ")
-        .title_style(Style::default().fg(app.theme.foreground))
+        .title(Span::styled(
+            " Usage ",
+            Style::default()
+                .fg(app.theme.accent)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .title_top(
+            Line::from(Span::styled(
+                status_label(app),
+                app.theme.subtle_text_style(),
+            ))
+            .right_aligned(),
+        )
         .style(Style::default().bg(app.theme.background));
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+
     let content = render_action_bar(frame, app, inner);
     let content = render_codex_login_panel(frame, app, content);
 
-    if app.subscription_usage.is_empty() {
+    let outputs = app.subscription_usage.clone();
+    if outputs.is_empty() {
         if app.is_fetching_usage() {
             render_fetching(frame, app, content);
         } else if app.usage_fetch_attempted {
             render_empty(frame, app, content);
         } else {
-            render_loading(frame, app, content);
+            render_ready(frame, app, content);
         }
-    } else if app.subscription_usage.iter().all(|o| o.metrics.is_empty()) {
-        render_empty(frame, app, content);
     } else {
-        // Take the outputs out so render_loaded can borrow `app` mutably for
-        // click-area registration without cloning every frame.
-        let outputs = std::mem::take(&mut app.subscription_usage);
         render_loaded(frame, app, content, &outputs);
-        app.subscription_usage = outputs;
+    }
+}
+
+fn status_label(app: &App) -> String {
+    if app.is_fetching_usage() {
+        return "Syncing usage".to_string();
+    }
+    if app.is_codex_login_running() {
+        return "Codex login".to_string();
+    }
+
+    let inventory = usage_inventory(&app.subscription_usage);
+
+    if inventory.providers == 0 && app.usage_fetch_attempted {
+        "No data".to_string()
+    } else if inventory.providers == 0 {
+        "Not loaded".to_string()
+    } else {
+        format!(
+            "{} providers · {}",
+            inventory.providers,
+            identity_count_label(inventory.saved, inventory.managed)
+        )
+    }
+}
+
+fn usage_inventory(outputs: &[UsageOutput]) -> UsageInventory {
+    let providers = outputs
+        .iter()
+        .map(|output| output.provider.as_str())
+        .collect::<std::collections::BTreeSet<_>>()
+        .len();
+    let saved = outputs
+        .iter()
+        .filter(|output| output.account.is_some())
+        .count();
+    UsageInventory {
+        providers,
+        saved,
+        managed: outputs.len().saturating_sub(saved),
+    }
+}
+
+fn identity_count_label(saved: usize, managed: usize) -> String {
+    match (saved, managed) {
+        (0, 0) => "0 saved".to_string(),
+        (saved, 0) => format!("{saved} saved"),
+        (0, managed) => format!("{managed} managed"),
+        (saved, managed) => format!("{saved} saved · {managed} managed"),
     }
 }
 
@@ -49,56 +142,69 @@ fn render_action_bar(frame: &mut Frame, app: &mut App, area: Rect) -> Rect {
     if area.height == 0 {
         return area;
     }
+    let compact = area.width < 48;
+    let show_prefix = area.width >= 36;
 
     let refresh_label = if app.is_fetching_usage() {
-        "Refreshing"
+        if compact { "r Sync" } else { "r Syncing" }.to_string()
     } else {
-        "Refresh"
+        "r Refresh".to_string()
     };
     let refresh_style = if app.is_fetching_usage() {
-        Style::default().fg(app.theme.muted)
+        ButtonKind::Disabled
     } else {
-        Style::default()
-            .fg(app.theme.accent)
-            .add_modifier(Modifier::BOLD)
+        ButtonKind::Primary
     };
 
     let add_label = if app.is_codex_login_running() {
-        "Adding Codex"
+        if compact {
+            "a Adding"
+        } else {
+            "a Adding Codex"
+        }
+        .to_string()
     } else {
-        "Add Codex"
+        if compact { "a Add" } else { "a Add Codex" }.to_string()
     };
     let add_style = if app.is_codex_login_running() {
-        Style::default().fg(app.theme.muted)
+        ButtonKind::Disabled
     } else {
-        Style::default().fg(app.theme.accent)
+        ButtonKind::Secondary
     };
 
-    let buttons = vec![
+    let mut buttons = vec![
         ButtonSpec {
             label: refresh_label,
-            style: refresh_style,
+            kind: refresh_style,
             action: ClickAction::UsageRefresh,
         },
         ButtonSpec {
             label: add_label,
-            style: add_style,
+            kind: add_style,
             action: ClickAction::CodexStartLogin,
         },
     ];
+    if !app.subscription_usage.is_empty() {
+        buttons.push(ButtonSpec {
+            label: if app.hide_usage_emails {
+                if compact { "m Show" } else { "m Show Emails" }.to_string()
+            } else {
+                if compact { "m Hide" } else { "m Hide Emails" }.to_string()
+            },
+            kind: ButtonKind::Secondary,
+            action: ClickAction::UsageToggleEmailPrivacy,
+        });
+    }
+    if let Some(button) = selected_reset_action_button(app) {
+        buttons.push(button);
+    }
 
-    let mut spans = vec![Span::raw(" ")];
-    let right_edge = area.x.saturating_add(area.width);
-    let bottom_edge = area.y.saturating_add(area.height);
-    push_click_buttons(
-        &mut spans,
-        app,
-        buttons,
-        area.x.saturating_add(1),
-        area.y,
-        right_edge,
-        bottom_edge,
-    );
+    let mut spans = Vec::new();
+    if show_prefix {
+        spans.push(Span::styled(" Actions ", app.theme.subtle_text_style()));
+    }
+    let start_x = area.x + Line::from(spans.clone()).width() as u16;
+    push_click_buttons(&mut spans, app, buttons, start_x, area.y, area.right());
 
     frame.render_widget(
         Paragraph::new(Line::from(spans)),
@@ -112,16 +218,18 @@ fn render_action_bar(frame: &mut Frame, app: &mut App, area: Rect) -> Rect {
     }
 }
 
-fn button_render_width(label: &str) -> usize {
-    label.chars().count() + 2
-}
+fn selected_reset_action_button(app: &App) -> Option<ButtonSpec> {
+    let output = app.subscription_usage.get(app.selected_index)?;
+    if !has_available_reset_credit(output) {
+        return None;
+    }
 
-fn click_buttons_width(buttons: &[ButtonSpec]) -> usize {
-    buttons
-        .iter()
-        .enumerate()
-        .map(|(index, button)| button_render_width(button.label) + usize::from(index > 0))
-        .sum()
+    let account_id = output.account.as_ref()?.id.clone();
+    Some(ButtonSpec {
+        label: "x Reset".to_string(),
+        kind: ButtonKind::Warning,
+        action: ClickAction::CodexResetAccount { account_id },
+    })
 }
 
 fn push_click_buttons(
@@ -131,25 +239,54 @@ fn push_click_buttons(
     start_x: u16,
     y: u16,
     right_edge: u16,
-    bottom_edge: u16,
 ) {
     let mut x = start_x;
     for (index, button) in buttons.into_iter().enumerate() {
+        let rendered = button_label(&button.label);
+        let width = Line::from(rendered.as_str()).width() as u16;
+        let separator_width = u16::from(index > 0);
+        if x.saturating_add(separator_width).saturating_add(width) > right_edge {
+            break;
+        }
+
         if index > 0 {
             spans.push(Span::raw(" "));
             x = x.saturating_add(1);
         }
 
-        let rendered = format!("[{}]", button.label);
-        let width = rendered.chars().count() as u16;
-        spans.push(Span::styled(rendered, button.style));
+        spans.push(Span::styled(
+            rendered,
+            button_style(app, button.kind, false),
+        ));
 
-        // Rows past the panel bottom are clipped by the renderer, so a click
-        // area there would be an invisible button hovering over the footer.
-        if x < right_edge && y < bottom_edge {
+        if x < right_edge {
             app.add_click_area(Rect::new(x, y, width.min(right_edge - x), 1), button.action);
         }
         x = x.saturating_add(width);
+    }
+}
+
+fn button_label(label: &str) -> String {
+    format!(" {label} ")
+}
+
+fn button_style(app: &App, kind: ButtonKind, selected: bool) -> Style {
+    if selected {
+        return Style::default()
+            .fg(Color::White)
+            .bg(Color::Blue)
+            .add_modifier(Modifier::BOLD);
+    }
+
+    match kind {
+        ButtonKind::Primary => Style::default()
+            .fg(app.theme.background)
+            .bg(app.theme.accent)
+            .add_modifier(Modifier::BOLD),
+        ButtonKind::Secondary => Style::default().fg(app.theme.accent).bg(app.theme.border),
+        ButtonKind::Warning => Style::default().fg(Color::Black).bg(Color::Yellow),
+        ButtonKind::Danger => Style::default().fg(Color::Red).bg(app.theme.border),
+        ButtonKind::Disabled => Style::default().fg(app.theme.muted).bg(app.theme.border),
     }
 }
 
@@ -158,7 +295,7 @@ fn render_codex_login_panel(frame: &mut Frame, app: &mut App, area: Rect) -> Rec
         return area;
     }
 
-    let max_output_lines = 5usize;
+    let max_output_lines = 4usize;
     let output_start = app.codex_login_lines.len().saturating_sub(max_output_lines);
     let output_lines: Vec<String> = app.codex_login_lines[output_start..].to_vec();
     let height = (2 + output_lines.len() as u16 + u16::from(app.codex_login_outcome.is_some()))
@@ -177,30 +314,34 @@ fn render_codex_login_panel(frame: &mut Frame, app: &mut App, area: Rect) -> Rec
 
     let mut header_spans = vec![
         Span::styled(
-            " Codex login ",
+            " Codex Login ",
             Style::default()
                 .fg(app.theme.foreground)
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled(status, Style::default().fg(app.theme.muted)),
+        Span::styled(status.to_string(), app.theme.subtle_text_style()),
     ];
-    if app.codex_login_outcome.is_some() {
-        let dismiss = "[Dismiss]";
-        let used_width = 14usize + status.chars().count();
-        let dismiss_width = dismiss.chars().count();
-        let dismiss_click_width = (dismiss_width as u16).min(area.width);
-        let padding = (area.width as usize).saturating_sub(used_width + dismiss_width);
+    if app.is_codex_login_running() || app.codex_login_outcome.is_some() {
+        let action_label = if app.is_codex_login_running() {
+            "[Cancel]"
+        } else {
+            "[Dismiss]"
+        };
+        let action_width = action_label.chars().count() as u16;
+        let used_width = Line::from(header_spans.clone()).width();
+        let padding = (area.width as usize).saturating_sub(used_width + action_width as usize);
         header_spans.push(Span::raw(" ".repeat(padding)));
-        header_spans.push(Span::styled(dismiss, Style::default().fg(app.theme.accent)));
+        header_spans.push(Span::styled(
+            action_label,
+            Style::default().fg(app.theme.accent),
+        ));
         let x = area
             .x
-            .saturating_add(area.width.saturating_sub(dismiss_click_width));
-        if dismiss_click_width > 0 {
-            app.add_click_area(
-                Rect::new(x, area.y, dismiss_click_width, 1),
-                ClickAction::CodexDismissLogin,
-            );
-        }
+            .saturating_add(area.width.saturating_sub(action_width));
+        app.add_click_area(
+            Rect::new(x, area.y, action_width.min(area.width), 1),
+            ClickAction::CodexDismissLogin,
+        );
     }
     lines.push(Line::from(header_spans));
 
@@ -212,7 +353,10 @@ fn render_codex_login_panel(frame: &mut Frame, app: &mut App, area: Rect) -> Rec
     } else {
         for line in output_lines {
             lines.push(Line::from(Span::styled(
-                format!("  {line}"),
+                format!(
+                    "  {}",
+                    truncate_string(&line, area.width.saturating_sub(4) as usize)
+                ),
                 Style::default().fg(app.theme.muted),
             )));
         }
@@ -231,7 +375,10 @@ fn render_codex_login_panel(frame: &mut Frame, app: &mut App, area: Rect) -> Rec
                 (format!("  {error}"), Style::default().fg(Color::Red))
             }
         };
-        lines.push(Line::from(Span::styled(label, style)));
+        lines.push(Line::from(Span::styled(
+            truncate_string(&label, area.width as usize),
+            style,
+        )));
     }
 
     frame.render_widget(
@@ -247,120 +394,1376 @@ fn render_codex_login_panel(frame: &mut Frame, app: &mut App, area: Rect) -> Rec
 }
 
 fn render_fetching(frame: &mut Frame, app: &App, area: Rect) {
-    let center = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Percentage(40),
-            Constraint::Length(3),
-            Constraint::Percentage(40),
-        ])
-        .split(area)[1];
-
+    let center = centered_rect(area, 3);
     let spin = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'][app.spinner_frame % 10];
-    let paragraph = Paragraph::new(format!("{spin} Fetching subscription data..."))
+    let message = if area.width < 40 {
+        format!("{spin} Fetching usage...")
+    } else {
+        format!("{spin} Fetching subscription data...")
+    };
+    let paragraph = Paragraph::new(message)
         .style(Style::default().fg(app.theme.muted))
         .alignment(Alignment::Center);
     frame.render_widget(paragraph, center);
 }
 
-fn render_loading(frame: &mut Frame, app: &App, area: Rect) {
-    let center = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Percentage(40),
-            Constraint::Length(3),
-            Constraint::Percentage(40),
-        ])
-        .split(area)[1];
-
-    let msg = if app.data.loading {
-        "Loading subscription data..."
+fn render_ready(frame: &mut Frame, app: &App, area: Rect) {
+    let center = centered_rect(area, 4);
+    let lines = if area.width < 40 {
+        vec![Line::from(Span::styled(
+            "No usage data",
+            Style::default()
+                .fg(app.theme.foreground)
+                .add_modifier(Modifier::BOLD),
+        ))]
     } else {
-        "Use Refresh to fetch subscription usage"
+        vec![
+            Line::from(Span::styled(
+                "No subscription data loaded",
+                Style::default()
+                    .fg(app.theme.foreground)
+                    .add_modifier(Modifier::BOLD),
+            )),
+            Line::from(Span::styled(
+                "Use Refresh to sync provider usage, or Add Codex to save another account.",
+                Style::default().fg(app.theme.muted),
+            )),
+        ]
     };
-    let paragraph = Paragraph::new(msg)
-        .style(Style::default().fg(app.theme.muted))
-        .alignment(Alignment::Center);
+    let paragraph = Paragraph::new(lines).alignment(Alignment::Center);
     frame.render_widget(paragraph, center);
 }
 
 fn render_empty(frame: &mut Frame, app: &App, area: Rect) {
-    let center = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Percentage(40),
-            Constraint::Length(3),
-            Constraint::Percentage(40),
-        ])
-        .split(area)[1];
-
-    let paragraph = Paragraph::new("No subscription data available")
+    let center = centered_rect(area, 3);
+    let message = if area.width < 40 {
+        "No usage data"
+    } else {
+        "No subscription data available"
+    };
+    let paragraph = Paragraph::new(message)
         .style(Style::default().fg(app.theme.muted))
         .alignment(Alignment::Center);
     frame.render_widget(paragraph, center);
 }
 
+fn centered_rect(area: Rect, height: u16) -> Rect {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage(40),
+            Constraint::Length(height.min(area.height)),
+            Constraint::Percentage(40),
+        ])
+        .split(area);
+    chunks[1]
+}
+
 fn render_loaded(frame: &mut Frame, app: &mut App, area: Rect, outputs: &[UsageOutput]) {
-    let mut lines: Vec<Line> = Vec::new();
-    let groups = group_outputs_by_provider(outputs);
+    app.selected_index = app.selected_index.min(outputs.len().saturating_sub(1));
 
-    for (group_index, group) in groups.iter().enumerate() {
-        if group_index > 0 {
-            lines.push(Line::from(""));
-        }
+    if area.width < 104 || area.height < 20 {
+        render_compact_loaded(frame, app, area, outputs);
+        return;
+    }
 
-        let account_group = group.outputs.iter().any(|output| output.account.is_some());
+    if area.width < 132 {
+        render_medium_loaded(frame, app, area, outputs);
+        return;
+    }
 
-        if account_group {
-            push_provider_header(&mut lines, app, group.provider);
+    let top_height = if area.height >= 36 {
+        19
+    } else if area.height >= 31 {
+        17
+    } else {
+        (area.height / 2).clamp(9, 13)
+    };
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(top_height), Constraint::Min(0)])
+        .split(area);
 
-            for (output_index, output) in group.outputs.iter().enumerate() {
-                if output_index > 0 {
-                    lines.push(Line::from(""));
-                }
-                push_account_header(&mut lines, app, output, area);
-                push_output_details(
-                    &mut lines,
-                    app,
-                    output,
-                    "   ",
-                    "Email",
-                    account_header_uses_email(output),
-                );
-            }
+    let (summary_width, detail_width) = usage_top_column_percentages(area.width);
+    let top = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(summary_width),
+            Constraint::Percentage(detail_width),
+        ])
+        .split(chunks[0]);
+
+    render_usage_status(frame, app, top[0], outputs);
+    let selected_index = app.selected_index;
+    render_selected_account(frame, app, top[1], &outputs[selected_index], outputs);
+    render_accounts_table(frame, app, chunks[1], outputs);
+}
+
+fn render_medium_loaded(frame: &mut Frame, app: &mut App, area: Rect, outputs: &[UsageOutput]) {
+    let summary_height = if area.height >= 36 { 8 } else { 6 }.min(area.height);
+    let selected_height =
+        if area.height >= 36 { 11 } else { 9 }.min(area.height.saturating_sub(summary_height));
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(summary_height),
+            Constraint::Length(selected_height),
+            Constraint::Min(0),
+        ])
+        .split(area);
+
+    render_usage_status(frame, app, chunks[0], outputs);
+    let selected_index = app.selected_index;
+    render_selected_account(frame, app, chunks[1], &outputs[selected_index], outputs);
+    render_accounts_table(frame, app, chunks[2], outputs);
+}
+
+fn usage_top_column_percentages(width: u16) -> (u16, u16) {
+    if width >= 128 {
+        (50, 50)
+    } else {
+        (48, 52)
+    }
+}
+
+fn render_compact_loaded(frame: &mut Frame, app: &mut App, area: Rect, outputs: &[UsageOutput]) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(7.min(area.height))])
+        .split(area);
+    render_accounts_table(frame, app, chunks[0], outputs);
+    if chunks.len() > 1 && chunks[1].height > 0 {
+        let selected_index = app.selected_index;
+        render_selected_account(frame, app, chunks[1], &outputs[selected_index], outputs);
+    }
+}
+
+fn render_usage_status(frame: &mut Frame, app: &mut App, area: Rect, outputs: &[UsageOutput]) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(app.theme.border))
+        .title(Span::styled(
+            " Usage Summary ",
+            Style::default()
+                .fg(app.theme.accent)
+                .add_modifier(Modifier::BOLD),
+        ));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+
+    let mut lines =
+        usage_status_summary_lines(app, outputs, inner.width as usize, inner.height as usize);
+
+    push_section_spacing(&mut lines, inner.height as usize);
+    append_credit_bank_summary_lines(
+        &mut lines,
+        app,
+        outputs,
+        inner.width as usize,
+        inner.height as usize,
+    );
+
+    let attention_outputs = attention_outputs(outputs);
+    push_section_spacing(&mut lines, inner.height as usize);
+    if lines.len() + 1 < inner.height as usize {
+        lines.push(section_heading("Attention", app));
+        if attention_outputs.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "  No accounts need attention",
+                app.theme.subtle_text_style(),
+            )));
         } else {
-            for (output_index, output) in group.outputs.iter().enumerate() {
-                if output_index > 0 {
-                    lines.push(Line::from(""));
-                }
-                push_provider_header(&mut lines, app, &output.display_name());
-                push_output_details(&mut lines, app, output, " ", "Account", false);
+            let available = (inner.height as usize).saturating_sub(lines.len());
+            let mut visible_count = attention_outputs.len().min(available.min(2));
+            if attention_outputs.len() > visible_count && visible_count == available {
+                visible_count = visible_count.saturating_sub(1);
+            }
+
+            for (index, output) in attention_outputs.iter().take(visible_count).copied() {
+                let y = inner.y.saturating_add(lines.len() as u16);
+                app.add_click_area(
+                    Rect::new(inner.x, y, inner.width, 1),
+                    ClickAction::UsageSelect { index },
+                );
+                lines.push(attention_line(app, output, inner.width as usize));
+            }
+
+            let hidden_count = attention_outputs.len().saturating_sub(visible_count);
+            if hidden_count > 0 && lines.len() < inner.height as usize {
+                lines.push(attention_more_line(hidden_count, inner.width as usize));
             }
         }
     }
 
-    let paragraph = Paragraph::new(lines);
-    frame.render_widget(paragraph, area);
+    push_section_spacing(&mut lines, inner.height as usize);
+    append_provider_summary_lines(
+        &mut lines,
+        app,
+        outputs,
+        inner.width as usize,
+        inner.height as usize,
+    );
+
+    frame.render_widget(Paragraph::new(lines), inner);
 }
 
-struct UsageProviderGroup<'a> {
-    provider: &'a str,
-    outputs: Vec<&'a UsageOutput>,
+fn usage_status_summary_lines(
+    app: &App,
+    outputs: &[UsageOutput],
+    width: usize,
+    height: usize,
+) -> Vec<Line<'static>> {
+    let ready_count = outputs
+        .iter()
+        .filter(|output| readiness_status(output) == UsageReadiness::Ready)
+        .count();
+    let watch_count = outputs
+        .iter()
+        .filter(|output| readiness_status(output) == UsageReadiness::Watch)
+        .count();
+    let critical_count = outputs
+        .iter()
+        .filter(|output| readiness_status(output) == UsageReadiness::Critical)
+        .count();
+    let unknown_count = outputs
+        .iter()
+        .filter(|output| readiness_status(output) == UsageReadiness::Unknown)
+        .count();
+
+    let overall = overall_readiness(outputs);
+    let active = active_output(outputs)
+        .map(|output| account_name(app, output))
+        .unwrap_or_else(|| "No active account".to_string());
+    let fallback = best_fallback_output(outputs)
+        .map(|output| {
+            let score = output_score(output);
+            if score > 0.0 {
+                format!("{} · {:.0}% left", account_name(app, output), score)
+            } else {
+                account_name(app, output)
+            }
+        })
+        .unwrap_or_else(|| "No ready fallback".to_string());
+    let next_reset = next_reset_label(app, outputs).unwrap_or_else(|| "No reset data".to_string());
+    let action = overall_action(app, outputs);
+    let capacity = format!(
+        "{ready_count} ready · {watch_count} watch · {critical_count} critical{}",
+        if unknown_count > 0 {
+            format!(" · {unknown_count} unknown")
+        } else {
+            String::new()
+        }
+    );
+
+    let mut lines = Vec::new();
+    let push_state = |lines: &mut Vec<Line<'static>>| {
+        push_kv_styled(
+            lines,
+            app,
+            "State",
+            overall_state_label(outputs),
+            Style::default()
+                .fg(readiness_color(app, overall))
+                .add_modifier(Modifier::BOLD),
+            width,
+        );
+    };
+    let push_active = |lines: &mut Vec<Line<'static>>| {
+        push_kv_styled(
+            lines,
+            app,
+            "Active",
+            &active,
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+            width,
+        );
+    };
+    let push_capacity = |lines: &mut Vec<Line<'static>>| {
+        push_kv_styled(
+            lines,
+            app,
+            "Capacity",
+            &capacity,
+            app.theme.secondary_text_style(),
+            width,
+        );
+    };
+    let push_fallback = |lines: &mut Vec<Line<'static>>| {
+        push_kv_styled(
+            lines,
+            app,
+            "Fallback",
+            &fallback,
+            app.theme.secondary_text_style(),
+            width,
+        );
+    };
+    let push_next_reset = |lines: &mut Vec<Line<'static>>| {
+        push_kv_styled(
+            lines,
+            app,
+            "Next Reset",
+            &next_reset,
+            app.theme.secondary_text_style(),
+            width,
+        );
+    };
+    let push_action = |lines: &mut Vec<Line<'static>>| {
+        push_kv_styled(
+            lines,
+            app,
+            "Action",
+            &action,
+            Style::default()
+                .fg(readiness_color(app, overall))
+                .add_modifier(Modifier::BOLD),
+            width,
+        );
+    };
+
+    match height {
+        0 => {}
+        1 => push_state(&mut lines),
+        2 => {
+            push_state(&mut lines);
+            push_action(&mut lines);
+        }
+        3 => {
+            push_state(&mut lines);
+            push_active(&mut lines);
+            push_action(&mut lines);
+        }
+        4 => {
+            push_state(&mut lines);
+            push_active(&mut lines);
+            push_capacity(&mut lines);
+            push_action(&mut lines);
+        }
+        5 => {
+            push_state(&mut lines);
+            push_active(&mut lines);
+            push_capacity(&mut lines);
+            push_next_reset(&mut lines);
+            push_action(&mut lines);
+        }
+        _ => {
+            push_state(&mut lines);
+            push_active(&mut lines);
+            push_capacity(&mut lines);
+            push_fallback(&mut lines);
+            push_next_reset(&mut lines);
+            push_action(&mut lines);
+        }
+    }
+    lines
+}
+
+fn push_section_spacing(lines: &mut Vec<Line<'static>>, max_lines: usize) {
+    if !lines.is_empty() && lines.len().saturating_add(1) < max_lines {
+        lines.push(Line::from(""));
+    }
+}
+
+fn append_provider_summary_lines(
+    lines: &mut Vec<Line<'static>>,
+    app: &App,
+    outputs: &[UsageOutput],
+    width: usize,
+    max_lines: usize,
+) {
+    if lines.len().saturating_add(1) >= max_lines {
+        return;
+    }
+
+    lines.push(section_heading("Providers", app));
+
+    for group in group_outputs_by_provider(outputs) {
+        if lines.len() >= max_lines {
+            break;
+        }
+        lines.push(provider_summary_line(app, &group, width));
+    }
+}
+
+fn section_heading(label: &'static str, app: &App) -> Line<'static> {
+    Line::from(Span::styled(
+        format!("  {label}"),
+        section_heading_style(app),
+    ))
+}
+
+fn section_heading_style(app: &App) -> Style {
+    app.theme
+        .secondary_text_style()
+        .add_modifier(Modifier::BOLD)
+}
+
+fn push_kv_styled(
+    lines: &mut Vec<Line<'static>>,
+    app: &App,
+    key: &'static str,
+    value: &str,
+    value_style: Style,
+    width: usize,
+) {
+    let max_value = width.saturating_sub(16);
+    lines.push(Line::from(vec![
+        Span::styled(format!("  {:<12}", key), app.theme.subtle_text_style()),
+        Span::styled(truncate_string(value, max_value), value_style),
+    ]));
+}
+
+fn attention_outputs(outputs: &[UsageOutput]) -> Vec<(usize, &UsageOutput)> {
+    let mut items: Vec<(usize, &UsageOutput)> = outputs
+        .iter()
+        .enumerate()
+        .filter(|(_, output)| readiness_status(output).is_at_risk())
+        .collect();
+
+    items.sort_by(|(left_index, left), (right_index, right)| {
+        attention_severity_rank(left)
+            .cmp(&attention_severity_rank(right))
+            .then_with(|| attention_action_rank(left).cmp(&attention_action_rank(right)))
+            .then_with(|| output_score(left).total_cmp(&output_score(right)))
+            .then_with(|| left_index.cmp(right_index))
+    });
+
+    items
+}
+
+fn attention_severity_rank(output: &UsageOutput) -> u8 {
+    match readiness_status(output) {
+        UsageReadiness::Critical => 0,
+        UsageReadiness::Watch => 1,
+        UsageReadiness::Ready => 2,
+        UsageReadiness::Unknown => 3,
+    }
+}
+
+fn attention_action_rank(output: &UsageOutput) -> u8 {
+    match &output.account {
+        Some(account) if account.is_active => 0,
+        Some(_) => 1,
+        None => 2,
+    }
+}
+
+fn attention_line(app: &App, output: &UsageOutput, width: usize) -> Line<'static> {
+    let status = readiness_status(output);
+    let metric = display_metric(output);
+    let detail = metric
+        .map(|metric| {
+            let reset = metric
+                .resets_at
+                .as_ref()
+                .map(|reset| format!(" · {}", helpers::format_reset_time(reset)))
+                .unwrap_or_default();
+            format!(
+                "{} {}{}",
+                compact_metric_label(&metric.label),
+                remaining_label(metric),
+                reset
+            )
+        })
+        .unwrap_or_else(|| "No quota metrics".to_string());
+    let account_width: usize = if width >= 52 { 24 } else { 18 };
+    let used = 2 + 11 + account_width;
+    Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            format!("{:<11}", readiness_label(status)),
+            Style::default().fg(readiness_color(app, status)),
+        ),
+        Span::styled(
+            format!(
+                "{:<width$}",
+                truncate_string(&account_name(app, output), account_width.saturating_sub(1)),
+                width = account_width
+            ),
+            app.theme.secondary_text_style(),
+        ),
+        Span::styled(
+            truncate_string(&detail, width.saturating_sub(used + 1)),
+            metric
+                .map(|metric| Style::default().fg(metric_color(app, metric)))
+                .unwrap_or_else(|| app.theme.subtle_text_style()),
+        ),
+    ])
+}
+
+fn attention_more_line(hidden_count: usize, width: usize) -> Line<'static> {
+    let label = if hidden_count == 1 {
+        "+1 more at risk".to_string()
+    } else {
+        format!("+{hidden_count} more at risk")
+    };
+    Line::from(Span::styled(
+        format!("  {}", truncate_string(&label, width.saturating_sub(2))),
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    ))
+}
+
+fn provider_summary_line(
+    app: &App,
+    group: &UsageProviderGroup<'_>,
+    _width: usize,
+) -> Line<'static> {
+    let saved = group
+        .outputs
+        .iter()
+        .filter(|(_, output)| output.account.is_some())
+        .count();
+    let managed = group.outputs.len().saturating_sub(saved);
+    let count_label = identity_count_label(saved, managed);
+    let ready = group
+        .outputs
+        .iter()
+        .filter(|(_, output)| readiness_status(output) == UsageReadiness::Ready)
+        .count();
+    let risk = group
+        .outputs
+        .iter()
+        .filter(|(_, output)| readiness_status(output).is_at_risk())
+        .count();
+    let summary = if risk > 0 {
+        format!("{count_label} · {ready} ready · {risk} at risk")
+    } else {
+        format!("{count_label} · {ready} ready")
+    };
+    Line::from(vec![
+        Span::styled(
+            format!("  {}", truncate_string(group.provider, 18)),
+            Style::default()
+                .fg(get_provider_shade(group.provider, 0))
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(format!("  {summary}"), app.theme.subtle_text_style()),
+    ])
+}
+
+fn render_selected_account(
+    frame: &mut Frame,
+    app: &mut App,
+    area: Rect,
+    selected: &UsageOutput,
+    outputs: &[UsageOutput],
+) {
+    let title = format!(" Selected Account  {} ", output_display_name(app, selected));
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(app.theme.border))
+        .title(Span::styled(
+            truncate_string(&title, area.width.saturating_sub(4) as usize),
+            Style::default()
+                .fg(app.theme.accent)
+                .add_modifier(Modifier::BOLD),
+        ));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+
+    let readiness = readiness_status(selected);
+    let max_lines = inner.height as usize;
+    let action_lines = max_lines.min(2);
+    let detail_limit = max_lines.saturating_sub(action_lines);
+    let mut lines = Vec::new();
+
+    if lines.len() < detail_limit {
+        push_kv_styled(
+            &mut lines,
+            app,
+            "Status",
+            &selected_status_line(selected),
+            Style::default()
+                .fg(readiness_color(app, readiness))
+                .add_modifier(Modifier::BOLD),
+            inner.width as usize,
+        );
+    }
+    if lines.len() < detail_limit {
+        push_kv_styled(
+            &mut lines,
+            app,
+            "Email",
+            &email_display(app, selected.email.as_deref()),
+            app.theme.secondary_text_style(),
+            inner.width as usize,
+        );
+    }
+    if lines.len() < detail_limit {
+        if let Some(account) = &selected.account {
+            push_kv_styled(
+                &mut lines,
+                app,
+                "Credential",
+                if account.is_active {
+                    "saved store, active auth.json"
+                } else {
+                    "saved store"
+                },
+                app.theme.secondary_text_style(),
+                inner.width as usize,
+            );
+        } else {
+            push_kv_styled(
+                &mut lines,
+                app,
+                "Credential",
+                "managed externally",
+                app.theme.secondary_text_style(),
+                inner.width as usize,
+            );
+        }
+    }
+    if lines.len() < detail_limit {
+        if let Some(label) = credits_status_line(selected) {
+            push_kv_styled(
+                &mut lines,
+                app,
+                "Credits",
+                &label,
+                app.theme.secondary_text_style(),
+                inner.width as usize,
+            );
+        }
+    }
+    if lines.len() < detail_limit {
+        if let Some(label) = reset_credits_line(selected) {
+            push_kv_styled(
+                &mut lines,
+                app,
+                "Reset Bank",
+                &label,
+                if has_available_reset_credit(selected) {
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    app.theme.secondary_text_style()
+                },
+                inner.width as usize,
+            );
+        }
+    }
+    push_section_spacing(&mut lines, detail_limit);
+    if lines.len() < detail_limit {
+        lines.push(section_heading("Limits", app));
+    }
+    let mut metric_index = 0usize;
+    while lines.len() < detail_limit {
+        if selected.metrics.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "  No quota metrics returned",
+                app.theme.subtle_text_style(),
+            )));
+            break;
+        }
+        if let Some(metric) = selected.metrics.get(metric_index) {
+            lines.push(metric_detail_line(app, metric, inner.width as usize));
+            metric_index += 1;
+        } else {
+            break;
+        }
+    }
+    if lines.len() < detail_limit {
+        lines.push(snapshot_line(app, outputs, inner.width as usize));
+    }
+    push_section_spacing(&mut lines, max_lines);
+    if lines.len() + 1 < max_lines {
+        lines.push(section_heading("Actions", app));
+    }
+    if lines.len() < max_lines {
+        let y = inner.y.saturating_add(lines.len() as u16);
+        lines.push(selected_account_actions_line(app, selected, inner, y));
+    }
+
+    frame.render_widget(Paragraph::new(lines), inner);
+}
+
+fn append_credit_bank_summary_lines(
+    lines: &mut Vec<Line<'static>>,
+    app: &App,
+    outputs: &[UsageOutput],
+    width: usize,
+    max_lines: usize,
+) {
+    if !outputs.iter().any(has_available_reset_credit) || lines.len() >= max_lines {
+        return;
+    }
+
+    lines.push(Line::from(vec![
+        Span::styled("  Credit Bank  ", section_heading_style(app)),
+        Span::styled(
+            truncate_string(&reset_bank_summary(outputs), width.saturating_sub(15)),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ]));
+
+    for output in outputs.iter().filter(|output| output.provider == "Codex") {
+        if lines.len() >= max_lines {
+            break;
+        }
+        let Some(credits) = output.reset_credits.as_ref() else {
+            continue;
+        };
+        if credits.available_count == 0 {
+            continue;
+        }
+        lines.push(reset_credit_account_line(
+            app,
+            output,
+            credits,
+            output
+                .account
+                .as_ref()
+                .is_some_and(|account| account.is_active),
+            width,
+        ));
+    }
+}
+
+fn reset_credit_account_line(
+    app: &App,
+    output: &UsageOutput,
+    credits: &crate::commands::usage::UsageResetCredits,
+    selected: bool,
+    width: usize,
+) -> Line<'static> {
+    let account = account_name(app, output);
+    let count = if credits.available_count == 1 {
+        "1 credit".to_string()
+    } else {
+        format!("{} credits", credits.available_count)
+    };
+    let expiry = credit_expiry_summary(credits);
+    let label_width: usize = if width >= 72 { 28 } else { 18 };
+    let count_width: usize = if width >= 72 { 12 } else { 10 };
+    let used = 2 + label_width + count_width + 2;
+    let marker = if selected { "> " } else { "  " };
+    Line::from(vec![
+        Span::raw(marker),
+        Span::styled(
+            format!(
+                "{:<width$}",
+                truncate_string(&account, label_width.saturating_sub(1)),
+                width = label_width
+            ),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("{:<width$}", count, width = count_width),
+            app.theme.secondary_text_style(),
+        ),
+        Span::styled(
+            truncate_string(&expiry, width.saturating_sub(used)),
+            app.theme.secondary_text_style(),
+        ),
+    ])
+}
+
+fn credit_expiry_summary(credits: &crate::commands::usage::UsageResetCredits) -> String {
+    let mut expiries: Vec<String> = credits
+        .credits
+        .iter()
+        .filter_map(|credit| credit.expires_at.as_deref())
+        .map(format_credit_expiry_label)
+        .collect();
+    expiries.sort();
+    expiries.dedup();
+
+    if expiries.is_empty() {
+        return "expiry unknown".to_string();
+    }
+
+    let visible: Vec<String> = expiries.iter().take(2).cloned().collect();
+    let hidden = expiries.len().saturating_sub(visible.len());
+    if hidden > 0 {
+        format!("expires {} +{hidden}", visible.join(", "))
+    } else {
+        format!("expires {}", visible.join(", "))
+    }
+}
+
+fn format_credit_expiry_label(value: &str) -> String {
+    let label = format_expiry_time(value);
+    label
+        .strip_prefix("expires ")
+        .or_else(|| label.strip_prefix("resets "))
+        .unwrap_or(&label)
+        .to_string()
+}
+
+fn selected_status_line(output: &UsageOutput) -> String {
+    let plan = output.plan.as_deref().unwrap_or("Unknown");
+    format!(
+        "{} · {}",
+        plan,
+        account_readiness_label(output, readiness_status(output))
+    )
+}
+
+fn selected_account_actions_line(
+    app: &mut App,
+    selected: &UsageOutput,
+    area: Rect,
+    y: u16,
+) -> Line<'static> {
+    if let Some(account) = &selected.account {
+        let mut spans = Vec::new();
+        let mut buttons = Vec::new();
+        if has_available_reset_credit(selected) {
+            buttons.push(reset_account_button(&account.id));
+        }
+        if account.is_active {
+            spans.push(Span::styled(
+                "  Current account  ",
+                app.theme.subtle_text_style(),
+            ));
+            let x = area
+                .x
+                .saturating_add(Line::from(spans.clone()).width() as u16);
+            buttons.push(remove_account_button(&account.id));
+            push_click_buttons(&mut spans, app, buttons, x, y, area.right());
+        } else {
+            spans.push(Span::raw("  "));
+            let x = area.x.saturating_add(2);
+            let mut all_buttons = vec![use_account_button(&account.id)];
+            all_buttons.extend(buttons);
+            all_buttons.push(remove_account_button(&account.id));
+            push_click_buttons(&mut spans, app, all_buttons, x, y, area.right());
+        }
+        return Line::from(spans);
+    }
+
+    Line::from(Span::styled(
+        "  Managed externally",
+        app.theme.subtle_text_style(),
+    ))
+}
+
+fn account_plan_label(account: &str, plan: Option<&str>) -> String {
+    match plan.map(str::trim).filter(|plan| !plan.is_empty()) {
+        Some(plan) => format!("{account}  {plan}"),
+        None => account.to_string(),
+    }
+}
+
+fn account_readiness_label(output: &UsageOutput, readiness: UsageReadiness) -> String {
+    let account_state = account_state_label(output);
+    let readiness = readiness_label(readiness);
+    if account_state.eq_ignore_ascii_case(readiness) {
+        readiness.to_string()
+    } else {
+        format!("{account_state} · {readiness}")
+    }
+}
+
+fn snapshot_line(app: &App, outputs: &[UsageOutput], width: usize) -> Line<'static> {
+    let ready = outputs
+        .iter()
+        .filter(|output| readiness_status(output) == UsageReadiness::Ready)
+        .count();
+    let at_risk = outputs
+        .iter()
+        .filter(|output| readiness_status(output).is_at_risk())
+        .count();
+    let inventory = usage_inventory(outputs);
+    let summary = format!(
+        "  Snapshot  {ready} ready · {at_risk} at risk · {}{}",
+        identity_count_label(inventory.saved, inventory.managed),
+        if app.hide_usage_emails {
+            " · emails hidden"
+        } else {
+            ""
+        }
+    );
+    Line::from(Span::styled(
+        truncate_string(&summary, width),
+        app.theme.subtle_text_style(),
+    ))
+}
+
+fn metric_detail_line(app: &App, metric: &UsageMetric, width: usize) -> Line<'static> {
+    let remaining = remaining_label(metric);
+    let label_width = metric_label_width(width);
+    let bar_width = width.saturating_sub(label_width + 25).clamp(10, 34);
+    let reset_width = width.saturating_sub(label_width + bar_width + 14);
+    let reset = metric
+        .resets_at
+        .as_ref()
+        .map(|r| helpers::format_reset_time(r))
+        .unwrap_or_default();
+    let color = metric_color(app, metric);
+    let mut spans = vec![Span::styled(
+        format!(
+            "  {:<width$}",
+            truncate_string(
+                &compact_metric_label(&metric.label),
+                label_width.saturating_sub(1),
+            ),
+            width = label_width
+        ),
+        app.theme.subtle_text_style(),
+    )];
+    spans.extend(quota_bar_spans(
+        metric.remaining_percent,
+        bar_width,
+        color,
+        app,
+    ));
+    spans.extend([
+        Span::raw(" "),
+        Span::styled(
+            format!("{:<11}", truncate_string(&remaining, 11)),
+            Style::default().fg(color),
+        ),
+        Span::styled(
+            truncate_string(&reset, reset_width),
+            app.theme.subtle_text_style(),
+        ),
+    ]);
+    Line::from(spans)
+}
+
+fn metric_label_width(width: usize) -> usize {
+    if width >= 96 {
+        18
+    } else if width >= 78 {
+        14
+    } else {
+        10
+    }
+}
+
+fn render_accounts_table(frame: &mut Frame, app: &mut App, area: Rect, outputs: &[UsageOutput]) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(app.theme.border))
+        .title(Span::styled(
+            " Accounts ",
+            Style::default()
+                .fg(app.theme.accent)
+                .add_modifier(Modifier::BOLD),
+        ));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+
+    if inner.width < 132 {
+        render_narrow_accounts_table(frame, app, inner, outputs);
+        return;
+    }
+
+    let max_rows = inner.height.saturating_sub(1) as usize;
+    app.set_max_visible_items(max_rows.max(1));
+    let start = app
+        .scroll_offset
+        .min(outputs.len().saturating_sub(max_rows));
+    let visible_rows = outputs
+        .iter()
+        .enumerate()
+        .skip(start)
+        .take(max_rows)
+        .collect::<Vec<_>>();
+
+    let rows = visible_rows
+        .iter()
+        .map(|(index, output)| account_table_row(app, output, *index))
+        .collect::<Vec<_>>();
+
+    let selected_visible = app
+        .selected_index
+        .checked_sub(start)
+        .filter(|index| *index < visible_rows.len());
+    let mut table_state = TableState::default().with_selected(selected_visible);
+    let table = Table::new(rows, account_table_widths(inner.width))
+        .header(account_table_header(app))
+        .column_spacing(1)
+        .highlight_spacing(HighlightSpacing::Never)
+        .row_highlight_style(Style::default().bg(app.theme.selection))
+        .flex(Flex::Start);
+    frame.render_stateful_widget(table, inner, &mut table_state);
+
+    for (visible_row, (index, _)) in visible_rows.into_iter().enumerate() {
+        let y = inner.y.saturating_add(1 + visible_row as u16);
+        app.add_click_area(
+            Rect::new(inner.x, y, inner.width, 1),
+            ClickAction::UsageSelect { index },
+        );
+    }
+}
+
+fn render_narrow_accounts_table(
+    frame: &mut Frame,
+    app: &mut App,
+    area: Rect,
+    outputs: &[UsageOutput],
+) {
+    let mut lines = vec![narrow_table_header(app, area.width)];
+    let row_height = 2usize;
+    let max_items = (area.height.saturating_sub(1) as usize / row_height).max(1);
+    app.set_max_visible_items(max_items);
+    let start = app
+        .scroll_offset
+        .min(outputs.len().saturating_sub(max_items));
+
+    for (visible_row, (index, output)) in outputs
+        .iter()
+        .enumerate()
+        .skip(start)
+        .take(max_items)
+        .enumerate()
+    {
+        let y = area
+            .y
+            .saturating_add(1)
+            .saturating_add((visible_row * row_height) as u16);
+        app.add_click_area(
+            Rect::new(
+                area.x,
+                y,
+                area.width,
+                row_height.min(area.bottom().saturating_sub(y) as usize) as u16,
+            ),
+            ClickAction::UsageSelect { index },
+        );
+        lines.extend(narrow_table_row(app, output, index, area, y));
+    }
+
+    frame.render_widget(Paragraph::new(lines), area);
+}
+
+fn account_table_header(app: &App) -> Row<'static> {
+    let style = app.theme.subtle_text_style();
+    Row::new([
+        table_right_cell("#", style),
+        table_text_cell("Provider", style),
+        table_text_cell("Account", style),
+        table_text_cell("Plan", style),
+        table_text_cell("Auth", style),
+        table_text_cell("Health", style),
+        table_text_cell("Limit", style),
+        table_text_cell("Reset", style),
+    ])
+}
+
+fn narrow_table_header(app: &App, width: u16) -> Line<'static> {
+    Line::from(Span::styled(
+        truncate_string(" #  Account / Status", width as usize),
+        app.theme.subtle_text_style(),
+    ))
+}
+
+fn account_table_widths(width: u16) -> [Constraint; 8] {
+    if width >= 170 {
+        [
+            Constraint::Length(3),
+            Constraint::Length(10),
+            Constraint::Length(30),
+            Constraint::Length(10),
+            Constraint::Length(8),
+            Constraint::Length(10),
+            Constraint::Min(30),
+            Constraint::Length(22),
+        ]
+    } else {
+        [
+            Constraint::Length(3),
+            Constraint::Length(8),
+            Constraint::Length(24),
+            Constraint::Length(8),
+            Constraint::Length(7),
+            Constraint::Length(8),
+            Constraint::Min(24),
+            Constraint::Length(16),
+        ]
+    }
+}
+
+fn narrow_table_row(
+    app: &mut App,
+    output: &UsageOutput,
+    index: usize,
+    area: Rect,
+    _y: u16,
+) -> Vec<Line<'static>> {
+    let selected = app.selected_index == index;
+    let width = area.width as usize;
+    let row = usage_row_view(app, output);
+    let state = if width >= 70 {
+        account_readiness_label(output, row.readiness)
+    } else {
+        readiness_label(row.readiness).to_string()
+    };
+    let state_width = if width >= 52 {
+        14usize
+    } else if width >= 40 {
+        10usize
+    } else {
+        0usize
+    };
+    let left_width = width.saturating_sub(4 + state_width);
+    let left = format!("{} {}", output.provider, row.account_summary);
+    let mut first = vec![
+        styled(
+            format!(" {:<2} ", index + 1),
+            app.theme.secondary_text_style(),
+            selected,
+        ),
+        styled(
+            format!(
+                "{:<width$}",
+                truncate_string(&left, left_width.saturating_sub(1)),
+                width = left_width
+            ),
+            app.theme.secondary_text_style(),
+            selected,
+        ),
+    ];
+    if state_width > 0 {
+        first.push(styled(
+            truncate_string(&state, state_width),
+            Style::default().fg(readiness_color(app, row.readiness)),
+            selected,
+        ));
+    }
+
+    let detail = if row.reset.is_empty() {
+        row.limit.clone()
+    } else {
+        format!("{} · {}", row.limit, row.reset)
+    };
+
+    let managed_label = if output.account.is_none() {
+        Some("Managed")
+    } else {
+        None
+    };
+    let action_width = managed_label.map(str::len).unwrap_or(0);
+    let available_detail_width = width
+        .saturating_sub(4 + action_width + usize::from(action_width > 0))
+        .max(8);
+    let detail_width = available_detail_width.min(if width >= 72 { 48 } else { 34 });
+    let detail_style = row
+        .metric
+        .map(|metric| Style::default().fg(metric_color(app, metric)))
+        .unwrap_or_else(|| app.theme.secondary_text_style());
+    let mut second = vec![
+        styled("    ", Style::default(), selected),
+        styled(
+            truncate_string(&detail, detail_width.saturating_sub(1)),
+            detail_style,
+            selected,
+        ),
+    ];
+    let used = Line::from(second.clone()).width();
+    if action_width > 0 && area.width as usize > used + action_width {
+        second.push(styled(" ", Style::default(), selected));
+    }
+    if let Some(label) = managed_label {
+        second.push(styled(label, app.theme.subtle_text_style(), selected));
+    }
+    pad_selected_row(&mut second, area.width as usize, selected);
+
+    vec![Line::from(first), Line::from(second)]
+}
+
+fn usage_row_view<'a>(app: &App, output: &'a UsageOutput) -> UsageRowView<'a> {
+    let account = account_name(app, output);
+    let metric = display_metric(output);
+    let plan = output
+        .plan
+        .as_deref()
+        .map(str::trim)
+        .filter(|plan| !plan.is_empty())
+        .unwrap_or("Unknown")
+        .to_string();
+    let limit = metric_summary(output);
+    let reset = metric.and_then(display_metric_reset).unwrap_or_default();
+    let account_summary = account_plan_label(&account, output.plan.as_deref());
+
+    UsageRowView {
+        account,
+        account_summary,
+        plan,
+        limit,
+        reset,
+        readiness: readiness_status(output),
+        metric,
+    }
+}
+
+fn metric_summary(output: &UsageOutput) -> String {
+    if output.metrics.is_empty() {
+        return "No limits".to_string();
+    }
+
+    let parts = output
+        .metrics
+        .iter()
+        .map(|metric| {
+            let label = compact_metric_label(&metric.label);
+            let label = truncate_string(&label, 14);
+            format!("{label} {:.0}%", metric.remaining_percent)
+        })
+        .collect::<Vec<_>>();
+    parts.join(" · ")
+}
+
+fn compact_metric_label(label: &str) -> String {
+    let mut value = label.trim().to_string();
+    for prefix in [
+        "GPT-5.3-Codex-",
+        "GPT-5.3-",
+        "Codex-",
+        "codex-",
+        "gpt-5.3-codex-",
+        "gpt-5.3-",
+    ] {
+        if let Some(stripped) = value.strip_prefix(prefix) {
+            value = stripped.to_string();
+            break;
+        }
+    }
+
+    value = value
+        .replace("Codex Spark", "Spark")
+        .replace("Codex-Spark", "Spark")
+        .replace("codex-spark", "Spark");
+
+    if value.eq_ignore_ascii_case("session") {
+        return "5h".to_string();
+    }
+    if value.eq_ignore_ascii_case("spark") {
+        return "Spark".to_string();
+    }
+    if value.eq_ignore_ascii_case("spark week") {
+        return "Spark weekly".to_string();
+    }
+    value
+}
+
+fn display_metric_reset(metric: &UsageMetric) -> Option<String> {
+    metric
+        .resets_at
+        .as_ref()
+        .map(|reset| helpers::format_reset_time(reset))
+}
+
+fn account_table_row(app: &App, output: &UsageOutput, index: usize) -> Row<'static> {
+    let row = usage_row_view(app, output);
+
+    let auth = account_auth_label(output);
+    let health = readiness_label(row.readiness);
+    let auth_color = account_auth_color(output);
+    let health_color = readiness_color(app, row.readiness);
+    let metric_color = row.metric.map(|metric| metric_color(app, metric));
+
+    Row::new([
+        table_right_cell((index + 1).to_string(), app.theme.secondary_text_style()),
+        table_text_cell(
+            output.provider.clone(),
+            Style::default()
+                .fg(get_provider_shade(&output.provider, 0))
+                .add_modifier(Modifier::BOLD),
+        ),
+        table_text_cell(row.account, app.theme.secondary_text_style()),
+        table_text_cell(row.plan, app.theme.secondary_text_style()),
+        table_text_cell(auth, Style::default().fg(auth_color)),
+        table_text_cell(health, Style::default().fg(health_color)),
+        table_text_cell(
+            row.limit,
+            metric_color
+                .map(|color| Style::default().fg(color))
+                .unwrap_or_else(|| app.theme.secondary_text_style()),
+        ),
+        table_text_cell(row.reset, app.theme.subtle_text_style()),
+    ])
+    .style(account_table_row_style(app, index))
+    .height(1)
+}
+
+fn pad_selected_row(spans: &mut Vec<Span<'static>>, width: usize, selected: bool) {
+    let used = Line::from(spans.clone()).width();
+    if used < width {
+        spans.push(styled(" ".repeat(width - used), Style::default(), selected));
+    }
+}
+
+fn table_text_cell(text: impl Into<String>, style: Style) -> Cell<'static> {
+    Cell::from(Span::styled(text.into(), style))
+}
+
+fn table_right_cell(text: impl Into<String>, style: Style) -> Cell<'static> {
+    Cell::from(Line::from(Span::styled(text.into(), style)).right_aligned())
+}
+
+fn account_table_row_style(app: &App, index: usize) -> Style {
+    if index % 2 == 1 {
+        app.theme.striped_row_style()
+    } else {
+        Style::default()
+    }
+}
+
+fn use_account_button(account_id: &str) -> ButtonSpec {
+    ButtonSpec {
+        label: "Use Account".to_string(),
+        kind: ButtonKind::Primary,
+        action: ClickAction::CodexUseAccount {
+            account_id: account_id.to_string(),
+        },
+    }
+}
+
+fn remove_account_button(account_id: &str) -> ButtonSpec {
+    ButtonSpec {
+        label: "Remove".to_string(),
+        kind: ButtonKind::Danger,
+        action: ClickAction::CodexRemoveAccount {
+            account_id: account_id.to_string(),
+        },
+    }
+}
+
+fn reset_account_button(account_id: &str) -> ButtonSpec {
+    ButtonSpec {
+        label: "Reset".to_string(),
+        kind: ButtonKind::Warning,
+        action: ClickAction::CodexResetAccount {
+            account_id: account_id.to_string(),
+        },
+    }
 }
 
 fn group_outputs_by_provider(outputs: &[UsageOutput]) -> Vec<UsageProviderGroup<'_>> {
     let mut groups: Vec<UsageProviderGroup<'_>> = Vec::new();
 
-    for output in outputs {
+    for (index, output) in outputs.iter().enumerate() {
         if let Some(group) = groups
             .iter_mut()
             .find(|group| group.provider == output.provider)
         {
-            group.outputs.push(output);
+            group.outputs.push((index, output));
         } else {
             groups.push(UsageProviderGroup {
                 provider: &output.provider,
-                outputs: vec![output],
+                outputs: vec![(index, output)],
             });
         }
     }
@@ -368,188 +1771,422 @@ fn group_outputs_by_provider(outputs: &[UsageOutput]) -> Vec<UsageProviderGroup<
     groups
 }
 
-fn push_provider_header(lines: &mut Vec<Line>, app: &App, label: &str) {
-    lines.push(Line::from(Span::styled(
-        format!(" {label} "),
-        Style::default()
-            .fg(app.theme.foreground)
-            .add_modifier(Modifier::BOLD),
-    )));
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum UsageReadiness {
+    Ready,
+    Watch,
+    Critical,
+    Unknown,
 }
 
-fn push_account_header(lines: &mut Vec<Line>, app: &mut App, output: &UsageOutput, area: Rect) {
-    let (name, is_active) = match &output.account {
-        Some(account) => (
-            output.account_display_name().unwrap_or_default(),
-            account.is_active,
-        ),
-        None => (output.display_name(), false),
-    };
-    let name_width = name.chars().count();
-    let marker = if is_active { "*" } else { "-" };
-    let marker_style = if is_active {
-        Style::default()
-            .fg(app.theme.accent)
-            .add_modifier(Modifier::BOLD)
+impl UsageReadiness {
+    fn is_at_risk(self) -> bool {
+        matches!(self, UsageReadiness::Watch | UsageReadiness::Critical)
+    }
+}
+
+fn readiness_status(output: &UsageOutput) -> UsageReadiness {
+    if output.metrics.is_empty() {
+        return UsageReadiness::Unknown;
+    }
+
+    let lowest = output_score(output);
+    if lowest < 10.0 {
+        UsageReadiness::Critical
+    } else if lowest < 25.0 {
+        UsageReadiness::Watch
     } else {
-        Style::default().fg(app.theme.muted)
-    };
-    let name_style = if is_active {
-        Style::default()
-            .fg(app.theme.foreground)
-            .add_modifier(Modifier::BOLD)
-    } else {
-        Style::default().fg(app.theme.foreground)
-    };
+        UsageReadiness::Ready
+    }
+}
 
-    let mut spans = vec![
-        Span::raw(" "),
-        Span::styled(marker, marker_style),
-        Span::raw(" "),
-        Span::styled(name, name_style),
-    ];
+fn overall_readiness(outputs: &[UsageOutput]) -> UsageReadiness {
+    if outputs.is_empty() {
+        return UsageReadiness::Unknown;
+    }
 
-    if let Some(account) = &output.account {
-        let y = area.y.saturating_add(lines.len() as u16);
-        let left_width = 3usize.saturating_add(name_width);
-        let pending_remove =
-            app.pending_codex_remove_account_id.as_deref() == Some(account.id.as_str());
-
-        let mut buttons: Vec<ButtonSpec> = Vec::new();
-        if !account.is_active {
-            buttons.push(ButtonSpec {
-                label: "Use",
-                style: Style::default()
-                    .fg(app.theme.accent)
-                    .add_modifier(Modifier::BOLD),
-                action: ClickAction::CodexUseAccount {
-                    account_id: account.id.clone(),
-                },
-            });
+    if let Some(active) = active_output(outputs) {
+        let active_status = readiness_status(active);
+        if active_status.is_at_risk() {
+            return active_status;
         }
+    }
 
-        buttons.push(ButtonSpec {
-            label: if pending_remove { "Confirm" } else { "Remove" },
-            style: Style::default().fg(if pending_remove {
-                Color::Red
+    if outputs.iter().any(|output| {
+        matches!(
+            readiness_status(output),
+            UsageReadiness::Critical | UsageReadiness::Watch
+        )
+    }) {
+        UsageReadiness::Watch
+    } else if outputs
+        .iter()
+        .any(|output| readiness_status(output) == UsageReadiness::Ready)
+    {
+        UsageReadiness::Ready
+    } else {
+        UsageReadiness::Unknown
+    }
+}
+
+fn overall_state_label(outputs: &[UsageOutput]) -> &'static str {
+    if let Some(active) = active_output(outputs) {
+        if readiness_status(active) == UsageReadiness::Critical
+            && best_fallback_output(outputs).is_some()
+        {
+            return "Switch recommended";
+        }
+    }
+
+    match overall_readiness(outputs) {
+        UsageReadiness::Ready => "Ready",
+        UsageReadiness::Watch => "Ready with warnings",
+        UsageReadiness::Critical => "Quota low",
+        UsageReadiness::Unknown => "Unknown",
+    }
+}
+
+fn readiness_label(status: UsageReadiness) -> &'static str {
+    match status {
+        UsageReadiness::Ready => "Ready",
+        UsageReadiness::Watch => "Watch",
+        UsageReadiness::Critical => "Quota Low",
+        UsageReadiness::Unknown => "Unknown",
+    }
+}
+
+fn readiness_color(app: &App, status: UsageReadiness) -> Color {
+    match status {
+        UsageReadiness::Ready => app.theme.accent,
+        UsageReadiness::Watch => Color::Yellow,
+        UsageReadiness::Critical => Color::Red,
+        UsageReadiness::Unknown => app.theme.muted,
+    }
+}
+
+fn active_output(outputs: &[UsageOutput]) -> Option<&UsageOutput> {
+    outputs.iter().find(|output| {
+        output
+            .account
+            .as_ref()
+            .is_some_and(|account| account.is_active)
+    })
+}
+
+fn best_fallback_output(outputs: &[UsageOutput]) -> Option<&UsageOutput> {
+    outputs
+        .iter()
+        .filter(|output| {
+            !output
+                .account
+                .as_ref()
+                .is_some_and(|account| account.is_active)
+                && readiness_status(output) == UsageReadiness::Ready
+        })
+        .max_by(|a, b| output_score(a).total_cmp(&output_score(b)))
+}
+
+fn output_score(output: &UsageOutput) -> f64 {
+    output
+        .metrics
+        .iter()
+        .map(|metric| metric.remaining_percent)
+        .min_by(|a, b| a.total_cmp(b))
+        .unwrap_or(0.0)
+}
+
+fn display_metric(output: &UsageOutput) -> Option<&UsageMetric> {
+    if output
+        .metrics
+        .iter()
+        .any(|metric| metric.remaining_percent < 25.0)
+    {
+        output
+            .metrics
+            .iter()
+            .min_by(|a, b| a.remaining_percent.total_cmp(&b.remaining_percent))
+    } else {
+        output.metrics.first()
+    }
+}
+
+fn next_reset_label(app: &App, outputs: &[UsageOutput]) -> Option<String> {
+    if let Some(active) = active_output(outputs) {
+        if let Some(label) = output_reset_label(app, active) {
+            return Some(label);
+        }
+    }
+
+    outputs
+        .iter()
+        .find_map(|output| output_reset_label(app, output))
+}
+
+fn output_reset_label(app: &App, output: &UsageOutput) -> Option<String> {
+    let metric = display_metric(output)?;
+    let reset = metric.resets_at.as_ref()?;
+    Some(format!(
+        "{} · {}",
+        truncate_string(&account_name(app, output), 22),
+        helpers::format_reset_time(reset)
+    ))
+}
+
+fn overall_action(app: &App, outputs: &[UsageOutput]) -> String {
+    let Some(active) = active_output(outputs) else {
+        return "Choose an active account".to_string();
+    };
+
+    match readiness_status(active) {
+        UsageReadiness::Ready => {
+            if outputs
+                .iter()
+                .any(|output| readiness_status(output) == UsageReadiness::Unknown)
+            {
+                "Refresh accounts with unknown limits".to_string()
             } else {
-                app.theme.muted
-            }),
-            action: ClickAction::CodexRemoveAccount {
-                account_id: account.id.clone(),
-            },
-        });
-
-        let button_width = click_buttons_width(&buttons);
-        let padding = (area.width as usize).saturating_sub(left_width + button_width);
-        spans.push(Span::raw(" ".repeat(padding)));
-
-        let x = area
-            .x
-            .saturating_add(left_width as u16)
-            .saturating_add(padding as u16);
-        let right_edge = area.x.saturating_add(area.width);
-        let bottom_edge = area.y.saturating_add(area.height);
-        push_click_buttons(&mut spans, app, buttons, x, y, right_edge, bottom_edge);
+                "Keep current account".to_string()
+            }
+        }
+        UsageReadiness::Watch => "Monitor active quota".to_string(),
+        UsageReadiness::Critical => best_fallback_output(outputs)
+            .map(|fallback| format!("Use {}", account_name(app, fallback)))
+            .unwrap_or_else(|| "Wait for reset or refresh".to_string()),
+        UsageReadiness::Unknown => "Refresh active account".to_string(),
     }
-
-    lines.push(Line::from(spans));
 }
 
-fn push_output_details(
-    lines: &mut Vec<Line>,
-    app: &App,
-    output: &UsageOutput,
-    indent: &str,
-    email_label: &str,
-    skip_email: bool,
-) {
-    for metric in &output.metrics {
-        lines.push(metric_line(app, metric, indent));
-    }
-
-    if !skip_email {
-        if let Some(ref email) = output.email {
-            push_metadata_line(lines, app, indent, email_label, email);
+fn output_display_name(app: &App, output: &UsageOutput) -> String {
+    match &output.account {
+        Some(_) => format!("{} ({})", output.provider, account_name(app, output)),
+        None => {
+            if output.email.is_some() {
+                format!("{} ({})", output.provider, account_name(app, output))
+            } else {
+                output.provider.clone()
+            }
         }
     }
-    if let Some(ref plan) = output.plan {
-        push_metadata_line(lines, app, indent, "Plan", plan);
-    }
 }
 
-fn account_header_uses_email(output: &UsageOutput) -> bool {
-    let Some(account) = &output.account else {
-        return false;
-    };
-    if account.label_name().is_some() {
-        return false;
+fn account_name(app: &App, output: &UsageOutput) -> String {
+    if app.hide_usage_emails {
+        if let Some(account) = &output.account {
+            if let Some(label) = account
+                .label_name()
+                .filter(|label| !looks_like_email(label))
+            {
+                return label.to_string();
+            }
+            return format!("Account {}", account.short_id());
+        }
+
+        if output.email.as_deref().is_some_and(looks_like_email) {
+            return "[hidden email]".to_string();
+        }
     }
 
     output
-        .email
-        .as_deref()
-        .map(str::trim)
-        .filter(|email| !email.is_empty())
-        .is_some()
+        .account_display_name()
+        .or_else(|| output.email.clone())
+        .map(|value| privacy_text(app, &value))
+        .unwrap_or_else(|| output.provider.clone())
 }
 
-fn metric_line(app: &App, metric: &UsageMetric, indent: &str) -> Line<'static> {
-    let remaining = metric
+fn email_display(app: &App, email: Option<&str>) -> String {
+    match email {
+        Some(email) => privacy_text(app, email),
+        None => "Unknown".to_string(),
+    }
+}
+
+fn privacy_text(app: &App, value: &str) -> String {
+    if app.hide_usage_emails && looks_like_email(value) {
+        "[hidden email]".to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+fn account_state_label(output: &UsageOutput) -> String {
+    match &output.account {
+        Some(account) if account.is_active => "Active".to_string(),
+        Some(_) => "Saved".to_string(),
+        None if output.metrics.iter().any(|m| m.remaining_percent < 25.0) => {
+            "Quota low".to_string()
+        }
+        None => "Authenticated".to_string(),
+    }
+}
+
+fn account_auth_label(output: &UsageOutput) -> &'static str {
+    match &output.account {
+        Some(account) if account.is_active => "Active",
+        Some(_) => "Saved",
+        None => "Managed",
+    }
+}
+
+fn account_auth_color(output: &UsageOutput) -> Color {
+    match &output.account {
+        Some(account) if account.is_active => Color::Green,
+        Some(_) => Color::Blue,
+        None => Color::Yellow,
+    }
+}
+
+fn remaining_label(metric: &UsageMetric) -> String {
+    metric
         .remaining_label
         .clone()
-        .unwrap_or_else(|| format!("{:.0}% left", metric.remaining_percent));
-    let bar = helpers::render_ascii_bar(metric.remaining_percent, BAR_WIDTH);
-    let reset = metric
-        .resets_at
-        .as_ref()
-        .map(|r| helpers::format_reset_time(r))
-        .unwrap_or_default();
-
-    let label = Span::styled(
-        format!("{indent}{:<14}", metric.label),
-        Style::default().fg(app.theme.foreground),
-    );
-    let value = Span::styled(
-        format!("{:<11}", remaining),
-        Style::default().fg(app.theme.foreground),
-    );
-    let bar_span = Span::styled(
-        format!("{:<24}", bar),
-        Style::default().fg(if metric.remaining_percent < 10.0 {
-            Color::Red
-        } else if metric.remaining_percent < 25.0 {
-            Color::Yellow
-        } else {
-            app.theme.accent
-        }),
-    );
-    let reset_span = Span::styled(reset, Style::default().fg(app.theme.muted));
-
-    Line::from(vec![label, value, bar_span, reset_span])
+        .unwrap_or_else(|| format!("{:.0}% left", metric.remaining_percent))
 }
 
-fn push_metadata_line(lines: &mut Vec<Line>, app: &App, indent: &str, label: &str, value: &str) {
-    lines.push(Line::from(Span::styled(
-        format!("{indent}{:<12}{value}", label),
-        Style::default().fg(app.theme.muted),
-    )));
+fn has_available_reset_credit(output: &UsageOutput) -> bool {
+    output.provider == "Codex"
+        && output
+            .reset_credits
+            .as_ref()
+            .is_some_and(|credits| credits.available_count > 0)
+}
+
+fn reset_bank_summary(outputs: &[UsageOutput]) -> String {
+    let available: u32 = outputs
+        .iter()
+        .filter(|output| output.provider == "Codex")
+        .filter_map(|output| output.reset_credits.as_ref())
+        .map(|credits| credits.available_count)
+        .sum();
+    if available == 0 {
+        return "No reset credits".to_string();
+    }
+
+    let nearest_expiry = outputs
+        .iter()
+        .filter_map(|output| output.reset_credits.as_ref())
+        .flat_map(|credits| credits.credits.iter())
+        .filter_map(|credit| credit.expires_at.as_deref())
+        .min()
+        .map(format_expiry_time);
+
+    let count = if available == 1 {
+        "1 available".to_string()
+    } else {
+        format!("{available} available across accounts")
+    };
+    match nearest_expiry {
+        Some(expiry) => format!("{count} · nearest {expiry}"),
+        None => count,
+    }
+}
+
+fn reset_credits_line(output: &UsageOutput) -> Option<String> {
+    let credits = output.reset_credits.as_ref()?;
+    let count = credits.available_count;
+    let mut label = if count == 1 {
+        "1 available".to_string()
+    } else {
+        format!("{count} available")
+    };
+    if let Some(expiry) = credits
+        .credits
+        .iter()
+        .filter_map(|credit| credit.expires_at.as_deref())
+        .min()
+    {
+        label.push_str(" · ");
+        label.push_str(&format_expiry_time(expiry));
+    }
+    Some(label)
+}
+
+fn credits_status_line(output: &UsageOutput) -> Option<String> {
+    let mut parts = Vec::new();
+    if let Some(credits) = &output.credit_status {
+        if let Some(balance) = credits.balance.as_deref() {
+            parts.push(format!("API credits {balance}"));
+        }
+        if credits.unlimited == Some(true) {
+            parts.push("unlimited".to_string());
+        }
+        if credits.has_credits == Some(false) {
+            parts.push("no API credits".to_string());
+        }
+        if credits.overage_limit_reached == Some(true) {
+            parts.push("API overage reached".to_string());
+        }
+    }
+    if let Some(control) = &output.spend_control {
+        if control.reached == Some(true) {
+            parts.push("spend limit reached".to_string());
+        } else if control.reached == Some(false) {
+            parts.push("spend OK".to_string());
+        }
+        if let Some(limit) = control.individual_limit.as_deref() {
+            parts.push(format!("spend limit {limit}"));
+        }
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(" · "))
+    }
+}
+
+fn format_expiry_time(value: &str) -> String {
+    helpers::format_reset_time(value).replace("resets", "expires")
+}
+
+fn metric_color(app: &App, metric: &UsageMetric) -> Color {
+    if metric.remaining_percent < 10.0 {
+        Color::Red
+    } else if metric.remaining_percent < 25.0 {
+        Color::Yellow
+    } else {
+        app.theme.accent
+    }
+}
+
+fn quota_bar_spans(
+    remaining_percent: f64,
+    width: usize,
+    color: Color,
+    app: &App,
+) -> Vec<Span<'static>> {
+    light_ratio_bar_spans(
+        remaining_percent / 100.0,
+        width,
+        Style::default().fg(color),
+        app.theme.subtle_text_style(),
+    )
+}
+
+fn styled<T: Into<String>>(text: T, style: Style, selected: bool) -> Span<'static> {
+    let style = if selected {
+        style.bg(Color::Blue).fg(Color::White)
+    } else {
+        style
+    };
+    Span::styled(text.into(), style)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commands::usage::{UsageAccount, UsageMetric};
-    use crate::tui::app::TuiConfig;
+    use crate::commands::usage::{
+        UsageAccount, UsageCreditStatus, UsageResetCredit, UsageResetCredits, UsageSpendControl,
+    };
+    use crate::tui::app::{Tab, TuiConfig};
     use crate::tui::data::UsageData;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use ratatui::{backend::TestBackend, Terminal};
 
     fn output(provider: &str, account: Option<UsageAccount>) -> UsageOutput {
         UsageOutput {
             provider: provider.to_string(),
             account,
-            plan: None,
-            email: None,
+            plan: Some("Pro".to_string()),
+            email: Some("user@example.com".to_string()),
             metrics: vec![UsageMetric {
                 label: "Session".to_string(),
                 used_percent: 10.0,
@@ -557,7 +2194,41 @@ mod tests {
                 remaining_label: Some("90% left".to_string()),
                 resets_at: None,
             }],
+            reset_credits: None,
+            credit_status: None,
+            spend_control: None,
         }
+    }
+
+    fn output_with_remaining(
+        provider: &str,
+        account: Option<UsageAccount>,
+        remaining_percent: f64,
+    ) -> UsageOutput {
+        let mut output = output(provider, account);
+        output.metrics[0].remaining_percent = remaining_percent;
+        output.metrics[0].remaining_label = Some(format!("{remaining_percent:.0}% left"));
+        output
+    }
+
+    fn output_with_reset_credits(
+        provider: &str,
+        account: Option<UsageAccount>,
+        available_count: u32,
+    ) -> UsageOutput {
+        let mut output = output(provider, account);
+        output.reset_credits = Some(UsageResetCredits {
+            available_count,
+            credits: vec![UsageResetCredit {
+                id: Some("credit_1".to_string()),
+                status: Some("available".to_string()),
+                reset_type: Some("codex_rate_limits".to_string()),
+                expires_at: Some("2026-07-12T01:31:33Z".to_string()),
+                title: Some("One free rate limit reset".to_string()),
+                description: None,
+            }],
+        });
+        output
     }
 
     fn make_app() -> App {
@@ -571,7 +2242,9 @@ mod tests {
             year: None,
             initial_tab: None,
         };
-        App::new_with_cached_data(config, Some(UsageData::default())).unwrap()
+        let mut app = App::new_with_cached_data(config, Some(UsageData::default())).unwrap();
+        app.current_tab = Tab::Usage;
+        app
     }
 
     fn render_body(app: &mut App, width: u16, height: u16) -> String {
@@ -592,6 +2265,164 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    fn line_text(line: &Line<'_>) -> String {
+        line.spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect::<String>()
+    }
+
+    fn visual_col(line: &str, needle: &str) -> Option<usize> {
+        let byte = line.find(needle)?;
+        Some(Line::from(&line[..byte]).width())
+    }
+
+    #[test]
+    fn usage_render_handles_current_non_codex_providers() {
+        let providers = [
+            "Claude",
+            "Z.ai",
+            "Amp",
+            "Copilot",
+            "Grok Build",
+            "Kimi",
+            "MiniMax",
+            "Warp/Oz",
+        ];
+        let mut app = make_app();
+        app.subscription_usage = providers
+            .iter()
+            .map(|provider| output(provider, None))
+            .collect();
+
+        let groups = group_outputs_by_provider(&app.subscription_usage);
+        assert_eq!(
+            groups
+                .iter()
+                .map(|group| group.provider)
+                .collect::<Vec<_>>(),
+            providers
+        );
+
+        let body = render_body(&mut app, 140, 34);
+
+        assert!(body.contains("Usage Summary"), "{body}");
+        assert!(!body.contains("x Reset"), "{body}");
+    }
+
+    #[test]
+    fn usage_render_keeps_outputs_visible_when_metrics_are_empty() {
+        let mut app = make_app();
+        let mut output = output_with_reset_credits(
+            "Codex",
+            Some(UsageAccount {
+                id: "acct_work".to_string(),
+                label: Some("work".to_string()),
+                is_active: true,
+            }),
+            1,
+        );
+        output.metrics.clear();
+        app.subscription_usage = vec![output];
+
+        let body = render_body(&mut app, 140, 34);
+
+        assert!(body.contains("Usage Summary"), "{body}");
+        assert!(body.contains("Accounts"), "{body}");
+        assert!(body.contains("No quota metrics returned"), "{body}");
+        assert!(!body.contains("No subscription data available"), "{body}");
+    }
+
+    #[test]
+    fn usage_quota_bar_uses_light_empty_track() {
+        let app = make_app();
+        let metric = UsageMetric {
+            label: "Session".to_string(),
+            used_percent: 50.0,
+            remaining_percent: 50.0,
+            remaining_label: Some("50% left".to_string()),
+            resets_at: None,
+        };
+
+        let line = metric_detail_line(&app, &metric, 72);
+        let text = line_text(&line);
+
+        assert!(text.contains("█"), "{text}");
+        assert!(text.contains("·"), "{text}");
+        assert!(!text.contains("░"), "{text}");
+    }
+
+    #[test]
+    fn usage_quota_bar_uses_trace_mark_for_sub_cell_remaining() {
+        let app = make_app();
+        let spans = quota_bar_spans(0.1, 20, Color::Red, &app);
+        let text = spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+
+        assert!(text.contains("▏"), "{text}");
+        assert!(!text.contains("█"), "{text}");
+        assert_eq!(text.chars().count(), 20);
+    }
+
+    #[test]
+    fn usage_status_distinguishes_not_loaded_from_empty_results() {
+        let mut app = make_app();
+        assert_eq!(status_label(&app), "Not loaded");
+
+        app.usage_fetch_attempted = true;
+        assert_eq!(status_label(&app), "No data");
+    }
+
+    #[test]
+    fn usage_summary_lines_fit_available_height() {
+        let app = make_app();
+        let outputs = vec![output(
+            "Codex",
+            Some(UsageAccount {
+                id: "acct_work".to_string(),
+                label: Some("work".to_string()),
+                is_active: true,
+            }),
+        )];
+
+        let lines = usage_status_summary_lines(&app, &outputs, 80, 4);
+        let body = lines.iter().map(line_text).collect::<Vec<_>>().join("\n");
+
+        assert_eq!(lines.len(), 4);
+        assert!(body.contains("State"), "{body}");
+        assert!(body.contains("Active"), "{body}");
+        assert!(body.contains("Capacity"), "{body}");
+        assert!(body.contains("Action"), "{body}");
+        assert!(!body.contains("Fallback"), "{body}");
+        assert!(!body.contains("Next Reset"), "{body}");
+    }
+
+    #[test]
+    fn usage_credit_status_uses_user_facing_copy() {
+        let mut output = output("Codex", None);
+        output.credit_status = Some(UsageCreditStatus {
+            balance: Some("0".to_string()),
+            has_credits: Some(false),
+            unlimited: Some(false),
+            overage_limit_reached: Some(true),
+        });
+        output.spend_control = Some(UsageSpendControl {
+            individual_limit: Some("$10".to_string()),
+            reached: Some(false),
+        });
+
+        let label = credits_status_line(&output).expect("missing credit status");
+
+        assert!(label.contains("API credits 0"), "{label}");
+        assert!(label.contains("no API credits"), "{label}");
+        assert!(label.contains("API overage reached"), "{label}");
+        assert!(label.contains("spend OK"), "{label}");
+        assert!(label.contains("spend limit $10"), "{label}");
+        assert!(!label.contains("billing"), "{label}");
     }
 
     #[test]
@@ -621,81 +2452,14 @@ mod tests {
         assert_eq!(groups.len(), 2);
         assert_eq!(groups[0].provider, "Codex");
         assert_eq!(groups[0].outputs.len(), 2);
+        assert_eq!(groups[0].outputs[0].0, 0);
+        assert_eq!(groups[0].outputs[1].0, 2);
         assert_eq!(groups[1].provider, "Claude");
         assert_eq!(groups[1].outputs.len(), 1);
     }
 
     #[test]
-    fn renders_codex_accounts_under_one_provider_section() {
-        let mut app = make_app();
-        app.subscription_usage = vec![
-            output(
-                "Codex",
-                Some(UsageAccount {
-                    id: "acct_work".to_string(),
-                    label: Some("work".to_string()),
-                    is_active: true,
-                }),
-            ),
-            output(
-                "Codex",
-                Some(UsageAccount {
-                    id: "acct_personal".to_string(),
-                    label: Some("personal".to_string()),
-                    is_active: false,
-                }),
-            ),
-            output("Claude", None),
-        ];
-
-        let body = render_body(&mut app, 100, 18);
-
-        assert_eq!(
-            body.matches(" Codex ").count(),
-            1,
-            "Codex provider should render once for grouped accounts\n{body}"
-        );
-        assert!(body.contains("* work"), "active account missing\n{body}");
-        assert!(
-            body.contains("- personal"),
-            "inactive account missing\n{body}"
-        );
-        assert!(
-            body.contains(" Claude "),
-            "other providers still render\n{body}"
-        );
-    }
-
-    #[test]
-    fn renders_codex_account_email_instead_of_raw_account_id() {
-        let mut app = make_app();
-        let raw_id = "123e4567-e89b-12d3-a456-426614174000";
-        app.subscription_usage = vec![UsageOutput {
-            provider: "Codex".to_string(),
-            account: Some(UsageAccount {
-                id: raw_id.to_string(),
-                label: None,
-                is_active: true,
-            }),
-            plan: None,
-            email: Some("user@example.com".to_string()),
-            metrics: vec![UsageMetric {
-                label: "Session".to_string(),
-                used_percent: 10.0,
-                remaining_percent: 90.0,
-                remaining_label: Some("90% left".to_string()),
-                resets_at: None,
-            }],
-        }];
-
-        let body = render_body(&mut app, 100, 10);
-
-        assert!(body.contains("* user@example.com"), "email missing\n{body}");
-        assert!(!body.contains(raw_id), "raw id leaked\n{body}");
-    }
-
-    #[test]
-    fn registers_usage_refresh_and_codex_account_click_areas() {
+    fn renders_usage_workspace_sections_and_codex_actions() {
         let mut app = make_app();
         app.subscription_usage = vec![
             output(
@@ -716,142 +2480,574 @@ mod tests {
             ),
         ];
 
-        let body = render_body(&mut app, 100, 18);
+        let body = render_body(&mut app, 150, 32);
 
-        assert!(body.contains("[Refresh]"), "refresh button missing\n{body}");
-        assert!(body.contains("[Add Codex]"), "add button missing\n{body}");
-        assert!(body.contains("* work"), "active marker missing\n{body}");
-        assert!(body.contains("[Use]"), "use button missing\n{body}");
-        assert!(body.contains("[Remove]"), "remove button missing\n{body}");
-        assert!(app
-            .click_areas
-            .iter()
-            .any(|area| matches!(area.action, ClickAction::UsageRefresh)));
-        assert!(app
-            .click_areas
-            .iter()
-            .any(|area| matches!(area.action, ClickAction::CodexStartLogin)));
-        assert!(app.click_areas.iter().any(|area| matches!(
-            &area.action,
-            ClickAction::CodexUseAccount { account_id } if account_id == "acct_personal"
-        )));
-        assert!(app.click_areas.iter().any(|area| matches!(
-            &area.action,
-            ClickAction::CodexRemoveAccount { account_id } if account_id == "acct_work"
-        )));
+        assert!(body.contains("Usage Summary"), "{body}");
+        assert!(body.contains("Selected Account"), "{body}");
+        assert!(body.contains("Accounts"), "{body}");
+        assert!(body.contains("Attention"), "{body}");
+        assert!(body.contains("Account") && body.contains("Plan"), "{body}");
+        assert!(body.contains("Keep current account"), "{body}");
+        assert!(body.contains("work"), "{body}");
+        assert!(body.contains("personal"), "{body}");
+        assert!(body.contains(" Remove "), "{body}");
+        assert!(body.contains("Show Emails"), "{body}");
     }
 
     #[test]
-    fn renders_confirm_for_pending_codex_removal() {
+    fn selected_account_panel_follows_selected_index() {
         let mut app = make_app();
-        app.pending_codex_remove_account_id = Some("acct_work".to_string());
-        app.subscription_usage = vec![output(
+        app.selected_index = 1;
+        app.subscription_usage = vec![
+            output(
+                "Codex",
+                Some(UsageAccount {
+                    id: "acct_work".to_string(),
+                    label: Some("work".to_string()),
+                    is_active: true,
+                }),
+            ),
+            output(
+                "Codex",
+                Some(UsageAccount {
+                    id: "acct_personal".to_string(),
+                    label: Some("personal".to_string()),
+                    is_active: false,
+                }),
+            ),
+        ];
+
+        let body = render_body(&mut app, 150, 28);
+
+        assert!(body.contains("Codex (personal)"), "{body}");
+        assert!(body.contains("Use Account"), "{body}");
+        assert!(body.contains("saved store"), "{body}");
+    }
+
+    #[test]
+    fn usage_header_counts_saved_and_managed_identities() {
+        let mut app = make_app();
+        app.subscription_usage = vec![
+            output(
+                "Codex",
+                Some(UsageAccount {
+                    id: "acct_work".to_string(),
+                    label: Some("work".to_string()),
+                    is_active: true,
+                }),
+            ),
+            output("Copilot", None),
+        ];
+
+        let body = render_body(&mut app, 160, 28);
+
+        assert!(body.contains("2 providers · 1 saved · 1 managed"), "{body}");
+        assert!(
+            body.contains("Snapshot  2 ready · 0 at risk · 1 saved · 1 managed"),
+            "{body}"
+        );
+    }
+
+    #[test]
+    fn usage_top_columns_balance_wide_and_medium_screens() {
+        assert_eq!(usage_top_column_percentages(160), (50, 50));
+        assert_eq!(usage_top_column_percentages(128), (50, 50));
+        assert_eq!(usage_top_column_percentages(127), (48, 52));
+        assert_eq!(usage_top_column_percentages(104), (48, 52));
+    }
+
+    #[test]
+    fn usage_account_actions_render_in_selected_account_panel() {
+        let mut app = make_app();
+        app.selected_index = 1;
+        app.subscription_usage = vec![
+            output(
+                "Codex",
+                Some(UsageAccount {
+                    id: "acct_work".to_string(),
+                    label: Some("work".to_string()),
+                    is_active: true,
+                }),
+            ),
+            output(
+                "Codex",
+                Some(UsageAccount {
+                    id: "acct_personal".to_string(),
+                    label: Some("personal".to_string()),
+                    is_active: false,
+                }),
+            ),
+        ];
+
+        let body = render_body(&mut app, 210, 30);
+        let saved_row = body
+            .lines()
+            .find(|line| line.contains("personal") && line.contains("5h"))
+            .expect("missing saved account table row");
+        let actions_line = body
+            .lines()
+            .find(|line| line.contains("Use Account") && line.contains("Remove"))
+            .expect("missing selected account action buttons");
+
+        assert!(!saved_row.contains("Use Account"), "{saved_row}");
+        assert!(!saved_row.contains("Remove"), "{saved_row}");
+        assert!(
+            visual_col(actions_line, "Use Account").is_some(),
+            "{actions_line}"
+        );
+    }
+
+    #[test]
+    fn usage_reset_button_renders_when_credit_available() {
+        let mut app = make_app();
+        app.subscription_usage = vec![output_with_reset_credits(
             "Codex",
             Some(UsageAccount {
                 id: "acct_work".to_string(),
                 label: Some("work".to_string()),
                 is_active: true,
             }),
+            2,
         )];
 
-        let body = render_body(&mut app, 100, 10);
+        let body = render_body(&mut app, 180, 32);
 
-        assert!(body.contains("[Confirm]"), "confirm button missing\n{body}");
-        assert!(
-            !body.contains("[Remove]"),
-            "stale remove button shown\n{body}"
+        assert!(body.contains("Reset Bank"), "{body}");
+        assert!(body.contains("2 available"), "{body}");
+        assert!(body.contains("x Reset"), "{body}");
+        assert!(body.contains(" Reset "), "{body}");
+        assert!(body.contains("Credit Bank"), "{body}");
+        assert!(body.contains("2 credits"), "{body}");
+        assert!(body.contains("expires Jul 12"), "{body}");
+        let state_line = body
+            .lines()
+            .find(|line| line.contains("State"))
+            .expect("missing state line");
+        let credit_heading = body
+            .lines()
+            .find(|line| line.contains("Credit Bank"))
+            .expect("missing credit bank heading");
+        let credit_account = body
+            .lines()
+            .find(|line| line.contains("2 credits"))
+            .expect("missing selected credit account");
+        assert_eq!(
+            visual_col(state_line, "State"),
+            visual_col(credit_heading, "Credit Bank"),
+            "{state_line}\n{credit_heading}"
         );
+        assert_eq!(
+            visual_col(credit_heading, "Credit Bank"),
+            visual_col(credit_account, "work"),
+            "{credit_heading}\n{credit_account}"
+        );
+        assert!(!body.contains("Active:"), "{body}");
+        assert!(!body.contains("Quota Recovery"), "{body}");
+        assert!(app.click_areas.iter().any(|area| matches!(
+            &area.action,
+            ClickAction::CodexResetAccount { account_id } if account_id == "acct_work"
+        )));
     }
 
     #[test]
-    fn renders_codex_login_panel_output_and_dismiss_action() {
+    fn selected_account_panel_aligns_detail_sections() {
         let mut app = make_app();
-        app.codex_login_lines = vec![
-            "Open https://example.com/device".to_string(),
-            "Code ABCD-EFGH".to_string(),
+        app.subscription_usage = vec![output_with_reset_credits(
+            "Codex",
+            Some(UsageAccount {
+                id: "acct_work".to_string(),
+                label: Some("work".to_string()),
+                is_active: true,
+            }),
+            2,
+        )];
+
+        let body = render_body(&mut app, 180, 32);
+        let status_line = body
+            .lines()
+            .find(|line| line.contains("Status") && line.contains("Ready"))
+            .expect("missing selected account status line");
+        let limits_line = body
+            .lines()
+            .find(|line| line.contains("Limits") && !line.contains("Limits / Reset"))
+            .expect("missing selected account limits heading");
+        let metric_line = body
+            .lines()
+            .find(|line| {
+                line.contains("5h") && line.contains("90% left") && !line.contains("Codex")
+            })
+            .expect("missing selected account metric row");
+        let actions_line = body
+            .lines()
+            .find(|line| line.contains("Actions") && !line.contains("Add Codex"))
+            .expect("missing selected account actions heading");
+        let current_line = body
+            .lines()
+            .find(|line| line.contains("Current account"))
+            .expect("missing selected account action row");
+        let selected_col = visual_col(status_line, "Status");
+        assert_eq!(selected_col, visual_col(limits_line, "Limits"));
+        assert_eq!(selected_col, visual_col(metric_line, "5h"));
+        assert_eq!(selected_col, visual_col(actions_line, "Actions"));
+        assert_eq!(selected_col, visual_col(current_line, "Current account"));
+    }
+
+    #[test]
+    fn usage_account_table_header_aligns_with_wide_columns() {
+        let mut app = make_app();
+        app.subscription_usage = vec![
+            {
+                let mut output = output(
+                    "Codex",
+                    Some(UsageAccount {
+                        id: "acct_work".to_string(),
+                        label: Some("work".to_string()),
+                        is_active: true,
+                    }),
+                );
+                output.metrics[0].resets_at = Some("resets soon".to_string());
+                output
+            },
+            output(
+                "Codex",
+                Some(UsageAccount {
+                    id: "acct_personal".to_string(),
+                    label: Some("personal".to_string()),
+                    is_active: false,
+                }),
+            ),
         ];
-        app.codex_login_outcome = Some(CodexLoginOutcome::Failed("expired".to_string()));
 
-        let body = render_body(&mut app, 100, 12);
+        let body = render_body(&mut app, 180, 24);
+        let header = body
+            .lines()
+            .find(|line| line.contains("Provider") && line.contains("Reset"))
+            .expect("missing account table header");
+        let active_row = body
+            .lines()
+            .find(|line| line.contains("Codex") && line.contains("work") && line.contains("5h"))
+            .expect("missing active account table row");
 
-        assert!(body.contains("Codex login"), "login panel missing\n{body}");
-        assert!(
-            body.contains("Open https://example.com/device"),
-            "login output missing\n{body}"
+        assert_eq!(
+            visual_col(header, "Provider"),
+            visual_col(active_row, "Codex"),
+            "{header}\n{active_row}"
         );
-        assert!(body.contains("expired"), "login error missing\n{body}");
-        assert!(body.contains("[Dismiss]"), "dismiss button missing\n{body}");
-        assert!(app
-            .click_areas
-            .iter()
-            .any(|area| matches!(area.action, ClickAction::CodexDismissLogin)));
+        assert_eq!(
+            visual_col(header, "Account"),
+            visual_col(active_row, "work"),
+            "{header}\n{active_row}"
+        );
+        assert_eq!(
+            visual_col(header, "Plan"),
+            visual_col(active_row, "Pro"),
+            "{header}\n{active_row}"
+        );
+        assert_eq!(
+            visual_col(header, "Auth"),
+            visual_col(active_row, "Active"),
+            "{header}\n{active_row}"
+        );
+        assert_eq!(
+            visual_col(header, "Health"),
+            visual_col(active_row, "Ready"),
+            "{header}\n{active_row}"
+        );
+        assert_eq!(
+            visual_col(header, "Limit"),
+            visual_col(active_row, "5h"),
+            "{header}\n{active_row}"
+        );
+        assert_eq!(
+            visual_col(header, "Reset"),
+            visual_col(active_row, "resets soon"),
+            "{header}\n{active_row}"
+        );
+        assert!(!header.contains("Use"), "{header}");
+        assert!(!header.contains("Remove"), "{header}");
+        assert!(!active_row.contains("Remove"), "{active_row}");
     }
 
     #[test]
-    fn account_button_click_areas_stay_inside_short_panel() {
+    fn usage_account_table_allocates_space_to_long_limit_summaries() {
         let mut app = make_app();
-        // Enough accounts that later rows fall below the panel on a short
-        // terminal (where the footer would sit in a real layout).
-        app.subscription_usage = (0..8)
+        let mut output = output(
+            "Codex",
+            Some(UsageAccount {
+                id: "acct_work".to_string(),
+                label: Some("work".to_string()),
+                is_active: true,
+            }),
+        );
+        output.metrics = vec![
+            UsageMetric {
+                label: "5h".to_string(),
+                used_percent: 8.0,
+                remaining_percent: 92.0,
+                remaining_label: Some("92% left".to_string()),
+                resets_at: Some("resets in 4h 24m".to_string()),
+            },
+            UsageMetric {
+                label: "Weekly".to_string(),
+                used_percent: 49.0,
+                remaining_percent: 51.0,
+                remaining_label: Some("51% left".to_string()),
+                resets_at: None,
+            },
+            UsageMetric {
+                label: "Spark 5h".to_string(),
+                used_percent: 0.0,
+                remaining_percent: 100.0,
+                remaining_label: Some("100% left".to_string()),
+                resets_at: None,
+            },
+            UsageMetric {
+                label: "Spark weekly".to_string(),
+                used_percent: 12.0,
+                remaining_percent: 88.0,
+                remaining_label: Some("88% left".to_string()),
+                resets_at: None,
+            },
+        ];
+        app.subscription_usage = vec![output];
+
+        let body = render_body(&mut app, 180, 24);
+        let row = body
+            .lines()
+            .find(|line| line.contains("Codex") && line.contains("5h 92%"))
+            .expect("missing account table row");
+
+        assert!(row.contains("Weekly 51%"), "{row}");
+        assert!(row.contains("Spark 5h 100%"), "{row}");
+        assert!(row.contains("Spark weekly 88%"), "{row}");
+        assert!(row.contains("resets in 4h 24m"), "{row}");
+    }
+
+    #[test]
+    fn usage_account_table_reset_follows_display_metric() {
+        let mut app = make_app();
+        let mut output = output(
+            "Codex",
+            Some(UsageAccount {
+                id: "acct_work".to_string(),
+                label: Some("work".to_string()),
+                is_active: true,
+            }),
+        );
+        output.metrics = vec![
+            UsageMetric {
+                label: "Weekly".to_string(),
+                used_percent: 8.0,
+                remaining_percent: 92.0,
+                remaining_label: Some("92% left".to_string()),
+                resets_at: Some("resets next week".to_string()),
+            },
+            UsageMetric {
+                label: "Session".to_string(),
+                used_percent: 96.0,
+                remaining_percent: 4.0,
+                remaining_label: Some("4% left".to_string()),
+                resets_at: Some("resets soon".to_string()),
+            },
+        ];
+        app.subscription_usage = vec![output];
+
+        let body = render_body(&mut app, 180, 24);
+        let row = body
+            .lines()
+            .find(|line| line.contains("Codex") && line.contains("Weekly 92%"))
+            .expect("missing account table row");
+
+        assert!(row.contains("resets soon"), "{row}");
+        assert!(!row.contains("resets next week"), "{row}");
+    }
+
+    #[test]
+    fn narrow_usage_keeps_account_actions_visible() {
+        let mut app = make_app();
+        app.subscription_usage = vec![
+            output(
+                "Codex",
+                Some(UsageAccount {
+                    id: "acct_work".to_string(),
+                    label: Some("work".to_string()),
+                    is_active: true,
+                }),
+            ),
+            output(
+                "Codex",
+                Some(UsageAccount {
+                    id: "acct_personal".to_string(),
+                    label: Some("personal".to_string()),
+                    is_active: false,
+                }),
+            ),
+        ];
+
+        let body = render_body(&mut app, 90, 28);
+
+        assert!(body.contains("work"), "{body}");
+        assert!(body.contains("personal"), "{body}");
+        assert!(body.contains(" Remove "), "{body}");
+    }
+
+    #[test]
+    fn very_narrow_ready_usage_uses_compact_actions_and_message() {
+        let mut app = make_app();
+        let body = render_body(&mut app, 28, 20);
+
+        assert!(body.contains("r Refresh"), "{body}");
+        assert!(body.contains("a Add"), "{body}");
+        assert!(body.contains("No usage data"), "{body}");
+        assert!(!body.contains("Add Codex"), "{body}");
+        assert!(!body.contains("No subscription data load"), "{body}");
+    }
+
+    #[test]
+    fn empty_usage_hides_email_privacy_action() {
+        let mut app = make_app();
+        let body = render_body(&mut app, 150, 20);
+
+        assert!(body.contains("r Refresh"), "{body}");
+        assert!(body.contains("a Add Codex"), "{body}");
+        assert!(!body.contains("Show Emails"), "{body}");
+        assert!(!body.contains("Hide Emails"), "{body}");
+    }
+
+    #[test]
+    fn usage_navigation_scrolls_by_rendered_capacity() {
+        let mut app = make_app();
+        app.subscription_usage = (0..30)
             .map(|index| {
                 output(
                     "Codex",
                     Some(UsageAccount {
-                        id: format!("acct_{index}"),
-                        label: Some(format!("account-{index}")),
+                        id: format!("acct_{index:02}"),
+                        label: Some(format!("acct-{index:02}")),
                         is_active: index == 0,
                     }),
                 )
             })
             .collect();
 
-        let height = 9u16;
-        let body = render_body(&mut app, 100, height);
-        assert!(body.contains("[Remove]"), "remove button missing\n{body}");
-
-        // The panel border occupies the last row; inner content ends above it.
-        let inner_bottom = height - 1;
-        for area in &app.click_areas {
-            if matches!(
-                area.action,
-                ClickAction::CodexUseAccount { .. } | ClickAction::CodexRemoveAccount { .. }
-            ) {
-                assert!(
-                    area.rect.y < inner_bottom,
-                    "click area for off-screen button leaked below panel: {:?}",
-                    area.rect
-                );
-            }
+        let _ = render_body(&mut app, 170, 32);
+        let visible = app.max_visible_items;
+        for _ in 0..visible {
+            app.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
         }
 
-        let remove_areas = app
-            .click_areas
-            .iter()
-            .filter(|area| matches!(area.action, ClickAction::CodexRemoveAccount { .. }))
-            .count();
-        assert!(
-            remove_areas < 8,
-            "expected off-screen remove buttons to be skipped, got {remove_areas}"
-        );
-        assert!(remove_areas > 0, "visible remove buttons must register");
+        assert!(app.scroll_offset > 0);
+        assert!(app.selected_index >= visible);
     }
 
     #[test]
-    fn codex_login_dismiss_click_area_stays_inside_narrow_panel() {
+    fn attention_outputs_prioritize_actionable_accounts() {
+        let outputs = vec![
+            output_with_remaining("Copilot", None, 0.0),
+            output_with_remaining(
+                "Codex",
+                Some(UsageAccount {
+                    id: "acct_saved".to_string(),
+                    label: Some("saved".to_string()),
+                    is_active: false,
+                }),
+                0.0,
+            ),
+            output_with_remaining(
+                "Codex",
+                Some(UsageAccount {
+                    id: "acct_active".to_string(),
+                    label: Some("active".to_string()),
+                    is_active: true,
+                }),
+                0.0,
+            ),
+        ];
+
+        let ordered_indices = attention_outputs(&outputs)
+            .into_iter()
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+
+        assert_eq!(ordered_indices, vec![2, 1, 0]);
+    }
+
+    #[test]
+    fn usage_attention_shows_more_when_clipped() {
         let mut app = make_app();
+        app.subscription_usage = vec![
+            output_with_remaining(
+                "Codex",
+                Some(UsageAccount {
+                    id: "acct_active".to_string(),
+                    label: Some("active".to_string()),
+                    is_active: true,
+                }),
+                0.0,
+            ),
+            output_with_remaining(
+                "Codex",
+                Some(UsageAccount {
+                    id: "acct_saved".to_string(),
+                    label: Some("saved".to_string()),
+                    is_active: false,
+                }),
+                0.0,
+            ),
+            output_with_remaining("Copilot", None, 0.0),
+        ];
+
+        let body = render_body(&mut app, 210, 34);
+
+        assert!(body.contains("3 critical"), "{body}");
+        assert!(body.contains("Attention"), "{body}");
+        assert!(body.contains("active"), "{body}");
+        assert!(body.contains("saved"), "{body}");
+        assert!(body.contains("+1 more at risk"), "{body}");
+    }
+
+    #[test]
+    fn usage_email_privacy_hides_email_addresses() {
+        let mut app = make_app();
+        app.hide_usage_emails = true;
+        app.subscription_usage = vec![UsageOutput {
+            provider: "Codex".to_string(),
+            account: Some(UsageAccount {
+                id: "acct_secret_123456789".to_string(),
+                label: None,
+                is_active: true,
+            }),
+            plan: Some("Pro".to_string()),
+            email: Some("secret@example.com".to_string()),
+            metrics: vec![UsageMetric {
+                label: "Session".to_string(),
+                used_percent: 5.0,
+                remaining_percent: 95.0,
+                remaining_label: Some("95% left".to_string()),
+                resets_at: None,
+            }],
+            reset_credits: None,
+            credit_status: None,
+            spend_control: None,
+        }];
+
+        let body = render_body(&mut app, 170, 28);
+
+        assert!(!body.contains("secret@example.com"), "{body}");
+        assert!(body.contains("[hidden email]"), "{body}");
+        assert!(body.contains("Account acct_s...6789"), "{body}");
+    }
+
+    #[test]
+    fn login_panel_renders_recent_output_and_dismiss() {
+        let mut app = make_app();
+        app.codex_login_lines = vec!["open browser".to_string()];
         app.codex_login_outcome = Some(CodexLoginOutcome::Failed("expired".to_string()));
 
-        let _body = render_body(&mut app, 6, 8);
+        let body = render_body(&mut app, 90, 14);
 
-        let dismiss_area = app
-            .click_areas
-            .iter()
-            .find(|area| matches!(area.action, ClickAction::CodexDismissLogin))
-            .expect("dismiss click area");
-        assert!(
-            dismiss_area.rect.x + dismiss_area.rect.width <= 6,
-            "dismiss click area exceeds panel: {:?}",
-            dismiss_area.rect
-        );
+        assert!(body.contains("Codex Login"), "{body}");
+        assert!(body.contains("open browser"), "{body}");
+        assert!(body.contains("[Dismiss]"), "{body}");
     }
 }

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -104,6 +104,54 @@ fn scrollbar_position(scroll_offset: usize, content_len: usize, viewport_len: us
     }
 }
 
+pub(crate) fn light_ratio_bar_spans(
+    ratio: f64,
+    width: usize,
+    fill_style: Style,
+    empty_style: Style,
+) -> Vec<Span<'static>> {
+    if width == 0 {
+        return Vec::new();
+    }
+
+    let ratio = ratio.clamp(0.0, 1.0);
+    let scaled = ratio * width as f64;
+    let trace = ratio > 0.0 && ratio < 0.01 && scaled < 1.0;
+    let filled = if ratio > 0.0 && !trace {
+        (scaled.round() as usize).clamp(1, width)
+    } else {
+        0
+    };
+    let empty = width.saturating_sub(filled + usize::from(trace));
+
+    let mut spans = Vec::with_capacity(3);
+    if filled > 0 {
+        spans.push(Span::styled("█".repeat(filled), fill_style));
+    }
+    if trace {
+        spans.push(Span::styled("▏", fill_style));
+    }
+    if empty > 0 {
+        spans.push(Span::styled("·".repeat(empty), empty_style));
+    }
+    spans
+}
+
+pub(crate) fn truncate_ellipsis(s: &str, max_chars: usize) -> String {
+    if max_chars == 0 {
+        return String::new();
+    }
+    let char_count = s.chars().count();
+    if char_count <= max_chars {
+        s.to_string()
+    } else if max_chars == 1 {
+        "…".to_string()
+    } else {
+        let head: String = s.chars().take(max_chars - 1).collect();
+        format!("{head}…")
+    }
+}
+
 pub fn get_model_color(model: &str) -> Color {
     get_provider_shade(get_provider_from_model(model), 0)
 }


### PR DESCRIPTION
## Summary

- Rebuilds the TUI Usage tab around subscription/provider usage, saved account inventory, readiness, reset timing, and responsive wide/medium/narrow layouts.
- Adds Codex saved account controls for login/import, switch, remove, email privacy, and reset-credit consumption with confirmation dialogs.
- Extends usage provider output with reset credits, credit status, spend controls, and current provider compatibility fields.

## Screenshots

Wide:

![Usage dashboard wide](https://gist.githubusercontent.com/astkaasa/3654f2ee7f79fdce51d275020ccecc6d/raw/usage-dashboard-wide.png)

Medium:

![Usage dashboard medium](https://gist.githubusercontent.com/astkaasa/3654f2ee7f79fdce51d275020ccecc6d/raw/usage-dashboard-medium.png)

Narrow:

![Usage dashboard narrow](https://gist.githubusercontent.com/astkaasa/3654f2ee7f79fdce51d275020ccecc6d/raw/usage-dashboard-narrow.png)

## Testing

- `cargo fmt`
- `git diff --check`
- `cargo test -p tokscale-cli --no-default-features` (passes outside the sandbox; the sandboxed run hit `Operation not permitted` in Antigravity local socket tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a subscription‑centric Usage dashboard in the TUI with provider cards, Codex account controls, and reset‑credit workflows. Shows extra limits, credit/spend status, and gives clear feedback for reset outcomes.

- **New Features**
  - Rebuilt Usage tab with responsive wide/medium/narrow layouts and auto‑fetch on entry.
  - Codex account management: login/import, switch/remove with confirmation, consume reset credits with confirmation, and an email‑privacy toggle.
  - Shows additional rate limits, reset‑credit availability/details, credit balance/unlimited/overage, and spend‑control flags.

- **Refactors**
  - Extend `UsageOutput` with `reset_credits`, `credit_status`, and `spend_control` (other providers set `None`); light renderer shows “Resets”.
  - Codex: fetch reset‑credit details, handle auth expiries/refresh, match active account by token identity, clear active selection when removing the active account, and expose `consume_rate_limit_reset_credit`.
  - Reset flow: handle response edge cases (“already redeemed”, “nothing to reset”, “no credit”), show outcome text, and preserve the success status while a background refresh reloads usage.

<sup>Written for commit 91ebf4106127eeff4cf3f3affd8d0cc5a57f4d32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

