### PR TITLE
fix(usage): surface active-provider fetch errors instead of dropping them

### DIFF
--- a/crates/tokscale-cli/src/commands/usage/mod.rs
+++ b/crates/tokscale-cli/src/commands/usage/mod.rs
@@ -228,7 +228,36 @@ impl Fetch {
 
 type UsageProvider = (&'static str, fn() -> bool, Fetch);
 
+/// A provider that is active (has credentials) but whose fetch failed.
+///
+/// `name` is the human-facing provider label and `error` is the formatted
+/// error message (e.g. sakana's "refresh SAKANA_SESSION_COOKIE" guidance).
+#[derive(Debug, Clone)]
+pub struct ProviderError {
+    pub name: &'static str,
+    pub error: String,
+}
+
+/// Backwards-compatible entry point: returns only successful provider outputs.
+///
+/// Per-provider errors are silently discarded here. Callers that need to make
+/// failures visible (e.g. the CLI `run`) should use [`fetch_all_with_errors`].
+///
+/// Used by the TUI dashboard (non-test builds only); the TUI test build stubs
+/// the fetch out, so allow it to be unused there.
+#[cfg_attr(test, allow(dead_code))]
 pub fn fetch_all() -> Vec<UsageOutput> {
+    fetch_all_with_errors().0
+}
+
+/// Fetch usage for every active provider in parallel, returning both the
+/// successful outputs and the per-provider errors.
+///
+/// Previously a provider whose `fetch` returned `Err` (notably a stale/expired
+/// session-cookie auth error) was silently dropped: `has_credentials()` reports
+/// the provider as active, yet it just vanished from the output. This collects
+/// those errors so the caller can surface them to the user instead.
+pub fn fetch_all_with_errors() -> (Vec<UsageOutput>, Vec<ProviderError>) {
     let providers: Vec<UsageProvider> = vec![
         (
             "Claude",
@@ -274,19 +303,47 @@ pub fn fetch_all() -> Vec<UsageOutput> {
     let active: Vec<_> = providers.into_iter().filter(|(_, has, _)| has()).collect();
 
     if active.is_empty() {
-        return vec![];
+        return (vec![], vec![]);
     }
 
-    std::thread::scope(|s| {
-        active
+    let results = std::thread::scope(|s| {
+        let handles: Vec<_> = active
             .into_iter()
-            .map(|(_, _, fetch)| s.spawn(move || fetch.call().ok()))
+            .map(|(name, _, fetch)| s.spawn(move || (name, fetch.call())))
+            .collect();
+
+        handles
+            .into_iter()
+            .filter_map(|handle| {
+                // A panicked provider thread should not take down the whole
+                // command; skip it (a join error has no message to surface).
+                handle.join().ok()
+            })
             .collect::<Vec<_>>()
-            .into_iter()
-            .filter_map(|h| h.join().ok().flatten())
-            .flatten()
-            .collect()
-    })
+    });
+
+    partition_results(results)
+}
+
+/// Split per-provider fetch results into (successful outputs, errors).
+///
+/// An active provider returning `Err` becomes a [`ProviderError`] rather than
+/// being silently dropped.
+fn partition_results(
+    results: Vec<(&'static str, Result<Vec<UsageOutput>>)>,
+) -> (Vec<UsageOutput>, Vec<ProviderError>) {
+    let mut outputs = Vec::new();
+    let mut errors = Vec::new();
+    for (name, result) in results {
+        match result {
+            Ok(mut provider_outputs) => outputs.append(&mut provider_outputs),
+            Err(err) => errors.push(ProviderError {
+                name,
+                error: err.to_string(),
+            }),
+        }
+    }
+    (outputs, errors)
 }
 
 // ── Light-mode rendering ──
@@ -350,12 +407,20 @@ fn render_light(output: &UsageOutput) {
 }
 
 pub fn run(json: bool, _light: bool) -> Result<()> {
-    let outputs = fetch_all();
+    let (outputs, errors) = fetch_all_with_errors();
     if json {
+        // Keep stdout pure JSON: do NOT emit provider warnings here, since they
+        // would corrupt downstream `--json` consumers that read stderr too.
         println!("{}", serde_json::to_string_pretty(&outputs)?);
     } else {
         for o in &outputs {
             render_light(o);
+        }
+        // Surface active-but-failed providers (e.g. an expired session cookie)
+        // so they don't silently vanish from the output. One concise line per
+        // failing provider, on stderr to keep stdout clean.
+        for err in &errors {
+            eprintln!("{}: {} — skipped", err.name, err.error);
         }
     }
     Ok(())
@@ -423,6 +488,62 @@ mod tests {
         };
 
         assert_eq!(output.display_name(), "Codex (Account 123e45...4000)");
+    }
+
+    fn sample_output(provider: &str) -> UsageOutput {
+        UsageOutput {
+            provider: provider.to_string(),
+            account: None,
+            plan: None,
+            email: None,
+            metrics: Vec::new(),
+            reset_credits: None,
+            credit_status: None,
+            spend_control: None,
+        }
+    }
+
+    #[test]
+    fn partition_results_surfaces_provider_errors_instead_of_dropping_them() {
+        let results: Vec<(&'static str, Result<Vec<UsageOutput>>)> = vec![
+            ("Claude", Ok(vec![sample_output("Claude")])),
+            (
+                "Sakana",
+                Err(anyhow::anyhow!(
+                    "Sakana session expired or invalid. Refresh SAKANA_SESSION_COOKIE."
+                )),
+            ),
+            ("Codex", Ok(vec![sample_output("Codex"), sample_output("Codex")])),
+        ];
+
+        let (outputs, errors) = partition_results(results);
+
+        // Successful providers are preserved (including a Multi provider's
+        // several outputs), in order.
+        assert_eq!(outputs.len(), 3);
+        assert_eq!(outputs[0].provider, "Claude");
+        assert_eq!(outputs[1].provider, "Codex");
+        assert_eq!(outputs[2].provider, "Codex");
+
+        // The failing provider's error is surfaced, not silently discarded.
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].name, "Sakana");
+        assert!(
+            errors[0].error.contains("SAKANA_SESSION_COOKIE"),
+            "expected the auth-refresh guidance to be preserved, got: {}",
+            errors[0].error
+        );
+    }
+
+    #[test]
+    fn partition_results_reports_no_errors_when_all_succeed() {
+        let results: Vec<(&'static str, Result<Vec<UsageOutput>>)> =
+            vec![("Claude", Ok(vec![sample_output("Claude")]))];
+
+        let (outputs, errors) = partition_results(results);
+
+        assert_eq!(outputs.len(), 1);
+        assert!(errors.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`fetch_all` in `crates/tokscale-cli/src/commands/usage/mod.rs` spawned each active provider as `fetch.call().ok()` and collapsed the results with `filter_map(|h| h.join().ok().flatten()).flatten()`. Any provider that returned `Err` was **silently dropped**.

The clearest failure case is Sakana: `sakana::fetch` deliberately builds a helpful "Sakana session expired or invalid. Refresh `SAKANA_SESSION_COOKIE`…" error when the session cookie is stale. But because `has_credentials()` returns `true` (a cookie exists, it's just expired), the provider is considered *active* — yet it just disappeared from the output with no message. This contradicts both `docs/providers/sakana.md` and `sakana::fetch`'s own carefully-worded error path. The same silent-drop affected **every** usage provider.

## Root cause

Errors were discarded at the join/merge step (`.ok()` + `filter_map`), with no channel to carry them back to the user.

## Fix

- Added `fetch_all_with_errors() -> (Vec<UsageOutput>, Vec<ProviderError>)`. Each active provider's thread now returns `(name, Result<...>)`; successes and errors are split by a new pure helper `partition_results`.
- `pub fn run` now calls `fetch_all_with_errors` and, **in non-JSON mode only**, prints one concise line per failing provider to **stderr**: `"Sakana: <error> — skipped"`.
- **JSON mode emits no warnings** — stdout stays pure JSON and nothing is written to stderr, so `--json` consumers that also read stderr are not corrupted. (Note: pre-existing unconditional `eprintln!`s in `minimax_tokenplan.rs` already violate this, but that's out of scope here.)
- `fetch_all` is retained as a thin error-discarding wrapper (`fetch_all_with_errors().0`), so the **TUI dashboard caller (`tui/app.rs`) is unchanged**. No `UsageOutput` struct change was needed.

### Approach / tradeoffs

I chose the least-invasive option from the brief: collect per-provider errors and surface them as a one-line stderr warning in non-JSON mode. Rejected a sweeping `UsageOutput`/struct redesign (carrying an error variant through serialization and the TUI rendering path) as unwarranted for the goal of making failures visible. The TUI continues to use `fetch_all` and ignores errors for now; `fetch_all_with_errors` is public so the TUI can adopt error display later without a signature change.

## Tests

- Refactored the join/collect logic into a pure `partition_results` and added two regression tests:
  - `partition_results_surfaces_provider_errors_instead_of_dropping_them` — a failing Sakana provider's error (including the `SAKANA_SESSION_COOKIE` guidance) is surfaced, not discarded, while successful providers (including a Multi provider's several outputs) are preserved in order. This fails against the old drop-everything behavior.
  - `partition_results_reports_no_errors_when_all_succeed` — success path unchanged.
- `cargo test -p tokscale-cli` and `cargo clippy -p tokscale-cli --tests` are clean for this file (remaining clippy warnings are pre-existing in `report.rs`, untouched here).

## Residual concerns

- Provider thread panics are skipped (join error has no useful message); this matches prior behavior of not crashing the command.
- No real network/auth round-trip is exercised — only the pure partition logic is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface fetch errors from active usage providers in the `usage` command instead of silently dropping them, so users know why a provider was skipped. Non-JSON runs now print one concise stderr warning per failing provider; JSON output is unchanged.

- **Bug Fixes**
  - Fixed silent drops by collecting per-provider `Err` instead of discarding them at join time.
  - Added `fetch_all_with_errors()` returning `(Vec<UsageOutput>, Vec<ProviderError>)` and a pure `partition_results` to split successes/errors.
  - Updated CLI `run` to print "Provider: <error> — skipped" to stderr in non-JSON mode only; `--json` emits clean JSON with no warnings.
  - Kept `fetch_all()` as a thin, error-discarding wrapper so the TUI remains unchanged.
  - Added regression tests to verify errors are surfaced and success paths are intact.

<sup>Written for commit bcd1785007f5745581d3948a8500d2920e9c1179. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

