### PR TITLE
feat(cli): add --hide-zero to models/monthly/hourly reports

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -61,6 +61,12 @@ struct Cli {
     )]
     no_write_cache: bool,
 
+    #[arg(
+        long = "hide-zero",
+        help = "Hide entries whose token counts, cost, and duration are all zero. Report totals still include them."
+    )]
+    hide_zero: bool,
+
     #[command(flatten)]
     clients: ClientFlags,
 
@@ -125,6 +131,11 @@ enum Commands {
             help = "Skip cache write even if settings.json `light.writeCache` is true. Only valid with --light."
         )]
         no_write_cache: bool,
+        #[arg(
+            long = "hide-zero",
+            help = "Hide entries whose token counts, cost, and duration are all zero. Report totals still include them."
+        )]
+        hide_zero: bool,
         #[arg(long, help = "Disable spinner")]
         no_spinner: bool,
     },
@@ -140,6 +151,11 @@ enum Commands {
         date: DateRangeFlags,
         #[arg(long, help = "Show processing time")]
         benchmark: bool,
+        #[arg(
+            long = "hide-zero",
+            help = "Hide entries whose token counts and cost are all zero. Report totals still include them."
+        )]
+        hide_zero: bool,
         #[arg(long, help = "Disable spinner")]
         no_spinner: bool,
     },
@@ -155,6 +171,11 @@ enum Commands {
         date: DateRangeFlags,
         #[arg(long, help = "Show processing time")]
         benchmark: bool,
+        #[arg(
+            long = "hide-zero",
+            help = "Hide entries whose token counts and cost are all zero. Report totals still include them."
+        )]
+        hide_zero: bool,
         #[arg(long, help = "Disable spinner")]
         no_spinner: bool,
     },
