### PR TITLE
fix(docs): use tokscale.ai everywhere; drop stale .com/.dev refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ Create `custom-pricing.json` in Tokscale's config directory (`~/.config/tokscale
 
 ```json
 {
-  "$schema": "https://tokscale.dev/custom-pricing.schema.json",
+  "$schema": "https://tokscale.ai/custom-pricing.schema.json",
   "models": {
     "accounts/fireworks/routers/kimi-k2p6-turbo": {
       "input_cost_per_million_tokens": 2.00,
@@ -501,7 +501,7 @@ tokscale submit
 TOKSCALE_API_TOKEN=tt_xxx tokscale submit
 
 # Revoke a token: visit Settings > API Tokens on the leaderboard site
-# (https://tokscale.com/settings) and click "Revoke" on the token row.
+# (https://tokscale.ai/settings) and click "Revoke" on the token row.
 # Revocation takes effect immediately — subsequent requests with that
 # token will get HTTP 401 "Invalid API token".
 

--- a/crates/tokscale-core/src/pricing/custom.rs
+++ b/crates/tokscale-core/src/pricing/custom.rs
@@ -414,7 +414,7 @@ mod tests {
         fs::write(
             &path,
             r#"{
-                "$schema": "https://tokscale.dev/custom-pricing.schema.json",
+                "$schema": "https://tokscale.ai/custom-pricing.schema.json",
                 "models": {
                         "accounts/fireworks/routers/kimi-k2p6-turbo": {
                         "input_cost_per_million_tokens": 2.00,


### PR DESCRIPTION
The only production origin is **tokscale.ai**, but EN docs/code carried stale domains:
- `README.md:504` — token-revocation pointed at `tokscale.com/settings` → **tokscale.ai/settings** (users following it after creating CI tokens hit the wrong host; matches `auth.rs` default + frontend metadata)
- `README.md:439` + `crates/tokscale-core/src/pricing/custom.rs:417` — custom-pricing `$schema` used `tokscale.dev` → **tokscale.ai** ($schema is informational; `loads_valid_file` test still passes)

Left intact: `packages/frontend/__tests__/lib/requestSessionCsrf.test.ts` — it *deliberately* asserts the `tokscale.dev` origin is rejected (documents the domain doesn't exist).

The same .com/.dev refs in the ja/ko/zh-cn ports are fixed in #767.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `tokscale.ai` everywhere in docs and a test fixture to match the production origin. Fixes a wrong settings link and an outdated custom-pricing $schema URL.

- **Bug Fixes**
  - `README.md`: token revocation link → https://tokscale.ai/settings; custom-pricing `$schema` → https://tokscale.ai/custom-pricing.schema.json.
  - `crates/tokscale-core` test fixture: `$schema` updated to `tokscale.ai`; kept the CSRF test that rejects `tokscale.dev`.

<sup>Written for commit fafde8a8487d1502a5eda2decfd7afb82314cfaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

