### PR TITLE
fix(copilot): prefer the root invoke_agent span when a trace has nested invokes

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -33,7 +33,11 @@ use std::time::UNIX_EPOCH;
 // turn-neutral, so a following brand-new journal turn is no longer robbed of
 // its is_turn_start; schema-25 caches carry the under-counted turn flags, so
 // invalidate them.
-const CACHE_SCHEMA_VERSION: u32 = 26;
+// 27: Copilot trace-level fallback agent now prefers the ROOT invoke_agent span
+// (via parentSpanId hierarchy) over a nested task/sub-agent invoke, so agentless
+// turns in a trace with nested invokes are no longer mis-attributed to the
+// sub-agent; schema-26 caches carry the mis-attributed agent, so invalidate them.
+const CACHE_SCHEMA_VERSION: u32 = 27;
 const CACHE_FILENAME: &str = "source-message-cache.bin";
 const CACHE_LOCK_FILENAME: &str = "source-message-cache.lock";
 const MAX_CACHE_FILE_BYTES: u64 = 256 * 1024 * 1024;

--- a/crates/tokscale-core/src/sessions/copilot.rs
+++ b/crates/tokscale-core/src/sessions/copilot.rs
@@ -85,7 +85,6 @@ struct TraceContext {
     session_id: Option<String>,
     session_id_priority: SessionIdPriority,
     agent_id: Option<String>,
-    agent_from_invoke_agent: bool,
 }
 
 struct CopilotUsageCandidate {
@@ -147,7 +146,6 @@ fn collect_trace_contexts(records: &[Value]) -> HashMap<String, TraceContext> {
                 session_id: None,
                 session_id_priority: SessionIdPriority::Missing,
                 agent_id: None,
-                agent_from_invoke_agent: false,
             });
 
         if context.model.is_none() {
@@ -160,26 +158,128 @@ fn collect_trace_contexts(records: &[Value]) -> HashMap<String, TraceContext> {
                 context.session_id_priority = priority;
             }
         }
+    }
 
