### PR TITLE
ci(release): smoke-test packaged CLI artifacts before publish

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -295,9 +295,45 @@ jobs:
           path: dist
           if-no-files-found: error
 
+  smoke-release-artifacts:
+    name: Smoke release artifacts
+    needs: [bump-versions, build-cli-binary]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download bumped release files
+        uses: actions/download-artifact@v6
+        with:
+          name: bumped-manifests
+          path: .
+
+      - name: Download CLI binary artifacts
+        uses: actions/download-artifact@v6
+        with:
+          pattern: cli-binary-*
+          path: release-artifacts
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.1.38
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+
+      - name: Install workspace dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Smoke release package artifacts
+        run: bash scripts/test-release-package-artifacts.sh
+
   prepare-release-provenance:
     name: Commit release provenance
-    needs: [bump-versions, build-cli-binary]
+    needs: [bump-versions, build-cli-binary, smoke-release-artifacts]
     runs-on: ubuntu-latest
     outputs:
       release_commit: ${{ steps.prepare.outputs.release_commit }}

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -12,6 +12,8 @@ on:
       - 'packages/tokscale/package.json'
       - 'packages/cli-*/package.json'
       - 'scripts/*.sh'
+      - 'scripts/*.py'
+      - '.github/workflows/build-native.yml'
       - '.github/workflows/publish-cli.yml'
       - '.github/workflows/test_coverage.yml'
   pull_request:
@@ -24,6 +26,8 @@ on:
       - 'packages/tokscale/package.json'
       - 'packages/cli-*/package.json'
       - 'scripts/*.sh'
+      - 'scripts/*.py'
+      - '.github/workflows/build-native.yml'
       - '.github/workflows/publish-cli.yml'
       - '.github/workflows/test_coverage.yml'
 
@@ -51,6 +55,7 @@ jobs:
           bash scripts/test-check-version-coherence.sh
           bash scripts/test-npm-release-state.sh
           bash scripts/test-prepare-release-provenance.sh
+          bash scripts/test-release-workflow-safety.sh
       - name: Cache cargo registry
         uses: actions/cache@v5
         with:

--- a/scripts/check-release-workflow-safety.py
+++ b/scripts/check-release-workflow-safety.py
@@ -137,6 +137,48 @@ def package_manifest_name(package_dir: str) -> str:
     return name
 
 
+def block_contains(block: list[str], needle: str) -> bool:
+    return any(needle in line for line in uncommented_lines(block))
+
+
+def uncommented_lines(lines: list[str]) -> list[str]:
+    return [line for line in lines if not line.lstrip().startswith("#")]
+
+
+def parse_needs(block: list[str]) -> set[str]:
+    lines = uncommented_lines(block)
+    for index, line in enumerate(lines):
+        match = re.match(r"(\s*)needs:\s*(.*)$", line)
+        if not match:
+            continue
+
+        needs_indent = len(match.group(1))
+        value = match.group(2).strip()
+        if value:
+            value = strip_yaml_scalar(value)
+            if value.startswith("[") and value.endswith("]"):
+                return {
+                    strip_yaml_scalar(item)
+                    for item in value[1:-1].split(",")
+                    if strip_yaml_scalar(item)
+                }
+            return {value}
+
+        needs: set[str] = set()
+        for child in lines[index + 1 :]:
+            if not child.strip():
+                continue
+            child_indent = len(child) - len(child.lstrip(" "))
+            if child_indent <= needs_indent:
+                break
+            item_match = re.match(r"\s*-\s*(.+?)\s*$", child)
+            if item_match:
+                needs.add(strip_yaml_scalar(item_match.group(1)))
+        return needs
+
+    return set()
+
+
 def main() -> None:
     publish_lines = read_lines(PUBLISH_WORKFLOW)
     native_lines = read_lines(BUILD_NATIVE_WORKFLOW)
@@ -229,6 +271,22 @@ def main() -> None:
             errors.append(
                 f"publish platform binary drift for {package_dir}: expected {build_entry.get('bin_name')}, found {platform_entry.get('binary_name')}"
             )
