### PR TITLE
fix(profile): move "Newest first" toggle to the Usage over time chart

### DIFF
--- a/packages/frontend/__tests__/components/profileContributionGraphData.test.ts
+++ b/packages/frontend/__tests__/components/profileContributionGraphData.test.ts
@@ -18,7 +18,6 @@ import {
   reconcileContributionSelectionRange,
   resolveContributionRange,
   resolveContributionSelectedDate,
-  reverseContributionCalendarWeeks,
 } from "../../src/components/profile/ProfileContributionGraph";
 import { BOX_BORDER_RADIUS, BOX_WIDTH } from "../../src/lib/constants";
 import type { DailyContribution } from "../../src/lib/types";
@@ -596,43 +595,5 @@ describe("profile contribution calendar", () => {
         expect(contrastRatio(color, "#191f2b")).toBeGreaterThanOrEqual(3);
       }
     }
-  });
-
-  it("mirrors 2D calendar weeks so the newest week renders first", () => {
-    const calendar = createContributionCalendar(
-      [contribution("2026-06-15", 200, 1)],
-      "2026-05-01",
-      "2026-07-31",
-    );
-
-    const reversed = reverseContributionCalendarWeeks(
-      calendar.cells,
-      calendar.monthMarkers,
-      calendar.weekCount,
-    );
-
-    // Same cells, regrouped so the newest chronological week leads.
-    expect(calendar.cells.length % 7).toBe(0);
-    expect(reversed.cells).toHaveLength(calendar.cells.length);
-    expect(reversed.cells.slice(0, 7)).toEqual(calendar.cells.slice(-7));
-    expect(reversed.cells.slice(-7)).toEqual(calendar.cells.slice(0, 7));
-
-    // Month markers move onto the mirrored week columns.
-    expect(calendar.monthMarkers.length).toBeGreaterThan(0);
-    expect(reversed.monthMarkers).toEqual(
-      calendar.monthMarkers.map((marker) => ({
-        ...marker,
-        weekIndex: calendar.weekCount - 1 - marker.weekIndex,
-      })),
-    );
-
-    // Reversing twice is the identity transform (the non-reversed rendering).
-    const roundTrip = reverseContributionCalendarWeeks(
-      reversed.cells,
-      reversed.monthMarkers,
-      calendar.weekCount,
-    );
-    expect(roundTrip.cells).toEqual(calendar.cells);
-    expect(roundTrip.monthMarkers).toEqual(calendar.monthMarkers);
   });
 });

