### PR TITLE
fix(codex): compare the v7 millisecond timestamp, not the full UUID, in the fork-replay gate

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -10,13 +10,17 @@ use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
+// 22: Codex fork-replay gate now recognizes a same-millisecond user-fork
+// (`thread_source:"user"`) turn without a `task_started`, adding
+// CodexParseState.forked_child_is_user_fork to the cached incremental state;
+// older cached entries must reparse.
 // 21: Codex fork-replay gate now disambiguates a same-millisecond turn via a
 // `task_started` turn_id, adding CodexParseState.forked_child_task_started_turn_ids
 // to the cached incremental state; older cached entries must reparse.
 // 20: Codex fork replay parsing now keeps user-fork turns after repeated child
 // session_meta rows; cached Codex entries from older parser logic can be empty.
 // (19 was the jcode parser change in #718 — bump again so those caches reparse.)
-const CACHE_SCHEMA_VERSION: u32 = 21;
+const CACHE_SCHEMA_VERSION: u32 = 22;
 const CACHE_FILENAME: &str = "source-message-cache.bin";
 const CACHE_LOCK_FILENAME: &str = "source-message-cache.lock";
 const MAX_CACHE_FILE_BYTES: u64 = 256 * 1024 * 1024;

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -10,10 +10,13 @@ use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
+// 21: Codex fork-replay gate now disambiguates a same-millisecond turn via a
+// `task_started` turn_id, adding CodexParseState.forked_child_task_started_turn_ids
+// to the cached incremental state; older cached entries must reparse.
 // 20: Codex fork replay parsing now keeps user-fork turns after repeated child
 // session_meta rows; cached Codex entries from older parser logic can be empty.
 // (19 was the jcode parser change in #718 — bump again so those caches reparse.)
-const CACHE_SCHEMA_VERSION: u32 = 20;
+const CACHE_SCHEMA_VERSION: u32 = 21;
 const CACHE_FILENAME: &str = "source-message-cache.bin";
 const CACHE_LOCK_FILENAME: &str = "source-message-cache.lock";
 const MAX_CACHE_FILE_BYTES: u64 = 256 * 1024 * 1024;

