### PR TITLE
fix(jcode): prefer journal token_usage over stale snapshot + parse tz-less timestamps

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -145,8 +145,10 @@ impl SourceFingerprint {
     /// until the next checkpoint rewrites the snapshot, so the source-message
     /// cache must invalidate when either file changes.
     pub(crate) fn from_jcode_path(path: &Path) -> Option<Self> {
-        let related_paths =
-            std::iter::once((".journal.jsonl".to_string(), jcode_journal_path(path)));
+        let related_paths = std::iter::once((
+            ".journal.jsonl".to_string(),
+            crate::sessions::jcode::jcode_journal_path(path),
+        ));
         Self::from_path_with_related(path, related_paths)
     }
 
@@ -207,17 +209,6 @@ impl SourceFingerprint {
             related_files,
         })
     }
-}
-
-fn jcode_journal_path(path: &Path) -> PathBuf {
-    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
-        return append_path_suffix(path, ".journal.jsonl");
-    };
-    let journal_name = file_name
-        .strip_suffix(".json")
-        .map(|stem| format!("{stem}.journal.jsonl"))
-        .unwrap_or_else(|| format!("{file_name}.journal.jsonl"));
-    path.with_file_name(journal_name)
 }
 
 impl RelatedFileFingerprint {

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -20,7 +20,10 @@ use std::time::UNIX_EPOCH;
 // 20: Codex fork replay parsing now keeps user-fork turns after repeated child
 // session_meta rows; cached Codex entries from older parser logic can be empty.
 // (19 was the jcode parser change in #718 — bump again so those caches reparse.)
-const CACHE_SCHEMA_VERSION: u32 = 22;
+// 23: Jcode parser now does journal-wins merge (first-occurrence-targeted) and
+// timezone-less timestamp parsing; schema-22 caches return stale snapshot
+// token_usage, so invalidate them.
+const CACHE_SCHEMA_VERSION: u32 = 23;
 const CACHE_FILENAME: &str = "source-message-cache.bin";
 const CACHE_LOCK_FILENAME: &str = "source-message-cache.lock";
 const MAX_CACHE_FILE_BYTES: u64 = 256 * 1024 * 1024;

--- a/crates/tokscale-core/src/sessions/jcode.rs
+++ b/crates/tokscale-core/src/sessions/jcode.rs
@@ -124,9 +124,17 @@ impl JcodeSessionContext {
     }
 }
 
-fn jcode_journal_path(path: &Path) -> std::path::PathBuf {
+/// Resolve the append-only journal sidecar path for a Jcode session snapshot.
+///
+/// Jcode persists recent changes in `session_*.journal.jsonl` until the next
+/// checkpoint rewrites the snapshot. This is the single source of truth for the
+/// snapshot→journal mapping; `message_cache.rs` reuses it so the parser and the
+/// cache-fingerprint logic can never disagree about which sidecar to read.
+pub(crate) fn jcode_journal_path(path: &Path) -> std::path::PathBuf {
     let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
-        return path.with_extension("journal.jsonl");
+        let mut os = std::ffi::OsString::from(path.as_os_str());
+        os.push(".journal.jsonl");
+        return std::path::PathBuf::from(os);
     };
     let journal_name = file_name
         .strip_suffix(".json")
@@ -216,6 +224,20 @@ pub fn parse_jcode_file(path: &Path) -> Vec<UnifiedMessage> {
         "snapshot",
     );
 
+    // Track where each dedup_key landed in `parsed`. The journal is written
+    // after the snapshot, so a journal entry that repeats a snapshotted
+    // message_id carries the *authoritative* (updated) token_usage. The
+    // downstream dedup (`should_keep_deduped_message`) keeps the FIRST
+    // occurrence per dedup_key, so emitting the snapshot then appending the
+    // journal would silently drop the journal's correction. Instead, replace
+    // the snapshot entry in place when the journal repeats its id — journal
+    // wins, and the message_id still collapses to exactly one entry.
+    let mut index_by_dedup_key: std::collections::HashMap<String, usize> = parsed
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, message)| message.dedup_key.clone().map(|key| (key, idx)))
+        .collect();
+
     let journal_path = jcode_journal_path(path);
     if let Ok(file) = std::fs::File::open(&journal_path) {
         use std::io::{BufRead, BufReader};
@@ -234,12 +256,33 @@ pub fn parse_jcode_file(path: &Path) -> Vec<UnifiedMessage> {
             if let Some(meta) = entry.meta {
                 context.apply_meta(meta);
             }
-            parsed.extend(parse_jcode_messages(
+            let journal_messages = parse_jcode_messages(
                 entry.append_messages,
                 &mut context,
                 journal_fallback_timestamp,
                 &format!("journal:{line_index}"),
-            ));
+            );
+            for mut message in journal_messages {
+                match message
+                    .dedup_key
+                    .as_ref()
+                    .and_then(|key| index_by_dedup_key.get(key).copied())
+                {
+                    Some(existing_index) => {
+                        // Preserve the snapshot's turn-start flag: turn structure
+                        // is derived from snapshot ordering, while the journal only
+                        // carries the corrected token_usage for this message_id.
+                        message.is_turn_start = parsed[existing_index].is_turn_start;
+                        parsed[existing_index] = message;
+                    }
+                    None => {
+                        if let Some(key) = message.dedup_key.clone() {
+                            index_by_dedup_key.insert(key, parsed.len());
+                        }
+                        parsed.push(message);
+                    }
+                }
+            }
         }
     }
 
