### PR TITLE
feat(workbuddy): add local usage parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 | <img width="48px" src="https://raw.githubusercontent.com/CommandCodeAI/command-code/main/.github/commandcode/logo/command-code-logo-black-bg.png" alt="Command Code" /> | [Command Code](https://github.com/CommandCodeAI/command-code) | `~/.commandcode/projects/**/*.jsonl` (token usage estimated from transcripts at ~4 chars/token; not persisted on disk) | ✅ Yes |
 | <img width="48px" src="https://github.com/zai-org.png" alt="ZCode" /> | [ZCode](https://zcode.z.ai/) | `~/.zcode/cli/db/db.sqlite` (v2 usage database) and `~/.zcode/projects/**/*.jsonl` (legacy transcripts) | ✅ Yes |
 | <img width="48px" src="https://github.com/alibaba.png" alt="OpenCodeReview" /> | [OpenCodeReview](https://github.com/alibaba/open-code-review) | `~/.opencodereview/sessions/**/*.jsonl` | ✅ Yes |
+| <img width="48px" src="https://github.com/Tencent.png" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/workbuddy.db` (aggregate session usage) | ✅ Yes |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | Re-attributed from other sources via `hf:` model prefix or `synthetic` provider (+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`) | ✅ Yes |
 
 Get real-time pricing calculations using [🚅 LiteLLM's pricing data](https://github.com/BerriAI/litellm), with support for tiered pricing models and cache token discounts.
@@ -161,7 +162,7 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
   - GitHub-style contribution graph with 9 color themes
   - Real-time filtering and sorting
   - Zero flicker rendering
-- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, and Synthetic
+- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, WorkBuddy, and Synthetic
 - **Real-time pricing** - Fetches current pricing from LiteLLM with 1-hour disk cache; automatic OpenRouter fallback and Cursor model pricing for newly released models
 - **Detailed breakdowns** - Input, output, cache read/write, and reasoning token tracking
 - **Native Rust core** - All parsing and aggregation done in Rust for 10x faster processing
@@ -965,7 +966,7 @@ The frontend provides a GitHub-style contribution graph visualization:
 - **Interactive tooltips**: Hover for detailed daily breakdowns
 - **Day breakdown panel**: Click to see per-source and per-model details
 - **Year filtering**: Navigate between years
-- **Source filtering**: Filter by platform (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, Synthetic)
+- **Source filtering**: Filter by platform (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, WorkBuddy, Synthetic)
 - **Stats panel**: Total cost, tokens, active days, streaks
 - **FOUC prevention**: Theme applied before React hydrates (no flash)
 
@@ -1306,6 +1307,7 @@ AI coding tools store their session data in cross-platform locations. Most tools
 | Junie | `~/.junie/sessions/` | `%USERPROFILE%\.junie\sessions\` | Same home-relative path on all platforms; parses `events.jsonl` usage events |
 | ZCode | `~/.zcode/cli/db/db.sqlite` and `~/.zcode/projects/` | `%USERPROFILE%\.zcode\cli\db\db.sqlite` and `%USERPROFILE%\.zcode\projects\` | Parses v2 SQLite model usage plus legacy `*.jsonl` session transcripts; Z.ai's ADE for GLM models |
 | OpenCodeReview | `~/.opencodereview/sessions/` | `%USERPROFILE%\.opencodereview\sessions\` | Parses `*.jsonl` session transcripts; Alibaba's AI code review tool |
+| WorkBuddy | `~/.workbuddy/workbuddy.db` | `%USERPROFILE%\.workbuddy\workbuddy.db` | Parses aggregate session usage from WorkBuddy's local SQLite database |
 | Synthetic | Re-attributed from other sources | Re-attributed from other sources | Detects `hf:` model prefix + `synthetic` provider |
 
 > **Note**: On Windows, `~` expands to `%USERPROFILE%` (e.g., `C:\Users\YourName`). These tools intentionally use Unix-style paths (like `.local/share`) even on Windows for cross-platform consistency, rather than Windows-native paths like `%APPDATA%`.

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -896,6 +896,7 @@ pub enum ClientFilter {
     Junie,
     Zcode,
     Opencodereview,
+    Workbuddy,
     Synthetic,
 }
 
@@ -940,6 +941,7 @@ impl ClientFilter {
             Self::Junie => "junie",
             Self::Zcode => "zcode",
             Self::Opencodereview => "opencodereview",
+            Self::Workbuddy => "workbuddy",
             Self::Synthetic => "synthetic",
         }
     }
@@ -987,6 +989,7 @@ impl ClientFilter {
             Self::Junie => Some(ClientId::Junie),
             Self::Zcode => Some(ClientId::Zcode),
             Self::Opencodereview => Some(ClientId::OpenCodeReview),
+            Self::Workbuddy => Some(ClientId::WorkBuddy),
             Self::Synthetic => None,
         }
     }
@@ -1031,6 +1034,7 @@ impl ClientFilter {
             ClientId::Junie => Self::Junie,
             ClientId::Zcode => Self::Zcode,
             ClientId::OpenCodeReview => Self::Opencodereview,
+            ClientId::WorkBuddy => Self::Workbuddy,
         }
     }
 
@@ -3511,6 +3515,7 @@ fn capitalize_client(client: &str) -> String {
         "commandcode" => "Command Code".to_string(),
         "junie" => "Junie".to_string(),
         "zcode" => "ZCode".to_string(),
+        "workbuddy" => "WorkBuddy".to_string(),
         other => other.to_string(),
     }
 }

--- a/crates/tokscale-cli/src/tui/client_ui.rs
+++ b/crates/tokscale-cli/src/tui/client_ui.rs
@@ -146,6 +146,10 @@ pub const CLIENT_UI: [ClientUi; ClientId::COUNT] = [
         display_name: "OpenCodeReview",
         hotkey: 'O',
     },
+    ClientUi {
+        display_name: "WorkBuddy",
+        hotkey: 'B',
+    },
 ];
 
 pub fn display_name(client: ClientId) -> &'static str {

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -1373,6 +1373,9 @@ mod tests {
         assert_eq!(clients[30], ClientId::MiMoCode);
         assert_eq!(clients[31], ClientId::AntigravityCli);
         assert_eq!(clients[32], ClientId::Junie);
+        assert_eq!(clients[33], ClientId::Zcode);
+        assert_eq!(clients[34], ClientId::OpenCodeReview);
+        assert_eq!(clients[35], ClientId::WorkBuddy);
     }
 
     #[test]
@@ -1468,6 +1471,10 @@ mod tests {
             crate::tui::client_ui::display_name(ClientId::Junie),
             "Junie"
         );
+        assert_eq!(
+            crate::tui::client_ui::display_name(ClientId::WorkBuddy),
+            "WorkBuddy"
+        );
     }
 
     #[test]
@@ -1501,6 +1508,7 @@ mod tests {
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Jcode), 'j');
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::AntigravityCli), 'f');
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Junie), 'p');
+        assert_eq!(crate::tui::client_ui::hotkey(ClientId::WorkBuddy), 'B');
     }
 
     #[test]
@@ -1600,6 +1608,10 @@ mod tests {
         assert_eq!(
             crate::tui::client_ui::from_hotkey('p'),
             Some(ClientId::Junie)
+        );
+        assert_eq!(
+            crate::tui::client_ui::from_hotkey('B'),
+            Some(ClientId::WorkBuddy)
         );
     }
 

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -579,8 +579,12 @@ mod tests {
 
     #[test]
     fn test_workbuddy_client_registered_as_local_sqlite_source() {
-        let client = ClientId::from_str("workbuddy").expect("workbuddy client should be registered");
-        assert_eq!(client.data().resolve_path("/tmp/home"), "/tmp/home/.workbuddy");
+        let client =
+            ClientId::from_str("workbuddy").expect("workbuddy client should be registered");
+        assert_eq!(
+            client.data().resolve_path("/tmp/home"),
+            "/tmp/home/.workbuddy"
+        );
         assert_eq!(client.data().pattern, "workbuddy.db");
         assert!(client.data().parse_local);
         assert!(client.data().submit_default);

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -513,6 +513,15 @@ define_clients!(
         headless: false,
         parse_local: true,
         submit_default: true
+    },
+    WorkBuddy = 35 => {
+        id: "workbuddy",
+        root: PathRoot::Home,
+        relative: ".workbuddy",
+        pattern: "workbuddy.db",
+        headless: false,
+        parse_local: true,
+        submit_default: true
     }
 );
 
@@ -565,7 +574,17 @@ mod tests {
 
     #[test]
     fn test_client_id_count() {
-        assert_eq!(ClientId::COUNT, 35);
+        assert_eq!(ClientId::COUNT, 36);
+    }
+
+    #[test]
+    fn test_workbuddy_client_registered_as_local_sqlite_source() {
+        let client = ClientId::from_str("workbuddy").expect("workbuddy client should be registered");
+        assert_eq!(client.data().resolve_path("/tmp/home"), "/tmp/home/.workbuddy");
+        assert_eq!(client.data().pattern, "workbuddy.db");
+        assert!(client.data().parse_local);
+        assert!(client.data().submit_default);
+        assert!(!client.data().headless);
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1542,6 +1542,21 @@ fn parse_all_messages_with_pricing_with_env_strategy(
     let deduped_trae_messages = dedupe_latest_trae_messages(trae_messages);
     all_messages.extend(deduped_trae_messages);
 
+    let workbuddy_messages: Vec<UnifiedMessage> = scan_result
+        .get(ClientId::WorkBuddy)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::workbuddy::parse_workbuddy_sqlite(path)
+                .into_iter()
+                .map(|mut msg| {
+                    apply_pricing_if_available(&mut msg, pricing);
+                    msg
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    all_messages.extend(workbuddy_messages);
+
     if include_synthetic {
         if let Some(db_path) = &scan_result.synthetic_db {
             let outcome = load_or_parse_sqlite_source(db_path, &source_cache, pricing, |path| {
@@ -2820,6 +2835,20 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     let warp_count = summed_parsed_message_count(&warp_msgs);
     counts.set(ClientId::Warp, warp_count);
     messages.extend(warp_msgs);
+
+    let workbuddy_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::WorkBuddy)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::workbuddy::parse_workbuddy_sqlite(path)
+                .into_iter()
+                .map(|msg| unified_to_parsed(&msg))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let workbuddy_count = summed_parsed_message_count(&workbuddy_msgs);
+    counts.set(ClientId::WorkBuddy, workbuddy_count);
+    messages.extend(workbuddy_msgs);
 
     let grok_msgs: Vec<ParsedMessage> = scan_result
         .get(ClientId::Grok)

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -335,6 +335,7 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
                 "ui_messages.json" => file_name == "ui_messages.json",
                 "session-usage.json" => file_name == "session-usage.json",
                 "chat-messages.json" => file_name == "chat-messages.json",
+                "workbuddy.db" => file_name == "workbuddy.db",
                 "state.db" => file_name == "state.db",
                 "threads.db" => file_name == "threads.db",
                 // Antigravity CLI conversation databases. `ends_with(".db")`
@@ -1519,6 +1520,20 @@ mod tests {
         assert!(jsonl_files
             .iter()
             .all(|p| p.extension().unwrap() == "jsonl"));
+    }
+
+    #[test]
+    fn test_scan_directory_workbuddy_db_pattern() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path();
+
+        File::create(path.join("workbuddy.db")).unwrap();
+        File::create(path.join("workbuddy.db-wal")).unwrap();
+        File::create(path.join("workbuddy.db-shm")).unwrap();
+
+        let db_files = scan_directory(path.to_str().unwrap(), "workbuddy.db");
+
+        assert_eq!(db_files, vec![path.join("workbuddy.db")]);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -37,6 +37,7 @@ pub mod synthetic;
 pub mod trae;
 pub(crate) mod utils;
 pub mod warp;
+pub mod workbuddy;
 pub mod zcode;
 pub mod zed;
 

--- a/crates/tokscale-core/src/sessions/workbuddy.rs
+++ b/crates/tokscale-core/src/sessions/workbuddy.rs
@@ -1,0 +1,218 @@
+//! WorkBuddy session usage parser.
+//!
+//! WorkBuddy stores aggregate session usage in `~/.workbuddy/workbuddy.db`.
+//! The `session_usage` table currently exposes a total `used` value, but does
+//! not split input/output/cache tokens. Tokscale preserves that measured total
+//! in the input bucket so reports can surface the usage without estimating.
+
+use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
+use crate::{provider_identity, TokenBreakdown};
+use rusqlite::{Connection, OpenFlags};
+use std::path::Path;
+use tracing::warn;
+
+#[derive(Debug)]
+struct WorkBuddyUsageRow {
+    session_id: String,
+    used: i64,
+    updated_at: i64,
+    model: Option<String>,
+    cwd: Option<String>,
+}
+
+pub fn parse_workbuddy_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
+    let conn = match Connection::open_with_flags(
+        db_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    ) {
+        Ok(conn) => conn,
+        Err(err) => {
+            warn!(
+                db_path = %db_path.display(),
+                error = %err,
+                "Failed to open WorkBuddy database"
+            );
+            return Vec::new();
+        }
+    };
+
+    let mut stmt = match conn.prepare(
+        r#"
+        SELECT
+            su.session_id,
+            su.used,
+            su.updated_at,
+            s.model,
+            s.cwd
+        FROM session_usage su
+        LEFT JOIN sessions s ON s.id = su.session_id
+        WHERE su.used IS NOT NULL
+          AND su.used > 0
+          AND su.updated_at IS NOT NULL
+          AND su.updated_at > 0
+        "#,
+    ) {
+        Ok(stmt) => stmt,
+        Err(err) => {
+            warn!(
+                db_path = %db_path.display(),
+                error = %err,
+                "Failed to prepare WorkBuddy usage query"
+            );
+            return Vec::new();
+        }
+    };
+
+    let rows = match stmt.query_map([], |row| {
+        Ok(WorkBuddyUsageRow {
+            session_id: row.get(0)?,
+            used: row.get::<_, Option<i64>>(1)?.unwrap_or(0),
+            updated_at: row.get::<_, Option<i64>>(2)?.unwrap_or(0),
+            model: row.get(3)?,
+            cwd: row.get(4)?,
+        })
+    }) {
+        Ok(rows) => rows,
+        Err(err) => {
+            warn!(
+                db_path = %db_path.display(),
+                error = %err,
+                "Failed to execute WorkBuddy usage query"
+            );
+            return Vec::new();
+        }
+    };
+
+    rows.filter_map(|row| match row {
+        Ok(row) => Some(usage_row_to_message(row)),
+        Err(err) => {
+            warn!(
+                db_path = %db_path.display(),
+                error = %err,
+                "Failed to decode WorkBuddy usage row"
+            );
+            None
+        }
+    })
+    .collect()
+}
+
+fn usage_row_to_message(row: WorkBuddyUsageRow) -> UnifiedMessage {
+    let model_id = row
+        .model
+        .as_deref()
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .unwrap_or("auto")
+        .to_string();
+    let provider_id = provider_identity::inferred_provider_from_model(&model_id)
+        .unwrap_or("workbuddy")
+        .to_string();
+
+    let mut message = UnifiedMessage::new(
+        "workbuddy",
+        model_id,
+        provider_id,
+        row.session_id.clone(),
+        normalize_timestamp_ms(row.updated_at),
+        TokenBreakdown {
+            input: row.used.max(0),
+            output: 0,
+            cache_read: 0,
+            cache_write: 0,
+            reasoning: 0,
+        },
+        0.0,
+    );
+    message.dedup_key = Some(format!("workbuddy:{}", row.session_id));
+
+    if let Some(workspace_key) = row.cwd.as_deref().and_then(normalize_workspace_key) {
+        let workspace_label = workspace_label_from_key(&workspace_key);
+        message.set_workspace(Some(workspace_key), workspace_label);
+    }
+
+    message
+}
+
+fn normalize_timestamp_ms(timestamp: i64) -> i64 {
+    if timestamp > 10_000_000_000 {
+        timestamp
+    } else {
+        timestamp.saturating_mul(1000)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::{params, Connection};
+
+    fn create_workbuddy_db(path: &Path) -> Connection {
+        let conn = Connection::open(path).unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                cwd TEXT,
+                model TEXT
+            );
+            CREATE TABLE session_usage (
+                session_id TEXT PRIMARY KEY,
+                used INTEGER,
+                size INTEGER,
+                updated_at INTEGER,
+                credit_json TEXT
+            );
+            "#,
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn parse_workbuddy_sqlite_reads_session_usage() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("workbuddy.db");
+        let conn = create_workbuddy_db(&db_path);
+        conn.execute(
+            "INSERT INTO sessions (id, cwd, model) VALUES (?1, ?2, ?3)",
+            params!["session-1", "/Users/alice/project", "deepseek-v4-pro"],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_usage (session_id, used, size, updated_at, credit_json) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params!["session-1", 1234, 1000000, 1_780_000_000_000_i64, "{}"],
+        )
+        .unwrap();
+        drop(conn);
+
+        let messages = parse_workbuddy_sqlite(&db_path);
+
+        assert_eq!(messages.len(), 1);
+        let message = &messages[0];
+        assert_eq!(message.client, "workbuddy");
+        assert_eq!(message.model_id, "deepseek-v4-pro");
+        assert_eq!(message.provider_id, "deepseek");
+        assert_eq!(message.session_id, "session-1");
+        assert_eq!(message.tokens.input, 1234);
+        assert_eq!(message.tokens.output, 0);
+        assert_eq!(message.message_count, 1);
+        assert_eq!(message.workspace_label.as_deref(), Some("project"));
+        assert_eq!(message.dedup_key.as_deref(), Some("workbuddy:session-1"));
+    }
+
+    #[test]
+    fn parse_workbuddy_sqlite_skips_zero_usage() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("workbuddy.db");
+        let conn = create_workbuddy_db(&db_path);
+        conn.execute(
+            "INSERT INTO session_usage (session_id, used, size, updated_at, credit_json) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params!["empty-session", 0, 1000000, 1_780_000_000_000_i64, "{}"],
+        )
+        .unwrap();
+        drop(conn);
+
+        assert!(parse_workbuddy_sqlite(&db_path).is_empty());
+    }
+}

--- a/crates/tokscale-core/src/sessions/workbuddy.rs
+++ b/crates/tokscale-core/src/sessions/workbuddy.rs
@@ -124,7 +124,9 @@ fn usage_row_to_message(row: WorkBuddyUsageRow) -> UnifiedMessage {
         },
         0.0,
     );
-    message.dedup_key = Some(format!("workbuddy:{}", row.session_id));
+    // Include `updated_at` so distinct usage rows for the same session (e.g.
+    // per-date or incremental writes) are not collapsed by the dedup key.
+    message.dedup_key = Some(format!("workbuddy:{}:{}", row.session_id, row.updated_at));
 
     if let Some(workspace_key) = row.cwd.as_deref().and_then(normalize_workspace_key) {
         let workspace_label = workspace_label_from_key(&workspace_key);
@@ -198,7 +200,10 @@ mod tests {
         assert_eq!(message.tokens.output, 0);
         assert_eq!(message.message_count, 1);
         assert_eq!(message.workspace_label.as_deref(), Some("project"));
-        assert_eq!(message.dedup_key.as_deref(), Some("workbuddy:session-1"));
+        assert_eq!(
+            message.dedup_key.as_deref(),
+            Some("workbuddy:session-1:1780000000000")
+        );
     }
 
     #[test]

--- a/packages/frontend/src/lib/constants.ts
+++ b/packages/frontend/src/lib/constants.ts
@@ -63,6 +63,7 @@ export const SOURCE_DISPLAY_NAMES: Record<ClientType, string> = {
   junie: "Junie",
   zcode: "ZCode",
   opencodereview: "OpenCodeReview",
+  workbuddy: "WorkBuddy",
 };
 
 // Client logos from GitHub CDN (public repo)
@@ -105,6 +106,7 @@ export const SOURCE_LOGOS: Record<ClientType, string> = {
   junie: "https://github.com/JetBrains.png",
   zcode: "https://github.com/zai-org.png",
   opencodereview: "https://github.com/alibaba.png",
+  workbuddy: "https://github.com/Tencent.png",
 };
 
 export const SOURCE_COLORS: Record<ClientType, string> = {
@@ -144,6 +146,7 @@ export const SOURCE_COLORS: Record<ClientType, string> = {
   junie: "#7B61FF",
   zcode: "#3B5BDB",
   opencodereview: "#FF6A00",
+  workbuddy: "#2563EB",
 };
 
 export const SOURCE_TEXT_COLORS: Partial<Record<ClientType, string>> = {

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -35,6 +35,7 @@ export const SUPPORTED_CLIENT_TYPES = [
   "junie",
   "zcode",
   "opencodereview",
+  "workbuddy",
 ] as const;
 
 export type CcMirrorClientType = `cc-mirror/${string}`;


### PR DESCRIPTION
## Summary
- add WorkBuddy as a local client backed by `~/.workbuddy/workbuddy.db`
- parse aggregate `session_usage.used` totals by session/model/date
- wire WorkBuddy through CLI filters, TUI labels, frontend constants, and README docs

## Notes
- WorkBuddy's local DB currently exposes aggregate `used` totals, not an input/output/cache split, so the parser preserves the measured total in the input bucket instead of estimating a breakdown.
- Local inspection on Windows found 53 `session_usage` rows in `~/.workbuddy/workbuddy.db` with model/date metadata.

## Testing
- `git diff --check`
- Local Rust tests not run: this machine does not have `cargo`/`rustc` installed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add WorkBuddy as a local client by parsing `~/.workbuddy/workbuddy.db` for session usage and showing it in the CLI, TUI, and web app. Totals are preserved as input tokens, and the dedup key is row-unique to prevent token loss.

- **New Features**
  - Register `WorkBuddy` as a local SQLite source (`.workbuddy/workbuddy.db`).
  - Parse `session_usage` joined with `sessions`: map `used` -> input tokens, infer provider from model, normalize ms timestamps, set workspace from `cwd`.
  - Integrate into the core parsing and pricing pipeline (`parse_local_clients` and the unified parse path).
  - Add CLI filter/name mapping, TUI label + hotkey (`B`), and frontend source name/logo/color with type support.
  - Update README to list WorkBuddy in supported platforms and data locations.

- **Bug Fixes**
  - Discover `workbuddy.db` via the scanner (ignores `-wal`/`-shm`) so the local DB is picked up automatically.
  - Make the dedup key row-unique by including `updated_at` (`workbuddy:{session_id}:{updated_at}`) to avoid collapsing multiple usage rows.

<sup>Written for commit fff23bfde7d4c4f79d7ab04d7e777f0036512149. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