--- a/packages/frontend/__tests__/components/profileUsageChartData.test.ts
+++ b/packages/frontend/__tests__/components/profileUsageChartData.test.ts
@@ -17,6 +17,7 @@ import {
   buildUsageChartData,
   fillMissingUsageDays,
   getActiveTooltipRows,
+  reverseUsageChartData,
   selectLegendModels,
   sumTokenBreakdown,
   toTrailingAverage,
@@ -860,5 +861,66 @@ describe("profile usage chart legend", () => {
       `shared-model · ${codexSeries?.providerLabel}`,
     ]);
     expect(new Set(visible.map(({ label }) => label)).size).toBe(2);
+  });
+
+  it("mirrors every per-day array so the newest day renders first", () => {
+    const aggregated = aggregateDailyUsage([
+      day("2026-01-01", [client("claude", { input: 100 }, 1, "model-a")]),
+      day("2026-01-02", [client("codex", { input: 40 }, 2, "model-b")]),
+      day("2026-01-03", [client("claude", { input: 7 }, 3, "model-a")]),
+    ]);
+    const chart = buildUsageChartData(aggregated, "tokens", "all", "daily");
+
+    const reversed = reverseUsageChartData(chart);
+
+    expect(reversed.dates).toEqual([...chart.dates].reverse());
+    expect(reversed.dailyTotals).toEqual([...chart.dailyTotals].reverse());
+    expect(reversed.rawDailyTotals).toEqual(
+      [...chart.rawDailyTotals].reverse(),
+    );
+    for (const [index, series] of reversed.series.entries()) {
+      expect(series.values).toEqual([...chart.series[index].values].reverse());
+      expect(series.rawValues).toEqual(
+        [...chart.series[index].rawValues].reverse(),
+      );
+    }
+
+    // Dates and values stay index-aligned: the same day keeps the same total.
+    for (const [index, date] of reversed.dates.entries()) {
+      const chronologicalIndex = chart.dates.indexOf(date);
+      expect(reversed.dailyTotals[index]).toBe(
+        chart.dailyTotals[chronologicalIndex],
+      );
+    }
+
+    // Order-independent aggregates are untouched.
+    expect(reversed.total).toBe(chart.total);
+    expect(reversed.maxDailyTotal).toBe(chart.maxDailyTotal);
+    expect(reversed.rawMaxDailyTotal).toBe(chart.rawMaxDailyTotal);
+    expect(reversed.view).toBe(chart.view);
+    expect(reversed.averageWindowDays).toBe(chart.averageWindowDays);
+    for (const [index, series] of reversed.series.entries()) {
+      expect(series.total).toBe(chart.series[index].total);
+    }
+  });
+
+  it("does not mutate its input and round-trips to chronological order", () => {
+    const aggregated = aggregateDailyUsage([
+      day("2026-02-01", [client("claude", { input: 5 }, 1, "model-a")]),
+      day("2026-02-02", [client("claude", { input: 9 }, 2, "model-a")]),
+    ]);
+    const chart = buildUsageChartData(aggregated, "tokens", "all", "daily");
+    const datesBefore = [...chart.dates];
+    const valuesBefore = chart.series.map(({ values }) => [...values]);
+
+    const roundTrip = reverseUsageChartData(reverseUsageChartData(chart));
+
+    expect(chart.dates).toEqual(datesBefore);
+    expect(chart.series.map(({ values }) => values)).toEqual(valuesBefore);
+    expect(roundTrip.dates).toEqual(chart.dates);
+    expect(roundTrip.dailyTotals).toEqual(chart.dailyTotals);
+    expect(roundTrip.series.map(({ values }) => values)).toEqual(
+      chart.series.map(({ values }) => values),
+    );
   });
 });

