### PR TITLE
feat(tui): add monthly usage tab with daily drill-down

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -571,7 +571,7 @@ fn main() -> Result<()> {
                     since,
                     until,
                     year,
-                    Some(Tab::Daily),
+                    Some(Tab::Monthly),
                 )
             }
         }

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use chrono::NaiveDate;
+use chrono::{Datelike, NaiveDate};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Rect;
 use tokscale_core::ClientId;
@@ -2260,9 +2260,15 @@ impl App {
         let Some(month) = self.selected_monthly_detail_month.as_ref() else {
             return Vec::new();
         };
+        let Some((year, month)) = month.split_once('-').and_then(|(year, month)| {
+            Some((year.parse::<i32>().ok()?, month.parse::<u32>().ok()?))
+        }) else {
+            return Vec::new();
+        };
+
         self.get_sorted_daily()
             .into_iter()
-            .filter(|day| day.date.format("%Y-%m").to_string() == *month)
+            .filter(|day| day.date.year() == year && day.date.month() == month)
             .collect()
     }
 

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -1982,8 +1982,8 @@ impl App {
         self.selected_index = restored_index;
 
         let max_visible = self.max_visible_items.max(1);
-        let viewport_still_holds = restored_index >= self.scroll_offset
-            && restored_index < self.scroll_offset + max_visible;
+        let viewport_still_holds = restored_index >= self.monthly_list_scroll_offset
+            && restored_index < self.monthly_list_scroll_offset + max_visible;
         self.scroll_offset = if viewport_still_holds {
             self.monthly_list_scroll_offset
         } else {
@@ -3225,6 +3225,32 @@ mod tests {
         assert!(!app.is_monthly_detail_active());
         assert_eq!(app.monthly_detail_month(), None);
         assert_eq!(app.current_tab, Tab::Monthly);
+    }
+
+    #[test]
+    fn test_close_monthly_detail_restores_saved_viewport() {
+        let mut app = make_app();
+        app.switch_tab(Tab::Monthly);
+        app.data.monthly = (1..=10)
+            .map(|month| monthly_usage(&format!("2026-{month:02}"), 100, 1.0))
+            .collect();
+        app.data.daily = vec![daily_usage(
+            "2026-03-10",
+            1.0,
+            vec![("model-a", "openai", 1.0)],
+        )];
+        app.max_visible_items = 4;
+        app.selected_index = 7;
+        app.scroll_offset = 6;
+
+        app.open_selected_monthly_detail();
+        assert_eq!(app.monthly_detail_month(), Some("2026-03"));
+        assert_eq!(app.scroll_offset, 0);
+
+        app.close_monthly_detail();
+
+        assert_eq!(app.selected_index, 7);
+        assert_eq!(app.scroll_offset, 6);
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -19,8 +19,8 @@ use super::codex_login::{
     CodexLoginOutcome,
 };
 use super::data::{
-    AgentUsage, DailyUsage, DataLoader, HourlyUsage, MinutelyUsage, ModelUsage, TokenBreakdown,
-    UsageData,
+    AgentUsage, DailyUsage, DataLoader, HourlyUsage, MinutelyUsage, ModelUsage, MonthlyUsage,
+    TokenBreakdown, UsageData,
 };
 use super::privacy::looks_like_email;
 use super::settings::Settings;
@@ -60,6 +60,7 @@ pub enum Tab {
     Daily,
     Hourly,
     Minutely,
+    Monthly,
     Stats,
     Agents,
 }
@@ -73,6 +74,7 @@ impl Tab {
             Tab::Daily,
             Tab::Hourly,
             Tab::Minutely,
+            Tab::Monthly,
             Tab::Stats,
             Tab::Agents,
         ]
@@ -86,6 +88,7 @@ impl Tab {
             Tab::Daily => "Daily",
             Tab::Hourly => "Hourly",
             Tab::Minutely => "Minutely",
+            Tab::Monthly => "Monthly",
             Tab::Stats => "Stats",
             Tab::Agents => "Agents",
         }
@@ -99,6 +102,7 @@ impl Tab {
             Tab::Daily => "Day",
             Tab::Hourly => "Hr",
             Tab::Minutely => "Min",
+            Tab::Monthly => "Mon",
             Tab::Stats => "Sta",
             Tab::Agents => "Agt",
         }
@@ -111,7 +115,8 @@ impl Tab {
             Tab::Models => Tab::Daily,
             Tab::Daily => Tab::Hourly,
             Tab::Hourly => Tab::Minutely,
-            Tab::Minutely => Tab::Stats,
+            Tab::Minutely => Tab::Monthly,
+            Tab::Monthly => Tab::Stats,
             Tab::Stats => Tab::Agents,
             Tab::Agents => Tab::Overview,
         }
@@ -125,7 +130,8 @@ impl Tab {
             Tab::Daily => Tab::Models,
             Tab::Hourly => Tab::Daily,
             Tab::Minutely => Tab::Hourly,
-            Tab::Stats => Tab::Minutely,
+            Tab::Monthly => Tab::Minutely,
+            Tab::Stats => Tab::Monthly,
             Tab::Agents => Tab::Stats,
         }
     }
@@ -304,6 +310,10 @@ pub struct App {
     daily_list_selected_index: usize,
     daily_list_scroll_offset: usize,
 
+    pub selected_monthly_detail_month: Option<String>,
+    monthly_list_selected_index: usize,
+    monthly_list_scroll_offset: usize,
+
     pub selected_graph_cell: Option<(usize, usize)>,
     pub stats_breakdown_total_lines: usize,
 
@@ -447,6 +457,9 @@ impl App {
             selected_daily_detail_date: None,
             daily_list_selected_index: 0,
             daily_list_scroll_offset: 0,
+            selected_monthly_detail_month: None,
+            monthly_list_selected_index: 0,
+            monthly_list_scroll_offset: 0,
             selected_graph_cell: None,
             stats_breakdown_total_lines: 0,
             auto_refresh,
@@ -533,6 +546,15 @@ impl App {
                 self.selected_daily_detail_date = None;
                 self.selected_index = self.daily_list_selected_index;
                 self.scroll_offset = self.daily_list_scroll_offset;
+            }
+        }
+
+        // Same for Monthly-detail mode: exit if the month disappeared.
+        if let Some(ref month) = self.selected_monthly_detail_month {
+            if !self.data.monthly.iter().any(|m| &m.month == month) {
+                self.selected_monthly_detail_month = None;
+                self.selected_index = self.monthly_list_selected_index;
+                self.scroll_offset = self.monthly_list_scroll_offset;
             }
         }
 
@@ -885,6 +907,9 @@ impl App {
             KeyCode::Enter if self.current_tab == Tab::Daily => {
                 self.open_selected_daily_detail();
             }
+            KeyCode::Enter if self.current_tab == Tab::Monthly => {
+                self.open_selected_monthly_detail();
+            }
             KeyCode::Enter if self.current_tab == Tab::Stats => {
                 self.handle_graph_selection();
             }
@@ -892,6 +917,11 @@ impl App {
                 if self.current_tab == Tab::Daily && self.is_daily_detail_active() =>
             {
                 self.close_daily_detail();
+            }
+            KeyCode::Esc | KeyCode::Backspace
+                if self.current_tab == Tab::Monthly && self.is_monthly_detail_active() =>
+            {
+                self.close_monthly_detail();
             }
             KeyCode::Esc if self.selected_graph_cell.is_some() => {
                 self.selected_graph_cell = None;
@@ -1541,6 +1571,9 @@ impl App {
         self.selected_daily_detail_date = None;
         self.daily_list_selected_index = 0;
         self.daily_list_scroll_offset = 0;
+        self.selected_monthly_detail_month = None;
+        self.monthly_list_selected_index = 0;
+        self.monthly_list_scroll_offset = 0;
         self.selected_graph_cell = None;
         self.stats_breakdown_total_lines = 0;
     }
@@ -1551,6 +1584,9 @@ impl App {
         self.current_tab = target;
         if target != Tab::Daily {
             self.selected_daily_detail_date = None;
+        }
+        if target != Tab::Monthly {
+            self.selected_monthly_detail_month = None;
         }
 
         let (field, dir) = self
@@ -1565,7 +1601,7 @@ impl App {
     }
 
     fn default_sort_for_tab(tab: Tab) -> (SortField, SortDirection) {
-        if matches!(tab, Tab::Hourly | Tab::Minutely) {
+        if matches!(tab, Tab::Hourly | Tab::Minutely | Tab::Monthly) {
             (SortField::Date, SortDirection::Descending)
         } else {
             (SortField::Cost, SortDirection::Descending)
@@ -1721,6 +1757,10 @@ impl App {
             Tab::Daily => self.data.daily.len(),
             Tab::Hourly => self.data.hourly.len(),
             Tab::Minutely => self.data.minutely.len(),
+            Tab::Monthly if self.is_monthly_detail_active() => {
+                self.get_sorted_monthly_detail_days().len()
+            }
+            Tab::Monthly => self.data.monthly.len(),
             Tab::Stats => {
                 if self.selected_graph_cell.is_some() {
                     self.stats_breakdown_total_lines
@@ -1747,7 +1787,9 @@ impl App {
             self.sort_direction = SortDirection::Descending;
         }
         self.persist_current_sort();
-        if self.current_tab == Tab::Daily && self.is_daily_detail_active() {
+        if (self.current_tab == Tab::Daily && self.is_daily_detail_active())
+            || (self.current_tab == Tab::Monthly && self.is_monthly_detail_active())
+        {
             self.selected_index = 0;
             self.scroll_offset = 0;
         } else {
@@ -1902,6 +1944,56 @@ impl App {
         self.clamp_selection();
     }
 
+    fn open_selected_monthly_detail(&mut self) {
+        if self.is_monthly_detail_active() {
+            return;
+        }
+
+        let selected_month = {
+            let monthly = self.get_sorted_monthly();
+            monthly.get(self.selected_index).map(|m| m.month.clone())
+        };
+
+        if let Some(month) = selected_month {
+            self.monthly_list_selected_index = self.selected_index;
+            self.monthly_list_scroll_offset = self.scroll_offset;
+            self.selected_monthly_detail_month = Some(month.clone());
+            self.selected_index = 0;
+            self.scroll_offset = 0;
+            self.set_status(&format!("Viewing daily breakdown for {}", month));
+            self.clamp_selection();
+        }
+    }
+
+    fn close_monthly_detail(&mut self) {
+        let Some(ref detail_month) = self.selected_monthly_detail_month else {
+            return;
+        };
+        let detail_month = detail_month.clone();
+
+        self.selected_monthly_detail_month = None;
+
+        let restored_index = self
+            .get_sorted_monthly()
+            .iter()
+            .position(|m| m.month == detail_month)
+            .unwrap_or(self.monthly_list_selected_index);
+
+        self.selected_index = restored_index;
+
+        let max_visible = self.max_visible_items.max(1);
+        let viewport_still_holds = restored_index >= self.scroll_offset
+            && restored_index < self.scroll_offset + max_visible;
+        self.scroll_offset = if viewport_still_holds {
+            self.monthly_list_scroll_offset
+        } else {
+            restored_index.saturating_sub(max_visible / 2)
+        };
+
+        self.set_status("Returned to monthly usage");
+        self.clamp_selection();
+    }
+
     fn toggle_auto_refresh(&mut self) {
         self.auto_refresh = !self.auto_refresh;
         if self.auto_refresh {
@@ -1997,6 +2089,14 @@ impl App {
                         m.cost
                     )
                 }),
+            Tab::Monthly if self.is_monthly_detail_active() => self
+                .get_sorted_monthly_detail_days()
+                .get(self.selected_index)
+                .map(|d| format!("{}: {} tokens, ${:.4}", d.date, d.tokens.total(), d.cost)),
+            Tab::Monthly => self
+                .get_sorted_monthly()
+                .get(self.selected_index)
+                .map(|m| format!("{}: {} tokens, ${:.4}", m.month, m.tokens.total(), m.cost)),
             Tab::Stats | Tab::Usage => None,
         };
 
@@ -2146,6 +2246,24 @@ impl App {
 
     pub fn daily_detail_date(&self) -> Option<NaiveDate> {
         self.selected_daily_detail_date
+    }
+
+    pub fn is_monthly_detail_active(&self) -> bool {
+        self.selected_monthly_detail_month.is_some()
+    }
+
+    pub fn monthly_detail_month(&self) -> Option<&str> {
+        self.selected_monthly_detail_month.as_deref()
+    }
+
+    pub fn get_sorted_monthly_detail_days(&self) -> Vec<&DailyUsage> {
+        let Some(month) = self.selected_monthly_detail_month.as_ref() else {
+            return Vec::new();
+        };
+        self.get_sorted_daily()
+            .into_iter()
+            .filter(|day| day.date.format("%Y-%m").to_string() == *month)
+            .collect()
     }
 
     pub fn get_sorted_daily_detail_rows(&self) -> Vec<DailyDetailRow<'_>> {
@@ -2321,6 +2439,43 @@ impl App {
             .collect()
     }
 
+    pub fn get_sorted_monthly(&self) -> Vec<&MonthlyUsage> {
+        let mut monthly: Vec<&MonthlyUsage> = self.data.monthly.iter().collect();
+
+        match (self.sort_field, self.sort_direction) {
+            (SortField::Cost, SortDirection::Descending) => monthly.sort_by(|a, b| {
+                b.cost
+                    .total_cmp(&a.cost)
+                    .then_with(|| b.month.cmp(&a.month))
+            }),
+            (SortField::Cost, SortDirection::Ascending) => monthly.sort_by(|a, b| {
+                a.cost
+                    .total_cmp(&b.cost)
+                    .then_with(|| a.month.cmp(&b.month))
+            }),
+            (SortField::Tokens, SortDirection::Descending) => monthly.sort_by(|a, b| {
+                b.tokens
+                    .total()
+                    .cmp(&a.tokens.total())
+                    .then_with(|| b.month.cmp(&a.month))
+            }),
+            (SortField::Tokens, SortDirection::Ascending) => monthly.sort_by(|a, b| {
+                a.tokens
+                    .total()
+                    .cmp(&b.tokens.total())
+                    .then_with(|| a.month.cmp(&b.month))
+            }),
+            (SortField::Date, SortDirection::Descending) => {
+                monthly.sort_by(|a, b| b.month.cmp(&a.month))
+            }
+            (SortField::Date, SortDirection::Ascending) => {
+                monthly.sort_by(|a, b| a.month.cmp(&b.month))
+            }
+        }
+
+        monthly
+    }
+
     pub fn is_narrow(&self) -> bool {
         self.terminal_width < 80
     }
@@ -2344,15 +2499,16 @@ mod tests {
     #[test]
     fn test_tab_all() {
         let tabs = Tab::all();
-        assert_eq!(tabs.len(), 8);
+        assert_eq!(tabs.len(), 9);
         assert_eq!(tabs[0], Tab::Overview);
         assert_eq!(tabs[1], Tab::Usage);
         assert_eq!(tabs[2], Tab::Models);
         assert_eq!(tabs[3], Tab::Daily);
         assert_eq!(tabs[4], Tab::Hourly);
         assert_eq!(tabs[5], Tab::Minutely);
-        assert_eq!(tabs[6], Tab::Stats);
-        assert_eq!(tabs[7], Tab::Agents);
+        assert_eq!(tabs[6], Tab::Monthly);
+        assert_eq!(tabs[7], Tab::Stats);
+        assert_eq!(tabs[8], Tab::Agents);
     }
 
     #[test]
@@ -2362,7 +2518,8 @@ mod tests {
         assert_eq!(Tab::Models.next(), Tab::Daily);
         assert_eq!(Tab::Daily.next(), Tab::Hourly);
         assert_eq!(Tab::Hourly.next(), Tab::Minutely);
-        assert_eq!(Tab::Minutely.next(), Tab::Stats);
+        assert_eq!(Tab::Minutely.next(), Tab::Monthly);
+        assert_eq!(Tab::Monthly.next(), Tab::Stats);
         assert_eq!(Tab::Stats.next(), Tab::Agents);
         assert_eq!(Tab::Agents.next(), Tab::Overview);
     }
@@ -2375,7 +2532,8 @@ mod tests {
         assert_eq!(Tab::Daily.prev(), Tab::Models);
         assert_eq!(Tab::Hourly.prev(), Tab::Daily);
         assert_eq!(Tab::Minutely.prev(), Tab::Hourly);
-        assert_eq!(Tab::Stats.prev(), Tab::Minutely);
+        assert_eq!(Tab::Monthly.prev(), Tab::Minutely);
+        assert_eq!(Tab::Stats.prev(), Tab::Monthly);
         assert_eq!(Tab::Agents.prev(), Tab::Stats);
     }
 
@@ -2387,6 +2545,7 @@ mod tests {
         assert_eq!(Tab::Daily.as_str(), "Daily");
         assert_eq!(Tab::Hourly.as_str(), "Hourly");
         assert_eq!(Tab::Minutely.as_str(), "Minutely");
+        assert_eq!(Tab::Monthly.as_str(), "Monthly");
         assert_eq!(Tab::Stats.as_str(), "Stats");
     }
 
@@ -2398,6 +2557,7 @@ mod tests {
         assert_eq!(Tab::Daily.short_name(), "Day");
         assert_eq!(Tab::Hourly.short_name(), "Hr");
         assert_eq!(Tab::Minutely.short_name(), "Min");
+        assert_eq!(Tab::Monthly.short_name(), "Mon");
         assert_eq!(Tab::Stats.short_name(), "Sta");
     }
 
@@ -2952,6 +3112,167 @@ mod tests {
         );
     }
 
+    fn monthly_usage(month: &str, input_tokens: u64, cost: f64) -> MonthlyUsage {
+        MonthlyUsage {
+            month: month.to_string(),
+            tokens: TokenBreakdown {
+                input: input_tokens,
+                output: 0,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            cost,
+            message_count: 1,
+            turn_count: 1,
+        }
+    }
+
+    #[test]
+    fn test_get_sorted_monthly_defaults_to_date_descending() {
+        let mut app = make_app();
+        app.switch_tab(Tab::Monthly);
+        app.data.monthly = vec![
+            monthly_usage("2026-03", 100, 1.0),
+            monthly_usage("2026-05", 200, 2.0),
+            monthly_usage("2026-04", 300, 3.0),
+        ];
+
+        let sorted = app
+            .get_sorted_monthly()
+            .iter()
+            .map(|m| m.month.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(sorted, vec!["2026-05", "2026-04", "2026-03"]);
+    }
+
+    #[test]
+    fn test_get_sorted_monthly_by_cost() {
+        let mut app = make_app();
+        app.current_tab = Tab::Monthly;
+        app.sort_field = SortField::Cost;
+        app.sort_direction = SortDirection::Ascending;
+        app.data.monthly = vec![
+            monthly_usage("2026-05", 100, 3.0),
+            monthly_usage("2026-04", 100, 1.0),
+            monthly_usage("2026-06", 100, 2.0),
+        ];
+
+        let sorted = app
+            .get_sorted_monthly()
+            .iter()
+            .map(|m| m.month.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(sorted, vec!["2026-04", "2026-06", "2026-05"]);
+    }
+
+    #[test]
+    fn test_get_sorted_monthly_detail_days_filters_by_month() {
+        let mut app = make_app();
+        app.current_tab = Tab::Monthly;
+        app.selected_monthly_detail_month = Some("2026-05".to_string());
+        app.data.daily = vec![
+            daily_usage("2026-05-10", 1.0, vec![("model-a", "openai", 1.0)]),
+            daily_usage("2026-05-20", 2.0, vec![("model-b", "anthropic", 2.0)]),
+            daily_usage("2026-06-01", 3.0, vec![("model-c", "google", 3.0)]),
+        ];
+
+        let days = app.get_sorted_monthly_detail_days();
+        assert_eq!(days.len(), 2);
+        assert_eq!(days[0].date.to_string(), "2026-05-20");
+        assert_eq!(days[1].date.to_string(), "2026-05-10");
+    }
+
+    #[test]
+    fn test_open_monthly_detail_shows_daily_breakdown() {
+        let mut app = make_app();
+        app.switch_tab(Tab::Monthly);
+        app.data.monthly = vec![
+            monthly_usage("2026-05", 100, 1.0),
+            monthly_usage("2026-04", 200, 2.0),
+        ];
+        app.data.daily = vec![
+            daily_usage("2026-05-10", 1.0, vec![("model-a", "openai", 1.0)]),
+            daily_usage("2026-04-05", 2.0, vec![("model-b", "anthropic", 2.0)]),
+        ];
+
+        app.handle_key_event(key(KeyCode::Enter));
+
+        assert!(app.is_monthly_detail_active());
+        assert_eq!(app.monthly_detail_month(), Some("2026-05"));
+        assert_eq!(app.get_sorted_monthly_detail_days().len(), 1);
+        assert_eq!(app.selected_index, 0);
+    }
+
+    #[test]
+    fn test_esc_closes_monthly_detail_and_restores_selection() {
+        let mut app = make_app();
+        app.switch_tab(Tab::Monthly);
+        app.data.monthly = vec![
+            monthly_usage("2026-05", 100, 1.0),
+            monthly_usage("2026-04", 200, 2.0),
+        ];
+        app.data.daily = vec![
+            daily_usage("2026-05-10", 1.0, vec![("model-a", "openai", 1.0)]),
+            daily_usage("2026-04-05", 2.0, vec![("model-b", "anthropic", 2.0)]),
+        ];
+
+        app.handle_key_event(key(KeyCode::Enter));
+        assert!(app.is_monthly_detail_active());
+
+        app.handle_key_event(key(KeyCode::Esc));
+
+        assert!(!app.is_monthly_detail_active());
+        assert_eq!(app.monthly_detail_month(), None);
+        assert_eq!(app.current_tab, Tab::Monthly);
+    }
+
+    #[test]
+    fn test_switch_tab_clears_monthly_detail() {
+        let mut app = make_app();
+        app.switch_tab(Tab::Monthly);
+        app.data.monthly = vec![monthly_usage("2026-05", 100, 1.0)];
+        app.data.daily = vec![daily_usage(
+            "2026-05-10",
+            1.0,
+            vec![("model-a", "openai", 1.0)],
+        )];
+
+        app.open_selected_monthly_detail();
+        assert!(app.is_monthly_detail_active());
+
+        app.switch_tab(Tab::Daily);
+
+        assert!(!app.is_monthly_detail_active());
+    }
+
+    #[test]
+    fn test_update_data_exits_monthly_detail_when_month_disappears() {
+        let mut app = make_app();
+        app.switch_tab(Tab::Monthly);
+        app.data.monthly = vec![monthly_usage("2026-05", 100, 1.0)];
+        app.data.daily = vec![daily_usage(
+            "2026-05-10",
+            1.0,
+            vec![("model-a", "openai", 1.0)],
+        )];
+
+        app.open_selected_monthly_detail();
+        assert!(app.is_monthly_detail_active());
+
+        app.update_data(UsageData {
+            monthly: vec![monthly_usage("2026-04", 200, 2.0)],
+            daily: vec![daily_usage(
+                "2026-04-05",
+                2.0,
+                vec![("model-b", "anthropic", 2.0)],
+            )],
+            ..Default::default()
+        });
+
+        assert!(!app.is_monthly_detail_active());
+    }
+
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
     }
@@ -3016,6 +3337,9 @@ mod tests {
         assert_eq!(app.current_tab, Tab::Hourly);
 
         app.handle_key_event(key(KeyCode::Tab));
+        assert_eq!(app.current_tab, Tab::Monthly);
+
+        app.handle_key_event(key(KeyCode::Tab));
         assert_eq!(app.current_tab, Tab::Stats);
 
         app.handle_key_event(key(KeyCode::Tab));
@@ -3035,6 +3359,9 @@ mod tests {
 
         app.handle_key_event(key(KeyCode::BackTab));
         assert_eq!(app.current_tab, Tab::Stats);
+
+        app.handle_key_event(key(KeyCode::BackTab));
+        assert_eq!(app.current_tab, Tab::Monthly);
 
         app.handle_key_event(key(KeyCode::BackTab));
         assert_eq!(app.current_tab, Tab::Hourly);
@@ -3064,6 +3391,7 @@ mod tests {
             Tab::Daily,
             Tab::Hourly,
             Tab::Minutely,
+            Tab::Monthly,
             Tab::Stats,
             Tab::Agents,
             Tab::Overview,

--- a/crates/tokscale-cli/src/tui/cache.rs
+++ b/crates/tokscale-cli/src/tui/cache.rs
@@ -15,8 +15,8 @@ use tokscale_core::{sessions, GroupBy, ModelPerformance};
 use crate::ClientFilter;
 
 use super::data::{
-    AgentUsage, ContributionDay, DailyModelInfo, DailySourceInfo, DailyUsage, GraphData,
-    HourlyModelInfo, HourlyUsage, ModelUsage, TokenBreakdown, UsageData,
+    aggregate_monthly_from_daily, AgentUsage, ContributionDay, DailyModelInfo, DailySourceInfo,
+    DailyUsage, GraphData, HourlyModelInfo, HourlyUsage, ModelUsage, TokenBreakdown, UsageData,
 };
 
 /// Cache staleness threshold: 5 minutes (matches TS implementation)
@@ -625,16 +625,19 @@ impl TryFrom<CachedUsageData> for UsageData {
         let hourly: Result<Vec<HourlyUsage>, _> =
             u.hourly.into_iter().map(|h| h.try_into()).collect();
         let graph: Option<Result<GraphData, _>> = u.graph.map(|g| g.try_into());
+        let daily = daily?;
+        let monthly = aggregate_monthly_from_daily(&daily);
 
         Ok(Self {
             models: u.models.into_iter().map(|m| m.into()).collect(),
             agents: normalize_cached_agents(u.agents),
-            daily: daily?,
+            daily,
             hourly: hourly?,
             // Minutely data is recomputed on each load (high cardinality,
             // not worth round-tripping through the on-disk cache); the
             // first foreground refresh after cache hit will populate it.
             minutely: Vec::new(),
+            monthly,
             graph: graph.transpose()?,
             total_tokens: u.total_tokens,
             total_cost: u.total_cost,

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -133,6 +133,15 @@ pub struct MinutelyUsage {
 }
 
 #[derive(Debug, Clone)]
+pub struct MonthlyUsage {
+    pub month: String,
+    pub tokens: TokenBreakdown,
+    pub cost: f64,
+    pub message_count: u32,
+    pub turn_count: u32,
+}
+
+#[derive(Debug, Clone)]
 pub struct ContributionDay {
     pub date: NaiveDate,
     pub tokens: u64,
@@ -152,6 +161,7 @@ pub struct UsageData {
     pub daily: Vec<DailyUsage>,
     pub hourly: Vec<HourlyUsage>,
     pub minutely: Vec<MinutelyUsage>,
+    pub monthly: Vec<MonthlyUsage>,
     pub graph: Option<GraphData>,
     pub total_tokens: u64,
     pub total_cost: f64,
@@ -896,6 +906,8 @@ impl DataLoader {
         let mut minutely: Vec<MinutelyUsage> = minutely_map.into_values().collect();
         minutely.sort_by_key(|b| std::cmp::Reverse(b.datetime));
 
+        let monthly = aggregate_monthly_from_daily(&daily);
+
         let total_tokens: u64 = models.iter().map(|m| m.tokens.total()).sum();
         let total_cost: f64 = models
             .iter()
@@ -911,6 +923,7 @@ impl DataLoader {
             daily,
             hourly,
             minutely,
+            monthly,
             graph: Some(graph),
             total_tokens,
             total_cost,
@@ -1052,6 +1065,42 @@ fn build_contribution_graph_for_today(daily: &[DailyUsage], today: NaiveDate) ->
 
 fn calculate_streaks(daily: &[DailyUsage]) -> (u32, u32) {
     calculate_streaks_for_today(daily, Local::now().date_naive())
+}
+
+pub fn aggregate_monthly_from_daily(daily: &[DailyUsage]) -> Vec<MonthlyUsage> {
+    let mut monthly_map: HashMap<String, MonthlyUsage> = HashMap::new();
+
+    for day in daily {
+        let month = day.date.format("%Y-%m").to_string();
+        let entry = monthly_map
+            .entry(month.clone())
+            .or_insert_with(|| MonthlyUsage {
+                month,
+                tokens: TokenBreakdown::default(),
+                cost: 0.0,
+                message_count: 0,
+                turn_count: 0,
+            });
+
+        entry.tokens.input = entry.tokens.input.saturating_add(day.tokens.input);
+        entry.tokens.output = entry.tokens.output.saturating_add(day.tokens.output);
+        entry.tokens.cache_read = entry
+            .tokens
+            .cache_read
+            .saturating_add(day.tokens.cache_read);
+        entry.tokens.cache_write = entry
+            .tokens
+            .cache_write
+            .saturating_add(day.tokens.cache_write);
+        entry.tokens.reasoning = entry.tokens.reasoning.saturating_add(day.tokens.reasoning);
+        entry.cost += day.cost;
+        entry.message_count = entry.message_count.saturating_add(day.message_count);
+        entry.turn_count = entry.turn_count.saturating_add(day.turn_count);
+    }
+
+    let mut monthly: Vec<MonthlyUsage> = monthly_map.into_values().collect();
+    monthly.sort_by(|a, b| b.month.cmp(&a.month));
+    monthly
 }
 
 fn calculate_streaks_for_today(daily: &[DailyUsage], today: NaiveDate) -> (u32, u32) {
@@ -2645,5 +2694,116 @@ after"#,
         assert_eq!(bucket.tokens.input, 0);
         assert_eq!(bucket.tokens.output, 0);
         assert_eq!(bucket.cost, 0.0);
+    }
+
+    fn daily_usage(
+        date: NaiveDate,
+        input: u64,
+        output: u64,
+        cost: f64,
+        message_count: u32,
+    ) -> DailyUsage {
+        DailyUsage {
+            date,
+            tokens: TokenBreakdown {
+                input,
+                output,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            cost,
+            source_breakdown: BTreeMap::new(),
+            message_count,
+            turn_count: 0,
+        }
+    }
+
+    #[test]
+    fn test_aggregate_monthly_from_daily_groups_by_month() {
+        let daily = vec![
+            daily_usage(
+                NaiveDate::from_ymd_opt(2026, 5, 10).unwrap(),
+                100,
+                50,
+                1.0,
+                2,
+            ),
+            daily_usage(
+                NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
+                200,
+                100,
+                2.0,
+                3,
+            ),
+            daily_usage(
+                NaiveDate::from_ymd_opt(2026, 6, 1).unwrap(),
+                300,
+                150,
+                3.0,
+                4,
+            ),
+        ];
+
+        let monthly = aggregate_monthly_from_daily(&daily);
+        assert_eq!(monthly.len(), 2);
+
+        let may = monthly.iter().find(|m| m.month == "2026-05").unwrap();
+        assert_eq!(may.tokens.input, 300);
+        assert_eq!(may.tokens.output, 150);
+        assert_eq!(may.tokens.total(), 450);
+        assert_eq!(may.cost, 3.0);
+        assert_eq!(may.message_count, 5);
+
+        let june = monthly.iter().find(|m| m.month == "2026-06").unwrap();
+        assert_eq!(june.tokens.input, 300);
+        assert_eq!(june.tokens.output, 150);
+        assert_eq!(june.tokens.total(), 450);
+        assert_eq!(june.cost, 3.0);
+        assert_eq!(june.message_count, 4);
+    }
+
+    #[test]
+    fn test_aggregate_messages_populates_monthly() {
+        let loader = DataLoader::new(None);
+        let base_ms = 1_736_899_200_000_i64; // mid-January 2025 in UTC
+        let usage = loader
+            .aggregate_messages(
+                vec![
+                    make_msg(base_ms, 100, 50, 1.0),
+                    make_msg(base_ms + 86_400_000, 200, 100, 2.0), // +1 day
+                ],
+                &GroupBy::Model,
+            )
+            .unwrap();
+
+        assert_eq!(usage.monthly.len(), 1);
+        assert_eq!(usage.monthly[0].month, "2025-01");
+        assert_eq!(usage.monthly[0].tokens.input, 300);
+        assert_eq!(usage.monthly[0].cost, 3.0);
+    }
+
+    #[test]
+    fn test_aggregate_monthly_sorts_descending() {
+        let daily = vec![
+            daily_usage(
+                NaiveDate::from_ymd_opt(2026, 3, 1).unwrap(),
+                100,
+                50,
+                1.0,
+                1,
+            ),
+            daily_usage(
+                NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+                200,
+                100,
+                2.0,
+                1,
+            ),
+        ];
+
+        let monthly = aggregate_monthly_from_daily(&daily);
+        assert_eq!(monthly[0].month, "2026-05");
+        assert_eq!(monthly[1].month, "2026-03");
     }
 }

--- a/crates/tokscale-cli/src/tui/export.rs
+++ b/crates/tokscale-cli/src/tui/export.rs
@@ -49,6 +49,19 @@ pub fn build_export_json(data: &UsageData) -> Result<String> {
             "turnCount": d.turn_count,
             "cost": d.cost
         })).collect::<Vec<_>>(),
+        "monthly": data.monthly.iter().map(|m| json!({
+            "month": m.month,
+            "tokens": {
+                "input": m.tokens.input,
+                "output": m.tokens.output,
+                "cacheRead": m.tokens.cache_read,
+                "cacheWrite": m.tokens.cache_write,
+                "total": m.tokens.total()
+            },
+            "messageCount": m.message_count,
+            "turnCount": m.turn_count,
+            "cost": m.cost
+        })).collect::<Vec<_>>(),
         "totals": {
             "tokens": data.total_tokens,
             "cost": data.total_cost

--- a/crates/tokscale-cli/src/tui/ui/footer.rs
+++ b/crates/tokscale-cli/src/tui/ui/footer.rs
@@ -158,6 +158,10 @@ fn current_count_label(app: &App) -> String {
         Tab::Daily => format!(" ({} days)", app.data.daily.len()),
         Tab::Hourly => format!(" ({} hours)", app.data.hourly.len()),
         Tab::Minutely => format!(" ({} minutes)", app.data.minutely.len()),
+        Tab::Monthly if app.is_monthly_detail_active() => {
+            format!(" ({} days)", app.get_sorted_monthly_detail_days().len())
+        }
+        Tab::Monthly => format!(" ({} months)", app.data.monthly.len()),
         Tab::Stats | Tab::Usage => String::new(),
     }
 }
@@ -193,6 +197,14 @@ fn render_help_row(frame: &mut Frame, app: &App, area: Rect) {
                 spans.push(Span::styled("j", Style::default().fg(Color::Yellow)));
             }
         }
+        if app.current_tab == Tab::Monthly {
+            spans.push(Span::styled("·", Style::default().fg(app.theme.muted)));
+            if app.is_monthly_detail_active() {
+                spans.push(Span::styled("esc", Style::default().fg(Color::Yellow)));
+            } else {
+                spans.push(Span::styled("↵", Style::default().fg(Color::Yellow)));
+            }
+        }
         if app.current_tab == Tab::Hourly {
             spans.push(Span::styled("·", Style::default().fg(app.theme.muted)));
             spans.push(Span::styled("v", Style::default().fg(Color::Yellow)));
@@ -221,6 +233,20 @@ fn render_help_row(frame: &mut Frame, app: &App, area: Rect) {
                 spans.push(Span::styled(" ", Style::default()));
                 spans.push(Span::styled(
                     "[j:today]",
+                    Style::default().fg(Color::Yellow),
+                ));
+            }
+            spans.push(Span::styled(" • ", Style::default().fg(app.theme.muted)));
+        }
+        if app.current_tab == Tab::Monthly {
+            if app.is_monthly_detail_active() {
+                spans.push(Span::styled(
+                    "[esc:back]",
+                    Style::default().fg(Color::Yellow),
+                ));
+            } else {
+                spans.push(Span::styled(
+                    "[enter:details]",
                     Style::default().fg(Color::Yellow),
                 ));
             }
@@ -406,6 +432,10 @@ mod tests {
         );
         assert_eq!(current_count_label(&make_app_on(Tab::Daily)), " (0 days)");
         assert_eq!(current_count_label(&make_app_on(Tab::Hourly)), " (0 hours)");
+        assert_eq!(
+            current_count_label(&make_app_on(Tab::Monthly)),
+            " (0 months)"
+        );
         assert_eq!(current_count_label(&make_app_on(Tab::Stats)), "");
     }
 

--- a/crates/tokscale-cli/src/tui/ui/mod.rs
+++ b/crates/tokscale-cli/src/tui/ui/mod.rs
@@ -8,6 +8,7 @@ mod hourly;
 mod hourly_profile;
 mod minutely;
 mod models;
+mod monthly;
 mod overview;
 pub mod spinner;
 mod stats;
@@ -51,6 +52,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
             Tab::Daily => daily::render(frame, app, chunks[1]),
             Tab::Hourly => hourly::render(frame, app, chunks[1]),
             Tab::Minutely => minutely::render(frame, app, chunks[1]),
+            Tab::Monthly => monthly::render(frame, app, chunks[1]),
             Tab::Stats => stats::render(frame, app, chunks[1]),
             Tab::Usage => usage::render(frame, app, chunks[1]),
         }

--- a/crates/tokscale-cli/src/tui/ui/monthly.rs
+++ b/crates/tokscale-cli/src/tui/ui/monthly.rs
@@ -1,0 +1,658 @@
+use ratatui::prelude::*;
+use ratatui::widgets::{
+    Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, Table,
+};
+
+use super::widgets::{
+    format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens,
+    viewport_scrollbar_state,
+};
+use crate::tui::app::{App, SortDirection, SortField};
+
+pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
+    if app.is_monthly_detail_active() {
+        render_detail(frame, app, area);
+        return;
+    }
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(app.theme.border))
+        .title(Span::styled(
+            " Monthly Usage ",
+            Style::default()
+                .fg(app.theme.accent)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .style(Style::default().bg(app.theme.background));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let visible_height = inner.height.saturating_sub(1) as usize;
+    app.set_max_visible_items(visible_height);
+
+    let monthly = app.get_sorted_monthly();
+    if monthly.is_empty() {
+        let empty_msg = Paragraph::new("No monthly usage data found. Press 'r' to refresh.")
+            .style(Style::default().fg(app.theme.muted))
+            .alignment(Alignment::Center);
+        frame.render_widget(empty_msg, inner);
+        return;
+    }
+
+    let is_narrow = app.is_narrow();
+    let is_very_narrow = app.is_very_narrow();
+    let has_turn_data = monthly.iter().any(|m| m.turn_count > 0);
+    let sort_field = app.sort_field;
+    let sort_direction = app.sort_direction;
+    let scroll_offset = app.scroll_offset;
+    let selected_index = app.selected_index;
+    let theme_accent = app.theme.accent;
+    let theme_selection = app.theme.selection;
+    let metric_input_style = app.theme.metric_input_style();
+    let metric_output_style = app.theme.metric_output_style();
+    let metric_cache_read_style = app.theme.metric_cache_read_style();
+    let metric_cache_write_style = app.theme.metric_cache_write_style();
+    let striped_row_style = app.theme.striped_row_style();
+
+    let full_layout_width: u16 = if has_turn_data { 112 } else { 105 };
+    let compact_full_date = !is_narrow && !is_very_narrow && inner.width < full_layout_width;
+    let month_col_width: u16 = if compact_full_date { 7 } else { 12 };
+
+    let header_cells = if is_very_narrow {
+        vec!["Month", "Cost"]
+    } else if is_narrow {
+        if has_turn_data {
+            vec!["Month", "Turn", "Msgs", "Tokens", "Cost"]
+        } else {
+            vec!["Month", "Msgs", "Tokens", "Cost"]
+        }
+    } else if has_turn_data {
+        vec![
+            "Month", "Turn", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache×", "Total",
+            "Cost", "Cost/1M",
+        ]
+    } else {
+        vec![
+            "Month", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache×", "Total", "Cost",
+            "Cost/1M",
+        ]
+    };
+
+    let sort_indicator = |field: SortField| -> &'static str {
+        if sort_field == field {
+            match sort_direction {
+                SortDirection::Ascending => " ▲",
+                SortDirection::Descending => " ▼",
+            }
+        } else {
+            ""
+        }
+    };
+
+    let header = Row::new(
+        header_cells
+            .iter()
+            .enumerate()
+            .map(|(i, h)| {
+                let indicator = match (i, is_narrow, is_very_narrow) {
+                    (0, _, _) => sort_indicator(SortField::Date),
+                    (8, false, false) if has_turn_data => sort_indicator(SortField::Tokens),
+                    (7, false, false) if !has_turn_data => sort_indicator(SortField::Tokens),
+                    (3, true, false) if has_turn_data => sort_indicator(SortField::Tokens),
+                    (2, true, false) if !has_turn_data => sort_indicator(SortField::Tokens),
+                    (9, false, false) if has_turn_data => sort_indicator(SortField::Cost),
+                    (8, false, false) if !has_turn_data => sort_indicator(SortField::Cost),
+                    (4, true, false) if has_turn_data => sort_indicator(SortField::Cost),
+                    (3, true, false) if !has_turn_data => sort_indicator(SortField::Cost),
+                    (1, _, true) => sort_indicator(SortField::Cost),
+                    _ => "",
+                };
+                Cell::from(format!("{}{}", h, indicator))
+            })
+            .collect::<Vec<_>>(),
+    )
+    .style(
+        Style::default()
+            .fg(theme_accent)
+            .add_modifier(Modifier::BOLD),
+    )
+    .height(1);
+
+    let monthly_len = monthly.len();
+    let start = scroll_offset.min(monthly_len);
+    let end = (start + visible_height).min(monthly_len);
+
+    if start >= monthly_len {
+        return;
+    }
+
+    let rows: Vec<Row> = monthly[start..end]
+        .iter()
+        .enumerate()
+        .map(|(i, month)| {
+            let idx = i + start;
+            let is_selected = idx == selected_index;
+            let is_striped = idx % 2 == 1;
+
+            let cells: Vec<Cell> = if is_very_narrow {
+                vec![
+                    Cell::from(month.month.clone()),
+                    Cell::from(format_cost(month.cost)).style(Style::default().fg(Color::Green)),
+                ]
+            } else if is_narrow {
+                let mut cells = vec![Cell::from(month.month.clone())];
+                if has_turn_data {
+                    let turn_str = if month.turn_count > 0 {
+                        month.turn_count.to_string()
+                    } else {
+                        "\u{2014}".to_string()
+                    };
+                    cells.push(Cell::from(turn_str));
+                }
+                cells.extend([
+                    Cell::from(month.message_count.to_string()),
+                    Cell::from(format_tokens(month.tokens.total())),
+                    Cell::from(format_cost(month.cost)).style(Style::default().fg(Color::Green)),
+                ]);
+                cells
+            } else {
+                let mut cells = vec![Cell::from(month.month.clone())];
+                if has_turn_data {
+                    let turn_str = if month.turn_count > 0 {
+                        month.turn_count.to_string()
+                    } else {
+                        "\u{2014}".to_string()
+                    };
+                    cells.push(Cell::from(turn_str));
+                }
+                cells.extend([
+                    Cell::from(month.message_count.to_string()),
+                    Cell::from(format_tokens(month.tokens.input)).style(metric_input_style),
+                    Cell::from(format_tokens(month.tokens.output)).style(metric_output_style),
+                    Cell::from(format_tokens(month.tokens.cache_read))
+                        .style(metric_cache_read_style),
+                    Cell::from(format_tokens(month.tokens.cache_write))
+                        .style(metric_cache_write_style),
+                    Cell::from(format_cache_hit_rate(
+                        month.tokens.cache_read,
+                        month.tokens.input,
+                        month.tokens.cache_write,
+                    ))
+                    .style(Style::default().fg(Color::Cyan)),
+                    Cell::from(format_tokens(month.tokens.total())),
+                    Cell::from(format_cost(month.cost)).style(Style::default().fg(Color::Green)),
+                    Cell::from(format_cost_per_million(month.cost, month.tokens.total()))
+                        .style(Style::default().fg(Color::Rgb(150, 200, 150))),
+                ]);
+                cells
+            };
+
+            let row_style = if is_selected {
+                Style::default().bg(theme_selection)
+            } else if is_striped {
+                striped_row_style
+            } else {
+                Style::default()
+            };
+
+            Row::new(cells).style(row_style).height(1)
+        })
+        .collect();
+
+    let widths = if is_very_narrow {
+        vec![Constraint::Percentage(60), Constraint::Percentage(40)]
+    } else if is_narrow && has_turn_data {
+        vec![
+            Constraint::Percentage(30),
+            Constraint::Percentage(15),
+            Constraint::Percentage(15),
+            Constraint::Percentage(20),
+            Constraint::Percentage(20),
+        ]
+    } else if is_narrow {
+        vec![
+            Constraint::Percentage(35),
+            Constraint::Percentage(20),
+            Constraint::Percentage(25),
+            Constraint::Percentage(20),
+        ]
+    } else if has_turn_data {
+        vec![
+            Constraint::Length(month_col_width),
+            Constraint::Length(6),
+            Constraint::Length(6),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(8),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+        ]
+    } else {
+        vec![
+            Constraint::Length(month_col_width),
+            Constraint::Length(6),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(8),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+        ]
+    };
+
+    let table = Table::new(rows, widths)
+        .header(header)
+        .row_highlight_style(Style::default().bg(theme_selection));
+
+    frame.render_widget(table, inner);
+
+    if monthly_len > visible_height {
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(Some("▲"))
+            .end_symbol(Some("▼"));
+
+        let mut scrollbar_state =
+            viewport_scrollbar_state(monthly_len, scroll_offset, visible_height);
+
+        frame.render_stateful_widget(
+            scrollbar,
+            area.inner(Margin {
+                horizontal: 0,
+                vertical: 1,
+            }),
+            &mut scrollbar_state,
+        );
+    }
+}
+
+fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
+    let title = app
+        .monthly_detail_month()
+        .map(|month| format!(" Daily Breakdown: {} ", month))
+        .unwrap_or_else(|| " Daily Breakdown ".to_string());
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(app.theme.border))
+        .title(Span::styled(
+            title,
+            Style::default()
+                .fg(app.theme.accent)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .style(Style::default().bg(app.theme.background));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let visible_height = inner.height.saturating_sub(1) as usize;
+    app.set_max_visible_items(visible_height);
+
+    let days = app.get_sorted_monthly_detail_days();
+    if days.is_empty() {
+        let empty_msg = Paragraph::new("No daily data found for this month. Press Esc to go back.")
+            .style(Style::default().fg(app.theme.muted))
+            .alignment(Alignment::Center);
+        frame.render_widget(empty_msg, inner);
+        return;
+    }
+
+    let is_narrow = app.is_narrow();
+    let is_very_narrow = app.is_very_narrow();
+    let has_turn_data = days.iter().any(|d| d.turn_count > 0);
+    let sort_field = app.sort_field;
+    let sort_direction = app.sort_direction;
+    let scroll_offset = app.scroll_offset;
+    let selected_index = app.selected_index;
+    let theme_accent = app.theme.accent;
+    let theme_selection = app.theme.selection;
+    let metric_input_style = app.theme.metric_input_style();
+    let metric_output_style = app.theme.metric_output_style();
+    let metric_cache_read_style = app.theme.metric_cache_read_style();
+    let metric_cache_write_style = app.theme.metric_cache_write_style();
+    let striped_row_style = app.theme.striped_row_style();
+
+    let full_layout_width: u16 = if has_turn_data { 112 } else { 105 };
+    let compact_full_date = !is_narrow && !is_very_narrow && inner.width < full_layout_width;
+    let date_col_width: u16 = if compact_full_date { 7 } else { 12 };
+    let date_fmt: &str = if is_very_narrow {
+        "%m/%d"
+    } else if is_narrow || compact_full_date {
+        "%m-%d"
+    } else {
+        "%Y-%m-%d"
+    };
+
+    let header_cells = if is_very_narrow {
+        vec!["Date", "Cost"]
+    } else if is_narrow {
+        if has_turn_data {
+            vec!["Date", "Turn", "Msgs", "Tokens", "Cost"]
+        } else {
+            vec!["Date", "Msgs", "Tokens", "Cost"]
+        }
+    } else if has_turn_data {
+        vec![
+            "Date", "Turn", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache×", "Total",
+            "Cost", "Cost/1M",
+        ]
+    } else {
+        vec![
+            "Date", "Msgs", "Input", "Output", "Cache R", "Cache W", "Cache×", "Total", "Cost",
+            "Cost/1M",
+        ]
+    };
+
+    let sort_indicator = |field: SortField| -> &'static str {
+        if sort_field == field {
+            match sort_direction {
+                SortDirection::Ascending => " ▲",
+                SortDirection::Descending => " ▼",
+            }
+        } else {
+            ""
+        }
+    };
+
+    let header = Row::new(
+        header_cells
+            .iter()
+            .enumerate()
+            .map(|(i, h)| {
+                let indicator = match (i, is_narrow, is_very_narrow) {
+                    (0, _, _) => sort_indicator(SortField::Date),
+                    (8, false, false) if has_turn_data => sort_indicator(SortField::Tokens),
+                    (7, false, false) if !has_turn_data => sort_indicator(SortField::Tokens),
+                    (3, true, false) if has_turn_data => sort_indicator(SortField::Tokens),
+                    (2, true, false) if !has_turn_data => sort_indicator(SortField::Tokens),
+                    (9, false, false) if has_turn_data => sort_indicator(SortField::Cost),
+                    (8, false, false) if !has_turn_data => sort_indicator(SortField::Cost),
+                    (4, true, false) if has_turn_data => sort_indicator(SortField::Cost),
+                    (3, true, false) if !has_turn_data => sort_indicator(SortField::Cost),
+                    (1, _, true) => sort_indicator(SortField::Cost),
+                    _ => "",
+                };
+                Cell::from(format!("{}{}", h, indicator))
+            })
+            .collect::<Vec<_>>(),
+    )
+    .style(
+        Style::default()
+            .fg(theme_accent)
+            .add_modifier(Modifier::BOLD),
+    )
+    .height(1);
+
+    let days_len = days.len();
+    let start = scroll_offset.min(days_len);
+    let end = (start + visible_height).min(days_len);
+
+    if start >= days_len {
+        return;
+    }
+
+    let rows: Vec<Row> = days[start..end]
+        .iter()
+        .enumerate()
+        .map(|(i, day)| {
+            let idx = i + start;
+            let is_selected = idx == selected_index;
+            let is_striped = idx % 2 == 1;
+
+            let cells: Vec<Cell> = if is_very_narrow {
+                vec![
+                    Cell::from(day.date.format(date_fmt).to_string()),
+                    Cell::from(format_cost(day.cost)).style(Style::default().fg(Color::Green)),
+                ]
+            } else if is_narrow {
+                let mut cells = vec![Cell::from(day.date.format(date_fmt).to_string())];
+                if has_turn_data {
+                    let turn_str = if day.turn_count > 0 {
+                        day.turn_count.to_string()
+                    } else {
+                        "\u{2014}".to_string()
+                    };
+                    cells.push(Cell::from(turn_str));
+                }
+                cells.extend([
+                    Cell::from(day.message_count.to_string()),
+                    Cell::from(format_tokens(day.tokens.total())),
+                    Cell::from(format_cost(day.cost)).style(Style::default().fg(Color::Green)),
+                ]);
+                cells
+            } else {
+                let mut cells = vec![Cell::from(day.date.format(date_fmt).to_string())];
+                if has_turn_data {
+                    let turn_str = if day.turn_count > 0 {
+                        day.turn_count.to_string()
+                    } else {
+                        "\u{2014}".to_string()
+                    };
+                    cells.push(Cell::from(turn_str));
+                }
+                cells.extend([
+                    Cell::from(day.message_count.to_string()),
+                    Cell::from(format_tokens(day.tokens.input)).style(metric_input_style),
+                    Cell::from(format_tokens(day.tokens.output)).style(metric_output_style),
+                    Cell::from(format_tokens(day.tokens.cache_read)).style(metric_cache_read_style),
+                    Cell::from(format_tokens(day.tokens.cache_write))
+                        .style(metric_cache_write_style),
+                    Cell::from(format_cache_hit_rate(
+                        day.tokens.cache_read,
+                        day.tokens.input,
+                        day.tokens.cache_write,
+                    ))
+                    .style(Style::default().fg(Color::Cyan)),
+                    Cell::from(format_tokens(day.tokens.total())),
+                    Cell::from(format_cost(day.cost)).style(Style::default().fg(Color::Green)),
+                    Cell::from(format_cost_per_million(day.cost, day.tokens.total()))
+                        .style(Style::default().fg(Color::Rgb(150, 200, 150))),
+                ]);
+                cells
+            };
+
+            let row_style = if is_selected {
+                Style::default().bg(theme_selection)
+            } else if is_striped {
+                striped_row_style
+            } else {
+                Style::default()
+            };
+
+            Row::new(cells).style(row_style).height(1)
+        })
+        .collect();
+
+    let widths = if is_very_narrow {
+        vec![Constraint::Percentage(60), Constraint::Percentage(40)]
+    } else if is_narrow && has_turn_data {
+        vec![
+            Constraint::Percentage(30),
+            Constraint::Percentage(15),
+            Constraint::Percentage(15),
+            Constraint::Percentage(20),
+            Constraint::Percentage(20),
+        ]
+    } else if is_narrow {
+        vec![
+            Constraint::Percentage(35),
+            Constraint::Percentage(20),
+            Constraint::Percentage(25),
+            Constraint::Percentage(20),
+        ]
+    } else if has_turn_data {
+        vec![
+            Constraint::Length(date_col_width),
+            Constraint::Length(6),
+            Constraint::Length(6),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(8),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+        ]
+    } else {
+        vec![
+            Constraint::Length(date_col_width),
+            Constraint::Length(6),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(8),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+        ]
+    };
+
+    let table = Table::new(rows, widths)
+        .header(header)
+        .row_highlight_style(Style::default().bg(theme_selection));
+
+    frame.render_widget(table, inner);
+
+    if days_len > visible_height {
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(Some("▲"))
+            .end_symbol(Some("▼"));
+
+        let mut scrollbar_state = viewport_scrollbar_state(days_len, scroll_offset, visible_height);
+
+        frame.render_stateful_widget(
+            scrollbar,
+            area.inner(Margin {
+                horizontal: 0,
+                vertical: 1,
+            }),
+            &mut scrollbar_state,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::app::{Tab, TuiConfig};
+    use crate::tui::data::{DailyUsage, MonthlyUsage, TokenBreakdown};
+    use chrono::NaiveDate;
+    use ratatui::{backend::TestBackend, Terminal};
+    use std::collections::BTreeMap;
+
+    fn month(month: &str, input: u64, cost: f64) -> MonthlyUsage {
+        MonthlyUsage {
+            month: month.to_string(),
+            tokens: TokenBreakdown {
+                input,
+                output: 0,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            cost,
+            message_count: 1,
+            turn_count: 0,
+        }
+    }
+
+    fn day(date: &str, input: u64, cost: f64) -> DailyUsage {
+        DailyUsage {
+            date: NaiveDate::parse_from_str(date, "%Y-%m-%d").unwrap(),
+            tokens: TokenBreakdown {
+                input,
+                output: 0,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            cost,
+            source_breakdown: BTreeMap::new(),
+            message_count: 1,
+            turn_count: 0,
+        }
+    }
+
+    fn make_app(width: u16) -> App {
+        let config = TuiConfig {
+            theme: "blue".to_string(),
+            refresh: 0,
+            sessions_path: None,
+            clients: None,
+            since: None,
+            until: None,
+            year: None,
+            initial_tab: None,
+        };
+        let mut app = App::new_with_cached_data(config, None).unwrap();
+        app.terminal_width = width;
+        app.current_tab = Tab::Monthly;
+        app.sort_field = SortField::Date;
+        app.sort_direction = SortDirection::Descending;
+        app
+    }
+
+    fn render_body(app: &mut App, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render(frame, app, Rect::new(0, 0, width, height)))
+            .unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .chunks(width as usize)
+            .map(|row| {
+                row.iter()
+                    .map(|c| c.symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn wide_terminal_renders_full_monthly_columns() {
+        let mut app = make_app(130);
+        app.data.monthly = vec![month("2026-05", 1000, 1.5)];
+        let body = render_body(&mut app, 130, 12);
+        assert!(
+            body.contains("Cache×"),
+            "expected cache hit rate column\n{body}"
+        );
+        assert!(
+            body.contains("Cost/1M"),
+            "expected cost per million column\n{body}"
+        );
+        assert!(body.contains("2026-05"), "expected month row\n{body}");
+    }
+
+    #[test]
+    fn monthly_detail_renders_daily_breakdown_title() {
+        let mut app = make_app(130);
+        app.data.monthly = vec![month("2026-05", 1000, 1.5)];
+        app.data.daily = vec![day("2026-05-10", 500, 0.75), day("2026-04-05", 200, 0.25)];
+        app.selected_monthly_detail_month = Some("2026-05".to_string());
+
+        let body = render_body(&mut app, 130, 12);
+        assert!(
+            body.contains("Daily Breakdown: 2026-05"),
+            "expected detail title\n{body}"
+        );
+        assert!(body.contains("2026-05-10"), "expected daily row\n{body}");
+        assert!(
+            !body.contains("2026-04-05"),
+            "should not show other months\n{body}"
+        );
+    }
+}


### PR DESCRIPTION
Adds a new **Monthly** tab to the TUI that mirrors the Daily Usage table columns and lets users drill down into a month’s daily breakdown.

## What's Changed
- Added `MonthlyUsage` data model and `aggregate_monthly_from_daily()` helper.
- Added `Tab::Monthly` with full Daily-style columns: Month/Date, Turn, Msgs, Input, Output, Cache R, Cache W, Cache×, Total, Cost, Cost/1M.
- Added Enter/Esc keybindings to open and close a month’s daily breakdown inline.
- Updated footer count labels and help text for summary and detail modes.
- Updated cache refresh and data export to include monthly aggregation.
- Updated `tokscale monthly` to launch the TUI on the Monthly tab.
- Added unit tests for aggregation, sorting, detail filtering, keybindings, and full-column rendering.
## Screenshots
<img width="978" height="247" alt="image" src="https://github.com/user-attachments/assets/9a1d19b8-e5f4-4c95-aeda-624c7ddddb93" />
<img width="1039" height="449" alt="image" src="https://github.com/user-attachments/assets/a3baa7f8-a6ea-429e-9867-91d6f8277fae" />
## Verification
- `cargo check -p tokscale-cli` passes.
- `cargo fmt -p tokscale-cli -- --check` passes.
- `cargo test -p tokscale-cli` passes except for one unrelated date-sensitive pre-existing test (`usage_reset_button_renders_when_credit_available`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Monthly tab to the TUI with inline daily drill-down, plus a fix to restore the monthly viewport after closing details and a small performance improvement in monthly detail filtering.

- **New Features**
  - Added `MonthlyUsage` and `aggregate_monthly_from_daily()`; monthly data computed on cache load/refresh and sortable by Date/Cost/Tokens (defaults to Date ↓).
  - New `Monthly` tab with Daily-style columns (adaptive on narrow screens) and Enter-to-open/Esc-to-close daily breakdown.
  - Tab cycle updated to include Monthly; `tokscale monthly` starts on the Monthly tab.
  - Footer counts and help text reflect summary/detail modes; export JSON now includes a `monthly` array.
  - Detail view exits if a month disappears after refresh and restores selection/scroll on close; tests cover aggregation, sorting, drill-down, keybindings, and rendering.

- **Performance**
  - Reduced allocations when filtering daily rows in the Monthly detail view.

<sup>Written for commit 2011b7fdd7cd7ced26fe6f13b30f2bd97f0fcbf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

