### PR TITLE
test(leaderboard): extract shared cost-cast-width assertion helper

### DIFF
--- a/packages/frontend/__tests__/api/usersProfile.test.ts
+++ b/packages/frontend/__tests__/api/usersProfile.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { expectNoNarrowedCostCast } from "../support/costCastWidths";
+
 const mockState = vi.hoisted(() => {
   const selectResults: Array<Array<Record<string, unknown>>> = [];
   const executeResults: Array<Array<Record<string, unknown>>> = [];
@@ -294,13 +296,7 @@ describe("GET /api/users/[username]", () => {
 
     // submissions.total_cost is decimal(18,4); a narrower cast overflows for a
     // profile whose lifetime cost has grown past the narrowed ceiling.
-    const costCastWidths = serializeSqlCalls()
-      .filter((text) => /CAST\([^)]*(?:total_cost|totalCost)[^)]*AS DECIMAL/.test(text))
-      .flatMap((text) =>
-        [...text.matchAll(/DECIMAL\((\d+),\s*4\)/g)].map((match) => Number(match[1]))
-      );
-    expect(costCastWidths.length).toBeGreaterThan(0);
-    expect(costCastWidths.every((width) => width >= 18)).toBe(true);
+    expectNoNarrowedCostCast(serializeSqlCalls());
   });
 
   it("rejects ambiguous case-insensitive username matches", async () => {

--- a/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { expectNoNarrowedCostCast } from "../support/costCastWidths";
+
 const mockState = vi.hoisted(() => {
   const periodRows: Array<Record<string, unknown>> = [];
   const allTimeRows: Array<Record<string, unknown>> = [];
@@ -312,13 +314,6 @@ describe("group leaderboard data", () => {
       }, "");
     });
 
-    const costCastWidths = sqlTexts
-      .filter((text) => /CAST\([^)]*(?:total_cost|totalCost)[^)]*AS DECIMAL/.test(text))
-      .flatMap((text) =>
-        [...text.matchAll(/DECIMAL\((\d+),\s*4\)/g)].map((match) => Number(match[1]))
-      );
-    expect(costCastWidths.length).toBeGreaterThan(0);
-    // total_cost is decimal(18,4); any narrower precision overflows on big costs.
-    expect(costCastWidths.every((width) => width >= 18)).toBe(true);
+    expectNoNarrowedCostCast(sqlTexts);
   });
 });

--- a/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { expectNoNarrowedCostCast } from "../support/costCastWidths";
+
 const mockState = vi.hoisted(() => {
   const awaitedResults: unknown[] = [];
   const limitCalls: unknown[] = [];
@@ -506,14 +508,8 @@ describe("all-time leaderboard freshness queries", () => {
     // Regression: total_cost is numeric(18,4) (migration 0014); every cost cast must stay >= 18 wide or costs >= 1e8 overflow.
     // Width-based (not literal) so it also catches a re-narrowing to any precision below the column, e.g. DECIMAL(15,4).
     await getLeaderboardData("all", 1, 50, "cost");
-    const sqlTexts = serializeSqlCalls();
 
-    const costCastWidths = sqlTexts
-      .filter((text) => /CAST\([^)]*(?:total_cost|totalCost)[^)]*AS DECIMAL/.test(text))
-      .flatMap((text) => [...text.matchAll(/DECIMAL\((\d+),\s*4\)/g)].map((match) => Number(match[1])));
-
-    expect(costCastWidths.length).toBeGreaterThan(0);
-    expect(costCastWidths.every((width) => width >= 18)).toBe(true);
+    expectNoNarrowedCostCast(serializeSqlCalls());
   });
 });
 
