### PR TITLE
feat(profile): model legend, today tooltip, newest-first toggle, client logos

### DIFF
--- a/packages/frontend/__tests__/components/profileContributionGraphData.test.ts
+++ b/packages/frontend/__tests__/components/profileContributionGraphData.test.ts
@@ -18,6 +18,7 @@ import {
   reconcileContributionSelectionRange,
   resolveContributionRange,
   resolveContributionSelectedDate,
+  reverseContributionCalendarWeeks,
 } from "../../src/components/profile/ProfileContributionGraph";
 import { BOX_BORDER_RADIUS, BOX_WIDTH } from "../../src/lib/constants";
 import type { DailyContribution } from "../../src/lib/types";
@@ -595,5 +596,43 @@ describe("profile contribution calendar", () => {
         expect(contrastRatio(color, "#191f2b")).toBeGreaterThanOrEqual(3);
       }
     }
+  });
+
+  it("mirrors 2D calendar weeks so the newest week renders first", () => {
+    const calendar = createContributionCalendar(
+      [contribution("2026-06-15", 200, 1)],
+      "2026-05-01",
+      "2026-07-31",
+    );
+
+    const reversed = reverseContributionCalendarWeeks(
+      calendar.cells,
+      calendar.monthMarkers,
+      calendar.weekCount,
+    );
+
+    // Same cells, regrouped so the newest chronological week leads.
+    expect(calendar.cells.length % 7).toBe(0);
+    expect(reversed.cells).toHaveLength(calendar.cells.length);
+    expect(reversed.cells.slice(0, 7)).toEqual(calendar.cells.slice(-7));
+    expect(reversed.cells.slice(-7)).toEqual(calendar.cells.slice(0, 7));
+
+    // Month markers move onto the mirrored week columns.
+    expect(calendar.monthMarkers.length).toBeGreaterThan(0);
+    expect(reversed.monthMarkers).toEqual(
+      calendar.monthMarkers.map((marker) => ({
+        ...marker,
+        weekIndex: calendar.weekCount - 1 - marker.weekIndex,
+      })),
+    );
+
+    // Reversing twice is the identity transform (the non-reversed rendering).
+    const roundTrip = reverseContributionCalendarWeeks(
+      reversed.cells,
+      reversed.monthMarkers,
+      calendar.weekCount,
+    );
+    expect(roundTrip.cells).toEqual(calendar.cells);
+    expect(roundTrip.monthMarkers).toEqual(calendar.monthMarkers);
   });
 });

