### PR TITLE
feat(tui): add readable surface themes

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -159,7 +159,7 @@ AI支援開発の時代において、**トークンは新しいエネルギー*
 - **インタラクティブTUIモード** - Ratatuiによる美しいターミナルUI（デフォルトモード）
   - 6つのインタラクティブビュー：概要、モデル、日別、時間別、統計、エージェント（オプションの Minutely ビューを `minutelyTabEnabled` でオプトイン可能）
   - キーボード＆マウスナビゲーション
-  - 9色テーマのGitHubスタイル貢献グラフ
+  - 設定可能なカラーテーマのGitHubスタイル貢献グラフ
   - リアルタイムフィルタリングとソート
   - ゼロフリッカーレンダリング
 - **マルチプラットフォームサポート** - OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、Synthetic全体の使用量追跡
@@ -279,12 +279,12 @@ tokscale models --json > report.json   # ファイルに保存
   - `h`: 日別/時間別のチャート粒度を切り替え（Overview タブ）
   - `v`: テーブル/プロフィールビューを切り替え（Hourly タブ）
   - `y`: 選択行をクリップボードにコピー
-  - `p`: 9色テーマを循環
+  - `p`: カラーテーマを循環
   - `r`: データを更新; `Shift+R` で自動更新の切り替え; `+`/`-` で間隔調整
   - `e`: JSONにエクスポート
   - `q` または `Ctrl+C`: 終了
 - **マウスサポート**: タブ、ボタン、フィルターをクリック
