### PR TITLE
fix(pi): tolerate OMP title-first session records

### DIFF
--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -1,6 +1,9 @@
 //! Pi (badlogic/pi-mono) session parser
 //!
-//! Parses JSONL files from ~/.pi/agent/sessions/<encoded-cwd>/*.jsonl
+//! Parses JSONL files from `~/.pi/agent/sessions/<encoded-cwd>/*.jsonl` (and,
+//! via the `pi` client's OMP scan root, `~/.omp/agent/sessions/...`). Current
+//! OMP builds write a `title` metadata record before the `session` header in
+//! newly-created session files; see [`PRE_SESSION_METADATA_TYPES`].
 
 use super::utils::file_modified_timestamp_ms;
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
@@ -21,6 +24,20 @@ pub struct PiSessionHeader {
     #[allow(dead_code)]
     pub cwd: Option<String>,
 }
+
+/// Loose type-only probe for a JSONL line, used to identify pre-session
+/// metadata records without requiring their full schema.
+#[derive(Debug, Deserialize)]
+struct PiEntryTypeProbe {
+    #[serde(rename = "type")]
+    entry_type: String,
+}
+
+/// Record types OMP may write before the `session` header (e.g. an
+/// auto-generated-title record). The parser skips these while looking for
+/// `session` rather than discarding the whole file. Any other unrecognized
+/// type before `session` is still treated as a malformed file.
+const PRE_SESSION_METADATA_TYPES: &[&str] = &["title"];
 
 /// Pi session entry (subsequent lines of JSONL)
 #[derive(Debug, Deserialize)]
@@ -85,14 +102,25 @@ pub fn parse_pi_file(path: &Path) -> Vec<UnifiedMessage> {
         if session_id.is_none() {
             buffer.clear();
             buffer.extend_from_slice(trimmed.as_bytes());
+            let entry_type = match simd_json::from_slice::<PiEntryTypeProbe>(&mut buffer) {
+                Ok(probe) => probe.entry_type,
+                Err(_) => return Vec::new(),
+            };
+
+            if entry_type != "session" {
+                if PRE_SESSION_METADATA_TYPES.contains(&entry_type.as_str()) {
+                    continue;
+                }
+                return Vec::new();
+            }
+
+            buffer.clear();
+            buffer.extend_from_slice(trimmed.as_bytes());
             let header = match simd_json::from_slice::<PiSessionHeader>(&mut buffer) {
                 Ok(h) => h,
                 Err(_) => return Vec::new(),
             };
 
-            if header.entry_type != "session" {
-                return Vec::new();
-            }
             session_id = Some(header.id);
             workspace_key = header.cwd.as_deref().and_then(normalize_workspace_key);
             workspace_label = workspace_key.as_deref().and_then(workspace_label_from_key);
@@ -247,5 +275,62 @@ not valid json
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].model_id, "gpt-4o-mini");
         assert_eq!(messages[0].provider_id, "openai");
