### PR TITLE
fix(kiro): de-duplicate snapshot traversal and align model-id key-sets

### DIFF
--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -384,9 +384,18 @@ fn collect_kiro_snapshot_text(
             // snapshots frequently store the identical text under more than one
             // alias in a single object (e.g. both `content` and `text`, or both
             // `messages` and `entries`). Descending into every present alias
-            // would count that text once per alias and inflate token totals, so
-            // we descend into only the FIRST present key in each group. This
-            // de-duplicates traversal so each node's text is collected once.
+            // would count that text once per alias and inflate token totals.
+            //
+            // However, an object may also legitimately hold *distinct* payloads
+            // under several keys of the same group (e.g. a turn with both
+            // `prompt` and `response`, or a chat with both `messages` and
+            // `history` pointing at different subtrees). Visiting only the first
+            // present key would silently drop those, undercounting tokens.
+            //
+            // So we descend into every present key in the group but de-duplicate
+            // by VALUE: subtrees structurally equal to one already visited in the
+            // same group are skipped. Distinct subtrees are all counted; repeated
+            // (aliased) subtrees are counted once.
             for group in [
                 // Inline text body of a single message.
                 &["prompt", "response", "content", "text", "message"][..],
@@ -396,8 +405,15 @@ fn collect_kiro_snapshot_text(
                 // Sub-parts of a single message.
                 &["parts", "items", "nodes"][..],
             ] {
-                if let Some(item) = group.iter().find_map(|key| map.get(*key)) {
-                    collect_kiro_snapshot_text(item, counts, role);
+                let mut visited: Vec<&Value> = Vec::new();
+                for key in group {
+                    if let Some(item) = map.get(*key) {
+                        if visited.contains(&item) {
+                            continue;
+                        }
+                        visited.push(item);
+                        collect_kiro_snapshot_text(item, counts, role);
+                    }
                 }
             }
         }
@@ -943,6 +959,49 @@ not valid json at all
 
         // "hello" counted once = 5 chars, not 10.
         assert_eq!(counts.prompt_chars, 5);
+        assert_eq!(counts.assistant_chars, 0);
+    }
+
+    #[test]
+    fn test_collect_kiro_snapshot_text_counts_distinct_alias_subtrees() {
+        // A single turn that stores DISTINCT payloads under two keys of the same
+        // alias group: `prompt` (user text) and `response` (assistant text).
+        // These are different subtrees, so both must be counted. A first-key-only
+        // traversal would drop the `response` body and undercount.
+        let value: Value = serde_json::from_str(
+            r#"{
+                "prompt": {"role": "user", "text": "hi there"},
+                "response": {"role": "assistant", "text": "hello back"}
+            }"#,
+        )
+        .unwrap();
+
+        let mut counts = KiroSnapshotTextCounts::default();
+        collect_kiro_snapshot_text(&value, &mut counts, None);
+
+        // "hi there" = 8 prompt chars, "hello back" = 10 assistant chars.
+        assert_eq!(counts.prompt_chars, 8);
+        assert_eq!(counts.assistant_chars, 10);
+    }
+
+    #[test]
+    fn test_collect_kiro_snapshot_text_counts_distinct_container_subtrees() {
+        // A chat object holding DISTINCT conversation lists under two container
+        // aliases (`messages` and `history`). Both must be counted; the
+        // value-based de-dup only skips structurally identical subtrees.
+        let value: Value = serde_json::from_str(
+            r#"{
+                "messages": [{"role": "user", "content": "alpha"}],
+                "history": [{"role": "user", "content": "bravo"}]
+            }"#,
+        )
+        .unwrap();
+
+        let mut counts = KiroSnapshotTextCounts::default();
+        collect_kiro_snapshot_text(&value, &mut counts, None);
+
+        // "alpha" (5) + "bravo" (5) = 10 prompt chars; nothing dropped.
+        assert_eq!(counts.prompt_chars, 10);
         assert_eq!(counts.assistant_chars, 0);
     }
 

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -379,28 +379,24 @@ fn collect_kiro_snapshot_text(
                 };
             }
 
