### PR TITLE
docs+test(codex): confirm archived_sessions scanning/dedup covers #779

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -5180,6 +5180,117 @@ mod tests {
         }
     }
 
+    /// Regression fixture for issue #779: Codex CLI moves aged sessions from
+    /// `~/.codex/sessions/` into a sibling `~/.codex/archived_sessions/`
+    /// directory. Three distinct scenarios are covered here:
+    /// - `live-only`: a session that only ever lived in `sessions/`.
+    /// - `archived-only`: a session that only exists in `archived_sessions/`
+    ///   (the case the collector was previously blind to, causing the
+    ///   undercount reported in #779).
+    /// - `shared`: the same upstream session content present in *both*
+    ///   directories at once (e.g. mid-archive), which must be counted once,
+    ///   not twice.
+    fn write_codex_sessions_and_archived_sessions_fixture(source_home: &std::path::Path) {
+        let sessions_dir = source_home.join(".codex/sessions");
+        let archived_dir = source_home.join(".codex/archived_sessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        std::fs::create_dir_all(&archived_dir).unwrap();
+
+        std::fs::write(
+            sessions_dir.join("live-only.jsonl"),
+            concat!(
+                r#"{"timestamp":"2026-06-25T10:00:00Z","type":"session_meta","payload":{"id":"33333333-3333-7333-8333-333333333333","source":"interactive","model_provider":"openai","cwd":"/repo"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-06-25T10:00:01Z","type":"turn_context","payload":{"model":"gpt-5.5"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-06-25T10:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":50,"output_tokens":5,"total_tokens":55},"last_token_usage":{"input_tokens":50,"output_tokens":5,"total_tokens":55}}}}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+
+        std::fs::write(
+            archived_dir.join("archived-only.jsonl"),
+            concat!(
+                r#"{"timestamp":"2026-06-20T09:00:00Z","type":"session_meta","payload":{"id":"44444444-4444-7444-8444-444444444444","source":"interactive","model_provider":"openai","cwd":"/repo"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-06-20T09:00:01Z","type":"turn_context","payload":{"model":"gpt-5.5"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-06-20T09:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":70,"output_tokens":7,"total_tokens":77},"last_token_usage":{"input_tokens":70,"output_tokens":7,"total_tokens":77}}}}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+
+        let shared_content = concat!(
+            r#"{"timestamp":"2026-06-22T08:00:00Z","type":"session_meta","payload":{"id":"55555555-5555-7555-8555-555555555555","source":"interactive","model_provider":"openai","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-06-22T08:00:01Z","type":"turn_context","payload":{"model":"gpt-5.5"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-06-22T08:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":30,"output_tokens":3,"total_tokens":33},"last_token_usage":{"input_tokens":30,"output_tokens":3,"total_tokens":33}}}}"#,
+            "\n"
+        );
+        std::fs::write(
+            sessions_dir.join("shared-in-sessions.jsonl"),
+            shared_content,
+        )
+        .unwrap();
+        std::fs::write(
+            archived_dir.join("shared-in-archived.jsonl"),
+            shared_content,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parse_all_messages_with_pricing_codex_scans_archived_sessions_without_double_counting()
+    {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            write_codex_sessions_and_archived_sessions_fixture(source_home.path());
+
+            let messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["codex".to_string()],
+                None,
+            );
+
+            // live-only + archived-only + shared (counted once, not twice).
+            assert_eq!(
+                messages.len(),
+                3,
+                "archived_sessions must be scanned (live-only + archived-only), and a session \
+                 present in both sessions/ and archived_sessions/ must be deduplicated to one \
+                 message, not counted twice"
+            );
+
+            let session_ids: HashSet<_> = messages
+                .iter()
+                .map(|message| message.session_id.as_str())
+                .collect();
+            assert!(session_ids.contains("live-only"));
+            assert!(
+                session_ids.contains("archived-only"),
+                "archived_sessions/archived-only.jsonl must be scanned and parsed"
+            );
+
+            // 50 (live-only) + 70 (archived-only) + 30 (shared, once) = 150.
+            assert_eq!(messages.iter().map(|m| m.tokens.input).sum::<i64>(), 150);
+            // 5 (live-only) + 7 (archived-only) + 3 (shared, once) = 15.
+            assert_eq!(messages.iter().map(|m| m.tokens.output).sum::<i64>(), 15);
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
     #[test]
     #[serial_test::serial]
     fn test_parse_all_messages_with_pricing_codex_deduplicates_parent_replay_across_forks() {

--- a/crates/tokscale-core/src/sessions/codex.rs
+++ b/crates/tokscale-core/src/sessions/codex.rs
@@ -1,6 +1,13 @@
 //! Codex CLI session parser
 //!
-//! Parses JSONL files from ~/.codex/sessions/
+//! Parses JSONL files from `~/.codex/sessions/` and its sibling
+//! `~/.codex/archived_sessions/` (where Codex CLI moves older sessions). Both
+//! directories share an identical JSONL schema, so a single parser handles
+//! both; the scan-root wiring that discovers `archived_sessions` lives in
+//! `crate::scanner`. Session identity for dedup is derived from in-file
+//! `session_meta` content (not the file path), so a session that happens to
+//! be present in both directories at once is still counted only once — see
+//! `codex_token_count_dedup_key`.
 //! Note: This parser has stateful logic to track model and delta calculations.
 
 use super::utils::{


### PR DESCRIPTION
## Summary

Issue #779 reports that the Codex CLI collector undercounts tokens because it allegedly only scans `~/.codex/sessions/` and never the sibling `~/.codex/archived_sessions/` directory that newer Codex CLI versions move aged sessions into, citing the module doc comment in `crates/tokscale-core/src/sessions/codex.rs` as source-code evidence.

**Investigation:** the scan-root wiring in `crates/tokscale-core/src/scanner.rs` already discovers `archived_sessions` as a sibling scan root (`push_unique_scan_task` for `ClientId::Codex`, added in `54f6e69c`, months before this issue was filed), and is already exercised by `test_scan_all_clients_codex_archived_sessions` / `test_scan_all_clients_codex_sessions_and_archived`. Per-message dedup (`codex_token_count_dedup_key` in `codex.rs`) already keys off in-file `session_meta` identity + cumulative token totals rather than the file path, so a session present in both directories at once is naturally deduplicated rather than double-counted.

What was missing: an end-to-end regression test that actually parses real token content from both roots together and asserts the combined totals — the existing tests only asserted file *discovery* counts, not parsed totals — plus the stale doc comment the issue cites as evidence.

## Changes

- `crates/tokscale-core/src/sessions/codex.rs`: update the module doc comment to describe both `sessions/` and `archived_sessions/`, and point at where dedup identity comes from, since the old comment (mentioning only `sessions/`) is exactly what the issue quotes as "source code evidence" of the bug.
- `crates/tokscale-core/src/lib.rs`: add `write_codex_sessions_and_archived_sessions_fixture` + `test_parse_all_messages_with_pricing_codex_scans_archived_sessions_without_double_counting`, covering:
  - a session that lives only in `sessions/`
  - a session that lives only in `archived_sessions/` (the scenario the issue reports as undercounted)
  - the same upstream session present in **both** directories at once, asserting it is counted exactly once, not twice

Fixes #779

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p tokscale-core --lib --tests -- -D warnings`
- [x] `cargo test -p tokscale-core --lib` (1092 passed, 0 failed)
- [x] New regression test `test_parse_all_messages_with_pricing_codex_scans_archived_sessions_without_double_counting` passes and fails if archived-only scanning or dedup regresses

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Confirm that Codex scans both `~/.codex/sessions/` and `~/.codex/archived_sessions/` and dedups shared sessions, with a new end-to-end test verifying correct token totals (no double counting). Fixes #779.

- **Bug Fixes**
  - Added a regression test that parses real fixtures from both roots and asserts combined totals and single-count dedup for shared sessions.
  - Updated `crates/tokscale-core/src/sessions/codex.rs` docs to mention both directories and explain content-based dedup keyed on `session_meta`, clarifying behavior cited in the issue.

<sup>Written for commit 128661ebb3461f470bccc5f8dd2a3b70970a084e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

