### PR TITLE
test(leaderboard): width-based cost-cast coverage across all query shapes

### DIFF
--- a/packages/frontend/__tests__/api/usersProfile.test.ts
+++ b/packages/frontend/__tests__/api/usersProfile.test.ts
@@ -259,6 +259,50 @@ describe("GET /api/users/[username]", () => {
     expect(body.user.username).toBe("ImLunaHey");
   });
 
+  it("casts total_cost at full column precision in the profile stats query", async () => {
+    mockState.pushSelectResult([
+      {
+        id: "user-alice",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        totalTokens: 0,
+        totalCost: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        reasoningTokens: 0,
+        submissionCount: 0,
+        earliestDate: null,
+        latestDate: null,
+      },
+    ]);
+    mockState.pushSelectResult([]);
+    mockState.pushSelectResult([]);
+    mockState.pushExecuteResult([]);
+
+    await GET(
+      new Request("http://localhost:3000/api/users/alice"),
+      { params: Promise.resolve({ username: "alice" }) }
+    );
+
+    // submissions.total_cost is decimal(18,4); a narrower cast overflows for a
+    // profile whose lifetime cost has grown past the narrowed ceiling.
+    const costCastWidths = serializeSqlCalls()
+      .filter((text) => /CAST\([^)]*(?:total_cost|totalCost)[^)]*AS DECIMAL/.test(text))
+      .flatMap((text) =>
+        [...text.matchAll(/DECIMAL\((\d+),\s*4\)/g)].map((match) => Number(match[1]))
+      );
+    expect(costCastWidths.length).toBeGreaterThan(0);
+    expect(costCastWidths.every((width) => width >= 18)).toBe(true);
+  });
+
   it("rejects ambiguous case-insensitive username matches", async () => {
     mockState.pushSelectResult([
       {

--- a/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
@@ -295,4 +295,30 @@ describe("group leaderboard data", () => {
     );
     expect(leaderboard.users.map((user) => user.username)).toEqual(["alice", "bob"]);
   });
+
+  // submissions.total_cost is decimal(18,4); narrowing the cast to DECIMAL(12,4)
+  // (max 99,999,999.9999) overflows for any row >= $100,000,000 and crashes the
+  // all-time group leaderboard exactly like the global leaderboard.
+  it("casts total_cost at full column precision for the all-time group leaderboard", async () => {
+    mockState.setAllTimeRows([]);
+
+    await getGroupLeaderboardData("group-1", "all", 1, 50, "cost");
+
+    const sqlTexts = mockState.sql.mock.calls.map((call) => {
+      const [strings, ...values] = call as [TemplateStringsArray, ...unknown[]];
+      return Array.from(strings).reduce((text, part, index) => {
+        const nextValue = index < values.length ? String(values[index]) : "";
+        return `${text}${part}${nextValue}`;
+      }, "");
+    });
+
+    const costCastWidths = sqlTexts
+      .filter((text) => /CAST\([^)]*(?:total_cost|totalCost)[^)]*AS DECIMAL/.test(text))
+      .flatMap((text) =>
+        [...text.matchAll(/DECIMAL\((\d+),\s*4\)/g)].map((match) => Number(match[1]))
+      );
+    expect(costCastWidths.length).toBeGreaterThan(0);
+    // total_cost is decimal(18,4); any narrower precision overflows on big costs.
+    expect(costCastWidths.every((width) => width >= 18)).toBe(true);
+  });
 });

--- a/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
@@ -516,3 +516,53 @@ describe("all-time leaderboard freshness queries", () => {
     expect(costCastWidths.every((width) => width >= 18)).toBe(true);
   });
 });
+
+describe("all-time cost aggregation precision across query shapes (numeric overflow regression)", () => {
+  // Complements the all-time-list check above with the search and user-rank
+  // shapes that also cast submissions.total_cost (decimal(18,4)). Any cast
+  // narrower than 18 overflows on costs >= the narrowed ceiling and 500s the
+  // query; width-based so a re-narrowing to e.g. DECIMAL(15,4) is still caught.
+  function expectNoNarrowedCostCast(sqlTexts: string[]): void {
+    const costCastWidths = sqlTexts
+      .filter((text) => /CAST\([^)]*(?:total_cost|totalCost)[^)]*AS DECIMAL/.test(text))
+      .flatMap((text) =>
+        [...text.matchAll(/DECIMAL\((\d+),\s*4\)/g)].map((match) => Number(match[1]))
+      );
+    expect(costCastWidths.length).toBeGreaterThan(0);
+    expect(costCastWidths.every((width) => width >= 18)).toBe(true);
+  }
+
+  it("casts total_cost at full column precision in the all-time search list", async () => {
+    mockState.pushAwaitedResult([]);
+    mockState.pushAwaitedResult([{ count: 0 }]);
+    mockState.pushAwaitedResult([
+      { totalTokens: 0, totalCost: 0, totalSubmissions: 0, uniqueUsers: 0 },
+    ]);
+
+    await getLeaderboardData("all", 1, 50, "cost", "ali");
+
+    expectNoNarrowedCostCast(serializeSqlCalls());
+  });
+
+  it("casts total_cost at full column precision for all-time user rank", async () => {
+    mockState.pushAwaitedResult([
+      { id: "user-alice", username: "alice", displayName: "Alice", avatarUrl: null },
+    ]);
+    mockState.pushAwaitedResult([
+      {
+        totalTokens: 3000,
+        totalCost: 40,
+        totalActiveTimeMs: 0,
+        submissionCount: 1,
+        lastSubmission: "2026-03-12T09:00:00.000Z",
+        cliVersion: "1.9.0",
+        schemaVersion: 1,
+      },
+    ]);
+    mockState.pushAwaitedResult([{ count: 0 }]);
+
+    await getUserRank("alice", "all", "cost");
+
+    expectNoNarrowedCostCast(serializeSqlCalls());
+  });
+});

