### PR TITLE
fix(leaderboard): prevent numeric overflow in all-time cost aggregation

### DIFF
--- a/packages/frontend/__tests__/api/usersProfile.test.ts
+++ b/packages/frontend/__tests__/api/usersProfile.test.ts
@@ -259,6 +259,50 @@ describe("GET /api/users/[username]", () => {
     expect(body.user.username).toBe("ImLunaHey");
   });
 
+  it("casts total_cost at full column precision in the profile stats query", async () => {
+    mockState.pushSelectResult([
+      {
+        id: "user-alice",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        totalTokens: 0,
+        totalCost: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        reasoningTokens: 0,
+        submissionCount: 0,
+        earliestDate: null,
+        latestDate: null,
+      },
+    ]);
+    mockState.pushSelectResult([]);
+    mockState.pushSelectResult([]);
+    mockState.pushExecuteResult([]);
+
+    await GET(
+      new Request("http://localhost:3000/api/users/alice"),
+      { params: Promise.resolve({ username: "alice" }) }
+    );
+
+    // submissions.total_cost is decimal(18,4); a narrower cast overflows for a
+    // profile whose lifetime cost has grown past the narrowed ceiling.
+    const costCastWidths = serializeSqlCalls()
+      .filter((text) => /CAST\([^)]*(?:total_cost|totalCost)[^)]*AS DECIMAL/.test(text))
+      .flatMap((text) =>
+        [...text.matchAll(/DECIMAL\((\d+),\s*4\)/g)].map((match) => Number(match[1]))
+      );
+    expect(costCastWidths.length).toBeGreaterThan(0);
+    expect(costCastWidths.every((width) => width >= 18)).toBe(true);
+  });
+
   it("rejects ambiguous case-insensitive username matches", async () => {
     mockState.pushSelectResult([
       {

--- a/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
@@ -295,4 +295,30 @@ describe("group leaderboard data", () => {
     );
     expect(leaderboard.users.map((user) => user.username)).toEqual(["alice", "bob"]);
   });
+
+  // submissions.total_cost is decimal(18,4); narrowing the cast to DECIMAL(12,4)
+  // (max 99,999,999.9999) overflows for any row >= $100,000,000 and crashes the
+  // all-time group leaderboard exactly like the global leaderboard.
+  it("casts total_cost at full column precision for the all-time group leaderboard", async () => {
+    mockState.setAllTimeRows([]);
+
+    await getGroupLeaderboardData("group-1", "all", 1, 50, "cost");
+
+    const sqlTexts = mockState.sql.mock.calls.map((call) => {
+      const [strings, ...values] = call as [TemplateStringsArray, ...unknown[]];
+      return Array.from(strings).reduce((text, part, index) => {
+        const nextValue = index < values.length ? String(values[index]) : "";
+        return `${text}${part}${nextValue}`;
+      }, "");
+    });
+
+    const costCastWidths = sqlTexts
+      .filter((text) => /CAST\([^)]*(?:total_cost|totalCost)[^)]*AS DECIMAL/.test(text))
+      .flatMap((text) =>
+        [...text.matchAll(/DECIMAL\((\d+),\s*4\)/g)].map((match) => Number(match[1]))
+      );
+    expect(costCastWidths.length).toBeGreaterThan(0);
+    // total_cost is decimal(18,4); any narrower precision overflows on big costs.
+    expect(costCastWidths.every((width) => width >= 18)).toBe(true);
+  });
 });

--- a/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
@@ -502,3 +502,65 @@ describe("all-time leaderboard freshness queries", () => {
     expect(mockState.limitCalls[0]).toBe(2);
   });
 });
