### PR TITLE
feat(copilot): parse VS Code Copilot Chat session token usage

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1217,6 +1217,39 @@ fn parse_all_messages_with_pricing_with_env_strategy(
                 }),
         );
     }
+    {
+        let existing_dedup_keys: HashSet<String> = all_messages
+            .iter()
+            .filter(|m| m.client == "copilot")
+            .filter_map(|m| m.dedup_key.clone())
+            .collect();
+        let existing_copilot_session_timestamps: HashSet<(String, i64)> = all_messages
+            .iter()
+            .filter(|m| m.client == "copilot")
+            .map(|m| (m.session_id.clone(), m.timestamp))
+            .collect();
+        let vscode_msgs = sessions::copilot_vscode::parse_copilot_vscode_sessions(
+            &scan_result.copilot_vscode_sessions,
+        );
+        all_messages.extend(
+            vscode_msgs
+                .into_iter()
+                .filter(|m| {
+                    let key_unique = m
+                        .dedup_key
+                        .as_deref()
+                        .map(|k| !existing_dedup_keys.contains(k))
+                        .unwrap_or(true);
+                    let session_ts_unique = !existing_copilot_session_timestamps
+                        .contains(&(m.session_id.clone(), m.timestamp));
+                    key_unique && session_ts_unique
+                })
+                .map(|mut message| {
+                    apply_pricing_if_available(&mut message, pricing);
+                    message
+                }),
+        );
+    }
 
     let gemini_outcomes: Vec<(PathBuf, CachedParseOutcome)> = scan_result
         .get(ClientId::Gemini)
@@ -2945,6 +2978,32 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
             sessions::copilot_desktop::parse_copilot_desktop_db(db_path)
                 .into_iter()
                 .filter(|message| !otel_sessions.contains(&message.session_id)),
+        );
+    }
+    {
+        let existing_dedup_keys: HashSet<String> = copilot_unified_msgs
+            .iter()
+            .filter_map(|m| m.dedup_key.clone())
+            .collect();
+        let existing_copilot_session_timestamps: HashSet<(String, i64)> = copilot_unified_msgs
+            .iter()
+            .map(|m| (m.session_id.clone(), m.timestamp))
+            .collect();
+        copilot_unified_msgs.extend(
+            sessions::copilot_vscode::parse_copilot_vscode_sessions(
+                &scan_result.copilot_vscode_sessions,
+            )
+            .into_iter()
+            .filter(|m| {
+                let key_unique = m
+                    .dedup_key
+                    .as_deref()
+                    .map(|k| !existing_dedup_keys.contains(k))
+                    .unwrap_or(true);
+                let session_ts_unique = !existing_copilot_session_timestamps
+                    .contains(&(m.session_id.clone(), m.timestamp));
+                key_unique && session_ts_unique
+            }),
         );
     }
     let copilot_msgs: Vec<ParsedMessage> =

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -98,6 +98,9 @@ pub struct ScanResult {
     /// Devin CLI SQLite databases, including the default data path and any
     /// user-configured scan roots.
     pub devin_dbs: Vec<PathBuf>,
+    /// VS Code Copilot chat session JSONL files discovered under
+    /// `workspaceStorage/*/chatSessions/*.jsonl`.
+    pub copilot_vscode_sessions: Vec<PathBuf>,
 }
 
 impl Default for ScanResult {
@@ -117,6 +120,7 @@ impl Default for ScanResult {
             micode_dbs: Vec::new(),
             opencode_json_dir: None,
             devin_dbs: Vec::new(),
+            copilot_vscode_sessions: Vec::new(),
         }
     }
 }
@@ -971,6 +975,63 @@ pub(crate) fn merge_user_opencode_db_paths(discovered: &mut Vec<PathBuf>, extra_
     }
 }
 
