### PR TITLE
fix(graph): correct client filter toggle inversion and stale breakdown panel

### DIFF
--- a/packages/frontend/__tests__/lib/graphClientFilter.test.ts
+++ b/packages/frontend/__tests__/lib/graphClientFilter.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { toggleClientFilter, resolveSelectedDay } from "../../src/lib/utils";
+import type { ClientType, DailyContribution } from "../../src/lib/types";
+
+const availableClients: ClientType[] = ["claude", "codex", "gemini"];
+
+function day(date: string): DailyContribution {
+  return {
+    date,
+    totals: { tokens: 0, cost: 0, messages: 0 },
+    intensity: 0,
+    tokenBreakdown: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+    clients: [],
+  };
+}
+
+describe("toggleClientFilter", () => {
+  it("treats an empty filter as all clients, so a click deselects that client", () => {
+    // Empty filter renders every chip active (show-all). Clicking one should remove
+    // it from the full set, not select only that one (the pre-fix inversion bug).
+    expect(toggleClientFilter("codex", [], availableClients)).toEqual(["claude", "gemini"]);
+  });
+
+  it("removes a client from an explicit subset when it is present", () => {
+    expect(toggleClientFilter("codex", ["claude", "codex"], availableClients)).toEqual(["claude"]);
+  });
+
+  it("adds a client to an explicit subset when it is absent", () => {
+    expect(toggleClientFilter("gemini", ["claude"], availableClients)).toEqual(["claude", "gemini"]);
+  });
+
+  it("normalizes back to the empty show-all sentinel when the toggle selects every client", () => {
+    // Adding the last missing client would explicitly list all of them; collapse to []
+    // so the Clear/Show-all affordances stay consistent.
+    expect(toggleClientFilter("gemini", ["claude", "codex"], availableClients)).toEqual([]);
+  });
+
+  it("normalizes to the empty show-all sentinel when the last selected client is removed", () => {
+    // Removing the only remaining client leaves zero selected, which means show-all
+    // everywhere else in the UI — reuse the empty sentinel instead of a new one.
+    expect(toggleClientFilter("claude", ["claude"], availableClients)).toEqual([]);
+  });
+
+  it("round-trips: deselect from empty then reselect returns to the empty sentinel", () => {
+    const afterFirstClick = toggleClientFilter("codex", [], availableClients);
+    expect(afterFirstClick).toEqual(["claude", "gemini"]);
+    // Clicking the same chip again re-adds it, restoring the full set -> empty sentinel.
+    expect(toggleClientFilter("codex", afterFirstClick, availableClients)).toEqual([]);
+  });
+});
+
+describe("resolveSelectedDay", () => {
+  const contributions = [day("2026-07-10"), day("2026-07-11"), day("2026-07-12")];
+
+  it("returns null when no date is selected", () => {
+    expect(resolveSelectedDay(null, contributions)).toBeNull();
+  });
+
+  it("resolves the live day object for a date present in the current data", () => {
+    const resolved = resolveSelectedDay("2026-07-11", contributions);
+    expect(resolved).toBe(contributions[1]);
+  });
+
+  it("returns null (closing the panel) when the date is absent from the filtered data", () => {
+    expect(resolveSelectedDay("2026-01-01", contributions)).toBeNull();
+  });
+
+  it("re-resolves to the fresh object after the underlying data is replaced", () => {
+    const filtered = [day("2026-07-11")];
+    // Same date, different (filtered) array -> caller gets the new object, never stale.
+    expect(resolveSelectedDay("2026-07-11", filtered)).toBe(filtered[0]);
+    expect(resolveSelectedDay("2026-07-11", filtered)).not.toBe(contributions[1]);
+  });
+});

--- a/packages/frontend/src/components/GraphContainer.tsx
+++ b/packages/frontend/src/components/GraphContainer.tsx
@@ -6,7 +6,7 @@ import dynamic from "next/dynamic";
 import type { TokenContributionData, DailyContribution, ViewMode, ClientType, TooltipPosition } from "@/lib/types";
 import { getPalette } from "@/lib/themes";
 import { useSettings } from "@/lib/useSettings";
-import { filterByClient, filterByYear, recalculateIntensity, findBestDay, calculateCurrentStreak, calculateLongestStreak } from "@/lib/utils";
+import { filterByClient, filterByYear, recalculateIntensity, findBestDay, calculateCurrentStreak, calculateLongestStreak, resolveSelectedDay } from "@/lib/utils";
 import { TokenGraph2D } from "./TokenGraph2D";
 
 // Lazy load 3D graph (Three.js) - reduces initial bundle, SSR disabled for WebGL
