### PR TITLE
feat(kiro): detect Kiro IDE (Windows) sess_*/session.json + messages.jsonl sessions

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1491,9 +1491,17 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         .get(ClientId::Kiro)
         .par_iter()
         .map(|path| {
-            load_or_parse_source(path, &source_cache, pricing, |path| {
-                sessions::kiro::parse_kiro_file(path)
-            })
+            // Kiro-aware fingerprint: IDE `sess_*/session.json` sources derive
+            // their token counts from the sibling `messages.jsonl`, so that
+            // file must participate in the cache key or an append landing
+            // after the last `session.json` write is ignored forever.
+            load_or_parse_source_with_fingerprint(
+                path,
+                &source_cache,
+                pricing,
+                message_cache::SourceFingerprint::from_kiro_path,
+                sessions::kiro::parse_kiro_file,
+            )
         })
         .collect();
     // Collect Kiro file messages before extending so snapshot suppression can

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -215,6 +215,22 @@ impl SourceFingerprint {
         Self::from_path_with_related(path, related_paths)
     }
 
+    /// Fingerprint for a Kiro source file. Kiro IDE sessions anchor discovery
+    /// on `sess_*/session.json` but derive every token count from the sibling
+    /// `messages.jsonl`, so an append to `messages.jsonl` that lands after the
+    /// last `session.json` write must still invalidate the cache — a
+    /// `session.json`-only fingerprint would serve the stale counts forever.
+    /// Non-IDE Kiro files (CLI `cli/*.json`, globalStorage snapshots) have no
+    /// sidecar and use the plain single-file fingerprint.
+    pub(crate) fn from_kiro_path(path: &Path) -> Option<Self> {
+        if !crate::sessions::kiro::is_kiro_ide_session_path(path) {
+            return Self::from_path(path);
+        }
+        let messages = path.with_file_name("messages.jsonl");
+        let related_paths = std::iter::once(("messages.jsonl".to_string(), messages));
+        Self::from_path_with_related(path, related_paths)
+    }
+
     fn from_path_with_related<I>(path: &Path, related_paths: I) -> Option<Self>
     where
         I: IntoIterator<Item = (String, PathBuf)>,