+
+    try:
+        smoke_block = job_block(publish_lines, "smoke-release-artifacts")
+    except SystemExit:
+        smoke_block = []
+        errors.append("publish workflow missing smoke-release-artifacts job")
+
+    if smoke_block:
+        if not block_contains(smoke_block, "pattern: cli-binary-*"):
+            errors.append("smoke-release-artifacts job must download cli-binary-* artifacts")
+        if not block_contains(smoke_block, "scripts/test-release-package-artifacts.sh"):
+            errors.append("smoke-release-artifacts job must run scripts/test-release-package-artifacts.sh")
+
+    prepare_block = job_block(publish_lines, "prepare-release-provenance")
+    if "smoke-release-artifacts" not in parse_needs(prepare_block):
+        errors.append("prepare-release-provenance must depend on smoke-release-artifacts")
 
     if errors:
         raise SystemExit("Release workflow safety check failed:\n- " + "\n- ".join(errors))

--- a/scripts/test-release-package-artifacts.sh
+++ b/scripts/test-release-package-artifacts.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+ARTIFACT_ROOT="${RELEASE_ARTIFACT_ROOT:-release-artifacts}"
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required for release artifact smoke tests"
+}
+
+require_cmd bun
+require_cmd node
+require_cmd npm
+
+[[ -d "${ARTIFACT_ROOT}" ]] || fail "Missing release artifact directory: ${ARTIFACT_ROOT}"
+
+BUN_BIN="${BUN_BIN:-$(command -v bun)}"
+NODE_BIN="${NODE_BIN:-$(command -v node)}"
+LDD_BIN="${LDD_BIN:-$(command -v ldd || true)}"
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/tokscale-release-artifact-smoke.XXXXXX")"
+cleanup() {
+  rm -rf "${TMP_ROOT}"
+}
+trap cleanup EXIT
+
+MATRIX_FILE="${TMP_ROOT}/release-matrix.tsv"
+node --input-type=module >"${MATRIX_FILE}" <<'NODE'
+const rows = [
+  ["cli-darwin-x64", "cli-binary-x86_64-apple-darwin", "tokscale"],
+  ["cli-darwin-arm64", "cli-binary-aarch64-apple-darwin", "tokscale"],
+  ["cli-linux-x64-gnu", "cli-binary-x86_64-unknown-linux-gnu", "tokscale"],
+  ["cli-linux-x64-musl", "cli-binary-x86_64-unknown-linux-musl", "tokscale"],
+  ["cli-linux-arm64-gnu", "cli-binary-aarch64-unknown-linux-gnu", "tokscale"],
+  ["cli-linux-arm64-musl", "cli-binary-aarch64-unknown-linux-musl", "tokscale"],
+  ["cli-win32-x64-msvc", "cli-binary-x86_64-pc-windows-msvc", "tokscale.exe"],
+  ["cli-win32-arm64-msvc", "cli-binary-aarch64-pc-windows-msvc", "tokscale.exe"],
+];
+for (const row of rows) {
+  console.log(row.join("\t"));
+}
+NODE
+
+HOST_PACKAGE="$(node --input-type=module <<'NODE'
+import { execSync } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
+
+function detectLibcKind() {
+  if (process.platform !== "linux") {
+    return null;
+  }
+
+  const override = process.env.TOKSCALE_LIBC?.trim().toLowerCase();
+  if (override === "musl") return "musl";
+  if (override === "gnu" || override === "glibc") return "gnu";
+
+  const report = process.report?.getReport?.();
+  if (report?.header?.glibcVersionRuntime) {
+    return "gnu";
+  }
+
+  if (
+    Array.isArray(report?.sharedObjects) &&
+    report.sharedObjects.some((obj) => obj.toLowerCase().includes("musl"))
+  ) {
+    return "musl";
+  }
+
+  if (report?.header?.release?.sourceUrl?.toLowerCase().includes("musl")) {
+    return "musl";
+  }
+
+  try {
+    const output = execSync("ldd --version", {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).toLowerCase();
+    if (output.includes("musl")) return "musl";
+    if (output.includes("glibc") || output.includes("gnu")) return "gnu";
+  } catch (error) {
+    const combined = `${error?.stdout ?? ""}\n${error?.stderr ?? ""}`.toLowerCase();
+    if (combined.includes("musl")) return "musl";
+    if (combined.includes("glibc") || combined.includes("gnu")) return "gnu";
+  }
+
+  const loaderPresent = (prefix) => {
+    for (const dir of ["/lib", "/lib64"]) {
+      try {
+        if (readdirSync(dir).some((entry) => entry.startsWith(prefix))) {
+          return true;
+        }
+      } catch {}
+    }
+    return false;
+  };
+  const hasGnuLoader = loaderPresent("ld-linux-");
+  const hasMuslLoader = loaderPresent("ld-musl-");
+  if (hasGnuLoader !== hasMuslLoader) return hasMuslLoader ? "musl" : "gnu";
+  if (hasGnuLoader && hasMuslLoader) {
+    return existsSync("/etc/alpine-release") ? "musl" : "gnu";
+  }
+
+  return "gnu";
+}
+
+const arch = process.arch;
+if (process.platform === "darwin") {
+  if (arch === "arm64") console.log("cli-darwin-arm64");
+  else if (arch === "x64") console.log("cli-darwin-x64");
+  else process.exit(1);
+} else if (process.platform === "linux") {
+  const libc = detectLibcKind();
+  if (arch === "arm64") console.log(libc === "musl" ? "cli-linux-arm64-musl" : "cli-linux-arm64-gnu");
+  else if (arch === "x64") console.log(libc === "musl" ? "cli-linux-x64-musl" : "cli-linux-x64-gnu");
+  else process.exit(1);
+} else if (process.platform === "win32") {
+  if (arch === "arm64") console.log("cli-win32-arm64-msvc");
+  else if (arch === "x64") console.log("cli-win32-x64-msvc");
+  else process.exit(1);
+} else {
+  process.exit(1);
+}
+NODE
+)"
+
+[[ -n "${HOST_PACKAGE}" ]] || fail "Unsupported host platform for launcher execution smoke"
+HOST_BINARY_NAME="$(awk -F '\t' -v package="${HOST_PACKAGE}" '$1 == package { print $3 }' "${MATRIX_FILE}")"
+[[ -n "${HOST_BINARY_NAME}" ]] || fail "Missing binary mapping for host package: ${HOST_PACKAGE}"
+
+PACKAGE_STAGE_ROOT="${TMP_ROOT}/packages"
+TARBALL_ROOT="${TMP_ROOT}/tarballs"
+INSTALL_DIR="${TMP_ROOT}/install"
+NPM_CACHE="${TMP_ROOT}/npm-cache"
+BUN_ONLY_DIR="${TMP_ROOT}/bun-only-path"
+NODE_ONLY_DIR="${TMP_ROOT}/node-only-path"
+mkdir -p "${PACKAGE_STAGE_ROOT}" "${TARBALL_ROOT}" "${INSTALL_DIR}" "${NPM_CACHE}" "${BUN_ONLY_DIR}" "${NODE_ONLY_DIR}"
+
+ln -s "${BUN_BIN}" "${BUN_ONLY_DIR}/bun"
+ln -s "${NODE_BIN}" "${NODE_ONLY_DIR}/node"
+if [[ -n "${LDD_BIN}" ]]; then
+  ln -s "${LDD_BIN}" "${BUN_ONLY_DIR}/ldd"
+  ln -s "${LDD_BIN}" "${NODE_ONLY_DIR}/ldd"
+fi
+
+echo "Building @tokscale/cli JavaScript entrypoint..."
+bun run --cwd packages/cli build >/dev/null
+
+LOCAL_TARBALLS_FILE="${TMP_ROOT}/platform-tarballs.tsv"
+: >"${LOCAL_TARBALLS_FILE}"
+while IFS=$'\t' read -r package_dir artifact_name binary_name; do
+  artifact_dir="${ARTIFACT_ROOT}/${artifact_name}"
+  source_binary="${artifact_dir}/${binary_name}"
+  [[ -f "${source_binary}" ]] || fail "Missing ${binary_name} in ${artifact_dir}"
+
+  stage_dir="${PACKAGE_STAGE_ROOT}/${package_dir}"
+  cp -R "packages/${package_dir}" "${stage_dir}"
+  mkdir -p "${stage_dir}/bin"
+  cp "${source_binary}" "${stage_dir}/bin/${binary_name}"
+  if [[ "${binary_name}" == "tokscale" ]]; then
+    chmod +x "${stage_dir}/bin/${binary_name}"
+  fi
+
+  if [[ -f "${artifact_dir}/libFoundationModels.dylib" ]]; then
+    cp "${artifact_dir}/libFoundationModels.dylib" "${stage_dir}/bin/libFoundationModels.dylib"
+  elif [[ "${package_dir}" == "cli-darwin-arm64" ]]; then
+    fail "Missing libFoundationModels.dylib in ${artifact_dir}"
+  fi
+
+  package_name="$(node --input-type=module - "${stage_dir}/package.json" <<'NODE'
+import fs from "node:fs";
+const manifest = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+console.log(manifest.name);
+NODE
+)"
+  tarball_name="$(cd "${stage_dir}" && NPM_CONFIG_CACHE="${NPM_CACHE}" npm pack --silent)"
+  printf '%s\t%s\n' "${package_name}" "file:${stage_dir}/${tarball_name}" >>"${LOCAL_TARBALLS_FILE}"
+  cp "${stage_dir}/${tarball_name}" "${TARBALL_ROOT}/"
+  echo "Packed ${package_name} from ${artifact_name}"
+done <"${MATRIX_FILE}"
+
+CLI_STAGE="${PACKAGE_STAGE_ROOT}/cli"
+cp -R packages/cli "${CLI_STAGE}"
+node --input-type=module - "${CLI_STAGE}/package.json" "${LOCAL_TARBALLS_FILE}" <<'NODE'
+import fs from "node:fs";
+
+const [manifestPath, mappingPath] = process.argv.slice(2);
+const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+const lines = fs.readFileSync(mappingPath, "utf8");
+const replacements = new Map(lines.trim().split("\n").filter(Boolean).map((line) => line.split("\t")));
+const optionalDependencies = {};
+for (const packageName of Object.keys(manifest.optionalDependencies ?? {}).sort()) {
+  const replacement = replacements.get(packageName);
+  if (!replacement) {
+    throw new Error(`Missing local tarball for optional dependency ${packageName}`);
+  }
+  optionalDependencies[packageName] = replacement;
+}
+manifest.optionalDependencies = optionalDependencies;
+fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+NODE
+CLI_TGZ="$(cd "${CLI_STAGE}" && NPM_CONFIG_CACHE="${NPM_CACHE}" npm pack --silent)"
+
+WRAPPER_STAGE="${PACKAGE_STAGE_ROOT}/tokscale"
+cp -R packages/tokscale "${WRAPPER_STAGE}"
+node --input-type=module - "${WRAPPER_STAGE}/package.json" "file:${CLI_STAGE}/${CLI_TGZ}" <<'NODE'
+import fs from "node:fs";
+const [manifestPath, cliSpec] = process.argv.slice(2);
+const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+manifest.dependencies = {
+  ...manifest.dependencies,
+  "@tokscale/cli": cliSpec,
+};
+fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+NODE
+WRAPPER_TGZ="$(cd "${WRAPPER_STAGE}" && NPM_CONFIG_CACHE="${NPM_CACHE}" npm pack --silent)"
+
+echo "Installing release wrapper tarball with Bun..."
+(
+  cd "${INSTALL_DIR}"
+  env PATH="${BUN_ONLY_DIR}" bun add "${WRAPPER_STAGE}/${WRAPPER_TGZ}" >/dev/null
+)
+
+WRAPPER_BIN="${INSTALL_DIR}/node_modules/tokscale/bin.js"
+CLI_BIN="${INSTALL_DIR}/node_modules/@tokscale/cli/bin.js"
+HOST_BINARY="${INSTALL_DIR}/node_modules/@tokscale/${HOST_PACKAGE}/bin/${HOST_BINARY_NAME}"
+[[ -f "${WRAPPER_BIN}" ]] || fail "Installed wrapper bin.js missing"
+[[ -f "${CLI_BIN}" ]] || fail "Installed @tokscale/cli bin.js missing"
+[[ -f "${HOST_BINARY}" ]] || fail "Installed host platform binary missing: ${HOST_BINARY}"
+
+echo "Checking installed wrapper with Node-only PATH..."
+VERSION_NODE="$(env PATH="${NODE_ONLY_DIR}" "${WRAPPER_BIN}" --version)"
+[[ "${VERSION_NODE}" == tokscale* ]] || fail "Unexpected Node-only wrapper output: ${VERSION_NODE}"
+
+echo "Checking installed launcher with Bun runtime..."
+VERSION_BUN="$(env PATH="${BUN_ONLY_DIR}" bun "${INSTALL_DIR}/node_modules/.bin/tokscale" --version)"
+[[ "${VERSION_BUN}" == tokscale* ]] || fail "Unexpected Bun launcher output: ${VERSION_BUN}"
+
+echo "Release artifact package smoke tests passed."

