### PR TITLE
fix(usage/codex): preserve reset-credit count and gate detail fetch

### DIFF
--- a/crates/tokscale-cli/src/commands/usage/codex.rs
+++ b/crates/tokscale-cli/src/commands/usage/codex.rs
@@ -893,14 +893,17 @@ fn reset_credits_from_response(response: ResetCreditsResponse) -> Option<UsageRe
 
 /// Decide whether to issue the extra detail GET for reset credits.
 ///
-/// The detail endpoint is only worth hitting when the cheap inline summary
-/// already tells us there is at least one available credit to enrich. When the
-/// summary is absent or reports zero credits we skip the call entirely: there
-/// is nothing to enrich, and firing the request on every periodic TUI refresh
-/// would roughly double backend request volume per Codex account and raise
-/// rate-limit risk.
+/// We fetch the detail endpoint whenever the cheap inline summary leaves the
+/// credit state unknown (absent) or already reports at least one available
+/// credit to enrich. The detail call is the only source of truth for accounts
+/// whose `/wham/usage` payload omits `rate_limit_reset_credits` entirely, so
+/// skipping it on an absent summary would hide reset credits that production
+/// can otherwise surface. We only skip when the summary is present and
+/// explicitly reports zero credits: there is nothing to enrich, and firing the
+/// request on every periodic TUI refresh would needlessly raise backend request
+/// volume and rate-limit risk.
 fn should_fetch_reset_details(summary: Option<&UsageResetCredits>) -> bool {
-    summary.is_some_and(|credits| credits.available_count > 0)
+    summary.is_none_or(|credits| credits.available_count > 0)
 }
 
 /// Merge the cheap summary count with an optional detail response.
@@ -1579,9 +1582,11 @@ mod tests {
     }
 
     #[test]
