### PR TITLE
fix: zcode empty-string content + codex login cancel barrier

### DIFF
--- a/crates/tokscale-cli/src/tui/codex_login.rs
+++ b/crates/tokscale-cli/src/tui/codex_login.rs
@@ -121,6 +121,14 @@ fn run_codex_login_in_home(
         anyhow::bail!("{}", codex_login_failure_message(&status, &output_lines));
     }
 
+    // `wait_for_codex_login_child` only observes cancellation while the child
+    // is still running. If the child exited successfully in the same tick the
+    // user dismissed, re-check the flag before importing — otherwise a
+    // cancelled login would still persist the account to the credentials store.
+    if login_was_cancelled(&child_slot) {
+        anyhow::bail!("Codex login cancelled");
+    }
+
     let auth_path = codex_home.join("auth.json");
     let import = crate::commands::usage::codex::import_login_auth_file(&auth_path)?;
     if let Some(warning) = import.warning {
@@ -142,6 +150,16 @@ fn put_codex_login_child(
         state.child = Some(child);
         Ok(None)
     }
+}
+
+/// Returns whether the login was cancelled (the TUI dismissed the panel or the
+/// app exited). A poisoned lock is treated as cancelled so the worker errs on
+/// the side of not committing a side effect.
+fn login_was_cancelled(child_slot: &CodexLoginChildSlot) -> bool {
+    child_slot
+        .lock()
+        .map(|state| state.cancelled)
+        .unwrap_or(true)
 }
 
 /// Polls the login child until it exits. Returns `Ok(None)` when the TUI
@@ -287,6 +305,17 @@ mod tests {
         cancel_codex_login_child(&slot);
         let status = wait_for_codex_login_child(&slot).unwrap();
         assert!(status.is_none());
+    }
+
+    #[test]
+    fn login_was_cancelled_tracks_cancellation() {
+        let slot = CodexLoginChildSlot::default();
+        // A fresh slot is not cancelled, so the import side effect may proceed.
+        assert!(!login_was_cancelled(&slot));
+        // After a dismiss/exit, the barrier reports cancelled so the worker
+        // bails before importing the account.
+        cancel_codex_login_child(&slot);
+        assert!(login_was_cancelled(&slot));
     }
 
     #[cfg(unix)]

--- a/crates/tokscale-cli/src/tui/codex_login.rs
+++ b/crates/tokscale-cli/src/tui/codex_login.rs
@@ -123,14 +123,15 @@ fn run_codex_login_in_home(
 
     // `wait_for_codex_login_child` only observes cancellation while the child
     // is still running. If the child exited successfully in the same tick the
-    // user dismissed, re-check the flag before importing — otherwise a
-    // cancelled login would still persist the account to the credentials store.
-    if login_was_cancelled(&child_slot) {
-        anyhow::bail!("Codex login cancelled");
-    }
-
+    // user dismissed, the import must not persist the account. The cancelled
+    // check and the import run under the same lock so a concurrent dismiss
+    // cannot slip between the check and the persistent save: either the cancel
+    // wins (we bail before importing) or the import wins (the dismiss blocks
+    // until the save completes, and a successful login is kept).
     let auth_path = codex_home.join("auth.json");
-    let import = crate::commands::usage::codex::import_login_auth_file(&auth_path)?;
+    let Some(import) = import_unless_cancelled(&child_slot, &auth_path)? else {
+        anyhow::bail!("Codex login cancelled");
+    };
     if let Some(warning) = import.warning {
         let _ = tx.send(CodexLoginEvent::Output(warning));
     }
@@ -152,14 +153,26 @@ fn put_codex_login_child(
     }
 }
 