--- a/scripts/test-release-workflow-safety.sh
+++ b/scripts/test-release-workflow-safety.sh
@@ -54,6 +54,16 @@ jobs:
             bin_name: tokscale
             build: cargo zigbuild --release -p tokscale-cli --target x86_64-unknown-linux-gnu
             strip: strip target/x86_64-unknown-linux-gnu/release/tokscale
+  smoke-release-artifacts:
+    needs: [bump-versions, build-cli-binary]
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          pattern: cli-binary-*
+          path: release-artifacts
+      - run: bash scripts/test-release-package-artifacts.sh
+  prepare-release-provenance:
+    needs: [bump-versions, build-cli-binary, smoke-release-artifacts]
   publish-platform-packages:
     strategy:
       matrix:
@@ -180,11 +190,109 @@ PY
   grep -q "publish platform artifact drift" "${output}"
 }
 
+test_rejects_missing_release_artifact_smoke_job() {
+  local work="${TMP_DIR}/missing-smoke"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/publish-cli.yml" <<'PY'
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text()
+text = re.sub(r"\n  smoke-release-artifacts:\n(?:    .*\n)*?  prepare-release-provenance:", "\n  prepare-release-provenance:", text)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/missing-smoke-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to reject missing release artifact smoke job" >&2
+    return 1
+  fi
+
+  grep -q "publish workflow missing smoke-release-artifacts job" "${output}"
+}
+
+test_rejects_commented_release_artifact_smoke_requirements() {
+  local work="${TMP_DIR}/commented-smoke-requirements"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/publish-cli.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text()
+text = text.replace("          pattern: cli-binary-*", "          # pattern: cli-binary-*")
+text = text.replace("      - run: bash scripts/test-release-package-artifacts.sh", "      # - run: bash scripts/test-release-package-artifacts.sh")
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/commented-smoke-requirements-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to reject commented release artifact smoke requirements" >&2
+    return 1
+  fi
+
+  grep -Fq "smoke-release-artifacts job must download cli-binary-* artifacts" "${output}"
+  grep -q "smoke-release-artifacts job must run scripts/test-release-package-artifacts.sh" "${output}"
+}
+
+test_accepts_multiline_release_artifact_smoke_dependency() {
+  local work="${TMP_DIR}/multiline-smoke-need"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/publish-cli.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace(
+    "needs: [bump-versions, build-cli-binary, smoke-release-artifacts]",
+    "needs:\n      - bump-versions\n      - build-cli-binary\n      - smoke-release-artifacts",
+)
+path.write_text(text)
+PY
+
+  (
+    cd "${work}"
+    python3 "${SCRIPT_UNDER_TEST}" >"${TMP_DIR}/multiline-smoke-need-output.txt" 2>&1
+  )
+
+  grep -q "Release workflow safety OK" "${TMP_DIR}/multiline-smoke-need-output.txt"
+}
+
+test_rejects_provenance_without_release_artifact_smoke_dependency() {
+  local work="${TMP_DIR}/missing-smoke-need"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/publish-cli.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace(
+    "needs: [bump-versions, build-cli-binary, smoke-release-artifacts]",
+    "needs: [bump-versions, build-cli-binary]",
+)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/missing-smoke-need-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to reject provenance without release artifact smoke dependency" >&2
+    return 1
+  fi
+
+  grep -q "prepare-release-provenance must depend on smoke-release-artifacts" "${output}"
+}
+
 test_accepts_matching_publish_and_native_workflows
 test_reads_workflows_as_utf8_when_locale_is_non_utf8
 test_rejects_build_matrix_target_drift
 test_rejects_release_env_drift
 test_rejects_missing_required_release_env
 test_rejects_platform_publish_matrix_drift