-        // Trace-level agent is only a FALLBACK for records that carry no
-        // gen_ai.agent.id of their own (see candidate_from_attributes). Prefer
-        // the invoke_agent span's agent id (the trace default) and otherwise
-        // keep the first non-empty id, because OTel export order is not
-        // guaranteed: a child chat/sub-agent span may be exported before its
-        // parent invoke_agent span, and a plain first-wins lock would then make
-        // the sub-agent the trace fallback and mis-attribute agentless turns.
-        // Per-record agent ids still take precedence at attribution time.
-        if let Some(agent_id) = first_non_empty_attr(attributes, &["gen_ai.agent.id"]) {
-            let from_invoke_agent = is_agent_summary_span_record(record, attributes);
-            if (from_invoke_agent && !context.agent_from_invoke_agent) || context.agent_id.is_none()
-            {
-                context.agent_id = Some(agent_id.to_string());
-                context.agent_from_invoke_agent = from_invoke_agent;
-            }
+    // Trace-level agent is only a FALLBACK for records that carry no
+    // gen_ai.agent.id of their own (see candidate_from_attributes). Prefer the
+    // ROOT invoke_agent span's agent id — the invoke_agent span whose parent
+    // chain contains no other invoke_agent span — so a nested task/sub-agent
+    // invoke inside the main invocation does not become the trace default.
+    // This is resolved in a dedicated pass because OTel export order is not
+    // guaranteed: the root invoke_agent span may export after a nested one (or
+    // after the chat spans it should cover), so the whole span hierarchy must
+    // be known before the root can be picked. Per-record agent ids still take
+    // precedence at attribution time.
+    for (trace_id, agent_id) in resolve_trace_fallback_agents(records) {
+        if let Some(context) = contexts.get_mut(&trace_id) {
+            context.agent_id = Some(agent_id);
         }
     }
 
     contexts
+}
+
+/// Resolve the trace-level fallback agent id for each trace, preferring the
+/// ROOT invoke_agent span (the invoke_agent span whose parent chain contains no
+/// other invoke_agent span). A trace can hold several invoke_agent spans when a
+/// task/sub-agent is invoked inside the main agent invocation; the sub-agent's
+/// invoke_agent is nested and must not become the trace default. When a trace
+/// has no invoke_agent span, fall back to the first non-empty gen_ai.agent.id
+/// seen in the trace (input order).
+fn resolve_trace_fallback_agents(records: &[Value]) -> HashMap<String, String> {
+    // spanId -> parentSpanId across every span that declares both. OTel span
+    // ids are globally unique, so a single flat map is safe across traces.
+    let mut parent_of: HashMap<&str, &str> = HashMap::new();
+    // Span ids of every invoke_agent span, used to detect a nested invoke.
+    let mut invoke_agent_span_ids: HashSet<&str> = HashSet::new();
+    // Per trace: invoke_agent spans in input order, each with its agent id.
+    let mut trace_invoke_agents: HashMap<&str, Vec<(&str, Option<&str>)>> = HashMap::new();
+    // Per trace: first non-empty agent id seen on any record (ultimate fallback
+    // for traces whose invoke_agent spans name no agent, or that have none).
+    let mut trace_first_agent: HashMap<&str, &str> = HashMap::new();
+
+    for record in records {
+        let Some(trace_id) = trace_id_from_record(record) else {
+            continue;
+        };
+        let Some(attributes) = record.get("attributes").and_then(Value::as_object) else {
+            continue;
+        };
+
+        let span_id = span_id_from_record(record);
+        if let Some(span_id) = span_id {
+            if let Some(parent_span_id) = parent_span_id_from_record(record) {
+                parent_of.insert(span_id, parent_span_id);
+            }
+        }
+
+        let agent_id = first_non_empty_attr(attributes, &["gen_ai.agent.id"]);
+
+        if is_agent_summary_span_record(record, attributes) {
+            if let Some(span_id) = span_id {
+                invoke_agent_span_ids.insert(span_id);
+                trace_invoke_agents
+                    .entry(trace_id)
+                    .or_default()
+                    .push((span_id, agent_id));
+            }
+        }
+
+        if let Some(agent_id) = agent_id {
+            trace_first_agent.entry(trace_id).or_insert(agent_id);
+        }
+    }
+
+    let mut fallback = HashMap::new();
+
+    for (trace_id, invokes) in &trace_invoke_agents {
+        // Prefer the first ROOT invoke_agent span that carries an agent id.
+        // Fall back to any invoke_agent span with an agent id when no root does
+        // (e.g. only a nested invoke names an agent) so the trace still
+        // resolves to an invoke_agent default rather than a bare chat span.
+        let resolved = invokes
+            .iter()
+            .filter(|(span_id, _)| {
+                is_root_invoke_agent(span_id, &parent_of, &invoke_agent_span_ids)
+            })
+            .find_map(|(_, agent_id)| *agent_id)
+            .or_else(|| invokes.iter().find_map(|(_, agent_id)| *agent_id));
+        if let Some(agent_id) = resolved {
+            fallback.insert((*trace_id).to_string(), agent_id.to_string());
+        }
+    }
+
+    // Traces without any invoke_agent span (or whose invoke_agent spans name no
+    // agent) keep the first non-empty agent id seen in the trace.
+    for (trace_id, agent_id) in trace_first_agent {
+        fallback
+            .entry(trace_id.to_string())
+            .or_insert_with(|| agent_id.to_string());
+    }
+
+    fallback
+}
+
+/// An invoke_agent span is a ROOT when no span in its parent chain is itself an
+/// invoke_agent span. Nested task/sub-agent invokes therefore resolve to false.
+fn is_root_invoke_agent(
+    span_id: &str,
+    parent_of: &HashMap<&str, &str>,
+    invoke_agent_span_ids: &HashSet<&str>,
+) -> bool {
+    let mut current = parent_of.get(span_id).copied();
+    let mut visited: HashSet<&str> = HashSet::new();
+    while let Some(parent) = current {
+        if invoke_agent_span_ids.contains(parent) {
+            return false;
+        }
+        if !visited.insert(parent) {
+            // Guard against malformed/cyclic parent references.
+            break;
+        }
+        current = parent_of.get(parent).copied();
+    }
+    true
 }
 
 fn usage_candidate_from_record(
@@ -507,6 +607,22 @@ fn span_id_from_record(value: &Value) -> Option<&str> {
             .and_then(|context| context.get("spanId"))
             .and_then(Value::as_str)
     })
