### PR TITLE
fix(tui): color gateway-served models by their own vendor

### DIFF
--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -570,11 +570,10 @@ impl App {
     }
 
     pub fn model_color_for(&self, provider: &str, model: &str) -> Color {
-        let provider = if provider.is_empty() || provider.contains(", ") {
-            get_provider_from_model(model)
-        } else {
-            provider
-        };
+        // Same key derivation as `build_model_shade_map`, so gateway providers
+        // (e.g. `github-copilot`) resolve to the model's own vendor ramp and the
+        // lookup never misses into the fallback for a model we've ranked.
+        let provider = super::colors::provider_color_key(provider, model);
         let lookup_key = super::colors::model_shade_key(provider, model);
         let color = self
             .model_shade_map
@@ -5016,6 +5015,53 @@ mod tests {
         assert_ne!(
             app.model_color_for("anthropic", "sonnet-shared"),
             app.model_color_for("openai", "sonnet-shared")
+        );
+    }
+
+    #[test]
+    fn test_gateway_provider_model_uses_model_vendor_color() {
+        // Regression: a Claude model served through the github-copilot gateway
+        // must render in the Anthropic ramp, not the neutral "unknown" gray.
+        // The gateway has no vendor palette of its own, so the model's own
+        // vendor decides the color.
+        let mut app = make_app();
+        let copilot_fable = ModelUsage {
+            model: "claude-fable-5".to_string(),
+            provider: "github-copilot".to_string(),
+            client: "opencode".to_string(),
+            workspace_key: None,
+            workspace_label: None,
+            tokens: TokenBreakdown::default(),
+            cost: 3.0,
+            performance: Default::default(),
+            session_count: 1,
+        };
+        app.data.models = vec![
+            ModelUsage {
+                provider: "anthropic".to_string(),
+                cost: 5.0,
+                ..copilot_fable.clone()
+            },
+            copilot_fable,
+        ];
+        app.build_model_shade_map();
+
+        // Fable is the flagship tier -> base Anthropic shade.
+        let anthropic_base = app.theme.color(get_provider_shade("anthropic", 0));
+        assert_eq!(
+            app.model_color_for("github-copilot", "claude-fable-5"),
+            anthropic_base,
+            "copilot-served Claude must use the Anthropic ramp, not unknown gray"
+        );
+        // Identical to the natively-served model.
+        assert_eq!(
+            app.model_color_for("anthropic", "claude-fable-5"),
+            app.model_color_for("github-copilot", "claude-fable-5")
+        );
+        // And definitively not the neutral gray a raw github-copilot key yields.
+        assert_ne!(
+            app.model_color_for("github-copilot", "claude-fable-5"),
+            app.theme.color(get_provider_shade("github-copilot", 0))
         );
     }
 }

--- a/crates/tokscale-cli/src/tui/colors.rs
+++ b/crates/tokscale-cli/src/tui/colors.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use ratatui::style::Color;
 
 use super::data::ModelUsage;
