### PR TITLE
fix(pricing): strip unrecognized provider prefixes before LiteLLM lookup

### DIFF
--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -389,6 +389,22 @@ impl PricingLookup {
             do_lookup(candidate).filter(|result| !unsafe_claude_resolution(result))
         };
 
+        // 1.5. Generic provider-routing prefix fallback: ids coming from a
+        // router/proxy (e.g. `cx/gpt-5.5` via an `omniroute` provider) carry a
+        // prefix outside the curated `PROVIDER_PREFIXES` list, so the
+        // known-prefix stripping inside `lookup_auto` never fires for them.
+        // The direct exact lookup above already had first crack at the full
+        // id, so a dataset key that legitimately keeps its prefix (e.g.
+        // `anthropic/claude-fable-5`) resolves there and never reaches this
+        // fallback. Only the terminal path segment is retried here, matching
+        // the `/`-scoped fallbacks already used by the Cursor/Sakana exact
+        // matchers.
+        if let Some(terminal) = strip_generic_provider_prefix(lower_ref) {
+            if let Some(result) = guarded_lookup(terminal) {
+                return Some(result);
+            }
+        }
+
         // 2. Try stripping unknown suffixes (e.g., -thinking, -high, -codex)
         if let Some(result) = try_strip_unknown_suffix(lower_ref, guarded_lookup) {
             return Some(result);
@@ -1598,6 +1614,26 @@ fn strip_known_provider_prefix(model_id: &str) -> Option<&str> {
         }
     }
     None
+}
+
+/// Generic routing-prefix fallback for ids whose leading segment is not one
+/// of the curated `PROVIDER_PREFIXES` (e.g. `cx/gpt-5.5` routed through an
+/// `omniroute` proxy, or any other CLI/router-assigned alias). Returns the
+/// terminal path segment — the part after the last `/` — when the id
+/// actually contains a `/`, so `cx/gpt-5.5` resolves to `gpt-5.5`.
+///
+/// This is intentionally unconditional (unlike `strip_known_provider_prefix`,
+/// which only recognizes canonical LLM provider names): the caller only
+/// invokes it as a fallback AFTER the exact/direct lookup on the full id has
+/// already failed, so dataset keys that legitimately keep their prefix (e.g.
+/// `anthropic/claude-fable-5`) are resolved by their own exact key first and
+/// never reach this fallback.
+fn strip_generic_provider_prefix(model_id: &str) -> Option<&str> {
+    let terminal = model_id.rsplit('/').next()?;
+    if terminal.is_empty() || terminal == model_id {
+        return None;
+    }
+    Some(terminal)
 }
 
 fn is_valid_price_value(value: f64) -> bool {
@@ -3700,6 +3736,48 @@ mod tests {
             let result = lookup.lookup(id).unwrap();
             assert_eq!(result.matched_key, "anthropic/claude-fable-5", "id: {id}");
         }
+    }
+
+    /// Regression (#831): router/proxy-assigned ids like `cx/gpt-5.5` (seen
+    /// from OpenCode's `omniroute` provider) carry a prefix outside the
+    /// curated `PROVIDER_PREFIXES` list, so the pricing lookup used to return
+    /// `None` (and thus bill $0) instead of stripping the prefix and pricing
+    /// the underlying `gpt-5.5` model.
+    #[test]
+    fn test_unknown_prefixed_model_id_strips_to_underlying_model() {
+        let lookup = create_lookup();
+        let direct = lookup.lookup("gpt-5.5").unwrap();
+        let prefixed = lookup.lookup("cx/gpt-5.5").unwrap();
+        assert_eq!(prefixed.matched_key, direct.matched_key);
+        assert_eq!(prefixed.source, direct.source);
+        assert_eq!(
+            prefixed.pricing.input_cost_per_token,
+            direct.pricing.input_cost_per_token
+        );
+        assert_eq!(
+            prefixed.pricing.output_cost_per_token,
+            direct.pricing.output_cost_per_token
+        );
+    }
+
+    /// Regression (#831): a dataset key that legitimately keeps its own
+    /// provider prefix (e.g. `anthropic/claude-fable-5`, which exists as its
+    /// own OpenRouter key) must still resolve via the exact/direct lookup —
+    /// the new generic prefix-stripping fallback must not preempt it.
+    #[test]
+    fn test_known_prefixed_dataset_key_still_resolves_exactly() {
+        let lookup = claude_family_fixture();
+        let result = lookup.lookup("anthropic/claude-fable-5").unwrap();
+        assert_eq!(result.matched_key, "anthropic/claude-fable-5");
+    }
+
+    /// Regression (#831): an id with an unrecognized provider prefix AND an
+    /// unrecognized underlying model must still return `None` rather than
+    /// fuzzy-matching something unrelated.
+    #[test]
+    fn test_unknown_prefixed_unknown_model_stays_none() {
+        let lookup = create_lookup();
+        assert!(lookup.lookup("unknown/nonexistent").is_none());
     }
 
     /// When the dataset later gains a major-5 key, the same ids resolve to it