-- **テーマ**: Green、Halloween、Teal、Blue、Pink、Purple、Orange、Monochrome、YlGnBu
+- **テーマ**: Green、Halloween、Teal、Blue、Pink、Purple、Orange、Monochrome、YlGnBu、Graphite、Lagoon、Dusk
 - **設定の永続化**: 設定は`~/.config/tokscale/settings.json`に保存（[設定](#設定)を参照）
 
 ### グループ基準戦略
@@ -820,7 +820,7 @@ Tokscaleは設定を`~/.config/tokscale/settings.json`に保存します：
 
 | 設定 | タイプ | デフォルト | 説明 |
 |---------|------|---------|-------------|
-| `colorPalette` | string | `"blue"` | TUIカラーテーマ（green、halloween、teal、blue、pink、purple、orange、monochrome、ylgnbu） |
+| `colorPalette` | string | `"blue"` | TUIカラーテーマ（green、halloween、teal、blue、pink、purple、orange、monochrome、ylgnbu、graphite、lagoon、dusk） |
 | `includeUnusedModels` | boolean | `false` | レポートでゼロトークンのモデルを表示 |
 | `autoRefreshEnabled` | boolean | `false` | TUIの自動更新を有効化 |
 | `autoRefreshMs` | number | `60000` | 自動更新間隔（30000-3600000ms） |

--- a/README.ko.md
+++ b/README.ko.md
@@ -157,7 +157,7 @@ AI 지원 개발 시대에 **토큰은 새로운 에너지**입니다. 토큰은
 - **인터랙티브 TUI 모드** - Ratatui 기반의 터미널 UI (기본 모드)
   - 6개 인터랙티브 뷰: 개요, 모델, 일별, 시간별, 통계, 에이전트 (선택적 Minutely 뷰는 `minutelyTabEnabled`로 활성화)
   - 키보드 및 마우스 지원
-  - 9가지 테마의 GitHub 스타일 기여 그래프
+  - 설정 가능한 색상 테마의 GitHub 스타일 기여 그래프
   - 실시간 필터링 및 정렬
   - 깜빡임 없는 렌더링
 - **멀티 플랫폼 지원** - OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, Synthetic 사용량 통합 추적
@@ -275,12 +275,12 @@ tokscale models --json > report.json   # 파일로 저장
   - `h`: Daily/Hourly 차트 단위 전환 (Overview 탭)
   - `v`: Table/Profile 뷰 전환 (Hourly 탭)
   - `y`: 선택된 행을 클립보드에 복사
-  - `p`: 9가지 색상 테마 순환
+  - `p`: 색상 테마 순환
   - `r`: 데이터 새로고침; `Shift+R`로 자동 새로고침 토글; `+`/`-`로 간격 조정
   - `e`: JSON으로 내보내기
   - `q` 또는 `Ctrl+C`: 종료
 - **마우스 지원**: 탭, 버튼, 필터 클릭
-- **테마**: Green, Halloween, Teal, Blue, Pink, Purple, Orange, Monochrome, YlGnBu
+- **테마**: Green, Halloween, Teal, Blue, Pink, Purple, Orange, Monochrome, YlGnBu, Graphite, Lagoon, Dusk
 - **설정 저장**: 설정이 `~/.config/tokscale/settings.json`에 저장됨 ([설정](#설정) 참조)
 
 ### 그룹 기준 전략
@@ -820,7 +820,7 @@ Tokscale은 설정을 `~/.config/tokscale/settings.json`에 저장합니다:
 
 | 설정 | 타입 | 기본값 | 설명 |
 |---------|------|---------|-------------|
-| `colorPalette` | string | `"blue"` | TUI 색상 테마 (green, halloween, teal, blue, pink, purple, orange, monochrome, ylgnbu) |
+| `colorPalette` | string | `"blue"` | TUI 색상 테마 (green, halloween, teal, blue, pink, purple, orange, monochrome, ylgnbu, graphite, lagoon, dusk) |
 | `includeUnusedModels` | boolean | `false` | 리포트에서 제로 토큰 모델 표시 |
 | `autoRefreshEnabled` | boolean | `false` | TUI 자동 새로고침 활성화 |
 | `autoRefreshMs` | number | `60000` | 자동 새로고침 간격 (30000-3600000ms) |

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
 - **Interactive TUI Mode** - Beautiful terminal UI powered by Ratatui (default mode)
   - 6 interactive views: Overview, Models, Daily, Hourly, Stats, Agents (plus an optional Minutely view, opt-in via `minutelyTabEnabled`)
   - Keyboard & mouse navigation
-  - GitHub-style contribution graph with 9 color themes
+  - GitHub-style contribution graph with configurable color themes
   - Real-time filtering and sorting
   - Zero flicker rendering
 - **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, and Synthetic
@@ -282,12 +282,12 @@ The interactive TUI mode provides:
   - `h`: Toggle Daily/Hourly chart granularity (Overview tab)
   - `v`: Toggle Table/Profile view (Hourly tab)
   - `y`: Copy selected row to clipboard
-  - `p`: Cycle through 9 color themes
+  - `p`: Cycle through color themes
   - `r`: Refresh data; `Shift+R` toggles auto-refresh; `+`/`-` adjusts interval
   - `e`: Export to JSON
   - `q` or `Ctrl+C`: Quit
 - **Mouse Support**: Click tabs, buttons, and filters
-- **Themes**: Green, Halloween, Teal, Blue, Pink, Purple, Orange, Monochrome, YlGnBu
+- **Themes**: Green, Halloween, Teal, Blue, Pink, Purple, Orange, Monochrome, YlGnBu, Graphite, Lagoon, Dusk
 - **Settings Persistence**: Preferences saved to `~/.config/tokscale/settings.json` (see [Configuration](#configuration))
 
 ### Group-By Strategies
@@ -855,7 +855,7 @@ Tokscale stores settings in `~/.config/tokscale/settings.json`:
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `colorPalette` | string | `"blue"` | TUI color theme (green, halloween, teal, blue, pink, purple, orange, monochrome, ylgnbu) |
+| `colorPalette` | string | `"blue"` | TUI color theme (green, halloween, teal, blue, pink, purple, orange, monochrome, ylgnbu, graphite, lagoon, dusk) |
 | `includeUnusedModels` | boolean | `false` | Show models with zero tokens in reports |
 | `autoRefreshEnabled` | boolean | `false` | Enable auto-refresh in TUI |
 | `autoRefreshMs` | number | `60000` | Auto-refresh interval (30000-3600000ms) |

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -157,7 +157,7 @@
 - **交互式 TUI 模式** - 由 Ratatui 驱动的精美终端 UI（默认模式）
   - 6 个交互式视图：概览、模型、每日、每时、统计、代理（可选的 Minutely 视图通过 `minutelyTabEnabled` 启用）
   - 键盘和鼠标导航
-  - 9 种颜色主题的 GitHub 风格贡献图
+  - 支持可配置颜色主题的 GitHub 风格贡献图
   - 实时筛选和排序
   - 零闪烁渲染
 - **多平台支持** - 跟踪 OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode 和 Synthetic 的使用情况
@@ -276,12 +276,12 @@ tokscale models --json > report.json   # 保存到文件
   - `h`：切换日/时图表粒度（Overview 标签）
   - `v`：切换表格/Profile 视图（Hourly 标签）
   - `y`：复制选中行到剪贴板
-  - `p`：循环 9 种颜色主题
+  - `p`：循环颜色主题
   - `r`：刷新数据；`Shift+R` 切换自动刷新；`+`/`-` 调整间隔
   - `e`：导出为 JSON
   - `q` 或 `Ctrl+C`：退出
 - **鼠标支持**：点击标签、按钮和筛选器
-- **主题**：Green、Halloween、Teal、Blue、Pink、Purple、Orange、Monochrome、YlGnBu
+- **主题**：Green、Halloween、Teal、Blue、Pink、Purple、Orange、Monochrome、YlGnBu、Graphite、Lagoon、Dusk
 - **设置持久化**：偏好设置保存到 `~/.config/tokscale/settings.json`（参见[配置](#配置)）
 
 ### 分组策略
@@ -816,7 +816,7 @@ Tokscale 将设置存储在 `~/.config/tokscale/settings.json`：
 
 | 设置 | 类型 | 默认值 | 描述 |
 |---------|------|---------|-------------|
-| `colorPalette` | string | `"blue"` | TUI 颜色主题（green、halloween、teal、blue、pink、purple、orange、monochrome、ylgnbu） |
+| `colorPalette` | string | `"blue"` | TUI 颜色主题（green、halloween、teal、blue、pink、purple、orange、monochrome、ylgnbu、graphite、lagoon、dusk） |
 | `includeUnusedModels` | boolean | `false` | 在报告中显示零 Token 的模型 |
 | `autoRefreshEnabled` | boolean | `false` | 在 TUI 中启用自动刷新 |
 | `autoRefreshMs` | number | `60000` | 自动刷新间隔（30000-3600000ms） |

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -3947,7 +3947,7 @@ mod tests {
         app.handle_key_event(key(KeyCode::Char('p')));
         assert_ne!(app.theme.name, initial_theme);
 
-        for _ in 0..8 {
+        for _ in 1..ThemeName::all().len() {
             app.handle_key_event(key(KeyCode::Char('p')));
         }
         assert_eq!(app.theme.name, initial_theme);

--- a/crates/tokscale-cli/src/tui/themes.rs
+++ b/crates/tokscale-cli/src/tui/themes.rs
@@ -1,4 +1,4 @@
-use ratatui::style::{Color, Style};
+use ratatui::style::{Color, Modifier, Style};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TerminalColorMode {
@@ -56,6 +56,9 @@ pub enum ThemeName {
     Orange,
     Monochrome,
     YlGnBu,
+    Graphite,
+    Lagoon,
+    Dusk,
 }
 
 impl ThemeName {
@@ -70,6 +73,9 @@ impl ThemeName {
             ThemeName::Orange,
             ThemeName::Monochrome,
             ThemeName::YlGnBu,
+            ThemeName::Graphite,
+            ThemeName::Lagoon,
+            ThemeName::Dusk,
         ]
     }
 
@@ -90,6 +96,9 @@ impl ThemeName {
             ThemeName::Orange => "orange",
             ThemeName::Monochrome => "monochrome",
             ThemeName::YlGnBu => "ylgnbu",
+            ThemeName::Graphite => "graphite",
+            ThemeName::Lagoon => "lagoon",
+            ThemeName::Dusk => "dusk",
         }
     }
 }
@@ -108,6 +117,9 @@ impl std::str::FromStr for ThemeName {
             "orange" => Ok(ThemeName::Orange),
             "monochrome" => Ok(ThemeName::Monochrome),
             "ylgnbu" => Ok(ThemeName::YlGnBu),
+            "graphite" => Ok(ThemeName::Graphite),
+            "lagoon" => Ok(ThemeName::Lagoon),
+            "dusk" => Ok(ThemeName::Dusk),
             _ => Err(()),
         }
     }
@@ -124,6 +136,8 @@ pub struct Theme {
     pub muted: Color,
     pub accent: Color,
     pub selection: Color,
+    striped_row: Color,
+    current_row: Color,
     color_mode: TerminalColorMode,
 }
 
@@ -201,6 +215,27 @@ impl Theme {
                 Color::Rgb(44, 127, 184),  // grade3: #2c7fb8
                 Color::Rgb(37, 52, 148),   // grade4: #253494
             ],
+            ThemeName::Graphite => [
+                Color::Rgb(24, 27, 34),    // grade0: empty
+                Color::Rgb(148, 163, 184), // grade1: #94a3b8
+                Color::Rgb(125, 211, 252), // grade2: #7dd3fc
+                Color::Rgb(56, 189, 248),  // grade3: #38bdf8
+                Color::Rgb(14, 116, 144),  // grade4: #0e7490
+            ],
+            ThemeName::Lagoon => [
+                Color::Rgb(6, 32, 36),     // grade0: empty
+                Color::Rgb(153, 246, 228), // grade1: #99f6e4
+                Color::Rgb(94, 234, 212),  // grade2: #5eead4
+                Color::Rgb(45, 212, 191),  // grade3: #2dd4bf
+                Color::Rgb(15, 118, 110),  // grade4: #0f766e
+            ],
+            ThemeName::Dusk => [
+                Color::Rgb(27, 24, 38),    // grade0: empty
+                Color::Rgb(196, 181, 253), // grade1: #c4b5fd
+                Color::Rgb(167, 139, 250), // grade2: #a78bfa
+                Color::Rgb(139, 92, 246),  // grade3: #8b5cf6
+                Color::Rgb(109, 40, 217),  // grade4: #6d28d9
+            ],
         };
 
         let mut theme = Self {
@@ -213,8 +248,44 @@ impl Theme {
             muted: Color::Rgb(139, 148, 158),
             accent: Color::Cyan,
             selection: Color::Rgb(48, 54, 61),
+            striped_row: Color::Rgb(20, 24, 30),
+            current_row: Color::Rgb(28, 42, 34),
             color_mode,
         };
+
+        match name {
+            ThemeName::Graphite => {
+                theme.background = Color::Rgb(10, 12, 16);
+                theme.foreground = Color::Rgb(226, 232, 240);
+                theme.border = Color::Rgb(55, 65, 81);
+                theme.muted = Color::Rgb(148, 163, 184);
+                theme.accent = Color::Rgb(125, 211, 252);
+                theme.selection = Color::Rgb(31, 41, 55);
+                theme.striped_row = Color::Rgb(15, 18, 24);
+                theme.current_row = Color::Rgb(24, 39, 38);
+            }
+            ThemeName::Lagoon => {
+                theme.background = Color::Rgb(5, 20, 23);
+                theme.foreground = Color::Rgb(216, 241, 238);
+                theme.border = Color::Rgb(31, 83, 88);
+                theme.muted = Color::Rgb(133, 177, 175);
+                theme.accent = Color::Rgb(94, 234, 212);
+                theme.selection = Color::Rgb(15, 54, 58);
+                theme.striped_row = Color::Rgb(7, 26, 30);
+                theme.current_row = Color::Rgb(18, 54, 42);
+            }
+            ThemeName::Dusk => {
+                theme.background = Color::Rgb(17, 16, 26);
+                theme.foreground = Color::Rgb(232, 226, 238);
+                theme.border = Color::Rgb(63, 57, 82);
+                theme.muted = Color::Rgb(166, 154, 184);
+                theme.accent = Color::Rgb(196, 181, 253);
+                theme.selection = Color::Rgb(43, 37, 58);
+                theme.striped_row = Color::Rgb(22, 20, 32);
+                theme.current_row = Color::Rgb(40, 45, 36);
+            }
+            _ => {}
+        }
 
         if color_mode == TerminalColorMode::Compatible {
             theme.colors = [
@@ -231,6 +302,8 @@ impl Theme {
             theme.muted = Color::DarkGray;
             theme.accent = Color::Cyan;
             theme.selection = Color::DarkGray;
+            theme.striped_row = Color::Black;
+            theme.current_row = Color::DarkGray;
         }
 
         theme
@@ -259,6 +332,12 @@ impl Theme {
         Style::default().fg(self.color(Color::Rgb(200, 150, 100)))
     }
 
+    pub(crate) fn metric_total_style(&self) -> Style {
+        Style::default()
+            .fg(self.foreground)
+            .add_modifier(Modifier::BOLD)
+    }
+
     pub(crate) fn secondary_text_style(&self) -> Style {
         Style::default().fg(self.color(Color::Rgb(170, 170, 170)))
     }
@@ -271,7 +350,7 @@ impl Theme {
         if self.color_mode == TerminalColorMode::Compatible {
             Style::default()
         } else {
-            Style::default().bg(Color::Rgb(20, 24, 30))
+            Style::default().bg(self.striped_row)
         }
     }
 
@@ -279,7 +358,7 @@ impl Theme {
         if self.color_mode == TerminalColorMode::Compatible {
             Style::default().bg(self.selection)
         } else {
-            Style::default().bg(Color::Rgb(28, 42, 34))
+            Style::default().bg(self.current_row)
         }
     }
 }
@@ -364,6 +443,53 @@ mod tests {
     }
 
     #[test]
+    fn theme_names_round_trip_through_settings_value() {
+        for theme in ThemeName::all() {
+            assert_eq!(theme.as_str().parse::<ThemeName>(), Ok(*theme));
+        }
+    }
+
+    #[test]
+    fn surface_themes_customize_background_and_row_colors() {
+        let cases = [
+            (
+                ThemeName::Graphite,
+                Color::Rgb(10, 12, 16),
+                Color::Rgb(226, 232, 240),
+                Color::Rgb(31, 41, 55),
+                Color::Rgb(15, 18, 24),
+                Color::Rgb(24, 39, 38),
+            ),
+            (
+                ThemeName::Lagoon,
+                Color::Rgb(5, 20, 23),
+                Color::Rgb(216, 241, 238),
+                Color::Rgb(15, 54, 58),
+                Color::Rgb(7, 26, 30),
+                Color::Rgb(18, 54, 42),
+            ),
+            (
+                ThemeName::Dusk,
+                Color::Rgb(17, 16, 26),
+                Color::Rgb(232, 226, 238),
+                Color::Rgb(43, 37, 58),
+                Color::Rgb(22, 20, 32),
+                Color::Rgb(40, 45, 36),
+            ),
+        ];
+
+        for (name, background, foreground, selection, striped, current) in cases {
+            let theme = Theme::from_name_with_color_mode(name, TerminalColorMode::FullColor);
+
+            assert_eq!(theme.background, background);
+            assert_eq!(theme.foreground, foreground);
+            assert_eq!(theme.selection, selection);
+            assert_eq!(theme.striped_row_style().bg, Some(striped));
+            assert_eq!(theme.current_row_style().bg, Some(current));
+        }
+    }
+
+    #[test]
     fn compatible_theme_preserves_name_and_avoids_rgb_palette() {
         let theme =
             Theme::from_name_with_color_mode(ThemeName::Green, TerminalColorMode::Compatible);
@@ -400,6 +526,7 @@ mod tests {
             theme.metric_output_style(),
             theme.metric_cache_read_style(),
             theme.metric_cache_write_style(),
+            theme.metric_total_style(),
             theme.secondary_text_style(),
             theme.subtle_text_style(),
             theme.striped_row_style(),

--- a/crates/tokscale-cli/src/tui/ui/agents.rs
+++ b/crates/tokscale-cli/src/tui/ui/agents.rs
@@ -36,6 +36,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let theme_accent = app.theme.accent;
     let theme_muted = app.theme.muted;
     let theme_selection = app.theme.selection;
+    let metric_total_style = app.theme.metric_total_style();
     let striped_row_style = app.theme.striped_row_style();
 
     let agents = app.get_sorted_agents();
@@ -116,7 +117,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                 vec![
                     Cell::from(truncate(&agent.agent, 18))
                         .style(Style::default().fg(app.theme.foreground)),
-                    Cell::from(format_tokens(agent.tokens.total())),
+                    Cell::from(format_tokens(agent.tokens.total())).style(metric_total_style),
                     Cell::from(format_cost(agent.cost)).style(Style::default().fg(Color::Green)),
                 ]
             } else {
@@ -129,7 +130,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                     ),
                     Cell::from(truncate(&client_labels(&agent.clients), 24))
                         .style(Style::default().fg(theme_muted)),
-                    Cell::from(format_tokens(agent.tokens.total())),
+                    Cell::from(format_tokens(agent.tokens.total())).style(metric_total_style),
                     Cell::from(format_cost(agent.cost)).style(Style::default().fg(Color::Green)),
                     Cell::from(agent.message_count.to_string())
                         .style(Style::default().fg(theme_muted)),

--- a/crates/tokscale-cli/src/tui/ui/daily.rs
+++ b/crates/tokscale-cli/src/tui/ui/daily.rs
@@ -55,6 +55,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let metric_output_style = app.theme.metric_output_style();
     let metric_cache_read_style = app.theme.metric_cache_read_style();
     let metric_cache_write_style = app.theme.metric_cache_write_style();
+    let metric_total_style = app.theme.metric_total_style();
     let current_row_style = app.theme.current_row_style();
     let striped_row_style = app.theme.striped_row_style();
     let today = Local::now().date_naive();
@@ -186,7 +187,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                 }
                 cells.extend([
                     Cell::from(day.message_count.to_string()),
-                    Cell::from(format_tokens(day.tokens.total())),
+                    Cell::from(format_tokens(day.tokens.total())).style(metric_total_style),
                     Cell::from(format_cost(day.cost)).style(Style::default().fg(Color::Green)),
                 ]);
                 cells
@@ -222,7 +223,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                         day.tokens.cache_write,
                     ))
                     .style(Style::default().fg(Color::Cyan)),
-                    Cell::from(format_tokens(day.tokens.total())),
+                    Cell::from(format_tokens(day.tokens.total())).style(metric_total_style),
                     Cell::from(format_cost(day.cost)).style(Style::default().fg(Color::Green)),
                     Cell::from(format_cost_per_million(day.cost, day.tokens.total()))
                         .style(Style::default().fg(Color::Rgb(150, 200, 150))),
@@ -361,6 +362,7 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
     let metric_output_style = app.theme.metric_output_style();
     let metric_cache_read_style = app.theme.metric_cache_read_style();
     let metric_cache_write_style = app.theme.metric_cache_write_style();
+    let metric_total_style = app.theme.metric_total_style();
     let striped_row_style = app.theme.striped_row_style();
 
     let header_cells = if is_very_narrow {
@@ -445,7 +447,7 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
                     Cell::from(get_client_display_name(row.source))
                         .style(Style::default().fg(theme_muted)),
                     Cell::from(row.messages.to_string()),
-                    Cell::from(format_tokens(row.tokens.total())),
+                    Cell::from(format_tokens(row.tokens.total())).style(metric_total_style),
                     Cell::from(format_cost(row.cost)).style(Style::default().fg(Color::Green)),
                 ]
             } else {
@@ -471,7 +473,7 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
                         row.tokens.cache_write,
                     ))
                     .style(Style::default().fg(Color::Cyan)),
-                    Cell::from(format_tokens(row.tokens.total())),
+                    Cell::from(format_tokens(row.tokens.total())).style(metric_total_style),
                     Cell::from(format_cost(row.cost)).style(Style::default().fg(Color::Green)),
                 ]
             };

--- a/crates/tokscale-cli/src/tui/ui/hourly.rs
+++ b/crates/tokscale-cli/src/tui/ui/hourly.rs
@@ -64,6 +64,7 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
     let metric_output_style = app.theme.metric_output_style();
     let metric_cache_read_style = app.theme.metric_cache_read_style();
     let metric_cache_write_style = app.theme.metric_cache_write_style();
+    let metric_total_style = app.theme.metric_total_style();
     let current_row_style = app.theme.current_row_style();
     let striped_row_style = app.theme.striped_row_style();
     let now = Local::now().naive_local();
@@ -225,7 +226,7 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
             }
             cells.extend([
                 Cell::from(hour.message_count.to_string()),
-                Cell::from(format_tokens(hour.tokens.total())),
+                Cell::from(format_tokens(hour.tokens.total())).style(metric_total_style),
                 Cell::from(format_cost(hour.cost)).style(Style::default().fg(Color::Green)),
             ]);
             cells