+
+describe("all-time cost aggregation precision (numeric overflow regression)", () => {
+  // The submissions.total_cost column is decimal(18,4). Casting it to a
+  // narrower DECIMAL(12,4) (max 99,999,999.9999) overflows the moment any row
+  // reports a cost >= $100,000,000, which throws "numeric field overflow" and
+  // takes down every all-time leaderboard query. Casts must match the column.
+  function expectNoNarrowedCostCast(sqlTexts: string[]): void {
+    const costCastWidths = sqlTexts
+      .filter((text) => /CAST\([^)]*(?:total_cost|totalCost)[^)]*AS DECIMAL/.test(text))
+      .flatMap((text) =>
+        [...text.matchAll(/DECIMAL\((\d+),\s*4\)/g)].map((match) => Number(match[1]))
+      );
+    expect(costCastWidths.length).toBeGreaterThan(0);
+    // total_cost is decimal(18,4); any narrower precision overflows on big costs.
+    expect(costCastWidths.every((width) => width >= 18)).toBe(true);
+  }
+
+  it("casts total_cost at full column precision in the all-time list", async () => {
+    mockState.pushAwaitedResult([]);
+    mockState.pushAwaitedResult([
+      { totalTokens: 0, totalCost: 0, totalSubmissions: 0, uniqueUsers: 0 },
+    ]);
+
+    await getLeaderboardData("all", 1, 50, "cost");
+
+    expectNoNarrowedCostCast(serializeSqlCalls());
+  });
+
+  it("casts total_cost at full column precision in the all-time search list", async () => {
+    mockState.pushAwaitedResult([]);
+    mockState.pushAwaitedResult([{ count: 0 }]);
+    mockState.pushAwaitedResult([
+      { totalTokens: 0, totalCost: 0, totalSubmissions: 0, uniqueUsers: 0 },
+    ]);
+
+    await getLeaderboardData("all", 1, 50, "cost", "ali");
+
+    expectNoNarrowedCostCast(serializeSqlCalls());
+  });
+
+  it("casts total_cost at full column precision for all-time user rank", async () => {
+    mockState.pushAwaitedResult([
+      { id: "user-alice", username: "alice", displayName: "Alice", avatarUrl: null },
+    ]);
+    mockState.pushAwaitedResult([
+      {
+        totalTokens: 3000,
+        totalCost: 40,
+        totalActiveTimeMs: 0,
+        submissionCount: 1,
+        lastSubmission: "2026-03-12T09:00:00.000Z",
+        cliVersion: "1.9.0",
+        schemaVersion: 1,
+      },
+    ]);
+    mockState.pushAwaitedResult([{ count: 0 }]);
+
+    await getUserRank("alice", "all", "cost");
+
+    expectNoNarrowedCostCast(serializeSqlCalls());
+  });
+});