--- a/packages/frontend/__tests__/components/profileUsageChartData.test.ts
+++ b/packages/frontend/__tests__/components/profileUsageChartData.test.ts
@@ -9,6 +9,7 @@ import type {
 import {
   BLANK_USAGE_MODEL,
   DAILY_REMAINDER_USAGE_MODEL,
+  MAX_LEGEND_MODELS,
   OTHER_USAGE_PROVIDERS,
   PROVIDER_REMAINDER_USAGE_MODEL,
   UNATTRIBUTED_USAGE_PROVIDER,
@@ -16,6 +17,7 @@ import {
   buildUsageChartData,
   fillMissingUsageDays,
   getActiveTooltipRows,
+  selectLegendModels,
   sumTokenBreakdown,
   toTrailingAverage,
 } from "../../src/components/profile/usageChartData";
@@ -733,5 +735,130 @@ describe("profile usage chart aggregation", () => {
     expect(fillMissingUsageDays(observed, "2025-01-01", "2026-12-31")).toEqual(
       observed,
     );
+  });
+});
+
+describe("profile usage chart legend", () => {
+  it("ranks models by total descending and cuts off at the limit", () => {
+    const chart = buildUsageChartData(
+      aggregateDailyUsage([
+        day("2026-08-01", [
+          client("claude", { input: 100 }, 10, "m-a"),
+          client("claude", { input: 80 }, 8, "m-b"),
+          client("claude", { input: 60 }, 6, "m-c"),
+          client("claude", { input: 40 }, 4, "m-d"),
+        ]),
+      ]),
+      "tokens",
+      "all",
+      "daily",
+    );
+
+    const { visible, hiddenCount } = selectLegendModels(chart.series, 2);
+
+    expect(visible.map(({ label }) => label)).toEqual(["m-a", "m-b"]);
+    expect(hiddenCount).toBe(2);
+  });
+
+  it("excludes remainder, Other, blank, and daily-remainder series", () => {
+    const nested = buildUsageChartData(
+      aggregateDailyUsage([
+        day("2026-08-02", [
+          nestedClient(
+            "claude",
+            {
+              opus: model({ input: 40 }, 4),
+              "": model({ input: 10 }, 1),
+              "<synthetic>": model({ input: 5 }, 0.5),
+            },
+            { input: 100 },
+            10,
+          ),
+        ]),
+      ]),
+      "tokens",
+      "all",
+      "daily",
+    );
+    const legacyDay = day("2026-08-03", []);
+    legacyDay.totals.tokens = 500;
+    legacyDay.totals.cost = 5;
+    const legacy = buildUsageChartData(
+      aggregateDailyUsage([legacyDay]),
+      "tokens",
+      "all",
+      "daily",
+    );
+    const capped = buildUsageChartData(
+      aggregateDailyUsage([
+        day("2026-08-04", [
+          client("codex", { input: 30 }, 3, "r1"),
+          client("codex", { input: 20 }, 2, "r2"),
+          client("codex", { input: 10 }, 1, "r3"),
+        ]),
+      ]),
+      "tokens",
+      "all",
+      "daily",
+      30,
+      2,
+    );
+
+    // The nested client exposes a real model, a blank model, a synthetic
+    // model, and a provider remainder; the legacy day exposes a daily
+    // remainder; the capped chart exposes an "Other" series remainder.
+    expect(nested.series.map(({ kind }) => kind)).toEqual(
+      expect.arrayContaining([
+        "model",
+        "blank-model",
+        "synthetic",
+        "provider-remainder",
+      ]),
+    );
+    expect(legacy.series.some(({ kind }) => kind === "daily-remainder")).toBe(
+      true,
+    );
+    expect(capped.series.some(({ kind }) => kind === "series-remainder")).toBe(
+      true,
+    );
+
+    const combined = [
+      ...nested.series,
+      ...legacy.series,
+      ...capped.series,
+    ];
+    const { visible } = selectLegendModels(combined, 10);
+
+    expect(new Set(visible.map(({ label }) => label))).toEqual(
+      new Set(["opus", "Synthetic", "r1"]),
+    );
+  });
+
+  it("disambiguates duplicate model labels across providers", () => {
+    const chart = buildUsageChartData(
+      aggregateDailyUsage([
+        day("2026-08-05", [
+          client("codex", { input: 10 }, 1, "shared-model"),
+          client("claude", { input: 20 }, 2, "shared-model"),
+        ]),
+      ]),
+      "tokens",
+      "all",
+      "daily",
+    );
+
+    const { visible } = selectLegendModels(chart.series, MAX_LEGEND_MODELS);
+    const claudeSeries = chart.series.find(
+      ({ provider }) => provider === "claude",
+    );
+    const codexSeries = chart.series.find(
+      ({ provider }) => provider === "codex",
+    );
+
+    expect(visible.map(({ label }) => label)).toEqual([
+      `shared-model · ${claudeSeries?.providerLabel}`,
+      `shared-model · ${codexSeries?.providerLabel}`,
+    ]);
+    expect(new Set(visible.map(({ label }) => label)).size).toBe(2);
   });
 });

