### PR TITLE
fix(core): handle Oh My Pi JSONL title line before session header

### DIFF
--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -1,7 +1,7 @@
-//! Pi (badlogic/pi-mono) session parser
+//! Pi (badlogic/pi-mono) and Oh My Pi session parser
 //!
-//! Parses JSONL files from ~/.pi/agent/sessions/<encoded-cwd>/*.jsonl
-
+//! Parses JSONL files from `~/.pi/agent/sessions/<encoded-cwd>/*.jsonl`
+//! and `~/.omp/agent/sessions/<encoded-cwd>/*.jsonl`.
 use super::utils::file_modified_timestamp_ms;
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::provider_identity::inferred_provider_from_model;
@@ -10,7 +10,10 @@ use serde::Deserialize;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 
-/// Pi session header (first line of JSONL)
+/// Pi/Oh My Pi session header — found in JSONL files as a line whose
+/// `type` field equals `"session"`. OMP files may precede it with a
+/// `title` line (type == "title"), so we scan for the first `"session"`
+/// entry rather than assuming it's line #1.
 #[derive(Debug, Deserialize)]
 pub struct PiSessionHeader {
     #[serde(rename = "type")]
@@ -55,7 +58,10 @@ pub struct PiUsage {
     pub total_tokens: Option<i64>,
 }
 
-/// Parse a Pi JSONL session file
+/// Parse a Pi or Oh My Pi JSONL session file.
+///
+/// OMP session files may start with a `title` line before the actual
+/// `session` header, so we skip non-`"session"` lines until we find it.
 pub fn parse_pi_file(path: &Path) -> Vec<UnifiedMessage> {
     let file = match std::fs::File::open(path) {
         Ok(f) => f,
@@ -90,8 +96,10 @@ pub fn parse_pi_file(path: &Path) -> Vec<UnifiedMessage> {
                 Err(_) => return Vec::new(),
             };
 
+            // OMP files may start with a `title` line — skip until we
+            // find the actual `"session"` header.
             if header.entry_type != "session" {
-                return Vec::new();
+                continue;
             }
             session_id = Some(header.id);
             workspace_key = header.cwd.as_deref().and_then(normalize_workspace_key);


### PR DESCRIPTION
Oh My Pi (OMP) session files start with a `title` line before the `session` header.

**Before:** The parser returned `Vec::new()` on any non-"`session`" line, causing OMP sessions to be silently skipped.

**After:** Skip non-"session" lines until the actual session header is found.

The scanner already adds `~/.omp/agent/sessions` as a scan root for Pi, but the parser was rejecting OMP files because of the extra title line.

**Changes:**
- `crates/tokscale-core/src/sessions/pi.rs`: Change early return to `continue` when encountering non-"session" lines in the header search phase

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix parsing of Oh My Pi JSONL files by skipping any non-"session" lines (like the leading `title`) until the actual session header. Sessions in `~/.omp/agent/sessions` are now imported instead of being silently skipped.

<sup>Written for commit 77cf795c51daf3f9c7230d848611913a8975f4ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

