### PR TITLE
test(tui): make usage_reset_button_renders_when_credit_available deterministic

### DIFF
--- a/crates/tokscale-cli/src/tui/ui/usage.rs
+++ b/crates/tokscale-cli/src/tui/ui/usage.rs
@@ -2501,6 +2501,7 @@ mod tests {
     };
     use crate::tui::app::{Tab, TuiConfig};
     use crate::tui::data::UsageData;
+    use chrono::{Duration, Utc};
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use ratatui::{backend::TestBackend, Terminal};
 
@@ -2534,10 +2535,22 @@ mod tests {
         output
     }
 
+    /// An RFC3339 instant far enough ahead of "now" that
+    /// `helpers::format_reset_time` always takes the absolute-date branch
+    /// (`resets <month> <day> <time>`), independent of wall-clock date or
+    /// local timezone. Using a hardcoded date here previously caused
+    /// `usage_reset_button_renders_when_credit_available` to fail whenever
+    /// tests ran within 24h of, on/after, or under a timezone that shifted,
+    /// the hardcoded expiry — see #828.
+    fn far_future_reset_timestamp() -> String {
+        (Utc::now() + Duration::days(10)).to_rfc3339()
+    }
+
     fn output_with_reset_credits(
         provider: &str,
         account: Option<UsageAccount>,
         available_count: u32,
+        expires_at: &str,
     ) -> UsageOutput {
         let mut output = output(provider, account);
         output.reset_credits = Some(UsageResetCredits {
@@ -2546,7 +2559,7 @@ mod tests {
                 id: Some("credit_1".to_string()),
                 status: Some("available".to_string()),
                 reset_type: Some("codex_rate_limits".to_string()),
-                expires_at: Some("2026-07-12T01:31:33Z".to_string()),
+                expires_at: Some(expires_at.to_string()),
                 title: Some("One free rate limit reset".to_string()),
                 description: None,
             }],
@@ -2670,6 +2683,7 @@ mod tests {
                 is_active: true,
             }),
             1,
+            &far_future_reset_timestamp(),
         );
         output.metrics.clear();
         app.subscription_usage = vec![output];
@@ -3062,6 +3076,7 @@ mod tests {
     #[test]
     fn usage_reset_button_renders_when_credit_available() {
         let mut app = make_app();
+        let expires_at = far_future_reset_timestamp();
         app.subscription_usage = vec![output_with_reset_credits(
             "Codex",
             Some(UsageAccount {
@@ -3070,9 +3085,11 @@ mod tests {
                 is_active: true,
             }),
             2,
+            &expires_at,
         )];
 
         let body = render_body(&mut app, 180, 32);
+        let expected_expiry = helpers::format_reset_time(&expires_at).replace("resets", "expires");
 
         assert!(body.contains("Reset Bank"), "{body}");
         assert!(body.contains("2 available"), "{body}");
@@ -3080,7 +3097,7 @@ mod tests {
         assert!(body.contains(" Reset "), "{body}");
         assert!(body.contains("Credit Bank"), "{body}");
         assert!(body.contains("2 credits"), "{body}");
-        assert!(body.contains("expires Jul 12"), "{body}");
+        assert!(body.contains(&expected_expiry), "{body}");
         let state_line = body
             .lines()
             .find(|line| line.contains("State"))
@@ -3207,6 +3224,7 @@ mod tests {
                     is_active: true,
                 }),
                 1,
+                &far_future_reset_timestamp(),
             ),
             output(
                 "Codex",
@@ -3250,6 +3268,7 @@ mod tests {
                 is_active: true,
             }),
             1,
+            &far_future_reset_timestamp(),
         )];
 
         let body = render_body(&mut app, 120, 24);


### PR DESCRIPTION
## Summary

Fixes #828. `tui::ui::usage::tests::usage_reset_button_renders_when_credit_available` hardcoded a fixed credit expiry (`2026-07-12T01:31:33Z`) and asserted a hardcoded rendered substring (`expires Jul 12`). `helpers::format_reset_time` derives that string from `Utc::now()` at test-run time, so the assertion silently depended on wall-clock time and the local/CI timezone.

## Root cause

Three independent ways this breaks, confirmed by simulating `format_reset_time`'s branch logic against the hardcoded date:

- Any local/CI timezone offset west of UTC by more than ~1.5h (US Pacific, US Eastern, etc.) renders the previous calendar day — `01:31 UTC` rolls back to `Jul 11` under a negative offset, since `chrono::Local` reads the OS/runner timezone. This fails on *any* date, not just near the deadline, which likely explains it showing up during review of #807, #812, and #825.
- Within 24h of the hardcoded expiry (from `2026-07-11T01:31:33Z` onward) it renders a relative countdown (`resets in Xh Ym`) instead of an absolute date.
- From the expiry onward — forever — it renders `resets now`, a permanent, unconditional failure once the calendar passes `2026-07-12T01:31:33Z`.

## Fix

- Added a `far_future_reset_timestamp()` test helper returning `(Utc::now() + Duration::days(10)).to_rfc3339()`, comfortably outside the 24h-relative window regardless of when the test runs.
- Threaded it through `output_with_reset_credits` as an explicit `expires_at: &str` parameter instead of a hardcoded literal, updating all 4 call sites.
- The flaky test now derives its expected substring via `helpers::format_reset_time(&expires_at).replace("resets", "expires")` — the same production code path the widget itself uses — instead of asserting against a hardcoded literal.

This mirrors the deterministic-test idiom already used elsewhere in the same file: `format_reset_time_with_now`'s own unit tests in `helpers.rs` call it with fixed instants for both `reset_at` and `now`, and the other reset-credit tests in `usage.rs` use unparseable placeholder strings like `"reset-a"` to sidestep date math via the `Err` fallback in `format_reset_time`.

## Testing

- `cargo test -p tokscale-cli` — full `tui::ui::usage::tests` module (40 tests) passes, including the fixed test.
- `TZ=America/Los_Angeles cargo test -p tokscale-cli usage_reset_button_renders_when_credit_available` — passes under the exact negative-UTC-offset condition that a Python simulation confirmed breaks the old hardcoded-date assertion (direct regression proof, not just logic review).
- `cargo fmt --all -- --check` and `cargo clippy --locked --workspace --all-features -- -D warnings` — clean.
- `cargo test --workspace --all-features` — 844+122+1091+10+4+3+3+4 passed, 0 failed.

## Note

I don't have write access to this repo, so I can't verify CI directly on this PR — happy to address any feedback.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `usage_reset_button_renders_when_credit_available` test deterministic by generating a future expiry and deriving the expected text from the same formatter used in the UI. This removes timezone and date-based flakiness.

- **Bug Fixes**
  - Added `far_future_reset_timestamp()` that returns `(Utc::now() + Duration::days(10)).to_rfc3339()` to force the absolute-date branch.
  - Passed `expires_at` into `output_with_reset_credits` and updated the call sites.
  - Derived the expected substring via `helpers::format_reset_time(expires_at).replace("resets", "expires")` instead of a hardcoded literal.
  - Test now passes regardless of local timezone and after the original date.

<sup>Written for commit 5d463607d55a607325463aed7c7fc78ea0b9880e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