@@ -249,7 +250,7 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
                     hour.tokens.cache_write,
                 ))
                 .style(Style::default().fg(Color::Cyan)),
-                Cell::from(format_tokens(hour.tokens.total())),
+                Cell::from(format_tokens(hour.tokens.total())).style(metric_total_style),
                 Cell::from(format_cost(hour.cost)).style(Style::default().fg(Color::Green)),
                 Cell::from(format_cost_per_million(hour.cost, hour.tokens.total()))
                     .style(Style::default().fg(Color::Rgb(150, 200, 150))),

--- a/crates/tokscale-cli/src/tui/ui/minutely.rs
+++ b/crates/tokscale-cli/src/tui/ui/minutely.rs
@@ -47,6 +47,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let metric_output_style = app.theme.metric_output_style();
     let metric_cache_read_style = app.theme.metric_cache_read_style();
     let metric_cache_write_style = app.theme.metric_cache_write_style();
+    let metric_total_style = app.theme.metric_total_style();
     let current_row_style = app.theme.current_row_style();
     let striped_row_style = app.theme.striped_row_style();
     let now = Local::now().naive_local();
@@ -174,7 +175,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                 }
                 cells.extend([
                     Cell::from(minute.message_count.to_string()),
-                    Cell::from(format_tokens(minute.tokens.total())),
+                    Cell::from(format_tokens(minute.tokens.total())).style(metric_total_style),
                     Cell::from(format_cost(minute.cost)).style(Style::default().fg(Color::Green)),
                 ]);
                 cells
