### PR TITLE
fix(display): preserve all providers in merged Models rows

### DIFF
--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -375,6 +375,29 @@ pub fn get_provider_display_name(provider: &str) -> String {
     if let Some(name) = config.get_provider_display_name(provider) {
         return name.to_string();
     }
+
+    // Merged Models rows store multiple providers as a ", "-joined string
+    // (aggregate_model_usage_entries sorts + dedups + joins). Map EACH segment
+    // independently and rejoin, otherwise a prefix/brand branch below would
+    // match the whole string and silently drop the rest — e.g.
+    // "openai, openrouter" must render "OpenAI, OpenRouter", not just "OpenAI".
+    if provider.contains(", ") {
+        return provider
+            .split(", ")
+            .map(|segment| map_single_provider(segment, &config))
+            .collect::<Vec<_>>()
+            .join(", ");
+    }
+
+    map_single_provider(provider, &config)
+}
+
+/// Display name for a SINGLE provider id (no comma-joined lists — the public
+/// `get_provider_display_name` splits those first).
+fn map_single_provider(provider: &str, config: &TokscaleConfig) -> String {
+    if let Some(name) = config.get_provider_display_name(provider) {
+        return name.to_string();
+    }
     let lower = provider.to_lowercase();
     match lower.as_str() {
         "anthropic" => return "Anthropic".to_string(),
@@ -386,6 +409,7 @@ pub fn get_provider_display_name(provider: &str) -> String {
         "mistral" => return "Mistral".to_string(),
         "cohere" => return "Cohere".to_string(),
         "opencode" => return "OpenCode".to_string(),
+        "openrouter" => return "OpenRouter".to_string(),
         // `canonical_provider` rewrites `google-vertex` → `google_vertex`, so
         // accept both spellings here.
         "google-vertex" | "google_vertex" => return "Google Vertex".to_string(),
@@ -637,6 +661,32 @@ mod tests {
         // Per-word acronym map applies inside the smart fallback.
         assert_eq!(get_provider_display_name("acme-ai"), "Acme AI");
         assert_eq!(get_provider_display_name("foo-api"), "Foo API");
+    }
+
+    #[test]
+    fn provider_display_name_merged_list_maps_each_segment() {
+        // Merged Models rows store providers as a ", "-joined string
+        // (aggregate_model_usage_entries). Each segment must be mapped
+        // independently — a prefix/contains-family branch on the whole string
+        // would otherwise silently drop the rest. Regression guard for that.
+        assert_eq!(
+            get_provider_display_name("openai, openrouter"),
+            "OpenAI, OpenRouter"
+        );
+        assert_eq!(
+            get_provider_display_name("kimi, anthropic"),
+            "Kimi, Anthropic"
+        );
+        // A `copilot` segment must not swallow its siblings via the contains()
+        // branch.
+        assert_eq!(
+            get_provider_display_name("anthropic, copilot"),
+            "Anthropic, GitHub Copilot"
+        );
+        assert_eq!(
+            get_provider_display_name("anthropic, openai"),
+            "Anthropic, OpenAI"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #763, addressing a P2 review note.

## The bug
`aggregate_model_usage_entries` joins multiple providers for a merged row as a `", "`-separated string (e.g. a model used via both openai and openrouter → `"openai, openrouter"`) for every grouping except `ClientProviderModel`. The display mapper introduced in #763 matched a brand **prefix/contains** branch (`openai*`, `kimi*`, `*copilot*`) against the **whole** joined string and returned a single brand — silently dropping the other providers:

- `"openai, openrouter"` → `"OpenAI"` (openrouter gone)
- `"kimi, anthropic"` → `"Kimi"` (anthropic gone)

(Ironically the old exact-match mapper didn't hit this; the new prefix matching did — a regression from #763.)

## The fix
Make the mapper **list-aware**: split `entry.provider` on `", "`, map each segment via a new `map_single_provider` helper, and rejoin. So `"openai, openrouter"` → `"OpenAI, OpenRouter"`. Also added an explicit `openrouter → "OpenRouter"` arm.

## Tests
New `provider_display_name_merged_list_maps_each_segment` covers `openai, openrouter` → `OpenAI, OpenRouter`, `kimi, anthropic` → `Kimi, Anthropic`, the copilot-contains case (`anthropic, copilot` → `Anthropic, GitHub Copilot`), and order preservation. `build`/`test`/`clippy`/`fmt --check` all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix provider display in merged Models rows by mapping each provider in comma-joined strings, preserving all providers (e.g., "openai, openrouter" → "OpenAI, OpenRouter"). Adds a helper for single-provider mapping and an explicit "OpenRouter" display name.

- **Bug Fixes**
  - Split on ", " and map each segment via `map_single_provider`, then rejoin.
  - Added explicit `openrouter` → "OpenRouter" mapping.
  - Added tests for merged lists, `*copilot*` contains case, and order preservation.

<sup>Written for commit e300409fe95aca71fc6d7bb80af456d9932517af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

