### PR TITLE
fix(tui): rank model shades by Claude family/version hierarchy instead of spend

### DIFF
--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -4346,7 +4346,7 @@ mod tests {
     }
 
     #[test]
-    fn test_shade_map_assigns_rank_0_to_highest_cost() {
+    fn test_shade_map_ranks_by_family_hierarchy() {
         let mut app = make_app();
         app.data.models = vec![
             model_usage("claude-haiku-4-5", 10.0, None),

--- a/crates/tokscale-cli/src/tui/colors.rs
+++ b/crates/tokscale-cli/src/tui/colors.rs
@@ -89,22 +89,26 @@ fn family_tier(provider: &str, model: &str) -> u8 {
 }
 
 /// Extracts a `(major, minor)` version from a model id:
-/// "claude-opus-4-6" -> (4, 6), "gpt-5.4" -> (5, 4), "claude-fable-5" -> (5, 0).
-/// Scanning stops at the first 4+ digit token (dates like 20241022) so ids
-/// such as "o1-2024-12-17" don't misparse a date fragment as a version;
-/// ids without a version yield (0, 0).
+/// "claude-opus-4-6" -> (4, 6), "gpt-5.4" -> (5, 4), "gpt-4o" -> (4, 0),
+/// "claude-fable-5" -> (5, 0). Tokens only need to *start* with digits, so
+/// alphanumeric versions like "4o" parse as their numeric prefix. Scanning
+/// stops at the first 4+ digit value (dates like 20241022) so ids such as
+/// "o1-2024-12-17" don't misparse a date fragment as a version; ids without
+/// a version yield (0, 0).
 fn model_version(model: &str) -> (u32, u32) {
     let tokens: Vec<&str> = model
         .split(|c: char| !c.is_ascii_alphanumeric())
         .filter(|t| !t.is_empty())
         .collect();
     for (i, token) in tokens.iter().enumerate() {
-        let Ok(major) = token.parse::<u32>() else {
+        let Some(major) = leading_number(token) else {
             continue;
         };
         if major >= 1000 {
             return (0, 0);
         }
+        // Minor must be fully numeric: suffix tokens like "1m" (from a
+        // "[1m]" context-window marker) are not version fragments.
         let minor = tokens
             .get(i + 1)
             .and_then(|t| t.parse::<u32>().ok())
@@ -113,6 +117,16 @@ fn model_version(model: &str) -> (u32, u32) {
         return (major, minor);
     }
     (0, 0)
+}
+
+/// Parses the leading digit run of a token: "4o" -> Some(4), "5" -> Some(5),
+/// "turbo" -> None.
+fn leading_number(token: &str) -> Option<u32> {
+    let end = token
+        .char_indices()
+        .find(|(_, c)| !c.is_ascii_digit())
+        .map_or(token.len(), |(i, _)| i);
+    token[..end].parse::<u32>().ok()
 }
 
 #[cfg(test)]
@@ -147,6 +161,12 @@ mod tests {
         assert_eq!(model_version("gpt-5.4"), (5, 4));
         assert_eq!(model_version("claude-3-5-sonnet-20241022"), (3, 5));
         assert_eq!(model_version("gpt-4-turbo"), (4, 0));
+        // Alphanumeric version tokens parse by their numeric prefix.
+        assert_eq!(model_version("gpt-4o"), (4, 0));
+        assert_eq!(model_version("gpt-4o-mini"), (4, 0));
+        assert_eq!(model_version("gpt-3.5-turbo"), (3, 5));
+        // A "[1m]" context marker is not a minor version.
+        assert_eq!(model_version("gpt-4o[1m]"), (4, 0));
         // Date fragments must not be read as versions.
         assert_eq!(model_version("o1-2024-12-17"), (0, 0));
         assert_eq!(model_version("codex-mini-latest"), (0, 0));
@@ -243,6 +263,24 @@ mod tests {
         );
         assert_eq!(
             shade(&map, "openai", "gpt-4"),
+            get_provider_shade("openai", 1)
+        );
+    }
+
+    #[test]
+    fn alphanumeric_versions_outrank_older_numeric_ones() {
+        // Regression (PR #810 review): "4o" used to parse as no version at
+        // all, letting gpt-3.5-turbo render darker than gpt-4o.
+        let map = build_model_shade_map(&[
+            usage("gpt-3.5-turbo", "openai", 900.0),
+            usage("gpt-4o", "openai", 1.0),
+        ]);
+        assert_eq!(
+            shade(&map, "openai", "gpt-4o"),
+            get_provider_shade("openai", 0)
+        );
+        assert_eq!(
+            shade(&map, "openai", "gpt-3.5-turbo"),
             get_provider_shade("openai", 1)
         );
     }

--- a/crates/tokscale-cli/src/tui/colors.rs
+++ b/crates/tokscale-cli/src/tui/colors.rs
@@ -10,13 +10,18 @@ pub fn model_shade_key(provider: &str, model: &str) -> String {
 }
 
 /// Builds a `(provider, model) -> Color` map where each provider's models are
-/// cost-ranked; rank 0 (highest cost) gets the base provider color and later
-/// ranks get progressively lighter shades.
+/// ranked into the provider's shade ramp; rank 0 gets the base provider color
+/// and later ranks get progressively lighter shades.
+///
+/// Ranking encodes the model hierarchy, not spend: family tier first (for
+/// Anthropic: fable > opus > sonnet > haiku), then version (newer = darker),
+/// then cost, then model name. Cost is only a tiebreaker so that variants of
+/// the same version (e.g. `-thinking`, `-high`) get stable adjacent shades.
 ///
 /// Aggregates cost per (provider, model) so the same model appearing in
 /// multiple group-by buckets (e.g. `GroupBy::WorkspaceModel`) doesn't inflate
-/// the rank count. Ties on cost are resolved by model name so shade assignment
-/// stays deterministic across refreshes.
+/// the rank count. Remaining ties are resolved by model name so shade
+/// assignment stays deterministic across refreshes.
 pub fn build_model_shade_map(models: &[ModelUsage]) -> HashMap<String, Color> {
     let mut by_provider: HashMap<&str, HashMap<&str, f64>> = HashMap::new();
     for m in models {
@@ -32,7 +37,13 @@ pub fn build_model_shade_map(models: &[ModelUsage]) -> HashMap<String, Color> {
     let mut map = HashMap::new();
     for (provider, models_map) in by_provider {
         let mut ranked: Vec<(&str, f64)> = models_map.into_iter().collect();
-        ranked.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+        ranked.sort_by(|a, b| {
+            family_tier(provider, a.0)
+                .cmp(&family_tier(provider, b.0))
+                .then_with(|| model_version(b.0).cmp(&model_version(a.0)))
+                .then_with(|| b.1.total_cmp(&a.1))
+                .then_with(|| a.0.cmp(b.0))
+        });
         for (rank, (name, _)) in ranked.iter().enumerate() {
             map.insert(
                 model_shade_key(provider, name),
@@ -48,5 +59,191 @@ fn provider_color_key<'a>(provider: &'a str, model: &'a str) -> &'a str {
         get_provider_from_model(model)
     } else {
         provider
+    }
+}
+
+/// Position of a model's family within its provider's lineup; lower tiers get
+/// darker shades. Only Anthropic has a known hierarchy — other providers rank
+/// purely by version and cost.
+fn family_tier(provider: &str, model: &str) -> u8 {
+    if !provider.to_lowercase().contains("anthropic") {
+        return 0;
+    }
+    let lower = model.to_lowercase();
+    // "fable" is matched as a delimited token (mirrors get_provider_from_model)
+    // so ids like "unfabled-x" don't land in the flagship tier.
+    if lower
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .any(|token| token == "fable")
+    {
+        0
+    } else if lower.contains("opus") {
+        1
+    } else if lower.contains("sonnet") {
+        2
+    } else if lower.contains("haiku") {
+        3
+    } else {
+        4
+    }
+}
+
+/// Extracts a `(major, minor)` version from a model id:
+/// "claude-opus-4-6" -> (4, 6), "gpt-5.4" -> (5, 4), "claude-fable-5" -> (5, 0).
+/// Scanning stops at the first 4+ digit token (dates like 20241022) so ids
+/// such as "o1-2024-12-17" don't misparse a date fragment as a version;
+/// ids without a version yield (0, 0).
+fn model_version(model: &str) -> (u32, u32) {
+    let tokens: Vec<&str> = model
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .collect();
+    for (i, token) in tokens.iter().enumerate() {
+        let Ok(major) = token.parse::<u32>() else {
+            continue;
+        };
+        if major >= 1000 {
+            return (0, 0);
+        }
+        let minor = tokens
+            .get(i + 1)
+            .and_then(|t| t.parse::<u32>().ok())
+            .filter(|&m| m < 1000)
+            .unwrap_or(0);
+        return (major, minor);
+    }
+    (0, 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::data::{ModelUsage, TokenBreakdown};
+
+    fn usage(model: &str, provider: &str, cost: f64) -> ModelUsage {
+        ModelUsage {
+            model: model.to_string(),
+            provider: provider.to_string(),
+            client: "claude".to_string(),
+            workspace_key: None,
+            workspace_label: None,
+            tokens: TokenBreakdown::default(),
+            cost,
+            performance: Default::default(),
+            session_count: 1,
+        }
+    }
+
+    fn shade(map: &HashMap<String, Color>, provider: &str, model: &str) -> Color {
+        map.get(&model_shade_key(provider, model)).copied().unwrap()
+    }
+
+    #[test]
+    fn model_version_parses_common_id_shapes() {
+        assert_eq!(model_version("claude-opus-4-6"), (4, 6));
+        assert_eq!(model_version("claude-4-5-opus-high-thinking"), (4, 5));
+        assert_eq!(model_version("claude-fable-5"), (5, 0));
+        assert_eq!(model_version("claude-fable-5[1m]"), (5, 0));
+        assert_eq!(model_version("gpt-5.4"), (5, 4));
+        assert_eq!(model_version("claude-3-5-sonnet-20241022"), (3, 5));
+        assert_eq!(model_version("gpt-4-turbo"), (4, 0));
+        // Date fragments must not be read as versions.
+        assert_eq!(model_version("o1-2024-12-17"), (0, 0));
+        assert_eq!(model_version("codex-mini-latest"), (0, 0));
+    }
+
+    #[test]
+    fn fable_outranks_higher_cost_opus() {
+        // Fable is the flagship tier: it takes the base shade even when the
+        // user has spent far more on Opus models.
+        let map = build_model_shade_map(&[
+            usage("claude-opus-4-6", "anthropic", 900.0),
+            usage("claude-fable-5", "anthropic", 1.0),
+        ]);
+        assert_eq!(
+            shade(&map, "anthropic", "claude-fable-5"),
+            get_provider_shade("anthropic", 0)
+        );
+        assert_eq!(
+            shade(&map, "anthropic", "claude-opus-4-6"),
+            get_provider_shade("anthropic", 1)
+        );
+    }
+
+    #[test]
+    fn newer_opus_outranks_older_despite_lower_cost() {
+        let map = build_model_shade_map(&[
+            usage("claude-opus-4-5", "anthropic", 500.0),
+            usage("claude-opus-4-7", "anthropic", 10.0),
+            usage("claude-opus-4-6", "anthropic", 300.0),
+        ]);
+        assert_eq!(
+            shade(&map, "anthropic", "claude-opus-4-7"),
+            get_provider_shade("anthropic", 0)
+        );
+        assert_eq!(
+            shade(&map, "anthropic", "claude-opus-4-6"),
+            get_provider_shade("anthropic", 1)
+        );
+        assert_eq!(
+            shade(&map, "anthropic", "claude-opus-4-5"),
+            get_provider_shade("anthropic", 2)
+        );
+    }
+
+    #[test]
+    fn family_tier_beats_version_within_anthropic() {
+        // A newer Sonnet never renders darker than an older Opus.
+        let map = build_model_shade_map(&[
+            usage("claude-sonnet-5", "anthropic", 800.0),
+            usage("claude-opus-4-1", "anthropic", 2.0),
+        ]);
+        assert_eq!(
+            shade(&map, "anthropic", "claude-opus-4-1"),
+            get_provider_shade("anthropic", 0)
+        );
+        assert_eq!(
+            shade(&map, "anthropic", "claude-sonnet-5"),
+            get_provider_shade("anthropic", 1)
+        );
+    }
+
+    #[test]
+    fn variant_suffixes_group_with_their_base_version() {
+        // Same version, different variants: cost then name break the tie, so
+        // the 4-5 family occupies adjacent shades below 4-6.
+        let map = build_model_shade_map(&[
+            usage("claude-opus-4-5-thinking-high", "anthropic", 50.0),
+            usage("claude-opus-4-6", "anthropic", 10.0),
+            usage("claude-opus-4-5", "anthropic", 100.0),
+        ]);
+        assert_eq!(
+            shade(&map, "anthropic", "claude-opus-4-6"),
+            get_provider_shade("anthropic", 0)
+        );
+        assert_eq!(
+            shade(&map, "anthropic", "claude-opus-4-5"),
+            get_provider_shade("anthropic", 1)
+        );
+        assert_eq!(
+            shade(&map, "anthropic", "claude-opus-4-5-thinking-high"),
+            get_provider_shade("anthropic", 2)
+        );
+    }
+
+    #[test]
+    fn non_anthropic_providers_rank_by_version_first() {
+        let map = build_model_shade_map(&[
+            usage("gpt-4", "openai", 700.0),
+            usage("gpt-5.4", "openai", 5.0),
+        ]);
+        assert_eq!(
+            shade(&map, "openai", "gpt-5.4"),
+            get_provider_shade("openai", 0)
+        );
+        assert_eq!(
+            shade(&map, "openai", "gpt-4"),
+            get_provider_shade("openai", 1)
+        );
     }
 }


### PR DESCRIPTION
## Problem

In the TUI, model colors come from a 7-step provider ramp (`ANTHROPIC_SHADES`: `#DA7756` → paler), but the rank into that ramp was **total cost**. Shade brightness encoded spend, not model tier — so `claude-fable-5` rendered pale (like `sonnet-4-5` / `opus-4-5`) next to deep-orange `opus-4-6`/`opus-4-7`, purely because less had been spent on it. The ordering also reshuffled as usage accumulated.

## Fix

`build_model_shade_map` now sorts each provider's models by:

1. **Family tier** — Anthropic: `fable` → `opus` → `sonnet` → `haiku` → other; other providers have a single tier
2. **Version, descending** — newer = darker; parsed generically as the first `major[-.]minor` numeric tokens (`claude-opus-4-6` → 4.6, `gpt-5.4` → 5.4); 4+ digit tokens abort the scan so dates (`o1-2024-12-17`, `-20241022`) never misparse as versions
3. **Cost, then name** — tiebreakers only, so same-version variants (`-thinking`, `-high`) hold stable adjacent shades across refreshes

Result: `claude-fable-5` takes the base deep orange `#DA7756`, the newest Opus sits one step behind it, Sonnet lands in the mid band, Haiku palest — and `gpt-5.x` renders darker than `gpt-4` regardless of spend.

Note: Fable stays **orange** (the Claude ramp), not red — the frontend is being aligned to this same ramp in #808.

## Verification

- 6 new unit tests in `tui/colors.rs` (version parsing incl. date rejection, fable-over-opus, newer-over-older, tier-over-version, variant grouping, non-Anthropic version ranking)
- All existing shade-map tests pass unchanged (dedup, tie determinism, NaN, provider separation) — one renamed to match the new semantics
- `cargo test -p tokscale-cli`: 830 passed; `cargo clippy`: 0 warnings; `cargo fmt` applied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make TUI model shades follow model hierarchy (family, then version) instead of spend. Colors show tier consistently and no longer shift with usage.

- **Bug Fixes**
  - Rank per provider by family tier (Anthropic: fable > opus > sonnet > haiku), then version (newer = darker), then cost, then name for deterministic ties.
  - Version parsing: scan first major/minor tokens; accept alphanumeric majors by numeric prefix (e.g., `gpt-4o` -> 4.0); minor must be numeric; ignore date-like tokens (e.g., `o1-2024-12-17`) and context markers (e.g., `[1m]`).
  - Visible impact: `claude-fable-5` gets the base Anthropic shade; newer Opus precedes older; `gpt-5.x` darker than `gpt-4`; `gpt-4o` outranks `gpt-3.5-turbo`.
  - Tests: 6 new unit tests in `tui/colors.rs`; existing shade-map tests remain green; one test renamed to match new semantics.

<sup>Written for commit 39bccf031e6ef9a9bdbe0fff9f8471081170fe4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

