### PR TITLE
refactor(tui): share total token table cell styling

### DIFF
--- a/crates/tokscale-cli/src/tui/ui/agents.rs
+++ b/crates/tokscale-cli/src/tui/ui/agents.rs
@@ -4,7 +4,7 @@ use ratatui::widgets::{
 };
 
 use super::widgets::{
-    format_cost, format_tokens, get_client_display_name, viewport_scrollbar_state,
+    format_cost, get_client_display_name, total_tokens_cell, viewport_scrollbar_state,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 use crate::ClientFilter;
@@ -36,7 +36,6 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let theme_accent = app.theme.accent;
     let theme_muted = app.theme.muted;
     let theme_selection = app.theme.selection;
-    let metric_total_style = app.theme.metric_total_style();
     let striped_row_style = app.theme.striped_row_style();
 
     let agents = app.get_sorted_agents();
@@ -117,7 +116,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                 vec![
                     Cell::from(truncate(&agent.agent, 18))
                         .style(Style::default().fg(app.theme.foreground)),
-                    Cell::from(format_tokens(agent.tokens.total())).style(metric_total_style),
+                    total_tokens_cell(agent.tokens.total(), &app.theme),
                     Cell::from(format_cost(agent.cost)).style(Style::default().fg(Color::Green)),
                 ]
             } else {
@@ -130,7 +129,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                     ),
                     Cell::from(truncate(&client_labels(&agent.clients), 24))
                         .style(Style::default().fg(theme_muted)),
-                    Cell::from(format_tokens(agent.tokens.total())).style(metric_total_style),
+                    total_tokens_cell(agent.tokens.total(), &app.theme),
                     Cell::from(format_cost(agent.cost)).style(Style::default().fg(Color::Green)),
                     Cell::from(agent.message_count.to_string())
                         .style(Style::default().fg(theme_muted)),

--- a/crates/tokscale-cli/src/tui/ui/daily.rs
+++ b/crates/tokscale-cli/src/tui/ui/daily.rs
@@ -6,7 +6,8 @@ use ratatui::widgets::{
 
 use super::widgets::{
     format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens,
-    get_client_display_name, get_provider_display_name, viewport_scrollbar_state,
+    get_client_display_name, get_provider_display_name, total_tokens_cell,
+    viewport_scrollbar_state,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 
@@ -55,7 +56,6 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let metric_output_style = app.theme.metric_output_style();
     let metric_cache_read_style = app.theme.metric_cache_read_style();
     let metric_cache_write_style = app.theme.metric_cache_write_style();
-    let metric_total_style = app.theme.metric_total_style();
     let current_row_style = app.theme.current_row_style();
     let striped_row_style = app.theme.striped_row_style();
     let today = Local::now().date_naive();
@@ -187,7 +187,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                 }
                 cells.extend([
                     Cell::from(day.message_count.to_string()),
-                    Cell::from(format_tokens(day.tokens.total())).style(metric_total_style),
+                    total_tokens_cell(day.tokens.total(), &app.theme),
                     Cell::from(format_cost(day.cost)).style(Style::default().fg(Color::Green)),
                 ]);
                 cells
@@ -223,7 +223,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                         day.tokens.cache_write,
                     ))
                     .style(Style::default().fg(Color::Cyan)),
-                    Cell::from(format_tokens(day.tokens.total())).style(metric_total_style),
+                    total_tokens_cell(day.tokens.total(), &app.theme),
                     Cell::from(format_cost(day.cost)).style(Style::default().fg(Color::Green)),
                     Cell::from(format_cost_per_million(day.cost, day.tokens.total()))
                         .style(Style::default().fg(Color::Rgb(150, 200, 150))),
@@ -362,7 +362,6 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
     let metric_output_style = app.theme.metric_output_style();
     let metric_cache_read_style = app.theme.metric_cache_read_style();
     let metric_cache_write_style = app.theme.metric_cache_write_style();