+test_rejects_missing_release_artifact_smoke_job
+test_rejects_commented_release_artifact_smoke_requirements
+test_accepts_multiline_release_artifact_smoke_dependency
+test_rejects_provenance_without_release_artifact_smoke_dependency
 
 echo "release workflow safety tests passed"


### PR DESCRIPTION
## Summary
- Add a publish-workflow smoke job that packages the downloaded native CLI artifacts before release provenance and npm publishing can proceed.
- Exercise the real wrapper/package installation path by packing every platform package, rewriting `@tokscale/cli` optional dependencies to local tarballs, installing the wrapper with Bun, and running the installed launcher.
- Extend release workflow safety checks so future workflow edits cannot accidentally remove the artifact smoke gate or let provenance run before it.

## Why
The publish pipeline built native binaries and then moved directly toward provenance and npm publishing without a packaging-level smoke test over the downloaded artifacts. That leaves a dangerous gap: a missing binary, missing macOS sidecar, broken optional dependency mapping, or launcher packaging regression could be discovered only after the release flow is already too far along. This PR makes the release workflow prove the assembled npm artifacts before publishing work starts.

## Diff scope
- `.github/workflows/publish-cli.yml`: adds `smoke-release-artifacts` after native builds and makes `prepare-release-provenance` depend on it.
- `scripts/test-release-package-artifacts.sh`: new release artifact smoke test that packs platform packages, `@tokscale/cli`, and `tokscale`, installs the wrapper, and runs the installed launcher.
- `scripts/check-release-workflow-safety.py` and `scripts/test-release-workflow-safety.sh`: enforce that the smoke job exists, downloads all CLI binary artifacts, runs the smoke script, and gates provenance.
- `.github/workflows/test_coverage.yml`: includes release workflow/script safety paths in the coverage workflow triggers and helper test set.