@@ -213,7 +214,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                         minute.tokens.cache_write,
                     ))
                     .style(Style::default().fg(Color::Cyan)),
-                    Cell::from(format_tokens(minute.tokens.total())),
+                    Cell::from(format_tokens(minute.tokens.total())).style(metric_total_style),
                     Cell::from(format_cost(minute.cost)).style(Style::default().fg(Color::Green)),
                 ]);
                 cells

--- a/crates/tokscale-cli/src/tui/ui/models.rs
+++ b/crates/tokscale-cli/src/tui/ui/models.rs
@@ -57,6 +57,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let metric_output_style = app.theme.metric_output_style();
     let metric_cache_read_style = app.theme.metric_cache_read_style();
     let metric_cache_write_style = app.theme.metric_cache_write_style();
+    let metric_total_style = app.theme.metric_total_style();
     let striped_row_style = app.theme.striped_row_style();
 
     let models = app.get_sorted_models();
@@ -159,7 +160,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             } else if is_narrow {
                 vec![
                     Cell::from(truncate(&display_name, 25)).style(Style::default().fg(model_color)),
-                    Cell::from(format_tokens(model.tokens.total())),
+                    Cell::from(format_tokens(model.tokens.total())).style(metric_total_style),
                     Cell::from(format_cost(model.cost)).style(Style::default().fg(Color::Green)),
                 ]
             } else if group_by == GroupBy::WorkspaceModel {
@@ -184,7 +185,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                         .style(metric_cache_read_style),
                     Cell::from(format_tokens(model.tokens.cache_write))
                         .style(metric_cache_write_style),
-                    Cell::from(format_tokens(model.tokens.total())),
+                    Cell::from(format_tokens(model.tokens.total())).style(metric_total_style),
                     Cell::from(format_ms_per_1k(model.performance.ms_per_1k_tokens))
                         .style(Style::default().fg(Color::Yellow)),
                     Cell::from(format_cost(model.cost)).style(Style::default().fg(Color::Green)),
@@ -214,7 +215,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                         model.tokens.cache_write,
                     ))
                     .style(Style::default().fg(Color::Cyan)),
