### PR TITLE
fix(frontend): render Fable models in Opus red on profile overview

### DIFF
--- a/packages/frontend/src/components/profile/index.tsx
+++ b/packages/frontend/src/components/profile/index.tsx
@@ -895,6 +895,9 @@ export function ProfileStats({ stats, favoriteModel }: ProfileStatsProps) {
 }
 
 const MODEL_COLORS: Record<string, string> = {
+  // "fable" must precede "claude": lookup is first-match and IDs like
+  // "claude-fable-5" contain both keys.
+  "fable": "#DC2626",
   "claude": "#D97706",
   "sonnet": "#D97706",
   "opus": "#DC2626",


### PR DESCRIPTION
## Problem

On the profile overview, Fable models rendered in the wrong color:

- `claude-fable-5` matched the generic `"claude"` key in `MODEL_COLORS` and rendered **amber `#D97706`** — the same color as Sonnet.
- A bare `fable-5` id matched nothing and fell to the unknown **gray `#6B7280`**.

Meanwhile Opus renders red `#DC2626`. Fable is a flagship-tier Claude model (above Opus), so it should render at the same level as Opus — the TUI already does this (`fable_gets_same_base_color_as_opus` test in `crates/tokscale-cli/src/tui/ui/widgets.rs`).

## Fix

Add a `"fable": "#DC2626"` entry to `MODEL_COLORS` in `packages/frontend/src/components/profile/index.tsx`.

Placement matters: `getModelColor` is first-match over `Object.entries` insertion order, and `claude-fable-5` contains both `"fable"` and `"claude"` — so the `fable` entry must precede `claude`. A comment documents this constraint.

## Verification

- `tsc --noEmit` on the frontend package reports no errors in the touched file (two pre-existing errors in `__tests__/api/groupMemberRoleRoute.test.ts` are unrelated).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Fable model color on the profile overview by mapping it to Opus red (#DC2626) and prioritizing the `fable` key over `claude` for correct matching. This makes `claude-fable-5` and `fable-5` render consistently with the TUI.

- **Bug Fixes**
  - Added `"fable": "#DC2626"` to `MODEL_COLORS` in `packages/frontend/src/components/profile/index.tsx`.
  - Placed `"fable"` before `"claude"` to respect first-match lookup and avoid amber on `claude-fable-5`.

<sup>Written for commit 5f53960c75259bc772d4b2aa63fbc68ba4071538. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