+    }
+
+    #[test]
+    fn test_parse_pi_skips_leading_title_record() {
+        // given: current OMP builds write a `title` metadata record before
+        // `session` (tokscale#802) — the parser must skip it, not discard
+        // the whole file.
+        let content = r#"{"type":"title","v":1,"title":"Comment on GitHub issue","source":"auto","updatedAt":"2026-07-02T18:08:49.723Z"}
+{"type":"session","id":"pi_ses_005","timestamp":"2026-07-02T18:07:14.690Z","cwd":"/tmp"}
+{"type":"message","timestamp":"2026-07-02T18:08:53.229Z","message":{"role":"assistant","model":"claude-sonnet-5","provider":"anthropic","usage":{"input":2,"output":180,"cacheRead":0,"cacheWrite":70844,"totalTokens":71026}}}"#;
+        let file = create_test_file(content);
+
+        // when
+        let messages = parse_pi_file(file.path());
+
+        // then
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].session_id, "pi_ses_005");
+        assert_eq!(messages[0].model_id, "claude-sonnet-5");
+        assert_eq!(messages[0].provider_id, "anthropic");
+        assert_eq!(messages[0].tokens.input, 2);
+        assert_eq!(messages[0].tokens.output, 180);
+        assert_eq!(messages[0].tokens.cache_write, 70844);
+    }
+
+    #[test]
+    fn test_parse_pi_skips_multiple_leading_title_records() {
+        // given: defensive against more than one pre-session metadata line
+        // in a row (e.g. a title record rewritten by a later auto-rename).
+        let content = r#"{"type":"title","v":1,"title":"first"}
+{"type":"title","v":1,"title":"renamed"}
+{"type":"session","id":"pi_ses_006","timestamp":"2026-07-02T18:07:14.690Z","cwd":"/tmp"}
+{"type":"message","timestamp":"2026-07-02T18:08:53.229Z","message":{"role":"assistant","model":"gpt-4o-mini","provider":"openai","usage":{"input":10,"output":5,"cacheRead":0,"cacheWrite":0,"totalTokens":15}}}"#;
+        let file = create_test_file(content);
+
+        // when
+        let messages = parse_pi_file(file.path());
+
+        // then
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].session_id, "pi_ses_006");
+    }
+
+    #[test]
+    fn test_parse_pi_rejects_unknown_leading_record_type() {
+        // given: an unrecognized type before `session` is still treated as
+        // a malformed file rather than silently scanned through.
+        let content = r#"{"type":"totally_unknown_thing","foo":"bar"}
+{"type":"session","id":"pi_ses_007","timestamp":"2026-07-02T18:07:14.690Z","cwd":"/tmp"}
+{"type":"message","timestamp":"2026-07-02T18:08:53.229Z","message":{"role":"assistant","model":"gpt-4o-mini","provider":"openai","usage":{"input":10,"output":5,"cacheRead":0,"cacheWrite":0,"totalTokens":15}}}"#;
+        let file = create_test_file(content);
+
+        // when
+        let messages = parse_pi_file(file.path());
+
+        // then
+        assert!(messages.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Fixes #802. `crates/tokscale-core/src/sessions/pi.rs::parse_pi_file` required the first non-empty JSONL line of an OMP/Pi session file to deserialize as `{"type":"session",...}`, and discarded the entire file (`Vec::new()`) if it didn't. Current OMP builds now write a `{"type":"title",...}` metadata record before the `session` header in newly-created session files, so every OMP session created since that format changed was silently dropped from the `pi` client's usage stats — not just the leading line, the whole file's messages.

## Root cause

Traced this against real session data: a July 2026 OMP session file with a valid `title` record on line 1 and `session` on line 2, containing four real assistant turns with proper `usage`/`model` fields, reported `0 messages / 0 tokens` through `tokscale models --light --json`. Removing only the leading `title` line made it parse correctly, matching the reproduction already described in #802.

## Fix

`parse_pi_file` now probes each pre-session line's `type` field with a lightweight `PiEntryTypeProbe` instead of requiring the full `PiSessionHeader` schema up front. If the type is a known pre-session metadata record (currently `title`), it's skipped and the parser keeps looking for `session`. Once `session` is found, the existing full-header parse runs unchanged. Any other unrecognized type before `session` still discards the file, preserving today's fail-fast behavior for genuinely malformed input rather than silently scanning through unexpected content.

## Testing

- `cargo test -p tokscale-core sessions::pi::` — all 7 tests pass, including 3 new regression tests: a `title`-then-`session` file parses correctly, repeated leading `title` records are tolerated, and a genuinely unrecognized leading record type still yields an empty result.
- `cargo test --workspace --all-features` — 2049 passed, 0 failed.
- `cargo fmt --all -- --check` and `cargo clippy --locked --workspace --all-features -- -D warnings` — clean.
- Reproduced the bug end-to-end against a real affected OMP session file in an isolated `--home` scratch directory before the fix (`0 messages`) and confirmed the fix recovers it (`4 messages`, correct tokens/cost) after.

## Note

I don't have write access to this repo, so I can't verify CI directly on this PR — happy to address any feedback.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Pi session parser to tolerate OMP sessions that start with a `{"type":"title",...}` record, so recent sessions aren’t dropped from usage stats. Restores accurate message/token accounting while keeping strictness for malformed files.

- **Bug Fixes**
  - Probe each pre-session line’s `type` and skip known metadata (`title`) until `session` is found (`parse_pi_file` in `crates/tokscale-core/src/sessions/pi.rs`; see `PRE_SESSION_METADATA_TYPES`).
  - Preserve fail-fast behavior: unrecognized types before `session` still discard the file.
  - Add regression tests for title-first, repeated titles, and unknown leading types.

<sup>Written for commit 70df7c0de5e0b2fa96b5f09f207cb2c4a6588e1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