+fn discover_copilot_vscode_sessions(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
+    let mut roots: Vec<PathBuf> = Vec::new();
+
+    roots.push(PathBuf::from(format!(
+        "{}/Library/Application Support/Code/User/workspaceStorage",
+        home_dir
+    )));
+    roots.push(PathBuf::from(format!(
+        "{}/.config/Code/User/workspaceStorage",
+        home_dir
+    )));
+
+    if cfg!(target_os = "windows") && use_env_roots {
+        if let Some(app_data) = std::env::var_os("APPDATA").filter(|v| !v.is_empty()) {
+            roots.push(PathBuf::from(app_data).join("Code/User/workspaceStorage"));
+        }
+    }
+    roots.push(PathBuf::from(home_dir).join("AppData/Roaming/Code/User/workspaceStorage"));
+
+    let mut files: Vec<PathBuf> = Vec::new();
+    let mut seen: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+
+    for workspace_storage in &roots {
+        let hash_dirs = match std::fs::read_dir(workspace_storage) {
+            Ok(rd) => rd,
+            Err(_) => continue,
+        };
+        for entry in hash_dirs.filter_map(|e| e.ok()) {
+            let chat_sessions_dir = entry.path().join("chatSessions");
+            if !chat_sessions_dir.is_dir() {
+                continue;
+            }
+            let chat_entries = match std::fs::read_dir(&chat_sessions_dir) {
+                Ok(rd) => rd,
+                Err(_) => continue,
+            };
+            for chat_entry in chat_entries.filter_map(|e| e.ok()) {
+                let path = chat_entry.path();
+                let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                if !name.ends_with(".jsonl") {
+                    continue;
+                }
+                if !path.is_file() {
+                    continue;
+                }
+                let key = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+                if seen.insert(key) {
+                    files.push(path);
+                }
+            }
+        }
+    }
+
+    files.sort_unstable();
+    files
+}
+
 /// Scan all session client directories in parallel, with user-controlled
 /// [`ScannerSettings`] merged in.
 ///