-                    Cell::from(format_tokens(model.tokens.total())),
+                    Cell::from(format_tokens(model.tokens.total())).style(metric_total_style),
                     Cell::from(format_ms_per_1k(model.performance.ms_per_1k_tokens))
                         .style(Style::default().fg(Color::Yellow)),
                     Cell::from(format_cost(model.cost)).style(Style::default().fg(Color::Green)),

--- a/crates/tokscale-cli/src/tui/ui/monthly.rs
+++ b/crates/tokscale-cli/src/tui/ui/monthly.rs
@@ -54,6 +54,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let metric_output_style = app.theme.metric_output_style();
     let metric_cache_read_style = app.theme.metric_cache_read_style();
     let metric_cache_write_style = app.theme.metric_cache_write_style();
+    let metric_total_style = app.theme.metric_total_style();
     let striped_row_style = app.theme.striped_row_style();
 
     let full_layout_width: u16 = if has_turn_data { 112 } else { 105 };
@@ -153,7 +154,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                 }
                 cells.extend([
                     Cell::from(month.message_count.to_string()),
-                    Cell::from(format_tokens(month.tokens.total())),
+                    Cell::from(format_tokens(month.tokens.total())).style(metric_total_style),
                     Cell::from(format_cost(month.cost)).style(Style::default().fg(Color::Green)),
                 ]);
                 cells
