### PR TITLE
feat(frontend): align Codex client color with the OpenAI palette

### DIFF
--- a/packages/frontend/__tests__/components/profileUsageChartData.test.ts
+++ b/packages/frontend/__tests__/components/profileUsageChartData.test.ts
@@ -360,6 +360,19 @@ describe("profile usage chart aggregation", () => {
     ).not.toBe("#f97316");
   });
 
+  it("uses the OpenAI green ramp for Codex CLI model series", () => {
+    const chart = buildUsageChartData(
+      aggregateDailyUsage([
+        day("2026-05-02", [client("codex", { input: 10 }, 1, "gpt-5")]),
+      ]),
+      "tokens",
+      "all",
+      "daily",
+    );
+
+    expect(chart.series[0]).toMatchObject({ color: "#10b981" });
+  });
+
   it("ranks source shades by the TUI family hierarchy without changing stack or tooltip order", () => {
     const chart = buildUsageChartData(
       aggregateDailyUsage([

--- a/packages/frontend/src/lib/constants.ts
+++ b/packages/frontend/src/lib/constants.ts
@@ -120,7 +120,7 @@ export const SOURCE_LOGOS: Record<ClientType, string> = {
 export const SOURCE_COLORS: Record<ClientType, string> = {
   opencode: "#00A8E8",
   claude: "#f97316",
-  codex: "#3b82f6",
+  codex: "#10B981",
   copilot: "#24292F",
   gemini: "#8b5cf6",
   cursor: "#22c55e",


### PR DESCRIPTION
## Summary

- Use the TUI OpenAI green (`#10B981`) for the frontend Codex client source color.
- Cover the profile usage chart's resolved shade with a regression test.

## Why

The frontend showed Codex in blue even though the TUI renders OpenAI model series with the green OpenAI ramp. This keeps shared frontend client-colored surfaces consistent with that palette.

## Validation

- `bun run --cwd packages/frontend lint` — passes with six existing warnings outside this change
- `bun run --cwd packages/frontend typecheck`
- `bun run --cwd packages/frontend test` — 600 tests passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the Codex client color to OpenAI green `#10B981` across the frontend to match the TUI palette. Added a regression test to ensure the profile usage chart uses the green ramp for Codex.

<sup>Written for commit 0353293eead003982994346ccedff6c8f3c082ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