@@ -1724,6 +1785,8 @@ fn scan_all_clients_with_env_strategy_inner(
         if desktop_db.is_file() {
             result.copilot_desktop_db = Some(desktop_db);
         }
+
+        result.copilot_vscode_sessions = discover_copilot_vscode_sessions(home_dir, use_env_roots);
 
         if let Some(path) = copilot_exporter_path_with_env_strategy(use_env_roots) {
             if path.is_file() && seen.insert(path.clone()) {

--- a/crates/tokscale-core/src/sessions/copilot_vscode.rs
+++ b/crates/tokscale-core/src/sessions/copilot_vscode.rs
@@ -1,0 +1,334 @@
+use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
+use crate::provider_identity::inferred_provider_from_model;
+use crate::TokenBreakdown;
+use serde_json::Value;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+pub fn parse_copilot_vscode_sessions(paths: &[PathBuf]) -> Vec<UnifiedMessage> {
+    paths.iter().flat_map(|path| parse_file(path)).collect()
+}
+
+fn parse_file(path: &Path) -> Vec<UnifiedMessage> {
+    let session_id = match path.file_stem().and_then(|s| s.to_str()) {
+        Some(stem) => stem.to_string(),
+        None => return Vec::new(),
+    };
+
+    let file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return Vec::new(),
+    };
+
+    let workspace = read_workspace_for_file(path);
+
+    let mut requests: Vec<Value> = Vec::new();
+
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(obj) = serde_json::from_str::<Value>(trimmed) else {
+            continue;
+        };
+        let kind = obj.get("kind").and_then(Value::as_i64).unwrap_or(-1);
+        match kind {
+            0 => {
+                if let Some(arr) = obj.pointer("/v/requests").and_then(Value::as_array) {
+                    requests.extend(arr.iter().cloned());
+                }
+            }
+            2 => {
+                if let Some(k) = obj.get("k").and_then(Value::as_array) {
+                    let is_requests = k
+                        .first()
+                        .and_then(Value::as_str)
+                        .map(|s| s == "requests")
+                        .unwrap_or(false);
+                    if is_requests {
+                        if let Some(arr) = obj.get("v").and_then(Value::as_array) {
+                            requests.extend(arr.iter().cloned());
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    requests
+        .iter()
+        .filter_map(|req| request_to_message(req, &session_id, &workspace))
+        .collect()
+}
+
+fn request_to_message(
+    req: &Value,
+    session_id: &str,
+    workspace: &Option<(String, Option<String>)>,
+) -> Option<UnifiedMessage> {
+    let prompt_tokens = req
+        .get("promptTokens")
+        .and_then(Value::as_i64)
+        .or_else(|| {
+            req.pointer("/result/metadata/promptTokens")
+                .and_then(Value::as_i64)
+        })
+        .unwrap_or(0);
+
+    let completion_tokens = req
+        .get("completionTokens")
+        .and_then(Value::as_i64)
+        .or_else(|| {
+            req.pointer("/result/metadata/outputTokens")
+                .and_then(Value::as_i64)
+        })
+        .unwrap_or(0);
+
+    if prompt_tokens == 0 && completion_tokens == 0 {
+        return None;
+    }
+
+    let timestamp_ms = req.get("timestamp").and_then(Value::as_i64).unwrap_or(0);
+
+    let resolved_model = req
+        .pointer("/result/metadata/resolvedModel")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
+    let model_id_raw = req
+        .get("modelId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
+    let model_id = resolved_model
+        .or_else(|| model_id_raw.map(|m| m.strip_prefix("copilot/").unwrap_or(m)))
+        .unwrap_or("auto")
+        .to_string();
+
+    // Filter: only include requests that are copilot-originated
+    // (modelId starts with "copilot/" or resolved model is present)
+    let is_copilot = resolved_model.is_some()
+        || model_id_raw
+            .map(|m| m.starts_with("copilot/"))
+            .unwrap_or(false);
+    if !is_copilot {
+        return None;
+    }
+
+    let provider_id = inferred_provider_from_model(&model_id)
+        .unwrap_or("github-copilot")
+        .to_string();
+
+    let reasoning_tokens: i64 = req
+        .pointer("/result/metadata/toolCallRounds")
+        .and_then(Value::as_array)
+        .map(|rounds| {
+            rounds
+                .iter()
+                .filter_map(|r| r.pointer("/thinking/tokens").and_then(Value::as_i64))
+                .sum()
+        })
+        .unwrap_or(0);
+
+    let tokens = TokenBreakdown {
+        input: prompt_tokens.max(0),
+        output: completion_tokens.max(0),
+        cache_read: 0,
+        cache_write: 0,
+        reasoning: reasoning_tokens.max(0),
+    };
+
+    let dedup_key = format!("copilot-vscode:{}:{}", session_id, timestamp_ms);
+
+    let mut message = UnifiedMessage::new_with_dedup(
+        "copilot",
+        model_id,
+        provider_id,
+        session_id.to_string(),
+        timestamp_ms,
+        tokens,
+        0.0,
+        Some(dedup_key),
+    );
+
+    if let Some((key, label)) = workspace {
+        message.set_workspace(Some(key.clone()), label.clone());
+    }
+
+    Some(message)
+}
+
+fn read_workspace_for_file(jsonl_path: &Path) -> Option<(String, Option<String>)> {
+    // Path: workspaceStorage/{hash}/chatSessions/{uuid}.jsonl
+    // workspace.json is at: workspaceStorage/{hash}/workspace.json
+    let hash_dir = jsonl_path.parent()?.parent()?;
+    let workspace_json = hash_dir.join("workspace.json");
+
+    let contents = std::fs::read_to_string(&workspace_json).ok()?;
+    let obj: Value = serde_json::from_str(&contents).ok()?;
+
+    let folder = obj
+        .get("folder")
+        .and_then(Value::as_str)
+        .or_else(|| obj.get("workspace").and_then(Value::as_str))?;
+
+    // folder is a URI like "file:///Users/alice/project"
+    let path_str = if let Some(stripped) = folder.strip_prefix("file://") {
+        // On Windows "file:///C:/..." → strip "file://" leaving "/C:/..."
+        // normalize_workspace_key handles slashes
+        stripped
+    } else {
+        folder
+    };
+
+    let workspace_key = normalize_workspace_key(path_str)?;
+    let workspace_label = workspace_label_from_key(&workspace_key);
+    Some((workspace_key, workspace_label))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_jsonl(path: &Path, lines: &[&str]) {
+        let mut f = std::fs::File::create(path).unwrap();
+        for line in lines {
+            writeln!(f, "{}", line).unwrap();
+        }
+    }
+
+    #[test]
+    fn parse_kind0_with_requests() {
+        let dir = tempfile::tempdir().unwrap();
+        let sessions_dir = dir.path().join("chatSessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let path = sessions_dir.join(format!("{}.jsonl", uuid));
+
+        write_jsonl(
+            &path,
+            &[
+                r#"{"kind":0,"v":{"requests":[{"requestId":"r1","timestamp":1783918304896,"modelId":"copilot/auto","completionTokens":154,"promptTokens":22079,"result":{"metadata":{"promptTokens":22079,"outputTokens":154,"resolvedModel":"gpt-5.3-codex"}}}]}}"#,
+            ],
+        );
+
+        let messages = parse_copilot_vscode_sessions(&[path]);
+        assert_eq!(messages.len(), 1);
+        let m = &messages[0];
+        assert_eq!(m.client, "copilot");
+        assert_eq!(m.session_id, uuid);
+        assert_eq!(m.model_id, "gpt-5.3-codex");
+        assert_eq!(m.timestamp, 1783918304896);
+        assert_eq!(m.tokens.input, 22079);
+        assert_eq!(m.tokens.output, 154);
+        assert_eq!(m.tokens.reasoning, 0);
+        assert_eq!(
+            m.dedup_key.as_deref(),
+            Some(format!("copilot-vscode:{}:1783918304896", uuid).as_str())
+        );
+    }
+
+    #[test]
+    fn parse_kind2_array_append() {
+        let dir = tempfile::tempdir().unwrap();
+        let sessions_dir = dir.path().join("chatSessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        let uuid = "650e8400-e29b-41d4-a716-446655440001";
+        let path = sessions_dir.join(format!("{}.jsonl", uuid));
+
+        write_jsonl(
+            &path,
+            &[
+                r#"{"kind":0,"v":{"requests":[]}}"#,
+                r#"{"kind":2,"k":["requests"],"v":[{"requestId":"r2","timestamp":1783918310000,"modelId":"copilot/auto","completionTokens":200,"promptTokens":5000,"result":{"metadata":{"promptTokens":5000,"outputTokens":200,"resolvedModel":"gpt-5.3-codex","toolCallRounds":[{"thinking":{"tokens":88}},{"thinking":{"tokens":12}}]}}}]}"#,
+            ],
+        );
+
+        let messages = parse_copilot_vscode_sessions(&[path]);
+        assert_eq!(messages.len(), 1);
+        let m = &messages[0];
+        assert_eq!(m.tokens.input, 5000);
+        assert_eq!(m.tokens.output, 200);
+        assert_eq!(m.tokens.reasoning, 100);
+    }
+
+    #[test]
+    fn skips_zero_token_requests() {
+        let dir = tempfile::tempdir().unwrap();
+        let sessions_dir = dir.path().join("chatSessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        let path = sessions_dir.join("aaaaaaaa-0000-0000-0000-000000000000.jsonl");
+
+        write_jsonl(
+            &path,
+            &[
+                r#"{"kind":2,"k":["requests"],"v":[{"requestId":"r0","timestamp":1000,"modelId":"copilot/auto","completionTokens":0,"promptTokens":0}]}"#,
+            ],
+        );
+
+        assert!(parse_copilot_vscode_sessions(&[path]).is_empty());
+    }
+
+    #[test]
+    fn model_fallback_from_model_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let sessions_dir = dir.path().join("chatSessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        let path = sessions_dir.join("bbbbbbbb-0000-0000-0000-000000000000.jsonl");
+
+        // No resolvedModel, only modelId with "copilot/" prefix
+        write_jsonl(
+            &path,
+            &[
+                r#"{"kind":2,"k":["requests"],"v":[{"requestId":"r3","timestamp":2000,"modelId":"copilot/gpt-4o","completionTokens":50,"promptTokens":300}]}"#,
+            ],
+        );
+
+        let messages = parse_copilot_vscode_sessions(&[path]);
+        assert_eq!(messages.len(), 1);
+        // "copilot/" prefix stripped
+        assert_eq!(messages[0].model_id, "gpt-4o");
+    }
+
+    #[test]
+    fn reasoning_tokens_summed_from_tool_call_rounds() {
+        let dir = tempfile::tempdir().unwrap();
+        let sessions_dir = dir.path().join("chatSessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        let path = sessions_dir.join("cccccccc-0000-0000-0000-000000000000.jsonl");
+
+        write_jsonl(
+            &path,
+            &[
+                r#"{"kind":2,"k":["requests"],"v":[{"requestId":"r4","timestamp":3000,"modelId":"copilot/auto","completionTokens":10,"promptTokens":100,"result":{"metadata":{"resolvedModel":"gpt-5.3-codex","toolCallRounds":[{"thinking":{"tokens":30}},{"thinking":{"tokens":70}}]}}}]}"#,
+            ],
+        );
+
+        let messages = parse_copilot_vscode_sessions(&[path]);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.reasoning, 100);
+    }
+
+    #[test]
+    fn non_copilot_model_id_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let sessions_dir = dir.path().join("chatSessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        let path = sessions_dir.join("dddddddd-0000-0000-0000-000000000000.jsonl");
+
+        // modelId does not start with "copilot/" and no resolvedModel
+        write_jsonl(
+            &path,
+            &[
+                r#"{"kind":2,"k":["requests"],"v":[{"requestId":"r5","timestamp":4000,"modelId":"some-other-extension/model","completionTokens":50,"promptTokens":300}]}"#,
+            ],
+        );
+
+        assert!(parse_copilot_vscode_sessions(&[path]).is_empty());
+    }
+}

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -13,6 +13,7 @@ pub mod codex;
 pub mod commandcode;
 pub mod copilot;
 pub mod copilot_desktop;
+pub mod copilot_vscode;
 pub mod crush;
 pub mod cursor;
 pub mod devin;


### PR DESCRIPTION
## Summary

Add support for parsing **VS Code Copilot Chat** token usage from local `chatSessions/*.jsonl` files. Previously, tokscale only tracked Copilot usage when OTEL export was explicitly enabled. Now VS Code panel chat usage is automatically discovered and tracked.

## What's Changed

- **New file**: `sessions/copilot_vscode.rs` — JSONL parser for VS Code chat session files
- **`sessions/mod.rs`** — module registration
- **`scanner.rs`** — `copilot_vscode_sessions: Vec<PathBuf>` + auto-discovery across macOS/Linux/Windows
- **`lib.rs`** — wired into both parse paths with dedup against OTEL sessions

## Data Source

VS Code stores chat sessions in:
- macOS: `~/Library/Application Support/Code/User/workspaceStorage/*/chatSessions/*.jsonl`
- Linux: `~/.config/Code/User/workspaceStorage/*/chatSessions/*.jsonl`
- Windows: `%APPDATA%/Code/User/workspaceStorage/*/chatSessions/*.jsonl`

Each JSONL file contains:
- `kind=0` lines with initial `requests[]` array
- `kind=2` lines with appended request items

From each request item we extract:
| Field | Source |
|-------|--------|
| input tokens | `promptTokens` or `result.metadata.promptTokens` |
| output tokens | `completionTokens` or `result.metadata.outputTokens` |
| reasoning tokens | sum of `toolCallRounds[*].thinking.tokens` |
| model | `result.metadata.resolvedModel` (fallback: `modelId` with `copilot/` prefix stripped) |
| timestamp | `timestamp` (epoch ms) |

## Dedup Strategy

- Existing OTEL and desktop app messages take priority
- VS Code parser only emits messages whose dedup_key is not already present
- Dedup key format: `copilot-vscode:{session_id}:{timestamp_ms}`

## Tested

- `cargo test -p tokscale-core --lib` — 1177 tests pass
- `cargo clippy -p tokscale-core -- -D warnings` — clean
- `cargo fmt -p tokscale-core --check` — clean
- Manual verification: today's VS Code Copilot Chat session correctly shows `gpt-5.3-codex`, 22K input, 154 output, 88 reasoning tokens, $0.042 cost

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for parsing VS Code Copilot Chat token usage from local `workspaceStorage/*/chatSessions/*.jsonl` files. Automatically tracks panel chat usage without OTEL and deduplicates against existing Copilot sources.

- **New Features**
  - Added `sessions/copilot_vscode.rs` to parse `kind=0` and `kind=2` entries, extract input/output/reasoning tokens, resolve model via `resolvedModel` (fallback strips `copilot/` from `modelId`), and ignore non‑Copilot requests.
  - Scanner discovers session files on macOS, Linux, and Windows and exposes them via `ScanResult.copilot_vscode_sessions`.
  - Integrated into both parse paths with pricing; dedup by `dedup_key` and `(session_id, timestamp)` with priority to OTEL and desktop app messages.
  - Associates messages with the VS Code workspace via `workspace.json` when available.

<sup>Written for commit 290ad7ac2017ec39d8945fda081f9996a58d373a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

