### PR TITLE
feat(tui): add provider breakdown tab

### DIFF
--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -19,8 +19,8 @@ use super::codex_login::{
     CodexLoginOutcome,
 };
 use super::data::{
-    AgentUsage, DailyUsage, DataLoader, HourlyUsage, MinutelyUsage, ModelUsage, TokenBreakdown,
-    UsageData,
+    AgentUsage, DailyUsage, DataLoader, HourlyUsage, MinutelyUsage, ModelUsage,
+    ProviderModelUsage, ProviderUsage, TokenBreakdown, UsageData,
 };
 use super::privacy::looks_like_email;
 use super::settings::Settings;
@@ -45,6 +45,7 @@ pub enum Tab {
     Overview,
     Usage,
     Models,
+    Providers,
     Daily,
     Hourly,
     Minutely,
@@ -58,6 +59,7 @@ impl Tab {
             Tab::Overview,
             Tab::Usage,
             Tab::Models,
+            Tab::Providers,
             Tab::Daily,
             Tab::Hourly,
             Tab::Minutely,
@@ -71,6 +73,7 @@ impl Tab {
             Tab::Overview => "Overview",
             Tab::Usage => "Usage",
             Tab::Models => "Models",
+            Tab::Providers => "Providers",
             Tab::Daily => "Daily",
             Tab::Hourly => "Hourly",
             Tab::Minutely => "Minutely",
@@ -84,6 +87,7 @@ impl Tab {
             Tab::Overview => "Ovw",
             Tab::Usage => "Use",
             Tab::Models => "Mod",
+            Tab::Providers => "Pro",
             Tab::Daily => "Day",
             Tab::Hourly => "Hr",
             Tab::Minutely => "Min",
@@ -96,7 +100,8 @@ impl Tab {
         match self {
             Tab::Overview => Tab::Usage,
             Tab::Usage => Tab::Models,
-            Tab::Models => Tab::Daily,
+            Tab::Models => Tab::Providers,
+            Tab::Providers => Tab::Daily,
             Tab::Daily => Tab::Hourly,
             Tab::Hourly => Tab::Minutely,
             Tab::Minutely => Tab::Stats,
@@ -110,7 +115,8 @@ impl Tab {
             Tab::Overview => Tab::Agents,
             Tab::Usage => Tab::Overview,
             Tab::Models => Tab::Usage,
-            Tab::Daily => Tab::Models,
+            Tab::Providers => Tab::Models,
+            Tab::Daily => Tab::Providers,
             Tab::Hourly => Tab::Daily,
             Tab::Minutely => Tab::Hourly,
             Tab::Stats => Tab::Minutely,
@@ -160,6 +166,15 @@ pub struct DailyDetailRow<'a> {
     pub tokens: &'a TokenBreakdown,
     pub cost: f64,
     pub messages: u64,
+}
+
+#[derive(Debug, Clone)]
+pub enum ProviderRow {
+    Provider(ProviderUsage),
+    Model {
+        provider: String,
+        model: ProviderModelUsage,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -291,6 +306,7 @@ pub struct App {
     pub selected_daily_detail_date: Option<NaiveDate>,
     daily_list_selected_index: usize,
     daily_list_scroll_offset: usize,
+    pub expanded_providers: HashSet<String>,
 
     pub selected_graph_cell: Option<(usize, usize)>,
     pub stats_breakdown_total_lines: usize,
@@ -433,6 +449,7 @@ impl App {
             selected_daily_detail_date: None,
             daily_list_selected_index: 0,
             daily_list_scroll_offset: 0,
+            expanded_providers: HashSet::new(),
             selected_graph_cell: None,
             stats_breakdown_total_lines: 0,
             auto_refresh,
@@ -848,6 +865,9 @@ impl App {
             }
             KeyCode::Char('x') if self.current_tab == Tab::Usage => {
                 self.confirm_selected_codex_rate_limit_reset();
+            }
+            KeyCode::Enter if self.current_tab == Tab::Providers => {
+                self.toggle_selected_provider();
             }
             KeyCode::Enter if self.current_tab == Tab::Daily => {
                 self.open_selected_daily_detail();
@@ -1640,6 +1660,7 @@ impl App {
     fn get_current_list_len(&self) -> usize {
         match self.current_tab {
             Tab::Overview | Tab::Models => self.data.models.len(),
+            Tab::Providers => self.get_provider_rows().len(),
             Tab::Agents => self.data.agents.len(),
             Tab::Daily if self.is_daily_detail_active() => {
                 self.get_sorted_daily_detail_rows().len()
@@ -1884,6 +1905,24 @@ impl App {
                 .get_sorted_models()
                 .get(self.selected_index)
                 .map(|m| format!("{}: {} tokens, ${:.4}", m.model, m.tokens.total(), m.cost)),
+            Tab::Providers => self
+                .get_provider_rows()
+                .get(self.selected_index)
+                .map(|row| match row {
+                    ProviderRow::Provider(provider) => format!(
+                        "{}: {} tokens, ${:.4}",
+                        provider.provider,
+                        provider.tokens.total(),
+                        provider.cost
+                    ),
+                    ProviderRow::Model { provider, model } => format!(
+                        "{} / {}: {} tokens, ${:.4}",
+                        provider,
+                        model.model,
+                        model.tokens.total(),
+                        model.cost
+                    ),
+                }),
             Tab::Agents => self
                 .get_sorted_agents()
                 .get(self.selected_index)
@@ -2033,6 +2072,100 @@ impl App {
         }
 
         agents
+    }
+
+    pub fn get_sorted_providers(&self) -> Vec<ProviderUsage> {
+        let mut by_provider: HashMap<String, ProviderUsage> = HashMap::new();
+
+        for model in &self.data.models {
+            let provider = model.provider.clone();
+            let entry = by_provider.entry(provider.clone()).or_insert_with(|| ProviderUsage {
+                provider: provider.clone(),
+                tokens: TokenBreakdown::default(),
+                cost: 0.0,
+                session_count: 0,
+                models: Vec::new(),
+            });
+
+            add_tokens(&mut entry.tokens, &model.tokens);
+            entry.cost += model.cost;
+            entry.session_count = entry.session_count.saturating_add(model.session_count);
+
+            if let Some(existing) = entry.models.iter_mut().find(|m| m.model == model.model) {
+                add_tokens(&mut existing.tokens, &model.tokens);
+                existing.cost += model.cost;
+                existing.session_count = existing.session_count.saturating_add(model.session_count);
+            } else {
+                entry.models.push(ProviderModelUsage {
+                    model: model.model.clone(),
+                    tokens: model.tokens.clone(),
+                    cost: model.cost,
+                    session_count: model.session_count,
+                });
+            }
+        }
+
+        let mut providers: Vec<ProviderUsage> = by_provider.into_values().collect();
+        for provider in &mut providers {
+            sort_provider_models(provider, self.sort_field, self.sort_direction);
+        }
+
+        let tie_breaker = |a: &ProviderUsage, b: &ProviderUsage| a.provider.cmp(&b.provider);
+        match (self.sort_field, self.sort_direction) {
+            (SortField::Cost, SortDirection::Descending) => {
+                providers.sort_by(|a, b| b.cost.total_cmp(&a.cost).then_with(|| tie_breaker(a, b)))
+            }
+            (SortField::Cost, SortDirection::Ascending) => {
+                providers.sort_by(|a, b| a.cost.total_cmp(&b.cost).then_with(|| tie_breaker(a, b)))
+            }
+            (SortField::Tokens, SortDirection::Descending) => providers.sort_by(|a, b| {
+                b.tokens
+                    .total()
+                    .cmp(&a.tokens.total())
+                    .then_with(|| tie_breaker(a, b))
+            }),
+            (SortField::Tokens, SortDirection::Ascending) => providers.sort_by(|a, b| {
+                a.tokens
+                    .total()
+                    .cmp(&b.tokens.total())
+                    .then_with(|| tie_breaker(a, b))
+            }),
+            (SortField::Date, _) => providers.sort_by(tie_breaker),
+        }
+
+        providers
+    }
+
+    pub fn get_provider_rows(&self) -> Vec<ProviderRow> {
+        let mut rows = Vec::new();
+        for provider in self.get_sorted_providers() {
+            rows.push(ProviderRow::Provider(provider.clone()));
+            if self.expanded_providers.contains(&provider.provider) {
+                for model in &provider.models {
+                    rows.push(ProviderRow::Model {
+                        provider: provider.provider.clone(),
+                        model: model.clone(),
+                    });
+                }
+            }
+        }
+        rows
+    }
+
+    fn toggle_selected_provider(&mut self) {
+        let provider = match self.get_provider_rows().get(self.selected_index) {
+            Some(ProviderRow::Provider(provider)) => provider.provider.clone(),
+            Some(ProviderRow::Model { provider, .. }) => provider.clone(),
+            None => return,
+        };
+
+        if !self.expanded_providers.remove(&provider) {
+            self.expanded_providers.insert(provider.clone());
+            self.set_status(&format!("Expanded {provider}"));
+        } else {
+            self.set_status(&format!("Collapsed {provider}"));
+        }
+        self.clamp_selection();
     }
 
     pub fn get_sorted_daily(&self) -> Vec<&DailyUsage> {
@@ -2256,6 +2389,43 @@ impl App {
     }
 }
 
+fn add_tokens(total: &mut TokenBreakdown, tokens: &TokenBreakdown) {
+    total.input = total.input.saturating_add(tokens.input);
+    total.output = total.output.saturating_add(tokens.output);
+    total.cache_read = total.cache_read.saturating_add(tokens.cache_read);
+    total.cache_write = total.cache_write.saturating_add(tokens.cache_write);
+    total.reasoning = total.reasoning.saturating_add(tokens.reasoning);
+}
+
+fn sort_provider_models(
+    provider: &mut ProviderUsage,
+    sort_field: SortField,
+    sort_direction: SortDirection,
+) {
+    let tie_breaker = |a: &ProviderModelUsage, b: &ProviderModelUsage| a.model.cmp(&b.model);
+    match (sort_field, sort_direction) {
+        (SortField::Cost, SortDirection::Descending) => provider
+            .models
+            .sort_by(|a, b| b.cost.total_cmp(&a.cost).then_with(|| tie_breaker(a, b))),
+        (SortField::Cost, SortDirection::Ascending) => provider
+            .models
+            .sort_by(|a, b| a.cost.total_cmp(&b.cost).then_with(|| tie_breaker(a, b))),
+        (SortField::Tokens, SortDirection::Descending) => provider.models.sort_by(|a, b| {
+            b.tokens
+                .total()
+                .cmp(&a.tokens.total())
+                .then_with(|| tie_breaker(a, b))
+        }),
+        (SortField::Tokens, SortDirection::Ascending) => provider.models.sort_by(|a, b| {
+            a.tokens
+                .total()
+                .cmp(&b.tokens.total())
+                .then_with(|| tie_breaker(a, b))
+        }),
+        (SortField::Date, _) => provider.models.sort_by(tie_breaker),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::ui::widgets::get_provider_shade;
@@ -2268,22 +2438,24 @@ mod tests {
     #[test]
     fn test_tab_all() {
         let tabs = Tab::all();
-        assert_eq!(tabs.len(), 8);
+        assert_eq!(tabs.len(), 9);
         assert_eq!(tabs[0], Tab::Overview);
         assert_eq!(tabs[1], Tab::Usage);
         assert_eq!(tabs[2], Tab::Models);
-        assert_eq!(tabs[3], Tab::Daily);
-        assert_eq!(tabs[4], Tab::Hourly);
-        assert_eq!(tabs[5], Tab::Minutely);
-        assert_eq!(tabs[6], Tab::Stats);
-        assert_eq!(tabs[7], Tab::Agents);
+        assert_eq!(tabs[3], Tab::Providers);
+        assert_eq!(tabs[4], Tab::Daily);
+        assert_eq!(tabs[5], Tab::Hourly);
+        assert_eq!(tabs[6], Tab::Minutely);
+        assert_eq!(tabs[7], Tab::Stats);
+        assert_eq!(tabs[8], Tab::Agents);
     }
 
     #[test]
     fn test_tab_next() {
         assert_eq!(Tab::Overview.next(), Tab::Usage);
         assert_eq!(Tab::Usage.next(), Tab::Models);
-        assert_eq!(Tab::Models.next(), Tab::Daily);
+        assert_eq!(Tab::Models.next(), Tab::Providers);
+        assert_eq!(Tab::Providers.next(), Tab::Daily);
         assert_eq!(Tab::Daily.next(), Tab::Hourly);
         assert_eq!(Tab::Hourly.next(), Tab::Minutely);
         assert_eq!(Tab::Minutely.next(), Tab::Stats);
@@ -2296,7 +2468,8 @@ mod tests {
         assert_eq!(Tab::Overview.prev(), Tab::Agents);
         assert_eq!(Tab::Usage.prev(), Tab::Overview);
         assert_eq!(Tab::Models.prev(), Tab::Usage);
-        assert_eq!(Tab::Daily.prev(), Tab::Models);
+        assert_eq!(Tab::Providers.prev(), Tab::Models);
+        assert_eq!(Tab::Daily.prev(), Tab::Providers);
         assert_eq!(Tab::Hourly.prev(), Tab::Daily);
         assert_eq!(Tab::Minutely.prev(), Tab::Hourly);
         assert_eq!(Tab::Stats.prev(), Tab::Minutely);
@@ -2307,6 +2480,7 @@ mod tests {
     fn test_tab_as_str() {
         assert_eq!(Tab::Overview.as_str(), "Overview");
         assert_eq!(Tab::Models.as_str(), "Models");
+        assert_eq!(Tab::Providers.as_str(), "Providers");
         assert_eq!(Tab::Agents.as_str(), "Agents");
         assert_eq!(Tab::Daily.as_str(), "Daily");
         assert_eq!(Tab::Hourly.as_str(), "Hourly");
@@ -2318,6 +2492,7 @@ mod tests {
     fn test_tab_short_name() {
         assert_eq!(Tab::Overview.short_name(), "Ovw");
         assert_eq!(Tab::Models.short_name(), "Mod");
+        assert_eq!(Tab::Providers.short_name(), "Pro");
         assert_eq!(Tab::Agents.short_name(), "Agt");
         assert_eq!(Tab::Daily.short_name(), "Day");
         assert_eq!(Tab::Hourly.short_name(), "Hr");
@@ -2862,6 +3037,9 @@ mod tests {
         assert_eq!(app.current_tab, Tab::Models);
 
         app.handle_key_event(key(KeyCode::Tab));
+        assert_eq!(app.current_tab, Tab::Providers);
+
+        app.handle_key_event(key(KeyCode::Tab));
         assert_eq!(app.current_tab, Tab::Daily);
 
         app.handle_key_event(key(KeyCode::Tab));
@@ -2895,6 +3073,9 @@ mod tests {
         assert_eq!(app.current_tab, Tab::Daily);
 
         app.handle_key_event(key(KeyCode::BackTab));
+        assert_eq!(app.current_tab, Tab::Providers);
+
+        app.handle_key_event(key(KeyCode::BackTab));
         assert_eq!(app.current_tab, Tab::Models);
 
         app.handle_key_event(key(KeyCode::BackTab));
@@ -2913,6 +3094,7 @@ mod tests {
         for expected in [
             Tab::Usage,
             Tab::Models,
+            Tab::Providers,
             Tab::Daily,
             Tab::Hourly,
             Tab::Minutely,

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -68,6 +68,23 @@ pub struct AgentUsage {
 }
 
 #[derive(Debug, Clone)]
+pub struct ProviderModelUsage {
+    pub model: String,
+    pub tokens: TokenBreakdown,
+    pub cost: f64,
+    pub session_count: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProviderUsage {
+    pub provider: String,
+    pub tokens: TokenBreakdown,
+    pub cost: f64,
+    pub session_count: u32,
+    pub models: Vec<ProviderModelUsage>,
+}
+
+#[derive(Debug, Clone)]
 pub struct DailyModelInfo {
     /// API provider identifier (e.g. "anthropic", "openai").
     ///

--- a/crates/tokscale-cli/src/tui/ui/footer.rs
+++ b/crates/tokscale-cli/src/tui/ui/footer.rs
@@ -151,6 +151,7 @@ fn render_main_row(frame: &mut Frame, app: &mut App, area: Rect) {
 fn current_count_label(app: &App) -> String {
     match app.current_tab {
         Tab::Overview | Tab::Models => format!(" ({} models)", app.data.models.len()),
+        Tab::Providers => format!(" ({} providers)", app.get_sorted_providers().len()),
         Tab::Agents => format!(" ({} agents)", app.data.agents.len()),
         Tab::Daily if app.is_daily_detail_active() => {
             format!(" ({} models)", app.get_sorted_daily_detail_rows().len())
@@ -399,6 +400,10 @@ mod tests {
         assert_eq!(
             current_count_label(&make_app_on(Tab::Models)),
             " (0 models)"
+        );
+        assert_eq!(
+            current_count_label(&make_app_on(Tab::Providers)),
+            " (0 providers)"
         );
         assert_eq!(
             current_count_label(&make_app_on(Tab::Agents)),

--- a/crates/tokscale-cli/src/tui/ui/mod.rs
+++ b/crates/tokscale-cli/src/tui/ui/mod.rs
@@ -9,6 +9,7 @@ mod hourly_profile;
 mod minutely;
 mod models;
 mod overview;
+mod providers;
 pub mod spinner;
 mod stats;
 mod usage;
@@ -47,6 +48,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         match app.current_tab {
             Tab::Overview => overview::render(frame, app, chunks[1]),
             Tab::Models => models::render(frame, app, chunks[1]),
+            Tab::Providers => providers::render(frame, app, chunks[1]),
             Tab::Agents => agents::render(frame, app, chunks[1]),
             Tab::Daily => daily::render(frame, app, chunks[1]),
             Tab::Hourly => hourly::render(frame, app, chunks[1]),

--- a/crates/tokscale-cli/src/tui/ui/providers.rs
+++ b/crates/tokscale-cli/src/tui/ui/providers.rs
@@ -1,0 +1,224 @@
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, Table};
+
+use super::widgets::{
+    format_cost, format_tokens, get_provider_display_name, viewport_scrollbar_state,
+};
+use crate::tui::app::{App, ProviderRow, SortDirection, SortField};
+
+pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(app.theme.border))
+        .title(Span::styled(
+            " Providers ",
+            Style::default()
+                .fg(app.theme.accent)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .style(Style::default().bg(app.theme.background));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let visible_height = inner.height.saturating_sub(1) as usize;
+    app.set_max_visible_items(visible_height);
+
+    let rows_data = app.get_provider_rows();
+    if rows_data.is_empty() {
+        let empty_msg = Paragraph::new("No provider usage data found. Press 'r' to refresh.")
+            .style(Style::default().fg(app.theme.muted))
+            .alignment(Alignment::Center);
+        frame.render_widget(empty_msg, inner);
+        return;
+    }
+
+    let is_narrow = app.is_narrow();
+    let is_very_narrow = app.is_very_narrow();
+    let sort_field = app.sort_field;
+    let sort_direction = app.sort_direction;
+    let scroll_offset = app.scroll_offset;
+    let selected_index = app.selected_index;
+    let theme_accent = app.theme.accent;
+    let theme_muted = app.theme.muted;
+    let theme_selection = app.theme.selection;
+    let striped_row_style = app.theme.striped_row_style();
+
+    let header_cells = if is_very_narrow {
+        vec!["Provider", "Cost"]
+    } else if is_narrow {
+        vec!["Provider / Model", "Tokens", "Cost"]
+    } else {
+        vec!["#", "Provider / Model", "Tokens", "Cost", "Sessions"]
+    };
+
+    let sort_indicator = |field: SortField| -> &'static str {
+        if sort_field == field {
+            match sort_direction {
+                SortDirection::Ascending => " ▲",
+                SortDirection::Descending => " ▼",
+            }
+        } else {
+            ""
+        }
+    };
+
+    let header = Row::new(
+        header_cells
+            .iter()
+            .enumerate()
+            .map(|(i, h)| {
+                let indicator = match i {
+                    2 if !is_narrow => sort_indicator(SortField::Tokens),
+                    3 if !is_narrow => sort_indicator(SortField::Cost),
+                    1 if is_very_narrow => sort_indicator(SortField::Cost),
+                    1 if is_narrow && !is_very_narrow => sort_indicator(SortField::Tokens),
+                    2 if is_narrow && !is_very_narrow => sort_indicator(SortField::Cost),
+                    _ => "",
+                };
+                Cell::from(format!("{}{}", h, indicator))
+            })
+            .collect::<Vec<_>>(),
+    )
+    .style(
+        Style::default()
+            .fg(theme_accent)
+            .add_modifier(Modifier::BOLD),
+    )
+    .height(1);
+
+    let total_len = rows_data.len();
+    let start = scroll_offset.min(total_len.saturating_sub(1));
+    let end = (start + visible_height).min(total_len);
+
+    if start >= total_len {
+        return;
+    }
+
+    let rows: Vec<Row> = rows_data[start..end]
+        .iter()
+        .enumerate()
+        .map(|(i, row)| {
+            let idx = i + start;
+            let is_selected = idx == selected_index;
+            let is_striped = idx % 2 == 1;
+
+            let (label, tokens, cost, sessions, is_provider) = match row {
+                ProviderRow::Provider(provider) => {
+                    let marker = if app.expanded_providers.contains(&provider.provider) {
+                        "▾"
+                    } else {
+                        "▸"
+                    };
+                    (
+                        format!("{} {}", marker, get_provider_display_name(&provider.provider)),
+                        provider.tokens.total(),
+                        provider.cost,
+                        provider.session_count,
+                        true,
+                    )
+                }
+                ProviderRow::Model { model, .. } => (
+                    format!("  └ {}", model.model),
+                    model.tokens.total(),
+                    model.cost,
+                    model.session_count,
+                    false,
+                ),
+            };
+
+            let name_style = if is_provider {
+                Style::default()
+                    .fg(app.theme.foreground)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme_muted)
+            };
+
+            let cells: Vec<Cell> = if is_very_narrow {
+                vec![
+                    Cell::from(truncate(&label, 22)).style(name_style),
+                    Cell::from(format_cost(cost)).style(Style::default().fg(Color::Green)),
+                ]
+            } else if is_narrow {
+                vec![
+                    Cell::from(truncate(&label, 28)).style(name_style),
+                    Cell::from(format_tokens(tokens)),
+                    Cell::from(format_cost(cost)).style(Style::default().fg(Color::Green)),
+                ]
+            } else {
+                vec![
+                    Cell::from(format!("{}", idx + 1)).style(Style::default().fg(theme_muted)),
+                    Cell::from(truncate(&label, 40)).style(name_style),
+                    Cell::from(format_tokens(tokens)),
+                    Cell::from(format_cost(cost)).style(Style::default().fg(Color::Green)),
+                    Cell::from(sessions.to_string()).style(Style::default().fg(theme_muted)),
+                ]
+            };
+
+            let row_style = if is_selected {
+                Style::default().bg(theme_selection)
+            } else if is_striped {
+                striped_row_style
+            } else {
+                Style::default()
+            };
+
+            Row::new(cells).style(row_style).height(1)
+        })
+        .collect();
+
+    let widths = if is_very_narrow {
+        vec![Constraint::Percentage(70), Constraint::Percentage(30)]
+    } else if is_narrow {
+        vec![
+            Constraint::Percentage(48),
+            Constraint::Percentage(25),
+            Constraint::Percentage(27),
+        ]
+    } else {
+        vec![
+            Constraint::Length(3),
+            Constraint::Min(28),
+            Constraint::Length(12),
+            Constraint::Length(10),
+            Constraint::Length(8),
+        ]
+    };
+
+    let table = Table::new(rows, widths)
+        .header(header)
+        .row_highlight_style(Style::default().bg(theme_selection));
+
+    frame.render_widget(table, inner);
+
+    if total_len > visible_height {
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(Some("▲"))
+            .end_symbol(Some("▼"));
+        let mut scrollbar_state = viewport_scrollbar_state(total_len, scroll_offset, visible_height);
+        frame.render_stateful_widget(
+            scrollbar,
+            area.inner(Margin {
+                horizontal: 0,
+                vertical: 1,
+            }),
+            &mut scrollbar_state,
+        );
+    }
+}
+
+fn truncate(s: &str, max_chars: usize) -> String {
+    if max_chars == 0 {
+        return String::new();
+    }
+    let char_count = s.chars().count();
+    if char_count <= max_chars {
+        s.to_string()
+    } else if max_chars <= 3 {
+        s.chars().take(max_chars).collect()
+    } else {
+        let head: String = s.chars().take(max_chars - 3).collect();
+        format!("{}...", head)
+    }
+}


### PR DESCRIPTION



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Providers tab to the `tokscale-cli` TUI that shows spend, tokens, and sessions grouped by provider, with expandable rows to see per-model totals. Improves navigation and clarity with Enter to toggle rows, sort indicators, and a provider count in the footer.

- New Features
  - New “Providers” tab between Models and Daily (short label “Pro”); navigable via Tab/BackTab.
  - Aggregates usage by provider for current filters; supports existing sort field/direction with header indicators.
  - Press Enter to expand/collapse a provider to view per-model usage; selection and expanded state are maintained.
  - Responsive table for narrow terminals, with scrollbar, striped rows, and selection highlighting.
  - Footer shows provider count; status messages on expand/collapse.

<sup>Written for commit 8bedeb53133cd57782f2c3ceb47a25767eeac353. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

