### PR TITLE
fix(profile): display last updated time in viewer's local timezone

### DIFF
--- a/packages/frontend/__tests__/components/profileHeader.test.ts
+++ b/packages/frontend/__tests__/components/profileHeader.test.ts
@@ -1,0 +1,57 @@
+// Pin a non-UTC timezone BEFORE any Date/Intl usage so the "local timezone"
+// assertions are deterministic on any host (CI often runs in UTC). America/
+// New_York is -04:00 in July (EDT) and -05:00 in January (EST).
+process.env.TZ = "America/New_York";
+
+import { describe, expect, it } from "vitest";
+import { formatLastUpdated } from "../../src/components/profile";
+
+// A fixed instant, 2026-07-10 15:30:00 UTC.
+const ISO_A = "2026-07-10T15:30:00.000Z";
+// A second, different instant used to prove the output tracks the *current*
+// argument rather than a previously-captured value.
+const ISO_B = "2025-01-02T08:05:00.000Z";
+
+const UTC_A = "7/10/2026, 3:30:00 PM"; // server render (UTC)
+const UTC_B = "1/2/2025, 8:05:00 AM";
+
+const LOCAL_A = "7/10/2026, 11:30:00 AM"; // viewer render (America/New_York, EDT)
+const LOCAL_B = "1/2/2025, 3:05:00 AM"; // America/New_York, EST
+
+describe("formatLastUpdated", () => {
+  it("returns null when there is no timestamp", () => {
+    expect(formatLastUpdated(undefined, false)).toBeNull();
+    expect(formatLastUpdated(null, true)).toBeNull();
+    expect(formatLastUpdated("", true)).toBeNull();
+  });
+
+  it("formats in UTC before mount so the first client render matches the server (no hydration mismatch)", () => {
+    // The server cannot know the viewer's timezone, so the pre-mount value must
+    // be the stable UTC string that the server also renders.
+    expect(formatLastUpdated(ISO_A, false)).toBe(UTC_A);
+    expect(formatLastUpdated(ISO_B, false)).toBe(UTC_B);
+  });
+
+  it("formats in the viewer's local (non-UTC) timezone after mount", () => {
+    const localA = formatLastUpdated(ISO_A, true);
+    expect(localA).toBe(LOCAL_A);
+    // The local value must genuinely differ from the UTC/server value, proving
+    // the viewer's timezone is applied rather than UTC.
+    expect(localA).not.toBe(UTC_A);
+  });
+
+  it("derives the label from the current timestamp with no stale carry-over", () => {
+    // Regression guard for the previous implementation, which stashed the
+    // formatted string in useState and refreshed it from a useEffect keyed on
+    // `lastUpdated`. On the render where the prop changed, that lagging state
+    // still held the PREVIOUS timestamp's formatted value. Because the value is
+    // now derived purely from the current argument, a change is reflected
+    // immediately — regardless of any prior call.
+    expect(formatLastUpdated(ISO_A, true)).toBe(LOCAL_A);
+    // Simulate the prop changing to a new value: the output must be B's value,
+    // never a stale A.
+    expect(formatLastUpdated(ISO_B, true)).toBe(LOCAL_B);
+    // And back again — still tracks the current argument exactly.
+    expect(formatLastUpdated(ISO_A, true)).toBe(LOCAL_A);
+  });
+});

--- a/packages/frontend/src/components/profile/index.tsx
+++ b/packages/frontend/src/components/profile/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useMemo, useSyncExternalStore } from "react";
 import Image from "next/image";
 import styled, { css } from "styled-components";
 import { toast } from "react-toastify";
@@ -357,16 +357,48 @@ const ActionText = styled.span`
   line-height: 1;
 `;
 