@@ -957,6 +973,47 @@ mod tests {
         .unwrap();
         let updated_journal = SourceFingerprint::from_jcode_path(&session_path).unwrap();
         assert_ne!(with_journal, updated_journal);
+    }
+
+    #[test]
+    fn test_kiro_ide_fingerprint_tracks_messages_sidecar_changes() {
+        let dir = TempDir::new().unwrap();
+        let sess_dir = dir.path().join("workspace-a/sess_02f1c107");
+        std::fs::create_dir_all(&sess_dir).unwrap();
+        let session_path = sess_dir.join("session.json");
+        std::fs::write(&session_path, br#"{"schemaVersion":"1.0.0"}"#).unwrap();
+
+        let base = SourceFingerprint::from_kiro_path(&session_path).unwrap();
+
+        // messages.jsonl appearing (session.json untouched) must invalidate.
+        let messages_path = sess_dir.join("messages.jsonl");
+        std::fs::write(
+            &messages_path,
+            br#"{"role":"user","content":"hello"}
+"#,
+        )
+        .unwrap();
+        let with_messages = SourceFingerprint::from_kiro_path(&session_path).unwrap();
+        assert_ne!(base, with_messages);
+
+        // An append landing after the last session.json write must invalidate.
+        std::fs::write(
+            &messages_path,
+            br#"{"role":"user","content":"hello"}
+{"role":"assistant","content":"world"}
+"#,
+        )
+        .unwrap();
+        let updated_messages = SourceFingerprint::from_kiro_path(&session_path).unwrap();
+        assert_ne!(with_messages, updated_messages);
+
+        // Non-IDE Kiro files (no sess_* parent) use the plain fingerprint.
+        let cli_path = dir.path().join("cli-session.json");
+        std::fs::write(&cli_path, b"{}").unwrap();
+        assert_eq!(
+            SourceFingerprint::from_kiro_path(&cli_path),
+            SourceFingerprint::from_path(&cli_path)
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -340,6 +340,22 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
                         || file_name.ends_with(".json")
                         || path.extension().is_none()
                 }
+                // Kiro IDE (VS Code-based) session layout on disk:
+                //   ~/.kiro/sessions/<workspace>/sess_<uuid>/session.json
+                //   ~/.kiro/sessions/<workspace>/sess_<uuid>/messages.jsonl
+                // Anchor discovery on `session.json` (the metadata file); the
+                // parser reads the sibling `messages.jsonl` itself. Requiring a
+                // `sess_*` parent keeps this from colliding with the CLI layout
+                // (`~/.kiro/sessions/cli/*.json`) that shares the same tree.
+                "kiro-ide-session" => {
+                    file_name == "session.json"
+                        && path
+                            .parent()
+                            .and_then(|parent| parent.file_name())
+                            .and_then(|name| name.to_str())
+                            .map(|name| name.starts_with("sess_"))
+                            .unwrap_or(false)
+                }
                 "sessions.json" => file_name == "sessions.json",
                 "wire.jsonl" => file_name == "wire.jsonl",
                 "updates.jsonl" => file_name == "updates.jsonl",
@@ -1332,6 +1348,20 @@ fn scan_all_clients_with_env_strategy_inner(
             );
         }
 
+        // Kiro IDE (VS Code-based) writes per-workspace sessions under
+        // ~/.kiro/sessions/<workspace>/sess_<uuid>/ (session.json + messages.jsonl),
+        // NOT the ~/.kiro/sessions/cli/*.json layout the base client path targets.
+        // Scan the sessions root and match session.json inside sess_* dirs. This
+        // resolves via home_dir on Windows too (Kiro IDE uses ~/.kiro there).
+        let kiro_ide_sessions_root = PathBuf::from(format!("{}/.kiro/sessions", home_dir));
+        push_unique_scan_task_with_pattern(
+            &mut tasks,
+            &mut seen_scan_roots,
+            ClientId::Kiro,
+            kiro_ide_sessions_root,
+            "kiro-ide-session",
+        );
+
         let xdg_path = PathBuf::from(format!("{}/.local/share/kiro-cli/data.sqlite3", home_dir));
         if xdg_path.is_file() {
             result.kiro_db = Some(xdg_path);
@@ -1780,6 +1810,42 @@ mod tests {
             .collect();
 
         assert_eq!(names, vec!["execution", "execution.chat", "session.json"]);
+    }
+
+    #[test]
+    fn test_scan_directory_kiro_ide_session_pattern() {
+        let dir = TempDir::new().unwrap();
+        let sessions_root = dir.path().join(".kiro/sessions");
+
+        // IDE layout: <workspace>/sess_<uuid>/{session.json,messages.jsonl}.
+        let sess_dir = sessions_root.join("workspace-a/sess_02f1c107");
+        fs::create_dir_all(&sess_dir).unwrap();
+        File::create(sess_dir.join("session.json")).unwrap();
+        File::create(sess_dir.join("messages.jsonl")).unwrap();
+
+        // CLI layout under the same tree must NOT be matched by this pattern
+        // (it is scanned separately as *.json), and a stray session.json outside
+        // a sess_* dir must be ignored.
+        let cli_dir = sessions_root.join("cli");
+        fs::create_dir_all(&cli_dir).unwrap();
+        File::create(cli_dir.join("session-001.json")).unwrap();
+        File::create(sessions_root.join("workspace-a/session.json")).unwrap();
+
+        let files = scan_directory(sessions_root.to_str().unwrap(), "kiro-ide-session");
+        let names: Vec<_> = files
+            .iter()
+            .map(|path| {
+                path.parent()
+                    .and_then(|p| p.file_name())
+                    .and_then(|n| n.to_str())
+                    .unwrap()
+                    .to_string()
+            })
+            .collect();
+
+        // Exactly one match: the session.json inside sess_02f1c107.
+        assert_eq!(files.len(), 1);
+        assert_eq!(names, vec!["sess_02f1c107"]);
     }
 
     #[test]
@@ -3034,6 +3100,28 @@ mod tests {
             .get(ClientId::Kiro)
             .iter()
             .any(|p| p.ends_with("execution")));
+    }
+
+    #[test]
+    fn test_scan_all_clients_kiro_includes_ide_sessions() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+
+        let sess_dir = home.join(".kiro/sessions/workspace-a/sess_02f1c107");
+        fs::create_dir_all(&sess_dir).unwrap();
+        File::create(sess_dir.join("session.json")).unwrap();
+        File::create(sess_dir.join("messages.jsonl")).unwrap();
+
+        let result = scan_all_clients(home.to_str().unwrap(), &["kiro".to_string()]);
+        assert!(result
+            .get(ClientId::Kiro)
+            .iter()
+            .any(|p| p.ends_with("sess_02f1c107/session.json")));
+        // The sibling messages.jsonl is read by the parser, not scanned directly.
+        assert!(!result
+            .get(ClientId::Kiro)
+            .iter()
+            .any(|p| p.ends_with("messages.jsonl")));
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -1,10 +1,13 @@
 //! Kiro session parser
 //!
-//! Parses session data from three sources:
-//! 1. File-based: ~/.kiro/sessions/cli/*.json + *.jsonl
+//! Parses session data from four sources:
+//! 1. File-based (Kiro CLI): ~/.kiro/sessions/cli/*.json + *.jsonl
 //! 2. Kiro IDE globalStorage snapshots
 //! 3. SQLite-based: ~/Library/Application Support/kiro-cli/data.sqlite3
 //!    (conversations_v2 table with history[*].request_metadata)
+//! 4. File-based (Kiro IDE): ~/.kiro/sessions/<workspace>/sess_<uuid>/
+//!    session.json (metadata) + messages.jsonl (conversation). This is the
+//!    VS Code-based Kiro IDE layout, distinct from the CLI's cli/*.json layout.
 //!
 //! Turn-level token counts are currently zero in both sources, so usage is
 //! estimated from context_usage_percentage * context_window (input) and
@@ -95,7 +98,22 @@ struct KiroMessageContent {
     prompt_timestamp_ms: Option<i64>,
 }
 
+/// Metadata half of the Kiro IDE session layout (`session.json`, schemaVersion
+/// 1.0.0). The conversation itself lives in the sibling `messages.jsonl`.
+#[derive(Debug, Deserialize)]
+struct KiroIdeSession {
+    id: Option<String>,
+    #[serde(rename = "createdAt")]
+    created_at: Option<String>,
+    #[serde(rename = "lastModifiedAt")]
+    last_modified_at: Option<String>,
+}
+
 pub fn parse_kiro_file(path: &Path) -> Vec<UnifiedMessage> {
+    if is_kiro_ide_session_path(path) {
+        return parse_kiro_ide_session_file(path);
+    }
+
     if is_kiro_global_storage_path(path)
         || path
             .extension()
@@ -340,6 +358,150 @@ fn session_id_from_path(path: &Path) -> String {
 fn is_kiro_global_storage_path(path: &Path) -> bool {
     let path_str = path.to_string_lossy();
     path_str.contains("globalStorage") && path_str.contains("kiro.kiroagent")
+}
+
+/// A Kiro IDE session file is `session.json` sitting inside a `sess_<uuid>`
+/// directory (`~/.kiro/sessions/<workspace>/sess_<uuid>/session.json`). The
+/// `sess_` parent requirement keeps this from matching the CLI layout, whose
+/// arbitrary `~/.kiro/sessions/cli/*.json` files share the same tree.
+fn is_kiro_ide_session_path(path: &Path) -> bool {
+    let is_session_json = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name == "session.json")
+        .unwrap_or(false);
+    if !is_session_json {
+        return false;
+    }
+    path.parent()
+        .and_then(|parent| parent.file_name())
+        .and_then(|name| name.to_str())
+        .map(|name| name.starts_with("sess_"))
+        .unwrap_or(false)
+}
+
+/// Parse the Kiro IDE session layout: `session.json` (metadata) plus the
+/// sibling `messages.jsonl` (conversation).
+///
+/// The IDE does NOT record per-turn token usage in these files (confirmed
+/// against issue #813's sample, which carries only session metadata), so — like
+/// every other Kiro path — token counts here are ESTIMATED from message text
+/// (chars / 4), never measured. `messages.jsonl`'s exact schema is not
+/// documented, so each line is parsed as generic JSON and fed through the
+/// role-tolerant snapshot text collector (user/assistant/human/bot/prompt/
+/// response). Lines with no role-tagged text contribute nothing rather than
+/// being guessed at, so a session with no recognizable content is dropped
+/// instead of fabricating usage.
+fn parse_kiro_ide_session_file(path: &Path) -> Vec<UnifiedMessage> {
+    let fallback_timestamp = file_modified_timestamp_ms(path);
+
+    let session_json = match std::fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(_) => return Vec::new(),
+    };
+    let session: KiroIdeSession = match serde_json::from_str(&session_json) {
+        Ok(session) => session,
+        Err(_) => return Vec::new(),
+    };
+
+    // Directory name is `sess_<uuid>`; its parent is the workspace folder:
+    // ~/.kiro/sessions/<workspace>/sess_<uuid>/session.json
+    let sess_dir = path.parent();
+    let sess_dir_name = sess_dir
+        .and_then(|dir| dir.file_name())
+        .and_then(|name| name.to_str());
+    let session_id = session
+        .id
+        .filter(|id| !id.trim().is_empty())
+        .or_else(|| sess_dir_name.map(|name| name.to_string()))
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let workspace = sess_dir
+        .and_then(|dir| dir.parent())
+        .and_then(|ws_dir| ws_dir.file_name())
+        .and_then(|name| name.to_str())
+        .map(|name| name.to_string());
+    let workspace_key = workspace.as_deref().and_then(normalize_workspace_key);
+    let workspace_label = workspace_key.as_deref().and_then(workspace_label_from_key);
+
+    let messages_path = path.with_file_name("messages.jsonl");
+    let mut counts = KiroSnapshotTextCounts::default();
+    let mut model_id: Option<String> = None;
+    let mut assistant_turns: i32 = 0;
+
+    if let Ok(file) = std::fs::File::open(&messages_path) {
+        let reader = BufReader::new(file);
+        for line in reader.lines() {
+            let line = match line {
+                Ok(l) => l,
+                Err(_) => continue,
+            };
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let value: Value = match serde_json::from_str(trimmed) {
+                Ok(value) => value,
+                Err(_) => continue,
+            };
+            if model_id.is_none() {
+                model_id = find_kiro_snapshot_model_id(&value);
+            }
+            let assistant_before = counts.assistant_chars;
+            collect_kiro_snapshot_text(&value, &mut counts, None);
+            if counts.assistant_chars > assistant_before {
+                assistant_turns += 1;
+            }
+        }
+    }
+
+    let input = estimate_tokens(counts.prompt_chars);
+    let output = estimate_tokens(counts.assistant_chars);
+    if input + output == 0 {
+        return Vec::new();
+    }
+
+    // schemaVersion 1.0.0 stores createdAt/lastModifiedAt as RFC3339 strings.
+    let created_value = session
+        .created_at
+        .as_deref()
+        .map(|s| Value::String(s.to_string()));
+    let created_ms = parse_timestamp_value(created_value.as_ref());
+    let modified_value = session
+        .last_modified_at
+        .as_deref()
+        .map(|s| Value::String(s.to_string()));
+    let modified_ms = parse_timestamp_value(modified_value.as_ref());
+
+    let timestamp = created_ms.or(modified_ms).unwrap_or(fallback_timestamp);
+    let duration_ms = duration_between_ms(created_ms, modified_ms);
+    let model_id = model_id
+        .filter(|model| !model.trim().is_empty())
+        .unwrap_or_else(|| "auto".to_string());
+
+    let mut message = UnifiedMessage::new_with_dedup(
+        CLIENT_ID,
+        model_id,
+        PROVIDER_ID,
+        session_id.clone(),
+        timestamp,
+        TokenBreakdown {
+            input,
+            output,
+            cache_read: 0,
+            cache_write: 0,
+            reasoning: 0,
+        },
+        0.0,
+        // Distinct from the globalStorage `:globalstorage`/`execution:` keys, so
+        // suppress_snapshots_covered_by_executions leaves IDE sessions untouched.
+        Some(format!("{}:ide-session", session_id)),
+    );
+    message.message_count = assistant_turns.max(1);
+    message.duration_ms = duration_ms;
+    message.is_turn_start = true;
+    message.set_workspace(workspace_key, workspace_label);
+    vec![message]
 }
 
 /// Extract the workspace folder name from a Kiro globalStorage path.
@@ -1730,5 +1892,169 @@ not valid json at all
             find_kiro_snapshot_model_id(&prompt_value),
             Some("claude-sonnet-4".to_string())
         );
