### PR TITLE
feat(grok): reconcile session usage from signals.json compaction totals

### DIFF
--- a/crates/tokscale-core/src/sessions/grok.rs
+++ b/crates/tokscale-core/src/sessions/grok.rs
@@ -643,7 +643,10 @@ mod tests {
             Some("grok:session-1:signals")
         );
         assert_eq!(
-            messages.iter().map(|message| message.tokens.input).sum::<i64>(),
+            messages
+                .iter()
+                .map(|message| message.tokens.input)
+                .sum::<i64>(),
             3396968
         );
     }

--- a/crates/tokscale-core/src/sessions/grok.rs
+++ b/crates/tokscale-core/src/sessions/grok.rs
@@ -2,9 +2,12 @@
 //!
 //! Grok Build writes JSON-RPC session updates under
 //! `~/.grok/sessions/<urlencoded-workspace>/<session-id>/updates.jsonl`.
-//! Current logs expose cumulative `totalTokens` counters without a stable
+//! Session rollups also land in sibling `signals.json` (including
+//! `totalTokensBeforeCompaction` and `contextTokensUsed`). Current update
+//! logs expose cumulative `totalTokens` counters without a stable
 //! input/output split, so this parser records per-turn positive total-token
-//! deltas as input tokens.
+//! deltas as input tokens and reconciles any remaining `signals.json` total
+//! so compacted sessions are not under-counted.
 
 use super::utils::{
     extract_i64, extract_string, file_modified_timestamp_ms, parse_timestamp_value,
@@ -203,7 +206,7 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
                 baseline_total: 0,
                 max_total: total_tokens,
                 timestamp: last_total_timestamp,
-                model_id: current_model,
+                model_id: current_model.clone(),
                 turn_index: 0,
             };
             if let Some(message) = aggregate_turn.into_message(&metadata) {
@@ -212,7 +215,90 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
         }
     }
 
+    append_signals_reconciliation(path, &metadata, &mut messages, &current_model);
     messages