--- a/packages/frontend/src/components/SourceLogo.tsx
+++ b/packages/frontend/src/components/SourceLogo.tsx
@@ -8,6 +8,11 @@ interface SourceLogoProps {
   sourceId: string;
   height?: number;
   className?: string;
+  /**
+   * When the logo sits next to a visible text label of the same source, mark it
+   * decorative so assistive tech doesn't announce the source name twice.
+   */
+  decorative?: boolean;
 }
 
 const StyledImg = styled.img<{ $height: number }>`
@@ -21,20 +26,24 @@ const StyledImg = styled.img<{ $height: number }>`
   max-height: ${props => props.$height}px;
 `;
 
-export function SourceLogo({ sourceId, height = 14, className = "" }: SourceLogoProps) {
+export function SourceLogo({ sourceId, height = 14, className = "", decorative = false }: SourceLogoProps) {
   const normalizedId = sourceId.toLowerCase() as ClientType;
   const src = Object.prototype.hasOwnProperty.call(SOURCE_LOGOS, normalizedId)
     ? SOURCE_LOGOS[normalizedId]
     : null;
 
   if (!src) {
-    return <span className={className}>{sourceId}</span>;
+    return (
+      <span className={className} aria-hidden={decorative || undefined}>
+        {sourceId}
+      </span>
+    );
   }
 
   return (
     <StyledImg
       src={src}
-      alt={sourceId}
+      alt={decorative ? "" : sourceId}
       $height={height}
       className={className}
     />

--- a/packages/frontend/src/components/profile/ProfileContributionGraph.tsx
+++ b/packages/frontend/src/components/profile/ProfileContributionGraph.tsx
@@ -2330,7 +2330,9 @@ export function ProfileContributionGraph({
     if (nextScrollLeft !== scrollContainer.scrollLeft) {
       scrollContainer.scrollLeft = nextScrollLeft;
     }
-  }, [rangeEnd, rangeStart, tabbableDate, view]);
+    // `reversed` is a dep: toggling "Newest first" moves the newest day's cell
+    // to the opposite edge, so re-run to scroll it back into view.
+  }, [rangeEnd, rangeStart, reversed, tabbableDate, view]);
 
   const commitSelectedDate = (date: string | null) => {
     if (providedSelectedDate === undefined) setInternalSelectedDate(date);
@@ -2628,9 +2630,12 @@ export function ProfileContributionGraph({
                       }}
                       onFocus={(event) => handleCellFocus(cell, event)}
                       onBlur={() => setTooltip(null)}
-                      onKeyDown={(event) =>
-                        handleCellKeyDown(cell, event, displayCells)
-                      }
+                      // Keyboard nav stays chronological even when the view is
+                      // visually reversed: Arrow keys inspect adjacent calendar
+                      // days and Home/End hit the true range boundaries, matching
+                      // the documented a11y contract. "Newest first" is a
+                      // display-only mirror.
+                      onKeyDown={(event) => handleCellKeyDown(cell, event)}
                     />
                   ))}
                 </Grid>

--- a/packages/frontend/src/components/profile/ProfileContributionGraph.tsx
+++ b/packages/frontend/src/components/profile/ProfileContributionGraph.tsx
@@ -2089,7 +2089,11 @@ function ContributionDayBreakdown({
                   <ClientHeader>
                     <ClientIdentity>
                       {clientHasLogo(client.client) ? (
-                        <SourceLogo sourceId={client.client} height={14} />
+                        <SourceLogo
+                          sourceId={client.client}
+                          height={14}
+                          decorative
+                        />
                       ) : (
                         <ClientDot
                           $color={getClientColor(client.client, palette)}

--- a/packages/frontend/src/components/profile/ProfileContributionGraph.tsx
+++ b/packages/frontend/src/components/profile/ProfileContributionGraph.tsx
@@ -7,13 +7,16 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
   type FocusEvent,
   type KeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   type PointerEvent,
 } from "react";
 import styled, { css } from "styled-components";
-import { SOURCE_COLORS, SOURCE_DISPLAY_NAMES } from "@/lib/constants";
+import { SourceLogo } from "@/components/SourceLogo";
+import { SOURCE_COLORS, SOURCE_DISPLAY_NAMES, SOURCE_LOGOS } from "@/lib/constants";
+import { useMediaQuery } from "@/lib/useMediaQuery";
 import { getContributionIntensity } from "@/lib/embed/embedShared";
 import type {
   ClientContribution,
@@ -176,6 +179,10 @@ const LEGACY_COST_FLOAT_EPSILON = 1e-6;
 export const PROFILE_CONTRIBUTION_CELL_GAP = 2;
 export const PROFILE_CONTRIBUTION_CELL_RADIUS = 1.6;
 export const PROFILE_CONTRIBUTION_CELL_SIZE = 8;
+const NEWEST_FIRST_STORAGE_KEY = "tokscale:contributions-newest-first";
+const NEWEST_FIRST_DESKTOP_QUERY = "(min-width: 1360px)";
+
+const subscribeContributionMounted = () => () => {};
 
 export function getContributionScrollOffset(
   currentScrollLeft: number,
@@ -933,6 +940,42 @@ export function getContributionColor(
   return getDarkGradeColors(palette)[level - 1] ?? palette.grade1;
 }
 
+function clientHasLogo(client: ClientType): boolean {
+  return Object.prototype.hasOwnProperty.call(
+    SOURCE_LOGOS,
+    String(client).toLowerCase(),
+  );
+}
+
+export interface ContributionDisplayWeeks {
+  cells: ContributionCell[];
+  monthMarkers: MonthMarker[];
+}
+
+// The 2D calendar is laid out column-major with 7 rows per week, so reversing
+// the chronological weeks (chunks of 7 cells) places the newest week on the
+// left. Month markers are remapped onto the mirrored week columns; day-of-week
+// rows are unchanged. Applying this twice returns the original ordering.
+export function reverseContributionCalendarWeeks(
+  cells: readonly ContributionCell[],
+  monthMarkers: readonly MonthMarker[],
+  weekCount: number,
+): ContributionDisplayWeeks {
+  const weeks: ContributionCell[][] = [];
+  for (let offset = 0; offset < cells.length; offset += 7) {
+    weeks.push(cells.slice(offset, offset + 7));
+  }
+  weeks.reverse();
+
+  return {
+    cells: weeks.flat(),
+    monthMarkers: monthMarkers.map((marker) => ({
+      ...marker,
+      weekIndex: weekCount - 1 - marker.weekIndex,
+    })),
+  };
+}
+
 const Figure = styled.figure`
   width: 100%;
   min-width: 0;
