### PR TITLE
fix(frontend): resolve Claude family colors before the generic claude key, on the TUI orange ramp

### DIFF
--- a/packages/frontend/__tests__/components/modelColors.test.ts
+++ b/packages/frontend/__tests__/components/modelColors.test.ts
@@ -45,4 +45,17 @@ describe("getModelColor", () => {
   it("falls back to gray for unknown models", () => {
     expect(getModelColor("fugu")).toBe(UNKNOWN_GRAY);
   });
+
+  it("matches keys as delimited tokens, not raw substrings", () => {
+    // Regression (PR #808 review): includes() matching painted unrelated ids
+    // containing "fable"/"opus" fragments in Anthropic colors.
+    expect(getModelColor("unfabled-5")).toBe(UNKNOWN_GRAY);
+    expect(getModelColor("fableton-1")).toBe(UNKNOWN_GRAY);
+    // But version digits may trail a key without a delimiter...
+    expect(getModelColor("gpt4")).toBe(getModelColor("gpt-4"));
+    expect(getModelColor("qwen2.5-72b")).toBe(getModelColor("qwen-max"));
+    // ...and bracketed context markers tokenize away cleanly.
+    expect(getModelColor("claude-fable-5[1m]")).toBe(FABLE_ORANGE);
+    expect(getModelColor("chatgpt-4o-latest")).toBe(getModelColor("gpt-4o"));
+  });
 });

--- a/packages/frontend/__tests__/components/modelColors.test.ts
+++ b/packages/frontend/__tests__/components/modelColors.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { getModelColor } from "../../src/components/profile/modelColors";
+
+const OPUS_RED = "#DC2626";
+const CLAUDE_AMBER = "#D97706";
+const HAIKU_GREEN = "#059669";
+const UNKNOWN_GRAY = "#6B7280";
+
+describe("getModelColor", () => {
+  it("renders Opus red even when the id carries the claude- prefix", () => {
+    // Regression: the generic "claude" key used to match first, so every
+    // real Opus id (they all start with "claude-") rendered amber.
+    expect(getModelColor("claude-opus-4-6")).toBe(OPUS_RED);
+    expect(getModelColor("claude-opus-4-5-thinking-high")).toBe(OPUS_RED);
+    expect(getModelColor("claude-4-5-opus-high-thinking")).toBe(OPUS_RED);
+  });
+
+  it("renders Fable in the same red as Opus", () => {
+    expect(getModelColor("claude-fable-5")).toBe(OPUS_RED);
+    expect(getModelColor("fable-5")).toBe(OPUS_RED);
+    expect(getModelColor("claude-fable-5")).toBe(getModelColor("claude-opus-4-6"));
+  });
+
+  it("renders Haiku green even when the id carries the claude- prefix", () => {
+    expect(getModelColor("claude-haiku-4-5")).toBe(HAIKU_GREEN);
+  });
+
+  it("keeps Sonnet and bare claude ids amber", () => {
+    expect(getModelColor("claude-sonnet-5")).toBe(CLAUDE_AMBER);
+    expect(getModelColor("claude-4-5-sonnet-thinking")).toBe(CLAUDE_AMBER);
+    expect(getModelColor("claude-3-5")).toBe(CLAUDE_AMBER);
+  });
+
+  it("falls back to gray for unknown models", () => {
+    expect(getModelColor("fugu")).toBe(UNKNOWN_GRAY);
+  });
+});

--- a/packages/frontend/__tests__/components/modelColors.test.ts
+++ b/packages/frontend/__tests__/components/modelColors.test.ts
@@ -1,34 +1,45 @@
 import { describe, expect, it } from "vitest";
 import { getModelColor } from "../../src/components/profile/modelColors";
 
-const OPUS_RED = "#DC2626";
-const CLAUDE_AMBER = "#D97706";
-const HAIKU_GREEN = "#059669";
+// The Claude family ramp mirrors the TUI's ANTHROPIC_SHADES: darker = higher
+// tier. See crates/tokscale-cli/src/tui/ui/widgets.rs.
+const FABLE_ORANGE = "#DA7756";
+const OPUS_ORANGE = "#DF886B";
+const SONNET_ORANGE = "#E39980";
+const HAIKU_ORANGE = "#E8AA95";
+const CLAUDE_ORANGE = "#ECB8A6";
 const UNKNOWN_GRAY = "#6B7280";
 
