### PR TITLE
fix(micode): normalize epoch seconds vs milliseconds in time.created

### DIFF
--- a/crates/tokscale-core/src/sessions/micode.rs
+++ b/crates/tokscale-core/src/sessions/micode.rs
@@ -130,8 +130,26 @@ fn merge_duplicate_workspace(
     }
 }
 
+/// Normalize an epoch `time.created`/`time.completed` value to milliseconds.
+///
+/// MiMo Code is expected to store epoch milliseconds (matching OpenCode), but
+/// some builds/channels have been observed writing epoch *seconds*, which made
+/// dates land ~1000x in the past (1970-era). A recent epoch is ~1.7e12 in ms
+/// versus ~1.7e9 in seconds, so a value at/under the `1e12` threshold is
+/// treated as seconds and scaled up. This mirrors `timestamp_secs_to_ms` in the
+/// goose/hermes parsers.
+fn micode_timestamp_to_ms(timestamp: f64) -> f64 {
+    if timestamp > 1e12 {
+        timestamp
+    } else {
+        timestamp * 1000.0
+    }
+}
+
 fn micode_duration_ms(time: &MiMoCodeTime) -> Option<i64> {
-    let duration = time.completed? - time.created;
+    // Normalize both endpoints so a seconds/ms mismatch (or both-in-seconds)
+    // still yields a millisecond duration rather than a value 1000x too small.
+    let duration = micode_timestamp_to_ms(time.completed?) - micode_timestamp_to_ms(time.created);
     if duration.is_finite() && duration > 0.0 {
         Some(duration as i64)
     } else {
@@ -236,6 +254,11 @@ pub fn parse_micode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
         let cache_read = cache.read.max(0);
         let cache_write = cache.write.max(0);
         let cost = msg.cost.unwrap_or(0.0).max(0.0);
+        // Normalize epoch values to milliseconds up front so the timestamp, the
+        // dedup fingerprint, and the duration all agree even when MiMo writes
+        // seconds instead of milliseconds.
+        let created_ms = micode_timestamp_to_ms(msg.time.created);
+        let completed_ms = msg.time.completed.map(micode_timestamp_to_ms);
         let dedup_key = match message_id.clone() {
             // Embedded ids are globally unique: keep them un-namespaced so the
             // same message in mimocode.db and mimocode-<channel>.db collapses.
@@ -244,8 +267,8 @@ pub fn parse_micode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             None => format!("{db_namespace}:{row_id}"),
         };
         let fingerprint = MiMoCodeSqliteFingerprint {
-            created_bits: msg.time.created.to_bits(),
-            completed_bits: msg.time.completed.map(f64::to_bits),
+            created_bits: created_ms.to_bits(),
+            completed_bits: completed_ms.map(f64::to_bits),
             model_id: model_id.clone(),
             provider_id: provider_id.clone(),
             input,
@@ -262,9 +285,10 @@ pub fn parse_micode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             model_id,
             provider_id,
             session_id,
-            // `time.created` is epoch milliseconds (matching OpenCode);
+            // `time.created` is normalized to epoch milliseconds above (MiMo
+            // matches OpenCode's ms, but some channels write seconds);
             // UnifiedMessage's timestamp_to_date treats it as ms.
-            msg.time.created as i64,
+            created_ms as i64,
             TokenBreakdown {
                 input,
                 output,
@@ -686,6 +710,146 @@ mod tests {
         let messages = parse_micode_sqlite(&db_path);
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].agent, Some("Build".to_string()));
+    }
+
+    /// Regression for PR #710: `time.created` was hard-assumed to be epoch
+    /// milliseconds. If MiMo writes epoch *seconds*, the date landed ~1000x in
+    /// the past (1970-era). A ms-valued and a seconds-valued `time.created` that
+    /// denote the SAME instant must normalize to the same date and the same
+    /// (millisecond-scale) timestamp. Without `micode_timestamp_to_ms`, the
+    /// seconds variant would yield 1970-01-20 instead of 2023-11-14.
+    #[test]
+    fn test_parse_micode_sqlite_normalizes_seconds_and_milliseconds() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_ms = dir.path().join("ms.db");
+        let db_secs = dir.path().join("secs.db");
+
+        // 1_700_000_000 s == 1_700_000_000_000 ms == 2023-11-14T22:13:20Z.
+        let msg_ms = r#"{
+            "role": "assistant",
+            "modelID": "mimo-v2.5-pro",
+            "providerID": "mimo",
+            "cost": 0.05,
+            "tokens": { "input": 10, "output": 5 },
+            "time": { "created": 1700000000000.0, "completed": 1700000001234.0 }
+        }"#;
+        // Same instant, expressed in epoch SECONDS (the bugged-input shape).
+        let msg_secs = r#"{
+            "role": "assistant",
+            "modelID": "mimo-v2.5-pro",
+            "providerID": "mimo",
+            "cost": 0.05,
+            "tokens": { "input": 10, "output": 5 },
+            "time": { "created": 1700000000.0, "completed": 1700000001.234 }
+        }"#;
+
+        for (db, data) in [(&db_ms, msg_ms), (&db_secs, msg_secs)] {
+            let conn = create_micode_sqlite_db(db);
+            conn.execute(
+                "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+                rusqlite::params!["msg_1", "ses_1", data],
+            )
+            .unwrap();
+            drop(conn);
+        }
+
+        let ms = parse_micode_sqlite(&db_ms);
+        let secs = parse_micode_sqlite(&db_secs);
+        assert_eq!(ms.len(), 1);
+        assert_eq!(secs.len(), 1);
+
+        // Both inputs resolve to the SAME instant: identical timestamp (ms) and
+        // identical, non-empty (i.e. not 1970-era-then-formatted) date.
+        assert_eq!(ms[0].timestamp, 1_700_000_000_000);
+        assert_eq!(secs[0].timestamp, 1_700_000_000_000);
+        assert_eq!(ms[0].date, secs[0].date);
+        assert!(!ms[0].date.is_empty());
+
+        // Duration is in milliseconds for BOTH representations (~1234 ms), not
+        // ~1 (which is what the seconds input would have produced unnormalized).
+        assert_eq!(ms[0].duration_ms, Some(1234));
+        assert_eq!(secs[0].duration_ms, Some(1234));
+    }
+
+    /// A non-object `path` field (e.g. a bare string instead of `{ "root": .. }`)
+    /// must not crash deserialization or fail the whole message: the custom
+    /// `deserialize_micode_path` extracts `root` defensively, leaving it `None`.
+    /// The message must still parse and have no embedded-path workspace.
+    #[test]
+    fn test_parse_micode_sqlite_non_object_path_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_micode.db");
+        let conn = create_micode_sqlite_db(&db_path);
+
+        // `path` is a string, not an object — the deserializer's `.get("root")`
+        // returns None rather than erroring, so the message survives.
+        let data_json = r#"{
+            "role": "assistant",
+            "modelID": "mimo-v2.5-pro",
+            "providerID": "mimo",
+            "cost": 0.05,
+            "tokens": { "input": 100, "output": 50 },
+            "path": "/some/string/not/an/object",
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["msg_badpath", "ses_001", data_json],
+        )
+        .unwrap();
+        drop(conn);
+
+        let messages = parse_micode_sqlite(&db_path);
+        assert_eq!(messages.len(), 1, "non-object path must not drop the message");
+        assert_eq!(messages[0].tokens.input, 100);
+        // No usable root -> no workspace derived from the embedded path.
+        assert_eq!(messages[0].workspace_key, None);
+        assert_eq!(messages[0].workspace_label, None);
+    }
+
+    /// Legacy-query fallback: when the database has no `session` table, the
+    /// modern query (which JOINs `session`) fails to prepare and the parser
+    /// falls back to `legacy_query`. In that path `workspace_root` from the row
+    /// is NULL, so the workspace must come from the message's EMBEDDED `path.root`.
+    #[test]
+    fn test_parse_micode_sqlite_legacy_fallback_embedded_path_workspace() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_micode.db");
+        // Note: create_micode_sqlite_db creates ONLY the `message` table, so the
+        // modern query's `LEFT JOIN session` cannot prepare and we exercise the
+        // legacy fallback.
+        let conn = create_micode_sqlite_db(&db_path);
+
+        let data_json = r#"{
+            "role": "assistant",
+            "modelID": "mimo-v2.5-pro",
+            "providerID": "mimo",
+            "cost": 0.05,
+            "tokens": { "input": 100, "output": 50 },
+            "path": { "root": "/Users/bob/embedded-repo" },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["msg_embedded", "ses_001", data_json],
+        )
+        .unwrap();
+        drop(conn);
+
+        let messages = parse_micode_sqlite(&db_path);
+        assert_eq!(messages.len(), 1);
+        // Row workspace_root is NULL on the legacy path, so the embedded
+        // `path.root` supplies the workspace.
+        assert_eq!(
+            messages[0].workspace_key.as_deref(),
+            Some("/Users/bob/embedded-repo")
+        );
+        assert_eq!(
+            messages[0].workspace_label.as_deref(),
+            Some("embedded-repo")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`crates/tokscale-core/src/sessions/micode.rs` hard-assumed `time.created`/`time.completed` are epoch **milliseconds** (matching OpenCode). Some MiMo Code channels/builds have been observed writing epoch **seconds**, which made dates land ~1000x in the past (1970-era) and durations ~1000x too small (PR #710).

## Fix

Added `micode_timestamp_to_ms`: a value at/under the `1e12` threshold is treated as seconds and scaled to ms, mirroring the existing `timestamp_secs_to_ms` helpers in the goose/hermes parsers. The normalized value now feeds:
- the `UnifiedMessage` timestamp (the date),
- the dedup fingerprint (`created_bits`/`completed_bits`),
- the duration calculation (`micode_duration_ms` normalizes both endpoints),

so all three agree regardless of the input unit. Smallest correct change; no unrelated refactors. ClientId / commit metadata untouched (not a code issue).

## Tests (would fail without the fix)

- `test_parse_micode_sqlite_normalizes_seconds_and_milliseconds`: a ms-valued and a seconds-valued `time.created` denoting the same instant yield identical timestamp (`1_700_000_000_000`) and date, plus a millisecond-scale duration (`Some(1234)`). Without normalization the seconds input formats to 1970 and a ~1ms duration.
- `test_parse_micode_sqlite_non_object_path_field`: a non-object `path` (bare string) no longer risks dropping the message; workspace stays `None` (previously untested, flagged).
- `test_parse_micode_sqlite_legacy_fallback_embedded_path_workspace`: with no `session` table the modern JOIN query fails to prepare and the legacy fallback runs; workspace is derived from the embedded `path.root` (previously untested, flagged).

`cargo test -p tokscale-core` and `cargo clippy -p tokscale-core --tests` both pass clean.

## Residual concern

A single real MiMo database that mixes seconds and ms across rows is not specifically tested, though each row is normalized independently so mixed units are handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize MiMo Code `time.created`/`time.completed` to milliseconds to fix 1970-era dates and 1000x-short durations when some channels write epoch seconds. The normalization now powers timestamps, dedup fingerprints, and duration so they stay consistent across mixed inputs.

- **Bug Fixes**
  - Added `micode_timestamp_to_ms` to treat values ≤ `1e12` as seconds and scale to ms.
  - Used normalized `created_ms`/`completed_ms` for `UnifiedMessage` timestamp, `created_bits`/`completed_bits`, and `micode_duration_ms`.
  - Tests cover seconds vs ms normalization, defensive parsing of non-object `path`, and legacy fallback deriving workspace from embedded `path.root`.

<sup>Written for commit d6da0cb0136dbfcbcb01332a4917022521e7f9fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