@@ -502,6 +523,7 @@ fn main() -> Result<()> {
             group_by,
             write_cache,
             no_write_cache,
+            hide_zero,
             no_spinner,
         }) => {
             use tokscale_core::GroupBy;
@@ -522,6 +544,7 @@ fn main() -> Result<()> {
                     group_by,
                     write_cache,
                     no_write_cache,
+                    hide_zero,
                 )
             } else {
                 let (since, until) = build_date_filter(&date);
@@ -546,6 +569,7 @@ fn main() -> Result<()> {
             clients,
             date,
             benchmark,
+            hide_zero,
             no_spinner,
         }) => {
             let clients = build_client_filter(clients, &cli.home);
@@ -557,6 +581,7 @@ fn main() -> Result<()> {
                     &date,
                     benchmark,
                     no_spinner || !can_use_tui,
+                    hide_zero,
                 )
             } else {
                 let (since, until) = build_date_filter(&date);
@@ -581,6 +606,7 @@ fn main() -> Result<()> {
             clients,
             date,
             benchmark,
+            hide_zero,
             no_spinner,
         }) => {
             let clients = build_client_filter(clients, &cli.home);
@@ -592,6 +618,7 @@ fn main() -> Result<()> {
                     &date,
                     benchmark,
                     no_spinner || !can_use_tui,
+                    hide_zero,
                 )
             } else {
                 let (since, until) = build_date_filter(&date);
@@ -830,6 +857,7 @@ fn main() -> Result<()> {
                     group_by,
                     cli.write_cache,
                     cli.no_write_cache,
+                    cli.hide_zero,
                 )
             } else if cli.light || !can_use_tui {
                 run_models_report(
@@ -842,6 +870,7 @@ fn main() -> Result<()> {
                     group_by,
                     cli.write_cache,
                     cli.no_write_cache,
+                    cli.hide_zero,
                 )
             } else {
                 let (since, until) = build_date_filter(&cli.date);
@@ -1719,6 +1748,7 @@ fn run_models_report(
     group_by: tokscale_core::GroupBy,
     cli_write_cache: bool,
     cli_no_write_cache: bool,
+    hide_zero: bool,
 ) -> Result<()> {
     use std::time::Instant;
     use tokio::runtime::Runtime;
@@ -1756,6 +1786,21 @@ fn run_models_report(
             .await
         })
         .map_err(|e| anyhow::anyhow!(e))?;
+    let mut report = report;
+    if hide_zero {
+        // Display-only filter: totals were computed in core over the full
+        // entry set and intentionally still include the hidden rows.
+        report.entries.retain(|e| {
+            e.input != 0
+                || e.output != 0
+                || e.cache_read != 0
+                || e.cache_write != 0
+                || e.reasoning != 0
+                || e.cost != 0.0
+                || e.performance.total_duration_ms != 0
+        });
+    }
+    let report = report;
 
     if let Some(spinner) = spinner {
         spinner.stop();
@@ -2570,6 +2615,7 @@ fn run_monthly_report(
     date: &DateRangeFlags,
     benchmark: bool,
     no_spinner: bool,
+    hide_zero: bool,
 ) -> Result<()> {
     use std::time::Instant;
     use tokio::runtime::Runtime;
@@ -2606,6 +2652,18 @@ fn run_monthly_report(
             .await
         })
         .map_err(|e| anyhow::anyhow!(e))?;
+    let mut report = report;
+    if hide_zero {
+        // Display-only filter: totals still include the hidden rows.
+        report.entries.retain(|e| {
+            e.input != 0
+                || e.output != 0
+                || e.cache_read != 0
+                || e.cache_write != 0
+                || e.cost != 0.0
+        });
+    }
+    let report = report;
 
     if let Some(spinner) = spinner {
         spinner.stop();
@@ -2880,6 +2938,7 @@ fn run_hourly_report(
     date: &DateRangeFlags,
     benchmark: bool,
     no_spinner: bool,
+    hide_zero: bool,
 ) -> Result<()> {
     use std::time::Instant;
     use tokio::runtime::Runtime;
@@ -2916,6 +2975,19 @@ fn run_hourly_report(
             .await
         })
         .map_err(|e| anyhow::anyhow!(e))?;
+    let mut report = report;
+    if hide_zero {
+        // Display-only filter: totals still include the hidden rows.
+        report.entries.retain(|e| {
+            e.input != 0
+                || e.output != 0
+                || e.cache_read != 0
+                || e.cache_write != 0
+                || e.reasoning != 0
+                || e.cost != 0.0
+        });
+    }
+    let report = report;
 
     if let Some(spinner) = spinner {
         spinner.stop();

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -63,7 +63,7 @@ struct Cli {
 
     #[arg(
         long = "hide-zero",
-        help = "Hide entries whose token counts, cost, and duration are all zero. Report totals still include them."
+        help = "Hide entries whose token counts, cost, and duration are all zero. Report totals still include them. Implies the static report view instead of the interactive TUI."
     )]
     hide_zero: bool,
 
@@ -133,7 +133,7 @@ enum Commands {
         no_write_cache: bool,
         #[arg(
             long = "hide-zero",
-            help = "Hide entries whose token counts, cost, and duration are all zero. Report totals still include them."
+            help = "Hide entries whose token counts, cost, and duration are all zero. Report totals still include them. Implies the static report view instead of the interactive TUI."
         )]
         hide_zero: bool,
         #[arg(long, help = "Disable spinner")]
@@ -153,7 +153,7 @@ enum Commands {
         benchmark: bool,
         #[arg(
             long = "hide-zero",
-            help = "Hide entries whose token counts and cost are all zero. Report totals still include them."
+            help = "Hide entries whose token counts and cost are all zero. Report totals still include them. Implies the static report view instead of the interactive TUI."
         )]
         hide_zero: bool,
         #[arg(long, help = "Disable spinner")]
@@ -173,7 +173,7 @@ enum Commands {
         benchmark: bool,
         #[arg(
             long = "hide-zero",
-            help = "Hide entries whose token counts and cost are all zero. Report totals still include them."
+            help = "Hide entries whose token counts and cost are all zero. Report totals still include them. Implies the static report view instead of the interactive TUI."
         )]
         hide_zero: bool,
         #[arg(long, help = "Disable spinner")]
@@ -533,7 +533,7 @@ fn main() -> Result<()> {
                 std::process::exit(1);
             });
             let clients = build_client_filter(clients, &cli.home);
