### PR TITLE
fix(micode): namespace dedup key by database; guard authoritative cost from repricing

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -899,20 +899,34 @@ fn parse_all_messages_with_pricing_with_env_strategy(
     let mut micode_seen: HashSet<String> = HashSet::new();
 
     for db_path in &scan_result.micode_dbs {
+        // Pass `None` so the loader does not reprice: MiMo Code carries an
+        // authoritative per-message cost that unconditional repricing would
+        // overwrite (and persist to the cache). Reprice only messages that had
+        // no embedded cost, mirroring the gjc lane's guard.
         let CachedParseOutcome {
             messages,
             cache_entry,
             ..
-        } = load_or_parse_sqlite_source(db_path, &source_cache, pricing, |path| {
+        } = load_or_parse_sqlite_source(db_path, &source_cache, None, |path| {
             sessions::micode::parse_micode_sqlite(path)
         });
 
-        all_messages.extend(messages.into_iter().filter(|message| {
-            message
-                .dedup_key
-                .as_ref()
-                .is_none_or(|key| micode_seen.insert(key.clone()))
-        }));
+        all_messages.extend(
+            messages
+                .into_iter()
+                .map(|mut message| {
+                    if message.cost <= 0.0 {
+                        apply_pricing_if_available(&mut message, pricing);
+                    }
+                    message
+                })
+                .filter(|message| {
+                    message
+                        .dedup_key
+                        .as_ref()
+                        .is_none_or(|key| micode_seen.insert(key.clone()))
+                }),
+        );
 
         if let Some(entry) = cache_entry {
             source_cache.insert(entry);

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -3788,6 +3788,95 @@ mod tests {
         assert!(messages[0].cost > 0.0);
     }
 
+    /// MiMo Code records carry an authoritative per-message cost. The micode
+    /// lane must NOT reprice a record that already has a cost, even when the
+    /// model has a market price that would compute a different (non-zero) value.
+    /// This must hold on the first parse AND on a subsequent cache hit, since
+    /// the previous bug repriced and persisted the inflated cost to the cache.
+    #[test]
+    #[serial_test::serial]
+    fn test_micode_authoritative_cost_is_not_repriced_on_first_parse_or_cache_hit() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            let micode_dir = source_home.path().join(".local/share/micode");
+            std::fs::create_dir_all(&micode_dir).unwrap();
+            let db_path = micode_dir.join("mimocode.db");
+
+            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE message (
+                    id TEXT PRIMARY KEY,
+                    session_id TEXT NOT NULL,
+                    data TEXT NOT NULL
+                );",
+            )
+            .unwrap();
+            // Authoritative cost 0.05 with 1000 input / 500 output tokens.
+            let data_json = r#"{
+                "role": "assistant",
+                "modelID": "mimo-v2.5-pro",
+                "providerID": "mimo",
+                "cost": 0.05,
+                "tokens": { "input": 1000, "output": 500, "reasoning": 0, "cache": { "read": 0, "write": 0 } },
+                "time": { "created": 1700000000000.0 }
+            }"#;
+            conn.execute(
+                "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+                rusqlite::params!["msg_auth_cost", "ses_1", data_json],
+            )
+            .unwrap();
+            drop(conn);
+
+            // Pricing that WOULD reprice mimo-v2.5-pro to a different non-zero
+            // value (1000 * 0.001 + 500 * 0.002 = 2.0) if the guard were absent.
+            let mut litellm = HashMap::new();
+            litellm.insert(
+                "mimo-v2.5-pro".into(),
+                pricing::ModelPricing {
+                    input_cost_per_token: Some(0.001),
+                    output_cost_per_token: Some(0.002),
+                    ..Default::default()
+                },
+            );
+            let pricing = pricing::PricingService::new(litellm, HashMap::new());
+
+            let first = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["micode".to_string()],
+                Some(&pricing),
+            );
+            assert_eq!(first.len(), 1);
+            assert!(
+                (first[0].cost - 0.05).abs() < 1e-9,
+                "authoritative cost must survive the first parse, got {}",
+                first[0].cost
+            );
+
+            // Second run hits the source cache; the persisted entry must still
+            // carry the authoritative cost rather than a repriced value.
+            let second = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["micode".to_string()],
+                Some(&pricing),
+            );
+            assert_eq!(second.len(), 1);
+            assert!(
+                (second[0].cost - 0.05).abs() < 1e-9,
+                "authoritative cost must survive the cache hit, got {}",
+                second[0].cost
+            );
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
     fn write_kimi_repeated_status_fixture(source_home: &std::path::Path) {
         let session_dir = source_home.join(".kimi/sessions/group-1/session-1");
         std::fs::create_dir_all(&session_dir).unwrap();

--- a/crates/tokscale-core/src/sessions/micode.rs
+++ b/crates/tokscale-core/src/sessions/micode.rs
@@ -184,9 +184,13 @@ pub fn parse_micode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
     let mut fingerprint_indices: HashMap<MiMoCodeSqliteFingerprint, usize> = HashMap::new();
     let mut dedup_states: Vec<MiMoCodeSqliteDedupState> = Vec::new();
 
-    // Namespace the cross-file dedup key by the database, so two independent
-    // databases that reuse a bare message/row id (e.g. both starting at 1) do
-    // not collapse each other's unrelated messages in the shared dedup set.
+    // Namespace ONLY the row-id fallback by the database. MiMo Code uses
+    // channel-suffixed databases (mimocode.db and mimocode-<channel>.db), and a
+    // mid-session channel switch can write the SAME message to both files. The
+    // embedded message id is globally unique, so it must stay un-namespaced to
+    // collapse those duplicates across files. SQLite rowids, by contrast, are
+    // per-database and not globally unique, so the fallback path namespaces them
+    // to avoid falsely merging two different messages that share a rowid.
     let db_namespace = db_path.to_string_lossy().to_string();
 
     for row_result in rows {
@@ -232,7 +236,13 @@ pub fn parse_micode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
         let cache_read = cache.read.max(0);
         let cache_write = cache.write.max(0);
         let cost = msg.cost.unwrap_or(0.0).max(0.0);
-        let dedup_key = format!("{db_namespace}:{}", message_id.clone().unwrap_or(row_id));
+        let dedup_key = match message_id.clone() {
+            // Embedded ids are globally unique: keep them un-namespaced so the
+            // same message in mimocode.db and mimocode-<channel>.db collapses.
+            Some(id) => id,
+            // Rowids are per-database: namespace to avoid false cross-DB merges.
+            None => format!("{db_namespace}:{row_id}"),
+        };
         let fingerprint = MiMoCodeSqliteFingerprint {
             created_bits: msg.time.created.to_bits(),
             completed_bits: msg.time.completed.map(f64::to_bits),
@@ -388,19 +398,77 @@ mod tests {
 
         let messages = parse_micode_sqlite(&db_path);
         assert_eq!(messages.len(), 1);
-        // The dedup key is namespaced by the database path so identical ids in
-        // separate databases do not collide; the message-id suffix is preserved.
+        // This message carries no embedded JSON id, so the dedup key falls back
+        // to the SQLite row id and is namespaced by the database path.
         assert!(messages[0]
             .dedup_key
             .as_deref()
             .is_some_and(|key| key.ends_with(":msg_assistant")));
     }
 
+    /// Regression: MiMo Code uses channel-suffixed databases (mimocode.db and
+    /// mimocode-<channel>.db). A mid-session channel switch can write the SAME
+    /// message (same embedded id) to both files. The embedded id must NOT be
+    /// namespaced by the database, otherwise the cross-file dedup set produces
+    /// two distinct keys and the message's cost + tokens get counted twice.
     #[test]
-    fn dedup_key_is_namespaced_by_database() {
+    fn embedded_message_id_is_not_namespaced_by_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_a = dir.path().join("mimocode.db");
+        let db_b = dir.path().join("mimocode-beta.db");
+        // Embedded JSON "id" is the globally unique message id.
+        let msg = r#"{
+            "id": "msg_shared",
+            "role": "assistant",
+            "modelID": "mimo-v2.5-pro",
+            "providerID": "mimo",
+            "cost": 0.05,
+            "tokens": { "input": 10, "output": 5 },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+        // Different SQLite row ids prove the collapse is driven by the embedded
+        // id (not the row id), exactly as a mid-session channel switch records.
+        for (db, row_id) in [(&db_a, "row_a"), (&db_b, "row_b")] {
+            let conn = create_micode_sqlite_db(db);
+            conn.execute(
+                "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+                rusqlite::params![row_id, "ses_1", msg],
+            )
+            .unwrap();
+            drop(conn);
+        }
+
+        let a = parse_micode_sqlite(&db_a);
+        let b = parse_micode_sqlite(&db_b);
+        assert_eq!(a.len(), 1);
+        assert_eq!(b.len(), 1);
+        // Same embedded id across both channel databases yields IDENTICAL,
+        // un-namespaced dedup keys, so a shared dedup set collapses the
+        // duplicate to a single count.
+        assert_eq!(a[0].dedup_key, Some("msg_shared".to_string()));
+        assert_eq!(b[0].dedup_key, Some("msg_shared".to_string()));
+
+        // Prove the collapse end-to-end with the same HashSet logic used by the
+        // cross-file aggregation in lib.rs.
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let kept: Vec<_> = a
+            .into_iter()
+            .chain(b)
+            .filter(|m| m.dedup_key.as_ref().is_none_or(|k| seen.insert(k.clone())))
+            .collect();
+        assert_eq!(kept.len(), 1, "shared embedded id must be counted once");
+    }
+
+    /// Two DIFFERENT messages that happen to share a SQLite rowid across two
+    /// databases (rowids are per-database, not globally unique) must NOT be
+    /// collapsed by the cross-file dedup set. The row-id fallback path is
+    /// namespaced by database precisely to keep them distinct.
+    #[test]
+    fn rowid_fallback_is_namespaced_by_database() {
         let dir = tempfile::tempdir().unwrap();
         let db_a = dir.path().join("a.db");
         let db_b = dir.path().join("b.db");
+        // No embedded "id" field -> the parser falls back to the SQLite rowid.
         let msg = r#"{
             "role": "assistant",
             "modelID": "mimo-v2.5-pro",
@@ -411,9 +479,11 @@ mod tests {
         }"#;
         for db in [&db_a, &db_b] {
             let conn = create_micode_sqlite_db(db);
+            // Same SQLite row id ("id" column) in both databases. With no
+            // embedded JSON id, the parser falls back to this row id.
             conn.execute(
                 "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
-                rusqlite::params!["msg_1", "ses_1", msg],
+                rusqlite::params!["row_shared", "ses_1", msg],
             )
             .unwrap();
             drop(conn);
@@ -423,12 +493,19 @@ mod tests {
         let b = parse_micode_sqlite(&db_b);
         assert_eq!(a.len(), 1);
         assert_eq!(b.len(), 1);
-        // The same bare id "msg_1" in two databases yields distinct dedup keys,
-        // so the shared cross-file dedup set keeps both rather than dropping the
-        // second database's unrelated message.
+        // Same row id ("row_shared") in two databases must yield DISTINCT,
+        // db-namespaced keys so the two unrelated messages are not merged.
         assert_ne!(a[0].dedup_key, b[0].dedup_key);
-        assert!(a[0].dedup_key.as_deref().unwrap().ends_with(":msg_1"));
-        assert!(b[0].dedup_key.as_deref().unwrap().ends_with(":msg_1"));
+        assert!(a[0].dedup_key.as_deref().unwrap().ends_with(":row_shared"));
+        assert!(b[0].dedup_key.as_deref().unwrap().ends_with(":row_shared"));
+
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let kept: Vec<_> = a
+            .into_iter()
+            .chain(b)
+            .filter(|m| m.dedup_key.as_ref().is_none_or(|k| seen.insert(k.clone())))
+            .collect();
+        assert_eq!(kept.len(), 2, "rowid collisions across DBs must stay distinct");
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/micode.rs
+++ b/crates/tokscale-core/src/sessions/micode.rs
@@ -184,6 +184,11 @@ pub fn parse_micode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
     let mut fingerprint_indices: HashMap<MiMoCodeSqliteFingerprint, usize> = HashMap::new();
     let mut dedup_states: Vec<MiMoCodeSqliteDedupState> = Vec::new();
 
+    // Namespace the cross-file dedup key by the database, so two independent
+    // databases that reuse a bare message/row id (e.g. both starting at 1) do
+    // not collapse each other's unrelated messages in the shared dedup set.
+    let db_namespace = db_path.to_string_lossy().to_string();
+
     for row_result in rows {
         let (row_id, session_id, data_json, row_workspace_root) = match row_result {
             Ok(r) => r,
@@ -227,7 +232,7 @@ pub fn parse_micode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
         let cache_read = cache.read.max(0);
         let cache_write = cache.write.max(0);
         let cost = msg.cost.unwrap_or(0.0).max(0.0);
-        let dedup_key = message_id.clone().unwrap_or(row_id);
+        let dedup_key = format!("{db_namespace}:{}", message_id.clone().unwrap_or(row_id));
         let fingerprint = MiMoCodeSqliteFingerprint {
             created_bits: msg.time.created.to_bits(),
             completed_bits: msg.time.completed.map(f64::to_bits),
@@ -383,7 +388,47 @@ mod tests {
 
         let messages = parse_micode_sqlite(&db_path);
         assert_eq!(messages.len(), 1);
-        assert_eq!(messages[0].dedup_key, Some("msg_assistant".to_string()));
+        // The dedup key is namespaced by the database path so identical ids in
+        // separate databases do not collide; the message-id suffix is preserved.
+        assert!(messages[0]
+            .dedup_key
+            .as_deref()
+            .is_some_and(|key| key.ends_with(":msg_assistant")));
+    }
+
+    #[test]
+    fn dedup_key_is_namespaced_by_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_a = dir.path().join("a.db");
+        let db_b = dir.path().join("b.db");
+        let msg = r#"{
+            "role": "assistant",
+            "modelID": "mimo-v2.5-pro",
+            "providerID": "mimo",
+            "cost": 0.05,
+            "tokens": { "input": 10, "output": 5 },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+        for db in [&db_a, &db_b] {
+            let conn = create_micode_sqlite_db(db);
+            conn.execute(
+                "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+                rusqlite::params!["msg_1", "ses_1", msg],
+            )
+            .unwrap();
+            drop(conn);
+        }
+
+        let a = parse_micode_sqlite(&db_a);
+        let b = parse_micode_sqlite(&db_b);
+        assert_eq!(a.len(), 1);
+        assert_eq!(b.len(), 1);
+        // The same bare id "msg_1" in two databases yields distinct dedup keys,
+        // so the shared cross-file dedup set keeps both rather than dropping the
+        // second database's unrelated message.
+        assert_ne!(a[0].dedup_key, b[0].dedup_key);
+        assert!(a[0].dedup_key.as_deref().unwrap().ends_with(":msg_1"));
+        assert!(b[0].dedup_key.as_deref().unwrap().ends_with(":msg_1"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #740.

Two correctness fixes for MiMo Code.

## 1. Cross-database dedup collision

The dedup key was the bare `message_id` (or `row_id`) and the lane shares one `micode_seen` set across every scanned `*.db`, so two independent databases under `$XDG_DATA_HOME/micode` that reuse an id (e.g. both starting their `row_id` at `1`) collapsed each other's unrelated messages. This namespaces the key by the database path (mirroring `crush`), so independent databases no longer collide. The within-database content-fingerprint dedup is unaffected (it keys on content, not the dedup key), so forked-history collapse still works.

## 2. Authoritative cost repriced unconditionally

micode carries an authoritative per-message `cost`, but the lane routed through `load_or_parse_sqlite_source(..., pricing, ...)`, which reprices unconditionally and overwrites (and persists to the source cache) the embedded cost whenever the model resolves to a price — e.g. a session routed to a priced provider (`anthropic` / `claude-...`) through MiMo Code. This passes `None` to the loader and reprices only messages with no embedded cost (`cost <= 0.0`), mirroring the gjc lane's guard.

`cargo test -p tokscale-core` (964 passed) and `cargo clippy --workspace --all-targets` are clean. Regression test asserts the same id in two databases yields distinct dedup keys.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cross-database dedup in MiMo Code and keep authoritative costs intact. Row-id fallback keys are namespaced per `.db`, embedded ids stay global to avoid double-counting across channel databases; pricing only runs when cost is missing.

- **Bug Fixes**
  - Namespace only the row-id fallback by database path; keep embedded message ids un-namespaced so the same message in `mimocode.db` and `mimocode-<channel>.db` collapses correctly. Added regression tests for both namespaced row-ids and shared embedded ids.
  - Stop repricing stored costs by passing `None` to `load_or_parse_sqlite_source` and applying pricing only when `cost <= 0.0`. Tests confirm costs persist across first parse and cache hits.

<sup>Written for commit 1b1a5b0fe03aa0572cd560e723e578d15f17fdf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

