### PR TITLE
feat: add OpenCodeReview as token tracking provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 | <img width="48px" src="https://github.com/JetBrains.png" alt="Junie" /> | [Junie](https://www.jetbrains.com/junie/) | `~/.junie/sessions/*/events.jsonl` | ✅ Yes |
 | <img width="48px" src="https://raw.githubusercontent.com/CommandCodeAI/command-code/main/.github/commandcode/logo/command-code-logo-black-bg.png" alt="Command Code" /> | [Command Code](https://github.com/CommandCodeAI/command-code) | `~/.commandcode/projects/**/*.jsonl` (token usage estimated from transcripts at ~4 chars/token; not persisted on disk) | ✅ Yes |
 | <img width="48px" src="https://github.com/zai-org.png" alt="ZCode" /> | [ZCode](https://zcode.z.ai/) | `~/.zcode/projects/**/*.jsonl` | ✅ Yes |
+| <img width="48px" src="https://github.com/alibaba.png" alt="OpenCodeReview" /> | [OpenCodeReview](https://github.com/alibaba/open-code-review) | `~/.opencodereview/sessions/**/*.jsonl` | ✅ Yes |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | Re-attributed from other sources via `hf:` model prefix or `synthetic` provider (+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`) | ✅ Yes |
 
 Get real-time pricing calculations using [🚅 LiteLLM's pricing data](https://github.com/BerriAI/litellm), with support for tiered pricing models and cache token discounts.
@@ -160,7 +161,7 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
   - GitHub-style contribution graph with 9 color themes
   - Real-time filtering and sorting
   - Zero flicker rendering
-- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, and Synthetic
+- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, and Synthetic
 - **Real-time pricing** - Fetches current pricing from LiteLLM with 1-hour disk cache; automatic OpenRouter fallback and Cursor model pricing for newly released models
 - **Detailed breakdowns** - Input, output, cache read/write, and reasoning token tracking
 - **Native Rust core** - All parsing and aggregation done in Rust for 10x faster processing
@@ -964,7 +965,7 @@ The frontend provides a GitHub-style contribution graph visualization:
 - **Interactive tooltips**: Hover for detailed daily breakdowns
 - **Day breakdown panel**: Click to see per-source and per-model details
 - **Year filtering**: Navigate between years
-- **Source filtering**: Filter by platform (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, Synthetic)
+- **Source filtering**: Filter by platform (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, Synthetic)
 - **Stats panel**: Total cost, tokens, active days, streaks
 - **FOUC prevention**: Theme applied before React hydrates (no flash)
 
@@ -1304,6 +1305,7 @@ AI coding tools store their session data in cross-platform locations. Most tools
 | Gajae-Code | `~/.gjc/agent/sessions/` | `%USERPROFILE%\.gjc\agent\sessions\` | Configurable via `GJC_CODING_AGENT_DIR` (also `GJC_CONFIG_DIR`/`PI_CONFIG_DIR`; `$XDG_DATA_HOME/gjc/sessions/` flattens on Linux/macOS) |
 | Junie | `~/.junie/sessions/` | `%USERPROFILE%\.junie\sessions\` | Same home-relative path on all platforms; parses `events.jsonl` usage events |
 | ZCode | `~/.zcode/projects/` | `%USERPROFILE%\.zcode\projects\` | Parses `*.jsonl` session transcripts; Z.ai's ADE for GLM models |
+| OpenCodeReview | `~/.opencodereview/sessions/` | `%USERPROFILE%\.opencodereview\sessions\` | Parses `*.jsonl` session transcripts; Alibaba's AI code review tool |
 | Synthetic | Re-attributed from other sources | Re-attributed from other sources | Detects `hf:` model prefix + `synthetic` provider |
 
 > **Note**: On Windows, `~` expands to `%USERPROFILE%` (e.g., `C:\Users\YourName`). These tools intentionally use Unix-style paths (like `.local/share`) even on Windows for cross-platform consistency, rather than Windows-native paths like `%APPDATA%`.

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -895,6 +895,7 @@ pub enum ClientFilter {
     AntigravityCli,
     Junie,
     Zcode,
+    Opencodereview,
     Synthetic,
 }
 
@@ -938,6 +939,7 @@ impl ClientFilter {
             Self::AntigravityCli => "antigravity-cli",
             Self::Junie => "junie",
             Self::Zcode => "zcode",
+            Self::Opencodereview => "opencodereview",
             Self::Synthetic => "synthetic",
         }
     }
@@ -984,6 +986,7 @@ impl ClientFilter {
             Self::AntigravityCli => Some(ClientId::AntigravityCli),
             Self::Junie => Some(ClientId::Junie),
             Self::Zcode => Some(ClientId::Zcode),
+            Self::Opencodereview => Some(ClientId::OpenCodeReview),
             Self::Synthetic => None,
         }
     }
@@ -1027,6 +1030,7 @@ impl ClientFilter {
             ClientId::AntigravityCli => Self::AntigravityCli,
             ClientId::Junie => Self::Junie,
             ClientId::Zcode => Self::Zcode,
+            ClientId::OpenCodeReview => Self::Opencodereview,
         }
     }
 

--- a/crates/tokscale-cli/src/tui/client_ui.rs
+++ b/crates/tokscale-cli/src/tui/client_ui.rs
@@ -142,6 +142,10 @@ pub const CLIENT_UI: [ClientUi; ClientId::COUNT] = [
         display_name: "ZCode",
         hotkey: 'q',
     },
+    ClientUi {
+        display_name: "OpenCodeReview",
+        hotkey: 'O',
+    },
 ];
 
 pub fn display_name(client: ClientId) -> &'static str {

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -504,6 +504,15 @@ define_clients!(
         headless: false,
         parse_local: true,
         submit_default: true
+    },
+    OpenCodeReview = 34 => {
+        id: "opencodereview",
+        root: PathRoot::Home,
+        relative: ".opencodereview/sessions",
+        pattern: "*.jsonl",
+        headless: false,
+        parse_local: true,
+        submit_default: true
     }
 );
 
@@ -556,7 +565,7 @@ mod tests {
 
     #[test]
     fn test_client_id_count() {
-        assert_eq!(ClientId::COUNT, 34);
+        assert_eq!(ClientId::COUNT, 35);
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -2540,6 +2540,20 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     counts.set(ClientId::Zcode, zcode_count);
     messages.extend(zcode_msgs);
 
+    let opencodereview_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::OpenCodeReview)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::opencodereview::parse_opencodereview_file(path)
+                .into_iter()
+                .map(|msg| unified_to_parsed(&msg))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let opencodereview_count = summed_parsed_message_count(&opencodereview_msgs);
+    counts.set(ClientId::OpenCodeReview, opencodereview_count);
+    messages.extend(opencodereview_msgs);
+
     // Parse Kimi wire.jsonl files in parallel
     let kimi_msgs: Vec<ParsedMessage> = scan_result
         .get(ClientId::Kimi)

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -29,6 +29,7 @@ pub mod micode;
 pub mod mux;
 pub mod openclaw;
 pub mod opencode;
+pub mod opencodereview;
 pub mod pi;
 pub mod qwen;
 pub mod roocode;

--- a/crates/tokscale-core/src/sessions/opencodereview.rs
+++ b/crates/tokscale-core/src/sessions/opencodereview.rs
@@ -1,0 +1,260 @@
+//! OpenCodeReview session parser
+//!
+//! OpenCodeReview stores sessions as JSONL files under
+//! `~/.opencodereview/sessions/<encoded-repo-path>/<session-id>.jsonl`.
+
+use super::utils::{file_modified_timestamp_ms, parse_timestamp_value};
+use super::UnifiedMessage;
+use crate::{pricing, provider_identity, TokenBreakdown};
+use serde_json::Value;
+use std::collections::HashSet;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+pub fn parse_opencodereview_file(path: &Path) -> Vec<UnifiedMessage> {
+    let file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return Vec::new(),
+    };
+
+    let session_id = session_id_from_path(path);
+    let fallback_timestamp = file_modified_timestamp_ms(path);
+
+    let mut workspace: Option<String> = None;
+    let mut messages = Vec::new();
+    let mut seen = HashSet::new();
+
+    for line in BufReader::new(file).lines() {
+        let Ok(line) = line else { continue };
+
+        if !line.contains("llm_response") && !line.contains("session_start") {
+            continue;
+        }
+
+        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+
+        let record_type = value.get("type").and_then(Value::as_str).unwrap_or("");
+
+        if record_type == "session_start" {
+            if workspace.is_none() {
+                workspace = value
+                    .get("cwd")
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+            }
+            continue;
+        }
+
+        if record_type != "llm_response" {
+            continue;
+        }
+
+        let usage = match value.get("usage") {
+            Some(u) => u,
+            None => continue,
+        };
+
+        let tokens = tokens_from_usage(usage);
+        if tokens.total() == 0 {
+            continue;
+        }
+
+        let timestamp = value
+            .get("timestamp")
+            .and_then(parse_timestamp_value)
+            .unwrap_or(fallback_timestamp);
+
+        let model_raw = value
+            .get("model")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let model_id = pricing::aliases::resolve_alias(model_raw)
+            .unwrap_or(model_raw)
+            .to_string();
+
+        let provider_id = provider_identity::inferred_provider_from_model(&model_id)
+            .map(str::to_string)
+            .unwrap_or_else(|| "opencodereview".to_string());
+
+        let duration_ms = value
+            .get("duration_ms")
+            .and_then(Value::as_i64)
+            .filter(|d| *d > 0);
+
+        let dedup_key = format!(
+            "opencodereview:{session_id}:{timestamp}:{model_id}:{}:{}:{}:{}",
+            tokens.input, tokens.output, tokens.cache_read, tokens.cache_write,
+        );
+        if !seen.insert(dedup_key.clone()) {
+            continue;
+        }
+
+        let mut msg = UnifiedMessage::new(
+            "opencodereview",
+            model_id,
+            provider_id,
+            &session_id,
+            timestamp,
+            tokens,
+            0.0,
+        );
+        msg.dedup_key = Some(dedup_key);
+        msg.duration_ms = duration_ms;
+
+        if let Some(ws) = &workspace {
+            if let Some(key) = super::normalize_workspace_key(ws) {
+                msg.workspace_label = super::workspace_label_from_key(&key);
+                msg.workspace_key = Some(key);
+            }
+        }
+
+        messages.push(msg);
+    }
+
+    messages
+}
+
+fn session_id_from_path(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+fn tokens_from_usage(usage: &Value) -> TokenBreakdown {
+    TokenBreakdown {
+        input: number_field(usage, "prompt_tokens"),
+        output: number_field(usage, "completion_tokens"),
+        cache_read: number_field(usage, "cache_read_tokens"),
+        cache_write: number_field(usage, "cache_write_tokens"),
+        reasoning: 0,
+    }
+}
+
+fn number_field(value: &Value, field: &str) -> i64 {
+    value
+        .get(field)
+        .and_then(|v| v.as_i64().or_else(|| v.as_u64().map(|u| u as i64)))
+        .unwrap_or(0)
+        .max(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn parse_events(content: &str) -> Vec<UnifiedMessage> {
+        let dir = TempDir::new().unwrap();
+        let repo_dir = dir.path().join("test-repo");
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        let path = repo_dir.join("test-session-123.jsonl");
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        file.flush().unwrap();
+        parse_opencodereview_file(&path)
+    }
+
+    fn session_start(cwd: &str) -> String {
+        format!(
+            r#"{{"type":"session_start","sessionId":"test-session-123","timestamp":"2026-01-15T10:00:00Z","cwd":"{cwd}","model":"claude-sonnet-4-20250514"}}"#
+        )
+    }
+
+    fn llm_response(
+        timestamp: &str,
+        model: &str,
+        prompt: i64,
+        completion: i64,
+        cache_read: i64,
+        cache_write: i64,
+    ) -> String {
+        format!(
+            r#"{{"type":"llm_response","sessionId":"test-session-123","timestamp":"{timestamp}","model":"{model}","duration_ms":1500,"usage":{{"prompt_tokens":{prompt},"completion_tokens":{completion},"cache_read_tokens":{cache_read},"cache_write_tokens":{cache_write}}}}}"#
+        )
+    }
+
+    #[test]
+    fn parses_single_llm_response() {
+        let content = format!(
+            "{}\n{}\n",
+            session_start("/home/user/project"),
+            llm_response("2026-01-15T10:00:05Z", "claude-sonnet-4-20250514", 1000, 200, 500, 100),
+        );
+        let msgs = parse_events(&content);
+
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].client, "opencodereview");
+        assert_eq!(msgs[0].tokens.input, 1000);
+        assert_eq!(msgs[0].tokens.output, 200);
+        assert_eq!(msgs[0].tokens.cache_read, 500);
+        assert_eq!(msgs[0].tokens.cache_write, 100);
+        assert_eq!(msgs[0].tokens.reasoning, 0);
+        assert_eq!(msgs[0].duration_ms, Some(1500));
+        assert_eq!(msgs[0].session_id, "test-session-123");
+        assert!(msgs[0].workspace_key.is_some());
+    }
+
+    #[test]
+    fn parses_multiple_responses() {
+        let content = format!(
+            "{}\n{}\n{}\n",
+            session_start("/home/user/project"),
+            llm_response("2026-01-15T10:00:05Z", "claude-sonnet-4-20250514", 1000, 200, 0, 0),
+            llm_response("2026-01-15T10:01:00Z", "gpt-4o", 500, 100, 0, 0),
+        );
+        let msgs = parse_events(&content);
+        assert_eq!(msgs.len(), 2);
+    }
+
+    #[test]
+    fn deduplicates_identical_records() {
+        let resp = llm_response("2026-01-15T10:00:05Z", "claude-sonnet-4-20250514", 1000, 200, 0, 0);
+        let content = format!(
+            "{}\n{}\n{}\n",
+            session_start("/home/user/project"),
+            resp,
+            resp,
+        );
+        let msgs = parse_events(&content);
+        assert_eq!(msgs.len(), 1, "duplicate records should be collapsed");
+    }
+
+    #[test]
+    fn skips_zero_token_records() {
+        let content = format!(
+            "{}\n{}\n",
+            session_start("/home/user/project"),
+            llm_response("2026-01-15T10:00:05Z", "claude-sonnet-4-20250514", 0, 0, 0, 0),
+        );
+        let msgs = parse_events(&content);
+        assert_eq!(msgs.len(), 0, "zero-token records should be skipped");
+    }
+
+    #[test]
+    fn works_without_session_start() {
+        let content = format!(
+            "{}\n",
+            llm_response("2026-01-15T10:00:05Z", "claude-sonnet-4-20250514", 1000, 200, 0, 0),
+        );
+        let msgs = parse_events(&content);
+        assert_eq!(msgs.len(), 1);
+        assert!(msgs[0].workspace_key.is_none());
+    }
+
+    #[test]
+    fn session_id_derived_from_filename() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("my-unique-session.jsonl");
+        let content = llm_response("2026-01-15T10:00:05Z", "gpt-4o", 100, 50, 0, 0);
+        std::fs::write(&path, format!("{content}\n")).unwrap();
+
+        let msgs = parse_opencodereview_file(&path);
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].session_id, "my-unique-session");
+    }
+}


### PR DESCRIPTION
## Summary

- Add [OpenCodeReview](https://github.com/alibaba/open-code-review) (Alibaba's AI code review tool) as client #34, parsing JSONL session files from `~/.opencodereview/sessions/`
- Implement full JSONL parser with deduplication, model alias resolution, provider inference, workspace detection, and duration tracking
- Register client in core (`clients.rs`, `lib.rs`), CLI filter (`main.rs`), and TUI display (`client_ui.rs`) with hotkey `O`

## Changes

| File | Change |
|------|--------|
| `crates/tokscale-core/src/sessions/opencodereview.rs` | **New** — JSONL session parser (modeled after `junie.rs`) |
| `crates/tokscale-core/src/sessions/mod.rs` | Register `opencodereview` module |
| `crates/tokscale-core/src/clients.rs` | Add `OpenCodeReview = 34` client definition, update count assertion |
| `crates/tokscale-core/src/lib.rs` | Add parsing dispatch block |
| `crates/tokscale-cli/src/main.rs` | Add `Opencodereview` CLI filter variant |
| `crates/tokscale-cli/src/tui/client_ui.rs` | Add TUI display entry |
| `README.md` | Add OpenCodeReview to supported clients table, platform list, filter list, and data directory table |

## Test plan

- [x] 6 unit tests: single response, multiple responses, dedup, zero-token skip, no session_start, filename-derived session ID
- [x] `cargo test -p tokscale-core` — all tests pass
- [x] `cargo clippy --all-targets` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add OpenCodeReview as a tracked client to parse `~/.opencodereview/sessions/**/*.jsonl` and show usage in the CLI and TUI (hotkey `O`). This lets users track tokens from Alibaba’s code review tool alongside other sources.

- **New Features**
  - Core: JSONL session parser with dedup, model alias resolution, provider inference, workspace detection, and `duration_ms` support.
  - Client: Registered `OpenCodeReview` (id `opencodereview`, pattern `*.jsonl`) in `clients.rs` and parse dispatch; updated client count.
  - CLI: Added `Opencodereview` filter that maps to `opencodereview`.
  - TUI: Added "OpenCodeReview" entry with hotkey `O`.
  - Docs/Tests: README updated; 6 unit tests added (single/multiple responses, dedup, zero-token skip, no session_start, filename session id).

<sup>Written for commit 5870185a219fa6162348f173b6fe67b12d7507f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