--- a/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
+++ b/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
@@ -177,7 +177,7 @@ describe("user embed data", () => {
 
     expect(tokenSqlTexts.some((text) => text.includes("RANK() OVER"))).toBe(true);
     expect(tokenSqlTexts.some((text) =>
-      text.includes("total_tokens DESC, CAST(total_cost AS DECIMAL(12,4)) DESC")
+      /total_tokens DESC, CAST\(total_cost AS DECIMAL\(\d+,4\)\) DESC/.test(text)
     )).toBe(false);
 
     mockState.reset();
@@ -200,8 +200,36 @@ describe("user embed data", () => {
 
     expect(costSqlTexts.some((text) => text.includes("RANK() OVER"))).toBe(true);
     expect(costSqlTexts.some((text) =>
-      text.includes("CAST(total_cost AS DECIMAL(12,4)) DESC, total_tokens DESC")
+      /CAST\(total_cost AS DECIMAL\(\d+,4\)\) DESC, total_tokens DESC/.test(text)
     )).toBe(false);
+  });
+
+  it("casts total_cost at full column precision for cost-sorted embed stats", async () => {
+    mockState.pushAwaitedResult([
+      {
+        id: "user-alice",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        totalTokens: 3000,
+        totalCost: 40,
+        submissionCount: 1,
+        updatedAt: new Date("2026-03-12T09:00:00.000Z"),
+      },
+    ]);
+    mockState.pushExecuteResult([{ rank: 2, total: 3 }]);
+
+    await getUserEmbedStats("alice", "cost");
+
+    // submissions.total_cost is decimal(18,4); narrowing the cast overflows for
+    // costs >= the narrowed ceiling and 500s the embed for that user.
+    const costCastWidths = serializeSqlCalls()
+      .filter((text) => /CAST\([^)]*(?:total_cost|totalCost)[^)]*AS DECIMAL/.test(text))
+      .flatMap((text) =>
+        [...text.matchAll(/DECIMAL\((\d+),\s*4\)/g)].map((match) => Number(match[1]))
+      );
+    expect(costCastWidths.length).toBeGreaterThan(0);
+    expect(costCastWidths.every((width) => width >= 18)).toBe(true);
   });
 
   it("looks up embed stats usernames case-insensitively and returns the canonical username", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #780 (the `numeric(18,4)` overflow fix). #780 already hardened the **all-time list** regression test to a width-based assertion; this PR lifts the **broader query-shape coverage** from @raw34's #782 (which raw34 closed as a duplicate of #780, [offering](https://github.com/junhoyeo/tokscale/pull/780#issuecomment-4814948483) to PR these on top).

Every query shape that casts `submissions.total_cost` / `daily_breakdown.cost` is now guarded:

| Shape | Test file |
|---|---|
| all-time **search** list + **user-rank** | `getLeaderboardAllTime.test.ts` |
| all-time **group** leaderboard | `getGroupLeaderboard.test.ts` |
| **profile** stats query | `usersProfile.test.ts` |
| cost-sorted **embed** stats + ranking | `getUserEmbedStats.test.ts` |

## Why width-based

Instead of pinning literals (`DECIMAL(18,4)` present / `DECIMAL(12,4)` absent), each test extracts **every** `total_cost` cost-cast precision and asserts `every(width >= 18)`. So a future re-narrowing to *any* precision below the `numeric(18,4)` column — e.g. `DECIMAL(15,4)` — fails the test instead of silently reintroducing the overflow. The two literal `DECIMAL(12,4)` assertions in the embed test become width-based regexes for the same reason.

**Tests only — no production change.** The fix itself shipped in #780.

## Testing

- `vitest run` on the 4 touched suites: **25 passed** ✅

Credit to **@raw34** (co-author) for the original coverage and the width-based approach in #782, and to @YoannLetacq for the production fix in #780.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened tests to prevent numeric overflow by asserting every `CAST(total_cost AS DECIMAL(...,4))` stays width >= 18 across leaderboard, profile, and embed queries. Tests only—no production changes.

- **Bug Fixes**
  - Added width-based assertions for `total_cost` casts in `getLeaderboardAllTime` (search list, user rank), `getGroupLeaderboard` (all-time group), `usersProfile` (profile stats), and `getUserEmbedStats` (cost-sorted stats + ranking).
  - Replaced literal `DECIMAL(12,4)` checks in embed tests with width-based regex so any narrowing (e.g., `DECIMAL(15,4)`) fails.

<sup>Written for commit 789802ea091457f17d0bf33fd5b00a0b7beeebc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

