### PR TITLE
fix(copilot): per-message agent attribution, whitespace ids, cache-key parity

### DIFF
--- a/crates/tokscale-cli/src/tui/cache.rs
+++ b/crates/tokscale-cli/src/tui/cache.rs
@@ -691,8 +691,14 @@ fn normalize_cached_agents(agents: Vec<CachedAgentUsage>) -> Vec<AgentUsage> {
 }
 
 fn normalize_cached_agent_name(agent: &str, clients: &str) -> String {
-    if clients.split(", ").any(|client| client == "opencode") {
+    // Mirror the per-client normalization in `tui::data` (see the `msg.agent`
+    // branch there): copilot and opencode agent ids use bespoke normalizers,
+    // everything else falls back to the generic one. Keep these two in sync.
+    let has_client = |name: &str| clients.split(", ").any(|client| client == name);
+    if has_client("opencode") {
         sessions::normalize_opencode_agent_name(agent)
+    } else if has_client("copilot") {
+        sessions::normalize_copilot_agent_name(agent)
     } else {
         sessions::normalize_agent_name(agent)
     }
@@ -997,6 +1003,28 @@ mod tests {
             .find(|agent| agent.agent == "Prometheus")
             .unwrap();
         assert_eq!(prometheus.message_count, 1);
+    }
+
+    #[test]
+    fn test_normalize_cached_agents_merges_copilot_display_variants() {
+        // Copilot cached agent ids must go through normalize_copilot_agent_name
+        // (mirroring tui::data). Without the copilot branch in
+        // normalize_cached_agent_name, the raw "github.copilot.default" id would
+        // be left untouched (generic normalizer titlecases it differently) and
+        // would NOT merge with the "GitHub Copilot" display name.
+        let agents = normalize_cached_agents(vec![
+            cached_agent("github.copilot.default", "copilot", 10),
+            cached_agent("GITHUB.COPILOT.DEFAULT", "copilot", 20),
+        ]);
+
+        assert_eq!(agents.len(), 1);
+        let copilot = agents
+            .iter()
+            .find(|agent| agent.agent == "GitHub Copilot")
+            .unwrap();
+        assert_eq!(copilot.clients, "copilot");
+        assert_eq!(copilot.message_count, 2);
+        assert_eq!(copilot.tokens.input, 30);
     }
 
     // ── check_client_match ──────────────────────────────────────────

--- a/crates/tokscale-core/src/sessions/copilot.rs
+++ b/crates/tokscale-core/src/sessions/copilot.rs
@@ -159,6 +159,13 @@ fn collect_trace_contexts(records: &[Value]) -> HashMap<String, TraceContext> {
             }
         }
 
+        // Trace-level agent is only a FALLBACK for records that carry no
+        // gen_ai.agent.id of their own (see candidate_from_attributes). We keep
+        // the first non-empty agent id in the trace — for Copilot CLI this is
+        // the invoke_agent span's agent, which is the right default for plain
+        // chat turns that omit the attribute. Per-record agent ids (e.g. a
+        // sub-agent turn) take precedence at attribution time, so this
+        // first-wins lock does not mis-attribute records that name their agent.
         if context.agent_id.is_none() {
             if let Some(agent_id) = first_non_empty_attr(attributes, &["gen_ai.agent.id"]) {
                 context.agent_id = Some(agent_id.to_string());
@@ -315,7 +322,14 @@ fn candidate_from_attributes(
         duration_ms,
         tokens,
         dedup_key,
-        agent: trace_context.and_then(|tc| tc.agent_id.clone()),
+        // Per-record attribution first: when a chat/inference record carries its
+        // own gen_ai.agent.id (e.g. a sub-agent turn inside a shared trace), use
+        // it so sub-agents are not mis-attributed to the trace's first agent.
+        // Fall back to the trace-level agent (typically from the invoke_agent
+        // span) only when the record itself has none.
+        agent: first_non_empty_attr(attributes, &["gen_ai.agent.id"])
+            .map(str::to_string)
+            .or_else(|| trace_context.and_then(|tc| tc.agent_id.clone())),
     })
 }
 
@@ -573,7 +587,12 @@ fn normalize_input_tokens(
 fn first_non_empty_attr<'a>(attributes: &'a Map<String, Value>, keys: &[&str]) -> Option<&'a str> {
     keys.iter()
         .filter_map(|key| attributes.get(*key).and_then(Value::as_str))
-        .find(|value| !value.trim().is_empty())
+        // Return the trimmed slice: callers store this value directly (model,
+        // agent id), and a surrounding-whitespace variant like
+        // " github.copilot.default " must match the same normalization branch
+        // as the trimmed form — otherwise it bypasses agent-name normalization.
+        .map(str::trim)
+        .find(|value| !value.is_empty())
 }
 
 fn best_session_attr(attributes: &Map<String, Value>) -> Option<(&str, SessionIdPriority)> {
@@ -849,6 +868,58 @@ mod tests {
 
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].agent.as_deref(), Some("github.copilot.default"));
+    }
+
+    #[test]
+    fn test_parse_copilot_cli_trims_whitespace_agent_id() {
+        // The invoke_agent span carries a gen_ai.agent.id padded with
+        // surrounding whitespace. first_non_empty_attr must store the TRIMMED
+        // value so the agent id matches the same normalization branch as a
+        // clean " github.copilot.default" id (without trimming, the stored
+        // agent would be " github.copilot.default " and bypass normalization).
+        let content = r#"{"type":"span","traceId":"trace-ws","spanId":"invoke-ws","name":"invoke_agent","endTime":[1775934260,0],"attributes":{"gen_ai.operation.name":"invoke_agent","gen_ai.provider.name":"github","gen_ai.conversation.id":"conv-ws","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.agent.id":"  github.copilot.default  "}}
+{"type":"span","traceId":"trace-ws","spanId":"chat-ws","name":"chat claude-sonnet-4.6","endTime":[1775934264,967317833],"attributes":{"gen_ai.operation.name":"chat","gen_ai.provider.name":"github","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.response.model":"claude-sonnet-4.6","gen_ai.conversation.id":"conv-ws","gen_ai.usage.input_tokens":5000,"gen_ai.usage.output_tokens":100}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].agent.as_deref(), Some("github.copilot.default"));
+    }
+
+    #[test]
+    fn test_parse_copilot_cli_per_record_agent_id_wins_over_trace_agent() {
+        // A trace's invoke_agent span names the default agent, but a later chat
+        // record carries its OWN gen_ai.agent.id for a sub-agent. Per-record
+        // attribution must win so the sub-agent's tokens are not mis-attributed
+        // to the trace's first (default) agent.
+        let content = r#"{"type":"span","traceId":"trace-sub","spanId":"invoke-sub","name":"invoke_agent","endTime":[1775934260,0],"attributes":{"gen_ai.operation.name":"invoke_agent","gen_ai.provider.name":"github","gen_ai.conversation.id":"conv-sub","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.agent.id":"github.copilot.default"}}
+{"type":"span","traceId":"trace-sub","spanId":"chat-sub","name":"chat claude-sonnet-4.6","endTime":[1775934264,967317833],"attributes":{"gen_ai.operation.name":"chat","gen_ai.provider.name":"github","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.response.model":"claude-sonnet-4.6","gen_ai.conversation.id":"conv-sub","gen_ai.agent.id":"github.copilot.reviewer","gen_ai.usage.input_tokens":5000,"gen_ai.usage.output_tokens":100}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].agent.as_deref(),
+            Some("github.copilot.reviewer")
+        );
+    }
+
+    #[test]
+    fn test_parse_copilot_cli_underscore_cache_write_attribute() {
+        // Copilot CLI may emit the cache-write bucket with the fully
+        // underscored key gen_ai.usage.cache_write_input_tokens (a sibling of
+        // the documented cache_read_input_tokens variant). It must map to the
+        // cache_write token bucket.
+        let content = r#"{"type":"span","traceId":"trace-cw","spanId":"span-cw","name":"chat claude-sonnet-4.6","endTime":[1775934264,967317833],"resource":{"attributes":{"service.name":"github-copilot"}},"attributes":{"gen_ai.operation.name":"chat","gen_ai.provider.name":"github","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.usage.input_tokens":21884,"gen_ai.usage.output_tokens":80,"gen_ai.usage.cache_write_input_tokens":21881}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.cache_write, 21881);
+        assert_eq!(messages[0].tokens.cache_read, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Four confirmed Copilot bugs from PRs #724/#723:

1. **Cache normalization gap (#724):** `tui::data` normalizes copilot agent ids via `normalize_copilot_agent_name`, but `normalize_cached_agent_name` in `tui/cache.rs` had no `copilot` branch — cached ids like `github.copilot.default` were left raw and never merged with the `GitHub Copilot` display name.
2. **Whitespace agent ids (#724):** `first_non_empty_attr` checked the *trimmed* form for emptiness but returned the *untrimmed* value, so a padded id (`" github.copilot.default "`) was stored verbatim and bypassed normalization.
3. **First agent_id wins (#724):** agent attribution always used the trace's *first* `gen_ai.agent.id`, mis-attributing sub-agent turns within a shared trace.
4. **Untested cache_write key (#723):** the speculative `gen_ai.usage.cache_write_input_tokens` underscore variant had no test.

## Fix

1. Added the `copilot` branch to `normalize_cached_agent_name` (mirrors `tui::data`).
2. `first_non_empty_attr` now returns the trimmed slice.
3. Attribution prefers each record's own `gen_ai.agent.id`, falling back to the trace-level agent only when absent; the trace-context first-wins lock is documented as a fallback.
4. Kept the underscore `cache_write` key and added a regression test confirming it maps to the cache_write bucket.

## Tests

Four new regression tests, each verified to **fail without** its production change (reverted the logic while keeping the tests):

- `test_parse_copilot_cli_trims_whitespace_agent_id`
- `test_parse_copilot_cli_per_record_agent_id_wins_over_trace_agent`
- `test_parse_copilot_cli_underscore_cache_write_attribute`
- `test_normalize_cached_agents_merges_copilot_display_variants`

`cargo test -p tokscale-core` (986 passed) and `-p tokscale-cli` pass; `cargo clippy --tests` introduces no new warnings (3 pre-existing `vec!` warnings in `commands/report.rs` are unrelated).

## Residual concern

Records where a sub-agent emits no `gen_ai.agent.id` on its own still fall back to the trace-level agent (same behavior as before) — documented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four Copilot parsing and cache issues: per-message agent attribution, trimmed agent IDs, Copilot cache normalization, and cache_write key parity. This ensures correct agent merging and token accounting.

- **Bug Fixes**
  - Normalize Copilot cached agent ids by adding a `copilot` branch in `normalize_cached_agent_name`, merging `github.copilot.default` with "GitHub Copilot".
  - Trim values returned by `first_non_empty_attr` so padded ids (e.g., `"  github.copilot.default  "`) normalize correctly.
  - Prefer each record’s `gen_ai.agent.id`; fall back to the trace-level agent only if missing (documented as a fallback).
  - Map `gen_ai.usage.cache_write_input_tokens` to the cache_write bucket; added regression tests covering all fixes.

<sup>Written for commit de6a7316bbbb26620c8c364ac8a46efe3016bfec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