-/// Returns whether the login was cancelled (the TUI dismissed the panel or the
-/// app exited). A poisoned lock is treated as cancelled so the worker errs on
-/// the side of not committing a side effect.
-fn login_was_cancelled(child_slot: &CodexLoginChildSlot) -> bool {
-    child_slot
-        .lock()
-        .map(|state| state.cancelled)
-        .unwrap_or(true)
+/// Imports the login auth file unless the slot was cancelled, holding the slot
+/// lock across the cancelled check and the persistent import so the two are
+/// atomic with respect to [`cancel_codex_login_child`]. Returns `Ok(None)` when
+/// the login was cancelled (so the caller bails without persisting an account);
+/// a poisoned lock is treated as cancelled to err away from a side effect.
+fn import_unless_cancelled(
+    child_slot: &CodexLoginChildSlot,
+    auth_path: &std::path::Path,
+) -> Result<Option<crate::commands::usage::codex::CodexLoginImport>> {
+    let Ok(state) = child_slot.lock() else {
+        return Ok(None);
+    };
+    if state.cancelled {
+        return Ok(None);
+    }
+    // Hold the guard across the import: a concurrent dismiss blocks on the lock
+    // until the save completes, closing the check-then-save race window.
+    let import = crate::commands::usage::codex::import_login_auth_file(auth_path)?;
+    drop(state);
+    Ok(Some(import))
 }
 
 /// Polls the login child until it exits. Returns `Ok(None)` when the TUI
@@ -308,14 +321,21 @@ mod tests {
     }
 
     #[test]
-    fn login_was_cancelled_tracks_cancellation() {
+    fn import_unless_cancelled_short_circuits_when_cancelled() {
+        // When the slot is cancelled, the import must be skipped entirely — it
+        // returns Ok(None) without touching the auth path (so no account is
+        // persisted). A path that does not exist would error if read, proving
+        // the cancelled check short-circuits before the import.
         let slot = CodexLoginChildSlot::default();
-        // A fresh slot is not cancelled, so the import side effect may proceed.
-        assert!(!login_was_cancelled(&slot));
-        // After a dismiss/exit, the barrier reports cancelled so the worker
-        // bails before importing the account.
         cancel_codex_login_child(&slot);
-        assert!(login_was_cancelled(&slot));
+        let missing = std::path::Path::new("/nonexistent/tokscale-codex-login/auth.json");
+
+        let result = import_unless_cancelled(&slot, missing).unwrap();
+
+        assert!(
+            result.is_none(),
+            "cancelled slot must skip the import side effect"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/tokscale-core/src/sessions/zcode.rs
+++ b/crates/tokscale-core/src/sessions/zcode.rs
@@ -213,6 +213,7 @@ fn canonicalize_model(model: &str) -> String {
 fn content_chars(content: &serde_json::Value) -> usize {
     match content {
         serde_json::Value::Null => 0,
+        serde_json::Value::String(s) if s.is_empty() => 0,
         serde_json::Value::Array(items) if items.is_empty() => 0,
         serde_json::Value::Object(map) if map.is_empty() => 0,
         _ => serde_json::to_string(content)
@@ -326,6 +327,35 @@ mod tests {
         assert_eq!(canonicalize_model("GLM-5.2"), "glm-5.2");
         assert_eq!(canonicalize_model("GLM-5-Turbo"), "glm-5-turbo");
         assert_eq!(canonicalize_model("glm-5.2"), "glm-5.2");
+    }
+
+    #[test]
+    fn test_content_chars_treats_empty_string_as_empty() {
+        // Empty string content must count as 0 chars, consistent with null,
+        // empty array, and empty object — otherwise serializing `""` yields 2
+        // chars and produces a spurious estimated token.
+        assert_eq!(content_chars(&json!("")), 0);
+        assert_eq!(content_chars(&serde_json::Value::Null), 0);
+        assert_eq!(content_chars(&json!([])), 0);
+        assert_eq!(content_chars(&json!({})), 0);
+        assert!(content_chars(&json!("abcd")) > 0);
+    }
+
+    #[test]
+    fn test_empty_string_assistant_content_emits_no_message() {
+        // An assistant entry with empty-string content and no token usage has
+        // nothing to estimate, so it must take the zero-token continue path
+        // instead of emitting a fake 1-token message.
+        let dir = TempDir::new().unwrap();
+        let jsonl = format!(
+            "{}\n{}",
+            json!({"role": "user", "sessionId": "s", "content": ""}),
+            json!({"role": "assistant", "sessionId": "s", "content": ""}),
+        );
+        let path = write_session(&dir, "proj", "s", &jsonl);
+        let messages = parse_zcode_file(&path);
+
+        assert!(messages.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two low-severity edge cases surfaced by an independent **Codex** review of the just-merged #769 (Codex login cancellation) and #770 (ZCode parser). Both validated against source before fixing.

### 1. ZCode parser — empty-string content not treated as empty
`crates/tokscale-core/src/sessions/zcode.rs`

`content_chars` normalized `null`, empty array, and empty object to `0` chars — but **not** an empty string. So `content: ""` serialized to `"\"\""` (2 chars) → `estimate_tokens(2) = 1`, causing an assistant entry with empty content to emit a **spurious ~1-token estimated message** instead of taking the zero-token skip path. Added a `Value::String(s) if s.is_empty() => 0` arm.

### 2. Codex login — cancellation isn't a barrier before the persistent import
`crates/tokscale-cli/src/tui/codex_login.rs`

`wait_for_codex_login_child` only observes cancellation **while the child is still running**. If the `codex login` child exited successfully in the same tick the user dismissed the panel, the worker still ran `import_login_auth_file` → `save_account_from_auth_at_path`, **persisting the account to the credentials store despite the cancel** (the UI never showed it because the dropped channel swallowed the event). Now re-checks the `cancelled` flag via a new `login_was_cancelled` helper before the import side effect.

## Severity

Both are narrow edge cases, not regressions in the headline behavior of #769/#770 — Codex reported **no P1**, and no orphaned-process/deadlock in the cancellation handoff.

## Testing

- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-features -- -D warnings` ✅
- `cargo test -p tokscale-core --lib zcode` ✅ 9/9 (added `test_content_chars_treats_empty_string_as_empty`, `test_empty_string_assistant_content_emits_no_message`)
- `cargo test -p tokscale-cli codex_login` ✅ 11/11 (added `login_was_cancelled_tracks_cancellation`)

🤖 Findings identified by Codex; validated and fixed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two edge cases: the ZCode parser treats empty-string content as empty, and Codex login cancellation is now an atomic barrier to credential persistence. Prevents spurious token estimates and unintended account saves.

- Bug Fixes
  - ZCode: `content_chars` returns 0 for `""`, so empty assistant content no longer emits a fake 1-token message.
  - Codex login: uses `import_unless_cancelled` to hold the child-slot lock across the cancelled check and `auth.json` import, eliminating the check-then-act race so cancelled logins never persist credentials.

<sup>Written for commit 790a24375173a073ebae54580dace3bc0d18da98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

