### PR TITLE
fix(usage): show reset times in local compact format

### DIFF
--- a/crates/tokscale-cli/src/commands/usage/helpers.rs
+++ b/crates/tokscale-cli/src/commands/usage/helpers.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Datelike, Duration, Local, Utc};
 
 pub fn capitalize(s: &str) -> String {
     let mut c = s.chars();
@@ -27,7 +27,18 @@ pub fn format_reset_time(resets_at: &str) -> String {
         Ok(d) => d.with_timezone(&Utc),
         Err(_) => return resets_at.into(),
     };
-    let diff = dt - Utc::now();
+    let local_dt = dt.with_timezone(&Local);
+    let now = Utc::now();
+    let display_time = compact_reset_time(local_dt, now.with_timezone(&Local), dt - now);
+    format_reset_time_with_now(dt, now, &display_time)
+}
+
+fn format_reset_time_with_now(
+    reset_at: DateTime<Utc>,
+    now: DateTime<Utc>,
+    display_time: &str,
+) -> String {
+    let diff = reset_at - now;
     if diff <= Duration::zero() {
         return "resets now".into();
     }
@@ -42,10 +53,18 @@ pub fn format_reset_time(resets_at: &str) -> String {
         } else {
             format!("resets in {h}h")
         }
-    } else if diff.num_days() < 7 {
-        format!("resets {} {}", dt.format("%a"), dt.format("%-I%P"))
     } else {
-        format!("resets {}", dt.format("%b %-d"))
+        format!("resets {display_time}")
+    }
+}
+
+fn compact_reset_time(reset_at: DateTime<Local>, now: DateTime<Local>, diff: Duration) -> String {
+    if reset_at.year() != now.year() {
+        reset_at.format("%Y-%m-%d %H:%M").to_string()
+    } else if diff.num_days() < 7 {
+        reset_at.format("%a %b %-d %H:%M").to_string()
+    } else {
+        reset_at.format("%b %-d %H:%M").to_string()
     }
 }
 
@@ -90,4 +109,48 @@ pub fn atomic_write_secret(path: &std::path::Path, data: &[u8]) -> std::io::Resu
         return Err(e);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn utc(value: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(value)
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    #[test]
+    fn reset_time_keeps_short_windows_relative() {
+        let label = format_reset_time_with_now(
+            utc("2026-06-25T02:45:00Z"),
+            utc("2026-06-25T01:30:00Z"),
+            "2026-06-25 10:45 +08:00",
+        );
+
+        assert_eq!(label, "resets in 1h 15m");
+    }
+
+    #[test]
+    fn reset_time_shows_absolute_local_time_for_daily_or_longer_windows() {
+        let label = format_reset_time_with_now(
+            utc("2026-06-27T01:30:00Z"),
+            utc("2026-06-25T01:30:00Z"),
+            "Sat Jun 27 09:30",
+        );
+
+        assert_eq!(label, "resets Sat Jun 27 09:30");
+    }
+
+    #[test]
+    fn reset_time_omits_weekday_for_long_windows() {
+        let label = format_reset_time_with_now(
+            utc("2026-07-18T00:43:00Z"),
+            utc("2026-06-25T01:30:00Z"),
+            "Jul 18 08:43",
+        );
+
+        assert_eq!(label, "resets Jul 18 08:43");
+    }
 }

