### PR TITLE
fix(leaderboard): align mobile cost figures

### DIFF
--- a/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
@@ -323,6 +323,7 @@ const CostValue = styled.span`
   font-weight: 400;
   font-size: 12px;
   color: var(--color-fg-muted);
+  font-variant-numeric: tabular-nums;
   
   @media (min-width: 561px) {
     display: none;


### PR DESCRIPTION
## Summary

- Apply tabular figures to the mobile-only leaderboard cost value.
- Match the existing tabular numeric treatment used by the adjacent token value without changing the current typeface.

## Validation

- `bun run --cwd packages/frontend typecheck`
- `bun run --cwd packages/frontend lint` (passes with 6 existing warnings outside this change)
- `bun run --cwd packages/frontend test __tests__/components/leaderboardPresentation.test.ts`
- `git diff --check`

Fixes #51


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align mobile leaderboard cost figures by applying tabular numerals to the mobile-only cost value, keeping equal-length amounts the same width and matching the adjacent token value. Fixes #51.

<sup>Written for commit c9ab436ae47687dd65eee25917bd27b94ddd330f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

