### PR TITLE
fix(usage): derive Codex labels from window duration

### DIFF
--- a/crates/tokscale-cli/src/commands/usage/codex.rs
+++ b/crates/tokscale-cli/src/commands/usage/codex.rs
@@ -58,6 +58,7 @@ struct RateLimit {
 #[serde(rename_all = "snake_case")]
 struct Window {
     used_percent: Option<f64>,
+    limit_window_seconds: Option<i64>,
     #[serde(alias = "resets_at")]
     reset_at: Option<i64>,
 }
@@ -1087,6 +1088,41 @@ fn metric_from_window(label: &str, window: &Window) -> UsageMetric {
     }
 }
 
+fn rate_limit_window_label(window: &Window) -> Option<String> {
+    let seconds = window.limit_window_seconds.filter(|seconds| *seconds > 0)?;
+    if seconds == 7 * 24 * 60 * 60 {
+        return Some("Weekly".to_string());
+    }
+    if seconds % (24 * 60 * 60) == 0 {
+        return Some(format!("{}d", seconds / (24 * 60 * 60)));
+    }
+    if seconds % (60 * 60) == 0 {
+        return Some(format!("{}h", seconds / (60 * 60)));
+    }
+    if seconds % 60 == 0 {
+        return Some(format!("{}m", seconds / 60));
+    }
+    Some(format!("{seconds}s"))
+}
+
+fn metric_label(
+    prefix: Option<&str>,
+    window: &Window,
+    fallback: &str,
+    prefixed_fallback: &str,
+) -> String {
+    let dynamic_label = rate_limit_window_label(window);
+    match prefix {
+        Some(prefix) => format!(
+            "{prefix} {}",
+            dynamic_label
+                .map(|label| label.to_ascii_lowercase())
+                .unwrap_or_else(|| prefixed_fallback.to_string())
+        ),
+        None => dynamic_label.unwrap_or_else(|| fallback.to_string()),
+    }
+}
+
 fn push_rate_limit_metrics(
     metrics: &mut Vec<UsageMetric>,
     prefix: Option<&str>,
@@ -1094,15 +1130,11 @@ fn push_rate_limit_metrics(
 ) {
     let label_prefix = prefix.map(str::trim).filter(|label| !label.is_empty());
     if let Some(ref w) = rate_limit.primary_window {
-        let label = label_prefix
-            .map(|prefix| format!("{prefix} 5h"))
-            .unwrap_or_else(|| "5h".to_string());
+        let label = metric_label(label_prefix, w, "5h", "5h");
         metrics.push(metric_from_window(&label, w));
     }
     if let Some(ref w) = rate_limit.secondary_window {
-        let label = label_prefix
-            .map(|prefix| format!("{prefix} week"))
-            .unwrap_or_else(|| "Weekly".to_string());
+        let label = metric_label(label_prefix, w, "Weekly", "week");
         metrics.push(metric_from_window(&label, w));
     }
 }
@@ -1855,6 +1887,54 @@ mod tests {
         assert_eq!(usage.email.as_deref(), Some("plus@example.com"));
         assert!(usage.additional_rate_limits.is_empty());
         Ok(())
+    }
+
+    #[test]
+    fn rate_limit_labels_follow_window_duration() -> Result<()> {
+        for (primary_seconds, secondary_seconds, expected) in [
+            (18_000, 604_800, ["5h", "Weekly"]),
+            (604_800, 18_000, ["Weekly", "5h"]),
+        ] {
+            let rate_limit: RateLimit = serde_json::from_value(serde_json::json!({
+                "primary_window": {
+                    "used_percent": 0,
+                    "limit_window_seconds": primary_seconds
+                },
+                "secondary_window": {
+                    "used_percent": 0,
+                    "limit_window_seconds": secondary_seconds
+                }
+            }))?;
+
+            let mut metrics = Vec::new();
+            push_rate_limit_metrics(&mut metrics, None, &rate_limit);
+            assert_eq!(metric_labels(&metrics), expected);
+
+            let mut prefixed_metrics = Vec::new();
+            push_rate_limit_metrics(&mut prefixed_metrics, Some("Spark"), &rate_limit);
+            assert_eq!(
+                metric_labels(&prefixed_metrics),
+                expected.map(|label| format!("Spark {}", label.to_ascii_lowercase()))
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn rate_limit_labels_keep_legacy_fallbacks_without_duration() -> Result<()> {
+        let rate_limit: RateLimit = serde_json::from_value(serde_json::json!({
+            "primary_window": { "used_percent": 10 },
+            "secondary_window": { "used_percent": 20 }
+        }))?;
+
+        let mut metrics = Vec::new();
+        push_rate_limit_metrics(&mut metrics, None, &rate_limit);
+        assert_eq!(metric_labels(&metrics), ["5h", "Weekly"]);
+        Ok(())
+    }
+
+    fn metric_labels(metrics: &[UsageMetric]) -> Vec<&str> {
+        metrics.iter().map(|metric| metric.label.as_str()).collect()
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- parse Codex `limit_window_seconds` instead of assuming the primary window is always 5 hours
- render weekly, day, hour, minute, and second window labels from the duration returned by the API
- preserve the legacy primary/secondary labels when older payloads omit the duration

## Root cause

Codex changed the general usage limit from a 5-hour window to a weekly window. Tokscale still labeled every `primary_window` as `5h`, so the percentage and reset timestamp were current while the displayed window name was stale.

The label now follows each window's own duration, so both the current weekly-only response and a future response containing both 5-hour and weekly windows render correctly regardless of primary/secondary ordering. The same behavior applies to additional model-specific limits such as Codex Spark.

## Validation

- `cargo test -p tokscale-cli commands::usage::codex::tests -- --test-threads=1`
- `cargo clippy --locked -p tokscale-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Codex usage window labels by deriving them from `limit_window_seconds` instead of hardcoding 5h/weekly, so displayed limits match the API. Keeps legacy fallbacks for older payloads.

- **Bug Fixes**
  - Derive labels from `limit_window_seconds` and render Weekly/day/hour/minute/second.
  - Keep legacy "5h" (primary) and "Weekly" (secondary) when duration is missing.
  - Prefixes (e.g., "Spark week") now follow the window duration; tests added in `tokscale-cli`.

<sup>Written for commit 78fb6c5ae5a18359c9ad2925ee14a45cea7c58ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

