### PR TITLE
feat(frontend): refine groups and leaderboard workflows

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -16,8 +16,8 @@
 
 ## Product goals
 
-- Goals: Make profiles understandable in one viewport; make global and group rankings immediately scannable; preserve tokens, cost, time, submissions, rank, and role at every viewport; make group discovery and membership workflows feel like one service; make every embed template communicate one distinct usage story; and work cleanly from 320px through desktop.
-- Non-goals: No database, API, authentication, settings, global landing/footer asset, or `/local` graph redesign in this pass. No new dependency and no pixel-for-pixel clone of the reference sites.
+- Goals: Make profiles understandable in one viewport; make global and group rankings immediately scannable; preserve tokens, cost, time, rank, and role at every viewport; make group discovery and membership workflows feel like one service; make every embed template communicate one distinct usage story; and work cleanly from 320px through desktop.
+- Non-goals: No database schema, authentication, settings, global landing/footer asset, or `/local` graph redesign in this pass. The leaderboard response may be narrowed to facts its ranking surfaces consume. No new dependency and no pixel-for-pixel clone of the reference sites.
 - Success signals: A visitor reaches leaderboard data without crossing a promotional hero; top ranks and active scope scan in seconds; public groups are compact enough to compare; group detail never collides with navigation; mobile ranking rows retain their decisive metrics without horizontal scrolling; and profile, leaderboard, groups, and embeds share one visual grammar.
 
 ## Personas and jobs
@@ -56,7 +56,7 @@
 
 ## Components
 
-- Existing components to reuse: `Navigation`, profile components, formatters in `lib/utils`, shared graph palettes/settings, `TabBar`, existing 16px icons, and current server/API contracts.
+- Existing components to reuse: `Navigation`, profile components, formatters in `lib/utils`, shared graph palettes/settings, `TabBar`, existing 16px icons, and established server-fetching patterns.
 - New/changed components: A shared compact application shell and `ServiceFooter` for profile/ranking routes; compact `LeaderboardViewSelector`, aggregate fact strip, responsive global ranking rows, `GroupDirectory`, deterministic group mark, scoped group overview, responsive group ranking rows, and focused create/join surfaces. Existing profile analytics and embed components remain unchanged in this follow-up.
 - Variants and states: Primary/secondary/ghost actions; active/inactive navigation and ranges; current-user and top-three rows; public/private/member/owner/admin group states; loading, empty, search-empty, error, pagination, copied-invite, and submitting states; desktop table and mobile ranking-list compositions.
 - Chart contract: Render one stable stacked area per provider/model pair. Order provider groups and their models by raw scoped usage ascending so dominant bands remain on top; sort only the active tooltip rows descending. Use provider-level legend colors, deterministic model shades, 40% fills, 1px monotone boundaries, and no chart animation.
@@ -98,9 +98,9 @@
 
 - Framework/styling system: Next.js 16, React 19, and styled-components. No Sass/Tailwind/chart package is introduced.
 - Design-token constraints: Add tokens without changing existing global aliases used by landing, leaderboard, settings, groups, or `/local`.
-- Performance constraints: Keep chart and contribution geometry derivation memoized; allow normal profiles to retain their model bands, apply a high pathological series cap with an explicit remainder, render only one contribution view at a time, and preserve server data fetching and ISR.
+- Performance constraints: Keep chart and contribution geometry derivation memoized; allow normal profiles to retain their model bands, apply a high pathological series cap with an explicit remainder, render only one contribution view at a time, and preserve server data fetching and ISR. Ranking queries and API payloads include only displayed identity, rank, token, cost, time, role, scope, and pagination facts; submission counts and freshness metadata stay on profile-specific surfaces.
 - Analytical constraints: Missing calendar dates are zero-valued. Lifetime defaults to a trailing 30-day average and finite ranges to a trailing 7-day average, with daily values available as an explicit display mode. Moving averages never alter raw range totals or stable series ranking.
-- Compatibility constraints: Leave API/auth/database contracts and canonical profile redirects unchanged. Do not mutate the shared `GraphContainer` behavior. Preserve all public embed template IDs and query parameters, XML escaping, CSP-compatible standalone SVG output, intrinsic template widths, and the classic fallback for invalid or omitted templates.
+- Compatibility constraints: Leave auth, database schema, profile APIs, and canonical profile redirects unchanged. The public leaderboard APIs intentionally omit unused submission-count and freshness fields. Do not mutate the shared `GraphContainer` behavior. Preserve all public embed template IDs and query parameters, XML escaping, CSP-compatible standalone SVG output, intrinsic template widths, and the classic fallback for invalid or omitted templates.
 - Test/screenshot expectations: Preserve existing profile/embed coverage; add focused tests for view-link filter preservation and responsive ranking/group presentation helpers; run frontend tests, lint, typecheck, and build; capture `/leaderboard`, `/leaderboard?view=groups`, and a populated public `/groups/[slug]` with actual API data at 1440×1100 and 390×844; exercise search, period, sort, view, and primary group navigation; persist the visual verdict under `.omx/state/groups-leaderboard/ralph-progress.json` with a pass target of 90.
 
 ## Open questions

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -4,9 +4,9 @@
 
 - Status: Active
 - Last refreshed: 2026-07-12
-- Primary product surfaces: Public user profiles at `/u/[username]`, the profile embed dialog, public README widgets at `/api/embed/[username]/svg`, and `/profile` as the authenticated redirect.
-- Evidence reviewed: `packages/frontend/src/app/u/[username]/ProfilePageClient.tsx`, `packages/frontend/src/components/profile/`, `packages/frontend/src/lib/embed/`, `packages/frontend/src/app/api/embed/[username]/svg/route.ts`, `packages/frontend/src/components/GraphContainer.tsx`, `packages/frontend/src/components/GraphControls.tsx`, `packages/frontend/src/components/StatsPanel.tsx`, `packages/frontend/src/components/layout/Navigation.tsx`, `packages/frontend/src/app/globals.css`, the current production profile and embed renderers for `junhoyeo`, and the compact content/usage references at `https://cho.sh/ko` and `https://cho.sh/ko/mini/usage`.
-- Visual reference captures: `.omx/artifacts/visual-ralph/compact-profile/cho-*-desktop.png`, `.omx/artifacts/visual-ralph/compact-profile/cho-*-mobile.png`, `.omx/artifacts/visual-ralph/compact-profile/current-profile-*.png`, and `.omx/artifacts/embed-redesign/`.
+- Primary product surfaces: Public user profiles at `/u/[username]`, the profile embed dialog, public README widgets at `/api/embed/[username]/svg`, the global leaderboard at `/leaderboard`, the group directory at `/leaderboard?view=groups`, group detail at `/groups/[slug]`, and the group create/join flows.
+- Evidence reviewed: `packages/frontend/src/app/u/[username]/ProfilePageClient.tsx`, `packages/frontend/src/components/profile/`, `packages/frontend/src/lib/embed/`, `packages/frontend/src/app/api/embed/[username]/svg/route.ts`, `packages/frontend/src/app/(main)/leaderboard/`, `packages/frontend/src/app/(main)/groups/`, `packages/frontend/src/lib/leaderboard/`, `packages/frontend/src/lib/groups/`, `packages/frontend/src/components/layout/Navigation.tsx`, `packages/frontend/src/app/globals.css`, actual local API data for the leaderboard and public groups, and the compact content/usage references at `https://cho.sh/ko` and `https://cho.sh/ko/mini/usage`.
+- Visual reference captures: `.omx/artifacts/visual-ralph/compact-profile/`, `.omx/artifacts/embed-redesign/`, and the desktop/mobile leaderboard and group baselines under `.omx/artifacts/groups-leaderboard/baseline/`.
 
 ## Brand
 
@@ -16,21 +16,21 @@
 
 ## Product goals
 
-- Goals: Make a profile understandable in one viewport; foreground usage history; make period, metric, and provider controls obvious; make every embed template communicate one distinct usage story at README scale; retain sharing utility; work cleanly from 320px through desktop.
-- Non-goals: No database, API, authentication, leaderboard, settings, or `/local` graph redesign in this pass. No new dependency and no pixel-for-pixel clone of the reference sites.
-- Success signals: Headline identity and four metrics scan in seconds, the default chart exposes a readable model-level trend without configuration, secondary data is progressively disclosed, and the mobile page has no nested horizontal scrollers.
+- Goals: Make profiles understandable in one viewport; make global and group rankings immediately scannable; preserve tokens, cost, time, submissions, rank, and role at every viewport; make group discovery and membership workflows feel like one service; make every embed template communicate one distinct usage story; and work cleanly from 320px through desktop.
+- Non-goals: No database, API, authentication, settings, global landing/footer asset, or `/local` graph redesign in this pass. No new dependency and no pixel-for-pixel clone of the reference sites.
+- Success signals: A visitor reaches leaderboard data without crossing a promotional hero; top ranks and active scope scan in seconds; public groups are compact enough to compare; group detail never collides with navigation; mobile ranking rows retain their decisive metrics without horizontal scrolling; and profile, leaderboard, groups, and embeds share one visual grammar.
 
 ## Personas and jobs
 
-- Primary personas: A developer reviewing their own activity; a visitor comparing a public profile; a maintainer debugging submitted usage.
-- User jobs: Identify the person, understand scale and recency, inspect a time trend, filter by provider, compare token categories/models/devices, configure a truthful embed, and share it in GitHub Markdown or HTML.
-- Key contexts of use: Desktop comparison, mobile link preview, GitHub README rendering on narrow and wide containers, keyboard-only navigation, and profiles with long names, many providers, sparse data, or no optional device/model detail.
+- Primary personas: A developer reviewing their own activity; a visitor comparing public users; a team owner managing a scoped ranking; a member checking standing; and a maintainer debugging submitted usage.
+- User jobs: Identify a person or group, understand ranking scope, compare decisive usage metrics, find a member, inspect personal standing, create or join a group, configure a truthful embed, and share the result.
+- Key contexts of use: Wide desktop comparison, narrow mobile ranking checks, keyboard-only navigation, authenticated and anonymous group discovery, GitHub README rendering, and datasets with long names, sparse activity, many pages, or missing optional metrics.
 
 ## Information architecture
 
-- Primary navigation: Existing Tokscale application navigation remains unchanged.
-- Core routes/screens: `/u/[username]` is the canonical public profile; `/profile` redirects authenticated users; profile tabs switch between Usage and Models without navigating away; the embed dialog configures the stable `/api/embed/[username]/svg` URL contract without hiding unsupported options.
-- Content hierarchy: Identity and freshness → headline metrics → range/tab controls → paired usage and contribution views → persistent selected-day contribution detail → compact supporting insights and token mix → devices.
+- Primary navigation: Existing Tokscale application navigation remains unchanged. `/leaderboard` uses link-based Users/Groups navigation so URLs, history, and server rendering stay authoritative.
+- Core routes/screens: `/u/[username]` is the canonical public profile; `/leaderboard` is the compact global ranking; `/leaderboard?view=groups` is the directory and membership entry point; `/groups/[slug]` is the scoped ranking and invite-management view; `/groups/new` and `/groups/join/[token]` are focused single-task forms.
+- Content hierarchy: Profiles retain identity → metrics → analysis. Global leaderboard uses title/scope → aggregate facts → range/search/sort → ranking → join instructions. Group directory uses purpose/action → owned/public filter → compact group list. Group detail uses identity/membership → scoped facts → period/search/sort → ranking → invite management when authorized.
 
 ## Design principles
 
@@ -38,6 +38,9 @@
 - One fact, one home: Do not repeat tokens, cost, active time, or sessions across multiple cards.
 - Lightest useful surface: Use whitespace and dividers first; reserve bordered panels for the identity overview, charts, Usage details, Token mix, and independently grouped datasets.
 - Compact, not cramped: Desktop controls use 28–36px heights; mobile keeps 44–48px coarse-pointer targets without inflating visual chrome.
+- Ranking before promotion: Application rankings begin with their title and data; the black-hole marketing hero does not appear on leaderboard or group routes.
+- Preserve comparison context: Responsive rankings recompose into compact rows rather than hiding cost, tokens, rank, role, or useful all-time facts.
+- Honest group identity: Missing group artwork uses a deterministic text monogram on a restrained surface, never an unrelated decorative gradient.
 - Reference, not replica: Adopt the reference's narrow content measure, restrained borders, chart-first composition, and low-noise controls while retaining Tokscale typography, data, and blue accent.
 - One widget, one job: Template differences come from information hierarchy and reading density, never costume, decorative metaphor, or renamed identical layouts.
 - Tradeoffs: The public profile keeps its purpose-built responsive usage trend and adds an optional inline isometric contribution view using the same scoped calendar as 2D. It does not reuse the heavier `/local` graph container or decorative 3D embed card. Raw totals remain authoritative, the usage trend still defaults to a trailing average, and 2D remains the default contribution view.
@@ -46,16 +49,16 @@
 
 - Color: Dark zinc-neutral canvas; raised surfaces only slightly lighter; translucent white borders; white/default/muted text with WCAG AA contrast; Tokscale blue for the single primary action and selected data emphasis; provider colors only in chart/legend context.
 - Typography: Existing Figtree UI font and JetBrains Mono for code only. Page title 20–24px medium/semibold, section title 16–18px medium, body 14–16px, metadata 12–13px where it is supplementary rather than body copy. Numeric values use tabular figures.
-- Spacing/layout rhythm: 4px base; common gaps 8/12/16/20/24px; profile analytics canvas max-width 1500px with responsive 16–32px gutters and roughly 650px reserved for the desktop contribution column. Keep headline profile metrics left-packed in compact tracks instead of stretching them across the canvas.
+- Spacing/layout rhythm: 4px base; common gaps 8/12/16/20/24px; application canvases max out at 1500px with responsive 16–32px gutters. Keep headline metrics left-packed in compact tracks instead of stretching sparse facts across the canvas. Ranking rows target 56–64px desktop height and an information-complete 76–92px mobile composition.
 - Shape/radius/elevation: 8px controls, 12px panels, full radius only for badges/avatars where semantically appropriate. Dark application surfaces use borders, not shadows.
 - Motion: Immediate color/background state changes; 120–160ms transform only for pressed controls; honor `prefers-reduced-motion`.
 - Imagery/iconography: GitHub avatar with a subtle dark-surface outline at 72px mobile and 80px desktop. Give rank one compact accent-backed emphasis beside identity metadata. Reuse existing 16px application icons and source assets; avoid decorative icon containers.
 
 ## Components
 
-- Existing components to reuse: `Navigation`, `ProfileDevices`, formatters in `lib/utils`, shared graph palettes/settings, source labels/colors, and existing 16px icons.
-- New/changed components: Compact `ProfileOverview`, `ProfileTabBar`, profile-only `ProfileUsageChart`, controlled 2D/3D `ProfileContributionGraph`, persistent `ProfileContributionBreakdown`, `ProfileInsights`, `TokenBreakdown`, and semantic models/devices tables.
-- Variants and states: Primary/secondary/ghost actions; active/inactive tabs and ranges; all/single-provider chart; tokens/cost metric; trailing-average/daily display; empty and sparse charts; hovered, keyboard-selected, and tapped chart days; selectable contribution palettes; responsive table overflow.
+- Existing components to reuse: `Navigation`, profile components, formatters in `lib/utils`, shared graph palettes/settings, `TabBar`, existing 16px icons, and current server/API contracts.
+- New/changed components: A shared compact application shell and `ServiceFooter` for profile/ranking routes; compact `LeaderboardViewSelector`, aggregate fact strip, responsive global ranking rows, `GroupDirectory`, deterministic group mark, scoped group overview, responsive group ranking rows, and focused create/join surfaces. Existing profile analytics and embed components remain unchanged in this follow-up.
+- Variants and states: Primary/secondary/ghost actions; active/inactive navigation and ranges; current-user and top-three rows; public/private/member/owner/admin group states; loading, empty, search-empty, error, pagination, copied-invite, and submitting states; desktop table and mobile ranking-list compositions.
 - Chart contract: Render one stable stacked area per provider/model pair. Order provider groups and their models by raw scoped usage ascending so dominant bands remain on top; sort only the active tooltip rows descending. Use provider-level legend colors, deterministic model shades, 40% fills, 1px monotone boundaries, and no chart animation.
 - Contribution contract: Render the complete requested UTC date range, including zero-valued outer days; derive 2D intensity and 3D height from the same token-scoped calendar; expose compact view and palette selectors; show a viewport-clamped daily tooltip on hover/focus; and let click, tap, Enter, or Space update one persistent token, cost, client, and model breakdown. Default that breakdown to the visible range end, preserve it across view and palette changes, retain roving keyboard navigation in both views, and expose a concise screen-reader summary.
 - Embed contract: Keep the live preview visually primary, place dense settings in a viewport-contained scroll region, expose only options the selected renderer consumes, and trap/restore focus while the dialog is open. The eight 2D templates share one solid surface, identity header, divider, footer, type scale, and restrained semantic colors while using distinct data hierarchies; decorative gradients, glows, patterns, fake chrome, and metaphor-heavy ornament are excluded. The 3D contribution view remains a supported first-class renderer with its own compatible controls. Desktop uses preview/settings panes; mobile uses one body scroll.
@@ -65,15 +68,15 @@
 ## Accessibility
 
 - Target standard: WCAG 2.2 AA.
-- Keyboard/focus behavior: Visible focus rings; roving focus for tabs; arrow-key chart day navigation; focusable contribution days; native selects; Tab containment plus Escape/opener focus restoration in the embed dialog.
+- Keyboard/focus behavior: Visible focus rings; link semantics for ranking destinations; native buttons, inputs, selects, and checkboxes; complete keyboard access to view, period, sort, pagination, copy, and membership actions; existing chart and embed focus contracts remain intact.
 - Contrast/readability: Muted text must remain at least 4.5:1 for normal text; provider color is never the only data label; body text is at least 16px on mobile.
-- Screen-reader semantics: Structured headings, `dl` for metrics, table semantics for models/devices, labeled tabpanels, accessible chart title/description, and a concise live textual readout for committed chart selections. Pointer hover never floods the live region.
+- Screen-reader semantics: Structured headings, `dl` for facts, real table semantics on wide ranking views, equivalent labeled lists on narrow views, `aria-current` on navigation, labeled search and date controls, status/alert regions for async results, and the existing chart/embed semantics.
 - Reduced motion and sensory considerations: Disable nonessential transform/animation under reduced motion; preserve labels and values independently of hue.
 
 ## Responsive behavior
 
 - Supported breakpoints/devices: 320px mobile through wide desktop; primary checks at 390, 768, and 1024+ CSS pixels. The usage chart targets 224px height on mobile and 256px on desktop.
-- Layout adaptations: Four metric cells become two columns; identity/actions and controls wrap. At 1360px and wider, activity becomes two independent stacks: a left Contributions + complete selected-day breakdown column at roughly 650px, and a still-wider right Usage over time + Usage details + Token mix column. Contribution cards keep intrinsic height, and the standalone breakdown expands with the full client/model list instead of using an internal scroll region. Tablet and mobile collapse to Contributions → selected-day breakdown → Usage → Usage details → Token mix → Devices. The area chart, seven-row 2D calendar, and range-sized isometric SVG compress within their containers without page overflow; tables expose secondary detail instead of silently dropping it. Embed SVGs retain their public intrinsic widths while scaling down proportionally in README and modal containers; the modal changes from two panes to one document scroll below 840px.
+- Layout adaptations: Profile behavior remains as defined. Leaderboard and group pages use a 1500px application shell with 16–32px gutters and no promotional hero. Aggregate facts use compact divider-separated tracks on desktop and a two-column grid on mobile. Global and group rankings render semantic tables where space permits and information-complete linked rows on mobile; no page-level or nested horizontal scroller is required. Group directory cards become compact list-like tiles with bounded descriptions instead of fixed empty height. Identity/actions and control bars wrap into a single column without overlapping the fixed navigation. Create and join forms remain bounded while using full mobile width.
 - Touch/hover differences: Coarse pointers receive at least 44px effective targets; chart selection works by tap and keyboard, with a compact detail panel below the chart. Fine pointers receive a clamped, internally scrollable floating tooltip; contribution cells expose the same value on hover and focus.
 
 ## Interaction states
@@ -98,8 +101,8 @@
 - Performance constraints: Keep chart and contribution geometry derivation memoized; allow normal profiles to retain their model bands, apply a high pathological series cap with an explicit remainder, render only one contribution view at a time, and preserve server data fetching and ISR.
 - Analytical constraints: Missing calendar dates are zero-valued. Lifetime defaults to a trailing 30-day average and finite ranges to a trailing 7-day average, with daily values available as an explicit display mode. Moving averages never alter raw range totals or stable series ranking.
 - Compatibility constraints: Leave API/auth/database contracts and canonical profile redirects unchanged. Do not mutate the shared `GraphContainer` behavior. Preserve all public embed template IDs and query parameters, XML escaping, CSP-compatible standalone SVG output, intrinsic template widths, and the classic fallback for invalid or omitted templates.
-- Test/screenshot expectations: Unit-test chart aggregation, contribution selection, isometric geometry, embed parsing/dispatch, shared SVG structure, bounds, escaping, and formatting; run frontend tests/lint/typecheck/build; capture `/u/junhoyeo` locally in 2D and 3D at 1440×1100 and 390×844; capture every embed template with actual data in dark and light themes plus representative graph and compact states; persist each visual verdict under `.omx/state/` with a pass target of 90.
+- Test/screenshot expectations: Preserve existing profile/embed coverage; add focused tests for view-link filter preservation and responsive ranking/group presentation helpers; run frontend tests, lint, typecheck, and build; capture `/leaderboard`, `/leaderboard?view=groups`, and a populated public `/groups/[slug]` with actual API data at 1440×1100 and 390×844; exercise search, period, sort, view, and primary group navigation; persist the visual verdict under `.omx/state/groups-leaderboard/ralph-progress.json` with a pass target of 90.
 
 ## Open questions
 
-- [ ] Decide in a future pass whether the compact service language should extend to leaderboard, groups, settings, navigation, and footer; owner: product/design; impact: global shell consistency, deliberately excluded from this profile-focused branch.
+- [ ] Decide in a future pass whether the compact service language should extend to settings, navigation, and the decorative global footer; owner: product/design; impact: site-wide shell consistency, deliberately excluded from this follow-up.