### PR DESCRIPTION
## Summary

Fixes #831.

Router/proxy-assigned model ids like `cx/gpt-5.5` (recorded by OpenCode when routed through its `omniroute` provider) use a routing prefix that isn't in the curated `PROVIDER_PREFIXES` list (`openai/`, `anthropic/`, `google/`, …). Because of that, the pricing lookup treated the whole string `cx/gpt-5.5` as the model id, found no match, and returned `None` — which meant the cost was silently billed at **$0** even though the underlying `gpt-5.5` model has real LiteLLM pricing ($5 / $30 per 1M tokens).

```
$ tokscale pricing "cx/gpt-5.5"
  Model not found: cx/gpt-5.5

$ tokscale pricing "gpt-5.5"
  Pricing for: gpt-5.5
  ...
  Input:  $5.00 / 1M tokens
  Output: $30.00 / 1M tokens
```

## Fix

In `crates/tokscale-core/src/pricing/lookup.rs`, after the direct/exact lookup on the full id has already failed (so a dataset key that legitimately keeps its own prefix, e.g. `anthropic/claude-fable-5`, still resolves first via its exact key), retry the lookup against the terminal path segment (the part after the last `/`). This generalizes the existing prefix-stripping behavior — which only recognized a curated list of canonical provider names — to any router/proxy-assigned prefix.

Verified end-to-end against the real dataset:

```
$ tokscale pricing "cx/gpt-5.5"
  Pricing for: cx/gpt-5.5
  Matched key: gpt-5.5
  Source: LiteLLM
  Input:  $5.00 / 1M tokens
  Output: $30.00 / 1M tokens
  Cache Read:  $0.50 / 1M tokens
```

## Tests added

- `test_unknown_prefixed_model_id_strips_to_underlying_model` — `cx/gpt-5.5` resolves to the same pricing as `gpt-5.5`.
- `test_known_prefixed_dataset_key_still_resolves_exactly` — `anthropic/claude-fable-5` (a real dataset key that keeps its prefix) still resolves via the exact/direct match, unaffected by the new fallback.
- `test_unknown_prefixed_unknown_model_stays_none` — `unknown/nonexistent` still returns `None` rather than fuzzy-matching something unrelated.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p tokscale-core --lib -- -D warnings`
- `cargo test -p tokscale-core --lib` (1094 passed, 0 failed)
- Manual CLI check against real LiteLLM data (`tokscale pricing "cx/gpt-5.5"`) shown above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents $0 pricing for router-prefixed model IDs by falling back to the terminal segment when exact lookup fails (e.g., `cx/gpt-5.5` → `gpt-5.5`). Keeps exact matches for legitimate prefixed dataset keys intact.

- **Bug Fixes**
  - Retry lookup using the part after the last `/` when the full ID misses, handling unknown prefixes like `cx/`.
  - Do not preempt exact keys such as `anthropic/claude-fable-5`; unknown/unknown stays `None`.
  - Added regression tests and verified correct LiteLLM pricing via CLI.

<sup>Written for commit c8a089cfd931ec58b28e972b55083bb8a04709b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

