### PR TITLE
fix(tui): refine usage dashboard interactions

### DIFF
--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -570,7 +570,10 @@ impl App {
         if self.auto_refresh && self.last_auto_refresh.elapsed() >= self.auto_refresh_interval {
             if self.current_tab == Tab::Usage {
                 self.last_auto_refresh = Instant::now();
-                self.fetch_subscription_usage();
+                // Auto-refresh is a silent background poll, not a user action,
+                // so it must not overwrite the current status message (e.g. a
+                // Codex reset result) with "Fetching usage data...".
+                self.fetch_subscription_usage_preserving_status();
             } else if !self.background_loading {
                 self.last_auto_refresh = Instant::now();
                 self.needs_reload = true;
@@ -3538,6 +3541,28 @@ mod tests {
         app.on_tick();
 
         assert_eq!(app.status_message.as_deref(), Some("Existing status"));
+        assert!(!app.needs_reload);
+    }
+
+    #[test]
+    fn test_auto_refresh_on_usage_when_idle_preserves_status() {
+        // The while-fetching case above hits the early return in
+        // fetch_subscription_usage_with_status. This covers the idle case
+        // (no fetch in flight), where a non-preserving fetch would overwrite
+        // the status with "Fetching usage data...". Auto-refresh must keep the
+        // existing message and start a silent background fetch.
+        let mut app = make_app();
+        app.current_tab = Tab::Usage;
+        app.auto_refresh = true;
+        app.auto_refresh_interval = Duration::from_millis(1);
+        app.last_auto_refresh = Instant::now() - Duration::from_secs(1);
+        app.status_message = Some("Existing status".into());
+        assert!(app.usage_rx.is_none());
+
+        app.on_tick();
+
+        assert_eq!(app.status_message.as_deref(), Some("Existing status"));
+        assert!(app.usage_fetch_attempted);
         assert!(!app.needs_reload);
     }
 

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -9,6 +9,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent,
 use ratatui::layout::Rect;
 use tokscale_core::ClientId;
 
+use crate::commands::usage::UsageOutput;
 use crate::ClientFilter;
 
 use ratatui::style::Color;
@@ -216,6 +217,45 @@ fn short_account_id(account_id: &str) -> String {
     format!("Account {head}...{tail}")
 }
 
+fn compare_codex_usage_outputs(a: &UsageOutput, b: &UsageOutput) -> std::cmp::Ordering {
+    let active_order = codex_usage_is_active(b).cmp(&codex_usage_is_active(a));
+    if active_order != std::cmp::Ordering::Equal {
+        return active_order;
+    }
+
+    codex_usage_sort_key(a)
+        .cmp(&codex_usage_sort_key(b))
+        .then_with(|| codex_usage_account_id(a).cmp(codex_usage_account_id(b)))
+}
+
+fn codex_usage_is_active(output: &UsageOutput) -> bool {
+    output
+        .account
+        .as_ref()
+        .is_some_and(|account| account.is_active)
+}
+
+fn codex_usage_sort_key(output: &UsageOutput) -> String {
+    output
+        .account
+        .as_ref()
+        .map(|account| {
+            account
+                .label_name()
+                .unwrap_or(account.id.as_str())
+                .to_lowercase()
+        })
+        .unwrap_or_else(|| output.display_name().to_lowercase())
+}
+
+fn codex_usage_account_id(output: &UsageOutput) -> &str {
+    output
+        .account
+        .as_ref()
+        .map(|account| account.id.as_str())
+        .unwrap_or_default()
+}
+
 struct MinutelySortCache {
     sort_field: SortField,
     sort_direction: SortDirection,
@@ -257,6 +297,7 @@ pub struct App {
 
     pub auto_refresh: bool,
     pub auto_refresh_interval: Duration,
+    pub last_auto_refresh: Instant,
     pub last_refresh: Instant,
 
     pub status_message: Option<String>,
@@ -396,6 +437,7 @@ impl App {
             stats_breakdown_total_lines: 0,
             auto_refresh,
             auto_refresh_interval,
+            last_auto_refresh: Instant::now(),
             last_refresh: Instant::now(),
             status_message: if has_data {
                 Some("Loaded from cache".to_string())
@@ -525,11 +567,14 @@ impl App {
             }
         }
 
-        if self.auto_refresh
-            && !self.background_loading
-            && self.last_refresh.elapsed() >= self.auto_refresh_interval
-        {
-            self.needs_reload = true;
+        if self.auto_refresh && self.last_auto_refresh.elapsed() >= self.auto_refresh_interval {
+            if self.current_tab == Tab::Usage {
+                self.last_auto_refresh = Instant::now();
+                self.fetch_subscription_usage();
+            } else if !self.background_loading {
+                self.last_auto_refresh = Instant::now();
+                self.needs_reload = true;
+            }
         }
 
         if *self.dialog_needs_reload.borrow() {
@@ -749,6 +794,7 @@ impl App {
                 self.cycle_theme();
             }
             KeyCode::Char('r') => {
+                self.last_auto_refresh = Instant::now();
                 if self.current_tab == Tab::Usage {
                     self.refresh_usage();
                 } else if self.background_loading {
@@ -799,9 +845,6 @@ impl App {
             }
             KeyCode::Char('x') if self.current_tab == Tab::Usage => {
                 self.confirm_selected_codex_rate_limit_reset();
-            }
-            KeyCode::Char('u') if self.current_tab == Tab::Usage => {
-                self.refresh_usage();
             }
             KeyCode::Enter if self.current_tab == Tab::Daily => {
                 self.open_selected_daily_detail();
@@ -976,6 +1019,7 @@ impl App {
                 self.scroll_offset = 0;
             }
             ClickAction::UsageRefresh => {
+                self.last_auto_refresh = Instant::now();
                 self.refresh_usage();
             }
             ClickAction::CodexStartLogin => {
@@ -1130,6 +1174,7 @@ impl App {
         match crate::commands::usage::codex::switch_active_account(account_id) {
             Ok(info) => {
                 self.mark_active_codex_account(&info.id);
+                self.sort_codex_subscription_usage();
                 if let Some(index) = self.subscription_usage.iter().position(|usage| {
                     usage
                         .account
@@ -1268,6 +1313,7 @@ impl App {
                     .find(|account| account.is_active)
                 {
                     self.mark_active_codex_account(&active.id);
+                    self.sort_codex_subscription_usage();
                 } else {
                     self.clear_active_codex_accounts();
                 }
@@ -1306,6 +1352,28 @@ impl App {
             if usage.provider == "Codex" {
                 if let Some(account) = &mut usage.account {
                     account.is_active = false;
+                }
+            }
+        }
+    }
+
+    fn sort_codex_subscription_usage(&mut self) {
+        let mut codex_outputs = self
+            .subscription_usage
+            .iter()
+            .filter(|usage| usage.provider == "Codex")
+            .cloned()
+            .collect::<Vec<_>>();
+        if codex_outputs.len() < 2 {
+            return;
+        }
+
+        codex_outputs.sort_by(compare_codex_usage_outputs);
+        let mut sorted = codex_outputs.into_iter();
+        for usage in &mut self.subscription_usage {
+            if usage.provider == "Codex" {
+                if let Some(next) = sorted.next() {
+                    *usage = next;
                 }
             }
         }
@@ -1759,6 +1827,9 @@ impl App {
 
     fn toggle_auto_refresh(&mut self) {
         self.auto_refresh = !self.auto_refresh;
+        if self.auto_refresh {
+            self.last_auto_refresh = Instant::now();
+        }
         self.settings.auto_refresh_enabled = self.auto_refresh;
         let save_result = self.settings.save();
         let msg = if self.auto_refresh {
@@ -2186,6 +2257,7 @@ impl App {
 mod tests {
     use super::super::ui::widgets::get_provider_shade;
     use super::*;
+    use crate::commands::usage::{UsageAccount, UsageMetric, UsageOutput};
     use crate::tui::data::{DailyModelInfo, DailySourceInfo, ModelUsage, TokenBreakdown};
     use chrono::{NaiveDate, NaiveDateTime};
     use std::collections::{BTreeMap, BTreeSet};
@@ -2478,6 +2550,67 @@ mod tests {
             initial_tab: None,
         };
         App::new_with_cached_data(config, None).unwrap()
+    }
+
+    fn usage_output(provider: &str, account: Option<UsageAccount>) -> UsageOutput {
+        UsageOutput {
+            provider: provider.to_string(),
+            account,
+            plan: Some("Pro".to_string()),
+            email: None,
+            metrics: vec![UsageMetric {
+                label: "Session".to_string(),
+                used_percent: 20.0,
+                remaining_percent: 80.0,
+                remaining_label: Some("80% left".to_string()),
+                resets_at: None,
+            }],
+            reset_credits: None,
+            credit_status: None,
+            spend_control: None,
+        }
+    }
+
+    #[test]
+    fn test_codex_usage_sort_moves_active_account_to_first_codex_row() {
+        let mut app = make_app();
+        app.subscription_usage = vec![
+            usage_output("Claude", None),
+            usage_output(
+                "Codex",
+                Some(UsageAccount {
+                    id: "acct_work".to_string(),
+                    label: Some("work".to_string()),
+                    is_active: true,
+                }),
+            ),
+            usage_output("Warp/Oz", None),
+            usage_output(
+                "Codex",
+                Some(UsageAccount {
+                    id: "acct_personal".to_string(),
+                    label: Some("personal".to_string()),
+                    is_active: false,
+                }),
+            ),
+        ];
+
+        app.mark_active_codex_account("acct_personal");
+        app.sort_codex_subscription_usage();
+
+        assert_eq!(app.subscription_usage[0].provider, "Claude");
+        assert_eq!(app.subscription_usage[2].provider, "Warp/Oz");
+        let codex_ids = app
+            .subscription_usage
+            .iter()
+            .filter(|usage| usage.provider == "Codex")
+            .filter_map(|usage| usage.account.as_ref().map(|account| account.id.as_str()))
+            .collect::<Vec<_>>();
+        assert_eq!(codex_ids, vec!["acct_personal", "acct_work"]);
+        assert!(app.subscription_usage[1]
+            .account
+            .as_ref()
+            .is_some_and(|account| account.is_active));
     }
 
     #[test]
@@ -3366,6 +3499,64 @@ mod tests {
     }
 
     #[test]
+    fn test_handle_key_u_on_usage_is_unassigned() {
+        let mut app = make_app();
+        app.current_tab = Tab::Usage;
+
+        app.handle_key_event(key(KeyCode::Char('u')));
+
+        assert!(!app.needs_reload);
+        assert!(!app.is_fetching_usage());
+        assert!(!app.usage_fetch_attempted);
+    }
+
+    #[test]
+    fn test_auto_refresh_on_usage_refreshes_usage_only() {
+        let mut app = make_app();
+        app.current_tab = Tab::Usage;
+        app.auto_refresh = true;
+        app.auto_refresh_interval = Duration::from_millis(1);
+        app.last_auto_refresh = Instant::now() - Duration::from_secs(1);
+
+        app.on_tick();
+
+        assert!(!app.needs_reload);
+        assert!(app.usage_fetch_attempted);
+    }
+
+    #[test]
+    fn test_auto_refresh_on_usage_while_fetching_preserves_status() {
+        let mut app = make_app();
+        app.current_tab = Tab::Usage;
+        app.auto_refresh = true;
+        app.auto_refresh_interval = Duration::from_millis(1);
+        app.last_auto_refresh = Instant::now() - Duration::from_secs(1);
+        let (_tx, rx) = std::sync::mpsc::channel();
+        app.usage_rx = Some(rx);
+        app.status_message = Some("Existing status".into());
+
+        app.on_tick();
+
+        assert_eq!(app.status_message.as_deref(), Some("Existing status"));
+        assert!(!app.needs_reload);
+    }
+
+    #[test]
+    fn test_auto_refresh_on_overview_refreshes_token_data_only() {
+        let mut app = make_app();
+        app.current_tab = Tab::Overview;
+        app.auto_refresh = true;
+        app.auto_refresh_interval = Duration::from_millis(1);
+        app.last_auto_refresh = Instant::now() - Duration::from_secs(1);
+
+        app.on_tick();
+
+        assert!(app.needs_reload);
+        assert!(!app.usage_fetch_attempted);
+        assert!(!app.is_fetching_usage());
+    }
+
+    #[test]
     fn test_codex_reset_success_status_survives_follow_up_usage_refresh() {
         let mut app = make_app();
         let (tx, rx) = std::sync::mpsc::channel();
@@ -3437,6 +3628,21 @@ mod tests {
         let initial = app.auto_refresh;
         app.handle_key_event(key_with_mod(KeyCode::Char('R'), KeyModifiers::SHIFT));
         assert_ne!(app.auto_refresh, initial);
+    }
+
+    #[test]
+    fn test_enabling_auto_refresh_waits_for_next_interval() {
+        let mut app = make_app();
+        app.auto_refresh = false;
+        app.auto_refresh_interval = Duration::from_secs(60);
+        app.last_auto_refresh = Instant::now() - Duration::from_secs(120);
+
+        app.handle_key_event(key_with_mod(KeyCode::Char('R'), KeyModifiers::SHIFT));
+        app.on_tick();
+
+        assert!(app.auto_refresh);
+        assert!(!app.needs_reload);
+        assert!(!app.usage_fetch_attempted);
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/ui/usage.rs
+++ b/crates/tokscale-cli/src/tui/ui/usage.rs
@@ -1414,21 +1414,36 @@ fn render_narrow_accounts_table(
     area: Rect,
     outputs: &[UsageOutput],
 ) {
-    let mut lines = vec![narrow_table_header(app, area.width)];
     let row_height = 2usize;
     let max_items = (area.height.saturating_sub(1) as usize / row_height).max(1);
     app.set_max_visible_items(max_items);
     let start = app
         .scroll_offset
         .min(outputs.len().saturating_sub(max_items));
-
-    for (visible_row, (index, output)) in outputs
+    let visible_rows = outputs
         .iter()
         .enumerate()
         .skip(start)
         .take(max_items)
-        .enumerate()
-    {
+        .collect::<Vec<_>>();
+
+    let rows = visible_rows
+        .iter()
+        .map(|(index, output)| narrow_table_row(app, output, *index, area))
+        .collect::<Vec<_>>();
+    let selected_visible = app
+        .selected_index
+        .checked_sub(start)
+        .filter(|index| *index < visible_rows.len());
+    let mut table_state = TableState::default().with_selected(selected_visible);
+    let table = Table::new(rows, [Constraint::Percentage(100)])
+        .header(Row::new([Cell::from(narrow_table_header(app, area.width))]))
+        .highlight_spacing(HighlightSpacing::Never)
+        .row_highlight_style(Style::default().bg(app.theme.selection))
+        .flex(Flex::Start);
+    frame.render_stateful_widget(table, area, &mut table_state);
+
+    for (visible_row, (index, _)) in visible_rows.into_iter().enumerate() {
         let y = area
             .y
             .saturating_add(1)
@@ -1442,10 +1457,7 @@ fn render_narrow_accounts_table(
             ),
             ClickAction::UsageSelect { index },
         );
-        lines.extend(narrow_table_row(app, output, index, area, y));
     }
-
-    frame.render_widget(Paragraph::new(lines), area);
 }
 
 fn account_table_header(app: &App) -> Row<'static> {
@@ -1495,13 +1507,7 @@ fn account_table_widths(width: u16) -> [Constraint; 8] {
     }
 }
 
-fn narrow_table_row(
-    app: &mut App,
-    output: &UsageOutput,
-    index: usize,
-    area: Rect,
-    _y: u16,
-) -> Vec<Line<'static>> {
+fn narrow_table_row(app: &mut App, output: &UsageOutput, index: usize, area: Rect) -> Row<'static> {
     let selected = app.selected_index == index;
     let width = area.width as usize;
     let row = usage_row_view(app, output);
@@ -1580,7 +1586,12 @@ fn narrow_table_row(
     }
     pad_selected_row(&mut second, area.width as usize, selected);
 
-    vec![Line::from(first), Line::from(second)]
+    Row::new([Cell::from(Text::from(vec![
+        Line::from(first),
+        Line::from(second),
+    ]))])
+    .style(account_table_row_style(app, index))
+    .height(2)
 }
 
 fn usage_row_view<'a>(app: &App, output: &'a UsageOutput) -> UsageRowView<'a> {


### PR DESCRIPTION
## Summary
- Keep the active Codex account first within the Codex rows after account switches or removals while preserving non-Codex row positions.
- Make auto refresh respect the current tab: Usage refreshes subscription usage without disturbing in-progress status messages, while other tabs refresh token data.
- Remove the hidden `u` refresh alias now that the UI advertises `r Refresh`.
- Render narrow Usage account rows through `ratatui::Table` for consistency with the wide table path.

## Tests
- `cargo test -p tokscale-cli tui::app::tests::`
- `cargo test -p tokscale-cli tui::ui::usage::tests::`
- `cargo test -p tokscale-cli` passed before the final one-line auto-refresh status fix; the final fix is covered by the app test suite above.
