### PR TITLE
fix(copilot): prefer the invoke_agent span for the trace fallback agent

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -25,7 +25,11 @@ use std::time::UNIX_EPOCH;
 // token_usage, so invalidate them.
 // 24: UnifiedMessage now carries cost_source so cached provider-reported costs
 // are not repriced as if they were missing.
-const CACHE_SCHEMA_VERSION: u32 = 24;
+// 25: Copilot trace-level fallback agent now prefers the invoke_agent span's
+// agent id over the first-exported span, so agentless turns are no longer
+// mis-attributed to a sub-agent under an out-of-order OTel export; schema-24
+// caches carry the mis-attributed agent, so invalidate them.
+const CACHE_SCHEMA_VERSION: u32 = 25;
 const CACHE_FILENAME: &str = "source-message-cache.bin";
 const CACHE_LOCK_FILENAME: &str = "source-message-cache.lock";
 const MAX_CACHE_FILE_BYTES: u64 = 256 * 1024 * 1024;

--- a/crates/tokscale-core/src/sessions/copilot.rs
+++ b/crates/tokscale-core/src/sessions/copilot.rs
@@ -85,6 +85,7 @@ struct TraceContext {
     session_id: Option<String>,
     session_id_priority: SessionIdPriority,
     agent_id: Option<String>,
+    agent_from_invoke_agent: bool,
 }
 
 struct CopilotUsageCandidate {
@@ -146,6 +147,7 @@ fn collect_trace_contexts(records: &[Value]) -> HashMap<String, TraceContext> {
                 session_id: None,
                 session_id_priority: SessionIdPriority::Missing,
                 agent_id: None,
+                agent_from_invoke_agent: false,
             });
 
         if context.model.is_none() {
@@ -160,15 +162,19 @@ fn collect_trace_contexts(records: &[Value]) -> HashMap<String, TraceContext> {
         }
 
         // Trace-level agent is only a FALLBACK for records that carry no
-        // gen_ai.agent.id of their own (see candidate_from_attributes). We keep
-        // the first non-empty agent id in the trace — for Copilot CLI this is
-        // the invoke_agent span's agent, which is the right default for plain
-        // chat turns that omit the attribute. Per-record agent ids (e.g. a
-        // sub-agent turn) take precedence at attribution time, so this
-        // first-wins lock does not mis-attribute records that name their agent.
-        if context.agent_id.is_none() {
-            if let Some(agent_id) = first_non_empty_attr(attributes, &["gen_ai.agent.id"]) {
+        // gen_ai.agent.id of their own (see candidate_from_attributes). Prefer
+        // the invoke_agent span's agent id (the trace default) and otherwise
+        // keep the first non-empty id, because OTel export order is not
+        // guaranteed: a child chat/sub-agent span may be exported before its
+        // parent invoke_agent span, and a plain first-wins lock would then make
+        // the sub-agent the trace fallback and mis-attribute agentless turns.
+        // Per-record agent ids still take precedence at attribution time.
+        if let Some(agent_id) = first_non_empty_attr(attributes, &["gen_ai.agent.id"]) {
+            let from_invoke_agent = is_agent_summary_span_record(record, attributes);
+            if (from_invoke_agent && !context.agent_from_invoke_agent) || context.agent_id.is_none()
+            {
                 context.agent_id = Some(agent_id.to_string());
+                context.agent_from_invoke_agent = from_invoke_agent;
             }
         }
     }
@@ -904,6 +910,36 @@ mod tests {
             messages[0].agent.as_deref(),
             Some("github.copilot.reviewer")
         );
+    }
+
+    #[test]
+    fn test_parse_copilot_cli_trace_agent_prefers_invoke_agent_over_child_span() {
+        // OTel export order is not guaranteed. A child chat span that carries
+        // its own gen_ai.agent.id (a sub-agent turn) can be exported BEFORE the
+        // parent invoke_agent span. The trace-level fallback agent must still
+        // resolve to the invoke_agent span's default rather than whichever agent
+        // id appears first in the trace, so a later agentless turn inherits the
+        // trace default instead of the sub-agent that happened to export first.
+        let content = r#"{"type":"span","traceId":"trace-order","spanId":"chat-sub","name":"chat claude-sonnet-4.6","endTime":[1775934261,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.provider.name":"github","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.response.model":"claude-sonnet-4.6","gen_ai.response.id":"resp-sub","gen_ai.agent.id":"github.copilot.reviewer","gen_ai.usage.input_tokens":100,"gen_ai.usage.output_tokens":10}}
+{"type":"span","traceId":"trace-order","spanId":"invoke-1","name":"invoke_agent","endTime":[1775934260,0],"attributes":{"gen_ai.operation.name":"invoke_agent","gen_ai.provider.name":"github","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.agent.id":"github.copilot.default"}}
+{"type":"span","traceId":"trace-order","spanId":"chat-plain","name":"chat gpt-5.4-mini","endTime":[1775934264,967317833],"attributes":{"gen_ai.operation.name":"chat","gen_ai.provider.name":"github","gen_ai.request.model":"gpt-5.4-mini","gen_ai.response.model":"gpt-5.4-mini","gen_ai.response.id":"resp-plain","gen_ai.usage.input_tokens":200,"gen_ai.usage.output_tokens":20}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        // The child sub-agent turn keeps its own agent id (per-record wins).
+        let sub = messages
+            .iter()
+            .find(|message| message.model_id == "claude-sonnet-4.6")
+            .unwrap();
+        assert_eq!(sub.agent.as_deref(), Some("github.copilot.reviewer"));
+        // The agentless turn inherits the invoke_agent default, not the
+        // sub-agent that happened to export first.
+        let plain = messages
+            .iter()
+            .find(|message| message.model_id == "gpt-5.4-mini")
+            .unwrap();
+        assert_eq!(plain.agent.as_deref(), Some("github.copilot.default"));
     }
 
     #[test]


### PR DESCRIPTION
`collect_trace_contexts` locked the trace-level fallback agent to the first non-empty `gen_ai.agent.id` seen in the trace, assuming the `invoke_agent` span exports before the per-turn chat spans. OTel export order is not guaranteed, so a child chat / sub-agent span that carries its own `gen_ai.agent.id` can be exported before its parent `invoke_agent` span. The fallback then locks onto the sub-agent, and a later agentless turn in the same trace inherits the sub-agent id instead of the trace default.

This prefers the `invoke_agent` span's agent id for the trace fallback (tracked with a new `agent_from_invoke_agent` flag) and otherwise keeps the first non-empty id. Per-record agent ids still take precedence at attribution time, so a record that names its own agent is unaffected.

`test_parse_copilot_cli_trace_agent_prefers_invoke_agent_over_child_span` exports a sub-agent chat span before its parent `invoke_agent` span and asserts a later agentless turn attributes to the trace default; it fails before the change (attributes to the sub-agent) and passes after.

Bumps `CACHE_SCHEMA_VERSION` 24 -> 25 so caches holding the mis-attributed agent reparse. (If a sibling schema-touching fix lands first, this needs a trivial rebase to the next number.)

Fixes #820


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mis-attribution of Copilot agent IDs when OTel exports child spans before the parent. Agentless turns now inherit the correct default from the `invoke_agent` span. Fixes #820.

- **Bug Fixes**
  - Prefer the `invoke_agent` span’s `gen_ai.agent.id` for the trace fallback; otherwise keep the first non-empty value. Per-record agent IDs still take precedence.
  - Track fallback source with `agent_from_invoke_agent` to prevent sub-agent spans from hijacking the trace default.
  - Add a regression test to cover out-of-order exports.

- **Migration**
  - Bump `CACHE_SCHEMA_VERSION` from 24 to 25 to invalidate caches with mis-attributed agents; old traces will reparse automatically.

<sup>Written for commit 480cd387db24e279a12fee976a9687c034fdf5cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