-    let metric_total_style = app.theme.metric_total_style();
     let striped_row_style = app.theme.striped_row_style();
 
     let header_cells = if is_very_narrow {
@@ -447,7 +446,7 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
                     Cell::from(get_client_display_name(row.source))
                         .style(Style::default().fg(theme_muted)),
                     Cell::from(row.messages.to_string()),
-                    Cell::from(format_tokens(row.tokens.total())).style(metric_total_style),
+                    total_tokens_cell(row.tokens.total(), &app.theme),
                     Cell::from(format_cost(row.cost)).style(Style::default().fg(Color::Green)),
                 ]
             } else {
@@ -473,7 +472,7 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
                         row.tokens.cache_write,
                     ))
                     .style(Style::default().fg(Color::Cyan)),
-                    Cell::from(format_tokens(row.tokens.total())).style(metric_total_style),
+                    total_tokens_cell(row.tokens.total(), &app.theme),
                     Cell::from(format_cost(row.cost)).style(Style::default().fg(Color::Green)),
                 ]
             };

--- a/crates/tokscale-cli/src/tui/ui/hourly.rs
+++ b/crates/tokscale-cli/src/tui/ui/hourly.rs
@@ -6,7 +6,7 @@ use ratatui::widgets::{
 
 use super::hourly_profile;
 use super::widgets::{
-    format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens,
+    format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens, total_tokens_cell,
     viewport_scrollbar_state,
 };
 use crate::tui::app::{App, HourlyViewMode, SortDirection, SortField};
@@ -64,7 +64,6 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
     let metric_output_style = app.theme.metric_output_style();
     let metric_cache_read_style = app.theme.metric_cache_read_style();
     let metric_cache_write_style = app.theme.metric_cache_write_style();
-    let metric_total_style = app.theme.metric_total_style();
     let current_row_style = app.theme.current_row_style();
     let striped_row_style = app.theme.striped_row_style();
     let now = Local::now().naive_local();
@@ -226,7 +225,7 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
             }
             cells.extend([
                 Cell::from(hour.message_count.to_string()),
-                Cell::from(format_tokens(hour.tokens.total())).style(metric_total_style),
+                total_tokens_cell(hour.tokens.total(), &app.theme),
                 Cell::from(format_cost(hour.cost)).style(Style::default().fg(Color::Green)),
             ]);
             cells
@@ -250,7 +249,7 @@ fn render_table(frame: &mut Frame, app: &mut App, area: Rect) {
                     hour.tokens.cache_write,
                 ))
                 .style(Style::default().fg(Color::Cyan)),
-                Cell::from(format_tokens(hour.tokens.total())).style(metric_total_style),
+                total_tokens_cell(hour.tokens.total(), &app.theme),
                 Cell::from(format_cost(hour.cost)).style(Style::default().fg(Color::Green)),
                 Cell::from(format_cost_per_million(hour.cost, hour.tokens.total()))
                     .style(Style::default().fg(Color::Rgb(150, 200, 150))),

--- a/crates/tokscale-cli/src/tui/ui/minutely.rs
+++ b/crates/tokscale-cli/src/tui/ui/minutely.rs
@@ -4,7 +4,9 @@ use ratatui::widgets::{
     Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, Table,
 };
 
-use super::widgets::{format_cache_hit_rate, format_cost, format_tokens, viewport_scrollbar_state};
+use super::widgets::{
+    format_cache_hit_rate, format_cost, format_tokens, total_tokens_cell, viewport_scrollbar_state,
+};
 use crate::tui::app::{App, SortDirection, SortField};
 
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
@@ -47,7 +49,6 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let metric_output_style = app.theme.metric_output_style();
     let metric_cache_read_style = app.theme.metric_cache_read_style();
     let metric_cache_write_style = app.theme.metric_cache_write_style();
-    let metric_total_style = app.theme.metric_total_style();
     let current_row_style = app.theme.current_row_style();
     let striped_row_style = app.theme.striped_row_style();
     let now = Local::now().naive_local();
