### PR TITLE
fix(usage): harden Codex account loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3446,6 +3446,7 @@ dependencies = [
  "crossterm 0.28.1",
  "csv",
  "dirs",
+ "fs2",
  "hostname",
  "image",
  "imageproc",

--- a/crates/tokscale-cli/Cargo.toml
+++ b/crates/tokscale-cli/Cargo.toml
@@ -37,6 +37,7 @@ dirs = { workspace = true }
 rayon = { workspace = true }
 arboard = { workspace = true }
 reqwest = { workspace = true }
+fs2 = { workspace = true }
 image = "0.25"
 imageproc = "0.25"
 ab_glyph = "0.2"

--- a/crates/tokscale-cli/src/commands/usage/codex.rs
+++ b/crates/tokscale-cli/src/commands/usage/codex.rs
@@ -1,15 +1,18 @@
 use anyhow::{Context, Result};
 use chrono::{TimeZone, Utc};
+use fs2::FileExt;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::fmt;
 use std::path::{Path, PathBuf};
 
 use super::helpers::capitalize;
 use super::{
-    UsageAccount, UsageCreditStatus, UsageMetric, UsageOutput, UsageResetCredit, UsageResetCredits,
-    UsageSpendControl,
+    UsageAccount, UsageCreditStatus, UsageFetchDiagnostic, UsageFetchDiagnosticKind,
+    UsageFetchDiagnosticSeverity, UsageFetchReport, UsageMetric, UsageOutput, UsageResetCredit,
+    UsageResetCredits, UsageSpendControl,
 };
 
 const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
@@ -19,7 +22,7 @@ struct Auth {
     tokens: Option<Tokens>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct Tokens {
     #[serde(skip_serializing_if = "Option::is_none")]
     access_token: Option<String>,
@@ -169,8 +172,189 @@ enum CredentialSource {
     Store(String),
 }
 
+#[derive(Debug)]
+enum CodexUsageError {
+    MissingCredentials,
+    NeedsAuth,
+    UnsupportedStoreVersion { version: i64, path: PathBuf },
+}
+
+impl fmt::Display for CodexUsageError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingCredentials => {
+                write!(f, "No Codex credentials found. Run 'codex' to log in.")
+            }
+            Self::NeedsAuth => write!(f, "Codex credentials need authentication"),
+            Self::UnsupportedStoreVersion { version, path } => write!(
+                f,
+                "Unsupported Codex account store version {version} at {} (this tokscale supports version 1); refusing to modify it",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CodexUsageError {}
+
+fn has_codex_error(error: &anyhow::Error, predicate: impl Fn(&CodexUsageError) -> bool) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<CodexUsageError>()
+            .is_some_and(&predicate)
+    })
+}
+
+fn is_missing_credentials(error: &anyhow::Error) -> bool {
+    has_codex_error(error, |error| {
+        matches!(error, CodexUsageError::MissingCredentials)
+    })
+}
+
+fn is_needs_auth(error: &anyhow::Error) -> bool {
+    has_codex_error(error, |error| matches!(error, CodexUsageError::NeedsAuth))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CodexFetchIntent {
+    ReadOnly,
+    SaveCurrentLogin,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StoreRepairPolicy {
+    InMemoryOnly,
+    Persist,
+}
+
 fn codex_store_path() -> PathBuf {
     crate::paths::get_config_dir().join("codex-credentials.json")
+}
+
+#[cfg(test)]
+fn codex_store_path_in_home(home_dir: &Path) -> PathBuf {
+    home_dir
+        .join(".config")
+        .join("tokscale")
+        .join("codex-credentials.json")
+}
+
+#[derive(Debug, Clone)]
+struct CodexAccountStore {
+    path: PathBuf,
+}
+
+impl CodexAccountStore {
+    fn default() -> Self {
+        Self {
+            path: codex_store_path(),
+        }
+    }
+
+    fn at_path(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    #[cfg(test)]
+    fn in_home(home_dir: &Path) -> Self {
+        Self::at_path(codex_store_path_in_home(home_dir))
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn lock_path(&self) -> PathBuf {
+        self.path.with_extension("lock")
+    }
+
+    fn with_lock<T>(&self, action: impl FnOnce(&Self) -> Result<T>) -> Result<T> {
+        let lock_path = self.lock_path();
+        if let Some(dir) = lock_path.parent() {
+            std::fs::create_dir_all(dir).with_context(|| {
+                format!("Failed to create Codex account lock dir {}", dir.display())
+            })?;
+        }
+        let lock_file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .with_context(|| {
+                format!("Failed to open Codex account lock {}", lock_path.display())
+            })?;
+        lock_file.lock_exclusive().with_context(|| {
+            format!("Failed to lock Codex account store {}", self.path.display())
+        })?;
+
+        let result = action(self);
+        let unlock_result = lock_file.unlock().with_context(|| {
+            format!(
+                "Failed to unlock Codex account store {}",
+                self.path.display()
+            )
+        });
+
+        match (result, unlock_result) {
+            (Ok(value), Ok(())) => Ok(value),
+            (Err(error), _) => Err(error),
+            (Ok(_), Err(error)) => Err(error),
+        }
+    }
+
+    fn read(&self) -> Option<CodexCredentialsStore> {
+        self.read_result().ok().flatten()
+    }
+
+    fn read_result(&self) -> Result<Option<CodexCredentialsStore>> {
+        self.read_unlocked(StoreRepairPolicy::InMemoryOnly)
+    }
+
+    fn read_for_update(&self) -> Result<Option<CodexCredentialsStore>> {
+        self.with_lock(|store| store.read_for_update_unlocked())
+    }
+
+    fn read_for_update_unlocked(&self) -> Result<Option<CodexCredentialsStore>> {
+        self.read_unlocked(StoreRepairPolicy::Persist)
+    }
+
+    fn read_unlocked(
+        &self,
+        repair_policy: StoreRepairPolicy,
+    ) -> Result<Option<CodexCredentialsStore>> {
+        load_credentials_store_from_path_unlocked(self.path(), repair_policy)
+    }
+
+    #[cfg(test)]
+    fn save(&self, store: &CodexCredentialsStore) -> Result<()> {
+        self.with_lock(|store_file| store_file.save_unlocked(store))
+    }
+
+    fn save_unlocked(&self, store: &CodexCredentialsStore) -> Result<()> {
+        let json = serde_json::to_string_pretty(store)?;
+        super::helpers::atomic_write_secret(self.path(), json.as_bytes()).with_context(|| {
+            format!(
+                "Failed to write Codex account store to {}",
+                self.path.display()
+            )
+        })
+    }
+
+    fn update_existing<T>(
+        &self,
+        missing_message: &'static str,
+        action: impl FnOnce(&mut CodexCredentialsStore) -> Result<T>,
+    ) -> Result<T> {
+        self.with_lock(|store_file| {
+            let mut store = store_file
+                .read_for_update_unlocked()?
+                .ok_or_else(|| anyhow::anyhow!(missing_message))?;
+            let result = action(&mut store)?;
+            store_file.save_unlocked(&store)?;
+            Ok(result)
+        })
+    }
 }
 
 fn current_auth_paths() -> Vec<PathBuf> {
@@ -240,7 +424,7 @@ fn read_current_credentials() -> Result<(Auth, CredentialSource)> {
         }
     }
 
-    anyhow::bail!("No Codex credentials found. Run 'codex' to log in.")
+    Err(CodexUsageError::MissingCredentials.into())
 }
 
 fn auth_document(tokens: &Tokens) -> serde_json::Value {
@@ -281,46 +465,77 @@ fn hash_token(token: &str) -> String {
         .collect::<String>()
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CodexAccountIdentity {
+    stable_id: String,
+    account_id: Option<String>,
+    id_token: Option<String>,
+    access_token: Option<String>,
+}
+
+impl CodexAccountIdentity {
+    fn from_tokens(tokens: &Tokens) -> Self {
+        let account_id = normalized_token_value(tokens.account_id.as_deref());
+        let id_token = normalized_token_value(tokens.id_token.as_deref());
+        let access_token = normalized_token_value(tokens.access_token.as_deref());
+        let stable_id = account_id
+            .clone()
+            .or_else(|| {
+                id_token
+                    .as_deref()
+                    .map(|token| format!("id-{}", hash_token(token)))
+            })
+            .or_else(|| {
+                access_token
+                    .as_deref()
+                    .map(|token| format!("token-{}", hash_token(token)))
+            })
+            .unwrap_or_else(|| "account".to_string());
+
+        Self {
+            stable_id,
+            account_id,
+            id_token,
+            access_token,
+        }
+    }
+
+    fn stable_id(&self) -> &str {
+        &self.stable_id
+    }
+
+    fn matches(&self, other: &Self) -> bool {
+        if let (Some(a_id), Some(b_id)) = (self.account_id.as_deref(), other.account_id.as_deref())
+        {
+            return a_id == b_id;
+        }
+
+        if let (Some(a_id), Some(b_id)) = (self.id_token.as_deref(), other.id_token.as_deref()) {
+            return a_id == b_id;
+        }
+
+        match (self.access_token.as_deref(), other.access_token.as_deref()) {
+            (Some(a_token), Some(b_token)) => a_token == b_token,
+            _ => false,
+        }
+    }
+}
+
 fn derive_account_id(tokens: &Tokens) -> String {
-    if let Some(account_id) = tokens.account_id.as_deref() {
-        let trimmed = account_id.trim();
-        if !trimmed.is_empty() {
-            return trimmed.to_string();
-        }
-    }
-
-    if let Some(id_token) = tokens.id_token.as_deref() {
-        let trimmed = id_token.trim();
-        if !trimmed.is_empty() {
-            return format!("id-{}", hash_token(trimmed));
-        }
-    }
-
-    tokens
-        .access_token
-        .as_deref()
-        .map(|token| format!("token-{}", hash_token(token)))
-        .unwrap_or_else(|| "account".to_string())
+    CodexAccountIdentity::from_tokens(tokens)
+        .stable_id()
+        .to_string()
 }
 
-fn normalized_token_field(value: Option<&str>) -> Option<&str> {
-    value.map(str::trim).filter(|value| !value.is_empty())
-}
-
-/// Compares one identity field; `None` means the field is not present on both
-/// sides and the next field should decide.
-fn field_identity(a: Option<&str>, b: Option<&str>) -> Option<bool> {
-    match (normalized_token_field(a), normalized_token_field(b)) {
-        (Some(a), Some(b)) => Some(a == b),
-        _ => None,
-    }
+fn normalized_token_value(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 fn same_token_identity(a: &Tokens, b: &Tokens) -> bool {
-    field_identity(a.account_id.as_deref(), b.account_id.as_deref())
-        .or_else(|| field_identity(a.id_token.as_deref(), b.id_token.as_deref()))
-        .or_else(|| field_identity(a.access_token.as_deref(), b.access_token.as_deref()))
-        .unwrap_or(false)
+    CodexAccountIdentity::from_tokens(a).matches(&CodexAccountIdentity::from_tokens(b))
 }
 
 fn next_available_account_id(store: &CodexCredentialsStore, base_id: &str) -> String {
@@ -368,18 +583,27 @@ fn validate_label_available(
 }
 
 pub fn load_credentials_store() -> Option<CodexCredentialsStore> {
-    load_credentials_store_from_path(&codex_store_path())
+    CodexAccountStore::default().read()
 }
 
+#[cfg(test)]
+fn load_credentials_store_from_home(home_dir: &Path) -> Option<CodexCredentialsStore> {
+    CodexAccountStore::in_home(home_dir).read()
+}
+
+#[cfg(test)]
 fn load_credentials_store_from_path(path: &Path) -> Option<CodexCredentialsStore> {
-    load_credentials_store_for_update(path).ok().flatten()
+    CodexAccountStore::at_path(path).read()
 }
 
 /// Loads the store while distinguishing "no usable store" (`Ok(None)`) from a
 /// store written by a newer tokscale (`Err`). Write paths must propagate the
 /// error instead of silently clobbering a future-version store; read paths can
 /// treat both as "nothing usable".
-fn load_credentials_store_for_update(path: &Path) -> Result<Option<CodexCredentialsStore>> {
+fn load_credentials_store_from_path_unlocked(
+    path: &Path,
+    repair_policy: StoreRepairPolicy,
+) -> Result<Option<CodexCredentialsStore>> {
     let Ok(content) = std::fs::read_to_string(path) else {
         return Ok(None);
     };
@@ -397,7 +621,9 @@ fn load_credentials_store_for_update(path: &Path) -> Result<Option<CodexCredenti
     {
         if let Some(first_id) = first_account_id(&store) {
             store.active_account_id = first_id;
-            let _ = save_credentials_store_at_path(path, &store);
+            if repair_policy == StoreRepairPolicy::Persist {
+                let _ = CodexAccountStore::at_path(path).save_unlocked(&store);
+            }
         }
     }
 
@@ -414,22 +640,23 @@ fn bail_on_unknown_store_version(path: &Path, content: &str) -> Result<()> {
         return Ok(());
     };
     if version != 1 {
-        anyhow::bail!(
-            "Unsupported Codex account store version {version} at {} (this tokscale supports version 1); refusing to modify it",
-            path.display()
-        );
+        return Err(CodexUsageError::UnsupportedStoreVersion {
+            version,
+            path: path.to_path_buf(),
+        }
+        .into());
     }
     Ok(())
 }
 
-fn save_credentials_store(store: &CodexCredentialsStore) -> Result<()> {
-    save_credentials_store_at_path(&codex_store_path(), store)
+#[cfg(test)]
+fn save_credentials_store_in_home(home_dir: &Path, store: &CodexCredentialsStore) -> Result<()> {
+    CodexAccountStore::in_home(home_dir).save(store)
 }
 
+#[cfg(test)]
 fn save_credentials_store_at_path(path: &Path, store: &CodexCredentialsStore) -> Result<()> {
-    let json = serde_json::to_string_pretty(store)?;
-    super::helpers::atomic_write_secret(path, json.as_bytes())
-        .with_context(|| format!("Failed to write Codex account store to {}", path.display()))
+    CodexAccountStore::at_path(path).save(store)
 }
 
 fn resolve_account_id(store: &CodexCredentialsStore, name_or_id: &str) -> Option<String> {
@@ -564,74 +791,89 @@ fn save_account_from_auth_at_path(
     }
 
     let base_account_id = derive_account_id(&tokens);
-    let mut store =
-        load_credentials_store_for_update(store_path)?.unwrap_or_else(|| CodexCredentialsStore {
-            version: 1,
-            active_account_id: if make_active {
-                base_account_id.clone()
-            } else {
-                String::new()
-            },
-            accounts: HashMap::new(),
-        });
+    CodexAccountStore::at_path(store_path).with_lock(|store_file| {
+        let mut store =
+            store_file
+                .read_for_update_unlocked()?
+                .unwrap_or_else(|| CodexCredentialsStore {
+                    version: 1,
+                    active_account_id: if make_active {
+                        base_account_id.clone()
+                    } else {
+                        String::new()
+                    },
+                    accounts: HashMap::new(),
+                });
 
-    // Scan every stored account (not just the base-id key) so an account that
-    // was stored under a collision-suffixed id (e.g. `acct_x-2`) is updated in
-    // place instead of re-importing as `acct_x-3`, `acct_x-4`, ...
-    let existing_identity_id = store
-        .accounts
-        .iter()
-        .find(|(_, existing)| same_token_identity(&existing.tokens, &tokens))
-        .map(|(id, _)| id.clone());
+        // Scan every stored account (not just the base-id key) so an account
+        // stored under a collision-suffixed id (e.g. `acct_x-2`) is updated in
+        // place instead of re-importing as `acct_x-3`, `acct_x-4`, ...
+        let existing_identity_id = store
+            .accounts
+            .iter()
+            .find(|(_, existing)| same_token_identity(&existing.tokens, &tokens))
+            .map(|(id, _)| id.clone());
 
-    if let Some(existing_id) = existing_identity_id {
-        validate_label_available(&store, &existing_id, label)?;
-        if let Some(existing) = store.accounts.get_mut(&existing_id) {
-            existing.tokens = tokens;
-            if let Some(label) = label.map(str::trim).filter(|s| !s.is_empty()) {
-                existing.label = Some(label.to_string());
+        if let Some(existing_id) = existing_identity_id {
+            validate_label_available(&store, &existing_id, label)?;
+            let label = label.map(str::trim).filter(|s| !s.is_empty());
+            let active_changed = make_active && store.active_account_id != existing_id;
+            let mut account_changed = false;
+            if let Some(existing) = store.accounts.get_mut(&existing_id) {
+                if existing.tokens != tokens {
+                    existing.tokens = tokens;
+                    account_changed = true;
+                }
+                if let Some(label) = label {
+                    if existing.label.as_deref() != Some(label) {
+                        existing.label = Some(label.to_string());
+                        account_changed = true;
+                    }
+                }
             }
+            if make_active {
+                store.active_account_id = existing_id.clone();
+            }
+            if account_changed || active_changed {
+                store_file.save_unlocked(&store)?;
+            }
+
+            let account = store
+                .accounts
+                .get(&existing_id)
+                .ok_or_else(|| anyhow::anyhow!("Failed to save Codex account"))?;
+            return Ok(account_info(&store, &existing_id, account));
         }
+
+        let account_id = if store.accounts.contains_key(&base_account_id) {
+            next_available_account_id(&store, &base_account_id)
+        } else {
+            base_account_id
+        };
+
+        validate_label_available(&store, &account_id, label)?;
+
+        let account = CodexAccount {
+            tokens,
+            created_at: chrono::Utc::now().to_rfc3339(),
+            label: label
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string),
+        };
+
+        store.accounts.insert(account_id.clone(), account);
         if make_active {
-            store.active_account_id = existing_id.clone();
+            store.active_account_id = account_id.clone();
         }
-        save_credentials_store_at_path(store_path, &store)?;
+        store_file.save_unlocked(&store)?;
 
         let account = store
             .accounts
-            .get(&existing_id)
+            .get(&account_id)
             .ok_or_else(|| anyhow::anyhow!("Failed to save Codex account"))?;
-        return Ok(account_info(&store, &existing_id, account));
-    }
-
-    let account_id = if store.accounts.contains_key(&base_account_id) {
-        next_available_account_id(&store, &base_account_id)
-    } else {
-        base_account_id
-    };
-
-    validate_label_available(&store, &account_id, label)?;
-
-    let account = CodexAccount {
-        tokens,
-        created_at: chrono::Utc::now().to_rfc3339(),
-        label: label
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(str::to_string),
-    };
-
-    store.accounts.insert(account_id.clone(), account);
-    if make_active {
-        store.active_account_id = account_id.clone();
-    }
-    save_credentials_store_at_path(store_path, &store)?;
-
-    let account = store
-        .accounts
-        .get(&account_id)
-        .ok_or_else(|| anyhow::anyhow!("Failed to save Codex account"))?;
-    Ok(account_info(&store, &account_id, account))
+        Ok(account_info(&store, &account_id, account))
+    })
 }
 
 pub struct CodexLoginImport {
@@ -672,15 +914,20 @@ pub fn import_login_auth_file(path: &Path) -> Result<CodexLoginImport> {
     Ok(CodexLoginImport { info, warning })
 }
 
+pub fn save_current_auth_account() -> Result<CodexAccountInfo> {
+    let (auth, _) = read_current_credentials()?;
+    save_account_from_auth(auth, None)
+}
+
 fn update_account_tokens(account_id: &str, tokens: Tokens) -> Result<()> {
-    let mut store =
-        load_credentials_store().ok_or_else(|| anyhow::anyhow!("No saved Codex accounts"))?;
-    let account = store
-        .accounts
-        .get_mut(account_id)
-        .ok_or_else(|| anyhow::anyhow!("Codex account not found: {account_id}"))?;
-    account.tokens = tokens;
-    save_credentials_store(&store)
+    CodexAccountStore::default().update_existing("No saved Codex accounts", |store| {
+        let account = store
+            .accounts
+            .get_mut(account_id)
+            .ok_or_else(|| anyhow::anyhow!("Codex account not found: {account_id}"))?;
+        account.tokens = tokens;
+        Ok(())
+    })
 }
 
 fn load_account(name_or_id: Option<&str>) -> Result<(String, CodexAccount, CodexAccountInfo)> {
@@ -741,7 +988,7 @@ where
     T: DeserializeOwned,
 {
     if body.trim_start().starts_with('<') {
-        anyhow::bail!("NEEDS_AUTH");
+        return Err(CodexUsageError::NeedsAuth.into());
     }
     Ok(serde_json::from_str(body)?)
 }
@@ -752,7 +999,7 @@ where
 {
     let status = resp.status();
     if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
-        anyhow::bail!("NEEDS_AUTH");
+        return Err(CodexUsageError::NeedsAuth.into());
     }
     if !status.is_success() {
         anyhow::bail!("{request_label} failed (HTTP {status})");
@@ -948,7 +1195,7 @@ async fn fetch_with_auth_async(
     let mut effective_access_token = access_token.clone();
     let resp = match fetch_usage(&client, &access_token, tokens.account_id.as_deref()).await {
         Ok(r) => r,
-        Err(e) if e.to_string().contains("NEEDS_AUTH") => {
+        Err(e) if is_needs_auth(&e) => {
             let rt_str = tokens
                 .refresh_token
                 .as_ref()
@@ -1061,19 +1308,18 @@ fn matching_account_id_for_tokens(
     store: &CodexCredentialsStore,
     tokens: &Tokens,
 ) -> Option<String> {
-    let derived = derive_account_id(tokens);
-    if store
-        .accounts
-        .get(&derived)
-        .is_some_and(|account| same_token_identity(tokens, &account.tokens))
-    {
+    let identity = CodexAccountIdentity::from_tokens(tokens);
+    let derived = identity.stable_id().to_string();
+    if store.accounts.get(&derived).is_some_and(|account| {
+        identity.matches(&CodexAccountIdentity::from_tokens(&account.tokens))
+    }) {
         return Some(derived);
     }
 
     store
         .accounts
         .iter()
-        .find(|(_, account)| same_token_identity(tokens, &account.tokens))
+        .find(|(_, account)| identity.matches(&CodexAccountIdentity::from_tokens(&account.tokens)))
         .map(|(account_id, _)| account_id.clone())
         .or_else(|| store.accounts.contains_key(&derived).then_some(derived))
 }
@@ -1094,11 +1340,9 @@ fn active_account_id_for_usage(store: &mut CodexCredentialsStore) -> Option<Stri
     match active_account_id.as_ref() {
         Some(active_account_id) if store.active_account_id != *active_account_id => {
             store.active_account_id = active_account_id.clone();
-            let _ = save_credentials_store(store);
         }
         None if !store.active_account_id.trim().is_empty() => {
             store.active_account_id.clear();
-            let _ = save_credentials_store(store);
         }
         _ => {}
     }
@@ -1106,16 +1350,86 @@ fn active_account_id_for_usage(store: &mut CodexCredentialsStore) -> Option<Stri
     active_account_id
 }
 
+fn fetch_current_auth_report(diagnostics: Vec<UsageFetchDiagnostic>) -> UsageFetchReport {
+    match fetch() {
+        Ok(output) => UsageFetchReport {
+            outputs: vec![output],
+            diagnostics,
+        },
+        Err(error) => {
+            let mut diagnostics = diagnostics;
+            diagnostics.push(UsageFetchDiagnostic::new("Codex", None, error.to_string()));
+            UsageFetchReport {
+                outputs: Vec::new(),
+                diagnostics,
+            }
+        }
+    }
+}
+
 pub fn fetch_all() -> Result<Vec<UsageOutput>> {
-    let Some(mut store) = load_credentials_store() else {
-        return fetch().map(|output| vec![output]);
+    let report = fetch_all_report();
+    if report.outputs.is_empty() {
+        if let Some(diagnostic) = report.diagnostics.into_iter().next() {
+            anyhow::bail!("{}", diagnostic.message);
+        }
+    }
+    Ok(report.outputs)
+}
+
+pub fn fetch_all_report() -> UsageFetchReport {
+    fetch_all_report_inner(CodexFetchIntent::ReadOnly)
+}
+
+pub fn fetch_all_report_importing_current_auth() -> UsageFetchReport {
+    fetch_all_report_inner(CodexFetchIntent::SaveCurrentLogin)
+}
+
+fn load_credentials_store_for_fetch_intent(
+    intent: CodexFetchIntent,
+) -> Option<CodexCredentialsStore> {
+    match intent {
+        CodexFetchIntent::ReadOnly => load_credentials_store(),
+        CodexFetchIntent::SaveCurrentLogin => CodexAccountStore::default()
+            .read_for_update()
+            .ok()
+            .flatten(),
+    }
+}
+
+fn fetch_all_report_inner(intent: CodexFetchIntent) -> UsageFetchReport {
+    let mut diagnostics = Vec::new();
+    let current_auth_account = if intent == CodexFetchIntent::SaveCurrentLogin {
+        match save_current_auth_account() {
+            Ok(info) => Some(info),
+            Err(error) => {
+                if !is_missing_credentials(&error) {
+                    diagnostics.push(UsageFetchDiagnostic::with_kind(
+                        "Codex",
+                        None,
+                        UsageFetchDiagnosticKind::ImportCurrentLoginFailed,
+                        UsageFetchDiagnosticSeverity::Warning,
+                        format!("failed to import current Codex login: {error}"),
+                    ));
+                }
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let Some(mut store) = load_credentials_store_for_fetch_intent(intent) else {
+        return fetch_current_auth_report(diagnostics);
     };
 
     if store.accounts.is_empty() {
-        return fetch().map(|output| vec![output]);
+        return fetch_current_auth_report(diagnostics);
     }
 
-    let active_account_id = active_account_id_for_usage(&mut store);
+    let active_account_id = current_auth_account
+        .map(|account| account.id)
+        .or_else(|| active_account_id_for_usage(&mut store));
     let mut account_ids: Vec<_> = store.accounts.keys().cloned().collect();
     account_ids.sort_by(|a, b| {
         if active_account_id.as_deref() == Some(a.as_str()) {
@@ -1140,7 +1454,6 @@ pub fn fetch_all() -> Result<Vec<UsageOutput>> {
     });
 
     let mut outputs = Vec::new();
-    let mut first_error = None;
     for account_id in account_ids {
         let Some(account) = store.accounts.get(&account_id) else {
             continue;
@@ -1151,22 +1464,20 @@ pub fn fetch_all() -> Result<Vec<UsageOutput>> {
             auth_from_account(account),
             CredentialSource::Store(account_id.clone()),
             "Codex".into(),
-            Some(usage_account),
+            Some(usage_account.clone()),
         ) {
             Ok(output) => outputs.push(output),
-            Err(e) if first_error.is_none() => first_error = Some(e),
-            Err(_) => {}
+            Err(error) => diagnostics.push(UsageFetchDiagnostic::new(
+                "Codex",
+                Some(usage_account),
+                error.to_string(),
+            )),
         }
     }
 
-    if outputs.is_empty() {
-        if let Some(error) = first_error {
-            Err(error)
-        } else {
-            Ok(outputs)
-        }
-    } else {
-        Ok(outputs)
+    UsageFetchReport {
+        outputs,
+        diagnostics,
     }
 }
 
@@ -1193,7 +1504,7 @@ async fn consume_reset_credit_with_auth_async(
     .await
     {
         Ok(result) => Ok(result),
-        Err(e) if e.to_string().contains("NEEDS_AUTH") => {
+        Err(e) if is_needs_auth(&e) => {
             let rt_str = tokens
                 .refresh_token
                 .as_ref()
@@ -1265,34 +1576,41 @@ pub fn import_current_account(label: Option<&str>) -> Result<CodexAccountInfo> {
 }
 
 pub fn switch_active_account(name_or_id: &str) -> Result<CodexAccountInfo> {
-    let mut store =
-        load_credentials_store().ok_or_else(|| anyhow::anyhow!("No saved Codex accounts"))?;
-    let resolved = resolve_account_id(&store, name_or_id)
-        .ok_or_else(|| anyhow::anyhow!("Codex account not found: {name_or_id}"))?;
-    let account = store
-        .accounts
-        .get(&resolved)
-        .cloned()
-        .ok_or_else(|| anyhow::anyhow!("Codex account not found: {resolved}"))?;
+    CodexAccountStore::default().update_existing("No saved Codex accounts", |store| {
+        let resolved = resolve_account_id(store, name_or_id)
+            .ok_or_else(|| anyhow::anyhow!("Codex account not found: {name_or_id}"))?;
+        let account = store
+            .accounts
+            .get(&resolved)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("Codex account not found: {resolved}"))?;
 
-    let path = auth_write_path()?;
-    save_auth_tokens(&path, &account.tokens)?;
+        let path = auth_write_path()?;
+        save_auth_tokens(&path, &account.tokens)?;
 
-    store.active_account_id = resolved.clone();
-    save_credentials_store(&store)?;
+        store.active_account_id = resolved.clone();
 
-    Ok(account_info(&store, &resolved, &account))
+        Ok(account_info(store, &resolved, &account))
+    })
 }
 
 /// Removes an account from tokscale's store only. The codex CLI's own
 /// `auth.json` is intentionally left untouched: rewriting it would silently
 /// re-log the codex CLI into a different account (or log it out entirely).
 pub fn remove_account(name_or_id: &str) -> Result<CodexAccountInfo> {
-    let mut store =
-        load_credentials_store().ok_or_else(|| anyhow::anyhow!("No saved Codex accounts"))?;
-    let removed = remove_account_from_store(&mut store, name_or_id)?;
-    save_credentials_store(&store)?;
-    Ok(removed)
+    CodexAccountStore::default().update_existing("No saved Codex accounts", |store| {
+        let resolved = resolve_account_id(store, name_or_id)
+            .ok_or_else(|| anyhow::anyhow!("Codex account not found: {name_or_id}"))?;
+        let active_account_id = current_auth_account_id_in_store(store).or_else(|| {
+            (!store.active_account_id.trim().is_empty()).then(|| store.active_account_id.clone())
+        });
+        if active_account_id.as_deref() == Some(resolved.as_str()) {
+            anyhow::bail!(
+                "Cannot remove the active Codex account. Switch to another Codex account or log out of Codex first."
+            );
+        }
+        remove_account_from_store(store, &resolved)
+    })
 }
 
 pub fn run_codex_import(name: Option<String>) -> Result<()> {
@@ -1490,6 +1808,32 @@ mod tests {
         }
     }
 
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set_path(key: &'static str, value: &Path) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
     #[test]
     fn usage_response_treats_null_additional_rate_limits_as_empty() -> Result<()> {
         let usage: Usage = serde_json::from_value(serde_json::json!({
@@ -1520,7 +1864,10 @@ mod tests {
         )
         .unwrap_err();
 
-        assert_eq!(error.to_string(), "NEEDS_AUTH");
+        assert!(
+            is_needs_auth(&error),
+            "expected Codex auth expiry, got: {error:#}"
+        );
     }
 
     #[test]
@@ -1690,6 +2037,59 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
+    fn active_account_id_for_usage_updates_only_loaded_snapshot() -> Result<()> {
+        let config = TempDir::new()?;
+        let codex_home = TempDir::new()?;
+        let auth = Auth {
+            tokens: Some(tokens("rotated-access-b", Some("acct_b"))),
+        };
+        std::fs::write(
+            codex_home.path().join("auth.json"),
+            serde_json::to_string_pretty(&auth)?,
+        )?;
+        let store_path = test_store_path(&config);
+        save_credentials_store_at_path(
+            &store_path,
+            &CodexCredentialsStore {
+                version: 1,
+                active_account_id: "acct_a".to_string(),
+                accounts: HashMap::from([
+                    (
+                        "acct_a".to_string(),
+                        CodexAccount {
+                            tokens: tokens("access-a", Some("acct_a")),
+                            created_at: "2026-01-01T00:00:00Z".to_string(),
+                            label: Some("work".to_string()),
+                        },
+                    ),
+                    (
+                        "acct_b".to_string(),
+                        CodexAccount {
+                            tokens: tokens("access-b", Some("acct_b")),
+                            created_at: "2026-01-02T00:00:00Z".to_string(),
+                            label: Some("personal".to_string()),
+                        },
+                    ),
+                ]),
+            },
+        )?;
+
+        let _config_guard = EnvVarGuard::set_path("TOKSCALE_CONFIG_DIR", config.path());
+        let _codex_guard = EnvVarGuard::set_path("CODEX_HOME", codex_home.path());
+
+        let mut loaded = load_credentials_store().expect("test store should load");
+        let active_id = active_account_id_for_usage(&mut loaded);
+
+        assert_eq!(active_id.as_deref(), Some("acct_b"));
+        assert_eq!(loaded.active_account_id, "acct_b");
+        let persisted: CodexCredentialsStore =
+            serde_json::from_str(&std::fs::read_to_string(&store_path)?)?;
+        assert_eq!(persisted.active_account_id, "acct_a");
+        Ok(())
+    }
+
+    #[test]
     fn load_credentials_store_repairs_missing_active_account() -> Result<()> {
         let tmp = TempDir::new()?;
         let mut accounts = HashMap::new();
@@ -1719,6 +2119,97 @@ mod tests {
 
         let loaded = load_credentials_store_from_path(&store_path).unwrap();
         assert_eq!(loaded.active_account_id, "acct_b");
+        Ok(())
+    }
+
+    #[test]
+    fn load_credentials_store_read_path_does_not_persist_active_account_repair() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let mut accounts = HashMap::new();
+        accounts.insert(
+            "acct_a".to_string(),
+            CodexAccount {
+                tokens: tokens("access-a", Some("acct_a")),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                label: Some("zulu".to_string()),
+            },
+        );
+        accounts.insert(
+            "acct_b".to_string(),
+            CodexAccount {
+                tokens: tokens("access-b", Some("acct_b")),
+                created_at: "2026-01-02T00:00:00Z".to_string(),
+                label: Some("alpha".to_string()),
+            },
+        );
+        let store_path = test_store_path(&tmp);
+        save_credentials_store_at_path(
+            &store_path,
+            &CodexCredentialsStore {
+                version: 1,
+                active_account_id: "missing".to_string(),
+                accounts,
+            },
+        )?;
+        let lock_path = CodexAccountStore::at_path(&store_path).lock_path();
+        if lock_path.exists() {
+            std::fs::remove_file(&lock_path)?;
+        }
+        let before = std::fs::read_to_string(&store_path)?;
+
+        let loaded = load_credentials_store_from_path(&store_path).unwrap();
+        let after = std::fs::read_to_string(&store_path)?;
+
+        assert_eq!(loaded.active_account_id, "acct_b");
+        assert_eq!(after, before);
+        assert!(!lock_path.exists());
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn usage_surface_store_loader_persists_active_account_repair() -> Result<()> {
+        let config = TempDir::new()?;
+        let store_path = test_store_path(&config);
+        save_credentials_store_at_path(
+            &store_path,
+            &CodexCredentialsStore {
+                version: 1,
+                active_account_id: "missing".to_string(),
+                accounts: HashMap::from([
+                    (
+                        "acct_a".to_string(),
+                        CodexAccount {
+                            tokens: tokens("access-a", Some("acct_a")),
+                            created_at: "2026-01-01T00:00:00Z".to_string(),
+                            label: Some("zulu".to_string()),
+                        },
+                    ),
+                    (
+                        "acct_b".to_string(),
+                        CodexAccount {
+                            tokens: tokens("access-b", Some("acct_b")),
+                            created_at: "2026-01-02T00:00:00Z".to_string(),
+                            label: Some("alpha".to_string()),
+                        },
+                    ),
+                ]),
+            },
+        )?;
+
+        let _config_guard = EnvVarGuard::set_path("TOKSCALE_CONFIG_DIR", config.path());
+
+        let loaded = load_credentials_store_for_fetch_intent(CodexFetchIntent::SaveCurrentLogin);
+
+        assert_eq!(
+            loaded
+                .as_ref()
+                .map(|store| store.active_account_id.as_str()),
+            Some("acct_b")
+        );
+        let persisted: CodexCredentialsStore =
+            serde_json::from_str(&std::fs::read_to_string(&store_path)?)?;
+        assert_eq!(persisted.active_account_id, "acct_b");
         Ok(())
     }
 
@@ -1792,6 +2283,93 @@ mod tests {
         let loaded = load_credentials_store_from_path(&store_path).unwrap();
         assert_eq!(loaded.active_account_id, "acct_a");
         assert!(loaded.accounts.contains_key("acct_a"));
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn save_current_auth_account_imports_codex_home_auth_when_store_missing() -> Result<()> {
+        let config = TempDir::new()?;
+        let codex_home = TempDir::new()?;
+        let auth = Auth {
+            tokens: Some(tokens("access-current", Some("acct_current"))),
+        };
+        std::fs::write(
+            codex_home.path().join("auth.json"),
+            serde_json::to_string_pretty(&auth)?,
+        )?;
+
+        let _config_guard = EnvVarGuard::set_path("TOKSCALE_CONFIG_DIR", config.path());
+        let _codex_guard = EnvVarGuard::set_path("CODEX_HOME", codex_home.path());
+
+        let info = save_current_auth_account()?;
+        assert_eq!(info.id, "acct_current");
+        assert!(info.is_active);
+
+        let store_path = test_store_path(&config);
+        let loaded = load_credentials_store_from_path(&store_path).unwrap();
+        assert_eq!(loaded.active_account_id, "acct_current");
+        let account = loaded.accounts.get("acct_current").unwrap();
+        assert_eq!(
+            account.tokens.access_token.as_deref(),
+            Some("access-current")
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn save_current_auth_account_imports_codex_home_auth_when_store_has_other_accounts(
+    ) -> Result<()> {
+        let config = TempDir::new()?;
+        let codex_home = TempDir::new()?;
+        let auth = Auth {
+            tokens: Some(tokens("access-current", Some("acct_current"))),
+        };
+        std::fs::write(
+            codex_home.path().join("auth.json"),
+            serde_json::to_string_pretty(&auth)?,
+        )?;
+        let store_path = test_store_path(&config);
+        save_credentials_store_at_path(
+            &store_path,
+            &CodexCredentialsStore {
+                version: 1,
+                active_account_id: String::new(),
+                accounts: HashMap::from([
+                    (
+                        "acct_a".to_string(),
+                        CodexAccount {
+                            tokens: tokens("access-a", Some("acct_a")),
+                            created_at: "2026-01-01T00:00:00Z".to_string(),
+                            label: Some("work".to_string()),
+                        },
+                    ),
+                    (
+                        "acct_b".to_string(),
+                        CodexAccount {
+                            tokens: tokens("access-b", Some("acct_b")),
+                            created_at: "2026-01-02T00:00:00Z".to_string(),
+                            label: Some("personal".to_string()),
+                        },
+                    ),
+                ]),
+            },
+        )?;
+
+        let _config_guard = EnvVarGuard::set_path("TOKSCALE_CONFIG_DIR", config.path());
+        let _codex_guard = EnvVarGuard::set_path("CODEX_HOME", codex_home.path());
+
+        let info = save_current_auth_account()?;
+        assert_eq!(info.id, "acct_current");
+        assert!(info.is_active);
+
+        let loaded = load_credentials_store_from_path(&store_path).unwrap();
+        assert_eq!(loaded.active_account_id, "acct_current");
+        assert_eq!(loaded.accounts.len(), 3);
+        assert!(loaded.accounts.contains_key("acct_a"));
+        assert!(loaded.accounts.contains_key("acct_b"));
+        assert!(loaded.accounts.contains_key("acct_current"));
         Ok(())
     }
 
@@ -1908,6 +2486,132 @@ mod tests {
         assert_eq!(loaded.active_account_id, "acct_a");
         assert!(loaded.accounts.contains_key("acct_a"));
         assert!(loaded.accounts.contains_key("acct_b"));
+        Ok(())
+    }
+
+    #[test]
+    fn save_account_from_auth_at_path_keeps_empty_active_when_inactive_import_is_first_account(
+    ) -> Result<()> {
+        let tmp = TempDir::new()?;
+        let store_path = test_store_path(&tmp);
+        let info = save_account_from_auth_at_path(
+            &store_path,
+            Auth {
+                tokens: Some(tokens("access-a", Some("acct_a"))),
+            },
+            Some("work"),
+            false,
+        )?;
+
+        assert_eq!(info.id, "acct_a");
+        assert!(!info.is_active);
+
+        let loaded = load_credentials_store_from_path(&store_path).unwrap();
+        assert!(loaded.active_account_id.is_empty());
+        assert!(loaded.accounts.contains_key("acct_a"));
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn remove_account_refuses_current_auth_account() -> Result<()> {
+        let config = TempDir::new()?;
+        let codex_home = TempDir::new()?;
+        let auth = Auth {
+            tokens: Some(tokens("access-current", Some("acct_current"))),
+        };
+        std::fs::write(
+            codex_home.path().join("auth.json"),
+            serde_json::to_string_pretty(&auth)?,
+        )?;
+        let store_path = test_store_path(&config);
+        save_credentials_store_at_path(
+            &store_path,
+            &CodexCredentialsStore {
+                version: 1,
+                active_account_id: "acct_current".to_string(),
+                accounts: HashMap::from([
+                    (
+                        "acct_current".to_string(),
+                        CodexAccount {
+                            tokens: tokens("access-current", Some("acct_current")),
+                            created_at: "2026-01-01T00:00:00Z".to_string(),
+                            label: Some("work".to_string()),
+                        },
+                    ),
+                    (
+                        "acct_other".to_string(),
+                        CodexAccount {
+                            tokens: tokens("access-other", Some("acct_other")),
+                            created_at: "2026-01-02T00:00:00Z".to_string(),
+                            label: Some("personal".to_string()),
+                        },
+                    ),
+                ]),
+            },
+        )?;
+
+        let _config_guard = EnvVarGuard::set_path("TOKSCALE_CONFIG_DIR", config.path());
+        let _codex_guard = EnvVarGuard::set_path("CODEX_HOME", codex_home.path());
+
+        let error =
+            remove_account("acct_current").expect_err("current auth account must not be removable");
+        assert!(
+            error.to_string().contains("Cannot remove the active"),
+            "unexpected error: {error:#}"
+        );
+        let loaded = load_credentials_store_from_path(&store_path).unwrap();
+        assert!(loaded.accounts.contains_key("acct_current"));
+        assert!(loaded.accounts.contains_key("acct_other"));
+        assert_eq!(loaded.active_account_id, "acct_current");
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn remove_account_refuses_store_active_account_without_current_auth() -> Result<()> {
+        let config = TempDir::new()?;
+        let codex_home = TempDir::new()?;
+        let store_path = test_store_path(&config);
+        save_credentials_store_at_path(
+            &store_path,
+            &CodexCredentialsStore {
+                version: 1,
+                active_account_id: "acct_current".to_string(),
+                accounts: HashMap::from([
+                    (
+                        "acct_current".to_string(),
+                        CodexAccount {
+                            tokens: tokens("access-current", Some("acct_current")),
+                            created_at: "2026-01-01T00:00:00Z".to_string(),
+                            label: Some("work".to_string()),
+                        },
+                    ),
+                    (
+                        "acct_other".to_string(),
+                        CodexAccount {
+                            tokens: tokens("access-other", Some("acct_other")),
+                            created_at: "2026-01-02T00:00:00Z".to_string(),
+                            label: Some("personal".to_string()),
+                        },
+                    ),
+                ]),
+            },
+        )?;
+
+        let _config_guard = EnvVarGuard::set_path("TOKSCALE_CONFIG_DIR", config.path());
+        let _codex_guard = EnvVarGuard::set_path("CODEX_HOME", codex_home.path());
+
+        let error =
+            remove_account("acct_current").expect_err("store active account must not be removable");
+        assert!(
+            error.to_string().contains("Cannot remove the active"),
+            "unexpected error: {error:#}"
+        );
+        let loaded = load_credentials_store_from_path(&store_path).unwrap();
+        assert!(loaded.accounts.contains_key("acct_current"));
+        assert!(loaded.accounts.contains_key("acct_other"));
+        assert_eq!(loaded.active_account_id, "acct_current");
         Ok(())
     }
 

--- a/crates/tokscale-cli/src/commands/usage/mod.rs
+++ b/crates/tokscale-cli/src/commands/usage/mod.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(dead_code))]
+
 mod amp;
 mod claude;
 pub mod codex;
@@ -130,6 +132,117 @@ impl UsageAccount {
     }
 }
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct UsageFetchDiagnostic {
+    pub provider: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account: Option<UsageAccount>,
+    #[serde(default)]
+    pub kind: UsageFetchDiagnosticKind,
+    #[serde(default)]
+    pub severity: UsageFetchDiagnosticSeverity,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UsageFetchDiagnosticKind {
+    #[default]
+    FetchFailed,
+    ImportCurrentLoginFailed,
+    ProviderPanicked,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UsageFetchDiagnosticSeverity {
+    Info,
+    Warning,
+    #[default]
+    Error,
+}
+
+impl UsageFetchDiagnostic {
+    pub fn new(
+        provider: impl Into<String>,
+        account: Option<UsageAccount>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::with_kind(
+            provider,
+            account,
+            UsageFetchDiagnosticKind::FetchFailed,
+            UsageFetchDiagnosticSeverity::Error,
+            message,
+        )
+    }
+
+    pub fn with_kind(
+        provider: impl Into<String>,
+        account: Option<UsageAccount>,
+        kind: UsageFetchDiagnosticKind,
+        severity: UsageFetchDiagnosticSeverity,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            provider: provider.into(),
+            account,
+            kind,
+            severity,
+            message: message.into(),
+        }
+    }
+
+    pub fn display_name(&self) -> String {
+        match &self.account {
+            Some(account) => format!("{} ({})", self.provider, account.display_name()),
+            None => self.provider.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct UsageFetchReport {
+    pub outputs: Vec<UsageOutput>,
+    pub diagnostics: Vec<UsageFetchDiagnostic>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UsageFetchIntent {
+    #[allow(dead_code)]
+    CliReadOnly,
+    TuiSurface,
+}
+
+impl UsageFetchReport {
+    fn from_outputs(outputs: Vec<UsageOutput>) -> Self {
+        Self {
+            outputs,
+            diagnostics: Vec::new(),
+        }
+    }
+
+    fn from_error(
+        provider: &'static str,
+        account: Option<UsageAccount>,
+        error: anyhow::Error,
+    ) -> Self {
+        Self {
+            outputs: Vec::new(),
+            diagnostics: vec![UsageFetchDiagnostic::new(
+                provider,
+                account,
+                error.to_string(),
+            )],
+        }
+    }
+
+    fn extend(&mut self, other: UsageFetchReport) {
+        self.outputs.extend(other.outputs);
+        self.diagnostics.extend(other.diagnostics);
+    }
+}
+
 impl UsageOutput {
     pub fn account_display_name(&self) -> Option<String> {
         let account = self.account.as_ref()?;
@@ -245,7 +358,7 @@ pub struct ProviderError {
 ///
 /// Used by the TUI dashboard (non-test builds only); the TUI test build stubs
 /// the fetch out, so allow it to be unused there.
-#[cfg_attr(test, allow(dead_code))]
+#[allow(dead_code)]
 pub fn fetch_all() -> Vec<UsageOutput> {
     fetch_all_with_errors().0
 }
@@ -258,17 +371,42 @@ pub fn fetch_all() -> Vec<UsageOutput> {
 /// the provider as active, yet it just vanished from the output. This collects
 /// those errors so the caller can surface them to the user instead.
 pub fn fetch_all_with_errors() -> (Vec<UsageOutput>, Vec<ProviderError>) {
-    let providers: Vec<UsageProvider> = vec![
+    let active: Vec<_> = usage_providers(Fetch::Multi(codex::fetch_all))
+        .into_iter()
+        .filter(|(_, has, _)| has())
+        .collect();
+
+    if active.is_empty() {
+        return (vec![], vec![]);
+    }
+
+    let results = std::thread::scope(|s| {
+        let handles: Vec<_> = active
+            .into_iter()
+            .map(|(name, _, fetch)| s.spawn(move || (name, fetch.call())))
+            .collect();
+
+        handles
+            .into_iter()
+            .filter_map(|handle| {
+                // A panicked provider thread should not take down the whole
+                // command; skip it (a join error has no message to surface).
+                handle.join().ok()
+            })
+            .collect::<Vec<_>>()
+    });
+
+    partition_results(results)
+}
+
+fn usage_providers(codex_fetch: Fetch) -> Vec<UsageProvider> {
+    vec![
         (
             "Claude",
             claude::has_credentials,
             Fetch::Single(claude::fetch),
         ),
-        (
-            "Codex",
-            codex::has_credentials,
-            Fetch::Multi(codex::fetch_all),
-        ),
+        ("Codex", codex::has_credentials, codex_fetch),
         ("Z.ai", zai::has_credentials, Fetch::Single(zai::fetch)),
         ("Amp", amp::has_credentials, Fetch::Single(amp::fetch)),
         (
@@ -298,31 +436,65 @@ pub fn fetch_all_with_errors() -> (Vec<UsageOutput>, Vec<ProviderError>) {
             sakana::has_credentials,
             Fetch::Single(sakana::fetch),
         ),
-    ];
+    ]
+}
 
-    let active: Vec<_> = providers.into_iter().filter(|(_, has, _)| has()).collect();
+fn fetch_provider_report(
+    provider: &'static str,
+    result: Result<Vec<UsageOutput>>,
+) -> UsageFetchReport {
+    match result {
+        Ok(outputs) => UsageFetchReport::from_outputs(outputs),
+        Err(error) => UsageFetchReport::from_error(provider, None, error),
+    }
+}
+
+pub fn fetch_all_report_with_intent(intent: UsageFetchIntent) -> UsageFetchReport {
+    let codex_fetch = match intent {
+        UsageFetchIntent::CliReadOnly => codex::fetch_all_report,
+        UsageFetchIntent::TuiSurface => codex::fetch_all_report_importing_current_auth,
+    };
+    fetch_all_report_with_codex(codex_fetch)
+}
+
+fn fetch_all_report_with_codex(codex_fetch: fn() -> UsageFetchReport) -> UsageFetchReport {
+    let active: Vec<_> = usage_providers(Fetch::Multi(codex::fetch_all))
+        .into_iter()
+        .filter(|(_, has, _)| has())
+        .collect();
 
     if active.is_empty() {
-        return (vec![], vec![]);
+        return UsageFetchReport::default();
     }
 
-    let results = std::thread::scope(|s| {
-        let handles: Vec<_> = active
+    std::thread::scope(|scope| {
+        let handles = active
             .into_iter()
-            .map(|(name, _, fetch)| s.spawn(move || (name, fetch.call())))
-            .collect();
-
-        handles
-            .into_iter()
-            .filter_map(|handle| {
-                // A panicked provider thread should not take down the whole
-                // command; skip it (a join error has no message to surface).
-                handle.join().ok()
+            .map(|(provider, _, fetch)| {
+                let handle = if provider == "Codex" {
+                    scope.spawn(codex_fetch)
+                } else {
+                    scope.spawn(move || fetch_provider_report(provider, fetch.call()))
+                };
+                (provider, handle)
             })
-            .collect::<Vec<_>>()
-    });
+            .collect::<Vec<_>>();
 
-    partition_results(results)
+        let mut report = UsageFetchReport::default();
+        for (provider, handle) in handles {
+            match handle.join() {
+                Ok(provider_report) => report.extend(provider_report),
+                Err(_) => report.diagnostics.push(UsageFetchDiagnostic::with_kind(
+                    provider,
+                    None,
+                    UsageFetchDiagnosticKind::ProviderPanicked,
+                    UsageFetchDiagnosticSeverity::Error,
+                    "usage fetch worker panicked",
+                )),
+            }
+        }
+        report
+    })
 }
 
 /// Split per-provider fetch results into (successful outputs, errors).

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -9,7 +9,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent,
 use ratatui::layout::Rect;
 use tokscale_core::ClientId;
 
-use crate::commands::usage::UsageOutput;
+use crate::commands::usage::{UsageFetchReport, UsageOutput};
 use crate::ClientFilter;
 
 use ratatui::style::Color;
@@ -38,6 +38,18 @@ pub struct TuiConfig {
     pub until: Option<String>,
     pub year: Option<String>,
     pub initial_tab: Option<Tab>,
+}
+
+#[cfg(not(test))]
+fn default_usage_fetcher() -> UsageFetchReport {
+    crate::commands::usage::fetch_all_report_with_intent(
+        crate::commands::usage::UsageFetchIntent::TuiSurface,
+    )
+}
+
+#[cfg(test)]
+fn test_usage_fetcher() -> UsageFetchReport {
+    UsageFetchReport::default()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -323,6 +335,7 @@ pub struct App {
     pub model_shade_map: HashMap<String, Color>,
 
     pub subscription_usage: Vec<crate::commands::usage::UsageOutput>,
+    pub usage_fetch_diagnostics: Vec<crate::commands::usage::UsageFetchDiagnostic>,
     confirmed_codex_use_account_id: Rc<RefCell<Option<String>>>,
     confirmed_codex_remove_account_id: Rc<RefCell<Option<String>>>,
     confirmed_codex_reset_account_id: Rc<RefCell<Option<String>>>,
@@ -331,8 +344,9 @@ pub struct App {
     pub(crate) codex_login_outcome: Option<CodexLoginOutcome>,
 
     pub usage_fetch_attempted: bool,
-    usage_rx: Option<std::sync::mpsc::Receiver<Vec<crate::commands::usage::UsageOutput>>>,
+    usage_rx: Option<std::sync::mpsc::Receiver<UsageFetchReport>>,
     usage_fetch_preserve_status: bool,
+    usage_fetcher: fn() -> UsageFetchReport,
     codex_reset_rx: Option<
         std::sync::mpsc::Receiver<
             Result<crate::commands::usage::codex::RateLimitResetConsumeResult, String>,
@@ -465,6 +479,7 @@ impl App {
                     Vec::new()
                 }
             },
+            usage_fetch_diagnostics: Vec::new(),
             confirmed_codex_use_account_id,
             confirmed_codex_remove_account_id,
             confirmed_codex_reset_account_id,
@@ -474,6 +489,16 @@ impl App {
             usage_fetch_attempted: false,
             usage_rx: None,
             usage_fetch_preserve_status: false,
+            usage_fetcher: {
+                #[cfg(test)]
+                {
+                    test_usage_fetcher
+                }
+                #[cfg(not(test))]
+                {
+                    default_usage_fetcher
+                }
+            },
             codex_reset_rx: None,
             codex_login_rx: None,
             codex_login_child: None,
@@ -588,20 +613,21 @@ impl App {
         // Poll background usage fetch
         if let Some(ref rx) = self.usage_rx {
             match rx.try_recv() {
-                Ok(results) => {
+                Ok(report) => {
                     let preserve_status = self.usage_fetch_preserve_status;
                     self.usage_fetch_preserve_status = false;
                     self.usage_rx = None;
-                    self.subscription_usage = results;
+                    self.subscription_usage = report.outputs;
+                    self.usage_fetch_diagnostics = report.diagnostics;
                     if !self.subscription_usage.is_empty() {
                         crate::commands::usage::save_cache(&self.subscription_usage);
                         if !preserve_status {
-                            self.status_message = Some("Usage data loaded".into());
+                            self.status_message = Some(self.usage_loaded_status());
                         }
                     } else {
                         crate::commands::usage::clear_cache();
                         if !preserve_status {
-                            self.status_message = Some("No usage data available".into());
+                            self.status_message = Some(self.usage_empty_status());
                         }
                     }
                     if !preserve_status {
@@ -888,19 +914,17 @@ impl App {
         }
         self.usage_fetch_attempted = true;
         self.usage_fetch_preserve_status = preserve_status;
+        self.usage_fetch_diagnostics.clear();
         if !preserve_status {
             self.status_message = Some("Fetching usage data...".into());
             self.status_message_time = Some(std::time::Instant::now());
         }
         let (tx, rx) = std::sync::mpsc::channel();
         self.usage_rx = Some(rx);
+        let fetcher = self.usage_fetcher;
         std::thread::spawn(move || {
-            // Tests must not hit real provider endpoints or credentials.
-            #[cfg(test)]
-            let results = Vec::new();
-            #[cfg(not(test))]
-            let results = crate::commands::usage::fetch_all();
-            let _ = tx.send(results);
+            let report = fetcher();
+            let _ = tx.send(report);
         });
     }
 
@@ -921,6 +945,39 @@ impl App {
 
     pub fn is_fetching_usage(&self) -> bool {
         self.usage_rx.is_some()
+    }
+
+    fn usage_loaded_status(&self) -> String {
+        match self.usage_fetch_diagnostics.len() {
+            0 => "Usage data loaded".to_string(),
+            1 => "Usage data loaded with 1 issue".to_string(),
+            count => format!("Usage data loaded with {count} issues"),
+        }
+    }
+
+    fn usage_empty_status(&self) -> String {
+        if self.usage_fetch_diagnostics.is_empty() {
+            "No usage data available".to_string()
+        } else {
+            format!("Usage fetch failed: {}", self.usage_diagnostic_summary())
+        }
+    }
+
+    fn usage_diagnostic_summary(&self) -> String {
+        let mut names = self
+            .usage_fetch_diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.display_name())
+            .collect::<Vec<_>>();
+        names.sort();
+        names.dedup();
+        let visible = names.iter().take(2).cloned().collect::<Vec<_>>();
+        let hidden = names.len().saturating_sub(visible.len());
+        if hidden == 0 {
+            visible.join(", ")
+        } else {
+            format!("{} +{hidden}", visible.join(", "))
+        }
     }
 
     /// Cache-first load of server-side aggregated multi-device stats.
@@ -1123,6 +1180,16 @@ impl App {
     }
 
     fn confirm_codex_account_removal(&mut self, account_id: &str) {
+        if self.subscription_usage.iter().any(|usage| {
+            usage
+                .account
+                .as_ref()
+                .is_some_and(|account| account.id == account_id && account.is_active)
+        }) {
+            self.set_status("Switch Codex accounts before removing the current account");
+            return;
+        }
+
         let account_label = self.codex_account_label(account_id);
         let dialog = ConfirmDialog::codex_remove(
             account_id.to_string(),
@@ -2260,7 +2327,9 @@ impl App {
 mod tests {
     use super::super::ui::widgets::get_provider_shade;
     use super::*;
-    use crate::commands::usage::{UsageAccount, UsageMetric, UsageOutput};
+    use crate::commands::usage::{
+        UsageAccount, UsageFetchDiagnostic, UsageFetchReport, UsageMetric, UsageOutput,
+    };
     use crate::tui::data::{DailyModelInfo, DailySourceInfo, ModelUsage, TokenBreakdown};
     use chrono::{NaiveDate, NaiveDateTime};
     use std::collections::{BTreeMap, BTreeSet};
@@ -2571,6 +2640,60 @@ mod tests {
             reset_credits: None,
             credit_status: None,
             spend_control: None,
+        }
+    }
+
+    fn sample_subscription_usage() -> Vec<UsageOutput> {
+        vec![usage_output(
+            "Codex",
+            Some(UsageAccount {
+                id: "acct_work".to_string(),
+                label: Some("work".to_string()),
+                is_active: true,
+            }),
+        )]
+    }
+
+    fn sample_usage_fetcher() -> UsageFetchReport {
+        UsageFetchReport {
+            outputs: sample_subscription_usage(),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    fn failing_usage_fetcher() -> UsageFetchReport {
+        UsageFetchReport {
+            outputs: Vec::new(),
+            diagnostics: vec![UsageFetchDiagnostic::new(
+                "Codex",
+                None,
+                "token refresh failed",
+            )],
+        }
+    }
+
+    fn partial_usage_fetcher() -> UsageFetchReport {
+        UsageFetchReport {
+            outputs: sample_subscription_usage(),
+            diagnostics: vec![UsageFetchDiagnostic::new(
+                "Codex",
+                Some(UsageAccount {
+                    id: "acct_personal".to_string(),
+                    label: Some("personal".to_string()),
+                    is_active: false,
+                }),
+                "usage endpoint rejected credentials",
+            )],
+        }
+    }
+
+    fn drain_usage_fetch(app: &mut App) {
+        for _ in 0..20 {
+            app.on_tick();
+            if !app.is_fetching_usage() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(5));
         }
     }
 
@@ -3489,6 +3612,7 @@ mod tests {
     #[test]
     fn test_handle_key_refresh_usage_tab_fetches_usage() {
         let mut app = make_app();
+        app.usage_fetcher = sample_usage_fetcher;
         app.current_tab = Tab::Usage;
 
         app.handle_key_event(key(KeyCode::Char('r')));
@@ -3499,6 +3623,58 @@ mod tests {
             app.status_message.as_deref(),
             Some("Fetching usage data...")
         );
+
+        drain_usage_fetch(&mut app);
+
+        assert_eq!(app.subscription_usage.len(), 1);
+        assert_eq!(app.subscription_usage[0].provider, "Codex");
+        assert_eq!(app.status_message.as_deref(), Some("Usage data loaded"));
+    }
+
+    #[test]
+    fn test_handle_key_refresh_usage_tab_reports_fetch_failure_diagnostic() {
+        let mut app = make_app();
+        app.usage_fetcher = failing_usage_fetcher;
+        app.current_tab = Tab::Usage;
+
+        app.handle_key_event(key(KeyCode::Char('r')));
+        drain_usage_fetch(&mut app);
+
+        assert!(app.subscription_usage.is_empty());
+        assert_eq!(app.usage_fetch_diagnostics.len(), 1);
+        assert_eq!(
+            app.status_message.as_deref(),
+            Some("Usage fetch failed: Codex")
+        );
+    }
+
+    #[test]
+    fn test_handle_key_refresh_usage_tab_keeps_partial_fetch_diagnostic() {
+        let mut app = make_app();
+        app.usage_fetcher = partial_usage_fetcher;
+        app.current_tab = Tab::Usage;
+
+        app.handle_key_event(key(KeyCode::Char('r')));
+        drain_usage_fetch(&mut app);
+
+        assert_eq!(app.subscription_usage.len(), 1);
+        assert_eq!(app.usage_fetch_diagnostics.len(), 1);
+        assert_eq!(
+            app.status_message.as_deref(),
+            Some("Usage data loaded with 1 issue")
+        );
+    }
+
+    #[test]
+    fn test_handle_key_refresh_usage_tab_clears_stale_diagnostics() {
+        let mut app = make_app();
+        app.current_tab = Tab::Usage;
+        app.usage_fetch_diagnostics = vec![UsageFetchDiagnostic::new("Codex", None, "stale issue")];
+
+        app.handle_key_event(key(KeyCode::Char('r')));
+
+        assert!(app.is_fetching_usage());
+        assert!(app.usage_fetch_diagnostics.is_empty());
     }
 
     #[test]
@@ -3777,6 +3953,32 @@ mod tests {
         assert_eq!(
             app.status_message.as_deref(),
             Some("Confirm Codex account removal")
+        );
+    }
+
+    #[test]
+    fn test_handle_mouse_click_codex_remove_refuses_active_account() {
+        let mut app = make_app();
+        app.subscription_usage = sample_subscription_usage();
+        app.add_click_area(
+            Rect::new(0, 0, 10, 2),
+            ClickAction::CodexRemoveAccount {
+                account_id: "acct_work".to_string(),
+            },
+        );
+
+        let event = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 5,
+            row: 1,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse_event(event);
+
+        assert!(!app.dialog_stack.is_active());
+        assert_eq!(
+            app.status_message.as_deref(),
+            Some("Switch Codex accounts before removing the current account")
         );
     }
 

--- a/crates/tokscale-cli/src/tui/ui/usage.rs
+++ b/crates/tokscale-cli/src/tui/ui/usage.rs
@@ -2,7 +2,9 @@ use ratatui::layout::Flex;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Cell, HighlightSpacing, Paragraph, Row, Table, TableState};
 
-use crate::commands::usage::{helpers, UsageMetric, UsageOutput};
+use crate::commands::usage::{
+    helpers, UsageFetchDiagnostic, UsageFetchDiagnosticSeverity, UsageMetric, UsageOutput,
+};
 use crate::tui::app::{App, ClickAction};
 use crate::tui::codex_login::CodexLoginOutcome;
 use crate::tui::privacy::looks_like_email;
@@ -100,14 +102,25 @@ fn status_label(app: &App) -> String {
     let inventory = usage_inventory(&app.subscription_usage);
 
     if inventory.providers == 0 && app.usage_fetch_attempted {
-        "No data".to_string()
+        if app.usage_fetch_diagnostics.is_empty() {
+            "No data".to_string()
+        } else {
+            usage_issue_count_label(app.usage_fetch_diagnostics.len())
+        }
     } else if inventory.providers == 0 {
         "Not loaded".to_string()
-    } else {
+    } else if app.usage_fetch_diagnostics.is_empty() {
         format!(
             "{} providers · {}",
             inventory.providers,
             identity_count_label(inventory.saved, inventory.managed)
+        )
+    } else {
+        format!(
+            "{} providers · {} · {}",
+            inventory.providers,
+            identity_count_label(inventory.saved, inventory.managed),
+            usage_issue_count_label(app.usage_fetch_diagnostics.len())
         )
     }
 }
@@ -135,6 +148,13 @@ fn identity_count_label(saved: usize, managed: usize) -> String {
         (saved, 0) => format!("{saved} saved"),
         (0, managed) => format!("{managed} managed"),
         (saved, managed) => format!("{saved} saved · {managed} managed"),
+    }
+}
+
+fn usage_issue_count_label(count: usize) -> String {
+    match count {
+        1 => "1 issue".to_string(),
+        count => format!("{count} issues"),
     }
 }
 
@@ -435,15 +455,49 @@ fn render_ready(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn render_empty(frame: &mut Frame, app: &App, area: Rect) {
-    let center = centered_rect(area, 3);
-    let message = if area.width < 40 {
-        "No usage data"
+    let center = centered_rect(area, 4);
+    let lines = if let Some(diagnostic) = app.usage_fetch_diagnostics.first() {
+        if area.width < 40 {
+            vec![
+                Line::from(Span::styled(
+                    "Usage fetch failed",
+                    Style::default().fg(app.theme.muted),
+                )),
+                Line::from(Span::styled(
+                    truncate_string(&diagnostic.display_name(), area.width as usize),
+                    Style::default().fg(diagnostic_severity_color(diagnostic.severity)),
+                )),
+            ]
+        } else {
+            vec![
+                Line::from(Span::styled(
+                    "Usage fetch failed",
+                    Style::default()
+                        .fg(app.theme.foreground)
+                        .add_modifier(Modifier::BOLD),
+                )),
+                Line::from(Span::styled(
+                    truncate_string(&diagnostic.display_name(), area.width as usize),
+                    Style::default().fg(diagnostic_severity_color(diagnostic.severity)),
+                )),
+                Line::from(Span::styled(
+                    truncate_string(&diagnostic.message, area.width as usize),
+                    Style::default().fg(app.theme.muted),
+                )),
+            ]
+        }
+    } else if area.width < 40 {
+        vec![Line::from(Span::styled(
+            "No usage data",
+            Style::default().fg(app.theme.muted),
+        ))]
     } else {
-        "No subscription data available"
+        vec![Line::from(Span::styled(
+            "No subscription data available",
+            Style::default().fg(app.theme.muted),
+        ))]
     };
-    let paragraph = Paragraph::new(message)
-        .style(Style::default().fg(app.theme.muted))
-        .alignment(Alignment::Center);
+    let paragraph = Paragraph::new(lines).alignment(Alignment::Center);
     frame.render_widget(paragraph, center);
 }
 
@@ -554,8 +608,10 @@ fn render_usage_status(frame: &mut Frame, app: &mut App, area: Rect, outputs: &[
         return;
     }
 
-    let mut lines =
-        usage_status_summary_lines(app, outputs, inner.width as usize, inner.height as usize);
+    let diagnostic_reserve = diagnostic_line_reserve(app, inner.height as usize);
+    let summary_height = (inner.height as usize).saturating_sub(diagnostic_reserve);
+    let mut lines = usage_status_summary_lines(app, outputs, inner.width as usize, summary_height);
+    append_usage_diagnostic_lines(&mut lines, app, inner.width as usize, inner.height as usize);
 
     push_section_spacing(&mut lines, inner.height as usize);
     append_credit_bank_summary_lines(
@@ -761,6 +817,115 @@ fn usage_status_summary_lines(
         }
     }
     lines
+}
+
+fn diagnostic_line_reserve(app: &App, max_lines: usize) -> usize {
+    if app.usage_fetch_diagnostics.is_empty() {
+        0
+    } else if max_lines >= 7 {
+        3
+    } else {
+        2.min(max_lines.saturating_sub(1))
+    }
+}
+
+fn append_usage_diagnostic_lines(
+    lines: &mut Vec<Line<'static>>,
+    app: &App,
+    width: usize,
+    max_lines: usize,
+) {
+    if app.usage_fetch_diagnostics.is_empty() || lines.len() >= max_lines {
+        return;
+    }
+
+    let remaining = max_lines.saturating_sub(lines.len());
+    if remaining < 2 {
+        return;
+    }
+    if !lines.is_empty() && remaining >= 3 {
+        lines.push(Line::from(""));
+    }
+    if max_lines.saturating_sub(lines.len()) < 2 {
+        return;
+    }
+
+    lines.push(section_heading("Diagnostics", app));
+    let available = max_lines.saturating_sub(lines.len());
+    if available == 0 {
+        return;
+    }
+
+    let visible_count = if app.usage_fetch_diagnostics.len() > available && available > 1 {
+        available - 1
+    } else {
+        app.usage_fetch_diagnostics.len().min(available)
+    };
+    for diagnostic in visible_usage_diagnostics(&app.usage_fetch_diagnostics, visible_count) {
+        lines.push(usage_diagnostic_line(diagnostic, width));
+    }
+
+    let hidden_count = app
+        .usage_fetch_diagnostics
+        .len()
+        .saturating_sub(visible_count);
+    if hidden_count > 0 && lines.len() < max_lines {
+        lines.push(Line::from(Span::styled(
+            truncate_string(
+                &format!(
+                    "  +{} more issue{}",
+                    hidden_count,
+                    if hidden_count == 1 { "" } else { "s" }
+                ),
+                width,
+            ),
+            app.theme.subtle_text_style(),
+        )));
+    }
+}
+
+fn visible_usage_diagnostics(
+    diagnostics: &[UsageFetchDiagnostic],
+    visible_count: usize,
+) -> Vec<&UsageFetchDiagnostic> {
+    let visible_count = visible_count.min(diagnostics.len());
+    if visible_count >= diagnostics.len() {
+        return diagnostics.iter().collect();
+    }
+
+    let mut indexed: Vec<_> = diagnostics.iter().enumerate().collect();
+    indexed
+        .sort_by_key(|(index, diagnostic)| (diagnostic_severity_rank(diagnostic.severity), *index));
+    indexed.truncate(visible_count);
+    indexed
+        .into_iter()
+        .map(|(_, diagnostic)| diagnostic)
+        .collect()
+}
+
+fn diagnostic_severity_rank(severity: UsageFetchDiagnosticSeverity) -> u8 {
+    match severity {
+        UsageFetchDiagnosticSeverity::Error => 0,
+        UsageFetchDiagnosticSeverity::Warning => 1,
+        UsageFetchDiagnosticSeverity::Info => 2,
+    }
+}
+
+fn usage_diagnostic_line(diagnostic: &UsageFetchDiagnostic, width: usize) -> Line<'static> {
+    let label = diagnostic.display_name();
+    let text = format!("  {label}: {}", diagnostic.message);
+    Line::from(Span::styled(
+        truncate_string(&text, width),
+        Style::default().fg(diagnostic_severity_color(diagnostic.severity)),
+    ))
+}
+
+fn diagnostic_severity_color(severity: UsageFetchDiagnosticSeverity) -> Color {
+    match severity {
+        UsageFetchDiagnosticSeverity::Info => Color::Cyan,
+        UsageFetchDiagnosticSeverity::Warning => Color::Yellow,
+        UsageFetchDiagnosticSeverity::Error => Color::Red,
+    }
 }
 
 fn push_section_spacing(lines: &mut Vec<Line<'static>>, max_lines: usize) {
@@ -1006,7 +1171,7 @@ fn render_selected_account(
                 app,
                 "Credential",
                 if account.is_active {
-                    "saved store, active auth.json"
+                    "saved store, current Codex login"
                 } else {
                     "saved store"
                 },
@@ -1235,7 +1400,6 @@ fn selected_account_actions_line(
             let x = area
                 .x
                 .saturating_add(Line::from(spans.clone()).width() as u16);
-            buttons.push(remove_account_button(&account.id));
             push_click_buttons(&mut spans, app, buttons, x, y, area.right());
         } else {
             spans.push(Span::raw("  "));
@@ -2198,7 +2362,8 @@ fn styled<T: Into<String>>(text: T, style: Style, selected: bool) -> Span<'stati
 mod tests {
     use super::*;
     use crate::commands::usage::{
-        UsageAccount, UsageCreditStatus, UsageResetCredit, UsageResetCredits, UsageSpendControl,
+        UsageAccount, UsageCreditStatus, UsageFetchDiagnostic, UsageFetchDiagnosticKind,
+        UsageFetchDiagnosticSeverity, UsageResetCredit, UsageResetCredits, UsageSpendControl,
     };
     use crate::tui::app::{Tab, TuiConfig};
     use crate::tui::data::UsageData;
@@ -2485,6 +2650,7 @@ mod tests {
     #[test]
     fn renders_usage_workspace_sections_and_codex_actions() {
         let mut app = make_app();
+        app.selected_index = 1;
         app.subscription_usage = vec![
             output(
                 "Codex",
@@ -2516,6 +2682,120 @@ mod tests {
         assert!(body.contains("personal"), "{body}");
         assert!(body.contains(" Remove "), "{body}");
         assert!(body.contains("Show Emails"), "{body}");
+    }
+
+    #[test]
+    fn usage_summary_reserves_space_for_diagnostics() {
+        let mut app = make_app();
+        app.usage_fetch_diagnostics = vec![UsageFetchDiagnostic::new(
+            "Codex",
+            Some(UsageAccount {
+                id: "acct_personal".to_string(),
+                label: Some("personal".to_string()),
+                is_active: false,
+            }),
+            "usage endpoint rejected credentials",
+        )];
+        let outputs = vec![output(
+            "Codex",
+            Some(UsageAccount {
+                id: "acct_work".to_string(),
+                label: Some("work".to_string()),
+                is_active: true,
+            }),
+        )];
+        let max_lines = 6;
+        let reserve = diagnostic_line_reserve(&app, max_lines);
+        let mut lines = usage_status_summary_lines(&app, &outputs, 80, max_lines - reserve);
+        append_usage_diagnostic_lines(&mut lines, &app, 80, max_lines);
+        let rendered = lines
+            .iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("Diagnostics"), "{rendered}");
+        assert!(rendered.contains("usage endpoint rejected"), "{rendered}");
+    }
+
+    #[test]
+    fn usage_summary_reserve_keeps_space_at_tiny_heights() {
+        let mut app = make_app();
+        app.usage_fetch_diagnostics = vec![UsageFetchDiagnostic::new(
+            "Codex",
+            None,
+            "usage endpoint failed",
+        )];
+
+        assert_eq!(diagnostic_line_reserve(&app, 0), 0);
+        assert_eq!(diagnostic_line_reserve(&app, 1), 0);
+        assert_eq!(diagnostic_line_reserve(&app, 2), 1);
+        assert_eq!(diagnostic_line_reserve(&app, 6), 2);
+    }
+
+    #[test]
+    fn usage_summary_compacts_hidden_diagnostics() {
+        let mut app = make_app();
+        app.usage_fetch_diagnostics = vec![
+            UsageFetchDiagnostic::new("Codex", None, "first issue"),
+            UsageFetchDiagnostic::new("Claude", None, "second issue"),
+            UsageFetchDiagnostic::new("Amp", None, "third issue"),
+        ];
+        let mut lines = Vec::new();
+
+        append_usage_diagnostic_lines(&mut lines, &app, 80, 3);
+        let rendered = lines
+            .iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("Diagnostics"), "{rendered}");
+        assert!(rendered.contains("first issue"), "{rendered}");
+        assert!(rendered.contains("+2 more issues"), "{rendered}");
+        assert!(!rendered.contains("second issue"), "{rendered}");
+    }
+
+    #[test]
+    fn usage_summary_prioritizes_error_diagnostics_when_compacted() {
+        let mut app = make_app();
+        app.usage_fetch_diagnostics = vec![
+            UsageFetchDiagnostic::with_kind(
+                "Claude",
+                None,
+                UsageFetchDiagnosticKind::FetchFailed,
+                UsageFetchDiagnosticSeverity::Info,
+                "low priority issue",
+            ),
+            UsageFetchDiagnostic::with_kind(
+                "Amp",
+                None,
+                UsageFetchDiagnosticKind::FetchFailed,
+                UsageFetchDiagnosticSeverity::Warning,
+                "medium priority issue",
+            ),
+            UsageFetchDiagnostic::with_kind(
+                "Codex",
+                None,
+                UsageFetchDiagnosticKind::FetchFailed,
+                UsageFetchDiagnosticSeverity::Error,
+                "high priority issue",
+            ),
+        ];
+        let mut lines = Vec::new();
+
+        append_usage_diagnostic_lines(&mut lines, &app, 80, 3);
+        let rendered = lines
+            .iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("Diagnostics"), "{rendered}");
+        assert!(rendered.contains("high priority issue"), "{rendered}");
+        assert!(rendered.contains("+2 more issues"), "{rendered}");
+        assert!(!rendered.contains("low priority issue"), "{rendered}");
+        assert!(!rendered.contains("medium priority issue"), "{rendered}");
     }
 
     #[test]
@@ -2687,6 +2967,7 @@ mod tests {
         )];
 
         let body = render_body(&mut app, 180, 32);
+        assert!(body.contains("current Codex login"), "{body}");
         let status_line = body
             .lines()
             .find(|line| line.contains("Status") && line.contains("Ready"))
@@ -2714,6 +2995,7 @@ mod tests {
         assert_eq!(selected_col, visual_col(metric_line, "5h"));
         assert_eq!(selected_col, visual_col(actions_line, "Actions"));
         assert_eq!(selected_col, visual_col(current_line, "Current account"));
+        assert!(!current_line.contains("Remove"), "{current_line}");
     }
 
     #[test]
@@ -2889,6 +3171,7 @@ mod tests {
     #[test]
     fn narrow_usage_keeps_account_actions_visible() {
         let mut app = make_app();
+        app.selected_index = 1;
         app.subscription_usage = vec![
             output(
                 "Codex",


### PR DESCRIPTION
## Summary

- Add a usage fetch report path so the TUI can keep successful provider results while surfacing per-provider or per-account fetch diagnostics.
- Import the current Codex login into the saved account store before TUI usage refreshes, serialize Codex account store updates with a lock file, and dedupe collision-suffixed Codex account identities.
- Prevent removing the active Codex account from the TUI/CLI and show usage diagnostics in the Usage header, empty state, and summary panel.

## Notes

This keeps the change inside the existing usage/app files to stay focused. A follow-up extraction of usage-specific app state/actions into a smaller module could make future usage changes easier to review, but I would keep that separate from this fix.

## Tests

- `cargo check -p tokscale-cli`
- `cargo test -p tokscale-cli commands::usage::codex -- --test-threads=1`
- `cargo test -p tokscale-cli tui::ui::usage::tests -- --test-threads=1`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Codex account loading and usage fetches. Adds a locked, version‑safe account store, imports the current Codex login for TUI fetches, and surfaces per‑provider diagnostics with severity in the Usage view.

- **Bug Fixes**
  - Serialize Codex account store writes via a lock file (`fs2`) to avoid concurrent corruption.
  - Refuse to modify unsupported store versions; only persist “active account” repairs on update (read‑only paths never persist repairs).
  - De‑dupe accounts by identity and update in place (handles collision‑suffixed IDs).
  - Treat Codex auth expiry as a typed error and refresh tokens before retrying.
  - Prevent removing the active Codex account (CLI and TUI).
  - Do not crash on provider panics; surface them as diagnostics.

- **New Features**
  - Introduce `UsageFetchReport` with per‑provider/account diagnostics (with severity/kind); keep successful results alongside errors, including import‑login and panic diagnostics.
  - TUI: import the current Codex login into the saved account store before refresh (CLI fetches remain read‑only). Show diagnostics in the Usage header, empty state, and a “Diagnostics” section; status now says “loaded with N issues” or a concise failure summary when nothing loads.

<sup>Written for commit 61fb561a3e3e78c361952737e91ec1cb0ab518cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