## Validation
- Validation tier: Tier 4 - CI/release tooling, touched publish workflow and release validation scripts.
- `git diff --check`: PASS.
- `git diff --cached --check`: PASS.
- `bash -n scripts/test-release-package-artifacts.sh scripts/test-release-workflow-safety.sh scripts/test-package-launchers.sh`: PASS.
- `python3 -m py_compile scripts/check-release-workflow-safety.py`: PASS.
- `python3 scripts/check-release-workflow-safety.py`: PASS.
- `bash scripts/test-calculate-release-version.sh && bash scripts/test-check-version-coherence.sh && bash scripts/test-npm-release-state.sh && bash scripts/test-prepare-release-provenance.sh && bash scripts/test-release-workflow-safety.sh`: PASS.
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "#{path}: OK" }' .github/workflows/publish-cli.yml .github/workflows/test_coverage.yml .github/workflows/build-native.yml`: PASS.
- `RELEASE_ARTIFACT_ROOT=<fake all-platform artifact tree> bash scripts/test-release-package-artifacts.sh`: PASS.
- `bash scripts/check-version-coherence.sh`: PASS, Version coherence OK: 4.0.6.
- Ledger: not applicable - not required for selected validation tier/change family.
- Not run: full workspace cargo test - not required for selected validation tier because runtime Rust code was not changed.

## Remote gates
Pending - GitHub Actions will run after the PR is created.

## Rollback
Revert this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a smoke-test gate to the release pipeline that packages and installs the CLI from built binaries before provenance and npm publish. This prevents missing binaries, bad optional deps, or launcher regressions from shipping.

- **New Features**
  - Added `smoke-release-artifacts` job in `publish-cli.yml` that downloads `cli-binary-*`, packs each platform package, rewrites `@tokscale/cli` optionalDependencies to local tarballs, packs `tokscale`, installs with Bun, and runs the launcher.
  - Gated `prepare-release-provenance` on the smoke job; the safety checker now requires downloading `cli-binary-*`, running `scripts/test-release-package-artifacts.sh`, verifies the dependency even with multiline `needs`, and rejects commented-out requirements.
  - Introduced `scripts/test-release-package-artifacts.sh`; expanded `test_coverage.yml` triggers to include `scripts/*.py` and `.github/workflows/build-native.yml`, and runs the workflow-safety test.

<sup>Written for commit fea80eb4a758e65ae5aeb991fa304da71b846588. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

