### PR TITLE
feat(leaderboard): drop estimated time as a public metric

### DIFF
--- a/packages/frontend/__tests__/api/leaderboard.test.ts
+++ b/packages/frontend/__tests__/api/leaderboard.test.ts
@@ -31,7 +31,6 @@ describe("GET /api/leaderboard", () => {
           avatarUrl: null,
           totalTokens: 1200,
           totalCost: 12.5,
-          totalActiveTimeMs: 3600000,
         },
       ],
       pagination: {
@@ -45,7 +44,6 @@ describe("GET /api/leaderboard", () => {
       stats: {
         totalTokens: 1200,
         totalCost: 12.5,
-        totalActiveTimeMs: null,
         uniqueUsers: 1,
       },
       period: "all",
@@ -73,7 +71,6 @@ describe("GET /api/leaderboard", () => {
       "avatarUrl",
       "displayName",
       "rank",
-      "totalActiveTimeMs",
       "totalCost",
       "totalTokens",
       "userId",
@@ -81,7 +78,7 @@ describe("GET /api/leaderboard", () => {
     ]);
   });
 
-  it("accepts time sort requests", async () => {
+  it("falls back to tokens sort for retired time sort links", async () => {
     getLeaderboardData.mockResolvedValue({
       users: [],
       pagination: {
@@ -95,11 +92,10 @@ describe("GET /api/leaderboard", () => {
       stats: {
         totalTokens: 0,
         totalCost: 0,
-        totalActiveTimeMs: 0,
         uniqueUsers: 0,
       },
       period: "all",
-      sortBy: "time",
+      sortBy: "tokens",
     });
 
     const response = await GET(
@@ -111,7 +107,7 @@ describe("GET /api/leaderboard", () => {
       "all",
       1,
       50,
-      "time",
+      "tokens",
       "",
       undefined,
       undefined,
@@ -132,7 +128,6 @@ describe("GET /api/leaderboard", () => {
       stats: {
         totalTokens: 0,
         totalCost: 0,
-        totalActiveTimeMs: 0,
         uniqueUsers: 0,
       },
       period: "all",
@@ -169,7 +164,6 @@ describe("GET /api/leaderboard", () => {
       stats: {
         totalTokens: 0,
         totalCost: 0,
-        totalActiveTimeMs: 0,
         uniqueUsers: 0,
       },
       period: "all",

--- a/packages/frontend/__tests__/api/usersProfile.test.ts
+++ b/packages/frontend/__tests__/api/usersProfile.test.ts
@@ -45,7 +45,6 @@ const mockState = vi.hoisted(() => {
       submissionId: "dailyBreakdown.submissionId",
       date: "dailyBreakdown.date",
       timestampMs: "dailyBreakdown.timestampMs",
-      activeTimeMs: "dailyBreakdown.activeTimeMs",
       tokens: "dailyBreakdown.tokens",
       cost: "dailyBreakdown.cost",
       inputTokens: "dailyBreakdown.inputTokens",
@@ -373,7 +372,6 @@ describe("GET /api/users/[username]", () => {
         submissionCount: 2,
         earliestDate: "2026-04-30",
         latestDate: "2026-04-30",
-        totalActiveTimeMs: 0,
         sessionCount: 0,
       },
     ]);
@@ -609,7 +607,6 @@ describe("GET /api/users/[username]", () => {
         submissionCount: 3,
         earliestDate: "2026-01-01",
         latestDate: "2026-06-28",
-        totalActiveTimeMs: 1200000,
         sessionCount: 8,
       },
     ]);
@@ -626,7 +623,6 @@ describe("GET /api/users/[username]", () => {
       {
         date: "2026-06-22",
         timestampMs: 100,
-        activeTimeMs: 300000,
         tokens: 200,
         cost: "2.0000",
         inputTokens: 120,
@@ -659,7 +655,6 @@ describe("GET /api/users/[username]", () => {
       {
         date: "2026-06-28",
         timestampMs: 200,
-        activeTimeMs: 600000,
         tokens: 300,
         cost: "3.0000",
         inputTokens: 180,
@@ -719,7 +714,6 @@ describe("GET /api/users/[username]", () => {
         cacheWriteTokens: 30,
         reasoningTokens: 15,
         activeDays: 2,
-        totalActiveTimeMs: 900000,
         sessionCount: 0,
       }),
     );

--- a/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
@@ -237,7 +237,6 @@ describe("group leaderboard data", () => {
       "displayName",
       "rank",
       "role",
-      "totalActiveTimeMs",
       "totalCost",
       "totalTokens",
       "userId",

--- a/packages/frontend/__tests__/lib/getLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboard.test.ts
@@ -22,7 +22,6 @@ const mockState = vi.hoisted(() => {
       date: "dailyBreakdown.date",
       tokens: "dailyBreakdown.tokens",
       cost: "dailyBreakdown.cost",
-      activeTimeMs: "dailyBreakdown.activeTimeMs",
     },
   };
 
@@ -163,7 +162,6 @@ describe("period leaderboard data", () => {
       avatarUrl: null,
       tokens: 100,
       cost: 1.25,
-      activeTimeMs: 10,
     },
     {
       userId: "user-alice",
@@ -172,7 +170,6 @@ describe("period leaderboard data", () => {
       avatarUrl: null,
       tokens: 150,
       cost: 1.75,
-      activeTimeMs: 15,
     },
     {
       userId: "user-bob",
@@ -181,7 +178,6 @@ describe("period leaderboard data", () => {
       avatarUrl: null,
       tokens: 1000,
       cost: 9.5,
-      activeTimeMs: 100,
     },
   ];
 
@@ -207,27 +203,23 @@ describe("period leaderboard data", () => {
       username: "bob",
       totalTokens: 1000,
       totalCost: 9.5,
-      totalActiveTimeMs: 100,
     });
     expect(leaderboard.users[1]).toMatchObject({
       rank: 2,
       username: "alice",
       totalTokens: 250,
       totalCost: 3,
-      totalActiveTimeMs: 25,
     });
     expect(Object.keys(leaderboard.users[0]).sort()).toEqual([
       "avatarUrl",
       "displayName",
       "rank",
-      "totalActiveTimeMs",
       "totalCost",
       "totalTokens",
       "userId",
       "username",
     ]);
     expect(leaderboard.stats).toEqual({
-      totalActiveTimeMs: 125,
       totalTokens: 1250,
       totalCost: 12.5,
       uniqueUsers: 2,
@@ -239,7 +231,6 @@ describe("period leaderboard data", () => {
       "avatarUrl",
       "tokens",
       "cost",
-      "activeTimeMs",
     ]);
   });
 
@@ -306,7 +297,6 @@ describe("period leaderboard data", () => {
       username: "alice",
       totalTokens: 250,
       totalCost: 3,
-      totalActiveTimeMs: 25,
     });
   });
 
@@ -337,7 +327,6 @@ describe("period leaderboard data", () => {
         avatarUrl: null,
         tokens: 50,
         cost: 0.5,
-        activeTimeMs: 5,
       },
     ]);
 

--- a/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
@@ -225,7 +225,6 @@ describe("all-time leaderboard queries", () => {
         avatarUrl: null,
         totalTokens: 5000,
         totalCost: 50,
-        totalActiveTimeMs: 500,
       },
       {
         rank: 2,
@@ -235,7 +234,6 @@ describe("all-time leaderboard queries", () => {
         avatarUrl: null,
         totalTokens: 3000,
         totalCost: 40,
-        totalActiveTimeMs: 400,
       },
       {
         rank: 2,
@@ -245,7 +243,6 @@ describe("all-time leaderboard queries", () => {
         avatarUrl: null,
         totalTokens: 3000,
         totalCost: 30,
-        totalActiveTimeMs: 300,
       },
     ]);
     mockState.pushAwaitedResult([
@@ -270,7 +267,6 @@ describe("all-time leaderboard queries", () => {
         avatarUrl: null,
         totalTokens: 3000,
         totalCost: 40,
-        totalActiveTimeMs: 400,
       },
       {
         rank: 2,
@@ -280,7 +276,6 @@ describe("all-time leaderboard queries", () => {
         avatarUrl: null,
         totalTokens: 3000,
         totalCost: 30,
-        totalActiveTimeMs: 300,
       },
     ]);
     mockState.pushAwaitedResult([{ count: 2 }]);
@@ -309,7 +304,6 @@ describe("all-time leaderboard queries", () => {
       {
         totalTokens: 3000,
         totalCost: 40,
-        totalActiveTimeMs: 400,
       },
     ]);
     mockState.pushAwaitedResult([{ count: 1 }]);
@@ -333,7 +327,6 @@ describe("all-time leaderboard queries", () => {
         avatarUrl: null,
         totalTokens: 3000,
         totalCost: 30,
-        totalActiveTimeMs: 300,
       },
     ]);
     mockState.pushAwaitedResult([
@@ -353,7 +346,6 @@ describe("all-time leaderboard queries", () => {
       "avatarUrl",
       "totalTokens",
       "totalCost",
-      "totalActiveTimeMs",
     ]);
     expect(selectedKeys(1)).toEqual([
       "totalTokens",
@@ -364,7 +356,6 @@ describe("all-time leaderboard queries", () => {
       "avatarUrl",
       "displayName",
       "rank",
-      "totalActiveTimeMs",
       "totalCost",
       "totalTokens",
       "userId",
@@ -373,7 +364,6 @@ describe("all-time leaderboard queries", () => {
     expect(leaderboard.stats).toEqual({
       totalTokens: 3000,
       totalCost: 30,
-      totalActiveTimeMs: null,
       uniqueUsers: 1,
     });
 
@@ -391,7 +381,6 @@ describe("all-time leaderboard queries", () => {
       {
         totalTokens: 3000,
         totalCost: 30,
-        totalActiveTimeMs: 300,
       },
     ]);
     mockState.pushAwaitedResult([
@@ -405,13 +394,11 @@ describe("all-time leaderboard queries", () => {
     expect(selectedKeys(1)).toEqual([
       "totalTokens",
       "totalCost",
-      "totalActiveTimeMs",
     ]);
     expect(Object.keys(rank || {}).sort()).toEqual([
       "avatarUrl",
       "displayName",
       "rank",
-      "totalActiveTimeMs",
       "totalCost",
       "totalTokens",
       "userId",
@@ -432,7 +419,6 @@ describe("all-time leaderboard queries", () => {
       {
         totalTokens: 1200,
         totalCost: 12,
-        totalActiveTimeMs: 0,
       },
     ]);
     mockState.pushAwaitedResult([{ count: 0 }]);
@@ -507,7 +493,6 @@ describe("all-time cost aggregation precision across query shapes (numeric overf
       {
         totalTokens: 3000,
         totalCost: 40,
-        totalActiveTimeMs: 0,
       },
     ]);
     mockState.pushAwaitedResult([{ count: 0 }]);

--- a/packages/frontend/__tests__/lib/leaderboardConstants.test.ts
+++ b/packages/frontend/__tests__/lib/leaderboardConstants.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSortByParam } from "@/lib/leaderboard/constants";
+
+describe("resolveSortByParam", () => {
+  it("keeps absent values available for persisted preference fallback", () => {
+    expect(resolveSortByParam(null)).toBeNull();
+    expect(resolveSortByParam(undefined)).toBeNull();
+  });
+
+  it("preserves supported explicit sort values", () => {
+    expect(resolveSortByParam("tokens")).toBe("tokens");
+    expect(resolveSortByParam("cost")).toBe("cost");
+  });
+
+  it("maps retired and unknown explicit values to tokens", () => {
+    expect(resolveSortByParam("time")).toBe("tokens");
+    expect(resolveSortByParam("unknown")).toBe("tokens");
+    expect(resolveSortByParam("")).toBe("tokens");
+  });
+});

--- a/packages/frontend/__tests__/lib/leaderboardViewSelector.test.ts
+++ b/packages/frontend/__tests__/lib/leaderboardViewSelector.test.ts
@@ -9,7 +9,7 @@ describe("leaderboard view selector links", () => {
         period: "custom",
         from: "2026-01-01",
         to: "2026-01-31",
-        sortBy: "time",
+        sortBy: "cost",
         search: "alice",
         page: "3",
       },
@@ -22,7 +22,7 @@ describe("leaderboard view selector links", () => {
     expect(url.searchParams.get("period")).toBe("custom");
     expect(url.searchParams.get("from")).toBe("2026-01-01");
     expect(url.searchParams.get("to")).toBe("2026-01-31");
-    expect(url.searchParams.get("sortBy")).toBe("time");
+    expect(url.searchParams.get("sortBy")).toBe("cost");
     expect(url.searchParams.get("search")).toBe("alice");
     expect(url.searchParams.has("page")).toBe(false);
   });

--- a/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
@@ -19,7 +19,10 @@ import {
 import { getLeaderboardPeriodLabel } from "@/components/leaderboard/presentation";
 import { formatCurrency, formatNumber } from "@/lib/utils";
 import { useSettings } from "@/lib/useSettings";
-import { isValidSortBy, type LeaderboardSortBy } from "@/lib/leaderboard/constants";
+import {
+  resolveSortByParam,
+  type LeaderboardSortBy,
+} from "@/lib/leaderboard/constants";
 import { parseCustomDateRange } from "@/lib/leaderboard/dateRange";
 import type { LeaderboardData, LeaderboardUser, Period } from "@/lib/leaderboard/types";
 
@@ -948,7 +951,7 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
   const urlPeriod = parsePeriodParam(searchParams.get("period"));
   const urlPage = searchParams.get("page") ? Math.max(1, Number(searchParams.get("page")) || 1) : null;
   const sortByParam = searchParams.get("sortBy");
-  const urlSortBy = isValidSortBy(sortByParam) ? sortByParam : null;
+  const urlSortBy = resolveSortByParam(sortByParam);
   const urlFrom = searchParams.get("from") || "";
   const urlTo = searchParams.get("to") || "";
   const urlSearch = searchParams.get("search")?.trim() || "";

--- a/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
@@ -17,7 +17,7 @@ import {
   SegmentedControl,
 } from "@/components/leaderboard/RankingUI";
 import { getLeaderboardPeriodLabel } from "@/components/leaderboard/presentation";
-import { formatCurrency, formatNumber, formatDuration } from "@/lib/utils";
+import { formatCurrency, formatNumber } from "@/lib/utils";
 import { useSettings } from "@/lib/useSettings";
 import { isValidSortBy, type LeaderboardSortBy } from "@/lib/leaderboard/constants";
 import { parseCustomDateRange } from "@/lib/leaderboard/dateRange";
@@ -823,7 +823,7 @@ const PaginationPages = styled.div`
 interface LeaderboardClientProps {
   initialData: LeaderboardData;
   currentUser: { id: string; username: string; displayName: string | null; avatarUrl: string | null } | null;
-  initialSortBy: 'tokens' | 'cost' | 'time';
+  initialSortBy: LeaderboardSortBy;
   initialUserRank: LeaderboardUser | null;
 }
 
@@ -841,14 +841,12 @@ function isValidLeaderboardData(data: unknown): data is LeaderboardData {
 interface LeaderboardRowProps {
   user: LeaderboardUser;
   isCurrentUser: boolean;
-  showTime: boolean;
   onRowClick: (username: string) => void;
 }
 
 const LeaderboardRow = memo(function LeaderboardRow({
   user,
   isCurrentUser,
-  showTime,
   onRowClick,
 }: LeaderboardRowProps) {
   const formattedTokens = useMemo(() => user.totalTokens.toLocaleString('en-US'), [user.totalTokens]);
@@ -900,11 +898,6 @@ const LeaderboardRow = memo(function LeaderboardRow({
           </CostValue>
         </CombinedValueContainer>
       </TableCell>
-      {showTime && (
-        <TableCell className="text-right hidden-mobile w-24">
-          <StatSpan>{formatDuration(user.totalActiveTimeMs)}</StatSpan>
-        </TableCell>
-      )}
     </TableRow>
   );
 });
@@ -920,14 +913,10 @@ function LeaderboardMobileRow({
 }) {
   const primary = sortBy === "cost"
     ? { label: "Cost", value: formatCurrency(user.totalCost) }
-    : sortBy === "time"
-      ? { label: "Active time", value: formatDuration(user.totalActiveTimeMs) }
-      : { label: "Tokens", value: formatNumber(user.totalTokens) };
-  const secondary = [
-    sortBy !== "tokens" ? `${formatNumber(user.totalTokens)} tokens` : null,
-    sortBy !== "cost" ? formatCurrency(user.totalCost) : null,
-    sortBy !== "time" ? formatDuration(user.totalActiveTimeMs) : null,
-  ].filter(Boolean).join(" · ");
+    : { label: "Tokens", value: formatNumber(user.totalTokens) };
+  const secondary = sortBy === "cost"
+    ? `${formatNumber(user.totalTokens)} tokens`
+    : formatCurrency(user.totalCost);
 
   return (
     <MobileRankingRow
@@ -1157,7 +1146,6 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
   }, [appliedFrom, appliedTo, debouncedSearch, effectiveSortBy, fetchData, isLoading, period, requestedPage, retryToken]);
 
   const sortedUsers = data.users || [];
-  const showTime = true;
 
   const handleCopyCommand = (command: string) => {
     navigator.clipboard.writeText(command);
@@ -1204,12 +1192,6 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
               </HoverTooltip>
             </MetricValue>
           </MetricItem>
-          {data.stats.totalActiveTimeMs !== null && (
-            <MetricItem>
-              <MetricLabel>Active time</MetricLabel>
-              <MetricValue>{formatDuration(data.stats.totalActiveTimeMs)}</MetricValue>
-            </MetricItem>
-          )}
         </MetricStrip>
       </Section>
 
@@ -1348,7 +1330,6 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
             options={[
               { value: "tokens", label: "Tokens" },
               { value: "cost", label: "Cost" },
-              { value: "time", label: "Time" },
             ]}
             onChange={(value) => {
               setUrlSortOverride(null);
@@ -1398,9 +1379,6 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
                       <TableHeaderCell>User</TableHeaderCell>
                       <TableHeaderCell className="text-right hidden-cost-mobile">Cost</TableHeaderCell>
                       <TableHeaderCell className="text-right">Tokens</TableHeaderCell>
-                      {showTime && (
-                        <TableHeaderCell className="text-right hidden-mobile w-24">Time</TableHeaderCell>
-                      )}
                     </tr>
                   </TableHead>
                   <TableBody>
@@ -1409,7 +1387,6 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
                         key={user.userId}
                         user={user}
                         isCurrentUser={!!(currentUser && user.username === currentUser.username)}
-                        showTime={showTime}
                         onRowClick={handleRowClick}
                       />
                     ))}

--- a/packages/frontend/src/app/(main)/leaderboard/page.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/page.tsx
@@ -6,7 +6,10 @@ import { LeaderboardSkeleton } from "@/components/Skeleton";
 import { getLeaderboardData, getUserRank } from "@/lib/leaderboard/getLeaderboard";
 import type { LeaderboardData, Period, SortBy } from "@/lib/leaderboard/types";
 import { getSession } from "@/lib/auth/session";
-import { SORT_BY_COOKIE_NAME, isValidSortBy } from "@/lib/leaderboard/constants";
+import {
+  SORT_BY_COOKIE_NAME,
+  resolveSortByParam,
+} from "@/lib/leaderboard/constants";
 import { parseCustomDateRange } from "@/lib/leaderboard/dateRange";
 import { listPublicGroups, listUserGroups } from "@/lib/groups/queries";
 import LeaderboardClient from "./LeaderboardClient";
@@ -92,11 +95,7 @@ async function LeaderboardWithPreferences({
     typeof searchParams.search === "string" ? searchParams.search.trim() : "";
 
   const sortBy: SortBy =
-    sortByParam && isValidSortBy(sortByParam)
-      ? sortByParam
-      : isValidSortBy(sortByCookie)
-      ? sortByCookie
-      : "tokens";
+    resolveSortByParam(sortByParam) ?? resolveSortByParam(sortByCookie) ?? "tokens";
 
   let period: Period =
     periodParam && VALID_PERIODS.includes(periodParam as Period)

--- a/packages/frontend/src/app/(main)/leaderboard/page.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/page.tsx
@@ -33,7 +33,6 @@ function createEmptyLeaderboardData(sortBy: SortBy): LeaderboardData {
     stats: {
       totalTokens: 0,
       totalCost: 0,
-      totalActiveTimeMs: null,
       uniqueUsers: 0,
     },
     period: "all",

--- a/packages/frontend/src/app/(main)/page.tsx
+++ b/packages/frontend/src/app/(main)/page.tsx
@@ -17,7 +17,6 @@ function createEmptyLeaderboardData(sortBy: "tokens" | "cost"): LeaderboardData 
     stats: {
       totalTokens: 0,
       totalCost: 0,
-      totalActiveTimeMs: null,
       uniqueUsers: 0,
     },
     period: "all",

--- a/packages/frontend/src/app/api/leaderboard/route.ts
+++ b/packages/frontend/src/app/api/leaderboard/route.ts
@@ -6,7 +6,7 @@ import { parseCustomDateRange } from "@/lib/leaderboard/dateRange";
 export const revalidate = 60;
 
 const VALID_PERIODS: Period[] = ["all", "month", "last-month", "week", "custom"];
-const VALID_SORT_BY: SortBy[] = ["tokens", "cost", "time"];
+const VALID_SORT_BY: SortBy[] = ["tokens", "cost"];
 
 function parseIntSafe(value: string | null, defaultValue: number): number {
   if (!value) return defaultValue;

--- a/packages/frontend/src/app/api/leaderboard/user/[username]/route.ts
+++ b/packages/frontend/src/app/api/leaderboard/user/[username]/route.ts
@@ -6,7 +6,7 @@ import { isValidGitHubUsername } from "@/lib/validation/username";
 export const revalidate = 60;
 
 const VALID_PERIODS: Period[] = ["all", "month", "last-month", "week", "custom"];
-const VALID_SORT_BY: SortBy[] = ["tokens", "cost", "time"];
+const VALID_SORT_BY: SortBy[] = ["tokens", "cost"];
 
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 

--- a/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
+++ b/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
@@ -28,7 +28,6 @@ import {
   type ProfileUser,
 } from "@/components/profile";
 import type { DailyContribution } from "@/lib/types";
-import { formatDuration } from "@/lib/format";
 import { useSettings } from "@/lib/useSettings";
 
 type ProfilePeriod = "all" | "week" | "month";
@@ -52,7 +51,6 @@ export interface ProfileData {
     reasoningTokens?: number;
     submissionCount: number;
     activeDays: number;
-    totalActiveTimeMs: number;
     sessionCount: number;
   };
   dateRange: {
@@ -198,7 +196,6 @@ export default function ProfilePageClient({
       reasoningTokens: data.stats.reasoningTokens ?? 0,
       activeDays: data.stats.activeDays,
       submissionCount: data.stats.submissionCount,
-      totalActiveTimeMs: data.stats.totalActiveTimeMs,
       sessionCount: data.stats.sessionCount,
     }),
     [data.stats],
@@ -383,17 +380,10 @@ function ProfileInsights({
 }) {
   const rangeLabel =
     period === "all" ? "1y" : period === "month" ? "30d" : "7d";
-  const activityLabel = period === "all" ? "all-time" : rangeLabel;
   const insights = [
     {
       label: `Favorite model (${rangeLabel})`,
       value: favoriteModel ?? "Not available",
-    },
-    {
-      label: `Active time (${activityLabel})`,
-      value: stats.totalActiveTimeMs
-        ? formatDuration(stats.totalActiveTimeMs)
-        : "Not available",
     },
     period === "all"
       ? {

--- a/packages/frontend/src/components/profile/types.ts
+++ b/packages/frontend/src/components/profile/types.ts
@@ -16,7 +16,6 @@ export interface ProfileStatsData {
   reasoningTokens?: number;
   activeDays: number;
   submissionCount?: number;
-  totalActiveTimeMs?: number;
   sessionCount?: number;
 }
 

--- a/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
+++ b/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
@@ -152,7 +152,6 @@ function buildPeriodGroupLeaderboardData(
       role: row.role,
       totalTokens: row.tokens,
       totalCost: row.cost,
-      totalActiveTimeMs: null,
     });
   }
 
@@ -264,7 +263,6 @@ async function fetchAllTimeRows(groupId: string, sortBy: SortBy): Promise<GroupL
     role: row.role,
     totalTokens: Number(row.totalTokens) || 0,
     totalCost: Number(row.totalCost) || 0,
-    totalActiveTimeMs: null,
   }));
 }
 

--- a/packages/frontend/src/lib/leaderboard/constants.ts
+++ b/packages/frontend/src/lib/leaderboard/constants.ts
@@ -1,7 +1,7 @@
-export type LeaderboardSortBy = 'tokens' | 'cost' | 'time';
+export type LeaderboardSortBy = 'tokens' | 'cost';
 
 export const SORT_BY_COOKIE_NAME = "leaderboard-sort-by";
-export const VALID_SORT_BY: LeaderboardSortBy[] = ['tokens', 'cost', 'time'];
+export const VALID_SORT_BY: LeaderboardSortBy[] = ['tokens', 'cost'];
 
 export function isValidSortBy(value: unknown): value is LeaderboardSortBy {
   return typeof value === 'string' && VALID_SORT_BY.includes(value as LeaderboardSortBy);

--- a/packages/frontend/src/lib/leaderboard/constants.ts
+++ b/packages/frontend/src/lib/leaderboard/constants.ts
@@ -6,3 +6,17 @@ export const VALID_SORT_BY: LeaderboardSortBy[] = ['tokens', 'cost'];
 export function isValidSortBy(value: unknown): value is LeaderboardSortBy {
   return typeof value === 'string' && VALID_SORT_BY.includes(value as LeaderboardSortBy);
 }
+
+/**
+ * Resolve a sort query/cookie value while preserving the distinction between
+ * an absent value and an explicitly retired/unknown value. Explicit invalid
+ * values must not fall through to a persisted preference: stale links should
+ * consistently land on the tokens ranking.
+ */
+export function resolveSortByParam(value: unknown): LeaderboardSortBy | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  return isValidSortBy(value) ? value : "tokens";
+}

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -18,7 +18,6 @@ interface LeaderboardPeriodRow {
   avatarUrl: string | null;
   tokens: number;
   cost: number;
-  activeTimeMs: number | null;
 }
 
 interface PeriodDateRange {
@@ -33,7 +32,6 @@ interface PeriodLeaderboardDbRow {
   avatarUrl: string | null;
   tokens: number | string | null;
   cost: number | string | null;
-  activeTimeMs: number | string | null;
 }
 
 interface AllTimeLeaderboardDbRow {
@@ -43,7 +41,6 @@ interface AllTimeLeaderboardDbRow {
   avatarUrl: string | null;
   totalTokens: number | string | null;
   totalCost: number | string | null;
-  totalActiveTimeMs: number | string | null;
 }
 
 interface RankedLeaderboardDbRow extends AllTimeLeaderboardDbRow {
@@ -105,16 +102,6 @@ function compareLeaderboardUsers(
   right: Omit<LeaderboardUser, "rank">,
   sortBy: SortBy
 ): number {
-  if (sortBy === "time") {
-    const leftTime = left.totalActiveTimeMs || 0;
-    const rightTime = right.totalActiveTimeMs || 0;
-    const primary = rightTime - leftTime;
-    if (primary !== 0) return primary;
-    const secondary = right.totalTokens - left.totalTokens;
-    if (secondary !== 0) return secondary;
-    return left.username.localeCompare(right.username);
-  }
-
   const primary = sortBy === "cost"
     ? right.totalCost - left.totalCost
     : right.totalTokens - left.totalTokens;
@@ -146,9 +133,6 @@ function aggregatePeriodRows(
     if (existing) {
       existing.totalTokens += row.tokens;
       existing.totalCost += row.cost;
-      if (row.activeTimeMs != null) {
-        existing.totalActiveTimeMs = (existing.totalActiveTimeMs || 0) + row.activeTimeMs;
-      }
       continue;
     }
 
@@ -159,7 +143,6 @@ function aggregatePeriodRows(
       avatarUrl: row.avatarUrl,
       totalTokens: row.tokens,
       totalCost: row.cost,
-      totalActiveTimeMs: row.activeTimeMs,
     });
   }
 
@@ -218,7 +201,6 @@ function buildPeriodLeaderboardData(
     stats: {
       totalTokens: aggregatedUsers.reduce((sum, user) => sum + user.totalTokens, 0),
       totalCost: aggregatedUsers.reduce((sum, user) => sum + user.totalCost, 0),
-      totalActiveTimeMs: aggregatedUsers.reduce((sum, user) => sum + (user.totalActiveTimeMs || 0), 0) || null,
       uniqueUsers: aggregatedUsers.length,
     },
     period,
@@ -267,7 +249,6 @@ async function fetchPeriodLeaderboardRows(
       avatarUrl: users.avatarUrl,
       tokens: dailyBreakdown.tokens,
       cost: dailyBreakdown.cost,
-      activeTimeMs: dailyBreakdown.activeTimeMs,
     })
     .from(dailyBreakdown)
     .innerJoin(submissions, eq(dailyBreakdown.submissionId, submissions.id))
@@ -286,7 +267,6 @@ async function fetchPeriodLeaderboardRows(
     avatarUrl: row.avatarUrl,
     tokens: Number(row.tokens) || 0,
     cost: Number(row.cost) || 0,
-    activeTimeMs: row.activeTimeMs != null ? Number(row.activeTimeMs) : null,
   }));
 }
 
@@ -308,12 +288,8 @@ async function fetchLeaderboardData(
 
   const orderByColumn = sortBy === "cost"
     ? sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`
-    : sortBy === "time"
-    ? sql`COALESCE(SUM(${submissions.totalActiveTimeMs}), 0)`
     : sql`SUM(${submissions.totalTokens})`;
   const secondaryOrderByColumn = sortBy === "cost"
-    ? sql`SUM(${submissions.totalTokens})`
-    : sortBy === "time"
     ? sql`SUM(${submissions.totalTokens})`
     : sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`;
 
@@ -329,15 +305,12 @@ async function fetchLeaderboardData(
         avatarUrl: users.avatarUrl,
         totalTokens: sql<number>`SUM(${submissions.totalTokens})`.as("total_tokens"),
         totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`.as("total_cost"),
-        totalActiveTimeMs: sql<number>`COALESCE(SUM(${submissions.totalActiveTimeMs}), 0)`.as("total_active_time_ms"),
       })
       .from(submissions)
       .innerJoin(users, eq(submissions.userId, users.id))
       .groupBy(users.id, users.username, users.displayName, users.avatarUrl)
       .as("ranked");
     const rankedSecondaryOrderByColumn = sortBy === "cost"
-      ? rankedSubquery.totalTokens
-      : sortBy === "time"
       ? rankedSubquery.totalTokens
       : rankedSubquery.totalCost;
 
@@ -382,7 +355,6 @@ async function fetchLeaderboardData(
         avatarUrl: row.avatarUrl,
         totalTokens: Number(row.totalTokens) || 0,
         totalCost: Number(row.totalCost) || 0,
-        totalActiveTimeMs: Number((row as AllTimeLeaderboardDbRow).totalActiveTimeMs) || null,
       })),
       pagination: {
         page,
@@ -395,7 +367,6 @@ async function fetchLeaderboardData(
       stats: {
         totalTokens: Number(globalStats[0]?.totalTokens) || 0,
         totalCost: Number(globalStats[0]?.totalCost) || 0,
-        totalActiveTimeMs: null,
         uniqueUsers: Number(globalStats[0]?.uniqueUsers) || 0,
       },
       period,
@@ -413,7 +384,6 @@ async function fetchLeaderboardData(
       avatarUrl: users.avatarUrl,
       totalTokens: sql<number>`SUM(${submissions.totalTokens})`.as("total_tokens"),
       totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`.as("total_cost"),
-      totalActiveTimeMs: sql<number>`COALESCE(SUM(${submissions.totalActiveTimeMs}), 0)`.as("total_active_time_ms"),
     })
     .from(submissions)
     .innerJoin(users, eq(submissions.userId, users.id))
@@ -449,7 +419,6 @@ async function fetchLeaderboardData(
       avatarUrl: row.avatarUrl,
       totalTokens: Number(row.totalTokens) || 0,
       totalCost: Number(row.totalCost) || 0,
-      totalActiveTimeMs: Number(row.totalActiveTimeMs) || null,
     })),
     pagination: {
       page,
@@ -462,7 +431,6 @@ async function fetchLeaderboardData(
     stats: {
       totalTokens: Number(globalStats[0]?.totalTokens) || 0,
       totalCost: Number(globalStats[0]?.totalCost) || 0,
-      totalActiveTimeMs: null,
       uniqueUsers: Number(globalStats[0]?.uniqueUsers) || 0,
     },
     period,
@@ -525,7 +493,6 @@ async function fetchUserRank(
     .select({
       totalTokens: sql<number>`SUM(${submissions.totalTokens})`.as("total_tokens"),
       totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`.as("total_cost"),
-      totalActiveTimeMs: sql<number>`COALESCE(SUM(${submissions.totalActiveTimeMs}), 0)`.as("total_active_time_ms"),
     })
     .from(submissions)
     .where(eq(submissions.userId, user.id));
@@ -537,17 +504,12 @@ async function fetchUserRank(
   const userStats = userStatsResult[0];
   const userTotalTokens = Number(userStats.totalTokens);
   const userTotalCost = userStats.totalCost != null ? Number(userStats.totalCost) : 0;
-  const userTotalActiveTimeMs = Number(userStats.totalActiveTimeMs) || 0;
 
   const userCompareValue = sortBy === "cost"
     ? userTotalCost
-    : sortBy === "time"
-    ? userTotalActiveTimeMs
     : userTotalTokens;
   const compareColumn = sortBy === "cost"
     ? sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`
-    : sortBy === "time"
-    ? sql`COALESCE(SUM(${submissions.totalActiveTimeMs}), 0)`
     : sql`SUM(${submissions.totalTokens})`;
 
   const higherRankedResult = await db
@@ -576,7 +538,6 @@ async function fetchUserRank(
     avatarUrl: user.avatarUrl,
     totalTokens: userTotalTokens,
     totalCost: userTotalCost,
-    totalActiveTimeMs: userTotalActiveTimeMs || null,
   };
 }
 

--- a/packages/frontend/src/lib/leaderboard/types.ts
+++ b/packages/frontend/src/lib/leaderboard/types.ts
@@ -1,5 +1,5 @@
 export type Period = "all" | "month" | "last-month" | "week" | "custom";
-export type SortBy = "tokens" | "cost" | "time";
+export type SortBy = "tokens" | "cost";
 
 export interface LeaderboardUser {
   rank: number;
@@ -9,7 +9,6 @@ export interface LeaderboardUser {
   avatarUrl: string | null;
   totalTokens: number;
   totalCost: number;
-  totalActiveTimeMs: number | null;
 }
 
 export interface LeaderboardData {
@@ -25,7 +24,6 @@ export interface LeaderboardData {
   stats: {
     totalTokens: number;
     totalCost: number;
-    totalActiveTimeMs: number | null;
     uniqueUsers: number;
   };
   period: Period;

--- a/packages/frontend/src/lib/publicProfileData.ts
+++ b/packages/frontend/src/lib/publicProfileData.ts
@@ -152,7 +152,6 @@ export async function getPublicProfileResponse(
             submissionCount: sql<number>`COALESCE(MAX(${submissions.submitCount}), 0)`,
             earliestDate: sql<string>`MIN(${submissions.dateStart})`,
             latestDate: sql<string>`MAX(${submissions.dateEnd})`,
-            totalActiveTimeMs: sql<number>`COALESCE(SUM(${submissions.totalActiveTimeMs}), 0)`,
             sessionCount: sql<number>`COALESCE(SUM(${submissions.sessionCount}), 0)`,
           })
           .from(submissions)
@@ -193,7 +192,6 @@ export async function getPublicProfileResponse(
           .select({
             date: dailyBreakdown.date,
             timestampMs: dailyBreakdown.timestampMs,
-            activeTimeMs: dailyBreakdown.activeTimeMs,
             tokens: dailyBreakdown.tokens,
             cost: dailyBreakdown.cost,
             inputTokens: dailyBreakdown.inputTokens,
@@ -294,7 +292,6 @@ export async function getPublicProfileResponse(
       {
         date: string;
         timestampMs: number | null;
-        activeTimeMs: number;
         tokens: number;
         cost: number;
         inputTokens: number;
@@ -317,7 +314,6 @@ export async function getPublicProfileResponse(
         existing.cost += Number(day.cost);
         existing.inputTokens += Number(day.inputTokens);
         existing.outputTokens += Number(day.outputTokens);
-        existing.activeTimeMs += Number(day.activeTimeMs) || 0;
         if (day.sourceBreakdown) {
           for (const [rawClient, data] of Object.entries(day.sourceBreakdown)) {
             const client = normalizeClientId(rawClient);
@@ -443,7 +439,6 @@ export async function getPublicProfileResponse(
         aggregatedDaily.set(day.date, {
           date: day.date,
           timestampMs: day.timestampMs ?? null,
-          activeTimeMs: Number(day.activeTimeMs) || 0,
           tokens: Number(day.tokens),
           cost: Number(day.cost),
           inputTokens: Number(day.inputTokens),
@@ -466,7 +461,6 @@ export async function getPublicProfileResponse(
         totals.totalCost += day.cost;
         totals.inputTokens += day.inputTokens;
         totals.outputTokens += day.outputTokens;
-        totals.totalActiveTimeMs += day.activeTimeMs;
 
         for (const clientData of Object.values(day.clients)) {
           totals.cacheReadTokens += clientData.cacheRead || 0;
@@ -484,7 +478,6 @@ export async function getPublicProfileResponse(
         cacheReadTokens: 0,
         cacheWriteTokens: 0,
         reasoningTokens: 0,
-        totalActiveTimeMs: 0,
       },
     );
 
@@ -610,9 +603,6 @@ export async function getPublicProfileResponse(
           : Number(stats?.reasoningTokens) || 0,
         submissionCount: Number(stats?.submissionCount) || 0,
         activeDays,
-        totalActiveTimeMs: isPeriodFiltered
-          ? periodTotals.totalActiveTimeMs
-          : Number(stats?.totalActiveTimeMs) || 0,
         // Session count is only stored at submission level, so hide it for rolling ranges.
         sessionCount: isPeriodFiltered ? 0 : Number(stats?.sessionCount) || 0,
       },


### PR DESCRIPTION
Stacked on #859 (base: `feat/compact-groups-leaderboard`). Continues the "leaderboard only shows numbers that are actually comparable" theme.

## Why

Estimated active time is not reliable as human coding time. Parallel agents, overlapping sessions, tool/runtime durations, device overlap, and client-specific parsing all inflate it far past wall-clock — a current-month leader showed **~19,163 hours** across a period with only **288 wall-clock hours**. A methodology tooltip under a number like that just advertises that we publish data we don't trust, so this removes it from every comparative surface instead.

## What changed (display + API only)

- **Sort dimension** — dropped `"time"` from `SortBy` / `LeaderboardSortBy` / `VALID_SORT_BY`. A stale `?sortBy=time` deep link now falls back to `tokens` rather than ranking on time.
- **Leaderboard payloads** — removed `totalActiveTimeMs` from `LeaderboardUser` and `stats`, the SQL aggregates in `getLeaderboard.ts` / `getGroupLeaderboard.ts`, the Time sort control, the desktop "Time" column, the mobile row's active-time line, and the metric strip's "Active time" tile.
- **Public profile** — removed the "Active time" insight from the profile Usage details panel and stripped `totalActiveTimeMs` from the `api/users/[username]` payload.

## What was deliberately kept

- **DB columns** (`total_active_time_ms`, `active_time_ms`, `session_count`, …) and **submit-path validation** — CLIs in the wild still POST these fields and must keep succeeding, and dropping columns would be a destructive migration on immutable-after-apply tables.
- **`/local` self-inspection view** — Active Time there is your own machine's data, not a cross-user comparison, so it stays. `GraphContainer`/`StatsPanel` retain the (now display-only) prop for that surface.
- **`sessionCount`** on profiles — a count, not a duration, so it's honest under the parallel-agent reality.

## Verification

- `vitest run` — **565/565** pass (leaderboard/profile/group test expectations updated for the leaner shape)
- `tsc --noEmit` — clean
- `eslint` — 0 errors (6 pre-existing warnings in untouched files)

## Risk

Narrowing the public leaderboard JSON could affect undocumented third-party consumers reading the removed `totalActiveTimeMs` field. Called out in the commit's `Not-tested` trailer.

## Follow-up idea (not in this PR)

If a third ranking dimension is wanted later, period-scoped **Active days** (from `daily_breakdown`) is bounded and immune to parallel-agent inflation — a much safer competition axis than time.
