### PR TITLE
feat(reasonix): parse local session usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
 | <img width="48px" src=".github/assets/client-pi.png" alt="Pi" /> | [Pi](https://github.com/badlogic/pi-mono) | `~/.pi/agent/sessions/` and `~/.omp/agent/sessions/` ([Oh My Pi](https://github.com/can1357/oh-my-pi)) |
 | <img width="48px" src=".github/assets/client-senpi.png" alt="Senpi" /> | [Senpi (OmO Native)](https://github.com/code-yeongyu/senpi) | `~/.senpi/agent/sessions/` (override via `SENPI_CODING_AGENT_DIR`) |
 | <img width="48px" src="https://github.com/getkimchi.png" alt="Kimchi" /> | [Kimchi Coding](https://kimchi.dev/) | `~/.config/kimchi/harness/sessions/` (override via `KIMCHI_CODING_AGENT_DIR`) |
+| <img width="48px" src=".github/assets/client-synthetic.png" alt="Reasonix" /> | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | `~/.reasonix/stats/*.jsonl` (override via `REASONIX_STATE_HOME` or `REASONIX_HOME`) |
 | <img width="48px" src=".github/assets/client-kimi.png" alt="Kimi" /> | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) / [Kimi Code](https://github.com/MoonshotAI/kimi-code) | kimi-cli: `~/.kimi/sessions/` kimi-code: `~/.kimi-code/sessions/` (override via `KIMI_CODE_HOME`) |
 | <img width="48px" src=".github/assets/client-qwen.png" alt="Qwen" /> | [Qwen CLI](https://github.com/QwenLM/qwen-cli) | `~/.qwen/projects/` |
 | <img width="48px" src=".github/assets/client-roocode.png" alt="Roo Code" /> | [Roo Code](https://github.com/RooCodeInc/Roo-Code) | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` (+ server: `~/.vscode-server/data/User/globalStorage/rooveterinaryinc.roo-cline/tasks/`) |
@@ -169,7 +170,7 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
   - GitHub-style contribution graph with configurable color themes
   - Real-time filtering and sorting
   - Zero flicker rendering
-- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimchi Coding, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, and Synthetic
+- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimchi Coding, Reasonix, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, and Synthetic
 - **Real-time pricing** - Fetches current pricing from LiteLLM with 1-hour disk cache; automatic OpenRouter fallback and Cursor model pricing for newly released models
 - **Detailed breakdowns** - Input, output, cache read/write, and reasoning token tracking
 - **Native Rust core** - All parsing and aggregation done in Rust for 10x faster processing

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1076,6 +1076,7 @@ pub enum ClientFilter {
     #[value(alias = "auggie")]
     Augment,
     Kimchi,
+    Reasonix,
     Synthetic,
 }
 
@@ -1128,6 +1129,7 @@ impl ClientFilter {
             Self::Senpi => "senpi",
             Self::Augment => "augment",
             Self::Kimchi => "kimchi",
+            Self::Reasonix => "reasonix",
             Self::Synthetic => "synthetic",
         }
     }
@@ -1183,6 +1185,7 @@ impl ClientFilter {
             Self::Senpi => Some(ClientId::Senpi),
             Self::Augment => Some(ClientId::Augment),
             Self::Kimchi => Some(ClientId::Kimchi),
+            Self::Reasonix => Some(ClientId::Reasonix),
             Self::Synthetic => None,
         }
     }
@@ -1234,6 +1237,7 @@ impl ClientFilter {
             ClientId::Senpi => Self::Senpi,
             ClientId::Augment => Self::Augment,
             ClientId::Kimchi => Self::Kimchi,
+            ClientId::Reasonix => Self::Reasonix,
         }
     }
 

--- a/crates/tokscale-cli/src/tui/client_ui.rs
+++ b/crates/tokscale-cli/src/tui/client_ui.rs
@@ -180,6 +180,10 @@ pub const CLIENT_UI: [ClientUi; ClientId::COUNT] = [
         display_name: "Kimchi",
         hotkey: 'K',
     },
+    ClientUi {
+        display_name: "Reasonix",
+        hotkey: 'R',
+    },
 ];
 
 pub fn display_name(client: ClientId) -> &'static str {

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -796,7 +796,9 @@ mod tests {
     fn test_reasonix_client_registered_as_local_session_source() {
         let client = ClientId::from_str("reasonix").expect("reasonix client should be registered");
         assert_eq!(
-            client.data().resolve_path("/tmp/home"),
+            client
+                .data()
+                .resolve_path_with_env_strategy("/tmp/home", false),
             "/tmp/home/.reasonix/stats"
         );
         assert_eq!(client.data().pattern, "*.jsonl");

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -108,6 +108,7 @@ impl PathRoot {
 
 fn clean_reasonix_env_dir(name: &str, home_dir: &str) -> Option<String> {
     let value = std::env::var(name).ok()?;
+    let value = expand_reasonix_env_vars(value.trim());
     let value = value.trim();
     if value.is_empty() {
         return None;
@@ -130,6 +131,47 @@ fn clean_reasonix_env_dir(name: &str, home_dir: &str) -> Option<String> {
         std::env::current_dir().ok()?.join(path)
     };
     Some(path.to_string_lossy().into_owned())
+}
+
+// Match Reasonix's config expansion for ${VAR} and ${VAR:-default}. This must
+// happen before tilde and relative-path handling because either expansion may
+// produce one of those forms.
+fn expand_reasonix_env_vars(value: &str) -> String {
+    let mut expanded = String::with_capacity(value.len());
+    let mut remainder = value;
+
+    while let Some(start) = remainder.find("${") {
+        expanded.push_str(&remainder[..start]);
+        let reference = &remainder[start + 2..];
+        let Some(end) = reference.find('}') else {
+            expanded.push_str(&remainder[start..]);
+            return expanded;
+        };
+
+        let expression = &reference[..end];
+        let (name, default) = expression
+            .split_once(":-")
+            .map_or((expression, None), |(name, default)| (name, Some(default)));
+        let is_valid_name = name.chars().enumerate().all(|(index, character)| {
+            (character == '_' || character.is_ascii_alphabetic())
+                || (index > 0 && character.is_ascii_digit())
+        });
+
+        if is_valid_name && !name.is_empty() {
+            match std::env::var(name) {
+                Ok(env_value) if !env_value.is_empty() => expanded.push_str(&env_value),
+                _ => expanded.push_str(default.unwrap_or_default()),
+            }
+        } else {
+            expanded.push_str("${");
+            expanded.push_str(expression);
+            expanded.push('}');
+        }
+        remainder = &reference[end + 1..];
+    }
+
+    expanded.push_str(remainder);
+    expanded
 }
 
 #[derive(Debug, Clone)]
@@ -816,6 +858,46 @@ mod tests {
 
         restore_env("REASONIX_STATE_HOME", state_previous);
         restore_env("REASONIX_HOME", home_previous);
+    }
+
+    #[test]
+    fn test_reasonix_stats_expands_environment_references_before_normalizing_paths() {
+        let _guard = env_lock().lock().unwrap();
+        let state_previous = std::env::var("REASONIX_STATE_HOME").ok();
+        let root_previous = std::env::var("TOKSCALE_REASONIX_TEST_ROOT").ok();
+        let unset_previous = std::env::var("TOKSCALE_REASONIX_TEST_UNSET").ok();
+        let client = ClientId::Reasonix;
+
+        unsafe {
+            std::env::set_var("TOKSCALE_REASONIX_TEST_ROOT", "~/reasonix-state");
+            std::env::remove_var("TOKSCALE_REASONIX_TEST_UNSET");
+            std::env::set_var(
+                "REASONIX_STATE_HOME",
+                "${TOKSCALE_REASONIX_TEST_ROOT}/nested",
+            );
+        }
+        assert_eq!(
+            client.data().resolve_path("/tmp/home"),
+            "/tmp/home/reasonix-state/nested/stats"
+        );
+
+        unsafe {
+            std::env::set_var(
+                "REASONIX_STATE_HOME",
+                "${TOKSCALE_REASONIX_TEST_UNSET:-relative-reasonix}",
+            );
+        }
+        let expected = std::env::current_dir()
+            .expect("test process has a current directory")
+            .join("relative-reasonix")
+            .join("stats")
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(client.data().resolve_path("/tmp/home"), expected);
+
+        restore_env("REASONIX_STATE_HOME", state_previous);
+        restore_env("TOKSCALE_REASONIX_TEST_ROOT", root_previous);
+        restore_env("TOKSCALE_REASONIX_TEST_UNSET", unset_previous);
     }
 
     #[test]

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -16,21 +16,26 @@ impl PathRoot {
             PathRoot::Home => home_dir.to_string(),
             PathRoot::ReasonixHome => {
                 if use_env_roots {
-                    if let Some(state_home) = std::env::var_os("REASONIX_STATE_HOME") {
-                        if !state_home.is_empty() {
-                            return state_home.to_string_lossy().into_owned();
-                        }
+                    if let Some(state_home) =
+                        clean_reasonix_env_dir("REASONIX_STATE_HOME", home_dir)
+                    {
+                        return state_home;
                     }
-                    if let Some(home) = std::env::var_os("REASONIX_HOME") {
-                        if !home.is_empty() {
-                            return home.to_string_lossy().into_owned();
-                        }
+                    if let Some(home) = clean_reasonix_env_dir("REASONIX_HOME", home_dir) {
+                        return home;
                     }
                 }
                 #[cfg(target_os = "windows")]
                 {
+                    if use_env_roots {
+                        if let Some(config_dir) = dirs::config_dir() {
+                            return config_dir.join("reasonix").to_string_lossy().into_owned();
+                        }
+                    }
                     return std::path::Path::new(home_dir)
-                        .join("AppData/Roaming/reasonix")
+                        .join("AppData")
+                        .join("Roaming")
+                        .join("reasonix")
                         .to_string_lossy()
                         .into_owned();
                 }
@@ -99,6 +104,32 @@ impl PathRoot {
     pub fn resolve(&self, home_dir: &str) -> String {
         self.resolve_with_env_strategy(home_dir, true)
     }
+}
+
+fn clean_reasonix_env_dir(name: &str, home_dir: &str) -> Option<String> {
+    let value = std::env::var(name).ok()?;
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+
+    let path = if value == "~" {
+        std::path::PathBuf::from(home_dir)
+    } else if let Some(relative) = value
+        .strip_prefix("~/")
+        .or_else(|| value.strip_prefix("~\\"))
+    {
+        std::path::Path::new(home_dir).join(relative)
+    } else {
+        std::path::PathBuf::from(value)
+    };
+
+    let path = if path.is_absolute() {
+        path
+    } else {
+        std::env::current_dir().ok()?.join(path)
+    };
+    Some(path.to_string_lossy().into_owned())
 }
 
 #[derive(Debug, Clone)]
@@ -751,6 +782,59 @@ mod tests {
             client.data().resolve_path("/tmp/home"),
             "/custom/reasonix-home/stats"
         );
+        restore_env("REASONIX_STATE_HOME", state_previous);
+        restore_env("REASONIX_HOME", home_previous);
+    }
+
+    #[test]
+    fn test_reasonix_stats_normalizes_env_roots_and_ignores_blank_values() {
+        let _guard = env_lock().lock().unwrap();
+        let state_previous = std::env::var("REASONIX_STATE_HOME").ok();
+        let home_previous = std::env::var("REASONIX_HOME").ok();
+        let client = ClientId::Reasonix;
+
+        unsafe {
+            std::env::set_var("REASONIX_STATE_HOME", "  ~/reasonix-state  ");
+            std::env::set_var("REASONIX_HOME", "/unused/reasonix-home");
+        }
+        assert_eq!(
+            client.data().resolve_path("/tmp/home"),
+            "/tmp/home/reasonix-state/stats"
+        );
+
+        unsafe {
+            std::env::set_var("REASONIX_STATE_HOME", " \t ");
+            std::env::set_var("REASONIX_HOME", " relative-reasonix ");
+        }
+        let expected = std::env::current_dir()
+            .expect("test process has a current directory")
+            .join("relative-reasonix")
+            .join("stats")
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(client.data().resolve_path("/tmp/home"), expected);
+
+        restore_env("REASONIX_STATE_HOME", state_previous);
+        restore_env("REASONIX_HOME", home_previous);
+    }
+
+    #[test]
+    fn test_reasonix_stats_ignores_env_roots_when_requested() {
+        let _guard = env_lock().lock().unwrap();
+        let state_previous = std::env::var("REASONIX_STATE_HOME").ok();
+        let home_previous = std::env::var("REASONIX_HOME").ok();
+        unsafe {
+            std::env::set_var("REASONIX_STATE_HOME", "/custom/reasonix-state");
+            std::env::set_var("REASONIX_HOME", "/custom/reasonix-home");
+        }
+
+        assert_eq!(
+            ClientId::Reasonix
+                .data()
+                .resolve_path_with_env_strategy("/tmp/home", false),
+            "/tmp/home/.reasonix/stats"
+        );
+
         restore_env("REASONIX_STATE_HOME", state_previous);
         restore_env("REASONIX_HOME", home_previous);
     }

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -1,6 +1,7 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PathRoot {
     Home,
+    ReasonixHome,
     XdgData,
     Config,
     EnvVar {
@@ -13,6 +14,31 @@ impl PathRoot {
     pub fn resolve_with_env_strategy(&self, home_dir: &str, use_env_roots: bool) -> String {
         match self {
             PathRoot::Home => home_dir.to_string(),
+            PathRoot::ReasonixHome => {
+                if use_env_roots {
+                    if let Some(state_home) = std::env::var_os("REASONIX_STATE_HOME") {
+                        if !state_home.is_empty() {
+                            return state_home.to_string_lossy().into_owned();
+                        }
+                    }
+                    if let Some(home) = std::env::var_os("REASONIX_HOME") {
+                        if !home.is_empty() {
+                            return home.to_string_lossy().into_owned();
+                        }
+                    }
+                }
+                #[cfg(target_os = "windows")]
+                {
+                    return std::path::Path::new(home_dir)
+                        .join("AppData/Roaming/reasonix")
+                        .to_string_lossy()
+                        .into_owned();
+                }
+                #[cfg(not(target_os = "windows"))]
+                {
+                    format!("{home_dir}/.reasonix")
+                }
+            }
             PathRoot::XdgData => {
                 if use_env_roots {
                     std::env::var("XDG_DATA_HOME")
@@ -592,6 +618,18 @@ define_clients!(
         headless: false,
         parse_local: true,
         submit_default: true
+    },
+    // Reasonix stores authoritative provider usage as daily append-only JSONL
+    // records under `<state root>/stats/`. Transcript JSONL is intentionally
+    // excluded: it lacks exact token counters and overlaps these records.
+    Reasonix = 42 => {
+        id: "reasonix",
+        root: PathRoot::ReasonixHome,
+        relative: "stats",
+        pattern: "*.jsonl",
+        headless: false,
+        parse_local: true,
+        submit_default: true
     }
 );
 
@@ -644,7 +682,7 @@ mod tests {
 
     #[test]
     fn test_client_id_count() {
-        assert_eq!(ClientId::COUNT, 42);
+        assert_eq!(ClientId::COUNT, 43);
     }
 
     #[test]
@@ -679,6 +717,42 @@ mod tests {
         assert!(client.data().parse_local);
         assert!(client.data().submit_default);
         assert!(!client.data().headless);
+    }
+
+    #[test]
+    fn test_reasonix_client_registered_as_local_session_source() {
+        let client = ClientId::from_str("reasonix").expect("reasonix client should be registered");
+        assert_eq!(
+            client.data().resolve_path("/tmp/home"),
+            "/tmp/home/.reasonix/stats"
+        );
+        assert_eq!(client.data().pattern, "*.jsonl");
+        assert!(client.data().parse_local);
+        assert!(client.data().submit_default);
+        assert!(!client.data().headless);
+    }
+
+    #[test]
+    fn test_reasonix_stats_prefers_state_home_then_reasonix_home() {
+        let _guard = env_lock().lock().unwrap();
+        let state_previous = std::env::var("REASONIX_STATE_HOME").ok();
+        let home_previous = std::env::var("REASONIX_HOME").ok();
+        unsafe {
+            std::env::set_var("REASONIX_HOME", "/custom/reasonix-home");
+            std::env::set_var("REASONIX_STATE_HOME", "/custom/reasonix-state");
+        }
+        let client = ClientId::Reasonix;
+        assert_eq!(
+            client.data().resolve_path("/tmp/home"),
+            "/custom/reasonix-state/stats"
+        );
+        unsafe { std::env::remove_var("REASONIX_STATE_HOME") };
+        assert_eq!(
+            client.data().resolve_path("/tmp/home"),
+            "/custom/reasonix-home/stats"
+        );
+        restore_env("REASONIX_STATE_HOME", state_previous);
+        restore_env("REASONIX_HOME", home_previous);
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -3648,7 +3648,9 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
                 .collect::<Vec<_>>()
         })
         .collect();
-    let reasonix_count = reasonix_msgs.len() as i32;
+    let reasonix_count = reasonix_msgs.iter().fold(0_i32, |count, message| {
+        count.saturating_add(message.message_count)
+    });
     counts.set(ClientId::Reasonix, reasonix_count);
     messages.extend(reasonix_msgs);
 
@@ -10494,6 +10496,34 @@ mod tests {
         assert!(dates.contains(&local_date(thread_created + 2000)));
         assert!(dates.contains(&local_date(ledger_timestamp)));
     }
+
+    #[test]
+    fn test_parse_local_clients_reasonix_counts_reported_requests() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let stats_dir = temp_dir.path().join(".reasonix/stats");
+        std::fs::create_dir_all(&stats_dir).unwrap();
+        std::fs::write(
+            stats_dir.join("2026-08-04.jsonl"),
+            "{\"ts\":\"2026-08-04T09:10:11Z\",\"model\":\"deepseek/chat\",\"prompt\":100,\"completion\":20,\"total\":120,\"requests\":3}\n",
+        )
+        .unwrap();
+
+        let parsed = parse_local_clients(LocalParseOptions {
+            home_dir: Some(temp_dir.path().to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(vec!["reasonix".to_string()]),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner::ScannerSettings::default(),
+        })
+        .unwrap();
+
+        assert_eq!(parsed.messages.len(), 1);
+        assert_eq!(parsed.messages[0].message_count, 3);
+        assert_eq!(parsed.counts.get(ClientId::Reasonix), 3);
+    }
+
     #[test]
     fn test_retain_for_requested_clients_gjc_superset_of_9router() {
         let gjc_requested: HashSet<&str> = HashSet::from(["gjc"]);

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1695,6 +1695,27 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         }
     }
 
+    let reasonix_outcomes: Vec<CachedParseOutcome> = scan_result
+        .get(ClientId::Reasonix)
+        .par_iter()
+        .map(|path| {
+            load_or_parse_source_with_fingerprint(
+                message_cache::CacheIdentity::for_client(ClientId::Reasonix),
+                path,
+                &source_cache,
+                pricing,
+                message_cache::SourceFingerprint::check_reasonix_path_samples_only,
+                sessions::reasonix::parse_reasonix_file,
+            )
+        })
+        .collect();
+    for outcome in reasonix_outcomes {
+        all_messages.extend(outcome.messages);
+        if let Some(entry) = outcome.cache_entry {
+            source_cache.insert(entry);
+        }
+    }
+
     let senpi_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::Senpi)
         .par_iter()
@@ -3616,6 +3637,20 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     let kimchi_count = kimchi_msgs.len() as i32;
     counts.set(ClientId::Kimchi, kimchi_count);
     messages.extend(kimchi_msgs);
+
+    let reasonix_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::Reasonix)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::reasonix::parse_reasonix_file(path)
+                .into_iter()
+                .map(|message| unified_to_parsed(&message))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let reasonix_count = reasonix_msgs.len() as i32;
+    counts.set(ClientId::Reasonix, reasonix_count);
+    messages.extend(reasonix_msgs);
 
     let senpi_msgs: Vec<ParsedMessage> = scan_result
         .get(ClientId::Senpi)

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -926,9 +926,8 @@ fn parser_version(client: ClientId) -> u32 {
         // v1->v2: Kimchi's Pi-compatible messages now carry stable namespaced
         // deduplication keys.
         ClientId::Kimchi => 2,
-        // Initial Reasonix implementation. The fingerprint includes its meta
-        // and checkpoint sidecars because they define model, workspace, and
-        // turn timestamps.
+        // Initial Reasonix implementation. The fingerprint samples the
+        // append-only stats JSONL source so appended records are reparsed.
         ClientId::Reasonix => 1,
         // v1->v2: per-model token attribution now comes from
         // session_model_usage instead of crediting the whole session to

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -511,6 +511,20 @@ impl SourceFingerprint {
         Self::check_kimi_path_with_mode(path, cached, ContentHashMode::SamplesOnly)
     }
 
+    /// Stats are append-only JSONL; use bounded samples to avoid hashing a
+    /// growing daily log on every warm scan.
+    pub(crate) fn check_reasonix_path_samples_only(
+        path: &Path,
+        cached: Option<&Self>,
+    ) -> Option<FingerprintStatus> {
+        Self::check_path_with_related_mode(
+            path,
+            std::iter::empty(),
+            cached,
+            ContentHashMode::SamplesOnly,
+        )
+    }
+
     fn check_kimi_path_with_mode(
         path: &Path,
         cached: Option<&Self>,
@@ -912,6 +926,10 @@ fn parser_version(client: ClientId) -> u32 {
         // v1->v2: Kimchi's Pi-compatible messages now carry stable namespaced
         // deduplication keys.
         ClientId::Kimchi => 2,
+        // Initial Reasonix implementation. The fingerprint includes its meta
+        // and checkpoint sidecars because they define model, workspace, and
+        // turn timestamps.
+        ClientId::Reasonix => 1,
         // v1->v2: per-model token attribution now comes from
         // session_model_usage instead of crediting the whole session to
         // sessions.model, and dedup keys are namespaced per (session, model).
@@ -2373,6 +2391,29 @@ mod tests {
         std::fs::write(&events_path, b"event-2\n").unwrap();
         let updated_events = SourceFingerprint::from_grok_path(&updates_path).unwrap();
         assert_ne!(with_events, updated_events);
+    }
+
+    #[test]
+    fn test_reasonix_stats_fingerprint_tracks_appends() {
+        let dir = TempDir::new().unwrap();
+        let session_path = dir.path().join("2026-08-04.jsonl");
+        std::fs::write(&session_path, b"{\"total\":1}\n").unwrap();
+
+        let initial = match SourceFingerprint::check_reasonix_path_samples_only(&session_path, None)
+        {
+            Some(FingerprintStatus::Changed(fingerprint)) => fingerprint,
+            _ => panic!("uncached Reasonix session must produce a fingerprint"),
+        };
+        assert!(matches!(
+            SourceFingerprint::check_reasonix_path_samples_only(&session_path, Some(&initial)),
+            Some(FingerprintStatus::Unchanged)
+        ));
+
+        std::fs::write(&session_path, b"{\"total\":1}\n{\"total\":2}\n").unwrap();
+        match SourceFingerprint::check_reasonix_path_samples_only(&session_path, Some(&initial)) {
+            Some(FingerprintStatus::Changed(fingerprint)) => fingerprint,
+            _ => panic!("Reasonix stats append must invalidate"),
+        };
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -498,6 +498,40 @@ mod tests {
         assert!((cost - 1.925).abs() < 1e-9, "unexpected cost: {cost}");
     }
 
+    #[test]
+    fn reasonix_uses_the_inferred_upstream_provider_for_pricing() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "deepseek/reasonix-fixture".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(2e-6),
+                output_cost_per_token: Some(8e-6),
+                ..Default::default()
+            },
+        );
+        let service = PricingService::new(litellm, HashMap::new());
+        let usage = TokenBreakdown {
+            input: 1_000,
+            output: 1_000,
+            ..Default::default()
+        };
+
+        assert!(service.covers_usage_with_provider(
+            "opencode/reasonix-fixture",
+            Some("deepseek"),
+            &usage,
+        ));
+        assert!(
+            (service.calculate_cost_with_provider(
+                "opencode/reasonix-fixture",
+                Some("deepseek"),
+                &usage,
+            ) - 0.01)
+                .abs()
+                < 1e-12
+        );
+    }
+
     // The two rows must be the same deal before one lends the other a rate.
     // `azure_ai/grok-code-fast-1` bills $3.50/$17.50 per million with no
     // cache-read rate while the canonical `xai/` row bills $0.20/$1.50 with

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -38,6 +38,7 @@ pub mod opencode;
 pub mod opencodereview;
 pub mod pi;
 pub mod qwen;
+pub mod reasonix;
 pub mod roocode;
 pub mod senpi;
 pub mod synthetic;

--- a/crates/tokscale-core/src/sessions/reasonix.rs
+++ b/crates/tokscale-core/src/sessions/reasonix.rs
@@ -26,8 +26,6 @@ struct ReasonixStat {
     #[serde(default)]
     cache_hit: i64,
     #[serde(default)]
-    cache_miss: i64,
-    #[serde(default)]
     total: i64,
     #[serde(default)]
     requests: i64,
@@ -76,15 +74,11 @@ pub fn parse_reasonix_file(path: &Path) -> Vec<UnifiedMessage> {
             let timestamp = parse_timestamp_value(&record.ts)?;
             let (provider_id, model_id) = split_model_ref(&record.model);
             let cache_read = non_negative(record.cache_hit);
-            let cache_miss = non_negative(record.cache_miss);
             let raw_input = non_negative(record.prompt);
-            // Reasonix defines cache_miss as prompt tokens not served from a
-            // cache. It is ordinary input, not a cache-creation/write charge.
-            let input = if cache_miss > 0 {
-                cache_miss
-            } else {
-                raw_input.saturating_sub(cache_read)
-            };
+            // Cache misses may be reported independently of the prompt
+            // total, so they must not replace ordinary input. Preserve the
+            // complete request total by subtracting only cache hits.
+            let input = raw_input.saturating_sub(cache_read);
             let reasoning = non_negative(record.reasoning).min(non_negative(record.completion));
             let tokens = TokenBreakdown {
                 input,
@@ -97,7 +91,7 @@ pub fn parse_reasonix_file(path: &Path) -> Vec<UnifiedMessage> {
                 return None;
             }
 
-            Some(UnifiedMessage::new_with_dedup(
+            let mut message = UnifiedMessage::new_with_dedup(
                 "reasonix",
                 model_id,
                 provider_id,
@@ -112,7 +106,9 @@ pub fn parse_reasonix_file(path: &Path) -> Vec<UnifiedMessage> {
                     record.requests,
                     record.total
                 )),
-            ))
+            );
+            message.message_count = record.requests.clamp(1, i64::from(i32::MAX)) as i32;
+            Some(message)
         })
         .collect()
 }
@@ -140,11 +136,13 @@ mod tests {
         assert_eq!(message.client, "reasonix");
         assert_eq!(message.provider_id, "deepseek");
         assert_eq!(message.model_id, "deepseek-v4");
-        assert_eq!(message.tokens.input, 10);
+        assert_eq!(message.tokens.input, 70);
         assert_eq!(message.tokens.output, 15);
         assert_eq!(message.tokens.reasoning, 5);
         assert_eq!(message.tokens.cache_read, 30);
         assert_eq!(message.tokens.cache_write, 0);
+        assert_eq!(message.tokens.total(), 120);
+        assert_eq!(message.message_count, 1);
         assert_eq!(
             message.timestamp,
             parse_timestamp_value(&serde_json::json!("2026-08-04T09:10:11Z")).unwrap()
@@ -175,6 +173,45 @@ mod tests {
         assert_eq!(
             split_model_ref("claude-sonnet-4"),
             ("anthropic".into(), "claude-sonnet-4".into())
+        );
+    }
+
+    #[test]
+    fn preserves_totals_when_cache_miss_disagrees_with_prompt_input() {
+        let file = NamedTempFile::new().unwrap();
+        std::fs::write(
+            file.path(),
+            "{\"ts\":\"2026-08-04T09:10:11Z\",\"model\":\"deepseek/chat\",\"prompt\":100,\"completion\":20,\"cache_hit\":30,\"cache_miss\":10,\"total\":120}\n",
+        )
+        .unwrap();
+
+        let messages = parse_reasonix_file(file.path());
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 70);
+        assert_eq!(messages[0].tokens.cache_read, 30);
+        assert_eq!(messages[0].tokens.total(), 120);
+    }
+
+    #[test]
+    fn maps_authoritative_request_count_to_bounded_message_count() {
+        let file = NamedTempFile::new().unwrap();
+        std::fs::write(
+            file.path(),
+            concat!(
+                "{\"ts\":\"2026-08-04T09:10:11Z\",\"model\":\"deepseek/chat\",\"prompt\":1,\"completion\":1,\"total\":2,\"requests\":3}\n",
+                "{\"ts\":\"2026-08-04T09:11:11Z\",\"model\":\"deepseek/chat\",\"prompt\":1,\"completion\":1,\"total\":2,\"requests\":0}\n",
+                "{\"ts\":\"2026-08-04T09:12:11Z\",\"model\":\"deepseek/chat\",\"prompt\":1,\"completion\":1,\"total\":2,\"requests\":9999999999}\n",
+            ),
+        )
+        .unwrap();
+
+        let messages = parse_reasonix_file(file.path());
+        assert_eq!(
+            messages
+                .iter()
+                .map(|message| message.message_count)
+                .collect::<Vec<_>>(),
+            vec![3, 1, i32::MAX]
         );
     }
 }

--- a/crates/tokscale-core/src/sessions/reasonix.rs
+++ b/crates/tokscale-core/src/sessions/reasonix.rs
@@ -1,0 +1,180 @@
+//! Parser for Reasonix's authoritative append-only statistics records.
+//!
+//! Reasonix writes one JSON object per provider request to
+//! `<REASONIX_HOME>/stats/YYYY-MM-DD.jsonl`. Session transcript JSONL is not
+//! scanned: it has no authoritative usage counters and would overlap stats.
+
+use super::utils::parse_timestamp_value;
+use super::UnifiedMessage;
+use crate::provider_identity::{canonical_provider, inferred_provider_from_model};
+use crate::TokenBreakdown;
+use serde::Deserialize;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+#[derive(Debug, Deserialize)]
+struct ReasonixStat {
+    ts: serde_json::Value,
+    #[serde(default)]
+    model: String,
+    #[serde(default)]
+    prompt: i64,
+    #[serde(default)]
+    completion: i64,
+    #[serde(default)]
+    reasoning: i64,
+    #[serde(default)]
+    cache_hit: i64,
+    #[serde(default)]
+    cache_miss: i64,
+    #[serde(default)]
+    total: i64,
+    #[serde(default)]
+    requests: i64,
+    #[serde(default)]
+    turn: bool,
+}
+
+fn split_model_ref(model_ref: &str) -> (String, String) {
+    let model_ref = model_ref.trim();
+    if let Some((provider, model)) = model_ref.split_once('/') {
+        // Reasonix may label an upstream model with its OpenCode-compatible
+        // routing surface. Preserve the real provider for pricing/grouping.
+        if matches!(provider, "opencode" | "openrouter" | "router") {
+            if let Some(inferred) = inferred_provider_from_model(model) {
+                return (inferred.to_string(), model.to_string());
+            }
+        }
+        if let Some(provider) = canonical_provider(provider) {
+            return (provider, model.to_string());
+        }
+    }
+    let provider = inferred_provider_from_model(model_ref)
+        .unwrap_or("reasonix")
+        .to_string();
+    (provider, model_ref.to_string())
+}
+
+fn non_negative(value: i64) -> i64 {
+    value.max(0)
+}
+
+pub fn parse_reasonix_file(path: &Path) -> Vec<UnifiedMessage> {
+    let Ok(file) = std::fs::File::open(path) else {
+        return Vec::new();
+    };
+
+    BufReader::new(file)
+        .lines()
+        .enumerate()
+        .filter_map(|(line_index, line)| {
+            let line = line.ok()?;
+            let record: ReasonixStat = serde_json::from_str(line.trim()).ok()?;
+            if record.turn || record.model.trim().is_empty() || record.total <= 0 {
+                return None;
+            }
+            let timestamp = parse_timestamp_value(&record.ts)?;
+            let (provider_id, model_id) = split_model_ref(&record.model);
+            let cache_read = non_negative(record.cache_hit);
+            let cache_miss = non_negative(record.cache_miss);
+            let raw_input = non_negative(record.prompt);
+            // Reasonix defines cache_miss as prompt tokens not served from a
+            // cache. It is ordinary input, not a cache-creation/write charge.
+            let input = if cache_miss > 0 {
+                cache_miss
+            } else {
+                raw_input.saturating_sub(cache_read)
+            };
+            let reasoning = non_negative(record.reasoning).min(non_negative(record.completion));
+            let tokens = TokenBreakdown {
+                input,
+                output: non_negative(record.completion).saturating_sub(reasoning),
+                cache_read,
+                cache_write: 0,
+                reasoning,
+            };
+            if tokens.total() <= 0 {
+                return None;
+            }
+
+            Some(UnifiedMessage::new_with_dedup(
+                "reasonix",
+                model_id,
+                provider_id,
+                format!("reasonix-stats:{}", path.display()),
+                timestamp,
+                tokens,
+                0.0,
+                Some(format!(
+                    "reasonix:{}:{}:{}:{}",
+                    path.display(),
+                    line_index,
+                    record.requests,
+                    record.total
+                )),
+            ))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn parses_authoritative_stats_with_provider_usage_and_timestamp() {
+        let file = NamedTempFile::new().unwrap();
+        std::fs::write(
+            file.path(),
+            concat!(
+                "{\"ts\":\"2026-08-04T09:10:11Z\",\"model\":\"opencode/deepseek-v4\",\"prompt\":100,\"completion\":20,\"reasoning\":5,\"cache_hit\":30,\"cache_miss\":10,\"total\":120,\"requests\":1}\n",
+                "{\"ts\":\"2026-08-04T09:11:11Z\",\"turn\":true}\n",
+            ),
+        )
+        .unwrap();
+
+        let messages = parse_reasonix_file(file.path());
+        assert_eq!(messages.len(), 1);
+        let message = &messages[0];
+        assert_eq!(message.client, "reasonix");
+        assert_eq!(message.provider_id, "deepseek");
+        assert_eq!(message.model_id, "deepseek-v4");
+        assert_eq!(message.tokens.input, 10);
+        assert_eq!(message.tokens.output, 15);
+        assert_eq!(message.tokens.reasoning, 5);
+        assert_eq!(message.tokens.cache_read, 30);
+        assert_eq!(message.tokens.cache_write, 0);
+        assert_eq!(
+            message.timestamp,
+            parse_timestamp_value(&serde_json::json!("2026-08-04T09:10:11Z")).unwrap()
+        );
+    }
+
+    #[test]
+    fn skips_turn_markers_malformed_and_zero_usage_records() {
+        let file = NamedTempFile::new().unwrap();
+        std::fs::write(
+            file.path(),
+            concat!(
+                "not json\n",
+                "{\"ts\":\"2026-08-04T09:10:11Z\",\"turn\":true}\n",
+                "{\"ts\":\"2026-08-04T09:10:11Z\",\"model\":\"deepseek/test\",\"total\":0}\n",
+            ),
+        )
+        .unwrap();
+        assert!(parse_reasonix_file(file.path()).is_empty());
+    }
+
+    #[test]
+    fn preserves_unknown_model_provider_as_reasonix_only_when_not_inferable() {
+        assert_eq!(
+            split_model_ref("deepseek/chat"),
+            ("deepseek".into(), "chat".into())
+        );
+        assert_eq!(
+            split_model_ref("claude-sonnet-4"),
+            ("anthropic".into(), "claude-sonnet-4".into())
+        );
+    }
+}

--- a/crates/tokscale-core/src/sessions/reasonix.rs
+++ b/crates/tokscale-core/src/sessions/reasonix.rs
@@ -25,6 +25,7 @@ struct ReasonixStat {
     reasoning: i64,
     #[serde(default)]
     cache_hit: i64,
+    cache_miss: Option<i64>,
     #[serde(default)]
     total: i64,
     #[serde(default)]
@@ -36,16 +37,8 @@ struct ReasonixStat {
 fn split_model_ref(model_ref: &str) -> (String, String) {
     let model_ref = model_ref.trim();
     if let Some((provider, model)) = model_ref.split_once('/') {
-        // Reasonix may label an upstream model with its OpenCode-compatible
-        // routing surface. Preserve the real provider for pricing/grouping.
-        if matches!(provider, "opencode" | "openrouter" | "router") {
-            if let Some(inferred) = inferred_provider_from_model(model) {
-                return (inferred.to_string(), model.to_string());
-            }
-        }
-        if let Some(provider) = canonical_provider(provider) {
-            return (provider, model.to_string());
-        }
+        let provider = canonical_provider(provider).unwrap_or_else(|| provider.to_string());
+        return (provider, model.to_string());
     }
     let provider = inferred_provider_from_model(model_ref)
         .unwrap_or("reasonix")
@@ -68,17 +61,23 @@ pub fn parse_reasonix_file(path: &Path) -> Vec<UnifiedMessage> {
         .filter_map(|(line_index, line)| {
             let line = line.ok()?;
             let record: ReasonixStat = serde_json::from_str(line.trim()).ok()?;
-            if record.turn || record.model.trim().is_empty() || record.total <= 0 {
+            if record.turn
+                || record.model.trim().is_empty()
+                || (record.total <= 0 && record.requests <= 0)
+            {
                 return None;
             }
             let timestamp = parse_timestamp_value(&record.ts)?;
             let (provider_id, model_id) = split_model_ref(&record.model);
             let cache_read = non_negative(record.cache_hit);
             let raw_input = non_negative(record.prompt);
-            // Cache misses may be reported independently of the prompt
-            // total, so they must not replace ordinary input. Preserve the
-            // complete request total by subtracting only cache hits.
-            let input = raw_input.saturating_sub(cache_read);
+            // An explicit nonzero cache miss is Reasonix's authoritative
+            // ordinary-input bucket. Older records omit it, so derive that
+            // bucket from prompt tokens and cache hits in that case.
+            let input = match record.cache_miss {
+                Some(cache_miss) if cache_miss != 0 => non_negative(cache_miss),
+                _ => raw_input.saturating_sub(cache_read),
+            };
             let reasoning = non_negative(record.reasoning).min(non_negative(record.completion));
             let tokens = TokenBreakdown {
                 input,
@@ -87,10 +86,6 @@ pub fn parse_reasonix_file(path: &Path) -> Vec<UnifiedMessage> {
                 cache_write: 0,
                 reasoning,
             };
-            if tokens.total() <= 0 {
-                return None;
-            }
-
             let mut message = UnifiedMessage::new_with_dedup(
                 "reasonix",
                 model_id,
@@ -124,7 +119,7 @@ mod tests {
         std::fs::write(
             file.path(),
             concat!(
-                "{\"ts\":\"2026-08-04T09:10:11Z\",\"model\":\"opencode/deepseek-v4\",\"prompt\":100,\"completion\":20,\"reasoning\":5,\"cache_hit\":30,\"cache_miss\":10,\"total\":120,\"requests\":1}\n",
+                "{\"ts\":\"2026-08-04T09:10:11Z\",\"model\":\"opencode/deepseek-v4\",\"prompt\":100,\"completion\":20,\"reasoning\":5,\"cache_hit\":30,\"cache_miss\":70,\"total\":120,\"requests\":1}\n",
                 "{\"ts\":\"2026-08-04T09:11:11Z\",\"turn\":true}\n",
             ),
         )
@@ -134,7 +129,7 @@ mod tests {
         assert_eq!(messages.len(), 1);
         let message = &messages[0];
         assert_eq!(message.client, "reasonix");
-        assert_eq!(message.provider_id, "deepseek");
+        assert_eq!(message.provider_id, "opencode");
         assert_eq!(message.model_id, "deepseek-v4");
         assert_eq!(message.tokens.input, 70);
         assert_eq!(message.tokens.output, 15);
@@ -171,13 +166,17 @@ mod tests {
             ("deepseek".into(), "chat".into())
         );
         assert_eq!(
+            split_model_ref("openrouter/google/gemini-2.5-pro"),
+            ("openrouter".into(), "google/gemini-2.5-pro".into())
+        );
+        assert_eq!(
             split_model_ref("claude-sonnet-4"),
             ("anthropic".into(), "claude-sonnet-4".into())
         );
     }
 
     #[test]
-    fn preserves_totals_when_cache_miss_disagrees_with_prompt_input() {
+    fn preserves_explicit_cache_miss_when_it_disagrees_with_prompt_input() {
         let file = NamedTempFile::new().unwrap();
         std::fs::write(
             file.path(),
@@ -187,8 +186,23 @@ mod tests {
 
         let messages = parse_reasonix_file(file.path());
         assert_eq!(messages.len(), 1);
-        assert_eq!(messages[0].tokens.input, 70);
+        assert_eq!(messages[0].tokens.input, 10);
         assert_eq!(messages[0].tokens.cache_read, 30);
+        assert_eq!(messages[0].tokens.total(), 60);
+    }
+
+    #[test]
+    fn falls_back_to_prompt_minus_cache_hit_when_cache_miss_is_absent() {
+        let file = NamedTempFile::new().unwrap();
+        std::fs::write(
+            file.path(),
+            "{\"ts\":\"2026-08-04T09:10:11Z\",\"model\":\"deepseek/chat\",\"prompt\":100,\"completion\":20,\"cache_hit\":30,\"total\":120}\n",
+        )
+        .unwrap();
+
+        let messages = parse_reasonix_file(file.path());
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 70);
         assert_eq!(messages[0].tokens.total(), 120);
     }
 
@@ -213,5 +227,23 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![3, 1, i32::MAX]
         );
+    }
+
+    #[test]
+    fn preserves_tokenless_request_counts_but_skips_plain_zero_rows() {
+        let file = NamedTempFile::new().unwrap();
+        std::fs::write(
+            file.path(),
+            concat!(
+                "{\"ts\":\"2026-08-04T09:10:11Z\",\"model\":\"deepseek/chat\",\"total\":0,\"requests\":2}\n",
+                "{\"ts\":\"2026-08-04T09:11:11Z\",\"model\":\"deepseek/chat\",\"total\":0}\n",
+            ),
+        )
+        .unwrap();
+
+        let messages = parse_reasonix_file(file.path());
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.total(), 0);
+        assert_eq!(messages[0].message_count, 2);
     }
 }

--- a/packages/frontend/src/lib/constants.ts
+++ b/packages/frontend/src/lib/constants.ts
@@ -71,6 +71,7 @@ export const SOURCE_DISPLAY_NAMES: Record<ClientType, string> = {
   senpi: "Senpi (OmO Native)",
   augment: "Augment Code",
   kimchi: "Kimchi",
+  reasonix: "Reasonix",
 };
 
 // Client logos from GitHub CDN (public repo)
@@ -125,6 +126,7 @@ export const SOURCE_LOGOS: Record<ClientType, string> = {
   senpi: `${GITHUB_CDN_BASE}/client-senpi.png`,
   augment: "https://github.com/augmentcode.png",
   kimchi: "https://github.com/getkimchi.png",
+  reasonix: `${GITHUB_CDN_BASE}/client-synthetic.png`,
 };
 
 export const SOURCE_COLORS: Record<ClientType, string> = {
@@ -172,6 +174,7 @@ export const SOURCE_COLORS: Record<ClientType, string> = {
   senpi: "#2F6F63",
   augment: "#9333EA",
   kimchi: "#14B8A6",
+  reasonix: "#6366F1",
 };
 
 // Derived values

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -43,6 +43,7 @@ export const SUPPORTED_CLIENT_TYPES = [
   "senpi",
   "augment",
   "kimchi",
+  "reasonix",
 ] as const;
 
 export type CcMirrorClientType = `cc-mirror/${string}`;


### PR DESCRIPTION
note: reasonix doesn't write cache reads data anywhere apparently(I am also quite surprised), so we only read in and out tokens

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Reasonix support by parsing append-only daily stats from `~/.reasonix/stats/*.jsonl` (overridable via `REASONIX_STATE_HOME`/`REASONIX_HOME`, supports `${VAR}`/`${VAR:-default}`). Integrated into local and priced parsing, caching with sampled fingerprints, CLI/TUI, and frontend, with proper provider mapping, cache accounting, and request counts.

- **New Features**
  - Register `reasonix` in `tokscale-core` and scan `stats/*.jsonl`; sampled fingerprint tracks appends efficiently.
  - Parse usage: input = `cache_miss` or `prompt - cache_hit`; output = `completion - reasoning`; reasoning = `min(reasoning, completion)`; `cache_write` = 0; preserve `cache_read`; map `requests` to `message_count`; keep tokenless rows with request counts; skip `turn` markers and all-zero rows.
  - Use explicit `provider/model` when present; otherwise infer provider from model for grouping and pricing.
  - Add CLI filter and TUI hotkey 'R'; add to frontend names/logo/color and `SUPPORTED_CLIENT_TYPES`; README lists Reasonix and stats path.

- **Bug Fixes**
  - Normalize `REASONIX_STATE_HOME`/`REASONIX_HOME`: prefer `REASONIX_STATE_HOME`, expand `${VAR}`/`${VAR:-default}`, handle `~` and relative paths, ignore blanks, allow ignoring env roots, and ensure local totals sum `requests`.

<sup>Written for commit cd2098ba507755b84517f4b2721e47f77e41b4d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

