### PR TITLE
feat(models): fold configurable model aliases into one canonical model

### DIFF
--- a/crates/tokscale-cli/src/commands/report.rs
+++ b/crates/tokscale-cli/src/commands/report.rs
@@ -146,6 +146,15 @@ fn populate_wiki_from_sessions(db: &WikiDb, opts: &ReportOptions) -> Result<()> 
         agg.total_output = agg.total_output.saturating_add(msg.output);
         agg.total_cache_read = agg.total_cache_read.saturating_add(msg.cache_read);
         agg.total_cost += compute_msg_cost(msg, pricing.as_deref());
+        // NOTE: the wiki `report` view intentionally groups on the raw model_id
+        // and does not apply `modelAliases` folding (nor the grouping
+        // normalization every other report uses). Wiki entries are persisted
+        // append-only — previously-recorded sessions are not rewritten (see the
+        // `existing.contains` skip below) — so folding here would leave a mix of
+        // raw and canonical names across sessions recorded before vs after
+        // aliases were configured. To fold in a future change, wrap the key with
+        // `tokscale_core::normalize_model_for_grouping(&msg.model_id)` here and in
+        // the by-model/daily/session/JSON surfaces.
         *agg.models.entry(msg.model_id.clone()).or_insert(0) += 1;
         agg.message_count += msg.message_count;
     }

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -507,6 +507,11 @@ fn main() -> Result<()> {
     use std::io::IsTerminal;
 
     let cli = Cli::parse();
+    // Install user-configured model aliases once, before any report/graph/TUI
+    // path runs, so model-name variants fold consistently across every command.
+    // Honors the global `--home` override exactly like scanner settings; an
+    // empty or absent config is a strict no-op.
+    tokscale_core::model_alias::set_global(&tui::settings::load_model_aliases_for_home(&cli.home));
     let can_use_tui = std::io::stdin().is_terminal() && std::io::stdout().is_terminal();
 
     if cli.test_data {

--- a/crates/tokscale-cli/src/tui/cache.rs
+++ b/crates/tokscale-cli/src/tui/cache.rs
@@ -21,7 +21,7 @@ use super::data::{
 
 /// Cache staleness threshold: 5 minutes (matches TS implementation)
 const CACHE_STALE_THRESHOLD_MS: u64 = 5 * 60 * 1000;
-const CACHE_SCHEMA_VERSION: u32 = 9;
+const CACHE_SCHEMA_VERSION: u32 = 10;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -1148,7 +1148,7 @@ mod tests {
         fs::write(
             &cache_path,
             r#"{
-  "schemaVersion": 9,
+  "schemaVersion": 10,
   "timestamp": 9999999999999,
   "enabledClients": ["claude"],
   "includeSynthetic": false,
@@ -1471,7 +1471,7 @@ mod tests {
         fs::write(
             &cache_path,
             r#"{
-  "schemaVersion": 9,
+  "schemaVersion": 10,
   "timestamp": 9999999999999,
   "enabledClients": ["claude", "cursor"],
   "includeSynthetic": false,
@@ -1753,7 +1753,7 @@ mod tests {
         fs::write(
             &legacy_path,
             r#"{
-  "schemaVersion": 9,
+  "schemaVersion": 10,
   "timestamp": 9999999999999,
   "enabledClients": ["claude"],
   "includeSynthetic": false,

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -151,6 +151,16 @@ pub struct Settings {
     pub minutely_tab_enabled: bool,
     #[serde(default)]
     pub autosubmit: AutosubmitSettings,
+    /// User-defined model-name aliases folded at grouping time. Different
+    /// name-strings for one physical model (e.g. `claude-opus-4-8-cc`,
+    /// `anthropic/claude-opus-4-8`) map to a single canonical name so usage
+    /// stats do not split across rows. Keys and values are matched
+    /// case-insensitively against the normalized model name.
+    ///
+    /// `#[serde(default)]` keeps settings.json files written before the field
+    /// existed loading cleanly; an absent or empty map means no folding.
+    #[serde(default)]
+    pub model_aliases: tokscale_core::ModelAliasMap,
 }
 
 /// Lossy deserializer for `defaultClients`: accepts an array of arbitrary
@@ -201,6 +211,7 @@ impl Default for Settings {
             light: LightSettings::default(),
             minutely_tab_enabled: false,
             autosubmit: AutosubmitSettings::default(),
+            model_aliases: tokscale_core::ModelAliasMap::default(),
         }
     }
 }
@@ -218,6 +229,13 @@ pub fn load_scanner_settings() -> ScannerSettings {
 
 pub fn load_scanner_settings_for_home(home_dir: &Option<String>) -> ScannerSettings {
     Settings::load_for_home_override(home_dir.as_deref().map(Path::new)).scanner
+}
+
+/// Loads the user's configured model aliases, honoring a `--home` override the
+/// same way [`load_scanner_settings_for_home`] does. A missing or malformed
+/// settings.json yields an empty map (no folding); this never errors.
+pub fn load_model_aliases_for_home(home_dir: &Option<String>) -> tokscale_core::ModelAliasMap {
+    Settings::load_for_home_override(home_dir.as_deref().map(Path::new)).model_aliases
 }
 
 /// Returns the user's configured `defaultClients` list as raw lowercase
@@ -561,6 +579,35 @@ mod tests {
             AutosubmitSettings::default().interval_minutes,
             DEFAULT_AUTOSUBMIT_INTERVAL_MINUTES
         );
+    }
+
+    #[test]
+    fn settings_backfills_model_aliases_when_missing_from_json() {
+        // Older settings.json files predate the `modelAliases` key; they must
+        // still deserialize cleanly and default to an empty (no-op) alias map.
+        let json = r#"{
+            "colorPalette": "blue",
+            "autoRefreshEnabled": false,
+            "autoRefreshMs": 60000,
+            "includeUnusedModels": false,
+            "nativeTimeoutMs": 300000
+        }"#;
+        let parsed: Settings = serde_json::from_str(json).unwrap();
+        assert!(parsed.model_aliases.entries.is_empty());
+    }
+
+    #[test]
+    fn settings_malformed_model_aliases_does_not_wipe_other_fields() {
+        // A malformed `modelAliases` (not an object, or non-string values) must
+        // degrade to an empty map without failing the whole settings load, so
+        // unrelated settings survive.
+        let json = r#"{
+            "colorPalette": "custom",
+            "modelAliases": ["oops", 5]
+        }"#;
+        let parsed: Settings = serde_json::from_str(json).unwrap();
+        assert!(parsed.model_aliases.entries.is_empty());
+        assert_eq!(parsed.color_palette, "custom");
     }
 
     #[test]

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -2341,6 +2341,191 @@ fn test_models_json_with_group_by_model() {
     }
 }
 
+/// Adds a third OpenCode session whose single message reports the same physical
+/// model as session 1 (claude sonnet 4) under a channel-variant name string
+/// (`claude-sonnet-4-cc`), so model-alias folding can be exercised end to end.
+fn add_alias_variant_message(tmp: &Path) {
+    let session3 = tmp.join(".local/share/opencode/storage/message/session3");
+    fs::create_dir_all(&session3).unwrap();
+    let msg = r#"{
+        "id": "msg_d",
+        "sessionID": "session3",
+        "role": "assistant",
+        "modelID": "claude-sonnet-4-cc",
+        "providerID": "anthropic",
+        "cost": 0.04,
+        "tokens": {
+            "input": 400,
+            "output": 100,
+            "reasoning": 0,
+            "cache": { "read": 0, "write": 0 }
+        },
+        "time": { "created": 1718460000000.0, "completed": 1718460002000.0 }
+    }"#;
+    fs::write(session3.join("msg_d.json"), msg).unwrap();
+}
+
+/// Writes a tokscale `settings.json` with the given `modelAliases` object into
+/// the sandbox config dir that `cmd_with_home` points at
+/// (`XDG_CONFIG_HOME/tokscale`). `cmd_with_home` clears `TOKSCALE_CONFIG_DIR`, so
+/// the config must live under the pinned XDG path to be read.
+fn write_model_aliases(tmp: &Path, aliases_json: &str) {
+    let config_dir = tmp.join(".config/tokscale");
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(
+        config_dir.join("settings.json"),
+        format!(r#"{{"modelAliases": {aliases_json}}}"#),
+    )
+    .unwrap();
+}
+
+fn models_by_name(tmp: &Path) -> serde_json::Value {
+    let output = cmd_with_home(tmp)
+        .args(["models", "--json", "--client", "opencode", "--no-spinner"])
+        .args(["--group-by", "model"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "command failed: {output:?}");
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+#[test]
+fn test_models_alias_folds_variants_into_one_row() {
+    let tmp = create_temp_fixture_dir();
+    add_alias_variant_message(tmp.path());
+    write_model_aliases(tmp.path(), r#"{"claude-sonnet-4-cc": "claude-sonnet-4"}"#);
+
+    let json = models_by_name(tmp.path());
+    let entries = json["entries"].as_array().unwrap();
+    let models: Vec<&str> = entries
+        .iter()
+        .map(|e| e["model"].as_str().unwrap())
+        .collect();
+
+    // The -cc variant folded into the canonical model: exactly one
+    // claude-sonnet-4 row and no claude-sonnet-4-cc row.
+    assert!(
+        models.contains(&"claude-sonnet-4"),
+        "expected folded model, got {models:?}"
+    );
+    assert!(
+        !models.contains(&"claude-sonnet-4-cc"),
+        "variant should have folded away, got {models:?}"
+    );
+
+    // The variant's tokens merged INTO the canonical row — the fold-sensitive
+    // check: session1 (input 1000 + 800) plus the folded -cc variant (400) =
+    // 2200. A no-op fold would leave this row at 1800 and emit a separate
+    // claude-sonnet-4-cc row instead.
+    let folded = entries
+        .iter()
+        .find(|e| e["model"] == "claude-sonnet-4")
+        .unwrap();
+    assert_eq!(
+        folded["input"].as_i64().unwrap(),
+        2200,
+        "folded row must include the variant's tokens, got {folded:?}"
+    );
+    assert!(
+        folded.get("mergedClients").is_some(),
+        "folded entry should retain mergedClients"
+    );
+
+    // Per-entry sums still reconcile with report totals — the fold must not
+    // double-count or drop tokens.
+    let sum_input: i64 = entries.iter().map(|e| e["input"].as_i64().unwrap()).sum();
+    assert_eq!(sum_input, json["totalInput"].as_i64().unwrap());
+}
+
+#[test]
+fn test_models_alias_folds_in_monthly_report() {
+    // The fold happens inside normalize_model_for_grouping, so it must apply at
+    // every grouping call site, not only the models report. Prove it on the
+    // monthly report (a distinct call site) too.
+    let tmp = create_temp_fixture_dir();
+    add_alias_variant_message(tmp.path());
+    write_model_aliases(tmp.path(), r#"{"claude-sonnet-4-cc": "claude-sonnet-4"}"#);
+
+    let output = cmd_with_home(tmp.path())
+        .args(["monthly", "--json", "--client", "opencode", "--no-spinner"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "command failed: {output:?}");
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    let models: Vec<&str> = json["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .flat_map(|entry| entry["models"].as_array().unwrap())
+        .map(|m| m.as_str().unwrap())
+        .collect();
+    assert!(
+        models.contains(&"claude-sonnet-4"),
+        "monthly models should include the canonical name, got {models:?}"
+    );
+    assert!(
+        !models.contains(&"claude-sonnet-4-cc"),
+        "monthly report must fold the -cc variant too, got {models:?}"
+    );
+}
+
+#[test]
+fn test_models_alias_absent_is_noop() {
+    let tmp = create_temp_fixture_dir();
+    add_alias_variant_message(tmp.path());
+    // No settings.json / no modelAliases configured.
+
+    let json = models_by_name(tmp.path());
+    let models: Vec<&str> = json["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| e["model"].as_str().unwrap())
+        .collect();
+
+    // Without aliases the variant stays a separate row (opt-in default off).
+    assert!(
+        models.contains(&"claude-sonnet-4"),
+        "expected base model, got {models:?}"
+    );
+    assert!(
+        models.contains(&"claude-sonnet-4-cc"),
+        "variant should remain separate without aliases, got {models:?}"
+    );
+}
+
+#[test]
+fn test_models_alias_totals_unchanged() {
+    // Folding relabels/merges buckets whose costs were already computed
+    // per-message, so grand totals must be identical with and without aliases.
+    let without = create_temp_fixture_dir();
+    add_alias_variant_message(without.path());
+    let base = models_by_name(without.path());
+
+    let with = create_temp_fixture_dir();
+    add_alias_variant_message(with.path());
+    write_model_aliases(with.path(), r#"{"claude-sonnet-4-cc": "claude-sonnet-4"}"#);
+    let aliased = models_by_name(with.path());
+
+    assert_eq!(
+        base["totalInput"].as_i64(),
+        aliased["totalInput"].as_i64(),
+        "totalInput must be unchanged by aliasing"
+    );
+    assert_eq!(
+        base["totalOutput"].as_i64(),
+        aliased["totalOutput"].as_i64(),
+        "totalOutput must be unchanged by aliasing"
+    );
+    let base_cost = base["totalCost"].as_f64().unwrap();
+    let aliased_cost = aliased["totalCost"].as_f64().unwrap();
+    assert!(
+        (base_cost - aliased_cost).abs() < 1e-9,
+        "totalCost must be unchanged by aliasing: {base_cost} vs {aliased_cost}"
+    );
+}
+
 #[test]
 fn test_models_group_by_session_emits_session_id_per_entry() {
     let tmp = create_temp_fixture_dir();

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -2527,6 +2527,68 @@ fn test_models_alias_totals_unchanged() {
 }
 
 #[test]
+fn test_alias_folds_local_report_but_not_submitted_payload() {
+    // Finding B: a machine-local `modelAliases` config must fold ONLY local
+    // presentation/grouping. The model identity that leaves the machine
+    // (submit/upload/export payload) must stay raw, or a per-device alias config
+    // would rewrite and fragment uploaded history across a user's machines. The
+    // `graph` command emits the exact byte shape that `submit` POSTs, so it is
+    // the faithful stand-in for the submitted payload.
+    let tmp = create_temp_fixture_dir();
+    add_alias_variant_message(tmp.path());
+    write_model_aliases(tmp.path(), r#"{"claude-sonnet-4-cc": "claude-sonnet-4"}"#);
+
+    // Local models report: the alias DOES fold (canonical name only, no variant).
+    let models = models_by_name(tmp.path());
+    let displayed: Vec<&str> = models["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| e["model"].as_str().unwrap())
+        .collect();
+    assert!(
+        displayed.contains(&"claude-sonnet-4"),
+        "local report must show the canonical name, got {displayed:?}"
+    );
+    assert!(
+        !displayed.contains(&"claude-sonnet-4-cc"),
+        "local report must fold the -cc variant away, got {displayed:?}"
+    );
+
+    // Submit/export payload (`graph` prints the submit shape to stdout): the raw
+    // variant MUST survive unfolded, both in the models summary and per-day.
+    let output = cmd_with_home(tmp.path())
+        .args(["graph", "--client", "opencode", "--no-spinner"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "graph command failed: {output:?}");
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    let submitted_models: Vec<&str> = payload["summary"]["models"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|m| m.as_str().unwrap())
+        .collect();
+    assert!(
+        submitted_models.contains(&"claude-sonnet-4-cc"),
+        "submitted payload must keep the RAW model id (alias must not leak), got {submitted_models:?}"
+    );
+
+    let per_contribution_models: Vec<&str> = payload["contributions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .flat_map(|c| c["clients"].as_array().unwrap())
+        .map(|s| s["modelId"].as_str().unwrap())
+        .collect();
+    assert!(
+        per_contribution_models.contains(&"claude-sonnet-4-cc"),
+        "submitted per-day contributions must carry the RAW model id, got {per_contribution_models:?}"
+    );
+}
+
+#[test]
 fn test_models_group_by_session_emits_session_id_per_entry() {
     let tmp = create_temp_fixture_dir();
     let output = cmd_with_home(tmp.path())

--- a/crates/tokscale-core/src/aggregator.rs
+++ b/crates/tokscale-core/src/aggregator.rs
@@ -274,17 +274,20 @@ impl DayAccumulator {
             .saturating_add(msg.tokens.reasoning);
 
         // Update client contribution
+        // Canonical (alias-free) id: this contribution is serialized into the
+        // submit/upload/export payload, so a machine-local `modelAliases` config
+        // must not rewrite the model identity that leaves the machine.
         let key = format!(
             "{}:{}",
             msg.client,
-            crate::normalize_model_for_grouping(&msg.model_id)
+            crate::canonical_model_id(&msg.model_id)
         );
         let client_entry = self
             .clients
             .entry(key)
             .or_insert_with(|| ClientContribution {
                 client: msg.client.clone(),
-                model_id: crate::normalize_model_for_grouping(&msg.model_id),
+                model_id: crate::canonical_model_id(&msg.model_id),
                 provider_id: msg.provider_id.clone(),
                 tokens: TokenBreakdown::default(),
                 cost: 0.0,
@@ -509,7 +512,9 @@ impl SessionAccumulator {
             .saturating_add(msg.tokens.reasoning);
 
         // Track tightest (client, provider, model) by cost contribution.
-        let normalized_model = crate::normalize_model_for_grouping(&msg.model_id);
+        // Canonical (alias-free) id — this feeds the submitted/exported payload,
+        // so machine-local aliases must not rewrite it (see `add_message`).
+        let normalized_model = crate::canonical_model_id(&msg.model_id);
         let key = format!("{}:{}:{}", msg.client, msg.provider_id, normalized_model);
         let client_entry = self
             .clients

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -60,12 +60,32 @@ pub(crate) fn strip_parenthesized_reasoning_tier(model_id: &str) -> Option<&str>
     Some(base_model)
 }
 
+/// Canonical model identity — the model id that leaves the machine.
+///
+/// This is [`normalize_syntactic`] with **no alias folding**: purely structural
+/// canonicalization (lowercase, strip a `(reasoning-tier)` suffix, strip a
+/// trailing `-YYYYMMDD` date, rewrite `.`→`-` inside claude version numbers, and
+/// fold an `anthropic/claude-…` prefix). It never consults the user's
+/// machine-local `modelAliases`.
+///
+/// Every path that submits, uploads, exports as raw data, or persists a model id
+/// MUST use this, not [`normalize_model_for_grouping`]. A machine-local alias
+/// config must never rewrite the model identity persisted server-side, or usage
+/// history would fragment and fork across a user's devices.
+pub fn canonical_model_id(model_id: &str) -> String {
+    normalize_syntactic(model_id)
+}
+
+/// Local display/grouping model name: [`canonical_model_id`] plus the user's
+/// configured `modelAliases` fold. Every local report-grouping surface — the
+/// models report, every `--group-by`, monthly, hourly, and the TUI — routes
+/// through this so name variants fold uniformly for presentation.
+///
+/// The alias fold is **presentation only** and must never reach the
+/// submit/upload/export/persist path (those use [`canonical_model_id`]), or a
+/// machine-local alias config would rewrite the uploaded model identity. An
+/// empty/unset alias config makes this identical to [`canonical_model_id`].
 pub fn normalize_model_for_grouping(model_id: &str) -> String {
-    // Every model-grouping path routes through this function, so folding the
-    // user-configured model aliases here (after syntactic normalization) applies
-    // them uniformly to the models report, every `--group-by`, monthly, hourly,
-    // the graph, and the TUI. An empty/unset alias config is a strict identity
-    // no-op, so behavior is byte-for-byte unchanged unless aliases are set.
     model_alias::global().apply(normalize_syntactic(model_id))
 }
 
@@ -73,10 +93,11 @@ pub fn normalize_model_for_grouping(model_id: &str) -> String {
 /// `(reasoning-tier)` suffix, strip a trailing `-YYYYMMDD` date, rewrite `.`→`-`
 /// inside claude version numbers, and fold an `anthropic/claude-…` prefix.
 ///
-/// This is the syntactic half of [`normalize_model_for_grouping`]. It is also
-/// used by [`model_alias::ModelAliasResolver`] to normalize configured alias
-/// keys and values into the same space, so a configured alias matches its model
-/// regardless of case, dated suffix, or `.`-vs-`-` spelling.
+/// This is the syntactic half of [`normalize_model_for_grouping`] /
+/// [`canonical_model_id`]. It is also used by [`model_alias::ModelAliasResolver`]
+/// to normalize configured alias keys and values into the same space, so a
+/// configured alias matches its model regardless of case, dated suffix, or
+/// `.`-vs-`-` spelling.
 pub(crate) fn normalize_syntactic(model_id: &str) -> String {
     let mut name = model_id.to_lowercase();
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod content_extractor;
 pub mod fs_atomic;
 pub mod mcp;
 mod message_cache;
+pub mod model_alias;
 mod parser;
 pub mod paths;
 pub mod pricing;
@@ -18,6 +19,7 @@ pub mod wiki;
 
 pub use aggregator::*;
 pub use clients::{ClientCounts, ClientDef, ClientId, PathRoot};
+pub use model_alias::ModelAliasMap;
 pub use parser::*;
 pub use scanner::*;
 pub use sessionize::{
@@ -59,6 +61,23 @@ pub(crate) fn strip_parenthesized_reasoning_tier(model_id: &str) -> Option<&str>
 }
 
 pub fn normalize_model_for_grouping(model_id: &str) -> String {
+    // Every model-grouping path routes through this function, so folding the
+    // user-configured model aliases here (after syntactic normalization) applies
+    // them uniformly to the models report, every `--group-by`, monthly, hourly,
+    // the graph, and the TUI. An empty/unset alias config is a strict identity
+    // no-op, so behavior is byte-for-byte unchanged unless aliases are set.
+    model_alias::global().apply(normalize_syntactic(model_id))
+}
+
+/// Structural-only model-name normalization: lowercase, strip a
+/// `(reasoning-tier)` suffix, strip a trailing `-YYYYMMDD` date, rewrite `.`→`-`
+/// inside claude version numbers, and fold an `anthropic/claude-…` prefix.
+///
+/// This is the syntactic half of [`normalize_model_for_grouping`]. It is also
+/// used by [`model_alias::ModelAliasResolver`] to normalize configured alias
+/// keys and values into the same space, so a configured alias matches its model
+/// regardless of case, dated suffix, or `.`-vs-`-` spelling.
+pub(crate) fn normalize_syntactic(model_id: &str) -> String {
     let mut name = model_id.to_lowercase();
 
     if let Some(base_model) = strip_parenthesized_reasoning_tier(&name) {

--- a/crates/tokscale-core/src/model_alias.rs
+++ b/crates/tokscale-core/src/model_alias.rs
@@ -1,0 +1,252 @@
+//! Config-driven model-name aliasing for grouping.
+//!
+//! Different supply channels report the same physical model under different
+//! name-strings (for example `claude-opus-4-8`, `claude-opus-4-8-cc`, and
+//! `anthropic/claude-opus-4-8` are all one model), so usage stats split across
+//! multiple rows. A user-configured `{alias: canonical}` map, read from
+//! `settings.json` under `modelAliases`, folds those variants into one canonical
+//! model.
+//!
+//! The fold runs as the terminal step of [`crate::normalize_model_for_grouping`],
+//! so it applies uniformly to the models report, every `--group-by`, monthly and
+//! hourly reports, the graph, and the TUI. It is deliberately **not** applied
+//! before pricing (per-message cost is computed on the raw model id upstream), so
+//! folding can only relabel and merge already-costed buckets and can never change
+//! a cost total. It is orthogonal to the pricing alias table
+//! ([`crate::pricing`]) and to `provider_identity` — it touches only the model
+//! dimension.
+
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashMap};
+use std::sync::OnceLock;
+
+/// Upper bound on the number of configured aliases retained. Oversized configs
+/// are truncated rather than rejected, mirroring the capacity guard in
+/// [`crate::pricing`]'s custom-pricing loader.
+const MAX_MODEL_ALIASES: usize = 4096;
+
+/// On-disk shape of the flat `modelAliases` object in `settings.json`
+/// (`{ "alias": "canonical" }`). `#[serde(transparent)]` keeps the serialized
+/// form a bare map. Deserialization is lossy: a malformed value (a non-object,
+/// or an entry whose value is not a string) is skipped instead of failing the
+/// whole settings load.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
+pub struct ModelAliasMap {
+    /// Raw `alias -> canonical` pairs exactly as written in the config.
+    pub entries: BTreeMap<String, String>,
+}
+
+impl<'de> Deserialize<'de> for ModelAliasMap {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Read the node as a generic value first so a malformed `modelAliases`
+        // (e.g. an array or scalar) degrades to an empty map instead of
+        // misaligning the parent settings deserializer. Keep only string-valued
+        // entries; skip anything else.
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let entries = match value {
+            serde_json::Value::Object(object) => object
+                .into_iter()
+                .filter_map(|(key, value)| match value {
+                    serde_json::Value::String(canonical) => Some((key, canonical)),
+                    _ => None,
+                })
+                .collect(),
+            _ => BTreeMap::new(),
+        };
+        Ok(Self { entries })
+    }
+}
+
+/// Runtime resolver built from [`ModelAliasMap`]: keys and values are normalized
+/// through [`crate::normalize_syntactic`] so lookups match regardless of case,
+/// dated suffix, or `.`-vs-`-` spelling, and canonical values land in the same
+/// space the grouping key uses. Empty keys/values and self-maps are dropped; the
+/// number of entries is capped.
+#[derive(Debug, Default)]
+pub(crate) struct ModelAliasResolver {
+    map: HashMap<String, String>,
+}
+
+impl ModelAliasResolver {
+    /// Build a resolver from configured aliases. Both sides of each pair are run
+    /// through [`crate::normalize_syntactic`] exactly once: keys are placed in the
+    /// same space as incoming (already-normalized) model names, and canonical
+    /// values are stored pre-normalized. `apply` returns a canonical value
+    /// verbatim — it is never re-resolved or re-normalized — so the value written
+    /// here is exactly the label shown in reports. Empty keys/values and
+    /// self-maps are dropped, and the number of entries is capped.
+    pub(crate) fn from_config(config: &ModelAliasMap) -> Self {
+        let mut map = HashMap::new();
+        for (raw_alias, raw_canonical) in &config.entries {
+            if map.len() >= MAX_MODEL_ALIASES {
+                break;
+            }
+            let alias = crate::normalize_syntactic(raw_alias);
+            let canonical = crate::normalize_syntactic(raw_canonical);
+            if alias.is_empty() || canonical.is_empty() || alias == canonical {
+                continue;
+            }
+            map.insert(alias, canonical);
+        }
+        Self { map }
+    }
+
+    /// Resolve one model name. `name` must already be `normalize_syntactic`'d (it
+    /// is, since the only caller is [`crate::normalize_model_for_grouping`]).
+    /// Resolution is single-hop — the canonical value is never re-resolved — so
+    /// alias chains collapse one step and cycles are structurally impossible.
+    /// Returns `name` unchanged on a miss.
+    pub(crate) fn apply(&self, name: String) -> String {
+        match self.map.get(&name) {
+            Some(canonical) => canonical.clone(),
+            None => name,
+        }
+    }
+}
+
+static GLOBAL: OnceLock<ModelAliasResolver> = OnceLock::new();
+static EMPTY: OnceLock<ModelAliasResolver> = OnceLock::new();
+
+/// Install the process-wide model-alias resolver. Intended to be called once at
+/// startup (mirroring the pricing service's one-time init); the first call wins
+/// and later calls are ignored. Until this is called, grouping is a strict
+/// identity no-op, so callers and tests that never install a resolver are
+/// unaffected.
+pub fn set_global(config: &ModelAliasMap) {
+    let _ = GLOBAL.set(ModelAliasResolver::from_config(config));
+}
+
+/// The installed resolver, or a shared empty one (identity no-op) when unset.
+pub(crate) fn global() -> &'static ModelAliasResolver {
+    GLOBAL
+        .get()
+        .unwrap_or_else(|| EMPTY.get_or_init(ModelAliasResolver::default))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn resolver(pairs: &[(&str, &str)]) -> ModelAliasResolver {
+        let entries = pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        ModelAliasResolver::from_config(&ModelAliasMap { entries })
+    }
+
+    #[test]
+    fn folds_three_variants_to_one_canonical() {
+        let r = resolver(&[
+            ("claude-opus-4-8-cc", "claude-opus-4-8"),
+            ("anthropic/claude-opus-4-8", "claude-opus-4-8"),
+        ]);
+        // All three real-world spellings collapse to the canonical name. The
+        // third needs no map entry: syntactic normalization already lowercases it.
+        for input in [
+            "claude-opus-4-8-cc",
+            "anthropic/claude-opus-4-8",
+            "Claude-Opus-4-8",
+        ] {
+            assert_eq!(
+                r.apply(crate::normalize_syntactic(input)),
+                "claude-opus-4-8",
+                "input {input} should fold to claude-opus-4-8"
+            );
+        }
+    }
+
+    #[test]
+    fn keys_match_case_and_dotted_insensitively() {
+        // Config key written with upper case and a dotted version still matches
+        // the normalized input, because both sides run through normalize_syntactic.
+        let r = resolver(&[("Claude-Opus-4.8-CC", "claude-opus-4-8")]);
+        assert_eq!(
+            r.apply(crate::normalize_syntactic("claude-opus-4-8-cc")),
+            "claude-opus-4-8"
+        );
+    }
+
+    #[test]
+    fn drops_empty_and_self_maps() {
+        let r = resolver(&[
+            ("", "claude-opus-4-8"),
+            ("claude-opus-4-8-cc", ""),
+            ("gpt-5.5", "gpt-5.5"),
+        ]);
+        assert!(r.map.is_empty());
+    }
+
+    #[test]
+    fn resolution_is_single_hop() {
+        // {a: b, b: c} resolves a -> b (not c) and never loops.
+        let r = resolver(&[("model-a", "model-b"), ("model-b", "model-c")]);
+        assert_eq!(r.apply("model-a".to_string()), "model-b");
+        assert_eq!(r.apply("model-b".to_string()), "model-c");
+    }
+
+    #[test]
+    fn miss_is_identity() {
+        let r = resolver(&[("claude-opus-4-8-cc", "claude-opus-4-8")]);
+        assert_eq!(r.apply("gpt-5.5".to_string()), "gpt-5.5");
+    }
+
+    #[test]
+    fn empty_resolver_is_identity() {
+        let r = ModelAliasResolver::default();
+        assert_eq!(
+            r.apply("claude-opus-4-8-cc".to_string()),
+            "claude-opus-4-8-cc"
+        );
+    }
+
+    #[test]
+    fn respects_capacity_cap() {
+        let entries: BTreeMap<String, String> = (0..MAX_MODEL_ALIASES + 100)
+            .map(|i| (format!("alias-{i}"), format!("canonical-{i}")))
+            .collect();
+        let r = ModelAliasResolver::from_config(&ModelAliasMap { entries });
+        assert_eq!(r.map.len(), MAX_MODEL_ALIASES);
+    }
+
+    #[test]
+    fn deserialize_is_lossy_over_non_string_values() {
+        // Non-string values are skipped; string entries survive.
+        let parsed: ModelAliasMap =
+            serde_json::from_str(r#"{"a": "b", "n": 5, "arr": ["x"]}"#).unwrap();
+        assert_eq!(parsed.entries.len(), 1);
+        assert_eq!(parsed.entries.get("a").map(String::as_str), Some("b"));
+    }
+
+    #[test]
+    fn deserialize_of_non_object_is_empty() {
+        // A misuse (array/scalar instead of an object) degrades to empty, not error.
+        assert!(serde_json::from_str::<ModelAliasMap>("[]")
+            .unwrap()
+            .entries
+            .is_empty());
+        assert!(serde_json::from_str::<ModelAliasMap>("\"oops\"")
+            .unwrap()
+            .entries
+            .is_empty());
+    }
+
+    #[test]
+    fn serialize_round_trips_as_flat_map() {
+        let map = ModelAliasMap {
+            entries: [(
+                "claude-opus-4-8-cc".to_string(),
+                "claude-opus-4-8".to_string(),
+            )]
+            .into_iter()
+            .collect(),
+        };
+        let json = serde_json::to_string(&map).unwrap();
+        assert_eq!(json, r#"{"claude-opus-4-8-cc":"claude-opus-4-8"}"#);
+        assert_eq!(serde_json::from_str::<ModelAliasMap>(&json).unwrap(), map);
+    }
+}

--- a/crates/tokscale-core/src/model_alias.rs
+++ b/crates/tokscale-core/src/model_alias.rs
@@ -8,8 +8,12 @@
 //! model.
 //!
 //! The fold runs as the terminal step of [`crate::normalize_model_for_grouping`],
-//! so it applies uniformly to the models report, every `--group-by`, monthly and
-//! hourly reports, the graph, and the TUI. It is deliberately **not** applied
+//! so it applies uniformly to the local models report, every `--group-by`,
+//! monthly and hourly reports, and the TUI. It is **presentation only**: the
+//! submit/upload/export/persist path uses [`crate::canonical_model_id`] (the
+//! same syntactic normalization *without* the alias fold), so a machine-local
+//! alias config can never rewrite the model identity that leaves the machine or
+//! fragment history across a user's devices. It is deliberately **not** applied
 //! before pricing (per-message cost is computed on the raw model id upstream), so
 //! folding can only relabel and merge already-costed buckets and can never change
 //! a cost total. It is orthogonal to the pricing alias table
@@ -85,12 +89,19 @@ impl ModelAliasResolver {
             if map.len() >= MAX_MODEL_ALIASES {
                 break;
             }
-            let alias = crate::normalize_syntactic(raw_alias);
+            // Store keys under a separator-insensitive match key so matching is
+            // provider-agnostic (not claude-only): `gpt-5-5` and `gpt-5.5` share
+            // the key `gpt-5-5`. The stored canonical value keeps its
+            // `normalize_syntactic` spelling — it is the label shown verbatim.
+            let alias_norm = crate::normalize_syntactic(raw_alias);
             let canonical = crate::normalize_syntactic(raw_canonical);
-            if alias.is_empty() || canonical.is_empty() || alias == canonical {
+            // Self-map drop compares the *exact* normalized forms, not the match
+            // keys: `{gpt-5-5: gpt-5.5}` is a real separator relabel that must be
+            // kept, whereas `{gpt-5.5: gpt-5.5}` is a genuine no-op to drop.
+            if alias_norm.is_empty() || canonical.is_empty() || alias_norm == canonical {
                 continue;
             }
-            map.insert(alias, canonical);
+            map.insert(match_key(&alias_norm), canonical);
         }
         Self { map }
     }
@@ -101,11 +112,21 @@ impl ModelAliasResolver {
     /// alias chains collapse one step and cycles are structurally impossible.
     /// Returns `name` unchanged on a miss.
     pub(crate) fn apply(&self, name: String) -> String {
-        match self.map.get(&name) {
+        match self.map.get(&match_key(&name)) {
             Some(canonical) => canonical.clone(),
             None => name,
         }
     }
+}
+
+/// Reduce an already-`normalize_syntactic`'d model name to a separator-
+/// insensitive match key by rewriting every `.` to `-`. This generalizes alias
+/// matching beyond claude: `normalize_syntactic` only rewrites `.`→`-` inside
+/// *claude* version numbers, so without this a `gpt-5-5` alias would miss
+/// `gpt-5.5`. Folding on the match key alone keeps the displayed canonical form
+/// (e.g. `gpt-5.5`) untouched for models that were never aliased.
+fn match_key(normalized: &str) -> String {
+    normalized.replace('.', "-")
 }
 
 static GLOBAL: OnceLock<ModelAliasResolver> = OnceLock::new();
@@ -187,6 +208,32 @@ mod tests {
         let r = resolver(&[("model-a", "model-b"), ("model-b", "model-c")]);
         assert_eq!(r.apply("model-a".to_string()), "model-b");
         assert_eq!(r.apply("model-b".to_string()), "model-c");
+    }
+
+    #[test]
+    fn separator_insensitive_match_is_provider_agnostic() {
+        // Finding A: `normalize_syntactic` rewrites `.`→`-` only for claude, so
+        // the resolver must fold separators itself for every other provider. The
+        // regression is when the CONFIGURED alias key and the model string the
+        // provider actually reports use different separators — the old exact
+        // HashMap lookup missed and left the variant unfolded.
+
+        // Dashed alias key (`gpt-5-5-cc`), dotted model spelling (`gpt-5.5-cc`):
+        // must still fold to the canonical `gpt-5.5`.
+        let dashed_key = resolver(&[("gpt-5-5-cc", "gpt-5.5")]);
+        assert_eq!(
+            dashed_key.apply(crate::normalize_syntactic("gpt-5.5-cc")),
+            "gpt-5.5",
+            "a dashed alias key must match the dotted model spelling (gpt-5-5 ↔ gpt-5.5)"
+        );
+
+        // Mirror: dotted alias key, dashed model spelling.
+        let dotted_key = resolver(&[("gpt-5.5-cc", "gpt-5.5")]);
+        assert_eq!(
+            dotted_key.apply(crate::normalize_syntactic("gpt-5-5-cc")),
+            "gpt-5.5",
+            "a dotted alias key must match the dashed model spelling"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

One physical model often arrives under several different name-strings depending on the supply channel — for example `claude-opus-4-8`, `claude-opus-4-8-cc` (a Claude Code channel), and `anthropic/claude-opus-4-8` (a namespaced provider) are all the same model. Because usage is grouped by the raw model-name string, that one model splits into multiple rows and its tokens, cost, and message counts are scattered across them. This adds an opt-in way to fold those variants into a single canonical model.

## What changed

A new `modelAliases` object in `settings.json` maps any alias to a canonical model name:

```json
{
  "modelAliases": {
    "claude-opus-4-8-cc": "claude-opus-4-8",
    "anthropic/claude-opus-4-8": "claude-opus-4-8"
  }
}
```

The fold is applied as the terminal step of `normalize_model_for_grouping`, the single function every grouping path already routes through, so it applies uniformly to the models report (table + `--json`), every `--group-by`, the monthly and hourly reports, the graph, per-model performance, and the TUI — in one place. The map is loaded once at startup into a process-global resolver, mirroring the existing `PRICING_SERVICE` pattern, and honors the global `--home` override exactly like scanner settings.

Keys and values are matched in the normalized model-name space (case-insensitive, dated-suffix- and `.`-vs-`-`-insensitive), resolution is single-hop, and empty/self-map entries are dropped. When no aliases are configured the behavior is byte-for-byte identical to today.

## Design notes

The fold runs strictly at grouping time, after per-message pricing has already been computed on the raw model id (`calculate_cost_with_provider`), and aggregation only sums the pre-computed cost — so folding can only relabel and merge already-costed buckets and can never change a cost total. It is independent of the pricing alias table (`pricing::aliases`) and orthogonal to `provider_identity`: it touches only the model dimension, and the existing provider-merge logic unions the providers of a folded model for free. The TUI light-cache schema version is bumped (9 → 10) because the normalized model string is persisted there, so a pre-feature cache refreshes once on upgrade.

## Scope and non-goals

Config-only: there is no built-in alias table, so nothing folds unless the user configures it, and distinct model families that happen to share a prefix (e.g. `gpt-5.1-codex` vs `gpt-5.2-codex`) are never merged by default. No new CLI flag, mirroring how provider canonicalization and scanner settings are config-only. No new dependencies.

The wiki `report` command intentionally continues to group on the raw `model_id` and is not folded: its entries are persisted append-only, so folding would leave a mix of raw and canonical names across sessions recorded before vs after aliases were configured. A `NOTE` in `commands/report.rs` records this and the one-line follow-up if it is ever wanted.

## Testing

- `cargo test -p tokscale-core model_alias` — resolver unit tests (folding, case/dotted-insensitive keys, single-hop, cap, lossy deserialize, flat-map round-trip).
- `cargo test -p tokscale-cli --test cli_tests alias` — end-to-end: variants fold into one row on `models --group-by model` and on `monthly`, an absent config is a no-op, and grand totals are unchanged by folding.
- `cargo test -p tokscale-cli --bin tokscale tui::settings` — old `settings.json` without `modelAliases` and a malformed `modelAliases` both load without wiping other settings.
- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-features -- -D warnings`
- `cargo test --workspace --all-features`

---

cc @junhoyeo — same one-chokepoint approach as #563; would appreciate a review when you have a moment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds config-driven model alias folding so model variants merge into one canonical name in local reports and the TUI, without changing totals. Folding is presentation-only; submit/upload/export payloads keep raw model ids.

- New Features
  - New `settings.json` key `modelAliases` for `{ "alias": "canonical" }` mappings (case/date-insensitive; dot/dash-insensitive across providers).
  - Folding runs in `normalize_model_for_grouping` for local grouping (models, group-bys, monthly/hourly, TUI). Submit/export paths use `canonical_model_id` and never fold.
  - Single-hop resolution; empty/self maps dropped; cap of 4096 entries. Loaded once at startup, respects `--home`. Independent of pricing aliases and does not affect costs.

- Migration
  - Optional: add to `settings.json`, e.g. `"modelAliases": {"claude-opus-4-8-cc":"claude-opus-4-8","anthropic/claude-opus-4-8":"claude-opus-4-8"}`.
  - TUI cache schema bumped to 10; it refreshes once after upgrade.
  - The wiki `report` and the `graph`/submit payload continue to use raw `model_id` (no folding).

<sup>Written for commit ce16814a6b7741c1e5de64f8b604ec9545490e59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

