### PR TITLE
fix(mux): make the dedup key workspace-scoped and stable across re-parses

### DIFF
--- a/crates/tokscale-core/src/sessions/mux.rs
+++ b/crates/tokscale-core/src/sessions/mux.rs
@@ -73,8 +73,7 @@ pub fn parse_mux_file(path: &Path) -> Vec<UnifiedMessage> {
 
     by_model
         .into_iter()
-        .enumerate()
-        .filter_map(|(index, (model_key, model_usage))| {
+        .filter_map(|(model_key, model_usage)| {
             let tokens =
                 |b: &Option<MuxTokenBucket>| b.as_ref().and_then(|b| b.tokens).unwrap_or(0).max(0);
             let cost =
@@ -94,9 +93,13 @@ pub fn parse_mux_file(path: &Path) -> Vec<UnifiedMessage> {
                 return None;
             }
 
-            // Stable per-row dedup key so incremental re-parse collapses the
-            // same model entry instead of double-counting it.
-            let dedup_key = Some(format!("mux:{model_key}:{index}"));
+            // Workspace-scoped, stable dedup key so an incremental re-parse
+            // collapses the same model entry instead of double-counting it,
+            // while two workspaces that used the same model stay distinct. The
+            // previous positional index was the HashMap iteration position
+            // (unstable across re-parses) and made the first model in every
+            // workspace file `mux:<model>:0`, colliding across workspaces.
+            let dedup_key = Some(format!("mux:{session_id}:{model_key}"));
 
             // Strip "provider:" prefix for model ID (e.g., "anthropic:claude-opus-4-6" -> "claude-opus-4-6")
             let (provider, model_id) = if model_key.contains(':') {
@@ -317,5 +320,51 @@ mod tests {
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].provider_id, "provider");
         assert_eq!(msgs[0].model_id, "sub:model-name");
+    }
+
+    #[test]
+    fn test_dedup_key_distinct_across_workspaces() {
+        // Two mux workspaces that recorded the same model must produce distinct
+        // dedup keys. The positional key `mux:<model>:<index>` gave the first
+        // model in every workspace file `mux:<model>:0`, so two
+        // `.mux/sessions/<workspaceId>/session-usage.json` files with the same
+        // model collided in a cross-file dedup set and one workspace's usage was
+        // dropped. The index is also the HashMap iteration position, unstable
+        // across re-parses. Keying on the workspace id (the file's parent
+        // directory) is both unique per workspace and stable across re-parses.
+        let dir = tempfile::tempdir().unwrap();
+        let json = r#"{
+            "version": 1,
+            "byModel": {
+                "anthropic:claude-opus-4-6": {
+                    "input": { "tokens": 100 },
+                    "output": { "tokens": 200 }
+                }
+            },
+            "lastRequest": { "timestamp": 1700000000000 }
+        }"#;
+
+        let write_workspace = |workspace: &str| {
+            let workspace_dir = dir.path().join(workspace);
+            std::fs::create_dir_all(&workspace_dir).unwrap();
+            let file = workspace_dir.join("session-usage.json");
+            std::fs::write(&file, json).unwrap();
+            file
+        };
+
+        let alpha = write_workspace("ws_alpha");
+        let beta = write_workspace("ws_beta");
+
+        let alpha_key = parse_mux_file(&alpha)[0].dedup_key.clone();
+        let beta_key = parse_mux_file(&beta)[0].dedup_key.clone();
+
+        assert!(alpha_key.is_some());
+        assert_ne!(
+            alpha_key, beta_key,
+            "same model in two workspaces must not share a dedup key"
+        );
+
+        // Re-parsing the same workspace file yields a stable key.
+        assert_eq!(alpha_key, parse_mux_file(&alpha)[0].dedup_key);
     }
 }


### PR DESCRIPTION
`parse_mux_file` keyed each model row on `mux:<model_key>:<index>`, and the comment states the key exists so an incremental re-parse collapses a repeated model entry. That key cannot serve the purpose: `<index>` is the `byModel` `HashMap` iteration position, so it is unstable across re-parses, and it is only per-file positional, so the first model in every `.mux/sessions/<workspaceId>/session-usage.json` file is `mux:<model>:0` and two workspaces with the same model collide.

This keys on the workspace id instead (the session file's parent directory, already computed for `session_id`): `mux:<workspaceId>:<model_key>` -- unique per workspace and stable across re-parses, aligning mux with the stable dedup keys the other parsers emit.

`test_dedup_key_distinct_across_workspaces` writes two workspace files with the same model and asserts their dedup keys differ; it fails on the pre-fix tree (both are `mux:anthropic:claude-opus-4-6:0`) and passes after.

mux's dedup_key currently has no consumer (it is `extend`ed without a `_seen` filter, unlike the other dedup_key-bearing clients), so I did not bump `CACHE_SCHEMA_VERSION`: changing an unread cached value does not warrant forcing a full reparse for all clients. Happy to add the bump, or to wire mux into a dedup filter, if you would prefer.

Fixes #816


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `mux` dedup keys workspace-scoped and stable to prevent cross-workspace collisions and double-counting on incremental re-parses. Replaces positional `mux:<model_key>:<index>` with `mux:<workspaceId>:<model_key>`.

- Bug Fixes
  - Dedup key now `mux:<workspaceId>:<model_key>`; stable across re-parses and unique per workspace.
  - Eliminates collisions from the old `mux:<model_key>:0` pattern and avoids double-counting.
  - Added `test_dedup_key_distinct_across_workspaces`; no `CACHE_SCHEMA_VERSION` bump (dedup key unused).

<sup>Written for commit c3c01620d7495ca3bfb30a148eca7b01fa7433f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

