### PR TITLE
fix(core): preserve OpenCode provider-reported costs through repricing

### DIFF
--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -521,6 +521,34 @@ fn write_pricing_cache(base: &Path, timestamp: u64) {
     }
 }
 
+/// Add an assistant message with NO embedded cost to the OpenCode fixture.
+///
+/// Provider-reported OpenCode costs are preserved verbatim (never repriced),
+/// so the stale-pricing-cache tests need an uncosted message to prove the
+/// cache is actually consulted: 1000 input * 0.0000025 + 400 output *
+/// 0.00001 = 0.0065 on top of the 0.10 embedded total.
+fn add_uncosted_opencode_message(base: &Path) {
+    let session2 = base.join(".local/share/opencode/storage/message/session2");
+    fs::create_dir_all(&session2).unwrap();
+
+    // Same hour as msg_c (2025-01-10 12:01 UTC) so hourly bucket counts hold
+    let msg_d = r#"{
+        "id": "msg_d",
+        "sessionID": "session2",
+        "role": "assistant",
+        "modelID": "gpt-4o",
+        "providerID": "openai",
+        "tokens": {
+            "input": 1000,
+            "output": 400,
+            "reasoning": 0,
+            "cache": { "read": 0, "write": 0 }
+        },
+        "time": { "created": 1736510460000.0 }
+    }"#;
+    fs::write(session2.join("msg_d.json"), msg_d).unwrap();
+}
+
 fn write_fireworks_pricing_cache(base: &Path) {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -1789,6 +1817,7 @@ fn test_hourly_json_offline_without_pricing_cache_still_succeeds() {
 fn test_models_json_offline_uses_stale_pricing_cache_when_available() {
     let tmp = create_temp_fixture_dir_without_pricing_cache();
     write_pricing_cache(tmp.path(), 1);
+    add_uncosted_opencode_message(tmp.path());
 
     let output = offline_cmd_with_home(tmp.path())
         .args(["models", "--json", "--client", "opencode", "--no-spinner"])
@@ -1803,7 +1832,7 @@ fn test_models_json_offline_uses_stale_pricing_cache_when_available() {
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let total_cost = json["totalCost"].as_f64().unwrap();
     assert!(
-        (total_cost - 0.0209).abs() < 1e-9,
+        (total_cost - 0.1065).abs() < 1e-9,
         "unexpected totalCost: {total_cost}"
     );
 }
@@ -1812,6 +1841,7 @@ fn test_models_json_offline_uses_stale_pricing_cache_when_available() {
 fn test_monthly_json_offline_uses_stale_pricing_cache_when_available() {
     let tmp = create_temp_fixture_dir_without_pricing_cache();
     write_pricing_cache(tmp.path(), 1);
+    add_uncosted_opencode_message(tmp.path());
 
     let output = offline_cmd_with_home(tmp.path())
         .args(["monthly", "--json", "--client", "opencode", "--no-spinner"])
@@ -1826,7 +1856,7 @@ fn test_monthly_json_offline_uses_stale_pricing_cache_when_available() {
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let total_cost = json["totalCost"].as_f64().unwrap();
     assert!(
-        (total_cost - 0.0209).abs() < 1e-9,
+        (total_cost - 0.1065).abs() < 1e-9,
         "unexpected totalCost: {total_cost}"
     );
 }
@@ -1835,6 +1865,7 @@ fn test_monthly_json_offline_uses_stale_pricing_cache_when_available() {
 fn test_graph_offline_uses_stale_pricing_cache_when_available() {
     let tmp = create_temp_fixture_dir_without_pricing_cache();
     write_pricing_cache(tmp.path(), 1);
+    add_uncosted_opencode_message(tmp.path());
 
     let output = offline_cmd_with_home(tmp.path())
         .args(["graph", "--client", "opencode", "--no-spinner"])
@@ -1849,7 +1880,7 @@ fn test_graph_offline_uses_stale_pricing_cache_when_available() {
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let total_cost = json["summary"]["totalCost"].as_f64().unwrap();
     assert!(
-        (total_cost - 0.0209).abs() < 1e-9,
+        (total_cost - 0.1065).abs() < 1e-9,
         "unexpected totalCost: {total_cost}"
     );
 }
@@ -1858,6 +1889,7 @@ fn test_graph_offline_uses_stale_pricing_cache_when_available() {
 fn test_hourly_json_offline_uses_stale_pricing_cache_when_available() {
     let tmp = create_temp_fixture_dir_without_pricing_cache();
     write_pricing_cache(tmp.path(), 1);
+    add_uncosted_opencode_message(tmp.path());
 
     let output = offline_cmd_with_home(tmp.path())
         .args(["hourly", "--json", "--client", "opencode", "--no-spinner"])
@@ -1877,18 +1909,18 @@ fn test_hourly_json_offline_uses_stale_pricing_cache_when_available() {
             .iter()
             .map(|entry| entry["input"].as_i64().unwrap())
             .sum::<i64>(),
-        2400
+        3400
     );
     assert_eq!(
         entries
             .iter()
             .map(|entry| entry["output"].as_i64().unwrap())
             .sum::<i64>(),
-        1000
+        1400
     );
     let total_cost = json["totalCost"].as_f64().unwrap();
     assert!(
-        (total_cost - 0.0209).abs() < 1e-9,
+        (total_cost - 0.1065).abs() < 1e-9,
         "unexpected totalCost: {total_cost}"
     );
 }

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -6677,7 +6677,7 @@ mod tests {
     }
 
     #[test]
-    fn test_opencode_embedded_cost_reprices_when_pricing_exists() {
+    fn test_opencode_embedded_cost_survives_repricing_while_missing_cost_reprices() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let message_dir = temp_dir
             .path()
@@ -6720,8 +6720,13 @@ mod tests {
             .iter()
             .find(|message| message.dedup_key.as_deref() == Some("msg-missing"))
             .expect("missing-cost message should parse");
-        assert_eq!(embedded.cost, 0.2);
+        assert_eq!(
+            embedded.cost, 0.05,
+            "OpenCode computes cost at request time; the embedded value must not be overwritten by LiteLLM repricing"
+        );
+        assert_eq!(embedded.cost_source, crate::CostSource::ProviderReported);
         assert_eq!(missing.cost, 0.2);
+        assert_eq!(missing.cost_source, crate::CostSource::Estimated);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -197,7 +197,19 @@ pub fn parse_opencode_file(path: &Path) -> Option<UnifiedMessage> {
     unified.duration_ms = opencode_duration_ms(&msg.time);
     unified.dedup_key = dedup_key;
     set_workspace_from_root(&mut unified, workspace_root.as_deref());
+    mark_opencode_cost_source(&mut unified);
     Some(unified)
+}
+
+/// OpenCode computes per-message cost at request time from its own pricing
+/// data (models.dev), so a positive `cost` is authoritative and must survive
+/// tokscale's LiteLLM repricing pass. A zero cost usually means OpenCode
+/// itself had no pricing for the model — leave it `Unknown` so
+/// `apply_pricing_if_available` can still estimate.
+fn mark_opencode_cost_source(unified: &mut UnifiedMessage) {
+    if unified.cost > 0.0 {
+        unified.mark_provider_reported_cost();
+    }
 }
 
 pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
@@ -326,6 +338,7 @@ pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             .as_deref()
             .or(embedded_workspace_root.as_deref());
         set_workspace_from_root(&mut unified, workspace_root);
+        mark_opencode_cost_source(&mut unified);
 
         if let Some(index) = fingerprint_indices.get(&fingerprint).copied() {
             let dedup_state = &mut dedup_states[index];
@@ -753,6 +766,131 @@ mod tests {
         );
         assert_eq!(messages[0].model_id, "claude-sonnet-4");
         assert_eq!(messages[0].tokens.input, 1000);
+    }
+
+    #[test]
+    fn test_parse_opencode_file_marks_positive_cost_as_provider_reported() {
+        use std::io::Write;
+        let json = r#"{
+            "id": "msg_cost_001",
+            "sessionID": "ses_cost",
+            "role": "assistant",
+            "modelID": "z-ai/glm-4.6",
+            "providerID": "openrouter",
+            "cost": 0.0025158,
+            "tokens": {
+                "input": 2675,
+                "output": 28,
+                "reasoning": 1,
+                "cache": { "read": 7700, "write": 0 }
+            },
+            "time": { "created": 1765915142201.0 }
+        }"#;
+
+        let mut temp_file = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+        temp_file.write_all(json.as_bytes()).unwrap();
+
+        let msg = parse_opencode_file(temp_file.path()).expect("Should parse");
+        assert_eq!(
+            msg.cost_source,
+            crate::sessions::CostSource::ProviderReported,
+            "positive embedded cost must survive the LiteLLM repricing pass"
+        );
+        assert!((msg.cost - 0.0025158).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_parse_opencode_file_keeps_zero_cost_unknown_for_estimation() {
+        use std::io::Write;
+        let json = r#"{
+            "id": "msg_cost_002",
+            "sessionID": "ses_cost",
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "cost": 0.0,
+            "tokens": {
+                "input": 1000,
+                "output": 500,
+                "reasoning": 0,
+                "cache": { "read": 0, "write": 0 }
+            },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        let mut temp_file = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+        temp_file.write_all(json.as_bytes()).unwrap();
+
+        let msg = parse_opencode_file(temp_file.path()).expect("Should parse");
+        assert_eq!(
+            msg.cost_source,
+            crate::sessions::CostSource::Unknown,
+            "zero cost means OpenCode had no pricing — leave repricing enabled"
+        );
+    }
+
+    #[test]
+    fn test_parse_opencode_sqlite_marks_positive_cost_as_provider_reported() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("test_opencode_cost.db");
+        let conn = create_opencode_sqlite_db(&db_path);
+
+        let costed = r#"{
+            "role": "assistant",
+            "modelID": "z-ai/glm-4.6",
+            "providerID": "openrouter",
+            "cost": 0.0025158,
+            "tokens": {
+                "input": 2675,
+                "output": 28,
+                "reasoning": 1,
+                "cache": { "read": 7700, "write": 0 }
+            },
+            "time": { "created": 1765915142201.0 }
+        }"#;
+        let free = r#"{
+            "role": "assistant",
+            "modelID": "claude-sonnet-4",
+            "providerID": "anthropic",
+            "cost": 0.0,
+            "tokens": {
+                "input": 1000,
+                "output": 500,
+                "reasoning": 0,
+                "cache": { "read": 0, "write": 0 }
+            },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["msg_costed", "ses_cost", costed],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["msg_free", "ses_cost", free],
+        )
+        .unwrap();
+        drop(conn);
+
+        let messages = parse_opencode_sqlite(&db_path);
+        assert_eq!(messages.len(), 2);
+
+        let costed_msg = messages
+            .iter()
+            .find(|m| m.dedup_key.as_deref() == Some("msg_costed"))
+            .unwrap();
+        assert_eq!(
+            costed_msg.cost_source,
+            crate::sessions::CostSource::ProviderReported
+        );
+
+        let free_msg = messages
+            .iter()
+            .find(|m| m.dedup_key.as_deref() == Some("msg_free"))
+            .unwrap();
+        assert_eq!(free_msg.cost_source, crate::sessions::CostSource::Unknown);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

#87: OpenCode embeds an authoritative per-message `cost` (computed at request time from models.dev pricing — see the payload in the issue), but tokscale's opencode parser never set `cost_source`, leaving it `Unknown`. `apply_pricing_if_available` therefore recalculated from LiteLLM and **overwrote** the provider-reported cost whenever a pricing row matched — exactly the edge @Necmttn flagged. Only models missing from LiteLLM kept their embedded cost, by accident.

## Fix

Wire OpenCode into the `CostSource` provenance mechanism from #791:

- Both `parse_opencode_file` and `parse_opencode_sqlite` now call `mark_provider_reported_cost()` when the embedded cost is positive, so it survives the repricing pass.
- A **zero** embedded cost stays `Unknown` on purpose: OpenCode writes `cost: 0` when its own pricing table lacks the model, and those messages should still get tokscale's LiteLLM estimate (the fallback #87 originally asked for). This deliberately differs from the gjc parser, where an explicit `cost.total: 0` is authoritative.

The dedup fingerprint already includes `cost_bits`, so fork/dedup behavior is unchanged.

## Tests

- `test_parse_opencode_file_marks_positive_cost_as_provider_reported` (uses the exact payload from #87)
- `test_parse_opencode_file_keeps_zero_cost_unknown_for_estimation`
- `test_parse_opencode_sqlite_marks_positive_cost_as_provider_reported`
- Updated `test_opencode_embedded_cost_reprices_when_pricing_exists` → `test_opencode_embedded_cost_survives_repricing_while_missing_cost_reprices`: that test (added in #791) snapshotted the old overwrite behavior; embedded `0.05` is now preserved while the cost-less sibling message still reprices to `0.2`.

Full `tokscale-core` suite: 1079 passed. Clippy clean.

Fixes #87

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves OpenCode provider-reported per‑message costs during repricing so embedded costs aren’t overwritten by LiteLLM. Offline CLI cache tests now verify embedded totals stay intact and only uncosted messages get repriced from the stale cache.

- **Bug Fixes**
  - Mark positive OpenCode `cost` as `ProviderReported` via `mark_opencode_cost_source()` in both file and SQLite parsers.
  - Keep `cost_source` as `Unknown` when `cost` is `0` to allow LiteLLM fallback.
  - Tests: renamed repricing test; added JSON/SQLite tests for preserved positive costs and zero‑cost estimation; updated CLI stale‑cache tests to add an uncosted message and assert preserved embedded total (0.10) plus cached pricing (+0.0065 → 0.1065).

<sup>Written for commit 7f84ee844ad48bb6ca6759d71108d8c8561862b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

