### PR TITLE
fix(zcode): subtract cache/reasoning overlap from input/output

### DIFF
--- a/crates/tokscale-core/src/sessions/zcode.rs
+++ b/crates/tokscale-core/src/sessions/zcode.rs
@@ -350,12 +350,12 @@ pub fn parse_zcode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
         ORDER BY COALESCE(mu.completed_at, mu.started_at, 0), mu.id
     "#;
 
-    let mut stmt = match conn
-        .prepare(modern_query)
-        .or_else(|_| conn.prepare(legacy_query))
-    {
-        Ok(stmt) => stmt,
-        Err(_) => return Vec::new(),
+    let (mut stmt, is_legacy_schema) = match conn.prepare(modern_query) {
+        Ok(stmt) => (stmt, false),
+        Err(_) => match conn.prepare(legacy_query) {
+            Ok(stmt) => (stmt, true),
+            Err(_) => return Vec::new(),
+        },
     };
 
     let rows = match stmt.query_map([], |row| {
@@ -418,18 +418,28 @@ pub fn parse_zcode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
                 raw_reasoning,
                 Some(total),
             ),
-            // `computed_total_tokens` is absent only on pre-migration rows
-            // read through the legacy-schema fallback query. Every sampled
-            // row in a real ZCode database (all providers/models) is
-            // cache/reasoning-inclusive — see the fix PR description for the
-            // sampled evidence — so subtract unconditionally rather than
-            // passing the raw, overlap-laden columns straight through.
-            None => (
+            // When `computed_total_tokens` is NULL, distinguish two cases:
+            // 1. Legacy schema (column doesn't exist): unconditionally subtract,
+            //    since every sampled row in a real ZCode database is confirmed
+            //    cache/reasoning-inclusive.
+            // 2. Modern schema but this row's value is NULL: can't detect shape,
+            //    so pass through unchanged (the normalize function's default when
+            //    total is None). Subtracting unconditionally here would undercount
+            //    rows that are already cache-exclusive.
+            None if is_legacy_schema => (
                 subtract_overlap(
                     raw_input,
                     raw_cache_read.max(0).saturating_add(raw_cache_write.max(0)),
                 ),
                 subtract_overlap(raw_output, raw_reasoning),
+            ),
+            None => normalize_zcode_input_and_output(
+                raw_input,
+                raw_output,
+                raw_cache_read,
+                raw_cache_write,
+                raw_reasoning,
+                None,
             ),
         };
 

--- a/crates/tokscale-core/src/sessions/zcode.rs
+++ b/crates/tokscale-core/src/sessions/zcode.rs
@@ -43,36 +43,59 @@ struct ZcodeEntry {
 /// Token usage block — field names follow the Z.ai / GLM API convention.
 #[derive(Debug, Deserialize)]
 struct ZcodeUsage {
-    #[serde(alias = "input_tokens", alias = "prompt_tokens")]
+    #[serde(alias = "input_tokens", alias = "prompt_tokens", alias = "inputTokens")]
     input: Option<i64>,
-    #[serde(alias = "output_tokens", alias = "completion_tokens")]
+    #[serde(
+        alias = "output_tokens",
+        alias = "completion_tokens",
+        alias = "outputTokens"
+    )]
     output: Option<i64>,
-    #[serde(alias = "input_cache_read", alias = "cache_read_tokens")]
+    #[serde(
+        alias = "input_cache_read",
+        alias = "cache_read_tokens",
+        alias = "cacheReadTokens"
+    )]
     cache_read: Option<i64>,
-    #[serde(alias = "input_cache_creation", alias = "cache_write_tokens")]
+    #[serde(
+        alias = "input_cache_creation",
+        alias = "cache_write_tokens",
+        alias = "cacheCreationTokens"
+    )]
     cache_write: Option<i64>,
-    #[serde(default)]
+    #[serde(default, alias = "reasoningTokens")]
     reasoning: Option<i64>,