--- a/crates/tokscale-cli/src/commands/usage/mod.rs
+++ b/crates/tokscale-cli/src/commands/usage/mod.rs
@@ -349,7 +349,12 @@ fn partition_results(
 // ── Light-mode rendering ──
 
 const BAR_WIDTH: usize = 12;
-const CARD_WIDTH: usize = 62;
+const METRIC_LABEL_WIDTH: usize = 14;
+const METRIC_REMAINING_WIDTH: usize = 11;
+const METRIC_BAR_WIDTH: usize = BAR_WIDTH + 2;
+const METRIC_RESET_WIDTH: usize = 24;
+const CARD_WIDTH: usize =
+    1 + METRIC_LABEL_WIDTH + METRIC_REMAINING_WIDTH + METRIC_BAR_WIDTH + METRIC_RESET_WIDTH;
 
 fn truncate(s: &str, max_len: usize) -> String {
     if s.chars().count() <= max_len {
@@ -379,8 +384,19 @@ fn render_light(output: &UsageOutput) {
             .as_ref()
             .map(|r| helpers::format_reset_time(r))
             .unwrap_or_default();
-        let label = truncate(&m.label, 14);
-        println!("│ {:<14}{:<11}{:<14}{:<22}│", label, rem, bar, reset);
+        let reset = truncate(&reset, METRIC_RESET_WIDTH);
+        let label = truncate(&m.label, METRIC_LABEL_WIDTH);
+        println!(
+            "│ {:<label_width$}{:<remaining_width$}{:<bar_width$}{:<reset_width$}│",
+            label,
+            rem,
+            bar,
+            reset,
+            label_width = METRIC_LABEL_WIDTH,
+            remaining_width = METRIC_REMAINING_WIDTH,
+            bar_width = METRIC_BAR_WIDTH,
+            reset_width = METRIC_RESET_WIDTH,
+        );
     }
     if let Some(ref email) = output.email {
         let email = truncate(email, CARD_WIDTH - 11);

--- a/crates/tokscale-cli/src/tui/ui/usage.rs
+++ b/crates/tokscale-cli/src/tui/ui/usage.rs
@@ -1299,7 +1299,10 @@ fn snapshot_line(app: &App, outputs: &[UsageOutput], width: usize) -> Line<'stat
 fn metric_detail_line(app: &App, metric: &UsageMetric, width: usize) -> Line<'static> {
     let remaining = remaining_label(metric);
     let label_width = metric_label_width(width);
-    let bar_width = width.saturating_sub(label_width + 25).clamp(10, 34);
+    let target_reset_width = width.saturating_sub(label_width + 12).min(24);
+    let bar_width = width
+        .saturating_sub(label_width + target_reset_width + 14)
+        .clamp(10, 34);
     let reset_width = width.saturating_sub(label_width + bar_width + 14);
     let reset = metric
         .resets_at
@@ -1491,7 +1494,7 @@ fn account_table_widths(width: u16) -> [Constraint; 8] {
             Constraint::Length(8),
             Constraint::Length(10),
             Constraint::Min(30),
-            Constraint::Length(22),
+            Constraint::Length(24),
         ]
     } else {
         [
@@ -1502,7 +1505,7 @@ fn account_table_widths(width: u16) -> [Constraint; 8] {
             Constraint::Length(7),
             Constraint::Length(8),
             Constraint::Min(24),
-            Constraint::Length(16),
+            Constraint::Length(24),
         ]
     }
 }
@@ -1523,7 +1526,8 @@ fn narrow_table_row(app: &mut App, output: &UsageOutput, index: usize, area: Rec
     } else {
         0usize
     };
-    let left_width = width.saturating_sub(4 + state_width);
+    let state_right_padding = usize::from(state_width > 0) * 2;
+    let left_width = width.saturating_sub(4 + state_width + state_right_padding);
     let left = format!("{} {}", output.provider, row.account_summary);
     let mut first = vec![
         styled(
@@ -1543,8 +1547,17 @@ fn narrow_table_row(app: &mut App, output: &UsageOutput, index: usize, area: Rec
     ];
     if state_width > 0 {
         first.push(styled(
-            truncate_string(&state, state_width),
+            format!(
+                "{:>width$}",
+                truncate_string(&state, state_width),
+                width = state_width
+            ),
             Style::default().fg(readiness_color(app, row.readiness)),
+            selected,
+        ));
+        first.push(styled(
+            " ".repeat(state_right_padding),
+            Style::default(),
             selected,
         ));
     }
@@ -2900,6 +2913,33 @@ mod tests {
         assert!(body.contains("work"), "{body}");
         assert!(body.contains("personal"), "{body}");
         assert!(body.contains(" Remove "), "{body}");
+    }
+
+    #[test]
+    fn narrow_usage_account_status_keeps_right_padding() {
+        let mut app = make_app();
+        app.subscription_usage = vec![output(
+            "Codex",
+            Some(UsageAccount {
+                id: "acct_work".to_string(),
+                label: Some("work".to_string()),
+                is_active: true,
+            }),
+        )];
+
+        let body = render_body(&mut app, 90, 24);
+        let row = body
+            .lines()
+            .find(|line| {
+                line.contains("Codex") && line.contains("Active") && line.contains("Ready")
+            })
+            .expect("missing active narrow account row");
+        let ready_end = row.rfind("Ready").expect(row) + "Ready".len();
+
+        assert!(
+            row[ready_end..].starts_with("  "),
+            "expected right padding after Ready: {row:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Show reset labels longer than one day with compact local date and time instead of dropping the time component.
- Keep short reset windows relative, such as `resets in 1h 15m`.
- Widen CLI and TUI reset columns so the local reset labels remain readable.
- Keep narrow Usage account status text aligned with right-side padding.

## Tests
- `cargo fmt --check`
- `cargo test -p tokscale-cli commands::usage::helpers::tests::`
- `cargo test -p tokscale-cli tui::ui::usage::tests::`
- `cargo test -p tokscale-cli`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show reset times in a compact local date+time while keeping short windows relative. Widens CLI/TUI columns so reset labels stay readable and preserves narrow status alignment.

- **Bug Fixes**
  - Use absolute local date+time when reset window is ≥1 day; keep shorter windows as “resets in Xh Ym”.
  - Compact formats: same year “Sat Jun 27 09:30”, different year “2026-06-25 10:45”.
  - Increase CLI reset column to 24 chars and adjust TUI widths; keep narrow account status right padding.
  - Add tests for reset formatting and narrow layout padding.

<sup>Written for commit 01fcc8643194ef23454931e3b4e2402db629338b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