--- a/packages/frontend/__tests__/api/leaderboard.test.ts
+++ b/packages/frontend/__tests__/api/leaderboard.test.ts
@@ -20,7 +20,7 @@ beforeEach(() => {
 });
 
 describe("GET /api/leaderboard", () => {
-  it("passes submission freshness metadata through unchanged", async () => {
+  it("returns the lean leaderboard payload", async () => {
     getLeaderboardData.mockResolvedValue({
       users: [
         {
@@ -31,14 +31,7 @@ describe("GET /api/leaderboard", () => {
           avatarUrl: null,
           totalTokens: 1200,
           totalCost: 12.5,
-          submissionCount: 2,
-          lastSubmission: "2026-01-10T10:00:00.000Z",
-          submissionFreshness: {
-            lastUpdated: "2026-01-10T10:00:00.000Z",
-            cliVersion: "1.4.2",
-            schemaVersion: 1,
-            isStale: true,
-          },
+          totalActiveTimeMs: 3600000,
         },
       ],
       pagination: {
@@ -52,7 +45,7 @@ describe("GET /api/leaderboard", () => {
       stats: {
         totalTokens: 1200,
         totalCost: 12.5,
-        totalSubmissions: 1,
+        totalActiveTimeMs: null,
         uniqueUsers: 1,
       },
       period: "all",
@@ -76,12 +69,16 @@ describe("GET /api/leaderboard", () => {
       undefined,
       undefined,
     );
-    expect(body.users[0].submissionFreshness).toEqual({
-      lastUpdated: "2026-01-10T10:00:00.000Z",
-      cliVersion: "1.4.2",
-      schemaVersion: 1,
-      isStale: true,
-    });
+    expect(Object.keys(body.users[0]).sort()).toEqual([
+      "avatarUrl",
+      "displayName",
+      "rank",
+      "totalActiveTimeMs",
+      "totalCost",
+      "totalTokens",
+      "userId",
+      "username",
+    ]);
   });
 
   it("accepts time sort requests", async () => {
@@ -99,7 +96,6 @@ describe("GET /api/leaderboard", () => {
         totalTokens: 0,
         totalCost: 0,
         totalActiveTimeMs: 0,
-        totalSubmissions: 0,
         uniqueUsers: 0,
       },
       period: "all",
@@ -137,7 +133,6 @@ describe("GET /api/leaderboard", () => {
         totalTokens: 0,
         totalCost: 0,
         totalActiveTimeMs: 0,
-        totalSubmissions: 0,
         uniqueUsers: 0,
       },
       period: "all",
@@ -175,7 +170,6 @@ describe("GET /api/leaderboard", () => {
         totalTokens: 0,
         totalCost: 0,
         totalActiveTimeMs: 0,
-        totalSubmissions: 0,
         uniqueUsers: 0,
       },
       period: "all",

--- a/packages/frontend/__tests__/components/leaderboardPresentation.test.ts
+++ b/packages/frontend/__tests__/components/leaderboardPresentation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatGroupMemberCount,
+  getGroupMonogram,
+  getLeaderboardPeriodLabel,
+} from "@/components/leaderboard/presentation";
+
+describe("leaderboard presentation helpers", () => {
+  it("builds stable group monograms from one-word and multi-word names", () => {
+    expect(getGroupMonogram("Team Australia")).toBe("TA");
+    expect(getGroupMonogram("system")).toBe("SY");
+    expect(getGroupMonogram("한국 AI 토큰 경쟁")).toBe("한A");
+    expect(getGroupMonogram("  ")).toBe("TG");
+  });
+
+  it("uses correct member-count grammar", () => {
+    expect(formatGroupMemberCount(0)).toBe("0 members");
+    expect(formatGroupMemberCount(1)).toBe("1 member");
+    expect(formatGroupMemberCount(2)).toBe("2 members");
+  });
+
+  it("describes predefined and custom leaderboard periods", () => {
+    expect(getLeaderboardPeriodLabel("all")).toBe("All time");
+    expect(getLeaderboardPeriodLabel("last-month")).toBe("Last month");
+    expect(getLeaderboardPeriodLabel("month")).toBe("This month");
+    expect(getLeaderboardPeriodLabel("week")).toBe("This week");
+    expect(
+      getLeaderboardPeriodLabel("custom", "2026-06-01", "2026-06-30"),
+    ).toBe("Jun 1–30, 2026");
+    expect(getLeaderboardPeriodLabel("custom")).toBe("Custom range");
+  });
+});

--- a/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
@@ -22,10 +22,6 @@ const mockState = vi.hoisted(() => {
       userId: "submissions.userId",
       totalTokens: "submissions.totalTokens",
       totalCost: "submissions.totalCost",
-      submitCount: "submissions.submitCount",
-      updatedAt: "submissions.updatedAt",
-      cliVersion: "submissions.cliVersion",
-      schemaVersion: "submissions.schemaVersion",
     },
     dailyBreakdown: {
       submissionId: "dailyBreakdown.submissionId",
@@ -148,10 +144,6 @@ vi.mock("@/lib/db", () => ({
   groupMembers: mockState.tables.groupMembers,
 }));
 
-vi.mock("@/lib/submissionFreshness", async () =>
-  import("../../src/lib/submissionFreshness")
-);
-
 vi.mock("drizzle-orm", () => ({
   eq: mockState.eq,
   desc: mockState.desc,
@@ -165,6 +157,13 @@ vi.mock("drizzle-orm", () => ({
 type ModuleExports = typeof import("../../src/lib/groups/getGroupLeaderboard");
 
 let getGroupLeaderboardData: ModuleExports["getGroupLeaderboardData"];
+
+function selectedKeys(callIndex: number): string[] {
+  const calls = mockState.db.select.mock.calls as unknown as Array<
+    [Record<string, unknown> | undefined]
+  >;
+  return Object.keys(calls[callIndex]?.[0] ?? {});
+}
 
 beforeAll(async () => {
   const groupLeaderboardModule = await import("../../src/lib/groups/getGroupLeaderboard");
@@ -189,9 +188,6 @@ describe("group leaderboard data", () => {
       role: "owner",
       tokens: 200,
       cost: 2,
-      updatedAt: "2026-03-07T11:00:00.000Z",
-      cliVersion: "1.5.0",
-      schemaVersion: 1,
     },
     {
       userId: "user-bob",
@@ -201,9 +197,6 @@ describe("group leaderboard data", () => {
       role: "member",
       tokens: 600,
       cost: 6,
-      updatedAt: "2026-03-06T11:00:00.000Z",
-      cliVersion: "1.5.0",
-      schemaVersion: 1,
     },
   ];
 
@@ -233,11 +226,32 @@ describe("group leaderboard data", () => {
       role: "member",
       totalTokens: 600,
     });
-    expect(leaderboard.stats).toMatchObject({
+    expect(leaderboard.stats).toEqual({
       totalTokens: 800,
       totalCost: 8,
       activeUsers: 2,
+      totalMembers: 0,
     });
+    expect(Object.keys(leaderboard.users[0]).sort()).toEqual([
+      "avatarUrl",
+      "displayName",
+      "rank",
+      "role",
+      "totalActiveTimeMs",
+      "totalCost",
+      "totalTokens",
+      "userId",
+      "username",
+    ]);
+    expect(selectedKeys(1)).toEqual([
+      "userId",
+      "username",
+      "displayName",
+      "avatarUrl",
+      "role",
+      "tokens",
+      "cost",
+    ]);
   });
 
   it("filters search results after computing scoped ranks", async () => {
@@ -265,10 +279,6 @@ describe("group leaderboard data", () => {
         role: "member",
         totalTokens: 100,
         totalCost: "3.0000",
-        submissionCount: 1,
-        lastSubmission: "2026-03-07T11:00:00.000Z",
-        cliVersion: "1.5.0",
-        schemaVersion: 1,
       },
       {
         userId: "user-bob",
@@ -278,10 +288,6 @@ describe("group leaderboard data", () => {
         role: "member",
         totalTokens: 100,
         totalCost: "3.0000",
-        submissionCount: 1,
-        lastSubmission: "2026-03-07T11:00:00.000Z",
-        cliVersion: "1.5.0",
-        schemaVersion: 1,
       },
     ]);
 
@@ -291,11 +297,16 @@ describe("group leaderboard data", () => {
     expect(mockState.orderByCalls[0]).toHaveLength(4);
     expect(mockState.asc).toHaveBeenCalledWith(mockState.tables.users.username);
     expect(mockState.asc).toHaveBeenCalledWith(mockState.tables.users.id);
-    expect(mockState.sql).toHaveBeenCalledWith(
-      expect.arrayContaining(["(\n        SELECT s2.cli_version FROM submissions s2\n        WHERE s2.user_id = ", "\n        ORDER BY s2.updated_at DESC, s2.id DESC LIMIT 1\n      )"]),
-      mockState.tables.users.id
-    );
     expect(leaderboard.users.map((user) => user.username)).toEqual(["alice", "bob"]);
+    expect(selectedKeys(1)).toEqual([
+      "userId",
+      "username",
+      "displayName",
+      "avatarUrl",
+      "role",
+      "totalTokens",
+      "totalCost",
+    ]);
   });
 
   // submissions.total_cost is decimal(18,4); narrowing the cast to DECIMAL(12,4)

--- a/packages/frontend/__tests__/lib/getLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboard.test.ts
@@ -14,18 +14,15 @@ const mockState = vi.hoisted(() => {
     submissions: {
       id: "submissions.id",
       userId: "submissions.userId",
-      submitCount: "submissions.submitCount",
-      updatedAt: "submissions.updatedAt",
       totalTokens: "submissions.totalTokens",
       totalCost: "submissions.totalCost",
-      cliVersion: "submissions.cliVersion",
-      schemaVersion: "submissions.schemaVersion",
     },
     dailyBreakdown: {
       submissionId: "dailyBreakdown.submissionId",
       date: "dailyBreakdown.date",
       tokens: "dailyBreakdown.tokens",
       cost: "dailyBreakdown.cost",
+      activeTimeMs: "dailyBreakdown.activeTimeMs",
     },
   };
 
@@ -122,10 +119,6 @@ vi.mock("@/lib/db/usernameLookup", () => {
   };
 });
 
-vi.mock("@/lib/submissionFreshness", async () =>
-  import("../../src/lib/submissionFreshness")
-);
-
 vi.mock("drizzle-orm", () => ({
   eq: mockState.eq,
   desc: mockState.desc,
@@ -139,6 +132,13 @@ type ModuleExports = typeof import("../../src/lib/leaderboard/getLeaderboard");
 
 let getLeaderboardData: ModuleExports["getLeaderboardData"];
 let getUserRank: ModuleExports["getUserRank"];
+
+function selectedKeys(callIndex: number): string[] {
+  const calls = mockState.db.select.mock.calls as unknown as Array<
+    [Record<string, unknown> | undefined]
+  >;
+  return Object.keys(calls[callIndex]?.[0] ?? {});
+}
 
 beforeAll(async () => {
   const leaderboardModule = await import("../../src/lib/leaderboard/getLeaderboard");
@@ -163,9 +163,7 @@ describe("period leaderboard data", () => {
       avatarUrl: null,
       tokens: 100,
       cost: 1.25,
-      updatedAt: "2026-03-07T11:00:00.000Z",
-      cliVersion: "1.5.0",
-      schemaVersion: 1,
+      activeTimeMs: 10,
     },
     {
       userId: "user-alice",
@@ -174,9 +172,7 @@ describe("period leaderboard data", () => {
       avatarUrl: null,
       tokens: 150,
       cost: 1.75,
-      updatedAt: "2026-03-07T11:00:00.000Z",
-      cliVersion: "1.5.0",
-      schemaVersion: 1,
+      activeTimeMs: 15,
     },
     {
       userId: "user-bob",
@@ -185,9 +181,7 @@ describe("period leaderboard data", () => {
       avatarUrl: null,
       tokens: 1000,
       cost: 9.5,
-      updatedAt: "2026-01-15T09:00:00.000Z",
-      cliVersion: "1.3.0",
-      schemaVersion: 0,
+      activeTimeMs: 100,
     },
   ];
 
@@ -213,32 +207,40 @@ describe("period leaderboard data", () => {
       username: "bob",
       totalTokens: 1000,
       totalCost: 9.5,
-      submissionFreshness: {
-        lastUpdated: "2026-01-15T09:00:00.000Z",
-        cliVersion: "1.3.0",
-        schemaVersion: 0,
-        isStale: true,
-      },
+      totalActiveTimeMs: 100,
     });
     expect(leaderboard.users[1]).toMatchObject({
       rank: 2,
       username: "alice",
       totalTokens: 250,
       totalCost: 3,
-      submissionCount: null,
-      submissionFreshness: {
-        lastUpdated: "2026-03-07T11:00:00.000Z",
-        cliVersion: "1.5.0",
-        schemaVersion: 1,
-        isStale: false,
-      },
+      totalActiveTimeMs: 25,
     });
-    expect(leaderboard.stats).toMatchObject({
+    expect(Object.keys(leaderboard.users[0]).sort()).toEqual([
+      "avatarUrl",
+      "displayName",
+      "rank",
+      "totalActiveTimeMs",
+      "totalCost",
+      "totalTokens",
+      "userId",
+      "username",
+    ]);
+    expect(leaderboard.stats).toEqual({
+      totalActiveTimeMs: 125,
       totalTokens: 1250,
       totalCost: 12.5,
-      totalSubmissions: null,
       uniqueUsers: 2,
     });
+    expect(selectedKeys(0)).toEqual([
+      "userId",
+      "username",
+      "displayName",
+      "avatarUrl",
+      "tokens",
+      "cost",
+      "activeTimeMs",
+    ]);
   });
 
   it("uses the current month for the month leaderboard range", async () => {
@@ -287,7 +289,6 @@ describe("period leaderboard data", () => {
     expect(leaderboard.stats).toMatchObject({
       totalTokens: 1250,
       totalCost: 12.5,
-      totalSubmissions: null,
       uniqueUsers: 2,
     });
   });
@@ -305,14 +306,7 @@ describe("period leaderboard data", () => {
       username: "alice",
       totalTokens: 250,
       totalCost: 3,
-      submissionCount: null,
-      lastSubmission: "2026-03-07T11:00:00.000Z",
-      submissionFreshness: {
-        lastUpdated: "2026-03-07T11:00:00.000Z",
-        cliVersion: "1.5.0",
-        schemaVersion: 1,
-        isStale: false,
-      },
+      totalActiveTimeMs: 25,
     });
   });
 
@@ -343,9 +337,7 @@ describe("period leaderboard data", () => {
         avatarUrl: null,
         tokens: 50,
         cost: 0.5,
-        updatedAt: "2026-03-07T11:00:00.000Z",
-        cliVersion: "1.5.0",
-        schemaVersion: 1,
+        activeTimeMs: 5,
       },
     ]);
 

--- a/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
@@ -193,6 +193,28 @@ describe("all-time leaderboard queries", () => {
     expect(searchSqlTexts.some((text) => text.includes("ROW_NUMBER() OVER"))).toBe(false);
   });
 
+  it("counts distinct users for all-time pagination and global stats", async () => {
+    mockState.pushAwaitedResult([]);
+    mockState.pushAwaitedResult([{ totalTokens: 0, totalCost: 0, uniqueUsers: 2 }]);
+
+    const list = await getLeaderboardData("all", 1, 50, "tokens");
+    expect(list.pagination.totalUsers).toBe(2);
+    expect(serializeSqlCalls().some((text) =>
+      text.includes("COUNT(DISTINCT submissions.userId)")
+    )).toBe(true);
+
+    mockState.reset();
+    mockState.pushAwaitedResult([]);
+    mockState.pushAwaitedResult([{ count: 0 }]);
+    mockState.pushAwaitedResult([{ totalTokens: 0, totalCost: 0, uniqueUsers: 2 }]);
+
+    const search = await getLeaderboardData("all", 1, 50, "tokens", "ali");
+    expect(search.stats.uniqueUsers).toBe(2);
+    expect(serializeSqlCalls().some((text) =>
+      text.includes("COUNT(DISTINCT submissions.userId)")
+    )).toBe(true);
+  });
+
   it("keeps tied all-time users at the same rank across list, search, and user rank", async () => {
     mockState.pushAwaitedResult([
       {

--- a/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
@@ -16,12 +16,8 @@ const mockState = vi.hoisted(() => {
     submissions: {
       id: "submissions.id",
       userId: "submissions.userId",
-      submitCount: "submissions.submitCount",
-      updatedAt: "submissions.updatedAt",
       totalTokens: "submissions.totalTokens",
       totalCost: "submissions.totalCost",
-      cliVersion: "submissions.cliVersion",
-      schemaVersion: "submissions.schemaVersion",
     },
     dailyBreakdown: {
       submissionId: "dailyBreakdown.submissionId",
@@ -127,10 +123,6 @@ vi.mock("@/lib/db/usernameLookup", () => {
   };
 });
 
-vi.mock("@/lib/submissionFreshness", async () =>
-  import("../../src/lib/submissionFreshness")
-);
-
 vi.mock("drizzle-orm", () => ({
   eq: mockState.eq,
   desc: mockState.desc,
@@ -144,6 +136,13 @@ type ModuleExports = typeof import("../../src/lib/leaderboard/getLeaderboard");
 
 let getLeaderboardData: ModuleExports["getLeaderboardData"];
 let getUserRank: ModuleExports["getUserRank"];
+
+function selectedKeys(callIndex: number): string[] {
+  const calls = mockState.db.select.mock.calls as unknown as Array<
+    [Record<string, unknown> | undefined]
+  >;
+  return Object.keys(calls[callIndex]?.[0] ?? {});
+}
 
 function serializeSqlCalls(): string[] {
   return mockState.sql.mock.calls.map((call) => {
@@ -171,10 +170,10 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe("all-time leaderboard freshness queries", () => {
+describe("all-time leaderboard queries", () => {
   it("uses competition-rank SQL for all-time list and search ranks", async () => {
     mockState.pushAwaitedResult([]);
-    mockState.pushAwaitedResult([{ totalTokens: 0, totalCost: 0, totalSubmissions: 0, uniqueUsers: 0 }]);
+    mockState.pushAwaitedResult([{ totalTokens: 0, totalCost: 0, uniqueUsers: 0 }]);
 
     await getLeaderboardData("all", 1, 50, "tokens");
     const listSqlTexts = serializeSqlCalls();
@@ -185,7 +184,7 @@ describe("all-time leaderboard freshness queries", () => {
     mockState.reset();
     mockState.pushAwaitedResult([]);
     mockState.pushAwaitedResult([{ count: 0 }]);
-    mockState.pushAwaitedResult([{ totalTokens: 0, totalCost: 0, totalSubmissions: 0, uniqueUsers: 0 }]);
+    mockState.pushAwaitedResult([{ totalTokens: 0, totalCost: 0, uniqueUsers: 0 }]);
 
     await getLeaderboardData("all", 1, 50, "tokens", "ali");
     const searchSqlTexts = serializeSqlCalls();
@@ -205,10 +204,6 @@ describe("all-time leaderboard freshness queries", () => {
         totalTokens: 5000,
         totalCost: 50,
         totalActiveTimeMs: 500,
-        submissionCount: 1,
-        lastSubmission: "2026-03-12T10:00:00.000Z",
-        cliVersion: "1.9.0",
-        schemaVersion: 1,
       },
       {
         rank: 2,
@@ -219,10 +214,6 @@ describe("all-time leaderboard freshness queries", () => {
         totalTokens: 3000,
         totalCost: 40,
         totalActiveTimeMs: 400,
-        submissionCount: 1,
-        lastSubmission: "2026-03-12T09:00:00.000Z",
-        cliVersion: "1.9.0",
-        schemaVersion: 1,
       },
       {
         rank: 2,
@@ -233,17 +224,12 @@ describe("all-time leaderboard freshness queries", () => {
         totalTokens: 3000,
         totalCost: 30,
         totalActiveTimeMs: 300,
-        submissionCount: 1,
-        lastSubmission: "2026-03-12T08:00:00.000Z",
-        cliVersion: "1.9.0",
-        schemaVersion: 1,
       },
     ]);
     mockState.pushAwaitedResult([
       {
         totalTokens: 11000,
         totalCost: 120,
-        totalSubmissions: 3,
         uniqueUsers: 3,
       },
     ]);
@@ -263,10 +249,6 @@ describe("all-time leaderboard freshness queries", () => {
         totalTokens: 3000,
         totalCost: 40,
         totalActiveTimeMs: 400,
-        submissionCount: 1,
-        lastSubmission: "2026-03-12T09:00:00.000Z",
-        cliVersion: "1.9.0",
-        schemaVersion: 1,
       },
       {
         rank: 2,
@@ -277,10 +259,6 @@ describe("all-time leaderboard freshness queries", () => {
         totalTokens: 3000,
         totalCost: 30,
         totalActiveTimeMs: 300,
-        submissionCount: 1,
-        lastSubmission: "2026-03-12T08:00:00.000Z",
-        cliVersion: "1.9.0",
-        schemaVersion: 1,
       },
     ]);
     mockState.pushAwaitedResult([{ count: 2 }]);
@@ -288,7 +266,6 @@ describe("all-time leaderboard freshness queries", () => {
       {
         totalTokens: 11000,
         totalCost: 120,
-        totalSubmissions: 3,
         uniqueUsers: 3,
       },
     ]);
@@ -311,10 +288,6 @@ describe("all-time leaderboard freshness queries", () => {
         totalTokens: 3000,
         totalCost: 40,
         totalActiveTimeMs: 400,
-        submissionCount: 1,
-        lastSubmission: "2026-03-12T09:00:00.000Z",
-        cliVersion: "1.9.0",
-        schemaVersion: 1,
       },
     ]);
     mockState.pushAwaitedResult([{ count: 1 }]);
@@ -328,10 +301,7 @@ describe("all-time leaderboard freshness queries", () => {
     expect(aliceUserRank?.rank).toBe(2);
   });
 
-  it("uses latest-row scalar subqueries instead of MAX(cliVersion/schemaVersion)", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-12T18:45:00Z"));
-
+  it("selects and returns only fields consumed by leaderboard surfaces", async () => {
     mockState.pushAwaitedResult([
       {
         rank: 1,
@@ -341,54 +311,51 @@ describe("all-time leaderboard freshness queries", () => {
         avatarUrl: null,
         totalTokens: 3000,
         totalCost: 30,
-        submissionCount: 2,
-        lastSubmission: "2026-03-12T09:00:00.000Z",
-        cliVersion: "1.9.0",
-        schemaVersion: 1,
+        totalActiveTimeMs: 300,
       },
     ]);
     mockState.pushAwaitedResult([
       {
         totalTokens: 3000,
         totalCost: 30,
-        totalSubmissions: 2,
         uniqueUsers: 1,
       },
     ]);
 
     const leaderboard = await getLeaderboardData("all", 1, 50, "tokens");
-    const sqlTexts = serializeSqlCalls();
-
-    expect(sqlTexts.some((text) =>
-      text.includes("SELECT s2.cli_version FROM submissions s2")
-        && text.includes("ORDER BY s2.updated_at DESC LIMIT 1")
-    )).toBe(true);
-    expect(sqlTexts.some((text) =>
-      text.includes("SELECT s2.schema_version FROM submissions s2")
-        && text.includes("ORDER BY s2.updated_at DESC LIMIT 1")
-    )).toBe(true);
-    expect(sqlTexts.some((text) =>
-      text.includes("MAX(") && text.includes("submissions.cliVersion")
-    )).toBe(false);
-    expect(sqlTexts.some((text) =>
-      text.includes("MAX(") && text.includes("submissions.schemaVersion")
-    )).toBe(false);
-    expect(leaderboard.users[0]).toMatchObject({
-      rank: 1,
-      username: "alice",
-      lastSubmission: "2026-03-12T09:00:00.000Z",
-      submissionFreshness: {
-        lastUpdated: "2026-03-12T09:00:00.000Z",
-        cliVersion: "1.9.0",
-        schemaVersion: 1,
-        isStale: false,
-      },
+    expect(selectedKeys(0)).toEqual([
+      "rank",
+      "userId",
+      "username",
+      "displayName",
+      "avatarUrl",
+      "totalTokens",
+      "totalCost",
+      "totalActiveTimeMs",
+    ]);
+    expect(selectedKeys(1)).toEqual([
+      "totalTokens",
+      "totalCost",
+      "uniqueUsers",
+    ]);
+    expect(Object.keys(leaderboard.users[0]).sort()).toEqual([
+      "avatarUrl",
+      "displayName",
+      "rank",
+      "totalActiveTimeMs",
+      "totalCost",
+      "totalTokens",
+      "userId",
+      "username",
+    ]);
+    expect(leaderboard.stats).toEqual({
+      totalTokens: 3000,
+      totalCost: 30,
+      totalActiveTimeMs: null,
+      uniqueUsers: 1,
     });
-  });
 
-  it("uses latest-row scalar subqueries for all-time user rank metadata", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-12T18:45:00Z"));
+    mockState.reset();
 
     mockState.pushAwaitedResult([
       {
@@ -402,10 +369,7 @@ describe("all-time leaderboard freshness queries", () => {
       {
         totalTokens: 3000,
         totalCost: 30,
-        submissionCount: 2,
-        lastSubmission: "2026-03-12T09:00:00.000Z",
-        cliVersion: "1.9.0",
-        schemaVersion: 1,
+        totalActiveTimeMs: 300,
       },
     ]);
     mockState.pushAwaitedResult([
@@ -415,36 +379,22 @@ describe("all-time leaderboard freshness queries", () => {
     ]);
 
     const rank = await getUserRank("alice", "all", "tokens");
-    const sqlTexts = serializeSqlCalls();
 
-    expect(sqlTexts.some((text) =>
-      text.includes("SELECT s2.cli_version FROM submissions s2")
-        && text.includes("WHERE s2.user_id = user-alice")
-    )).toBe(true);
-    expect(sqlTexts.some((text) =>
-      text.includes("SELECT s2.schema_version FROM submissions s2")
-        && text.includes("WHERE s2.user_id = user-alice")
-    )).toBe(true);
-    expect(sqlTexts.some((text) =>
-      text.includes("MAX(") && text.includes("submissions.cliVersion")
-    )).toBe(false);
-    expect(sqlTexts.some((text) =>
-      text.includes("MAX(") && text.includes("submissions.schemaVersion")
-    )).toBe(false);
-    expect(rank).toMatchObject({
-      rank: 1,
-      username: "alice",
-      totalTokens: 3000,
-      totalCost: 30,
-      submissionCount: 2,
-      lastSubmission: "2026-03-12T09:00:00.000Z",
-      submissionFreshness: {
-        lastUpdated: "2026-03-12T09:00:00.000Z",
-        cliVersion: "1.9.0",
-        schemaVersion: 1,
-        isStale: false,
-      },
-    });
+    expect(selectedKeys(1)).toEqual([
+      "totalTokens",
+      "totalCost",
+      "totalActiveTimeMs",
+    ]);
+    expect(Object.keys(rank || {}).sort()).toEqual([
+      "avatarUrl",
+      "displayName",
+      "rank",
+      "totalActiveTimeMs",
+      "totalCost",
+      "totalTokens",
+      "userId",
+      "username",
+    ]);
   });
 
   it("looks up all-time user rank usernames case-insensitively", async () => {
@@ -460,10 +410,7 @@ describe("all-time leaderboard freshness queries", () => {
       {
         totalTokens: 1200,
         totalCost: 12,
-        submissionCount: 1,
-        lastSubmission: "2026-03-12T09:00:00.000Z",
-        cliVersion: "1.9.0",
-        schemaVersion: 1,
+        totalActiveTimeMs: 0,
       },
     ]);
     mockState.pushAwaitedResult([{ count: 0 }]);
@@ -522,7 +469,7 @@ describe("all-time cost aggregation precision across query shapes (numeric overf
     mockState.pushAwaitedResult([]);
     mockState.pushAwaitedResult([{ count: 0 }]);
     mockState.pushAwaitedResult([
-      { totalTokens: 0, totalCost: 0, totalSubmissions: 0, uniqueUsers: 0 },
+      { totalTokens: 0, totalCost: 0, uniqueUsers: 0 },
     ]);
 
     await getLeaderboardData("all", 1, 50, "cost", "ali");
@@ -539,10 +486,6 @@ describe("all-time cost aggregation precision across query shapes (numeric overf
         totalTokens: 3000,
         totalCost: 40,
         totalActiveTimeMs: 0,
-        submissionCount: 1,
-        lastSubmission: "2026-03-12T09:00:00.000Z",
-        cliVersion: "1.9.0",
-        schemaVersion: 1,
       },
     ]);
     mockState.pushAwaitedResult([{ count: 0 }]);

--- a/packages/frontend/src/app/(main)/groups/[slug]/GroupDetailClient.tsx
+++ b/packages/frontend/src/app/(main)/groups/[slug]/GroupDetailClient.tsx
@@ -409,11 +409,9 @@ function roleLabel(role: string): string {
 
 function GroupRow({
   user,
-  showSubmissionCount,
   isCurrentUser,
 }: {
   user: GroupLeaderboardUser;
-  showSubmissionCount: boolean;
   isCurrentUser: boolean;
 }) {
   return (
@@ -434,19 +432,16 @@ function GroupRow({
       <Td>{roleLabel(user.role)}</Td>
       <Td className="right">{formatCurrency(user.totalCost)}</Td>
       <Td className="right">{formatNumber(user.totalTokens)}</Td>
-      {showSubmissionCount && <Td className="right">{user.submissionCount ?? "-"}</Td>}
     </DesktopRow>
   );
 }
 
 function GroupMobileRow({
   user,
-  showSubmissionCount,
   isCurrentUser,
   sortBy,
 }: {
   user: GroupLeaderboardUser;
-  showSubmissionCount: boolean;
   isCurrentUser: boolean;
   sortBy: SortBy;
 }) {
@@ -458,9 +453,6 @@ function GroupMobileRow({
     sortBy === "cost"
       ? `${formatNumber(user.totalTokens)} tokens`
       : formatCurrency(user.totalCost),
-    showSubmissionCount && user.submissionCount !== null
-      ? `${user.submissionCount.toLocaleString("en-US")} submits`
-      : null,
   ].filter(Boolean).join(" · ");
 
   return (
@@ -500,7 +492,6 @@ export default function GroupDetailClient({
   const didMountLeaderboard = useRef(false);
 
   const canInvite = isAdminRole(group.membership?.role);
-  const showSubmissionCount = period === "all";
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -715,7 +706,6 @@ export default function GroupDetailClient({
                     <Th>Role</Th>
                     <Th className="right">Cost</Th>
                     <Th className="right">Tokens</Th>
-                    {showSubmissionCount && <Th className="right">Submits</Th>}
                   </tr>
                 </thead>
                 <tbody>
@@ -723,7 +713,6 @@ export default function GroupDetailClient({
                     <GroupRow
                       key={user.userId}
                       user={user}
-                      showSubmissionCount={showSubmissionCount}
                       isCurrentUser={currentUser?.username === user.username}
                     />
                   ))}
@@ -735,7 +724,6 @@ export default function GroupDetailClient({
                 <GroupMobileRow
                   key={user.userId}
                   user={user}
-                  showSubmissionCount={showSubmissionCount}
                   isCurrentUser={currentUser?.username === user.username}
                   sortBy={sortBy}
                 />

--- a/packages/frontend/src/app/(main)/groups/[slug]/GroupDetailClient.tsx
+++ b/packages/frontend/src/app/(main)/groups/[slug]/GroupDetailClient.tsx
@@ -5,6 +5,20 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "nextjs-toploader/app";
 import styled from "styled-components";
 import { CheckIcon, CopyIcon, SearchIcon, XIcon } from "@/components/ui/Icons";
+import {
+  CompactBadge,
+  GroupMark,
+  MetricItem,
+  MetricLabel,
+  MetricStrip,
+  MetricValue,
+  MobileRankingList,
+  MobileRankingRow,
+  SecondaryActionLink,
+  SecondaryButton,
+  SegmentedControl,
+} from "@/components/leaderboard/RankingUI";
+import { formatGroupMemberCount } from "@/components/leaderboard/presentation";
 import { formatCurrency, formatNumber } from "@/lib/utils";
 import type { GroupLeaderboardData, GroupLeaderboardUser } from "@/lib/groups/getGroupLeaderboard";
 import type { Period, SortBy } from "@/lib/leaderboard/types";
@@ -36,9 +50,9 @@ interface GroupDetailClientProps {
 }
 
 const Header = styled.section`
-  margin: 32px 0 24px;
   display: grid;
-  gap: 18px;
+  gap: 16px;
+  margin-bottom: 24px;
 `;
 
 const HeaderTop = styled.div`
@@ -48,31 +62,30 @@ const HeaderTop = styled.div`
   align-items: flex-start;
 
   @media (max-width: 720px) {
+    align-items: stretch;
     flex-direction: column;
   }
 `;
 
 const Identity = styled.div`
   display: flex;
-  gap: 14px;
+  min-width: 0;
   align-items: center;
+  gap: 14px;
 `;
 
-const Avatar = styled.div<{ $image?: string | null }>`
-  width: 58px;
-  height: 58px;
-  border-radius: 8px;
-  border: 1px solid var(--color-border-default);
-  background:
-    ${({ $image }) => $image ? `url(${$image}) center/cover` : "linear-gradient(135deg, #0073ff, #13a10e)"};
-  flex: 0 0 auto;
+const IdentityCopy = styled.div`
+  min-width: 0;
 `;
 
 const Title = styled.h1`
   margin: 0;
-  color: var(--color-fg-default);
-  font-size: 30px;
-  font-weight: 700;
+  overflow-wrap: anywhere;
+  color: var(--service-text);
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  text-wrap: balance;
 `;
 
 const Meta = styled.div`
@@ -80,25 +93,19 @@ const Meta = styled.div`
   flex-wrap: wrap;
   gap: 8px;
   margin-top: 6px;
-  color: var(--color-fg-muted);
-  font-size: 13px;
-`;
-
-const Badge = styled.span`
-  display: inline-flex;
-  align-items: center;
-  min-height: 24px;
-  padding: 0 8px;
-  border: 1px solid var(--color-border-default);
-  border-radius: 999px;
-  color: var(--color-fg-muted);
-  background: var(--color-bg-subtle);
 `;
 
 const Description = styled.p`
   margin: 0;
-  color: var(--color-fg-muted);
-  line-height: 1.6;
+  max-width: 76ch;
+  color: var(--service-text-muted);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  text-wrap: pretty;
+
+  @media (max-width: 640px) {
+    font-size: 1rem;
+  }
 `;
 
 const Actions = styled.div`
@@ -107,76 +114,38 @@ const Actions = styled.div`
   flex-wrap: wrap;
 `;
 
-const Button = styled.button`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+const Button = styled(SecondaryButton)`
   gap: 8px;
-  min-height: 38px;
-  padding: 0 14px;
-  border-radius: 8px;
-  border: 1px solid var(--color-border-default);
-  background: var(--color-bg-default);
-  color: var(--color-fg-default);
-  font-weight: 600;
-  cursor: pointer;
-
-  &:disabled {
-    opacity: 0.65;
-    cursor: not-allowed;
-  }
-`;
-
-const PrimaryLink = styled(Link)`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 38px;
-  padding: 0 14px;
-  border-radius: 8px;
-  border: 1px solid var(--color-primary);
-  background: var(--color-primary);
-  color: #fff;
-  font-weight: 600;
-  text-decoration: none;
-`;
-
-const StatsGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 10px;
-
-  @media (max-width: 760px) {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-`;
-
-const StatCard = styled.div`
-  padding: 12px;
-  border: 1px solid var(--color-border-default);
-  border-radius: 8px;
-  background: var(--color-bg-default);
-`;
-
-const StatLabel = styled.div`
-  color: var(--color-fg-muted);
-  font-size: 12px;
-`;
-
-const StatValue = styled.div`
-  margin-top: 4px;
-  color: var(--color-fg-default);
-  font-weight: 700;
-  font-size: 18px;
 `;
 
 const InvitePanel = styled.div`
   display: grid;
   gap: 12px;
-  padding: 14px;
-  border: 1px solid var(--color-border-default);
-  border-radius: 8px;
-  background: var(--color-bg-default);
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 1px solid var(--service-border);
+`;
+
+const InviteHeading = styled.div`
+  display: grid;
+  gap: 4px;
+`;
+
+const InviteTitle = styled.h2`
+  margin: 0;
+  color: var(--service-text);
+  font-size: 1rem;
+  font-weight: 600;
+`;
+
+const InviteDescription = styled.p`
+  margin: 0;
+  color: var(--service-text-muted);
+  font-size: 0.8125rem;
+
+  @media (max-width: 640px) {
+    font-size: 1rem;
+  }
 `;
 
 const InviteForm = styled.div`
@@ -190,23 +159,45 @@ const InviteForm = styled.div`
 `;
 
 const Input = styled.input`
-  min-height: 38px;
+  min-height: 36px;
   padding: 0 12px;
-  border: 1px solid var(--color-border-default);
+  border: 1px solid var(--service-border-strong);
   border-radius: 8px;
-  background: var(--color-bg-subtle);
-  color: var(--color-fg-default);
+  background: var(--service-surface);
+  color: var(--service-text);
   font: inherit;
+
+  &:focus-visible {
+    border-color: var(--service-focus);
+    outline: 2px solid var(--service-focus);
+    outline-offset: -1px;
+  }
+
+  @media (max-width: 640px) {
+    min-height: 44px;
+    font-size: 1rem;
+  }
 `;
 
 const Select = styled.select`
-  min-height: 38px;
+  min-height: 36px;
   padding: 0 12px;
-  border: 1px solid var(--color-border-default);
+  border: 1px solid var(--service-border-strong);
   border-radius: 8px;
-  background: var(--color-bg-subtle);
-  color: var(--color-fg-default);
+  background: var(--service-surface);
+  color: var(--service-text);
   font: inherit;
+
+  &:focus-visible {
+    border-color: var(--service-focus);
+    outline: 2px solid var(--service-focus);
+    outline-offset: -1px;
+  }
+
+  @media (max-width: 640px) {
+    min-height: 44px;
+    font-size: 1rem;
+  }
 `;
 
 const LinkBox = styled.div`
@@ -215,10 +206,10 @@ const LinkBox = styled.div`
   justify-content: space-between;
   gap: 8px;
   padding: 10px 12px;
-  border: 1px solid var(--color-border-default);
+  border: 1px solid var(--service-border);
   border-radius: 8px;
-  background: var(--color-bg-subtle);
-  color: var(--color-fg-default);
+  background: var(--service-surface);
+  color: var(--service-text);
   overflow: hidden;
 `;
 
@@ -233,37 +224,29 @@ const Toolbar = styled.div`
   justify-content: space-between;
   gap: 12px;
   flex-wrap: wrap;
-  margin: 22px 0 14px;
-`;
-
-const Segmented = styled.div`
-  display: inline-flex;
-  padding: 4px;
-  border: 1px solid var(--color-border-default);
-  border-radius: 8px;
-  background: var(--color-bg-subtle);
-`;
-
-const SegmentButton = styled.button<{ $active: boolean }>`
-  min-height: 32px;
-  padding: 0 12px;
-  border: 0;
-  border-radius: 6px;
-  background: ${({ $active }) => ($active ? "var(--color-bg-default)" : "transparent")};
-  color: ${({ $active }) => ($active ? "var(--color-fg-default)" : "var(--color-fg-muted)")};
-  font-weight: 600;
-  cursor: pointer;
+  margin: 0 0 14px;
 `;
 
 const SearchWrapper = styled.div`
   display: flex;
   align-items: center;
   gap: 8px;
-  min-height: 38px;
+  min-height: 36px;
   padding: 0 10px;
-  border: 1px solid var(--color-border-default);
+  border: 1px solid var(--service-border-strong);
   border-radius: 8px;
-  background: var(--color-bg-subtle);
+  background: var(--service-surface);
+  color: var(--service-text-muted);
+
+  &:focus-within {
+    border-color: var(--service-focus);
+    outline: 2px solid var(--service-focus);
+    outline-offset: -1px;
+  }
+
+  @media (max-width: 640px) {
+    min-height: 44px;
+  }
 `;
 
 const SearchInput = styled.input`
@@ -271,34 +254,62 @@ const SearchInput = styled.input`
   border: 0;
   outline: 0;
   background: transparent;
-  color: var(--color-fg-default);
+  color: var(--service-text);
   font: inherit;
+
+  @media (max-width: 640px) {
+    width: 100%;
+    min-width: 0;
+    font-size: 1rem;
+  }
+`;
+
+const ClearSearchButton = styled.button`
+  display: inline-grid;
+  width: 30px;
+  height: 30px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--service-text-muted);
+
+  &:hover {
+    color: var(--service-text);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--service-focus);
+    outline-offset: 2px;
+  }
 `;
 
 const TableContainer = styled.div`
-  border: 1px solid var(--color-border-default);
-  border-radius: 8px;
-  overflow: hidden;
-  background: var(--color-bg-default);
+  border-top: 1px solid var(--service-border);
+  border-bottom: 1px solid var(--service-border);
 `;
 
 const TableWrapper = styled.div`
-  overflow-x: auto;
+  display: none;
+
+  @media (min-width: 720px) {
+    display: block;
+  }
 `;
 
 const Table = styled.table`
   width: 100%;
-  min-width: 680px;
 `;
 
 const Th = styled.th`
   padding: 12px 16px;
   text-align: left;
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 600;
-  color: var(--color-fg-muted);
-  background: var(--color-bg-elevated);
-  border-bottom: 1px solid var(--color-border-default);
+  color: var(--service-text-muted);
+  border-bottom: 1px solid var(--service-border);
+  white-space: nowrap;
 
   &.right {
     text-align: right;
@@ -307,8 +318,10 @@ const Th = styled.th`
 
 const Td = styled.td`
   padding: 12px 16px;
-  border-bottom: 1px solid var(--color-border-default);
-  color: var(--color-fg-default);
+  border-bottom: 1px solid var(--service-border);
+  color: var(--service-text);
+  font-size: 0.875rem;
+  font-variant-numeric: tabular-nums;
 
   &.right {
     text-align: right;
@@ -321,6 +334,11 @@ const UserCell = styled(Link)`
   gap: 10px;
   color: inherit;
   text-decoration: none;
+
+  &:focus-visible {
+    outline: 2px solid var(--service-focus);
+    outline-offset: 3px;
+  }
 `;
 
 const UserAvatar = styled.img`
@@ -328,24 +346,57 @@ const UserAvatar = styled.img`
   height: 34px;
   border-radius: 50%;
   object-fit: cover;
-  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.1);
+  outline: 1px solid var(--service-border);
+  outline-offset: -1px;
 `;
 
 const Muted = styled.span`
   display: block;
-  color: var(--color-fg-muted);
-  font-size: 12px;
+  color: var(--service-text-muted);
+  font-size: 0.75rem;
+`;
+
+const DesktopRow = styled.tr<{ $current: boolean }>`
+  background: ${({ $current }) => $current ? "var(--service-accent-soft)" : "transparent"};
+  box-shadow: ${({ $current }) => $current ? "inset 2px 0 0 var(--service-accent)" : "none"};
+`;
+
+const Pagination = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 0;
+`;
+
+const PaginationStatus = styled.p`
+  margin: 0;
+  color: var(--service-text-muted);
+  font-size: 0.8125rem;
+
+  @media (max-width: 640px) {
+    font-size: 0.875rem;
+  }
+`;
+
+const PaginationActions = styled.div`
+  display: flex;
+  gap: 8px;
 `;
 
 const EmptyState = styled.div`
   padding: 32px;
   text-align: center;
-  color: var(--color-fg-muted);
+  color: var(--service-text-muted);
+
+  @media (max-width: 640px) {
+    font-size: 1rem;
+  }
 `;
 
 const ErrorText = styled.p`
   margin: 0;
-  color: var(--color-danger-fg, #f85149);
+  color: #ff8c85;
 `;
 
 function isAdminRole(role: GroupRole | undefined): boolean {
@@ -359,16 +410,21 @@ function roleLabel(role: string): string {
 function GroupRow({
   user,
   showSubmissionCount,
+  isCurrentUser,
 }: {
   user: GroupLeaderboardUser;
   showSubmissionCount: boolean;
+  isCurrentUser: boolean;
 }) {
   return (
-    <tr>
+    <DesktopRow $current={isCurrentUser}>
       <Td>#{user.rank}</Td>
       <Td>
-        <UserCell href={`/u/${user.username}`}>
-          <UserAvatar src={user.avatarUrl || `https://github.com/${user.username}.png`} alt={user.username} />
+        <UserCell
+          href={`/u/${user.username}`}
+          aria-current={isCurrentUser ? "true" : undefined}
+        >
+          <UserAvatar src={user.avatarUrl || `https://github.com/${user.username}.png`} alt="" />
           <span>
             {user.displayName || user.username}
             <Muted>@{user.username}</Muted>
@@ -379,12 +435,52 @@ function GroupRow({
       <Td className="right">{formatCurrency(user.totalCost)}</Td>
       <Td className="right">{formatNumber(user.totalTokens)}</Td>
       {showSubmissionCount && <Td className="right">{user.submissionCount ?? "-"}</Td>}
-    </tr>
+    </DesktopRow>
+  );
+}
+
+function GroupMobileRow({
+  user,
+  showSubmissionCount,
+  isCurrentUser,
+  sortBy,
+}: {
+  user: GroupLeaderboardUser;
+  showSubmissionCount: boolean;
+  isCurrentUser: boolean;
+  sortBy: SortBy;
+}) {
+  const primary = sortBy === "cost"
+    ? { label: "Cost", value: formatCurrency(user.totalCost) }
+    : { label: "Tokens", value: formatNumber(user.totalTokens) };
+  const secondary = [
+    roleLabel(user.role),
+    sortBy === "cost"
+      ? `${formatNumber(user.totalTokens)} tokens`
+      : formatCurrency(user.totalCost),
+    showSubmissionCount && user.submissionCount !== null
+      ? `${user.submissionCount.toLocaleString("en-US")} submits`
+      : null,
+  ].filter(Boolean).join(" · ");
+
+  return (
+    <MobileRankingRow
+      rank={user.rank}
+      href={`/u/${user.username}`}
+      avatarUrl={user.avatarUrl}
+      username={user.username}
+      displayName={user.displayName || user.username}
+      primaryLabel={primary.label}
+      primaryValue={primary.value}
+      meta={secondary}
+      isCurrentUser={isCurrentUser}
+    />
   );
 }
 
 export default function GroupDetailClient({
   group,
+  currentUser,
   initialData,
 }: GroupDetailClientProps) {
   const router = useRouter();
@@ -503,7 +599,7 @@ export default function GroupDetailClient({
   async function leaveGroup() {
     const response = await fetch(`/api/groups/${group.slug}/leave`, { method: "POST" });
     if (response.ok) {
-      router.push("/groups");
+      router.push("/leaderboard?view=groups");
     }
   }
 
@@ -514,151 +610,204 @@ export default function GroupDetailClient({
       <Header>
         <HeaderTop>
           <Identity>
-            <Avatar $image={group.avatarUrl} />
-            <div>
+            <GroupMark name={group.name} avatarUrl={group.avatarUrl} size="detail" />
+            <IdentityCopy>
               <Title>{group.name}</Title>
               <Meta>
-                <Badge>{group.isPublic ? "Public" : "Private"}</Badge>
-                <Badge>{group.memberCount} members</Badge>
-                {group.membership && <Badge>{roleLabel(group.membership.role)}</Badge>}
+                <CompactBadge>{group.isPublic ? "Public" : "Private"}</CompactBadge>
+                {group.membership && <CompactBadge>{roleLabel(group.membership.role)}</CompactBadge>}
               </Meta>
-            </div>
+            </IdentityCopy>
           </Identity>
           <Actions>
-            <PrimaryLink href="/groups">All groups</PrimaryLink>
+            <SecondaryActionLink href="/leaderboard?view=groups">All groups</SecondaryActionLink>
             {group.membership && group.membership.role !== "owner" && (
-              <Button onClick={leaveGroup}>Leave</Button>
+              <Button type="button" onClick={leaveGroup}>Leave group</Button>
             )}
           </Actions>
         </HeaderTop>
         {group.description && <Description>{group.description}</Description>}
 
-        <StatsGrid>
-          <StatCard>
-            <StatLabel>Active users</StatLabel>
-            <StatValue>{data.stats.activeUsers}</StatValue>
-          </StatCard>
-          <StatCard>
-            <StatLabel>Members</StatLabel>
-            <StatValue>{data.stats.totalMembers || group.memberCount}</StatValue>
-          </StatCard>
-          <StatCard>
-            <StatLabel>Total tokens</StatLabel>
-            <StatValue>{formatNumber(data.stats.totalTokens)}</StatValue>
-          </StatCard>
-          <StatCard>
-            <StatLabel>Total cost</StatLabel>
-            <StatValue>{formatCurrency(data.stats.totalCost)}</StatValue>
-          </StatCard>
-        </StatsGrid>
-
-        {canInvite && (
-          <InvitePanel>
-            <InviteForm>
-              <Input
-                value={inviteUsername}
-                onChange={(event) => setInviteUsername(event.target.value)}
-                placeholder="GitHub username (optional)"
-              />
-              <Select
-                value={inviteRole}
-                onChange={(event) => setInviteRole(event.target.value as Exclude<GroupRole, "owner">)}
-              >
-                <option value="member">Member</option>
-                <option value="admin">Admin</option>
-              </Select>
-              <Button onClick={createInvite}>Create invite</Button>
-            </InviteForm>
-            {inviteError && <ErrorText>{inviteError}</ErrorText>}
-            {inviteUrl && (
-              <LinkBox>
-                <LinkText>{inviteUrl}</LinkText>
-                <Button onClick={copyInvite} aria-label="Copy invite link">
-                  {copied ? <CheckIcon size={16} /> : <CopyIcon size={16} />}
-                  {copied ? "Copied" : "Copy"}
-                </Button>
-              </LinkBox>
-            )}
-          </InvitePanel>
-        )}
+        <MetricStrip>
+          <MetricItem>
+            <MetricLabel>Active users</MetricLabel>
+            <MetricValue>{data.stats.activeUsers.toLocaleString("en-US")}</MetricValue>
+          </MetricItem>
+          <MetricItem>
+            <MetricLabel>Members</MetricLabel>
+            <MetricValue aria-label={formatGroupMemberCount(data.stats.totalMembers || group.memberCount)}>
+              {(data.stats.totalMembers || group.memberCount).toLocaleString("en-US")}
+            </MetricValue>
+          </MetricItem>
+          <MetricItem>
+            <MetricLabel>Tokens</MetricLabel>
+            <MetricValue $accent>{formatNumber(data.stats.totalTokens)}</MetricValue>
+          </MetricItem>
+          <MetricItem>
+            <MetricLabel>Cost</MetricLabel>
+            <MetricValue>{formatCurrency(data.stats.totalCost)}</MetricValue>
+          </MetricItem>
+        </MetricStrip>
       </Header>
 
       <Toolbar>
-        <Segmented aria-label="Period">
-          {(["all", "month", "week"] as Period[]).map((value) => (
-            <SegmentButton
-              key={value}
-              $active={period === value}
-              onClick={() => {
-                setPeriod(value);
-                setPage(1);
-              }}
-            >
-              {value === "all" ? "All time" : value === "month" ? "Month" : "Week"}
-            </SegmentButton>
-          ))}
-        </Segmented>
+        <SegmentedControl
+          label="Group leaderboard period"
+          value={period}
+          options={[
+            { value: "all" as Period, label: "All time" },
+            { value: "month" as Period, label: "This month" },
+            { value: "week" as Period, label: "This week" },
+          ]}
+          onChange={(value) => {
+            setPeriod(value);
+            setPage(1);
+          }}
+        />
 
         <Actions>
           <SearchWrapper>
             <SearchIcon size={16} />
             <SearchInput
+              type="text"
+              name="group-member-search"
+              aria-label="Search group members"
               value={search}
               onChange={(event) => setSearch(event.target.value)}
               placeholder="Search members"
             />
             {search && (
-              <Button onClick={() => setSearch("")} aria-label="Clear search">
+              <ClearSearchButton type="button" onClick={() => setSearch("")} aria-label="Clear search">
                 <XIcon size={16} />
-              </Button>
+              </ClearSearchButton>
             )}
           </SearchWrapper>
-          <Segmented aria-label="Sort">
-            {(["tokens", "cost"] as SortBy[]).map((value) => (
-              <SegmentButton
-                key={value}
-                $active={sortBy === value}
-                onClick={() => {
-                  setSortBy(value);
-                  setPage(1);
-                }}
-              >
-                {value === "tokens" ? "Tokens" : "Cost"}
-              </SegmentButton>
-            ))}
-          </Segmented>
+          <SegmentedControl
+            label="Group leaderboard sort"
+            value={sortBy}
+            options={[
+              { value: "tokens" as SortBy, label: "Tokens" },
+              { value: "cost" as SortBy, label: "Cost" },
+            ]}
+            onChange={(value) => {
+              setSortBy(value);
+              setPage(1);
+            }}
+          />
         </Actions>
       </Toolbar>
 
       <TableContainer>
         {error ? (
-          <EmptyState>{error}</EmptyState>
+          <EmptyState role="alert">{error}</EmptyState>
         ) : isLoading ? (
-          <EmptyState>Loading leaderboard...</EmptyState>
+          <EmptyState role="status">Loading leaderboard...</EmptyState>
         ) : sortedUsers.length === 0 ? (
           <EmptyState>No submitted usage for this group yet.</EmptyState>
         ) : (
-          <TableWrapper>
-            <Table>
-              <thead>
-                <tr>
-                  <Th>Rank</Th>
-                  <Th>User</Th>
-                  <Th>Role</Th>
-                  <Th className="right">Cost</Th>
-                  <Th className="right">Tokens</Th>
-                  {showSubmissionCount && <Th className="right">Submits</Th>}
-                </tr>
-              </thead>
-              <tbody>
-                {sortedUsers.map((user) => (
-                  <GroupRow key={user.userId} user={user} showSubmissionCount={showSubmissionCount} />
-                ))}
-              </tbody>
-            </Table>
-          </TableWrapper>
+          <>
+            <TableWrapper>
+              <Table>
+                <thead>
+                  <tr>
+                    <Th>Rank</Th>
+                    <Th>User</Th>
+                    <Th>Role</Th>
+                    <Th className="right">Cost</Th>
+                    <Th className="right">Tokens</Th>
+                    {showSubmissionCount && <Th className="right">Submits</Th>}
+                  </tr>
+                </thead>
+                <tbody>
+                  {sortedUsers.map((user) => (
+                    <GroupRow
+                      key={user.userId}
+                      user={user}
+                      showSubmissionCount={showSubmissionCount}
+                      isCurrentUser={currentUser?.username === user.username}
+                    />
+                  ))}
+                </tbody>
+              </Table>
+            </TableWrapper>
+            <MobileRankingList role="list" aria-label="Group leaderboard rankings">
+              {sortedUsers.map((user) => (
+                <GroupMobileRow
+                  key={user.userId}
+                  user={user}
+                  showSubmissionCount={showSubmissionCount}
+                  isCurrentUser={currentUser?.username === user.username}
+                  sortBy={sortBy}
+                />
+              ))}
+            </MobileRankingList>
+            {data.pagination.totalPages > 1 && (
+              <Pagination>
+                <PaginationStatus>
+                  Showing {(data.pagination.page - 1) * data.pagination.limit + 1}–{Math.min(data.pagination.page * data.pagination.limit, data.pagination.totalUsers)} of {data.pagination.totalUsers.toLocaleString("en-US")}
+                </PaginationStatus>
+                <PaginationActions>
+                  <SecondaryButton
+                    type="button"
+                    disabled={!data.pagination.hasPrev}
+                    onClick={() => setPage(Math.max(1, data.pagination.page - 1))}
+                  >
+                    Previous
+                  </SecondaryButton>
+                  <SecondaryButton
+                    type="button"
+                    disabled={!data.pagination.hasNext}
+                    onClick={() => setPage(data.pagination.page + 1)}
+                  >
+                    Next
+                  </SecondaryButton>
+                </PaginationActions>
+              </Pagination>
+            )}
+          </>
         )}
       </TableContainer>
+
+      {canInvite && (
+        <InvitePanel>
+          <InviteHeading>
+            <InviteTitle>Invite members</InviteTitle>
+            <InviteDescription>
+              Create a scoped link, optionally restricted to one GitHub username.
+            </InviteDescription>
+          </InviteHeading>
+          <InviteForm>
+            <Input
+              type="text"
+              name="invite-username"
+              aria-label="Invitee GitHub username"
+              value={inviteUsername}
+              onChange={(event) => setInviteUsername(event.target.value)}
+              placeholder="GitHub username (optional)"
+            />
+            <Select
+              name="invite-role"
+              aria-label="Invite role"
+              value={inviteRole}
+              onChange={(event) => setInviteRole(event.target.value as Exclude<GroupRole, "owner">)}
+            >
+              <option value="member">Member</option>
+              <option value="admin">Admin</option>
+            </Select>
+            <Button type="button" onClick={createInvite}>Create invite</Button>
+          </InviteForm>
+          {inviteError && <ErrorText role="alert">{inviteError}</ErrorText>}
+          {inviteUrl && (
+            <LinkBox>
+              <LinkText>{inviteUrl}</LinkText>
+              <Button type="button" onClick={copyInvite} aria-label="Copy invite link">
+                {copied ? <CheckIcon size={16} /> : <CopyIcon size={16} />}
+                {copied ? "Copied" : "Copy"}
+              </Button>
+            </LinkBox>
+          )}
+        </InvitePanel>
+      )}
     </>
   );
 }

--- a/packages/frontend/src/app/(main)/groups/[slug]/page.tsx
+++ b/packages/frontend/src/app/(main)/groups/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import { Navigation } from "@/components/layout/Navigation";
-import { Footer } from "@/components/layout/Footer";
+import { ServiceFooter } from "@/components/layout/ServiceFooter";
 import { getSession } from "@/lib/auth/session";
 import { getGroupLeaderboardData } from "@/lib/groups/getGroupLeaderboard";
 import { getGroupMembership } from "@/lib/groups/permissions";
@@ -13,17 +13,10 @@ interface GroupPageProps {
 
 function PageShell({ children }: { children: React.ReactNode }) {
   return (
-    <div
-      style={{
-        minHeight: "100vh",
-        display: "flex",
-        flexDirection: "column",
-        backgroundColor: "var(--color-bg-default)",
-      }}
-    >
+    <div className="service-page-shell">
       <Navigation />
-      <main className="main-container">{children}</main>
-      <Footer />
+      <main className="service-main" id="main-content">{children}</main>
+      <ServiceFooter />
     </div>
   );
 }

--- a/packages/frontend/src/app/(main)/groups/join/[token]/JoinGroupClient.tsx
+++ b/packages/frontend/src/app/(main)/groups/join/[token]/JoinGroupClient.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter } from "nextjs-toploader/app";
 import styled from "styled-components";
+import { SecondaryActionLink } from "@/components/leaderboard/RankingUI";
 
 interface InvitePreview {
   group: {
@@ -18,32 +18,62 @@ interface InvitePreview {
 
 const Shell = styled.section`
   max-width: 620px;
-  margin: 48px auto;
-  padding: 24px;
-  border: 1px solid var(--color-border-default);
-  border-radius: 8px;
-  background: var(--color-bg-default);
+  margin: 0 auto;
+  padding: 20px 0;
+  border-top: 1px solid var(--service-border);
+  border-bottom: 1px solid var(--service-border);
 `;
 
 const Title = styled.h1`
-  margin: 0 0 8px;
-  color: var(--color-fg-default);
-  font-size: 28px;
-  font-weight: 700;
+  margin: 0;
+  color: var(--service-text);
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  text-wrap: balance;
 `;
 
 const Text = styled.p`
-  margin: 0 0 16px;
-  color: var(--color-fg-muted);
-  line-height: 1.6;
+  margin: 6px 0 16px;
+  color: var(--service-text-muted);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  text-wrap: pretty;
+
+  @media (max-width: 640px) {
+    font-size: 1rem;
+  }
 `;
 
-const Meta = styled.div`
+const Meta = styled.dl`
   display: grid;
-  gap: 8px;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: 8px 16px;
   margin: 18px 0;
-  color: var(--color-fg-muted);
-  font-size: 14px;
+  padding: 14px 0;
+  border-top: 1px solid var(--service-border);
+  border-bottom: 1px solid var(--service-border);
+`;
+
+const MetaLabel = styled.dt`
+  color: var(--service-text);
+  font-size: 0.8125rem;
+  font-weight: 500;
+
+  @media (max-width: 640px) {
+    font-size: 1rem;
+  }
+`;
+
+const MetaValue = styled.dd`
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--service-text-muted);
+  font-size: 0.8125rem;
+
+  @media (max-width: 640px) {
+    font-size: 1rem;
+  }
 `;
 
 const Actions = styled.div`
@@ -53,35 +83,39 @@ const Actions = styled.div`
 `;
 
 const Button = styled.button`
-  min-height: 40px;
-  padding: 0 16px;
+  min-height: 36px;
+  padding: 0 12px;
   border-radius: 8px;
-  border: 1px solid var(--color-primary);
-  background: var(--color-primary);
+  border: 1px solid var(--service-accent);
+  background: var(--service-accent);
   color: #fff;
+  font-size: 0.875rem;
   font-weight: 600;
-  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    border-color: var(--service-accent-hover);
+    background: var(--service-accent-hover);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--service-focus);
+    outline-offset: 2px;
+  }
 
   &:disabled {
     opacity: 0.65;
     cursor: not-allowed;
   }
-`;
 
-const SecondaryLink = styled(Link)`
-  display: inline-flex;
-  align-items: center;
-  min-height: 40px;
-  padding: 0 16px;
-  border-radius: 8px;
-  border: 1px solid var(--color-border-default);
-  color: var(--color-fg-default);
-  text-decoration: none;
+  @media (max-width: 640px) {
+    min-height: 44px;
+    font-size: 1rem;
+  }
 `;
 
 const ErrorText = styled.p`
   margin: 0;
-  color: var(--color-danger-fg, #f85149);
+  color: #ff8c85;
 `;
 
 function formatRole(role: InvitePreview["role"]): string {
@@ -153,9 +187,9 @@ export default function JoinGroupClient({ token }: { token: string }) {
     return (
       <Shell>
         <Title>Invite unavailable</Title>
-        <ErrorText>{error || "This invite is invalid or expired."}</ErrorText>
+        <ErrorText role="alert">{error || "This invite is invalid or expired."}</ErrorText>
         <Actions>
-          <SecondaryLink href="/groups">Browse groups</SecondaryLink>
+          <SecondaryActionLink href="/leaderboard?view=groups">Browse groups</SecondaryActionLink>
         </Actions>
       </Shell>
     );
@@ -166,16 +200,30 @@ export default function JoinGroupClient({ token }: { token: string }) {
       <Title>Join {preview.group.name}</Title>
       <Text>You were invited to join this group leaderboard.</Text>
       <Meta>
-        <span>Role: {formatRole(preview.role)}</span>
-        <span>Visibility: {preview.group.isPublic ? "Public" : "Private"}</span>
-        {preview.invitedUsername && <span>For: @{preview.invitedUsername}</span>}
+        <MetaLabel>Role</MetaLabel>
+        <MetaValue>{formatRole(preview.role)}</MetaValue>
+        <MetaLabel>Visibility</MetaLabel>
+        <MetaValue>{preview.group.isPublic ? "Public" : "Private"}</MetaValue>
+        {preview.invitedUsername && (
+          <>
+            <MetaLabel>Invited account</MetaLabel>
+            <MetaValue>@{preview.invitedUsername}</MetaValue>
+          </>
+        )}
+        <MetaLabel>Expires</MetaLabel>
+        <MetaValue>
+          {new Date(preview.expiresAt).toLocaleString(undefined, {
+            dateStyle: "medium",
+            timeStyle: "short",
+          })}
+        </MetaValue>
       </Meta>
-      {error && <ErrorText>{error}</ErrorText>}
+      {error && <ErrorText role="alert">{error}</ErrorText>}
       <Actions>
-        <Button onClick={acceptInvite} disabled={isJoining}>
+        <Button type="button" onClick={acceptInvite} disabled={isJoining}>
           {isJoining ? "Joining..." : "Join group"}
         </Button>
-        <SecondaryLink href="/groups">Cancel</SecondaryLink>
+        <SecondaryActionLink href="/leaderboard?view=groups">Cancel</SecondaryActionLink>
       </Actions>
     </Shell>
   );

--- a/packages/frontend/src/app/(main)/groups/join/[token]/page.tsx
+++ b/packages/frontend/src/app/(main)/groups/join/[token]/page.tsx
@@ -1,5 +1,5 @@
 import { Navigation } from "@/components/layout/Navigation";
-import { Footer } from "@/components/layout/Footer";
+import { ServiceFooter } from "@/components/layout/ServiceFooter";
 import JoinGroupClient from "./JoinGroupClient";
 
 export default async function JoinGroupPage({
@@ -10,19 +10,12 @@ export default async function JoinGroupPage({
   const { token } = await params;
 
   return (
-    <div
-      style={{
-        minHeight: "100vh",
-        display: "flex",
-        flexDirection: "column",
-        backgroundColor: "var(--color-bg-default)",
-      }}
-    >
+    <div className="service-page-shell">
       <Navigation />
-      <main className="main-container">
+      <main className="service-main" id="main-content">
         <JoinGroupClient token={token} />
       </main>
-      <Footer />
+      <ServiceFooter />
     </div>
   );
 }

--- a/packages/frontend/src/app/(main)/groups/new/CreateGroupClient.tsx
+++ b/packages/frontend/src/app/(main)/groups/new/CreateGroupClient.tsx
@@ -1,72 +1,132 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import { useRouter } from "nextjs-toploader/app";
 import styled from "styled-components";
+import { SecondaryActionLink } from "@/components/leaderboard/RankingUI";
 
 const Shell = styled.section`
-  max-width: 680px;
-  margin: 32px 0;
+  max-width: 640px;
 `;
 
 const Title = styled.h1`
-  margin: 0 0 8px;
-  color: var(--color-fg-default);
-  font-size: 30px;
-  font-weight: 700;
+  margin: 0;
+  color: var(--service-text);
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  text-wrap: balance;
 `;
 
 const Description = styled.p`
-  margin: 0 0 24px;
-  color: var(--color-fg-muted);
-  line-height: 1.6;
+  margin: 6px 0 24px;
+  color: var(--service-text-muted);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  text-wrap: pretty;
+
+  @media (max-width: 640px) {
+    font-size: 1rem;
+  }
 `;
 
 const Form = styled.form`
   display: grid;
   gap: 16px;
-  padding: 20px;
-  border: 1px solid var(--color-border-default);
-  border-radius: 8px;
-  background: var(--color-bg-default);
+  padding: 20px 0;
+  border-top: 1px solid var(--service-border);
+  border-bottom: 1px solid var(--service-border);
 `;
 
 const Field = styled.label`
   display: grid;
   gap: 8px;
-  color: var(--color-fg-default);
-  font-size: 14px;
-  font-weight: 600;
+  color: var(--service-text);
+  font-size: 0.875rem;
+  font-weight: 500;
+
+  @media (max-width: 640px) {
+    font-size: 1rem;
+  }
 `;
 
 const Input = styled.input`
-  min-height: 40px;
+  min-height: 38px;
   padding: 0 12px;
-  border: 1px solid var(--color-border-default);
+  border: 1px solid var(--service-border-strong);
   border-radius: 8px;
-  background: var(--color-bg-subtle);
-  color: var(--color-fg-default);
+  background: var(--service-surface);
+  color: var(--service-text);
   font: inherit;
+
+  &:focus-visible {
+    border-color: var(--service-focus);
+    outline: 2px solid var(--service-focus);
+    outline-offset: -1px;
+  }
+
+  @media (max-width: 640px) {
+    min-height: 44px;
+    font-size: 1rem;
+  }
 `;
 
 const Textarea = styled.textarea`
   min-height: 96px;
   padding: 10px 12px;
-  border: 1px solid var(--color-border-default);
+  border: 1px solid var(--service-border-strong);
   border-radius: 8px;
-  background: var(--color-bg-subtle);
-  color: var(--color-fg-default);
+  background: var(--service-surface);
+  color: var(--service-text);
   font: inherit;
   resize: vertical;
+
+  &:focus-visible {
+    border-color: var(--service-focus);
+    outline: 2px solid var(--service-focus);
+    outline-offset: -1px;
+  }
+
+  @media (max-width: 640px) {
+    font-size: 1rem;
+  }
 `;
 
 const CheckboxLabel = styled.label`
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 10px;
-  color: var(--color-fg-default);
-  font-size: 14px;
+  color: var(--service-text);
+  font-size: 0.875rem;
+
+  input {
+    width: 18px;
+    height: 18px;
+    flex: 0 0 auto;
+    margin: 1px 0 0;
+    accent-color: var(--service-accent);
+  }
+
+  @media (max-width: 640px) {
+    font-size: 1rem;
+
+    input {
+      width: 20px;
+      height: 20px;
+    }
+  }
+`;
+
+const CheckboxCopy = styled.span`
+  display: grid;
+  gap: 2px;
+`;
+
+const FieldHint = styled.span`
+  display: block;
+  color: var(--service-text-muted);
+  font-size: 0.8125rem;
+  font-weight: 400;
 `;
 
 const Actions = styled.div`
@@ -77,35 +137,39 @@ const Actions = styled.div`
 `;
 
 const Button = styled.button`
-  min-height: 40px;
-  padding: 0 16px;
+  min-height: 36px;
+  padding: 0 12px;
   border-radius: 8px;
-  border: 1px solid var(--color-primary);
-  background: var(--color-primary);
+  border: 1px solid var(--service-accent);
+  background: var(--service-accent);
   color: #fff;
+  font-size: 0.875rem;
   font-weight: 600;
-  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    border-color: var(--service-accent-hover);
+    background: var(--service-accent-hover);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--service-focus);
+    outline-offset: 2px;
+  }
 
   &:disabled {
     cursor: not-allowed;
     opacity: 0.65;
   }
-`;
 
-const SecondaryLink = styled(Link)`
-  display: inline-flex;
-  align-items: center;
-  min-height: 40px;
-  padding: 0 16px;
-  border-radius: 8px;
-  border: 1px solid var(--color-border-default);
-  color: var(--color-fg-default);
-  text-decoration: none;
+  @media (max-width: 640px) {
+    min-height: 44px;
+    font-size: 1rem;
+  }
 `;
 
 const ErrorText = styled.p`
   margin: 0;
-  color: var(--color-danger-fg, #f85149);
+  color: #ff8c85;
 `;
 
 export default function CreateGroupClient() {
@@ -155,32 +219,42 @@ export default function CreateGroupClient() {
         <Field>
           Group name
           <Input
+            type="text"
+            name="group-name"
             value={name}
             onChange={(event) => setName(event.target.value)}
             maxLength={100}
             required
             autoFocus
+            placeholder="Team or workspace name"
           />
         </Field>
         <Field>
           Description
+          <FieldHint>Optional context shown in the public group directory.</FieldHint>
           <Textarea
+            name="group-description"
             value={description}
             onChange={(event) => setDescription(event.target.value)}
             maxLength={500}
+            placeholder="What brings this group together?"
           />
         </Field>
         <CheckboxLabel>
           <input
             type="checkbox"
+            name="group-public"
             checked={isPublic}
             onChange={(event) => setIsPublic(event.target.checked)}
           />
-          Make this group public
+          <CheckboxCopy>
+            <span>Make this group public</span>
+            <FieldHint>Anyone can discover the group and view its ranking.</FieldHint>
+          </CheckboxCopy>
         </CheckboxLabel>
-        {error && <ErrorText>{error}</ErrorText>}
+        {error && <ErrorText role="alert">{error}</ErrorText>}
         <Actions>
-          <SecondaryLink href="/groups">Cancel</SecondaryLink>
+          <SecondaryActionLink href="/leaderboard?view=groups">Cancel</SecondaryActionLink>
           <Button disabled={isSubmitting || !name.trim()} type="submit">
             {isSubmitting ? "Creating..." : "Create group"}
           </Button>

--- a/packages/frontend/src/app/(main)/groups/new/page.tsx
+++ b/packages/frontend/src/app/(main)/groups/new/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation";
 import { Navigation } from "@/components/layout/Navigation";
-import { Footer } from "@/components/layout/Footer";
+import { ServiceFooter } from "@/components/layout/ServiceFooter";
 import { getSession } from "@/lib/auth/session";
 import CreateGroupClient from "./CreateGroupClient";
 
@@ -12,19 +12,12 @@ export default async function NewGroupPage() {
   }
 
   return (
-    <div
-      style={{
-        minHeight: "100vh",
-        display: "flex",
-        flexDirection: "column",
-        backgroundColor: "var(--color-bg-default)",
-      }}
-    >
+    <div className="service-page-shell">
       <Navigation />
-      <main className="main-container">
+      <main className="service-main" id="main-content">
         <CreateGroupClient />
       </main>
-      <Footer />
+      <ServiceFooter />
     </div>
   );
 }

--- a/packages/frontend/src/app/(main)/leaderboard/GroupsBrowser.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/GroupsBrowser.tsx
@@ -3,6 +3,14 @@
 import Link from "next/link";
 import { useCallback, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
+import {
+  CompactBadge,
+  GroupMark,
+  PrimaryActionLink,
+  SecondaryButton,
+  SegmentedControl,
+} from "@/components/leaderboard/RankingUI";
+import { formatGroupMemberCount } from "@/components/leaderboard/presentation";
 
 // Inlined view of the groups list that lives under the /leaderboard ?view=groups
 // segmented control. The /groups/[slug], /groups/new, and /groups/join/[token]
@@ -48,115 +56,94 @@ interface GroupsBrowserProps {
 
 type ActiveTab = "public" | "mine";
 
-const Header = styled.section`
-  margin: 16px 0 20px;
+const Toolbar = styled.section`
   display: flex;
   justify-content: space-between;
-  gap: 16px;
-  align-items: flex-start;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 16px;
 
   @media (max-width: 640px) {
-    flex-direction: column;
+    align-items: stretch;
+    flex-direction: column-reverse;
   }
 `;
 
-const Description = styled.p`
+const DirectoryStatus = styled.p`
   margin: 0;
-  max-width: 680px;
-  color: var(--color-fg-muted);
-  line-height: 1.6;
-`;
+  color: var(--service-text-muted);
+  font-size: 0.8125rem;
 
-const PrimaryLink = styled(Link)`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 40px;
-  padding: 0 16px;
-  border-radius: 8px;
-  border: 1px solid var(--color-primary);
-  background: var(--color-primary);
-  color: #fff;
-  font-size: 14px;
-  font-weight: 600;
-  text-decoration: none;
-  white-space: nowrap;
-`;
-
-const Tabs = styled.div`
-  display: inline-flex;
-  padding: 4px;
-  margin-bottom: 16px;
-  border: 1px solid var(--color-border-default);
-  border-radius: 8px;
-  background: var(--color-bg-subtle);
-`;
-
-const TabButton = styled.button<{ $active: boolean }>`
-  min-height: 32px;
-  padding: 0 14px;
-  border: 0;
-  border-radius: 6px;
-  background: ${({ $active }) => ($active ? "var(--color-bg-default)" : "transparent")};
-  color: ${({ $active }) => ($active ? "var(--color-fg-default)" : "var(--color-fg-muted)")};
-  font-weight: 600;
-  cursor: pointer;
-
-  &:focus-visible {
-    outline: 2px solid var(--color-primary);
-    outline-offset: 2px;
-  }
-
-  &:disabled {
-    cursor: not-allowed;
-    opacity: 0.5;
+  @media (max-width: 640px) {
+    font-size: 1rem;
   }
 `;
 
-const Grid = styled.div`
+const FilterGroup = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 8px;
+`;
+
+const DirectoryAction = styled(PrimaryActionLink)`
+  align-self: flex-start;
+`;
+
+const Grid = styled.ul`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 340px), 1fr));
   gap: 12px;
+  margin: 0;
+  padding: 0;
+
+  @media (min-width: 1240px) {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+`;
+
+const GridItem = styled.li`
+  min-width: 0;
+  list-style: none;
 `;
 
 const Card = styled(Link)`
-  display: flex;
-  flex-direction: column;
-  min-height: 150px;
-  padding: 16px;
-  border: 1px solid var(--color-border-default);
-  border-radius: 8px;
-  background: var(--color-bg-default);
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 12px;
+  min-height: 100%;
+  padding: 14px;
+  border: 1px solid var(--service-border);
+  border-radius: 10px;
+  background: var(--service-surface);
   color: inherit;
   text-decoration: none;
-  transition: border-color 0.15s, background 0.15s;
 
   &:hover {
-    border-color: var(--color-primary);
-    background: var(--color-bg-subtle);
+    border-color: var(--service-border-strong);
+    background: var(--service-surface-muted);
   }
 
   &:focus-visible {
-    outline: 2px solid var(--color-primary);
+    outline: 2px solid var(--service-focus);
     outline-offset: 2px;
-    border-color: var(--color-primary);
   }
 `;
 
-const SkeletonGrid = styled(Grid)`
+const SkeletonGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 340px), 1fr));
+  gap: 12px;
   pointer-events: none;
 `;
 
 const SkeletonCard = styled.div`
-  min-height: 150px;
-  padding: 16px;
-  border: 1px solid var(--color-border-default);
-  border-radius: 8px;
+  min-height: 94px;
+  border: 1px solid var(--service-border);
+  border-radius: 10px;
   background: linear-gradient(
     90deg,
-    var(--color-bg-default) 0%,
-    var(--color-bg-subtle) 50%,
-    var(--color-bg-default) 100%
+    var(--service-surface) 0%,
+    var(--service-surface-muted) 50%,
+    var(--service-surface) 100%
   );
   background-size: 200% 100%;
   animation: groups-skeleton-shimmer 1.6s ease-in-out infinite;
@@ -171,89 +158,85 @@ const SkeletonCard = styled.div`
   }
 `;
 
-const CardTop = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  margin-bottom: 12px;
-`;
-
-const Avatar = styled.div<{ $image?: string | null }>`
-  width: 42px;
-  height: 42px;
-  border-radius: 8px;
-  flex: 0 0 auto;
-  border: 1px solid var(--color-border-default);
-  background: ${({ $image }) =>
-    $image ? `url(${$image}) center/cover` : "linear-gradient(135deg, #0073ff, #13a10e)"};
+const CardContent = styled.div`
+  min-width: 0;
 `;
 
 const CardTitle = styled.h2`
   margin: 0;
-  font-size: 16px;
-  color: var(--color-fg-default);
+  overflow: hidden;
+  color: var(--service-text);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  @media (max-width: 640px) {
+    font-size: 1rem;
+  }
 `;
 
 const Meta = styled.div`
-  margin-top: 3px;
   display: flex;
-  gap: 8px;
   flex-wrap: wrap;
-  color: var(--color-fg-muted);
-  font-size: 12px;
+  gap: 6px;
+  margin-top: 6px;
 `;
 
 const BodyText = styled.p`
-  margin: 0;
-  color: var(--color-fg-muted);
-  line-height: 1.5;
-  font-size: 14px;
+  display: -webkit-box;
+  margin: 10px 0 0;
+  overflow: hidden;
+  color: var(--service-text-muted);
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  text-wrap: pretty;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+
+  @media (max-width: 640px) {
+    font-size: 1rem;
+    line-height: 1.5;
+  }
 `;
 
 const EmptyState = styled.div`
-  padding: 28px;
-  border: 1px solid var(--color-border-default);
-  border-radius: 8px;
-  background: var(--color-bg-default);
-  color: var(--color-fg-muted);
+  padding: 28px 0;
+  border-top: 1px solid var(--service-border);
+  border-bottom: 1px solid var(--service-border);
+  color: var(--service-text-muted);
+  font-size: 0.875rem;
+
+  @media (max-width: 640px) {
+    font-size: 1rem;
+  }
 `;
 
 const ErrorText = styled.p`
-  color: var(--color-danger-fg, #f85149);
+  margin: 0 0 12px;
+  color: #ff8c85;
 `;
 
-const LoadMoreButton = styled.button`
+const LoadMoreButton = styled(SecondaryButton)`
   margin-top: 16px;
-  min-height: 36px;
-  padding: 0 16px;
-  border-radius: 8px;
-  border: 1px solid var(--color-border-default);
-  background: var(--color-bg-default);
-  color: var(--color-fg-default);
-  cursor: pointer;
-
-  &:disabled {
-    cursor: not-allowed;
-    opacity: 0.6;
-  }
 `;
 
 function GroupCard({ group }: { group: GroupCardData }) {
   return (
-    <Card href={`/groups/${group.slug}`}>
-      <CardTop>
-        <Avatar $image={group.avatarUrl} />
-        <div>
+    <GridItem>
+      <Card href={`/groups/${group.slug}`}>
+        <GroupMark name={group.name} avatarUrl={group.avatarUrl} />
+        <CardContent>
           <CardTitle>{group.name}</CardTitle>
           <Meta>
-            <span>{group.isPublic ? "Public" : "Private"}</span>
-            <span>{group.memberCount} members</span>
-            {group.role && <span>{group.role}</span>}
+            <CompactBadge>{group.isPublic ? "Public" : "Private"}</CompactBadge>
+            <CompactBadge>{formatGroupMemberCount(group.memberCount)}</CompactBadge>
+            {group.role && <CompactBadge>{group.role}</CompactBadge>}
           </Meta>
-        </div>
-      </CardTop>
-      <BodyText>{group.description || "A scoped Tokscale leaderboard."}</BodyText>
-    </Card>
+          {group.description && <BodyText>{group.description}</BodyText>}
+        </CardContent>
+      </Card>
+    </GridItem>
   );
 }
 
@@ -395,33 +378,33 @@ export default function GroupsBrowser({
   // Send unauthenticated users back to /leaderboard?view=groups so they land
   // on the groups view after sign-in (was /groups before the consolidation).
   const signInHref = "/api/auth/github?returnTo=/leaderboard?view=groups";
+  const directoryCount = activePagination.total;
 
   return (
     <>
-      <Header>
-        <Description>
-          Create private or public leaderboards for teams, friends, and workspaces without changing
-          the global Tokscale rankings.
-        </Description>
+      <Toolbar>
+        <FilterGroup>
+          <SegmentedControl
+            label="Group filter"
+            value={activeTab}
+            options={[
+              { value: "public", label: "Public" },
+              { value: "mine", label: "My groups", disabled: !currentUser },
+            ]}
+            onChange={handleTabChange}
+          />
+          <DirectoryStatus role="status" aria-live="polite">
+            {activeTab === "mine"
+              ? `${directoryCount.toLocaleString("en-US")} ${directoryCount === 1 ? "group" : "groups"}`
+              : `${directoryCount.toLocaleString("en-US")} public ${directoryCount === 1 ? "group" : "groups"}`}
+          </DirectoryStatus>
+        </FilterGroup>
         {currentUser ? (
-          <PrimaryLink href="/groups/new">New group</PrimaryLink>
+          <DirectoryAction href="/groups/new">New group</DirectoryAction>
         ) : (
-          <PrimaryLink href={signInHref}>Sign in</PrimaryLink>
+          <DirectoryAction href={signInHref}>Sign in</DirectoryAction>
         )}
-      </Header>
-
-      <Tabs aria-label="Group filters">
-        <TabButton $active={activeTab === "public"} onClick={() => handleTabChange("public")}>
-          Public
-        </TabButton>
-        <TabButton
-          $active={activeTab === "mine"}
-          onClick={() => handleTabChange("mine")}
-          disabled={!currentUser}
-        >
-          My groups
-        </TabButton>
-      </Tabs>
+      </Toolbar>
 
       {error && <ErrorText role="alert">{error}</ErrorText>}
       {isLoading && groups.length === 0 ? (
@@ -438,7 +421,7 @@ export default function GroupsBrowser({
             </EmptyState>
           ) : (
             <>
-              <Grid>
+              <Grid role="list">
                 {groups.map((group) => (
                   <GroupCard key={group.id} group={group} />
                 ))}

--- a/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
@@ -1,73 +1,54 @@
 "use client";
 
 import { useState, useEffect, useRef, useMemo, memo, useCallback } from "react";
+import Link from "next/link";
 import { useRouter } from "nextjs-toploader/app";
 import { useSearchParams, usePathname } from "next/navigation";
 import styled from "styled-components";
 import { CopyIcon, CheckIcon, SearchIcon, XIcon } from "@/components/ui/Icons";
-import { TabBar } from "@/components/TabBar";
 import { LeaderboardSkeleton } from "@/components/Skeleton";
+import {
+  MetricItem,
+  MetricLabel,
+  MetricStrip,
+  MetricValue,
+  MobileRankingList,
+  MobileRankingRow,
+  SegmentedControl,
+} from "@/components/leaderboard/RankingUI";
+import { getLeaderboardPeriodLabel } from "@/components/leaderboard/presentation";
 import { formatCurrency, formatNumber, formatDuration } from "@/lib/utils";
 import { useSettings } from "@/lib/useSettings";
 import { isValidSortBy, type LeaderboardSortBy } from "@/lib/leaderboard/constants";
 import { parseCustomDateRange } from "@/lib/leaderboard/dateRange";
 
 const Section = styled.div`
-  margin-bottom: 40px;
-`;
-
-const Description = styled.p`
-  margin-bottom: 24px;
-  color: var(--color-fg-muted);
-`;
-
-const StatsGrid = styled.div`
   display: grid;
-  grid-template-columns: 1fr;
-  gap: 8px;
-  
-  @media (min-width: 480px) {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 12px;
+  gap: 10px;
+  margin-bottom: 24px;
+`;
+
+const ScopeLabel = styled.p`
+  margin: 0;
+  color: var(--service-text-muted);
+  font-size: 0.8125rem;
+  font-weight: 500;
+
+  @media (max-width: 640px) {
+    font-size: 1rem;
   }
-  
-  @media (min-width: 768px) {
-    display: flex;
-  }
-`;
-
-const StatCard = styled.div`
-  flex: 1;
-  border-radius: 12px;
-  border: 1px solid var(--color-border-default);
-  padding: 12px;
-  background-color: var(--color-bg-default);
-`;
-
-const StatLabel = styled.p`
-  font-size: 12px;
-  color: var(--color-fg-muted);
-`;
-
-const StatValue = styled.p`
-  font-size: 16px;
-  font-weight: bold;
-  color: var(--color-fg-default);
-`;
-
-const StatValuePrimary = styled(StatValue)`
-  color: var(--color-primary);
 `;
 
 const TabSection = styled.div`
-  margin-bottom: 24px;
+  width: 100%;
+  max-width: 100%;
+  margin-bottom: 14px;
+  overflow: hidden;
 `;
 
 const TableContainer = styled.div`
-  border-radius: 16px;
-  border: 1px solid var(--color-border-default);
-  overflow: hidden;
-  background-color: var(--color-bg-default);
+  border-top: 1px solid var(--service-border);
+  border-bottom: 1px solid var(--service-border);
 `;
 
 const EmptyState = styled.div`
@@ -105,21 +86,19 @@ const CodeSnippet = styled.code`
 `;
 
 const TableWrapper = styled.div`
-  overflow-x: auto;
+  display: none;
+
+  @media (min-width: 720px) {
+    display: block;
+  }
 `;
 
 const Table = styled.table`
   width: 100%;
-  min-width: 500px;
-  
-  @media (max-width: 560px) {
-    min-width: unset;
-  }
 `;
 
 const TableHead = styled.thead`
-  border-bottom: 1px solid var(--color-border-default);
-  background-color: var(--color-bg-elevated);
+  border-bottom: 1px solid var(--service-border);
 `;
 
 const TableHeaderCell = styled.th`
@@ -130,16 +109,8 @@ const TableHeaderCell = styled.th`
   text-align: left;
   font-size: 12px;
   font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--color-fg-muted);
-  
-  @media (max-width: 480px) {
-    padding-left: 8px;
-    padding-right: 8px;
-    padding-top: 8px;
-    padding-bottom: 8px;
-  }
+  color: var(--service-text-muted);
+  white-space: nowrap;
   
   @media (min-width: 640px) {
     padding-left: 24px;
@@ -158,12 +129,6 @@ const TableHeaderCell = styled.th`
     }
   }
   
-  &.hidden-cost-mobile {
-    @media (max-width: 560px) {
-      display: none;
-    }
-  }
-  
   &.w-24 {
     width: 96px;
   }
@@ -172,10 +137,6 @@ const TableHeaderCell = styled.th`
     width: 1%;
     white-space: nowrap;
     
-    @media (max-width: 560px) {
-      padding-left: 8px;
-      padding-right: 4px;
-    }
   }
 `;
 
@@ -183,20 +144,22 @@ const TableBody = styled.tbody``;
 
 const TableRow = styled.tr`
   cursor: pointer;
-  transition: all 0.2s;
   position: relative;
   
   &:hover {
-    background-color: rgba(20, 26, 33, 0.6);
+    background: var(--service-surface);
+  }
+
+  &:not(:last-child) td {
+    border-bottom: 1px solid var(--service-border);
   }
 
   &[data-current-user="true"] {
-    background: rgba(0, 115, 255, 0.05);
-    box-shadow: inset 4px 0 0 #0073FF, inset 0 0 0 2px #0073FF;
-    border-radius: 4px;
+    background: var(--service-accent-soft);
+    box-shadow: inset 2px 0 0 var(--service-accent);
     
     &:hover {
-      background-color: rgba(0, 115, 255, 0.12);
+      background: var(--service-accent-soft);
     }
   }
 `;
@@ -209,16 +172,9 @@ const TableCell = styled.td`
   white-space: nowrap;
   vertical-align: middle;
   
-  @media (max-width: 480px) {
-    padding-left: 8px;
-    padding-right: 8px;
-    padding-top: 8px;
-    padding-bottom: 8px;
-  }
-  
   @media (min-width: 640px) {
-    padding-left: 24px;
-    padding-right: 24px;
+    padding-left: 18px;
+    padding-right: 18px;
   }
   
   &.text-right {
@@ -233,12 +189,6 @@ const TableCell = styled.td`
     }
   }
   
-  &.hidden-cost-mobile {
-    @media (max-width: 560px) {
-      display: none;
-    }
-  }
-  
   &.w-24 {
     width: 96px;
   }
@@ -247,48 +197,42 @@ const TableCell = styled.td`
     width: 1%;
     white-space: nowrap;
     
-    @media (max-width: 560px) {
-      padding-left: 8px;
-      padding-right: 4px;
-    }
   }
 `;
 
 const RankBadge = styled.span`
-  font-size: 16px;
-  font-weight: bold;
-  color: var(--color-fg-muted);
+  color: var(--service-text-muted);
+  font-size: 0.875rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
   
-  &[data-rank="1"] { color: #EAB308; }
-  &[data-rank="2"] { color: #9CA3AF; }
-  &[data-rank="3"] { color: #D97706; }
-  
-  @media (max-width: 480px) {
-    font-size: 14px;
-  }
-  
-  @media (min-width: 640px) {
-    font-size: 18px;
-  }
+  &[data-rank="1"] { color: #f4c95d; }
+  &[data-rank="2"] { color: #c4ccda; }
+  &[data-rank="3"] { color: #d99a68; }
 `;
 
-const UserContainer = styled.div`
+const UserContainer = styled(Link)`
   display: flex;
   align-items: center;
   gap: 8px;
-  
-  @media (max-width: 480px) {
-    gap: 6px;
-    
-    img {
-      width: 32px !important;
-      height: 32px !important;
-    }
+  min-width: 0;
+  color: inherit;
+  text-decoration: none;
+
+  &:focus-visible {
+    outline: 2px solid var(--service-focus);
+    outline-offset: 3px;
   }
-  
-  @media (min-width: 640px) {
-    gap: 12px;
-  }
+`;
+
+const DesktopAvatar = styled.img`
+  width: 36px;
+  height: 36px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  object-fit: cover;
+  outline: 1px solid var(--service-border);
+  outline-offset: -1px;
 `;
 
 const UserInfo = styled.div`
@@ -297,67 +241,50 @@ const UserInfo = styled.div`
 
 const UserDisplayName = styled.p`
   font-weight: 500;
-  font-size: 14px;
+  font-size: 0.875rem;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 120px;
-  color: var(--color-fg-default);
-  
-  @media (max-width: 480px) {
-    max-width: 80px;
-    font-size: 13px;
-  }
+  color: var(--service-text);
   
   @media (min-width: 640px) {
-    font-size: 16px;
+    font-size: 0.9375rem;
     max-width: none;
   }
 `;
 
 const Username = styled.p`
-  font-size: 12px;
+  font-size: 0.75rem;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 120px;
-  color: var(--color-fg-muted);
-  
-  @media (max-width: 480px) {
-    max-width: 80px;
-    font-size: 11px;
-  }
+  color: var(--service-text-muted);
   
   @media (min-width: 640px) {
-    font-size: 14px;
+    font-size: 0.8125rem;
     max-width: none;
   }
 `;
 
 const StatSpan = styled.span`
   font-weight: 500;
-  font-size: 14px;
-  color: var(--color-fg-default);
+  font-size: 0.875rem;
+  color: var(--service-text);
+  font-variant-numeric: tabular-nums;
   
   @media (min-width: 640px) {
-    font-size: 16px;
+    font-size: 0.9375rem;
   }
 `;
 
 const TokenValue = styled.span`
   font-weight: 500;
-  font-size: 14px;
-  color: var(--color-primary);
-  transition: color 0.12s ease;
-  
-  @media (max-width: 480px) {
-    font-size: 13px;
-  }
+  font-size: 0.875rem;
+  color: var(--service-accent-hover);
+  font-variant-numeric: tabular-nums;
   
   @media (min-width: 640px) {
-    font-size: 16px;
-  }
-  
-  ${TableRow}:hover & {
-    color: #0073FF;
+    font-size: 0.9375rem;
   }
 `;
 
@@ -399,7 +326,7 @@ const CostValue = styled.span`
 `;
 
 const SubmitCount = styled.span`
-  color: var(--color-fg-muted);
+  color: var(--service-text-muted);
 `;
 
 const PaginationContainer = styled.div`
@@ -436,26 +363,25 @@ const PaginationText = styled.p`
 
 const CTASection = styled.div`
   margin-top: 32px;
-  padding: 24px;
-  border-radius: 16px;
-  border: 1px solid var(--color-border-default);
-  background-color: var(--color-bg-default);
+  padding-top: 24px;
+  border-top: 1px solid var(--service-border);
 `;
 
 const CTATitle = styled.h2`
   font-size: 18px;
   font-weight: 600;
   margin-bottom: 12px;
-  color: var(--color-fg-default);
+  color: var(--service-text);
 `;
 
 const CTADescription = styled.p`
   margin-bottom: 16px;
-  color: var(--color-fg-muted);
+  color: var(--service-text-muted);
 `;
 
 const CodeBlock = styled.div`
   display: flex;
+  min-width: 0;
   flex-direction: column;
   gap: 8px;
   font-family: monospace;
@@ -463,6 +389,8 @@ const CodeBlock = styled.div`
 `;
 
 const CodeLine = styled.div`
+  width: 100%;
+  min-width: 0;
   padding: 12px;
   border-radius: 8px;
   display: flex;
@@ -470,7 +398,9 @@ const CodeLine = styled.div`
   font-size: 16px;
   font-weight: 500;
   letter-spacing: -0.8px;
-  background-color: var(--color-bg-subtle);
+  border: 1px solid var(--service-border);
+  background: var(--service-surface);
+  overflow: hidden;
 
   * {
     font-family: "Inconsolata", monospace !important;
@@ -478,11 +408,13 @@ const CodeLine = styled.div`
 `;
 
 const CommandPrompt = styled.span`
+  flex: 0 0 auto;
   color: #4B6486;
   margin-right: 8px;
 `;
 
 const CommandPrefix = styled.span`
+  flex: 0 0 auto;
   color: #FFF;
   &::after {
     content: " ";
@@ -491,6 +423,7 @@ const CommandPrefix = styled.span`
 `;
 
 const CommandName = styled.span`
+  flex: 0 0 auto;
   background: linear-gradient(90deg, #0CF 0%, #0073FF 100%);
   background-clip: text;
   -webkit-background-clip: text;
@@ -498,7 +431,12 @@ const CommandName = styled.span`
 `;
 
 const CommandArg = styled.span`
+  min-width: 0;
+  flex: 0 1 auto;
+  overflow: hidden;
   color: #FFF;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   &::before {
     content: " ";
     white-space: pre;
@@ -533,8 +471,8 @@ const CurrentUserCard = styled.div`
   margin-bottom: 24px;
   padding: 16px;
   border-radius: 12px;
-  border: 2px solid #0073FF;
-  background: rgba(0, 115, 255, 0.05);
+  border: 1px solid var(--service-accent);
+  background: var(--service-accent-soft);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -555,6 +493,16 @@ const CurrentUserInfo = styled.div`
   min-width: 0;
 `;
 
+const CurrentUserAvatar = styled.img`
+  width: 48px;
+  height: 48px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  object-fit: cover;
+  outline: 1px solid var(--service-border);
+  outline-offset: -1px;
+`;
+
 const CurrentUserDetails = styled.div`
   min-width: 0;
   flex: 1;
@@ -563,7 +511,7 @@ const CurrentUserDetails = styled.div`
 const CurrentUserName = styled.p`
   font-weight: 600;
   font-size: 16px;
-  color: var(--color-fg-default);
+  color: var(--service-text);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -571,7 +519,7 @@ const CurrentUserName = styled.p`
 
 const CurrentUserUsername = styled.p`
   font-size: 14px;
-  color: var(--color-fg-muted);
+  color: var(--service-text-muted);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -597,23 +545,23 @@ const CurrentUserStat = styled.div`
 
 const CurrentUserStatLabel = styled.p`
   font-size: 12px;
-  color: var(--color-fg-muted);
+  color: var(--service-text-muted);
   margin-bottom: 4px;
 `;
 
 const CurrentUserStatValue = styled.p`
   font-size: 16px;
   font-weight: 600;
-  color: #0073FF;
+  color: var(--service-accent-hover);
 `;
 
 const ErrorBanner = styled.div`
   margin-bottom: 24px;
   padding: 12px 16px;
   border-radius: 8px;
-  border: 1px solid #F85149;
+  border: 1px solid rgba(248, 81, 73, 0.55);
   background: rgba(248, 81, 73, 0.1);
-  color: #F85149;
+  color: #ff8c85;
   font-size: 14px;
   display: flex;
   align-items: center;
@@ -621,9 +569,13 @@ const ErrorBanner = styled.div`
 `;
 
 const SortLabel = styled.span`
-  font-size: 12px;
-  color: var(--color-fg-muted);
+  color: var(--service-text-muted);
+  font-size: 0.8125rem;
   font-weight: 500;
+
+  @media (max-width: 640px) {
+    font-size: 1rem;
+  }
 `;
 
 const SearchSortRow = styled.div`
@@ -631,7 +583,7 @@ const SearchSortRow = styled.div`
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  margin-bottom: 16px;
+  margin-bottom: 14px;
 
   @media (max-width: 560px) {
     flex-direction: column;
@@ -642,7 +594,7 @@ const SearchSortRow = styled.div`
 const SearchInputWrapper = styled.div`
   position: relative;
   flex: 1;
-  max-width: 320px;
+  max-width: 360px;
 
   @media (max-width: 560px) {
     max-width: none;
@@ -654,7 +606,7 @@ const SearchInputIcon = styled.span`
   left: 12px;
   top: 50%;
   transform: translateY(-50%);
-  color: var(--color-fg-muted);
+  color: var(--service-text-muted);
   pointer-events: none;
   display: flex;
   align-items: center;
@@ -662,22 +614,28 @@ const SearchInputIcon = styled.span`
 
 const SearchInput = styled.input`
   width: 100%;
-  padding: 8px 36px 8px 36px;
+  min-height: 36px;
+  padding: 0 36px;
   border-radius: 8px;
-  border: 1px solid var(--color-border-default);
-  background-color: var(--color-bg-subtle);
-  color: var(--color-fg-default);
-  font-size: 14px;
+  border: 1px solid var(--service-border-strong);
+  background: var(--service-surface);
+  color: var(--service-text);
+  font-size: 0.875rem;
   outline: none;
-  transition: border-color 0.15s ease;
 
   &::placeholder {
-    color: var(--color-fg-muted);
+    color: var(--service-text-muted);
   }
 
-  &:focus {
-    border-color: #0073FF;
-    box-shadow: 0 0 0 3px rgba(0, 115, 255, 0.15);
+  &:focus-visible {
+    border-color: var(--service-focus);
+    outline: 2px solid var(--service-focus);
+    outline-offset: -1px;
+  }
+
+  @media (max-width: 640px) {
+    min-height: 44px;
+    font-size: 1rem;
   }
 `;
 
@@ -692,13 +650,11 @@ const ClearSearchButton = styled.button`
   padding: 4px;
   border: none;
   background: transparent;
-  color: var(--color-fg-muted);
+  color: var(--service-text-muted);
   cursor: pointer;
   border-radius: 4px;
-  transition: color 0.15s ease;
-
   &:hover {
-    color: var(--color-fg-default);
+    color: var(--service-text);
   }
 `;
 
@@ -706,89 +662,82 @@ const SortToggleInner = styled.div`
   display: flex;
   align-items: center;
   gap: 12px;
-  flex-shrink: 0;
+  flex: 0 0 auto;
+
+  @media (max-width: 560px) {
+    justify-content: space-between;
+  }
 `;
 
 const DateRangeRow = styled.div`
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-bottom: 16px;
+  margin-bottom: 14px;
   flex-wrap: wrap;
 `;
 
 const DateInput = styled.input`
-  padding: 8px 12px;
+  min-height: 36px;
+  padding: 0 10px;
   border-radius: 8px;
-  border: 1px solid var(--color-border-default);
-  background-color: var(--color-bg-subtle);
-  color: var(--color-fg-default);
-  font-size: 14px;
+  border: 1px solid var(--service-border-strong);
+  background: var(--service-surface);
+  color: var(--service-text);
+  font-size: 0.875rem;
   outline: none;
-  transition: border-color 0.15s ease;
   min-width: 140px;
 
-  &:focus {
-    border-color: #0073FF;
-    box-shadow: 0 0 0 3px rgba(0, 115, 255, 0.15);
+  &:focus-visible {
+    border-color: var(--service-focus);
+    outline: 2px solid var(--service-focus);
+    outline-offset: -1px;
   }
 
   &::-webkit-calendar-picker-indicator {
     filter: invert(0.7);
     cursor: pointer;
   }
+
+  @media (max-width: 640px) {
+    min-height: 44px;
+    font-size: 1rem;
+  }
 `;
 
 const DateSeparator = styled.span`
   font-size: 14px;
-  color: var(--color-fg-muted);
+  color: var(--service-text-muted);
 `;
 
 const DateApplyButton = styled.button`
-  padding: 8px 16px;
+  min-height: 36px;
+  padding: 0 12px;
   border-radius: 8px;
-  border: 1px solid #0073FF;
-  background-color: #0073FF;
+  border: 1px solid var(--service-accent);
+  background: var(--service-accent);
   color: #fff;
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: 500;
-  cursor: pointer;
-  transition: opacity 150ms;
 
   &:hover {
-    opacity: 0.85;
+    border-color: var(--service-accent-hover);
+    background: var(--service-accent-hover);
   }
 
   &:disabled {
     opacity: 0.4;
     cursor: default;
   }
-`;
 
-const SortOptions = styled.div`
-  display: inline-flex;
-  border-radius: 8px;
-  border: 1px solid var(--color-border-default);
-  overflow: hidden;
-`;
-
-const SortOption = styled.button<{ $active: boolean }>`
-  padding: 6px 12px;
-  font-size: 12px;
-  font-weight: ${({ $active }) => ($active ? 600 : 400)};
-  color: ${({ $active }) => ($active ? '#fff' : 'var(--color-fg-muted)')};
-  background-color: ${({ $active }) => ($active ? '#0073FF' : 'transparent')};
-  border: none;
-  cursor: pointer;
-  transition: all 150ms;
-
-  &:hover:not([disabled]) {
-    color: ${({ $active }) => ($active ? '#fff' : 'var(--color-fg-default)')};
-    background-color: ${({ $active }) => ($active ? '#0073FF' : 'var(--color-bg-subtle)')};
+  &:focus-visible {
+    outline: 2px solid var(--service-focus);
+    outline-offset: 2px;
   }
 
-  & + & {
-    border-left: 1px solid var(--color-border-default);
+  @media (max-width: 640px) {
+    min-height: 44px;
+    font-size: 1rem;
   }
 `;
 
@@ -931,7 +880,6 @@ function isValidLeaderboardData(data: unknown): data is LeaderboardData {
 interface LeaderboardRowProps {
   user: LeaderboardUser;
   isCurrentUser: boolean;
-  isLastRow: boolean;
   showSubmissionCount: boolean;
   showTime: boolean;
   onRowClick: (username: string) => void;
@@ -940,7 +888,6 @@ interface LeaderboardRowProps {
 const LeaderboardRow = memo(function LeaderboardRow({
   user,
   isCurrentUser,
-  isLastRow,
   showSubmissionCount,
   showTime,
   onRowClick,
@@ -952,7 +899,6 @@ const LeaderboardRow = memo(function LeaderboardRow({
     <TableRow
       onClick={() => onRowClick(user.username)}
       data-current-user={isCurrentUser}
-      style={isLastRow ? undefined : { borderBottom: "1px solid var(--color-border-default)" }}
     >
       <TableCell className="rank-cell">
         <RankBadge data-rank={user.rank <= 3 ? user.rank : undefined}>
@@ -960,13 +906,14 @@ const LeaderboardRow = memo(function LeaderboardRow({
         </RankBadge>
       </TableCell>
       <TableCell>
-        <UserContainer>
-          <img
+        <UserContainer
+          href={`/u/${user.username}`}
+          onClick={(event) => event.stopPropagation()}
+          aria-current={isCurrentUser ? "true" : undefined}
+        >
+          <DesktopAvatar
             src={user.avatarUrl || `https://github.com/${user.username}.png`}
-            alt={user.username}
-            width={40}
-            height={40}
-            style={{ borderRadius: "50%", objectFit: "cover", flexShrink: 0, boxShadow: "0 0 0 1px rgba(255, 255, 255, 0.1)" }}
+            alt=""
           />
           <UserInfo>
             <UserDisplayName>
@@ -1007,6 +954,46 @@ const LeaderboardRow = memo(function LeaderboardRow({
     </TableRow>
   );
 });
+
+function LeaderboardMobileRow({
+  user,
+  isCurrentUser,
+  showSubmissionCount,
+  sortBy,
+}: {
+  user: LeaderboardUser;
+  isCurrentUser: boolean;
+  showSubmissionCount: boolean;
+  sortBy: LeaderboardSortBy;
+}) {
+  const primary = sortBy === "cost"
+    ? { label: "Cost", value: formatCurrency(user.totalCost) }
+    : sortBy === "time"
+      ? { label: "Active time", value: formatDuration(user.totalActiveTimeMs) }
+      : { label: "Tokens", value: formatNumber(user.totalTokens) };
+  const secondary = [
+    sortBy !== "tokens" ? `${formatNumber(user.totalTokens)} tokens` : null,
+    sortBy !== "cost" ? formatCurrency(user.totalCost) : null,
+    sortBy !== "time" ? formatDuration(user.totalActiveTimeMs) : null,
+    showSubmissionCount && user.submissionCount !== null
+      ? `${user.submissionCount.toLocaleString("en-US")} submits`
+      : null,
+  ].filter(Boolean).join(" · ");
+
+  return (
+    <MobileRankingRow
+      rank={user.rank}
+      href={`/u/${user.username}`}
+      avatarUrl={user.avatarUrl}
+      username={user.username}
+      displayName={user.displayName || user.username}
+      primaryLabel={primary.label}
+      primaryValue={primary.value}
+      meta={secondary}
+      isCurrentUser={isCurrentUser}
+    />
+  );
+}
 
 const VALID_PERIODS: Period[] = ["all", "month", "last-month", "week", "custom"];
 
@@ -1237,35 +1224,54 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
   return (
     <>
       <Section>
-        <Description>See who&apos;s using the most tokens</Description>
+        <ScopeLabel>
+          {getLeaderboardPeriodLabel(period, appliedFrom, appliedTo)} aggregate
+        </ScopeLabel>
 
-        <StatsGrid>
-          <StatCard>
-            <StatLabel>Users</StatLabel>
-            <StatValue>{data.stats.uniqueUsers}</StatValue>
-          </StatCard>
-          <StatCard>
-            <StatLabel>Total Tokens</StatLabel>
-            <StatValuePrimary>
+        <MetricStrip>
+          <MetricItem>
+            <MetricLabel>Ranked users</MetricLabel>
+            <MetricValue>{data.stats.uniqueUsers.toLocaleString("en-US")}</MetricValue>
+          </MetricItem>
+          <MetricItem>
+            <MetricLabel>Tokens</MetricLabel>
+            <MetricValue
+              $accent
+              aria-label={`Tokens ${data.stats.totalTokens.toLocaleString("en-US")}`}
+              title={data.stats.totalTokens.toLocaleString("en-US")}
+            >
               <HoverTooltip data-tooltip={data.stats.totalTokens.toLocaleString('en-US')}>
                 {formatNumber(data.stats.totalTokens)}
               </HoverTooltip>
-            </StatValuePrimary>
-          </StatCard>
-          <StatCard>
-            <StatLabel>Total Cost</StatLabel>
-            <StatValue>
+            </MetricValue>
+          </MetricItem>
+          <MetricItem>
+            <MetricLabel>Cost</MetricLabel>
+            <MetricValue
+              aria-label={`Cost ${data.stats.totalCost.toLocaleString("en-US", { style: "currency", currency: "USD", minimumFractionDigits: 2 })}`}
+              title={data.stats.totalCost.toLocaleString("en-US", { style: "currency", currency: "USD", minimumFractionDigits: 2 })}
+            >
               <HoverTooltip data-tooltip={data.stats.totalCost.toLocaleString('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 2 })}>
                 {formatCurrency(data.stats.totalCost)}
               </HoverTooltip>
-            </StatValue>
-          </StatCard>
-        </StatsGrid>
+            </MetricValue>
+          </MetricItem>
+          {data.stats.totalActiveTimeMs !== null ? (
+            <MetricItem>
+              <MetricLabel>Active time</MetricLabel>
+              <MetricValue>{formatDuration(data.stats.totalActiveTimeMs)}</MetricValue>
+            </MetricItem>
+          ) : data.stats.totalSubmissions !== null ? (
+            <MetricItem>
+              <MetricLabel>Submissions</MetricLabel>
+              <MetricValue>{data.stats.totalSubmissions.toLocaleString("en-US")}</MetricValue>
+            </MetricItem>
+          ) : null}
+        </MetricStrip>
       </Section>
 
       {currentUser && currentUserRankError && (
         <ErrorBanner>
-          <span>⚠️</span>
           <span>Unable to load your ranking. Please refresh the page.</span>
         </ErrorBanner>
       )}
@@ -1273,12 +1279,9 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
       {currentUser && currentUserRank && (
         <CurrentUserCard>
           <CurrentUserInfo>
-            <img
+            <CurrentUserAvatar
               src={currentUser.avatarUrl || `https://github.com/${currentUser.username}.png`}
-              alt={currentUser.username}
-              width={48}
-              height={48}
-              style={{ borderRadius: "50%", objectFit: "cover", flexShrink: 0, boxShadow: "0 0 0 1px rgba(255, 255, 255, 0.1)" }}
+              alt=""
             />
             <CurrentUserDetails>
               <CurrentUserName>
@@ -1315,19 +1318,20 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
       )}
 
       <TabSection>
-        <TabBar
-          tabs={[
-            { id: "all" as Period, label: "All Time" },
-            { id: "last-month" as Period, label: "Last Month" },
-            { id: "month" as Period, label: "This Month" },
-            { id: "week" as Period, label: "This Week" },
-            { id: "custom" as Period, label: "Custom" },
+        <SegmentedControl
+          label="Leaderboard period"
+          options={[
+            { value: "all" as Period, label: "All time" },
+            { value: "last-month" as Period, label: "Last month" },
+            { value: "month" as Period, label: "This month" },
+            { value: "week" as Period, label: "This week" },
+            { value: "custom" as Period, label: "Custom" },
           ]}
-          activeTab={period}
-          onTabChange={(tab) => {
-            setPeriod(tab);
+          value={period}
+          onChange={(value) => {
+            setPeriod(value);
             setPage(1);
-            if (tab !== "custom") {
+            if (value !== "custom") {
               setAppliedFrom("");
               setAppliedTo("");
               setCustomFrom("");
@@ -1341,6 +1345,8 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
         <DateRangeRow>
           <DateInput
             type="date"
+            name="leaderboard-from"
+            aria-label="Leaderboard start date"
             value={customFrom}
             onChange={(e) => setCustomFrom(e.target.value)}
             max={customTo || undefined}
@@ -1348,11 +1354,14 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
           <DateSeparator>~</DateSeparator>
           <DateInput
             type="date"
+            name="leaderboard-to"
+            aria-label="Leaderboard end date"
             value={customTo}
             onChange={(e) => setCustomTo(e.target.value)}
             min={customFrom || undefined}
           />
           <DateApplyButton
+            type="button"
             disabled={!parseCustomDateRange(customFrom, customTo)}
             onClick={() => {
               const parsed = parseCustomDateRange(customFrom, customTo);
@@ -1376,47 +1385,33 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
           </SearchInputIcon>
           <SearchInput
             type="text"
+            name="leaderboard-search"
+            aria-label="Search leaderboard users"
             placeholder="Search users..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
           />
           {searchQuery && (
-            <ClearSearchButton onClick={() => setSearchQuery("")} aria-label="Clear search">
+            <ClearSearchButton type="button" onClick={() => setSearchQuery("")} aria-label="Clear search">
               <XIcon size={16} />
             </ClearSearchButton>
           )}
         </SearchInputWrapper>
         <SortToggleInner>
-          <SortLabel>Sort by:</SortLabel>
-          <SortOptions>
-            <SortOption
-              $active={effectiveSortBy === 'tokens'}
-              onClick={() => {
-                setUrlSortOverride(null);
-                setLeaderboardSort('tokens');
-              }}
-            >
-              Tokens
-            </SortOption>
-            <SortOption
-              $active={effectiveSortBy === 'cost'}
-              onClick={() => {
-                setUrlSortOverride(null);
-                setLeaderboardSort('cost');
-              }}
-            >
-              Cost
-            </SortOption>
-            <SortOption
-              $active={effectiveSortBy === 'time'}
-              onClick={() => {
-                setUrlSortOverride(null);
-                setLeaderboardSort('time');
-              }}
-            >
-              Time
-            </SortOption>
-          </SortOptions>
+          <SortLabel>Sort</SortLabel>
+          <SegmentedControl
+            label="Leaderboard sort"
+            value={effectiveSortBy}
+            options={[
+              { value: "tokens", label: "Tokens" },
+              { value: "cost", label: "Cost" },
+              { value: "time", label: "Time" },
+            ]}
+            onChange={(value) => {
+              setUrlSortOverride(null);
+              setLeaderboardSort(value);
+            }}
+          />
         </SortToggleInner>
       </SearchSortRow>
 
@@ -1427,7 +1422,7 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
           <EmptyState>
             <EmptyMessage>Failed to load leaderboard</EmptyMessage>
             <EmptyHint>{error}</EmptyHint>
-            <RetryButton onClick={() => setRetryToken((prev) => prev + 1)}>
+            <RetryButton type="button" onClick={() => setRetryToken((prev) => prev + 1)}>
               Retry
             </RetryButton>
           </EmptyState>
@@ -1469,12 +1464,11 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
                     </tr>
                   </TableHead>
                   <TableBody>
-                    {sortedUsers.map((user, index) => (
+                    {sortedUsers.map((user) => (
                       <LeaderboardRow
                         key={user.userId}
                         user={user}
                         isCurrentUser={!!(currentUser && user.username === currentUser.username)}
-                        isLastRow={index === sortedUsers.length - 1}
                         showSubmissionCount={showSubmissionCount}
                         showTime={showTime}
                         onRowClick={handleRowClick}
@@ -1483,6 +1477,18 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
                   </TableBody>
                 </Table>
               </TableWrapper>
+
+              <MobileRankingList role="list" aria-label="Leaderboard rankings">
+                {sortedUsers.map((user) => (
+                  <LeaderboardMobileRow
+                    key={user.userId}
+                    user={user}
+                    isCurrentUser={!!(currentUser && user.username === currentUser.username)}
+                    showSubmissionCount={showSubmissionCount}
+                    sortBy={effectiveSortBy}
+                  />
+                ))}
+              </MobileRankingList>
 
               {data.pagination.totalPages > 1 && (
                 <PaginationContainer>
@@ -1493,6 +1499,7 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
                   </PaginationText>
                   <PaginationNav>
                     <PageButton
+                      type="button"
                       disabled={data.pagination.page <= 1}
                       onClick={() => setPage(data.pagination.page - 1)}
                       aria-label="Previous page"
@@ -1519,7 +1526,7 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
                             pages.push(<PageEllipsis key={`e${p}`}>…</PageEllipsis>);
                           }
                           pages.push(
-                            <PageButton key={p} $active={p === current} onClick={() => setPage(p)}>
+                            <PageButton type="button" key={p} $active={p === current} onClick={() => setPage(p)}>
                               {p}
                             </PageButton>
                           );
@@ -1529,6 +1536,7 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
                       })()}
                     </PaginationPages>
                     <PageButton
+                      type="button"
                       disabled={data.pagination.page >= data.pagination.totalPages}
                       onClick={() => setPage(data.pagination.page + 1)}
                       aria-label="Next page"
@@ -1554,6 +1562,7 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
               <CommandName>TOKSCALE_API_URL</CommandName>
               <CommandArg>={`${window.location.origin}`}</CommandArg>
               <CopyIconButton
+                type="button"
                 onClick={() => handleCopyCommand(`export TOKSCALE_API_URL=${window.location.origin}`)}
                 className={copiedCommand === `export TOKSCALE_API_URL=${window.location.origin}` ? "copied" : ""}
                 aria-label="Copy command"
@@ -1568,6 +1577,7 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
             <CommandName>tokscale</CommandName>
             <CommandArg>login</CommandArg>
             <CopyIconButton
+              type="button"
               onClick={() => handleCopyCommand("bunx tokscale login")}
               className={copiedCommand === "bunx tokscale login" ? "copied" : ""}
               aria-label="Copy command"
@@ -1581,6 +1591,7 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
             <CommandName>tokscale</CommandName>
             <CommandArg>submit</CommandArg>
             <CopyIconButton
+              type="button"
               onClick={() => handleCopyCommand("bunx tokscale submit")}
               className={copiedCommand === "bunx tokscale submit" ? "copied" : ""}
               aria-label="Copy command"

--- a/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
@@ -21,6 +21,7 @@ import { formatCurrency, formatNumber, formatDuration } from "@/lib/utils";
 import { useSettings } from "@/lib/useSettings";
 import { isValidSortBy, type LeaderboardSortBy } from "@/lib/leaderboard/constants";
 import { parseCustomDateRange } from "@/lib/leaderboard/dateRange";
+import type { LeaderboardData, LeaderboardUser, Period } from "@/lib/leaderboard/types";
 
 const Section = styled.div`
   display: grid;
@@ -323,10 +324,6 @@ const CostValue = styled.span`
   @media (min-width: 561px) {
     display: none;
   }
-`;
-
-const SubmitCount = styled.span`
-  color: var(--service-text-muted);
 `;
 
 const PaginationContainer = styled.div`
@@ -823,42 +820,6 @@ const PaginationPages = styled.div`
   }
 `;
 
-export type Period = "all" | "month" | "last-month" | "week" | "custom";
-
-export interface LeaderboardUser {
-  rank: number;
-  userId: string;
-  username: string;
-  displayName: string | null;
-  avatarUrl: string | null;
-  totalTokens: number;
-  totalCost: number;
-  totalActiveTimeMs: number | null;
-  submissionCount: number | null;
-  lastSubmission: string;
-}
-
-export interface LeaderboardData {
-  users: LeaderboardUser[];
-  pagination: {
-    page: number;
-    limit: number;
-    totalUsers: number;
-    totalPages: number;
-    hasNext: boolean;
-    hasPrev: boolean;
-  };
-  stats: {
-    totalTokens: number;
-    totalCost: number;
-    totalActiveTimeMs: number | null;
-    totalSubmissions: number | null;
-    uniqueUsers: number;
-  };
-  period: Period;
-  sortBy?: 'tokens' | 'cost' | 'time';
-}
-
 interface LeaderboardClientProps {
   initialData: LeaderboardData;
   currentUser: { id: string; username: string; displayName: string | null; avatarUrl: string | null } | null;
@@ -880,7 +841,6 @@ function isValidLeaderboardData(data: unknown): data is LeaderboardData {
 interface LeaderboardRowProps {
   user: LeaderboardUser;
   isCurrentUser: boolean;
-  showSubmissionCount: boolean;
   showTime: boolean;
   onRowClick: (username: string) => void;
 }
@@ -888,7 +848,6 @@ interface LeaderboardRowProps {
 const LeaderboardRow = memo(function LeaderboardRow({
   user,
   isCurrentUser,
-  showSubmissionCount,
   showTime,
   onRowClick,
 }: LeaderboardRowProps) {
@@ -946,11 +905,6 @@ const LeaderboardRow = memo(function LeaderboardRow({
           <StatSpan>{formatDuration(user.totalActiveTimeMs)}</StatSpan>
         </TableCell>
       )}
-      {showSubmissionCount && (
-        <TableCell className="text-right hidden-mobile w-24">
-          <SubmitCount>{user.submissionCount ?? "—"}</SubmitCount>
-        </TableCell>
-      )}
     </TableRow>
   );
 });
@@ -958,12 +912,10 @@ const LeaderboardRow = memo(function LeaderboardRow({
 function LeaderboardMobileRow({
   user,
   isCurrentUser,
-  showSubmissionCount,
   sortBy,
 }: {
   user: LeaderboardUser;
   isCurrentUser: boolean;
-  showSubmissionCount: boolean;
   sortBy: LeaderboardSortBy;
 }) {
   const primary = sortBy === "cost"
@@ -975,9 +927,6 @@ function LeaderboardMobileRow({
     sortBy !== "tokens" ? `${formatNumber(user.totalTokens)} tokens` : null,
     sortBy !== "cost" ? formatCurrency(user.totalCost) : null,
     sortBy !== "time" ? formatDuration(user.totalActiveTimeMs) : null,
-    showSubmissionCount && user.submissionCount !== null
-      ? `${user.submissionCount.toLocaleString("en-US")} submits`
-      : null,
   ].filter(Boolean).join(" · ");
 
   return (
@@ -1208,7 +1157,6 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
   }, [appliedFrom, appliedTo, debouncedSearch, effectiveSortBy, fetchData, isLoading, period, requestedPage, retryToken]);
 
   const sortedUsers = data.users || [];
-  const showSubmissionCount = period === "all";
   const showTime = true;
 
   const handleCopyCommand = (command: string) => {
@@ -1256,17 +1204,12 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
               </HoverTooltip>
             </MetricValue>
           </MetricItem>
-          {data.stats.totalActiveTimeMs !== null ? (
+          {data.stats.totalActiveTimeMs !== null && (
             <MetricItem>
               <MetricLabel>Active time</MetricLabel>
               <MetricValue>{formatDuration(data.stats.totalActiveTimeMs)}</MetricValue>
             </MetricItem>
-          ) : data.stats.totalSubmissions !== null ? (
-            <MetricItem>
-              <MetricLabel>Submissions</MetricLabel>
-              <MetricValue>{data.stats.totalSubmissions.toLocaleString("en-US")}</MetricValue>
-            </MetricItem>
-          ) : null}
+          )}
         </MetricStrip>
       </Section>
 
@@ -1458,9 +1401,6 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
                       {showTime && (
                         <TableHeaderCell className="text-right hidden-mobile w-24">Time</TableHeaderCell>
                       )}
-                      {showSubmissionCount && (
-                        <TableHeaderCell className="text-right hidden-mobile w-24">Submits</TableHeaderCell>
-                      )}
                     </tr>
                   </TableHead>
                   <TableBody>
@@ -1469,7 +1409,6 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
                         key={user.userId}
                         user={user}
                         isCurrentUser={!!(currentUser && user.username === currentUser.username)}
-                        showSubmissionCount={showSubmissionCount}
                         showTime={showTime}
                         onRowClick={handleRowClick}
                       />
@@ -1484,7 +1423,6 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
                     key={user.userId}
                     user={user}
                     isCurrentUser={!!(currentUser && user.username === currentUser.username)}
-                    showSubmissionCount={showSubmissionCount}
                     sortBy={effectiveSortBy}
                   />
                 ))}

--- a/packages/frontend/src/app/(main)/leaderboard/ViewSelector.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/ViewSelector.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import styled from "styled-components";
 
 // Top-of-page segmented control that swaps between the global user leaderboard
@@ -15,71 +15,83 @@ import styled from "styled-components";
 
 export type LeaderboardView = "users" | "groups";
 
-const Bar = styled.nav`
-  margin: 24px 0 0;
+const Header = styled.header`
   display: flex;
-  align-items: center;
-  gap: 16px;
-  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 24px;
 
-  @media (max-width: 480px) {
-    gap: 12px;
+  @media (max-width: 640px) {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 16px;
   }
 `;
 
-const Group = styled.div`
+const HeadingGroup = styled.div`
+  min-width: 0;
+`;
+
+const Group = styled.nav`
   display: inline-flex;
-  padding: 4px;
-  border: 1px solid var(--color-border-default);
+  flex: 0 0 auto;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--service-border);
   border-radius: 8px;
-  background: var(--color-bg-subtle);
+  background: var(--service-surface-muted);
 `;
 
 const Item = styled(Link)<{ $active: boolean }>`
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  min-height: 32px;
-  padding: 0 14px;
+  min-height: 30px;
+  padding: 0 12px;
   border-radius: 6px;
-  font-size: 13px;
-  font-weight: 600;
+  font-size: 0.8125rem;
+  font-weight: 500;
   text-decoration: none;
-  color: ${({ $active }) => ($active ? "var(--color-fg-default)" : "var(--color-fg-muted)")};
-  background: ${({ $active }) => ($active ? "var(--color-bg-default)" : "transparent")};
-  transition: background 0.12s, color 0.12s;
+  color: ${({ $active }) => ($active ? "var(--service-text)" : "var(--service-text-muted)")};
+  background: ${({ $active }) => ($active ? "var(--service-surface)" : "transparent")};
+  white-space: nowrap;
 
   &:hover {
-    color: var(--color-fg-default);
+    color: var(--service-text);
   }
 
   &:focus-visible {
-    outline: 2px solid var(--color-primary);
+    outline: 2px solid var(--service-focus);
     outline-offset: 2px;
+  }
+
+  @media (max-width: 640px) {
+    min-height: 40px;
+    padding: 0 14px;
+    font-size: 1rem;
   }
 `;
 
 const Title = styled.h1`
   margin: 0;
-  font-size: 30px;
-  font-weight: 700;
-  color: var(--color-fg-default);
-
-  @media (max-width: 480px) {
-    font-size: 24px;
-  }
+  color: var(--service-text);
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  text-wrap: balance;
 `;
 
-const VisuallyHidden = styled.span`
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
+const Description = styled.p`
+  max-width: 68ch;
+  margin: 6px 0 0;
+  color: var(--service-text-muted);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  text-wrap: pretty;
+
+  @media (max-width: 640px) {
+    font-size: 1rem;
+  }
 `;
 
 export type LeaderboardSearchParams = Record<string, string | string[] | undefined>;
@@ -120,45 +132,51 @@ export function buildLeaderboardViewHref(
   return `/leaderboard?${params.toString()}`;
 }
 
-const VIEW_LABELS: Record<LeaderboardView, string> = {
-  users: "Users",
-  groups: "Groups",
-};
-
 export default function ViewSelector({ current, searchParams }: ViewSelectorProps) {
-  const [announcement, setAnnouncement] = useState("");
-  const isFirstRender = useRef(true);
+  const liveSearchParams = useSearchParams();
+  const liveSearchParamsRecord: LeaderboardSearchParams = {};
 
-  useEffect(() => {
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
-      return;
+  liveSearchParams.forEach((value, key) => {
+    const existing = liveSearchParamsRecord[key];
+    if (existing === undefined) {
+      liveSearchParamsRecord[key] = value;
+    } else if (Array.isArray(existing)) {
+      existing.push(value);
+    } else {
+      liveSearchParamsRecord[key] = [existing, value];
     }
-    setAnnouncement(`Showing ${VIEW_LABELS[current]}`);
-  }, [current]);
+  });
+
+  const activeSearchParams = liveSearchParams.toString()
+    ? liveSearchParamsRecord
+    : searchParams;
 
   return (
-    <Bar aria-label="Leaderboard view">
-      <Title>{current === "groups" ? "Groups" : "Leaderboard"}</Title>
-      <Group>
+    <Header>
+      <HeadingGroup>
+        <Title>{current === "groups" ? "Groups" : "Leaderboard"}</Title>
+        <Description>
+          {current === "groups"
+            ? "Scoped rankings for teams, friends, and workspaces."
+            : "Global rankings across public Tokscale submissions."}
+        </Description>
+      </HeadingGroup>
+      <Group aria-label="Leaderboard view">
         <Item
-          href={buildLeaderboardViewHref(searchParams, "users")}
+          href={buildLeaderboardViewHref(activeSearchParams, "users")}
           $active={current === "users"}
           aria-current={current === "users" ? "page" : undefined}
         >
           Users
         </Item>
         <Item
-          href={buildLeaderboardViewHref(searchParams, "groups")}
+          href={buildLeaderboardViewHref(activeSearchParams, "groups")}
           $active={current === "groups"}
           aria-current={current === "groups" ? "page" : undefined}
         >
           Groups
         </Item>
       </Group>
-      <VisuallyHidden role="status" aria-live="polite">
-        {announcement}
-      </VisuallyHidden>
-    </Bar>
+    </Header>
   );
 }

--- a/packages/frontend/src/app/(main)/leaderboard/ViewSelector.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/ViewSelector.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import styled from "styled-components";
+import { SegmentButton, SegmentedGroup } from "@/components/leaderboard/RankingUI";
 
 // Top-of-page segmented control that swaps between the global user leaderboard
 // and the group browser. Pure-link nav (no client state), so SSR + back/forward
@@ -31,45 +32,6 @@ const Header = styled.header`
 
 const HeadingGroup = styled.div`
   min-width: 0;
-`;
-
-const Group = styled.nav`
-  display: inline-flex;
-  flex: 0 0 auto;
-  gap: 2px;
-  padding: 2px;
-  border: 1px solid var(--service-border);
-  border-radius: 8px;
-  background: var(--service-surface-muted);
-`;
-
-const Item = styled(Link)<{ $active: boolean }>`
-  display: inline-flex;
-  align-items: center;
-  min-height: 30px;
-  padding: 0 12px;
-  border-radius: 6px;
-  font-size: 0.8125rem;
-  font-weight: 500;
-  text-decoration: none;
-  color: ${({ $active }) => ($active ? "var(--service-text)" : "var(--service-text-muted)")};
-  background: ${({ $active }) => ($active ? "var(--service-surface)" : "transparent")};
-  white-space: nowrap;
-
-  &:hover {
-    color: var(--service-text);
-  }
-
-  &:focus-visible {
-    outline: 2px solid var(--service-focus);
-    outline-offset: 2px;
-  }
-
-  @media (max-width: 640px) {
-    min-height: 40px;
-    padding: 0 14px;
-    font-size: 1rem;
-  }
 `;
 
 const Title = styled.h1`
@@ -161,22 +123,24 @@ export default function ViewSelector({ current, searchParams }: ViewSelectorProp
             : "Global rankings across public Tokscale submissions."}
         </Description>
       </HeadingGroup>
-      <Group aria-label="Leaderboard view">
-        <Item
+      <SegmentedGroup as="nav" aria-label="Leaderboard view">
+        <SegmentButton
+          as={Link}
           href={buildLeaderboardViewHref(activeSearchParams, "users")}
           $active={current === "users"}
           aria-current={current === "users" ? "page" : undefined}
         >
           Users
-        </Item>
-        <Item
+        </SegmentButton>
+        <SegmentButton
+          as={Link}
           href={buildLeaderboardViewHref(activeSearchParams, "groups")}
           $active={current === "groups"}
           aria-current={current === "groups" ? "page" : undefined}
         >
           Groups
-        </Item>
-      </Group>
+        </SegmentButton>
+      </SegmentedGroup>
     </Header>
   );
 }

--- a/packages/frontend/src/app/(main)/leaderboard/page.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/page.tsx
@@ -34,7 +34,6 @@ function createEmptyLeaderboardData(sortBy: SortBy): LeaderboardData {
       totalTokens: 0,
       totalCost: 0,
       totalActiveTimeMs: null,
-      totalSubmissions: null,
       uniqueUsers: 0,
     },
     period: "all",

--- a/packages/frontend/src/app/(main)/leaderboard/page.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/page.tsx
@@ -1,8 +1,7 @@
 import { Suspense } from "react";
 import { cookies } from "next/headers";
 import { Navigation } from "@/components/layout/Navigation";
-import { Footer } from "@/components/layout/Footer";
-import { BlackholeHero } from "@/components/BlackholeHero";
+import { ServiceFooter } from "@/components/layout/ServiceFooter";
 import { LeaderboardSkeleton } from "@/components/Skeleton";
 import { getLeaderboardData, getUserRank } from "@/lib/leaderboard/getLeaderboard";
 import type { LeaderboardData, Period, SortBy } from "@/lib/leaderboard/types";
@@ -53,24 +52,16 @@ interface PageProps {
 
 export default function LeaderboardPage({ searchParams }: PageProps) {
   return (
-    <div
-      style={{
-        minHeight: "100vh",
-        display: "flex",
-        flexDirection: "column",
-        backgroundColor: "var(--color-bg-default)",
-      }}
-    >
+    <div className="service-page-shell">
       <Navigation />
 
-      <main className="main-container">
-        <BlackholeHero />
+      <main className="service-main" id="main-content">
         <Suspense fallback={<LeaderboardSkeleton />}>
           <LeaderboardWithPreferences searchParams={searchParams} />
         </Suspense>
       </main>
 
-      <Footer />
+      <ServiceFooter />
     </div>
   );
 }

--- a/packages/frontend/src/app/(main)/page.tsx
+++ b/packages/frontend/src/app/(main)/page.tsx
@@ -18,7 +18,6 @@ function createEmptyLeaderboardData(sortBy: "tokens" | "cost"): LeaderboardData 
       totalTokens: 0,
       totalCost: 0,
       totalActiveTimeMs: null,
-      totalSubmissions: null,
       uniqueUsers: 0,
     },
     period: "all",

--- a/packages/frontend/src/app/globals.css
+++ b/packages/frontend/src/app/globals.css
@@ -128,6 +128,31 @@ a:hover {
   width: 100%;
 }
 
+.service-page-shell {
+  isolation: isolate;
+  color-scheme: dark;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background: var(--service-canvas);
+  color: var(--service-text);
+}
+
+.service-main {
+  width: 100%;
+  max-width: 1500px;
+  flex: 1;
+  margin-right: auto;
+  margin-left: auto;
+  padding: 96px 32px 48px;
+}
+
+@media (max-width: 520px) {
+  .service-main {
+    padding: 88px 16px 40px;
+  }
+}
+
 @media (max-width: 560px) {
   .main-container {
     padding-left: 12px;

--- a/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
+++ b/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
@@ -4,6 +4,7 @@ import { useId, useMemo, useState } from "react";
 import Link from "next/link";
 import styled from "styled-components";
 import { Navigation } from "@/components/layout/Navigation";
+import { ServiceFooter } from "@/components/layout/ServiceFooter";
 import {
   createContributionRangeOptions,
   getContributionDayForDate,
@@ -360,21 +361,7 @@ export default function ProfilePageClient({
         </ContentWrapper>
       </MainContent>
 
-      <ServiceFooter>
-        <ServiceFooterInner>
-          <FooterProduct>Tokscale</FooterProduct>
-          <FooterLinks aria-label="Profile footer links">
-            <Link href="/leaderboard">Leaderboard</Link>
-            <a
-              href="https://github.com/junhoyeo/tokscale"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Source
-            </a>
-          </FooterLinks>
-        </ServiceFooterInner>
-      </ServiceFooter>
+      <ServiceFooter />
     </PageContainer>
   );
 }
@@ -852,53 +839,4 @@ const MetadataChip = styled.span`
   font-size: 13px;
   text-overflow: ellipsis;
   white-space: nowrap;
-`;
-
-const ServiceFooter = styled.footer`
-  width: 100%;
-  border-top: 1px solid var(--service-border);
-`;
-
-const ServiceFooterInner = styled.div`
-  width: 100%;
-  max-width: 1500px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  margin: 0 auto;
-  padding: 20px 32px;
-
-  @media (max-width: 520px) {
-    padding-right: 16px;
-    padding-left: 16px;
-  }
-`;
-
-const FooterProduct = styled.span`
-  color: var(--service-text-muted);
-  font-size: 13px;
-  font-weight: 500;
-`;
-
-const FooterLinks = styled.nav`
-  display: flex;
-  align-items: center;
-  gap: 16px;
-
-  a {
-    color: var(--service-text-muted);
-    font-size: 13px;
-    text-decoration: none;
-  }
-
-  a:hover {
-    color: var(--service-text);
-  }
-
-  a:focus-visible {
-    border-radius: 4px;
-    outline: 2px solid var(--service-focus);
-    outline-offset: 3px;
-  }
 `;

--- a/packages/frontend/src/components/layout/Footer.tsx
+++ b/packages/frontend/src/components/layout/Footer.tsx
@@ -1,10 +1,7 @@
 "use client";
 
-import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import styled from 'styled-components';
-
-const DEFAULT_COPYRIGHT_YEAR = 2026;
 
 const Container = styled.div`
   width: 100%;
@@ -200,11 +197,7 @@ const SpinningGlobe = styled(Image)`
 `;
 
 export function Footer() {
-  const [currentYear, setCurrentYear] = useState(DEFAULT_COPYRIGHT_YEAR);
-
-  useEffect(() => {
-    setCurrentYear(new Date().getFullYear());
-  }, []);
+  const currentYear = new Date().getFullYear();
 
   return (
     <Container>
@@ -215,6 +208,7 @@ export function Footer() {
               src="/assets/footer-logo-icon.png"
               alt="Tokscale Icon"
               fill
+              sizes="(max-width: 400px) 64px, (max-width: 560px) 80px, 108px"
             />
           </LogoContainer>
 
@@ -235,7 +229,7 @@ export function Footer() {
 
           <TextContainer>
             <CopyrightText>
-              © {currentYear} Tokscale. All rights reserved.
+              © <time dateTime={String(currentYear)} suppressHydrationWarning>{currentYear}</time> Tokscale. All rights reserved.
             </CopyrightText>
             <GitHubLink 
               href="https://github.com/junhoyeo/tokscale" 

--- a/packages/frontend/src/components/layout/ServiceFooter.tsx
+++ b/packages/frontend/src/components/layout/ServiceFooter.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import Link from "next/link";
+import styled from "styled-components";
+
+export function ServiceFooter() {
+  return (
+    <Footer>
+      <Inner>
+        <Product>Tokscale</Product>
+        <Links aria-label="Footer links">
+          <Link href="/leaderboard">Leaderboard</Link>
+          <Link href="/leaderboard?view=groups">Groups</Link>
+          <a
+            href="https://github.com/junhoyeo/tokscale"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Source
+          </a>
+        </Links>
+      </Inner>
+    </Footer>
+  );
+}
+
+const Footer = styled.footer`
+  width: 100%;
+  border-top: 1px solid var(--service-border);
+`;
+
+const Inner = styled.div`
+  width: 100%;
+  max-width: 1500px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 0 auto;
+  padding: 20px 32px;
+
+  @media (max-width: 520px) {
+    padding-right: 16px;
+    padding-left: 16px;
+  }
+`;
+
+const Product = styled.span`
+  color: var(--service-text-muted);
+  font-size: 0.8125rem;
+  font-weight: 500;
+`;
+
+const Links = styled.nav`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+
+  a {
+    color: var(--service-text-muted);
+    font-size: 0.8125rem;
+    text-decoration: none;
+  }
+
+  a:hover {
+    color: var(--service-text);
+  }
+
+  a:focus-visible {
+    border-radius: 4px;
+    outline: 2px solid var(--service-focus);
+    outline-offset: 3px;
+  }
+`;

--- a/packages/frontend/src/components/leaderboard/RankingUI.tsx
+++ b/packages/frontend/src/components/leaderboard/RankingUI.tsx
@@ -1,0 +1,443 @@
+"use client";
+
+import Link from "next/link";
+import styled from "styled-components";
+import { getGroupMonogram } from "./presentation";
+
+export const CompactBadge = styled.span`
+  display: inline-flex;
+  min-height: 22px;
+  align-items: center;
+  padding: 0 8px;
+  border: 1px solid var(--service-border);
+  border-radius: 999px;
+  background: var(--service-surface-muted);
+  color: var(--service-text-muted);
+  font-size: 0.75rem;
+  font-weight: 500;
+  white-space: nowrap;
+`;
+
+export const MetricStrip = styled.dl`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: 0;
+  border-top: 1px solid var(--service-border);
+  border-bottom: 1px solid var(--service-border);
+
+  @media (min-width: 720px) {
+    display: flex;
+    max-width: max-content;
+  }
+`;
+
+export const MetricItem = styled.div`
+  min-width: 0;
+  overflow: hidden;
+  padding: 12px 16px 12px 0;
+
+  &:nth-child(2n) {
+    padding-right: 0;
+    padding-left: 16px;
+    border-left: 1px solid var(--service-border);
+  }
+
+  &:nth-child(n + 3) {
+    border-top: 1px solid var(--service-border);
+  }
+
+  @media (min-width: 720px) {
+    min-width: 152px;
+    padding: 12px 20px;
+    border-top: 0 !important;
+
+    &:first-child {
+      padding-left: 0;
+    }
+
+    &:last-child {
+      padding-right: 0;
+    }
+
+    &:not(:first-child) {
+      border-left: 1px solid var(--service-border);
+    }
+  }
+`;
+
+export const MetricLabel = styled.dt`
+  overflow: hidden;
+  color: var(--service-text-muted);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const MetricValue = styled.dd<{ $accent?: boolean }>`
+  min-width: 0;
+  margin: 4px 0 0;
+  overflow: hidden;
+  color: ${({ $accent }) => $accent ? "var(--service-accent-hover)" : "var(--service-text)"};
+  font-size: 1.125rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  @media (max-width: 640px) {
+    font-size: 1.25rem;
+  }
+
+  @media (max-width: 360px) {
+    font-size: 1.125rem;
+  }
+`;
+
+const Mark = styled.span<{ $size: "compact" | "detail" }>`
+  display: inline-grid;
+  width: ${({ $size }) => $size === "detail" ? "64px" : "42px"};
+  height: ${({ $size }) => $size === "detail" ? "64px" : "42px"};
+  flex: 0 0 auto;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid var(--service-border-strong);
+  border-radius: ${({ $size }) => $size === "detail" ? "12px" : "9px"};
+  background: var(--service-surface-muted);
+  color: var(--service-accent-hover);
+  font-size: ${({ $size }) => $size === "detail" ? "1rem" : "0.75rem"};
+  font-weight: 600;
+  letter-spacing: 0.04em;
+`;
+
+const MarkImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
+export function GroupMark({
+  name,
+  avatarUrl,
+  size = "compact",
+}: {
+  name: string;
+  avatarUrl?: string | null;
+  size?: "compact" | "detail";
+}) {
+  return (
+    <Mark $size={size} aria-hidden="true">
+      {avatarUrl ? <MarkImage src={avatarUrl} alt="" /> : getGroupMonogram(name)}
+    </Mark>
+  );
+}
+
+export const MobileRankingList = styled.ol`
+  margin: 0;
+  padding: 0;
+
+  @media (min-width: 720px) {
+    display: none;
+  }
+`;
+
+const MobileRankingItem = styled.li`
+  list-style: none;
+
+  &:not(:last-child) {
+    border-bottom: 1px solid var(--service-border);
+  }
+`;
+
+const MobileRankingLink = styled(Link)<{ $current: boolean }>`
+  display: grid;
+  grid-template-columns: 34px 38px minmax(0, 1fr) auto;
+  grid-template-rows: auto auto;
+  gap: 3px 8px;
+  align-items: center;
+  min-height: 80px;
+  padding: 10px 8px;
+  background: ${({ $current }) => $current ? "var(--service-accent-soft)" : "transparent"};
+  color: inherit;
+  text-decoration: none;
+
+  &:focus-visible {
+    outline: 2px solid var(--service-focus);
+    outline-offset: -2px;
+  }
+`;
+
+const MobileRank = styled.span`
+  grid-row: 1 / 3;
+  align-self: center;
+  color: var(--service-text-muted);
+  font-size: 0.875rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+
+  &[data-rank="1"] { color: #f4c95d; }
+  &[data-rank="2"] { color: #c4ccda; }
+  &[data-rank="3"] { color: #d99a68; }
+`;
+
+const MobileAvatar = styled.img`
+  grid-row: 1 / 3;
+  width: 38px;
+  height: 38px;
+  align-self: center;
+  border-radius: 50%;
+  object-fit: cover;
+  outline: 1px solid var(--service-border);
+  outline-offset: -1px;
+`;
+
+const MobileIdentity = styled.div`
+  min-width: 0;
+`;
+
+const MobileName = styled.p`
+  margin: 0;
+  overflow: hidden;
+  color: var(--service-text);
+  font-size: 1rem;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const MobileUsername = styled.p`
+  margin: 0;
+  overflow: hidden;
+  color: var(--service-text-muted);
+  font-size: 0.8125rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const MobilePrimary = styled.div`
+  align-self: center;
+  text-align: right;
+`;
+
+const MobilePrimaryValue = styled.p`
+  margin: 0;
+  color: var(--service-accent-hover);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+`;
+
+const MobilePrimaryLabel = styled.p`
+  margin: 1px 0 0;
+  color: var(--service-text-muted);
+  font-size: 0.6875rem;
+  text-align: right;
+`;
+
+const MobileMeta = styled.p`
+  grid-column: 3 / 5;
+  margin: 0;
+  overflow: hidden;
+  color: var(--service-text-muted);
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export function MobileRankingRow({
+  rank,
+  href,
+  avatarUrl,
+  username,
+  displayName,
+  primaryLabel,
+  primaryValue,
+  meta,
+  isCurrentUser,
+}: {
+  rank: number;
+  href: string;
+  avatarUrl: string | null;
+  username: string;
+  displayName: string;
+  primaryLabel: string;
+  primaryValue: string;
+  meta: string;
+  isCurrentUser: boolean;
+}) {
+  return (
+    <MobileRankingItem>
+      <MobileRankingLink
+        href={href}
+        $current={isCurrentUser}
+        aria-current={isCurrentUser ? "true" : undefined}
+      >
+        <MobileRank data-rank={rank <= 3 ? rank : undefined}>#{rank}</MobileRank>
+        <MobileAvatar
+          src={avatarUrl || `https://github.com/${username}.png`}
+          alt=""
+        />
+        <MobileIdentity>
+          <MobileName>{displayName}</MobileName>
+          <MobileUsername>@{username}</MobileUsername>
+        </MobileIdentity>
+        <MobilePrimary>
+          <MobilePrimaryValue>{primaryValue}</MobilePrimaryValue>
+          <MobilePrimaryLabel>{primaryLabel}</MobilePrimaryLabel>
+        </MobilePrimary>
+        <MobileMeta>{meta}</MobileMeta>
+      </MobileRankingLink>
+    </MobileRankingItem>
+  );
+}
+
+const SegmentedGroup = styled.div`
+  display: inline-flex;
+  width: max-content;
+  max-width: 100%;
+  box-sizing: border-box;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  overflow-x: auto;
+  border: 1px solid var(--service-border);
+  border-radius: 8px;
+  background: var(--service-surface-muted);
+  scrollbar-width: none;
+  overscroll-behavior-inline: contain;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+const SegmentButton = styled.button<{ $active: boolean }>`
+  min-height: 30px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 6px;
+  background: ${({ $active }) => $active ? "var(--service-surface)" : "transparent"};
+  color: ${({ $active }) => $active ? "var(--service-text)" : "var(--service-text-muted)"};
+  font-size: 0.8125rem;
+  font-weight: 500;
+  white-space: nowrap;
+
+  &:hover {
+    color: var(--service-text);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--service-focus);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+  }
+
+  @media (max-width: 640px) {
+    min-height: 40px;
+    padding: 0 12px;
+    font-size: 1rem;
+  }
+`;
+
+export interface SegmentedOption<T extends string> {
+  value: T;
+  label: string;
+  disabled?: boolean;
+}
+
+export function SegmentedControl<T extends string>({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: T;
+  options: readonly SegmentedOption<T>[];
+  onChange: (value: T) => void;
+}) {
+  return (
+    <SegmentedGroup role="group" aria-label={label}>
+      {options.map((option) => (
+        <SegmentButton
+          key={option.value}
+          type="button"
+          $active={value === option.value}
+          aria-pressed={value === option.value}
+          disabled={option.disabled}
+          onClick={() => onChange(option.value)}
+        >
+          {option.label}
+        </SegmentButton>
+      ))}
+    </SegmentedGroup>
+  );
+}
+
+const actionStyles = `
+  display: inline-flex;
+  min-height: 36px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 12px;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+
+  &:focus-visible {
+    outline: 2px solid var(--service-focus);
+    outline-offset: 2px;
+  }
+
+  @media (max-width: 640px) {
+    min-height: 44px;
+    font-size: 1rem;
+  }
+`;
+
+export const PrimaryActionLink = styled(Link)`
+  ${actionStyles}
+  border: 1px solid var(--service-accent);
+  background: var(--service-accent);
+  color: #fff;
+
+  &:hover {
+    border-color: var(--service-accent-hover);
+    background: var(--service-accent-hover);
+  }
+`;
+
+export const SecondaryActionLink = styled(Link)`
+  ${actionStyles}
+  border: 1px solid var(--service-border-strong);
+  background: transparent;
+  color: var(--service-text);
+
+  &:hover {
+    background: var(--service-surface-muted);
+  }
+`;
+
+export const SecondaryButton = styled.button`
+  ${actionStyles}
+  border: 1px solid var(--service-border-strong);
+  background: transparent;
+  color: var(--service-text);
+
+  &:hover:not(:disabled) {
+    background: var(--service-surface-muted);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+`;

--- a/packages/frontend/src/components/leaderboard/RankingUI.tsx
+++ b/packages/frontend/src/components/leaderboard/RankingUI.tsx
@@ -293,7 +293,7 @@ export function MobileRankingRow({
   );
 }
 
-const SegmentedGroup = styled.div`
+export const SegmentedGroup = styled.div`
   display: inline-flex;
   width: max-content;
   max-width: 100%;
@@ -313,7 +313,10 @@ const SegmentedGroup = styled.div`
   }
 `;
 
-const SegmentButton = styled.button<{ $active: boolean }>`
+export const SegmentButton = styled.button<{ $active: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   min-height: 30px;
   padding: 0 10px;
   border: 0;
@@ -322,6 +325,7 @@ const SegmentButton = styled.button<{ $active: boolean }>`
   color: ${({ $active }) => $active ? "var(--service-text)" : "var(--service-text-muted)"};
   font-size: 0.8125rem;
   font-weight: 500;
+  text-decoration: none;
   white-space: nowrap;
 
   &:hover {

--- a/packages/frontend/src/components/leaderboard/presentation.ts
+++ b/packages/frontend/src/components/leaderboard/presentation.ts
@@ -1,0 +1,88 @@
+import type { Period } from "@/lib/leaderboard/types";
+
+const MONTH_NAMES = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+] as const;
+
+interface CalendarDate {
+  year: number;
+  month: number;
+  day: number;
+}
+
+function parseCalendarDate(value?: string): CalendarDate | null {
+  if (!value) return null;
+
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return { year, month, day };
+}
+
+export function getGroupMonogram(name: string): string {
+  const words = name.trim().split(/\s+/u).filter(Boolean);
+  if (words.length === 0) return "TG";
+
+  const letters = words.length > 1
+    ? [Array.from(words[0])[0], Array.from(words[1])[0]]
+    : Array.from(words[0]).slice(0, 2);
+
+  return letters.join("").toLocaleUpperCase("en-US");
+}
+
+export function formatGroupMemberCount(count: number): string {
+  const safeCount = Number.isFinite(count) ? Math.max(0, Math.trunc(count)) : 0;
+  return `${safeCount.toLocaleString("en-US")} ${safeCount === 1 ? "member" : "members"}`;
+}
+
+export function getLeaderboardPeriodLabel(
+  period: Period,
+  from?: string,
+  to?: string,
+): string {
+  if (period === "all") return "All time";
+  if (period === "last-month") return "Last month";
+  if (period === "month") return "This month";
+  if (period === "week") return "This week";
+
+  const start = parseCalendarDate(from);
+  const end = parseCalendarDate(to);
+  if (!start || !end) return "Custom range";
+
+  const startMonth = MONTH_NAMES[start.month - 1];
+  const endMonth = MONTH_NAMES[end.month - 1];
+
+  if (start.year === end.year && start.month === end.month) {
+    return `${startMonth} ${start.day}–${end.day}, ${end.year}`;
+  }
+
+  if (start.year === end.year) {
+    return `${startMonth} ${start.day}–${endMonth} ${end.day}, ${end.year}`;
+  }
+
+  return `${startMonth} ${start.day}, ${start.year}–${endMonth} ${end.day}, ${end.year}`;
+}

--- a/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
+++ b/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
@@ -1,7 +1,6 @@
 import { unstable_cache } from "next/cache";
 import { and, asc, desc, eq, gte, lte, sql } from "drizzle-orm";
 import { db, dailyBreakdown, groupMembers, submissions, users } from "@/lib/db";
-import { buildSubmissionFreshness } from "@/lib/submissionFreshness";
 import type { LeaderboardUser, Period, SortBy } from "@/lib/leaderboard/types";
 
 interface GroupLeaderboardPeriodRow {
@@ -12,9 +11,6 @@ interface GroupLeaderboardPeriodRow {
   role: string;
   tokens: number;
   cost: number;
-  updatedAt: string;
-  cliVersion: string | null;
-  schemaVersion: number;
 }
 
 interface GroupLeaderboardDbRow {
@@ -25,10 +21,6 @@ interface GroupLeaderboardDbRow {
   role: string;
   totalTokens: number | string | null;
   totalCost: number | string | null;
-  submissionCount: number | string | null;
-  lastSubmission: string;
-  cliVersion: string | null;
-  schemaVersion: number | null;
 }
 
 export interface GroupLeaderboardUser extends LeaderboardUser {
@@ -48,8 +40,6 @@ export interface GroupLeaderboardData {
   stats: {
     totalTokens: number;
     totalCost: number;
-    totalSubmissions: number | null;
-    uniqueUsers: number;
     activeUsers: number;
     totalMembers: number;
   };
@@ -108,8 +98,7 @@ function paginateRankedUsers(
   period: Period,
   sortBy: SortBy,
   search: string,
-  totalMembers: number,
-  totalSubmissions: number | null
+  totalMembers: number
 ): GroupLeaderboardData {
   const offset = (page - 1) * limit;
   const filteredUsers = usersWithRanks.filter((user) => matchesSearch(user, search));
@@ -128,8 +117,6 @@ function paginateRankedUsers(
     stats: {
       totalTokens: usersWithRanks.reduce((sum, user) => sum + user.totalTokens, 0),
       totalCost: usersWithRanks.reduce((sum, user) => sum + user.totalCost, 0),
-      totalSubmissions,
-      uniqueUsers: usersWithRanks.length,
       activeUsers: usersWithRanks.length,
       totalMembers,
     },
@@ -154,14 +141,6 @@ function buildPeriodGroupLeaderboardData(
     if (existing) {
       existing.totalTokens += row.tokens;
       existing.totalCost += row.cost;
-      if (row.updatedAt > existing.lastSubmission) {
-        existing.lastSubmission = row.updatedAt;
-        existing.submissionFreshness = buildSubmissionFreshness({
-          updatedAt: row.updatedAt,
-          cliVersion: row.cliVersion,
-          schemaVersion: row.schemaVersion,
-        });
-      }
       continue;
     }
 
@@ -174,13 +153,6 @@ function buildPeriodGroupLeaderboardData(
       totalTokens: row.tokens,
       totalCost: row.cost,
       totalActiveTimeMs: null,
-      submissionCount: null,
-      lastSubmission: row.updatedAt,
-      submissionFreshness: buildSubmissionFreshness({
-        updatedAt: row.updatedAt,
-        cliVersion: row.cliVersion,
-        schemaVersion: row.schemaVersion,
-      }),
     });
   }
 
@@ -195,8 +167,7 @@ function buildPeriodGroupLeaderboardData(
     period,
     sortBy,
     search,
-    totalMembers,
-    null
+    totalMembers
   );
 }
 
@@ -225,9 +196,6 @@ async function fetchPeriodRows(
       role: groupMembers.role,
       tokens: dailyBreakdown.tokens,
       cost: dailyBreakdown.cost,
-      updatedAt: submissions.updatedAt,
-      cliVersion: submissions.cliVersion,
-      schemaVersion: submissions.schemaVersion,
     })
     .from(dailyBreakdown)
     .innerJoin(submissions, eq(dailyBreakdown.submissionId, submissions.id))
@@ -249,11 +217,6 @@ async function fetchPeriodRows(
     role: row.role,
     tokens: Number(row.tokens) || 0,
     cost: Number(row.cost) || 0,
-    updatedAt: row.updatedAt instanceof Date
-      ? row.updatedAt.toISOString()
-      : new Date(row.updatedAt).toISOString(),
-    cliVersion: row.cliVersion,
-    schemaVersion: Number(row.schemaVersion) || 0,
   }));
 }
 
@@ -274,18 +237,6 @@ async function fetchAllTimeRows(groupId: string, sortBy: SortBy): Promise<GroupL
       role: groupMembers.role,
       totalTokens: sql<number>`SUM(${submissions.totalTokens})`.as("total_tokens"),
       totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`.as("total_cost"),
-      submissionCount: sql<number>`COALESCE(SUM(${submissions.submitCount}), 0)`.as("submission_count"),
-      lastSubmission: sql<string>`MAX(${submissions.updatedAt})`.as("last_submission"),
-      cliVersion: sql<string | null>`(
-        SELECT s2.cli_version FROM submissions s2
-        WHERE s2.user_id = ${users.id}
-        ORDER BY s2.updated_at DESC, s2.id DESC LIMIT 1
-      )`.as("cli_version"),
-      schemaVersion: sql<number>`COALESCE((
-        SELECT s2.schema_version FROM submissions s2
-        WHERE s2.user_id = ${users.id}
-        ORDER BY s2.updated_at DESC, s2.id DESC LIMIT 1
-      ), 0)`.as("schema_version"),
     })
     .from(submissions)
     .innerJoin(users, eq(submissions.userId, users.id))
@@ -314,13 +265,6 @@ async function fetchAllTimeRows(groupId: string, sortBy: SortBy): Promise<GroupL
     totalTokens: Number(row.totalTokens) || 0,
     totalCost: Number(row.totalCost) || 0,
     totalActiveTimeMs: null,
-    submissionCount: Number(row.submissionCount) || 0,
-    lastSubmission: row.lastSubmission,
-    submissionFreshness: buildSubmissionFreshness({
-      updatedAt: row.lastSubmission,
-      cliVersion: row.cliVersion,
-      schemaVersion: row.schemaVersion,
-    }),
   }));
 }
 
@@ -340,10 +284,6 @@ async function fetchGroupLeaderboardData(
   }
 
   const usersWithRanks = await fetchAllTimeRows(groupId, sortBy);
-  const totalSubmissions = usersWithRanks.reduce(
-    (sum, user) => sum + (user.submissionCount ?? 0),
-    0
-  );
 
   return paginateRankedUsers(
     usersWithRanks,
@@ -352,8 +292,7 @@ async function fetchGroupLeaderboardData(
     period,
     sortBy,
     search,
-    totalMembers,
-    totalSubmissions
+    totalMembers
   );
 }
 

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -7,7 +7,6 @@ import {
   usernameEqualsIgnoreCase,
 } from "@/lib/db/usernameLookup";
 import { eq, desc, sql, and, gte, lte } from "drizzle-orm";
-import { buildSubmissionFreshness } from "@/lib/submissionFreshness";
 import type { LeaderboardData, LeaderboardUser, Period, SortBy } from "@/lib/leaderboard/types";
 
 export type { LeaderboardData, LeaderboardUser, Period, SortBy } from "@/lib/leaderboard/types";
@@ -20,9 +19,6 @@ interface LeaderboardPeriodRow {
   tokens: number;
   cost: number;
   activeTimeMs: number | null;
-  updatedAt: string;
-  cliVersion: string | null;
-  schemaVersion: number;
 }
 
 interface PeriodDateRange {
@@ -38,9 +34,6 @@ interface PeriodLeaderboardDbRow {
   tokens: number | string | null;
   cost: number | string | null;
   activeTimeMs: number | string | null;
-  updatedAt: Date | string;
-  cliVersion: string | null;
-  schemaVersion: number | null;
 }
 
 interface AllTimeLeaderboardDbRow {
@@ -51,10 +44,6 @@ interface AllTimeLeaderboardDbRow {
   totalTokens: number | string | null;
   totalCost: number | string | null;
   totalActiveTimeMs: number | string | null;
-  submissionCount: number | string | null;
-  lastSubmission: string;
-  cliVersion: string | null;
-  schemaVersion: number | null;
 }
 
 interface RankedLeaderboardDbRow extends AllTimeLeaderboardDbRow {
@@ -160,14 +149,6 @@ function aggregatePeriodRows(
       if (row.activeTimeMs != null) {
         existing.totalActiveTimeMs = (existing.totalActiveTimeMs || 0) + row.activeTimeMs;
       }
-      if (row.updatedAt > existing.lastSubmission) {
-        existing.lastSubmission = row.updatedAt;
-        existing.submissionFreshness = buildSubmissionFreshness({
-          updatedAt: row.updatedAt,
-          cliVersion: row.cliVersion,
-          schemaVersion: row.schemaVersion,
-        });
-      }
       continue;
     }
 
@@ -179,13 +160,6 @@ function aggregatePeriodRows(
       totalTokens: row.tokens,
       totalCost: row.cost,
       totalActiveTimeMs: row.activeTimeMs,
-      submissionCount: null,
-      lastSubmission: row.updatedAt,
-      submissionFreshness: buildSubmissionFreshness({
-        updatedAt: row.updatedAt,
-        cliVersion: row.cliVersion,
-        schemaVersion: row.schemaVersion,
-      }),
     });
   }
 
@@ -245,8 +219,6 @@ function buildPeriodLeaderboardData(
       totalTokens: aggregatedUsers.reduce((sum, user) => sum + user.totalTokens, 0),
       totalCost: aggregatedUsers.reduce((sum, user) => sum + user.totalCost, 0),
       totalActiveTimeMs: aggregatedUsers.reduce((sum, user) => sum + (user.totalActiveTimeMs || 0), 0) || null,
-      // submitCount lives on the all-time submission row, so period-scoped submit totals are unavailable here.
-      totalSubmissions: null,
       uniqueUsers: aggregatedUsers.length,
     },
     period,
@@ -296,9 +268,6 @@ async function fetchPeriodLeaderboardRows(
       tokens: dailyBreakdown.tokens,
       cost: dailyBreakdown.cost,
       activeTimeMs: dailyBreakdown.activeTimeMs,
-      updatedAt: submissions.updatedAt,
-      cliVersion: submissions.cliVersion,
-      schemaVersion: submissions.schemaVersion,
     })
     .from(dailyBreakdown)
     .innerJoin(submissions, eq(dailyBreakdown.submissionId, submissions.id))
@@ -318,11 +287,6 @@ async function fetchPeriodLeaderboardRows(
     tokens: Number(row.tokens) || 0,
     cost: Number(row.cost) || 0,
     activeTimeMs: row.activeTimeMs != null ? Number(row.activeTimeMs) : null,
-    updatedAt: row.updatedAt instanceof Date
-      ? row.updatedAt.toISOString()
-      : new Date(row.updatedAt).toISOString(),
-    cliVersion: row.cliVersion,
-    schemaVersion: Number(row.schemaVersion) || 0,
   }));
 }
 
@@ -366,18 +330,6 @@ async function fetchLeaderboardData(
         totalTokens: sql<number>`SUM(${submissions.totalTokens})`.as("total_tokens"),
         totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`.as("total_cost"),
         totalActiveTimeMs: sql<number>`COALESCE(SUM(${submissions.totalActiveTimeMs}), 0)`.as("total_active_time_ms"),
-        submissionCount: sql<number>`COALESCE(SUM(${submissions.submitCount}), 0)`.as("submission_count"),
-        lastSubmission: sql<string>`MAX(${submissions.updatedAt})`.as("last_submission"),
-        cliVersion: sql<string | null>`(
-          SELECT s2.cli_version FROM submissions s2
-          WHERE s2.user_id = ${users.id}
-          ORDER BY s2.updated_at DESC LIMIT 1
-        )`.as("cli_version"),
-        schemaVersion: sql<number>`COALESCE((
-          SELECT s2.schema_version FROM submissions s2
-          WHERE s2.user_id = ${users.id}
-          ORDER BY s2.updated_at DESC LIMIT 1
-        ), 0)`.as("schema_version"),
       })
       .from(submissions)
       .innerJoin(users, eq(submissions.userId, users.id))
@@ -417,8 +369,7 @@ async function fetchLeaderboardData(
       .select({
         totalTokens: sql<number>`SUM(${submissions.totalTokens})`,
         totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`,
-        totalSubmissions: sql<number>`COUNT(${submissions.id})`,
-        uniqueUsers: sql<number>`COUNT(DISTINCT ${submissions.userId})`,
+        uniqueUsers: sql<number>`COUNT(*)`,
       })
       .from(submissions);
 
@@ -432,13 +383,6 @@ async function fetchLeaderboardData(
         totalTokens: Number(row.totalTokens) || 0,
         totalCost: Number(row.totalCost) || 0,
         totalActiveTimeMs: Number((row as AllTimeLeaderboardDbRow).totalActiveTimeMs) || null,
-        submissionCount: Number(row.submissionCount) || 0,
-        lastSubmission: row.lastSubmission,
-        submissionFreshness: buildSubmissionFreshness({
-          updatedAt: row.lastSubmission,
-          cliVersion: row.cliVersion,
-          schemaVersion: row.schemaVersion,
-        }),
       })),
       pagination: {
         page,
@@ -452,7 +396,6 @@ async function fetchLeaderboardData(
         totalTokens: Number(globalStats[0]?.totalTokens) || 0,
         totalCost: Number(globalStats[0]?.totalCost) || 0,
         totalActiveTimeMs: null,
-        totalSubmissions: Number(globalStats[0]?.totalSubmissions) || 0,
         uniqueUsers: Number(globalStats[0]?.uniqueUsers) || 0,
       },
       period,
@@ -471,18 +414,6 @@ async function fetchLeaderboardData(
       totalTokens: sql<number>`SUM(${submissions.totalTokens})`.as("total_tokens"),
       totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`.as("total_cost"),
       totalActiveTimeMs: sql<number>`COALESCE(SUM(${submissions.totalActiveTimeMs}), 0)`.as("total_active_time_ms"),
-      submissionCount: sql<number>`COALESCE(SUM(${submissions.submitCount}), 0)`.as("submission_count"),
-      lastSubmission: sql<string>`MAX(${submissions.updatedAt})`.as("last_submission"),
-      cliVersion: sql<string | null>`(
-        SELECT s2.cli_version FROM submissions s2
-        WHERE s2.user_id = ${users.id}
-        ORDER BY s2.updated_at DESC LIMIT 1
-      )`.as("cli_version"),
-      schemaVersion: sql<number>`COALESCE((
-        SELECT s2.schema_version FROM submissions s2
-        WHERE s2.user_id = ${users.id}
-        ORDER BY s2.updated_at DESC LIMIT 1
-      ), 0)`.as("schema_version"),
     })
     .from(submissions)
     .innerJoin(users, eq(submissions.userId, users.id))
@@ -501,8 +432,7 @@ async function fetchLeaderboardData(
       .select({
         totalTokens: sql<number>`SUM(${submissions.totalTokens})`,
         totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`,
-        totalSubmissions: sql<number>`COUNT(${submissions.id})`,
-        uniqueUsers: sql<number>`COUNT(DISTINCT ${submissions.userId})`,
+        uniqueUsers: sql<number>`COUNT(*)`,
       })
       .from(submissions),
   ]);
@@ -520,13 +450,6 @@ async function fetchLeaderboardData(
       totalTokens: Number(row.totalTokens) || 0,
       totalCost: Number(row.totalCost) || 0,
       totalActiveTimeMs: Number(row.totalActiveTimeMs) || null,
-      submissionCount: Number(row.submissionCount) || 0,
-      lastSubmission: row.lastSubmission,
-      submissionFreshness: buildSubmissionFreshness({
-        updatedAt: row.lastSubmission,
-        cliVersion: row.cliVersion,
-        schemaVersion: row.schemaVersion,
-      }),
     })),
     pagination: {
       page,
@@ -540,7 +463,6 @@ async function fetchLeaderboardData(
       totalTokens: Number(globalStats[0]?.totalTokens) || 0,
       totalCost: Number(globalStats[0]?.totalCost) || 0,
       totalActiveTimeMs: null,
-      totalSubmissions: Number(globalStats[0]?.totalSubmissions) || 0,
       uniqueUsers: Number(globalStats[0]?.uniqueUsers) || 0,
     },
     period,
@@ -604,18 +526,6 @@ async function fetchUserRank(
       totalTokens: sql<number>`SUM(${submissions.totalTokens})`.as("total_tokens"),
       totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`.as("total_cost"),
       totalActiveTimeMs: sql<number>`COALESCE(SUM(${submissions.totalActiveTimeMs}), 0)`.as("total_active_time_ms"),
-      submissionCount: sql<number>`COALESCE(SUM(${submissions.submitCount}), 0)`.as("submission_count"),
-      lastSubmission: sql<string>`MAX(${submissions.updatedAt})`.as("last_submission"),
-      cliVersion: sql<string | null>`(
-        SELECT s2.cli_version FROM submissions s2
-        WHERE s2.user_id = ${user.id}
-        ORDER BY s2.updated_at DESC LIMIT 1
-      )`.as("cli_version"),
-      schemaVersion: sql<number>`COALESCE((
-        SELECT s2.schema_version FROM submissions s2
-        WHERE s2.user_id = ${user.id}
-        ORDER BY s2.updated_at DESC LIMIT 1
-      ), 0)`.as("schema_version"),
     })
     .from(submissions)
     .where(eq(submissions.userId, user.id));
@@ -667,13 +577,6 @@ async function fetchUserRank(
     totalTokens: userTotalTokens,
     totalCost: userTotalCost,
     totalActiveTimeMs: userTotalActiveTimeMs || null,
-    submissionCount: Number(userStats.submissionCount) || 0,
-    lastSubmission: userStats.lastSubmission,
-    submissionFreshness: buildSubmissionFreshness({
-      updatedAt: userStats.lastSubmission,
-      cliVersion: userStats.cliVersion,
-      schemaVersion: userStats.schemaVersion,
-    }),
   };
 }
 

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -369,7 +369,7 @@ async function fetchLeaderboardData(
       .select({
         totalTokens: sql<number>`SUM(${submissions.totalTokens})`,
         totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`,
-        uniqueUsers: sql<number>`COUNT(*)`,
+        uniqueUsers: sql<number>`COUNT(DISTINCT ${submissions.userId})`,
       })
       .from(submissions);
 
@@ -432,7 +432,7 @@ async function fetchLeaderboardData(
       .select({
         totalTokens: sql<number>`SUM(${submissions.totalTokens})`,
         totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`,
-        uniqueUsers: sql<number>`COUNT(*)`,
+        uniqueUsers: sql<number>`COUNT(DISTINCT ${submissions.userId})`,
       })
       .from(submissions),
   ]);

--- a/packages/frontend/src/lib/leaderboard/types.ts
+++ b/packages/frontend/src/lib/leaderboard/types.ts
@@ -1,5 +1,3 @@
-import type { SubmissionFreshness } from "@/lib/submissionFreshness";
-
 export type Period = "all" | "month" | "last-month" | "week" | "custom";
 export type SortBy = "tokens" | "cost" | "time";
 
@@ -12,9 +10,6 @@ export interface LeaderboardUser {
   totalTokens: number;
   totalCost: number;
   totalActiveTimeMs: number | null;
-  submissionCount: number | null;
-  lastSubmission: string;
-  submissionFreshness: SubmissionFreshness | null;
 }
 
 export interface LeaderboardData {
@@ -31,7 +26,6 @@ export interface LeaderboardData {
     totalTokens: number;
     totalCost: number;
     totalActiveTimeMs: number | null;
-    totalSubmissions: number | null;
     uniqueUsers: number;
   };
   period: Period;


### PR DESCRIPTION
## Summary

- Remove the black-hole hero from `/leaderboard` and move rankings onto the compact service shell shared with public profiles.
- Keep rank, identity, tokens, cost, and active time available in responsive global ranking rows without page-level horizontal scrolling.
- Remove submission volume from global and scoped rankings, and narrow their queries/API payloads so unused count and freshness metadata is no longer selected or returned.
- Preserve live range, sort, and search state when navigating between the Users and Groups views.
- Replace generic group gradients and tall cards with deterministic group marks, bounded descriptions, compact membership facts, responsive scoped rankings, and the previously missing group pagination controls.
- Align group discovery, detail, create, join, and invite states around shared controls, fact strips, mobile rows, and the compact service footer.

## Stack

This is a stacked follow-up to #857 and intentionally targets `feat/compact-user-profiles`. Review or merge the parent profile PR first; this PR contains only the leaderboard and group follow-up commits.

## Validation

- `bun run test` — 61 files and 565 tests passed.
- Focused leaderboard regression suite — 22 tests passed.
- `bun run lint` — zero errors; six unchanged warnings remain outside this change.
- `bun run build` — production build and Next.js type-check passed.
- `bunx tsc --noEmit --pretty false` — only the existing test-mock errors at `__tests__/api/groupMemberRoleRoute.test.ts:159-160`; this branch does not modify that file.
- Actual-data API checks confirmed the reduced global and group response shapes.
- Actual-data browser checks covered global range/sort/search, Users/Groups URL preservation, public group navigation, scoped range/sort/search and empty states, invalid invite handling, labeled form controls, and root overflow at 320px and 390px.
- Visual verdict passed at 96/100 across 1440px desktop plus 390px and 320px mobile captures.

## Constraints

- The public leaderboard JSON intentionally drops `submissionCount`, `lastSubmission`, `submissionFreshness`, and `totalSubmissions`; profile and embed contracts remain unchanged.
- `COUNT(*)` represents unique ranked users because `submissions.user_id` has a database unique constraint.
- No database schema, authentication, or dependency changes.
- Existing 50-row leaderboard pagination and persisted sort behavior are preserved.
