### PR TITLE
fix(tui): honor saved color theme on launch

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -27,8 +27,8 @@ struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
 
-    #[arg(short, long, default_value = "blue")]
-    theme: String,
+    #[arg(short, long)]
+    theme: Option<String>,
 
     #[arg(short, long, default_value = "0")]
     refresh: u64,
@@ -552,7 +552,7 @@ fn main() -> Result<()> {
                 ensure_home_supported_for_tui(&cli.home)?;
                 auto_sync_cursor_before_tui(&cli.home, &clients)?;
                 tui::run(
-                    &cli.theme,
+                    cli.theme.as_deref().unwrap_or(""),
                     cli.refresh,
                     cli.debug,
                     clients,
@@ -589,7 +589,7 @@ fn main() -> Result<()> {
                 ensure_home_supported_for_tui(&cli.home)?;
                 auto_sync_cursor_before_tui(&cli.home, &clients)?;
                 tui::run(
-                    &cli.theme,
+                    cli.theme.as_deref().unwrap_or(""),
                     cli.refresh,
                     cli.debug,
                     clients,
@@ -626,7 +626,7 @@ fn main() -> Result<()> {
                 ensure_home_supported_for_tui(&cli.home)?;
                 auto_sync_cursor_before_tui(&cli.home, &clients)?;
                 tui::run(
-                    &cli.theme,
+                    cli.theme.as_deref().unwrap_or(""),
                     cli.refresh,
                     cli.debug,
                     clients,
@@ -691,7 +691,7 @@ fn main() -> Result<()> {
             let clients = build_client_filter(clients, &cli.home);
             auto_sync_cursor_before_tui(&cli.home, &clients)?;
             tui::run(
-                &cli.theme,
+                cli.theme.as_deref().unwrap_or(""),
                 cli.refresh,
                 cli.debug,
                 clients,
@@ -878,7 +878,7 @@ fn main() -> Result<()> {
                 ensure_home_supported_for_tui(&cli.home)?;
                 auto_sync_cursor_before_tui(&cli.home, &clients)?;
                 tui::run(
-                    &cli.theme,
+                    cli.theme.as_deref().unwrap_or(""),
                     cli.refresh,
                     cli.debug,
                     clients,

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -381,10 +381,14 @@ pub struct App {
 impl App {
     pub fn new_with_cached_data(config: TuiConfig, cached_data: Option<UsageData>) -> Result<Self> {
         let settings = Settings::load();
-        let theme_name: ThemeName = config
-            .theme
-            .parse()
-            .unwrap_or_else(|_| settings.theme_name());
+        let theme_name: ThemeName = if config.theme.is_empty() {
+            settings.theme_name()
+        } else {
+            config
+                .theme
+                .parse()
+                .unwrap_or_else(|_| settings.theme_name())
+        };
         let theme = Theme::from_name_for_current_terminal(theme_name);
 
         let enabled_clients: HashSet<ClientFilter> = if let Some(ref cli_clients) = config.clients {
@@ -2501,6 +2505,7 @@ mod tests {
     use crate::tui::data::{DailyModelInfo, DailySourceInfo, ModelUsage, TokenBreakdown};
     use chrono::{NaiveDate, NaiveDateTime};
     use std::collections::{BTreeMap, BTreeSet};
+    use std::{env, fs};
 
     #[test]
     fn test_tab_all() {
@@ -2779,6 +2784,76 @@ mod tests {
         let app = App::new_with_cached_data(config, None).unwrap();
 
         assert!(!app.should_quit);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn app_uses_saved_theme_when_cli_theme_is_absent() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let previous_config_dir = env::var_os("TOKSCALE_CONFIG_DIR");
+        unsafe {
+            env::set_var("TOKSCALE_CONFIG_DIR", temp.path());
+        }
+        fs::write(
+            temp.path().join("settings.json"),
+            r#"{"colorPalette":"halloween"}"#,
+        )
+        .unwrap();
+
+        let config = TuiConfig {
+            theme: String::new(),
+            refresh: 0,
+            sessions_path: None,
+            clients: None,
+            since: None,
+            until: None,
+            year: None,
+            initial_tab: None,
+        };
+        let app = App::new_with_cached_data(config, None).unwrap();
+
+        unsafe {
+            match previous_config_dir {
+                Some(value) => env::set_var("TOKSCALE_CONFIG_DIR", value),
+                None => env::remove_var("TOKSCALE_CONFIG_DIR"),
+            }
+        }
+        assert_eq!(app.theme.name, ThemeName::Halloween);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn app_explicit_cli_theme_overrides_saved_theme() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let previous_config_dir = env::var_os("TOKSCALE_CONFIG_DIR");
+        unsafe {
+            env::set_var("TOKSCALE_CONFIG_DIR", temp.path());
+        }
+        fs::write(
+            temp.path().join("settings.json"),
+            r#"{"colorPalette":"halloween"}"#,
+        )
+        .unwrap();
+
+        let config = TuiConfig {
+            theme: "blue".to_string(),
+            refresh: 0,
+            sessions_path: None,
+            clients: None,
+            since: None,
+            until: None,
+            year: None,
+            initial_tab: None,
+        };
+        let app = App::new_with_cached_data(config, None).unwrap();
+
+        unsafe {
+            match previous_config_dir {
+                Some(value) => env::set_var("TOKSCALE_CONFIG_DIR", value),
+                None => env::remove_var("TOKSCALE_CONFIG_DIR"),
+            }
+        }
+        assert_eq!(app.theme.name, ThemeName::Blue);
     }
 
     // ── Helper ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes saved TUI color themes being ignored on a normal launch. The global `--theme` option no longer injects the implicit `"blue"` default before the TUI can read `settings.json`; explicit `--theme` still overrides saved settings.

## Root Cause

`clap` always populated `Cli::theme` with `"blue"`, so `App::new_with_cached_data` saw a valid theme string and never fell back to `Settings::theme_name()`.

## Tests

* `cargo fmt --check`
* `cargo check -p tokscale-cli`
* `cargo test -p tokscale-cli app_ -- --nocapture`
* `cargo test -p tokscale-cli test_handle_key_theme_cycle -- --nocapture`
* `cargo test -p tokscale-cli test_global_theme_flag -- --nocapture`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors the saved TUI color theme on launch by distinguishing an omitted `--theme` from an explicit override. If `--theme` is not provided, the app now reads `settings.json`; an explicit `--theme` still takes priority.

- **Bug Fixes**
  - Replaced `--theme` default with `Option<String>` in `clap` to avoid forcing `"blue"`.
  - TUI now falls back to `Settings::theme_name()` only when the CLI theme is absent.
  - Added tests covering saved-theme fallback and explicit CLI override.

<sup>Written for commit 92420bf4f1287a45ad114c732bf134690e06d494. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