@@ -175,7 +176,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                 }
                 cells.extend([
                     Cell::from(minute.message_count.to_string()),
-                    Cell::from(format_tokens(minute.tokens.total())).style(metric_total_style),
+                    total_tokens_cell(minute.tokens.total(), &app.theme),
                     Cell::from(format_cost(minute.cost)).style(Style::default().fg(Color::Green)),
                 ]);
                 cells
@@ -214,7 +215,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                         minute.tokens.cache_write,
                     ))
                     .style(Style::default().fg(Color::Cyan)),
-                    Cell::from(format_tokens(minute.tokens.total())).style(metric_total_style),
+                    total_tokens_cell(minute.tokens.total(), &app.theme),
                     Cell::from(format_cost(minute.cost)).style(Style::default().fg(Color::Green)),
                 ]);
                 cells

--- a/crates/tokscale-cli/src/tui/ui/models.rs
+++ b/crates/tokscale-cli/src/tui/ui/models.rs
@@ -5,7 +5,8 @@ use ratatui::widgets::{
 
 use super::widgets::{
     format_cache_hit_rate, format_cost, format_cost_per_million, format_ms_per_1k, format_tokens,
-    get_client_display_name, get_provider_display_name, viewport_scrollbar_state,
+    get_client_display_name, get_provider_display_name, total_tokens_cell,
+    viewport_scrollbar_state,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 use tokscale_core::GroupBy;
@@ -57,7 +58,6 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let metric_output_style = app.theme.metric_output_style();
     let metric_cache_read_style = app.theme.metric_cache_read_style();
     let metric_cache_write_style = app.theme.metric_cache_write_style();
-    let metric_total_style = app.theme.metric_total_style();
     let striped_row_style = app.theme.striped_row_style();
 
     let models = app.get_sorted_models();
@@ -160,7 +160,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             } else if is_narrow {
                 vec![
                     Cell::from(truncate(&display_name, 25)).style(Style::default().fg(model_color)),
-                    Cell::from(format_tokens(model.tokens.total())).style(metric_total_style),
+                    total_tokens_cell(model.tokens.total(), &app.theme),
                     Cell::from(format_cost(model.cost)).style(Style::default().fg(Color::Green)),
                 ]
             } else if group_by == GroupBy::WorkspaceModel {
@@ -185,7 +185,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                         .style(metric_cache_read_style),
                     Cell::from(format_tokens(model.tokens.cache_write))
                         .style(metric_cache_write_style),
-                    Cell::from(format_tokens(model.tokens.total())).style(metric_total_style),
+                    total_tokens_cell(model.tokens.total(), &app.theme),
                     Cell::from(format_ms_per_1k(model.performance.ms_per_1k_tokens))
                         .style(Style::default().fg(Color::Yellow)),
                     Cell::from(format_cost(model.cost)).style(Style::default().fg(Color::Green)),
@@ -215,7 +215,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                         model.tokens.cache_write,
                     ))
                     .style(Style::default().fg(Color::Cyan)),
-                    Cell::from(format_tokens(model.tokens.total())).style(metric_total_style),
+                    total_tokens_cell(model.tokens.total(), &app.theme),
                     Cell::from(format_ms_per_1k(model.performance.ms_per_1k_tokens))
                         .style(Style::default().fg(Color::Yellow)),
                     Cell::from(format_cost(model.cost)).style(Style::default().fg(Color::Green)),

--- a/crates/tokscale-cli/src/tui/ui/monthly.rs
+++ b/crates/tokscale-cli/src/tui/ui/monthly.rs
@@ -4,7 +4,7 @@ use ratatui::widgets::{
 };
 
 use super::widgets::{
-    format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens,
+    format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens, total_tokens_cell,
     viewport_scrollbar_state,
 };
 use crate::tui::app::{App, SortDirection, SortField};
@@ -54,7 +54,6 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let metric_output_style = app.theme.metric_output_style();
     let metric_cache_read_style = app.theme.metric_cache_read_style();
     let metric_cache_write_style = app.theme.metric_cache_write_style();