-    fn should_fetch_reset_details_only_when_summary_has_credits() {
-        // Absent summary: do NOT fire the extra round-trip on every refresh.
-        assert!(!should_fetch_reset_details(None));
+    fn should_fetch_reset_details_unless_summary_is_explicitly_zero() {
+        // Absent summary (unknown): fetch the detail endpoint, since it is the
+        // only source of credits for accounts whose usage payload omits the
+        // inline summary. Skipping here would hide reset credits in production.
+        assert!(should_fetch_reset_details(None));
         // Summary present but zero credits: nothing to enrich, skip.
         assert!(!should_fetch_reset_details(Some(&UsageResetCredits {
             available_count: 0,

--- a/crates/tokscale-cli/src/commands/usage/codex.rs
+++ b/crates/tokscale-cli/src/commands/usage/codex.rs
@@ -891,6 +891,31 @@ fn reset_credits_from_response(response: ResetCreditsResponse) -> Option<UsageRe
         })
 }
 
+/// Decide whether to issue the extra detail GET for reset credits.
+///
+/// The detail endpoint is only worth hitting when the cheap inline summary
+/// already tells us there is at least one available credit to enrich. When the
+/// summary is absent or reports zero credits we skip the call entirely: there
+/// is nothing to enrich, and firing the request on every periodic TUI refresh
+/// would roughly double backend request volume per Codex account and raise
+/// rate-limit risk.
+fn should_fetch_reset_details(summary: Option<&UsageResetCredits>) -> bool {
+    summary.is_some_and(|credits| credits.available_count > 0)
+}
+
+/// Merge the cheap summary count with an optional detail response.
+///
+/// The detail response is only allowed to *replace* the summary when it carries
+/// a concrete count (`Some`). A detail body whose `available_count` is null maps
+/// to `None`; in that case we keep the known summary count rather than silently
+/// dropping it (which would make the Reset button show nothing).
+fn merge_reset_credits(
+    summary: Option<UsageResetCredits>,
+    details: Option<UsageResetCredits>,
+) -> Option<UsageResetCredits> {
+    details.or(summary)
+}
+
 fn json_scalar_string(value: Option<serde_json::Value>) -> Option<String> {
     match value? {
         serde_json::Value::Null => None,
@@ -962,11 +987,7 @@ async fn fetch_with_auth_async(
     }
 
     let mut reset_credits = reset_credits_from_summary(resp.rate_limit_reset_credits.as_ref());
-    let should_fetch_reset_details = reset_credits
-        .as_ref()
-        .map(|credits| credits.available_count > 0)
-        .unwrap_or(true);
-    if should_fetch_reset_details {
+    if should_fetch_reset_details(reset_credits.as_ref()) {
         if let Ok(details) = fetch_reset_credits(
             &client,
             &effective_access_token,
@@ -974,7 +995,9 @@ async fn fetch_with_auth_async(
         )
         .await
         {
-            reset_credits = reset_credits_from_response(details);
+            // Only let the detail response replace the summary when it carries a
+            // concrete count; a null detail count must not drop a known summary.
+            reset_credits = merge_reset_credits(reset_credits, reset_credits_from_response(details));
         }
     }
 
@@ -1506,6 +1529,69 @@ mod tests {
         assert_eq!(response.credits.len(), 1);
         assert_eq!(response.credits[0].id.as_deref(), Some("credit_1"));
         Ok(())
+    }
+
+    #[test]
+    fn merge_reset_credits_preserves_summary_when_detail_count_is_null() {
+        // Summary reports a known non-zero count; the detail body's
+        // available_count is null (-> None). The summary count must survive so
+        // the Reset button still shows it.
+        let summary = Some(UsageResetCredits {
+            available_count: 2,
+            credits: Vec::new(),
+        });
+        let details = reset_credits_from_response(
+            parse_chatgpt_json_body(r#"{"available_count":null}"#).unwrap(),
+        );
+        assert!(details.is_none());
+
+        let merged = merge_reset_credits(summary, details);
+        assert_eq!(merged.expect("summary preserved").available_count, 2);
+    }
+
+    #[test]
+    fn merge_reset_credits_prefers_detail_when_present() {
+        let summary = Some(UsageResetCredits {
+            available_count: 2,
+            credits: Vec::new(),
+        });
+        let details = reset_credits_from_response(
+            parse_chatgpt_json_body(
+                r#"{"available_count":1,"credits":[{"id":"credit_1","status":"available"}]}"#,
+            )
+            .unwrap(),
+        );
+
+        let merged = merge_reset_credits(summary, details).expect("detail applied");
+        assert_eq!(merged.available_count, 1);
+        assert_eq!(merged.credits.len(), 1);
+        assert_eq!(merged.credits[0].id.as_deref(), Some("credit_1"));
+    }
+
+    #[test]
+    fn merge_reset_credits_returns_detail_when_summary_absent() {
+        let details = Some(UsageResetCredits {
+            available_count: 3,
+            credits: Vec::new(),
+        });
+        let merged = merge_reset_credits(None, details).expect("detail used");
+        assert_eq!(merged.available_count, 3);
+    }
+
+    #[test]
+    fn should_fetch_reset_details_only_when_summary_has_credits() {
+        // Absent summary: do NOT fire the extra round-trip on every refresh.
+        assert!(!should_fetch_reset_details(None));
+        // Summary present but zero credits: nothing to enrich, skip.
+        assert!(!should_fetch_reset_details(Some(&UsageResetCredits {
+            available_count: 0,
+            credits: Vec::new(),
+        })));
+        // Summary present with available credits: enrich via detail call.
+        assert!(should_fetch_reset_details(Some(&UsageResetCredits {
+            available_count: 1,
+            credits: Vec::new(),
+        })));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

In the Codex usage path (`crates/tokscale-cli/src/commands/usage/codex.rs`), two issues affected reset-credit handling:

1. **Silent drop of a known count (correctness).** `reset_credits` is first derived from the cheap inline summary (`rate_limit_reset_credits.available_count`). When a detail fetch was issued, an `Ok` detail response *unconditionally* overwrote `reset_credits` via `reset_credits_from_response(details)`, which returns `None` when the detail body's `available_count` is null. A non-zero summary count was silently dropped and the Reset button then showed nothing.

2. **Extra round-trip per refresh (efficiency / rate-limit risk).** `should_fetch_reset_details` defaulted to `true` (`unwrap_or(true)`) whenever the summary was absent, so the TUI's ~30s periodic refresh fired a second GET per Codex account every cycle, roughly doubling backend request volume.

## Root cause

The merge took the detail response verbatim instead of treating it as an optional enrichment, and the fetch gate was permissive when the summary was absent.

## Fix

- Extracted `merge_reset_credits(summary, details)` (= `details.or(summary)`): a `None`/null detail count keeps the known summary count instead of dropping it.
- Extracted `should_fetch_reset_details(summary)`: only fires when the summary is present with `available_count > 0`; absent or zero-count summaries skip the call entirely.

Both helpers are pure, so the merge/gate logic is now unit-testable without network I/O.

## Tests

Added unit tests:
- `merge_reset_credits_preserves_summary_when_detail_count_is_null` (regression for finding a)
- `merge_reset_credits_prefers_detail_when_present`
- `merge_reset_credits_returns_detail_when_summary_absent`
- `should_fetch_reset_details_only_when_summary_has_credits` (regression for finding b)

`cargo test -p tokscale-cli` passes (122 + new unit tests). `cargo clippy -p tokscale-cli --tests` is clean for `codex.rs` (3 unrelated pre-existing warnings remain in `report.rs`).

## Residual concerns

- Live HTTP behavior of `fetch_reset_credits` is not unit-tested; the extracted helpers are pure and tested in isolation.
- Gating on `available_count > 0` means a future "0 -> N" transition is only picked up on the next refresh that has a non-zero summary, which is the intended conservative behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves reset-credit counts in Codex usage and gates detail fetches to fix empty Reset states and cut extra requests. Fetches detail when the summary is unknown or positive; skips when it’s explicitly zero.

- **Bug Fixes**
  - Keep the summary `available_count` when detail `available_count` is null via `merge_reset_credits`; prefer detail when present.
  - Gate detail fetch with `should_fetch_reset_details`: fetch when summary is absent or `available_count > 0`; skip on explicit zero.

- **Tests**
  - Added unit tests for merge behavior and the fetch gate (absent/zero/positive summary).

<sup>Written for commit 376f5810d57c455429b89e4dfdd1c6cd4821101c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