+    }
+
+    /// Build the Kiro IDE session layout on disk:
+    /// `<base>/.kiro/sessions/<workspace>/<sess_dir>/{session.json,messages.jsonl}`
+    /// and return the path to `session.json`.
+    fn create_ide_session_files(
+        dir: &TempDir,
+        workspace: &str,
+        sess_dir: &str,
+        session_json: &str,
+        messages_jsonl: &str,
+    ) -> std::path::PathBuf {
+        let sess_path = dir
+            .path()
+            .join(".kiro/sessions")
+            .join(workspace)
+            .join(sess_dir);
+        fs::create_dir_all(&sess_path).unwrap();
+        let session_path = sess_path.join("session.json");
+        fs::write(&session_path, session_json).unwrap();
+        fs::write(sess_path.join("messages.jsonl"), messages_jsonl).unwrap();
+        session_path
+    }
+
+    #[test]
+    fn test_parse_kiro_ide_session_estimates_tokens_from_messages_jsonl() {
+        // session.json is the schemaVersion 1.0.0 sample from issue #813.
+        let session_json = r#"{
+            "schemaVersion": "1.0.0",
+            "dataModelVersion": 1,
+            "id": "sess_02f1c107-37e8-4398-8b95-c3847bf59335",
+            "title": "Writing README docs for projects",
+            "agentMode": "vibe",
+            "createdAt": "2026-06-30T12:57:10.991Z",
+            "lastModifiedAt": "2026-06-30T12:57:12.991Z",
+            "status": "completed"
+        }"#;
+        let messages_jsonl = "{\"role\":\"user\",\"content\":\"hello world\"}\n{\"role\":\"assistant\",\"content\":\"response text\"}\n";
+
+        let dir = TempDir::new().unwrap();
+        let path = create_ide_session_files(
+            &dir,
+            "my-project",
+            "sess_02f1c107-37e8-4398-8b95-c3847bf59335",
+            session_json,
+            messages_jsonl,
+        );
+
+        let messages = parse_kiro_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, "kiro");
+        assert_eq!(messages[0].provider_id, "amazon-bedrock");
+        assert_eq!(
+            messages[0].session_id,
+            "sess_02f1c107-37e8-4398-8b95-c3847bf59335"
+        );
+        // "hello world" = 11 chars -> ceil(11/4) = 3; "response text" = 13 -> 4.
+        assert_eq!(messages[0].tokens.input, 3);
+        assert_eq!(messages[0].tokens.output, 4);
+        assert!(messages[0].is_turn_start);
+        // Workspace is the folder holding the sess_* dir.
+        assert_eq!(messages[0].workspace_key, Some("my-project".to_string()));
+        assert_eq!(messages[0].workspace_label, Some("my-project".to_string()));
+        // createdAt -> ms; duration = lastModifiedAt - createdAt = 2000ms.
+        assert_eq!(messages[0].timestamp, 1782824230991);
+        assert_eq!(messages[0].duration_ms, Some(2000));
+        assert!(messages[0].date.starts_with("2026-"));
+        // No model in session.json/messages.jsonl -> "auto" so pricing can resolve.
+        assert_eq!(messages[0].model_id, "auto");
+        // Dedup key is IDE-session-scoped and survives execution suppression.
+        assert_eq!(
+            messages[0].dedup_key,
+            Some("sess_02f1c107-37e8-4398-8b95-c3847bf59335:ide-session".to_string())
+        );
+        // One assistant response -> message_count 1.
+        assert_eq!(messages[0].message_count, 1);
+    }
+
+    #[test]
+    fn test_parse_kiro_ide_session_extracts_model_and_counts_turns() {
+        let session_json = r#"{
+            "schemaVersion": "1.0.0",
+            "id": "sess_abc",
+            "createdAt": "2026-06-30T12:57:10.000Z",
+            "lastModifiedAt": "2026-06-30T12:57:10.000Z"
+        }"#;
+        // Two assistant turns and a Kiro IDE model codename embedded in a line.
+        let messages_jsonl = concat!(
+            "{\"role\":\"user\",\"content\":\"first question here\"}\n",
+            "{\"role\":\"assistant\",\"model\":\"big-pickle\",\"content\":\"first answer\"}\n",
+            "{\"role\":\"user\",\"content\":\"second question\"}\n",
+            "{\"role\":\"assistant\",\"content\":\"second answer\"}\n"
+        );
+
+        let dir = TempDir::new().unwrap();
+        let path = create_ide_session_files(&dir, "ws", "sess_abc", session_json, messages_jsonl);
+
+        let messages = parse_kiro_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        // Model codename is picked up from messages.jsonl (not a Kiro-internal id).
+        assert_eq!(messages[0].model_id, "big-pickle");
+        // Two assistant responses -> message_count 2.
+        assert_eq!(messages[0].message_count, 2);
+        assert!(messages[0].tokens.input > 0);
+        assert!(messages[0].tokens.output > 0);
+    }
+
+    #[test]
+    fn test_parse_kiro_ide_session_dropped_when_no_recognizable_content() {
+        let session_json = r#"{"schemaVersion":"1.0.0","id":"sess_empty"}"#;
+        // Only tool/system noise with no role-tagged conversation text.
+        let messages_jsonl = "{\"kind\":\"toolCall\",\"name\":\"read_file\"}\n";
+
+        let dir = TempDir::new().unwrap();
+        let path = create_ide_session_files(&dir, "ws", "sess_empty", session_json, messages_jsonl);
+
+        let messages = parse_kiro_file(&path);
+
+        // No estimable usage -> no fabricated message.
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_parse_kiro_ide_session_falls_back_to_dir_name_and_mtime() {
+        // session.json with no id and no timestamps: session id falls back to the
+        // sess_* directory name and timestamp to the file mtime.
+        let session_json = r#"{"schemaVersion":"1.0.0"}"#;
+        let messages_jsonl = "{\"role\":\"user\",\"content\":\"hello\"}\n";
+
+        let dir = TempDir::new().unwrap();
+        let path =
+            create_ide_session_files(&dir, "ws", "sess_no_meta", session_json, messages_jsonl);
+
+        let messages = parse_kiro_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].session_id, "sess_no_meta");
+        assert_eq!(
+            messages[0].dedup_key,
+            Some("sess_no_meta:ide-session".to_string())
+        );
+        assert!(messages[0].timestamp > 0);
+    }
+
+    #[test]
+    fn suppress_snapshots_leaves_ide_sessions_untouched() {
+        // An IDE-session message must never be dropped by execution suppression,
+        // even when a globalStorage execution is present in the same batch.
+        let messages = vec![
+            make_globalstorage_message("chat-abc", "execution:exec-1", Some("ws")),
+            make_globalstorage_message("sess_abc", "sess_abc:ide-session", Some("ws")),
+        ];
+
+        let kept = suppress_snapshots_covered_by_executions(messages);
+
+        let keys: Vec<&str> = kept
+            .iter()
+            .filter_map(|message| message.dedup_key.as_deref())
+            .collect();
+        assert_eq!(kept.len(), 2);
+        assert!(keys.contains(&"sess_abc:ide-session"));
+        assert!(keys.contains(&"execution:exec-1"));
     }
 }

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -364,7 +364,7 @@ fn is_kiro_global_storage_path(path: &Path) -> bool {
 /// directory (`~/.kiro/sessions/<workspace>/sess_<uuid>/session.json`). The
 /// `sess_` parent requirement keeps this from matching the CLI layout, whose
 /// arbitrary `~/.kiro/sessions/cli/*.json` files share the same tree.
-fn is_kiro_ide_session_path(path: &Path) -> bool {
+pub(crate) fn is_kiro_ide_session_path(path: &Path) -> bool {
     let is_session_json = path
         .file_name()
         .and_then(|name| name.to_str())


### PR DESCRIPTION
## Summary

Fixes #813. Kiro IDE (the VS Code-based app, not the Kiro CLI) on Windows writes per-workspace sessions to:

```
~/.kiro/sessions/<workspace>/sess_<uuid>/session.json    # metadata (schemaVersion 1.0.0)
~/.kiro/sessions/<workspace>/sess_<uuid>/messages.jsonl  # conversation
```

tokscale only scanned the CLI layout (`~/.kiro/sessions/cli/*.json`), so on Windows none of these IDE sessions were tracked even though Kiro shows as a supported agent.

## Changes

**Scanner (`scanner.rs`)**
- Add a `~/.kiro/sessions` scan root with a new `kiro-ide-session` pattern that matches `session.json` files living inside a `sess_*` directory. Requiring the `sess_` parent keeps this from colliding with the CLI layout (`cli/*.json`) that shares the same tree, and it resolves via `home_dir` on Windows too since Kiro IDE uses `~/.kiro` there.
- The Windows globalStorage root (`%APPDATA%/Kiro/User/globalStorage`) mentioned in the issue is already handled by `kiro_global_storage_roots` (APPDATA + `AppData/Roaming` variants), so no change was needed there.

**Parser (`kiro.rs`)**
- `parse_kiro_ide_session_file` reads session metadata (`id`, `createdAt`, `lastModifiedAt`) from `session.json` (the schemaVersion 1.0.0 sample in the issue) and estimates tokens from the sibling `messages.jsonl`.
- Kiro records no per-turn token usage in these files, so — consistent with every other Kiro source — token counts are **estimated** from message text (chars / 4), never presented as measured. `messages.jsonl`'s schema is undocumented, so each line is parsed as generic JSON through the existing role-tolerant snapshot collector (`user`/`assistant`/`human`/`bot`/`prompt`/`response`); lines with no role-tagged text contribute nothing rather than fabricating usage, and a session with no recognizable content is dropped.
- The IDE message uses a distinct `{session_id}:ide-session` dedup key, so it folds cleanly into the merged PR #814 execution/promptLogs dedup — `suppress_snapshots_covered_by_executions` leaves it untouched.

## Tests

Fixture-based tests cover:
- scan pattern matching (`session.json` in `sess_*` only, CLI/stray files ignored; `messages.jsonl` not scanned directly)
- `scan_all_clients` discovery of the IDE layout
- token estimation from `messages.jsonl` (using the issue's `session.json` sample), workspace attribution, timestamp/duration from `createdAt`/`lastModifiedAt`
- model-codename extraction (e.g. `big-pickle`) and assistant-turn counting
- empty/unrecognized content → no message
- `id`/timestamp fallback to `sess_*` dir name and file mtime
- dedup pass-through (IDE sessions never dropped by execution suppression)

## Gates

- `cargo fmt --all -- --check` clean
- `cargo clippy -p tokscale-core --all-targets` clean
- `cargo test -p tokscale-core --lib kiro` → 31 pass; scanner suite → 72 pass

Not tested: a real Kiro IDE `messages.jsonl` (no sample in the issue), so parsing is estimation-only; if a schema with real token counts surfaces, measured usage should be preferred over the chars/4 estimate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for Kiro IDE sessions on Windows by scanning `~/.kiro/sessions/<workspace>/sess_*/session.json` and parsing the sibling `messages.jsonl`. Also ensures appends to `messages.jsonl` invalidate the cache so token counts stay accurate. Fixes #813.

- **New Features**
  - Added a `~/.kiro/sessions` scan with the `kiro-ide-session` pattern (matches `session.json` inside `sess_*`, not CLI `cli/*.json`).
  - Parsed `session.json` metadata and estimated tokens from `messages.jsonl` via the role-tolerant collector; drops empty sessions, extracts model codenames and assistant turns, uses `{session_id}:ide-session` dedup, and falls back to `sess_*` dir name/mtime when needed.

- **Bug Fixes**
  - Included `messages.jsonl` in the cache fingerprint for IDE sessions using `SourceFingerprint::from_kiro_path` with `load_or_parse_source_with_fingerprint`, so appends update counts; non-IDE Kiro files keep the single-file fingerprint.

<sup>Written for commit b3f83bcca1703e4f5ee596ba9b9c7eb416625238. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