@@ -401,6 +444,120 @@ mod tests {
         assert_eq!(messages.len(), 2);
         assert_eq!(messages[0].timestamp, snapshot_fallback);
         assert_eq!(messages[1].timestamp, journal_fallback);
+    }
+
+    #[test]
+    fn journal_update_for_snapshotted_id_wins_and_collapses_to_one_entry() {
+        // The snapshot persists an in-flight assistant message with partial
+        // token_usage; the next checkpoint hasn't rewritten the snapshot yet, so
+        // the journal carries the SAME message_id with the final (larger)
+        // token_usage. The journal value must win and the message_id must
+        // collapse to exactly one entry (no double-counting).
+        let dir = tempfile::TempDir::new().unwrap();
+        let snapshot = dir.path().join("session_test.json");
+        std::fs::write(
+            &snapshot,
+            r#"{
+  "id":"session_test",
+  "model":"snapshot-model",
+  "messages":[
+    {"id":"assistant_live","role":"assistant","timestamp":"2026-06-16T12:00:01Z","token_usage":{"input_tokens":100,"output_tokens":10}}
+  ]
+}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("session_test.journal.jsonl"),
+            r#"{"append_messages":[{"id":"assistant_live","role":"assistant","timestamp":"2026-06-16T12:00:05Z","token_usage":{"input_tokens":900,"output_tokens":300,"cache_read_input_tokens":40}}]}
+"#,
+        )
+        .unwrap();
+
+        let messages = parse_jcode_file(&snapshot);
+        // Exactly one entry for the repeated id (no double-counting).
+        assert_eq!(messages.len(), 1);
+        // Journal value wins over the stale snapshot value.
+        assert_eq!(messages[0].tokens.input, 900);
+        assert_eq!(messages[0].tokens.output, 300);
+        assert_eq!(messages[0].tokens.cache_read, 40);
+    }
+
+    #[test]
+    fn journal_update_replaces_value_after_downstream_dedup() {
+        // Mirror the lib.rs dedup contract: should_keep_deduped_message keeps the
+        // FIRST occurrence per dedup_key. The in-parser merge must therefore have
+        // already replaced the snapshot value in place, so the surviving entry
+        // carries the journal's token_usage even after downstream dedup.
+        use std::collections::HashSet;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let snapshot = dir.path().join("session_test.json");
+        std::fs::write(
+            &snapshot,
+            r#"{
+  "id":"session_test",
+  "model":"snapshot-model",
+  "messages":[
+    {"id":"assistant_live","role":"assistant","timestamp":"2026-06-16T12:00:01Z","token_usage":{"input_tokens":100,"output_tokens":10}}
+  ]
+}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("session_test.journal.jsonl"),
+            r#"{"append_messages":[{"id":"assistant_live","role":"assistant","timestamp":"2026-06-16T12:00:05Z","token_usage":{"input_tokens":900,"output_tokens":300}}]}
+"#,
+        )
+        .unwrap();
+
+        let messages = parse_jcode_file(&snapshot);
+        let mut seen: HashSet<String> = HashSet::new();
+        let deduped: Vec<_> = messages
+            .into_iter()
+            .filter(|message| {
+                message
+                    .dedup_key
+                    .as_ref()
+                    .is_none_or(|key| seen.insert(key.clone()))
+            })
+            .collect();
+        assert_eq!(deduped.len(), 1);
+        assert_eq!(deduped[0].tokens.input, 900);
+        assert_eq!(deduped[0].tokens.output, 300);
+    }
+
+    #[test]
+    fn parses_timezone_less_timestamps_instead_of_falling_back_to_mtime() {
+        // Jcode (and proxy variants) sometimes emit naive ISO-8601 datetimes
+        // with no `Z`/offset. These must parse as UTC, not collapse to the
+        // file mtime (which would scatter the message into the wrong bucket).
+        let dir = tempfile::TempDir::new().unwrap();
+        let snapshot = dir.path().join("session_test.json");
+        std::fs::write(
+            &snapshot,
+            r#"{
+  "id":"session_test",
+  "model":"snapshot-model",
+  "messages":[
+    {"id":"assistant_naive","role":"assistant","timestamp":"2026-06-16T12:00:00","token_usage":{"input_tokens":100,"output_tokens":10}}
+  ]
+}"#,
+        )
+        .unwrap();
+
+        // Force a clearly-different mtime so a fallback would be detectable.
+        let mtime =
+            std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000_000);
+        if let Ok(file) = std::fs::OpenOptions::new().write(true).open(&snapshot) {
+            let _ = file.set_modified(mtime);
+        }
+        let fallback = file_modified_timestamp_ms(&snapshot);
+
+        let messages = parse_jcode_file(&snapshot);
+        assert_eq!(messages.len(), 1);
+        // "2026-06-16T12:00:00" UTC == 1781611200000 ms.
+        assert_eq!(messages[0].timestamp, 1_781_611_200_000);
+        assert_ne!(messages[0].timestamp, fallback);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/jcode.rs
+++ b/crates/tokscale-core/src/sessions/jcode.rs
@@ -232,11 +232,19 @@ pub fn parse_jcode_file(path: &Path) -> Vec<UnifiedMessage> {
     // journal would silently drop the journal's correction. Instead, replace
     // the snapshot entry in place when the journal repeats its id — journal
     // wins, and the message_id still collapses to exactly one entry.
-    let mut index_by_dedup_key: std::collections::HashMap<String, usize> = parsed
-        .iter()
-        .enumerate()
-        .filter_map(|(idx, message)| message.dedup_key.clone().map(|key| (key, idx)))
-        .collect();
+    // Downstream dedup is first-wins, so when the snapshot itself replays a
+    // duplicate dedup_key we must map the key to its FIRST index — that's the
+    // entry that survives dedup. Mapping to the last index would let a journal
+    // update overwrite a row that is later discarded, preserving the stale
+    // first snapshot row. `collect()` keeps the last insertion, so build the
+    // map explicitly with `or_insert` to keep the first.
+    let mut index_by_dedup_key: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+    for (idx, message) in parsed.iter().enumerate() {
+        if let Some(key) = message.dedup_key.clone() {
+            index_by_dedup_key.entry(key).or_insert(idx);
+        }
+    }
 
     let journal_path = jcode_journal_path(path);
     if let Ok(file) = std::fs::File::open(&journal_path) {

--- a/crates/tokscale-core/src/sessions/utils.rs
+++ b/crates/tokscale-core/src/sessions/utils.rs
@@ -40,6 +40,22 @@ pub(crate) fn parse_timestamp_str(value: &str) -> Option<i64> {
         return Some(dt.timestamp_millis());
     }
 
+    // Timezone-less ISO-8601 datetimes (e.g. "2026-06-16T12:00:00",
+    // "2026-06-16 12:00:00", optional fractional seconds) carry no offset, so
+    // `parse_from_rfc3339` rejects them. Interpret them as UTC rather than
+    // collapsing to the file mtime, which would scatter the message into the
+    // wrong day/month bucket.
+    for format in [
+        "%Y-%m-%dT%H:%M:%S%.f",
+        "%Y-%m-%dT%H:%M:%S",
+        "%Y-%m-%d %H:%M:%S%.f",
+        "%Y-%m-%d %H:%M:%S",
+    ] {
+        if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(value, format) {
+            return Some(naive.and_utc().timestamp_millis());
+        }
+    }
+
     if let Ok(numeric) = value.parse::<i64>() {
         if numeric <= 0 {
             return None;
@@ -105,5 +121,28 @@ mod tests {
     fn parse_timestamp_str_rejects_zero_and_negative_strings() {
         assert!(parse_timestamp_str("0").is_none());
         assert!(parse_timestamp_str("-5").is_none());
+    }
+
+    #[test]
+    fn parse_timestamp_str_accepts_timezone_less_datetimes_as_utc() {
+        // "2026-06-16T12:00:00" UTC == 1781611200000 ms.
+        assert_eq!(
+            parse_timestamp_str("2026-06-16T12:00:00"),
+            Some(1_781_611_200_000)
+        );
+        // Space separator and fractional seconds variants.
+        assert_eq!(
+            parse_timestamp_str("2026-06-16 12:00:00"),
+            Some(1_781_611_200_000)
+        );
+        assert_eq!(
+            parse_timestamp_str("2026-06-16T12:00:00.500"),
+            Some(1_781_611_200_500)
+        );
+        // Offset-bearing input still goes through the rfc3339 path unchanged.
+        assert_eq!(
+            parse_timestamp_str("2026-06-16T12:00:00Z"),
+            Some(1_781_611_200_000)
+        );
     }
 }

--- a/crates/tokscale-core/tests/jcode.rs
+++ b/crates/tokscale-core/tests/jcode.rs
@@ -117,3 +117,56 @@ async fn test_jcode_deduplicates_replayed_message_ids() {
     assert_eq!(messages.len(), 1);
     assert_eq!(messages[0].tokens.input, 100);
 }
+
+/// Regression: when the snapshot replays a duplicate message id, the journal
+/// update for that id must target the *surviving* (first) occurrence, because
+/// downstream dedup is first-wins. A previous version built the merge index
+/// with `collect()`, which kept the *last* duplicate index — so the journal
+/// overwrote a row that dedup later discarded, preserving the stale first
+/// snapshot token_usage instead of the corrected journal value.
+#[tokio::test]
+async fn test_jcode_journal_corrects_replayed_snapshot_duplicate() {
+    let home_dir = tempfile::TempDir::new().unwrap();
+    let home = home_dir.path();
+
+    // Snapshot replays the same message id twice (stale token_usage = 100).
+    let session_body = r#"{
+  "id":"session_dup",
+  "provider_key":"openai",
+  "model":"jcode-test-model",
+  "messages":[
+    {"id":"assistant_replayed","role":"assistant","timestamp":"2026-06-16T00:00:01Z","token_usage":{"input_tokens":100,"output_tokens":10}},
+    {"id":"assistant_replayed","role":"assistant","timestamp":"2026-06-16T00:00:02Z","token_usage":{"input_tokens":100,"output_tokens":10}}
+  ]
+}"#;
+    let session_path = write_jcode_session(home, "session_dup.json", session_body);
+
+    // Journal carries the authoritative correction (input_tokens = 999) for
+    // the same message id.
+    let journal_path = session_path.with_file_name("session_dup.journal.jsonl");
+    fs::write(
+        &journal_path,
+        r#"{"append_messages":[{"id":"assistant_replayed","role":"assistant","timestamp":"2026-06-16T00:00:03Z","token_usage":{"input_tokens":999,"output_tokens":10}}]}
+"#,
+    )
+    .unwrap();
+
+    let messages = parse_local_unified_messages_with_pricing(
+        LocalParseOptions {
+            home_dir: Some(home.to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(vec!["jcode".to_string()]),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: ScannerSettings::default(),
+        },
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(messages.len(), 1);
+    // The journal correction must win over the stale snapshot duplicate.
+    assert_eq!(messages[0].tokens.input, 999);
+}


### PR DESCRIPTION
## Problem

In `crates/tokscale-core/src/sessions/jcode.rs`, `parse_jcode_file` returns snapshot messages first, then journal messages. The downstream dedup (`should_keep_deduped_message`, lib.rs ~1102-1108) keeps the **first** occurrence per `dedup_key` (`jcode:{session_id}:{message_id}`).

Three confirmed bugs (PR #718):

- **(a) journal dedup (high):** the journal is append-only and Jcode only rewrites the snapshot at the next checkpoint, so the journal can carry an **updated** `token_usage` for a `message_id` already present in the snapshot. Because the snapshot was emitted first, the corrected journal value was silently discarded and stale token counts were reported.
- **(b) tz-less timestamps:** naive ISO-8601 datetimes with no `Z`/offset (e.g. `2026-06-16T12:00:00`) failed `parse_from_rfc3339` and collapsed to the file mtime, scattering messages into the wrong day/month bucket.
- **(c) duplicated helper (nit):** `jcode_journal_path` was duplicated verbatim in `jcode.rs` and `message_cache.rs`.

## Fix

- **(a)** `parse_jcode_file` now merges in place: a journal entry repeating a snapshotted `dedup_key` overwrites that entry (journal wins) while preserving the snapshot's turn-start flag. Each `message_id` still collapses to exactly **one** entry — no double-counting, and the journal value survives downstream dedup.
- **(b)** `parse_timestamp_str` (`sessions/utils.rs`) gains a naive-datetime fallback (T or space separator, optional fractional seconds) interpreted as UTC.
- **(c)** Extracted a single `pub(crate)` `jcode_journal_path` in `sessions::jcode`; `message_cache.rs` reuses it. The no-filename fallback uses suffix-append semantics (matching the previous cache behavior).

## Tests

- `journal_update_for_snapshotted_id_wins_and_collapses_to_one_entry` — one entry, journal value wins.
- `journal_update_replaces_value_after_downstream_dedup` — journal value survives the lib.rs first-wins dedup contract.
- `parses_timezone_less_timestamps_instead_of_falling_back_to_mtime` — end-to-end vs a forced-distinct mtime.
- `parse_timestamp_str_accepts_timezone_less_datetimes_as_utc` — unit coverage (T/space/fractional/offset variants).

All `cargo test -p tokscale-core` pass; `cargo clippy -p tokscale-core --tests` is clean.

## Residual concerns

The cache schema version (already bumped to 22 in `message_cache.rs`, note #19 references #718) ensures stale jcode caches reparse. Fractional precision beyond 3 digits and leap seconds are untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale token counts and timestamp parsing in Jcode sessions by merging journal updates into the parsed snapshot and treating timezone-less timestamps as UTC. Also targets the first-win duplicate during merge and bumps the source-message cache schema to 23 to drop stale caches.

- **Bug Fixes**
  - Journal entries replace matching snapshot messages in place by `dedup_key` (journal wins), preserve the snapshot’s turn-start flag, and keep one entry per `message_id`. The merge index now targets the first occurrence so the journal correction survives downstream first-wins dedup, even if the snapshot replayed the id.
  - `parse_timestamp_str` accepts ISO datetimes without a `Z`/offset (T or space, optional fractional) and interprets them as UTC to avoid mtime fallback and mis-bucketing.

- **Refactors**
  - Consolidated `jcode_journal_path` into a single `pub(crate)` helper in `sessions::jcode`; `message_cache.rs` reuses it with suffix-append fallback semantics. Also bumped `CACHE_SCHEMA_VERSION` to 23 to force reparse.

<sup>Written for commit 39d6007523348e89824125fa9a7545530e82d528. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