@@ -74,7 +74,7 @@ export function GraphContainer({ data, totalActiveTimeMs, sessionCount, mcpServe
   const [selectedYear, setSelectedYear] = useState<string>(() => data.years.length > 0 ? data.years[data.years.length - 1].year : "");
   const [hoveredDay, setHoveredDay] = useState<DailyContribution | null>(null);
   const [tooltipPosition, setTooltipPosition] = useState<TooltipPosition | null>(null);
-  const [selectedDay, setSelectedDay] = useState<DailyContribution | null>(null);
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [clientFilter, setClientFilter] = useState<ClientType[]>([]);
   const initializedRef = useRef(false);
 
@@ -91,6 +91,14 @@ export function GraphContainer({ data, totalActiveTimeMs, sessionCount, mcpServe
     const filtered = filterByYear(filteredByClient.contributions, selectedYear);
     return recalculateIntensity(filtered);
   }, [filteredByClient.contributions, selectedYear]);
+
+  // Derive the breakdown panel's day from the live contributions so it re-resolves
+  // (and closes when the date drops out of the filtered data) whenever the client
+  // filter or selected year changes, instead of showing a stale pre-filter snapshot.
+  const selectedDay = useMemo(
+    () => resolveSelectedDay(selectedDate, yearContributions),
+    [selectedDate, yearContributions]
+  );
 
   const maxTokens = useMemo(() => Math.max(...yearContributions.map((c) => c.totals.tokens), 0), [yearContributions]);
   const totalCost = useMemo(() => yearContributions.reduce((sum, c) => sum + c.totals.cost, 0), [yearContributions]);
@@ -117,7 +125,7 @@ export function GraphContainer({ data, totalActiveTimeMs, sessionCount, mcpServe
         const latestDay = activeDaysWithTokens[activeDaysWithTokens.length - 1];
         // Intentional one-time initialization on first data load
         // eslint-disable-next-line react-hooks/set-state-in-effect
-        setSelectedDay(latestDay);
+        setSelectedDate(latestDay.date);
         initializedRef.current = true;
       }
     }
@@ -129,7 +137,7 @@ export function GraphContainer({ data, totalActiveTimeMs, sessionCount, mcpServe
   }, []);
 
   const handleDayClick = useCallback((day: DailyContribution | null) => {
-    setSelectedDay((prev) => (prev?.date === day?.date ? null : day));
+    setSelectedDate((prev) => (prev === day?.date ? null : day?.date ?? null));
   }, []);
 
   return (
@@ -181,7 +189,7 @@ export function GraphContainer({ data, totalActiveTimeMs, sessionCount, mcpServe
         </GraphWrapper>
       </GraphCard>
 
-      {selectedDay && <BreakdownPanel day={selectedDay} onClose={() => setSelectedDay(null)} palette={palette} />}
+      {selectedDay && <BreakdownPanel day={selectedDay} onClose={() => setSelectedDate(null)} palette={palette} />}
       {view === "2d" && <StatsPanel data={filteredByClient} palette={palette} totalActiveTimeMs={clientFilter.length === 0 ? totalActiveTimeMs : null} sessionCount={clientFilter.length === 0 ? sessionCount : null} mcpServers={mcpServers} />}
       <Tooltip day={hoveredDay} position={tooltipPosition} visible={hoveredDay !== null} palette={palette} />
     </Container>

--- a/packages/frontend/src/components/GraphControls.tsx
+++ b/packages/frontend/src/components/GraphControls.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import type { ViewMode, ColorPaletteName, ClientType, GraphColorPalette } from "@/lib/types";
 import { getPaletteNames, colorPalettes } from "@/lib/themes";
 import { SOURCE_DISPLAY_NAMES, SOURCE_LOGOS } from "@/lib/constants";
-import { formatTokenCount } from "@/lib/utils";
+import { formatTokenCount, toggleClientFilter } from "@/lib/utils";
 
 interface GraphControlsProps {
   view: ViewMode;
@@ -264,11 +264,7 @@ export function GraphControls({
   const paletteNames = getPaletteNames();
 
   const handleClientToggle = (client: ClientType) => {
-    if (clientFilter.includes(client)) {
-      onClientFilterChange(clientFilter.filter((c) => c !== client));
-    } else {
-      onClientFilterChange([...clientFilter, client]);
-    }
+    onClientFilterChange(toggleClientFilter(client, clientFilter, availableClients));
   };
 
   return (

--- a/packages/frontend/src/lib/utils.ts
+++ b/packages/frontend/src/lib/utils.ts
@@ -94,6 +94,54 @@ export function filterByYear(contributions: DailyContribution[], year: string): 
   return contributions.filter((c) => c.date.startsWith(year));
 }
 
+/**
+ * Toggle a client within the client filter, honoring the "empty means all" convention.
+ *
+ * An empty `clientFilter` is the show-all sentinel: every chip renders as active. To
+ * keep the toggle in sync with that affordance, we expand an empty filter to the full
+ * `availableClients` set before toggling, so clicking a highlighted chip deselects it
+ * instead of collapsing the selection to that single client.
+ *
+ * The result is normalized back to the empty sentinel whenever the toggle would leave
+ * every available client selected, or leave none selected — both states mean "show all"
+ * elsewhere in the UI (the Clear/Show-all actions), so we avoid introducing a new
+ * "nothing selected" sentinel.
+ */
+export function toggleClientFilter(
+  client: ClientType,
+  clientFilter: ClientType[],
+  availableClients: ClientType[]
+): ClientType[] {
+  const effective = clientFilter.length === 0 ? [...availableClients] : clientFilter;
+
+  const next = effective.includes(client)
+    ? effective.filter((c) => c !== client)
+    : [...effective, client];
+
+  if (next.length === 0 || next.length === availableClients.length) {
+    return [];
+  }
+
+  return next;
+}
+
+/**
+ * Resolve the currently selected day from a date string against the live contributions.
+ *
+ * Storing the selected date (instead of a snapshot of the day object) lets the
+ * breakdown panel re-derive its data whenever the underlying contributions change
+ * (e.g. after a client filter change), so it never shows stale pre-filter totals.
+ * Returns null when no date is selected or the date is absent from the current data,
+ * which the caller uses to close the panel.
+ */
+export function resolveSelectedDay(
+  selectedDate: string | null,
+  contributions: DailyContribution[]
+): DailyContribution | null {
+  if (!selectedDate) return null;
+  return contributions.find((c) => c.date === selectedDate) ?? null;
+}
+
 function recalculateDayTotals(day: DailyContribution): DailyContribution {
   const tokenBreakdown: TokenBreakdown = {
     input: 0,


### PR DESCRIPTION
## Summary

Fixes two adversarially-verified P1 bugs in the contribution graph's client filter.

### Bug 1 — Client filter chips invert on first click
**User-visible scenario:** With no filter applied, every client chip renders highlighted/active (the "show all" state). Clicking any highlighted chip *should* deselect it, leaving the others. Instead, it selected **only** that one client — the exact opposite of what the pressed-state affordance promises.

**Cause:** An empty `clientFilter` is the "show all" sentinel (`GraphControls` renders `isSelected = clientFilter.length === 0 || clientFilter.includes(client)`), but `handleClientToggle` ignored that convention. `[].includes(client)` is `false`, so the toggle fell into the "add" branch and produced `[client]`.

**Fix:** Toggling now expands an empty filter to the full available-clients set before toggling, so a click on an active chip removes it. The result is normalized back to `[]` when it would cover **every** client or **none** — both mean "show all" elsewhere in the UI (the Clear / Show-all controls and `StatsPanel`), so no new sentinel is introduced.

### Bug 2 — Day breakdown panel shows stale pre-filter data
**User-visible scenario:** Open a day's breakdown panel, then change the client filter. The heatmap and stats update to the filtered data, but the open panel keeps showing the pre-filter clients and totals — contradicting the rest of the view.

**Cause:** `selectedDay` was a `DailyContribution` snapshot set only by `handleDayClick`. `yearContributions` re-derives whenever `clientFilter` changes, but nothing re-resolved the snapshot.

**Fix:** The panel now stores the selected **date** and resolves the day object from the live `yearContributions` via `useMemo`. It can't go stale, and it closes automatically when the selected date is no longer present in the filtered data (e.g. after a year change).

## Implementation
- Extracted the two behaviors into pure, exported helpers in `src/lib/utils.ts`:
  - `toggleClientFilter(client, clientFilter, availableClients)`
  - `resolveSelectedDay(selectedDate, contributions)`
- `GraphControls` delegates its toggle to the helper; `GraphContainer` stores `selectedDate` and derives `selectedDay`.
- Added `__tests__/lib/graphClientFilter.test.ts` (10 vitest cases) covering the toggle semantics (empty→click removes from full set, collapse-to-all/collapse-to-none normalize to the sentinel, round-trip) and day resolution (present/absent/null, re-resolves to fresh object).

## Verification (from `packages/frontend`)
- `bunx tsc --noEmit` — exit 0
- `bunx eslint <changed files>` — 0 errors (3 pre-existing unused-styled-component warnings, outside the diff)
- `bun run test` — 63 files, 598 tests passed (incl. 10 new)
- `bun run build` — exit 0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two P1 issues in the contribution graph: client filter chips no longer invert on first click, and the day breakdown panel now always shows data for the current client filter.

- **Bug Fixes**
  - Client filter respects the empty “show all” sentinel. Clicking an active chip now deselects it. Normalizes back to empty when all or none are selected.
  - Breakdown panel stores the selected date and resolves the day from live contributions. It updates with the filter and closes if the date disappears.

- **Refactors**
  - Extracted pure helpers: toggleClientFilter and resolveSelectedDay. Components delegate to them.
  - Added unit tests for toggle semantics and day resolution.

<sup>Written for commit 4a3940cc72a3687ba04dae16ff7316cbf2bfeb7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

