### PR TITLE
fix(profile): repair four adversarially-found UI defects

### DIFF
--- a/packages/frontend/__tests__/components/profileUsageChartData.test.ts
+++ b/packages/frontend/__tests__/components/profileUsageChartData.test.ts
@@ -828,11 +828,64 @@ describe("profile usage chart legend", () => {
       ...legacy.series,
       ...capped.series,
     ];
-    const { visible } = selectLegendModels(combined, 10);
+    const { visible, hiddenCount } = selectLegendModels(combined, 10);
 
     expect(new Set(visible.map(({ label }) => label))).toEqual(
       new Set(["opus", "Synthetic", "r1"]),
     );
+
+    // The legend lists 3 model series (opus, Synthetic, r1) but the chart also
+    // paints 4 non-model bands (blank-model, provider-remainder,
+    // daily-remainder, series-remainder). "+N more" must count every plotted
+    // band the legend omits, not just hidden models.
+    const plottedBands = combined.filter(({ total }) => total > 0).length;
+    expect(plottedBands).toBe(7);
+    expect(hiddenCount).toBe(4);
+  });
+
+  it("counts non-model bands and skips zero-total series in hiddenCount", () => {
+    const chart = buildUsageChartData(
+      aggregateDailyUsage([
+        day("2026-08-06", [
+          nestedClient(
+            "claude",
+            {
+              opus: model({ input: 40 }, 4),
+              "": model({ input: 12 }, 1),
+            },
+            { input: 100 },
+            10,
+          ),
+        ]),
+      ]),
+      "tokens",
+      "all",
+      "daily",
+    );
+
+    // Real bands: opus (model), blank-model, provider-remainder — all nonzero.
+    expect(chart.series.map(({ kind }) => kind)).toEqual(
+      expect.arrayContaining(["model", "blank-model", "provider-remainder"]),
+    );
+    expect(chart.series.every(({ total }) => total > 0)).toBe(true);
+
+    // Legend lists only "opus"; the two non-model bands are hidden but drawn.
+    const { visible, hiddenCount } = selectLegendModels(chart.series, 5);
+    expect(visible.map(({ label }) => label)).toEqual(["opus"]);
+    expect(hiddenCount).toBe(2);
+
+    // A remainder band with a zero total is never drawn, so it must not inflate
+    // the "+N more" count.
+    const withZeroBand = [
+      ...chart.series,
+      {
+        ...chart.series[0],
+        id: "zero-band" as (typeof chart.series)[number]["id"],
+        kind: "daily-remainder" as const,
+        total: 0,
+      },
+    ];
+    expect(selectLegendModels(withZeroBand, 5).hiddenCount).toBe(2);
   });
 
   it("disambiguates duplicate model labels across providers", () => {

--- a/packages/frontend/src/components/profile/ProfileContributionGraph.tsx
+++ b/packages/frontend/src/components/profile/ProfileContributionGraph.tsx
@@ -2249,7 +2249,10 @@ export function ProfileContributionGraph({
   };
 
   const positionCellTooltip = (cell: ContributionCell, target: Element) => {
-    if (!cell.inRange || typeof window === "undefined") {
+    // In-range-but-unselectable cells (e.g. future days in the current year)
+    // must stay fully inert: no tooltip on hover or focus. `selectable` implies
+    // `inRange`, and today remains selectable, so its tooltip is unaffected.
+    if (!cell.selectable || typeof window === "undefined") {
       setTooltip(null);
       return;
     }
@@ -2295,6 +2298,30 @@ export function ProfileContributionGraph({
   ) => {
     setKeyboardDate(cell.date);
     positionCellTooltip(cell, event.currentTarget);
+  };
+
+  const handleCellPointerLeave = (event: PointerEvent<Element>) => {
+    const active = document.activeElement;
+    // Still focused within the cell the pointer is leaving: keep its tooltip.
+    if (active === event.currentTarget) return;
+
+    // The pointer left, but keyboard focus may rest on a different cell whose
+    // aria-describedby points at the tooltip. Re-anchor the tooltip to that
+    // focused cell instead of stranding its description on a cleared tooltip.
+    if (active) {
+      for (const [date, node] of cellRefs.current) {
+        if (node !== active) continue;
+        const focusedCell = calendar.cells.find(
+          (candidate) => candidate.date === date,
+        );
+        if (focusedCell) {
+          positionCellTooltip(focusedCell, node);
+          return;
+        }
+      }
+    }
+
+    setTooltip(null);
   };
 
   const handleCellKeyDown = (
@@ -2483,7 +2510,7 @@ export function ProfileContributionGraph({
                           cellRefs.current.set(cell.date, node);
                         else cellRefs.current.delete(cell.date);
                       }}
-                      disabled={!cell.inRange}
+                      disabled={!cell.inRange || !cell.selectable}
                       tabIndex={
                         cell.selectable && cell.date === tabbableDate ? 0 : -1
                       }
@@ -2516,11 +2543,7 @@ export function ProfileContributionGraph({
                       onPointerEnter={(event) =>
                         handleCellPointerEnter(cell, event)
                       }
-                      onPointerLeave={(event) => {
-                        if (document.activeElement !== event.currentTarget) {
-                          setTooltip(null);
-                        }
-                      }}
+                      onPointerLeave={handleCellPointerLeave}
                       onFocus={(event) => handleCellFocus(cell, event)}
                       onBlur={() => setTooltip(null)}
                       onKeyDown={(event) => handleCellKeyDown(cell, event)}
@@ -2580,13 +2603,9 @@ export function ProfileContributionGraph({
                       $selected={selected}
                       onClick={interactive ? () => selectCell(cell) : undefined}
                       onPointerEnter={(event) =>
-                        handleCellPointerEnter(cell, event)
+                        interactive && handleCellPointerEnter(cell, event)
                       }
-                      onPointerLeave={(event) => {
-                        if (document.activeElement !== event.currentTarget) {
-                          setTooltip(null);
-                        }
-                      }}
+                      onPointerLeave={handleCellPointerLeave}
                       onFocus={(event) =>
                         interactive && handleCellFocus(cell, event)
                       }

--- a/packages/frontend/src/components/profile/ProfileContributionGraph.tsx
+++ b/packages/frontend/src/components/profile/ProfileContributionGraph.tsx
@@ -2308,7 +2308,9 @@ export function ProfileContributionGraph({
     // The pointer left, but keyboard focus may rest on a different cell whose
     // aria-describedby points at the tooltip. Re-anchor the tooltip to that
     // focused cell instead of stranding its description on a cleared tooltip.
-    if (active) {
+    // Only while a tooltip is open: if Escape already dismissed it, leaving
+    // the hovered cell must not resurrect it.
+    if (active && tooltip) {
       for (const [date, node] of cellRefs.current) {
         if (node !== active) continue;
         const focusedCell = calendar.cells.find(

--- a/packages/frontend/src/components/profile/ProfileUsageChart.tsx
+++ b/packages/frontend/src/components/profile/ProfileUsageChart.tsx
@@ -1432,7 +1432,7 @@ export function ProfileUsageChart({
         </VisuallyHidden>
       </PlotRegion>
 
-      {modelLegend.visible.length > 0 && (
+      {(modelLegend.visible.length > 0 || modelLegend.hiddenCount > 0) && (
         <Legend role="list" aria-label="Usage models">
           {modelLegend.visible.map((entry) => (
             <LegendItem key={entry.id}>

--- a/packages/frontend/src/components/profile/ProfileUsageChart.tsx
+++ b/packages/frontend/src/components/profile/ProfileUsageChart.tsx
@@ -1180,13 +1180,21 @@ export function ProfileUsageChart({
   const activeTooltipLeft = tooltipLeft(activeOffset, plotWidth);
   const modeLabel = viewLabel(view, chartData.averageWindowDays);
   const chartTitle = `${modeLabel} ${metricLabel(metric).toLowerCase()} usage by model and provider`;
+  // Screen readers should hear the true chronological span, so build from/to
+  // from `chronologicalChartData` (unmirrored source) rather than the possibly
+  // reversed display order. When "Newest first" mirrors the visible axis, note
+  // it so AT users know the plotted direction is flipped.
+  const descriptionDates = chronologicalChartData.dates;
   const chartDescription = `${chartTitle} from ${
-    chartData.dates[0] ? formatDate(chartData.dates[0]) : "no start date"
+    descriptionDates[0] ? formatDate(descriptionDates[0]) : "no start date"
   } to ${
-    chartData.dates.at(-1)
-      ? formatDate(chartData.dates.at(-1) as string)
+    descriptionDates.at(-1)
+      ? formatDate(descriptionDates.at(-1) as string)
       : "no end date"
-  }. Raw range total: ${formatMetric(chartData.total, metric)}.`;
+  }${newestFirst ? ", displayed newest first" : ""}. Raw range total: ${formatMetric(
+    chartData.total,
+    metric,
+  )}.`;
   const announcedIndex = announcedDate
     ? chartData.dates.indexOf(announcedDate)
     : -1;

--- a/packages/frontend/src/components/profile/usageChartData.ts
+++ b/packages/frontend/src/components/profile/usageChartData.ts
@@ -906,10 +906,18 @@ export interface LegendModel {
 }
 
 /**
- * Pick the highest-usage real model series for the chart legend. Remainder,
- * "Other", blank, and daily-remainder buckets are excluded so the legend mirrors
- * exactly what the model-shaded areas plot. Duplicate labels are disambiguated
- * with their provider the same way the tooltip does.
+ * Pick the highest-usage real model series for the chart legend. Legend ENTRIES
+ * stay models-only (real models plus synthetic) — remainder, "Other", blank,
+ * and daily-remainder buckets are never listed, so the legend keeps showing the
+ * user's best models. Duplicate labels are disambiguated with their provider the
+ * same way the tooltip does.
+ *
+ * `hiddenCount` ("+N more") counts every plotted series the legend does NOT
+ * list, including the non-model buckets (blank-model, provider-remainder,
+ * daily-remainder, series-remainder) that the chart still draws. Only series
+ * with a nonzero total are counted, because a band with total 0 is never
+ * visibly drawn. This keeps "+N more" aligned with the number of bands the
+ * chart actually paints rather than only the hidden model series.
  */
 export function selectLegendModels(
   series: readonly UsageChartSeries[],
@@ -941,7 +949,12 @@ export function selectLegendModels(
     color: item.color,
   }));
 
-  return { visible, hiddenCount: ranked.length - top.length };
+  const legendIds = new Set(top.map(({ id }) => id));
+  const hiddenCount = series.filter(
+    (item) => finiteUsage(item.total) > 0 && !legendIds.has(item.id),
+  ).length;
+
+  return { visible, hiddenCount };
 }
 
 /** Positive active-day rows in visual descending order with stable ties. */


### PR DESCRIPTION
Four accessibility/interaction defects found while auditing the profile contribution graph and usage chart. Each fix is the smallest viable change; legend/product behavior is preserved.

## Bug A (P1) — Future contribution cells looked interactive but clicking was a silent no-op
When the range dropdown selects the current year, cells after today have `inRange: true, selectable: false`. The button used `disabled={!cell.inRange}` only, so future cells kept the pointer cursor and hover tooltip, yet `selectCell` early-returns on `!cell.selectable`. Now the tooltip is gated on `cell.selectable` centrally (covers hover and focus, 2D and 3D), the 2D button is `disabled` for unselectable cells, and the 3D isometric `onPointerEnter` is gated on `interactive`. TODAY stays selectable (`selectableEndDate` includes it), so its tooltip and click are unaffected.

## Bug B (P2/P3) — SVG chart `<desc>` read the date range backwards under "Newest first"
`chartDescription` used the display-ordered `chartData.dates`, so with the desktop newest-first default a screen reader heard "from <newest> to <oldest>". The from/to span is now built from the chronological source (`chronologicalChartData.dates`), and when newest-first is active the description appends ", displayed newest first" so AT users know the visual axis is mirrored. The visible `DateRange` labels stay display-ordered (correct as-is).

## Bug C (P3) — Usage legend's "+N more" undercounted plotted bands
The legend lists top model/synthetic series, but the chart also draws non-model buckets (blank-model, provider-remainder, daily-remainder, series-remainder). `hiddenCount` only counted hidden *model* series, so "+N more" was lower than the number of bands actually drawn. Legend entries stay models-only (product decision), but `hiddenCount` now counts every plotted series the legend omits. Zero-total series are excluded because a band with total 0 is never visibly drawn (candidates are already filtered to `total > 0`). Docstring updated; tests extended.

## Bug D (P3) — Contribution cell tooltip stranded off a keyboard-focused cell
Sequence: keyboard-focus cell A (tooltip A shows) → mouse across cell B (tooltip moves to B) → mouse leaves B → tooltip cleared, but cell A still has focus and its `aria-describedby` pointed at nothing. On pointer leave, if `document.activeElement` is a registered cell button, the tooltip is re-anchored to that focused cell; otherwise it clears as before. Escape-to-close behavior is intact.

## Verification (from `packages/frontend`)
- `bunx tsc --noEmit` — clean (no errors in changed files)
- `bunx eslint <changed files>` — clean
- `bun run test` — 589 passed / 62 files
- `bun run build` — Compiled successfully

## Tests
Extended `__tests__/components/profileUsageChartData.test.ts`: the existing multi-bucket fixture now asserts `hiddenCount` counts the 4 non-model bands, plus a new case asserting non-model bands are counted and zero-total bands are skipped. Bug A's data-layer invariant (future cells `selectable: false`, today `selectable: true`) is already covered by `profileContributionGraphData.test.ts`. Bug A/D component-only interaction is not unit-tested to avoid introducing a DOM test framework into this package.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix four accessibility and interaction issues in the profile contribution graph and usage chart. Improves keyboard/mouse behavior, screen reader descriptions, and legend accuracy.

- **Bug Fixes**
  - Future contribution cells: now fully inert. Tooltips show only for `selectable` cells; 2D button disabled when not selectable; 3D hover gated on `interactive`. Today stays selectable.
  - SVG `<desc>` date range: now built from `chronologicalChartData`; adds ", displayed newest first" when mirrored so screen readers hear the correct span.
  - Usage legend "+N more": `hiddenCount` includes all plotted non-model series with `total > 0` (blank-model and remainders). Legend entries remain models-only, and the legend still renders to show "+N more" when only non-model bands are plotted.
  - Tooltip focus handoff: on pointer leave, re-anchors to the currently focused cell if any; if the tooltip was dismissed with Escape it stays closed; otherwise clears.

<sup>Written for commit 28617c7ec9de0c650203bc23b06e0111919b6fe2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