-            if json || light || !can_use_tui {
+            if json || light || hide_zero || !can_use_tui {
                 run_models_report(
                     json,
                     cli.home.clone(),
@@ -573,7 +573,7 @@ fn main() -> Result<()> {
             no_spinner,
         }) => {
             let clients = build_client_filter(clients, &cli.home);
-            if json || light || !can_use_tui {
+            if json || light || hide_zero || !can_use_tui {
                 run_monthly_report(
                     json,
                     cli.home.clone(),
@@ -610,7 +610,7 @@ fn main() -> Result<()> {
             no_spinner,
         }) => {
             let clients = build_client_filter(clients, &cli.home);
-            if json || light || !can_use_tui {
+            if json || light || hide_zero || !can_use_tui {
                 run_hourly_report(
                     json,
                     cli.home.clone(),
@@ -859,7 +859,7 @@ fn main() -> Result<()> {
                     cli.no_write_cache,
                     cli.hide_zero,
                 )
-            } else if cli.light || !can_use_tui {
+            } else if cli.light || cli.hide_zero || !can_use_tui {
                 run_models_report(
                     false,
                     cli.home.clone(),

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -549,6 +549,33 @@ fn add_uncosted_opencode_message(base: &Path) {
     fs::write(session2.join("msg_d.json"), msg_d).unwrap();
 }
 
+/// Add an assistant message whose usage is entirely zero (tokens, cost, no
+/// duration) in its own month/hour, for `--hide-zero` tests. Uses a distinct
+/// model and a 2023-03-15 timestamp so it forms an all-zero row in the
+/// models, monthly, and hourly reports without touching other buckets.
+fn add_zero_usage_opencode_message(base: &Path) {
+    let session3 = base.join(".local/share/opencode/storage/message/session3");
+    fs::create_dir_all(&session3).unwrap();
+
+    // 2023-03-15 12:00:00 UTC = 1678881600000 ms
+    let msg_z = r#"{
+        "id": "msg_z",
+        "sessionID": "session3",
+        "role": "assistant",
+        "modelID": "zero-model",
+        "providerID": "openai",
+        "cost": 0.0,
+        "tokens": {
+            "input": 0,
+            "output": 0,
+            "reasoning": 0,
+            "cache": { "read": 0, "write": 0 }
+        },
+        "time": { "created": 1678881600000.0 }
+    }"#;
+    fs::write(session3.join("msg_z.json"), msg_z).unwrap();
+}
+
 fn write_fireworks_pricing_cache(base: &Path) {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -1955,6 +1982,71 @@ fn test_empty_report_total_cost_is_positive_zero() {
             "{subcmd} totalCost serialized as -0.0"
         );
     }
+}
+
+#[test]
+fn test_hide_zero_drops_all_zero_entries_but_keeps_totals() {
+    let tmp = create_temp_fixture_dir_without_pricing_cache();
+    add_zero_usage_opencode_message(tmp.path());
+
+    let run = |args: &[&str]| -> serde_json::Value {
+        let output = offline_cmd_with_home(tmp.path())
+            .args(args)
+            .args(["--json", "--client", "opencode", "--no-spinner"])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{args:?} stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        serde_json::from_slice(&output.stdout).unwrap()
+    };
+
+    // models: the all-zero (opencode, zero-model) row disappears with the flag
+    let full = run(&["models"]);
+    let filtered = run(&["models", "--hide-zero"]);
+    let has_zero_model = |json: &serde_json::Value| {
+        json["entries"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|e| e["model"] == "zero-model")
+    };
+    assert!(has_zero_model(&full), "zero row must show without the flag");
+    assert!(!has_zero_model(&filtered), "--hide-zero must drop the row");
+    assert!(filtered["entries"].as_array().unwrap().iter().all(|e| {
+        e["input"].as_i64().unwrap() != 0
+            || e["output"].as_i64().unwrap() != 0
+            || e["cost"].as_f64().unwrap() != 0.0
+    }));
+    // totals are display-independent: hidden rows still count
+    assert_eq!(full["totalMessages"], filtered["totalMessages"]);
+    assert_eq!(full["totalCost"], filtered["totalCost"]);
+
+    // monthly: the all-zero 2023-03 bucket disappears with the flag
+    let full = run(&["monthly"]);
+    let filtered = run(&["monthly", "--hide-zero"]);
+    let months = |json: &serde_json::Value| -> Vec<String> {
+        json["entries"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| e["month"].as_str().unwrap().to_string())
+            .collect()
+    };
+    assert!(months(&full).contains(&"2023-03".to_string()));
+    assert!(!months(&filtered).contains(&"2023-03".to_string()));
+    assert_eq!(full["totalCost"], filtered["totalCost"]);
+
+    // hourly: exactly one all-zero hour bucket disappears with the flag
+    let full = run(&["hourly"]);
+    let filtered = run(&["hourly", "--hide-zero"]);
+    assert_eq!(
+        full["entries"].as_array().unwrap().len(),
+        filtered["entries"].as_array().unwrap().len() + 1
+    );
+    assert_eq!(full["totalCost"], filtered["totalCost"]);
 }
 
 #[test]


### PR DESCRIPTION
## Problem

#841: the models table renders a row for every (client, model) group that has messages, even when every token count and the cost are zero — users with many zero-usage Cursor/OpenCode models get a wall of `0 / 0 / 0 / $0.00` rows (see the screenshot in the issue) and there was no parameter to suppress them.

## Change

Opt-in `--hide-zero` flag on `models`, `monthly`, `hourly`, and the bare `tokscale` root invocation. When set, entries whose usage is entirely zero — all token fields, cost, and (for models) recorded duration — are dropped after the report is built and before any rendering, so the table, `--light`, and `--json` all honor it.

Deliberate choices:
- **Opt-in, default unchanged** — `--json` consumers keep seeing every row unless they ask otherwise.
- **Display-only** — report totals (`totalCost`, `totalMessages`, token totals) are computed in core over the full entry set and still include hidden rows; the flag never changes the numbers, only which rows are listed.
- **`--write-cache` unaffected** — `write_light_cache` regenerates its data independently and never sees the filtered entries.
- Rows with zero tokens but non-zero cost (e.g. Crush's cost-only entries) or non-zero duration are kept.

## Tests

`test_hide_zero_drops_all_zero_entries_but_keeps_totals`: fixture with an all-zero message in its own month/hour; asserts the zero row/bucket shows without the flag, disappears with it, and totals are identical either way — across all three subcommands.

Full CLI suites: 124 integration + 850 bin-target tests passed; clippy clean.

Closes #841

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an opt-in `--hide-zero` flag to hide all-zero usage rows in `models`, `monthly`, `hourly`, and the root `tokscale`. It reduces noise and now forces the static report view so the flag works in interactive terminals; totals are unchanged.

- **New Features**
  - `--hide-zero` drops entries where all token counts and cost are zero; for `models`, duration must also be zero. Rows with any non-zero cost or duration remain.
  - Display-only filter honored by table, `--light`, and `--json`; totals still include hidden rows.
  - `--write-cache` behavior is unchanged.

- **Bug Fixes**
  - `--hide-zero` implies the static report path (like `--light`) so it takes effect instead of being ignored by the TUI.

<sup>Written for commit d43525db20d72eb378f3be79254e3dccf28e41fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