+    #[serde(default, alias = "totalTokens")]
+    total: Option<i64>,
 }
 
 impl ZcodeUsage {
     fn to_breakdown(&self) -> Option<TokenBreakdown> {
-        let input = self.input.unwrap_or(0).max(0);
-        let output = self.output.unwrap_or(0).max(0);
-        let cache_read = self.cache_read.unwrap_or(0).max(0);
-        let cache_write = self.cache_write.unwrap_or(0).max(0);
-        let reasoning = self.reasoning.unwrap_or(0).max(0);
+        let raw_input = self.input.unwrap_or(0).max(0);
+        let raw_output = self.output.unwrap_or(0).max(0);
+        let raw_cache_read = self.cache_read.unwrap_or(0).max(0);
+        let raw_cache_write = self.cache_write.unwrap_or(0).max(0);
+        let raw_reasoning = self.reasoning.unwrap_or(0).max(0);
 
-        if input + output + cache_read + cache_write + reasoning == 0 {
+        if raw_input + raw_output + raw_cache_read + raw_cache_write + raw_reasoning == 0 {
             return None;
         }
 
+        let (net_input, net_output) = normalize_zcode_input_and_output(
+            raw_input,
+            raw_output,
+            raw_cache_read,
+            raw_cache_write,
+            raw_reasoning,
+            self.total,
+        );
+
         Some(TokenBreakdown {
-            input,
-            output,
-            cache_read,
-            cache_write,
-            reasoning,
+            input: net_input,
+            output: net_output,
+            cache_read: raw_cache_read,
+            cache_write: raw_cache_write,
+            reasoning: raw_reasoning,
         })
     }
 }
@@ -203,6 +226,68 @@ pub fn parse_zcode_file(path: &Path) -> Vec<UnifiedMessage> {
     messages
 }
 
+/// Subtract `overlap` out of `value`, clamping both operands to non-negative
+/// and never going below zero. Mirrors `gemini.rs`'s `subtract_cached_overlap`
+/// but takes the pre-summed overlap directly, since ZCode's `input_tokens`
+/// absorbs two separate buckets (cache read + cache write) rather than one.
+fn subtract_overlap(value: i64, overlap: i64) -> i64 {
+    let value = value.max(0);
+    let overlap = overlap.max(0);
+    value.saturating_sub(overlap.min(value))
+}
+
+/// ZCode's `model_usage` rows report `input_tokens` and `output_tokens` as
+/// cache/reasoning-inclusive: `input_tokens` already contains
+/// `cache_read_input_tokens` + `cache_creation_input_tokens`, and
+/// `output_tokens` already contains `reasoning_tokens`. Tokscale's
+/// `TokenBreakdown` instead expects five non-overlapping buckets, so passing
+/// the raw columns straight through double-counts cache and reasoning in
+/// `TokenBreakdown::total()`.
+///
+/// When a reported `total` is available we use it to detect which shape
+/// we're looking at, mirroring `gemini.rs`'s
+/// `normalize_gemini_session_input_and_cache`: if the reported total matches
+/// the cache/reasoning-inclusive sum (`input + output`) rather than the fully
+/// additive sum (`input + output + cache_read + cache_write + reasoning`),
+/// the row is inclusive and needs the overlap subtracted.
+///
+/// When `total` is absent, the shape can't be detected here, so the raw
+/// input/output are returned unchanged; callers that have separate evidence
+/// about their data source's shape (e.g. `parse_zcode_sqlite`'s legacy-schema
+/// fallback) apply their own subtraction. Returns `(net_input, net_output)`.
+fn normalize_zcode_input_and_output(
+    input: i64,
+    output: i64,
+    cache_read: i64,
+    cache_write: i64,
+    reasoning: i64,
+    total: Option<i64>,
+) -> (i64, i64) {
+    let input = input.max(0);
+    let output = output.max(0);
+    let cache_overlap = cache_read.max(0).saturating_add(cache_write.max(0));
+    let reasoning = reasoning.max(0);
+
+    let Some(total) = total.map(|value| value.max(0)) else {
+        return (input, output);
+    };
+
+    let inclusive_total = input.saturating_add(output);
+    let exclusive_total = inclusive_total
+        .saturating_add(cache_overlap)
+        .saturating_add(reasoning);
+
+    if (cache_overlap > 0 || reasoning > 0) && total == inclusive_total && total != exclusive_total
+    {
+        return (
+            subtract_overlap(input, cache_overlap),
+            subtract_overlap(output, reasoning),
+        );
+    }
+
+    (input, output)
+}
+
 pub fn parse_zcode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
     let Some(conn) = open_readonly_sqlite(db_path) else {
         return Vec::new();
@@ -223,6 +308,7 @@ pub fn parse_zcode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             mu.reasoning_tokens,
             mu.cache_read_input_tokens,
             mu.cache_creation_input_tokens,
+            mu.computed_total_tokens,
             NULLIF(mu.agent, ''),
             NULLIF(mu.mode, ''),
             NULLIF(s.directory, ''),
@@ -250,6 +336,7 @@ pub fn parse_zcode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             mu.reasoning_tokens,
             mu.cache_read_input_tokens,
             mu.cache_creation_input_tokens,
+            NULL,
             NULLIF(mu.agent, ''),
             NULLIF(mu.mode, ''),
             NULL,
@@ -285,10 +372,11 @@ pub fn parse_zcode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             reasoning_tokens: row.get(9)?,
             cache_read_input_tokens: row.get(10)?,
             cache_creation_input_tokens: row.get(11)?,
-            agent: row.get(12)?,
-            mode: row.get(13)?,
-            session_directory: row.get(14)?,
-            session_path: row.get(15)?,
+            computed_total_tokens: row.get(12)?,
+            agent: row.get(13)?,
+            mode: row.get(14)?,
+            session_directory: row.get(15)?,
+            session_path: row.get(16)?,
         })
     }) {
         Ok(rows) => rows,
@@ -314,12 +402,43 @@ pub fn parse_zcode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             .completed_at
             .or(row.started_at)
             .unwrap_or(fallback_timestamp);
+
+        let raw_input = row.input_tokens.unwrap_or(0);
+        let raw_output = row.output_tokens.unwrap_or(0);
+        let raw_cache_read = row.cache_read_input_tokens.unwrap_or(0);
+        let raw_cache_write = row.cache_creation_input_tokens.unwrap_or(0);
+        let raw_reasoning = row.reasoning_tokens.unwrap_or(0);
+
+        let (net_input, net_output) = match row.computed_total_tokens {
+            Some(total) => normalize_zcode_input_and_output(
+                raw_input,
+                raw_output,
+                raw_cache_read,
+                raw_cache_write,
+                raw_reasoning,
+                Some(total),
+            ),
+            // `computed_total_tokens` is absent only on pre-migration rows
+            // read through the legacy-schema fallback query. Every sampled
+            // row in a real ZCode database (all providers/models) is
+            // cache/reasoning-inclusive — see the fix PR description for the
+            // sampled evidence — so subtract unconditionally rather than
+            // passing the raw, overlap-laden columns straight through.
+            None => (
+                subtract_overlap(
+                    raw_input,
+                    raw_cache_read.max(0).saturating_add(raw_cache_write.max(0)),
+                ),
+                subtract_overlap(raw_output, raw_reasoning),
+            ),
+        };
+
         let tokens = TokenBreakdown {
-            input: row.input_tokens.unwrap_or(0).max(0),
-            output: row.output_tokens.unwrap_or(0).max(0),
-            cache_read: row.cache_read_input_tokens.unwrap_or(0).max(0),
-            cache_write: row.cache_creation_input_tokens.unwrap_or(0).max(0),
-            reasoning: row.reasoning_tokens.unwrap_or(0).max(0),
+            input: net_input,
+            output: net_output,
+            cache_read: raw_cache_read.max(0),
+            cache_write: raw_cache_write.max(0),
+            reasoning: raw_reasoning.max(0),
         };
 
         if tokens.total() == 0 {
@@ -371,6 +490,7 @@ struct ZcodeUsageRow {
     reasoning_tokens: Option<i64>,
     cache_read_input_tokens: Option<i64>,
     cache_creation_input_tokens: Option<i64>,
+    computed_total_tokens: Option<i64>,
     agent: Option<String>,
     mode: Option<String>,
     session_directory: Option<String>,
@@ -456,6 +576,7 @@ mod tests {
                 reasoning_tokens INTEGER,
                 cache_read_input_tokens INTEGER,
                 cache_creation_input_tokens INTEGER,
+                computed_total_tokens INTEGER,
                 agent TEXT,
                 mode TEXT
             );
@@ -693,8 +814,8 @@ mod tests {
             INSERT INTO model_usage (
                 id, session_id, turn_id, model_id, started_at, completed_at,
                 duration_ms, input_tokens, output_tokens, reasoning_tokens,
-                cache_read_input_tokens, cache_creation_input_tokens, agent, mode
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+                cache_read_input_tokens, cache_creation_input_tokens, computed_total_tokens, agent, mode
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
             "#,
             params![
                 "usage_1",
@@ -709,6 +830,7 @@ mod tests {
                 5_i64,
                 7_i64,
                 3_i64,
+                120_i64,
                 "zcode-agent",
                 "yolo",
             ],
@@ -725,8 +847,8 @@ mod tests {
         assert_eq!(msg.session_id, "sess_1");
         assert_eq!(msg.timestamp, 1_782_718_001_000_i64);
         assert_eq!(msg.duration_ms, Some(1000));
-        assert_eq!(msg.tokens.input, 100);
-        assert_eq!(msg.tokens.output, 20);
+        assert_eq!(msg.tokens.input, 90);
+        assert_eq!(msg.tokens.output, 15);
         assert_eq!(msg.tokens.reasoning, 5);
         assert_eq!(msg.tokens.cache_read, 7);
         assert_eq!(msg.tokens.cache_write, 3);
@@ -768,5 +890,85 @@ mod tests {
         assert_eq!(messages.len(), 2);
         assert!(messages[0].is_turn_start);
         assert!(!messages[1].is_turn_start);
+    }
+
+    #[test]
+    fn test_parse_zcode_sqlite_cache_inclusive_normalization() {
+        let dir = TempDir::new().unwrap();
+        let db_path = create_zcode_sqlite_db(&dir);
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            r#"
+            INSERT INTO model_usage (
+                id, session_id, model_id, completed_at,
+                input_tokens, output_tokens, reasoning_tokens,
+                cache_read_input_tokens, cache_creation_input_tokens, computed_total_tokens
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+            "#,
+            params![
+                "usage_cache_incl",
+                "sess_cache",
+                "glm-5.2",
+                1_000_i64,
+                100_i64,
+                50_i64,
+                10_i64,
+                80_i64,
+                5_i64,
+                150_i64,
+            ],
+        )
+        .unwrap();
+
+        let messages = parse_zcode_sqlite(&db_path);
+
+        assert_eq!(messages.len(), 1);
+        let msg = &messages[0];
+        assert_eq!(msg.tokens.input, 15);
+        assert_eq!(msg.tokens.output, 40);
+        assert_eq!(msg.tokens.cache_read, 80);
+        assert_eq!(msg.tokens.cache_write, 5);
+        assert_eq!(msg.tokens.reasoning, 10);
+        assert_eq!(msg.tokens.total(), 150);
+    }
+
+    #[test]
+    fn test_parse_zcode_sqlite_cache_exclusive_preserved() {
+        let dir = TempDir::new().unwrap();
+        let db_path = create_zcode_sqlite_db(&dir);
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            r#"
+            INSERT INTO model_usage (
+                id, session_id, model_id, completed_at,
+                input_tokens, output_tokens, reasoning_tokens,
+                cache_read_input_tokens, cache_creation_input_tokens, computed_total_tokens
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+            "#,
+            params![
+                "usage_cache_excl",
+                "sess_excl",
+                "claude-sonnet-5",
+                1_000_i64,
+                20_i64,
+                30_i64,
+                5_i64,
+                80_i64,
+                10_i64,
+                145_i64,
+            ],
+        )
+        .unwrap();
+
+        let messages = parse_zcode_sqlite(&db_path);
+
+        assert_eq!(messages.len(), 1);
+        let msg = &messages[0];
+        assert_eq!(msg.tokens.input, 20);
+        assert_eq!(msg.tokens.output, 30);
+        assert_eq!(msg.tokens.cache_read, 80);
+        assert_eq!(msg.tokens.cache_write, 10);
+        assert_eq!(msg.tokens.reasoning, 5);
+        assert_eq!(msg.tokens.total(), 145);
     }
 }

--- a/crates/tokscale-core/src/sessions/zcode.rs
+++ b/crates/tokscale-core/src/sessions/zcode.rs
@@ -350,10 +350,21 @@ pub fn parse_zcode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
         ORDER BY COALESCE(mu.completed_at, mu.started_at, 0), mu.id
     "#;
 
-    let (mut stmt, is_legacy_schema) = match conn.prepare(modern_query) {
-        Ok(stmt) => (stmt, false),
+    // Probe the `computed_total_tokens` column directly instead of inferring
+    // legacy schema from the modern query failing to prepare: the modern query
+    // also LEFT JOINs the `session` table, so it can fail for reasons
+    // unrelated to the column's existence (e.g. a missing or renamed session
+    // table). Conflating those would send modern-schema rows with NULL totals
+    // through the unconditional subtraction below (potential undercount)
+    // instead of the safe pass-through.
+    let is_legacy_schema = conn
+        .prepare("SELECT computed_total_tokens FROM model_usage LIMIT 1")
+        .is_err();
+
+    let mut stmt = match conn.prepare(modern_query) {
+        Ok(stmt) => stmt,
         Err(_) => match conn.prepare(legacy_query) {
-            Ok(stmt) => (stmt, true),
+            Ok(stmt) => stmt,
             Err(_) => return Vec::new(),
         },
     };
@@ -940,6 +951,111 @@ mod tests {
         assert_eq!(msg.tokens.cache_write, 5);
         assert_eq!(msg.tokens.reasoning, 10);
         assert_eq!(msg.tokens.total(), 150);
+    }
+
+    #[test]
+    fn test_parse_zcode_sqlite_legacy_schema_subtracts_unconditionally() {
+        // True legacy schema: no `computed_total_tokens` column (and no
+        // `session` table), so the column probe and the modern query both
+        // fail and the legacy fallback runs with is_legacy_schema=true.
+        // Every row must then take the unconditional-subtraction branch.
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("db.sqlite");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE model_usage (
+                id TEXT PRIMARY KEY,
+                session_id TEXT,
+                turn_id TEXT,
+                model_id TEXT,
+                started_at INTEGER,
+                completed_at INTEGER,
+                duration_ms INTEGER,
+                input_tokens INTEGER,
+                output_tokens INTEGER,
+                reasoning_tokens INTEGER,
+                cache_read_input_tokens INTEGER,
+                cache_creation_input_tokens INTEGER,
+                agent TEXT,
+                mode TEXT
+            );
+            "#,
+        )
+        .unwrap();
+        conn.execute(
+            r#"
+            INSERT INTO model_usage (
+                id, session_id, model_id, completed_at,
+                input_tokens, output_tokens, reasoning_tokens,
+                cache_read_input_tokens, cache_creation_input_tokens
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+            "#,
+            params![
+                "usage_legacy",
+                "sess_legacy",
+                "glm-5.2",
+                1_000_i64,
+                100_i64,
+                50_i64,
+                10_i64,
+                80_i64,
+                5_i64,
+            ],
+        )
+        .unwrap();
+
+        let messages = parse_zcode_sqlite(&db_path);
+
+        assert_eq!(messages.len(), 1);
+        let msg = &messages[0];
+        assert_eq!(msg.tokens.input, 15);
+        assert_eq!(msg.tokens.output, 40);
+        assert_eq!(msg.tokens.cache_read, 80);
+        assert_eq!(msg.tokens.cache_write, 5);
+        assert_eq!(msg.tokens.reasoning, 10);
+        assert_eq!(msg.tokens.total(), 150);
+    }
+
+    #[test]
+    fn test_parse_zcode_sqlite_modern_schema_null_total_passes_through() {
+        // Modern schema (computed_total_tokens column exists) but this row's
+        // value is NULL: the shape can't be detected, so input/output must
+        // pass through unchanged rather than being unconditionally subtracted.
+        let dir = TempDir::new().unwrap();
+        let db_path = create_zcode_sqlite_db(&dir);
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            r#"
+            INSERT INTO model_usage (
+                id, session_id, model_id, completed_at,
+                input_tokens, output_tokens, reasoning_tokens,
+                cache_read_input_tokens, cache_creation_input_tokens, computed_total_tokens
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, NULL)
+            "#,
+            params![
+                "usage_null_total",
+                "sess_null",
+                "glm-5.2",
+                1_000_i64,
+                100_i64,
+                50_i64,
+                10_i64,
+                80_i64,
+                5_i64,
+            ],
+        )
+        .unwrap();
+
+        let messages = parse_zcode_sqlite(&db_path);
+
+        assert_eq!(messages.len(), 1);
+        let msg = &messages[0];
+        assert_eq!(msg.tokens.input, 100);
+        assert_eq!(msg.tokens.output, 50);
+        assert_eq!(msg.tokens.cache_read, 80);
+        assert_eq!(msg.tokens.cache_write, 5);
+        assert_eq!(msg.tokens.reasoning, 10);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

ZCode's `model_usage` SQLite table (and the JSONL transcript `usage`/`token_usage` blocks) report `input_tokens` and `output_tokens` as **inclusive** of cache and reasoning tokens, not disjoint from them:

- `input_tokens` already contains `cache_read_input_tokens` + `cache_creation_input_tokens`
- `output_tokens` already contains `reasoning_tokens`

`parse_zcode_sqlite()` and `ZcodeUsage::to_breakdown()` pass these columns straight through into `TokenBreakdown`, and `TokenBreakdown::total()` sums all five buckets as if they were disjoint — so cache and reasoning tokens get double-counted.

## Evidence

Sampled the full `model_usage` table from a real `~/.zcode/cli/db/db.sqlite` (1300+ rows, every provider/model combination — Claude, GLM, GPT, DeepSeek, Qwen — all via the ZCode client):

- `computed_total_tokens == input_tokens + output_tokens` holds with **zero exceptions** across the entire table.
- `output_tokens >= reasoning_tokens` always holds (reasoning is nested inside output, never additional).
- `input_tokens >= cache_read_input_tokens + cache_creation_input_tokens` always holds (both cache buckets are nested inside input).

Sample rows (GLM-5.2 via ZCode):

| input_tokens | cache_read_input_tokens | input − cache_read | output_tokens |
|---|---|---|---|
| 140159 | 139584 | 575 | 139 |
| 139524 | 139264 | 260 | 96 |
| 139252 | 138944 | 308 | 227 |

Sample rows (Claude Sonnet 5 via ZCode) — a row with both cache and reasoning double-counting present:

```
input_tokens=15211, output_tokens=2295, reasoning_tokens=2094,
cache_read_input_tokens=14336, cache_creation_input_tokens=0,
computed_total_tokens=17506

naive total() = 15211+2295+2094+14336+0 = 33936   (94% inflated)
correct total = input+output              = 17506
```

The same Claude model routed through the **`claude` client** (Claude Code's own session files, not ZCode) shows the opposite, cache-exclusive shape (`input` far smaller than `cache_read`), confirming this is a ZCode-client-specific data format issue, not a provider/model quirk.

## Fix

Following the existing pattern in `gemini.rs` (`normalize_gemini_session_input_and_cache` / `subtract_cached_overlap`):

- Added `normalize_zcode_input_and_output()`: when a reported total is available, compares it against the inclusive sum (`input + output`) vs. the fully-additive sum to detect the shape, then subtracts the cache/reasoning overlap out of `input`/`output` accordingly.
- `parse_zcode_sqlite()` now selects `computed_total_tokens` and uses it for detection. For the legacy-schema fallback query (no `computed_total_tokens` column), subtracts unconditionally — every sampled row in a real database is confirmed inclusive.
- `ZcodeUsage::to_breakdown()` (JSONL path) gets the same detection, gated on an optional `total`/`totalTokens` field. When absent, behavior is unchanged, since I don't have confirmed evidence about the shape of JSONL usage blocks that omit a total (see note below).

## Scope note: JSONL path directory/field mismatch

While verifying this, I found that `parse_zcode_file()`'s assumptions (path `~/.zcode/projects/<slug>/<session>.jsonl`, snake_case `usage` fields) don't match a real, current ZCode installation, which stores transcripts at `~/.zcode/cli/agents/<sess>/<agent>/transcript.jsonl` with camelCase fields (`inputTokens`, `outputTokens`, `totalTokens`, `cacheReadTokens`, `reasoningTokens`). I added the camelCase aliases and the `total`/`totalTokens` field to `ZcodeUsage` so the detection now also works against real transcript data, but did not change the directory-scanning logic — that's a separate, pre-existing bug outside this PR's scope, and I don't have enough certainty about which ZCode versions use which layout to safely change the file-discovery code here.

## Testing

- Added `test_parse_zcode_sqlite_cache_inclusive_normalization` and `test_parse_zcode_sqlite_cache_exclusive_preserved` (non-regression) to `zcode.rs`.
- Updated `test_parse_zcode_sqlite_model_usage`'s fixture to include `computed_total_tokens` and assert the normalized (not raw) input/output values.
- `cargo test --package tokscale-core sessions::zcode` — 13/13 pass.
- `cargo test --package tokscale-core` — no new failures vs. `main` (pre-existing 35 failures are unrelated path/env-var isolation issues on Windows, confirmed identical on `main` before this change).
- `cargo fmt` and `cargo clippy --package tokscale-core --lib` — clean.

## Related

[`Javis603/token-monitor` PR #68](https://github.com/Javis603/token-monitor/pull/68) hit the same cache-inclusive issue downstream. If this lands, that patch could likely be simplified or removed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes double-counted ZCode tokens by subtracting cache and reasoning overlap from input/output so totals reflect real usage. Adds shape detection using reported totals and supports camelCase JSONL fields.

- **Bug Fixes**
  - Detect inclusive shape via computed totals; subtract `cache_read + cache_write` from input and `reasoning` from output.
  - `parse_zcode_sqlite()` reads `computed_total_tokens` and normalizes; probes the column directly to detect legacy schema and only subtracts unconditionally for true legacy DBs. Modern rows with NULL totals pass through unchanged.
  - `ZcodeUsage` adds camelCase aliases (`inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`, `reasoningTokens`, `totalTokens`) and applies detection only when a total is present.
  - Tests cover inclusive normalization, exclusive preservation, legacy unconditional subtraction, and modern NULL-total pass-through; fixtures updated.

<sup>Written for commit daf12af8d3055a14c882367ee0442b4fbd6a8f0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

