### PR TITLE
feat(tui): brand the Sakana usage provider red in the dashboard

### DIFF
--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -173,6 +173,7 @@ pub fn get_provider_shade(provider: &str, rank: usize) -> Color {
         s if s.contains("xai") || s.contains("grok") => &XAI_SHADES,
         s if s.contains("meta") || s.contains("llama") => &META_SHADES,
         s if s.contains("cursor") => &CURSOR_SHADES,
+        s if s.contains("sakana") || s.contains("fugu") => &SAKANA_SHADES,
         _ => &UNKNOWN_SHADES,
     };
 
@@ -266,6 +267,17 @@ const CURSOR_SHADES: [(u8, u8, u8); 7] = [
     (199, 177, 251), // #C7B1FB
     (215, 199, 252), // #D7C7FC
     (230, 220, 253), // #E6DCFD
+];
+
+/// Sakana (Fugu) red — the brand's "one red fish leading the school" accent.
+const SAKANA_SHADES: [(u8, u8, u8); 7] = [
+    (219, 43, 31),   // #DB2B1F
+    (223, 66, 56),   // #DF4238
+    (227, 90, 80),   // #E35A50
+    (231, 113, 105), // #E77169
+    (235, 136, 130), // #EB8882
+    (239, 162, 156), // #EFA29C
+    (243, 185, 181), // #F3B9B5
 ];
 
 /// Neutral gray ramp for providers that don't match any known palette.


### PR DESCRIPTION
Follow-up to the Sakana usage provider (#745). The #731 subscription-usage dashboard colors each provider via `get_provider_shade()`, but Sakana fell through to the neutral gray `UNKNOWN_SHADES`. Adds `SAKANA_SHADES` — the brand's "one red fish leading the school" accent (derived from the logo) — so Sakana renders with the same branded parity as Anthropic/OpenAI/Google/etc. Matches on `sakana`/`fugu`. Pure cosmetic; no logic change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brand the Sakana usage provider in the TUI subscription-usage dashboard with a red palette so entries matching "sakana" or "fugu" render in branded shades instead of neutral gray. Visual-only change; no logic impact.

<sup>Written for commit 2f2f09dfe69e8e4bb1b107cc65c1c9023117785a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