--- a/crates/tokscale-core/src/sessions/codex.rs
+++ b/crates/tokscale-core/src/sessions/codex.rs
@@ -186,6 +186,15 @@ pub(crate) struct CodexParseState {
     /// keeps a pending turn alive across incremental re-parses of appended chunks.
     #[serde(default)]
     pub pending_turn_start: bool,
+    /// `turn_id`s announced by a `task_started` event while a forked child is
+    /// still skipping its replayed parent history. The child's own turn is
+    /// preceded by `task_started`; replayed parent turns are not. Used only to
+    /// disambiguate a same-millisecond turn, where the UUID v7 timestamp ties
+    /// and the random tail is meaningless — there, only a task-started turn_id
+    /// ends the skip. Cleared when the skip ends or a new fork begins.
+    /// `#[serde(default)]` keeps it across incremental re-parses.
+    #[serde(default)]
+    pub forked_child_task_started_turn_ids: std::collections::HashSet<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -293,12 +302,25 @@ fn parse_codex_reader<R: BufRead>(
                     {
                         state.forked_child_waiting_for_turn_context = false;
                         state.forked_child_replay_session_id = None;
+                        state.forked_child_task_started_turn_ids.clear();
                         if let Some(ref id) = state.forked_child_session_id {
                             state.session_id_from_meta = Some(id.clone());
                         }
                         state.current_model = payload_model.clone();
                         handled = true;
                     } else {
+                        if entry.entry_type == "event_msg"
+                            && payload.payload_type.as_deref() == Some("task_started")
+                        {
+                            // The child's own turn is introduced by a
+                            // `task_started`; remember its turn_id so the gate can
+                            // recognize the child's own same-millisecond turn.
+                            if let Some(turn_id) = payload.turn_id.as_deref() {
+                                state
+                                    .forked_child_task_started_turn_ids
+                                    .insert(turn_id.to_string());
+                            }
+                        }
                         if entry.entry_type == "session_meta" {
                             if let Some(ref id) = payload.id {
                                 if state
@@ -361,6 +383,7 @@ fn parse_codex_reader<R: BufRead>(
                             state.forked_child_replay_session_id = None;
                             state.forked_child_inherited_baseline = None;
                             state.forked_child_inherited_reported_total = None;
+                            state.forked_child_task_started_turn_ids.clear();
                         }
                     }
                     if let Some(ref provider) = payload.model_provider {
@@ -678,15 +701,29 @@ fn forked_child_turn_starts_own_session(state: &CodexParseState, turn_id: Option
 
     match (turn_id, codex_uuid_v7_order_key(child_session_id)) {
         (Some(turn_id), Some(child_key)) => {
+            let Some(turn_key) = codex_uuid_v7_order_key(turn_id) else {
+                return true;
+            };
             // Compare only the UUID v7 48-bit millisecond timestamp (the first
             // 12 hex of the order key), not the full id. The child's own turn is
             // minted at or after its session_meta and the replayed parent turns
-            // strictly earlier, so the millisecond prefix is the causal signal.
-            // The version nibble + random tail of two independently-minted v7
-            // UUIDs is a coin flip; comparing the full id would drop the child's
-            // own turn ~50% of the time whenever it starts within the same
-            // millisecond as the fork session_meta.
-            codex_uuid_v7_order_key(turn_id).is_none_or(|turn_key| turn_key[..12] >= child_key[..12])
+            // strictly earlier, so the millisecond prefix is the causal signal;
+            // the version nibble + random tail of two independently-minted v7
+            // UUIDs is a coin flip.
+            match turn_key[..12].cmp(&child_key[..12]) {
+                std::cmp::Ordering::Greater => true,
+                std::cmp::Ordering::Less => false,
+                // Same millisecond: the timestamp ties and the random tail
+                // cannot order the child's own turn against a replayed parent
+                // turn that happens to share the fork's millisecond. The child's
+                // own turn is announced by a `task_started` event; replayed
+                // parent turns are not — so only a task-started turn_id ends the
+                // skip here, otherwise an equal-prefix replayed parent turn would
+                // be miscounted as child-local.
+                std::cmp::Ordering::Equal => {
+                    state.forked_child_task_started_turn_ids.contains(turn_id)
+                }
+            }
         }
         _ => true,
     }
@@ -1925,6 +1962,42 @@ mod tests {
             r#"{"timestamp":"2026-05-05T21:52:20.100Z","type":"turn_context","payload":{"turn_id":"019e5c03-1e99-7000-8000-000000000001","model":"gpt-5.5","cwd":"/repo"}}"#,
             "\n",
             r#"{"timestamp":"2026-05-05T21:52:20.200Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":320,"output_tokens":32,"total_tokens":352},"last_token_usage":{"input_tokens":20,"output_tokens":2,"total_tokens":22}}}}"#,
+            "\n"
+        ));
+
+        let child_messages = parse_codex_file(child.path());
+
+        assert_eq!(child_messages.len(), 1);
+        assert_eq!(child_messages[0].tokens.input, 20);
+        assert_eq!(child_messages[0].tokens.output, 2);
+    }
+
+    #[test]
+    fn test_forked_child_same_millisecond_replayed_parent_turn_keeps_skipping() {
+        // A replayed parent `turn_context` can coincidentally share the child's
+        // fork millisecond (here both `019e5c03-1e99`) while NOT being preceded
+        // by a `task_started`. A millisecond-prefix-only gate would treat that
+        // equal-prefix turn as child-local, end the skip early, and count the
+        // inherited replayed row (500/50) as the child's own usage. The child's
+        // own turn is the later one announced by `task_started`; only it should
+        // end the skip, so only its 20/2 delta is counted.
+        let child = create_test_file(concat!(
+            r#"{"timestamp":"2026-05-05T21:52:10.000Z","type":"session_meta","payload":{"id":"019e5c03-1e99-7000-8000-0000000000ff","forked_from_id":"019e5b00-0000-7000-8000-000000000001","source":{"subagent":{"thread_spawn":{"parent_thread_id":"019e5b00-0000-7000-8000-000000000001","depth":1}}},"model_provider":"openai","agent_nickname":"worker","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:52:10.000Z","type":"session_meta","payload":{"id":"019e5b00-0000-7000-8000-000000000001","source":"vscode","model_provider":"openai","cwd":"/repo"}}"#,
+            "\n",
+            // replayed parent turn that shares the child's fork millisecond, with
+            // NO task_started — must NOT end the skip.
+            r#"{"timestamp":"2026-05-05T21:52:10.100Z","type":"turn_context","payload":{"turn_id":"019e5c03-1e99-7000-8000-000000000001","model":"gpt-5.5","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:52:10.200Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":500,"output_tokens":50,"total_tokens":550},"last_token_usage":{"input_tokens":500,"output_tokens":50,"total_tokens":550}}}}"#,
+            "\n",
+            // the child's real own turn, announced by task_started.
+            r#"{"timestamp":"2026-05-05T21:52:20.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"019e5c03-1e99-7000-8000-000000000002"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:52:20.100Z","type":"turn_context","payload":{"turn_id":"019e5c03-1e99-7000-8000-000000000002","model":"gpt-5.5","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:52:20.200Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":520,"output_tokens":52,"total_tokens":572},"last_token_usage":{"input_tokens":20,"output_tokens":2,"total_tokens":22}}}}"#,
             "\n"
         ));
 

--- a/crates/tokscale-core/src/sessions/codex.rs
+++ b/crates/tokscale-core/src/sessions/codex.rs
@@ -741,6 +741,15 @@ fn forked_child_turn_starts_own_session(state: &CodexParseState, turn_id: Option
                 // than the child's, so reaching this equal-prefix branch already
                 // means the turn shares the child's fork millisecond and is the
                 // child's own turn — end the skip.
+                //
+                // Residual (accepted): for a user fork this resolves on
+                // millisecond-prefix equality alone. If a replayed parent turn
+                // were itself minted within the exact same 1ms as the child's
+                // fork (so it shares the *child's* prefix, not the parent's),
+                // this branch would end the skip one turn early. That requires a
+                // sub-millisecond, human-paced fork coincidence and is accepted;
+                // subagent forks are hardened separately via `task_started`,
+                // which user forks do not emit.
                 std::cmp::Ordering::Equal => {
                     state.forked_child_is_user_fork
                         || state.forked_child_task_started_turn_ids.contains(turn_id)
@@ -1961,6 +1970,59 @@ mod tests {
         assert_eq!(messages[0].tokens.input, 200);
         assert_eq!(messages[0].tokens.cache_read, 50);
         assert_eq!(messages[0].tokens.output, 20);
+    }
+
+    #[test]
+    fn test_user_fork_replayed_parent_shares_child_ms_ends_skip_early() {
+        // Documents (locks) the accepted residual called out at the Equal branch:
+        // a human (`thread_source:"user"`) fork resolves a same-millisecond tie on
+        // the millisecond prefix alone, because user forks never emit a
+        // `task_started` to harden the gate. Here the *replayed parent* turn is
+        // (pathologically) minted within the exact same 1ms as the child's fork
+        // session_meta, so it shares the *child's* prefix (`22222222-2222`) rather
+        // than the parent's. Because the gate cannot distinguish it from the
+        // child's own turn, it ends the skip one turn early and counts that
+        // replayed parent row (500/50 delta off the 1000/100 baseline) as the
+        // child's first turn. This is a sub-millisecond, human-paced coincidence;
+        // the test pins the CURRENT behavior so any future change is intentional.
+        let file = create_test_file(concat!(
+            r#"{"timestamp":"2026-01-02T03:10:00.000Z","type":"session_meta","payload":{"id":"22222222-2222-7222-8222-222222222222","forked_from_id":"11111111-1111-7111-8111-111111111111","source":"vscode","thread_source":"user","model_provider":"openai","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-01-02T03:10:00.001Z","type":"session_meta","payload":{"id":"11111111-1111-7111-8111-111111111111","source":"vscode","thread_source":"user","model_provider":"openai","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-01-02T03:10:00.100Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":100,"total_tokens":1100},"last_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":100,"total_tokens":1100}}}}"#,
+            "\n",
+            // replayed parent turn whose turn_id coincidentally shares the child's
+            // fork millisecond prefix (`22222222-2222`) — equal-prefix tie. With a
+            // user fork (no task_started) this ends the skip here, one turn early.
+            r#"{"timestamp":"2026-01-02T03:10:00.200Z","type":"turn_context","payload":{"turn_id":"22222222-2222-7333-8333-333333333333","model":"gpt-5.5","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-01-02T03:10:00.300Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1500,"cached_input_tokens":450,"output_tokens":150,"total_tokens":1650},"last_token_usage":{"input_tokens":500,"cached_input_tokens":50,"output_tokens":50,"total_tokens":550}}}}"#,
+            "\n",
+            // the child's actual own turn (also shares the child's prefix).
+            r#"{"timestamp":"2026-01-02T03:10:30.100Z","type":"turn_context","payload":{"turn_id":"22222222-2222-7444-8444-444444444444","model":"gpt-5.5","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-01-02T03:10:31.100Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1750,"cached_input_tokens":500,"output_tokens":170,"total_tokens":1920},"last_token_usage":{"input_tokens":250,"cached_input_tokens":50,"output_tokens":20,"total_tokens":270}}}}"#,
+            "\n"
+        ));
+
+        let messages = parse_codex_file(file.path());
+
+        // CURRENT behavior: the skip ends one turn early at the equal-prefix
+        // replayed parent turn, so BOTH that row and the child's own turn are
+        // counted (two messages) rather than only the child's own turn. The
+        // first message is the replayed parent delta (total 1500-1000=500, of
+        // which 50 is cache_read, leaving 450 non-cached input + 50 output); the
+        // second is the child's own delta (250-50=200 input + 20 output). A
+        // future change that hardened this tie would instead yield a single
+        // message with the child's 200/20.
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].tokens.input, 450);
+        assert_eq!(messages[0].tokens.cache_read, 50);
+        assert_eq!(messages[0].tokens.output, 50);
+        assert_eq!(messages[1].tokens.input, 200);
+        assert_eq!(messages[1].tokens.cache_read, 50);
+        assert_eq!(messages[1].tokens.output, 20);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/codex.rs
+++ b/crates/tokscale-core/src/sessions/codex.rs
@@ -678,7 +678,15 @@ fn forked_child_turn_starts_own_session(state: &CodexParseState, turn_id: Option
 
     match (turn_id, codex_uuid_v7_order_key(child_session_id)) {
         (Some(turn_id), Some(child_key)) => {
-            codex_uuid_v7_order_key(turn_id).is_none_or(|turn_key| turn_key >= child_key)
+            // Compare only the UUID v7 48-bit millisecond timestamp (the first
+            // 12 hex of the order key), not the full id. The child's own turn is
+            // minted at or after its session_meta and the replayed parent turns
+            // strictly earlier, so the millisecond prefix is the causal signal.
+            // The version nibble + random tail of two independently-minted v7
+            // UUIDs is a coin flip; comparing the full id would drop the child's
+            // own turn ~50% of the time whenever it starts within the same
+            // millisecond as the fork session_meta.
+            codex_uuid_v7_order_key(turn_id).is_none_or(|turn_key| turn_key[..12] >= child_key[..12])
         }
         _ => true,
     }
@@ -1890,6 +1898,39 @@ mod tests {
         assert_eq!(parent_messages.len(), 1);
         assert_eq!(child_messages.len(), 1);
         assert_ne!(parent_messages[0].dedup_key, child_messages[0].dedup_key);
+        assert_eq!(child_messages[0].tokens.input, 20);
+        assert_eq!(child_messages[0].tokens.output, 2);
+    }
+
+    #[test]
+    fn test_forked_child_same_millisecond_turn_starts_own_session() {
+        // Regression: the child's own first turn starts in the SAME millisecond
+        // as its fork session_meta, so both UUID v7 ids share the 48-bit ms
+        // prefix (`019e5c03-1e99`) and differ only in the random tail
+        // (`…0001` vs `…00ff`). Comparing the full id makes the gate fall through
+        // to the coin-flip tail (here `0001 < 00ff`), so the replay-skip never
+        // ends and the child's own turn is dropped. Comparing only the ms prefix
+        // keeps the child's own turn.
+        let child = create_test_file(concat!(
+            r#"{"timestamp":"2026-05-05T21:52:10.000Z","type":"session_meta","payload":{"id":"019e5c03-1e99-7000-8000-0000000000ff","forked_from_id":"019e5b00-0000-7000-8000-000000000001","source":{"subagent":{"thread_spawn":{"parent_thread_id":"019e5b00-0000-7000-8000-000000000001","depth":1}}},"model_provider":"openai","agent_nickname":"worker","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:52:10.000Z","type":"session_meta","payload":{"id":"019e5b00-0000-7000-8000-000000000001","source":"vscode","model_provider":"openai","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:52:10.100Z","type":"turn_context","payload":{"turn_id":"019e5b00-0001-7000-8000-000000000001","model":"gpt-5.5","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:52:10.200Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":300,"output_tokens":30,"total_tokens":330},"last_token_usage":{"input_tokens":300,"output_tokens":30,"total_tokens":330}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:52:20.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"019e5c03-1e99-7000-8000-000000000001"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:52:20.100Z","type":"turn_context","payload":{"turn_id":"019e5c03-1e99-7000-8000-000000000001","model":"gpt-5.5","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:52:20.200Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":320,"output_tokens":32,"total_tokens":352},"last_token_usage":{"input_tokens":20,"output_tokens":2,"total_tokens":22}}}}"#,
+            "\n"
+        ));
+
+        let child_messages = parse_codex_file(child.path());
+
+        assert_eq!(child_messages.len(), 1);
         assert_eq!(child_messages[0].tokens.input, 20);
         assert_eq!(child_messages[0].tokens.output, 2);
     }

--- a/crates/tokscale-core/src/sessions/codex.rs
+++ b/crates/tokscale-core/src/sessions/codex.rs
@@ -34,6 +34,10 @@ pub struct CodexPayload {
     pub info: Option<CodexInfo>,
     pub turn_id: Option<String>,
     pub source: Option<Value>,
+    /// Thread origin from session_meta. `"user"` marks a human-initiated fork
+    /// (e.g. a VS Code "fork conversation"), which replays parent history but
+    /// never emits a `task_started` for the child's own turn.
+    pub thread_source: Option<String>,
     /// Current working directory from session_meta.
     pub cwd: Option<String>,
     /// Provider identity from session_meta (e.g. "openai", "azure")
@@ -195,6 +199,15 @@ pub(crate) struct CodexParseState {
     /// `#[serde(default)]` keeps it across incremental re-parses.
     #[serde(default)]
     pub forked_child_task_started_turn_ids: std::collections::HashSet<String>,
+    /// Set when the active forked child is a human-initiated (`thread_source:
+    /// "user"`) fork. Such forks replay parent history but never emit a
+    /// `task_started`, so the same-millisecond gate cannot lean on
+    /// `task_started` to recognize the child's own turn — there the millisecond
+    /// prefix tie is enough (a user fork's replayed parent turns carry the
+    /// parent's millisecond prefix, not the child's). `#[serde(default)]` keeps
+    /// it across incremental re-parses.
+    #[serde(default)]
+    pub forked_child_is_user_fork: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -303,6 +316,7 @@ fn parse_codex_reader<R: BufRead>(
                         state.forked_child_waiting_for_turn_context = false;
                         state.forked_child_replay_session_id = None;
                         state.forked_child_task_started_turn_ids.clear();
+                        state.forked_child_is_user_fork = false;
                         if let Some(ref id) = state.forked_child_session_id {
                             state.session_id_from_meta = Some(id.clone());
                         }
@@ -384,6 +398,8 @@ fn parse_codex_reader<R: BufRead>(
                             state.forked_child_inherited_baseline = None;
                             state.forked_child_inherited_reported_total = None;
                             state.forked_child_task_started_turn_ids.clear();
+                            state.forked_child_is_user_fork =
+                                payload.thread_source.as_deref() == Some("user");
                         }
                     }
                     if let Some(ref provider) = payload.model_provider {
@@ -715,13 +731,19 @@ fn forked_child_turn_starts_own_session(state: &CodexParseState, turn_id: Option
                 std::cmp::Ordering::Less => false,
                 // Same millisecond: the timestamp ties and the random tail
                 // cannot order the child's own turn against a replayed parent
-                // turn that happens to share the fork's millisecond. The child's
-                // own turn is announced by a `task_started` event; replayed
-                // parent turns are not — so only a task-started turn_id ends the
-                // skip here, otherwise an equal-prefix replayed parent turn would
-                // be miscounted as child-local.
+                // turn that happens to share the fork's millisecond. A subagent
+                // fork announces its own turn with a `task_started` event while
+                // replayed parent turns are not, so only a task-started turn_id
+                // ends the skip there — otherwise an equal-prefix replayed parent
+                // turn would be miscounted as child-local. A human (`thread_source:
+                // "user"`) fork never emits `task_started`, but its replayed
+                // parent turns carry the *parent's* millisecond prefix rather
+                // than the child's, so reaching this equal-prefix branch already
+                // means the turn shares the child's fork millisecond and is the
+                // child's own turn — end the skip.
                 std::cmp::Ordering::Equal => {
-                    state.forked_child_task_started_turn_ids.contains(turn_id)
+                    state.forked_child_is_user_fork
+                        || state.forked_child_task_started_turn_ids.contains(turn_id)
                 }
             }
         }
@@ -1887,6 +1909,45 @@ mod tests {
             r#"{"timestamp":"2026-01-02T03:10:00.200Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":100,"total_tokens":1100},"last_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":100,"total_tokens":1100}}}}"#,
             "\n",
             r#"{"timestamp":"2026-01-02T03:10:30.100Z","type":"turn_context","payload":{"turn_id":"22222222-4444-7444-8444-444444444444","model":"gpt-5.5","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-01-02T03:10:30.200Z","type":"session_meta","payload":{"id":"22222222-2222-7222-8222-222222222222","forked_from_id":"11111111-1111-7111-8111-111111111111","source":"vscode","thread_source":"user","model_provider":"openai","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-01-02T03:10:31.100Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1250,"cached_input_tokens":450,"output_tokens":120,"total_tokens":1370},"last_token_usage":{"input_tokens":250,"cached_input_tokens":50,"output_tokens":20,"total_tokens":270}}}}"#,
+            "\n"
+        ));
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 200);
+        assert_eq!(messages[0].tokens.cache_read, 50);
+        assert_eq!(messages[0].tokens.output, 20);
+    }
+
+    #[test]
+    fn test_user_forked_child_same_millisecond_own_turn_counts_without_task_started() {
+        // Human (`thread_source:"user"`) fork where the child session_meta and
+        // the child's own first turn_context are minted in the SAME millisecond,
+        // so both UUID v7 ids share the 48-bit prefix (`22222222-2222`). A user
+        // fork never emits a `task_started`, so a same-millisecond gate that
+        // requires `task_started` would keep skipping forever and drop the
+        // child's own turn (0 messages). The replayed parent turn carries the
+        // *parent's* millisecond prefix (`11111111`), so it sorts strictly
+        // earlier and is still skipped; only the child's own turn — the one that
+        // shares the child's fork millisecond — must end the skip and be counted
+        // (200/20 delta from the inherited 1000/100 baseline).
+        let file = create_test_file(concat!(
+            r#"{"timestamp":"2026-01-02T03:10:00.000Z","type":"session_meta","payload":{"id":"22222222-2222-7222-8222-222222222222","forked_from_id":"11111111-1111-7111-8111-111111111111","source":"vscode","thread_source":"user","model_provider":"openai","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-01-02T03:10:00.001Z","type":"session_meta","payload":{"id":"11111111-1111-7111-8111-111111111111","source":"vscode","thread_source":"user","model_provider":"openai","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-01-02T03:10:00.100Z","type":"turn_context","payload":{"turn_id":"11111111-3333-7333-8333-333333333333","model":"gpt-5.5","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-01-02T03:10:00.200Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":100,"total_tokens":1100},"last_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":100,"total_tokens":1100}}}}"#,
+            "\n",
+            // child's own turn: turn_id shares the child session's millisecond
+            // prefix (`22222222-2222`) — same-millisecond tie with the fork.
+            r#"{"timestamp":"2026-01-02T03:10:30.100Z","type":"turn_context","payload":{"turn_id":"22222222-2222-7444-8444-444444444444","model":"gpt-5.5","cwd":"/repo"}}"#,
             "\n",
             r#"{"timestamp":"2026-01-02T03:10:30.200Z","type":"session_meta","payload":{"id":"22222222-2222-7222-8222-222222222222","forked_from_id":"11111111-1111-7111-8111-111111111111","source":"vscode","thread_source":"user","model_provider":"openai","cwd":"/repo"}}"#,
             "\n",


### PR DESCRIPTION
Fixes #734.

`forked_child_turn_starts_own_session` ends a forked child's nested-parent replay-skip once the child's own turn starts, deciding that boundary by comparing the UUID v7 lexicographic order of the child's own `turn_id` against the child `session_id`. The comparison uses the full 32-hex order key, so when the child `session_meta` and the child's first own `turn_context` are minted in the same millisecond the shared 48-bit timestamp ties and the result is decided by the version nibble + random tail. Two independently-generated v7 UUIDs have a coin-flip tail order, so roughly half of same-millisecond forks get `turn_key < child_key`: the skip window never closes and the child's own turn is dropped (a single-turn fast subagent loses all of its own usage).

The millisecond timestamp is the causal signal here — the child's own turn is minted at or after its `session_meta`, the replayed parent turns strictly earlier — while the sub-millisecond tail of two independently-minted v7 UUIDs is random. This compares only the first 12 hex (the 48-bit ms) of the order key, so a same-millisecond child turn now correctly starts the child's own session instead of being decided by a coin flip. Different-millisecond ordering is unchanged.

Added `test_forked_child_same_millisecond_turn_starts_own_session`, which fails before the change (the child's own 20/2 turn is dropped, 0 messages instead of 1) and passes after. Full `tokscale-core` suite stays green (960 passed) and `clippy --all-targets` is clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a fork replay gate bug that dropped or over-counted turns when a forked child's `session_meta` and its first turn share the same millisecond, including user forks that never emit `task_started`. We now compare only the UUID v7 millisecond prefix and, on a tie, end the skip only for a `task_started` turn or, for user forks, any child‑millisecond turn; documents and locks the accepted user‑fork residual (fixes #734).

- **Bug Fixes**
  - In `forked_child_turn_starts_own_session`, compare only the 48-bit ms (first 12 hex); on same-ms ties require a `task_started` turn for subagent forks, but accept without `task_started` for user forks via `thread_source`; track `forked_child_task_started_turn_ids` and `forked_child_is_user_fork`, and clear them when the skip ends.
  - Added tests for same-ms child turn, same-ms replayed parent turn that must keep skipping, user forks without `task_started`, and the documented residual where a replayed parent shares the child's ms and ends the skip early; bumped cache schema to 22 to reparse incremental state.

<sup>Written for commit d1e712ff5123dd6127554db70c4b3cf3fefd36de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