+}
+
+fn parent_span_id_from_record(value: &Value) -> Option<&str> {
+    value
+        .get("parentSpanId")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            value
+                .get("spanContext")
+                .and_then(Value::as_object)
+                .and_then(|context| context.get("parentSpanId"))
+                .and_then(Value::as_str)
+        })
+        // OTel exporters may emit an empty (or absent) parent for a root span;
+        // treat empty as "no parent" so it never matches a real span id.
+        .filter(|parent_span_id| !parent_span_id.is_empty())
 }
 
 fn dedup_key_for_record(
@@ -935,6 +1051,57 @@ mod tests {
         assert_eq!(sub.agent.as_deref(), Some("github.copilot.reviewer"));
         // The agentless turn inherits the invoke_agent default, not the
         // sub-agent that happened to export first.
+        let plain = messages
+            .iter()
+            .find(|message| message.model_id == "gpt-5.4-mini")
+            .unwrap();
+        assert_eq!(plain.agent.as_deref(), Some("github.copilot.default"));
+    }
+
+    #[test]
+    fn test_parse_copilot_cli_trace_agent_prefers_root_invoke_agent_over_nested() {
+        // A trace can contain several invoke_agent spans: the top-level agent
+        // invocation plus a NESTED invoke_agent when the main agent launches a
+        // task/sub-agent via a tool call. The nested invoke's parent chain runs
+        // execute_tool -> root invoke_agent, so it must NOT become the trace
+        // fallback. The nested invoke and its sub-agent chat are exported BEFORE
+        // the root invoke_agent (OTel export order is not guaranteed), which is
+        // exactly the case a first-invoke-wins lock would mis-attribute.
+        let content = r#"{"type":"span","traceId":"trace-nested","spanId":"invoke-sub","parentSpanId":"tool-task","name":"invoke_agent","endTime":[1775934261,0],"attributes":{"gen_ai.operation.name":"invoke_agent","gen_ai.provider.name":"github","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.agent.id":"github.copilot.subagent"}}
+{"type":"span","traceId":"trace-nested","spanId":"chat-sub","parentSpanId":"invoke-sub","name":"chat claude-sonnet-4.6","endTime":[1775934262,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.provider.name":"github","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.response.model":"claude-sonnet-4.6","gen_ai.response.id":"resp-sub","gen_ai.agent.id":"github.copilot.subagent","gen_ai.usage.input_tokens":100,"gen_ai.usage.output_tokens":10}}
+{"type":"span","traceId":"trace-nested","spanId":"tool-task","parentSpanId":"invoke-root","name":"execute_tool task","endTime":[1775934263,0],"attributes":{"gen_ai.operation.name":"execute_tool","gen_ai.tool.name":"task"}}
+{"type":"span","traceId":"trace-nested","spanId":"invoke-root","name":"invoke_agent","endTime":[1775934260,0],"attributes":{"gen_ai.operation.name":"invoke_agent","gen_ai.provider.name":"github","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.agent.id":"github.copilot.default"}}
+{"type":"span","traceId":"trace-nested","spanId":"chat-plain","parentSpanId":"invoke-root","name":"chat gpt-5.4-mini","endTime":[1775934264,967317833],"attributes":{"gen_ai.operation.name":"chat","gen_ai.provider.name":"github","gen_ai.request.model":"gpt-5.4-mini","gen_ai.response.model":"gpt-5.4-mini","gen_ai.response.id":"resp-plain","gen_ai.usage.input_tokens":200,"gen_ai.usage.output_tokens":20}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        // The sub-agent chat keeps its own agent id (per-record wins).
+        let sub = messages
+            .iter()
+            .find(|message| message.model_id == "claude-sonnet-4.6")
+            .unwrap();
+        assert_eq!(sub.agent.as_deref(), Some("github.copilot.subagent"));
+        // The agentless turn inherits the ROOT invoke_agent default, not the
+        // nested sub-agent invoke that exported first.
+        let plain = messages
+            .iter()
+            .find(|message| message.model_id == "gpt-5.4-mini")
+            .unwrap();
+        assert_eq!(plain.agent.as_deref(), Some("github.copilot.default"));
+    }
+
+    #[test]
+    fn test_parse_copilot_cli_trace_agent_single_invoke_agent_unchanged() {
+        // The common single-invoke_agent trace (no nesting) is unaffected by the
+        // root-preference logic: the one invoke_agent span is trivially the root,
+        // so its agent id still propagates to an agentless chat turn.
+        let content = r#"{"type":"span","traceId":"trace-single","spanId":"invoke-1","name":"invoke_agent","endTime":[1775934260,0],"attributes":{"gen_ai.operation.name":"invoke_agent","gen_ai.provider.name":"github","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.agent.id":"github.copilot.default"}}
+{"type":"span","traceId":"trace-single","spanId":"chat-1","parentSpanId":"invoke-1","name":"chat gpt-5.4-mini","endTime":[1775934264,967317833],"attributes":{"gen_ai.operation.name":"chat","gen_ai.provider.name":"github","gen_ai.request.model":"gpt-5.4-mini","gen_ai.response.model":"gpt-5.4-mini","gen_ai.response.id":"resp-single","gen_ai.usage.input_tokens":50,"gen_ai.usage.output_tokens":8}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
         let plain = messages
             .iter()
             .find(|message| message.model_id == "gpt-5.4-mini")


### PR DESCRIPTION
## Problem

Follow-up to #821. That PR made the Copilot collector prefer an `invoke_agent` span (rather than the first-exported span) as the trace-level fallback agent, but it locked onto the **first** `invoke_agent` span it encountered.

When a trace contains **several** `invoke_agent` spans — e.g. the main agent launches a task/sub-agent via a tool call, nesting a second `invoke_agent` inside the root invocation — and the nested span exports first (OTel file-export order is not guaranteed), the **sub-agent** became the trace default. Agentless turns in that trace were then mis-attributed to the sub-agent instead of the top-level agent.

Fixes #829.

## Fix

`crates/tokscale-core/src/sessions/copilot.rs`:

- Parse `parentSpanId` (new `parent_span_id_from_record`, mirroring `span_id_from_record`, tolerant of an empty/absent parent on root spans).
- Resolve the trace fallback agent in a dedicated pass (`resolve_trace_fallback_agents`) that prefers the **ROOT** `invoke_agent` span — the `invoke_agent` span whose parent chain contains no other `invoke_agent` span (`is_root_invoke_agent`, with a visited-set guard against cyclic parent refs).
- A dedicated pass is required because the whole span hierarchy must be known before the root can be identified (export order is not guaranteed).
- Fallbacks preserved: if only a nested invoke names an agent, still resolve to an `invoke_agent` default; a trace with no `invoke_agent` span keeps the first non-empty `gen_ai.agent.id`. Per-record `gen_ai.agent.id` still takes precedence at attribution time, so a record that names its own agent is unaffected.
- Removes the now-obsolete `agent_from_invoke_agent` first-wins flag on `TraceContext`.

`crates/tokscale-core/src/message_cache.rs`: bumps `CACHE_SCHEMA_VERSION` 26 → 27 so schema-26 caches holding the mis-attributed sub-agent reparse.

## Tests

- `test_parse_copilot_cli_trace_agent_prefers_root_invoke_agent_over_nested` — realistic multi-span fixture (root `invoke_agent` → `execute_tool task` → nested `invoke_agent` → sub-agent chat, plus an agentless chat), with the nested invoke and its sub-agent chat exported **before** the root. Asserts the agentless turn inherits the ROOT default and the sub-agent chat keeps its own id.
- `test_parse_copilot_cli_trace_agent_single_invoke_agent_unchanged` — a single-`invoke_agent` trace is unaffected (the lone invoke is trivially the root and still propagates to an agentless turn).

Gates: `cargo fmt --all -- --check` clean, `cargo clippy -p tokscale-core --all-targets` clean (0 warnings), copilot module tests 38 passed, `message_cache` tests 23 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mis-attributed agents in Copilot traces with nested `invoke_agent` spans by preferring the root `invoke_agent` when choosing the trace-level fallback. Agentless turns now inherit the top-level agent even if nested spans export first.

- **Bug Fixes**
  - Parse `parentSpanId` to build the span hierarchy.
  - Resolve the fallback agent in a dedicated pass, preferring the root `invoke_agent` span.
  - Keep per-record `gen_ai.agent.id` precedence; if no `invoke_agent` exists, fall back to the first non-empty `gen_ai.agent.id`.
  - Guard against cyclic parent chains and remove the obsolete `agent_from_invoke_agent` flag.

- **Migration**
  - Bump `CACHE_SCHEMA_VERSION` to 27 to invalidate caches that stored sub-agent defaults; stale entries will re-parse automatically.

<sup>Written for commit eb9fef4afb87f8f69f0aa1df52c75a9a9a07f1b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