@@ -522,16 +518,6 @@ describe("all-time cost aggregation precision across query shapes (numeric overf
   // shapes that also cast submissions.total_cost (decimal(18,4)). Any cast
   // narrower than 18 overflows on costs >= the narrowed ceiling and 500s the
   // query; width-based so a re-narrowing to e.g. DECIMAL(15,4) is still caught.
-  function expectNoNarrowedCostCast(sqlTexts: string[]): void {
-    const costCastWidths = sqlTexts
-      .filter((text) => /CAST\([^)]*(?:total_cost|totalCost)[^)]*AS DECIMAL/.test(text))
-      .flatMap((text) =>
-        [...text.matchAll(/DECIMAL\((\d+),\s*4\)/g)].map((match) => Number(match[1]))
-      );
-    expect(costCastWidths.length).toBeGreaterThan(0);
-    expect(costCastWidths.every((width) => width >= 18)).toBe(true);
-  }
-
   it("casts total_cost at full column precision in the all-time search list", async () => {
     mockState.pushAwaitedResult([]);
     mockState.pushAwaitedResult([{ count: 0 }]);

--- a/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
+++ b/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
@@ -1,5 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { expectNoNarrowedCostCast } from "../support/costCastWidths";
+
 const mockState = vi.hoisted(() => {
   const awaitedResults: unknown[] = [];
   const executeResults: Array<Array<Record<string, unknown>>> = [];
@@ -223,13 +225,7 @@ describe("user embed data", () => {
 
     // submissions.total_cost is decimal(18,4); narrowing the cast overflows for
     // costs >= the narrowed ceiling and 500s the embed for that user.
-    const costCastWidths = serializeSqlCalls()
-      .filter((text) => /CAST\([^)]*(?:total_cost|totalCost)[^)]*AS DECIMAL/.test(text))
-      .flatMap((text) =>
-        [...text.matchAll(/DECIMAL\((\d+),\s*4\)/g)].map((match) => Number(match[1]))
-      );
-    expect(costCastWidths.length).toBeGreaterThan(0);
-    expect(costCastWidths.every((width) => width >= 18)).toBe(true);
+    expectNoNarrowedCostCast(serializeSqlCalls());
   });
 
   it("looks up embed stats usernames case-insensitively and returns the canonical username", async () => {

--- a/packages/frontend/__tests__/support/costCastWidths.ts
+++ b/packages/frontend/__tests__/support/costCastWidths.ts
@@ -1,0 +1,30 @@
+import { expect } from "vitest";
+
+/**
+ * Extracts every `total_cost` cost-cast precision width from a set of
+ * serialized SQL statements.
+ *
+ * The leaderboard / profile / embed queries cast cost columns to DECIMAL for
+ * `ORDER BY` and `SUM`. `submissions.total_cost` is `decimal(18,4)`; a
+ * width-based check (rather than a literal `DECIMAL(18,4)` string match)
+ * catches a re-narrowing to ANY precision below the column — e.g.
+ * `DECIMAL(15,4)` — which would overflow on costs past the narrowed ceiling.
+ */
+export function costCastWidths(sqlTexts: string[]): number[] {
+  return sqlTexts
+    .filter((text) => /CAST\([^)]*(?:total_cost|totalCost)[^)]*AS DECIMAL/.test(text))
+    .flatMap((text) =>
+      [...text.matchAll(/DECIMAL\((\d+),\s*4\)/g)].map((match) => Number(match[1]))
+    );
+}
+
+/**
+ * Asserts the SQL casts at least one cost column and that every cost cast stays
+ * at the full `decimal(18,4)` column precision (width >= 18), so a narrowed
+ * cast that would overflow on large totals fails the test.
+ */
+export function expectNoNarrowedCostCast(sqlTexts: string[]): void {
+  const widths = costCastWidths(sqlTexts);
+  expect(widths.length).toBeGreaterThan(0);
+  expect(widths.every((width) => width >= 18)).toBe(true);
+}


### PR DESCRIPTION
## Summary

Addresses cubic's DRY finding on #787: the width-based cost-cast extraction + `>= 18` assertion was duplicated across **four** test files (five inline copies plus one local helper).

Consolidated into a single shared utility — `packages/frontend/__tests__/support/costCastWidths.ts`:
- `costCastWidths(sqlTexts)` — extracts every `total_cost` cast precision from serialized SQL.
- `expectNoNarrowedCostCast(sqlTexts)` — asserts at least one cost cast exists and every one stays `>= 18` wide (the `decimal(18,4)` column).

All four suites now import it:
- `__tests__/lib/getLeaderboardAllTime.test.ts`
- `__tests__/lib/getGroupLeaderboard.test.ts`
- `__tests__/lib/getUserEmbedStats.test.ts`
- `__tests__/api/usersProfile.test.ts`

Now the regex and the width invariant live in **one place** and can't drift between files.

## Notes
- **Behavior-preserving** — same 25 tests, all green.
- The support file has no `.test.` suffix, so vitest doesn't collect it as a suite (verified against `vitest.config.ts`, whose `src/**` glob is coverage-only).

## Testing
- `vitest run` on the 4 suites: **25 passed** ✅
- `tsc --noEmit`: clean for the helper + touched files ✅

Tests-only; no production change. Identified by cubic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared test helper to dedupe the SQL cost-cast width assertion used in leaderboard, group, user embed, and users profile tests. Centralizes the `>= 18` precision check for `total_cost` casts; tests-only change.

- **Refactors**
  - Added `packages/frontend/__tests__/support/costCastWidths.ts` with `costCastWidths()` and `expectNoNarrowedCostCast()`.
  - Replaced inline logic in `__tests__/lib/getLeaderboardAllTime.test.ts`, `__tests__/lib/getGroupLeaderboard.test.ts`, `__tests__/lib/getUserEmbedStats.test.ts`, and `__tests__/api/usersProfile.test.ts`.
  - Helper ensures at least one `total_cost` cast and that all widths are `>= 18` for `decimal(18,4)` to avoid drift.

<sup>Written for commit 406d7092a0e18aa5a78ec4efeee7e1c44d9301eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