@@ -181,7 +182,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                         month.tokens.cache_write,
                     ))
                     .style(Style::default().fg(Color::Cyan)),
-                    Cell::from(format_tokens(month.tokens.total())),
+                    Cell::from(format_tokens(month.tokens.total())).style(metric_total_style),
                     Cell::from(format_cost(month.cost)).style(Style::default().fg(Color::Green)),
                     Cell::from(format_cost_per_million(month.cost, month.tokens.total()))
                         .style(Style::default().fg(Color::Rgb(150, 200, 150))),
@@ -317,6 +318,7 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
     let metric_output_style = app.theme.metric_output_style();
     let metric_cache_read_style = app.theme.metric_cache_read_style();
     let metric_cache_write_style = app.theme.metric_cache_write_style();
+    let metric_total_style = app.theme.metric_total_style();
     let striped_row_style = app.theme.striped_row_style();
 
     let full_layout_width: u16 = if has_turn_data { 112 } else { 105 };
@@ -423,7 +425,7 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
                 }
                 cells.extend([
                     Cell::from(day.message_count.to_string()),
-                    Cell::from(format_tokens(day.tokens.total())),
+                    Cell::from(format_tokens(day.tokens.total())).style(metric_total_style),
                     Cell::from(format_cost(day.cost)).style(Style::default().fg(Color::Green)),
                 ]);
                 cells
