### PR TITLE
fix(core): normalize empty-report totalCost from -0.0 to 0.0

### DIFF
--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -1926,6 +1926,38 @@ fn test_hourly_json_offline_uses_stale_pricing_cache_when_available() {
 }
 
 #[test]
+fn test_empty_report_total_cost_is_positive_zero() {
+    // f64's Sum identity is -0.0; without normalization an empty report
+    // serializes as "totalCost": -0.0.
+    let tmp = TempDir::new().unwrap();
+    for subcmd in ["models", "monthly", "hourly"] {
+        let output = offline_cmd_with_home(tmp.path())
+            .args([subcmd, "--json", "--client", "crush", "--no-spinner"])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{subcmd} stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            !stdout.contains("-0.0"),
+            "{subcmd} JSON contains negative zero: {stdout}"
+        );
+
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        let total_cost = json["totalCost"].as_f64().unwrap();
+        assert_eq!(total_cost, 0.0, "{subcmd} totalCost should be zero");
+        assert!(
+            total_cost.is_sign_positive(),
+            "{subcmd} totalCost serialized as -0.0"
+        );
+    }
+}
+
+#[test]
 fn test_models_json_total_consistency() {
     let tmp = create_temp_fixture_dir();
     let output = cmd_with_home(tmp.path())

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1964,7 +1964,10 @@ pub async fn get_model_report(options: ReportOptions) -> Result<ModelReport, Str
     let (total_input, total_output, total_cache_read, total_cache_write) =
         model_report_token_totals(&entries);
     let total_messages: i32 = entries.iter().map(|e| e.message_count).sum();
-    let total_cost: f64 = entries.iter().map(|e| e.cost).sum();
+    // f64's Sum identity is -0.0, so an empty report would serialize as
+    // "totalCost": -0.0; adding +0.0 normalizes the sign without changing
+    // any non-zero total.
+    let total_cost: f64 = entries.iter().map(|e| e.cost).sum::<f64>() + 0.0;
 
     Ok(ModelReport {
         entries,
@@ -2054,7 +2057,10 @@ pub async fn get_monthly_report(options: ReportOptions) -> Result<MonthlyReport,
 
     entries.sort_by(|a, b| a.month.cmp(&b.month));
 
-    let total_cost: f64 = entries.iter().map(|e| e.cost).sum();
+    // f64's Sum identity is -0.0, so an empty report would serialize as
+    // "totalCost": -0.0; adding +0.0 normalizes the sign without changing
+    // any non-zero total.
+    let total_cost: f64 = entries.iter().map(|e| e.cost).sum::<f64>() + 0.0;
 
     Ok(MonthlyReport {
         entries,
@@ -2168,7 +2174,10 @@ pub async fn get_hourly_report(options: ReportOptions) -> Result<HourlyReport, S
 
     entries.sort_by(|a, b| a.hour.cmp(&b.hour));
 
-    let total_cost: f64 = entries.iter().map(|e| e.cost).sum();
+    // f64's Sum identity is -0.0, so an empty report would serialize as
+    // "totalCost": -0.0; adding +0.0 normalizes the sign without changing
+    // any non-zero total.
+    let total_cost: f64 = entries.iter().map(|e| e.cost).sum::<f64>() + 0.0;
 
     Ok(HourlyReport {
         entries,


### PR DESCRIPTION
## Problem

An empty report (e.g. `tokscale models --json --client crush` with no Crush data) serialized as `"totalCost": -0.0`.

Root cause is a Rust stdlib subtlety: `impl Sum for f64` folds from an identity of **`-0.0`** (chosen so that summing lists of negative zeros preserves the sign), so `empty.iter().map(|e| e.cost).sum::<f64>()` returns negative zero, and serde_json faithfully prints it. All three report totals in core (models, monthly, hourly) were affected; the graph summary accumulates with `+=` from `0.0` and the two CLI-side sums are guarded by empty early-returns, so they were fine.

Found while validating #838/#839 end-to-end (the empty-registry control case printed `totalCost=-0.0`).

## Fix

Append `+ 0.0` to the three sums: `-0.0 + 0.0 = +0.0` per IEEE 754, and `x + 0.0 = x` for every other value, so no non-zero total changes. (`.max(0.0)` was rejected — IEEE max on equal-magnitude zeros has an unspecified sign.)

## Tests

- New `test_empty_report_total_cost_is_positive_zero`: runs `models`/`monthly`/`hourly --json` against an empty hermetic home and asserts the raw JSON contains no `-0.0` and the parsed value is sign-positive zero.
- Full suites: core 1115 passed, CLI 123 passed, clippy clean.
- Verified against the rebuilt binary: empty report now prints `"totalCost": 0.0`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes negative zero in JSON `totalCost` for empty reports, normalizing `-0.0` to `0.0` for `models`, `monthly`, and `hourly`. Non-zero totals are unchanged.

- **Bug Fixes**
  - In `tokscale-core`, normalize empty-report totals by adding `+ 0.0` after cost sums to flip `-0.0` to `0.0` without affecting other values.
  - In `tokscale-cli`, add a test to verify empty `--json` outputs contain no `-0.0` and that `totalCost` is positive zero.

<sup>Written for commit b123652f40fcef565982e06082b3019458c25e45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

