### PR TITLE
fix(kiro): improve IDE globalStorage model detection

### DIFF
--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -453,21 +453,21 @@ fn collect_kiro_snapshot_text(
 }
 
 fn find_kiro_snapshot_model_id(value: &Value) -> Option<String> {
+    static KIRO_INTERNAL_MODELS: &[&str] = &["agent", "auto", "qdev"];
+
     match value {
         Value::Object(map) => {
             for key in ["model_id", "modelId", "model"] {
                 if let Some(model) = map.get(key).and_then(|v| v.as_str()) {
                     let model = model.trim();
-                    if !model.is_empty() {
+                    if !model.is_empty()
+                        && !KIRO_INTERNAL_MODELS.contains(&model.to_lowercase().as_str())
+                    {
                         return Some(model.to_string());
                     }
                 }
             }
 
-            // Recurse into the same containers `collect_kiro_snapshot_text`
-            // descends into, so the model id is discoverable wherever text is
-            // (otherwise a model id nested under e.g. `parts` or `prompt` would
-            // be missed and fall back to `unknown`). Keep these key-sets aligned.
             for key in [
                 "messages",
                 "conversation",
@@ -484,6 +484,8 @@ fn find_kiro_snapshot_model_id(value: &Value) -> Option<String> {
                 "parts",
                 "items",
                 "nodes",
+                "promptLogs",
+                "completionOptions",
             ] {
                 if let Some(item) = map.get(key) {
                     if let Some(model) = find_kiro_snapshot_model_id(item) {
@@ -526,7 +528,7 @@ fn parse_kiro_global_storage_file(path: &Path) -> Vec<UnifiedMessage> {
         Some(ws) => format!("{}/{}", ws, file_stem),
         None => file_stem.to_string(),
     };
-    let model_id = find_kiro_snapshot_model_id(&value).unwrap_or_else(|| UNKNOWN_MODEL.to_string());
+    let model_id = find_kiro_snapshot_model_id(&value).unwrap_or_else(|| "auto".to_string());
 
     let mut counts = KiroSnapshotTextCounts::default();
     collect_kiro_snapshot_text(&value, &mut counts, None);
@@ -773,6 +775,40 @@ mod tests {
         assert_eq!(messages[0].duration_ms, Some(580));
         assert_eq!(messages[0].workspace_key, Some("/tmp/project".to_string()));
         assert_eq!(messages[0].workspace_label, Some("project".to_string()));
+    }
+
+    #[test]
+    fn test_real_kiro_ide_model_detection() {
+        let home = std::env::var("HOME").unwrap();
+        let path = std::path::Path::new(&home)
+            .join("Library/Application Support/Kiro/User/globalStorage/kiro.kiroagent/workspace-sessions/L1VzZXJzL3QxMDAwMDQw/d23984e6-4a36-4d8f-9dfb-3bf0e4431f31.json");
+        if !path.exists() {
+            eprintln!("Skipping: IDE file not found");
+            return;
+        }
+        eprintln!(
+            "is_kiro_global_storage_path: {}",
+            is_kiro_global_storage_path(&path)
+        );
+
+        let json = std::fs::read_to_string(&path).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let model = find_kiro_snapshot_model_id(&value);
+        eprintln!("find_kiro_snapshot_model_id result: {:?}", model);
+
+        let messages = parse_kiro_file(&path);
+        eprintln!("Messages: {}", messages.len());
+        for m in &messages {
+            eprintln!(
+                "  model={}, input={}, output={}",
+                m.model_id, m.tokens.input, m.tokens.output
+            );
+        }
+        assert!(!messages.is_empty());
+        assert_ne!(
+            messages[0].model_id, "unknown",
+            "Model should not be unknown"
+        );
     }
 
     #[test]
@@ -1049,10 +1085,11 @@ not valid json at all
             Some("claude-sonnet-4-5".to_string())
         );
 
-        let prompt_value: Value = serde_json::from_str(r#"{"prompt": {"model": "auto"}}"#).unwrap();
+        let prompt_value: Value =
+            serde_json::from_str(r#"{"prompt": {"model": "claude-sonnet-4"}}"#).unwrap();
         assert_eq!(
             find_kiro_snapshot_model_id(&prompt_value),
-            Some("auto".to_string())
+            Some("claude-sonnet-4".to_string())
         );
     }
 }

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -778,40 +778,6 @@ mod tests {
     }
 
     #[test]
-    fn test_real_kiro_ide_model_detection() {
-        let home = std::env::var("HOME").unwrap();
-        let path = std::path::Path::new(&home)
-            .join("Library/Application Support/Kiro/User/globalStorage/kiro.kiroagent/workspace-sessions/L1VzZXJzL3QxMDAwMDQw/d23984e6-4a36-4d8f-9dfb-3bf0e4431f31.json");
-        if !path.exists() {
-            eprintln!("Skipping: IDE file not found");
-            return;
-        }
-        eprintln!(
-            "is_kiro_global_storage_path: {}",
-            is_kiro_global_storage_path(&path)
-        );
-
-        let json = std::fs::read_to_string(&path).unwrap();
-        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
-        let model = find_kiro_snapshot_model_id(&value);
-        eprintln!("find_kiro_snapshot_model_id result: {:?}", model);
-
-        let messages = parse_kiro_file(&path);
-        eprintln!("Messages: {}", messages.len());
-        for m in &messages {
-            eprintln!(
-                "  model={}, input={}, output={}",
-                m.model_id, m.tokens.input, m.tokens.output
-            );
-        }
-        assert!(!messages.is_empty());
-        assert_ne!(
-            messages[0].model_id, "unknown",
-            "Model should not be unknown"
-        );
-    }
-
-    #[test]
     fn test_parse_kiro_skips_zero_content_turns() {
         let dir = TempDir::new().unwrap();
         let json = r#"{"session_id":"session-2","cwd":"/tmp","session_state":{"rts_model_state":{"model_info":{"model_id":"model"}},"conversation_metadata":{"user_turn_metadatas":[{"input_token_count":0,"output_token_count":0,"message_ids":["missing"]}]}}}"#;


### PR DESCRIPTION
Fix Kiro IDE sessions reporting model as unknown instead of merging with CLI sessions under auto. Skip Kiro-internal model names (agent, auto, qdev), add promptLogs/completionOptions to recursion search, fall back to auto for IDE sessions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Kiro IDE globalStorage model detection so IDE sessions no longer show as unknown and aggregate with CLI sessions under `auto`. Detection skips Kiro-internal routing names and looks deeper into snapshot fields.

- **Bug Fixes**
  - Ignore internal IDs `agent`, `auto`, `qdev` (case-insensitive).
  - Search `promptLogs` and `completionOptions` for `model`.
  - Default IDE snapshots to `auto` to match CLI aggregation.

- **Refactors**
  - Remove machine-specific IDE model-detection test that never ran in CI; coverage stays via fixture tests.

<sup>Written for commit 24434f91e4a891eaec7abe6f0e003840d811e2eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

