### PR TITLE
feat(codebuddy): add local usage parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 | <img width="48px" src="https://raw.githubusercontent.com/CommandCodeAI/command-code/main/.github/commandcode/logo/command-code-logo-black-bg.png" alt="Command Code" /> | [Command Code](https://github.com/CommandCodeAI/command-code) | `~/.commandcode/projects/**/*.jsonl` (token usage estimated from transcripts at ~4 chars/token; not persisted on disk) | ✅ Yes |
 | <img width="48px" src="https://github.com/zai-org.png" alt="ZCode" /> | [ZCode](https://zcode.z.ai/) | `~/.zcode/cli/db/db.sqlite` (v2 usage database) and `~/.zcode/projects/**/*.jsonl` (legacy transcripts) | ✅ Yes |
 | <img width="48px" src="https://github.com/alibaba.png" alt="OpenCodeReview" /> | [OpenCodeReview](https://github.com/alibaba/open-code-review) | `~/.opencodereview/sessions/**/*.jsonl` | ✅ Yes |
+| <img width="48px" src="https://github.com/Tencent.png" alt="CodeBuddy" /> | [CodeBuddy CLI](https://www.codebuddy.cn/docs/cli/overview) | `~/.codebuddy/projects/**/*.jsonl` | ✅ Yes |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | Re-attributed from other sources via `hf:` model prefix or `synthetic` provider (+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`) | ✅ Yes |
 
 Get real-time pricing calculations using [🚅 LiteLLM's pricing data](https://github.com/BerriAI/litellm), with support for tiered pricing models and cache token discounts.
@@ -161,7 +162,7 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
   - GitHub-style contribution graph with 9 color themes
   - Real-time filtering and sorting
   - Zero flicker rendering
-- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, and Synthetic
+- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, and Synthetic
 - **Real-time pricing** - Fetches current pricing from LiteLLM with 1-hour disk cache; automatic OpenRouter fallback and Cursor model pricing for newly released models
 - **Detailed breakdowns** - Input, output, cache read/write, and reasoning token tracking
 - **Native Rust core** - All parsing and aggregation done in Rust for 10x faster processing
@@ -372,7 +373,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-Possible values: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `synthetic`.
+Possible values: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `synthetic`.
 
 > **Breaking change (v4.0.0):** The per-client boolean flags (`--opencode`, `--claude`, `--codex`, etc.) have been removed and now error. Use the canonical `--client`/`-c` flag instead — e.g. `tokscale --client opencode,claude`.
 
@@ -965,7 +966,7 @@ The frontend provides a GitHub-style contribution graph visualization:
 - **Interactive tooltips**: Hover for detailed daily breakdowns
 - **Day breakdown panel**: Click to see per-source and per-model details
 - **Year filtering**: Navigate between years
-- **Source filtering**: Filter by platform (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, Synthetic)
+- **Source filtering**: Filter by platform (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, Synthetic)
 - **Stats panel**: Total cost, tokens, active days, streaks
 - **FOUC prevention**: Theme applied before React hydrates (no flash)
 
@@ -1306,6 +1307,7 @@ AI coding tools store their session data in cross-platform locations. Most tools
 | Junie | `~/.junie/sessions/` | `%USERPROFILE%\.junie\sessions\` | Same home-relative path on all platforms; parses `events.jsonl` usage events |
 | ZCode | `~/.zcode/cli/db/db.sqlite` and `~/.zcode/projects/` | `%USERPROFILE%\.zcode\cli\db\db.sqlite` and `%USERPROFILE%\.zcode\projects\` | Parses v2 SQLite model usage plus legacy `*.jsonl` session transcripts; Z.ai's ADE for GLM models |
 | OpenCodeReview | `~/.opencodereview/sessions/` | `%USERPROFILE%\.opencodereview\sessions\` | Parses `*.jsonl` session transcripts; Alibaba's AI code review tool |
+| CodeBuddy | `~/.codebuddy/projects/` | `%USERPROFILE%\.codebuddy\projects\` | Parses CodeBuddy CLI assistant message usage from project `*.jsonl` transcripts |
 | Synthetic | Re-attributed from other sources | Re-attributed from other sources | Detects `hf:` model prefix + `synthetic` provider |
 
 > **Note**: On Windows, `~` expands to `%USERPROFILE%` (e.g., `C:\Users\YourName`). These tools intentionally use Unix-style paths (like `.local/share`) even on Windows for cross-platform consistency, rather than Windows-native paths like `%APPDATA%`.

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -896,6 +896,7 @@ pub enum ClientFilter {
     Junie,
     Zcode,
     Opencodereview,
+    Codebuddy,
     Synthetic,
 }
 
@@ -940,6 +941,7 @@ impl ClientFilter {
             Self::Junie => "junie",
             Self::Zcode => "zcode",
             Self::Opencodereview => "opencodereview",
+            Self::Codebuddy => "codebuddy",
             Self::Synthetic => "synthetic",
         }
     }
@@ -987,6 +989,7 @@ impl ClientFilter {
             Self::Junie => Some(ClientId::Junie),
             Self::Zcode => Some(ClientId::Zcode),
             Self::Opencodereview => Some(ClientId::OpenCodeReview),
+            Self::Codebuddy => Some(ClientId::CodeBuddy),
             Self::Synthetic => None,
         }
     }
@@ -1031,6 +1034,7 @@ impl ClientFilter {
             ClientId::Junie => Self::Junie,
             ClientId::Zcode => Self::Zcode,
             ClientId::OpenCodeReview => Self::Opencodereview,
+            ClientId::CodeBuddy => Self::Codebuddy,
         }
     }
 
@@ -3511,6 +3515,7 @@ fn capitalize_client(client: &str) -> String {
         "commandcode" => "Command Code".to_string(),
         "junie" => "Junie".to_string(),
         "zcode" => "ZCode".to_string(),
+        "codebuddy" => "CodeBuddy".to_string(),
         other => other.to_string(),
     }
 }

--- a/crates/tokscale-cli/src/tui/client_ui.rs
+++ b/crates/tokscale-cli/src/tui/client_ui.rs
@@ -146,6 +146,10 @@ pub const CLIENT_UI: [ClientUi; ClientId::COUNT] = [
         display_name: "OpenCodeReview",
         hotkey: 'O',
     },
+    ClientUi {
+        display_name: "CodeBuddy",
+        hotkey: 'C',
+    },
 ];
 
 pub fn display_name(client: ClientId) -> &'static str {

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -1373,6 +1373,9 @@ mod tests {
         assert_eq!(clients[30], ClientId::MiMoCode);
         assert_eq!(clients[31], ClientId::AntigravityCli);
         assert_eq!(clients[32], ClientId::Junie);
+        assert_eq!(clients[33], ClientId::Zcode);
+        assert_eq!(clients[34], ClientId::OpenCodeReview);
+        assert_eq!(clients[35], ClientId::CodeBuddy);
     }
 
     #[test]
@@ -1468,6 +1471,10 @@ mod tests {
             crate::tui::client_ui::display_name(ClientId::Junie),
             "Junie"
         );
+        assert_eq!(
+            crate::tui::client_ui::display_name(ClientId::CodeBuddy),
+            "CodeBuddy"
+        );
     }
 
     #[test]
@@ -1501,6 +1508,7 @@ mod tests {
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Jcode), 'j');
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::AntigravityCli), 'f');
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Junie), 'p');
+        assert_eq!(crate::tui::client_ui::hotkey(ClientId::CodeBuddy), 'C');
     }
 
     #[test]
@@ -1600,6 +1608,10 @@ mod tests {
         assert_eq!(
             crate::tui::client_ui::from_hotkey('p'),
             Some(ClientId::Junie)
+        );
+        assert_eq!(
+            crate::tui::client_ui::from_hotkey('C'),
+            Some(ClientId::CodeBuddy)
         );
     }
 

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -579,7 +579,8 @@ mod tests {
 
     #[test]
     fn test_codebuddy_client_registered_as_local_session_source() {
-        let client = ClientId::from_str("codebuddy").expect("codebuddy client should be registered");
+        let client =
+            ClientId::from_str("codebuddy").expect("codebuddy client should be registered");
         assert_eq!(
             client.data().resolve_path("/tmp/home"),
             "/tmp/home/.codebuddy/projects"

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -513,6 +513,15 @@ define_clients!(
         headless: false,
         parse_local: true,
         submit_default: true
+    },
+    CodeBuddy = 35 => {
+        id: "codebuddy",
+        root: PathRoot::Home,
+        relative: ".codebuddy/projects",
+        pattern: "*.jsonl",
+        headless: false,
+        parse_local: true,
+        submit_default: true
     }
 );
 
@@ -565,7 +574,20 @@ mod tests {
 
     #[test]
     fn test_client_id_count() {
-        assert_eq!(ClientId::COUNT, 35);
+        assert_eq!(ClientId::COUNT, 36);
+    }
+
+    #[test]
+    fn test_codebuddy_client_registered_as_local_session_source() {
+        let client = ClientId::from_str("codebuddy").expect("codebuddy client should be registered");
+        assert_eq!(
+            client.data().resolve_path("/tmp/home"),
+            "/tmp/home/.codebuddy/projects"
+        );
+        assert_eq!(client.data().pattern, "*.jsonl");
+        assert!(client.data().parse_local);
+        assert!(client.data().submit_default);
+        assert!(!client.data().headless);
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1542,6 +1542,28 @@ fn parse_all_messages_with_pricing_with_env_strategy(
     let deduped_trae_messages = dedupe_latest_trae_messages(trae_messages);
     all_messages.extend(deduped_trae_messages);
 
+    let codebuddy_outcomes: Vec<CachedParseOutcome> = scan_result
+        .get(ClientId::CodeBuddy)
+        .par_iter()
+        .map(|path| {
+            load_or_parse_source(path, &source_cache, pricing, |path| {
+                sessions::codebuddy::parse_codebuddy_file(path)
+            })
+        })
+        .collect();
+    let mut codebuddy_seen: HashSet<String> = HashSet::new();
+    for outcome in codebuddy_outcomes {
+        all_messages.extend(outcome.messages.into_iter().filter(|message| {
+            message
+                .dedup_key
+                .as_ref()
+                .is_none_or(|key| codebuddy_seen.insert(key.clone()))
+        }));
+        if let Some(entry) = outcome.cache_entry {
+            source_cache.insert(entry);
+        }
+    }
+
     if include_synthetic {
         if let Some(db_path) = &scan_result.synthetic_db {
             let outcome = load_or_parse_sqlite_source(db_path, &source_cache, pricing, |path| {
@@ -2820,6 +2842,26 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     let warp_count = summed_parsed_message_count(&warp_msgs);
     counts.set(ClientId::Warp, warp_count);
     messages.extend(warp_msgs);
+
+    let codebuddy_msgs_raw: Vec<UnifiedMessage> = scan_result
+        .get(ClientId::CodeBuddy)
+        .par_iter()
+        .flat_map(|path| sessions::codebuddy::parse_codebuddy_file(path))
+        .collect();
+    let mut codebuddy_seen: HashSet<String> = HashSet::new();
+    let codebuddy_msgs: Vec<ParsedMessage> = codebuddy_msgs_raw
+        .into_iter()
+        .filter(|message| {
+            message
+                .dedup_key
+                .as_ref()
+                .is_none_or(|key| codebuddy_seen.insert(key.clone()))
+        })
+        .map(|msg| unified_to_parsed(&msg))
+        .collect();
+    let codebuddy_count = summed_parsed_message_count(&codebuddy_msgs);
+    counts.set(ClientId::CodeBuddy, codebuddy_count);
+    messages.extend(codebuddy_msgs);
 
     let grok_msgs: Vec<ParsedMessage> = scan_result
         .get(ClientId::Grok)

--- a/crates/tokscale-core/src/sessions/codebuddy.rs
+++ b/crates/tokscale-core/src/sessions/codebuddy.rs
@@ -198,14 +198,20 @@ pub fn parse_codebuddy_file(path: &Path) -> Vec<UnifiedMessage> {
         let model_id = provider_data
             .and_then(|provider| provider.model.as_deref())
             .or_else(|| provider_data.and_then(|provider| provider.request_model_id.as_deref()))
-            .or_else(|| item.message.as_ref().and_then(|message| message.model.as_deref()))
+            .or_else(|| {
+                item.message
+                    .as_ref()
+                    .and_then(|message| message.model.as_deref())
+            })
             .filter(|model| !model.trim().is_empty())
             .unwrap_or(DEFAULT_MODEL)
             .to_string();
         let provider_id = provider_identity::inferred_provider_from_model(&model_id)
             .unwrap_or(DEFAULT_PROVIDER)
             .to_string();
-        let session_id = item.session_id.unwrap_or_else(|| fallback_session_id.clone());
+        let session_id = item
+            .session_id
+            .unwrap_or_else(|| fallback_session_id.clone());
         let timestamp = item.timestamp.unwrap_or(fallback_timestamp);
 
         let mut message = UnifiedMessage::new(

--- a/crates/tokscale-core/src/sessions/codebuddy.rs
+++ b/crates/tokscale-core/src/sessions/codebuddy.rs
@@ -1,0 +1,303 @@
+//! CodeBuddy CLI session parser.
+//!
+//! CodeBuddy stores per-project JSONL transcripts under
+//! `~/.codebuddy/projects/<project-key>/*.jsonl`. Completed assistant
+//! messages carry usage in `message.usage`, with provider fallbacks under
+//! `providerData.usage` / `providerData.rawUsage`.
+
+use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
+use crate::{provider_identity, TokenBreakdown};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+const DEFAULT_MODEL: &str = "codebuddy";
+const DEFAULT_PROVIDER: &str = "tencent";
+
+#[derive(Debug, Deserialize)]
+struct CodeBuddyLine {
+    id: Option<String>,
+    timestamp: Option<i64>,
+    #[serde(rename = "type")]
+    line_type: Option<String>,
+    role: Option<String>,
+    status: Option<String>,
+    #[serde(rename = "sessionId")]
+    session_id: Option<String>,
+    cwd: Option<String>,
+    message: Option<CodeBuddyMessage>,
+    #[serde(rename = "providerData")]
+    provider_data: Option<CodeBuddyProviderData>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodeBuddyMessage {
+    model: Option<String>,
+    usage: Option<CodeBuddyUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodeBuddyProviderData {
+    model: Option<String>,
+    #[serde(rename = "requestModelId")]
+    request_model_id: Option<String>,
+    #[serde(rename = "messageId")]
+    message_id: Option<String>,
+    #[serde(rename = "traceId")]
+    trace_id: Option<String>,
+    usage: Option<CodeBuddyUsage>,
+    #[serde(rename = "rawUsage")]
+    raw_usage: Option<CodeBuddyUsage>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CodeBuddyUsage {
+    #[serde(rename = "input_tokens")]
+    input_tokens: Option<i64>,
+    #[serde(rename = "inputTokens")]
+    input_tokens_camel: Option<i64>,
+    prompt_tokens: Option<i64>,
+    #[serde(rename = "output_tokens")]
+    output_tokens: Option<i64>,
+    #[serde(rename = "outputTokens")]
+    output_tokens_camel: Option<i64>,
+    completion_tokens: Option<i64>,
+    #[serde(rename = "cache_read_input_tokens")]
+    cache_read_input_tokens: Option<i64>,
+    #[serde(rename = "cacheReadInputTokens")]
+    cache_read_input_tokens_camel: Option<i64>,
+    prompt_cache_hit_tokens: Option<i64>,
+    cached_tokens: Option<i64>,
+    #[serde(rename = "cache_creation_input_tokens")]
+    cache_creation_input_tokens: Option<i64>,
+    #[serde(rename = "cacheCreationInputTokens")]
+    cache_creation_input_tokens_camel: Option<i64>,
+    prompt_cache_write_tokens: Option<i64>,
+    #[serde(rename = "completion_thinking_tokens")]
+    completion_thinking_tokens: Option<i64>,
+    #[serde(rename = "completionThinkingTokens")]
+    completion_thinking_tokens_camel: Option<i64>,
+}
+
+impl CodeBuddyUsage {
+    fn to_breakdown(&self) -> Option<TokenBreakdown> {
+        let tokens = TokenBreakdown {
+            input: first_present(&[
+                self.input_tokens,
+                self.input_tokens_camel,
+                self.prompt_tokens,
+            ]),
+            output: first_present(&[
+                self.output_tokens,
+                self.output_tokens_camel,
+                self.completion_tokens,
+            ]),
+            cache_read: first_positive(&[
+                self.cache_read_input_tokens,
+                self.cache_read_input_tokens_camel,
+                self.prompt_cache_hit_tokens,
+                self.cached_tokens,
+            ]),
+            cache_write: first_positive(&[
+                self.cache_creation_input_tokens,
+                self.cache_creation_input_tokens_camel,
+                self.prompt_cache_write_tokens,
+            ]),
+            reasoning: first_present(&[
+                self.completion_thinking_tokens,
+                self.completion_thinking_tokens_camel,
+            ]),
+        };
+
+        if tokens.total() == 0 {
+            None
+        } else {
+            Some(tokens)
+        }
+    }
+}
+
+fn first_present(values: &[Option<i64>]) -> i64 {
+    values.iter().copied().flatten().next().unwrap_or(0).max(0)
+}
+
+fn first_positive(values: &[Option<i64>]) -> i64 {
+    values
+        .iter()
+        .copied()
+        .flatten()
+        .find(|count| *count > 0)
+        .or_else(|| values.iter().copied().flatten().next())
+        .unwrap_or(0)
+        .max(0)
+}
+
+pub fn parse_codebuddy_file(path: &Path) -> Vec<UnifiedMessage> {
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(_) => return Vec::new(),
+    };
+
+    let fallback_session_id = path
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let fallback_timestamp = super::utils::file_modified_timestamp_ms(path);
+    let mut keyed_indices: HashMap<String, usize> = HashMap::new();
+    let mut messages: Vec<UnifiedMessage> = Vec::new();
+
+    for line in BufReader::new(file).lines() {
+        let Ok(line) = line else {
+            continue;
+        };
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let mut bytes = trimmed.as_bytes().to_vec();
+        let item = match simd_json::from_slice::<CodeBuddyLine>(&mut bytes) {
+            Ok(item) => item,
+            Err(_) => continue,
+        };
+
+        if item.line_type.as_deref() != Some("message") || item.role.as_deref() != Some("assistant")
+        {
+            continue;
+        }
+
+        if item
+            .status
+            .as_deref()
+            .is_some_and(|status| status != "completed")
+        {
+            continue;
+        }
+
+        let usage = item
+            .message
+            .as_ref()
+            .and_then(|message| message.usage.as_ref())
+            .or_else(|| {
+                item.provider_data
+                    .as_ref()
+                    .and_then(|provider| provider.usage.as_ref())
+            })
+            .or_else(|| {
+                item.provider_data
+                    .as_ref()
+                    .and_then(|provider| provider.raw_usage.as_ref())
+            });
+        let Some(tokens) = usage.and_then(CodeBuddyUsage::to_breakdown) else {
+            continue;
+        };
+
+        let provider_data = item.provider_data.as_ref();
+        let model_id = provider_data
+            .and_then(|provider| provider.model.as_deref())
+            .or_else(|| provider_data.and_then(|provider| provider.request_model_id.as_deref()))
+            .or_else(|| item.message.as_ref().and_then(|message| message.model.as_deref()))
+            .filter(|model| !model.trim().is_empty())
+            .unwrap_or(DEFAULT_MODEL)
+            .to_string();
+        let provider_id = provider_identity::inferred_provider_from_model(&model_id)
+            .unwrap_or(DEFAULT_PROVIDER)
+            .to_string();
+        let session_id = item.session_id.unwrap_or_else(|| fallback_session_id.clone());
+        let timestamp = item.timestamp.unwrap_or(fallback_timestamp);
+
+        let mut message = UnifiedMessage::new(
+            "codebuddy",
+            model_id,
+            provider_id,
+            session_id.clone(),
+            timestamp,
+            tokens,
+            0.0,
+        );
+
+        if let Some(workspace_key) = item.cwd.as_deref().and_then(normalize_workspace_key) {
+            let workspace_label = workspace_label_from_key(&workspace_key);
+            message.set_workspace(Some(workspace_key), workspace_label);
+        }
+
+        let dedup_key = provider_data
+            .and_then(|provider| provider.message_id.as_deref())
+            .or_else(|| provider_data.and_then(|provider| provider.trace_id.as_deref()))
+            .or(item.id.as_deref())
+            .map(|key| format!("codebuddy:{session_id}:{key}"));
+        message.dedup_key = dedup_key.clone();
+
+        if let Some(key) = dedup_key {
+            if let Some(existing_index) = keyed_indices.get(&key).copied() {
+                if message.tokens.total() >= messages[existing_index].tokens.total() {
+                    messages[existing_index] = message;
+                }
+                continue;
+            }
+            keyed_indices.insert(key, messages.len());
+        }
+
+        messages.push(message);
+    }
+
+    messages
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_codebuddy_file_reads_message_usage() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_dir = dir.path().join("projects").join("c-Users-alice-repo");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let path = project_dir.join("session-1.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"id":"user-1","timestamp":1780000000000,"type":"message","role":"user","sessionId":"session-1","cwd":"/Users/alice/repo"}
+{"id":"assistant-1","timestamp":1780000000100,"type":"message","role":"assistant","status":"completed","sessionId":"session-1","cwd":"/Users/alice/repo","providerData":{"model":"glm-5.2","messageId":"msg-1"},"message":{"usage":{"input_tokens":24486,"output_tokens":3,"total_tokens":24489,"cache_read_input_tokens":14720}}}"#,
+        )
+        .unwrap();
+
+        let messages = parse_codebuddy_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        let message = &messages[0];
+        assert_eq!(message.client, "codebuddy");
+        assert_eq!(message.model_id, "glm-5.2");
+        assert_eq!(message.provider_id, "tencent");
+        assert_eq!(message.session_id, "session-1");
+        assert_eq!(message.tokens.input, 24486);
+        assert_eq!(message.tokens.output, 3);
+        assert_eq!(message.tokens.cache_read, 14720);
+        assert_eq!(message.workspace_label.as_deref(), Some("repo"));
+        assert_eq!(
+            message.dedup_key.as_deref(),
+            Some("codebuddy:session-1:msg-1")
+        );
+    }
+
+    #[test]
+    fn parse_codebuddy_file_falls_back_to_raw_usage() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session-2.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"id":"assistant-1","timestamp":1780000000100,"type":"message","role":"assistant","status":"completed","sessionId":"session-2","providerData":{"requestModelId":"glm-5.2","rawUsage":{"prompt_tokens":10,"completion_tokens":2,"prompt_cache_hit_tokens":3,"prompt_cache_write_tokens":4,"completion_thinking_tokens":5}}}"#,
+        )
+        .unwrap();
+
+        let messages = parse_codebuddy_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 10);
+        assert_eq!(messages[0].tokens.output, 2);
+        assert_eq!(messages[0].tokens.cache_read, 3);
+        assert_eq!(messages[0].tokens.cache_write, 4);
+        assert_eq!(messages[0].tokens.reasoning, 5);
+    }
+}

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -7,6 +7,7 @@ pub mod antigravity;
 pub mod antigravity_cli;
 pub mod claudecode;
 pub mod cline;
+pub mod codebuddy;
 pub mod codebuff;
 pub mod codex;
 pub mod commandcode;

--- a/packages/frontend/src/lib/constants.ts
+++ b/packages/frontend/src/lib/constants.ts
@@ -63,6 +63,7 @@ export const SOURCE_DISPLAY_NAMES: Record<ClientType, string> = {
   junie: "Junie",
   zcode: "ZCode",
   opencodereview: "OpenCodeReview",
+  codebuddy: "CodeBuddy",
 };
 
 // Client logos from GitHub CDN (public repo)
@@ -105,6 +106,7 @@ export const SOURCE_LOGOS: Record<ClientType, string> = {
   junie: "https://github.com/JetBrains.png",
   zcode: "https://github.com/zai-org.png",
   opencodereview: "https://github.com/alibaba.png",
+  codebuddy: "https://github.com/Tencent.png",
 };
 
 export const SOURCE_COLORS: Record<ClientType, string> = {
@@ -144,6 +146,7 @@ export const SOURCE_COLORS: Record<ClientType, string> = {
   junie: "#7B61FF",
   zcode: "#3B5BDB",
   opencodereview: "#FF6A00",
+  codebuddy: "#00A4FF",
 };
 
 export const SOURCE_TEXT_COLORS: Partial<Record<ClientType, string>> = {

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -35,6 +35,7 @@ export const SUPPORTED_CLIENT_TYPES = [
   "junie",
   "zcode",
   "opencodereview",
+  "codebuddy",
 ] as const;
 
 export type CcMirrorClientType = `cc-mirror/${string}`;


### PR DESCRIPTION
## Summary
- Add CodeBuddy as a local session client backed by ~/.codebuddy/projects JSONL logs.
- Register CodeBuddy in CLI/TUI/frontend client lists.
- Parse assistant usage from message.usage/providerData.usage/rawUsage, including cache read/write and reasoning fields.

## Verification
- cargo test -p tokscale-core --lib codebuddy
- cargo build -p tokscale-cli
- target\debug\tokscale.exe --client codebuddy --no-spinner --json (local: 1 message, glm-5.2, input 24486, output 3, cacheRead 14720)
- target\debug\tokscale.exe clients --json (codebuddy exists true, messageCount 1)

Note: VS Code/CodeBuddy IDE extension caches found locally did not contain standalone token usage; the supported data source is the CodeBuddy CLI/project JSONL logs under ~/.codebuddy/projects.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CodeBuddy as a local client and parser, reading `~/.codebuddy/projects/**/*.jsonl` to track token usage. Enables full token breakdowns (input/output/cache/reasoning) across the CLI, TUI, and web UI.

- **New Features**
  - New local client `codebuddy` with JSONL parsing from project logs.
  - Parses assistant usage from `message.usage`, `providerData.usage`, or `providerData.rawUsage`; maps cache read/write and reasoning; infers provider from model (default `tencent`).
  - Deduplicates by `sessionId` + `messageId`/`traceId`/line `id`; attaches workspace from `cwd`.
  - Registered in CLI filters, TUI (display “CodeBuddy”, hotkey C), and frontend names/logos/colors/types; README updated.
  - Client registry/count updated with tests.

<sup>Written for commit 630cdf043f960db6a1e964d680abaf84b6cb6e58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

