### PR TITLE
docs: full ja/ko/zh-cn re-sync with EN README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -15,7 +15,7 @@
 >
 > | [<img alt="GitHub Follow" src="https://img.shields.io/github/followers/junhoyeo?style=flat-square&logo=github&labelColor=black&color=24292f" width="156px" />](https://github.com/junhoyeo) | GitHubで[@junhoyeo](https://github.com/junhoyeo)をフォローして、他のプロジェクトもチェックしてください。AI、インフラ、その他様々な分野で開発しています。 |
 > | :-----| :----- |
-> [<img alt="Discord link" src="https://img.shields.io/discord/1480206352755458110?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=flat-square" width="156px" />](https://discord.gg/h6DUGWdBbm) | [Discord](https://discord.gg/h6DUGWdBbm)に参加しよう — ���界最高のバイバーたちと一緒に。 |
+> [<img alt="Discord link" src="https://img.shields.io/discord/1480206352755458110?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=flat-square" width="156px" />](https://discord.gg/h6DUGWdBbm) | [Discord](https://discord.gg/h6DUGWdBbm)に参加しよう — 世界最高のバイバーたちと一緒に。 |
 
 <div align="center">
 
@@ -55,14 +55,14 @@
 | ロゴ | クライアント | データ場所 | サポート |
 |------|----------|---------------|-----------|
 | <img width="48px" src=".github/assets/client-opencode.png" alt="OpenCode" /> | [OpenCode](https://github.com/sst/opencode) | `~/.local/share/opencode/opencode.db` (1.2+、`opencode-stable.db` など全チャンネル対応) または `~/.local/share/opencode/storage/message/` | ✅ 対応 |
-| <img width="48px" src=".github/assets/client-claude.jpg" alt="Claude" /> | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `~/.claude/projects/` | ✅ 対応 |
+| <img width="48px" src=".github/assets/client-claude.jpg" alt="Claude" /> | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `~/.claude/projects/` および `~/.claude/transcripts/` | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-openclaw.jpg" alt="OpenClaw" /> | [OpenClaw](https://openclaw.ai/) | `~/.openclaw/agents/` (+ レガシー: `.clawdbot`, `.moltbot`, `.moldbot`) | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-openai.jpg" alt="Codex" /> | [Codex CLI](https://github.com/openai/codex) | `~/.codex/sessions/` | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-sakana.png" alt="Sakana Fugu" /> | [Sakana Fugu](https://sakana.ai/fugu/) | Codex 経由で追跡 — `~/.codex/sessions/*.jsonl` (`model_provider: sakana`) | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-copilot.jpg" alt="Copilot" /> | [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-the-github-copilot-coding-agent-in-cli) | `~/.copilot/otel/*.jsonl` (+ `COPILOT_OTEL_FILE_EXPORTER_PATH`) | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-hermes.png" alt="Hermes Agent" /> | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `$HERMES_HOME/state.db`（フォールバック: `~/.hermes/state.db`） | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `$GEMINI_CLI_HOME/tmp/*/chats/*.json`（フォールバック: `~/.gemini/tmp/*/chats/*.json`） | ✅ 対応 |
-| <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | `~/.config/tokscale/cursor-cache/`経由でAPI同期 | ✅ 対応 |
+| <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | Cursor API のエクスポートを `~/.config/tokscale/cursor-cache/usage*.csv` にキャッシュ（`~/.cursor` ではない） | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-amp.png" alt="Amp" /> | [Amp (AmpCode)](https://ampcode.com/) | `~/.local/share/amp/threads/` | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-codebuff.png" alt="Codebuff" /> | [Codebuff](https://codebuff.com/) | `~/.config/manicode/` (+ `manicode-dev`、`manicode-staging`; `CODEBUFF_DATA_DIR` でオーバーライド可能) | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-droid.png" alt="Droid" /> | [Droid (Factory Droid)](https://factory.ai/) | `~/.factory/sessions/` | ✅ 対応 |
@@ -85,14 +85,16 @@
 | <img width="48px" src="https://github.com/cline.png" alt="Cline" /> | [Cline](https://github.com/cline/cline) | VS Code globalStorage のタスクディレクトリ（Linux: `~/.config/Code/...`; macOS: `~/Library/Application Support/Code/...`; Windows: `%APPDATA%\Code\...`; サーバー: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/`） | ✅ 対応 |
 | <img width="48px" src="https://github.com/user-attachments/assets/7246e920-f3f8-4b6e-847e-030ae04e86c2" alt="Gajae-Code" /> | [gajae-code (gjc)](https://github.com/Yeachan-Heo/gajae-code) | `~/.gjc/agent/sessions/`（`GJC_CODING_AGENT_DIR`、`GJC_CONFIG_DIR`、`PI_CONFIG_DIR` でオーバーライド可能；Linux/macOS では `$XDG_DATA_HOME/gjc/sessions/` も解決） | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-jcode.png" alt="Jcode" /> | [Jcode](https://github.com/1jehuang/jcode) | `~/.jcode/sessions/session_*.json` + `session_*.journal.jsonl` サイドカー（`JCODE_HOME` で上書き可） | ✅ 対応 |
-| <img width="48px" src="https://github.com/XiaomiMiMo.png" alt="MiMo Code" /> | [MiMo Code](https://github.com/XiaomiMiMo/MiMo) | `~/.local/share/micode/mimocode.db`（XDG データディレクトリ；SQLite） | ✅ 対応 |
+| <img width="48px" src="https://github.com/XiaomiMiMo.png" alt="MiMo Code" /> | [MiMo Code](https://github.com/XiaomiMiMo/MiMo-Code) | `~/.local/share/micode/mimocode.db`（XDG データディレクトリ；SQLite） | ✅ 対応 |
 | <img width="48px" src="https://github.com/JetBrains.png" alt="Junie" /> | [Junie](https://www.jetbrains.com/junie/) | `~/.junie/sessions/*/events.jsonl` | ✅ 対応 |
-| <img width="48px" src="https://raw.githubusercontent.com/CommandCodeAI/command-code/main/.github/commandcode/logo/command-code-logo-black-bg.png" alt="Command Code" /> | [Command Code](https://github.com/CommandCodeAI/command-code) | `~/.commandcode/projects/**/*.jsonl` | ✅ 対応 |
+| <img width="48px" src="https://raw.githubusercontent.com/CommandCodeAI/command-code/main/.github/commandcode/logo/command-code-logo-black-bg.png" alt="Command Code" /> | [Command Code](https://github.com/CommandCodeAI/command-code) | `~/.commandcode/projects/**/*.jsonl`（トークン使用量はトランスクリプトから約4文字/トークンで推定；ディスクには永続化されない） | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | `hf:`モデルや`synthetic`プロバイダを検出して他ソースから再帰属（+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`） | ✅ 対応 |
 
 [🚅 LiteLLMの価格データ](https://github.com/BerriAI/litellm)を使用してリアルタイム価格計算を提供し、階層型価格モデルとキャッシュトークン割引をサポートしています。
 
 ### なぜ「Tokscale」？
+
+[![Tokscale](./.github/assets/hero.png)](https://tokscale.ai)
 
 このプロジェクトは **[カルダシェフ・スケール(Kardashev Scale)](https://ja.wikipedia.org/wiki/%E3%82%AB%E3%83%AB%E3%83%80%E3%82%B7%E3%82%A7%E3%83%95%E3%83%BB%E3%82%B9%E3%82%B1%E3%83%BC%E3%83%AB)** に触発されています。これは天体物理学者ニコライ・カルダシェフがエネルギー消費量に基づいて文明の技術的発展レベルを測定するために提案した方法です。タイプI文明は惑星上で利用可能なすべてのエネルギーを活用し、タイプIIは恒星の全出力を捕捉し、タイプIIIは銀河全体のエネルギーを支配します。
 
@@ -114,6 +116,7 @@ AI支援開発の時代において、**トークンは新しいエネルギー*
   - [プラットフォーム別フィルタリング](#プラットフォーム別フィルタリング)
   - [日付フィルタリング](#日付フィルタリング)
   - [価格検索](#価格検索)
+  - [カスタム価格オーバーライド](#カスタム価格オーバーライド)
   - [ソーシャルプラットフォームコマンド](#ソーシャルプラットフォームコマンド)
   - [Cursor IDEコマンド](#cursor-ideコマンド)
   - [Antigravity コマンド](#antigravity-コマンド)
@@ -239,6 +242,7 @@ tokscale
 # 特定のタブでTUIを起動
 tokscale models    # モデルタブ
 tokscale monthly   # 日別ビュー（日別内訳を表示）
+tokscale hourly    # 時間別タブ
 
 # レガシーCLIテーブル出力を使用
 tokscale --light
@@ -261,7 +265,7 @@ tokscale models --json > report.json   # ファイルに保存
 
 インタラクティブTUIモードは以下を提供します：
 
-- **6つのビュー**: 概要（チャート + トップモデル）、モデル、日別、時間別、統計（貢献グラフ）、エージェント
+- **8つのビュー**: 概要（チャート + トップモデル）、Usage（サブスクリプションクォータ）、モデル、日別、時間別、統計（貢献グラフ）、エージェント。分単位の Minutely ビューはデフォルトで非表示で、`settings.json` の `minutelyTabEnabled` で有効化できます — [設定](#設定)を参照
 - **キーボードナビゲーション**:
   - `←/→/Tab/BackTab`: ビュー切り替え
   - `↑/↓` または `Home/End`: リスト操作
@@ -270,7 +274,7 @@ tokscale models --json > report.json   # ファイルに保存
   - `c/d/t`: コスト/日付/トークンでソート
   - `j`: 今日にジャンプ
   - `s`: ソース選択ダイアログを開く
-  - `g`: グループ基準選択ダイアログを開く（モデル、クライアント+モデル、クライアント+プロバイダー+モデル）
+  - `g`: グループ基準選択ダイアログを開く（モデル、クライアント+モデル、クライアント+プロバイダー+モデル、ワークスペース+モデル、セッション+モデル、クライアント+セッション+モデル）
   - `h`: 日別/時間別のチャート粒度を切り替え（Overview タブ）
   - `v`: テーブル/プロフィールビューを切り替え（Hourly タブ）
   - `y`: 選択行をクリップボードにコピー
@@ -291,6 +295,9 @@ TUIで`g`を押すか、`--light`/`--json`モードで`--group-by`を使用し�
 | **モデル** | `--group-by model` | ✅ | モデルごとに1行 — すべてのクライアントとプロバイダーを統合 |
 | **クライアント + モデル** | `--group-by client,model` | | クライアント-モデルペアごとに1行 |
 | **クライアント + プロバイダー + モデル** | `--group-by client,provider,model` | | 最も詳細 — 統合なし |
+| **ワークスペース + モデル** | `--group-by workspace,model` | | ローカル使用量をワークスペースキー、次にモデルでグループ化 |
+| **セッション + モデル** | `--group-by session,model` | | `session_id` とモデルごとに1行 — 特定のエージェント CLI セッションにコストを帰属 |
+| **クライアント + セッション + モデル** | `--group-by client,session,model` | | クライアント・セッション・モデルごとに1行 — `session_id` で結合するマルチエージェントランナーに便利 |
 
 **`--group-by model`**（最も統合）
 
@@ -313,6 +320,33 @@ TUIで`g`を押すか、`--light`/`--json`モードで`--group-by`を使用し�
 | OpenCode | github-copilot | claude-opus-4-5 | $1,200 |
 | OpenCode | anthropic | claude-opus-4-5 | $168 |
 | Claude | anthropic | claude-opus-4-5 | $970 |
+
+**`--group-by session,model`**（セッション単位のコスト帰属）
+
+`tokscale models --json --group-by session,model` は `(session_id, model)` ごとに1エントリを出力します。各エントリにはトップレベルの `sessionId` フィールドが含まれるため、ダウンストリームツール（例: マルチエージェント IDE）はコストデータを特定のエージェント CLI セッションに結合できます：
+
+```json
+{
+  "groupBy": "session,model",
+  "entries": [
+    {
+      "sessionId": "019e1e27-af49-7cd1-89b7-7bad1c3f3be2",
+      "client": "codex",
+      "provider": "openai",
+      "model": "gpt-5",
+      "input": 25251,
+      "output": 47,
+      "cacheRead": 1920,
+      "cacheWrite": 0,
+      "reasoning": 40,
+      "messageCount": 12,
+      "cost": 0.0123
+    }
+  ]
+}
+```
+
+すべての行にクライアント名も必要な場合は `--group-by client,session,model` を使用してください（20以上の対応 CLI 全体を一度に1スポーンで処理）。
 
 ### プラットフォーム別フィルタリング
 
@@ -380,19 +414,55 @@ tokscale pricing "grok-code"
 # 特定のプロバイダーソースを強制
 tokscale pricing "grok-code" --provider openrouter
 tokscale pricing "claude-3-5-sonnet" --provider litellm
+
+# カスタム価格オーバーライドを確認
+tokscale pricing list-overrides
 ```
 
 **検索戦略：**
 
 価格検索は多段階の解決戦略を使用します：
 
-1. **完全一致** - LiteLLM/OpenRouterデータベースでの直接検索
-2. **エイリアス解決** - 親しみやすい名前を解決（例：`big-pickle` → `glm-4.7`）
-3. **ティアサフィックス除去** - 品質ティアを削除（`gpt-5.2-xhigh` → `gpt-5.2`）
-4. **バージョン正規化** - バージョン形式を処理（`claude-3-5-sonnet` ↔ `claude-3.5-sonnet`）
-5. **プロバイダープレフィックスマッチング** - 一般的なプレフィックスを試行（`anthropic/`、`openai/`など）
-6. **Cursorモデル価格** - LiteLLM/OpenRouterにまだ存在しないモデルのハードコード価格（例：`gpt-5.3-codex`）
-7. **ファジーマッチング** - 部分モデル名の単語境界マッチング
+1. **カスタム価格オーバーライド** - `~/.config/tokscale/custom-pricing.json` のユーザー定義エントリの完全一致
+2. **完全一致** - LiteLLM/OpenRouterデータベースでの直接検索
+3. **エイリアス解決** - 親しみやすい名前を解決（例：`big-pickle` → `glm-4.7`）
+4. **ティアサフィックス除去** - 品質ティアを削除（`gpt-5.2-xhigh` → `gpt-5.2`）
+5. **バージョン正規化** - バージョン形式を処理（`claude-3-5-sonnet` ↔ `claude-3.5-sonnet`）
+6. **プロバイダープレフィックスマッチング** - 一般的なプレフィックスを試行（`anthropic/`、`openai/`など）
+7. **Cursorモデル価格** - LiteLLM/OpenRouterにまだ存在しないモデルのハードコード価格（例：`gpt-5.3-codex`）
+8. **ファジーマッチング** - 部分モデル名の単語境界マッチング
+
+### カスタム価格オーバーライド
+
+アップストリームの価格データベースがまだ正しくカバーしていないモデル ID の価格を上書きするには、Tokscale の設定ディレクトリ（デフォルトでは macOS/Linux の `~/.config/tokscale/custom-pricing.json`；`TOKSCALE_CONFIG_DIR` を設定した場合は同じく解決されるディレクトリ）に `custom-pricing.json` を作成します。
+
+```json
+{
+  "$schema": "https://tokscale.dev/custom-pricing.schema.json",
+  "models": {
+    "accounts/fireworks/routers/kimi-k2p6-turbo": {
+      "input_cost_per_million_tokens": 2.00,
+      "output_cost_per_million_tokens": 8.00,
+      "cache_read_input_token_cost_per_million_tokens": 0.30,
+      "source": "https://docs.fireworks.ai/serverless/pricing",
+      "notes": "Fireworks Kimi K2.6 Turbo (preview)"
+    },
+    "accounts/fireworks/models/kimi-k2p6": {
+      "input_cost_per_million_tokens": 0.95,
+      "output_cost_per_million_tokens": 4.00,
+      "cache_read_input_token_cost_per_million_tokens": 0.16
+    },
+    "kimi-k2p6-turbo": {
+      "input_cost_per_million_tokens": 2.00,
+      "output_cost_per_million_tokens": 8.00
+    }
+  }
+}
+```
+
+オーバーライド価格は、ほとんどの API プロバイダーが価格を公開する方法と同じく、100万トークンあたりのドルで入力します；Tokscale は内部でこれをトークンあたりのレートに変換します。`input_cost_per_million_tokens` または `output_cost_per_million_tokens` の少なくとも一方が存在し正の値である必要があり、キャッシュ読み取り/キャッシュ作成フィールドは任意です。コピー/ペーストの互換性のため、`input_cost_per_token`、`output_cost_per_token`、`cache_read_input_token_cost` などの LiteLLM スタイルのトークンあたりフィールド名も受け付けますが、ユーザー向けには100万トークンあたりの名前を推奨します。ティアやキャッシュ価格を省略するにはフィールドを残さないでください；負の値や非有限な値は無効として扱われ、タイプミスが集計を密かに変えないようにモデルエントリ全体がスキップされます。任意の `source` および `notes` フィールドは Tokscale には無視され、自分の記録用に使用できます。
+
+オーバーライドは完全一致のみで、大文字小文字を区別しません。Tokscale はまず生のモデル ID をチェックし、次に既存の synthetic な `/models/` 正規化、その後オーバーライドが一致しなければ LiteLLM、OpenRouter、Cursor 価格、ファジーマッチングへフォールスルーします。生の完全一致は正規化された完全一致より優先されるため、`accounts/fireworks/routers/kimi-k2p6-turbo` で特定のゲートウェイ固有モデルを上書きしつつ、`kimi-k2p6-turbo` で正規化された `/models/` パスをカバーできます。オーバーライドは起動時に一度だけ読み込まれます；ファイルを編集したらコマンドを再起動してください。これは、アップストリームの LiteLLM 価格更新を待つ間、誤ったモデル価格のバグを修正するための推奨ローカル対処法です。
 
 **プロバイダー優先順位：**
 
@@ -414,11 +484,28 @@ tokscale pricing "claude-3-5-sonnet" --provider litellm
 # Tokscaleにログイン（GitHub認証用にブラウザを開く）
 tokscale login
 
+# ブラウザ認証なしで既存の Tokscale API トークンを保存
+tokscale login --token tt_xxx
+
 # ログイン中のユーザーを確認
 tokscale whoami
 
+# 保存済みの API トークンを QR コードとして表示（別デバイスへの共有に便利）
+# {"token":"tt_xxx","username":"..."} をエンコード — 任意の QR リーダーでスキャン
+tokscale qr
+
 # 使用量データをリーダーボードに送信
 tokscale submit
+
+# 認証情報を書き込まずに CI/ヘッドレス環境で送信
+# 優先順位: TOKSCALE_API_TOKEN 環境変数 > 保存済み認証情報ファイル（~/.config/tokscale/credentials.json）。
+# 環境変数が設定されている場合、その実行では保存済みファイルは無視されます。
+TOKSCALE_API_TOKEN=tt_xxx tokscale submit
+
+# トークンの失効: リーダーボードサイトの Settings > API Tokens
+# （https://tokscale.com/settings）を開き、該当トークン行の "Revoke" をクリック。
+# 失効は即座に有効になり、以降そのトークンを使ったリクエストは
+# HTTP 401 "Invalid API token" を返します。
 
 # フィルター付きで送信
 tokscale submit --client opencode,claude --since 2024-01-01
@@ -446,6 +533,9 @@ tokscale cursor status
 
 # 保存済みのCursorアカウント一覧
 tokscale cursor accounts
+
+# キャッシュされたCursor使用量を手動で更新
+tokscale cursor sync --json
 
 # アクティブアカウントを切り替え（cursor-cache/usage.csvに同期されるアカウント）
 tokscale cursor switch work
@@ -649,6 +739,7 @@ TUI では **Usage** タブに移動するとサブスクリプションデー�
 | **Kimi** | OAuth（`~/.kimi/credentials/kimi-code.json`） | Session、Weekly クォータ | `kimi` を実行してログイン |
 | **MiniMax** | API キー（環境変数） | モデルごとのプロンプトクォータ | `MINIMAX_API_KEY` または `MINIMAX_API_TOKEN` を設定 |
 | **MiniMax Token Plan** | API キー（環境変数） | 期間 + 週間の残量パーセントクォータ（リージョン別: CN minimaxi.com + Global minimax.io） | `MINIMAX_TOKEN_PLAN_CN_KEY` および/または `MINIMAX_TOKEN_PLAN_GLOBAL_KEY` を設定 |
+| **Sakana**（Fugu） | セッションクッキー（環境変数またはファイル） — 課金コンソールの HTML スクレイプ、公開 API なし | 5時間、Weekly クォータウィンドウ（プランティアと月額料金をメタデータとして） | `SAKANA_SESSION_COOKIE` を設定（[docs/providers/sakana.md](docs/providers/sakana.md) を参照） |
 
 プロバイダーは自動検出されます — 有効な資格情報を持つものだけが表示されます。プロバイダーが表示されない場合は、ログイン済みか、必要な環境変数が設定されているか確認してください。
 
@@ -710,7 +801,19 @@ Tokscaleは設定を`~/.config/tokscale/settings.json`に保存します：
 {
   "colorPalette": "blue",
   "includeUnusedModels": false,
-  "defaultClients": ["opencode", "claude"]
+  "defaultClients": ["opencode", "claude"],
+  "scanner": {
+    "extraScanPaths": {
+      "codex": [
+        "/Users/me/workspace/project-a/.codex/sessions",
+        "/Users/me/workspace/project-b/.codex/archived_sessions"
+      ],
+      "hermes": [
+        "/Users/me/.hermes/profiles/director_planning",
+        "/Users/me/.hermes/profiles/research/state.db"
+      ]
+    }
+  }
 }
 ```
 
@@ -724,8 +827,9 @@ Tokscaleは設定を`~/.config/tokscale/settings.json`に保存します：
 | `defaultClients` | string[] | `[]` | `--client/-c` フラグを渡さない場合に適用されるクライアントフィルター。`--client` と同じ ID を受け付けます（例: `["opencode", "claude", "synthetic"]`）。未知の ID は無視されます。CLI フラグが指定されるとこのリストは完全に無視されます — マージはしません。 |
 | `light.writeCache` | boolean | `false` | `true` のとき、`tokscale --light` はレンダリング直後に TUI キャッシュを原子的に上書きします。CLI フラグ `--write-cache` / `--no-write-cache` が実行ごとに優先されます。 |
 | `minutelyTabEnabled` | boolean | `false` | TUI に分単位の Minutely タブを表示し、データ読み込み時に分単位の集計を実行します。分単位の粒度はほとんどのユーザーにとってニッチな診断ビューであり、大規模データセットでは分単位のバケット処理に無視できないコストがかかるため、既定では無効になっています。 |
+| `scanner.extraScanPaths` | object | `{}` | Tokscale のデフォルトのホームルート以外にあるセッション向けの、クライアントごとの追加スキャンルート |
 
-#### Minutely タブの有効化
+プロジェクトレベルの `.codex` ディレクトリ、インポートした Gemini/OpenClaw 履歴、Hermes プロファイルデータベースなど、恒久的な追加ルートには `scanner.extraScanPaths` を使用してください。Hermes のエントリは `state.db` を含むプロファイルディレクトリ、または `state.db` ファイルを直接指すことができます。Tokscale はこれらのパスを毎回デフォルトのスキャンルートとマージし、重複するルートを正規パスで重複排除します。
 
 Minutely タブはトークン使用量を分単位で表示し、バーストパターンの診断、単一セッションのデバッグ、`autoRefreshEnabled` と組み合わせたほぼリアルタイムの監視に最も有用です。分単位の集計はデータ読み込み時にすべての解析済みメッセージを処理するため、ほとんどのユーザーには不要な RAM と CPU コストが発生します。そのため既定では非表示になっています。
 
@@ -758,15 +862,23 @@ Minutely タブはトークン使用量を分単位で表示し、バースト�
 | 変数 | デフォルト | 説明 |
 |----------|---------|-------------|
 | `TOKSCALE_NATIVE_TIMEOUT_MS` | `300000`（5分） | `nativeTimeoutMs` 設定をオーバーライド |
+| `TOKSCALE_API_TOKEN` | unset | 非対話的な `submit` および `delete-submitted-data` 実行用の Tokscale 個人 API トークン。Settings > API Tokens から作成するか、`tokscale login --token tt_xxx` でローカルに保存できます。 |
+| `TOKSCALE_EXTRA_DIRS` | unset | 一時的な追加セッションルートを `client:/abs/path,client:/abs/path` 形式で指定 |
 | `TOKSCALE_CONFIG_DIR` | unset | 設定ディレクトリのルート（`settings.json`、`star-cache.json`、`cache/`、`antigravity-cache/`、`trae-cache/` の保存場所）をオーバーライドします。絶対パス推奨；相対パスはプロセス CWD を基準に解決されます。CI サンドボックスや非デフォルトの場所を固定したい場合に便利です。設定されている場合、tokscale は macOS のレガシーパス（`~/Library/Application Support/tokscale/`）にフォールバックしません。 |
 | `TOKSCALE_FM_DEBUG` | unset | 設定すると、Apple Foundation Models の診断情報（macOS バージョンゲート、dlopen の dylib パス、ロード/シンボルエラー）を stderr に出力し、オンデバイスの apple-fm が動作した（またはしなかった）理由を説明します。 |
 
 ```bash
 # 例：非常に大きなデータセット用にタイムアウトを増加
 TOKSCALE_NATIVE_TIMEOUT_MS=600000 tokscale graph --output data.json
+
+# 例：一時的な追加スキャンルート
+TOKSCALE_EXTRA_DIRS='codex:/Users/me/workspace/project-a/.codex/sessions,gemini:/Users/me/imports/imac/gemini/tmp' tokscale
+
+# 例：対話的なブラウザログインなしで CI から送信
+TOKSCALE_API_TOKEN=tt_xxx tokscale submit
 ```
 
-> **注**: 恒久的な変更には、`~/.config/tokscale/settings.json`で`nativeTimeoutMs`を設定することをお勧めします。環境変数は一時的なオーバーライドやCI/CDに適しています。
+> **注**: 恒久的な追加ルートには、`~/.config/tokscale/settings.json` の `scanner.extraScanPaths` を推奨します。`TOKSCALE_EXTRA_DIRS` は一時的なオーバーライドや CI/CD に適しています。
 
 ### ヘッドレスモード
 
@@ -876,13 +988,27 @@ GitHubプロフィールREADMEにTokscaleの公開統計を直接埋め込むこ
 [![Tokscale Stats](https://tokscale.ai/api/embed/<username>/svg)](https://tokscale.ai/u/<username>)
 ```
 
-- `<username>`をGitHubユーザー名に置き換えてください
-- オプションのクエリパラメータ：
-  - `theme=light` ライトテーマを使用
-  - `sort=tokens`（デフォルト）または`sort=cost` ランキング基準を制御
-  - `compact=1` コンパクトレイアウト + コンパクトな数値表記（例：`1.2M`、`$3.4K`）
-- 例：
-  - `https://tokscale.ai/api/embed/<username>/svg?theme=light&sort=cost&compact=1`
+`<username>` を GitHub ユーザー名に置き換えてください。クエリパラメータを付けない場合は既定の `classic` カードがレンダリングされます。以下のパラメータを追加してデザインをカスタマイズできます。
+
+| パラメータ | 値 | 効果 |
+| --- | --- | --- |
+| `template` | `classic`（デフォルト）· `minimal` · `terminal` · `graph` · `orbit` · `vitals` · `blueprint` · `receipt` | カードデザイン |
+| `color` | `blue` · `green` · `teal` · `purple` · `pink` · `orange` · `monochrome` · `halloween` · `YlGnBu` | アクセントカラーと貢献グラフのパレット |
+| `theme` | `dark`（デフォルト）· `light` | ライトまたはダークのカード |
+| `sort` | `tokens`（デフォルト）· `cost` | ランクを取得するリーダーボード |
+| `tokens`, `cost` | `compact` · `full` | 数値フォーマット、個別に設定可能 — `20.9B` か `20,941,000,000` |
+| `rank` | `plain`（デフォルト、`#134`）· `percent`（`top 12%`）· `total`（`#134 / 1,174`） | リーダーボードのランクの表示方法 |
+| `graph` | `1` で貢献グラフを追加（既定はオフ） | `classic`、`minimal`、`terminal`、`orbit`、`blueprint`、`receipt` でサポート |
+| `compact` | `1` でコンパクトレイアウト | `classic` のみ |
+
+例：
+
+```md
+![](https://tokscale.ai/api/embed/<username>/svg?template=minimal&color=purple&graph=1)
+![](https://tokscale.ai/api/embed/<username>/svg?template=orbit&color=pink&rank=percent)
+![](https://tokscale.ai/api/embed/<username>/svg?template=terminal&color=green&theme=light)
+![](https://tokscale.ai/api/embed/<username>/svg?template=receipt&color=YlGnBu&graph=1)
+```
 
 ### GitHubプロフィールバッジ
 
@@ -906,7 +1032,7 @@ shields.ioスタイルのよりコンパクトなバッジも使用できます�
 
 ### はじめに
 
-1. **ログイン** - `tokscale login`を実行してGitHubで認証
+1. **ログイン** - `tokscale login`を実行してGitHubで認証するか、CI/ヘッドレス用途では Settings で API トークンを作成
 2. **送信** - `tokscale submit`を実行して使用量データをアップロード
 3. **表示** - Webプラットフォームを訪問してプロフィールとリーダーボードを確認
 
@@ -1112,6 +1238,8 @@ cd packages/core && bun run bench
 | Windows | x86_64 | ✅ サポート |
 | Windows | aarch64 | ✅ サポート |
 
+Linux では、ランチャーが glibc と musl を自動検出します（`process.report`、`/lib/ld-musl-*.so.1` の musl 動的ローダー、`ldd` を使用）。検出が誤ったフレーバーを選んでしまう場合（例: 最小構成のコンテナ）は、`TOKSCALE_LIBC=musl`（または `TOKSCALE_LIBC=gnu`）を設定して強制してください。
+
 ### Windowsサポート
 
 TokscaleはWindowsを完全にサポートしています。TUIとCLIはmacOS/Linuxと同様に動作します。
@@ -1139,7 +1267,7 @@ AIコーディングツールはクロスプラットフォームの場所にセ
 | Hermes Agent | `~/.hermes/` | `%USERPROFILE%\.hermes\` | `HERMES_HOME`環境変数で設定可能（[ソース](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/developer-guide/session-storage.md)） |
 | Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | `GEMINI_CLI_HOME`環境変数で設定可能 |
 | Amp | `~/.local/share/amp/` | `%USERPROFILE%\.local\share\amp\` | OpenCodeと同様に`xdg-basedir`を使用 |
-| Cursor | API同期 | API同期 | APIでデータを取得、`%USERPROFILE%\.config\tokscale\cursor-cache\`にキャッシュ |
+| Cursor | API同期 | API同期 | Cursor API から取得したデータを `usage*.csv` としてキャッシュ；ローカルの `~/.cursor` セッションデータは解析しない |
 | Droid | `~/.factory/` | `%USERPROFILE%\.factory\` | すべてのプラットフォームで同じパス |
 | Pi | `~/.pi/` and `~/.omp/` | `%USERPROFILE%\.pi\` and `%USERPROFILE%\.omp\` | すべてのプラットフォームで同じパス（Pi と [Oh My Pi](https://github.com/can1357/oh-my-pi) の両方をサポート） |
 | Kimi CLI | `~/.kimi/` | `%USERPROFILE%\.kimi\` | すべてのプラットフォームで同じパス |
@@ -1147,13 +1275,17 @@ AIコーディングツールはクロスプラットフォームの場所にセ
 | Qwen CLI | `~/.qwen/` | `%USERPROFILE%\.qwen\` | すべてのプラットフォームで同じパス |
 | Roo Code | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks\` | VS Code globalStorageタスクログ |
 | Kilo | `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\kilocode.kilo-code\tasks\` | VS Code globalStorageタスクログ |
+| Cline | Linux: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`; macOS: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`; サーバー: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/` | `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\tasks\` | VS Code globalStorageタスクログ |
 | Mux | `~/.mux/sessions/` | `%USERPROFILE%\.mux\sessions\` | 全プラットフォームで同じパス |
 | Codebuff | `~/.config/manicode/projects/` (+ `manicode-dev`、`manicode-staging`) | `%USERPROFILE%\.config\manicode\projects\` | `CODEBUFF_DATA_DIR` 環境変数でオーバーライド |
 | Kilo CLI | `~/.local/share/kilo/` | `%USERPROFILE%\.local\share\kilo\` | OpenCodeと同様に`xdg-basedir`を使用 |
 | Crush | `$XDG_DATA_HOME/crush/`（フォールバック: `~/.local/share/crush/`） | `%USERPROFILE%\.local\share\crush\`（設定されていれば `%XDG_DATA_HOME%\crush\`） | フォールバック付きでXDGデータディレクトリを使用 |
 | Goose | `~/.local/share/goose/sessions/` (+ macOS Application Support、レガシー Block パス) | `%USERPROFILE%\.local\share\goose\sessions\` | `GOOSE_PATH_ROOT` 環境変数で設定可能 |
 | Antigravity | `~/.config/tokscale/antigravity-cache/sessions/` | — | `tokscale antigravity sync` は現在 macOS / Linux でのみサポート |
+| Zed Agent | `~/.local/share/zed/threads/threads.db` | `%LOCALAPPDATA%\Zed\threads\threads.db` | ホスティング済み Zed モデルの使用量のみ；外部 ACP エージェントは対象外 |
+| Kiro | `~/.kiro/sessions/cli/` および `~/.local/share/kiro-cli/data.sqlite3` | `%USERPROFILE%\.kiro\sessions\cli\` および `%USERPROFILE%\.local\share\kiro-cli\data.sqlite3` | Kiro セッションファイルに加え、存在する場合は Kiro CLI の SQLite データベースを解析 |
 | Trae | `~/.config/tokscale/trae-cache/sessions/` | `%APPDATA%\tokscale\trae-cache\sessions\` | `tokscale trae sync` で 1 回だけ同期。インストール済みの Trae IDE または Trae Solo デスクトップアプリから資格情報を自動検出 |
+| Warp/Oz | `~/.config/tokscale/warp-cache/usage.json` | `%APPDATA%\tokscale\warp-cache\usage.json` | `tokscale warp sync` で同期；集計リクエスト数と使用金額のみ、トークントランスクリプトは含まない |
 | Grok Build | `~/.grok/sessions/` | `%USERPROFILE%\.grok\sessions\` | `GROK_HOME` 環境変数で設定可能。`updates.jsonl` セッション更新を解析 |
 | Jcode | `~/.jcode/sessions/` | `%USERPROFILE%\.jcode\sessions\` | `JCODE_HOME` 環境変数で設定可能。`session_*.json` スナップショットと `session_*.journal.jsonl` サイドカーを解析 |
 | MiMo Code | `~/.local/share/micode/` | `%USERPROFILE%\.local\share\micode\` | XDG データディレクトリを使用；SQLite データベース `mimocode.db` |
@@ -1271,12 +1403,16 @@ OpenCodeはビルド時のリリースチャンネルに応じてDBファイル�
 
 ### Claude Code
 
-場所: `~/.claude/projects/{projectPath}/*.jsonl`
+場所: `~/.claude/projects/{projectPath}/*.jsonl` および `~/.claude/transcripts/*.jsonl`
 
 アシスタントメッセージの使用量データを含むJSONL形式：
 ```json
 {"type": "assistant", "message": {"model": "claude-sonnet-4-20250514", "usage": {"input_tokens": 1234, "output_tokens": 567, "cache_read_input_tokens": 890}}, "timestamp": "2024-01-01T00:00:00Z"}
 ```
+
+`~/.claude/transcripts/` 配下のラッパートランスクリプトファイルは、実際の Claude 使用量メタデータを含む場合のみカウントされます。ユーザー/ツールイベントはあるが `usage` ブロックがないファイルは、推定せずにスキップされます。
+
+Tokscale の `claude` クライアントは Claude Code のトークン集計であり、Claude Desktop チャットの集計ではありません。Claude Desktop は `~/Library/Application Support/Claude` などの場所にアプリデータを保存しますが、Anthropic はコンシューマー向けデスクトップチャットやチャット履歴エクスポートについて、安定したローカルのメッセージ単位トークン台帳を文書化していません。Claude Desktop のデータは存在するが Claude Code の JSONL ルートのみがスキャン可能な場合は、`tokscale clients` を実行すると診断が表示されます。`tokscale usage` は Claude Code の認証情報からベストエフォートで Claude サブスクリプションのクォータバーを表示できますが、組織/API 使用量は Anthropic の Admin Usage and Cost API に属し、ローカルのトランスクリプトスキャンとは意図的に分離されています。
 
 ### Codex CLI
 
@@ -1462,6 +1598,19 @@ KiloはRoo Codeと同じタスクログ形式を使用します。Tokscaleは同
 - `text` JSONから`tokensIn`、`tokensOut`、`cacheReads`、`cacheWrites`、`cost`、`apiProtocol`を解析
 - 利用可能な場合、隣接する`api_conversation_history.json`からモデル/エージェントメタデータを補完
 
+### Cline
+
+場所:
+- Linux デスクトップ VS Code: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/{TASK_ID}/ui_messages.json`
+- macOS デスクトップ VS Code: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/{TASK_ID}/ui_messages.json`
+- Windows デスクトップ VS Code: `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\tasks\{TASK_ID}\ui_messages.json`
+- サーバー（ベストエフォート）: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/{TASK_ID}/ui_messages.json`
+
+Cline は Roo Code と Kilo がフォークした元となるアップストリームプロジェクトであり、同じ VS Code globalStorage のタスクログ形式を使用します。Tokscale は同じルールを適用します：
+- `ui_messages.json`から`say/api_req_started`イベントのみをカウント
+- `text` JSONから`tokensIn`、`tokensOut`、`cacheReads`、`cacheWrites`、`cost`、`apiProtocol`を解析
+- 利用可能な場合、隣接する`api_conversation_history.json`からモデル/エージェントメタデータを補完
+
 ### Mux
 
 場所:
@@ -1568,7 +1717,7 @@ Tokscaleは[LiteLLMの価格データベース](https://github.com/BerriAI/litel
 - キャッシュ読み取りトークン（割引）
 - キャッシュ書き込みトークン
 - 推論トークン（o1などのモデル用）
-- 階層型価格（200kトークン以上）
+- モデル固有の階層型価格（例: 200k または 272k トークン以上）
 
 ## コントリビューション
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -438,7 +438,7 @@ tokscale pricing list-overrides
 
 ```json
 {
-  "$schema": "https://tokscale.dev/custom-pricing.schema.json",
+  "$schema": "https://tokscale.ai/custom-pricing.schema.json",
   "models": {
     "accounts/fireworks/routers/kimi-k2p6-turbo": {
       "input_cost_per_million_tokens": 2.00,
@@ -503,7 +503,7 @@ tokscale submit
 TOKSCALE_API_TOKEN=tt_xxx tokscale submit
 
 # トークンの失効: リーダーボードサイトの Settings > API Tokens
-# （https://tokscale.com/settings）を開き、該当トークン行の "Revoke" をクリック。
+# （https://tokscale.ai/settings）を開き、該当トークン行の "Revoke" をクリック。
 # 失効は即座に有効になり、以降そのトークンを使ったリクエストは
 # HTTP 401 "Invalid API token" を返します。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -434,7 +434,7 @@ tokscale pricing list-overrides
 
 ```json
 {
-  "$schema": "https://tokscale.dev/custom-pricing.schema.json",
+  "$schema": "https://tokscale.ai/custom-pricing.schema.json",
   "models": {
     "accounts/fireworks/routers/kimi-k2p6-turbo": {
       "input_cost_per_million_tokens": 2.00,
@@ -499,7 +499,7 @@ tokscale submit
 TOKSCALE_API_TOKEN=tt_xxx tokscale submit
 
 # 토큰 폐기: 리더보드 사이트의 Settings > API Tokens
-# (https://tokscale.com/settings)를 방문해 해당 토큰 행의 "Revoke"를 클릭.
+# (https://tokscale.ai/settings)를 방문해 해당 토큰 행의 "Revoke"를 클릭.
 # 폐기는 즉시 적용됩니다 — 이후 해당 토큰을 사용한 요청은
 # HTTP 401 "Invalid API token"을 받습니다.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -55,14 +55,14 @@
 | 로고 | 클라이언트 | 데이터 위치 | 지원 여부 |
 |------|----------|---------------|-----------|
 | <img width="48px" src=".github/assets/client-opencode.png" alt="OpenCode" /> | [OpenCode](https://github.com/sst/opencode) | `~/.local/share/opencode/opencode.db` (1.2+, `opencode-stable.db` 등 모든 채널 포함) 또는 `~/.local/share/opencode/storage/message/` | ✅ 지원 |
-| <img width="48px" src=".github/assets/client-claude.jpg" alt="Claude" /> | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `~/.claude/projects/` | ✅ 지원 |
+| <img width="48px" src=".github/assets/client-claude.jpg" alt="Claude" /> | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `~/.claude/projects/` 및 `~/.claude/transcripts/` | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-openclaw.jpg" alt="OpenClaw" /> | [OpenClaw](https://openclaw.ai/) | `~/.openclaw/agents/` (+ 레거시: `.clawdbot`, `.moltbot`, `.moldbot`) | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-openai.jpg" alt="Codex" /> | [Codex CLI](https://github.com/openai/codex) | `~/.codex/sessions/` | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-sakana.png" alt="Sakana Fugu" /> | [Sakana Fugu](https://sakana.ai/fugu/) | Codex를 통해 추적 — `~/.codex/sessions/*.jsonl` (`model_provider: sakana`) | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-copilot.jpg" alt="Copilot" /> | [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-the-github-copilot-coding-agent-in-cli) | `~/.copilot/otel/*.jsonl` (+ `COPILOT_OTEL_FILE_EXPORTER_PATH`) | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-hermes.png" alt="Hermes Agent" /> | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `$HERMES_HOME/state.db` (폴백: `~/.hermes/state.db`) | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `$GEMINI_CLI_HOME/tmp/*/chats/*.json` (폴백: `~/.gemini/tmp/*/chats/*.json`) | ✅ 지원 |
-| <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | `~/.config/tokscale/cursor-cache/`를 통한 API 동기화 | ✅ 지원 |
+| <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | Cursor API 내보내기를 `~/.config/tokscale/cursor-cache/usage*.csv`에 캐싱 (`~/.cursor` 아님) | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-amp.png" alt="Amp" /> | [Amp (AmpCode)](https://ampcode.com/) | `~/.local/share/amp/threads/` | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-codebuff.png" alt="Codebuff" /> | [Codebuff](https://codebuff.com/) | `~/.config/manicode/` (+ `manicode-dev`, `manicode-staging`; `CODEBUFF_DATA_DIR`로 오버라이드 가능) | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-droid.png" alt="Droid" /> | [Droid (Factory Droid)](https://factory.ai/) | `~/.factory/sessions/` | ✅ 지원 |
@@ -85,9 +85,9 @@
 | <img width="48px" src="https://github.com/kirodotdev.png" alt="Kiro" /> | Kiro | `~/.kiro/sessions/cli/*.json` (+ `*.jsonl`), `~/.local/share/kiro-cli/data.sqlite3` (macOS: `~/Library/Application Support/kiro-cli/data.sqlite3`), 그리고 Kiro IDE globalStorage 스냅샷 (`Kiro/User/globalStorage/kiro.kiroagent`; macOS Application Support, Linux `~/.config/Kiro`, Windows `%APPDATA%\Kiro`) | ✅ 지원 |
 | <img width="48px" src="https://github.com/user-attachments/assets/7246e920-f3f8-4b6e-847e-030ae04e86c2" alt="Gajae-Code" /> | [gajae-code (gjc)](https://github.com/Yeachan-Heo/gajae-code) | `~/.gjc/agent/sessions/` (`GJC_CODING_AGENT_DIR`, `GJC_CONFIG_DIR`, `PI_CONFIG_DIR`로 오버라이드 가능; Linux/macOS에서는 `$XDG_DATA_HOME/gjc/sessions/`도 확인) | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-jcode.png" alt="Jcode" /> | [Jcode](https://github.com/1jehuang/jcode) | `~/.jcode/sessions/session_*.json` + `session_*.journal.jsonl` 사이드카 (`JCODE_HOME`으로 재정의 가능) | ✅ 지원 |
-| <img width="48px" src="https://github.com/XiaomiMiMo.png" alt="MiMo Code" /> | [MiMo Code](https://github.com/XiaomiMiMo/MiMo) | `~/.local/share/micode/mimocode.db` (XDG 데이터 디렉토리; SQLite) | ✅ 지원 |
+| <img width="48px" src="https://github.com/XiaomiMiMo.png" alt="MiMo Code" /> | [MiMo Code](https://github.com/XiaomiMiMo/MiMo-Code) | `~/.local/share/micode/mimocode.db` (XDG 데이터 디렉토리; SQLite) | ✅ 지원 |
 | <img width="48px" src="https://github.com/JetBrains.png" alt="Junie" /> | [Junie](https://www.jetbrains.com/junie/) | `~/.junie/sessions/*/events.jsonl` | ✅ 지원 |
-| <img width="48px" src="https://raw.githubusercontent.com/CommandCodeAI/command-code/main/.github/commandcode/logo/command-code-logo-black-bg.png" alt="Command Code" /> | [Command Code](https://github.com/CommandCodeAI/command-code) | `~/.commandcode/projects/**/*.jsonl` | ✅ 지원 |
+| <img width="48px" src="https://raw.githubusercontent.com/CommandCodeAI/command-code/main/.github/commandcode/logo/command-code-logo-black-bg.png" alt="Command Code" /> | [Command Code](https://github.com/CommandCodeAI/command-code) | `~/.commandcode/projects/**/*.jsonl` (토큰 사용량은 트랜스크립트에서 토큰당 약 4자 기준으로 추정; 디스크에 저장되지 않음) | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | `hf:` 모델/`synthetic` provider 감지로 다른 소스에서 재귀속 (+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`) | ✅ 지원 |
 
 [🚅 LiteLLM의 가격 데이터](https://github.com/BerriAI/litellm)를 사용해 **실시간 비용 계산**을 제공합니다. 구간별 가격 모델(대용량 컨텍스트 등)과 **캐시 토큰 할인**도 지원합니다.
@@ -114,6 +114,7 @@ AI 지원 개발 시대에 **토큰은 새로운 에너지**입니다. 토큰은
   - [플랫폼별 필터링](#플랫폼별-필터링)
   - [날짜 필터링](#날짜-필터링)
   - [가격 조회](#가격-조회)
+  - [사용자 정의 가격 오버라이드](#사용자-정의-가격-오버라이드)
   - [소셜 플랫폼 명령어](#소셜-플랫폼-명령어)
   - [Cursor IDE 명령어](#cursor-ide-명령어)
   - [Antigravity 명령어](#antigravity-명령어)
@@ -260,7 +261,7 @@ tokscale models --json > report.json   # 파일로 저장
 
 인터랙티브 TUI 모드는 다음을 제공합니다:
 
-- **6개 뷰**: 개요 (차트 + 상위 모델), 모델, 일별, 시간별, 통계 (기여 그래프), 에이전트
+- **8개 뷰**: 개요 (차트 + 상위 모델), Usage (구독 할당량), 모델, 일별, 시간별, 통계 (기여 그래프), 에이전트. 분 단위 뷰(Minutely)는 기본적으로 숨겨져 있으며 `settings.json`의 `minutelyTabEnabled`로 활성화할 수 있습니다 — [설정](#설정) 참조
 - **키보드 내비게이션**:
   - `←/→/Tab/BackTab`: 뷰 전환
   - `↑/↓` 또는 `Home/End`: 목록 탐색
@@ -269,7 +270,7 @@ tokscale models --json > report.json   # 파일로 저장
   - `c/d/t`: 비용/날짜/토큰별 정렬
   - `j`: 오늘로 이동
   - `s`: 소스 선택 다이얼로그 열기
-  - `g`: 그룹 기준 선택 다이얼로그 열기 (모델, 클라이언트+모델, 클라이언트+프로바이더+모델)
+  - `g`: 그룹 기준 선택 다이얼로그 열기 (모델, 클라이언트+모델, 클라이언트+프로바이더+모델, 워크스페이스+모델, 세션+모델, 클라이언트+세션+모델)
   - `h`: Daily/Hourly 차트 단위 전환 (Overview 탭)
   - `v`: Table/Profile 뷰 전환 (Hourly 탭)
   - `y`: 선택된 행을 클립보드에 복사
@@ -290,6 +291,9 @@ TUI에서 `g`를 누르거나 `--light`/`--json` 모드에서 `--group-by`를 �
 | **모델** | `--group-by model` | ✅ | 모델당 한 행 — 모든 클라이언트와 프로바이더 병합 |
 | **클라이언트 + 모델** | `--group-by client,model` | | 클라이언트-모델 쌍당 한 행 |
 | **클라이언트 + 프로바이더 + 모델** | `--group-by client,provider,model` | | 가장 세분화 — 병합 없음 |
+| **워크스페이스 + 모델** | `--group-by workspace,model` | | 로컬 사용량을 워크스페이스 키별로, 그 다음 모델별로 그룹화 |
+| **세션 + 모델** | `--group-by session,model` | | `session_id`와 모델당 한 행 — 특정 에이전트-CLI 세션에 비용 귀속 |
+| **클라이언트 + 세션 + 모델** | `--group-by client,session,model` | | 클라이언트, 세션, 모델당 한 행 — `session_id`로 조인하는 멀티 에이전트 러너에 유용 |
 
 **`--group-by model`** (가장 통합)
 
@@ -313,6 +317,33 @@ TUI에서 `g`를 누르거나 `--light`/`--json` 모드에서 `--group-by`를 �
 | OpenCode | anthropic | claude-opus-4-5 | $168 |
 | Claude | anthropic | claude-opus-4-5 | $970 |
 
+**`--group-by session,model`** (세션별 비용 귀속)
+
+`tokscale models --json --group-by session,model`은 `(session_id, model)`당 하나의 항목을 출력합니다. 각 항목은 최상위 `sessionId` 필드를 포함하므로, 다운스트림 도구(예: 멀티 에이전트 IDE)가 비용 데이터를 특정 에이전트-CLI 세션에 다시 조인할 수 있습니다:
+
+```json
+{
+  "groupBy": "session,model",
+  "entries": [
+    {
+      "sessionId": "019e1e27-af49-7cd1-89b7-7bad1c3f3be2",
+      "client": "codex",
+      "provider": "openai",
+      "model": "gpt-5",
+      "input": 25251,
+      "output": 47,
+      "cacheRead": 1920,
+      "cacheWrite": 0,
+      "reasoning": 40,
+      "messageCount": 12,
+      "cost": 0.0123
+    }
+  ]
+}
+```
+
+모든 행에 클라이언트 이름도 필요하다면 `--group-by client,session,model`을 사용하세요 (20개 이상 지원되는 모든 CLI에 걸친 단일 스폰).
+
 ### 플랫폼별 필터링
 
 `--client` (단축형 `-c`) 플래그로 하나 이상의 클라이언트로 리포트 범위를 좁힐 수 있습니다. 반복 사용 가능하며 콤마로 구분된 값도 지원하고, 모든 리포트 명령에서 동작합니다:
@@ -327,7 +358,7 @@ tokscale --client opencode,claude
 # 반복: 같은 효과 (쉘 alias와 함께 쓰기 좋음)
 tokscale -c opencode -c claude
 
-# Cursor IDE는 사전에 `tokscale cursor login` 필요
+# Cursor IDE는 Tokscale의 API 캐시를 사용; 먼저 login + sync --json 실행
 tokscale --client cursor
 
 # Synthetic (synthetic.new) 은 다른 에이전트 세션에서 검출됨
@@ -379,19 +410,55 @@ tokscale pricing "grok-code"
 # 특정 프로바이더 소스 강제 지정
 tokscale pricing "grok-code" --provider openrouter
 tokscale pricing "claude-3-5-sonnet" --provider litellm
+
+# 사용자 정의 가격 오버라이드 확인
+tokscale pricing list-overrides
 ```
 
 **조회 전략:**
 
 가격 조회는 다단계 해석 전략을 사용합니다:
 
-1. **정확한 일치** - LiteLLM/OpenRouter 데이터베이스에서 직접 조회
-2. **별칭 해석** - 친숙한 이름 해석 (예: `big-pickle` → `glm-4.7`)
-3. **티어 접미사 제거** - 품질 티어 제거 (`gpt-5.2-xhigh` → `gpt-5.2`)
-4. **버전 정규화** - 버전 형식 처리 (`claude-3-5-sonnet` ↔ `claude-3.5-sonnet`)
-5. **프로바이더 접두사 매칭** - 일반 접두사 시도 (`anthropic/`, `openai/` 등)
-6. **Cursor 모델 가격** - LiteLLM/OpenRouter에 아직 없는 모델의 하드코딩 가격 (예: `gpt-5.3-codex`)
-7. **퍼지 매칭** - 부분 모델 이름에 대한 단어 경계 매칭
+1. **사용자 정의 가격 오버라이드** - `~/.config/tokscale/custom-pricing.json`의 정확한 사용자 정의 항목
+2. **정확한 일치** - LiteLLM/OpenRouter 데이터베이스에서 직접 조회
+3. **별칭 해석** - 친숙한 이름 해석 (예: `big-pickle` → `glm-4.7`)
+4. **티어 접미사 제거** - 품질 티어 제거 (`gpt-5.2-xhigh` → `gpt-5.2`)
+5. **버전 정규화** - 버전 형식 처리 (`claude-3-5-sonnet` ↔ `claude-3.5-sonnet`)
+6. **프로바이더 접두사 매칭** - 일반 접두사 시도 (`anthropic/`, `openai/` 등)
+7. **Cursor 모델 가격** - LiteLLM/OpenRouter에 아직 없는 모델의 하드코딩 가격 (예: `gpt-5.3-codex`)
+8. **퍼지 매칭** - 부분 모델 이름에 대한 단어 경계 매칭
+
+### 사용자 정의 가격 오버라이드
+
+업스트림 가격 데이터베이스가 아직 정확히 다루지 못하는 모델 ID의 가격을 오버라이드하려면 Tokscale의 설정 디렉터리(기본값은 macOS/Linux의 `~/.config/tokscale/custom-pricing.json`; `TOKSCALE_CONFIG_DIR`가 설정된 경우 동일한 디렉터리로 해석됨)에 `custom-pricing.json`을 생성하세요.
+
+```json
+{
+  "$schema": "https://tokscale.dev/custom-pricing.schema.json",
+  "models": {
+    "accounts/fireworks/routers/kimi-k2p6-turbo": {
+      "input_cost_per_million_tokens": 2.00,
+      "output_cost_per_million_tokens": 8.00,
+      "cache_read_input_token_cost_per_million_tokens": 0.30,
+      "source": "https://docs.fireworks.ai/serverless/pricing",
+      "notes": "Fireworks Kimi K2.6 Turbo (preview)"
+    },
+    "accounts/fireworks/models/kimi-k2p6": {
+      "input_cost_per_million_tokens": 0.95,
+      "output_cost_per_million_tokens": 4.00,
+      "cache_read_input_token_cost_per_million_tokens": 0.16
+    },
+    "kimi-k2p6-turbo": {
+      "input_cost_per_million_tokens": 2.00,
+      "output_cost_per_million_tokens": 8.00
+    }
+  }
+}
+```
+
+오버라이드 가격은 대부분의 API 프로바이더가 가격을 공개하는 방식과 같이 백만 토큰당 달러 단위로 입력하며, Tokscale은 내부적으로 토큰당 요율로 변환합니다. `input_cost_per_million_tokens` 또는 `output_cost_per_million_tokens` 중 적어도 하나는 존재하고 양수여야 하며, 캐시 읽기/캐시 생성 필드는 선택 사항입니다. 복사/붙여넣기 호환성을 위해 `input_cost_per_token`, `output_cost_per_token`, `cache_read_input_token_cost` 같은 LiteLLM 스타일의 토큰당 필드명도 허용되지만, 백만 토큰당 이름이 권장되는 사용자용 형식입니다. 티어나 캐시 가격을 생략하려면 해당 필드를 비워 두세요. 음수이거나 유한하지 않은 값은 잘못된 것으로 처리되어 오타가 회계를 조용히 바꾸지 않도록 해당 모델 항목 전체를 건너뜁니다. 선택적 `source` 및 `notes` 필드는 Tokscale이 무시하므로 사용자 자신의 기록용으로 사용할 수 있습니다.
+
+오버라이드는 정확 일치 전용이며 대소문자를 구분하지 않습니다. Tokscale은 원본 모델 ID를 먼저 확인하고, 그다음 기존 합성 `/models/` 정규화를 확인한 뒤, 일치하는 오버라이드가 없으면 LiteLLM, OpenRouter, Cursor 가격, 퍼지 매칭으로 넘어갑니다. 원본 정확 일치가 정규화된 정확 일치보다 우선하므로, `accounts/fireworks/routers/kimi-k2p6-turbo`는 특정 게이트웨이 모델을 오버라이드할 수 있고 `kimi-k2p6-turbo`는 정규화된 `/models/` 경로를 커버할 수 있습니다. 오버라이드는 시작 시 한 번 로드되므로 파일을 편집한 후에는 명령을 다시 실행하세요. 업스트림 LiteLLM 가격 업데이트를 기다리는 동안 잘못된 모델 가격 버그를 로컬에서 수정하는 권장 방법입니다.
 
 **프로바이더 우선순위:**
 
@@ -413,11 +480,28 @@ tokscale pricing "claude-3-5-sonnet" --provider litellm
 # Tokscale 로그인 (GitHub 인증을 위해 브라우저 열기)
 tokscale login
 
+# 브라우저 인증 없이 기존 Tokscale API 토큰 저장
+tokscale login --token tt_xxx
+
 # 로그인한 사용자 확인
 tokscale whoami
 
+# 저장된 API 토큰을 QR 코드로 표시 (다른 기기로 공유할 때 유용)
+# {"token":"tt_xxx","username":"..."}를 인코딩 — 아무 QR 리더로 스캔
+tokscale qr
+
 # 사용량 데이터를 리더보드에 제출
 tokscale submit
+
+# 자격 증명을 기록하지 않고 CI/헤드리스 환경에서 제출
+# 우선순위: TOKSCALE_API_TOKEN 환경 변수 > 저장된 자격 증명 파일 (~/.config/tokscale/credentials.json).
+# 환경 변수가 설정되면 해당 실행에서는 저장된 파일이 무시됩니다.
+TOKSCALE_API_TOKEN=tt_xxx tokscale submit
+
+# 토큰 폐기: 리더보드 사이트의 Settings > API Tokens
+# (https://tokscale.com/settings)를 방문해 해당 토큰 행의 "Revoke"를 클릭.
+# 폐기는 즉시 적용됩니다 — 이후 해당 토큰을 사용한 요청은
+# HTTP 401 "Invalid API token"을 받습니다.
 
 # 필터와 함께 제출
 tokscale submit --client opencode,claude --since 2024-01-01
@@ -433,11 +517,23 @@ tokscale logout
 
 ### Cursor IDE 명령어
 
-Cursor IDE는 세션 토큰을 통한 별도의 인증이 필요합니다 (소셜 플랫폼 로그인과 다름):
+Cursor IDE 지원은 Cursor의 웹 API 내보내기를 사용하며, Tokscale이 `~/.config/tokscale/cursor-cache/usage*.csv`에 캐싱합니다. Tokscale은 `~/.cursor` 아래의 로컬 Cursor Agent CLI 상태를 파싱하지 않습니다.
+
+설정:
+
+1. 브라우저에서 https://www.cursor.com/settings 를 열고 로그인하세요.
+2. `WorkosCursorSessionToken` 쿠키 값을 복사하세요:
+   - Network 탭: `cursor.com/api/*`로 아무 요청이나 보낸 뒤, `Cookie` 요청 헤더에서 `WorkosCursorSessionToken=` 뒤의 값을 복사합니다.
+   - Application 탭: Cookies → `https://www.cursor.com`을 열고 `WorkosCursorSessionToken` 값을 복사합니다.
+3. `tokscale cursor login --name work`를 실행하고 토큰을 붙여 넣으세요.
+4. `tokscale cursor sync --json`을 실행해 `~/.config/tokscale/cursor-cache/usage.csv`를 채우세요.
+5. `tokscale --client cursor` 또는 아무 리포트 명령을 실행하세요.
+
+세션 토큰은 비밀번호처럼 취급하세요. 토큰은 `~/.config/tokscale/cursor-credentials.json`에 로컬로 저장됩니다.
 
 ```bash
 # Cursor 로그인 (브라우저에서 세션 토큰 필요)
-# --name은 선택이며, 나중에 계정을 구분하기 위한 라벨입니다
+# --name은 선택이며, 나중에 계정을 구분하는 데만 도움이 됩니다
 tokscale cursor login --name work
 
 # Cursor 인증 상태 및 세션 유효성 확인
@@ -446,7 +542,10 @@ tokscale cursor status
 # 저장된 Cursor 계정 목록
 tokscale cursor accounts
 
-# 활성 계정 전환 (cursor-cache/usage.csv에 동기화되는 계정)
+# 캐시된 Cursor 사용량 수동 새로고침
+tokscale cursor sync --json
+
+# 활성 계정 전환 (cursor-cache/usage.csv에 동기화되는 계정 제어)
 tokscale cursor switch work
 
 # 특정 계정 로그아웃 (기록은 보관, 합산에서는 제외)
@@ -462,19 +561,9 @@ tokscale cursor logout --all
 tokscale cursor logout --all --purge-cache
 ```
 
-**자격 증명 저장**: Cursor 계정들은 `~/.config/tokscale/cursor-credentials.json`에 저장됩니다. 사용량 데이터는 `~/.config/tokscale/cursor-cache/`에 캐시됩니다 (활성 계정은 `usage.csv`, 추가 계정은 `usage.<account>.csv`).
+기본적으로 Tokscale은 `cursor-cache/usage*.csv`를 읽어 저장된 모든 Cursor 계정의 사용량을 합산합니다. 활성 계정은 `usage.csv`에 동기화되고, 추가 계정은 `usage.<account>.csv`에 동기화됩니다.
 
-기본적으로 tokscale은 **저장된 모든 Cursor 계정의 사용량을 합산**합니다 (`cursor-cache/usage*.csv` 전체). 호환성을 위해 활성 계정은 `cursor-cache/usage.csv`에 동기화됩니다.
-
-로그아웃 시에는 캐시된 사용량 기록을 `cursor-cache/archive/`로 옮겨 보관하며(그래서 합산에서는 제외됨), 완전 삭제를 원하면 `--purge-cache`를 사용하세요.
-
-**Cursor 세션 토큰 얻는 방법:**
-1. 브라우저에서 https://www.cursor.com/settings 열기
-2. 개발자 도구 열기 (F12)
-3. **옵션 A - Network 탭**: 페이지에서 아무 동작을 하고, `cursor.com/api/*`에 대한 요청을 찾아, Request Headers에서 `Cookie` 헤더를 확인하고, `WorkosCursorSessionToken=` 뒤의 값만 복사
-4. **옵션 B - Application 탭**: Application → Cookies → `https://www.cursor.com`으로 이동, `WorkosCursorSessionToken` 쿠키를 찾아 값 복사 (쿠키 이름이 아닌 값)
-
-> ⚠️ **보안 경고**: 세션 토큰을 비밀번호처럼 취급하세요. 절대 공개적으로 공유하거나 버전 관리에 커밋하지 마세요. 토큰은 Cursor 계정에 대한 전체 액세스 권한을 부여합니다.
+로그아웃 시 Tokscale은 캐시된 사용량을 `cursor-cache/archive/`로 옮겨 더 이상 합산되지 않도록 합니다. 캐시된 사용량을 대신 삭제하려면 `--purge-cache`를 사용하세요.
 
 ### Antigravity 명령어
 
@@ -524,6 +613,8 @@ tokscale trae logout --variant solo
 **캐시 위치**: `~/.config/tokscale/trae-cache/`
 
 **동작 방식**: tokscale은 데스크톱 클라이언트의 `iCubeAuthInfo://*` blob(`globalStorage/storage.json`)을 복호화해 JWT를 얻거나, `--manual`로 붙여 넣은 JWT를 사용합니다. 이후 `POST /trae/api/v1/pay/query_user_usage_group_by_session`을 페이지 단위로 호출하고 원본 JSON을 저장합니다. 최신 Trae 데이터를 반영하려면 리포트 실행 전에 sync를 먼저 실행하세요.
+
+> **가격에 대한 참고**: Trae 비용 수치는 **벤더가 보고한 값**입니다 — tokscale은 토큰 수로부터 tokscale의 가격 엔진을 통해 비용을 재계산하는 대신 Trae 자체 API가 반환한 `dollar_float` 값을 그대로 표시합니다. 따라서 수치는 동일한 사용량에 대해 tokscale이 계산했을 값이 아니라 `trae.ai/account-setting#usage`에서 보이는 값과 일치합니다.
 
 > **중국판**: 중국판(`trae.com.cn`)은 의도적으로 지원하지 않습니다. CN 백엔드는 세션 단위 사용량 조회 API를 공개하지 않습니다. 공식 엔드포인트가 제공되면 지원을 추가할 예정입니다.
 
@@ -648,6 +739,7 @@ TUI에서는 **Usage** 탭으로 이동해 구독 데이터를 확인하세요. 
 | **Kimi** | OAuth (`~/.kimi/credentials/kimi-code.json`) | 세션, 주간 할당량 | `kimi`를 실행해 로그인 |
 | **MiniMax** | API 키 (환경 변수) | 모델별 프롬프트 할당량 | `MINIMAX_API_KEY` 또는 `MINIMAX_API_TOKEN` 설정 |
 | **MiniMax Token Plan** | API 키 (환경 변수) | 구간 + 주간 잔여 비율 할당량 (지역별: CN minimaxi.com + Global minimax.io) | `MINIMAX_TOKEN_PLAN_CN_KEY` 및/또는 `MINIMAX_TOKEN_PLAN_GLOBAL_KEY` 설정 |
+| **Sakana** (Fugu) | 세션 쿠키 (환경 변수 또는 파일) — 빌링 콘솔 HTML 스크레이프, 공개 API 없음 | 5시간, 주간 할당량 창 (플랜 티어 + 월 가격은 메타데이터) | `SAKANA_SESSION_COOKIE` 설정 ([docs/providers/sakana.md](docs/providers/sakana.md) 참조) |
 
 프로바이더는 자동 감지됩니다 — 유효한 자격 증명이 있는 프로바이더만 표시됩니다. 프로바이더가 보이지 않으면 로그인했는지 또는 필요한 환경 변수를 설정했는지 확인하세요.
 
@@ -709,7 +801,19 @@ Tokscale은 설정을 `~/.config/tokscale/settings.json`에 저장합니다:
 {
   "colorPalette": "blue",
   "includeUnusedModels": false,
-  "defaultClients": ["opencode", "claude"]
+  "defaultClients": ["opencode", "claude"],
+  "scanner": {
+    "extraScanPaths": {
+      "codex": [
+        "/Users/me/workspace/project-a/.codex/sessions",
+        "/Users/me/workspace/project-b/.codex/archived_sessions"
+      ],
+      "hermes": [
+        "/Users/me/.hermes/profiles/director_planning",
+        "/Users/me/.hermes/profiles/research/state.db"
+      ]
+    }
+  }
 }
 ```
 
@@ -723,6 +827,11 @@ Tokscale은 설정을 `~/.config/tokscale/settings.json`에 저장합니다:
 | `defaultClients` | string[] | `[]` | `--client/-c` 플래그를 전달하지 않을 때 적용되는 기본 클라이언트 필터. `--client`와 동일한 ID를 받습니다 (예: `["opencode", "claude", "synthetic"]`). 알 수 없는 ID는 자동으로 무시됩니다. CLI 플래그가 있으면 이 목록은 완전히 무시됩니다 — 병합되지 않습니다. |
 | `light.writeCache` | boolean | `false` | `true`이면 `tokscale --light`가 렌더링 직후 TUI 캐시를 원자적으로 덮어씁니다. CLI 플래그 `--write-cache` / `--no-write-cache`가 실행별로 우선합니다. |
 | `minutelyTabEnabled` | boolean | `false` | TUI에 분 단위 Minutely 탭을 표시하고 데이터 로딩 중에 분 단위 집계를 수행합니다. 대부분의 사용자에게 분 단위 세분화는 틈새/진단 뷰이며, 대규모 데이터셋에서는 분 단위 버케팅에 무시할 수 없는 비용이 들기 때문에 기본적으로 비활성화되어 있습니다. |
+| `scanner.extraScanPaths` | object | `{}` | Tokscale의 기본 home-root 위치 밖에 있는 세션을 위한 클라이언트별 추가 스캔 루트 |
+
+`scanner.extraScanPaths`는 프로젝트 단위 `.codex` 디렉터리, 가져온 Gemini/OpenClaw 히스토리, Hermes 프로필 데이터베이스 같은 영구적인 추가 루트에 사용하세요. Hermes 항목은 `state.db`를 포함하는 프로필 디렉터리를 가리키거나 `state.db` 파일을 직접 가리킬 수 있습니다. Tokscale은 매 실행마다 이 경로들을 기본 스캔 루트와 병합하고, 겹치는 루트는 정규 경로(canonical path) 기준으로 중복 제거합니다.
+
+`defaultClients`로 개인 기본값을 고정할 수 있습니다 — 예를 들어 OpenCode와 Claude만 사용한다면 `["opencode", "claude"]`로 설정하면, `tokscale`(플래그 없이)은 모든 리포트를 자동으로 해당 클라이언트로 범위를 좁힙니다. 단일 실행에 대해 재정의하려면 명령줄에서 `--client`를 전달하세요.
 
 #### Minutely 탭 활성화
 
@@ -757,15 +866,23 @@ Minutely 탭은 토큰 사용량을 분 단위로 표시하며, 버스트 패턴
 | 변수 | 기본값 | 설명 |
 |----------|---------|-------------|
 | `TOKSCALE_NATIVE_TIMEOUT_MS` | `300000` (5분) | `nativeTimeoutMs` 설정 오버라이드 |
+| `TOKSCALE_API_TOKEN` | unset | 비대화형 `submit` 및 `delete-submitted-data` 실행을 위한 Tokscale 개인 API 토큰. Settings > API Tokens에서 생성하거나 `tokscale login --token tt_xxx`로 로컬에 저장하세요. |
+| `TOKSCALE_EXTRA_DIRS` | unset | 일회성 추가 세션 루트, `client:/abs/path,client:/abs/path` 형식 |
 | `TOKSCALE_CONFIG_DIR` | unset | 설정 디렉토리 루트(`settings.json`, `star-cache.json`, `cache/`, `antigravity-cache/`, `trae-cache/` 위치)를 오버라이드합니다. 절대 경로 권장; 상대 경로는 프로세스 CWD 기준으로 해석됩니다. CI 샌드박스나 비기본 위치를 고정할 때 유용합니다. 설정되면 tokscale은 macOS 레거시 경로(`~/Library/Application Support/tokscale/`)로 폴백하지 않습니다. |
 | `TOKSCALE_FM_DEBUG` | unset | 설정되면 Apple Foundation Models 진단 정보(macOS 버전 게이트, dlopen dylib 경로, 로드/심볼 오류)를 stderr로 출력하여 온디바이스 apple-fm이 동작했는지 또는 동작하지 않았는지 이유를 설명합니다. |
 
 ```bash
 # 예시: 매우 큰 데이터셋에 대한 타임아웃 증가
 TOKSCALE_NATIVE_TIMEOUT_MS=600000 tokscale graph --output data.json
+
+# 예시: 일회성 추가 스캔 루트
+TOKSCALE_EXTRA_DIRS='codex:/Users/me/workspace/project-a/.codex/sessions,gemini:/Users/me/imports/imac/gemini/tmp' tokscale
+
+# 예시: 대화형 브라우저 로그인 없이 CI에서 제출
+TOKSCALE_API_TOKEN=tt_xxx tokscale submit
 ```
 
-> **참고**: 영구적인 변경은 `~/.config/tokscale/settings.json`에서 `nativeTimeoutMs`를 설정하는 것을 권장합니다. 환경 변수는 일회성 오버라이드나 CI/CD에 적합합니다.
+> **참고**: 영구적인 추가 루트는 `~/.config/tokscale/settings.json`의 `scanner.extraScanPaths`를 권장합니다. `TOKSCALE_EXTRA_DIRS`는 일회성 오버라이드나 CI/CD에 가장 적합합니다.
 
 ### Headless 모드
 
@@ -875,13 +992,29 @@ GitHub 프로필 README에 Tokscale 공개 통계를 직접 임베드할 수 있
 [![Tokscale Stats](https://tokscale.ai/api/embed/<username>/svg)](https://tokscale.ai/u/<username>)
 ```
 
-- `<username>`을 GitHub 사용자명으로 교체하세요
-- 선택적 쿼리 파라미터:
-  - `theme=light` 라이트 테마 사용
-  - `sort=tokens` (기본값) 또는 `sort=cost` 랭킹 기준 제어
-  - `compact=1` 컴팩트 레이아웃 + 축약 숫자 표기법 사용 (예: `1.2M`, `$3.4K`)
-- 예시:
-  - `https://tokscale.ai/api/embed/<username>/svg?theme=light&sort=cost&compact=1`
+`<username>`을 GitHub 사용자명으로 교체하세요. 쿼리 파라미터가 없으면
+기본 `classic` 카드가 렌더링됩니다. 디자인을 커스터마이즈하려면 아래
+파라미터를 덧붙이세요.
+
+| 파라미터 | 값 | 효과 |
+| --- | --- | --- |
+| `template` | `classic` (기본값) · `minimal` · `terminal` · `graph` · `orbit` · `vitals` · `blueprint` · `receipt` | 카드 디자인 |
+| `color` | `blue` · `green` · `teal` · `purple` · `pink` · `orange` · `monochrome` · `halloween` · `YlGnBu` | 강조 색상 및 기여 그래프 팔레트 |
+| `theme` | `dark` (기본값) · `light` | 라이트 또는 다크 카드 |
+| `sort` | `tokens` (기본값) · `cost` | 랭크를 가져올 리더보드 기준 |
+| `tokens`, `cost` | `compact` · `full` | 숫자 형식, 독립적으로 설정 — `20.9B` vs `20,941,000,000` |
+| `rank` | `plain` (기본값, `#134`) · `percent` (`top 12%`) · `total` (`#134 / 1,174`) | 리더보드 랭크 표시 방식 |
+| `graph` | `1`로 기여 그래프 추가 (기본값은 꺼짐) | `classic`, `minimal`, `terminal`, `orbit`, `blueprint`, `receipt`에서 지원 |
+| `compact` | `1`로 컴팩트 레이아웃 사용 | `classic` 전용 |
+
+예시:
+
+```md
+![](https://tokscale.ai/api/embed/<username>/svg?template=minimal&color=purple&graph=1)
+![](https://tokscale.ai/api/embed/<username>/svg?template=orbit&color=pink&rank=percent)
+![](https://tokscale.ai/api/embed/<username>/svg?template=terminal&color=green&theme=light)
+![](https://tokscale.ai/api/embed/<username>/svg?template=receipt&color=YlGnBu&graph=1)
+```
 
 ### GitHub 프로필 뱃지
 
@@ -1111,6 +1244,8 @@ cd packages/core && bun run bench
 | Windows | x86_64 | ✅ 지원 |
 | Windows | aarch64 | ✅ 지원 |
 
+Linux에서는 런처가 glibc와 musl을 자동으로 감지합니다 (`process.report`, `/lib/ld-musl-*.so.1`의 musl 동적 로더, 그리고 `ldd`를 통해). 감지가 잘못된 종류를 선택하는 경우 — 예를 들어 최소 컨테이너에서 — `TOKSCALE_LIBC=musl` (또는 `TOKSCALE_LIBC=gnu`)를 설정해 강제할 수 있습니다.
+
 ### Windows 지원
 
 Tokscale은 Windows를 완벽하게 지원합니다. TUI와 CLI는 macOS/Linux와 동일하게 작동합니다.
@@ -1146,14 +1281,19 @@ AI 코딩 도구들은 크로스 플랫폼 위치에 세션 데이터를 저장�
 | Qwen CLI | `~/.qwen/` | `%USERPROFILE%\.qwen\` | 모든 플랫폼에서 동일한 경로 |
 | Roo Code | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks\` | VS Code globalStorage 작업 로그 |
 | Kilo | `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\kilocode.kilo-code\tasks\` | VS Code globalStorage 작업 로그 |
+| Cline | Linux: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`; macOS: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`; 서버: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/` | `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\tasks\` | VS Code globalStorage 작업 로그 |
 | Mux | `~/.mux/sessions/` | `%USERPROFILE%\.mux\sessions\` | 모든 플랫폼에서 동일한 경로 |
 | Codebuff | `~/.config/manicode/projects/` (+ `manicode-dev`, `manicode-staging`) | `%USERPROFILE%\.config\manicode\projects\` | `CODEBUFF_DATA_DIR` 환경변수로 오버라이드 |
 | Kilo CLI | `~/.local/share/kilo/` | `%USERPROFILE%\.local\share\kilo\` | OpenCode와 같이 `xdg-basedir` 사용 |
 | Crush | `$XDG_DATA_HOME/crush/` (기본값: `~/.local/share/crush/`) | `%USERPROFILE%\.local\share\crush\` (설정된 경우 `%XDG_DATA_HOME%\crush\`) | 기본 경로를 포함한 XDG 데이터 디렉토리 사용 |
 | Goose | `~/.local/share/goose/sessions/` (+ macOS Application Support, 레거시 Block 경로) | `%USERPROFILE%\.local\share\goose\sessions\` | `GOOSE_PATH_ROOT` 환경변수로 설정 가능 |
 | Antigravity | `~/.config/tokscale/antigravity-cache/sessions/` | — | `tokscale antigravity sync`는 현재 macOS/Linux에서만 지원 |
+| Zed Agent | `~/.local/share/zed/threads/threads.db` | `%LOCALAPPDATA%\Zed\threads\threads.db` | 호스팅된 Zed 모델 사용량 전용; 외부 ACP 에이전트는 포함되지 않음 |
+| Kiro | `~/.kiro/sessions/cli/` 및 `~/.local/share/kiro-cli/data.sqlite3` | `%USERPROFILE%\.kiro\sessions\cli\` 및 `%USERPROFILE%\.local\share\kiro-cli\data.sqlite3` | Kiro 세션 파일과 함께 존재하는 경우 Kiro CLI SQLite 데이터베이스를 파싱 |
 | Trae | `~/.config/tokscale/trae-cache/sessions/` | `%APPDATA%\tokscale\trae-cache\sessions\` | `tokscale trae sync`로 한 번 동기화; 설치된 Trae IDE 또는 Trae Solo 데스크톱 앱에서 자격 증명 자동 발견 |
+| Warp/Oz | `~/.config/tokscale/warp-cache/usage.json` | `%APPDATA%\tokscale\warp-cache\usage.json` | `tokscale warp sync`로 동기화; 집계된 요청 수와 비용만, 토큰 트랜스크립트 없음 |
 | Grok Build | `~/.grok/sessions/` | `%USERPROFILE%\.grok\sessions\` | `GROK_HOME` 환경변수로 설정 가능; `updates.jsonl` 세션 업데이트 파싱 |
+| Jcode | `~/.jcode/sessions/` | `%USERPROFILE%\.jcode\sessions\` | `JCODE_HOME` 환경변수로 설정 가능; `session_*.json` 스냅샷과 `session_*.journal.jsonl` 사이드카 파싱 |
 | MiMo Code | `~/.local/share/micode/` | `%USERPROFILE%\.local\share\micode\` | XDG 데이터 디렉토리 사용; SQLite 데이터베이스 `mimocode.db` |
 | Gajae-Code | `~/.gjc/agent/sessions/` | `%USERPROFILE%\.gjc\agent\sessions\` | `GJC_CODING_AGENT_DIR`로 설정 가능 (`GJC_CONFIG_DIR`/`PI_CONFIG_DIR`도 지원; Linux/macOS에서는 `$XDG_DATA_HOME/gjc/sessions/`도 확인) |
 | Junie | `~/.junie/sessions/` | `%USERPROFILE%\.junie\sessions\` | 모든 플랫폼에서 동일한 home 상대 경로 사용; `events.jsonl` 사용 이벤트 파싱 |
@@ -1250,6 +1390,44 @@ OpenCode 1.2+는 세션을 SQLite에 저장합니다. Tokscale은 SQLite를 먼�
 
 OpenCode는 빌드된 릴리스 채널에 따라 DB 파일명을 결정합니다: `latest`, `beta` 채널은 `opencode.db`를 사용하고, 나머지 채널은 `opencode-<channel>.db` (예: `opencode-stable.db`, `opencode-nightly.db`)를 사용합니다. Tokscale은 모든 변형을 스캔하므로 여러 채널을 함께 사용하는 경우에도 통합된 뷰를 제공합니다.
 
+`OPENCODE_DB`를 `~/.local/share/opencode` 밖의 파일로 지정해 opencode를 실행한 경우, tokscale이 매 실행마다 찾을 수 있도록 `~/.config/tokscale/settings.json`에 절대 경로를 추가하세요:
+
+```json
+{
+  "scanner": {
+    "opencodeDbPaths": [
+      "/custom/location/opencode.db",
+      "/another/location/opencode-stable.db"
+    ]
+  }
+}
+```
+
+경로는 자동 발견과 병합되고, 정규 경로 기준으로 중복 제거되며, 존재하지 않는 항목은 조용히 건너뜁니다 (오래된 설정이 스캔을 깨뜨리지 않도록). `opencode.db-wal`, `opencode.db-shm` 및 기타 SQLite 사이드카는 거부됩니다.
+
+Tokscale의 기본 home-root 위치 밖에 세션을 보관하는 경우, 클라이언트별 추가 스캔 루트를 영구적으로 지정할 수도 있습니다:
+
+```json
+{
+  "scanner": {
+    "extraScanPaths": {
+      "codex": [
+        "/Users/me/workspace/project-a/.codex/sessions",
+        "/Users/me/workspace/project-b/.codex/archived_sessions"
+      ],
+      "gemini": ["/Users/me/imports/imac/gemini/tmp"],
+      "hermes": [
+        "/Users/me/.hermes/profiles/director_planning",
+        "/Users/me/.hermes/profiles/research/state.db"
+      ],
+      "openclaw": ["/Users/me/imports/imac/openclaw/agents"]
+    }
+  }
+}
+```
+
+이는 프로젝트 단위 `.codex` 디렉터리, 가져온 히스토리, 그리고 기본 `$HERMES_HOME/state.db`나 `~/.hermes/state.db` 위치 밖의 Hermes 프로필 데이터베이스에 유용합니다. Tokscale은 여전히 기본 루트를 스캔한 다음, 그 위에 `scanner.extraScanPaths`와 `TOKSCALE_EXTRA_DIRS`를 정규 경로 중복 제거와 함께 병합합니다. 워크스페이스 전체를 자동 발견하지는 않습니다.
+
 각 메시지 포함 내용:
 ```json
 {
@@ -1269,12 +1447,16 @@ OpenCode는 빌드된 릴리스 채널에 따라 DB 파일명을 결정합니다
 
 ### Claude Code
 
-위치: `~/.claude/projects/{projectPath}/*.jsonl`
+위치: `~/.claude/projects/{projectPath}/*.jsonl` 및 `~/.claude/transcripts/*.jsonl`
 
 어시스턴트 메시지의 사용량 데이터를 포함하는 JSONL 형식:
 ```json
 {"type": "assistant", "message": {"model": "claude-sonnet-4-20250514", "usage": {"input_tokens": 1234, "output_tokens": 567, "cache_read_input_tokens": 890}}, "timestamp": "2024-01-01T00:00:00Z"}
 ```
+
+`~/.claude/transcripts/` 아래의 래퍼 트랜스크립트 파일은 실제 Claude 사용량 메타데이터를 포함할 때만 계산됩니다. 사용자/도구 이벤트는 있지만 `usage` 블록이 없는 파일은 추정하지 않고 건너뜁니다.
+
+Tokscale의 `claude` 클라이언트는 Claude Code 토큰 회계이며, Claude Desktop 채팅 회계가 아닙니다. Claude Desktop은 `~/Library/Application Support/Claude` 같은 위치에 앱 데이터를 저장하지만, Anthropic은 소비자용 데스크톱 채팅이나 채팅 기록 내보내기에 대한 안정적인 로컬 메시지별 토큰 원장을 문서화하지 않습니다. Claude Desktop 데이터는 존재하지만 Claude Code JSONL 루트만 스캔 가능한 경우 `tokscale clients`를 실행하면 진단 정보를 볼 수 있습니다. `tokscale usage`는 Claude Code 자격 증명으로부터 best-effort Claude 구독 할당량 막대를 표시할 수 있는 반면, 조직/API 사용량은 Anthropic의 Admin Usage and Cost API에 속하며 로컬 트랜스크립트 스캔과는 의도적으로 분리되어 있습니다.
 
 ### Codex CLI
 
@@ -1334,9 +1516,9 @@ Tokscale은 `chat` span을 토큰 집계의 출처로 취급하고, 도구 span�
 
 ### Cursor IDE
 
-위치: `~/.config/tokscale/cursor-cache/` (Cursor API를 통해 동기화)
+위치: `~/.config/tokscale/cursor-cache/usage*.csv` (Cursor API를 통해 동기화)
 
-Cursor 데이터는 세션 토큰을 사용하여 Cursor API에서 가져와 로컬에 캐시됩니다. 인증하려면 `tokscale cursor login`을 실행하세요. 설정 안내는 [Cursor IDE 명령어](#cursor-ide-명령어)를 참조하세요.
+Cursor 데이터는 세션 토큰을 사용하여 Cursor API에서 가져와 로컬에 캐시됩니다. Tokscale은 리포트를 위해 해당 캐시 파일을 읽으며, 로컬 `~/.cursor` 세션 데이터는 파싱하지 않습니다. 설정 안내는 [Cursor IDE 명령어](#cursor-ide-명령어)를 참조하세요.
 
 ### Antigravity
 
@@ -1566,7 +1748,7 @@ Tokscale은 [LiteLLM의 가격 데이터베이스](https://github.com/BerriAI/li
 - 캐시 읽기 토큰 (할인)
 - 캐시 쓰기 토큰
 - 추론 토큰 (o1과 같은 모델용)
-- 구간별 가격 (200k 토큰 이상)
+- 모델별 구간 가격 (예: 200k 또는 272k 토큰 이상)
 
 ## 기여
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -20,6 +20,7 @@
 <div align="center">
 
 [![GitHub Release](https://img.shields.io/github/v/release/junhoyeo/tokscale?color=0073FF&labelColor=black&logo=github&style=flat-square)](https://github.com/junhoyeo/tokscale/releases)
+[![npm Version](https://img.shields.io/npm/v/tokscale?color=0073FF&labelColor=black&style=flat-square&logo=npm)](https://www.npmjs.com/package/tokscale)
 [![npm Downloads](https://img.shields.io/npm/dt/tokscale?color=0073FF&labelColor=black&style=flat-square)](https://www.npmjs.com/package/tokscale)
 [![GitHub Contributors](https://img.shields.io/github/contributors/junhoyeo/tokscale?color=0073FF&labelColor=black&style=flat-square)](https://github.com/junhoyeo/tokscale/graphs/contributors)
 [![GitHub Forks](https://img.shields.io/github/forks/junhoyeo/tokscale?color=0073FF&labelColor=black&style=flat-square)](https://github.com/junhoyeo/tokscale/network/members)
@@ -55,19 +56,19 @@
 | 图标 | 客户端 | 数据位置 | 支持状态 |
 |------|----------|---------------|-----------|
 | <img width="48px" src=".github/assets/client-opencode.png" alt="OpenCode" /> | [OpenCode](https://github.com/sst/opencode) | `~/.local/share/opencode/opencode.db` (1.2+，包含 `opencode-stable.db` 等所有渠道) 或 `~/.local/share/opencode/storage/message/` | ✅ 支持 |
-| <img width="48px" src=".github/assets/client-claude.jpg" alt="Claude" /> | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `~/.claude/projects/` | ✅ 支持 |
+| <img width="48px" src=".github/assets/client-claude.jpg" alt="Claude" /> | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `~/.claude/projects/` 和 `~/.claude/transcripts/` | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-openclaw.jpg" alt="OpenClaw" /> | [OpenClaw](https://openclaw.ai/) | `~/.openclaw/agents/` (+ 旧版: `.clawdbot`, `.moltbot`, `.moldbot`) | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-openai.jpg" alt="Codex" /> | [Codex CLI](https://github.com/openai/codex) | `~/.codex/sessions/` | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-sakana.png" alt="Sakana Fugu" /> | [Sakana Fugu](https://sakana.ai/fugu/) | 通过 Codex 追踪 — `~/.codex/sessions/*.jsonl` (`model_provider: sakana`) | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-copilot.jpg" alt="Copilot" /> | [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-the-github-copilot-coding-agent-in-cli) | `~/.copilot/otel/*.jsonl` (+ `COPILOT_OTEL_FILE_EXPORTER_PATH`) | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-hermes.png" alt="Hermes Agent" /> | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `$HERMES_HOME/state.db`（回退：`~/.hermes/state.db`） | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `$GEMINI_CLI_HOME/tmp/*/chats/*.json`（回退：`~/.gemini/tmp/*/chats/*.json`） | ✅ 支持 |
-| <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | 通过 `~/.config/tokscale/cursor-cache/` API 同步 | ✅ 支持 |
+| <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | Cursor API 导出缓存于 `~/.config/tokscale/cursor-cache/usage*.csv`（而非 `~/.cursor`） | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-amp.png" alt="Amp" /> | [Amp (AmpCode)](https://ampcode.com/) | `~/.local/share/amp/threads/` | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-codebuff.png" alt="Codebuff" /> | [Codebuff](https://codebuff.com/) | `~/.config/manicode/`（+ `manicode-dev`、`manicode-staging`；可通过 `CODEBUFF_DATA_DIR` 覆盖） | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-droid.png" alt="Droid" /> | [Droid (Factory Droid)](https://factory.ai/) | `~/.factory/sessions/` | ✅ 支持 |
-| <img width="48px" src=".github/assets/client-pi.png" alt="Pi" /> | [Pi](https://github.com/badlogic/pi-mono) | `~/.pi/agent/sessions/` and `~/.omp/agent/sessions/` ([Oh My Pi](https://github.com/can1357/oh-my-pi)) | ✅ 支持 |
-| <img width="48px" src=".github/assets/client-kimi.png" alt="Kimi" /> | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) / [Kimi Code](https://github.com/MoonshotAI/kimi-code) | kimi-cli: `~/.kimi/sessions/` kimi-code: `~/.kimi-code/sessions/`（override via `KIMI_CODE_HOME`） | ✅ 支持 |
+| <img width="48px" src=".github/assets/client-pi.png" alt="Pi" /> | [Pi](https://github.com/badlogic/pi-mono) | `~/.pi/agent/sessions/` 和 `~/.omp/agent/sessions/`（[Oh My Pi](https://github.com/can1357/oh-my-pi)） | ✅ 支持 |
+| <img width="48px" src=".github/assets/client-kimi.png" alt="Kimi" /> | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) / [Kimi Code](https://github.com/MoonshotAI/kimi-code) | kimi-cli: `~/.kimi/sessions/` kimi-code: `~/.kimi-code/sessions/`（可通过 `KIMI_CODE_HOME` 覆盖） | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-qwen.png" alt="Qwen" /> | [Qwen CLI](https://github.com/QwenLM/qwen-cli) | `~/.qwen/projects/` | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-roocode.png" alt="Roo Code" /> | [Roo Code](https://github.com/RooCodeInc/Roo-Code) | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` (+ server: `~/.vscode-server/data/User/globalStorage/rooveterinaryinc.roo-cline/tasks/`) | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-kilocode.png" alt="Kilo" /> | [Kilo](https://github.com/Kilo-Org/kilocode) | `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks/` (+ server: `~/.vscode-server/data/User/globalStorage/kilocode.kilo-code/tasks/`) | ✅ 支持 |
@@ -85,9 +86,9 @@
 | <img width="48px" src="https://github.com/cline.png" alt="Cline" /> | [Cline](https://github.com/cline/cline) | VS Code globalStorage 任务（Linux: `~/.config/Code/...`；macOS: `~/Library/Application Support/Code/...`；Windows: `%APPDATA%\Code\...`；server: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/`） | ✅ 支持 |
 | <img width="48px" src="https://github.com/user-attachments/assets/7246e920-f3f8-4b6e-847e-030ae04e86c2" alt="Gajae-Code" /> | [gajae-code (gjc)](https://github.com/Yeachan-Heo/gajae-code) | `~/.gjc/agent/sessions/`（可通过 `GJC_CODING_AGENT_DIR`、`GJC_CONFIG_DIR`、`PI_CONFIG_DIR` 覆盖；Linux/macOS 上 `$XDG_DATA_HOME/gjc/sessions/` 亦支持） | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-jcode.png" alt="Jcode" /> | [Jcode](https://github.com/1jehuang/jcode) | `~/.jcode/sessions/session_*.json` + `session_*.journal.jsonl` sidecar（可通过 `JCODE_HOME` 覆盖） | ✅ 支持 |
-| <img width="48px" src="https://github.com/XiaomiMiMo.png" alt="MiMo Code" /> | [MiMo Code](https://github.com/XiaomiMiMo/MiMo) | `~/.local/share/micode/mimocode.db`（XDG 数据目录；SQLite） | ✅ 支持 |
+| <img width="48px" src="https://github.com/XiaomiMiMo.png" alt="MiMo Code" /> | [MiMo Code](https://github.com/XiaomiMiMo/MiMo-Code) | `~/.local/share/micode/mimocode.db`（XDG 数据目录；SQLite） | ✅ 支持 |
 | <img width="48px" src="https://github.com/JetBrains.png" alt="Junie" /> | [Junie](https://www.jetbrains.com/junie/) | `~/.junie/sessions/*/events.jsonl` | ✅ 支持 |
-| <img width="48px" src="https://raw.githubusercontent.com/CommandCodeAI/command-code/main/.github/commandcode/logo/command-code-logo-black-bg.png" alt="Command Code" /> | [Command Code](https://github.com/CommandCodeAI/command-code) | `~/.commandcode/projects/**/*.jsonl` | ✅ 支持 |
+| <img width="48px" src="https://raw.githubusercontent.com/CommandCodeAI/command-code/main/.github/commandcode/logo/command-code-logo-black-bg.png" alt="Command Code" /> | [Command Code](https://github.com/CommandCodeAI/command-code) | `~/.commandcode/projects/**/*.jsonl`（Token 使用量按 ~4 字符/Token 从转录估算；不会持久化到磁盘） | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | 通过 `hf:` 模型前缀或 `synthetic` provider 从其他来源重归属（+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`） | ✅ 支持 |
 
 使用 [🚅 LiteLLM 的价格数据](https://github.com/BerriAI/litellm)提供实时价格计算，支持分层定价模型和缓存 Token 折扣。
@@ -261,7 +262,7 @@ tokscale models --json > report.json   # 保存到文件
 
 交互式 TUI 模式提供：
 
-- **6 个视图**：概览（图表 + 热门模型）、模型、每日、每时、统计（贡献图）、代理
+- **8 个视图**：概览（图表 + 热门模型）、Usage（订阅配额）、模型、每日、每时、统计（贡献图）、代理。按分钟视图（Minutely）默认隐藏，可在 `settings.json` 中通过 `minutelyTabEnabled` 启用 —— 参见[配置](#配置)
 - **键盘导航**：
   - `←/→/Tab/BackTab`：切换视图
   - `↑/↓` 或 `Home/End`：导航列表
@@ -270,7 +271,7 @@ tokscale models --json > report.json   # 保存到文件
   - `c/d/t`：按成本/日期/Token 排序
   - `j`：跳转到今天
   - `s`：打开来源选择对话框
-  - `g`：打开分组方式选择对话框（模型、客户端+模型、客户端+提供商+模型）
+  - `g`：打开分组方式选择对话框（模型、客户端+模型、客户端+提供商+模型、工作区+模型、会话+模型、客户端+会话+模型）
   - `h`：切换日/时图表粒度（Overview 标签）
   - `v`：切换表格/Profile 视图（Hourly 标签）
   - `y`：复制选中行到剪贴板
@@ -291,6 +292,9 @@ tokscale models --json > report.json   # 保存到文件
 | **模型** | `--group-by model` | ✅ | 每个模型一行 — 合并所有客户端和提供商 |
 | **客户端 + 模型** | `--group-by client,model` | | 每个客户端-模型对一行 |
 | **客户端 + 提供商 + 模型** | `--group-by client,provider,model` | | 最详细 — 不合并 |
+| **工作区 + 模型** | `--group-by workspace,model` | | 先按工作区键、再按模型对本地使用量分组 |
+| **会话 + 模型** | `--group-by session,model` | | 每个 `session_id` 和模型一行 — 将成本归因到特定的 agent-CLI 会话 |
+| **客户端 + 会话 + 模型** | `--group-by client,session,model` | | 每个客户端、会话和模型一行 — 适用于按 `session_id` 关联的多代理运行器 |
 
 **`--group-by model`**（最精简）
 
@@ -313,6 +317,33 @@ tokscale models --json > report.json   # 保存到文件
 | OpenCode | github-copilot | claude-opus-4-5 | $1,200 |
 | OpenCode | anthropic | claude-opus-4-5 | $168 |
 | Claude | anthropic | claude-opus-4-5 | $970 |
+
+**`--group-by session,model`**（按会话归因成本）
+
+`tokscale models --json --group-by session,model` 会为每个 `(session_id, model)` 输出一个条目。每个条目都包含顶层的 `sessionId` 字段，以便下游工具（例如多代理 IDE）能将成本数据关联回特定的 agent-CLI 会话：
+
+```json
+{
+  "groupBy": "session,model",
+  "entries": [
+    {
+      "sessionId": "019e1e27-af49-7cd1-89b7-7bad1c3f3be2",
+      "client": "codex",
+      "provider": "openai",
+      "model": "gpt-5",
+      "input": 25251,
+      "output": 47,
+      "cacheRead": 1920,
+      "cacheWrite": 0,
+      "reasoning": 40,
+      "messageCount": 12,
+      "cost": 0.0123
+    }
+  ]
+}
+```
+
+当你还需要每行都带有客户端名称时，请使用 `--group-by client,session,model`（一次涵盖全部 20+ 个受支持的 CLI）。
 
 ### 按平台筛选
 
@@ -380,19 +411,55 @@ tokscale pricing "grok-code"
 # 强制指定提供商来源
 tokscale pricing "grok-code" --provider openrouter
 tokscale pricing "claude-3-5-sonnet" --provider litellm
+
+# 查看自定义价格覆盖
+tokscale pricing list-overrides
 ```
 
 **查询策略：**
 
 价格查询使用多步解析策略：
 
-1. **精确匹配** - 在 LiteLLM/OpenRouter 数据库中直接查找
-2. **别名解析** - 解析友好名称（例如：`big-pickle` → `glm-4.7`）
-3. **层级后缀剥离** - 移除质量层级（`gpt-5.2-xhigh` → `gpt-5.2`）
-4. **版本标准化** - 处理版本格式（`claude-3-5-sonnet` ↔ `claude-3.5-sonnet`）
-5. **提供商前缀匹配** - 尝试常见前缀（`anthropic/`、`openai/` 等）
-6. **Cursor 模型定价** - LiteLLM/OpenRouter 中尚未收录的模型的硬编码定价（例如：`gpt-5.3-codex`）
-7. **模糊匹配** - 部分模型名称的词边界匹配
+1. **自定义价格覆盖** - 来自 `~/.config/tokscale/custom-pricing.json` 的用户自定义精确条目
+2. **精确匹配** - 在 LiteLLM/OpenRouter 数据库中直接查找
+3. **别名解析** - 解析友好名称（例如：`big-pickle` → `glm-4.7`）
+4. **层级后缀剥离** - 移除质量层级（`gpt-5.2-xhigh` → `gpt-5.2`）
+5. **版本标准化** - 处理版本格式（`claude-3-5-sonnet` ↔ `claude-3.5-sonnet`）
+6. **提供商前缀匹配** - 尝试常见前缀（`anthropic/`、`openai/` 等）
+7. **Cursor 模型定价** - LiteLLM/OpenRouter 中尚未收录的模型的硬编码定价（例如：`gpt-5.3-codex`）
+8. **模糊匹配** - 部分模型名称的词边界匹配
+
+### 自定义价格覆盖
+
+在 Tokscale 的配置目录中创建 `custom-pricing.json`（macOS/Linux 上默认为 `~/.config/tokscale/custom-pricing.json`；若设置了 `TOKSCALE_CONFIG_DIR`，则为其解析出的同一目录），以覆盖上游价格数据库尚未正确收录的模型 ID 的价格。
+
+```json
+{
+  "$schema": "https://tokscale.dev/custom-pricing.schema.json",
+  "models": {
+    "accounts/fireworks/routers/kimi-k2p6-turbo": {
+      "input_cost_per_million_tokens": 2.00,
+      "output_cost_per_million_tokens": 8.00,
+      "cache_read_input_token_cost_per_million_tokens": 0.30,
+      "source": "https://docs.fireworks.ai/serverless/pricing",
+      "notes": "Fireworks Kimi K2.6 Turbo (preview)"
+    },
+    "accounts/fireworks/models/kimi-k2p6": {
+      "input_cost_per_million_tokens": 0.95,
+      "output_cost_per_million_tokens": 4.00,
+      "cache_read_input_token_cost_per_million_tokens": 0.16
+    },
+    "kimi-k2p6-turbo": {
+      "input_cost_per_million_tokens": 2.00,
+      "output_cost_per_million_tokens": 8.00
+    }
+  }
+}
+```
+
+覆盖价格以每百万 Token 的美元数输入，这与大多数 API 提供商公布价格的方式一致；Tokscale 会在内部将其转换为每 Token 的费率。`input_cost_per_million_tokens` 或 `output_cost_per_million_tokens` 中至少要有一个存在且为正值，缓存读取/缓存创建字段为可选。为兼容复制粘贴，也接受 LiteLLM 风格的每 Token 字段名，例如 `input_cost_per_token`、`output_cost_per_token` 和 `cache_read_input_token_cost`，但推荐面向用户使用每百万的命名形式。要省略某个层级或缓存价格，直接不写该字段即可；负值或非有限值会被视为无效，并跳过整个模型条目，以免拼写错误悄悄改变统计。可选的 `source` 和 `notes` 字段会被 Tokscale 忽略，可用于您自己的记账。
+
+覆盖是仅精确匹配且不区分大小写的。Tokscale 先检查原始模型 ID，再检查现有的合成 `/models/` 归一化，然后才在没有覆盖匹配时回退到 LiteLLM、OpenRouter、Cursor 定价和模糊匹配。原始精确匹配优先于归一化精确匹配，因此 `accounts/fireworks/routers/kimi-k2p6-turbo` 可以覆盖某个特定网关的模型，而 `kimi-k2p6-turbo` 可以覆盖归一化的 `/models/` 路径。覆盖在启动时仅加载一次；编辑文件后请重启命令。这是在等待上游 LiteLLM 价格更新期间，针对错误模型定价 Bug 的推荐本地修复方案。
 
 **提供商优先级：**
 
@@ -414,11 +481,27 @@ tokscale pricing "claude-3-5-sonnet" --provider litellm
 # 登录 Tokscale（打开浏览器进行 GitHub 认证）
 tokscale login
 
+# 无需浏览器认证即可保存已有的 Tokscale API token
+tokscale login --token tt_xxx
+
 # 查看当前登录用户
 tokscale whoami
 
+# 将已保存的 API token 显示为二维码（便于分享到另一台设备）
+# 编码内容为 {"token":"tt_xxx","username":"..."} —— 可用任意二维码扫描器扫描
+tokscale qr
+
 # 提交使用量数据到排行榜
 tokscale submit
+
+# 在 CI/无头环境中提交，且不写入凭据
+# 优先级：TOKSCALE_API_TOKEN 环境变量 > 已保存的凭据文件（~/.config/tokscale/credentials.json）。
+# 设置了该环境变量时，本次调用会忽略已保存的文件。
+TOKSCALE_API_TOKEN=tt_xxx tokscale submit
+
+# 撤销 token：访问排行榜站点的 Settings > API Tokens
+#（https://tokscale.com/settings），点击对应 token 行的 "Revoke"。
+# 撤销立即生效 —— 之后使用该 token 的请求将收到 HTTP 401 "Invalid API token"。
 
 # 带筛选提交
 tokscale submit --client opencode,claude --since 2024-01-01
@@ -652,6 +735,7 @@ tokscale usage --light
 | **Kimi** | OAuth（`~/.kimi/credentials/kimi-code.json`） | Session、Weekly 配额 | 运行 `kimi` 登录 |
 | **MiniMax** | API key（环境变量） | 各模型的 Prompt 配额 | 设置 `MINIMAX_API_KEY` 或 `MINIMAX_API_TOKEN` |
 | **MiniMax Token Plan** | API key（环境变量） | 区间 + 每周剩余百分比配额（按区域：CN minimaxi.com + Global minimax.io） | 设置 `MINIMAX_TOKEN_PLAN_CN_KEY` 和/或 `MINIMAX_TOKEN_PLAN_GLOBAL_KEY` |
+| **Sakana**（Fugu） | 会话 cookie（环境变量或文件）—— 计费控制台 HTML 抓取，无公开 API | 5 小时、Weekly 配额窗口（套餐等级 + 月度价格作为元数据） | 设置 `SAKANA_SESSION_COOKIE`（参见 [docs/providers/sakana.md](docs/providers/sakana.md)） |
 
 提供商会被自动检测——仅显示具有有效凭据的提供商。如果缺少某个提供商，请确认您已登录或设置了所需的环境变量。
 
@@ -713,7 +797,19 @@ Tokscale 将设置存储在 `~/.config/tokscale/settings.json`：
 {
   "colorPalette": "blue",
   "includeUnusedModels": false,
-  "defaultClients": ["opencode", "claude"]
+  "defaultClients": ["opencode", "claude"],
+  "scanner": {
+    "extraScanPaths": {
+      "codex": [
+        "/Users/me/workspace/project-a/.codex/sessions",
+        "/Users/me/workspace/project-b/.codex/archived_sessions"
+      ],
+      "hermes": [
+        "/Users/me/.hermes/profiles/director_planning",
+        "/Users/me/.hermes/profiles/research/state.db"
+      ]
+    }
+  }
 }
 ```
 
@@ -727,6 +823,11 @@ Tokscale 将设置存储在 `~/.config/tokscale/settings.json`：
 | `defaultClients` | string[] | `[]` | 未传递 `--client/-c` 选项时应用的客户端筛选。接受与 `--client` 相同的 ID（例如 `["opencode", "claude", "synthetic"]`）。未知 ID 会被静默丢弃。命令行选项会完全覆盖此列表 — 不会合并。 |
 | `light.writeCache` | boolean | `false` | 为 `true` 时，`tokscale --light` 会在渲染完成后以原子方式覆盖 TUI 缓存。CLI 标志 `--write-cache` / `--no-write-cache` 会按次运行覆盖该设置。 |
 | `minutelyTabEnabled` | boolean | `false` | 在 TUI 中显示按分钟的 Minutely 标签，并在数据加载期间执行分钟级聚合。对大多数用户而言，分钟级粒度是较为小众的诊断视图，而在大数据集上分钟分桶有非平凡的代价，因此默认关闭。 |
+| `scanner.extraScanPaths` | object | `{}` | 针对 Tokscale 默认 home 根位置之外的会话，为各客户端额外指定的扫描根目录 |
+
+使用 `scanner.extraScanPaths` 配置持久化的额外根目录，例如项目级的 `.codex` 目录、导入的 Gemini/OpenClaw 历史，或 Hermes 配置文件数据库。Hermes 条目既可以指向包含 `state.db` 的配置文件目录，也可以直接指向 `state.db` 文件。Tokscale 在每次运行时都会将这些路径与默认扫描根目录合并，并按规范路径去重重叠的根目录。
+
+使用 `defaultClients` 固定一个个人默认值 —— 例如，如果您只使用 OpenCode 和 Claude，就将其设为 `["opencode", "claude"]`，那么 `tokscale`（不带任何选项）会自动将每个报告的范围限定为它们。在命令行传入 `--client` 可针对单次运行进行覆盖。
 
 #### 启用 Minutely 标签
 
@@ -761,15 +862,23 @@ Minutely 标签按分钟显示 Token 使用情况，最适合用于诊断突发�
 | 变量 | 默认值 | 描述 |
 |----------|---------|-------------|
 | `TOKSCALE_NATIVE_TIMEOUT_MS` | `300000`（5 分钟） | 覆盖 `nativeTimeoutMs` 配置 |
+| `TOKSCALE_API_TOKEN` | unset | 用于非交互式 `submit` 和 `delete-submitted-data` 运行的 Tokscale 个人 API token。可从 Settings > API Tokens 创建一个，或用 `tokscale login --token tt_xxx` 保存到本地。 |
+| `TOKSCALE_EXTRA_DIRS` | unset | 一次性的额外会话根目录，格式为 `client:/abs/path,client:/abs/path` |
 | `TOKSCALE_CONFIG_DIR` | unset | 覆盖配置目录根（`settings.json`、`star-cache.json`、`cache/`、`antigravity-cache/`、`trae-cache/` 的存放位置）。建议使用绝对路径；相对路径将基于进程 CWD 解析。适用于 CI 沙箱或固定到非默认位置。设置后，tokscale 不会回退到 macOS 旧路径（`~/Library/Application Support/tokscale/`）。 |
 | `TOKSCALE_FM_DEBUG` | unset | 设置后，会将 Apple Foundation Models 的诊断信息（macOS 版本门槛、dlopen dylib 路径、加载/符号错误）打印到 stderr，以说明本机端 apple-fm 为何启用或未启用。 |
 
 ```bash
 # 示例：为非常大的数据集增加超时时间
 TOKSCALE_NATIVE_TIMEOUT_MS=600000 tokscale graph --output data.json
+
+# 示例：一次性的额外扫描根目录
+TOKSCALE_EXTRA_DIRS='codex:/Users/me/workspace/project-a/.codex/sessions,gemini:/Users/me/imports/imac/gemini/tmp' tokscale
+
+# 示例：在 CI 中提交，无需交互式浏览器登录
+TOKSCALE_API_TOKEN=tt_xxx tokscale submit
 ```
 
-> **注意**：如需永久更改，建议在 `~/.config/tokscale/settings.json` 中设置 `nativeTimeoutMs`。环境变量适用于一次性覆盖或 CI/CD。
+> **注意**：对于持久化的额外根目录，建议在 `~/.config/tokscale/settings.json` 中使用 `scanner.extraScanPaths`。`TOKSCALE_EXTRA_DIRS` 最适合一次性覆盖或 CI/CD。
 
 ### Headless 模式
 
@@ -879,13 +988,27 @@ Tokscale 包含一个社交平台，您可以在其中分享使用数据并与�
 [![Tokscale Stats](https://tokscale.ai/api/embed/<username>/svg)](https://tokscale.ai/u/<username>)
 ```
 
-- 将 `<username>` 替换为您的 GitHub 用户名
-- 可选查询参数：
-  - `theme=light` 使用浅色主题
-  - `sort=tokens`（默认）或 `sort=cost` 控制排名依据
-  - `compact=1` 使用紧凑布局 + 紧凑数字表示法（例如 `1.2M`、`$3.4K`）
-- 示例：
-  - `https://tokscale.ai/api/embed/<username>/svg?theme=light&sort=cost&compact=1`
+将 `<username>` 替换为您的 GitHub 用户名。不带任何查询参数时，渲染默认的 `classic` 卡片；追加下面的任意参数即可自定义设计。
+
+| 参数 | 取值 | 效果 |
+| --- | --- | --- |
+| `template` | `classic`（默认）· `minimal` · `terminal` · `graph` · `orbit` · `vitals` · `blueprint` · `receipt` | 卡片设计 |
+| `color` | `blue` · `green` · `teal` · `purple` · `pink` · `orange` · `monochrome` · `halloween` · `YlGnBu` | 强调色和贡献图配色 |
+| `theme` | `dark`（默认）· `light` | 浅色或深色卡片 |
+| `sort` | `tokens`（默认）· `cost` | 排名取自哪个排行榜 |
+| `tokens`、`cost` | `compact` · `full` | 数字格式，可分别设置 —— `20.9B` 对比 `20,941,000,000` |
+| `rank` | `plain`（默认，`#134`）· `percent`（`top 12%`）· `total`（`#134 / 1,174`） | 排行榜名次的显示方式 |
+| `graph` | `1` 表示追加贡献图（默认关闭） | `classic`、`minimal`、`terminal`、`orbit`、`blueprint`、`receipt` 支持 |
+| `compact` | `1` 表示紧凑布局 | 仅 `classic` |
+
+示例：
+
+```md
+![](https://tokscale.ai/api/embed/<username>/svg?template=minimal&color=purple&graph=1)
+![](https://tokscale.ai/api/embed/<username>/svg?template=orbit&color=pink&rank=percent)
+![](https://tokscale.ai/api/embed/<username>/svg?template=terminal&color=green&theme=light)
+![](https://tokscale.ai/api/embed/<username>/svg?template=receipt&color=YlGnBu&graph=1)
+```
 
 ### GitHub 个人资料徽章
 
@@ -909,7 +1032,7 @@ Tokscale 包含一个社交平台，您可以在其中分享使用数据并与�
 
 ### 入门
 
-1. **登录** - 运行 `tokscale login` 通过 GitHub 认证
+1. **登录** - 运行 `tokscale login` 通过 GitHub 认证，或在 Settings 中创建一个 API token 供 CI/无头环境使用
 2. **提交** - 运行 `tokscale submit` 上传使用数据
 3. **查看** - 访问 Web 平台查看您的资料和排行榜
 
@@ -1150,13 +1273,17 @@ AI 编程工具将会话数据存储在跨平台位置。大多数工具在所�
 | Qwen CLI | `~/.qwen/` | `%USERPROFILE%\.qwen\` | 所有平台使用相同路径 |
 | Roo Code | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks\` | VS Code globalStorage 任务日志 |
 | Kilo | `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\kilocode.kilo-code\tasks\` | VS Code globalStorage 任务日志 |
+| Cline | Linux: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`；macOS: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`；server: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/` | `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\tasks\` | VS Code globalStorage 任务日志 |
 | Mux | `~/.mux/sessions/` | `%USERPROFILE%\.mux\sessions\` | 所有平台相同路径 |
 | Codebuff | `~/.config/manicode/projects/`（+ `manicode-dev`、`manicode-staging`） | `%USERPROFILE%\.config\manicode\projects\` | 通过 `CODEBUFF_DATA_DIR` 环境变量覆盖 |
 | Kilo CLI | `~/.local/share/kilo/` | `%USERPROFILE%\.local\share\kilo\` | 与 OpenCode 一样使用 `xdg-basedir` |
 | Crush | `$XDG_DATA_HOME/crush/`（回退路径：`~/.local/share/crush/`） | `%USERPROFILE%\.local\share\crush\`（如果设置了 `%XDG_DATA_HOME%`，则为 `%XDG_DATA_HOME%\crush\`） | 使用带回退路径的 XDG 数据目录 |
 | Goose | `~/.local/share/goose/sessions/`（+ macOS Application Support、旧版 Block 路径） | `%USERPROFILE%\.local\share\goose\sessions\` | 可通过 `GOOSE_PATH_ROOT` 环境变量配置 |
 | Antigravity | `~/.config/tokscale/antigravity-cache/sessions/` | — | `tokscale antigravity sync` 目前仅支持 macOS / Linux |
+| Zed Agent | `~/.local/share/zed/threads/threads.db` | `%LOCALAPPDATA%\Zed\threads\threads.db` | 仅限托管 Zed 模型的使用量；不含外部 ACP 代理 |
+| Kiro | `~/.kiro/sessions/cli/` 和 `~/.local/share/kiro-cli/data.sqlite3` | `%USERPROFILE%\.kiro\sessions\cli\` 和 `%USERPROFILE%\.local\share\kiro-cli\data.sqlite3` | 解析 Kiro 会话文件，以及存在时的 Kiro CLI SQLite 数据库 |
 | Trae | `~/.config/tokscale/trae-cache/sessions/` | `%APPDATA%\tokscale\trae-cache\sessions\` | 通过 `tokscale trae sync` 同步一次；凭据会从已安装的任意 Trae IDE 或 Trae Solo 桌面端自动发现 |
+| Warp/Oz | `~/.config/tokscale/warp-cache/usage.json` | `%APPDATA%\tokscale\warp-cache\usage.json` | 通过 `tokscale warp sync` 同步；仅汇总请求数和消费金额，不含 token 转录 |
 | Grok Build | `~/.grok/sessions/` | `%USERPROFILE%\.grok\sessions\` | 可通过 `GROK_HOME` 环境变量配置；解析 `updates.jsonl` 会话更新 |
 | Jcode | `~/.jcode/sessions/` | `%USERPROFILE%\.jcode\sessions\` | 可通过 `JCODE_HOME` 环境变量配置；解析 `session_*.json` 快照以及 `session_*.journal.jsonl` sidecar |
 | MiMo Code | `~/.local/share/micode/` | `%USERPROFILE%\.local\share\micode\` | 使用 XDG 数据目录；SQLite 数据库 `mimocode.db` |
@@ -1255,6 +1382,44 @@ OpenCode 1.2+ 将会话存储在 SQLite 中。Tokscale 优先从 SQLite 读取�
 
 OpenCode 根据构建时的发布渠道决定数据库文件名：`latest`/`beta` 渠道使用 `opencode.db`，其他渠道使用 `opencode-<channel>.db`（例如 `opencode-stable.db`、`opencode-nightly.db`）。Tokscale 会扫描所有这些文件，因此同时使用多个渠道的用户也能获得统一的视图。
 
+如果您用 `OPENCODE_DB` 指向 `~/.local/share/opencode` 之外的文件来启动 opencode，请将该绝对路径添加到 `~/.config/tokscale/settings.json`，以便 tokscale 每次运行都能找到它：
+
+```json
+{
+  "scanner": {
+    "opencodeDbPaths": [
+      "/custom/location/opencode.db",
+      "/another/location/opencode-stable.db"
+    ]
+  }
+}
+```
+
+这些路径会与自动发现结果合并，按规范路径去重，不存在的条目会被静默跳过（因此过时的配置不会让扫描中断）。`opencode.db-wal`、`opencode.db-shm` 及其他 SQLite sidecar 会被拒绝。
+
+如果您将会话保存在 Tokscale 默认 home 根位置之外，也可以为各客户端持久化额外的扫描根目录：
+
+```json
+{
+  "scanner": {
+    "extraScanPaths": {
+      "codex": [
+        "/Users/me/workspace/project-a/.codex/sessions",
+        "/Users/me/workspace/project-b/.codex/archived_sessions"
+      ],
+      "gemini": ["/Users/me/imports/imac/gemini/tmp"],
+      "hermes": [
+        "/Users/me/.hermes/profiles/director_planning",
+        "/Users/me/.hermes/profiles/research/state.db"
+      ],
+      "openclaw": ["/Users/me/imports/imac/openclaw/agents"]
+    }
+  }
+}
+```
+
+这对于项目级的 `.codex` 目录、导入的历史，以及默认 `$HERMES_HOME/state.db` 或 `~/.hermes/state.db` 位置之外的 Hermes 配置文件数据库都很有用。Tokscale 仍会扫描其默认根目录，然后在其上合并 `scanner.extraScanPaths` 和 `TOKSCALE_EXTRA_DIRS`，并按规范路径去重。它不会自动发现您的整个工作区。
+
 每个消息包含：
 ```json
 {
@@ -1274,12 +1439,16 @@ OpenCode 根据构建时的发布渠道决定数据库文件名：`latest`/`beta
 
 ### Claude Code
 
-位置：`~/.claude/projects/{projectPath}/*.jsonl`
+位置：`~/.claude/projects/{projectPath}/*.jsonl` 和 `~/.claude/transcripts/*.jsonl`
 
 包含使用数据的助手消息的 JSONL 格式：
 ```json
 {"type": "assistant", "message": {"model": "claude-sonnet-4-20250514", "usage": {"input_tokens": 1234, "output_tokens": 567, "cache_read_input_tokens": 890}}, "timestamp": "2024-01-01T00:00:00Z"}
 ```
+
+`~/.claude/transcripts/` 下的包装转录文件仅在包含真实 Claude 使用量元数据时才会被统计。包含用户/工具事件但没有 `usage` 块的文件会被跳过，而不会进行估算。
+
+Tokscale 的 `claude` 客户端统计的是 Claude Code 的 Token，而非 Claude Desktop 聊天。Claude Desktop 会将应用数据存储在 `~/Library/Application Support/Claude` 等位置，但 Anthropic 并未为消费级桌面聊天或聊天历史导出提供文档化、稳定的本地按消息 Token 账本。当存在 Claude Desktop 数据但只有 Claude Code JSONL 根目录可扫描时，运行 `tokscale clients` 可看到一条诊断信息。`tokscale usage` 可以根据 Claude Code 凭据尽力显示 Claude 订阅配额条，而组织/API 使用量属于 Anthropic 的 Admin Usage 和 Cost API，与本地转录扫描有意分离。
 
 ### Codex CLI
 
@@ -1339,9 +1508,9 @@ Tokscale 将 `chat` span 作为 Token 统计的真实来源，并在第一阶段
 
 ### Cursor IDE
 
-位置：`~/.config/tokscale/cursor-cache/`（通过 Cursor API 同步）
+位置：`~/.config/tokscale/cursor-cache/usage*.csv`（通过 Cursor API 同步）
 
-Cursor 数据使用您的会话令牌从 Cursor API 获取并本地缓存。运行 `tokscale cursor login` 进行认证。设置说明请参阅 [Cursor IDE 命令](#cursor-ide-命令)。
+Cursor 数据使用您的会话令牌从 Cursor API 获取并本地缓存。Tokscale 读取这些缓存文件来生成报告；它不会解析本地的 `~/.cursor` 会话数据。设置说明请参阅 [Cursor IDE 命令](#cursor-ide-命令)。
 
 ### Antigravity
 
@@ -1354,6 +1523,12 @@ Antigravity 数据不会被根命令自动获取。请在启用了 Antigravity �
 位置：`~/.config/tokscale/trae-cache/sessions/*.json`（通过官方使用量 API 同步）
 
 Trae 数据不会被根命令自动获取。先运行一次 `tokscale trae login`，然后在生成报告前运行 `tokscale trae sync`。Tokscale 会将同步得到的 API dump 解析为会话级记录，并保留 Trae 返回的成本总额。
+
+### Warp/Oz
+
+位置：`~/.config/tokscale/warp-cache/usage.json`（通过已认证的 GraphQL API 同步）
+
+Warp/Oz 数据不会被根命令自动获取。先运行 `tokscale warp login`，然后在生成报告前运行 `tokscale warp sync`。由于 Warp 不暴露基于 token 归因的本地转录，Tokscale 仅记录汇总的请求数和消费金额。
 
 ### Grok Build
 
@@ -1554,7 +1729,7 @@ Tokscale 使用时间戳、模型、provider、token 计数、成本和 agent �
 
 Tokscale 从 [LiteLLM 的价格数据库](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json)获取实时价格。
 
-**动态回退**：对于 LiteLLM 中尚未收录的模型（例如最近发布的模型），Tokscale 会自动从 [OpenRouter 的端点 API](https://openrouter.ai/docs/api/api-reference/endpoints/list-endpoints) 获取定价。
+**动态回退**：对于 LiteLLM 中尚未收录的模型（例如最近发布的模型），Tokscale 会自动从 [OpenRouter 的端点 API](https://openrouter.ai/docs/api/api-reference/endpoints/list-endpoints) 获取定价。这确保您无需等待 LiteLLM 更新，就能从模型的作者提供商（例如 glm-4.7 的 Z.AI）获得准确的价格。
 
 **Cursor 模型定价**：对于 LiteLLM 和 OpenRouter 中都尚未收录的最新模型（例如 `gpt-5.3-codex`），Tokscale 使用从 [Cursor 模型文档](https://cursor.com/en-US/docs/models)获取的硬编码定价。这些覆盖在所有上游来源之后、模糊匹配之前检查，因此当真正的上游定价可用时会自动让步。
 
@@ -1570,7 +1745,7 @@ Tokscale 从 [LiteLLM 的价格数据库](https://github.com/BerriAI/litellm/blo
 - 缓存读取 Token（折扣）
 - 缓存写入 Token
 - 推理 Token（用于 o1 等模型）
-- 分层定价（200k Token 以上）
+- 模型专属的分层定价（例如 200k 或 272k Token 以上）
 
 ## 贡献
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -435,7 +435,7 @@ tokscale pricing list-overrides
 
 ```json
 {
-  "$schema": "https://tokscale.dev/custom-pricing.schema.json",
+  "$schema": "https://tokscale.ai/custom-pricing.schema.json",
   "models": {
     "accounts/fireworks/routers/kimi-k2p6-turbo": {
       "input_cost_per_million_tokens": 2.00,
@@ -500,7 +500,7 @@ tokscale submit
 TOKSCALE_API_TOKEN=tt_xxx tokscale submit
 
 # 撤销 token：访问排行榜站点的 Settings > API Tokens
-#（https://tokscale.com/settings），点击对应 token 行的 "Revoke"。
+#（https://tokscale.ai/settings），点击对应 token 行的 "Revoke"。
 # 撤销立即生效 —— 之后使用该 token 的请求将收到 HTTP 401 "Invalid API token"。
 
 # 带筛选提交


### PR DESCRIPTION
## Full ja / ko / zh-cn re-sync with EN

Closes the cross-locale drift found in the README sync audit. Ports the sections that had fallen behind `README.md` into all three localized READMEs.

**Per locale (ja / ko / zh-cn):**
- **Sakana (Fugu)** subscription provider row (+ `SAKANA_SESSION_COOKIE`)
- `TOKSCALE_API_TOKEN` + `TOKSCALE_EXTRA_DIRS` env-var rows
- **Custom Pricing Overrides** section (+ as Pricing-Lookup resolution step #1)
- `scanner.extraScanPaths` config (JSON example + table row)
- Full **6 Group-By strategies** (+ session,model example) and the `g` picker list
- TUI **"8 Views"** incl. the **Usage** tab (was "6")
- GitHub Profile Embed Widget **parameter table**
- Windows **Data-Locations** rows: Cline, Zed Agent, Kiro, Warp/Oz (+ Jcode where missing)
- Data-source details: OpenCode (`OPENCODE_DB`/`opencodeDbPaths`), Claude transcripts path, Cline subsection
- **MiMo Code link fix** → `XiaomiMiMo/MiMo-Code`; Command Code "~4 chars/token" note; Cursor cache-path wording
- **ja**: fixed the hero-blurb mojibake (`���界最高` → `世界最高`), added the Why-Tokscale hero image

Stat: ja +205 / ko +266 / zh-cn +235. Code fences balanced; code tokens (flags, env vars, paths, URLs, JSON keys) kept verbatim.

### ⚠️ Review notes
- **Machine-generated translations — please give a native-speaker pass** before merge (terminology consistency, esp. the long Custom Pricing Overrides paragraphs).
- The ported custom-pricing example carries `"$schema": "https://tokscale.dev/custom-pricing.schema.json"` verbatim from EN (`README.md:439`). Heads-up since `tokscale.dev` was previously flagged as not-owned — if that EN reference should be scrubbed, it's a separate EN+locale cleanup (kept consistent with EN here).
- Agents did **not** invent Windows-table rows for Antigravity CLI / Command Code (those don't exist in EN's Windows table either).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-synced the Japanese, Korean, and Simplified Chinese READMEs with the English README to close drift and add recent features, settings, and data paths. Locales now have parity for pricing overrides, group-by modes, the Usage tab, Cursor docs, and provider rows.

- **New Features**
  - Added Sakana (Fugu) subscription provider row and `SAKANA_SESSION_COOKIE`.
  - Documented `TOKSCALE_API_TOKEN` and `TOKSCALE_EXTRA_DIRS`; added Custom Pricing Overrides (now pricing resolution step #1).
  - Added `scanner.extraScanPaths`; expanded Group-By to 6 strategies (incl. workspace/session); TUI now shows 8 views incl. Usage.
  - Expanded Cursor docs: API export cache at `~/.config/tokscale/cursor-cache/usage*.csv`, `cursor sync --json`, and clarified not parsing `~/.cursor`.
  - GitHub profile embed parameter table; Windows data locations for Cline/Zed Agent/Kiro/Warp-Oz; more OpenCode/Claude/Cline data-source details.

- **Bug Fixes**
  - Fixed MiMo Code link to `XiaomiMiMo/MiMo-Code` and noted Command Code token estimation (~4 chars/token).
  - ja: corrected hero-blurb mojibake and added the Why-Tokscale hero image.
  - Updated all schema and settings links to use `tokscale.ai` (replacing `.dev`/`.com`) across ja/ko/zh-cn.

<sup>Written for commit 968301c20bb528a066457ee2fa6fe974690e06ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