--- a/packages/frontend/src/components/profile/ProfileContributionGraph.tsx
+++ b/packages/frontend/src/components/profile/ProfileContributionGraph.tsx
@@ -7,7 +7,6 @@ import {
   useMemo,
   useRef,
   useState,
-  useSyncExternalStore,
   type FocusEvent,
   type KeyboardEvent,
   type MouseEvent as ReactMouseEvent,
@@ -16,7 +15,6 @@ import {
 import styled, { css } from "styled-components";
 import { SourceLogo } from "@/components/SourceLogo";
 import { SOURCE_COLORS, SOURCE_DISPLAY_NAMES, SOURCE_LOGOS } from "@/lib/constants";
-import { useMediaQuery } from "@/lib/useMediaQuery";
 import { getContributionIntensity } from "@/lib/embed/embedShared";
 import type {
   ClientContribution,
@@ -179,10 +177,6 @@ const LEGACY_COST_FLOAT_EPSILON = 1e-6;
 export const PROFILE_CONTRIBUTION_CELL_GAP = 2;
 export const PROFILE_CONTRIBUTION_CELL_RADIUS = 1.6;
 export const PROFILE_CONTRIBUTION_CELL_SIZE = 8;
-const NEWEST_FIRST_STORAGE_KEY = "tokscale:contributions-newest-first";
-const NEWEST_FIRST_DESKTOP_QUERY = "(min-width: 1360px)";
-
-const subscribeContributionMounted = () => () => {};
 
 export function getContributionScrollOffset(
   currentScrollLeft: number,
@@ -947,35 +941,6 @@ function clientHasLogo(client: ClientType): boolean {
   );
 }
 
-export interface ContributionDisplayWeeks {
-  cells: ContributionCell[];
-  monthMarkers: MonthMarker[];
-}
-
-// The 2D calendar is laid out column-major with 7 rows per week, so reversing
-// the chronological weeks (chunks of 7 cells) places the newest week on the
-// left. Month markers are remapped onto the mirrored week columns; day-of-week
-// rows are unchanged. Applying this twice returns the original ordering.
-export function reverseContributionCalendarWeeks(
-  cells: readonly ContributionCell[],
-  monthMarkers: readonly MonthMarker[],
-  weekCount: number,
-): ContributionDisplayWeeks {
-  const weeks: ContributionCell[][] = [];
-  for (let offset = 0; offset < cells.length; offset += 7) {
-    weeks.push(cells.slice(offset, offset + 7));
-  }
-  weeks.reverse();
-
-  return {
-    cells: weeks.flat(),
-    monthMarkers: monthMarkers.map((marker) => ({
-      ...marker,
-      weekIndex: weekCount - 1 - marker.weekIndex,
-    })),
-  };
-}
-
 const Figure = styled.figure`
   width: 100%;
   min-width: 0;
@@ -1495,33 +1460,6 @@ const LegendSwatch = styled.span<{ $color: string }>`
   background: ${(props) => props.$color};
   border-radius: 2px;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
-`;
-
-const NewestFirstControl = styled.label`
-  display: inline-flex;
-  min-width: 0;
-  align-items: center;
-  gap: 0.375rem;
-  color: var(--service-text-muted);
-  font-size: 0.6875rem;
-  white-space: nowrap;
-  cursor: pointer;
-
-  input {
-    width: 0.8125rem;
-    height: 0.8125rem;
-    margin: 0;
-    accent-color: var(--service-focus);
-    cursor: pointer;
-  }
-
-  &:focus-within {
-    color: var(--service-text);
-  }
-
-  @media (pointer: coarse) {
-    min-height: 2.75rem;
-  }
 `;
 
 const CellTooltip = styled.div<{
@@ -2216,38 +2154,6 @@ export function ProfileContributionGraph({
     useState<ColorPaletteName>(DEFAULT_PALETTE);
   const [internalView, setInternalView] =
     useState<ProfileContributionView>("2d");
-  // Reversal is resolved after mount so the server render and the first client
-  // paint share a stable, chronological default (no hydration mismatch). The
-  // explicit toggle, once set, is persisted and wins over the responsive
-  // default (newest-first on the desktop 2-column layout, chronological below).
-  const isMounted = useSyncExternalStore(
-    subscribeContributionMounted,
-    () => true,
-    () => false,
-  );
-  const isDesktopReverseDefault = useMediaQuery(NEWEST_FIRST_DESKTOP_QUERY);
-  const [storedNewestFirst, setStoredNewestFirst] = useState<boolean | null>(
-    null,
-  );
-  useEffect(() => {
-    try {
-      const stored = window.localStorage.getItem(NEWEST_FIRST_STORAGE_KEY);
-      setStoredNewestFirst(stored === "1" ? true : stored === "0" ? false : null);
-    } catch {
-      // localStorage may be unavailable (private mode / disabled).
-    }
-  }, []);
-  const newestFirst = isMounted
-    ? (storedNewestFirst ?? isDesktopReverseDefault)
-    : false;
-  const commitNewestFirst = (next: boolean) => {
-    setStoredNewestFirst(next);
-    try {
-      window.localStorage.setItem(NEWEST_FIRST_STORAGE_KEY, next ? "1" : "0");
-    } catch {
-      // Ignore persistence failures; the in-memory choice still applies.
-    }
-  };
   const selectedDate =
     providedSelectedDate === undefined
       ? internalSelectedDate
@@ -2269,21 +2175,6 @@ export function ProfileContributionGraph({
       ),
     [contributions, rangeStart, rangeEnd, selectableRangeEnd],
   );
-  // Only the 2D calendar mirrors; the 3D view stays chronological.
-  const reversed = newestFirst && view === "2d";
-  const displayWeeks = useMemo(
-    () =>
-      reversed
-        ? reverseContributionCalendarWeeks(
-            calendar.cells,
-            calendar.monthMarkers,
-            calendar.weekCount,
-          )
-        : null,
-    [reversed, calendar],
-  );
-  const displayCells = displayWeeks?.cells ?? calendar.cells;
-  const displayMonthMarkers = displayWeeks?.monthMarkers ?? calendar.monthMarkers;
   const activeDayLabel = `${calendar.activeDays.toLocaleString("en-US")} active ${
     calendar.activeDays === 1 ? "day" : "days"
   }`;
@@ -2334,9 +2225,7 @@ export function ProfileContributionGraph({
     if (nextScrollLeft !== scrollContainer.scrollLeft) {
       scrollContainer.scrollLeft = nextScrollLeft;
     }
-    // `reversed` is a dep: toggling "Newest first" moves the newest day's cell
-    // to the opposite edge, so re-run to scroll it back into view.
-  }, [rangeEnd, rangeStart, reversed, tabbableDate, view]);
+  }, [rangeEnd, rangeStart, tabbableDate, view]);
 
   const commitSelectedDate = (date: string | null) => {
     if (providedSelectedDate === undefined) setInternalSelectedDate(date);
@@ -2561,7 +2450,7 @@ export function ProfileContributionGraph({
           {view === "2d" ? (
             <CalendarBody id={calendarId} ref={calendarScrollRef}>
               <MonthRow $weeks={calendar.weekCount} aria-hidden="true">
-                {displayMonthMarkers.map((marker) => (
+                {calendar.monthMarkers.map((marker) => (
                   <Month
                     key={`${marker.weekIndex}-${marker.label}`}
                     $compactVisible={marker.compactVisible}
@@ -2585,7 +2474,7 @@ export function ProfileContributionGraph({
                   data-contribution-hit-surface="2d"
                   onClick={selectNearestCell}
                 >
-                  {displayCells.map((cell) => (
+                  {calendar.cells.map((cell) => (
                     <Cell
                       key={cell.date}
                       type="button"
@@ -2634,11 +2523,6 @@ export function ProfileContributionGraph({
                       }}
                       onFocus={(event) => handleCellFocus(cell, event)}
                       onBlur={() => setTooltip(null)}
-                      // Keyboard nav stays chronological even when the view is
-                      // visually reversed: Arrow keys inspect adjacent calendar
-                      // days and Home/End hit the true range boundaries, matching
-                      // the documented a11y contract. "Newest first" is a
-                      // display-only mirror.
                       onKeyDown={(event) => handleCellKeyDown(cell, event)}
                     />
                   ))}
@@ -2768,20 +2652,6 @@ export function ProfileContributionGraph({
                 ))}
               </PaletteSelect>
             </PaletteControl>
-            {view === "2d" && (
-              <NewestFirstControl title="Show newest activity on the left">
-                <input
-                  type="checkbox"
-                  name="profile-contribution-newest-first"
-                  aria-label="Show newest activity on the left"
-                  checked={newestFirst}
-                  onChange={(event) =>
-                    commitNewestFirst(event.currentTarget.checked)
-                  }
-                />
-                <span>Newest first</span>
-              </NewestFirstControl>
-            )}
             <Legend aria-label="Contribution intensity, low to high">
               <span>Low</span>
               <LegendSwatches>

--- a/packages/frontend/src/components/profile/ProfileUsageChart.tsx
+++ b/packages/frontend/src/components/profile/ProfileUsageChart.tsx
@@ -6,11 +6,13 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
   type KeyboardEvent,
   type PointerEvent,
 } from "react";
 import styled, { css } from "styled-components";
 import { SOURCE_DISPLAY_NAMES } from "@/lib/constants";
+import { useMediaQuery } from "@/lib/useMediaQuery";
 import type { DailyContribution } from "@/lib/types";
 import { formatCurrency, formatDate, formatNumber } from "@/lib/utils";
 import {
@@ -21,6 +23,7 @@ import {
   getActiveTooltipRows,
   getUsageProviderTotals,
   providerColor,
+  reverseUsageChartData,
   selectLegendModels,
   toTrailingAverage,
   type UsageChartSeries,
@@ -61,6 +64,12 @@ const TOOLTIP_GAP = 12;
 const TOOLTIP_EDGE = 8;
 const TOOLTIP_VIEWPORT_EDGE = 16;
 const TOOLTIP_MAX_HEIGHT = 416;
+const NEWEST_FIRST_STORAGE_KEY = "tokscale:usage-newest-first";
+// Matches the profile dashboard breakpoint where this card moves into the
+// right-hand column, which is when the newest-on-the-left default applies.
+const NEWEST_FIRST_DESKTOP_QUERY = "(min-width: 1360px)";
+
+const subscribeUsageChartMounted = () => () => {};
 
 type InteractionMode = "idle" | "hover" | "committed";
 
@@ -451,6 +460,33 @@ const SelectControl = styled.label`
 
 const SelectCaption = styled.span`
   flex: 0 0 auto;
+`;
+
+const NewestFirstControl = styled.label`
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.375rem;
+  color: var(--service-text-muted);
+  font-size: 0.75rem;
+  white-space: nowrap;
+  cursor: pointer;
+
+  input {
+    width: 0.8125rem;
+    height: 0.8125rem;
+    margin: 0;
+    accent-color: var(--service-focus);
+    cursor: pointer;
+  }
+
+  &:focus-within {
+    color: var(--service-text);
+  }
+
+  @media (pointer: coarse) {
+    min-height: 2.75rem;
+  }
 `;
 
 const CompactSelect = styled.select`
@@ -890,6 +926,42 @@ export function ProfileUsageChart({
   const [view, setView] = useState<UsageView>("average");
   const [providerFilter, setProviderFilter] =
     useState<UsageProviderFilter>(ALL_USAGE_PROVIDERS);
+  // Reversal is resolved after mount so the server render and the first client
+  // paint share a stable, chronological default (no hydration mismatch). The
+  // explicit toggle, once set, is persisted and wins over the responsive
+  // default (newest-first when this card sits in the desktop right-hand
+  // column, chronological below that breakpoint).
+  const isMounted = useSyncExternalStore(
+    subscribeUsageChartMounted,
+    () => true,
+    () => false,
+  );
+  const isDesktopReverseDefault = useMediaQuery(NEWEST_FIRST_DESKTOP_QUERY);
+  // Lazy initializer: reads once on the client; the server (and the hydration
+  // render, via the isMounted gate below) always resolves chronological.
+  const [storedNewestFirst, setStoredNewestFirst] = useState<boolean | null>(
+    () => {
+      if (typeof window === "undefined") return null;
+      try {
+        const stored = window.localStorage.getItem(NEWEST_FIRST_STORAGE_KEY);
+        return stored === "1" ? true : stored === "0" ? false : null;
+      } catch {
+        // localStorage may be unavailable (private mode / disabled).
+        return null;
+      }
+    },
+  );
+  const newestFirst = isMounted
+    ? (storedNewestFirst ?? isDesktopReverseDefault)
+    : false;
+  const commitNewestFirst = (next: boolean) => {
+    setStoredNewestFirst(next);
+    try {
+      window.localStorage.setItem(NEWEST_FIRST_STORAGE_KEY, next ? "1" : "0");
+    } catch {
+      // Ignore persistence failures; the in-memory choice still applies.
+    }
+  };
   const [activeDate, setActiveDate] = useState<string | null>(null);
   const [announcedDate, setAnnouncedDate] = useState<string | null>(null);
   const [interactionMode, setInteractionMode] =
@@ -920,7 +992,7 @@ export function ProfileUsageChart({
     providerTotals.some(({ provider }) => provider === providerFilter)
       ? providerFilter
       : ALL_USAGE_PROVIDERS;
-  const chartData = useMemo(
+  const chronologicalChartData = useMemo(
     () =>
       buildUsageChartData(
         days,
@@ -930,6 +1002,16 @@ export function ProfileUsageChart({
         averageWindowDays,
       ),
     [days, metric, selectedProvider, view, averageWindowDays],
+  );
+  // Everything below renders in visual order: with "Newest first" on, the
+  // whole per-day pipeline (dates, series, totals) is mirrored once here so
+  // pointer, keyboard, and tooltip index math needs no special cases.
+  const chartData = useMemo(
+    () =>
+      newestFirst
+        ? reverseUsageChartData(chronologicalChartData)
+        : chronologicalChartData,
+    [chronologicalChartData, newestFirst],
   );
   const chartStack = useMemo(
     () =>
@@ -988,23 +1070,32 @@ export function ProfileUsageChart({
   const requestedActiveIndex = activeDate
     ? chartData.dates.indexOf(activeDate)
     : -1;
+  // The idle inspection target is always the newest day, whichever edge it
+  // renders on.
   const activeIndex =
     requestedActiveIndex >= 0
       ? requestedActiveIndex
-      : chartData.dates.length - 1;
+      : newestFirst
+        ? 0
+        : chartData.dates.length - 1;
   const currentDate = chartData.dates[activeIndex] ?? null;
   const currentTotal = chartData.dailyTotals[activeIndex] ?? 0;
   const activeRows = useMemo(
     () => getActiveTooltipRows(chartData.series, activeIndex),
     [chartData.series, activeIndex],
   );
+  // `days` stays chronological, so the visual index is mapped back before
+  // indexing per-provider cost values.
+  const chronologicalActiveIndex = newestFirst
+    ? chartData.dates.length - 1 - activeIndex
+    : activeIndex;
   const providerCostRows = useMemo(
     () =>
       getProviderCostRows(
         days,
         costProviderTotals,
         selectedProvider,
-        activeIndex,
+        chronologicalActiveIndex,
         view,
         chartData.averageWindowDays,
       ),
@@ -1012,7 +1103,7 @@ export function ProfileUsageChart({
       days,
       costProviderTotals,
       selectedProvider,
-      activeIndex,
+      chronologicalActiveIndex,
       view,
       chartData.averageWindowDays,
     ],
@@ -1173,26 +1264,40 @@ export function ProfileUsageChart({
           </SelectControl>
         </ControlCluster>
 
-        <SelectControl>
-          <SelectCaption>Provider</SelectCaption>
-          <CompactSelect
-            name="profile-usage-provider"
-            aria-label="Usage provider"
-            value={selectedProvider}
-            onChange={(event) =>
-              setProviderFilter(
-                event.currentTarget.value as UsageProviderFilter,
-              )
-            }
-          >
-            <option value={ALL_USAGE_PROVIDERS}>All</option>
-            {providerTotals.map(({ provider }) => (
-              <option key={provider} value={provider}>
-                {providerName(provider)}
-              </option>
-            ))}
-          </CompactSelect>
-        </SelectControl>
+        <ControlCluster>
+          <NewestFirstControl title="Show newest activity on the left">
+            <input
+              type="checkbox"
+              name="profile-usage-newest-first"
+              aria-label="Show newest activity on the left"
+              checked={newestFirst}
+              onChange={(event) =>
+                commitNewestFirst(event.currentTarget.checked)
+              }
+            />
+            <span>Newest first</span>
+          </NewestFirstControl>
+          <SelectControl>
+            <SelectCaption>Provider</SelectCaption>
+            <CompactSelect
+              name="profile-usage-provider"
+              aria-label="Usage provider"
+              value={selectedProvider}
+              onChange={(event) =>
+                setProviderFilter(
+                  event.currentTarget.value as UsageProviderFilter,
+                )
+              }
+            >
+              <option value={ALL_USAGE_PROVIDERS}>All</option>
+              {providerTotals.map(({ provider }) => (
+                <option key={provider} value={provider}>
+                  {providerName(provider)}
+                </option>
+              ))}
+            </CompactSelect>
+          </SelectControl>
+        </ControlCluster>
       </Controls>
 
       <PlotRegion>

--- a/packages/frontend/src/components/profile/usageChartData.ts
+++ b/packages/frontend/src/components/profile/usageChartData.ts
@@ -876,6 +876,29 @@ export function buildUsageChartData(
   };
 }
 
+/**
+ * Mirror the chart's time axis so the newest day renders on the left. Every
+ * per-day array (dates, series values, daily totals) is reversed together,
+ * keeping index positions aligned, so hover, keyboard, and tooltip lookups
+ * work in visual order unchanged. Order-independent aggregates (totals,
+ * maximums, the averaging window) are untouched — trailing averages must
+ * already be computed on chronological data before mirroring. The input is
+ * not mutated, and applying this twice returns the chronological ordering.
+ */
+export function reverseUsageChartData(data: UsageChartData): UsageChartData {
+  return {
+    ...data,
+    dates: [...data.dates].reverse(),
+    series: data.series.map((item) => ({
+      ...item,
+      rawValues: [...item.rawValues].reverse(),
+      values: [...item.values].reverse(),
+    })),
+    rawDailyTotals: [...data.rawDailyTotals].reverse(),
+    dailyTotals: [...data.dailyTotals].reverse(),
+  };
+}
+
 export interface LegendModel {
   id: string;
   label: string;


### PR DESCRIPTION
#863 put the reverse-render toggle on the wrong card: it belongs on **Usage over time** — the card in the right-hand column of the ≥1360px dashboard grid — not the Contributions calendar.

### Removed (Contributions calendar)
- `reverseContributionCalendarWeeks`, the footer "Newest first" checkbox, the `tokscale:contributions-newest-first` localStorage key, media-query/mount plumbing, and the mirror-related scroll-effect dep. The calendar is purely chronological again. The today-tooltip and client-logo fixes from #863 are untouched.

### Added (Usage over time)
- "Newest first" checkbox in the controls row, persisted to `tokscale:usage-newest-first`.
- Default: **reversed on desktop** (`min-width: 1360px`, where the card sits on the right) and **chronological on mobile**; an explicit choice always wins. SSR/first paint render chronological, the resolved value applies after mount (no hydration mismatch).
- New pure `reverseUsageChartData` mirrors dates, per-series values, and daily totals together, so pointer, keyboard (←/→/Home/End), tooltip, and date-range labels all follow visual order with no per-consumer mirror logic. Trailing averages stay computed on chronological data; per-provider cost rows map the visual index back into the chronological `days` array. Idle inspection still defaults to the newest day on either edge.

### Tests
- Dropped the calendar-mirroring tests; added `reverseUsageChartData` coverage (per-day arrays mirrored + index-aligned, aggregates untouched, input not mutated, double-reverse round-trips).
- `tsc` clean, eslint clean, 588 tests pass, production build passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the "Newest first" toggle from the Contributions calendar to the Usage over time chart. The calendar is chronological again; the usage chart now mirrors time with correct interactions and a responsive default.

- **Bug Fixes**
  - Moved the toggle to Usage over time; removed calendar mirroring and its storage key.  
  - Usage chart reverses dates, series, and totals together so hover, keyboard, and tooltips follow visual order.  
  - Toggle persists to `tokscale:usage-newest-first`; default is reversed on desktop (≥1360px) and chronological on mobile; applied after mount to avoid hydration mismatch.  
  - Provider cost rows map the visual index back to chronological days; added tests for the reversal and removed calendar mirror tests.

<sup>Written for commit 139ad4c0bc8d25e57c60839f6cfc3cdacb70c67c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

