### PR TITLE
fix(claude): exclude workflow journals and count deep-nested subagent transcripts

### DIFF
--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -2795,6 +2795,32 @@ mod tests {
         assert!(result.get(ClientId::OpenCode).is_empty());
     }
 
+    /// Regression for #815: nested-layout subagent/workflow transcripts
+    /// (`<session>/subagents/workflows/<wf>/agent-*.jsonl`) must be discovered by
+    /// the recursive project-dir walk, so their usage is counted. The sibling
+    /// `journal.jsonl` orchestration metadata is discovered too, but the parser
+    /// drops it (covered in the claudecode parser tests).
+    #[test]
+    fn test_scan_all_clients_claude_nested_workflow_agents() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let wf = home.join(".claude/projects/myproject/sess-uuid/subagents/workflows/wf_abc");
+        fs::create_dir_all(&wf).unwrap();
+        let agent = wf.join("agent-a123.jsonl");
+        File::create(&agent).unwrap().write_all(b"{}\n").unwrap();
+        File::create(wf.join("journal.jsonl"))
+            .unwrap()
+            .write_all(b"{}\n")
+            .unwrap();
+
+        let result = scan_all_clients(home.to_str().unwrap(), &["claude".to_string()]);
+        assert!(
+            result.get(ClientId::Claude).iter().any(|p| p == &agent),
+            "nested workflow agent transcript must be discovered, got {:?}",
+            result.get(ClientId::Claude)
+        );
+    }
+
     #[test]
     fn test_scan_all_clients_claude_transcripts() {
         let dir = TempDir::new().unwrap();

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -128,24 +128,49 @@ fn resolve_subagent_name(
     normalize_agent_name("claude-code-subagent")
 }
 
+/// True for nested-layout workflow orchestration journals
+/// (`.../<session>/subagents/**/journal.jsonl`).
+///
+/// Claude Code writes a `journal.jsonl` alongside `agent-*.jsonl` transcripts to
+/// record subagent workflow orchestration (spawn/verdict/result events). It shares
+/// the `.jsonl` extension and lives under the recursively-scanned project dir, so
+/// the dir-walk discovers it — but it is metadata, NOT a message transcript, and
+/// must never be ingested as usage. Its lines carry `type: "started"`/`"result"`
+/// (not `user`/`assistant`) so they currently parse to zero usage, but we drop it
+/// explicitly so a future journal schema can't silently leak token-like fields.
+fn is_workflow_journal(path: &Path) -> bool {
+    if path.file_name().and_then(|n| n.to_str()) != Some("journal.jsonl") {
+        return false;
+    }
+    path.ancestors()
+        .any(|ancestor| ancestor.file_name().and_then(|n| n.to_str()) == Some("subagents"))
+}
+
 /// Locate the parent main-session JSONL for a sidechain transcript.
 ///
 /// Nested layout: `.../projects/<key>/<session>/subagents/agent-X.jsonl`
+///   → parent at `.../projects/<key>/<session>.jsonl`
+/// Deep nested layout (workflows): `.../projects/<key>/<session>/subagents/workflows/<wf>/agent-X.jsonl`
 ///   → parent at `.../projects/<key>/<session>.jsonl`
 /// Flat layout: `.../projects/<key>/agent-X.jsonl`
 ///   → parent at `.../projects/<key>/<session-id>.jsonl`
 fn find_parent_session_path(sidechain_path: &Path, parent_session_id: &str) -> Option<PathBuf> {
     let parent_filename = format!("{}.jsonl", parent_session_id);
 
-    // Nested layout: parent dir is 3 levels up (file → subagents → session-dir → project-dir)
-    if let Some(dir) = sidechain_path.parent() {
-        if dir.file_name().and_then(|n| n.to_str()) == Some("subagents") {
-            if let Some(project_dir) = dir.parent().and_then(|d| d.parent()) {
+    // Nested layout: locate the `subagents` directory anywhere in the ancestry.
+    // The session dir is its parent and the project dir its grandparent, so the
+    // parent session file sits at `<project>/<session>.jsonl`. Anchoring on the
+    // `subagents` marker (rather than a fixed depth) handles both the shallow
+    // `subagents/agent-X.jsonl` and the deeper `subagents/workflows/<wf>/agent-X.jsonl`.
+    for ancestor in sidechain_path.ancestors() {
+        if ancestor.file_name().and_then(|n| n.to_str()) == Some("subagents") {
+            if let Some(project_dir) = ancestor.parent().and_then(|d| d.parent()) {
                 let candidate = project_dir.join(&parent_filename);
                 if candidate.exists() {
                     return Some(candidate);
                 }
             }
+            break;
         }
     }
 
@@ -328,6 +353,11 @@ pub fn parse_claude_file_with_cache_and_home(
     parent_cache: &mut ParentSubagentTypeCache,
     home_dir: Option<&Path>,
 ) -> Vec<UnifiedMessage> {
+    // Workflow orchestration journals are metadata, not transcripts — never ingest.
+    if is_workflow_journal(path) {
+        return Vec::new();
+    }
+
     let (workspace_key, workspace_label) = claude_workspace_from_path(path);
     let cc_mirror_metadata = cc_mirror_variant_metadata_from_path(path, home_dir);
     let client_id = cc_mirror_metadata
@@ -2267,6 +2297,145 @@ mod tests {
             "Without meta sidecar, should fall back to generic label"
         );
         assert_eq!(messages[0].session_id, "parent-uuid-002");
+    }
+
+    /// Helper: create a deep nested-layout workflow transcript
+    /// `.../projects/<project>/<parent_session>/subagents/workflows/<wf>/<agent_stem>.jsonl`.
+    fn create_workflow_files(
+        project: &str,
+        parent_session: &str,
+        workflow: &str,
+        file_stem: &str,
+        jsonl_content: &str,
+        meta_content: Option<&str>,
+    ) -> (TempDir, std::path::PathBuf) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let workflow_dir = temp_dir
+            .path()
+            .join(".claude")
+            .join("projects")
+            .join(project)
+            .join(parent_session)
+            .join("subagents")
+            .join("workflows")
+            .join(workflow);
+        std::fs::create_dir_all(&workflow_dir).unwrap();
+
+        let jsonl_path = workflow_dir.join(format!("{}.jsonl", file_stem));
+        std::fs::write(&jsonl_path, jsonl_content).unwrap();
+
+        if let Some(meta) = meta_content {
+            let meta_path = workflow_dir.join(format!("{}.meta.json", file_stem));
+            std::fs::write(&meta_path, meta).unwrap();
+        }
+
+        (temp_dir, jsonl_path)
+    }
+
+    #[test]
+    fn test_workflow_agent_transcript_counts_tokens() {
+        // #815: agent-*.jsonl nested under subagents/workflows/<wf>/ is a real
+        // transcript and its usage must be counted, keyed to the parent session.
+        let jsonl = r#"{"type":"user","isSidechain":true,"sessionId":"wf-parent-001","agentId":"wfa1","timestamp":"2024-12-01T10:00:00.000Z","message":{"content":"do work"}}
+{"type":"assistant","isSidechain":true,"sessionId":"wf-parent-001","agentId":"wfa1","timestamp":"2024-12-01T10:00:01.000Z","requestId":"req_wf1","message":{"id":"msg_wf1","model":"claude-3-5-sonnet","usage":{"input_tokens":500,"output_tokens":200,"cache_read_input_tokens":100,"cache_creation_input_tokens":40}}}"#;
+        let meta = r#"{"agentType":"workflow-subagent","spawnDepth":1}"#;
+
+        let (_dir, path) = create_workflow_files(
+            "myproject",
+            "wf-parent-001",
+            "wf_de048031",
+            "agent-wfa1",
+            jsonl,
+            Some(meta),
+        );
+        let messages = parse_claude_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].session_id, "wf-parent-001",
+            "deep nested transcript must key to the parent session, not the file/workflow"
+        );
+        assert_eq!(messages[0].tokens.input, 500);
+        assert_eq!(messages[0].tokens.output, 200);
+        assert_eq!(messages[0].tokens.cache_read, 100);
+        assert_eq!(messages[0].tokens.cache_write, 40);
+        assert_eq!(
+            messages[0].agent,
+            Some("Workflow Subagent".to_string()),
+            "Tier 1 meta sidecar next to the deep nested transcript should resolve the name"
+        );
+    }
+
+    #[test]
+    fn test_workflow_journal_not_ingested() {
+        // #815 CRITICAL: journal.jsonl is workflow orchestration metadata, not a
+        // transcript. Even if it grows lines that superficially resemble usage, the
+        // parser must drop the whole file.
+        let journal = r#"{"type":"started","key":"v2:abc","agentId":"wfa1"}
+{"type":"result","key":"v2:abc","agentId":"wfa1","result":{"verdict":"needs_fixes","summary":"Input tokens are estimated"}}
+{"type":"assistant","isSidechain":true,"sessionId":"wf-parent-002","timestamp":"2024-12-01T10:00:01.000Z","requestId":"req_j","message":{"id":"msg_j","model":"claude-3-5-sonnet","usage":{"input_tokens":9999,"output_tokens":9999}}}"#;
+
+        let (_dir, path) = create_workflow_files(
+            "myproject",
+            "wf-parent-002",
+            "wf_journal",
+            "journal",
+            journal,
+            None,
+        );
+        assert_eq!(path.file_name().unwrap().to_str().unwrap(), "journal.jsonl");
+        let messages = parse_claude_file(&path);
+
+        assert!(
+            messages.is_empty(),
+            "journal.jsonl must never be ingested, even with usage-shaped lines; got {:?}",
+            messages
+        );
+    }
+
+    #[test]
+    fn test_tier2_deep_nested_workflow_recovers_agent() {
+        // Deep nested layout without a meta sidecar: agent name must be recovered
+        // from the parent session tool_use, proving find_parent_session_path walks
+        // up past the extra workflows/<wf>/ levels.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let project_dir = temp_dir
+            .path()
+            .join(".claude")
+            .join("projects")
+            .join("myproject");
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        let parent_session_id = "deep-parent-uuid";
+        let parent_content = r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","message":{"id":"msg_dp","model":"claude-3-5-sonnet","role":"assistant","content":[{"type":"tool_use","id":"toolu_deep","name":"Agent","input":{"subagent_type":"code-reviewer","prompt":"review"}}],"usage":{"input_tokens":80,"output_tokens":40}}}
+{"type":"user","timestamp":"2024-12-01T10:00:01.000Z","message":{"role":"user","content":[{"tool_use_id":"toolu_deep","type":"tool_result","content":[{"type":"text","text":"agentId: deepagent1 (use SendMessage)"}]}]}}"#;
+        std::fs::write(
+            project_dir.join(format!("{}.jsonl", parent_session_id)),
+            parent_content,
+        )
+        .unwrap();
+
+        let workflow_dir = project_dir
+            .join(parent_session_id)
+            .join("subagents")
+            .join("workflows")
+            .join("wf_deep");
+        std::fs::create_dir_all(&workflow_dir).unwrap();
+        let sidechain_content = r#"{"type":"user","isSidechain":true,"sessionId":"deep-parent-uuid","agentId":"deepagent1","timestamp":"2024-12-01T10:00:00.500Z","message":{"content":"task"}}
+{"type":"assistant","isSidechain":true,"sessionId":"deep-parent-uuid","agentId":"deepagent1","timestamp":"2024-12-01T10:00:01.000Z","requestId":"req_deep","message":{"id":"msg_deep","model":"claude-3-5-sonnet","usage":{"input_tokens":300,"output_tokens":120}}}"#;
+        let sidechain_path = workflow_dir.join("agent-deepagent1.jsonl");
+        std::fs::write(&sidechain_path, sidechain_content).unwrap();
+
+        let messages = parse_claude_file(&sidechain_path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].agent,
+            Some("Code Reviewer".to_string()),
+            "Tier 2 must resolve the agent name across the deep workflows/<wf>/ nesting"
+        );
+        assert_eq!(messages[0].session_id, parent_session_id);
+        assert_eq!(messages[0].tokens.input, 300);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Claude Code now stores subagent transcripts in a nested layout:

```
~/.claude/projects/<project>/<session>/subagents/workflows/<wf>/agent-*.jsonl
~/.claude/projects/<project>/<session>/subagents/workflows/<wf>/journal.jsonl
```

Issue #815 reports this usage as uncounted. Investigating against real
transcripts on this machine showed the picture is more nuanced:

- **Discovery already works.** The Claude scan walks `~/.claude/projects`
  recursively (`WalkDir`, no depth cap), so `agent-*.jsonl` at any depth is
  found, parsed, and — because each sidechain line carries the parent
  `sessionId` — keyed to the parent session with a full token breakdown. A real
  workflow's `agent-*.jsonl` files parsed to 65 messages / 2.18M tokens keyed to
  the parent session.
- **No double counting.** Across a real workflow, the `agent-*.jsonl` files hold
  973 unique assistant message ids with **zero** overlap against the parent
  `<session>.jsonl` (which had zero `isSidechain` lines). Subagent usage lives
  only in the nested files, and message dedup is keyed globally on
  `messageId:requestId` regardless.

What was actually fragile / broken:

1. **`journal.jsonl` is ingested by accident-avoidance only.** It shares the
   `.jsonl` extension and is picked up by the recursive walk. It parses to zero
   usage today solely because its `type: "started"`/`"result"` lines don't match
   a transcript shape — but the file *does* contain free-text like "Input
   tokens…", and a future journal schema could leak token-shaped fields.
2. **Deep-nested subagent name resolution was broken.**
   `find_parent_session_path` assumed `subagents` was the transcript's immediate
   parent dir, so Tier-2 name inference from the parent session failed for the
   deeper `subagents/workflows/<wf>/` layout when no `.meta.json` sidecar was
   present.

## Fix

- Add `is_workflow_journal` and drop `journal.jsonl` (under any `subagents`
  ancestor) explicitly in the Claude parser — a robust guarantee that
  orchestration metadata is never counted as usage.
- Anchor `find_parent_session_path` on the `subagents` marker anywhere in the
  ancestry instead of a fixed depth, so Tier-2 name recovery works for both the
  shallow `subagents/agent-X.jsonl` and deep `subagents/workflows/<wf>/agent-X.jsonl`
  layouts.

Journal exclusion is scoped to the Claude parser rather than the shared
`scan_directory` walk, so other clients that legitimately use journal-suffixed
files are unaffected.

## Tests

- `test_scan_all_clients_claude_nested_workflow_agents` — nested-workflow
  `agent-*.jsonl` is discovered end-to-end.
- `test_workflow_agent_transcript_counts_tokens` — deep-nested transcript counts
  its full token breakdown, keyed to the parent session.
- `test_workflow_journal_not_ingested` — `journal.jsonl` yields zero messages
  even when it contains usage-shaped lines.
- `test_tier2_deep_nested_workflow_recovers_agent` — Tier-2 name resolution
  works across the extra `workflows/<wf>/` levels.

Gates: `cargo fmt --all -- --check`, `cargo clippy -p tokscale-core --lib -- -D
warnings`, and `tokscale-core` `sessions::`/`scanner::` module tests all pass.

Fixes #815

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude workflow `journal.jsonl` files from Claude ingestion and correctly count deep‑nested subagent transcripts under `subagents/workflows/**`. Fixes #815 by tying usage to the parent session and avoiding accidental ingestion of orchestration logs.

- **Bug Fixes**
  - Drop `journal.jsonl` under any `subagents` path in the Claude parser to ensure orchestration metadata is never ingested.
  - Anchor parent session lookup on the `subagents` directory anywhere in the ancestry so `subagents/workflows/<wf>/agent-*.jsonl` transcripts count and map to the parent session.
  - Add regression tests for nested discovery, token counting, journal exclusion, and deep‑nested Tier‑2 agent name recovery.

<sup>Written for commit 1af320dd7fc2e4699fbd8d45590303a892ed3514. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

