### PR TITLE
docs(sakana): create session-cookie file mode 600 at creation

### DIFF
--- a/docs/providers/sakana.md
+++ b/docs/providers/sakana.md
@@ -56,10 +56,16 @@ Provide the cookie string via **either** of these (env var takes precedence):
 
   ```bash
   mkdir -p ~/.config/tokscale
-  printf '%s' '__Secure-authjs.session-token.0=...; __Secure-authjs.session-token.1=...' \
-    > ~/.config/tokscale/sakana-session
-  chmod 600 ~/.config/tokscale/sakana-session
+  # Create the file mode 600 from the start (umask 077) so the cookie is never
+  # briefly world-readable in the window between writing and chmod.
+  ( umask 077 && printf '%s' '__Secure-authjs.session-token.0=...; __Secure-authjs.session-token.1=...' \
+      > ~/.config/tokscale/sakana-session )
+  # Alternative: install -m 600 /dev/null ~/.config/tokscale/sakana-session first.
   ```
+
+  The file lives in tokscale's config dir, which honors `TOKSCALE_CONFIG_DIR`
+  (and `$XDG_CONFIG_HOME/tokscale` on Linux); `~/.config/tokscale` is just the
+  common default.
 
 Then:
 


### PR DESCRIPTION
Re-opens the fix from the accidentally-closed #758. Replaces the documented post-write `chmod 600` (transient world-readable window) with `umask 077` so the secret file is created mode 600 atomically; documents the `install -m 600` alternative and `TOKSCALE_CONFIG_DIR`/XDG config-dir resolution. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Sakana provider docs to create the session cookie file with mode 600 at creation using `umask 077`, avoiding any brief world-readable window. Also documents an `install -m 600` alternative and how the config dir resolves via `TOKSCALE_CONFIG_DIR` and `XDG_CONFIG_HOME` (default `~/.config/tokscale`).

<sup>Written for commit 7a389b22238eaa2650ccd7e9dc926007d12ab4e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

