### PR TITLE
fix(profile): default usage chart to chronological order

### DIFF
--- a/packages/frontend/__tests__/components/profileUsageChart.test.tsx
+++ b/packages/frontend/__tests__/components/profileUsageChart.test.tsx
@@ -1,0 +1,51 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ProfileUsageChart } from "../../src/components/profile/ProfileUsageChart";
+import type { DailyContribution } from "../../src/lib/types";
+
+const EMPTY_TOKENS = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  reasoning: 0,
+};
+
+function contribution(date: string, input: number): DailyContribution {
+  return {
+    date,
+    totals: { tokens: input, cost: 0, messages: 1 },
+    intensity: 1,
+    tokenBreakdown: { ...EMPTY_TOKENS, input },
+    clients: [
+      {
+        client: "claude",
+        modelId: "claude-test",
+        tokens: { ...EMPTY_TOKENS, input },
+        cost: 0,
+        messages: 1,
+      },
+    ],
+  };
+}
+
+describe("ProfileUsageChart", () => {
+  it("renders an unset preference in chronological order", () => {
+    const markup = renderToStaticMarkup(
+      <ProfileUsageChart
+        contributions={[
+          contribution("2026-01-03", 30),
+          contribution("2026-01-01", 10),
+          contribution("2026-01-02", 20),
+        ]}
+      />,
+    );
+
+    const range = markup.slice(markup.indexOf('aria-label="Chart date range"'));
+    expect(range).toContain("Jan 1, 2026");
+    expect(range).toContain("Jan 3, 2026");
+    expect(range.indexOf("Jan 1, 2026")).toBeLessThan(
+      range.indexOf("Jan 3, 2026"),
+    );
+  });
+});

--- a/packages/frontend/src/components/profile/ProfileUsageChart.tsx
+++ b/packages/frontend/src/components/profile/ProfileUsageChart.tsx
@@ -12,7 +12,6 @@ import {
 } from "react";
 import styled, { css } from "styled-components";
 import { SOURCE_DISPLAY_NAMES } from "@/lib/constants";
-import { useMediaQuery } from "@/lib/useMediaQuery";
 import type { DailyContribution } from "@/lib/types";
 import { formatCurrency, formatDate, formatNumber } from "@/lib/utils";
 import {
@@ -65,9 +64,6 @@ const TOOLTIP_EDGE = 8;
 const TOOLTIP_VIEWPORT_EDGE = 16;
 const TOOLTIP_MAX_HEIGHT = 416;
 const NEWEST_FIRST_STORAGE_KEY = "tokscale:usage-newest-first";
-// Matches the profile dashboard breakpoint where this card moves into the
-// right-hand column, which is when the newest-on-the-left default applies.
-const NEWEST_FIRST_DESKTOP_QUERY = "(min-width: 1360px)";
 
 const subscribeUsageChartMounted = () => () => {};
 
@@ -927,16 +923,13 @@ export function ProfileUsageChart({
   const [providerFilter, setProviderFilter] =
     useState<UsageProviderFilter>(ALL_USAGE_PROVIDERS);
   // Reversal is resolved after mount so the server render and the first client
-  // paint share a stable, chronological default (no hydration mismatch). The
-  // explicit toggle, once set, is persisted and wins over the responsive
-  // default (newest-first when this card sits in the desktop right-hand
-  // column, chronological below that breakpoint).
+  // paint stay chronological (no hydration mismatch). A persisted explicit
+  // choice is the only way to start newest-first.
   const isMounted = useSyncExternalStore(
     subscribeUsageChartMounted,
     () => true,
     () => false,
   );
-  const isDesktopReverseDefault = useMediaQuery(NEWEST_FIRST_DESKTOP_QUERY);
   // Lazy initializer: reads once on the client; the server (and the hydration
   // render, via the isMounted gate below) always resolves chronological.
   const [storedNewestFirst, setStoredNewestFirst] = useState<boolean | null>(
@@ -951,9 +944,7 @@ export function ProfileUsageChart({
       }
     },
   );
-  const newestFirst = isMounted
-    ? (storedNewestFirst ?? isDesktopReverseDefault)
-    : false;
+  const newestFirst = isMounted && storedNewestFirst === true;
   const commitNewestFirst = (next: boolean) => {
     setStoredNewestFirst(next);
     try {


### PR DESCRIPTION
## Summary

- Default the profile Usage over time chart to chronological order at every viewport width.
- Preserve explicit persisted Newest first choices and the existing toggle.
- Add an SSR regression test for the unset chronological default.

Fixes #868

## Validation

- `bun run lint -- src/components/profile/ProfileUsageChart.tsx __tests__/components/profileUsageChart.test.tsx`
- `bun run typecheck`
- `bun run test` (601 tests)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default the profile “Usage over time” chart to chronological order on all viewports. Keep the persisted “Newest first” preference and toggle; only an explicit preference reverses the chart. Fixes #868.

- **Bug Fixes**
  - Remove viewport-based default; no media-query reversal.
  - Preserve saved newest-first preference; apply only when true after mount.
  - Add SSR test to ensure unset default renders chronologically and avoids hydration mismatches.

<sup>Written for commit 88224eb9ab35a8044ddf8b3c878fb0aab2738b64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