@@ -450,7 +452,7 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
                         day.tokens.cache_write,
                     ))
                     .style(Style::default().fg(Color::Cyan)),
-                    Cell::from(format_tokens(day.tokens.total())),
+                    Cell::from(format_tokens(day.tokens.total())).style(metric_total_style),
                     Cell::from(format_cost(day.cost)).style(Style::default().fg(Color::Green)),
                     Cell::from(format_cost_per_million(day.cost, day.tokens.total()))
                         .style(Style::default().fg(Color::Rgb(150, 200, 150))),


### PR DESCRIPTION
## Summary

* Add Graphite, Lagoon, and Dusk TUI themes with their own background, foreground, border, selection, striped row, and current row colors.
* Render total token cells with a high-contrast bold foreground across TUI tables.
* Update localized README theme lists.

## Tests

* `cargo fmt --check`
* `cargo test -p tokscale-cli tui::themes -- --nocapture`
* `cargo test -p tokscale-cli tui::ui -- --nocapture`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three readable TUI themes (Graphite, Lagoon, Dusk) and improves table legibility by bolding “Total tokens” and using theme-specific row backgrounds across all data tables.

- **New Features**
  - New themes: Graphite, Lagoon, Dusk with custom background, foreground, border, selection, striped row, and current row colors.
  - “Total tokens” cells are now high-contrast and bold across Agents, Daily, Hourly, Minutely, Models, and Monthly tables.
  - Striped/current row styles are theme-aware; fall back to simple colors in compatible mode.
  - Updated README (EN/JA/KO/ZH) to list new themes and configurable color themes; expanded tests for theme parsing, settings round-trip, and surface colors.

<sup>Written for commit da39f647323a49b3d58cf9cb774cd700eaf90d11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