+}
+
+fn non_negative_i64(value: Option<&Value>) -> i64 {
+    extract_i64(value).unwrap_or(0).max(0)
+}
+
+fn effective_total_from_signals(value: &Value) -> i64 {
+    let before = non_negative_i64(value.get("totalTokensBeforeCompaction"));
+    let total = non_negative_i64(value.get("totalTokens"));
+    match value.get("contextTokensUsed") {
+        None => before.saturating_add(total),
+        Some(ctx) => total.max(before.saturating_add(non_negative_i64(Some(ctx)))),
+    }
+}
+
+fn model_id_from_signals(value: &Value) -> Option<String> {
+    extract_string(value.get("primaryModelId")).or_else(|| {
+        value
+            .get("modelsUsed")
+            .and_then(|models| models.as_array())
+            .and_then(|models| models.first())
+            .and_then(|model| extract_string(Some(model)))
+    })
+}
+
+fn append_signals_reconciliation(
+    updates_path: &Path,
+    metadata: &GrokMetadata,
+    messages: &mut Vec<UnifiedMessage>,
+    fallback_model: &str,
+) {
+    let signals_path = match sibling(updates_path, "signals.json") {
+        Some(path) => path,
+        None => return,
+    };
+    let data = match read_file_or_none(&signals_path) {
+        Some(data) => data,
+        None => return,
+    };
+    let value: Value = match serde_json::from_slice(&data) {
+        Ok(value) => value,
+        Err(_) => return,
+    };
+
+    let signals_total = effective_total_from_signals(&value);
+    if signals_total <= 0 {
+        return;
+    }
+
+    let updates_total: i64 = messages.iter().map(|message| message.tokens.input).sum();
+    let extra = signals_total.saturating_sub(updates_total);
+    if extra <= 0 {
+        return;
+    }
+
+    let model_id = model_id_from_signals(&value)
+        .filter(|model| !model.trim().is_empty())
+        .or_else(|| metadata.model_id.clone())
+        .unwrap_or_else(|| fallback_model.to_string());
+    let timestamp = file_modified_timestamp_ms(&signals_path).max(metadata.timestamp);
+
+    let mut message = UnifiedMessage::new_with_dedup(
+        CLIENT_ID,
+        model_id,
+        PROVIDER_ID,
+        metadata.session_id.clone(),
+        timestamp,
+        TokenBreakdown {
+            input: extra,
+            output: 0,
+            cache_read: 0,
+            cache_write: 0,
+            reasoning: 0,
+        },
+        0.0,
+        Some(format!("grok:{}:signals", metadata.session_id)),
+    );
+    message.set_workspace(
+        metadata.workspace_key.clone(),
+        metadata.workspace_label.clone(),
+    );
+    messages.push(message);
 }
 
 fn read_metadata(path: &Path) -> GrokMetadata {
@@ -247,8 +333,24 @@ fn read_metadata(path: &Path) -> GrokMetadata {
     if let Some(events_path) = sibling(path, "events.jsonl") {
         read_events_metadata(&events_path, &mut metadata);
     }
+    if let Some(signals_path) = sibling(path, "signals.json") {
+        read_signals_metadata(&signals_path, &mut metadata);
+    }
 
     metadata
+}
+
+fn read_signals_metadata(path: &Path, metadata: &mut GrokMetadata) {
+    let Some(data) = read_file_or_none(path) else {
+        return;
+    };
+    let Ok(value) = serde_json::from_slice::<Value>(&data) else {
+        return;
+    };
+
+    if metadata.model_id.is_none() {
+        metadata.model_id = model_id_from_signals(&value);
+    }
 }
 
 fn read_summary_metadata(path: &Path, metadata: &mut GrokMetadata) {
@@ -402,6 +504,7 @@ mod tests {
     fn write_fixture(
         updates_jsonl: &str,
         summary_json: Option<&str>,
+        signals_json: Option<&str>,
     ) -> (tempfile::TempDir, PathBuf) {
         let temp = tempfile::TempDir::new().unwrap();
         let session_dir = temp
@@ -415,6 +518,9 @@ mod tests {
         std::fs::write(&updates_path, updates_jsonl).unwrap();
         if let Some(summary_json) = summary_json {
             std::fs::write(session_dir.join("summary.json"), summary_json).unwrap();
+        }
+        if let Some(signals_json) = signals_json {
+            std::fs::write(session_dir.join("signals.json"), signals_json).unwrap();
         }
         (temp, updates_path)
     }
@@ -431,6 +537,7 @@ mod tests {
             Some(
                 r#"{"current_model_id":"grok-composer-2.5-fast","updated_at":"2023-11-14T22:13:20Z"}"#,
             ),
+            None,
         );
 
         let messages = parse_grok_updates_file(&path);
@@ -456,6 +563,7 @@ mod tests {
             Some(
                 r#"{"current_model_id":"grok-composer-2.5-fast","updated_at":"2023-11-14T22:13:20Z"}"#,
             ),
+            None,
         );
 
         let messages = parse_grok_updates_file(&path);
@@ -474,6 +582,7 @@ mod tests {
 {"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"agent_message_chunk"},"_meta":{"totalTokens":120,"agentTimestampMs":1700000004000}}}
 {"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"agent_message_chunk"},"_meta":{"totalTokens":200,"agentTimestampMs":1700000005000}}}"#,
             None,
+            None,
         );
 
         let messages = parse_grok_updates_file(&path);
@@ -486,6 +595,7 @@ mod tests {
     fn preserves_total_tokens_without_model_metadata() {
         let (_temp, path) = write_fixture(
             r#"{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"available_commands_update"},"_meta":{"totalTokens":120,"agentTimestampMs":1700000000000}}}"#,
+            None,
             None,
         );
 
@@ -502,6 +612,7 @@ mod tests {
             r#"{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"available_commands_update"},"_meta":{"totalTokens":100,"agentTimestampMs":1700000000000}}}
 {"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"agent_message_chunk"},"_meta":{"totalTokens":250,"agentTimestampMs":1700000002000}}}"#,
             None,
+            None,
         );
 
         let messages = parse_grok_updates_file(&path);
@@ -509,5 +620,60 @@ mod tests {
         assert_eq!(messages[0].model_id, UNKNOWN_MODEL);
         assert_eq!(messages[0].tokens.input, 150);
         assert_eq!(messages[0].timestamp, 1700000002000);
+    }
+
+    #[test]
+    fn adds_signals_reconciliation_when_compaction_exceeds_updates() {
+        let (_temp, path) = write_fixture(
+            r#"{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"user_message_chunk","_meta":{"modelId":"grok-build"}},"_meta":{"agentTimestampMs":1700000000000}}}
+{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"agent_message_chunk"},"_meta":{"totalTokens":171056,"agentTimestampMs":1700000001000}}}"#,
+            None,
+            Some(
+                r#"{"primaryModelId":"grok-build","totalTokensBeforeCompaction":3224659,"contextTokensUsed":172309}"#,
+            ),
+        );
+
+        let messages = parse_grok_updates_file(&path);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].tokens.input, 171056);
+        assert_eq!(messages[1].tokens.input, 3225912);
+        assert_eq!(messages[1].model_id, "grok-build");
+        assert_eq!(
+            messages[1].dedup_key.as_deref(),
+            Some("grok:session-1:signals")
+        );
+        assert_eq!(
+            messages.iter().map(|message| message.tokens.input).sum::<i64>(),
+            3396968
+        );
+    }
+
+    #[test]
+    fn skips_signals_reconciliation_when_updates_already_cover_signals() {
+        let (_temp, path) = write_fixture(
+            r#"{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"user_message_chunk"},"_meta":{"agentTimestampMs":1700000000000}}}
+{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"agent_message_chunk"},"_meta":{"totalTokens":500,"agentTimestampMs":1700000001000}}}"#,
+            None,
+            Some(r#"{"primaryModelId":"grok-build","contextTokensUsed":400}"#),
+        );
+
+        let messages = parse_grok_updates_file(&path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 500);
+    }
+
+    #[test]
+    fn uses_signals_model_when_updates_model_is_missing() {
+        let (_temp, path) = write_fixture(
+            r#"{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"available_commands_update"},"_meta":{"totalTokens":50,"agentTimestampMs":1700000000000}}}"#,
+            None,
+            Some(r#"{"primaryModelId":"grok-composer-2.5-fast","contextTokensUsed":250}"#),
+        );
+
+        let messages = parse_grok_updates_file(&path);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].tokens.input, 50);
+        assert_eq!(messages[1].tokens.input, 200);
+        assert_eq!(messages[1].model_id, "grok-composer-2.5-fast");
     }
 }


### PR DESCRIPTION
## Summary

Closes #797.

Grok Build sessions expose two telemetry sources per session directory:

- `updates.jsonl` — cumulative `totalTokens` streamed during the session (already parsed as per-turn input deltas)
- `signals.json` — end-of-session rollup including `totalTokensBeforeCompaction` and `contextTokensUsed`

Tokscale previously only counted `updates.jsonl`, which under-reports long / compacted sessions. On a real dev machine, all-time Grok totals were ~4.0M (tokscale) vs ~19.2M (`signals.json` effective sum).

This PR keeps the existing turn-delta parsing and appends **one reconciliation message per session** when `signals` effective total exceeds the summed update deltas:

```
session_billable = max(updates_delta_sum, signals_effective_total)
extra = session_billable - updates_delta_sum  // emitted as input-only tokens
```

Dedup key: `grok:{session_id}:signals`

## Changes

- `crates/tokscale-core/src/sessions/grok.rs`
  - `effective_total_from_signals()` — same semantics as other Grok session consumers
  - `append_signals_reconciliation()` — no double-count when sources agree
  - `read_signals_metadata()` — model fallback from `primaryModelId` / `modelsUsed`
  - Tests: compaction gap, agreement skip, signals model fallback

## Validation

```bash
cargo test -p tokscale-core grok
cargo fmt --check
```

(CI should run on this PR — Rust toolchain not available on the author's Windows dev box.)

## Non-goals

- Input/output/cache split for Grok (still unavailable from Grok CLI telemetry)
- Pricing alias changes for `grok-composer-2.5-fast`

## Example fixture (from production session shape)

| Source | Tokens |
|--------|--------|
| `updates.jsonl` summed deltas | 171,056 |
| `signals.json` effective total | 3,396,968 |
| **After reconciliation** | **3,396,968** |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconcile Grok session token usage with compaction rollups in `signals.json` so compacted sessions aren’t under-counted. If the rollup total is higher than the sum of `updates.jsonl` deltas, emit one reconciliation message with the difference.

- **New Features**
  - Parse `signals.json` and compute an effective total from `totalTokensBeforeCompaction`, `contextTokensUsed`, and `totalTokens`.
  - Add one `UnifiedMessage` (dedup `grok:<sessionId>:signals`) with extra input tokens, timestamped by `signals.json` mtime.
  - Use the model ID from `signals.json` (`primaryModelId` or first `modelsUsed`) when missing in updates; also stored in metadata.
  - Tests cover reconciliation when compaction exceeds updates, skipping when covered, and model fallback.

- **Refactors**
  - Applied `cargo fmt` to the reconciliation test.

<sup>Written for commit 81de73abf232ee48d1139552916b7da2993065da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

