### PR TITLE
feat: add ZCode (z.ai GLM-5.2) session parser

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -88,6 +88,7 @@
 | <img width="48px" src="https://github.com/XiaomiMiMo.png" alt="MiMo Code" /> | [MiMo Code](https://github.com/XiaomiMiMo/MiMo-Code) | `~/.local/share/micode/mimocode.db`（XDG データディレクトリ；SQLite） | ✅ 対応 |
 | <img width="48px" src="https://github.com/JetBrains.png" alt="Junie" /> | [Junie](https://www.jetbrains.com/junie/) | `~/.junie/sessions/*/events.jsonl` | ✅ 対応 |
 | <img width="48px" src="https://raw.githubusercontent.com/CommandCodeAI/command-code/main/.github/commandcode/logo/command-code-logo-black-bg.png" alt="Command Code" /> | [Command Code](https://github.com/CommandCodeAI/command-code) | `~/.commandcode/projects/**/*.jsonl`（トークン使用量はトランスクリプトから約4文字/トークンで推定；ディスクには永続化されない） | ✅ 対応 |
+| <img width="48px" src="https://github.com/zai-org.png" alt="ZCode" /> | [ZCode](https://zcode.z.ai/) | `~/.zcode/projects/**/*.jsonl` | ✅ 対応 |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | `hf:`モデルや`synthetic`プロバイダを検出して他ソースから再帰属（+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`） | ✅ 対応 |
 
 [🚅 LiteLLMの価格データ](https://github.com/BerriAI/litellm)を使用してリアルタイム価格計算を提供し、階層型価格モデルとキャッシュトークン割引をサポートしています。
@@ -161,7 +162,7 @@ AI支援開発の時代において、**トークンは新しいエネルギー*
   - 9色テーマのGitHubスタイル貢献グラフ
   - リアルタイムフィルタリングとソート
   - ゼロフリッカーレンダリング
-- **マルチプラットフォームサポート** - OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、Synthetic全体の使用量追跡
+- **マルチプラットフォームサポート** - OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、Synthetic全体の使用量追跡
 - **リアルタイム価格** - 1時間ディスクキャッシュ付きでLiteLLMから現在の価格を取得；OpenRouter自動フォールバックと新規モデル向けCursor価格サポート
 - **詳細な内訳** - 入力、出力、キャッシュ読み書き、推論トークン追跡
 - **ネイティブRustコア** - 10倍高速な処理のため、すべての解析と集計をRustで実行
@@ -372,7 +373,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-利用可能な値: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `synthetic`。
+利用可能な値: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `synthetic`。
 
 > **破壊的変更 (v4.0.0)**: クライアント単位のブール型フラグ（`--opencode`、`--claude`、`--codex` など）は削除され、現在はエラーになります。代わりに正規の `--client`/`-c` フラグを使用してください — 例: `tokscale --client opencode,claude`。
 
@@ -954,7 +955,7 @@ tokscale sources --json
 - **インタラクティブツールチップ**: ホバーで詳細な日別内訳を表示
 - **日別内訳パネル**: クリックでソース別、モデル別の詳細を確認
 - **年別フィルタリング**: 年間を移動
-- **ソースフィルタリング**: プラットフォーム別フィルター（OpenCode、Claude、Codex、Copilot、Cursor、Gemini、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi、Qwen、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、Synthetic）
+- **ソースフィルタリング**: プラットフォーム別フィルター（OpenCode、Claude、Codex、Copilot、Cursor、Gemini、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi、Qwen、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、Synthetic）
 - **統計パネル**: 総コスト、トークン、活動日数、連続記録
 - **FOUC防止**: Reactハイドレーション前にテーマを適用（フラッシュなし）
 
@@ -1291,6 +1292,7 @@ AIコーディングツールはクロスプラットフォームの場所にセ
 | MiMo Code | `~/.local/share/micode/` | `%USERPROFILE%\.local\share\micode\` | XDG データディレクトリを使用；SQLite データベース `mimocode.db` |
 | Gajae-Code | `~/.gjc/agent/sessions/` | `%USERPROFILE%\.gjc\agent\sessions\` | `GJC_CODING_AGENT_DIR` で設定可能（`GJC_CONFIG_DIR`/`PI_CONFIG_DIR` も解決；Linux/macOS では `$XDG_DATA_HOME/gjc/sessions/` も対応） |
 | Junie | `~/.junie/sessions/` | `%USERPROFILE%\.junie\sessions\` | すべてのプラットフォームで同じホーム相対パス；`events.jsonl` 使用イベントを解析 |
+| ZCode | `~/.zcode/projects/` | `%USERPROFILE%.zcodeprojects` | `*.jsonl` セッショントランスクリプトを解析；Z.ai の GLM モデル向け ADE |
 | Synthetic | 他ソースから再帰属 | 他ソースから再帰属 | `hf:`モデル + `synthetic`プロバイダを検出 |
 
 > **注**: Windowsでは`~`は`%USERPROFILE%`に展開されます（例：`C:\Users\ユーザー名`）。これらのツールは`%APPDATA%`のようなWindowsネイティブパスではなく、クロスプラットフォームの一貫性のためにUnixスタイルのパス（`.local/share`など）を意図的に使用しています。

--- a/README.ja.md
+++ b/README.ja.md
@@ -1292,7 +1292,7 @@ AIコーディングツールはクロスプラットフォームの場所にセ
 | MiMo Code | `~/.local/share/micode/` | `%USERPROFILE%\.local\share\micode\` | XDG データディレクトリを使用；SQLite データベース `mimocode.db` |
 | Gajae-Code | `~/.gjc/agent/sessions/` | `%USERPROFILE%\.gjc\agent\sessions\` | `GJC_CODING_AGENT_DIR` で設定可能（`GJC_CONFIG_DIR`/`PI_CONFIG_DIR` も解決；Linux/macOS では `$XDG_DATA_HOME/gjc/sessions/` も対応） |
 | Junie | `~/.junie/sessions/` | `%USERPROFILE%\.junie\sessions\` | すべてのプラットフォームで同じホーム相対パス；`events.jsonl` 使用イベントを解析 |
-| ZCode | `~/.zcode/projects/` | `%USERPROFILE%.zcodeprojects` | `*.jsonl` セッショントランスクリプトを解析；Z.ai の GLM モデル向け ADE |
+| ZCode | `~/.zcode/projects/` | `%USERPROFILE%\.zcode\projects\` | `*.jsonl` セッショントランスクリプトを解析；Z.ai の GLM モデル向け ADE |
 | Synthetic | 他ソースから再帰属 | 他ソースから再帰属 | `hf:`モデル + `synthetic`プロバイダを検出 |
 
 > **注**: Windowsでは`~`は`%USERPROFILE%`に展開されます（例：`C:\Users\ユーザー名`）。これらのツールは`%APPDATA%`のようなWindowsネイティブパスではなく、クロスプラットフォームの一貫性のためにUnixスタイルのパス（`.local/share`など）を意図的に使用しています。

--- a/README.ko.md
+++ b/README.ko.md
@@ -88,6 +88,7 @@
 | <img width="48px" src="https://github.com/XiaomiMiMo.png" alt="MiMo Code" /> | [MiMo Code](https://github.com/XiaomiMiMo/MiMo-Code) | `~/.local/share/micode/mimocode.db` (XDG 데이터 디렉토리; SQLite) | ✅ 지원 |
 | <img width="48px" src="https://github.com/JetBrains.png" alt="Junie" /> | [Junie](https://www.jetbrains.com/junie/) | `~/.junie/sessions/*/events.jsonl` | ✅ 지원 |
 | <img width="48px" src="https://raw.githubusercontent.com/CommandCodeAI/command-code/main/.github/commandcode/logo/command-code-logo-black-bg.png" alt="Command Code" /> | [Command Code](https://github.com/CommandCodeAI/command-code) | `~/.commandcode/projects/**/*.jsonl` (토큰 사용량은 트랜스크립트에서 토큰당 약 4자 기준으로 추정; 디스크에 저장되지 않음) | ✅ 지원 |
+| <img width="48px" src="https://github.com/zai-org.png" alt="ZCode" /> | [ZCode](https://zcode.z.ai/) | `~/.zcode/projects/**/*.jsonl` | ✅ 지원 |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | `hf:` 모델/`synthetic` provider 감지로 다른 소스에서 재귀속 (+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`) | ✅ 지원 |
 
 [🚅 LiteLLM의 가격 데이터](https://github.com/BerriAI/litellm)를 사용해 **실시간 비용 계산**을 제공합니다. 구간별 가격 모델(대용량 컨텍스트 등)과 **캐시 토큰 할인**도 지원합니다.
@@ -159,7 +160,7 @@ AI 지원 개발 시대에 **토큰은 새로운 에너지**입니다. 토큰은
   - 9가지 테마의 GitHub 스타일 기여 그래프
   - 실시간 필터링 및 정렬
   - 깜빡임 없는 렌더링
-- **멀티 플랫폼 지원** - OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, Synthetic 사용량 통합 추적
+- **멀티 플랫폼 지원** - OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, Synthetic 사용량 통합 추적
 - **실시간 가격 반영** - LiteLLM에서 최신 가격을 가져와(디스크 캐시 1시간) 비용 계산; OpenRouter 자동 폴백 및 신규 모델용 Cursor 가격 지원
 - **상세 분석** - 입력, 출력, 캐시 읽기/쓰기, 추론 토큰까지 추적
 - **네이티브 Rust 코어** - 모든 파싱과 집계를 Rust로 처리해 최대 10배 빠른 성능
@@ -368,7 +369,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-가능한 값: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `synthetic`.
+가능한 값: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `synthetic`.
 
 > **Breaking change (v4.0.0):** 클라이언트별 boolean 플래그(`--opencode`, `--claude`, `--codex` 등)는 제거되었으며 이제 오류를 발생시킵니다. 대신 정식 `--client`/`-c` 플래그를 사용하세요 — 예: `tokscale --client opencode,claude`.
 
@@ -958,7 +959,7 @@ tokscale sources --json
 - **인터랙티브 툴팁**: 호버 시 상세 일별 분석 표시
 - **일별 분석 패널**: 클릭하여 소스별, 모델별 세부사항 확인
 - **연도 필터링**: 연도 간 탐색
-- **소스 필터링**: 플랫폼별 필터 (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, Synthetic)
+- **소스 필터링**: 플랫폼별 필터 (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, Synthetic)
 - **통계 패널**: 총 비용, 토큰, 활동 일수, 연속 기록
 - **FOUC 방지**: React 하이드레이션 전 테마 적용 (깜빡임 없음)
 
@@ -1297,6 +1298,7 @@ AI 코딩 도구들은 크로스 플랫폼 위치에 세션 데이터를 저장�
 | MiMo Code | `~/.local/share/micode/` | `%USERPROFILE%\.local\share\micode\` | XDG 데이터 디렉토리 사용; SQLite 데이터베이스 `mimocode.db` |
 | Gajae-Code | `~/.gjc/agent/sessions/` | `%USERPROFILE%\.gjc\agent\sessions\` | `GJC_CODING_AGENT_DIR`로 설정 가능 (`GJC_CONFIG_DIR`/`PI_CONFIG_DIR`도 지원; Linux/macOS에서는 `$XDG_DATA_HOME/gjc/sessions/`도 확인) |
 | Junie | `~/.junie/sessions/` | `%USERPROFILE%\.junie\sessions\` | 모든 플랫폼에서 동일한 home 상대 경로 사용; `events.jsonl` 사용 이벤트 파싱 |
+| ZCode | `~/.zcode/projects/` | `%USERPROFILE%.zcodeprojects` | `*.jsonl` 세션 트랜스크립트 파싱; Z.ai의 GLM 모델용 ADE |
 | Synthetic | 다른 소스에서 재귀속 | 다른 소스에서 재귀속 | `hf:` 모델 접두사 + `synthetic` provider 감지 |
 
 > **참고**: Windows에서 `~`는 `%USERPROFILE%`로 확장됩니다 (예: `C:\Users\사용자이름`). 이러한 도구들은 `%APPDATA%`와 같은 Windows 기본 경로 대신 크로스 플랫폼 일관성을 위해 의도적으로 Unix 스타일 경로(`.local/share` 등)를 사용합니다.

--- a/README.ko.md
+++ b/README.ko.md
@@ -1298,7 +1298,7 @@ AI 코딩 도구들은 크로스 플랫폼 위치에 세션 데이터를 저장�
 | MiMo Code | `~/.local/share/micode/` | `%USERPROFILE%\.local\share\micode\` | XDG 데이터 디렉토리 사용; SQLite 데이터베이스 `mimocode.db` |
 | Gajae-Code | `~/.gjc/agent/sessions/` | `%USERPROFILE%\.gjc\agent\sessions\` | `GJC_CODING_AGENT_DIR`로 설정 가능 (`GJC_CONFIG_DIR`/`PI_CONFIG_DIR`도 지원; Linux/macOS에서는 `$XDG_DATA_HOME/gjc/sessions/`도 확인) |
 | Junie | `~/.junie/sessions/` | `%USERPROFILE%\.junie\sessions\` | 모든 플랫폼에서 동일한 home 상대 경로 사용; `events.jsonl` 사용 이벤트 파싱 |
-| ZCode | `~/.zcode/projects/` | `%USERPROFILE%.zcodeprojects` | `*.jsonl` 세션 트랜스크립트 파싱; Z.ai의 GLM 모델용 ADE |
+| ZCode | `~/.zcode/projects/` | `%USERPROFILE%\.zcode\projects\` | `*.jsonl` 세션 트랜스크립트 파싱; Z.ai의 GLM 모델용 ADE |
 | Synthetic | 다른 소스에서 재귀속 | 다른 소스에서 재귀속 | `hf:` 모델 접두사 + `synthetic` provider 감지 |
 
 > **참고**: Windows에서 `~`는 `%USERPROFILE%`로 확장됩니다 (예: `C:\Users\사용자이름`). 이러한 도구들은 `%APPDATA%`와 같은 Windows 기본 경로 대신 크로스 플랫폼 일관성을 위해 의도적으로 Unix 스타일 경로(`.local/share` 등)를 사용합니다.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
   - GitHub-style contribution graph with 9 color themes
   - Real-time filtering and sorting
   - Zero flicker rendering
-- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes runtime, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, and Synthetic
+- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, and Synthetic
 - **Real-time pricing** - Fetches current pricing from LiteLLM with 1-hour disk cache; automatic OpenRouter fallback and Cursor model pricing for newly released models
 - **Detailed breakdowns** - Input, output, cache read/write, and reasoning token tracking
 - **Native Rust core** - All parsing and aggregation done in Rust for 10x faster processing
@@ -964,7 +964,7 @@ The frontend provides a GitHub-style contribution graph visualization:
 - **Interactive tooltips**: Hover for detailed daily breakdowns
 - **Day breakdown panel**: Click to see per-source and per-model details
 - **Year filtering**: Navigate between years
-- **Source filtering**: Filter by platform (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes runtime, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, ZCode, Synthetic)
+- **Source filtering**: Filter by platform (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, Synthetic)
 - **Stats panel**: Total cost, tokens, active days, streaks
 - **FOUC prevention**: Theme applied before React hydrates (no flash)
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@
 | <img width="48px" src="https://github.com/XiaomiMiMo.png" alt="MiMo Code" /> | [MiMo Code](https://github.com/XiaomiMiMo/MiMo-Code) | `~/.local/share/micode/mimocode.db` (XDG data dir; SQLite) | ✅ Yes |
 | <img width="48px" src="https://github.com/JetBrains.png" alt="Junie" /> | [Junie](https://www.jetbrains.com/junie/) | `~/.junie/sessions/*/events.jsonl` | ✅ Yes |
 | <img width="48px" src="https://raw.githubusercontent.com/CommandCodeAI/command-code/main/.github/commandcode/logo/command-code-logo-black-bg.png" alt="Command Code" /> | [Command Code](https://github.com/CommandCodeAI/command-code) | `~/.commandcode/projects/**/*.jsonl` (token usage estimated from transcripts at ~4 chars/token; not persisted on disk) | ✅ Yes |
+| <img width="48px" src="https://github.com/zai-org.png" alt="ZCode" /> | [ZCode](https://zcode.z.ai/) | `~/.zcode/projects/**/*.jsonl` | ✅ Yes |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | Re-attributed from other sources via `hf:` model prefix or `synthetic` provider (+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`) | ✅ Yes |
 
 Get real-time pricing calculations using [🚅 LiteLLM's pricing data](https://github.com/BerriAI/litellm), with support for tiered pricing models and cache token discounts.
@@ -159,7 +160,7 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
   - GitHub-style contribution graph with 9 color themes
   - Real-time filtering and sorting
   - Zero flicker rendering
-- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, and Synthetic
+- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes runtime, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, and Synthetic
 - **Real-time pricing** - Fetches current pricing from LiteLLM with 1-hour disk cache; automatic OpenRouter fallback and Cursor model pricing for newly released models
 - **Detailed breakdowns** - Input, output, cache read/write, and reasoning token tracking
 - **Native Rust core** - All parsing and aggregation done in Rust for 10x faster processing
@@ -370,7 +371,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-Possible values: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `synthetic`.
+Possible values: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `synthetic`.
 
 > **Breaking change (v4.0.0):** The per-client boolean flags (`--opencode`, `--claude`, `--codex`, etc.) have been removed and now error. Use the canonical `--client`/`-c` flag instead — e.g. `tokscale --client opencode,claude`.
 
@@ -963,7 +964,7 @@ The frontend provides a GitHub-style contribution graph visualization:
 - **Interactive tooltips**: Hover for detailed daily breakdowns
 - **Day breakdown panel**: Click to see per-source and per-model details
 - **Year filtering**: Navigate between years
-- **Source filtering**: Filter by platform (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, Synthetic)
+- **Source filtering**: Filter by platform (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes runtime, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, ZCode, Synthetic)
 - **Stats panel**: Total cost, tokens, active days, streaks
 - **FOUC prevention**: Theme applied before React hydrates (no flash)
 
@@ -1302,6 +1303,7 @@ AI coding tools store their session data in cross-platform locations. Most tools
 | MiMo Code | `~/.local/share/micode/` | `%USERPROFILE%\.local\share\micode\` | Uses XDG data directory; SQLite database `mimocode.db` |
 | Gajae-Code | `~/.gjc/agent/sessions/` | `%USERPROFILE%\.gjc\agent\sessions\` | Configurable via `GJC_CODING_AGENT_DIR` (also `GJC_CONFIG_DIR`/`PI_CONFIG_DIR`; `$XDG_DATA_HOME/gjc/sessions/` flattens on Linux/macOS) |
 | Junie | `~/.junie/sessions/` | `%USERPROFILE%\.junie\sessions\` | Same home-relative path on all platforms; parses `events.jsonl` usage events |
+| ZCode | `~/.zcode/projects/` | `%USERPROFILE%\.zcode\projects\` | Parses `*.jsonl` session transcripts; Z.ai's ADE for GLM models |
 | Synthetic | Re-attributed from other sources | Re-attributed from other sources | Detects `hf:` model prefix + `synthetic` provider |
 
 > **Note**: On Windows, `~` expands to `%USERPROFILE%` (e.g., `C:\Users\YourName`). These tools intentionally use Unix-style paths (like `.local/share`) even on Windows for cross-platform consistency, rather than Windows-native paths like `%APPDATA%`.

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -89,6 +89,7 @@
 | <img width="48px" src="https://github.com/XiaomiMiMo.png" alt="MiMo Code" /> | [MiMo Code](https://github.com/XiaomiMiMo/MiMo-Code) | `~/.local/share/micode/mimocode.db`（XDG 数据目录；SQLite） | ✅ 支持 |
 | <img width="48px" src="https://github.com/JetBrains.png" alt="Junie" /> | [Junie](https://www.jetbrains.com/junie/) | `~/.junie/sessions/*/events.jsonl` | ✅ 支持 |
 | <img width="48px" src="https://raw.githubusercontent.com/CommandCodeAI/command-code/main/.github/commandcode/logo/command-code-logo-black-bg.png" alt="Command Code" /> | [Command Code](https://github.com/CommandCodeAI/command-code) | `~/.commandcode/projects/**/*.jsonl`（Token 使用量按 ~4 字符/Token 从转录估算；不会持久化到磁盘） | ✅ 支持 |
+| <img width="48px" src="https://github.com/zai-org.png" alt="ZCode" /> | [ZCode](https://zcode.z.ai/) | `~/.zcode/projects/**/*.jsonl` | ✅ 支持 |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | 通过 `hf:` 模型前缀或 `synthetic` provider 从其他来源重归属（+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`） | ✅ 支持 |
 
 使用 [🚅 LiteLLM 的价格数据](https://github.com/BerriAI/litellm)提供实时价格计算，支持分层定价模型和缓存 Token 折扣。
@@ -159,7 +160,7 @@
   - 9 种颜色主题的 GitHub 风格贡献图
   - 实时筛选和排序
   - 零闪烁渲染
-- **多平台支持** - 跟踪 OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie 和 Synthetic 的使用情况
+- **多平台支持** - 跟踪 OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode 和 Synthetic 的使用情况
 - **实时定价** - 从 LiteLLM 获取当前价格，带 1 小时磁盘缓存；OpenRouter 自动回退和新模型的 Cursor 定价支持
 - **详细分解** - 输入、输出、缓存读写和推理 Token 跟踪
 - **原生 Rust 核心** - 所有解析和聚合在 Rust 中完成，处理速度提升 10 倍
@@ -369,7 +370,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-可用值：`opencode`、`claude`、`codex`、`copilot`、`gemini`、`cursor`、`amp`、`codebuff`、`droid`、`openclaw`、`hermes`、`pi`、`kimi`、`qwen`、`roocode`、`kilocode`、`kilo`、`mux`、`crush`、`goose`、`antigravity`、`antigravity-cli`、`zed`、`kiro`、`trae`、`warp`、`cline`、`gjc`、`grok`、`jcode`、`micode`、`commandcode`、`junie`、`synthetic`。
+可用值：`opencode`、`claude`、`codex`、`copilot`、`gemini`、`cursor`、`amp`、`codebuff`、`droid`、`openclaw`、`hermes`、`pi`、`kimi`、`qwen`、`roocode`、`kilocode`、`kilo`、`mux`、`crush`、`goose`、`antigravity`、`antigravity-cli`、`zed`、`kiro`、`trae`、`warp`、`cline`、`gjc`、`grok`、`jcode`、`micode`、`commandcode`、`junie`、`zcode`、`synthetic`。
 
 > **破坏性变更（v4.0.0）**：单客户端布尔选项（`--opencode`、`--claude`、`--codex` 等）已被移除，现在会直接报错。请改用规范的 `--client`/`-c` 选项——例如 `tokscale --client opencode,claude`。
 
@@ -954,7 +955,7 @@ tokscale sources --json
 - **交互式提示**：悬停查看详细的每日分解
 - **每日分解面板**：点击查看每个来源和模型的详情
 - **年份筛选**：在年份之间导航
-- **来源筛选**：按平台筛选（OpenCode、Claude、Codex、Copilot、Cursor、Gemini、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi、Qwen、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、Synthetic）
+- **来源筛选**：按平台筛选（OpenCode、Claude、Codex、Copilot、Cursor、Gemini、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi、Qwen、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、Synthetic）
 - **统计面板**：总成本、Token、活跃天数、连续记录
 - **FOUC 防护**：在 React 水合前应用主题（无闪烁）
 
@@ -1289,6 +1290,7 @@ AI 编程工具将会话数据存储在跨平台位置。大多数工具在所�
 | MiMo Code | `~/.local/share/micode/` | `%USERPROFILE%\.local\share\micode\` | 使用 XDG 数据目录；SQLite 数据库 `mimocode.db` |
 | Gajae-Code | `~/.gjc/agent/sessions/` | `%USERPROFILE%\.gjc\agent\sessions\` | 可通过 `GJC_CODING_AGENT_DIR`（也可用 `GJC_CONFIG_DIR`/`PI_CONFIG_DIR`；Linux/macOS 上 `$XDG_DATA_HOME/gjc/sessions/` 亦支持）配置 |
 | Junie | `~/.junie/sessions/` | `%USERPROFILE%\.junie\sessions\` | 所有平台使用相同的 home 相对路径；解析 `events.jsonl` 使用事件 |
+| ZCode | `~/.zcode/projects/` | `%USERPROFILE%.zcodeprojects` | 解析 `*.jsonl` 会话记录；Z.ai 的 GLM 模型专用 ADE |
 | Synthetic | 从其他来源重归属 | 从其他来源重归属 | 检测 `hf:` 模型前缀 + `synthetic` provider |
 
 > **注意**：在 Windows 上，`~` 扩展为 `%USERPROFILE%`（例如 `C:\Users\用户名`）。这些工具故意使用 Unix 风格的路径（如 `.local/share`）而不是 Windows 原生路径（如 `%APPDATA%`），以实现跨平台一致性。

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -1290,7 +1290,7 @@ AI 编程工具将会话数据存储在跨平台位置。大多数工具在所�
 | MiMo Code | `~/.local/share/micode/` | `%USERPROFILE%\.local\share\micode\` | 使用 XDG 数据目录；SQLite 数据库 `mimocode.db` |
 | Gajae-Code | `~/.gjc/agent/sessions/` | `%USERPROFILE%\.gjc\agent\sessions\` | 可通过 `GJC_CODING_AGENT_DIR`（也可用 `GJC_CONFIG_DIR`/`PI_CONFIG_DIR`；Linux/macOS 上 `$XDG_DATA_HOME/gjc/sessions/` 亦支持）配置 |
 | Junie | `~/.junie/sessions/` | `%USERPROFILE%\.junie\sessions\` | 所有平台使用相同的 home 相对路径；解析 `events.jsonl` 使用事件 |
-| ZCode | `~/.zcode/projects/` | `%USERPROFILE%.zcodeprojects` | 解析 `*.jsonl` 会话记录；Z.ai 的 GLM 模型专用 ADE |
+| ZCode | `~/.zcode/projects/` | `%USERPROFILE%\.zcode\projects\` | 解析 `*.jsonl` 会话记录；Z.ai 的 GLM 模型专用 ADE |
 | Synthetic | 从其他来源重归属 | 从其他来源重归属 | 检测 `hf:` 模型前缀 + `synthetic` provider |
 
 > **注意**：在 Windows 上，`~` 扩展为 `%USERPROFILE%`（例如 `C:\Users\用户名`）。这些工具故意使用 Unix 风格的路径（如 `.local/share`）而不是 Windows 原生路径（如 `%APPDATA%`），以实现跨平台一致性。

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -894,6 +894,7 @@ pub enum ClientFilter {
     #[value(name = "antigravity-cli")]
     AntigravityCli,
     Junie,
+    Zcode,
     Synthetic,
 }
 
@@ -936,6 +937,7 @@ impl ClientFilter {
             Self::Micode => "micode",
             Self::AntigravityCli => "antigravity-cli",
             Self::Junie => "junie",
+            Self::Zcode => "zcode",
             Self::Synthetic => "synthetic",
         }
     }
@@ -981,6 +983,7 @@ impl ClientFilter {
             Self::Micode => Some(ClientId::MiMoCode),
             Self::AntigravityCli => Some(ClientId::AntigravityCli),
             Self::Junie => Some(ClientId::Junie),
+            Self::Zcode => Some(ClientId::Zcode),
             Self::Synthetic => None,
         }
     }
@@ -1023,6 +1026,7 @@ impl ClientFilter {
             ClientId::MiMoCode => Self::Micode,
             ClientId::AntigravityCli => Self::AntigravityCli,
             ClientId::Junie => Self::Junie,
+            ClientId::Zcode => Self::Zcode,
         }
     }
 
@@ -3502,6 +3506,7 @@ fn capitalize_client(client: &str) -> String {
         "jcode" => "Jcode".to_string(),
         "commandcode" => "Command Code".to_string(),
         "junie" => "Junie".to_string(),
+        "zcode" => "ZCode".to_string(),
         other => other.to_string(),
     }
 }

--- a/crates/tokscale-cli/src/tui/client_ui.rs
+++ b/crates/tokscale-cli/src/tui/client_ui.rs
@@ -138,6 +138,10 @@ pub const CLIENT_UI: [ClientUi; ClientId::COUNT] = [
         display_name: "Junie",
         hotkey: 'p',
     },
+    ClientUi {
+        display_name: "ZCode",
+        hotkey: 'q',
+    },
 ];
 
 pub fn display_name(client: ClientId) -> &'static str {

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -495,6 +495,15 @@ define_clients!(
         headless: false,
         parse_local: true,
         submit_default: true
+    },
+    Zcode = 33 => {
+        id: "zcode",
+        root: PathRoot::Home,
+        relative: ".zcode/projects",
+        pattern: "*.jsonl",
+        headless: false,
+        parse_local: true,
+        submit_default: true
     }
 );
 
@@ -547,7 +556,7 @@ mod tests {
 
     #[test]
     fn test_client_id_count() {
-        assert_eq!(ClientId::COUNT, 33);
+        assert_eq!(ClientId::COUNT, 34);
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1275,6 +1275,23 @@ fn parse_all_messages_with_pricing_with_env_strategy(
             .filter(|message| should_keep_deduped_message(&mut junie_seen, message)),
     );
 
+    // ZCode (Z.ai GLM-5.2 ADE) JSONL sessions. Token usage may be embedded
+    // from the API response; otherwise estimated from content.
+    let zcode_messages: Vec<UnifiedMessage> = scan_result
+        .get(ClientId::Zcode)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::zcode::parse_zcode_file(path)
+                .into_iter()
+                .map(|mut msg| {
+                    apply_pricing_if_available(&mut msg, pricing);
+                    msg
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    all_messages.extend(zcode_messages);
+
     let kimi_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::Kimi)
         .par_iter()
@@ -2511,6 +2528,17 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     let junie_count = summed_parsed_message_count(&junie_msgs);
     counts.set(ClientId::Junie, junie_count);
     messages.extend(junie_msgs);
+
+    // ZCode (Z.ai GLM-5.2 ADE) session transcripts
+    let zcode_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::Zcode)
+        .par_iter()
+        .flat_map(|path| sessions::zcode::parse_zcode_file(path))
+        .map(|message| unified_to_parsed(&message))
+        .collect();
+    let zcode_count = summed_parsed_message_count(&zcode_msgs);
+    counts.set(ClientId::Zcode, zcode_count);
+    messages.extend(zcode_msgs);
 
     // Parse Kimi wire.jsonl files in parallel
     let kimi_msgs: Vec<ParsedMessage> = scan_result

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -36,6 +36,7 @@ pub mod synthetic;
 pub mod trae;
 pub(crate) mod utils;
 pub mod warp;
+pub mod zcode;
 pub mod zed;
 
 use crate::TokenBreakdown;

--- a/crates/tokscale-core/src/sessions/zcode.rs
+++ b/crates/tokscale-core/src/sessions/zcode.rs
@@ -1,0 +1,363 @@
+//! ZCode (z.ai) session parser
+//!
+//! Parses JSONL transcripts from `~/.zcode/projects/<slug>/<session>.jsonl`.
+//!
+//! ZCode is Z.ai's Agentic Development Environment (ADE), an Electron-based
+//! desktop IDE deeply adapted for the GLM-5.2 model family. Session
+//! transcripts follow a JSONL format similar to Claude Code, with each line
+//! containing role/content metadata. Token usage may be embedded per-message
+//! from the Z.ai API response.
+//!
+//! When token usage is present in the transcript (fields like `usage`,
+//! `token_usage`, or `input_tokens`/`output_tokens`), those authoritative
+//! counts are used. When absent, tokens are estimated at ~4 chars/token,
+//! consistent with tokscale's other estimated sources (see CommandCode, Kiro).
+
+use super::utils::file_modified_timestamp_ms;
+use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
+use crate::TokenBreakdown;
+use serde::Deserialize;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+const CLIENT_ID: &str = "zcode";
+const PROVIDER_ID: &str = "zhipu";
+const UNKNOWN_MODEL: &str = "glm-5.2";
+
+/// A single JSONL line in a ZCode session transcript.
+#[derive(Debug, Deserialize)]
+struct ZcodeEntry {
+    role: Option<String>,
+    content: Option<serde_json::Value>,
+    #[serde(default)]
+    usage: Option<ZcodeUsage>,
+    #[serde(default)]
+    token_usage: Option<ZcodeUsage>,
+    model: Option<String>,
+    timestamp: Option<String>,
+    #[serde(rename = "sessionId")]
+    session_id: Option<String>,
+}
+
+/// Token usage block — field names follow the Z.ai / GLM API convention.
+#[derive(Debug, Deserialize)]
+struct ZcodeUsage {
+    #[serde(alias = "input_tokens", alias = "prompt_tokens")]
+    input: Option<i64>,
+    #[serde(alias = "output_tokens", alias = "completion_tokens")]
+    output: Option<i64>,
+    #[serde(alias = "input_cache_read", alias = "cache_read_tokens")]
+    cache_read: Option<i64>,
+    #[serde(alias = "input_cache_creation", alias = "cache_write_tokens")]
+    cache_write: Option<i64>,
+    #[serde(default)]
+    reasoning: Option<i64>,
+}
+
+impl ZcodeUsage {
+    fn to_breakdown(&self) -> Option<TokenBreakdown> {
+        let input = self.input.unwrap_or(0).max(0);
+        let output = self.output.unwrap_or(0).max(0);
+        let cache_read = self.cache_read.unwrap_or(0).max(0);
+        let cache_write = self.cache_write.unwrap_or(0).max(0);
+        let reasoning = self.reasoning.unwrap_or(0).max(0);
+
+        if input + output + cache_read + cache_write + reasoning == 0 {
+            return None;
+        }
+
+        Some(TokenBreakdown {
+            input,
+            output,
+            cache_read,
+            cache_write,
+            reasoning,
+        })
+    }
+}
+
+pub fn parse_zcode_file(path: &Path) -> Vec<UnifiedMessage> {
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(_) => return Vec::new(),
+    };
+
+    let fallback_timestamp = file_modified_timestamp_ms(path);
+    let session_id_from_path = session_id_from_path(path);
+    let workspace_key = workspace_key_from_path(path);
+    let workspace_label = workspace_key.as_deref().and_then(workspace_label_from_key);
+
+    let mut messages = Vec::new();
+    let mut session_id: Option<String> = None;
+    let mut model_id: Option<String> = None;
+    // Running char count for token estimation fallback.
+    let mut context_chars: usize = 0;
+    let mut pending_turn_start = false;
+    let mut assistant_index = 0usize;
+
+    let reader = BufReader::new(file);
+    for line in reader.lines() {
+        let line = match line {
+            Ok(line) => line,
+            Err(_) => continue,
+        };
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let entry = match serde_json::from_str::<ZcodeEntry>(trimmed) {
+            Ok(entry) => entry,
+            Err(_) => continue,
+        };
+
+        if session_id.is_none() {
+            if let Some(id) = entry.session_id.as_deref().filter(|id| !id.is_empty()) {
+                session_id = Some(id.to_string());
+            }
+        }
+
+        if model_id.is_none() {
+            if let Some(m) = entry.model.as_deref().filter(|m| !m.is_empty()) {
+                model_id = Some(canonicalize_model(m));
+            }
+        }
+
+        let resolved_model = model_id.as_deref().unwrap_or(UNKNOWN_MODEL).to_string();
+        let chars = entry.content.as_ref().map(content_chars).unwrap_or(0);
+
+        // Prefer authoritative token usage from the API.
+        let usage = entry.usage.as_ref().or(entry.token_usage.as_ref());
+
+        match entry.role.as_deref() {
+            Some("assistant") => {
+                let breakdown = if let Some(u) = usage.and_then(|u| u.to_breakdown()) {
+                    u
+                } else {
+                    // Estimate from content.
+                    let input = estimate_tokens(context_chars);
+                    let output = estimate_tokens(chars);
+                    if input + output == 0 {
+                        context_chars += chars;
+                        pending_turn_start = false;
+                        continue;
+                    }
+                    TokenBreakdown {
+                        input,
+                        output,
+                        cache_read: 0,
+                        cache_write: 0,
+                        reasoning: 0,
+                    }
+                };
+
+                context_chars += chars;
+                let resolved_session = session_id
+                    .clone()
+                    .unwrap_or_else(|| session_id_from_path.clone());
+                let timestamp = entry
+                    .timestamp
+                    .as_deref()
+                    .and_then(parse_rfc3339_ms)
+                    .unwrap_or(fallback_timestamp);
+
+                let mut message = UnifiedMessage::new_with_dedup(
+                    CLIENT_ID,
+                    resolved_model,
+                    PROVIDER_ID,
+                    resolved_session.clone(),
+                    timestamp,
+                    breakdown,
+                    0.0,
+                    Some(format!("{}:{}", resolved_session, assistant_index)),
+                );
+                message.message_count = 1;
+                message.is_turn_start = pending_turn_start;
+                message.set_workspace(workspace_key.clone(), workspace_label.clone());
+                messages.push(message);
+
+                assistant_index += 1;
+                pending_turn_start = false;
+            }
+            Some("user") => {
+                pending_turn_start = true;
+                context_chars += chars;
+            }
+            _ => {
+                context_chars += chars;
+            }
+        }
+    }
+
+    messages
+}
+
+/// Canonicalize ZCode model ids. ZCode reports GLM model names in various
+/// forms (e.g. "glm-5.2", "GLM-5.2", "glm-5-turbo"); normalize to lowercase
+/// canonical form for pricing lookup.
+fn canonicalize_model(model: &str) -> String {
+    model.to_lowercase()
+}
+
+/// Char count of a message's `content` for token estimation.
+fn content_chars(content: &serde_json::Value) -> usize {
+    match content {
+        serde_json::Value::Null => 0,
+        serde_json::Value::Array(items) if items.is_empty() => 0,
+        serde_json::Value::Object(map) if map.is_empty() => 0,
+        _ => serde_json::to_string(content)
+            .map(|serialized| serialized.chars().count())
+            .unwrap_or(0),
+    }
+}
+
+fn estimate_tokens(chars: usize) -> i64 {
+    chars.div_ceil(4) as i64
+}
+
+fn parse_rfc3339_ms(timestamp: &str) -> Option<i64> {
+    chrono::DateTime::parse_from_rfc3339(timestamp)
+        .ok()
+        .map(|dt| dt.timestamp_millis())
+}
+
+fn session_id_from_path(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+fn workspace_key_from_path(path: &Path) -> Option<String> {
+    path.parent()
+        .and_then(|dir| dir.file_name())
+        .and_then(|name| name.to_str())
+        .and_then(normalize_workspace_key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn write_session(dir: &TempDir, slug: &str, session: &str, jsonl: &str) -> std::path::PathBuf {
+        let project_dir = dir.path().join("projects").join(slug);
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let path = project_dir.join(format!("{session}.jsonl"));
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(jsonl.as_bytes()).unwrap();
+        path
+    }
+
+    #[test]
+    fn test_parse_with_authoritative_usage() {
+        let dir = TempDir::new().unwrap();
+        let jsonl = format!(
+            "{}\n{}",
+            json!({
+                "role": "user",
+                "sessionId": "s1",
+                "timestamp": "2026-06-20T10:00:00Z",
+                "content": "hello"
+            }),
+            json!({
+                "role": "assistant",
+                "sessionId": "s1",
+                "timestamp": "2026-06-20T10:00:05Z",
+                "model": "glm-5.2",
+                "content": "Hi there!",
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "input_cache_read": 20
+                }
+            }),
+        );
+        let path = write_session(&dir, "proj", "s1", &jsonl);
+        let messages = parse_zcode_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        let msg = &messages[0];
+        assert_eq!(msg.client, "zcode");
+        assert_eq!(msg.provider_id, "zhipu");
+        assert_eq!(msg.model_id, "glm-5.2");
+        assert_eq!(msg.session_id, "s1");
+        assert_eq!(msg.tokens.input, 100);
+        assert_eq!(msg.tokens.output, 50);
+        assert_eq!(msg.tokens.cache_read, 20);
+        assert!(msg.is_turn_start);
+    }
+
+    #[test]
+    fn test_parse_with_estimated_tokens() {
+        let dir = TempDir::new().unwrap();
+        let user_content = json!([{"type": "text", "text": "12345678"}]);
+        let asst_content = json!([{"type": "text", "text": "abcd"}]);
+        let jsonl = format!(
+            "{}\n{}",
+            json!({"role": "user", "sessionId": "s2", "content": user_content}),
+            json!({"role": "assistant", "sessionId": "s2", "content": asst_content}),
+        );
+        let path = write_session(&dir, "repo", "s2", &jsonl);
+        let messages = parse_zcode_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        let msg = &messages[0];
+        assert_eq!(msg.model_id, "glm-5.2"); // default
+        assert!(msg.tokens.input > 0);
+        assert!(msg.tokens.output > 0);
+        assert_eq!(msg.tokens.cache_read, 0);
+    }
+
+    #[test]
+    fn test_canonicalize_model() {
+        assert_eq!(canonicalize_model("GLM-5.2"), "glm-5.2");
+        assert_eq!(canonicalize_model("GLM-5-Turbo"), "glm-5-turbo");
+        assert_eq!(canonicalize_model("glm-5.2"), "glm-5.2");
+    }
+
+    #[test]
+    fn test_usage_with_alternative_field_names() {
+        let dir = TempDir::new().unwrap();
+        let jsonl = format!(
+            "{}\n{}",
+            json!({"role": "user", "sessionId": "s3", "content": "hi"}),
+            json!({
+                "role": "assistant",
+                "sessionId": "s3",
+                "content": "bye",
+                "token_usage": {
+                    "prompt_tokens": 200,
+                    "completion_tokens": 100
+                }
+            }),
+        );
+        let path = write_session(&dir, "p", "s3", &jsonl);
+        let messages = parse_zcode_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 200);
+        assert_eq!(messages[0].tokens.output, 100);
+    }
+
+    #[test]
+    fn test_cumulative_context_estimation() {
+        let dir = TempDir::new().unwrap();
+        let jsonl = concat!(
+            r#"{"role":"user","sessionId":"s","content":[{"type":"text","text":"aaaa"}]}"#,
+            "\n",
+            r#"{"role":"assistant","sessionId":"s","content":[{"type":"text","text":"bbbb"}]}"#,
+            "\n",
+            r#"{"role":"user","sessionId":"s","content":[{"type":"text","text":"cccc"}]}"#,
+            "\n",
+            r#"{"role":"assistant","sessionId":"s","content":[{"type":"text","text":"dddd"}]}"#,
+        );
+        let path = write_session(&dir, "proj", "s", jsonl);
+        let messages = parse_zcode_file(&path);
+
+        assert_eq!(messages.len(), 2);
+        assert!(messages[1].tokens.input > messages[0].tokens.input);
+    }
+}

--- a/crates/tokscale-core/src/sessions/zcode.rs
+++ b/crates/tokscale-core/src/sessions/zcode.rs
@@ -117,29 +117,39 @@ pub fn parse_zcode_file(path: &Path) -> Vec<UnifiedMessage> {
             }
         }
 
-        if model_id.is_none() {
-            if let Some(m) = entry.model.as_deref().filter(|m| !m.is_empty()) {
-                model_id = Some(canonicalize_model(m));
-            }
+        // Track the most-recently-seen model so per-entry pricing reflects the
+        // model in effect at that point in the transcript. When the user
+        // switches models mid-session, later messages must not be priced under
+        // the first model.
+        if let Some(m) = entry.model.as_deref().filter(|m| !m.is_empty()) {
+            model_id = Some(canonicalize_model(m));
         }
 
         let resolved_model = model_id.as_deref().unwrap_or(UNKNOWN_MODEL).to_string();
         let chars = entry.content.as_ref().map(content_chars).unwrap_or(0);
 
-        // Prefer authoritative token usage from the API.
-        let usage = entry.usage.as_ref().or(entry.token_usage.as_ref());
+        // Prefer authoritative token usage from the API. Choose the first block
+        // that actually yields a breakdown, so an empty `usage` does not shadow
+        // a populated `token_usage`.
+        let breakdown_from_usage = entry
+            .usage
+            .as_ref()
+            .and_then(|u| u.to_breakdown())
+            .or_else(|| entry.token_usage.as_ref().and_then(|u| u.to_breakdown()));
 
         match entry.role.as_deref() {
             Some("assistant") => {
-                let breakdown = if let Some(u) = usage.and_then(|u| u.to_breakdown()) {
+                let breakdown = if let Some(u) = breakdown_from_usage {
                     u
                 } else {
                     // Estimate from content.
                     let input = estimate_tokens(context_chars);
                     let output = estimate_tokens(chars);
                     if input + output == 0 {
+                        // Do not consume pending_turn_start here: no message is
+                        // emitted, so the next real assistant message in this
+                        // turn must keep its is_turn_start marker.
                         context_chars += chars;
-                        pending_turn_start = false;
                         continue;
                     }
                     TokenBreakdown {
@@ -359,5 +369,74 @@ mod tests {
 
         assert_eq!(messages.len(), 2);
         assert!(messages[1].tokens.input > messages[0].tokens.input);
+    }
+
+    #[test]
+    fn test_model_switch_mid_session() {
+        let dir = TempDir::new().unwrap();
+        let jsonl = format!(
+            "{}\n{}\n{}\n{}\n{}\n{}",
+            json!({"role": "user", "sessionId": "s", "content": "hi"}),
+            json!({
+                "role": "assistant",
+                "sessionId": "s",
+                "model": "GLM-5.2",
+                "content": "first",
+                "usage": {"input_tokens": 10, "output_tokens": 5}
+            }),
+            json!({"role": "user", "sessionId": "s", "content": "switch"}),
+            json!({
+                "role": "assistant",
+                "sessionId": "s",
+                "model": "glm-5-turbo",
+                "content": "second",
+                "usage": {"input_tokens": 10, "output_tokens": 5}
+            }),
+            json!({"role": "user", "sessionId": "s", "content": "again"}),
+            json!({
+                "role": "assistant",
+                "sessionId": "s",
+                "content": "third",
+                "usage": {"input_tokens": 10, "output_tokens": 5}
+            }),
+        );
+        let path = write_session(&dir, "proj", "s", &jsonl);
+        let messages = parse_zcode_file(&path);
+
+        assert_eq!(messages.len(), 3);
+        // Each assistant message reflects the model in effect at that point.
+        assert_eq!(messages[0].model_id, "glm-5.2");
+        assert_eq!(messages[1].model_id, "glm-5-turbo");
+        assert_ne!(messages[0].model_id, messages[1].model_id);
+        // An entry with no `model` field inherits the most-recently-seen model.
+        assert_eq!(messages[2].model_id, "glm-5-turbo");
+    }
+
+    #[test]
+    fn test_empty_usage_falls_back_to_token_usage() {
+        let dir = TempDir::new().unwrap();
+        let jsonl = format!(
+            "{}\n{}",
+            json!({"role": "user", "sessionId": "s", "content": "hi"}),
+            json!({
+                "role": "assistant",
+                "sessionId": "s",
+                "content": "bye",
+                "usage": {},
+                "token_usage": {
+                    "input_tokens": 321,
+                    "output_tokens": 123,
+                    "input_cache_read": 7
+                }
+            }),
+        );
+        let path = write_session(&dir, "p", "s", &jsonl);
+        let messages = parse_zcode_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        // Authoritative token_usage counts are used, NOT estimated.
+        assert_eq!(messages[0].tokens.input, 321);
+        assert_eq!(messages[0].tokens.output, 123);
+        assert_eq!(messages[0].tokens.cache_read, 7);
     }
 }


### PR DESCRIPTION
## Summary

Adds local session parser for **ZCode** (z.ai's Agentic Development Environment), closing #730.

This is a re-open of #761 (closed by maintainer to address review feedback). All issues are now resolved:

- ✅ **Hotkey conflict fixed** — ZCode hotkey changed from `z` → `q` to avoid collision with Zed (identified by cubic, P1)
- ✅ **Reasoning token check fixed** — `to_breakdown()` now includes reasoning in the non-zero check (identified by cubic, P2)
- ✅ **READMEs updated** — all 4 language files (en/ko/ja/zh-cn)
- ✅ **ClientId::COUNT assertion** updated to 34

---

ZCode is an Electron-based desktop IDE deeply adapted for the GLM-5.2 model family. It stores session transcripts as JSONL files under `~/.zcode/projects/<slug>/<session>.jsonl`.

### Changes

- **`clients.rs`**: Register `Zcode` client (id: `"zcode"`, path: `~/.zcode/projects`, pattern: `*.jsonl`)
- **`sessions/zcode.rs`**: JSONL session parser with dual token strategy:
  - **Authoritative mode**: When `usage`/`token_usage` fields are present (Z.ai API fields like `input_tokens`/`output_tokens`/`input_cache_read`), those exact counts are used
  - **Estimation fallback**: When no token data is stored, tokens are estimated at ~4 chars/token from cumulative context
- **`sessions/mod.rs`**: Register `zcode` module
- **`lib.rs`**: Add dispatch in both full-parse and usage-count paths
- **`main.rs`**: Add `Zcode` to `ClientFilter` enum + all conversion/mapping functions
- **`client_ui.rs`**: Add ZCode to TUI client array (hotkey: `q`)
- **READMEs**: Client table, platform list, `--client` values, source filtering, data location table (all 4 languages)
- Provider: `zhipu`, default model: `glm-5.2`

### Testing

- `cargo fmt` ✅
- `cargo clippy --workspace --all-features -- -D warnings` ✅
- `cargo test -p tokscale-core --lib -- zcode` ✅ (5/5 passed)

Closes #730



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add local session support for ZCode (z.ai’s GLM‑5.2 ADE), parsing `*.jsonl` transcripts from `~/.zcode/projects` with authoritative token usage and a 4‑chars/token fallback. Integrated into parsing, pricing, CLI/TUI, and docs.

- **New Features**
  - Register `Zcode` client (`id: "zcode"`, `~/.zcode/projects`, `*.jsonl`), provider `zhipu`, default model `glm-5.2`.
  - Add `sessions/zcode.rs`: uses `usage`/`token_usage` (input/output/cache*/reasoning) or estimates; canonicalizes model ids.
  - Integrate into parse/pricing in `tokscale-core`; update `ClientId::COUNT` to 34.
  - CLI/TUI: `--client zcode`, listed as “ZCode” (hotkey `q`).
  - Docs: list ZCode and its `--client` value in all READMEs.

- **Bug Fixes**
  - Parsing: resolve model per assistant entry (correctly price mid-session switches), prefer the first usage block that yields tokens (empty `usage` no longer hides `token_usage`), and preserve turn-start when skipping zero-token estimated entries.
  - Docs: fix Windows path separators for ZCode in `ja/ko/zh-cn` READMEs (`%USERPROFILE%\.zcode\projects\`).
  - Docs: restore EN README items accidentally changed (Hermes Agent, Junie) to match other locales.

<sup>Written for commit 37d73245472dc29181599c3020fbb28f4a56c160. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



