### PR TITLE
fix(antigravity-cli): clamp untrusted token varints + pre-release hardening

### DIFF
--- a/crates/tokscale-cli/src/commands/usage/minimax.rs
+++ b/crates/tokscale-cli/src/commands/usage/minimax.rs
@@ -221,7 +221,11 @@ pub fn fetch() -> Result<UsageOutput> {
             // Reset time: prefer end_time, fallback to remains_time
             let resets_at = model.end_time.map(parse_end_time).or_else(|| {
                 model.remains_time.map(|rt| {
-                    let ms = if rt > 1_000_000_000 { rt } else { rt * 1000 };
+                    let ms = if rt > 1_000_000_000 {
+                        rt
+                    } else {
+                        rt.saturating_mul(1000)
+                    };
                     let dt = Utc::now() + chrono::Duration::milliseconds(ms);
                     dt.to_rfc3339()
                 })

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -390,12 +390,12 @@ pub fn get_provider_display_name(provider: &str) -> String {
     if provider.contains(", ") {
         return provider
             .split(", ")
-            .map(|segment| map_single_provider(segment, &config))
+            .map(|segment| map_single_provider(segment, config))
             .collect::<Vec<_>>()
             .join(", ");
     }
 
-    map_single_provider(provider, &config)
+    map_single_provider(provider, config)
 }
 
 /// Display name for a SINGLE provider id (no comma-joined lists — the public

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -434,7 +434,8 @@ fn create_conflicting_codex_fixture_dir() -> TempDir {
     tmp
 }
 
-/// Build a Command pointing HOME at the given temp dir, with --no-spinner and --opencode flags.
+/// Build a Command pointing HOME and the XDG dirs at the given temp dir for
+/// hermetic test runs (no flags are added; callers append their own).
 fn cmd_with_home(tmp: &Path) -> Command {
     let mut cmd = cargo_bin_cmd!("tokscale");
     cmd.env("HOME", tmp)

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -184,7 +184,13 @@ pub struct TokenBreakdown {
 
 impl TokenBreakdown {
     pub fn total(&self) -> i64 {
-        self.input + self.output + self.cache_read + self.cache_write + self.reasoning
+        // saturating so clamped (i64::MAX) buckets from a corrupt source can't
+        // overflow the sum.
+        self.input
+            .saturating_add(self.output)
+            .saturating_add(self.cache_read)
+            .saturating_add(self.cache_write)
+            .saturating_add(self.reasoning)
     }
 }
 
@@ -1703,11 +1709,13 @@ fn aggregate_model_usage_entries(
     let mut entries: Vec<ModelUsage> = model_map
         .into_values()
         .map(|mut entry| {
-            let total_tokens = entry.input.max(0)
-                + entry.output.max(0)
-                + entry.cache_read.max(0)
-                + entry.cache_write.max(0)
-                + entry.reasoning.max(0);
+            let total_tokens = entry
+                .input
+                .max(0)
+                .saturating_add(entry.output.max(0))
+                .saturating_add(entry.cache_read.max(0))
+                .saturating_add(entry.cache_write.max(0))
+                .saturating_add(entry.reasoning.max(0));
             entry.performance.finalize(total_tokens);
             let mut providers: Vec<&str> = entry.provider.split(", ").collect();
             providers.sort_unstable();
@@ -1730,11 +1738,14 @@ fn aggregate_model_usage_entries(
 }
 
 fn positive_token_total(tokens: &TokenBreakdown) -> i64 {
-    tokens.input.max(0)
-        + tokens.output.max(0)
-        + tokens.cache_read.max(0)
-        + tokens.cache_write.max(0)
-        + tokens.reasoning.max(0)
+    // saturating so multiple clamped (i64::MAX) buckets can't overflow the sum.
+    tokens
+        .input
+        .max(0)
+        .saturating_add(tokens.output.max(0))
+        .saturating_add(tokens.cache_read.max(0))
+        .saturating_add(tokens.cache_write.max(0))
+        .saturating_add(tokens.reasoning.max(0))
 }
 
 pub async fn get_model_report(options: ReportOptions) -> Result<ModelReport, String> {
@@ -2921,6 +2932,21 @@ mod tests {
     use std::io::Write;
     use std::str::FromStr;
     use std::sync::Arc;
+
+    #[test]
+    fn token_total_saturates_on_overlarge_buckets() {
+        // Multiple clamped (i64::MAX) buckets from a corrupt source must
+        // saturate rather than overflow when summed.
+        let t = TokenBreakdown {
+            input: i64::MAX,
+            output: i64::MAX,
+            cache_read: i64::MAX,
+            cache_write: 0,
+            reasoning: 0,
+        };
+        assert_eq!(t.total(), i64::MAX);
+        assert_eq!(super::positive_token_total(&t), i64::MAX);
+    }
 
     fn make_workspace_message(
         client: &str,

--- a/crates/tokscale-core/src/sessions/antigravity_cli.rs
+++ b/crates/tokscale-core/src/sessions/antigravity_cli.rs
@@ -104,11 +104,15 @@ fn parse_gen_metadata(
     // constant #1 is, to the best of our reverse-engineering, the agent's fixed
     // system prompt and counts as billable input; if an official schema later
     // contradicts this, only the input total needs revisiting.
-    let input =
-        varint_field(usage, 1).unwrap_or(0) as i64 + varint_field(usage, 2).unwrap_or(0) as i64;
-    let cache_read = varint_field(usage, 5).unwrap_or(0) as i64;
-    let output = varint_field(usage, 9).unwrap_or(0) as i64;
-    let reasoning = varint_field(usage, 10).unwrap_or(0) as i64;
+    // Clamp untrusted u64 varints into i64 (a corrupt/malicious blob could
+    // encode a value > i64::MAX, which `as i64` would wrap to a negative count)
+    // and combine with saturating_add so totals never overflow.
+    let to_i64 = |v: u64| i64::try_from(v).unwrap_or(i64::MAX);
+    let input = to_i64(varint_field(usage, 1).unwrap_or(0))
+        .saturating_add(to_i64(varint_field(usage, 2).unwrap_or(0)));
+    let cache_read = to_i64(varint_field(usage, 5).unwrap_or(0));
+    let output = to_i64(varint_field(usage, 9).unwrap_or(0));
+    let reasoning = to_i64(varint_field(usage, 10).unwrap_or(0));
     if input == 0 && output == 0 && cache_read == 0 && reasoning == 0 {
         return None;
     }
@@ -435,6 +439,27 @@ mod tests {
         blob.extend(enc_len(1, &workspace));
         blob.extend(enc_len(2, &created));
         blob
+    }
+
+    #[test]
+    fn overlarge_varint_token_counts_are_clamped_not_wrapped() {
+        // A corrupt/malicious blob encoding a varint > i64::MAX must clamp to a
+        // non-negative i64 (saturating), never wrap `as i64` to a negative count.
+        let mut usage = Vec::new();
+        usage.extend(enc_varint(1, u64::MAX)); // huge fixed system prompt
+        usage.extend(enc_varint(2, 10)); // + small input -> saturating_add
+        usage.extend(enc_varint(9, u64::MAX)); // huge output
+        usage.extend(enc_len(11, b"resp-overflow"));
+        let mut chat_model = Vec::new();
+        chat_model.extend(enc_len(4, &usage));
+        chat_model.extend(enc_len(19, b"gemini-3-flash-a"));
+        let blob = enc_len(1, &chat_model);
+
+        let mut seen = HashSet::new();
+        let msg = parse_gen_metadata(&blob, "s", 1_000, &mut seen).expect("parses");
+        assert_eq!(msg.tokens.output, i64::MAX);
+        assert_eq!(msg.tokens.input, i64::MAX); // saturating_add, not negative
+        assert!(msg.tokens.input >= 0 && msg.tokens.output >= 0);
     }
 
     #[test]


### PR DESCRIPTION
Final pre-v4.0.0 hardening from the comprehensive release review.

- **P1** `antigravity_cli.rs`: token counts read as `u64 as i64` + plain add → a corrupt SQLite blob with a varint > `i64::MAX` wrapped to a negative/garbage count (silent in release builds; no `overflow-checks`). Now clamped via `i64::try_from(..).unwrap_or(i64::MAX)` + `saturating_add`. **Regression test added** (`overlarge_varint_token_counts_are_clamped_not_wrapped`).
- **P2** `usage/minimax.rs`: `remains_time` ms conversion uses `saturating_mul`.
- **clippy**: fixed the 2 needless-borrow warnings in `tui/ui/widgets.rs` (now clippy-clean).
- **docs**: corrected a stale `cmd_with_home` comment referencing the removed `--opencode` flag.

Deferred (separate follow-ups, non-blocking): `provider_identity` non-canonical tags, and ko/zh-cn locale drift (Warp/Oz + Fugu pricing sections).

`cargo test` + `clippy` green on both crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Harden token parsing and totals to prevent negative or overflowed counts from corrupt varints. Also fix a milliseconds conversion overflow and clean up clippy/docs before v4.0.0.

- **Bug Fixes**
  - Clamp untrusted varints to `i64` and sum with `saturating_add` in `tokscale-core` (antigravity + token totals in `TokenBreakdown::total`, model aggregation, and `positive_token_total`); tests cover clamping and saturation.
  - Use `saturating_mul` for `remains_time` → ms in `tokscale-cli`; minor clippy and doc comment fixes.

<sup>Written for commit cde7905c981e98a0daac48fdaa6b61add46925f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