+function luminance(hex: string): number {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return 0.299 * r + 0.587 * g + 0.114 * b;
+}
+
 describe("getModelColor", () => {
-  it("renders Opus red even when the id carries the claude- prefix", () => {
+  it("resolves family colors even when the id carries the claude- prefix", () => {
     // Regression: the generic "claude" key used to match first, so every
-    // real Opus id (they all start with "claude-") rendered amber.
-    expect(getModelColor("claude-opus-4-6")).toBe(OPUS_RED);
-    expect(getModelColor("claude-opus-4-5-thinking-high")).toBe(OPUS_RED);
-    expect(getModelColor("claude-4-5-opus-high-thinking")).toBe(OPUS_RED);
+    // real Opus/Haiku id (they all start with "claude-") got the fallback.
+    expect(getModelColor("claude-opus-4-6")).toBe(OPUS_ORANGE);
+    expect(getModelColor("claude-opus-4-5-thinking-high")).toBe(OPUS_ORANGE);
+    expect(getModelColor("claude-4-5-opus-high-thinking")).toBe(OPUS_ORANGE);
+    expect(getModelColor("claude-haiku-4-5")).toBe(HAIKU_ORANGE);
   });
 
-  it("renders Fable in the same red as Opus", () => {
-    expect(getModelColor("claude-fable-5")).toBe(OPUS_RED);
-    expect(getModelColor("fable-5")).toBe(OPUS_RED);
-    expect(getModelColor("claude-fable-5")).toBe(getModelColor("claude-opus-4-6"));
+  it("renders Fable in the darkest Claude orange, one step above Opus", () => {
+    expect(getModelColor("claude-fable-5")).toBe(FABLE_ORANGE);
+    expect(getModelColor("fable-5")).toBe(FABLE_ORANGE);
   });
 
-  it("renders Haiku green even when the id carries the claude- prefix", () => {
-    expect(getModelColor("claude-haiku-4-5")).toBe(HAIKU_GREEN);
-  });
+  it("orders the Claude ramp by family tier: fable > opus > sonnet > haiku > generic", () => {
+    expect(getModelColor("claude-sonnet-5")).toBe(SONNET_ORANGE);
+    expect(getModelColor("claude-3-5")).toBe(CLAUDE_ORANGE);
 
-  it("keeps Sonnet and bare claude ids amber", () => {
-    expect(getModelColor("claude-sonnet-5")).toBe(CLAUDE_AMBER);
-    expect(getModelColor("claude-4-5-sonnet-thinking")).toBe(CLAUDE_AMBER);
-    expect(getModelColor("claude-3-5")).toBe(CLAUDE_AMBER);
+    const ramp = [FABLE_ORANGE, OPUS_ORANGE, SONNET_ORANGE, HAIKU_ORANGE, CLAUDE_ORANGE];
+    for (let i = 1; i < ramp.length; i++) {
+      expect(luminance(ramp[i])).toBeGreaterThan(luminance(ramp[i - 1]));
+    }
   });
 
   it("falls back to gray for unknown models", () => {

--- a/packages/frontend/src/components/profile/index.tsx
+++ b/packages/frontend/src/components/profile/index.tsx
@@ -10,6 +10,7 @@ import { formatNumber, formatCurrency, formatDuration } from "@/lib/utils";
 import { legacy } from "@/lib/responsive";
 import { ProfileEmbedDialog } from "./ProfileEmbedDialog";
 import { ListCard, ListHeader, ListMetricCell, ListRow } from "./listStyles";
+import { getModelColor } from "./modelColors";
 
 export { ProfileDevices } from "./ProfileDevices";
 export type { ProfileDevice } from "./ProfileDevices";
@@ -892,32 +893,6 @@ export function ProfileStats({ stats, favoriteModel }: ProfileStatsProps) {
       </StatsGrid>
     </StatsContainer>
   );
-}
-
-const MODEL_COLORS: Record<string, string> = {
-  // "fable" must precede "claude": lookup is first-match and IDs like
-  // "claude-fable-5" contain both keys.
-  "fable": "#DC2626",
-  "claude": "#D97706",
-  "sonnet": "#D97706",
-  "opus": "#DC2626",
-  "haiku": "#059669",
-  "gpt": "#10B981",
-  "o1": "#6366F1",
-  "o3": "#8B5CF6",
-  "gemini": "#3B82F6",
-  "deepseek": "#06B6D4",
-  "codex": "#F59E0B",
-  "kimi": "#A855F7",
-  "qwen": "#1A73E8",
-};
-
-function getModelColor(modelName: string): string {
-  const lowerName = modelName.toLowerCase();
-  for (const [key, color] of Object.entries(MODEL_COLORS)) {
-    if (lowerName.includes(key)) return color;
-  }
-  return "#6B7280";
 }
 
 export interface ModelUsage {

--- a/packages/frontend/src/components/profile/modelColors.ts
+++ b/packages/frontend/src/components/profile/modelColors.ts
@@ -1,12 +1,15 @@
 const MODEL_COLORS: Record<string, string> = {
-  // Lookup is first-match, so family keys (fable/opus/sonnet/haiku) must
-  // precede the generic "claude" fallback: real IDs like "claude-opus-4-6"
-  // contain both keys and would otherwise never reach their family color.
-  "fable": "#DC2626",
-  "opus": "#DC2626",
-  "sonnet": "#D97706",
-  "haiku": "#059669",
-  "claude": "#D97706",
+  // Anthropic families use the same orange ramp as the TUI's ANTHROPIC_SHADES
+  // (crates/tokscale-cli/src/tui/ui/widgets.rs): brightness encodes the family
+  // hierarchy — fable darkest, then opus, sonnet, haiku, generic claude palest.
+  // Lookup is first-match, so family keys must precede the generic "claude"
+  // fallback: real IDs like "claude-opus-4-6" contain both keys and would
+  // otherwise never reach their family color.
+  "fable": "#DA7756",
+  "opus": "#DF886B",
+  "sonnet": "#E39980",
+  "haiku": "#E8AA95",
+  "claude": "#ECB8A6",
   "gpt": "#10B981",
   "o1": "#6366F1",
   "o3": "#8B5CF6",

--- a/packages/frontend/src/components/profile/modelColors.ts
+++ b/packages/frontend/src/components/profile/modelColors.ts
@@ -11,6 +11,7 @@ const MODEL_COLORS: Record<string, string> = {
   "haiku": "#E8AA95",
   "claude": "#ECB8A6",
   "gpt": "#10B981",
+  "chatgpt": "#10B981",
   "o1": "#6366F1",
   "o3": "#8B5CF6",
   "gemini": "#3B82F6",
@@ -21,9 +22,17 @@ const MODEL_COLORS: Record<string, string> = {
 };
 
 export function getModelColor(modelName: string): string {
-  const lowerName = modelName.toLowerCase();
+  // Match keys as delimited tokens (optionally followed by a version digit,
+  // e.g. "gpt4"), not raw substrings — otherwise ids like "unfabled-x" would
+  // land in the Anthropic palette. Mirrors the TUI's delimited matching in
+  // get_provider_from_model.
+  const tokens = modelName.toLowerCase().split(/[^a-z0-9]+/);
   for (const [key, color] of Object.entries(MODEL_COLORS)) {
-    if (lowerName.includes(key)) return color;
+    for (const token of tokens) {
+      if (token === key || (token.startsWith(key) && /^\d/.test(token.slice(key.length)))) {
+        return color;
+      }
+    }
   }
   return "#6B7280";
 }

--- a/packages/frontend/src/components/profile/modelColors.ts
+++ b/packages/frontend/src/components/profile/modelColors.ts
@@ -1,0 +1,26 @@
+const MODEL_COLORS: Record<string, string> = {
+  // Lookup is first-match, so family keys (fable/opus/sonnet/haiku) must
+  // precede the generic "claude" fallback: real IDs like "claude-opus-4-6"
+  // contain both keys and would otherwise never reach their family color.
+  "fable": "#DC2626",
+  "opus": "#DC2626",
+  "sonnet": "#D97706",
+  "haiku": "#059669",
+  "claude": "#D97706",
+  "gpt": "#10B981",
+  "o1": "#6366F1",
+  "o3": "#8B5CF6",
+  "gemini": "#3B82F6",
+  "deepseek": "#06B6D4",
+  "codex": "#F59E0B",
+  "kimi": "#A855F7",
+  "qwen": "#1A73E8",
+};
+
+export function getModelColor(modelName: string): string {
+  const lowerName = modelName.toLowerCase();
+  for (const [key, color] of Object.entries(MODEL_COLORS)) {
+    if (lowerName.includes(key)) return color;
+  }
+  return "#6B7280";
+}


### PR DESCRIPTION
## Problem

Follow-up to #806, which added a `fable` entry but didn't actually make Fable match the flagship tier on the live site. Checking production (tokscale.ai/u/junhoyeo, models tab) after deploy:

- `claude-fable-5` → red (the #806 entry works)
- **every** `claude-opus-*` id → amber `#D97706` (the generic `claude` color)

Root cause: `getModelColor` is first-match over insertion order, and every real Opus id carries the `claude-` prefix (`claude-opus-4-6`, `claude-opus-4-5-thinking-high`, …), so the generic `"claude"` key matched before `"opus"` ever could. The `"opus"` entry was dead code — same bug hit Haiku (`claude-haiku-4-5` rendered amber instead of green).

Additionally, the red `#DC2626` from #806 was inferred from that dead `"opus"` entry, not an actual design decision — Claude family models should be **orange**.

## Fix

- Reorder `MODEL_COLORS` so family keys (`fable`, `opus`, `sonnet`, `haiku`) precede the generic `"claude"` fallback.
- Replace red/amber/green with the same orange ramp the TUI uses (`ANTHROPIC_SHADES` in `crates/tokscale-cli/src/tui/ui/widgets.rs`), so brightness encodes the family hierarchy — matching #810's TUI shade ranking:

| Family | Color |
|---|---|
| fable | `#DA7756` (darkest) |
| opus | `#DF886B` |
| sonnet | `#E39980` |
| haiku | `#E8AA95` |
| generic claude | `#ECB8A6` (palest) |

- Extract the map + `getModelColor` into `modelColors.ts` so the ordering contract is unit-testable without pulling styled-components/next into vitest.
- Regression tests lock in: family colors resolve despite the `claude-` prefix, Fable one step darker than Opus, and the ramp's luminance is strictly increasing down the tiers.

## Verification

- `vitest run __tests__/components/modelColors.test.ts` — 4/4 pass
- `tsc --noEmit` — no new errors (pre-existing `groupMemberRoleRoute.test.ts` errors untouched)
- Production dot colors above were read directly off the deployed DOM via browser inspection

Companion PR: #810 (TUI shade ranking by family/version hierarchy).