-use super::ui::widgets::{get_provider_from_model, get_provider_shade};
+use super::ui::widgets::{get_provider_from_model, get_provider_shade, provider_has_palette};
 
 pub fn model_shade_key(provider: &str, model: &str) -> String {
     format!("{provider}\0{model}")
@@ -54,8 +54,16 @@ pub fn build_model_shade_map(models: &[ModelUsage]) -> HashMap<String, Color> {
     map
 }
 
-fn provider_color_key<'a>(provider: &'a str, model: &'a str) -> &'a str {
-    if provider.is_empty() || provider.contains(", ") {
+/// Resolves the provider whose color ramp a model's name should render in.
+///
+/// Empty or mixed (`", "`-joined) providers color by the model's own vendor.
+/// So do gateway providers that resell other vendors' models (e.g.
+/// `github-copilot`, `openrouter`): they have no vendor palette of their own, so
+/// a Claude model served through Copilot still gets the Anthropic ramp instead
+/// of the neutral "unknown" gray. Both the shade-map build and the per-cell
+/// lookup route through this, so their keys always agree.
+pub(crate) fn provider_color_key<'a>(provider: &'a str, model: &'a str) -> &'a str {
+    if provider.is_empty() || provider.contains(", ") || !provider_has_palette(provider) {
         get_provider_from_model(model)
     } else {
         provider
@@ -150,6 +158,52 @@ mod tests {
 
     fn shade(map: &HashMap<String, Color>, provider: &str, model: &str) -> Color {
         map.get(&model_shade_key(provider, model)).copied().unwrap()
+    }
+
+    #[test]
+    fn provider_color_key_routes_gateways_to_model_vendor() {
+        // Known vendor providers keep their own identity.
+        assert_eq!(
+            provider_color_key("anthropic", "claude-opus-4-8"),
+            "anthropic"
+        );
+        assert_eq!(provider_color_key("openai", "gpt-5.4"), "openai");
+        // Gateway providers with no vendor palette color by the model's vendor.
+        assert_eq!(
+            provider_color_key("github-copilot", "claude-fable-5"),
+            "anthropic"
+        );
+        assert_eq!(
+            provider_color_key("github-copilot", "gpt-5.3-codex"),
+            "openai"
+        );
+        // Empty / mixed providers also defer to the model.
+        assert_eq!(provider_color_key("", "claude-fable-5"), "anthropic");
+        assert_eq!(
+            provider_color_key("anthropic, github-copilot", "claude-fable-5"),
+            "anthropic"
+        );
+    }
+
+    #[test]
+    fn gateway_and_native_claude_share_one_shade_bucket() {
+        // Regression: the same Claude model served natively and via the
+        // github-copilot gateway must fold into one Anthropic-ramp bucket and
+        // rank by family tier, not split into a separate "unknown" gray key.
+        let map = build_model_shade_map(&[
+            usage("claude-fable-5", "github-copilot", 3.0),
+            usage("claude-opus-4-8", "anthropic", 100.0),
+        ]);
+        assert_eq!(
+            shade(&map, "anthropic", "claude-fable-5"),
+            get_provider_shade("anthropic", 0),
+            "copilot fable takes the flagship Anthropic shade"
+        );
+        assert_eq!(
+            shade(&map, "anthropic", "claude-opus-4-8"),
+            get_provider_shade("anthropic", 1),
+            "opus ranks below fable in the shared bucket"
+        );
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -161,6 +161,36 @@ pub fn get_model_color(model: &str) -> Color {
     get_provider_shade(get_provider_from_model(model), 0)
 }
 
+/// Maps a lowercased provider id to its built-in vendor shade ramp, or `None`
+/// when the provider has no known vendor palette. Kept as the single source of
+/// truth so [`get_provider_shade`] and [`provider_has_palette`] never drift.
+fn known_provider_palette(provider_lower: &str) -> Option<&'static [(u8, u8, u8)]> {
+    let palette: &[(u8, u8, u8)] = match provider_lower {
+        s if s.contains("anthropic") => &ANTHROPIC_SHADES,
+        s if s.contains("openai") => &OPENAI_SHADES,
+        s if s.contains("google") || s.contains("gemini") => &GOOGLE_SHADES,
+        s if s.contains("deepseek") => &DEEPSEEK_SHADES,
+        s if s.contains("xai") || s.contains("grok") => &XAI_SHADES,
+        s if s.contains("meta") || s.contains("llama") => &META_SHADES,
+        s if s.contains("cursor") => &CURSOR_SHADES,
+        s if s.contains("sakana") || s.contains("fugu") => &SAKANA_SHADES,
+        _ => return None,
+    };
+    Some(palette)
+}
+
+/// Whether `provider` resolves to a known vendor color — either a built-in
+/// shade ramp or a user `[colors.providers]` override. Gateway providers that
+/// resell other vendors' models (e.g. `github-copilot`, `openrouter`) have no
+/// vendor palette of their own and return `false`, so callers can color by the
+/// model's own vendor instead of the neutral "unknown" gray.
+pub fn provider_has_palette(provider: &str) -> bool {
+    TokscaleConfig::load()
+        .get_provider_color(provider)
+        .is_some()
+        || known_provider_palette(&provider.to_lowercase()).is_some()
+}
+
 /// Returns the shade for a given `(provider, rank)` pair.
 /// Honors `[colors.providers]` config overrides at every rank by deriving
 /// a 7-step lighten-to-white palette from the override base color.
@@ -170,17 +200,7 @@ pub fn get_provider_shade(provider: &str, rank: usize) -> Color {
     }
 
     let p = provider.to_lowercase();
-    let palette: &[(u8, u8, u8)] = match p.as_str() {
-        s if s.contains("anthropic") => &ANTHROPIC_SHADES,
-        s if s.contains("openai") => &OPENAI_SHADES,
-        s if s.contains("google") || s.contains("gemini") => &GOOGLE_SHADES,
-        s if s.contains("deepseek") => &DEEPSEEK_SHADES,
-        s if s.contains("xai") || s.contains("grok") => &XAI_SHADES,
-        s if s.contains("meta") || s.contains("llama") => &META_SHADES,
-        s if s.contains("cursor") => &CURSOR_SHADES,
-        s if s.contains("sakana") || s.contains("fugu") => &SAKANA_SHADES,
-        _ => &UNKNOWN_SHADES,
-    };
+    let palette = known_provider_palette(&p).unwrap_or(&UNKNOWN_SHADES);
 
     let idx = rank.min(palette.len() - 1);
     let (r, g, b) = palette[idx];
@@ -763,5 +783,19 @@ mod tests {
             get_provider_shade("meta-llama-endpoint", 0),
             get_provider_shade("meta", 0)
         );
+    }
+
+    #[test]
+    fn provider_has_palette_flags_only_known_vendors() {
+        // Known vendors (and fuzzy substrings of them) have their own ramp.
+        assert!(provider_has_palette("anthropic"));
+        assert!(provider_has_palette("openai"));
+        assert!(provider_has_palette("openrouter-gemini-prod"));
+        // Gateway/reseller providers do not — callers must color by the
+        // model's own vendor instead of the neutral "unknown" gray.
+        assert!(!provider_has_palette("github-copilot"));
+        assert!(!provider_has_palette("openrouter"));
+        assert!(!provider_has_palette("unknown"));
+        assert!(!provider_has_palette(""));
     }
 }


### PR DESCRIPTION
## Problem

Models routed through a **gateway provider** — most visibly `github-copilot`, which resells Anthropic / OpenAI / etc. models — carry the gateway id as their `provider`. The model-name color path keyed on that provider id, and because a gateway has no vendor color palette of its own, it fell through to the neutral **"unknown" gray**.

Result: `claude-fable-5` served via GitHub Copilot rendered gray instead of the Anthropic orange ramp (see the Daily Detail — row for `claude-fable-5` / `GitHub Copilot`), while the identical model served natively by Anthropic was correctly orange.

## Fix

- Add `provider_has_palette(provider)` backed by a new shared `known_provider_palette` helper, so it can never drift from `get_provider_shade`'s palette selection.
- Route **both** the shade-map build (`build_model_shade_map`) and the per-cell lookup (`model_color_for`) through one `provider_color_key`. Empty, mixed (`", "`-joined), **and palette-less gateway providers** now color by the model's own vendor (`get_provider_from_model`).

A Claude model folds into the Anthropic bucket and ranks by family tier (fable > opus > sonnet > haiku) regardless of which gateway served it; a GPT model via Copilot gets the OpenAI ramp, and so on. Native providers and `[colors.providers]` config overrides are unaffected. Because the map build and the lookup now share the exact same key derivation, the per-cell lookup can never miss into the fallback for a model we've already ranked.

## Tests

- `provider_has_palette_flags_only_known_vendors` (widgets)
- `provider_color_key_routes_gateways_to_model_vendor` (colors)
- `gateway_and_native_claude_share_one_shade_bucket` (colors)
- `test_gateway_provider_model_uses_model_vendor_color` (app, end-to-end via `model_color_for`)

All fail on the pre-fix code (gray) and pass after. `cargo fmt` clean, `cargo clippy --workspace --all-targets -D warnings` clean, full `tokscale-cli` bin suite: 860 passed / 0 failed.

https://claude.ai/code/session_01YTwnnT7dC3tTeLZ5xc4WiZ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TUI colors so gateway-served models render in their own vendor ramp (Anthropic/OpenAI) instead of the neutral gray, and ensures the shade map and per-cell lookup use the same provider key.

- **Bug Fixes**
  - Added `provider_has_palette`, backed by shared `known_provider_palette`, to stay in sync with `get_provider_shade`.
  - Routed `build_model_shade_map` and `model_color_for` through `provider_color_key`; empty/mixed and palette-less gateways like `github-copilot` and `openrouter` now color by the model vendor via `get_provider_from_model`.
  - Gateway and native models share the same vendor bucket and ranking; `[colors.providers]` overrides and native providers are unchanged.

<sup>Written for commit c4459616f24041677e00ad69a33f5b0f7bb263ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

