### PR TITLE
fix(report): bucket and filter report dates in local time

### DIFF
--- a/crates/tokscale-cli/src/commands/report.rs
+++ b/crates/tokscale-cli/src/commands/report.rs
@@ -1149,17 +1149,41 @@ fn parse_date_range(since: &Option<String>, until: &Option<String>) -> (Option<i
     (since_ts, until_ts)
 }
 
-/// Returns the Unix-millisecond timestamp for midnight (00:00:00) of `date` in
-/// the local timezone, or `None` when that wall-clock time does not exist
-/// locally (e.g. a DST spring-forward gap).
+/// Returns the Unix-millisecond timestamp for the start of `date` in the local
+/// timezone.
+///
+/// This is normally midnight (00:00:00), but in zones that spring forward at
+/// local midnight (e.g. `America/Nuuk` on `2024-03-31`) that wall-clock time
+/// does not exist. Rather than dropping the boundary (which would silently make
+/// date filtering unbounded), we walk forward to the first representable instant
+/// after the gap so the day boundary is preserved.
 fn local_start_of_day_millis(date: chrono::NaiveDate) -> Option<i64> {
-    let midnight = date.and_hms_opt(0, 0, 0)?;
-    match Local.from_local_datetime(&midnight) {
-        chrono::LocalResult::Single(dt) | chrono::LocalResult::Ambiguous(dt, _) => {
-            Some(dt.timestamp_millis())
+    start_of_day_millis_with(date, |wall| Local.from_local_datetime(wall))
+}
+
+/// Core of [`local_start_of_day_millis`], parameterized over the timezone
+/// resolver so the DST-gap handling can be exercised deterministically in tests.
+///
+/// Starts at midnight and, when that wall-clock time is skipped (a spring-forward
+/// gap), walks forward in 1-minute steps to the first representable instant. The
+/// probe window covers a full day so even unusual offsets resolve rather than
+/// silently dropping the boundary.
+fn start_of_day_millis_with<F>(date: chrono::NaiveDate, resolve: F) -> Option<i64>
+where
+    F: Fn(&chrono::NaiveDateTime) -> chrono::LocalResult<chrono::DateTime<Local>>,
+{
+    let mut wall = date.and_hms_opt(0, 0, 0)?;
+    for _ in 0..=(24 * 60) {
+        match resolve(&wall) {
+            chrono::LocalResult::Single(dt) | chrono::LocalResult::Ambiguous(dt, _) => {
+                return Some(dt.timestamp_millis());
+            }
+            chrono::LocalResult::None => {
+                wall += chrono::Duration::minutes(1);
+            }
         }
-        chrono::LocalResult::None => None,
     }
+    None
 }
 
 /// Loads the canonical pricing dataset for cost attribution, preferring a fresh
@@ -1341,6 +1365,55 @@ mod tests {
         } else {
             assert_eq!(since, Some(utc_since));
         }
+    }
+
+    #[test]
+    fn start_of_day_preserves_boundary_across_dst_gap() {
+        use chrono::{Local, LocalResult, TimeZone};
+
+        // Simulate a zone that springs forward at local midnight (like
+        // `America/Nuuk` on 2024-03-31, where 00:00–00:59 do not exist). The
+        // resolver maps any wall-clock time before 01:00 to `None` (the gap) and
+        // resolves 01:00+ as a real instant. The first valid instant after the
+        // gap must be returned instead of dropping the boundary.
+        let date = chrono::NaiveDate::from_ymd_opt(2024, 3, 31).unwrap();
+        let resolve = |wall: &chrono::NaiveDateTime| -> LocalResult<chrono::DateTime<Local>> {
+            if wall.time() < chrono::NaiveTime::from_hms_opt(1, 0, 0).unwrap() {
+                LocalResult::None
+            } else {
+                // Resolve against the machine's local zone for an arbitrary but
+                // representable instant; the value just needs to be `Single`.
+                Local.from_local_datetime(wall)
+            }
+        };
+
+        let result = start_of_day_millis_with(date, resolve);
+        let expected = Local
+            .from_local_datetime(&date.and_hms_opt(1, 0, 0).unwrap())
+            .single()
+            .map(|dt| dt.timestamp_millis());
+
+        // Boundary must be preserved (not `None`) and equal to the first valid
+        // post-gap instant (01:00 local).
+        assert!(
+            result.is_some(),
+            "DST-gap midnight must not drop the date boundary (would make filtering unbounded)"
+        );
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn start_of_day_uses_midnight_when_representable() {
+        use chrono::{Local, TimeZone};
+
+        // Sanity: when midnight exists, it is used unchanged (no forward walk).
+        let date = chrono::NaiveDate::from_ymd_opt(2026, 6, 22).unwrap();
+        let result = start_of_day_millis_with(date, |wall| Local.from_local_datetime(wall));
+        let expected = Local
+            .from_local_datetime(&date.and_hms_opt(0, 0, 0).unwrap())
+            .single()
+            .map(|dt| dt.timestamp_millis());
+        assert_eq!(result, expected);
     }
 
     #[test]

--- a/crates/tokscale-cli/src/commands/report.rs
+++ b/crates/tokscale-cli/src/commands/report.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use chrono::{TimeZone, Utc};
+use chrono::{Local, TimeZone};
 use colored::Colorize;
 use std::collections::HashMap;
 use std::io::Write;
@@ -1048,8 +1048,8 @@ fn print_daily_breakdown(entries: &[WikiEntry]) {
 
     let mut by_date: BTreeMap<String, (f64, i64, usize, Vec<&WikiEntry>)> = BTreeMap::new();
     for entry in entries {
-        let date_key = Utc
-            .timestamp_opt(entry.created_at / 1000, 0)
+        let date_key = Local
+            .timestamp_millis_opt(entry.created_at)
             .single()
             .map(|dt| dt.format("%Y-%m-%d").to_string())
             .unwrap_or_else(|| "unknown".to_string());
@@ -1102,8 +1102,8 @@ fn print_session_list(entries: &[WikiEntry]) {
         println!("  Sessions:");
         println!("  {}", "─".repeat(80));
         for entry in recent {
-            let date = Utc
-                .timestamp_opt(entry.created_at / 1000, 0)
+            let date = Local
+                .timestamp_millis_opt(entry.created_at)
                 .single()
                 .map(|dt| dt.format("%H:%M").to_string())
                 .unwrap_or_else(|| "??:??".to_string());
@@ -1132,25 +1132,34 @@ fn extract_content_for_session(entry: &WikiEntry) -> SessionContent {
 }
 
 fn parse_date_range(since: &Option<String>, until: &Option<String>) -> (Option<i64>, Option<i64>) {
-    let since_ts = since.as_ref().and_then(|s| {
-        chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d")
-            .ok()
-            .map(|d| d.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp_millis())
-    });
-    let until_ts = until.as_ref().and_then(|s| {
-        chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d")
-            .ok()
-            .map(|d| {
-                d.succ_opt()
-                    .unwrap()
-                    .and_hms_opt(0, 0, 0)
-                    .unwrap()
-                    .and_utc()
-                    .timestamp_millis()
-                    - 1
-            })
-    });
+    // The `since`/`until` strings are local-calendar dates (e.g. produced by
+    // `build_date_filter`, which derives them from `chrono::Local::now()`), and
+    // session dates are bucketed in local time (see
+    // `sessions::timestamp_to_date`). Interpret the day boundaries in local time
+    // so filtering lines up with grouping and avoids off-by-a-day mismatches.
+    let since_ts = since
+        .as_ref()
+        .and_then(|s| chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").ok())
+        .and_then(local_start_of_day_millis);
+    let until_ts = until
+        .as_ref()
+        .and_then(|s| chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").ok())
+        .and_then(|d| d.succ_opt())
+        .and_then(|next| local_start_of_day_millis(next).map(|ms| ms - 1));
     (since_ts, until_ts)
+}
+
+/// Returns the Unix-millisecond timestamp for midnight (00:00:00) of `date` in
+/// the local timezone, or `None` when that wall-clock time does not exist
+/// locally (e.g. a DST spring-forward gap).
+fn local_start_of_day_millis(date: chrono::NaiveDate) -> Option<i64> {
+    let midnight = date.and_hms_opt(0, 0, 0)?;
+    match Local.from_local_datetime(&midnight) {
+        chrono::LocalResult::Single(dt) | chrono::LocalResult::Ambiguous(dt, _) => {
+            Some(dt.timestamp_millis())
+        }
+        chrono::LocalResult::None => None,
+    }
 }
 
 /// Loads the canonical pricing dataset for cost attribution, preferring a fresh
@@ -1274,6 +1283,64 @@ mod tests {
             canonical > 0.0,
             "expected a positive cost for a known model"
         );
+    }
+
+    #[test]
+    fn parse_date_range_buckets_in_local_time() {
+        use chrono::{Local, TimeZone};
+
+        // Pick an arbitrary calendar day. The exact day is irrelevant; what
+        // matters is that `parse_date_range` interprets the boundaries in the
+        // *local* timezone, matching how `sessions::timestamp_to_date` buckets
+        // each message (and how `build_date_filter` derives these strings from
+        // `chrono::Local::now()`).
+        let day = "2026-03-08";
+        let (since, until) = parse_date_range(&Some(day.into()), &Some(day.into()));
+
+        let expected_since = Local
+            .with_ymd_and_hms(2026, 3, 8, 0, 0, 0)
+            .single()
+            .map(|dt| dt.timestamp_millis())
+            .expect("local midnight exists for this fixed date");
+        // The window is inclusive of the whole local day: [00:00:00.000,
+        // next-day 00:00:00.000 - 1ms].
+        let expected_until = Local
+            .with_ymd_and_hms(2026, 3, 9, 0, 0, 0)
+            .single()
+            .map(|dt| dt.timestamp_millis() - 1)
+            .expect("local midnight exists for this fixed date");
+
+        assert_eq!(since, Some(expected_since));
+        assert_eq!(until, Some(expected_until));
+
+        // Regression guard: the previous implementation interpreted the day as
+        // UTC. Any machine running in a non-UTC zone would then see boundaries
+        // shifted by the offset. Confirm the local boundary differs from the
+        // UTC one whenever the local offset is non-zero, so this test actually
+        // exercises the fix on offset machines (and stays correct on UTC ones).
+        let utc_since = chrono::NaiveDate::from_ymd_opt(2026, 3, 8)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+            .and_utc()
+            .timestamp_millis();
+        let local_offset_secs = Local
+            .offset_from_utc_datetime(
+                &chrono::NaiveDate::from_ymd_opt(2026, 3, 8)
+                    .unwrap()
+                    .and_hms_opt(0, 0, 0)
+                    .unwrap(),
+            )
+            .local_minus_utc();
+        if local_offset_secs != 0 {
+            assert_ne!(
+                since,
+                Some(utc_since),
+                "local-time bucketing must differ from UTC on offset machines"
+            );
+        } else {
+            assert_eq!(since, Some(utc_since));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`tokscale report` filtered and grouped session dates in **UTC**, while the rest of tokscale buckets each message by its **local-calendar** date (`sessions::timestamp_to_date` uses `chrono::Local`), and `--today` / `--week` / `--month` derive their date strings from `chrono::Local::now()` via `build_date_filter` in `main.rs`. On any non-UTC machine this produced off-by-a-day mismatches — sessions landing in the wrong day bucket, and the `--since`/`--until` window including or excluding the wrong sessions. (PR #633)

## Fix

In `crates/tokscale-cli/src/commands/report.rs`, switch the three offending sites to `chrono::Local`:

- `parse_date_range` — day boundaries now computed in local time via a new `local_start_of_day_millis` helper that handles DST spring-forward gaps (`LocalResult::None`) and ambiguous wall-clock times explicitly.
- `print_daily_breakdown` — date key bucketed with `Local`.
- `print_session_list` — per-session `HH:MM` rendered with `Local`.

Boundary conversion now uses full-millisecond timestamps (`timestamp_millis_opt`) to match `sessions/mod.rs`. The summarizer / `extract_content_for_session` is intentionally untouched (separate PR).

## Tests

Adds `parse_date_range_buckets_in_local_time`, which pins the window to local-midnight boundaries and asserts the result diverges from the old UTC interpretation on offset machines (and stays equal on UTC ones). Verified failing against the old UTC code and passing under `TZ=America/New_York`. Full `cargo test -p tokscale-cli` (122 tests) passes; `cargo clippy -p tokscale-cli --tests` introduces no new warnings (remaining `useless_vec` warnings are pre-existing in unrelated `cluster_titles` tests).

## Residual concern

The DST spring-forward gap path (`LocalResult::None` → no boundary) is handled defensively but not exercised by a test, since it requires a specific timezone + date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `tokscale report` bucket and filter dates in local time to align with session grouping and the `--today`/`--week`/`--month` presets. Also preserve date boundaries across DST midnight gaps.

- **Bug Fixes**
  - Switched `parse_date_range`, `print_daily_breakdown`, and `print_session_list` to `chrono::Local`; per-session times render in local `HH:MM`.
  - Added `local_start_of_day_millis` to compute local day starts with millisecond precision; if local midnight is skipped by DST, walk forward to the first valid instant. Extracted `start_of_day_millis_with` to support deterministic testing.
  - Added tests: `parse_date_range_buckets_in_local_time`, `start_of_day_preserves_boundary_across_dst_gap`, and `start_of_day_uses_midnight_when_representable`.

<sup>Written for commit fd5b3f1a0854f0443ac1211f07a7093f4547edc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