-            for key in ["prompt", "response", "content", "text", "message"] {
-                if let Some(item) = map.get(key) {
-                    collect_kiro_snapshot_text(item, counts, role);
-                }
-            }
-
-            for key in [
-                "messages",
-                "conversation",
-                "chat",
-                "transcript",
-                "entries",
-                "events",
-                "history",
+            // Each group below is an ordered list of *aliases* for the same
+            // logical payload (text body, conversation list, sub-parts). Kiro
+            // snapshots frequently store the identical text under more than one
+            // alias in a single object (e.g. both `content` and `text`, or both
+            // `messages` and `entries`). Descending into every present alias
+            // would count that text once per alias and inflate token totals, so
+            // we descend into only the FIRST present key in each group. This
+            // de-duplicates traversal so each node's text is collected once.
+            for group in [
+                // Inline text body of a single message.
+                &["prompt", "response", "content", "text", "message"][..],
+                // Container holding a list of messages/turns.
+                &["messages", "conversation", "chat", "transcript", "entries", "events", "history"]
+                    [..],
+                // Sub-parts of a single message.
+                &["parts", "items", "nodes"][..],
             ] {
-                if let Some(item) = map.get(key) {
-                    collect_kiro_snapshot_text(item, counts, role);
-                }
-            }
-
-            for key in ["parts", "items", "nodes"] {
-                if let Some(item) = map.get(key) {
+                if let Some(item) = group.iter().find_map(|key| map.get(*key)) {
                     collect_kiro_snapshot_text(item, counts, role);
                 }
             }
@@ -431,6 +427,10 @@ fn find_kiro_snapshot_model_id(value: &Value) -> Option<String> {
                 }
             }
 
+            // Recurse into the same containers `collect_kiro_snapshot_text`
+            // descends into, so the model id is discoverable wherever text is
+            // (otherwise a model id nested under e.g. `parts` or `prompt` would
+            // be missed and fall back to `unknown`). Keep these key-sets aligned.
             for key in [
                 "messages",
                 "conversation",
@@ -439,9 +439,14 @@ fn find_kiro_snapshot_model_id(value: &Value) -> Option<String> {
                 "entries",
                 "events",
                 "history",
+                "prompt",
+                "response",
                 "content",
                 "text",
                 "message",
+                "parts",
+                "items",
+                "nodes",
             ] {
                 if let Some(item) = map.get(key) {
                     if let Some(model) = find_kiro_snapshot_model_id(item) {
@@ -495,12 +500,23 @@ fn parse_kiro_global_storage_file(path: &Path) -> Vec<UnifiedMessage> {
         return Vec::new();
     }
 
+    // Date-bucketing limitation: Kiro IDE globalStorage snapshots are a single
+    // rolling JSON blob with no per-turn timestamps — turns carry only their
+    // text, not a `timestamp`/`end_timestamp` field (unlike the CLI `.jsonl`
+    // and the sqlite `request_metadata` sources, which do expose per-turn
+    // times). We therefore emit the entire snapshot as ONE message stamped at
+    // the file's mtime. This mis-buckets historical usage into the day the file
+    // was last written rather than the days the turns actually occurred. We do
+    // NOT synthesize timestamps; if a future snapshot schema adds per-turn
+    // times, read them here and split into one message per turn.
+    let snapshot_timestamp = fallback_timestamp;
+
     let mut message = UnifiedMessage::new_with_dedup(
         CLIENT_ID,
         model_id,
         PROVIDER_ID,
         session_id.clone(),
-        fallback_timestamp,
+        snapshot_timestamp,
         TokenBreakdown {
             input,
             output,
@@ -883,5 +899,78 @@ not valid json at all
 
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].tokens.output, 4);
+    }
+
+    #[test]
+    fn test_collect_kiro_snapshot_text_does_not_double_count_aliased_keys() {
+        // (a) A single message object that stores the SAME assistant body under
+        // two aliased text keys (`content` and `text`). Before the fix, the
+        // traversal descended into every present alias and counted "response
+        // text" twice (8 assistant chars -> output 2). After the fix it descends
+        // into only the first present alias in the group, counting once.
+        let value: Value = serde_json::from_str(
+            r#"{
+                "messages": [
+                    {"role": "assistant", "content": "abcd", "text": "abcd"}
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let mut counts = KiroSnapshotTextCounts::default();
+        collect_kiro_snapshot_text(&value, &mut counts, None);
+
+        // "abcd" counted once = 4 chars, not 8.
+        assert_eq!(counts.assistant_chars, 4);
+        assert_eq!(counts.prompt_chars, 0);
+    }
+
+    #[test]
+    fn test_collect_kiro_snapshot_text_does_not_double_count_aliased_containers() {
+        // (a) An object that stores the SAME conversation list under two aliased
+        // container keys (`messages` and `entries`). Before the fix both were
+        // traversed and the text was counted twice.
+        let value: Value = serde_json::from_str(
+            r#"{
+                "messages": [{"role": "user", "content": "hello"}],
+                "entries": [{"role": "user", "content": "hello"}]
+            }"#,
+        )
+        .unwrap();
+
+        let mut counts = KiroSnapshotTextCounts::default();
+        collect_kiro_snapshot_text(&value, &mut counts, None);
+
+        // "hello" counted once = 5 chars, not 10.
+        assert_eq!(counts.prompt_chars, 5);
+        assert_eq!(counts.assistant_chars, 0);
+    }
+
+    #[test]
+    fn test_find_kiro_snapshot_model_id_descends_into_aliased_text_keys() {
+        // (b) Model id nested under `parts` / `prompt` — keys that
+        // `collect_kiro_snapshot_text` descends into but the model-id finder
+        // previously omitted, causing the model to fall back to `unknown`.
+        let parts_value: Value = serde_json::from_str(
+            r#"{
+                "messages": [
+                    {"parts": [{"model_id": "claude-sonnet-4-5"}]}
+                ]
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            find_kiro_snapshot_model_id(&parts_value),
+            Some("claude-sonnet-4-5".to_string())
+        );
+
+        let prompt_value: Value = serde_json::from_str(
+            r#"{"prompt": {"model": "auto"}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            find_kiro_snapshot_model_id(&prompt_value),
+            Some("auto".to_string())
+        );
     }
 }


### PR DESCRIPTION
## Problem

`crates/tokscale-core/src/sessions/kiro.rs` parses Kiro IDE globalStorage snapshots. Three confirmed bugs (#715):

- **(a) Double-count.** `collect_kiro_snapshot_text` recursed into *every* present key across three overlapping key-sets (`[prompt,response,content,text,message]`, the container set, and `[parts,items,nodes]`). When a single object stored the same payload under aliased keys — e.g. both `content` and `text`, or both `messages` and `entries` — the text was counted once per alias, inflating estimated token totals.
- **(b) Key-set mismatch.** `find_kiro_snapshot_model_id` omitted `prompt`/`response`/`parts`/`items`/`nodes` — keys that `collect_kiro_snapshot_text` descends into — so a model id nested under those keys was missed and fell back to `unknown`.
- **(c) Date bucketing.** The snapshot is emitted as one message at the file mtime, mis-bucketing historical usage into the day the file was last written.

## Fix

- **(a)** Treat each key-set as an ordered list of *aliases* for the same logical payload and descend into only the first present key per group, so each node's text is collected exactly once.
- **(b)** Align `find_kiro_snapshot_model_id`'s key-set with `collect_kiro_snapshot_text` (adds `prompt`, `response`, `parts`, `items`, `nodes`).
- **(c)** Kiro snapshots carry no per-turn timestamps (unlike the CLI `.jsonl` and sqlite `request_metadata` sources). No timestamps are synthesized; mtime is kept and the limitation is documented with a clear comment so a future schema with per-turn times can split into per-turn messages.

## Tests

Added regression tests:
- `test_collect_kiro_snapshot_text_does_not_double_count_aliased_keys` — same body under `content` + `text` counted once.
- `test_collect_kiro_snapshot_text_does_not_double_count_aliased_containers` — same list under `messages` + `entries` counted once.
- `test_find_kiro_snapshot_model_id_descends_into_aliased_text_keys` — model id under `parts` and `prompt` is discovered.

`cargo test -p tokscale-core` (13 kiro tests pass) and `cargo clippy -p tokscale-core --tests` are green.

## Residual concern

(c) is documented, not fixed — it requires a snapshot schema that exposes per-turn timestamps, which does not currently exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes double-counting in Kiro snapshot parsing by de-duplicating alias keys by value while still counting distinct subtrees, and aligns model-ID discovery. Fixes #715; date bucketing remains at file mtime and is documented.

- **Bug Fixes**
  - De-duplicate traversal in `collect_kiro_snapshot_text` by visiting all keys in each alias group but skipping structurally equal subtrees, so identical aliased text is counted once while distinct `prompt`/`response` or `messages`/`history` bodies are both counted (regression tests added).
  - Align `find_kiro_snapshot_model_id` with the same key-sets so IDs under `prompt`, `response`, `content`, `text`, `message`, container aliases, and `parts`/`items`/`nodes` are found (regression tests added).
  - Keep snapshot date bucketing at file mtime; document the limitation and future path if per-turn timestamps appear.

<sup>Written for commit 86b088391afd5e5b34006a6b4cac9640a9263bdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

