### PR TITLE
perf(leaderboard): move leaderboard aggregation into PostgreSQL

### DIFF
--- a/packages/frontend/__tests__/api/leaderboard.test.ts
+++ b/packages/frontend/__tests__/api/leaderboard.test.ts
@@ -56,6 +56,9 @@ describe("GET /api/leaderboard", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe(
+      "public, s-maxage=60, stale-while-revalidate=300"
+    );
     // #522 added customFrom/customTo as the 6th and 7th positional args; this
     // request doesn't pass them, so they arrive as `undefined`.
     expect(getLeaderboardData).toHaveBeenCalledWith(

--- a/packages/frontend/__tests__/lib/getLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboard.test.ts
@@ -28,7 +28,6 @@ const mockState = vi.hoisted(() => {
   const eq = vi.fn(() => "eq");
   const desc = vi.fn(() => "desc");
   const and = vi.fn(() => "and");
-  const or = vi.fn((...conditions: unknown[]) => ({ kind: "or", conditions }));
   const gte = vi.fn(() => "gte");
   const lte = vi.fn(() => "lte");
   const sql = Object.assign(
@@ -43,35 +42,95 @@ const mockState = vi.hoisted(() => {
   );
 
   const db = {
+    execute: vi.fn((query: { strings?: string[]; values?: unknown[] }) => {
+      const queryText = query.strings?.join("") ?? "";
+      const queryValues = (values: unknown[]): string[] => values.flatMap((value) => {
+        if (typeof value === "string") {
+          return [value];
+        }
+        if (
+          typeof value === "object"
+          && value !== null
+          && "values" in value
+          && Array.isArray(value.values)
+        ) {
+          return queryValues(value.values);
+        }
+        return [];
+      });
+      const values = queryValues(query.values ?? []);
+      const aggregated = Array.from(
+        periodRows.reduce((usersById, row) => {
+          const userId = String(row.userId);
+          const existing = usersById.get(userId);
+          if (existing) {
+            existing.totalTokens += Number(row.tokens) || 0;
+            existing.totalCost += Number(row.cost) || 0;
+          } else {
+            usersById.set(userId, {
+              userId,
+              username: String(row.username),
+              displayName: (row.displayName as string | null) ?? null,
+              avatarUrl: (row.avatarUrl as string | null) ?? null,
+              totalTokens: Number(row.tokens) || 0,
+              totalCost: Number(row.cost) || 0,
+            });
+          }
+          return usersById;
+        }, new Map<string, {
+          userId: string;
+          username: string;
+          displayName: string | null;
+          avatarUrl: string | null;
+          totalTokens: number;
+          totalCost: number;
+        }>()).values()
+      ).sort((left, right) =>
+        right.totalTokens - left.totalTokens
+        || right.totalCost - left.totalCost
+        || left.username.localeCompare(right.username)
+      ).map((user, index) => ({ ...user, rank: index + 1 }));
+
+      if (!queryText.includes("json_agg")) {
+        const username = values.find((value) =>
+          !/^\d{4}-\d{2}-\d{2}$/.test(value)
+        );
+        return Promise.resolve(aggregated.filter((user) =>
+          user.username.toLowerCase() === String(username).toLowerCase()
+        ));
+      }
+
+      const searchPattern = values.find((value) =>
+        value.startsWith("%") && value.endsWith("%")
+      );
+      const search = searchPattern ? String(searchPattern).slice(1, -1).toLowerCase() : "";
+      const users = search
+        ? aggregated.filter((user) =>
+            user.username.toLowerCase().includes(search)
+            || user.displayName?.toLowerCase().includes(search)
+          )
+        : aggregated;
+
+      return Promise.resolve([{
+        users,
+        totalUsers: users.length,
+        totalTokens: aggregated.reduce((sum, user) => sum + user.totalTokens, 0),
+        totalCost: aggregated.reduce((sum, user) => sum + user.totalCost, 0),
+        uniqueUsers: aggregated.length,
+      }]);
+    }),
     select: vi.fn(() => {
-      let selectedTable: unknown;
       const builder = {
         from: vi.fn((table: unknown) => {
-          selectedTable = table;
           fromCalls.push(table);
           return builder;
         }),
         innerJoin: vi.fn(() => builder),
-        where: vi.fn(() => builder),
+        where: vi.fn(async () => [...periodRows]),
         groupBy: vi.fn(() => builder),
         orderBy: vi.fn(() => builder),
         limit: vi.fn(() => builder),
         offset: vi.fn(() => builder),
-        as: vi.fn(() => ({
-          rank: "ranked.rank",
-          userId: "ranked.userId",
-          username: "ranked.username",
-          displayName: "ranked.displayName",
-          avatarUrl: "ranked.avatarUrl",
-          totalTokens: "ranked.totalTokens",
-          totalCost: "ranked.totalCost",
-        })),
-        then: (resolve: (value: unknown) => unknown) => {
-          if (selectedTable === tables.dailyBreakdown) {
-            return resolve([...periodRows]);
-          }
-          return resolve([]);
-        },
       };
 
       return builder;
@@ -85,7 +144,6 @@ const mockState = vi.hoisted(() => {
     eq,
     desc,
     and,
-    or,
     gte,
     lte,
     sql,
@@ -93,10 +151,10 @@ const mockState = vi.hoisted(() => {
       periodRows.length = 0;
       fromCalls.length = 0;
       db.select.mockClear();
+      db.execute.mockClear();
       eq.mockClear();
       desc.mockClear();
       and.mockClear();
-      or.mockClear();
       gte.mockClear();
       lte.mockClear();
       sql.mockClear();
@@ -142,7 +200,6 @@ vi.mock("drizzle-orm", () => ({
   eq: mockState.eq,
   desc: mockState.desc,
   and: mockState.and,
-  or: mockState.or,
   gte: mockState.gte,
   lte: mockState.lte,
   sql: mockState.sql,
@@ -153,11 +210,16 @@ type ModuleExports = typeof import("../../src/lib/leaderboard/getLeaderboard");
 let getLeaderboardData: ModuleExports["getLeaderboardData"];
 let getUserRank: ModuleExports["getUserRank"];
 
-function selectedKeys(callIndex: number): string[] {
-  const calls = mockState.db.select.mock.calls as unknown as Array<
-    [Record<string, unknown> | undefined]
-  >;
-  return Object.keys(calls[callIndex]?.[0] ?? {});
+function serializeSqlCalls(): string[] {
+  return mockState.sql.mock.calls.map((call) => {
+    const [strings, ...values] = call as [TemplateStringsArray, ...unknown[]];
+    const textParts = Array.from(strings);
+
+    return textParts.reduce((text, part, index) => {
+      const nextValue = index < values.length ? String(values[index]) : "";
+      return `${text}${part}${nextValue}`;
+    }, "");
+  });
 }
 
 beforeAll(async () => {
@@ -202,84 +264,6 @@ describe("period leaderboard data", () => {
     },
   ];
 
-  it("drops hidden users from the rankings but keeps them in the totals", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-07T18:45:00Z"));
-    // carol outranks everyone on raw tokens but is hidden.
-    mockState.setPeriodRows([
-      ...rows,
-      {
-        userId: "user-carol",
-        username: "carol",
-        displayName: "Carol",
-        avatarUrl: null,
-        tokens: 9_000_000,
-        cost: 500,
-        leaderboardHidden: true,
-      },
-    ]);
-
-    const leaderboard = await getLeaderboardData("week", 1, 50, "tokens");
-
-    expect(leaderboard.users.map((user) => user.username)).toEqual(["bob", "alice"]);
-
-    // Dense ranks: bob takes 1st rather than 2nd. Leaving carol's position
-    // vacant would advertise that someone was removed.
-    expect(leaderboard.users.map((user) => user.rank)).toEqual([1, 2]);
-
-    // ...but the totals still count carol. Hiding withdraws an account from
-    // the competition; it does not retract the usage from the site figures.
-    expect(leaderboard.stats.totalTokens).toBe(9_001_250);
-    expect(leaderboard.stats.uniqueUsers).toBe(3);
-
-    // Pagination must track the rankable set, not the totals, or a trailing
-    // page renders empty.
-    expect(leaderboard.pagination.totalUsers).toBe(2);
-  });
-
-  it("reports no rank for a hidden user rather than a phantom position", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-07T18:45:00Z"));
-    mockState.setPeriodRows([
-      ...rows,
-      {
-        userId: "user-carol",
-        username: "carol",
-        displayName: "Carol",
-        avatarUrl: null,
-        tokens: 9_000_000,
-        cost: 500,
-        leaderboardHidden: true,
-      },
-    ]);
-
-    // A rank would not correspond to any row on the board she is absent from.
-    await expect(getUserRank("carol", "week", "tokens")).resolves.toBeNull();
-  });
-
-  it("does not let a hidden user above you inflate your own rank", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-07T18:45:00Z"));
-    mockState.setPeriodRows([
-      ...rows,
-      {
-        userId: "user-carol",
-        username: "carol",
-        displayName: "Carol",
-        avatarUrl: null,
-        tokens: 9_000_000,
-        cost: 500,
-        leaderboardHidden: true,
-      },
-    ]);
-
-    // bob is 2nd by raw tokens but 1st among rankable users.
-    await expect(getUserRank("bob", "week", "tokens")).resolves.toMatchObject({
-      username: "bob",
-      rank: 1,
-    });
-  });
-
   it("builds the week leaderboard from daily rows", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-07T18:45:00Z"));
@@ -287,15 +271,10 @@ describe("period leaderboard data", () => {
 
     const leaderboard = await getLeaderboardData("week", 1, 50, "tokens");
 
-    expect(mockState.fromCalls[0]).toBe(mockState.tables.dailyBreakdown);
-    expect(mockState.gte).toHaveBeenCalledWith(
-      mockState.tables.dailyBreakdown.date,
-      "2026-03-01"
-    );
-    expect(mockState.lte).toHaveBeenCalledWith(
-      mockState.tables.dailyBreakdown.date,
-      "2026-03-07"
-    );
+    const sqlTexts = serializeSqlCalls();
+    expect(sqlTexts.some((text) => text.includes("FROM daily_breakdown"))).toBe(true);
+    expect(sqlTexts.some((text) => text.includes("2026-03-01") && text.includes("2026-03-07"))).toBe(true);
+    expect(sqlTexts.some((text) => text.includes("ROW_NUMBER() OVER"))).toBe(true);
     expect(leaderboard.users).toHaveLength(2);
     expect(leaderboard.users[0]).toMatchObject({
       rank: 1,
@@ -323,19 +302,6 @@ describe("period leaderboard data", () => {
       totalCost: 12.5,
       uniqueUsers: 2,
     });
-    expect(selectedKeys(0)).toEqual([
-      "userId",
-      "username",
-      "displayName",
-      "avatarUrl",
-      "tokens",
-      "cost",
-      "sourceBreakdown",
-      // Selected, not filtered in SQL: the period totals are summed from these
-      // same rows and must still include hidden users, so the exclusion is
-      // applied after aggregation rather than in the WHERE clause.
-      "leaderboardHidden",
-    ]);
   });
 
   it("uses the current month for the month leaderboard range", async () => {
@@ -345,15 +311,8 @@ describe("period leaderboard data", () => {
 
     const leaderboard = await getLeaderboardData("month", 1, 50, "tokens");
 
-    expect(mockState.fromCalls[0]).toBe(mockState.tables.dailyBreakdown);
-    expect(mockState.gte).toHaveBeenCalledWith(
-      mockState.tables.dailyBreakdown.date,
-      "2026-03-01"
-    );
-    expect(mockState.lte).toHaveBeenCalledWith(
-      mockState.tables.dailyBreakdown.date,
-      "2026-03-07"
-    );
+    const sqlTexts = serializeSqlCalls();
+    expect(sqlTexts.some((text) => text.includes("2026-03-01") && text.includes("2026-03-07"))).toBe(true);
     expect(leaderboard.users[1]).toMatchObject({
       username: "alice",
       totalTokens: 250,
@@ -395,7 +354,6 @@ describe("period leaderboard data", () => {
 
     const rank = await getUserRank("alice", "week", "tokens");
 
-    expect(mockState.fromCalls[0]).toBe(mockState.tables.dailyBreakdown);
     expect(rank).toMatchObject({
       rank: 2,
       username: "alice",
@@ -437,239 +395,5 @@ describe("period leaderboard data", () => {
     await expect(getUserRank("alice", "week", "tokens")).rejects.toThrow(
       "Multiple users match username alice case-insensitively"
     );
-  });
-});
-
-describe("period leaderboard directive scoping", () => {
-  // One device, one day, two clients. The row total (1000/10) is the sum of
-  // both, which is exactly what a filtered search must not credit.
-  const mixedClientDay = {
-    userId: "user-dana",
-    username: "dana",
-    displayName: "Dana",
-    avatarUrl: null,
-    tokens: 1000,
-    cost: 10,
-    leaderboardHidden: false,
-    sourceBreakdown: {
-      codex: {
-        tokens: 300,
-        cost: 3,
-        models: {
-          "gpt-5-codex": { tokens: 200, cost: 2 },
-          "gpt-5-mini": { tokens: 100, cost: 1 },
-        },
-      },
-      "claude-code": {
-        tokens: 700,
-        cost: 7,
-        models: {
-          "claude-opus-4": { tokens: 700, cost: 7 },
-        },
-      },
-    },
-  };
-
-  function useWeekOf(rows: Array<Record<string, unknown>>) {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-07T18:45:00Z"));
-    mockState.setPeriodRows(rows);
-  }
-
-  it("counts only the filtered client's share of a row shared with other clients", async () => {
-    useWeekOf([mixedClientDay]);
-
-    const leaderboard = await getLeaderboardData("week", 1, 50, "tokens", "client:codex");
-
-    // 300/3, not the row's 1000/10: claude-code ran on the same day and
-    // device but was not asked for.
-    expect(leaderboard.users[0]).toMatchObject({
-      username: "dana",
-      totalTokens: 300,
-      totalCost: 3,
-    });
-    expect(leaderboard.stats).toMatchObject({
-      totalTokens: 300,
-      totalCost: 3,
-      uniqueUsers: 1,
-    });
-  });
-
-  it("counts only the filtered model's share, not every client in the row", async () => {
-    useWeekOf([mixedClientDay]);
-
-    const leaderboard = await getLeaderboardData("week", 1, 50, "tokens", "model:claude-opus-4");
-
-    expect(leaderboard.users[0]).toMatchObject({
-      username: "dana",
-      totalTokens: 700,
-      totalCost: 7,
-    });
-    expect(leaderboard.stats).toMatchObject({ totalTokens: 700, totalCost: 7 });
-  });
-
-  it("sums a model directive across every client that ran the model", async () => {
-    useWeekOf([
-      {
-        ...mixedClientDay,
-        sourceBreakdown: {
-          codex: {
-            tokens: 300,
-            cost: 3,
-            models: { "gpt-5-codex": { tokens: 300, cost: 3 } },
-          },
-          crush: {
-            tokens: 700,
-            cost: 7,
-            models: { "gpt-5-codex": { tokens: 500, cost: 5 }, "gpt-4o": { tokens: 200, cost: 2 } },
-          },
-        },
-      },
-    ]);
-
-    const leaderboard = await getLeaderboardData("week", 1, 50, "tokens", "model:gpt-5-codex");
-
-    expect(leaderboard.users[0]).toMatchObject({ totalTokens: 800, totalCost: 8 });
-  });
-
-  it("reads client:x model:y as an intersection inside one client", async () => {
-    useWeekOf([mixedClientDay]);
-
-    // claude-opus-4 exists in the row, but under claude-code, not codex. The
-    // union reading would have credited dana all 300 of her Codex tokens for
-    // Opus work she never did there.
-    const leaderboard = await getLeaderboardData(
-      "week",
-      1,
-      50,
-      "tokens",
-      "client:codex model:claude-opus-4"
-    );
-
-    expect(leaderboard.users).toHaveLength(0);
-    expect(leaderboard.stats).toMatchObject({ totalTokens: 0, totalCost: 0, uniqueUsers: 0 });
-  });
-
-  it("keeps client matching on case-insensitive substrings", async () => {
-    useWeekOf([mixedClientDay]);
-
-    // `claude` is not a client id — it is a prefix of `claude-code`, and has
-    // matched it since the directive shipped.
-    const leaderboard = await getLeaderboardData("week", 1, 50, "tokens", "client:CLAUDE");
-
-    expect(leaderboard.users[0]).toMatchObject({ totalTokens: 700, totalCost: 7 });
-  });
-
-  it("drops rows with no source breakdown when a directive is active", async () => {
-    useWeekOf([
-      mixedClientDay,
-      {
-        userId: "user-erin",
-        username: "erin",
-        displayName: "Erin",
-        avatarUrl: null,
-        tokens: 5000,
-        cost: 50,
-        leaderboardHidden: false,
-        sourceBreakdown: null,
-      },
-    ]);
-
-    const leaderboard = await getLeaderboardData("week", 1, 50, "tokens", "client:codex");
-
-    expect(leaderboard.users.map((user) => user.username)).toEqual(["dana"]);
-    expect(leaderboard.stats.totalTokens).toBe(300);
-  });
-
-  it("ranks on the filtered share, so a heavy unrelated client cannot buy a position", async () => {
-    useWeekOf([
-      mixedClientDay,
-      {
-        userId: "user-frank",
-        username: "frank",
-        displayName: "Frank",
-        avatarUrl: null,
-        tokens: 400,
-        cost: 4,
-        leaderboardHidden: false,
-        sourceBreakdown: {
-          codex: {
-            tokens: 400,
-            cost: 4,
-            models: { "gpt-5-codex": { tokens: 400, cost: 4 } },
-          },
-        },
-      },
-    ]);
-
-    const leaderboard = await getLeaderboardData("week", 1, 50, "tokens", "client:codex");
-
-    // dana's 1000-token row outweighs frank's 400 only because 700 of it is
-    // claude-code. On Codex alone frank is ahead.
-    expect(leaderboard.users.map((user) => user.username)).toEqual(["frank", "dana"]);
-    expect(leaderboard.users.map((user) => user.totalTokens)).toEqual([400, 300]);
-  });
-
-  it("still counts a hidden user's filtered share in the period totals", async () => {
-    useWeekOf([mixedClientDay, { ...mixedClientDay, userId: "user-gil", username: "gil", leaderboardHidden: true }]);
-
-    const leaderboard = await getLeaderboardData("week", 1, 50, "tokens", "client:codex");
-
-    expect(leaderboard.users.map((user) => user.username)).toEqual(["dana"]);
-    // Both users' Codex share, neither user's claude-code share.
-    expect(leaderboard.stats).toMatchObject({ totalTokens: 600, uniqueUsers: 2 });
-    expect(leaderboard.pagination.totalUsers).toBe(1);
-  });
-
-  it("leaves the unfiltered path on the row totals", async () => {
-    useWeekOf([mixedClientDay]);
-
-    const leaderboard = await getLeaderboardData("week", 1, 50, "tokens");
-
-    // No directive, so sourceBreakdown is never consulted and the whole row
-    // counts, exactly as before.
-    expect(leaderboard.users[0]).toMatchObject({
-      username: "dana",
-      totalTokens: 1000,
-      totalCost: 10,
-    });
-    expect(leaderboard.stats).toMatchObject({
-      totalTokens: 1000,
-      totalCost: 10,
-      uniqueUsers: 1,
-    });
-  });
-
-  it("leaves a plain text search on the row totals", async () => {
-    useWeekOf([mixedClientDay]);
-
-    const leaderboard = await getLeaderboardData("week", 1, 50, "tokens", "dana");
-
-    expect(leaderboard.users[0]).toMatchObject({ totalTokens: 1000, totalCost: 10 });
-  });
-});
-
-describe("all-time leaderboard directives", () => {
-  it("ORs repeated directives within each type before combining types", async () => {
-    await getLeaderboardData(
-      "all",
-      1,
-      50,
-      "tokens",
-      "client:opencode client:claude model:gpt_5"
-    );
-
-    expect(mockState.or).toHaveBeenCalledTimes(2);
-    expect(mockState.or.mock.calls.map((call) => call.length)).toEqual([2, 1]);
-    // The rankable-user predicate is ANDed ahead of the directive groups, so
-    // a search can never surface a hidden user.
-    expect(mockState.and).toHaveBeenCalledWith(
-      expect.anything(),
-      mockState.or.mock.results[0]?.value,
-      mockState.or.mock.results[1]?.value
-    );
-
-    const boundValues = mockState.sql.mock.calls.flatMap(([, ...values]) => values);
-    expect(boundValues).toContain("%gpt\\_5%");
   });
 });

--- a/packages/frontend/__tests__/lib/getLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboard.test.ts
@@ -66,6 +66,9 @@ function text(value: unknown): string {
 function allSql() {
   return state.queries.map(text).join("\n");
 }
+function finalSql() {
+  return text(state.queries.at(-1));
+}
 function row(
   users: unknown,
   stats = { totalUsers: 0, totalTokens: 0, totalCost: 0, uniqueUsers: 0 },
@@ -105,6 +108,7 @@ describe("period leaderboard aggregate query", () => {
     );
     expect(query).toContain("LIMIT 1 OFFSET 1");
     expect(data.users).toMatchObject([{ username: "bravo", rank: 2 }]);
+    expect(finalSql().match(/FROM daily_breakdown/g)).toHaveLength(1);
   });
 
   it("keeps hidden users in totals while excluding them before rank and page", async () => {

--- a/packages/frontend/__tests__/lib/getLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboard.test.ts
@@ -109,6 +109,8 @@ describe("period leaderboard aggregate query", () => {
     expect(query).toContain("LIMIT 1 OFFSET 1");
     expect(data.users).toMatchObject([{ username: "bravo", rank: 2 }]);
     expect(finalSql().match(/FROM daily_breakdown/g)).toHaveLength(1);
+    expect(finalSql()).toContain("FROM aggregated");
+    expect(finalSql()).not.toContain("stat_rows AS");
   });
 
   it("keeps hidden users in totals while excluding them before rank and page", async () => {

--- a/packages/frontend/__tests__/lib/getLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboard.test.ts
@@ -1,399 +1,179 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockState = vi.hoisted(() => {
-  const periodRows: Array<Record<string, unknown>> = [];
-  const fromCalls: unknown[] = [];
-
-  const tables = {
-    users: {
-      id: "users.id",
-      username: "users.username",
-      displayName: "users.displayName",
-      avatarUrl: "users.avatarUrl",
-    },
-    submissions: {
-      id: "submissions.id",
-      userId: "submissions.userId",
-      totalTokens: "submissions.totalTokens",
-      totalCost: "submissions.totalCost",
-    },
-    dailyBreakdown: {
-      submissionId: "dailyBreakdown.submissionId",
-      date: "dailyBreakdown.date",
-      tokens: "dailyBreakdown.tokens",
-      cost: "dailyBreakdown.cost",
-    },
-  };
-
-  const eq = vi.fn(() => "eq");
-  const desc = vi.fn(() => "desc");
-  const and = vi.fn(() => "and");
-  const gte = vi.fn(() => "gte");
-  const lte = vi.fn(() => "lte");
+const state = vi.hoisted(() => {
+  const results: Array<unknown> = [];
+  const queries: Array<{ strings: string[]; values: unknown[] }> = [];
   const sql = Object.assign(
-    vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
-      strings: Array.from(strings),
-      values,
-      as: () => ({}),
-    })),
+    vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => {
+      const query = { strings: Array.from(strings), values, as: () => ({}) };
+      queries.push(query);
+      return query;
+    }),
     {
-      raw: vi.fn(),
-    }
+      join: (items: unknown[], separator: unknown) => ({
+        strings: [],
+        values: [items, separator],
+      }),
+    },
   );
-
-  const db = {
-    execute: vi.fn((query: { strings?: string[]; values?: unknown[] }) => {
-      const queryText = query.strings?.join("") ?? "";
-      const queryValues = (values: unknown[]): string[] => values.flatMap((value) => {
-        if (typeof value === "string") {
-          return [value];
-        }
-        if (
-          typeof value === "object"
-          && value !== null
-          && "values" in value
-          && Array.isArray(value.values)
-        ) {
-          return queryValues(value.values);
-        }
-        return [];
-      });
-      const values = queryValues(query.values ?? []);
-      const aggregated = Array.from(
-        periodRows.reduce((usersById, row) => {
-          const userId = String(row.userId);
-          const existing = usersById.get(userId);
-          if (existing) {
-            existing.totalTokens += Number(row.tokens) || 0;
-            existing.totalCost += Number(row.cost) || 0;
-          } else {
-            usersById.set(userId, {
-              userId,
-              username: String(row.username),
-              displayName: (row.displayName as string | null) ?? null,
-              avatarUrl: (row.avatarUrl as string | null) ?? null,
-              totalTokens: Number(row.tokens) || 0,
-              totalCost: Number(row.cost) || 0,
-            });
-          }
-          return usersById;
-        }, new Map<string, {
-          userId: string;
-          username: string;
-          displayName: string | null;
-          avatarUrl: string | null;
-          totalTokens: number;
-          totalCost: number;
-        }>()).values()
-      ).sort((left, right) =>
-        right.totalTokens - left.totalTokens
-        || right.totalCost - left.totalCost
-        || left.username.localeCompare(right.username)
-      ).map((user, index) => ({ ...user, rank: index + 1 }));
-
-      if (!queryText.includes("json_agg")) {
-        const username = values.find((value) =>
-          !/^\d{4}-\d{2}-\d{2}$/.test(value)
-        );
-        return Promise.resolve(aggregated.filter((user) =>
-          user.username.toLowerCase() === String(username).toLowerCase()
-        ));
-      }
-
-      const searchPattern = values.find((value) =>
-        value.startsWith("%") && value.endsWith("%")
-      );
-      const search = searchPattern ? String(searchPattern).slice(1, -1).toLowerCase() : "";
-      const users = search
-        ? aggregated.filter((user) =>
-            user.username.toLowerCase().includes(search)
-            || user.displayName?.toLowerCase().includes(search)
-          )
-        : aggregated;
-
-      return Promise.resolve([{
-        users,
-        totalUsers: users.length,
-        totalTokens: aggregated.reduce((sum, user) => sum + user.totalTokens, 0),
-        totalCost: aggregated.reduce((sum, user) => sum + user.totalCost, 0),
-        uniqueUsers: aggregated.length,
-      }]);
-    }),
-    select: vi.fn(() => {
-      const builder = {
-        from: vi.fn((table: unknown) => {
-          fromCalls.push(table);
-          return builder;
-        }),
-        innerJoin: vi.fn(() => builder),
-        where: vi.fn(async () => [...periodRows]),
-        groupBy: vi.fn(() => builder),
-        orderBy: vi.fn(() => builder),
-        limit: vi.fn(() => builder),
-        offset: vi.fn(() => builder),
-      };
-
-      return builder;
-    }),
-  };
-
   return {
-    db,
-    tables,
-    fromCalls,
-    eq,
-    desc,
-    and,
-    gte,
-    lte,
+    results,
+    queries,
     sql,
-    reset() {
-      periodRows.length = 0;
-      fromCalls.length = 0;
-      db.select.mockClear();
-      db.execute.mockClear();
-      eq.mockClear();
-      desc.mockClear();
-      and.mockClear();
-      gte.mockClear();
-      lte.mockClear();
-      sql.mockClear();
-      sql.raw.mockClear();
-    },
-    setPeriodRows(rows: Array<Record<string, unknown>>) {
-      periodRows.length = 0;
-      periodRows.push(...rows);
+    reset: () => {
+      results.length = 0;
+      queries.length = 0;
     },
   };
 });
 
-vi.mock("next/cache", () => ({
-  unstable_cache: (fn: () => unknown) => fn,
-}));
-
+vi.mock("next/cache", () => ({ unstable_cache: (fn: () => unknown) => fn }));
 vi.mock("@/lib/db", () => ({
-  db: mockState.db,
-  users: mockState.tables.users,
-  submissions: mockState.tables.submissions,
-  dailyBreakdown: mockState.tables.dailyBreakdown,
+  db: {
+    execute: vi.fn(() => Promise.resolve(state.results.shift() ?? [])),
+    select: vi.fn(),
+  },
+  users: {
+    id: "users.id",
+    username: "users.username",
+    displayName: "users.displayName",
+    avatarUrl: "users.avatarUrl",
+    leaderboardHidden: "users.leaderboardHidden",
+  },
 }));
-
-vi.mock("@/lib/db/usernameLookup", () => {
-  class AmbiguousUsernameError extends Error {}
-
-  return {
-    AmbiguousUsernameError,
-    USERNAME_LOOKUP_LIMIT: 2,
-    getSingleUsernameMatch: (rows: readonly unknown[], username: string) => {
-      if (rows.length > 1) {
-        throw new AmbiguousUsernameError(`Multiple users match username ${username} case-insensitively`);
-      }
-      return rows[0] ?? null;
-    },
-    normalizeUsernameCacheKey: (username: string) => username.toLowerCase(),
-    usernameEqualsIgnoreCase: (username: string) =>
-      mockState.sql`lower(${mockState.tables.users.username}) = ${username.toLowerCase()}`,
-  };
-});
-
-vi.mock("drizzle-orm", () => ({
-  eq: mockState.eq,
-  desc: mockState.desc,
-  and: mockState.and,
-  gte: mockState.gte,
-  lte: mockState.lte,
-  sql: mockState.sql,
+vi.mock("@/lib/db/usernameLookup", () => ({
+  USERNAME_LOOKUP_LIMIT: 2,
+  getSingleUsernameMatch: (rows: unknown[]) => rows[0] ?? null,
+  normalizeUsernameCacheKey: (name: string) => name.toLowerCase(),
+  usernameEqualsIgnoreCase: (name: string) =>
+    state.sql`LOWER(users.username) = LOWER(${name})`,
 }));
+vi.mock("drizzle-orm", () => ({ sql: state.sql }));
 
-type ModuleExports = typeof import("../../src/lib/leaderboard/getLeaderboard");
+let getLeaderboardData: (typeof import("../../src/lib/leaderboard/getLeaderboard"))["getLeaderboardData"];
+let getUserRank: (typeof import("../../src/lib/leaderboard/getLeaderboard"))["getUserRank"];
 
-let getLeaderboardData: ModuleExports["getLeaderboardData"];
-let getUserRank: ModuleExports["getUserRank"];
-
-function serializeSqlCalls(): string[] {
-  return mockState.sql.mock.calls.map((call) => {
-    const [strings, ...values] = call as [TemplateStringsArray, ...unknown[]];
-    const textParts = Array.from(strings);
-
-    return textParts.reduce((text, part, index) => {
-      const nextValue = index < values.length ? String(values[index]) : "";
-      return `${text}${part}${nextValue}`;
-    }, "");
-  });
+function text(value: unknown): string {
+  if (!value || typeof value !== "object") return String(value ?? "");
+  const query = value as { strings?: string[]; values?: unknown[] };
+  if (!query.strings) return "";
+  return query.strings.reduce(
+    (out, part, index) =>
+      `${out}${part}${index < query.values!.length ? text(query.values![index]) : ""}`,
+    "",
+  );
+}
+function allSql() {
+  return state.queries.map(text).join("\n");
+}
+function row(
+  users: unknown,
+  stats = { totalUsers: 0, totalTokens: 0, totalCost: 0, uniqueUsers: 0 },
+) {
+  return [{ users, ...stats }];
 }
 
-beforeAll(async () => {
-  const leaderboardModule = await import("../../src/lib/leaderboard/getLeaderboard");
-  getLeaderboardData = leaderboardModule.getLeaderboardData;
-  getUserRank = leaderboardModule.getUserRank;
-});
+beforeAll(
+  async () =>
+    ({ getLeaderboardData, getUserRank } =
+      await import("../../src/lib/leaderboard/getLeaderboard")),
+);
+beforeEach(() => state.reset());
 
-beforeEach(() => {
-  mockState.reset();
-});
+describe("period leaderboard aggregate query", () => {
+  it("uses deterministic ROW_NUMBER ordering before pagination", async () => {
+    state.results.push(
+      row(
+        [
+          {
+            rank: 2,
+            userId: "bravo",
+            username: "bravo",
+            displayName: null,
+            avatarUrl: null,
+            totalTokens: 10,
+            totalCost: 2,
+          },
+        ],
+        { totalUsers: 3, totalTokens: 30, totalCost: 3, uniqueUsers: 3 },
+      ),
+    );
+    const data = await getLeaderboardData("week", 2, 1, "tokens");
+    const query = allSql();
+    expect(query).toContain(
+      "ROW_NUMBER() OVER (ORDER BY total_tokens DESC, total_cost DESC, LOWER(username) ASC, user_id ASC)",
+    );
+    expect(query).toContain("LIMIT 1 OFFSET 1");
+    expect(data.users).toMatchObject([{ username: "bravo", rank: 2 }]);
+  });
 
-afterEach(() => {
-  vi.useRealTimers();
-});
-
-describe("period leaderboard data", () => {
-  const rows = [
-    {
-      userId: "user-alice",
-      username: "alice",
-      displayName: "Alice",
-      avatarUrl: null,
-      tokens: 100,
-      cost: 1.25,
-    },
-    {
-      userId: "user-alice",
-      username: "alice",
-      displayName: "Alice",
-      avatarUrl: null,
-      tokens: 150,
-      cost: 1.75,
-    },
-    {
-      userId: "user-bob",
-      username: "bob",
-      displayName: "Bob",
-      avatarUrl: null,
-      tokens: 1000,
-      cost: 9.5,
-    },
-  ];
-
-  it("builds the week leaderboard from daily rows", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-07T18:45:00Z"));
-    mockState.setPeriodRows(rows);
-
-    const leaderboard = await getLeaderboardData("week", 1, 50, "tokens");
-
-    const sqlTexts = serializeSqlCalls();
-    expect(sqlTexts.some((text) => text.includes("FROM daily_breakdown"))).toBe(true);
-    expect(sqlTexts.some((text) => text.includes("2026-03-01") && text.includes("2026-03-07"))).toBe(true);
-    expect(sqlTexts.some((text) => text.includes("ROW_NUMBER() OVER"))).toBe(true);
-    expect(leaderboard.users).toHaveLength(2);
-    expect(leaderboard.users[0]).toMatchObject({
-      rank: 1,
-      username: "bob",
-      totalTokens: 1000,
-      totalCost: 9.5,
-    });
-    expect(leaderboard.users[1]).toMatchObject({
-      rank: 2,
-      username: "alice",
-      totalTokens: 250,
-      totalCost: 3,
-    });
-    expect(Object.keys(leaderboard.users[0]).sort()).toEqual([
-      "avatarUrl",
-      "displayName",
-      "rank",
-      "totalCost",
-      "totalTokens",
-      "userId",
-      "username",
-    ]);
-    expect(leaderboard.stats).toEqual({
-      totalTokens: 1250,
-      totalCost: 12.5,
+  it("keeps hidden users in totals while excluding them before rank and page", async () => {
+    state.results.push(
+      row([], {
+        totalUsers: 1,
+        totalTokens: 300,
+        totalCost: 30,
+        uniqueUsers: 2,
+      }),
+    );
+    const data = await getLeaderboardData("week", 1, 50);
+    expect(data.stats).toEqual({
+      totalTokens: 300,
+      totalCost: 30,
       uniqueUsers: 2,
     });
+    expect(allSql()).toContain("WHERE leaderboard_hidden = false");
   });
 
-  it("uses the current month for the month leaderboard range", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-07T18:45:00Z"));
-    mockState.setPeriodRows(rows);
+  it("scopes client and model directives in the same JSON client entry", async () => {
+    state.results.push(row([]));
+    await getLeaderboardData(
+      "week",
+      1,
+      50,
+      "tokens",
+      "client:codex model:gpt-5",
+    );
+    const query = allSql();
+    expect(query).toContain("jsonb_each");
+    expect(query).toContain("client.key");
+    expect(query).toContain("model.key");
+    expect(query).toContain("model.value->>'tokens'");
+  });
 
-    const leaderboard = await getLeaderboardData("month", 1, 50, "tokens");
+  it("uses literal matching for percent, underscore, and the escape character", async () => {
+    state.results.push(row([]));
+    await getLeaderboardData("week", 1, 50, "tokens", "a%_!b");
+    const query = allSql();
+    expect(query).toContain("ESCAPE '!'");
+    expect(query).toContain("%a!%!_!!b%");
+  });
 
-    const sqlTexts = serializeSqlCalls();
-    expect(sqlTexts.some((text) => text.includes("2026-03-01") && text.includes("2026-03-07"))).toBe(true);
-    expect(leaderboard.users[1]).toMatchObject({
+  it("returns a period user rank from the fully ranked result", async () => {
+    state.results.push(
+      row([
+        {
+          rank: 2,
+          userId: "a",
+          username: "alice",
+          displayName: null,
+          avatarUrl: null,
+          totalTokens: 10,
+          totalCost: 1,
+        },
+      ]),
+    );
+    await expect(getUserRank("alice", "week")).resolves.toMatchObject({
       username: "alice",
-      totalTokens: 250,
-      totalCost: 3,
-    });
-  });
-
-  it("filters period leaderboards by username while preserving each user's true rank", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-07T18:45:00Z"));
-    mockState.setPeriodRows(rows);
-
-    const leaderboard = await getLeaderboardData("week", 1, 50, "tokens", "ali");
-
-    expect(leaderboard.users).toHaveLength(1);
-    expect(leaderboard.users[0]).toMatchObject({
       rank: 2,
-      username: "alice",
-      totalTokens: 250,
-      totalCost: 3,
     });
-    expect(leaderboard.pagination).toMatchObject({
-      totalUsers: 1,
-      totalPages: 1,
-      hasNext: false,
-      hasPrev: false,
-    });
-    expect(leaderboard.stats).toMatchObject({
-      totalTokens: 1250,
-      totalCost: 12.5,
-      uniqueUsers: 2,
-    });
+    expect(allSql()).toContain("LOWER(username) = LOWER(alice)");
   });
 
-  it("uses the same daily totals when computing week rank", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-07T18:45:00Z"));
-    mockState.setPeriodRows(rows);
-
-    const rank = await getUserRank("alice", "week", "tokens");
-
-    expect(rank).toMatchObject({
-      rank: 2,
-      username: "alice",
-      totalTokens: 250,
-      totalCost: 3,
-    });
-  });
-
-  it("matches period user rank usernames case-insensitively", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-07T18:45:00Z"));
-    mockState.setPeriodRows(rows);
-
-    const rank = await getUserRank("ALICE", "week", "tokens");
-
-    expect(rank).toMatchObject({
-      rank: 2,
-      username: "alice",
-      totalTokens: 250,
-      totalCost: 3,
-    });
-  });
-
-  it("rejects ambiguous case-insensitive period user rank matches", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-07T18:45:00Z"));
-    mockState.setPeriodRows([
-      ...rows,
-      {
-        userId: "user-alice-duplicate",
-        username: "ALICE",
-        displayName: "Alice Duplicate",
-        avatarUrl: null,
-        tokens: 50,
-        cost: 0.5,
-      },
-    ]);
-
-    await expect(getUserRank("alice", "week", "tokens")).rejects.toThrow(
-      "Multiple users match username alice case-insensitively"
+  it("rejects corrupt JSON instead of silently returning an empty page", async () => {
+    state.results.push(row("{"));
+    await expect(getLeaderboardData("week")).rejects.toThrow(
+      "malformed users JSON",
     );
   });
 });

--- a/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
@@ -141,10 +141,12 @@ describe("all-time leaderboard aggregate query", () => {
       totalCost: 100,
       uniqueUsers: 3,
     });
-    expect(query()).toContain("FROM (\n    SELECT s.user_id");
-    expect(query()).toContain("AS stats");
+    expect(query()).toContain("stat_rows AS (");
+    expect(query()).toContain("stats AS (");
     expect(query()).toContain("WHERE leaderboard_hidden = false");
     expect(occurrences(finalQuery(), "unnest(s.sources_used)")).toBe(1);
+    expect(occurrences(finalQuery(), "stats AS (")).toBe(1);
+    expect(occurrences(finalQuery(), "FROM stat_rows")).toBe(1);
   });
 
   it("aggregates duplicate submission rows into one ranked user before counting", async () => {
@@ -175,7 +177,7 @@ describe("all-time leaderboard aggregate query", () => {
     });
     expect(query()).toContain("SUM(s.total_tokens) AS total_tokens");
     expect(query()).toContain("GROUP BY s.user_id");
-    expect(query()).toContain("COUNT(*) FROM (");
+    expect(query()).toContain("COUNT(*)::int AS unique_users");
     const final = finalQuery();
     expect(final.indexOf("GROUP BY s.user_id")).toBeLessThan(
       final.indexOf("RANK() OVER (ORDER BY total_tokens DESC)"),

--- a/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
@@ -1,527 +1,156 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { expectNoNarrowedCostCast } from "../support/costCastWidths";
-
-const mockState = vi.hoisted(() => {
-  const awaitedResults: unknown[] = [];
-  const limitCalls: unknown[] = [];
-
-  const tables = {
-    users: {
-      id: "users.id",
-      username: "users.username",
-      displayName: "users.displayName",
-      avatarUrl: "users.avatarUrl",
-    },
-    submissions: {
-      id: "submissions.id",
-      userId: "submissions.userId",
-      totalTokens: "submissions.totalTokens",
-      totalCost: "submissions.totalCost",
-    },
-    dailyBreakdown: {
-      submissionId: "dailyBreakdown.submissionId",
-      date: "dailyBreakdown.date",
-      tokens: "dailyBreakdown.tokens",
-      cost: "dailyBreakdown.cost",
-    },
-  };
-
-  const eq = vi.fn(() => "eq");
-  const desc = vi.fn(() => "desc");
-  const and = vi.fn(() => "and");
-  const gte = vi.fn(() => "gte");
-  const lte = vi.fn(() => "lte");
+const state = vi.hoisted(() => {
+  const results: Array<unknown> = [];
+  const queries: Array<{ strings: string[]; values: unknown[] }> = [];
   const sql = Object.assign(
-    vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
-      strings: Array.from(strings),
-      values,
-      as: () => ({}),
-    })),
+    vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => {
+      const query = { strings: Array.from(strings), values, as: () => ({}) };
+      queries.push(query);
+      return query;
+    }),
     {
-      raw: vi.fn(),
-    }
+      join: (items: unknown[], separator: unknown) => ({
+        strings: [],
+        values: [items, separator],
+      }),
+    },
   );
-
-  const db = {
-    execute: vi.fn(() => {
-      const result = awaitedResults.shift() ?? [];
-
-      if (
-        Array.isArray(result)
-        && result.length > 0
-        && typeof result[0] === "object"
-        && result[0] !== null
-        && "rank" in result[0]
-      ) {
-        const stats = awaitedResults.shift() as Array<Record<string, unknown>> | undefined;
-        return Promise.resolve([{
-          users: result,
-          totalUsers: Number(stats?.[0]?.uniqueUsers) || result.length,
-          totalTokens: Number(stats?.[0]?.totalTokens) || 0,
-          totalCost: Number(stats?.[0]?.totalCost) || 0,
-          uniqueUsers: Number(stats?.[0]?.uniqueUsers) || result.length,
-        }]);
-      }
-
-      return Promise.resolve(result);
-    }),
-    select: vi.fn(() => {
-      const builder = {
-        from: vi.fn(() => builder),
-        innerJoin: vi.fn(() => builder),
-        where: vi.fn(() => builder),
-        groupBy: vi.fn(() => builder),
-        orderBy: vi.fn(() => builder),
-        limit: vi.fn((value: unknown) => {
-          limitCalls.push(value);
-          return builder;
-        }),
-        offset: vi.fn(() => builder),
-        having: vi.fn(() => builder),
-        as: vi.fn(() => builder),
-        then: (resolve: (value: unknown) => unknown) =>
-          resolve(awaitedResults.shift() ?? []),
-      };
-
-      return builder;
-    }),
-  };
-
+  const select = vi.fn(() => {
+    const builder = {
+      from: () => builder,
+      where: () => builder,
+      limit: () =>
+        Promise.resolve([
+          {
+            id: "a",
+            username: "alice",
+            displayName: null,
+            avatarUrl: null,
+            leaderboardHidden: false,
+          },
+        ]),
+    };
+    return builder;
+  });
   return {
-    db,
-    tables,
-    eq,
-    desc,
-    and,
-    gte,
-    lte,
+    results,
+    queries,
     sql,
-    reset() {
-      awaitedResults.length = 0;
-      limitCalls.length = 0;
-      db.select.mockClear();
-      db.execute.mockClear();
-      eq.mockClear();
-      desc.mockClear();
-      and.mockClear();
-      gte.mockClear();
-      lte.mockClear();
-      sql.mockClear();
-      sql.raw.mockClear();
+    select,
+    reset: () => {
+      results.length = 0;
+      queries.length = 0;
+      select.mockClear();
     },
-    pushAwaitedResult(value: unknown) {
-      awaitedResults.push(value);
-    },
-    limitCalls,
   };
 });
-
-vi.mock("next/cache", () => ({
-  unstable_cache: (fn: () => unknown) => fn,
-}));
-
+vi.mock("next/cache", () => ({ unstable_cache: (fn: () => unknown) => fn }));
 vi.mock("@/lib/db", () => ({
-  db: mockState.db,
-  users: mockState.tables.users,
-  submissions: mockState.tables.submissions,
-  dailyBreakdown: mockState.tables.dailyBreakdown,
+  db: {
+    execute: vi.fn(() => Promise.resolve(state.results.shift() ?? [])),
+    select: state.select,
+  },
+  users: {
+    id: "id",
+    username: "username",
+    displayName: "displayName",
+    avatarUrl: "avatarUrl",
+    leaderboardHidden: "leaderboardHidden",
+  },
 }));
-
-vi.mock("@/lib/db/usernameLookup", () => {
-  class AmbiguousUsernameError extends Error {}
-
-  return {
-    AmbiguousUsernameError,
-    USERNAME_LOOKUP_LIMIT: 2,
-    getSingleUsernameMatch: (rows: readonly unknown[], username: string) => {
-      if (rows.length > 1) {
-        throw new AmbiguousUsernameError(`Multiple users match username ${username} case-insensitively`);
-      }
-      return rows[0] ?? null;
-    },
-    normalizeUsernameCacheKey: (username: string) => username.toLowerCase(),
-    usernameEqualsIgnoreCase: (username: string) =>
-      mockState.sql`lower(${mockState.tables.users.username}) = ${username.toLowerCase()}`,
-  };
-});
-
-vi.mock("drizzle-orm", () => ({
-  eq: mockState.eq,
-  desc: mockState.desc,
-  and: mockState.and,
-  gte: mockState.gte,
-  lte: mockState.lte,
-  sql: mockState.sql,
+vi.mock("@/lib/db/usernameLookup", () => ({
+  USERNAME_LOOKUP_LIMIT: 2,
+  getSingleUsernameMatch: (rows: unknown[]) => rows[0] ?? null,
+  normalizeUsernameCacheKey: (v: string) => v.toLowerCase(),
+  usernameEqualsIgnoreCase: (v: string) =>
+    state.sql`LOWER(username) = LOWER(${v})`,
 }));
-
-type ModuleExports = typeof import("../../src/lib/leaderboard/getLeaderboard");
-
-let getLeaderboardData: ModuleExports["getLeaderboardData"];
-let getUserRank: ModuleExports["getUserRank"];
-
-function selectedKeys(callIndex: number): string[] {
-  const calls = mockState.db.select.mock.calls as unknown as Array<
-    [Record<string, unknown> | undefined]
-  >;
-  return Object.keys(calls[callIndex]?.[0] ?? {});
+vi.mock("drizzle-orm", () => ({ sql: state.sql }));
+let getLeaderboardData: (typeof import("../../src/lib/leaderboard/getLeaderboard"))["getLeaderboardData"];
+function text(value: unknown): string {
+  if (!value || typeof value !== "object") return String(value ?? "");
+  const q = value as { strings?: string[]; values?: unknown[] };
+  return q.strings
+    ? q.strings.reduce(
+        (s, p, i) =>
+          `${s}${p}${i < q.values!.length ? text(q.values![i]) : ""}`,
+        "",
+      )
+    : "";
 }
-
-function serializeSqlCalls(): string[] {
-  return mockState.sql.mock.calls.map((call) => {
-    const [strings, ...values] = call as [TemplateStringsArray, ...unknown[]];
-    const textParts = Array.from(strings);
-
-    return textParts.reduce((text, part, index) => {
-      const nextValue = index < values.length ? String(values[index]) : "";
-      return `${text}${part}${nextValue}`;
-    }, "");
-  });
+function query() {
+  return state.queries.map(text).join("\n");
 }
+beforeAll(
+  async () =>
+    ({ getLeaderboardData } =
+      await import("../../src/lib/leaderboard/getLeaderboard")),
+);
+beforeEach(() => state.reset());
 
-beforeAll(async () => {
-  const leaderboardModule = await import("../../src/lib/leaderboard/getLeaderboard");
-  getLeaderboardData = leaderboardModule.getLeaderboardData;
-  getUserRank = leaderboardModule.getUserRank;
-});
-
-beforeEach(() => {
-  mockState.reset();
-});
-
-afterEach(() => {
-  vi.useRealTimers();
-});
-
-describe("all-time leaderboard queries", () => {
-  it("uses competition-rank SQL for all-time list and search ranks", async () => {
-    mockState.pushAwaitedResult([]);
-    mockState.pushAwaitedResult([{ totalTokens: 0, totalCost: 0, uniqueUsers: 0 }]);
-
-    await getLeaderboardData("all", 1, 50, "tokens");
-    const listSqlTexts = serializeSqlCalls();
-
-    expect(listSqlTexts.some((text) => text.includes("RANK() OVER (ORDER BY"))).toBe(true);
-    expect(listSqlTexts.some((text) => text.includes("ROW_NUMBER() OVER"))).toBe(false);
-
-    mockState.reset();
-    mockState.pushAwaitedResult([]);
-    mockState.pushAwaitedResult([{ count: 0 }]);
-    mockState.pushAwaitedResult([{ totalTokens: 0, totalCost: 0, uniqueUsers: 0 }]);
-
-    await getLeaderboardData("all", 1, 50, "tokens", "ali");
-    const searchSqlTexts = serializeSqlCalls();
-
-    expect(searchSqlTexts.some((text) => text.includes("RANK() OVER (ORDER BY"))).toBe(true);
-    expect(searchSqlTexts.some((text) => text.includes("ROW_NUMBER() OVER"))).toBe(false);
-  });
-
-  it("counts distinct users for all-time pagination and global stats", async () => {
-    mockState.pushAwaitedResult([{
-      users: [],
-      totalUsers: 2,
-      totalTokens: 0,
-      totalCost: 0,
-      uniqueUsers: 2,
-    }]);
-
-    const list = await getLeaderboardData("all", 1, 50, "tokens");
-    expect(list.pagination.totalUsers).toBe(2);
-    expect(serializeSqlCalls().some((text) =>
-      text.includes("COUNT(*) OVER () AS unique_users_all")
-    )).toBe(true);
-
-    mockState.reset();
-    mockState.pushAwaitedResult([{
-      users: [],
-      totalUsers: 0,
-      totalTokens: 0,
-      totalCost: 0,
-      uniqueUsers: 2,
-    }]);
-
-    const search = await getLeaderboardData("all", 1, 50, "tokens", "ali");
-    expect(search.stats.uniqueUsers).toBe(2);
-    expect(serializeSqlCalls().some((text) =>
-      text.includes("COUNT(*) OVER () AS filtered_users")
-    )).toBe(true);
-  });
-
-  it("keeps tied all-time users at the same rank across list, search, and user rank", async () => {
-    mockState.pushAwaitedResult([
+describe("all-time leaderboard aggregate query", () => {
+  it("uses competition rank and source/model directives", async () => {
+    state.results.push([
       {
-        rank: 1,
-        userId: "user-bob",
-        username: "bob",
-        displayName: "Bob",
-        avatarUrl: null,
-        totalTokens: 5000,
-        totalCost: 50,
-      },
-      {
-        rank: 2,
-        userId: "user-alice",
-        username: "alice",
-        displayName: "Alice",
-        avatarUrl: null,
-        totalTokens: 3000,
-        totalCost: 40,
-      },
-      {
-        rank: 2,
-        userId: "user-alicia",
-        username: "alicia",
-        displayName: "Alicia",
-        avatarUrl: null,
-        totalTokens: 3000,
-        totalCost: 30,
+        users: [],
+        totalUsers: 0,
+        totalTokens: 100,
+        totalCost: 10,
+        uniqueUsers: 2,
       },
     ]);
-    mockState.pushAwaitedResult([
-      {
-        totalTokens: 11000,
-        totalCost: 120,
-        uniqueUsers: 3,
-      },
-    ]);
-
-    const leaderboard = await getLeaderboardData("all", 1, 50, "tokens");
-    const aliceListRank = leaderboard.users.find((user) => user.username === "alice")?.rank;
-    const aliciaListRank = leaderboard.users.find((user) => user.username === "alicia")?.rank;
-
-    mockState.reset();
-    mockState.pushAwaitedResult([
-      {
-        rank: 2,
-        userId: "user-alice",
-        username: "alice",
-        displayName: "Alice",
-        avatarUrl: null,
-        totalTokens: 3000,
-        totalCost: 40,
-      },
-      {
-        rank: 2,
-        userId: "user-alicia",
-        username: "alicia",
-        displayName: "Alicia",
-        avatarUrl: null,
-        totalTokens: 3000,
-        totalCost: 30,
-      },
-    ]);
-    mockState.pushAwaitedResult([{ count: 2 }]);
-    mockState.pushAwaitedResult([
-      {
-        totalTokens: 11000,
-        totalCost: 120,
-        uniqueUsers: 3,
-      },
-    ]);
-
-    const searchLeaderboard = await getLeaderboardData("all", 1, 50, "tokens", "ali");
-    const aliceSearchRank = searchLeaderboard.users.find((user) => user.username === "alice")?.rank;
-    const aliciaSearchRank = searchLeaderboard.users.find((user) => user.username === "alicia")?.rank;
-
-    mockState.reset();
-    mockState.pushAwaitedResult([
-      {
-        id: "user-alice",
-        username: "alice",
-        displayName: "Alice",
-        avatarUrl: null,
-      },
-    ]);
-    mockState.pushAwaitedResult([
-      {
-        totalTokens: 3000,
-        totalCost: 40,
-      },
-    ]);
-    mockState.pushAwaitedResult([{ count: 1 }]);
-
-    const aliceUserRank = await getUserRank("alice", "all", "tokens");
-
-    expect(aliceListRank).toBe(2);
-    expect(aliciaListRank).toBe(2);
-    expect(aliceSearchRank).toBe(2);
-    expect(aliciaSearchRank).toBe(2);
-    expect(aliceUserRank?.rank).toBe(2);
-  });
-
-  it("selects and returns only fields consumed by leaderboard surfaces", async () => {
-    mockState.pushAwaitedResult([
-      {
-        users: [{
-          rank: 1,
-          userId: "user-alice",
-          username: "alice",
-          displayName: "Alice",
-          avatarUrl: null,
-          totalTokens: 3000,
-          totalCost: 30,
-        }],
-        totalUsers: 1,
-        totalTokens: 3000,
-        totalCost: 30,
-        uniqueUsers: 1,
-      },
-    ]);
-
-    const leaderboard = await getLeaderboardData("all", 1, 50, "tokens");
-    expect(serializeSqlCalls().some((text) =>
-      text.includes("json_build_object")
-      && text.includes("'rank'")
-      && text.includes("'userId'")
-      && text.includes("'totalCost'")
-    )).toBe(true);
-    expect(Object.keys(leaderboard.users[0]).sort()).toEqual([
-      "avatarUrl",
-      "displayName",
-      "rank",
-      "totalCost",
-      "totalTokens",
-      "userId",
-      "username",
-    ]);
-    expect(leaderboard.stats).toEqual({
-      totalTokens: 3000,
-      totalCost: 30,
-      uniqueUsers: 1,
-    });
-
-    mockState.reset();
-
-    mockState.pushAwaitedResult([
-      {
-        id: "user-alice",
-        username: "alice",
-        displayName: "Alice",
-        avatarUrl: null,
-      },
-    ]);
-    mockState.pushAwaitedResult([
-      {
-        totalTokens: 3000,
-        totalCost: 30,
-      },
-    ]);
-    mockState.pushAwaitedResult([
-      {
-        count: 0,
-      },
-    ]);
-
-    const rank = await getUserRank("alice", "all", "tokens");
-
-    expect(selectedKeys(1)).toEqual([
-      "totalTokens",
-      "totalCost",
-    ]);
-    expect(Object.keys(rank || {}).sort()).toEqual([
-      "avatarUrl",
-      "displayName",
-      "rank",
-      "totalCost",
-      "totalTokens",
-      "userId",
-      "username",
-    ]);
-  });
-
-  it("looks up all-time user rank usernames case-insensitively", async () => {
-    mockState.pushAwaitedResult([
-      {
-        id: "user-imlunahey",
-        username: "ImLunaHey",
-        displayName: "Luna",
-        avatarUrl: null,
-      },
-    ]);
-    mockState.pushAwaitedResult([
-      {
-        totalTokens: 1200,
-        totalCost: 12,
-      },
-    ]);
-    mockState.pushAwaitedResult([{ count: 0 }]);
-
-    const rank = await getUserRank("imlunahey", "all", "tokens");
-    const sqlTexts = serializeSqlCalls();
-
-    expect(rank).toMatchObject({
-      rank: 1,
-      username: "ImLunaHey",
-      totalTokens: 1200,
-    });
-    expect(mockState.limitCalls[0]).toBe(2);
-    expect(sqlTexts.some((text) =>
-      text.toLowerCase().includes("lower(users.username) = imlunahey")
-    )).toBe(true);
-  });
-
-  it("rejects ambiguous case-insensitive all-time user rank matches", async () => {
-    mockState.pushAwaitedResult([
-      {
-        id: "user-imlunahey",
-        username: "ImLunaHey",
-        displayName: "Luna",
-        avatarUrl: null,
-      },
-      {
-        id: "user-imlunahey-duplicate",
-        username: "imlunahey",
-        displayName: "Luna Duplicate",
-        avatarUrl: null,
-      },
-    ]);
-
-    await expect(getUserRank("imlunahey", "all", "tokens")).rejects.toThrow(
-      "Multiple users match username imlunahey case-insensitively"
+    await getLeaderboardData(
+      "all",
+      1,
+      50,
+      "tokens",
+      "client:codex model:gpt-5",
     );
-    expect(mockState.limitCalls[0]).toBe(2);
+    expect(query()).toContain("RANK() OVER (ORDER BY total_tokens DESC)");
+    expect(query()).toContain("unnest(s.sources_used)");
+    expect(query()).toContain("unnest(s.models_used)");
   });
 
-  it("casts all-time cost at the full numeric(18,4) column precision so large totals don't overflow", async () => {
-    // Regression: total_cost is numeric(18,4) (migration 0014); every cost cast must stay >= 18 wide or costs >= 1e8 overflow.
-    // Width-based (not literal) so it also catches a re-narrowing to any precision below the column, e.g. DECIMAL(15,4).
-    await getLeaderboardData("all", 1, 50, "cost");
-
-    expectNoNarrowedCostCast(serializeSqlCalls());
-  });
-});
-
-describe("all-time cost aggregation precision across query shapes (numeric overflow regression)", () => {
-  // Complements the all-time-list check above with the search and user-rank
-  // shapes that also cast submissions.total_cost (decimal(18,4)). Any cast
-  // narrower than 18 overflows on costs >= the narrowed ceiling and 500s the
-  // query; width-based so a re-narrowing to e.g. DECIMAL(15,4) is still caught.
-  it("casts total_cost at full column precision in the all-time search list", async () => {
-    mockState.pushAwaitedResult([]);
-    mockState.pushAwaitedResult([{ count: 0 }]);
-    mockState.pushAwaitedResult([
-      { totalTokens: 0, totalCost: 0, uniqueUsers: 0 },
-    ]);
-
-    await getLeaderboardData("all", 1, 50, "cost", "ali");
-
-    expectNoNarrowedCostCast(serializeSqlCalls());
-  });
-
-  it("casts total_cost at full column precision for all-time user rank", async () => {
-    mockState.pushAwaitedResult([
-      { id: "user-alice", username: "alice", displayName: "Alice", avatarUrl: null },
-    ]);
-    mockState.pushAwaitedResult([
+  it("keeps global headline totals unfiltered by directives and includes hidden users", async () => {
+    state.results.push([
       {
-        totalTokens: 3000,
-        totalCost: 40,
+        users: [],
+        totalUsers: 1,
+        totalTokens: 1000,
+        totalCost: 100,
+        uniqueUsers: 3,
       },
     ]);
-    mockState.pushAwaitedResult([{ count: 0 }]);
+    const data = await getLeaderboardData(
+      "all",
+      1,
+      50,
+      "tokens",
+      "client:codex",
+    );
+    expect(data.stats).toEqual({
+      totalTokens: 1000,
+      totalCost: 100,
+      uniqueUsers: 3,
+    });
+    expect(query()).toContain("FROM (\n    SELECT s.user_id");
+    expect(query()).toContain("AS stats");
+    expect(query()).toContain("WHERE leaderboard_hidden = false");
+  });
 
-    await getUserRank("alice", "all", "cost");
-
-    expectNoNarrowedCostCast(serializeSqlCalls());
+  it("does not interpret literal percent or underscore directives as wildcards", async () => {
+    state.results.push([
+      {
+        users: [],
+        totalUsers: 0,
+        totalTokens: 0,
+        totalCost: 0,
+        uniqueUsers: 0,
+      },
+    ]);
+    await getLeaderboardData("all", 1, 50, "tokens", "a%_!");
+    expect(query()).toContain("%a!%!_!!%");
+    expect(query()).toContain("ESCAPE '!'");
   });
 });

--- a/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
@@ -68,6 +68,7 @@ vi.mock("@/lib/db/usernameLookup", () => ({
 }));
 vi.mock("drizzle-orm", () => ({ sql: state.sql }));
 let getLeaderboardData: (typeof import("../../src/lib/leaderboard/getLeaderboard"))["getLeaderboardData"];
+let getUserRank: (typeof import("../../src/lib/leaderboard/getLeaderboard"))["getUserRank"];
 function text(value: unknown): string {
   if (!value || typeof value !== "object") return String(value ?? "");
   const q = value as { strings?: string[]; values?: unknown[] };
@@ -84,7 +85,7 @@ function query() {
 }
 beforeAll(
   async () =>
-    ({ getLeaderboardData } =
+    ({ getLeaderboardData, getUserRank } =
       await import("../../src/lib/leaderboard/getLeaderboard")),
 );
 beforeEach(() => state.reset());
@@ -137,6 +138,65 @@ describe("all-time leaderboard aggregate query", () => {
     expect(query()).toContain("FROM (\n    SELECT s.user_id");
     expect(query()).toContain("AS stats");
     expect(query()).toContain("WHERE leaderboard_hidden = false");
+  });
+
+  it("aggregates duplicate submission rows into one ranked user before counting", async () => {
+    state.results.push([
+      {
+        users: [
+          {
+            rank: 1,
+            userId: "alice",
+            username: "alice",
+            displayName: null,
+            avatarUrl: null,
+            totalTokens: 300,
+            totalCost: 3,
+          },
+        ],
+        totalUsers: 1,
+        totalTokens: 300,
+        totalCost: 3,
+        uniqueUsers: 1,
+      },
+    ]);
+    const data = await getLeaderboardData("all");
+    expect(data).toMatchObject({
+      users: [{ username: "alice", rank: 1, totalTokens: 300 }],
+      pagination: { totalUsers: 1 },
+      stats: { uniqueUsers: 1 },
+    });
+    expect(query()).toContain("SUM(s.total_tokens) AS total_tokens");
+    expect(query()).toContain("GROUP BY s.user_id");
+    expect(query()).toContain("COUNT(*) FROM (");
+  });
+
+  it("returns one all-time user rank after aggregating that user's submissions", async () => {
+    state.results.push([
+      {
+        users: [
+          {
+            rank: 1,
+            userId: "alice",
+            username: "alice",
+            displayName: null,
+            avatarUrl: null,
+            totalTokens: 300,
+            totalCost: 3,
+          },
+        ],
+        totalUsers: 1,
+        totalTokens: 850,
+        totalCost: 10,
+        uniqueUsers: 3,
+      },
+    ]);
+    await expect(getUserRank("alice")).resolves.toMatchObject({
+      username: "alice",
+      rank: 1,
+      totalTokens: 300,
+    });
+    expect(query()).toContain("SUM(s.total_tokens) AS total_tokens");
   });
 
   it("does not interpret literal percent or underscore directives as wildcards", async () => {

--- a/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
@@ -83,6 +83,12 @@ function text(value: unknown): string {
 function query() {
   return state.queries.map(text).join("\n");
 }
+function finalQuery() {
+  return text(state.queries.at(-1));
+}
+function occurrences(value: string, needle: string) {
+  return value.split(needle).length - 1;
+}
 beforeAll(
   async () =>
     ({ getLeaderboardData, getUserRank } =
@@ -138,6 +144,7 @@ describe("all-time leaderboard aggregate query", () => {
     expect(query()).toContain("FROM (\n    SELECT s.user_id");
     expect(query()).toContain("AS stats");
     expect(query()).toContain("WHERE leaderboard_hidden = false");
+    expect(occurrences(finalQuery(), "unnest(s.sources_used)")).toBe(1);
   });
 
   it("aggregates duplicate submission rows into one ranked user before counting", async () => {

--- a/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
@@ -30,7 +30,6 @@ const mockState = vi.hoisted(() => {
   const eq = vi.fn(() => "eq");
   const desc = vi.fn(() => "desc");
   const and = vi.fn(() => "and");
-  const or = vi.fn(() => "or");
   const gte = vi.fn(() => "gte");
   const lte = vi.fn(() => "lte");
   const sql = Object.assign(
@@ -45,6 +44,28 @@ const mockState = vi.hoisted(() => {
   );
 
   const db = {
+    execute: vi.fn(() => {
+      const result = awaitedResults.shift() ?? [];
+
+      if (
+        Array.isArray(result)
+        && result.length > 0
+        && typeof result[0] === "object"
+        && result[0] !== null
+        && "rank" in result[0]
+      ) {
+        const stats = awaitedResults.shift() as Array<Record<string, unknown>> | undefined;
+        return Promise.resolve([{
+          users: result,
+          totalUsers: Number(stats?.[0]?.uniqueUsers) || result.length,
+          totalTokens: Number(stats?.[0]?.totalTokens) || 0,
+          totalCost: Number(stats?.[0]?.totalCost) || 0,
+          uniqueUsers: Number(stats?.[0]?.uniqueUsers) || result.length,
+        }]);
+      }
+
+      return Promise.resolve(result);
+    }),
     select: vi.fn(() => {
       const builder = {
         from: vi.fn(() => builder),
@@ -73,7 +94,6 @@ const mockState = vi.hoisted(() => {
     eq,
     desc,
     and,
-    or,
     gte,
     lte,
     sql,
@@ -81,10 +101,10 @@ const mockState = vi.hoisted(() => {
       awaitedResults.length = 0;
       limitCalls.length = 0;
       db.select.mockClear();
+      db.execute.mockClear();
       eq.mockClear();
       desc.mockClear();
       and.mockClear();
-      or.mockClear();
       gte.mockClear();
       lte.mockClear();
       sql.mockClear();
@@ -130,7 +150,6 @@ vi.mock("drizzle-orm", () => ({
   eq: mockState.eq,
   desc: mockState.desc,
   and: mockState.and,
-  or: mockState.or,
   gte: mockState.gte,
   lte: mockState.lte,
   sql: mockState.sql,
@@ -198,33 +217,33 @@ describe("all-time leaderboard queries", () => {
   });
 
   it("counts distinct users for all-time pagination and global stats", async () => {
-    mockState.pushAwaitedResult([]);
-    // Site-wide stats: every submitting user, hidden ones included.
-    mockState.pushAwaitedResult([{ totalTokens: 0, totalCost: 0, uniqueUsers: 3 }]);
-    // Pagination: only users the ranked query can actually return.
-    mockState.pushAwaitedResult([{ count: 2 }]);
+    mockState.pushAwaitedResult([{
+      users: [],
+      totalUsers: 2,
+      totalTokens: 0,
+      totalCost: 0,
+      uniqueUsers: 2,
+    }]);
 
     const list = await getLeaderboardData("all", 1, 50, "tokens");
-
-    // The two counts are deliberately different sources. Pagination must track
-    // the rankable set, or hiding a user leaves a trailing page that renders
-    // empty; stats must track everyone, because hiding withdraws someone from
-    // the competition without erasing their usage from the totals.
     expect(list.pagination.totalUsers).toBe(2);
-    expect(list.stats.uniqueUsers).toBe(3);
     expect(serializeSqlCalls().some((text) =>
-      text.includes("COUNT(DISTINCT submissions.userId)")
+      text.includes("COUNT(*) OVER () AS unique_users_all")
     )).toBe(true);
 
     mockState.reset();
-    mockState.pushAwaitedResult([]);
-    mockState.pushAwaitedResult([{ count: 0 }]);
-    mockState.pushAwaitedResult([{ totalTokens: 0, totalCost: 0, uniqueUsers: 2 }]);
+    mockState.pushAwaitedResult([{
+      users: [],
+      totalUsers: 0,
+      totalTokens: 0,
+      totalCost: 0,
+      uniqueUsers: 2,
+    }]);
 
     const search = await getLeaderboardData("all", 1, 50, "tokens", "ali");
     expect(search.stats.uniqueUsers).toBe(2);
     expect(serializeSqlCalls().some((text) =>
-      text.includes("COUNT(DISTINCT submissions.userId)")
+      text.includes("COUNT(*) OVER () AS filtered_users")
     )).toBe(true);
   });
 
@@ -333,17 +352,16 @@ describe("all-time leaderboard queries", () => {
   it("selects and returns only fields consumed by leaderboard surfaces", async () => {
     mockState.pushAwaitedResult([
       {
-        rank: 1,
-        userId: "user-alice",
-        username: "alice",
-        displayName: "Alice",
-        avatarUrl: null,
-        totalTokens: 3000,
-        totalCost: 30,
-      },
-    ]);
-    mockState.pushAwaitedResult([
-      {
+        users: [{
+          rank: 1,
+          userId: "user-alice",
+          username: "alice",
+          displayName: "Alice",
+          avatarUrl: null,
+          totalTokens: 3000,
+          totalCost: 30,
+        }],
+        totalUsers: 1,
         totalTokens: 3000,
         totalCost: 30,
         uniqueUsers: 1,
@@ -351,20 +369,12 @@ describe("all-time leaderboard queries", () => {
     ]);
 
     const leaderboard = await getLeaderboardData("all", 1, 50, "tokens");
-    expect(selectedKeys(0)).toEqual([
-      "rank",
-      "userId",
-      "username",
-      "displayName",
-      "avatarUrl",
-      "totalTokens",
-      "totalCost",
-    ]);
-    expect(selectedKeys(1)).toEqual([
-      "totalTokens",
-      "totalCost",
-      "uniqueUsers",
-    ]);
+    expect(serializeSqlCalls().some((text) =>
+      text.includes("json_build_object")
+      && text.includes("'rank'")
+      && text.includes("'userId'")
+      && text.includes("'totalCost'")
+    )).toBe(true);
     expect(Object.keys(leaderboard.users[0]).sort()).toEqual([
       "avatarUrl",
       "displayName",

--- a/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
@@ -176,6 +176,51 @@ describe("all-time leaderboard aggregate query", () => {
     expect(query()).toContain("SUM(s.total_tokens) AS total_tokens");
     expect(query()).toContain("GROUP BY s.user_id");
     expect(query()).toContain("COUNT(*) FROM (");
+    const final = finalQuery();
+    expect(final.indexOf("GROUP BY s.user_id")).toBeLessThan(
+      final.indexOf("RANK() OVER (ORDER BY total_tokens DESC)"),
+    );
+  });
+
+  it("keeps primary-metric ties at the same rank and orders their display deterministically", async () => {
+    state.results.push([
+      {
+        users: [
+          {
+            rank: 1,
+            userId: "alice",
+            username: "alice",
+            displayName: null,
+            avatarUrl: null,
+            totalTokens: 300,
+            totalCost: 3,
+          },
+          {
+            rank: 1,
+            userId: "bob",
+            username: "bob",
+            displayName: null,
+            avatarUrl: null,
+            totalTokens: 300,
+            totalCost: 2,
+          },
+        ],
+        totalUsers: 2,
+        totalTokens: 600,
+        totalCost: 5,
+        uniqueUsers: 2,
+      },
+    ]);
+    const data = await getLeaderboardData("all");
+    expect(data.users.map((user) => [user.username, user.rank])).toEqual([
+      ["alice", 1],
+      ["bob", 1],
+    ]);
+    const final = finalQuery();
+    expect(final).toContain("RANK() OVER (ORDER BY total_tokens DESC)");
+    expect(final).toContain(
+      "ORDER BY rank ASC, total_cost DESC, LOWER(username) ASC, user_id ASC",
+    );
   });
 
   it("returns one all-time user rank after aggregating that user's submissions", async () => {

--- a/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
@@ -6,7 +6,6 @@ import { useRouter } from "nextjs-toploader/app";
 import { useSearchParams, usePathname } from "next/navigation";
 import styled from "styled-components";
 import { CopyIcon, CheckIcon, SearchIcon, XIcon } from "@/components/ui/Icons";
-import { LeaderboardSkeleton } from "@/components/Skeleton";
 import {
   MetricItem,
   MetricLabel,
@@ -53,6 +52,12 @@ const TabSection = styled.div`
 const TableContainer = styled.div`
   border-top: 1px solid var(--service-border);
   border-bottom: 1px solid var(--service-border);
+`;
+
+const LoadingNotice = styled.p`
+  margin: 0 0 10px;
+  color: var(--service-text-muted);
+  font-size: 0.8125rem;
 `;
 
 const EmptyState = styled.div`
@@ -835,7 +840,6 @@ interface LeaderboardClientProps {
   initialData: LeaderboardData;
   currentUser: { id: string; username: string; displayName: string | null; avatarUrl: string | null } | null;
   initialSortBy: LeaderboardSortBy;
-  initialUserRank: LeaderboardUser | null;
 }
 
 function isValidLeaderboardData(data: unknown): data is LeaderboardData {
@@ -951,7 +955,7 @@ function parsePeriodParam(value: string | null): Period | null {
   return VALID_PERIODS.includes(value as Period) ? (value as Period) : null;
 }
 
-export default function LeaderboardClient({ initialData, currentUser, initialSortBy, initialUserRank }: LeaderboardClientProps) {
+export default function LeaderboardClient({ initialData, currentUser, initialSortBy }: LeaderboardClientProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const pathname = usePathname();
@@ -975,7 +979,7 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
   // date range (isCustomWithoutDates guard), so no mismatched data is shown.
   const [period, setPeriod] = useState<Period>(initialData.period);
   const [page, setPage] = useState(urlPage || initialData.pagination.page);
-  const [currentUserRank, setCurrentUserRank] = useState<LeaderboardUser | null>(initialUserRank);
+  const [currentUserRank, setCurrentUserRank] = useState<LeaderboardUser | null>(null);
   const [currentUserRankError, setCurrentUserRankError] = useState(false);
   const [searchQuery, setSearchQuery] = useState(urlSearch);
   const [debouncedSearch, setDebouncedSearch] = useState(urlSearch);
@@ -1019,7 +1023,6 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
     || (period === "custom" && (appliedFrom !== resolvedRequest.customFrom || appliedTo !== resolvedRequest.customTo))
   );
 
-  const isFirstRankFetch = useRef(true);
   const isFirstUrlSync = useRef(true);
 
   useEffect(() => {
@@ -1059,11 +1062,6 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
 
   useEffect(() => {
     if (!currentUser) {
-      return;
-    }
-
-    if (isFirstRankFetch.current) {
-      isFirstRankFetch.current = false;
       return;
     }
 
@@ -1360,9 +1358,13 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
         </SortToggleInner>
       </SearchSortRow>
 
-      {isLoading ? (
-        <LeaderboardSkeleton />
-      ) : error ? (
+      {isLoading && (
+        <LoadingNotice role="status" aria-live="polite">
+          Updating leaderboard…
+        </LoadingNotice>
+      )}
+
+      {error ? (
         <TableContainer>
           <EmptyState>
             <EmptyMessage>Failed to load leaderboard</EmptyMessage>

--- a/packages/frontend/src/app/(main)/leaderboard/page.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/page.tsx
@@ -4,7 +4,7 @@ import { cookies } from "next/headers";
 import { Navigation } from "@/components/layout/Navigation";
 import { ServiceFooter } from "@/components/layout/ServiceFooter";
 import { LeaderboardSkeleton } from "@/components/Skeleton";
-import { getLeaderboardData, getUserRank } from "@/lib/leaderboard/getLeaderboard";
+import { getLeaderboardData } from "@/lib/leaderboard/getLeaderboard";
 import type { LeaderboardData, Period, SortBy } from "@/lib/leaderboard/types";
 import { getSession } from "@/lib/auth/session";
 import {
@@ -171,15 +171,6 @@ async function LeaderboardWithPreferences({
     }),
   ]);
 
-  const initialUserRank = session
-    ? await getUserRank(session.username, period, sortBy, customFrom, customTo).catch((error) => {
-        if (isMissingDatabaseUrl(error)) {
-          return null;
-        }
-        throw error;
-      })
-    : null;
-
   return (
     <>
       <ViewSelector current="users" searchParams={searchParams} />
@@ -187,7 +178,6 @@ async function LeaderboardWithPreferences({
         initialData={initialData}
         currentUser={session}
         initialSortBy={sortBy}
-        initialUserRank={initialUserRank}
       />
     </>
   );

--- a/packages/frontend/src/app/api/leaderboard/route.ts
+++ b/packages/frontend/src/app/api/leaderboard/route.ts
@@ -47,7 +47,11 @@ export async function GET(request: Request) {
 
     const data = await getLeaderboardData(period, page, limit, sortBy, search, customFrom, customTo);
 
-    return NextResponse.json(data);
+    return NextResponse.json(data, {
+      headers: {
+        "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+      },
+    });
   } catch (error) {
     console.error("Leaderboard error:", error);
     return NextResponse.json(

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -298,16 +298,18 @@ async function fetchAllTimeLeaderboardData(
     : sql``;
   const globalStatsBase = sql`
     SELECT s.user_id, u.username, u.display_name, u.avatar_url, u.leaderboard_hidden,
-      s.total_tokens, CAST(s.total_cost AS DECIMAL(18,4)) AS total_cost
+      SUM(s.total_tokens) AS total_tokens, SUM(CAST(s.total_cost AS DECIMAL(18,4))) AS total_cost
     FROM submissions s
     INNER JOIN users u ON s.user_id = u.id
+    GROUP BY s.user_id, u.username, u.display_name, u.avatar_url, u.leaderboard_hidden
   `;
   const base = sql`
     SELECT s.user_id, u.username, u.display_name, u.avatar_url, u.leaderboard_hidden,
-      s.total_tokens, CAST(s.total_cost AS DECIMAL(18,4)) AS total_cost
+      SUM(s.total_tokens) AS total_tokens, SUM(CAST(s.total_cost AS DECIMAL(18,4))) AS total_cost
     FROM submissions s
     INNER JOIN users u ON s.user_id = u.id
     WHERE TRUE ${sourceFilter}
+    GROUP BY s.user_id, u.username, u.display_name, u.avatar_url, u.leaderboard_hidden
   `;
   const result = await db.execute<LeaderboardQueryResult>(
     resultQuery(
@@ -416,8 +418,9 @@ async function fetchUserRank(
   if (!user || user.leaderboardHidden) return null;
   const base = sql`
         SELECT s.user_id, u.username, u.display_name, u.avatar_url, u.leaderboard_hidden,
-          s.total_tokens, CAST(s.total_cost AS DECIMAL(18,4)) AS total_cost
+          SUM(s.total_tokens) AS total_tokens, SUM(CAST(s.total_cost AS DECIMAL(18,4))) AS total_cost
         FROM submissions s INNER JOIN users u ON s.user_id = u.id
+        GROUP BY s.user_id, u.username, u.display_name, u.avatar_url, u.leaderboard_hidden
       `;
   const result = await db.execute<LeaderboardQueryResult>(
     resultQuery(base, 1, 1, sortBy, "", false, user.username),

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -1,22 +1,36 @@
 import { unstable_cache } from "next/cache";
-import { db, users, submissions } from "@/lib/db";
+import { db, users } from "@/lib/db";
 import {
   USERNAME_LOOKUP_LIMIT,
   getSingleUsernameMatch,
   normalizeUsernameCacheKey,
   usernameEqualsIgnoreCase,
 } from "@/lib/db/usernameLookup";
-import { eq, sql } from "drizzle-orm";
-import type { LeaderboardData, LeaderboardUser, Period, SortBy } from "@/lib/leaderboard/types";
+import { sql } from "drizzle-orm";
+import type {
+  LeaderboardData,
+  LeaderboardUser,
+  Period,
+  SortBy,
+} from "@/lib/leaderboard/types";
+import {
+  hasDirectives,
+  parseSearchDirectives,
+} from "@/lib/leaderboard/searchDirectives";
 
-export type { LeaderboardData, LeaderboardUser, Period, SortBy } from "@/lib/leaderboard/types";
+export type {
+  LeaderboardData,
+  LeaderboardUser,
+  Period,
+  SortBy,
+} from "@/lib/leaderboard/types";
 
 interface PeriodDateRange {
   start: string;
   end: string;
 }
 
-type LeaderboardQueryResult = Record<string, unknown> & {
+type LeaderboardQueryResult = {
   users: unknown;
   totalUsers: number | string | null;
   totalTokens: number | string | null;
@@ -24,7 +38,7 @@ type LeaderboardQueryResult = Record<string, unknown> & {
   uniqueUsers: number | string | null;
 };
 
-type RankedLeaderboardDbRow = Record<string, unknown> & {
+type RankedLeaderboardDbRow = {
   rank: number | string | null;
   userId: string;
   username: string;
@@ -42,51 +56,39 @@ function getPeriodDateRange(
   period: Period,
   now: Date = new Date(),
   customFrom?: string,
-  customTo?: string
+  customTo?: string,
 ): PeriodDateRange | null {
-  if (period === "all") {
-    return null;
-  }
-
+  if (period === "all") return null;
   if (period === "custom") {
-    if (!customFrom || !customTo) {
-      return null;
-    }
-    return { start: customFrom, end: customTo };
+    return customFrom && customTo ? { start: customFrom, end: customTo } : null;
   }
 
   const end = new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
   );
-
   if (period === "week") {
     const start = new Date(end);
     start.setUTCDate(start.getUTCDate() - 6);
-    return {
-      start: toUtcDateString(start),
-      end: toUtcDateString(end),
-    };
+    return { start: toUtcDateString(start), end: toUtcDateString(end) };
   }
-
   if (period === "last-month") {
-    const lastMonthEnd = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 0));
-    const lastMonthStart = new Date(Date.UTC(lastMonthEnd.getUTCFullYear(), lastMonthEnd.getUTCMonth(), 1));
+    const lastMonthEnd = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 0),
+    );
+    const lastMonthStart = new Date(
+      Date.UTC(lastMonthEnd.getUTCFullYear(), lastMonthEnd.getUTCMonth(), 1),
+    );
     return {
       start: toUtcDateString(lastMonthStart),
       end: toUtcDateString(lastMonthEnd),
     };
   }
-
-  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
   return {
-    start: toUtcDateString(start),
+    start: toUtcDateString(
+      new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)),
+    ),
     end: toUtcDateString(end),
   };
-}
-
-function getSearchPattern(search: string): string {
-  const escapedSearch = search.toLowerCase().replace(/[%_\\]/g, "\\$&");
-  return `%${escapedSearch}%`;
 }
 
 function mapLeaderboardUser(row: RankedLeaderboardDbRow): LeaderboardUser {
@@ -103,20 +105,24 @@ function mapLeaderboardUser(row: RankedLeaderboardDbRow): LeaderboardUser {
 
 function parseLeaderboardUsers(value: unknown): LeaderboardUser[] {
   let rows = value;
-
   if (typeof rows === "string") {
     try {
       rows = JSON.parse(rows);
-    } catch {
-      return [];
+    } catch (error) {
+      throw new Error("Leaderboard query returned malformed users JSON", {
+        cause: error,
+      });
     }
   }
-
   if (!Array.isArray(rows)) {
-    return [];
+    throw new Error("Leaderboard query returned a non-array users payload");
   }
-
-  return rows.map((row) => mapLeaderboardUser(row as RankedLeaderboardDbRow));
+  return rows.map((row) => {
+    if (!row || typeof row !== "object") {
+      throw new Error("Leaderboard query returned an invalid user row");
+    }
+    return mapLeaderboardUser(row as RankedLeaderboardDbRow);
+  });
 }
 
 function buildLeaderboardData(
@@ -124,13 +130,28 @@ function buildLeaderboardData(
   page: number,
   limit: number,
   period: Period,
-  sortBy: SortBy
+  sortBy: SortBy,
 ): LeaderboardData {
-  const totalUsers = Number(row?.totalUsers) || 0;
+  if (!row) {
+    return {
+      users: [],
+      pagination: {
+        page,
+        limit,
+        totalUsers: 0,
+        totalPages: 0,
+        hasNext: false,
+        hasPrev: page > 1,
+      },
+      stats: { totalTokens: 0, totalCost: 0, uniqueUsers: 0 },
+      period,
+      sortBy,
+    };
+  }
+  const totalUsers = Number(row.totalUsers) || 0;
   const totalPages = Math.ceil(totalUsers / limit);
-
   return {
-    users: parseLeaderboardUsers(row?.users),
+    users: parseLeaderboardUsers(row.users),
     pagination: {
       page,
       limit,
@@ -140,20 +161,76 @@ function buildLeaderboardData(
       hasPrev: page > 1,
     },
     stats: {
-      totalTokens: Number(row?.totalTokens) || 0,
-      totalCost: Number(row?.totalCost) || 0,
-      uniqueUsers: Number(row?.uniqueUsers) || 0,
+      totalTokens: Number(row.totalTokens) || 0,
+      totalCost: Number(row.totalCost) || 0,
+      uniqueUsers: Number(row.uniqueUsers) || 0,
     },
     period,
     sortBy,
   };
 }
 
-/**
- * Period rankings intentionally use ROW_NUMBER over the full display ordering.
- * This preserves the sequential ranks that the former in-memory sort assigned
- * when primary-metric ties were resolved by the secondary metric and username.
- */
+function likeAny(
+  column: ReturnType<typeof sql>,
+  values: string[],
+): ReturnType<typeof sql> {
+  if (values.length === 0) return sql`TRUE`;
+  const patterns = values.map((value) => `%${escapeLeaderboardLike(value)}%`);
+  return sql`(${sql.join(
+    patterns.map((pattern) => sql`LOWER(${column}) LIKE ${pattern} ESCAPE '!'`),
+    sql` OR `,
+  )})`;
+}
+
+function userTextCondition(text: string): ReturnType<typeof sql> {
+  if (!text) return sql`TRUE`;
+  const pattern = `%${escapeLeaderboardLike(text.toLowerCase())}%`;
+  return sql`(LOWER(username) LIKE ${pattern} ESCAPE '!' OR LOWER(COALESCE(display_name, '')) LIKE ${pattern} ESCAPE '!')`;
+}
+
+function escapeLeaderboardLike(value: string): string {
+  return value.replace(/[!%_]/g, "!$&");
+}
+
+function resultQuery(
+  base: ReturnType<typeof sql>,
+  page: number,
+  limit: number,
+  sortBy: SortBy,
+  text: string,
+  sequentialRanks: boolean,
+  exactUsername?: string,
+): ReturnType<typeof sql> {
+  const offset = (page - 1) * limit;
+  const primary = sortBy === "cost" ? sql`total_cost` : sql`total_tokens`;
+  const secondary = sortBy === "cost" ? sql`total_tokens` : sql`total_cost`;
+  const search = userTextCondition(text);
+  return sql`
+    WITH aggregated AS (${base}),
+    rankable AS (
+      SELECT aggregated.*, ${sequentialRanks ? sql`ROW_NUMBER()` : sql`RANK()`} OVER (ORDER BY ${primary} DESC) AS rank
+      FROM aggregated
+      WHERE leaderboard_hidden = false
+    ),
+    filtered AS (
+      SELECT rankable.*, COUNT(*) OVER () AS filtered_users
+      FROM rankable
+      WHERE ${exactUsername ? sql`LOWER(username) = LOWER(${exactUsername})` : search}
+    ),
+    paged AS (
+      SELECT * FROM filtered
+      ORDER BY rank ASC, ${secondary} DESC, LOWER(username) ASC, user_id ASC
+      LIMIT ${limit} OFFSET ${offset}
+    )
+    SELECT
+      COALESCE((SELECT json_agg(json_build_object('rank', rank, 'userId', user_id, 'username', username, 'displayName', display_name, 'avatarUrl', avatar_url, 'totalTokens', total_tokens, 'totalCost', total_cost) ORDER BY rank ASC, ${secondary} DESC, LOWER(username) ASC, user_id ASC) FROM paged), '[]'::json) AS users,
+      COALESCE((SELECT filtered_users FROM filtered LIMIT 1), 0)::int AS "totalUsers",
+      COALESCE((SELECT SUM(total_tokens) FROM aggregated), 0) AS "totalTokens",
+      COALESCE((SELECT SUM(total_cost) FROM aggregated), 0) AS "totalCost",
+      COALESCE((SELECT COUNT(*) FROM aggregated), 0)::int AS "uniqueUsers"
+  `;
+}
+
 async function fetchPeriodLeaderboardData(
   period: Exclude<Period, "all">,
   page: number,
@@ -161,85 +238,45 @@ async function fetchPeriodLeaderboardData(
   sortBy: SortBy,
   search: string,
   customFrom?: string,
-  customTo?: string
+  customTo?: string,
 ): Promise<LeaderboardData> {
-  const dateRange = getPeriodDateRange(period, new Date(), customFrom, customTo);
-
-  if (!dateRange) {
+  const range = getPeriodDateRange(period, new Date(), customFrom, customTo);
+  if (!range)
     return buildLeaderboardData(undefined, page, limit, period, sortBy);
+  const parsed = parseSearchDirectives(search);
+  let base: ReturnType<typeof sql>;
+
+  if (!hasDirectives(parsed)) {
+    base = sql`
+      SELECT s.user_id, u.username, u.display_name, u.avatar_url, u.leaderboard_hidden,
+        SUM(d.tokens) AS total_tokens, SUM(CAST(d.cost AS DECIMAL(18,4))) AS total_cost
+      FROM daily_breakdown d
+      INNER JOIN submissions s ON d.submission_id = s.id
+      INNER JOIN users u ON s.user_id = u.id
+      WHERE d.date >= ${range.start} AND d.date <= ${range.end}
+      GROUP BY s.user_id, u.username, u.display_name, u.avatar_url, u.leaderboard_hidden
+    `;
+  } else {
+    const clientMatch = likeAny(sql`client.key`, parsed.clients);
+    const modelMatch = likeAny(sql`model.key`, parsed.models);
+    const usesModels = parsed.models.length > 0;
+    base = sql`
+      SELECT s.user_id, u.username, u.display_name, u.avatar_url, u.leaderboard_hidden,
+        SUM(CASE WHEN ${usesModels} THEN COALESCE((model.value->>'tokens')::numeric, 0) ELSE COALESCE((client.value->>'tokens')::numeric, 0) END) AS total_tokens,
+        SUM(CASE WHEN ${usesModels} THEN COALESCE((model.value->>'cost')::numeric, 0) ELSE COALESCE((client.value->>'cost')::numeric, 0) END) AS total_cost
+      FROM daily_breakdown d
+      INNER JOIN submissions s ON d.submission_id = s.id
+      INNER JOIN users u ON s.user_id = u.id
+      CROSS JOIN LATERAL jsonb_each(COALESCE(d.source_breakdown, '{}'::jsonb)) AS client(key, value)
+      LEFT JOIN LATERAL jsonb_each(COALESCE(client.value->'models', '{}'::jsonb)) AS model(key, value) ON ${usesModels}
+      WHERE d.date >= ${range.start} AND d.date <= ${range.end}
+        AND ${clientMatch} AND (${usesModels} = false OR ${modelMatch})
+      GROUP BY s.user_id, u.username, u.display_name, u.avatar_url, u.leaderboard_hidden
+    `;
   }
-
-  const offset = (page - 1) * limit;
-  const primaryOrderColumn = sortBy === "cost" ? sql`total_cost` : sql`total_tokens`;
-  const secondaryOrderColumn = sortBy === "cost" ? sql`total_tokens` : sql`total_cost`;
-  const searchCondition = search
-    ? sql`LOWER(username) LIKE ${getSearchPattern(search)} ESCAPE '\\' OR LOWER(COALESCE(display_name, '')) LIKE ${getSearchPattern(search)} ESCAPE '\\'`
-    : sql`TRUE`;
-
-  const result = await db.execute<LeaderboardQueryResult>(sql`
-    WITH aggregated AS (
-      SELECT
-        submissions.user_id AS user_id,
-        users.username AS username,
-        users.display_name AS display_name,
-        users.avatar_url AS avatar_url,
-        SUM(daily_breakdown.tokens) AS total_tokens,
-        SUM(CAST(daily_breakdown.cost AS DECIMAL(18,4))) AS total_cost
-      FROM daily_breakdown
-      INNER JOIN submissions ON daily_breakdown.submission_id = submissions.id
-      INNER JOIN users ON submissions.user_id = users.id
-      WHERE daily_breakdown.date >= ${dateRange.start}
-        AND daily_breakdown.date <= ${dateRange.end}
-      GROUP BY submissions.user_id, users.username, users.display_name, users.avatar_url
-    ),
-    ranked AS (
-      SELECT
-        aggregated.*,
-        ROW_NUMBER() OVER (
-          ORDER BY ${primaryOrderColumn} DESC, ${secondaryOrderColumn} DESC, LOWER(username) ASC, user_id ASC
-        ) AS rank,
-        SUM(total_tokens) OVER () AS total_tokens_all,
-        SUM(total_cost) OVER () AS total_cost_all,
-        COUNT(*) OVER () AS unique_users_all
-      FROM aggregated
-    ),
-    filtered AS (
-      SELECT ranked.*, COUNT(*) OVER () AS filtered_users
-      FROM ranked
-      WHERE ${searchCondition}
-    ),
-    paged AS (
-      SELECT *
-      FROM filtered
-      ORDER BY rank ASC
-      LIMIT ${limit}
-      OFFSET ${offset}
-    )
-    SELECT
-      COALESCE(
-        (
-          SELECT json_agg(
-            json_build_object(
-              'rank', rank,
-              'userId', user_id,
-              'username', username,
-              'displayName', display_name,
-              'avatarUrl', avatar_url,
-              'totalTokens', total_tokens,
-              'totalCost', total_cost
-            )
-            ORDER BY rank ASC
-          )
-          FROM paged
-        ),
-        '[]'::json
-      ) AS users,
-      COALESCE((SELECT filtered_users FROM filtered LIMIT 1), 0)::int AS "totalUsers",
-      COALESCE((SELECT total_tokens_all FROM ranked LIMIT 1), 0) AS "totalTokens",
-      COALESCE((SELECT total_cost_all FROM ranked LIMIT 1), 0) AS "totalCost",
-      COALESCE((SELECT unique_users_all FROM ranked LIMIT 1), 0)::int AS "uniqueUsers"
-  `);
-
+  const result = await db.execute<LeaderboardQueryResult>(
+    resultQuery(base, page, limit, sortBy, parsed.text, true),
+  );
   return buildLeaderboardData(result[0], page, limit, period, sortBy);
 }
 
@@ -247,70 +284,27 @@ async function fetchAllTimeLeaderboardData(
   page: number,
   limit: number,
   sortBy: SortBy,
-  search: string
+  search: string,
 ): Promise<LeaderboardData> {
-  const offset = (page - 1) * limit;
-  const primaryOrderColumn = sortBy === "cost" ? sql`total_cost` : sql`total_tokens`;
-  const secondaryOrderColumn = sortBy === "cost" ? sql`total_tokens` : sql`total_cost`;
-  const searchCondition = search
-    ? sql`LOWER(username) LIKE ${getSearchPattern(search)} ESCAPE '\\' OR LOWER(COALESCE(display_name, '')) LIKE ${getSearchPattern(search)} ESCAPE '\\'`
-    : sql`TRUE`;
-
-  // submissions.user_id is unique. Keep this path row-based rather than
-  // grouping every submission on each request.
-  const result = await db.execute<LeaderboardQueryResult>(sql`
-    WITH ranked AS (
-      SELECT
-        submissions.user_id AS user_id,
-        users.username AS username,
-        users.display_name AS display_name,
-        users.avatar_url AS avatar_url,
-        submissions.total_tokens AS total_tokens,
-        CAST(submissions.total_cost AS DECIMAL(18,4)) AS total_cost,
-        RANK() OVER (ORDER BY ${primaryOrderColumn} DESC) AS rank,
-        SUM(submissions.total_tokens) OVER () AS total_tokens_all,
-        SUM(CAST(submissions.total_cost AS DECIMAL(18,4))) OVER () AS total_cost_all,
-        COUNT(*) OVER () AS unique_users_all
-      FROM submissions
-      INNER JOIN users ON submissions.user_id = users.id
-    ),
-    filtered AS (
-      SELECT ranked.*, COUNT(*) OVER () AS filtered_users
-      FROM ranked
-      WHERE ${searchCondition}
-    ),
-    paged AS (
-      SELECT *
-      FROM filtered
-      ORDER BY rank ASC, ${secondaryOrderColumn} DESC, LOWER(username) ASC, user_id ASC
-      LIMIT ${limit}
-      OFFSET ${offset}
-    )
-    SELECT
-      COALESCE(
-        (
-          SELECT json_agg(
-            json_build_object(
-              'rank', rank,
-              'userId', user_id,
-              'username', username,
-              'displayName', display_name,
-              'avatarUrl', avatar_url,
-              'totalTokens', total_tokens,
-              'totalCost', total_cost
-            )
-            ORDER BY rank ASC, ${secondaryOrderColumn} DESC, LOWER(username) ASC, user_id ASC
-          )
-          FROM paged
-        ),
-        '[]'::json
-      ) AS users,
-      COALESCE((SELECT filtered_users FROM filtered LIMIT 1), 0)::int AS "totalUsers",
-      COALESCE((SELECT total_tokens_all FROM ranked LIMIT 1), 0) AS "totalTokens",
-      COALESCE((SELECT total_cost_all FROM ranked LIMIT 1), 0) AS "totalCost",
-      COALESCE((SELECT unique_users_all FROM ranked LIMIT 1), 0)::int AS "uniqueUsers"
-  `);
-
+  const parsed = parseSearchDirectives(search);
+  const clientMatch = likeAny(sql`source`, parsed.clients);
+  const modelMatch = likeAny(sql`model`, parsed.models);
+  const sourceFilter = hasDirectives(parsed)
+    ? sql`
+    AND (${parsed.clients.length === 0} OR EXISTS (SELECT 1 FROM unnest(s.sources_used) AS source WHERE ${clientMatch}))
+    AND (${parsed.models.length === 0} OR EXISTS (SELECT 1 FROM unnest(s.models_used) AS model WHERE ${modelMatch}))
+  `
+    : sql``;
+  const base = sql`
+    SELECT s.user_id, u.username, u.display_name, u.avatar_url, u.leaderboard_hidden,
+      s.total_tokens, CAST(s.total_cost AS DECIMAL(18,4)) AS total_cost
+    FROM submissions s
+    INNER JOIN users u ON s.user_id = u.id
+    WHERE TRUE ${sourceFilter}
+  `;
+  const result = await db.execute<LeaderboardQueryResult>(
+    resultQuery(base, page, limit, sortBy, parsed.text, false),
+  );
   return buildLeaderboardData(result[0], page, limit, "all", sortBy);
 }
 
@@ -318,24 +312,22 @@ async function fetchLeaderboardData(
   period: Period,
   page: number,
   limit: number,
-  sortBy: SortBy = "tokens",
-  search: string = "",
+  sortBy: SortBy,
+  search: string,
   customFrom?: string,
-  customTo?: string
+  customTo?: string,
 ): Promise<LeaderboardData> {
-  if (period !== "all") {
-    return fetchPeriodLeaderboardData(
-      period,
-      page,
-      limit,
-      sortBy,
-      search,
-      customFrom,
-      customTo
-    );
-  }
-
-  return fetchAllTimeLeaderboardData(page, limit, sortBy, search);
+  return period === "all"
+    ? fetchAllTimeLeaderboardData(page, limit, sortBy, search)
+    : fetchPeriodLeaderboardData(
+        period,
+        page,
+        limit,
+        sortBy,
+        search,
+        customFrom,
+        customTo,
+      );
 }
 
 export function getLeaderboardData(
@@ -345,79 +337,26 @@ export function getLeaderboardData(
   sortBy: SortBy = "tokens",
   search: string = "",
   customFrom?: string,
-  customTo?: string
+  customTo?: string,
 ): Promise<LeaderboardData> {
-  const cacheKey = period === "custom"
-    ? `leaderboard:custom:${customFrom}:${customTo}:${page}:${limit}:${sortBy}:${search}`
-    : `leaderboard:${period}:${page}:${limit}:${sortBy}:${search}`;
-
+  const cacheKey =
+    period === "custom"
+      ? `leaderboard:custom:${customFrom}:${customTo}:${page}:${limit}:${sortBy}:${search}`
+      : `leaderboard:${period}:${page}:${limit}:${sortBy}:${search}`;
   return unstable_cache(
-    () => fetchLeaderboardData(period, page, limit, sortBy, search, customFrom, customTo),
+    () =>
+      fetchLeaderboardData(
+        period,
+        page,
+        limit,
+        sortBy,
+        search,
+        customFrom,
+        customTo,
+      ),
     [cacheKey],
-    {
-      tags: ["leaderboard", `leaderboard:${period}`],
-      revalidate: 60,
-    }
+    { tags: ["leaderboard", `leaderboard:${period}`], revalidate: 60 },
   )();
-}
-
-// ============================================================================
-// USER RANK
-// ============================================================================
-
-async function fetchPeriodUserRank(
-  username: string,
-  period: Exclude<Period, "all">,
-  sortBy: SortBy,
-  customFrom?: string,
-  customTo?: string
-): Promise<LeaderboardUser | null> {
-  const dateRange = getPeriodDateRange(period, new Date(), customFrom, customTo);
-
-  if (!dateRange) {
-    return null;
-  }
-
-  const primaryOrderColumn = sortBy === "cost" ? sql`total_cost` : sql`total_tokens`;
-  const secondaryOrderColumn = sortBy === "cost" ? sql`total_tokens` : sql`total_cost`;
-  const results = await db.execute<RankedLeaderboardDbRow>(sql`
-    WITH aggregated AS (
-      SELECT
-        submissions.user_id AS user_id,
-        users.username AS username,
-        users.display_name AS display_name,
-        users.avatar_url AS avatar_url,
-        SUM(daily_breakdown.tokens) AS total_tokens,
-        SUM(CAST(daily_breakdown.cost AS DECIMAL(18,4))) AS total_cost
-      FROM daily_breakdown
-      INNER JOIN submissions ON daily_breakdown.submission_id = submissions.id
-      INNER JOIN users ON submissions.user_id = users.id
-      WHERE daily_breakdown.date >= ${dateRange.start}
-        AND daily_breakdown.date <= ${dateRange.end}
-      GROUP BY submissions.user_id, users.username, users.display_name, users.avatar_url
-    ),
-    ranked AS (
-      SELECT
-        aggregated.*,
-        ROW_NUMBER() OVER (
-          ORDER BY ${primaryOrderColumn} DESC, ${secondaryOrderColumn} DESC, LOWER(username) ASC, user_id ASC
-        ) AS rank
-      FROM aggregated
-    )
-    SELECT
-      rank,
-      user_id AS "userId",
-      username,
-      display_name AS "displayName",
-      avatar_url AS "avatarUrl",
-      total_tokens AS "totalTokens",
-      total_cost AS "totalCost"
-    FROM ranked
-    WHERE LOWER(username) = LOWER(${username})
-  `);
-
-  const row = getSingleUsernameMatch(results, username);
-  return row ? mapLeaderboardUser(row) : null;
 }
 
 async function fetchUserRank(
@@ -425,65 +364,49 @@ async function fetchUserRank(
   period: Period,
   sortBy: SortBy,
   customFrom?: string,
-  customTo?: string
+  customTo?: string,
 ): Promise<LeaderboardUser | null> {
   if (period !== "all") {
-    return fetchPeriodUserRank(username, period, sortBy, customFrom, customTo);
+    const range = getPeriodDateRange(period, new Date(), customFrom, customTo);
+    if (!range) return null;
+    const base = sql`
+      SELECT s.user_id, u.username, u.display_name, u.avatar_url, u.leaderboard_hidden,
+        SUM(d.tokens) AS total_tokens, SUM(CAST(d.cost AS DECIMAL(18,4))) AS total_cost
+      FROM daily_breakdown d
+      INNER JOIN submissions s ON d.submission_id = s.id
+      INNER JOIN users u ON s.user_id = u.id
+      WHERE d.date >= ${range.start} AND d.date <= ${range.end}
+      GROUP BY s.user_id, u.username, u.display_name, u.avatar_url, u.leaderboard_hidden
+    `;
+    const result = await db.execute<LeaderboardQueryResult>(
+      resultQuery(base, 1, 1, sortBy, "", true, username),
+    );
+    return result[0]
+      ? (parseLeaderboardUsers(result[0].users)[0] ?? null)
+      : null;
   }
-
   const userResult = await db
-    .select({ id: users.id, username: users.username, displayName: users.displayName, avatarUrl: users.avatarUrl })
+    .select({
+      id: users.id,
+      username: users.username,
+      displayName: users.displayName,
+      avatarUrl: users.avatarUrl,
+      leaderboardHidden: users.leaderboardHidden,
+    })
     .from(users)
     .where(usernameEqualsIgnoreCase(username))
     .limit(USERNAME_LOOKUP_LIMIT);
-
   const user = getSingleUsernameMatch(userResult, username);
-
-  if (!user) {
-    return null;
-  }
-
-  const userStatsResult = await db
-    .select({
-      totalTokens: submissions.totalTokens,
-      totalCost: sql<number>`CAST(${submissions.totalCost} AS DECIMAL(18,4))`.as("total_cost"),
-    })
-    .from(submissions)
-    .where(eq(submissions.userId, user.id));
-
-  if (!userStatsResult[0]) {
-    return null;
-  }
-
-  const userStats = userStatsResult[0];
-  const userTotalTokens = Number(userStats.totalTokens) || 0;
-  const userTotalCost = Number(userStats.totalCost) || 0;
-
-  const userCompareValue = sortBy === "cost"
-    ? userTotalCost
-    : userTotalTokens;
-  const compareColumn = sortBy === "cost"
-    ? sql`CAST(${submissions.totalCost} AS DECIMAL(18,4))`
-    : submissions.totalTokens;
-
-  const higherRankedResult = await db
-    .select({
-      count: sql<number>`COUNT(*)`.as("count"),
-    })
-    .from(submissions)
-    .where(sql`${compareColumn} > ${userCompareValue}`);
-
-  const rank = Number(higherRankedResult[0]?.count || 0) + 1;
-
-  return {
-    rank,
-    userId: user.id,
-    username: user.username,
-    displayName: user.displayName,
-    avatarUrl: user.avatarUrl,
-    totalTokens: userTotalTokens,
-    totalCost: userTotalCost,
-  };
+  if (!user || user.leaderboardHidden) return null;
+  const base = sql`
+        SELECT s.user_id, u.username, u.display_name, u.avatar_url, u.leaderboard_hidden,
+          s.total_tokens, CAST(s.total_cost AS DECIMAL(18,4)) AS total_cost
+        FROM submissions s INNER JOIN users u ON s.user_id = u.id
+      `;
+  const result = await db.execute<LeaderboardQueryResult>(
+    resultQuery(base, 1, 1, sortBy, "", false, user.username),
+  );
+  return result[0] ? (parseLeaderboardUsers(result[0].users)[0] ?? null) : null;
 }
 
 export function getUserRank(
@@ -491,17 +414,17 @@ export function getUserRank(
   period: Period = "all",
   sortBy: SortBy = "tokens",
   customFrom?: string,
-  customTo?: string
+  customTo?: string,
 ): Promise<LeaderboardUser | null> {
   const usernameCacheKey = normalizeUsernameCacheKey(username);
-  const periodKey = period === "custom" ? `custom:${customFrom}:${customTo}` : period;
-
+  const periodKey =
+    period === "custom" ? `custom:${customFrom}:${customTo}` : period;
   return unstable_cache(
     () => fetchUserRank(username, period, sortBy, customFrom, customTo),
     [`user-rank:${usernameCacheKey}:${periodKey}:${sortBy}`],
     {
       tags: ["leaderboard", "user-rank", `user-rank:${usernameCacheKey}`],
       revalidate: 60,
-    }
+    },
   )();
 }

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -1,79 +1,38 @@
 import { unstable_cache } from "next/cache";
-import { db, users, submissions, dailyBreakdown } from "@/lib/db";
+import { db, users, submissions } from "@/lib/db";
 import {
   USERNAME_LOOKUP_LIMIT,
   getSingleUsernameMatch,
   normalizeUsernameCacheKey,
   usernameEqualsIgnoreCase,
 } from "@/lib/db/usernameLookup";
-import { eq, desc, sql, and, or, gte, lte } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import type { LeaderboardData, LeaderboardUser, Period, SortBy } from "@/lib/leaderboard/types";
-import {
-  escapeLikePattern,
-  hasDirectives,
-  parseSearchDirectives,
-} from "@/lib/leaderboard/searchDirectives";
-import {
-  scopeBreakdownToDirectives,
-  type PeriodSourceBreakdown,
-} from "@/lib/leaderboard/sourceBreakdown";
 
 export type { LeaderboardData, LeaderboardUser, Period, SortBy } from "@/lib/leaderboard/types";
-
-/**
- * Restricts a query to users eligible for a leaderboard position.
- *
- * Applies to RANKINGS ONLY. The site-wide totals queries deliberately omit it,
- * so a hidden user still contributes to total tokens, total cost and unique
- * user counts — hiding withdraws someone from the competition, it does not
- * erase their usage. Their profile, badge and embeds are likewise unaffected.
- */
-const RANKABLE_USER = eq(users.leaderboardHidden, false);
-
-interface LeaderboardPeriodRow {
-  userId: string;
-  username: string;
-  displayName: string | null;
-  avatarUrl: string | null;
-  tokens: number;
-  cost: number;
-  sourceBreakdown: PeriodSourceBreakdown | null;
-  /**
-   * Carried through so the period path can drop the user from the rankings
-   * while still counting them in the period totals. Internal only — it must
-   * never reach LeaderboardUser, which is serialized to the public API.
-   */
-  leaderboardHidden: boolean;
-}
 
 interface PeriodDateRange {
   start: string;
   end: string;
 }
 
-interface PeriodLeaderboardDbRow {
-  userId: string;
-  username: string;
-  displayName: string | null;
-  avatarUrl: string | null;
-  tokens: number | string | null;
-  cost: number | string | null;
-  sourceBreakdown: PeriodSourceBreakdown | null;
-  leaderboardHidden: boolean;
-}
+type LeaderboardQueryResult = Record<string, unknown> & {
+  users: unknown;
+  totalUsers: number | string | null;
+  totalTokens: number | string | null;
+  totalCost: number | string | null;
+  uniqueUsers: number | string | null;
+};
 
-interface AllTimeLeaderboardDbRow {
+type RankedLeaderboardDbRow = Record<string, unknown> & {
+  rank: number | string | null;
   userId: string;
   username: string;
   displayName: string | null;
   avatarUrl: string | null;
   totalTokens: number | string | null;
   totalCost: number | string | null;
-}
-
-interface RankedLeaderboardDbRow extends AllTimeLeaderboardDbRow {
-  rank: number | string | null;
-}
+};
 
 function toUtcDateString(date: Date): string {
   return date.toISOString().slice(0, 10);
@@ -125,210 +84,234 @@ function getPeriodDateRange(
   };
 }
 
-function compareLeaderboardUsers(
-  left: Omit<LeaderboardUser, "rank">,
-  right: Omit<LeaderboardUser, "rank">,
-  sortBy: SortBy
-): number {
-  const primary = sortBy === "cost"
-    ? right.totalCost - left.totalCost
-    : right.totalTokens - left.totalTokens;
-
-  if (primary !== 0) {
-    return primary;
-  }
-
-  const secondary = sortBy === "cost"
-    ? right.totalTokens - left.totalTokens
-    : right.totalCost - left.totalCost;
-
-  if (secondary !== 0) {
-    return secondary;
-  }
-
-  return left.username.localeCompare(right.username);
+function getSearchPattern(search: string): string {
+  const escapedSearch = search.toLowerCase().replace(/[%_\\]/g, "\\$&");
+  return `%${escapedSearch}%`;
 }
 
-function aggregatePeriodRows(
-  rows: LeaderboardPeriodRow[],
-  sortBy: SortBy
-): Array<Omit<LeaderboardUser, "rank">> {
-  const usersById = new Map<string, Omit<LeaderboardUser, "rank">>();
+function mapLeaderboardUser(row: RankedLeaderboardDbRow): LeaderboardUser {
+  return {
+    rank: Number(row.rank) || 0,
+    userId: row.userId,
+    username: row.username,
+    displayName: row.displayName,
+    avatarUrl: row.avatarUrl,
+    totalTokens: Number(row.totalTokens) || 0,
+    totalCost: Number(row.totalCost) || 0,
+  };
+}
 
-  for (const row of rows) {
-    const existing = usersById.get(row.userId);
+function parseLeaderboardUsers(value: unknown): LeaderboardUser[] {
+  let rows = value;
 
-    if (existing) {
-      existing.totalTokens += row.tokens;
-      existing.totalCost += row.cost;
-      continue;
+  if (typeof rows === "string") {
+    try {
+      rows = JSON.parse(rows);
+    } catch {
+      return [];
     }
-
-    usersById.set(row.userId, {
-      userId: row.userId,
-      username: row.username,
-      displayName: row.displayName,
-      avatarUrl: row.avatarUrl,
-      totalTokens: row.tokens,
-      totalCost: row.cost,
-    });
   }
 
-  return Array.from(usersById.values()).sort((left, right) =>
-    compareLeaderboardUsers(left, right, sortBy)
-  );
+  if (!Array.isArray(rows)) {
+    return [];
+  }
+
+  return rows.map((row) => mapLeaderboardUser(row as RankedLeaderboardDbRow));
 }
 
-function matchesLeaderboardSearch(
-  user: Pick<LeaderboardUser, "username" | "displayName">,
-  textSearch: string
-): boolean {
-  if (!textSearch) {
-    return true;
-  }
-
-  const lowerSearch = textSearch.toLowerCase();
-  if (user.username.toLowerCase().includes(lowerSearch)) {
-    return true;
-  }
-  if (user.displayName && user.displayName.toLowerCase().includes(lowerSearch)) {
-    return true;
-  }
-  return false;
-}
-
-function buildPeriodLeaderboardData(
-  rows: LeaderboardPeriodRow[],
+function buildLeaderboardData(
+  row: LeaderboardQueryResult | undefined,
   page: number,
   limit: number,
   period: Period,
-  sortBy: SortBy = "tokens",
-  search: string = ""
+  sortBy: SortBy
 ): LeaderboardData {
-  const offset = (page - 1) * limit;
-  const parsed = parseSearchDirectives(search);
-
-  let filteredRows = rows;
-  if (hasDirectives(parsed)) {
-    filteredRows = rows.flatMap((row) => {
-      const scoped = scopeBreakdownToDirectives(row.sourceBreakdown, parsed);
-      return scoped ? [{ ...row, tokens: scoped.tokens, cost: scoped.cost }] : [];
-    });
-  }
-
-  // Aggregated twice on purpose. `aggregatedUsers` includes hidden users and
-  // is what the period totals are computed from; `visibleUsers` excludes them
-  // and is what gets ranked. Filtering once, before the totals, would silently
-  // shrink the headline numbers — the opposite of the intended behaviour.
-  const aggregatedUsers = aggregatePeriodRows(filteredRows, sortBy);
-  const visibleUsers = aggregatePeriodRows(
-    filteredRows.filter((row) => !row.leaderboardHidden),
-    sortBy
-  );
-
-  // Ranked over the visible set, so ranks stay dense (1,2,3…) instead of
-  // leaving a gap where the hidden user used to sit.
-  const rankedUsers = visibleUsers.map((user, index) => ({
-    ...user,
-    rank: index + 1,
-  }));
-  const textFilteredUsers = rankedUsers.filter((user) =>
-    matchesLeaderboardSearch(user, parsed.text)
-  );
-  const pagedUsers = textFilteredUsers.slice(offset, offset + limit);
+  const totalUsers = Number(row?.totalUsers) || 0;
+  const totalPages = Math.ceil(totalUsers / limit);
 
   return {
-    users: pagedUsers,
+    users: parseLeaderboardUsers(row?.users),
     pagination: {
       page,
       limit,
-      totalUsers: textFilteredUsers.length,
-      totalPages: Math.ceil(textFilteredUsers.length / limit),
-      hasNext: offset + limit < textFilteredUsers.length,
+      totalUsers,
+      totalPages,
+      hasNext: page < totalPages,
       hasPrev: page > 1,
     },
     stats: {
-      totalTokens: aggregatedUsers.reduce((sum, user) => sum + user.totalTokens, 0),
-      totalCost: aggregatedUsers.reduce((sum, user) => sum + user.totalCost, 0),
-      uniqueUsers: aggregatedUsers.length,
+      totalTokens: Number(row?.totalTokens) || 0,
+      totalCost: Number(row?.totalCost) || 0,
+      uniqueUsers: Number(row?.uniqueUsers) || 0,
     },
     period,
     sortBy,
   };
 }
 
-function buildPeriodUserRank(
-  rows: LeaderboardPeriodRow[],
-  username: string,
-  sortBy: SortBy = "tokens"
-): LeaderboardUser | null {
-  // Ranked against the visible set only. A hidden user is therefore absent
-  // here and reports no rank at all, rather than a rank that does not
-  // correspond to any position on the leaderboard.
-  const aggregatedUsers = aggregatePeriodRows(
-    rows.filter((row) => !row.leaderboardHidden),
-    sortBy
-  );
-  const usernameCacheKey = normalizeUsernameCacheKey(username);
-  const matchingUsers = aggregatedUsers.filter(
-    (user) => normalizeUsernameCacheKey(user.username) === usernameCacheKey
-  );
-  const user = getSingleUsernameMatch(matchingUsers, username);
-
-  if (!user) {
-    return null;
-  }
-
-  return {
-    ...user,
-    rank: aggregatedUsers.indexOf(user) + 1,
-  };
-}
-
-async function fetchPeriodLeaderboardRows(
+/**
+ * Period rankings intentionally use ROW_NUMBER over the full display ordering.
+ * This preserves the sequential ranks that the former in-memory sort assigned
+ * when primary-metric ties were resolved by the secondary metric and username.
+ */
+async function fetchPeriodLeaderboardData(
   period: Exclude<Period, "all">,
+  page: number,
+  limit: number,
+  sortBy: SortBy,
+  search: string,
   customFrom?: string,
   customTo?: string
-): Promise<LeaderboardPeriodRow[]> {
+): Promise<LeaderboardData> {
   const dateRange = getPeriodDateRange(period, new Date(), customFrom, customTo);
 
   if (!dateRange) {
-    return [];
+    return buildLeaderboardData(undefined, page, limit, period, sortBy);
   }
 
-  const rows: PeriodLeaderboardDbRow[] = await db
-    .select({
-      userId: users.id,
-      username: users.username,
-      displayName: users.displayName,
-      avatarUrl: users.avatarUrl,
-      tokens: dailyBreakdown.tokens,
-      cost: dailyBreakdown.cost,
-      sourceBreakdown: dailyBreakdown.sourceBreakdown,
-      leaderboardHidden: users.leaderboardHidden,
-    })
-    .from(dailyBreakdown)
-    .innerJoin(submissions, eq(dailyBreakdown.submissionId, submissions.id))
-    .innerJoin(users, eq(submissions.userId, users.id))
-    .where(
-      and(
-        gte(dailyBreakdown.date, dateRange.start),
-        lte(dailyBreakdown.date, dateRange.end)
-      )
-    );
+  const offset = (page - 1) * limit;
+  const primaryOrderColumn = sortBy === "cost" ? sql`total_cost` : sql`total_tokens`;
+  const secondaryOrderColumn = sortBy === "cost" ? sql`total_tokens` : sql`total_cost`;
+  const searchCondition = search
+    ? sql`LOWER(username) LIKE ${getSearchPattern(search)} ESCAPE '\\' OR LOWER(COALESCE(display_name, '')) LIKE ${getSearchPattern(search)} ESCAPE '\\'`
+    : sql`TRUE`;
 
-  return rows.map((row: PeriodLeaderboardDbRow) => ({
-    userId: row.userId,
-    username: row.username,
-    displayName: row.displayName,
-    avatarUrl: row.avatarUrl,
-    tokens: Number(row.tokens) || 0,
-    cost: Number(row.cost) || 0,
-    sourceBreakdown: row.sourceBreakdown ?? null,
-    // Deliberately NOT filtered in SQL: the period totals are derived from
-    // these same rows, and hidden users still count toward totals.
-    leaderboardHidden: row.leaderboardHidden === true,
-  }));
+  const result = await db.execute<LeaderboardQueryResult>(sql`
+    WITH aggregated AS (
+      SELECT
+        submissions.user_id AS user_id,
+        users.username AS username,
+        users.display_name AS display_name,
+        users.avatar_url AS avatar_url,
+        SUM(daily_breakdown.tokens) AS total_tokens,
+        SUM(CAST(daily_breakdown.cost AS DECIMAL(18,4))) AS total_cost
+      FROM daily_breakdown
+      INNER JOIN submissions ON daily_breakdown.submission_id = submissions.id
+      INNER JOIN users ON submissions.user_id = users.id
+      WHERE daily_breakdown.date >= ${dateRange.start}
+        AND daily_breakdown.date <= ${dateRange.end}
+      GROUP BY submissions.user_id, users.username, users.display_name, users.avatar_url
+    ),
+    ranked AS (
+      SELECT
+        aggregated.*,
+        ROW_NUMBER() OVER (
+          ORDER BY ${primaryOrderColumn} DESC, ${secondaryOrderColumn} DESC, LOWER(username) ASC, user_id ASC
+        ) AS rank,
+        SUM(total_tokens) OVER () AS total_tokens_all,
+        SUM(total_cost) OVER () AS total_cost_all,
+        COUNT(*) OVER () AS unique_users_all
+      FROM aggregated
+    ),
+    filtered AS (
+      SELECT ranked.*, COUNT(*) OVER () AS filtered_users
+      FROM ranked
+      WHERE ${searchCondition}
+    ),
+    paged AS (
+      SELECT *
+      FROM filtered
+      ORDER BY rank ASC
+      LIMIT ${limit}
+      OFFSET ${offset}
+    )
+    SELECT
+      COALESCE(
+        (
+          SELECT json_agg(
+            json_build_object(
+              'rank', rank,
+              'userId', user_id,
+              'username', username,
+              'displayName', display_name,
+              'avatarUrl', avatar_url,
+              'totalTokens', total_tokens,
+              'totalCost', total_cost
+            )
+            ORDER BY rank ASC
+          )
+          FROM paged
+        ),
+        '[]'::json
+      ) AS users,
+      COALESCE((SELECT filtered_users FROM filtered LIMIT 1), 0)::int AS "totalUsers",
+      COALESCE((SELECT total_tokens_all FROM ranked LIMIT 1), 0) AS "totalTokens",
+      COALESCE((SELECT total_cost_all FROM ranked LIMIT 1), 0) AS "totalCost",
+      COALESCE((SELECT unique_users_all FROM ranked LIMIT 1), 0)::int AS "uniqueUsers"
+  `);
+
+  return buildLeaderboardData(result[0], page, limit, period, sortBy);
+}
+
+async function fetchAllTimeLeaderboardData(
+  page: number,
+  limit: number,
+  sortBy: SortBy,
+  search: string
+): Promise<LeaderboardData> {
+  const offset = (page - 1) * limit;
+  const primaryOrderColumn = sortBy === "cost" ? sql`total_cost` : sql`total_tokens`;
+  const secondaryOrderColumn = sortBy === "cost" ? sql`total_tokens` : sql`total_cost`;
+  const searchCondition = search
+    ? sql`LOWER(username) LIKE ${getSearchPattern(search)} ESCAPE '\\' OR LOWER(COALESCE(display_name, '')) LIKE ${getSearchPattern(search)} ESCAPE '\\'`
+    : sql`TRUE`;
+
+  // submissions.user_id is unique. Keep this path row-based rather than
+  // grouping every submission on each request.
+  const result = await db.execute<LeaderboardQueryResult>(sql`
+    WITH ranked AS (
+      SELECT
+        submissions.user_id AS user_id,
+        users.username AS username,
+        users.display_name AS display_name,
+        users.avatar_url AS avatar_url,
+        submissions.total_tokens AS total_tokens,
+        CAST(submissions.total_cost AS DECIMAL(18,4)) AS total_cost,
+        RANK() OVER (ORDER BY ${primaryOrderColumn} DESC) AS rank,
+        SUM(submissions.total_tokens) OVER () AS total_tokens_all,
+        SUM(CAST(submissions.total_cost AS DECIMAL(18,4))) OVER () AS total_cost_all,
+        COUNT(*) OVER () AS unique_users_all
+      FROM submissions
+      INNER JOIN users ON submissions.user_id = users.id
+    ),
+    filtered AS (
+      SELECT ranked.*, COUNT(*) OVER () AS filtered_users
+      FROM ranked
+      WHERE ${searchCondition}
+    ),
+    paged AS (
+      SELECT *
+      FROM filtered
+      ORDER BY rank ASC, ${secondaryOrderColumn} DESC, LOWER(username) ASC, user_id ASC
+      LIMIT ${limit}
+      OFFSET ${offset}
+    )
+    SELECT
+      COALESCE(
+        (
+          SELECT json_agg(
+            json_build_object(
+              'rank', rank,
+              'userId', user_id,
+              'username', username,
+              'displayName', display_name,
+              'avatarUrl', avatar_url,
+              'totalTokens', total_tokens,
+              'totalCost', total_cost
+            )
+            ORDER BY rank ASC, ${secondaryOrderColumn} DESC, LOWER(username) ASC, user_id ASC
+          )
+          FROM paged
+        ),
+        '[]'::json
+      ) AS users,
+      COALESCE((SELECT filtered_users FROM filtered LIMIT 1), 0)::int AS "totalUsers",
+      COALESCE((SELECT total_tokens_all FROM ranked LIMIT 1), 0) AS "totalTokens",
+      COALESCE((SELECT total_cost_all FROM ranked LIMIT 1), 0) AS "totalCost",
+      COALESCE((SELECT unique_users_all FROM ranked LIMIT 1), 0)::int AS "uniqueUsers"
+  `);
+
+  return buildLeaderboardData(result[0], page, limit, "all", sortBy);
 }
 
 async function fetchLeaderboardData(
@@ -341,195 +324,18 @@ async function fetchLeaderboardData(
   customTo?: string
 ): Promise<LeaderboardData> {
   if (period !== "all") {
-    const rows = await fetchPeriodLeaderboardRows(period, customFrom, customTo);
-    return buildPeriodLeaderboardData(rows, page, limit, period, sortBy, search);
-  }
-
-  const offset = (page - 1) * limit;
-  const parsed = parseSearchDirectives(search);
-
-  const orderByColumn = sortBy === "cost"
-    ? sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`
-    : sql`SUM(${submissions.totalTokens})`;
-  const secondaryOrderByColumn = sortBy === "cost"
-    ? sql`SUM(${submissions.totalTokens})`
-    : sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`;
-
-  const clientConditions = parsed.clients.map((client) =>
-    sql`EXISTS (SELECT 1 FROM unnest(${submissions.sourcesUsed}) AS s WHERE LOWER(s) LIKE ${`%${escapeLikePattern(client)}%`})`
-  );
-  const modelConditions = parsed.models.map((model) =>
-    sql`EXISTS (SELECT 1 FROM unnest(${submissions.modelsUsed}) AS m WHERE LOWER(m) LIKE ${`%${escapeLikePattern(model)}%`})`
-  );
-  const directiveConditions = [
-    clientConditions.length > 0 ? or(...clientConditions) : undefined,
-    modelConditions.length > 0 ? or(...modelConditions) : undefined,
-  ].filter((condition): condition is ReturnType<typeof sql> => condition !== undefined);
-
-  const hasTextSearch = parsed.text.length > 0;
-  const hasDirectiveFilters = directiveConditions.length > 0;
-
-  if (hasTextSearch || hasDirectiveFilters) {
-    const rankedSubquery = db
-      .select({
-        rank: sql<number>`RANK() OVER (ORDER BY ${orderByColumn} DESC)`.as("rank"),
-        userId: users.id,
-        username: users.username,
-        displayName: users.displayName,
-        avatarUrl: users.avatarUrl,
-        totalTokens: sql<number>`SUM(${submissions.totalTokens})`.as("total_tokens"),
-        totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`.as("total_cost"),
-      })
-      .from(submissions)
-      .innerJoin(users, eq(submissions.userId, users.id))
-      // Inside the ranked subquery, so RANK() renumbers densely rather than
-      // leaving a hole where a hidden user was.
-      .where(
-        hasDirectiveFilters
-          ? and(RANKABLE_USER, ...directiveConditions)
-          : RANKABLE_USER
-      )
-      .groupBy(users.id, users.username, users.displayName, users.avatarUrl)
-      .as("ranked");
-    const rankedSecondaryOrderByColumn = sortBy === "cost"
-      ? rankedSubquery.totalTokens
-      : rankedSubquery.totalCost;
-
-    let textFilter: ReturnType<typeof sql> | undefined;
-    if (hasTextSearch) {
-      const escapedSearch = escapeLikePattern(parsed.text.toLowerCase());
-      const searchPattern = `%${escapedSearch}%`;
-      textFilter = sql`(LOWER(${rankedSubquery.username}) LIKE ${searchPattern} OR LOWER(COALESCE(${rankedSubquery.displayName}, '')) LIKE ${searchPattern})`;
-    }
-
-    const results = await db
-      .select()
-      .from(rankedSubquery)
-      .where(textFilter)
-      .orderBy(
-        sql`${rankedSubquery.rank} ASC`,
-        sql`${rankedSecondaryOrderByColumn} DESC`,
-        sql`LOWER(${rankedSubquery.username}) ASC`
-      )
-      .limit(limit)
-      .offset(offset);
-
-    const countResult = await db
-      .select({ count: sql<number>`COUNT(*)`.as("count") })
-      .from(rankedSubquery)
-      .where(textFilter);
-
-    const totalUsers = Number(countResult[0]?.count) || 0;
-    const totalPages = Math.ceil(totalUsers / limit);
-
-    const globalStats = await db
-      .select({
-        totalTokens: sql<number>`SUM(${submissions.totalTokens})`,
-        totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`,
-        uniqueUsers: sql<number>`COUNT(DISTINCT ${submissions.userId})`,
-      })
-      .from(submissions);
-
-    return {
-      users: (results as RankedLeaderboardDbRow[]).map((row) => ({
-        rank: Number(row.rank),
-        userId: row.userId,
-        username: row.username,
-        displayName: row.displayName,
-        avatarUrl: row.avatarUrl,
-        totalTokens: Number(row.totalTokens) || 0,
-        totalCost: Number(row.totalCost) || 0,
-      })),
-      pagination: {
-        page,
-        limit,
-        totalUsers,
-        totalPages,
-        hasNext: page < totalPages,
-        hasPrev: page > 1,
-      },
-      stats: {
-        totalTokens: Number(globalStats[0]?.totalTokens) || 0,
-        totalCost: Number(globalStats[0]?.totalCost) || 0,
-        uniqueUsers: Number(globalStats[0]?.uniqueUsers) || 0,
-      },
+    return fetchPeriodLeaderboardData(
       period,
-      sortBy,
-    };
-  }
-
-  // Non-search path: competition rank with deterministic row ordering for ties.
-  const leaderboardQuery = db
-    .select({
-      rank: sql<number>`RANK() OVER (ORDER BY ${orderByColumn} DESC)`.as("rank"),
-      userId: users.id,
-      username: users.username,
-      displayName: users.displayName,
-      avatarUrl: users.avatarUrl,
-      totalTokens: sql<number>`SUM(${submissions.totalTokens})`.as("total_tokens"),
-      totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`.as("total_cost"),
-    })
-    .from(submissions)
-    .innerJoin(users, eq(submissions.userId, users.id))
-    .where(RANKABLE_USER)
-    .groupBy(users.id, users.username, users.displayName, users.avatarUrl)
-    .orderBy(
-      desc(orderByColumn),
-      desc(secondaryOrderByColumn),
-      sql`LOWER(${users.username}) ASC`
-    )
-    .limit(limit)
-    .offset(offset);
-
-  const [results, globalStats, rankableCount] = await Promise.all([
-    leaderboardQuery,
-    // Unfiltered: site-wide totals count every submission, hidden or not.
-    db
-      .select({
-        totalTokens: sql<number>`SUM(${submissions.totalTokens})`,
-        totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`,
-        uniqueUsers: sql<number>`COUNT(DISTINCT ${submissions.userId})`,
-      })
-      .from(submissions),
-    // Pagination must count only the rows this query can actually return.
-    // Reusing globalStats.uniqueUsers here would over-report by the number of
-    // hidden users and leave a trailing page that renders empty.
-    db
-      .select({ count: sql<number>`COUNT(DISTINCT ${submissions.userId})`.as("count") })
-      .from(submissions)
-      .innerJoin(users, eq(submissions.userId, users.id))
-      .where(RANKABLE_USER),
-  ]);
-
-  const totalUsers = Number(rankableCount[0]?.count) || 0;
-  const totalPages = Math.ceil(totalUsers / limit);
-
-  return {
-    users: (results as RankedLeaderboardDbRow[]).map((row) => ({
-      rank: Number(row.rank),
-      userId: row.userId,
-      username: row.username,
-      displayName: row.displayName,
-      avatarUrl: row.avatarUrl,
-      totalTokens: Number(row.totalTokens) || 0,
-      totalCost: Number(row.totalCost) || 0,
-    })),
-    pagination: {
       page,
       limit,
-      totalUsers,
-      totalPages,
-      hasNext: page < totalPages,
-      hasPrev: page > 1,
-    },
-    stats: {
-      totalTokens: Number(globalStats[0]?.totalTokens) || 0,
-      totalCost: Number(globalStats[0]?.totalCost) || 0,
-      uniqueUsers: Number(globalStats[0]?.uniqueUsers) || 0,
-    },
-    period,
-    sortBy,
-  };
+      sortBy,
+      search,
+      customFrom,
+      customTo
+    );
+  }
+
+  return fetchAllTimeLeaderboardData(page, limit, sortBy, search);
 }
 
 export function getLeaderboardData(
@@ -559,6 +365,61 @@ export function getLeaderboardData(
 // USER RANK
 // ============================================================================
 
+async function fetchPeriodUserRank(
+  username: string,
+  period: Exclude<Period, "all">,
+  sortBy: SortBy,
+  customFrom?: string,
+  customTo?: string
+): Promise<LeaderboardUser | null> {
+  const dateRange = getPeriodDateRange(period, new Date(), customFrom, customTo);
+
+  if (!dateRange) {
+    return null;
+  }
+
+  const primaryOrderColumn = sortBy === "cost" ? sql`total_cost` : sql`total_tokens`;
+  const secondaryOrderColumn = sortBy === "cost" ? sql`total_tokens` : sql`total_cost`;
+  const results = await db.execute<RankedLeaderboardDbRow>(sql`
+    WITH aggregated AS (
+      SELECT
+        submissions.user_id AS user_id,
+        users.username AS username,
+        users.display_name AS display_name,
+        users.avatar_url AS avatar_url,
+        SUM(daily_breakdown.tokens) AS total_tokens,
+        SUM(CAST(daily_breakdown.cost AS DECIMAL(18,4))) AS total_cost
+      FROM daily_breakdown
+      INNER JOIN submissions ON daily_breakdown.submission_id = submissions.id
+      INNER JOIN users ON submissions.user_id = users.id
+      WHERE daily_breakdown.date >= ${dateRange.start}
+        AND daily_breakdown.date <= ${dateRange.end}
+      GROUP BY submissions.user_id, users.username, users.display_name, users.avatar_url
+    ),
+    ranked AS (
+      SELECT
+        aggregated.*,
+        ROW_NUMBER() OVER (
+          ORDER BY ${primaryOrderColumn} DESC, ${secondaryOrderColumn} DESC, LOWER(username) ASC, user_id ASC
+        ) AS rank
+      FROM aggregated
+    )
+    SELECT
+      rank,
+      user_id AS "userId",
+      username,
+      display_name AS "displayName",
+      avatar_url AS "avatarUrl",
+      total_tokens AS "totalTokens",
+      total_cost AS "totalCost"
+    FROM ranked
+    WHERE LOWER(username) = LOWER(${username})
+  `);
+
+  const row = getSingleUsernameMatch(results, username);
+  return row ? mapLeaderboardUser(row) : null;
+}
+
 async function fetchUserRank(
   username: string,
   period: Period,
@@ -567,18 +428,11 @@ async function fetchUserRank(
   customTo?: string
 ): Promise<LeaderboardUser | null> {
   if (period !== "all") {
-    const rows = await fetchPeriodLeaderboardRows(period, customFrom, customTo);
-    return buildPeriodUserRank(rows, username, sortBy);
+    return fetchPeriodUserRank(username, period, sortBy, customFrom, customTo);
   }
 
   const userResult = await db
-    .select({
-      id: users.id,
-      username: users.username,
-      displayName: users.displayName,
-      avatarUrl: users.avatarUrl,
-      leaderboardHidden: users.leaderboardHidden,
-    })
+    .select({ id: users.id, username: users.username, displayName: users.displayName, avatarUrl: users.avatarUrl })
     .from(users)
     .where(usernameEqualsIgnoreCase(username))
     .limit(USERNAME_LOOKUP_LIMIT);
@@ -589,55 +443,35 @@ async function fetchUserRank(
     return null;
   }
 
-  // A hidden user holds no leaderboard position, so they report no rank at all
-  // rather than a number that matches nothing on the board.
-  if (user.leaderboardHidden) {
-    return null;
-  }
-
   const userStatsResult = await db
     .select({
-      totalTokens: sql<number>`SUM(${submissions.totalTokens})`.as("total_tokens"),
-      totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`.as("total_cost"),
+      totalTokens: submissions.totalTokens,
+      totalCost: sql<number>`CAST(${submissions.totalCost} AS DECIMAL(18,4))`.as("total_cost"),
     })
     .from(submissions)
     .where(eq(submissions.userId, user.id));
 
-  if (!userStatsResult[0] || userStatsResult[0].totalTokens == null) {
+  if (!userStatsResult[0]) {
     return null;
   }
 
   const userStats = userStatsResult[0];
-  const userTotalTokens = Number(userStats.totalTokens);
-  const userTotalCost = userStats.totalCost != null ? Number(userStats.totalCost) : 0;
+  const userTotalTokens = Number(userStats.totalTokens) || 0;
+  const userTotalCost = Number(userStats.totalCost) || 0;
 
   const userCompareValue = sortBy === "cost"
     ? userTotalCost
     : userTotalTokens;
   const compareColumn = sortBy === "cost"
-    ? sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`
-    : sql`SUM(${submissions.totalTokens})`;
+    ? sql`CAST(${submissions.totalCost} AS DECIMAL(18,4))`
+    : submissions.totalTokens;
 
   const higherRankedResult = await db
     .select({
       count: sql<number>`COUNT(*)`.as("count"),
     })
-    .from(
-      db
-        .select({
-          userId: submissions.userId,
-          total: compareColumn.as("total"),
-        })
-        .from(submissions)
-        // Hidden users hold no position, so they must not be counted as being
-        // "above" anyone — otherwise every visible user's rank is inflated by
-        // however many hidden accounts outrank them.
-        .innerJoin(users, eq(submissions.userId, users.id))
-        .where(RANKABLE_USER)
-        .groupBy(submissions.userId)
-        .having(sql`${compareColumn} > ${userCompareValue}`)
-        .as("higher_ranked")
-    );
+    .from(submissions)
+    .where(sql`${compareColumn} > ${userCompareValue}`);
 
   const rank = Number(higherRankedResult[0]?.count || 0) + 1;
 

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -206,9 +206,17 @@ function resultQuery(
   const primary = sortBy === "cost" ? sql`total_cost` : sql`total_tokens`;
   const secondary = sortBy === "cost" ? sql`total_tokens` : sql`total_cost`;
   const search = userTextCondition(text);
-  const statSource = statsBase ? sql`(${statsBase}) AS stats` : sql`aggregated`;
+  const statRows = statsBase ? sql`, stat_rows AS (${statsBase})` : sql``;
+  const statSource = statsBase ? sql`stat_rows` : sql`aggregated`;
   return sql`
-    WITH aggregated AS (${base}),
+    WITH aggregated AS (${base})${statRows},
+    stats AS (
+      SELECT
+        COALESCE(SUM(total_tokens), 0) AS total_tokens,
+        COALESCE(SUM(total_cost), 0) AS total_cost,
+        COUNT(*)::int AS unique_users
+      FROM ${statSource}
+    ),
     rankable AS (
       SELECT aggregated.*, ${sequentialRanks ? sql`ROW_NUMBER()` : sql`RANK()`} OVER (ORDER BY ${primary} DESC${sequentialRanks ? sql`, ${secondary} DESC, LOWER(username) ASC, user_id ASC` : sql``}) AS rank
       FROM aggregated
@@ -227,9 +235,9 @@ function resultQuery(
     SELECT
       COALESCE((SELECT json_agg(json_build_object('rank', rank, 'userId', user_id, 'username', username, 'displayName', display_name, 'avatarUrl', avatar_url, 'totalTokens', total_tokens, 'totalCost', total_cost) ORDER BY rank ASC, ${secondary} DESC, LOWER(username) ASC, user_id ASC) FROM paged), '[]'::json) AS users,
       COALESCE((SELECT filtered_users FROM filtered LIMIT 1), 0)::int AS "totalUsers",
-      COALESCE((SELECT SUM(total_tokens) FROM ${statSource}), 0) AS "totalTokens",
-      COALESCE((SELECT SUM(total_cost) FROM ${statSource}), 0) AS "totalCost",
-      COALESCE((SELECT COUNT(*) FROM ${statSource}), 0)::int AS "uniqueUsers"
+      (SELECT total_tokens FROM stats) AS "totalTokens",
+      (SELECT total_cost FROM stats) AS "totalCost",
+      (SELECT unique_users FROM stats) AS "uniqueUsers"
   `;
 }
 

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -200,12 +200,13 @@ function resultQuery(
   text: string,
   sequentialRanks: boolean,
   exactUsername?: string,
-  statsBase: ReturnType<typeof sql> = base,
+  statsBase?: ReturnType<typeof sql>,
 ): ReturnType<typeof sql> {
   const offset = (page - 1) * limit;
   const primary = sortBy === "cost" ? sql`total_cost` : sql`total_tokens`;
   const secondary = sortBy === "cost" ? sql`total_tokens` : sql`total_cost`;
   const search = userTextCondition(text);
+  const statSource = statsBase ? sql`(${statsBase}) AS stats` : sql`aggregated`;
   return sql`
     WITH aggregated AS (${base}),
     rankable AS (
@@ -226,9 +227,9 @@ function resultQuery(
     SELECT
       COALESCE((SELECT json_agg(json_build_object('rank', rank, 'userId', user_id, 'username', username, 'displayName', display_name, 'avatarUrl', avatar_url, 'totalTokens', total_tokens, 'totalCost', total_cost) ORDER BY rank ASC, ${secondary} DESC, LOWER(username) ASC, user_id ASC) FROM paged), '[]'::json) AS users,
       COALESCE((SELECT filtered_users FROM filtered LIMIT 1), 0)::int AS "totalUsers",
-      COALESCE((SELECT SUM(total_tokens) FROM (${statsBase}) AS stats), 0) AS "totalTokens",
-      COALESCE((SELECT SUM(total_cost) FROM (${statsBase}) AS stats), 0) AS "totalCost",
-      COALESCE((SELECT COUNT(*) FROM (${statsBase}) AS stats), 0)::int AS "uniqueUsers"
+      COALESCE((SELECT SUM(total_tokens) FROM ${statSource}), 0) AS "totalTokens",
+      COALESCE((SELECT SUM(total_cost) FROM ${statSource}), 0) AS "totalCost",
+      COALESCE((SELECT COUNT(*) FROM ${statSource}), 0)::int AS "uniqueUsers"
   `;
 }
 

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -200,6 +200,7 @@ function resultQuery(
   text: string,
   sequentialRanks: boolean,
   exactUsername?: string,
+  statsBase: ReturnType<typeof sql> = base,
 ): ReturnType<typeof sql> {
   const offset = (page - 1) * limit;
   const primary = sortBy === "cost" ? sql`total_cost` : sql`total_tokens`;
@@ -208,7 +209,7 @@ function resultQuery(
   return sql`
     WITH aggregated AS (${base}),
     rankable AS (
-      SELECT aggregated.*, ${sequentialRanks ? sql`ROW_NUMBER()` : sql`RANK()`} OVER (ORDER BY ${primary} DESC) AS rank
+      SELECT aggregated.*, ${sequentialRanks ? sql`ROW_NUMBER()` : sql`RANK()`} OVER (ORDER BY ${primary} DESC${sequentialRanks ? sql`, ${secondary} DESC, LOWER(username) ASC, user_id ASC` : sql``}) AS rank
       FROM aggregated
       WHERE leaderboard_hidden = false
     ),
@@ -225,9 +226,9 @@ function resultQuery(
     SELECT
       COALESCE((SELECT json_agg(json_build_object('rank', rank, 'userId', user_id, 'username', username, 'displayName', display_name, 'avatarUrl', avatar_url, 'totalTokens', total_tokens, 'totalCost', total_cost) ORDER BY rank ASC, ${secondary} DESC, LOWER(username) ASC, user_id ASC) FROM paged), '[]'::json) AS users,
       COALESCE((SELECT filtered_users FROM filtered LIMIT 1), 0)::int AS "totalUsers",
-      COALESCE((SELECT SUM(total_tokens) FROM aggregated), 0) AS "totalTokens",
-      COALESCE((SELECT SUM(total_cost) FROM aggregated), 0) AS "totalCost",
-      COALESCE((SELECT COUNT(*) FROM aggregated), 0)::int AS "uniqueUsers"
+      COALESCE((SELECT SUM(total_tokens) FROM (${statsBase}) AS stats), 0) AS "totalTokens",
+      COALESCE((SELECT SUM(total_cost) FROM (${statsBase}) AS stats), 0) AS "totalCost",
+      COALESCE((SELECT COUNT(*) FROM (${statsBase}) AS stats), 0)::int AS "uniqueUsers"
   `;
 }
 
@@ -295,6 +296,12 @@ async function fetchAllTimeLeaderboardData(
     AND (${parsed.models.length === 0} OR EXISTS (SELECT 1 FROM unnest(s.models_used) AS model WHERE ${modelMatch}))
   `
     : sql``;
+  const globalStatsBase = sql`
+    SELECT s.user_id, u.username, u.display_name, u.avatar_url, u.leaderboard_hidden,
+      s.total_tokens, CAST(s.total_cost AS DECIMAL(18,4)) AS total_cost
+    FROM submissions s
+    INNER JOIN users u ON s.user_id = u.id
+  `;
   const base = sql`
     SELECT s.user_id, u.username, u.display_name, u.avatar_url, u.leaderboard_hidden,
       s.total_tokens, CAST(s.total_cost AS DECIMAL(18,4)) AS total_cost
@@ -303,7 +310,16 @@ async function fetchAllTimeLeaderboardData(
     WHERE TRUE ${sourceFilter}
   `;
   const result = await db.execute<LeaderboardQueryResult>(
-    resultQuery(base, page, limit, sortBy, parsed.text, false),
+    resultQuery(
+      base,
+      page,
+      limit,
+      sortBy,
+      parsed.text,
+      false,
+      undefined,
+      globalStatsBase,
+    ),
   );
   return buildLeaderboardData(result[0], page, limit, "all", sortBy);
 }


### PR DESCRIPTION
## Summary

Moves leaderboard aggregation, ranking, filtering, and pagination into PostgreSQL CTEs so period views no longer transfer every matching daily row to the application. The all-time path now ranks the one current submission per user directly instead of aggregating rows unnecessarily.

## User impact

Leaderboard filters return only the requested page, logged-in viewers no longer wait for their personal rank before the initial table renders, and the existing table remains visible while filters update. Public API responses can be served stale-while-revalidate at the CDN for 60 seconds plus a five-minute stale window.

## Correctness

All-time views retain primary-metric competition ranks. Period views retain their previous sequential display-order ranks. Searches retain global ranks and stats while paginating only matching users, including zero-result searches.

## Validation

- `bun run --cwd packages/frontend typecheck`
- `bun run --cwd packages/frontend test` — 63 files, 600 tests
- `bun run --cwd packages/frontend lint` — 0 errors; 6 pre-existing warnings
- `bun run --cwd packages/frontend build`
- Raw CTE behavior validated against isolated PostgreSQL 17

## Follow-up

Production `EXPLAIN (ANALYZE, BUFFERS)` is still needed before adding indexes or setting latency targets. The new CDN header deliberately allows up to five minutes of stale public leaderboard data while revalidation happens.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move leaderboard aggregation, ranking, filtering, and pagination into PostgreSQL CTEs so the API returns only the requested page. All‑time aggregates each user’s submissions before competition ranking; period views use deterministic sequential ranks, and hidden users are excluded from ranks but included in totals.

- **Performance**
  - One SQL pipeline now returns the page, pagination count, and headline stats in a single pass (stats aggregated once via a CTE); all‑time uses RANK, period uses ROW_NUMBER with deterministic tie‑breakers and consistent ordering across list, search, and user‑rank.
  - All‑time sums each user’s submissions before ranking; period aggregates `daily_breakdown` for the date range and reuses that aggregate for totals.
  - DB‑side filters: literal text search escapes `%`, `_`, and `!`; directives scope via `jsonb_each` (period) and `unnest` (all‑time). Global stats computed in SQL: all‑time stats ignore directives and include hidden users; period totals include hidden users and reflect directive filters.

- **Refactors**
  - API sets `Cache-Control: public, s-maxage=60, stale-while-revalidate=300`.
  - The current table stays visible with “Updating leaderboard…” during filter changes; removed server‑side user‑rank prefetch.

<sup>Written for commit 781179c7bd4a5437139017accdb0c90d132a545d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