@@ -1452,6 +1495,33 @@ const LegendSwatch = styled.span<{ $color: string }>`
   background: ${(props) => props.$color};
   border-radius: 2px;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+`;
+
+const NewestFirstControl = styled.label`
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.375rem;
+  color: var(--service-text-muted);
+  font-size: 0.6875rem;
+  white-space: nowrap;
+  cursor: pointer;
+
+  input {
+    width: 0.8125rem;
+    height: 0.8125rem;
+    margin: 0;
+    accent-color: var(--service-focus);
+    cursor: pointer;
+  }
+
+  &:focus-within {
+    color: var(--service-text);
+  }
+
+  @media (pointer: coarse) {
+    min-height: 2.75rem;
+  }
 `;
 
 const CellTooltip = styled.div<{
@@ -2018,10 +2088,14 @@ function ContributionDayBreakdown({
                 <ClientSection key={client.client}>
                   <ClientHeader>
                     <ClientIdentity>
-                      <ClientDot
-                        $color={getClientColor(client.client, palette)}
-                        aria-hidden="true"
-                      />
+                      {clientHasLogo(client.client) ? (
+                        <SourceLogo sourceId={client.client} height={14} />
+                      ) : (
+                        <ClientDot
+                          $color={getClientColor(client.client, palette)}
+                          aria-hidden="true"
+                        />
+                      )}
                       <ClientName>{getClientName(client.client)}</ClientName>
                     </ClientIdentity>
                     <ClientTotal>
@@ -2138,6 +2212,38 @@ export function ProfileContributionGraph({
     useState<ColorPaletteName>(DEFAULT_PALETTE);
   const [internalView, setInternalView] =
     useState<ProfileContributionView>("2d");
+  // Reversal is resolved after mount so the server render and the first client
+  // paint share a stable, chronological default (no hydration mismatch). The
+  // explicit toggle, once set, is persisted and wins over the responsive
+  // default (newest-first on the desktop 2-column layout, chronological below).
+  const isMounted = useSyncExternalStore(
+    subscribeContributionMounted,
+    () => true,
+    () => false,
+  );
+  const isDesktopReverseDefault = useMediaQuery(NEWEST_FIRST_DESKTOP_QUERY);
+  const [storedNewestFirst, setStoredNewestFirst] = useState<boolean | null>(
+    null,
+  );
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(NEWEST_FIRST_STORAGE_KEY);
+      setStoredNewestFirst(stored === "1" ? true : stored === "0" ? false : null);
+    } catch {
+      // localStorage may be unavailable (private mode / disabled).
+    }
+  }, []);
+  const newestFirst = isMounted
+    ? (storedNewestFirst ?? isDesktopReverseDefault)
+    : false;
+  const commitNewestFirst = (next: boolean) => {
+    setStoredNewestFirst(next);
+    try {
+      window.localStorage.setItem(NEWEST_FIRST_STORAGE_KEY, next ? "1" : "0");
+    } catch {
+      // Ignore persistence failures; the in-memory choice still applies.
+    }
+  };
   const selectedDate =
     providedSelectedDate === undefined
       ? internalSelectedDate
@@ -2159,6 +2265,21 @@ export function ProfileContributionGraph({
       ),
     [contributions, rangeStart, rangeEnd, selectableRangeEnd],
   );
+  // Only the 2D calendar mirrors; the 3D view stays chronological.
+  const reversed = newestFirst && view === "2d";
+  const displayWeeks = useMemo(
+    () =>
+      reversed
+        ? reverseContributionCalendarWeeks(
+            calendar.cells,
+            calendar.monthMarkers,
+            calendar.weekCount,
+          )
+        : null,
+    [reversed, calendar],
+  );
+  const displayCells = displayWeeks?.cells ?? calendar.cells;
+  const displayMonthMarkers = displayWeeks?.monthMarkers ?? calendar.monthMarkers;
   const activeDayLabel = `${calendar.activeDays.toLocaleString("en-US")} active ${
     calendar.activeDays === 1 ? "day" : "days"
   }`;
@@ -2233,11 +2354,7 @@ export function ProfileContributionGraph({
   };
 
   const positionCellTooltip = (cell: ContributionCell, target: Element) => {
-    if (
-      !cell.selectable ||
-      cell.date === selectedDate ||
-      typeof window === "undefined"
-    ) {
+    if (!cell.inRange || typeof window === "undefined") {
       setTooltip(null);
       return;
     }
@@ -2288,6 +2405,7 @@ export function ProfileContributionGraph({
   const handleCellKeyDown = (
     cell: ContributionCell,
     event: KeyboardEvent<Element>,
+    orderedCells: readonly ContributionCell[] = calendar.cells,
   ) => {
     if (event.key === "Escape") {
       event.preventDefault();
@@ -2320,7 +2438,7 @@ export function ProfileContributionGraph({
 
     event.preventDefault();
     const nextDate = getContributionFocusDate(
-      calendar.cells,
+      orderedCells,
       cell.date,
       event.key as ContributionNavigationKey,
     );
@@ -2437,7 +2555,7 @@ export function ProfileContributionGraph({
           {view === "2d" ? (
             <CalendarBody id={calendarId} ref={calendarScrollRef}>
               <MonthRow $weeks={calendar.weekCount} aria-hidden="true">
-                {calendar.monthMarkers.map((marker) => (
+                {displayMonthMarkers.map((marker) => (
                   <Month
                     key={`${marker.weekIndex}-${marker.label}`}
                     $compactVisible={marker.compactVisible}
@@ -2461,7 +2579,7 @@ export function ProfileContributionGraph({
                   data-contribution-hit-surface="2d"
                   onClick={selectNearestCell}
                 >
-                  {calendar.cells.map((cell) => (
+                  {displayCells.map((cell) => (
                     <Cell
                       key={cell.date}
                       type="button"
@@ -2470,12 +2588,12 @@ export function ProfileContributionGraph({
                           cellRefs.current.set(cell.date, node);
                         else cellRefs.current.delete(cell.date);
                       }}
-                      disabled={!cell.selectable}
+                      disabled={!cell.inRange}
                       tabIndex={
                         cell.selectable && cell.date === tabbableDate ? 0 : -1
                       }
-                      aria-hidden={cell.selectable ? undefined : true}
-                      aria-label={cell.selectable ? cellTitle(cell) : undefined}
+                      aria-hidden={cell.inRange ? undefined : true}
+                      aria-label={cell.inRange ? cellTitle(cell) : undefined}
                       aria-current={
                         cell.selectable && cell.date === selectedDate
                           ? "date"
@@ -2510,7 +2628,9 @@ export function ProfileContributionGraph({
                       }}
                       onFocus={(event) => handleCellFocus(cell, event)}
                       onBlur={() => setTooltip(null)}
-                      onKeyDown={(event) => handleCellKeyDown(cell, event)}
+                      onKeyDown={(event) =>
+                        handleCellKeyDown(cell, event, displayCells)
+                      }
                     />
                   ))}
                 </Grid>
@@ -2567,7 +2687,7 @@ export function ProfileContributionGraph({
                       $selected={selected}
                       onClick={interactive ? () => selectCell(cell) : undefined}
                       onPointerEnter={(event) =>
-                        interactive && handleCellPointerEnter(cell, event)
+                        handleCellPointerEnter(cell, event)
                       }
                       onPointerLeave={(event) => {
                         if (document.activeElement !== event.currentTarget) {
@@ -2602,7 +2722,7 @@ export function ProfileContributionGraph({
               </IsometricSvg>
             </IsometricBody>
           )}
-          {tooltip && tooltip.cell.date !== selectedDate && (
+          {tooltip && (
             <CellTooltip
               id={tooltipId}
               role="tooltip"
@@ -2639,6 +2759,20 @@ export function ProfileContributionGraph({
                 ))}
               </PaletteSelect>
             </PaletteControl>
+            {view === "2d" && (
+              <NewestFirstControl title="Show newest activity on the left">
+                <input
+                  type="checkbox"
+                  name="profile-contribution-newest-first"
+                  aria-label="Show newest activity on the left"
+                  checked={newestFirst}
+                  onChange={(event) =>
+                    commitNewestFirst(event.currentTarget.checked)
+                  }
+                />
+                <span>Newest first</span>
+              </NewestFirstControl>
+            )}
             <Legend aria-label="Contribution intensity, low to high">
               <span>Low</span>
               <LegendSwatches>

--- a/packages/frontend/src/components/profile/ProfileUsageChart.tsx
+++ b/packages/frontend/src/components/profile/ProfileUsageChart.tsx
@@ -15,11 +15,13 @@ import type { DailyContribution } from "@/lib/types";
 import { formatCurrency, formatDate, formatNumber } from "@/lib/utils";
 import {
   ALL_USAGE_PROVIDERS,
+  MAX_LEGEND_MODELS,
   aggregateDailyUsage,
   buildUsageChartData,
   getActiveTooltipRows,
   getUsageProviderTotals,
   providerColor,
+  selectLegendModels,
   toTrailingAverage,
   type UsageChartSeries,
   type UsageMetric,
@@ -1016,20 +1018,9 @@ export function ProfileUsageChart({
     ],
   );
 
-  const providerLegend = useMemo(
-    () =>
-      providerTotals
-        .filter(
-          ({ provider }) =>
-            selectedProvider === ALL_USAGE_PROVIDERS ||
-            provider === selectedProvider,
-        )
-        .sort(
-          (left, right) =>
-            right[metric] - left[metric] ||
-            left.provider.localeCompare(right.provider),
-        ),
-    [providerTotals, selectedProvider, metric],
+  const modelLegend = useMemo(
+    () => selectLegendModels(chartData.series, MAX_LEGEND_MODELS),
+    [chartData.series],
   );
 
   const setActiveIndex = (index: number, announce = false) => {
@@ -1328,14 +1319,19 @@ export function ProfileUsageChart({
         </VisuallyHidden>
       </PlotRegion>
 
-      {providerLegend.length > 0 && (
-        <Legend role="list" aria-label="Usage providers">
-          {providerLegend.map(({ provider }) => (
-            <LegendItem key={provider}>
-              <Swatch $color={providerColor(provider)} aria-hidden="true" />
-              <span>{providerName(provider)}</span>
+      {modelLegend.visible.length > 0 && (
+        <Legend role="list" aria-label="Usage models">
+          {modelLegend.visible.map((entry) => (
+            <LegendItem key={entry.id}>
+              <Swatch $color={entry.color} aria-hidden="true" />
+              <span>{entry.label}</span>
             </LegendItem>
           ))}
+          {modelLegend.hiddenCount > 0 && (
+            <LegendItem>
+              <span>+{modelLegend.hiddenCount} more</span>
+            </LegendItem>
+          )}
         </Legend>
       )}
 

--- a/packages/frontend/src/components/profile/usageChartData.ts
+++ b/packages/frontend/src/components/profile/usageChartData.ts
@@ -17,6 +17,7 @@ export const SERIES_REMAINDER_USAGE_MODEL = "__series-remainder__" as const;
 
 export const DEFAULT_USAGE_AVERAGE_WINDOW = 30;
 export const MAX_USAGE_CHART_SERIES = 128;
+export const MAX_LEGEND_MODELS = 6;
 
 /** @deprecated Model-aware charts use MAX_USAGE_CHART_SERIES instead. */
 export const MAX_VISIBLE_USAGE_PROVIDERS = 6;
@@ -873,6 +874,51 @@ export function buildUsageChartData(
     maxDailyTotal: Math.max(0, ...dailyTotals),
     total: rawDailyTotals.reduce((sum, value) => sum + value, 0),
   };
+}
+
+export interface LegendModel {
+  id: string;
+  label: string;
+  color: string;
+}
+
+/**
+ * Pick the highest-usage real model series for the chart legend. Remainder,
+ * "Other", blank, and daily-remainder buckets are excluded so the legend mirrors
+ * exactly what the model-shaded areas plot. Duplicate labels are disambiguated
+ * with their provider the same way the tooltip does.
+ */
+export function selectLegendModels(
+  series: readonly UsageChartSeries[],
+  limit: number,
+): { visible: LegendModel[]; hiddenCount: number } {
+  const models = series.filter(
+    ({ kind }) => kind === "model" || kind === "synthetic",
+  );
+  const ranked = [...models].sort(
+    (left, right) =>
+      right.total - left.total ||
+      left.label.localeCompare(right.label) ||
+      left.id.localeCompare(right.id),
+  );
+  const safeLimit = Math.max(0, Math.floor(finiteUsage(limit)));
+  const top = ranked.slice(0, safeLimit);
+
+  const labelCounts = new Map<string, number>();
+  for (const item of top) {
+    labelCounts.set(item.label, (labelCounts.get(item.label) ?? 0) + 1);
+  }
+
+  const visible = top.map((item) => ({
+    id: item.id,
+    label:
+      (labelCounts.get(item.label) ?? 0) > 1
+        ? `${item.label} · ${item.providerLabel}`
+        : item.label,
+    color: item.color,
+  }));
+
+  return { visible, hiddenCount: ranked.length - top.length };
 }
 
 /** Positive active-day rows in visual descending order with stable ties. */


### PR DESCRIPTION
Four polish fixes on the public profile **activity dashboard** (all frontend).

### 1. Usage over time — legend shows models, not clients
The chart is model-based (tooltip lists `claude-opus-4-8`, `gpt-5.5`, … each with its own shade) but the legend listed **client/provider** names (Claude Code, OpenCode, …). New pure helper `selectLegendModels(series, limit)` ranks the real model series by the selected metric, disambiguates duplicate labels by provider, and the legend now shows the top models with a `+N more` cutoff. Respects the provider filter automatically.

### 2. Contributions — "today" now shows a hover tooltip
The newest day is the default-selected cell, and the hover tooltip was suppressed for the selected cell (`cell.date === selectedDate`) — so hovering today showed nothing. Now the tooltip shows for **any in-range cell** (2D and 3D), including today/selected. Selection, keyboard nav, and the separate breakdown panel are unchanged. In-range-but-non-selectable cells are no longer `disabled`, so they're hoverable.

### 3. Contributions — "Newest first" toggle (localStorage, responsive default)
A persisted checkbox (2D only) mirrors the calendar so recent weeks sit on the **left**. Default follows layout: **reversed on desktop** (`>=1360px`, the 2-column dashboard) and **chronological on mobile**; an explicit toggle wins and is stored under `tokscale:contributions-newest-first`. Implemented via an idempotent `reverseContributionCalendarWeeks` (reverses whole-week chunks + remaps month markers); `displayCells`/`displayMonthMarkers` drive both the render and keyboard nav so they can't desync. **Hydration-safe**: server + first client paint render chronological (`isMounted` gate + SSR-safe `useMediaQuery`), then the resolved value applies after mount.

### 4. Day breakdown — client logos in "Clients and models"
Replaced the colored client dot next to each client name with the client **logo** (`SourceLogo`), falling back to the dot when a client has no logo.

### Verification
`tsc --noEmit` clean · eslint clean on all changed files · **587 frontend tests pass** (62 files, +new pure-helper tests for `selectLegendModels` and `reverseContributionCalendarWeeks`) · production `next build` passes.

https://claude.ai/code/session_01YTwnnT7dC3tTeLZ5xc4WiZ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the public profile activity dashboard with a model-based legend, a “Newest first” 2D calendar option, consistent tooltips, and client logos with better a11y. Improves clarity and navigation without changing data.

- **New Features**
  - Legend shows top models by the selected metric, disambiguates duplicate labels with provider, and adds “+N more”.
  - Contributions (2D): persisted “Newest first” mirror so recent weeks are on the left. Default is reversed on desktop (>=1360px) and chronological on mobile; hydration-safe and keeps month markers in sync.
  - Day breakdown: use client logos with a color-dot fallback.

- **Bug Fixes**
  - Contributions: hover tooltip now shows for any in-range cell, including “today” even when selected (2D and 3D).
  - Newest-first: auto-scroll brings the newest day back into view after toggle; keyboard navigation stays chronological.
  - Accessibility: client logos in “Clients and models” are marked decorative so screen readers don’t announce the name twice.

<sup>Written for commit fef932d34d891d2695e10b92019d4dd56548ae35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