-    let metric_total_style = app.theme.metric_total_style();
     let striped_row_style = app.theme.striped_row_style();
 
     let full_layout_width: u16 = if has_turn_data { 112 } else { 105 };
@@ -154,7 +153,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                 }
                 cells.extend([
                     Cell::from(month.message_count.to_string()),
-                    Cell::from(format_tokens(month.tokens.total())).style(metric_total_style),
+                    total_tokens_cell(month.tokens.total(), &app.theme),
                     Cell::from(format_cost(month.cost)).style(Style::default().fg(Color::Green)),
                 ]);
                 cells
@@ -182,7 +181,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                         month.tokens.cache_write,
                     ))
                     .style(Style::default().fg(Color::Cyan)),
-                    Cell::from(format_tokens(month.tokens.total())).style(metric_total_style),
+                    total_tokens_cell(month.tokens.total(), &app.theme),
                     Cell::from(format_cost(month.cost)).style(Style::default().fg(Color::Green)),
                     Cell::from(format_cost_per_million(month.cost, month.tokens.total()))
                         .style(Style::default().fg(Color::Rgb(150, 200, 150))),
@@ -318,7 +317,6 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
     let metric_output_style = app.theme.metric_output_style();
     let metric_cache_read_style = app.theme.metric_cache_read_style();
     let metric_cache_write_style = app.theme.metric_cache_write_style();
-    let metric_total_style = app.theme.metric_total_style();
     let striped_row_style = app.theme.striped_row_style();
 
     let full_layout_width: u16 = if has_turn_data { 112 } else { 105 };
@@ -425,7 +423,7 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
                 }
                 cells.extend([
                     Cell::from(day.message_count.to_string()),
-                    Cell::from(format_tokens(day.tokens.total())).style(metric_total_style),
+                    total_tokens_cell(day.tokens.total(), &app.theme),
                     Cell::from(format_cost(day.cost)).style(Style::default().fg(Color::Green)),
                 ]);
                 cells
@@ -452,7 +450,7 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
                         day.tokens.cache_write,
                     ))
                     .style(Style::default().fg(Color::Cyan)),
-                    Cell::from(format_tokens(day.tokens.total())).style(metric_total_style),
+                    total_tokens_cell(day.tokens.total(), &app.theme),
                     Cell::from(format_cost(day.cost)).style(Style::default().fg(Color::Green)),
                     Cell::from(format_cost_per_million(day.cost, day.tokens.total()))
                         .style(Style::default().fg(Color::Rgb(150, 200, 150))),

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -1,9 +1,10 @@
 use ratatui::prelude::*;
-use ratatui::widgets::ScrollbarState;
+use ratatui::widgets::{Cell, ScrollbarState};
 use tokscale_core::ClientId;
 
 use crate::tui::client_ui;
 use crate::tui::config::TokscaleConfig;
+use crate::tui::themes::Theme;
 
 pub fn format_tokens_compact(tokens: u64) -> String {
     if tokens >= 1_000_000_000 {
@@ -19,6 +20,10 @@ pub fn format_tokens_compact(tokens: u64) -> String {
 
 pub fn format_tokens(tokens: u64) -> String {
     format_tokens_compact(tokens)
+}
+
+pub(crate) fn total_tokens_cell(total_tokens: u64, theme: &Theme) -> Cell<'static> {
+    Cell::from(format_tokens(total_tokens)).style(theme.metric_total_style())
 }
 
 pub fn format_tokens_with_commas(n: u64) -> String {


### PR DESCRIPTION
## Summary

Extracts the repeated “total tokens” table cell construction into `total_tokens_cell()` so the bold high-contrast styling has one shared call path.

## Notes

This PR is now based directly on `main`. #843 and #844 have both landed in `main`, so this branch contains only the helper extraction commit.

## Tests

* `cargo fmt --check`
* `cargo check -p tokscale-cli`
* `cargo test -p tokscale-cli tui::ui -- --nocapture`