--- a/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
+++ b/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
@@ -177,7 +177,7 @@ describe("user embed data", () => {
 
     expect(tokenSqlTexts.some((text) => text.includes("RANK() OVER"))).toBe(true);
     expect(tokenSqlTexts.some((text) =>
-      text.includes("total_tokens DESC, CAST(total_cost AS DECIMAL(12,4)) DESC")
+      /total_tokens DESC, CAST\(total_cost AS DECIMAL\(\d+,4\)\) DESC/.test(text)
     )).toBe(false);
 
     mockState.reset();
@@ -200,8 +200,36 @@ describe("user embed data", () => {
 
     expect(costSqlTexts.some((text) => text.includes("RANK() OVER"))).toBe(true);
     expect(costSqlTexts.some((text) =>
-      text.includes("CAST(total_cost AS DECIMAL(12,4)) DESC, total_tokens DESC")
+      /CAST\(total_cost AS DECIMAL\(\d+,4\)\) DESC, total_tokens DESC/.test(text)
     )).toBe(false);
+  });
+
+  it("casts total_cost at full column precision for cost-sorted embed stats", async () => {
+    mockState.pushAwaitedResult([
+      {
+        id: "user-alice",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        totalTokens: 3000,
+        totalCost: 40,
+        submissionCount: 1,
+        updatedAt: new Date("2026-03-12T09:00:00.000Z"),
+      },
+    ]);
+    mockState.pushExecuteResult([{ rank: 2, total: 3 }]);
+
+    await getUserEmbedStats("alice", "cost");
+
+    // submissions.total_cost is decimal(18,4); narrowing the cast overflows for
+    // costs >= the narrowed ceiling and 500s the embed for that user.
+    const costCastWidths = serializeSqlCalls()
+      .filter((text) => /CAST\([^)]*(?:total_cost|totalCost)[^)]*AS DECIMAL/.test(text))
+      .flatMap((text) =>
+        [...text.matchAll(/DECIMAL\((\d+),\s*4\)/g)].map((match) => Number(match[1]))
+      );
+    expect(costCastWidths.length).toBeGreaterThan(0);
+    expect(costCastWidths.every((width) => width >= 18)).toBe(true);
   });
 
   it("looks up embed stats usernames case-insensitively and returns the canonical username", async () => {

--- a/packages/frontend/src/app/api/users/[username]/route.ts
+++ b/packages/frontend/src/app/api/users/[username]/route.ts
@@ -53,7 +53,7 @@ export async function GET(_request: Request, { params }: RouteParams) {
       db
         .select({
           totalTokens: sql<number>`COALESCE(SUM(${submissions.totalTokens}), 0)`,
-          totalCost: sql<number>`COALESCE(SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4))), 0)`,
+          totalCost: sql<number>`COALESCE(SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4))), 0)`,
           inputTokens: sql<number>`COALESCE(SUM(${submissions.inputTokens}), 0)`,
           outputTokens: sql<number>`COALESCE(SUM(${submissions.outputTokens}), 0)`,
           cacheReadTokens: sql<number>`COALESCE(SUM(${submissions.cacheReadTokens}), 0)`,

--- a/packages/frontend/src/lib/embed/getUserEmbedStats.ts
+++ b/packages/frontend/src/lib/embed/getUserEmbedStats.ts
@@ -43,7 +43,7 @@ async function fetchUserEmbedStats(username: string, sortBy: EmbedSortBy): Promi
       displayName: users.displayName,
       avatarUrl: users.avatarUrl,
       totalTokens: sql<number>`COALESCE(${submissions.totalTokens}, 0)`,
-      totalCost: sql<number>`COALESCE(CAST(${submissions.totalCost} AS DECIMAL(12,4)), 0)`,
+      totalCost: sql<number>`COALESCE(CAST(${submissions.totalCost} AS DECIMAL(18,4)), 0)`,
       submissionCount: sql<number>`COALESCE(${submissions.submitCount}, 0)`,
       updatedAt: submissions.updatedAt,
     })
@@ -70,7 +70,7 @@ async function fetchUserEmbedStats(username: string, sortBy: EmbedSortBy): Promi
           RANK() OVER (
             ORDER BY
               ${sortBy === "cost"
-                ? sql`CAST(total_cost AS DECIMAL(12,4)) DESC`
+                ? sql`CAST(total_cost AS DECIMAL(18,4)) DESC`
                 : sql`total_tokens DESC`}
           ) AS rank
         FROM submissions

--- a/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
+++ b/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
@@ -259,11 +259,11 @@ async function fetchPeriodRows(
 
 async function fetchAllTimeRows(groupId: string, sortBy: SortBy): Promise<GroupLeaderboardUser[]> {
   const primaryOrderByColumn = sortBy === "cost"
-    ? sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`
+    ? sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`
     : sql`SUM(${submissions.totalTokens})`;
   const secondaryOrderByColumn = sortBy === "cost"
     ? sql`SUM(${submissions.totalTokens})`
-    : sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`;
+    : sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`;
 
   const rows = await db
     .select({
@@ -273,7 +273,7 @@ async function fetchAllTimeRows(groupId: string, sortBy: SortBy): Promise<GroupL
       avatarUrl: users.avatarUrl,
       role: groupMembers.role,
       totalTokens: sql<number>`SUM(${submissions.totalTokens})`.as("total_tokens"),
-      totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`.as("total_cost"),
+      totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`.as("total_cost"),
       submissionCount: sql<number>`COALESCE(SUM(${submissions.submitCount}), 0)`.as("submission_count"),
       lastSubmission: sql<string>`MAX(${submissions.updatedAt})`.as("last_submission"),
       cliVersion: sql<string | null>`(

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -343,7 +343,7 @@ async function fetchLeaderboardData(
   const offset = (page - 1) * limit;
 
   const orderByColumn = sortBy === "cost"
-    ? sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`
+    ? sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`
     : sortBy === "time"
     ? sql`COALESCE(SUM(${submissions.totalActiveTimeMs}), 0)`
     : sql`SUM(${submissions.totalTokens})`;
@@ -351,7 +351,7 @@ async function fetchLeaderboardData(
     ? sql`SUM(${submissions.totalTokens})`
     : sortBy === "time"
     ? sql`SUM(${submissions.totalTokens})`
-    : sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`;
+    : sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`;
 
   if (search) {
     // When searching, use a subquery to compute global ranks for ALL users,
@@ -364,7 +364,7 @@ async function fetchLeaderboardData(
         displayName: users.displayName,
         avatarUrl: users.avatarUrl,
         totalTokens: sql<number>`SUM(${submissions.totalTokens})`.as("total_tokens"),
-        totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`.as("total_cost"),
+        totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`.as("total_cost"),
         totalActiveTimeMs: sql<number>`COALESCE(SUM(${submissions.totalActiveTimeMs}), 0)`.as("total_active_time_ms"),
         submissionCount: sql<number>`COALESCE(SUM(${submissions.submitCount}), 0)`.as("submission_count"),
         lastSubmission: sql<string>`MAX(${submissions.updatedAt})`.as("last_submission"),
@@ -416,7 +416,7 @@ async function fetchLeaderboardData(
     const globalStats = await db
       .select({
         totalTokens: sql<number>`SUM(${submissions.totalTokens})`,
-        totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`,
+        totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`,
         totalSubmissions: sql<number>`COUNT(${submissions.id})`,
         uniqueUsers: sql<number>`COUNT(DISTINCT ${submissions.userId})`,
       })
@@ -469,7 +469,7 @@ async function fetchLeaderboardData(
       displayName: users.displayName,
       avatarUrl: users.avatarUrl,
       totalTokens: sql<number>`SUM(${submissions.totalTokens})`.as("total_tokens"),
-      totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`.as("total_cost"),
+      totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`.as("total_cost"),
       totalActiveTimeMs: sql<number>`COALESCE(SUM(${submissions.totalActiveTimeMs}), 0)`.as("total_active_time_ms"),
       submissionCount: sql<number>`COALESCE(SUM(${submissions.submitCount}), 0)`.as("submission_count"),
       lastSubmission: sql<string>`MAX(${submissions.updatedAt})`.as("last_submission"),
@@ -500,7 +500,7 @@ async function fetchLeaderboardData(
     db
       .select({
         totalTokens: sql<number>`SUM(${submissions.totalTokens})`,
-        totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`,
+        totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`,
         totalSubmissions: sql<number>`COUNT(${submissions.id})`,
         uniqueUsers: sql<number>`COUNT(DISTINCT ${submissions.userId})`,
       })
@@ -602,7 +602,7 @@ async function fetchUserRank(
   const userStatsResult = await db
     .select({
       totalTokens: sql<number>`SUM(${submissions.totalTokens})`.as("total_tokens"),
-      totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`.as("total_cost"),
+      totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`.as("total_cost"),
       totalActiveTimeMs: sql<number>`COALESCE(SUM(${submissions.totalActiveTimeMs}), 0)`.as("total_active_time_ms"),
       submissionCount: sql<number>`COALESCE(SUM(${submissions.submitCount}), 0)`.as("submission_count"),
       lastSubmission: sql<string>`MAX(${submissions.updatedAt})`.as("last_submission"),
@@ -635,7 +635,7 @@ async function fetchUserRank(
     ? userTotalActiveTimeMs
     : userTotalTokens;
   const compareColumn = sortBy === "cost"
-    ? sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(12,4)))`
+    ? sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`
     : sortBy === "time"
     ? sql`COALESCE(SUM(${submissions.totalActiveTimeMs}), 0)`
     : sql`SUM(${submissions.totalTokens})`;


### PR DESCRIPTION
## Problem

The hosted all-time leaderboard (`/leaderboard`, the default view) is currently down: it renders Next.js's server-side error boundary (`Application error: a server-side exception has occurred`, digest `250786165`). Period-filtered views (`?period=month|week|last-month`) work fine.

Reproduced against production with read-only probes:

| Request | Result |
|---|---|
| `GET /api/leaderboard?period=all` (any `sortBy`) | **500** |
| `GET /api/leaderboard?period=month` (any `sortBy`) | 200 |
| `GET /api/leaderboard/user/<name>?sortBy=cost` | **500** |
| `GET /api/leaderboard/user/<name>?sortBy=tokens` | 200 |
| body of `GET /leaderboard` (all-time) | contains digest `250786165` |

## Root cause

Every all-time query casts `submissions.total_cost` — a `decimal(18,4)` column ([`schema.ts`](../blob/main/packages/frontend/src/lib/db/schema.ts#L171)) — down to **`DECIMAL(12,4)`**, whose ceiling is `99,999,999.9999`. `total_cost` is a per-submission lifetime aggregate that grows over time; once it crosses **$100M** for any user, the per-row `CAST` throws `numeric field overflow` and the whole query 500s.

Period-scoped queries aggregate cost in JS (`Number(...)` / `.reduce`) with no SQL cast, so they were unaffected — which is exactly why only the all-time views broke.

The same narrowed cast appears in the group leaderboard, profile, and embed queries, so those surfaces 500 for an affected user too.

## Fix

Widen each affected cast to the column's own precision, `DECIMAL(18,4)`:
- `lib/leaderboard/getLeaderboard.ts` (8 sites)
- `lib/groups/getGroupLeaderboard.ts` (3 sites)
- `app/api/users/[username]/route.ts` (1 site)
- `lib/embed/getUserEmbedStats.ts` (2 sites)

`SUM` promotes numeric scale automatically, so no value the column can legally hold can overflow the per-row cast. Scale stays `4`, so results are byte-for-byte identical for normal-sized costs (no rounding/ordering/type change). No migration needed.

## Tests

Added SQL-shape regression tests asserting cost casts never narrow below the column precision, covering the all-time **list**, **search**, **user-rank**, **group**, **profile**, and **embed** paths. Each was confirmed to fail (RED) against the pre-fix `DECIMAL(12,4)` and pass (GREEN) after widening.

```
4 regression files: 25 passed
full suite: 433 passed (2 failures are pre-existing in clientRegistry.test.ts, unrelated)
eslint: clean on all changed files
```

## Out of scope (follow-up)

`app/api/submit/route.ts` still narrows the per-day `dailyBreakdown.cost` to `DECIMAL(12,4)` / `numeric(10,4)`. Those are write/recalc paths whose per-day inputs sit far below the overflow threshold, so they are not the live failure; left untouched to keep this fix focused on the read surfaces causing the outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 500s in the all‑time leaderboard by preventing numeric overflow in cost aggregation. Casts now match the `decimal(18,4)` column across queries, restoring `/leaderboard`, group views, profiles, and embeds.

- **Bug Fixes**
  - Replaced `DECIMAL(12,4)` with `DECIMAL(18,4)` in all-time cost queries for leaderboard list/search/user-rank, group leaderboard, profile API, and embed (including `SUM` and `ORDER BY`).
  - Keeps scale at 4; results and ordering unchanged for normal values; no schema changes.
  - Added regression tests to ensure no narrowed casts across all affected paths.

<sup>Written for commit dbbedbc5b566c8c323b3056d2657a68556c737e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

