### PR TITLE
fix(display): render provider names correctly in Models views

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1887,7 +1887,10 @@ fn run_models_report(
                             entry.input + entry.output + entry.cache_read + entry.cache_write;
                         table.add_row(vec![
                             Cell::new(capitalized_clients),
-                            Cell::new(&entry.provider).add_attribute(Attribute::Dim),
+                            Cell::new(crate::tui::ui::widgets::get_provider_display_name(
+                                &entry.provider,
+                            ))
+                            .add_attribute(Attribute::Dim),
                             Cell::new(&entry.model),
                             Cell::new(format_tokens_with_commas(entry.input))
                                 .set_alignment(CellAlignment::Right),
@@ -1946,7 +1949,10 @@ fn run_models_report(
                             entry.input + entry.output + entry.cache_read + entry.cache_write;
                         table.add_row(vec![
                             Cell::new(capitalize_client(&entry.client)),
-                            Cell::new(&entry.provider).add_attribute(Attribute::Dim),
+                            Cell::new(crate::tui::ui::widgets::get_provider_display_name(
+                                &entry.provider,
+                            ))
+                            .add_attribute(Attribute::Dim),
                             Cell::new(&entry.model),
                             Cell::new(format_tokens_with_commas(entry.input))
                                 .set_alignment(CellAlignment::Right),
@@ -2118,7 +2124,10 @@ fn run_models_report(
                             .join(", ");
                         table.add_row(vec![
                             Cell::new(capitalized_clients),
-                            Cell::new(&entry.provider).add_attribute(Attribute::Dim),
+                            Cell::new(crate::tui::ui::widgets::get_provider_display_name(
+                                &entry.provider,
+                            ))
+                            .add_attribute(Attribute::Dim),
                             Cell::new(&entry.model),
                             Cell::new(format_tokens_with_commas(entry.input))
                                 .set_alignment(CellAlignment::Right),
@@ -2206,7 +2215,10 @@ fn run_models_report(
                         }
                         row.extend([
                             Cell::new(session_label),
-                            Cell::new(&entry.provider).add_attribute(Attribute::Dim),
+                            Cell::new(crate::tui::ui::widgets::get_provider_display_name(
+                                &entry.provider,
+                            ))
+                            .add_attribute(Attribute::Dim),
                             Cell::new(&entry.model),
                             Cell::new(format_tokens_with_commas(entry.input))
                                 .set_alignment(CellAlignment::Right),
@@ -2285,7 +2297,10 @@ fn run_models_report(
 
                         table.add_row(vec![
                             Cell::new(capitalize_client(&entry.client)),
-                            Cell::new(&entry.provider).add_attribute(Attribute::Dim),
+                            Cell::new(crate::tui::ui::widgets::get_provider_display_name(
+                                &entry.provider,
+                            ))
+                            .add_attribute(Attribute::Dim),
                             Cell::new(&entry.model),
                             Cell::new(format_model_name(&entry.model)),
                             Cell::new(format_tokens_with_commas(entry.input))
@@ -2371,7 +2386,10 @@ fn run_models_report(
 
                         table.add_row(vec![
                             Cell::new(workspace_name(entry.workspace_label.as_deref())),
-                            Cell::new(&entry.provider).add_attribute(Attribute::Dim),
+                            Cell::new(crate::tui::ui::widgets::get_provider_display_name(
+                                &entry.provider,
+                            ))
+                            .add_attribute(Attribute::Dim),
                             Cell::new(capitalized_clients),
                             Cell::new(&entry.model),
                             Cell::new(format_tokens_with_commas(entry.input))

--- a/crates/tokscale-cli/src/tui/mod.rs
+++ b/crates/tokscale-cli/src/tui/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod privacy;
 pub mod remote;
 pub mod settings;
 mod themes;
-mod ui;
+pub(crate) mod ui;
 
 pub use app::{App, Tab, TuiConfig};
 pub use cache::{

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -375,19 +375,65 @@ pub fn get_provider_display_name(provider: &str) -> String {
     if let Some(name) = config.get_provider_display_name(provider) {
         return name.to_string();
     }
-    match provider.to_lowercase().as_str() {
-        "anthropic" => "Anthropic".to_string(),
+    let lower = provider.to_lowercase();
+    match lower.as_str() {
+        "anthropic" => return "Anthropic".to_string(),
+        "google" => return "Google".to_string(),
+        "cursor" => return "Cursor".to_string(),
+        "deepseek" => return "DeepSeek".to_string(),
+        "xai" => return "xAI".to_string(),
+        "meta" => return "Meta".to_string(),
+        "mistral" => return "Mistral".to_string(),
+        "cohere" => return "Cohere".to_string(),
+        "opencode" => return "OpenCode".to_string(),
+        // `canonical_provider` rewrites `google-vertex` → `google_vertex`, so
+        // accept both spellings here.
+        "google-vertex" | "google_vertex" => return "Google Vertex".to_string(),
+        _ => {}
+    }
+
+    // Brand families: any provider id that starts with these stems collapses to
+    // the brand name. Covers `openai`, `openai-codex`, `kimi`, `kimi-code`,
+    // `kimi-for-coding`, etc. without enumerating every variant.
+    if lower.starts_with("openai") {
+        return "OpenAI".to_string();
+    }
+    if lower.starts_with("kimi") {
+        return "Kimi".to_string();
+    }
+    if lower.starts_with("github-cop") || lower.contains("copilot") {
+        return "GitHub Copilot".to_string();
+    }
+
+    // Smart fallback: split on `-`, `_`, and whitespace, title-case each word,
+    // and map known acronyms/brands per word. So unknown multi-word providers
+    // like `google-vertex` → "Google Vertex" and `some-new-provider` →
+    // "Some New Provider".
+    smart_titlecase(provider)
+}
+
+/// Title-cases a provider/brand identifier word-by-word, splitting on `-`, `_`,
+/// and whitespace. Per-word acronym/brand overrides (e.g. `ai` → "AI",
+/// `gpt` → "GPT") win over plain capitalization. Empty input yields an empty
+/// string; runs of separators are collapsed.
+fn smart_titlecase(s: &str) -> String {
+    s.split(['-', '_', ' '])
+        .filter(|word| !word.is_empty())
+        .map(titlecase_word)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn titlecase_word(word: &str) -> String {
+    match word.to_lowercase().as_str() {
+        "ai" => "AI".to_string(),
+        "gpt" => "GPT".to_string(),
         "openai" => "OpenAI".to_string(),
-        "google" => "Google".to_string(),
-        "cursor" => "Cursor".to_string(),
-        "deepseek" => "DeepSeek".to_string(),
         "xai" => "xAI".to_string(),
-        "meta" => "Meta".to_string(),
-        "mistral" => "Mistral".to_string(),
-        "cohere" => "Cohere".to_string(),
-        "opencode" => "OpenCode".to_string(),
-        s if s.starts_with("github-cop") || s.contains("copilot") => "GitHub Copilot".to_string(),
-        _ => capitalize_first(provider),
+        "vertex" => "Vertex".to_string(),
+        "llm" => "LLM".to_string(),
+        "api" => "API".to_string(),
+        _ => capitalize_first(word),
     }
 }
 
@@ -521,6 +567,83 @@ mod tests {
         let last = get_provider_shade("anthropic", 6);
         let past_end = get_provider_shade("anthropic", 99);
         assert_eq!(last, past_end);
+    }
+
+    #[test]
+    fn provider_display_name_target_cases() {
+        // The four cases the user reported as rendering wrong.
+        assert_eq!(get_provider_display_name("openai"), "OpenAI");
+        assert_eq!(get_provider_display_name("kimi-for-coding"), "Kimi");
+        assert_eq!(get_provider_display_name("google-vertex"), "Google Vertex");
+        assert_eq!(get_provider_display_name("opencode"), "OpenCode");
+    }
+
+    #[test]
+    fn provider_display_name_openai_family() {
+        // Any openai* id collapses to the brand name.
+        assert_eq!(get_provider_display_name("openai"), "OpenAI");
+        assert_eq!(get_provider_display_name("openai-codex"), "OpenAI");
+        assert_eq!(get_provider_display_name("OpenAI"), "OpenAI");
+    }
+
+    #[test]
+    fn provider_display_name_kimi_family() {
+        assert_eq!(get_provider_display_name("kimi"), "Kimi");
+        assert_eq!(get_provider_display_name("kimi-code"), "Kimi");
+        assert_eq!(get_provider_display_name("kimi-for-coding"), "Kimi");
+    }
+
+    #[test]
+    fn provider_display_name_google_vertex_both_spellings() {
+        // `canonical_provider` rewrites the hyphen to an underscore, so both
+        // spellings must map to the same clean label.
+        assert_eq!(get_provider_display_name("google-vertex"), "Google Vertex");
+        assert_eq!(get_provider_display_name("google_vertex"), "Google Vertex");
+    }
+
+    #[test]
+    fn provider_display_name_smart_fallback_multiword() {
+        // Unknown multi-word providers get split + title-cased instead of the
+        // old naive capitalize-first ("Some-new-provider").
+        assert_eq!(
+            get_provider_display_name("some-new-provider"),
+            "Some New Provider"
+        );
+        assert_eq!(
+            get_provider_display_name("some_new_provider"),
+            "Some New Provider"
+        );
+    }
+
+    #[test]
+    fn provider_display_name_known_regressions() {
+        assert_eq!(get_provider_display_name("anthropic"), "Anthropic");
+        assert_eq!(get_provider_display_name("google"), "Google");
+        assert_eq!(get_provider_display_name("xai"), "xAI");
+        assert_eq!(get_provider_display_name("deepseek"), "DeepSeek");
+        assert_eq!(get_provider_display_name("meta"), "Meta");
+        assert_eq!(get_provider_display_name("mistral"), "Mistral");
+        assert_eq!(get_provider_display_name("cohere"), "Cohere");
+        assert_eq!(get_provider_display_name("cursor"), "Cursor");
+        assert_eq!(
+            get_provider_display_name("github-copilot"),
+            "GitHub Copilot"
+        );
+        assert_eq!(get_provider_display_name("copilot"), "GitHub Copilot");
+    }
+
+    #[test]
+    fn provider_display_name_acronym_words_in_fallback() {
+        // Per-word acronym map applies inside the smart fallback.
+        assert_eq!(get_provider_display_name("acme-ai"), "Acme AI");
+        assert_eq!(get_provider_display_name("foo-api"), "Foo API");
+    }
+
+    #[test]
+    fn provider_display_name_empty_is_empty() {
+        assert_eq!(get_provider_display_name(""), "");
+        // A string of only separators collapses to empty rather than panicking.
+        assert_eq!(get_provider_display_name("--_-"), "");
     }
 
     #[test]


### PR DESCRIPTION
Fixes provider display names that rendered raw or mis-cased: **openai → OpenAI**, **kimi-for-coding → Kimi**, **google-vertex → Google Vertex**, **opencode → OpenCode**.

## Root cause
Two layers:
- The CLI `models` report rendered the **raw** provider id (`Cell::new(&entry.provider)`) in 6 places — so you saw `openai` / `opencode` / `google-vertex` verbatim.
- The shared `get_provider_display_name` mapper's fallback was a naive capitalize-first, producing `Google-vertex` / `Kimi-for-coding` for hyphenated ids.

## Fix
- **Enriched the canonical mapper** (`get_provider_display_name`): brand-family prefixes (`openai*`→OpenAI, `kimi*`→Kimi, copilot→GitHub Copilot), explicit `google-vertex`/`google_vertex`→"Google Vertex" (both spellings, since `canonical_provider` rewrites the hyphen to an underscore), and a **smart title-case fallback** that splits on `-`/`_`/space with a per-word acronym map (AI, GPT, API, LLM, xAI, Vertex). Unknown multi-word providers like `some-new-provider` now render "Some New Provider".
- **Routed the 6 raw provider cells** in `run_models_report` through the mapper, so the CLI matches the TUI (which already used it). Confirmed no other raw-provider cell renders remain.

## Tests (all green)
8 new unit tests covering the four reported cases, openai/kimi families, both google-vertex spellings, the smart multi-word fallback, per-word acronyms, known-brand regressions (Anthropic/xAI/DeepSeek/GitHub Copilot/…), and empty/separator-only edges. `cargo build`/`test`/`clippy`/`fmt --check` all pass (730 + 122 tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes provider names across Models views so brands render correctly and consistently (e.g., openai → OpenAI, kimi-for-coding → Kimi, google-vertex → Google Vertex). The CLI now matches the TUI, and unknown ids get clean title-casing.

- **Bug Fixes**
  - Routed all `entry.provider` cells in the `models` report through `get_provider_display_name`.
  - Expanded `get_provider_display_name` with brand-family rules (`openai*`, `kimi*`, Copilot variants) and explicit `google-vertex`/`google_vertex` → Google Vertex.
  - Replaced naive capitalization with a split-and-title-case fallback with acronym handling (AI, GPT, API, LLM, xAI, Vertex).
  - Added unit tests for reported cases, brand families, both Google Vertex spellings, fallback behavior, and regressions.

<sup>Written for commit 3b544dd28795d5b05ce23c76e2164278a463f83f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