+// No-op subscription for `useSyncExternalStore`: the "is this the client?"
+// signal never changes after hydration, so there is nothing to subscribe to.
+const subscribeNoop = () => () => {};
+
+/**
+ * Formats the "last updated" timestamp for display.
+ *
+ * Derived purely from its arguments so the rendered value always reflects the
+ * CURRENT `lastUpdated` prop — there is no one-render lag from stashing the
+ * formatted string in state and updating it from an effect. Before the component
+ * has mounted on the client (`isMounted === false`) we format in UTC so the
+ * first client render matches the server-rendered markup and no hydration
+ * mismatch occurs; once mounted we switch to the viewer's local timezone.
+ */
+export function formatLastUpdated(
+  lastUpdated: string | null | undefined,
+  isMounted: boolean,
+): string | null {
+  if (!lastUpdated) return null;
+  const date = new Date(lastUpdated);
+  return isMounted
+    ? date.toLocaleString("en-US")
+    : date.toLocaleString("en-US", { timeZone: "UTC" });
+}
+
 export function ProfileHeader({ user, stats, lastUpdated }: ProfileHeaderProps) {
   const [isEmbedDialogOpen, setIsEmbedDialogOpen] = useState(false);
-  const [localUpdatedAt, setLocalUpdatedAt] = useState<string | null>(null);
   const avatarUrl = user.avatarUrl || `https://github.com/${user.username}.png`;
 
-  useEffect(() => {
-    if (lastUpdated) {
-      setLocalUpdatedAt(new Date(lastUpdated).toLocaleString("en-US"));
-    }
-  }, [lastUpdated]);
+  // Reports the server value (false) during SSR and the first hydration render,
+  // then the client value (true) afterwards — flipping us from UTC to local
+  // time without a hydration mismatch and without a setState-in-effect.
+  const isMounted = useSyncExternalStore(
+    subscribeNoop,
+    () => true,
+    () => false,
+  );
+
+  const formattedLastUpdated = useMemo(
+    () => formatLastUpdated(lastUpdated, isMounted),
+    [lastUpdated, isMounted],
+  );
 
   const handleShareClick = async () => {
     try {
@@ -471,7 +503,7 @@ export function ProfileHeader({ user, stats, lastUpdated }: ProfileHeaderProps) 
             style={{ color: "var(--color-fg-muted)" }}
             suppressHydrationWarning
           >
-            Last Updated: {localUpdatedAt ?? new Date(lastUpdated).toLocaleString("en-US", { timeZone: "UTC" })}
+            Last Updated: {formattedLastUpdated}
           </LastUpdatedText>
         )}
 

--- a/packages/frontend/src/components/profile/index.tsx
+++ b/packages/frontend/src/components/profile/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Image from "next/image";
 import styled, { css } from "styled-components";
 import { toast } from "react-toastify";
@@ -359,7 +359,14 @@ const ActionText = styled.span`
 
 export function ProfileHeader({ user, stats, lastUpdated }: ProfileHeaderProps) {
   const [isEmbedDialogOpen, setIsEmbedDialogOpen] = useState(false);
+  const [localUpdatedAt, setLocalUpdatedAt] = useState<string | null>(null);
   const avatarUrl = user.avatarUrl || `https://github.com/${user.username}.png`;
+
+  useEffect(() => {
+    if (lastUpdated) {
+      setLocalUpdatedAt(new Date(lastUpdated).toLocaleString("en-US"));
+    }
+  }, [lastUpdated]);
 
   const handleShareClick = async () => {
     try {
@@ -462,8 +469,9 @@ export function ProfileHeader({ user, stats, lastUpdated }: ProfileHeaderProps) 
         {lastUpdated && (
           <LastUpdatedText
             style={{ color: "var(--color-fg-muted)" }}
+            suppressHydrationWarning
           >
-            Last Updated: {new Date(lastUpdated).toLocaleString("en-US", { timeZone: "UTC" })}
+            Last Updated: {localUpdatedAt ?? new Date(lastUpdated).toLocaleString("en-US", { timeZone: "UTC" })}
           </LastUpdatedText>
         )}
 


### PR DESCRIPTION
Profile header's "Last Updated" timestamp was hardcoded to UTC via `toLocaleString("en-US", { timeZone: "UTC" })`. This meant users always saw UTC time regardless of their location.

Fix: render UTC on server (SSR) then swap to local timezone on client mount via `useEffect`, with `suppressHydrationWarning` to avoid mismatch warnings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the profile header “Last Updated” in the viewer’s local timezone. Render UTC on SSR, then switch to local time after hydration via `useSyncExternalStore` and a pure `formatLastUpdated` helper (no stale one-render lag), with tests added and `suppressHydrationWarning` to match SSR.

<sup>Written for commit ce2a964051870a44b06c578431e5c64ba8251def. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

