### PR TITLE
feat(leaderboard): add client: and model: search directives

### DIFF
--- a/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
@@ -250,6 +250,7 @@ describe("group leaderboard data", () => {
       "role",
       "tokens",
       "cost",
+      "sourceBreakdown",
     ]);
   });
 

--- a/packages/frontend/__tests__/lib/getLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboard.test.ts
@@ -231,6 +231,7 @@ describe("period leaderboard data", () => {
       "avatarUrl",
       "tokens",
       "cost",
+      "sourceBreakdown",
     ]);
   });
 

--- a/packages/frontend/__tests__/lib/searchDirectives.test.ts
+++ b/packages/frontend/__tests__/lib/searchDirectives.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { parseSearchDirectives, hasDirectives } from "@/lib/leaderboard/searchDirectives";
+
+describe("parseSearchDirectives", () => {
+  it("returns empty directives and original text when no directives present", () => {
+    const result = parseSearchDirectives("junhoyeo");
+    expect(result).toEqual({ text: "junhoyeo", clients: [], models: [] });
+  });
+
+  it("extracts a single client directive", () => {
+    const result = parseSearchDirectives("client:opencode");
+    expect(result).toEqual({ text: "", clients: ["opencode"], models: [] });
+  });
+
+  it("extracts a single model directive", () => {
+    const result = parseSearchDirectives("model:claude-sonnet-4");
+    expect(result).toEqual({ text: "", clients: [], models: ["claude-sonnet-4"] });
+  });
+
+  it("extracts multiple client directives", () => {
+    const result = parseSearchDirectives("client:opencode client:claude");
+    expect(result).toEqual({ text: "", clients: ["opencode", "claude"], models: [] });
+  });
+
+  it("extracts mixed directives with free text", () => {
+    const result = parseSearchDirectives("client:opencode junhoyeo model:gpt-5");
+    expect(result).toEqual({
+      text: "junhoyeo",
+      clients: ["opencode"],
+      models: ["gpt-5"],
+    });
+  });
+
+  it("lowercases directive values", () => {
+    const result = parseSearchDirectives("client:OpenCode model:Claude-Sonnet-4");
+    expect(result).toEqual({
+      text: "",
+      clients: ["opencode"],
+      models: ["claude-sonnet-4"],
+    });
+  });
+
+  it("handles directives case-insensitively", () => {
+    const result = parseSearchDirectives("Client:amp MODEL:gpt-5");
+    expect(result).toEqual({
+      text: "",
+      clients: ["amp"],
+      models: ["gpt-5"],
+    });
+  });
+
+  it("trims extra whitespace from remaining text", () => {
+    const result = parseSearchDirectives("  client:opencode   some user   model:gpt-5  ");
+    expect(result).toEqual({
+      text: "some user",
+      clients: ["opencode"],
+      models: ["gpt-5"],
+    });
+  });
+
+  it("returns empty text for empty input", () => {
+    const result = parseSearchDirectives("");
+    expect(result).toEqual({ text: "", clients: [], models: [] });
+  });
+
+  it("handles directive at end of string", () => {
+    const result = parseSearchDirectives("someuser client:claude");
+    expect(result).toEqual({
+      text: "someuser",
+      clients: ["claude"],
+      models: [],
+    });
+  });
+
+  it("does not capture trailing punctuation in directive values", () => {
+    const result = parseSearchDirectives("client:opencode, model:gpt-5.");
+    expect(result).toEqual({
+      text: ",",
+      clients: ["opencode"],
+      models: ["gpt-5"],
+    });
+  });
+
+  it("preserves dots within model names", () => {
+    const result = parseSearchDirectives("model:claude-3.5-sonnet");
+    expect(result).toEqual({
+      text: "",
+      clients: [],
+      models: ["claude-3.5-sonnet"],
+    });
+  });
+});
+
+describe("hasDirectives", () => {
+  it("returns false when no directives", () => {
+    expect(hasDirectives({ text: "foo", clients: [], models: [] })).toBe(false);
+  });
+
+  it("returns true when clients present", () => {
+    expect(hasDirectives({ text: "", clients: ["opencode"], models: [] })).toBe(true);
+  });
+
+  it("returns true when models present", () => {
+    expect(hasDirectives({ text: "", clients: [], models: ["gpt-5"] })).toBe(true);
+  });
+
+  it("returns true when both present", () => {
+    expect(hasDirectives({ text: "", clients: ["claude"], models: ["gpt-5"] })).toBe(true);
+  });
+});

--- a/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
+++ b/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
@@ -2,6 +2,7 @@ import { unstable_cache } from "next/cache";
 import { and, asc, desc, eq, gte, lte, sql } from "drizzle-orm";
 import { db, dailyBreakdown, groupMembers, submissions, users } from "@/lib/db";
 import type { LeaderboardUser, Period, SortBy } from "@/lib/leaderboard/types";
+import { parseSearchDirectives, hasDirectives } from "@/lib/leaderboard/searchDirectives";
 
 interface GroupLeaderboardPeriodRow {
   userId: string;
@@ -11,6 +12,7 @@ interface GroupLeaderboardPeriodRow {
   role: string;
   tokens: number;
   cost: number;
+  sourceBreakdown: Record<string, { models: Record<string, unknown> }> | null;
 }
 
 interface GroupLeaderboardDbRow {
@@ -88,7 +90,8 @@ function compareGroupUsers(
 }
 
 function matchesSearch(user: Pick<GroupLeaderboardUser, "username">, search: string): boolean {
-  return !search || user.username.toLowerCase().includes(search.toLowerCase());
+  const parsed = parseSearchDirectives(search);
+  return !parsed.text || user.username.toLowerCase().includes(parsed.text.toLowerCase());
 }
 
 function paginateRankedUsers(
@@ -134,9 +137,39 @@ function buildPeriodGroupLeaderboardData(
   search: string,
   totalMembers: number
 ): GroupLeaderboardData {
+  const parsed = parseSearchDirectives(search);
+
+  let filteredRows = rows;
+  if (hasDirectives(parsed)) {
+    filteredRows = rows.filter((row) => {
+      if (!row.sourceBreakdown) return false;
+
+      const clientKeys = Object.keys(row.sourceBreakdown).map((k) => k.toLowerCase());
+      const modelKeys = Object.values(row.sourceBreakdown).flatMap((client) =>
+        client.models ? Object.keys(client.models).map((m) => m.toLowerCase()) : []
+      );
+
+      if (parsed.clients.length > 0) {
+        const hasMatchingClient = parsed.clients.some((c) =>
+          clientKeys.some((k) => k.includes(c))
+        );
+        if (!hasMatchingClient) return false;
+      }
+
+      if (parsed.models.length > 0) {
+        const hasMatchingModel = parsed.models.some((m) =>
+          modelKeys.some((k) => k.includes(m))
+        );
+        if (!hasMatchingModel) return false;
+      }
+
+      return true;
+    });
+  }
+
   const usersById = new Map<string, Omit<GroupLeaderboardUser, "rank">>();
 
-  for (const row of rows) {
+  for (const row of filteredRows) {
     const existing = usersById.get(row.userId);
     if (existing) {
       existing.totalTokens += row.tokens;
@@ -195,6 +228,7 @@ async function fetchPeriodRows(
       role: groupMembers.role,
       tokens: dailyBreakdown.tokens,
       cost: dailyBreakdown.cost,
+      sourceBreakdown: dailyBreakdown.sourceBreakdown,
     })
     .from(dailyBreakdown)
     .innerJoin(submissions, eq(dailyBreakdown.submissionId, submissions.id))
@@ -216,16 +250,31 @@ async function fetchPeriodRows(
     role: row.role,
     tokens: Number(row.tokens) || 0,
     cost: Number(row.cost) || 0,
+    sourceBreakdown: (row.sourceBreakdown as Record<string, { models: Record<string, unknown> }>) ?? null,
   }));
 }
 
-async function fetchAllTimeRows(groupId: string, sortBy: SortBy): Promise<GroupLeaderboardUser[]> {
+async function fetchAllTimeRows(groupId: string, sortBy: SortBy, search: string = ""): Promise<GroupLeaderboardUser[]> {
+  const parsed = parseSearchDirectives(search);
+
   const primaryOrderByColumn = sortBy === "cost"
     ? sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`
     : sql`SUM(${submissions.totalTokens})`;
   const secondaryOrderByColumn = sortBy === "cost"
     ? sql`SUM(${submissions.totalTokens})`
     : sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`;
+
+  const conditions: ReturnType<typeof sql>[] = [];
+  for (const client of parsed.clients) {
+    conditions.push(
+      sql`EXISTS (SELECT 1 FROM unnest(${submissions.sourcesUsed}) AS s WHERE LOWER(s) LIKE ${`%${client}%`})`
+    );
+  }
+  for (const model of parsed.models) {
+    conditions.push(
+      sql`EXISTS (SELECT 1 FROM unnest(${submissions.modelsUsed}) AS m WHERE LOWER(m) LIKE ${`%${model}%`})`
+    );
+  }
 
   const rows = await db
     .select({
@@ -246,6 +295,7 @@ async function fetchAllTimeRows(groupId: string, sortBy: SortBy): Promise<GroupL
         eq(groupMembers.groupId, groupId)
       )
     )
+    .where(conditions.length > 0 ? and(...conditions) : undefined)
     .groupBy(users.id, users.username, users.displayName, users.avatarUrl, groupMembers.role)
     .orderBy(
       desc(primaryOrderByColumn),
@@ -281,7 +331,7 @@ async function fetchGroupLeaderboardData(
     return buildPeriodGroupLeaderboardData(rows, page, limit, period, sortBy, search, totalMembers);
   }
 
-  const usersWithRanks = await fetchAllTimeRows(groupId, sortBy);
+  const usersWithRanks = await fetchAllTimeRows(groupId, sortBy, search);
 
   return paginateRankedUsers(
     usersWithRanks,

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/db/usernameLookup";
 import { eq, desc, sql, and, gte, lte } from "drizzle-orm";
 import type { LeaderboardData, LeaderboardUser, Period, SortBy } from "@/lib/leaderboard/types";
+import { parseSearchDirectives, hasDirectives } from "@/lib/leaderboard/searchDirectives";
 
 export type { LeaderboardData, LeaderboardUser, Period, SortBy } from "@/lib/leaderboard/types";
 
@@ -18,6 +19,7 @@ interface LeaderboardPeriodRow {
   avatarUrl: string | null;
   tokens: number;
   cost: number;
+  sourceBreakdown: Record<string, { models: Record<string, unknown> }> | null;
 }
 
 interface PeriodDateRange {
@@ -32,6 +34,7 @@ interface PeriodLeaderboardDbRow {
   avatarUrl: string | null;
   tokens: number | string | null;
   cost: number | string | null;
+  sourceBreakdown: Record<string, { models: Record<string, unknown> }> | null;
 }
 
 interface AllTimeLeaderboardDbRow {
@@ -153,13 +156,13 @@ function aggregatePeriodRows(
 
 function matchesLeaderboardSearch(
   user: Pick<LeaderboardUser, "username" | "displayName">,
-  search: string
+  textSearch: string
 ): boolean {
-  if (!search) {
+  if (!textSearch) {
     return true;
   }
 
-  const lowerSearch = search.toLowerCase();
+  const lowerSearch = textSearch.toLowerCase();
   if (user.username.toLowerCase().includes(lowerSearch)) {
     return true;
   }
@@ -178,24 +181,54 @@ function buildPeriodLeaderboardData(
   search: string = ""
 ): LeaderboardData {
   const offset = (page - 1) * limit;
-  const aggregatedUsers = aggregatePeriodRows(rows, sortBy);
+  const parsed = parseSearchDirectives(search);
+
+  let filteredRows = rows;
+  if (hasDirectives(parsed)) {
+    filteredRows = rows.filter((row) => {
+      if (!row.sourceBreakdown) return false;
+
+      const clientKeys = Object.keys(row.sourceBreakdown).map((k) => k.toLowerCase());
+      const modelKeys = Object.values(row.sourceBreakdown).flatMap((client) =>
+        client.models ? Object.keys(client.models).map((m) => m.toLowerCase()) : []
+      );
+
+      if (parsed.clients.length > 0) {
+        const hasMatchingClient = parsed.clients.some((c) =>
+          clientKeys.some((k) => k.includes(c))
+        );
+        if (!hasMatchingClient) return false;
+      }
+
+      if (parsed.models.length > 0) {
+        const hasMatchingModel = parsed.models.some((m) =>
+          modelKeys.some((k) => k.includes(m))
+        );
+        if (!hasMatchingModel) return false;
+      }
+
+      return true;
+    });
+  }
+
+  const aggregatedUsers = aggregatePeriodRows(filteredRows, sortBy);
   const rankedUsers = aggregatedUsers.map((user, index) => ({
     ...user,
     rank: index + 1,
   }));
-  const filteredUsers = rankedUsers.filter((user) =>
-    matchesLeaderboardSearch(user, search)
+  const textFilteredUsers = rankedUsers.filter((user) =>
+    matchesLeaderboardSearch(user, parsed.text)
   );
-  const pagedUsers = filteredUsers.slice(offset, offset + limit);
+  const pagedUsers = textFilteredUsers.slice(offset, offset + limit);
 
   return {
     users: pagedUsers,
     pagination: {
       page,
       limit,
-      totalUsers: filteredUsers.length,
-      totalPages: Math.ceil(filteredUsers.length / limit),
-      hasNext: offset + limit < filteredUsers.length,
+      totalUsers: textFilteredUsers.length,
+      totalPages: Math.ceil(textFilteredUsers.length / limit),
+      hasNext: offset + limit < textFilteredUsers.length,
       hasPrev: page > 1,
     },
     stats: {
@@ -249,6 +282,7 @@ async function fetchPeriodLeaderboardRows(
       avatarUrl: users.avatarUrl,
       tokens: dailyBreakdown.tokens,
       cost: dailyBreakdown.cost,
+      sourceBreakdown: dailyBreakdown.sourceBreakdown,
     })
     .from(dailyBreakdown)
     .innerJoin(submissions, eq(dailyBreakdown.submissionId, submissions.id))
@@ -267,6 +301,7 @@ async function fetchPeriodLeaderboardRows(
     avatarUrl: row.avatarUrl,
     tokens: Number(row.tokens) || 0,
     cost: Number(row.cost) || 0,
+    sourceBreakdown: row.sourceBreakdown ?? null,
   }));
 }
 
@@ -285,6 +320,7 @@ async function fetchLeaderboardData(
   }
 
   const offset = (page - 1) * limit;
+  const parsed = parseSearchDirectives(search);
 
   const orderByColumn = sortBy === "cost"
     ? sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`
@@ -293,9 +329,22 @@ async function fetchLeaderboardData(
     ? sql`SUM(${submissions.totalTokens})`
     : sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`;
 
-  if (search) {
-    // When searching, use a subquery to compute global ranks for ALL users,
-    // then filter by username. This preserves each user's true rank.
+  const directiveConditions: ReturnType<typeof sql>[] = [];
+  for (const client of parsed.clients) {
+    directiveConditions.push(
+      sql`EXISTS (SELECT 1 FROM unnest(${submissions.sourcesUsed}) AS s WHERE LOWER(s) LIKE ${`%${client}%`})`
+    );
+  }
+  for (const model of parsed.models) {
+    directiveConditions.push(
+      sql`EXISTS (SELECT 1 FROM unnest(${submissions.modelsUsed}) AS m WHERE LOWER(m) LIKE ${`%${model}%`})`
+    );
+  }
+
+  const hasTextSearch = parsed.text.length > 0;
+  const hasDirectiveFilters = directiveConditions.length > 0;
+
+  if (hasTextSearch || hasDirectiveFilters) {
     const rankedSubquery = db
       .select({
         rank: sql<number>`RANK() OVER (ORDER BY ${orderByColumn} DESC)`.as("rank"),
@@ -308,18 +357,24 @@ async function fetchLeaderboardData(
       })
       .from(submissions)
       .innerJoin(users, eq(submissions.userId, users.id))
+      .where(hasDirectiveFilters ? and(...directiveConditions) : undefined)
       .groupBy(users.id, users.username, users.displayName, users.avatarUrl)
       .as("ranked");
     const rankedSecondaryOrderByColumn = sortBy === "cost"
       ? rankedSubquery.totalTokens
       : rankedSubquery.totalCost;
 
-    const escapedSearch = search.toLowerCase().replace(/[%_\\]/g, "\\$&");
-    const searchPattern = `%${escapedSearch}%`;
+    let textFilter: ReturnType<typeof sql> | undefined;
+    if (hasTextSearch) {
+      const escapedSearch = parsed.text.toLowerCase().replace(/[%_\\]/g, "\\$&");
+      const searchPattern = `%${escapedSearch}%`;
+      textFilter = sql`(LOWER(${rankedSubquery.username}) LIKE ${searchPattern} OR LOWER(COALESCE(${rankedSubquery.displayName}, '')) LIKE ${searchPattern})`;
+    }
+
     const results = await db
       .select()
       .from(rankedSubquery)
-      .where(sql`(LOWER(${rankedSubquery.username}) LIKE ${searchPattern} OR LOWER(COALESCE(${rankedSubquery.displayName}, '')) LIKE ${searchPattern})`)
+      .where(textFilter)
       .orderBy(
         sql`${rankedSubquery.rank} ASC`,
         sql`${rankedSecondaryOrderByColumn} DESC`,
@@ -328,16 +383,14 @@ async function fetchLeaderboardData(
       .limit(limit)
       .offset(offset);
 
-    // Count total matching users for pagination
     const countResult = await db
       .select({ count: sql<number>`COUNT(*)`.as("count") })
       .from(rankedSubquery)
-      .where(sql`(LOWER(${rankedSubquery.username}) LIKE ${searchPattern} OR LOWER(COALESCE(${rankedSubquery.displayName}, '')) LIKE ${searchPattern})`);
+      .where(textFilter);
 
     const totalUsers = Number(countResult[0]?.count) || 0;
     const totalPages = Math.ceil(totalUsers / limit);
 
-    // Global stats remain unfiltered
     const globalStats = await db
       .select({
         totalTokens: sql<number>`SUM(${submissions.totalTokens})`,

--- a/packages/frontend/src/lib/leaderboard/searchDirectives.ts
+++ b/packages/frontend/src/lib/leaderboard/searchDirectives.ts
@@ -1,0 +1,54 @@
+/**
+ * Parses search directives from a leaderboard search string.
+ *
+ * Supported directives:
+ * - `client:<value>` — filter users who have submitted data from this client
+ * - `model:<value>` — filter users who have used this model
+ *
+ * Directives are case-insensitive and can appear anywhere in the search string.
+ * Multiple directives of the same type are OR-ed (user matches if ANY applies).
+ * Remaining non-directive text is treated as a username/displayName search term.
+ *
+ * Examples:
+ *   "client:opencode junhoyeo"  → { clients: ["opencode"], models: [], text: "junhoyeo" }
+ *   "model:claude-sonnet-4"    → { clients: [], models: ["claude-sonnet-4"], text: "" }
+ *   "client:claude client:amp" → { clients: ["claude", "amp"], models: [], text: "" }
+ */
+
+export interface ParsedSearchDirectives {
+  /** Free-text portion (username/displayName search). Trimmed. */
+  text: string;
+  /** Client IDs extracted from `client:` directives. Lowercased. */
+  clients: string[];
+  /** Model IDs extracted from `model:` directives. Lowercased. */
+  models: string[];
+}
+
+const DIRECTIVE_REGEX = /\b(client|model):([\w.:\-/]+)/gi;
+
+export function parseSearchDirectives(raw: string): ParsedSearchDirectives {
+  const clients: string[] = [];
+  const models: string[] = [];
+
+  const text = raw
+    .replace(DIRECTIVE_REGEX, (_, directive: string, value: string) => {
+      const lowerDirective = directive.toLowerCase();
+      const lowerValue = value.toLowerCase().replace(/[.,;)]+$/, "");
+
+      if (lowerDirective === "client" && lowerValue) {
+        clients.push(lowerValue);
+      } else if (lowerDirective === "model" && lowerValue) {
+        models.push(lowerValue);
+      }
+
+      return "";
+    })
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return { text, clients, models };
+}
+
+export function hasDirectives(parsed: ParsedSearchDirectives): boolean {
+  return parsed.clients.length > 0 || parsed.models.length > 0;
+}


### PR DESCRIPTION
## feat(leaderboard): add client: and model: search directives

Adds `client:` and `model:` search directives to the leaderboard search box, enabling users to filter the leaderboard by which AI coding client or model they've used.

### Usage

- `client:opencode` — show only users who submitted data from OpenCode
- `model:claude-sonnet-4` — show only users who used claude-sonnet-4
- `client:claude model:gpt-5 junhoyeo` — combine directives with username search
- Multiple same-type directives are OR-ed: `client:opencode client:claude`

### Changes

- **New**: `packages/frontend/src/lib/leaderboard/searchDirectives.ts` — parser extracting `client:` / `model:` directives from raw search string
- **Modified**: `packages/frontend/src/lib/leaderboard/getLeaderboard.ts` — integrated directive filtering in both period (in-memory via sourceBreakdown JSON) and all-time (SQL via sourcesUsed/modelsUsed arrays) paths
- **Modified**: `packages/frontend/src/lib/groups/getGroupLeaderboard.ts` — same directive support for group leaderboards
- **New**: `packages/frontend/__tests__/lib/searchDirectives.test.ts` — 14 unit tests for the parser

### Testing

- All existing leaderboard tests pass (6/6 global, 3/3 group)
- New parser tests pass (14/14)
- Zero LSP diagnostics on changed files
- Deployed to `tokscale.tmobiweb.com` via Jenkins build #43 + ArgoCD sync

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `client:` and `model:` search directives to the leaderboard so users can filter by coding client and model across period, all‑time, and group views. Text search still preserves global ranks; directives can be used with or without text.

- **New Features**
  - Search directives: case‑insensitive `client:<id>` and `model:<id>`; can combine with text; same‑type directives are OR‑ed.
  - Filtering: period and group period filter via `sourceBreakdown` before aggregation; all‑time (global and group) use SQL EXISTS on `sourcesUsed`/`modelsUsed`. Text search preserves global ranks; directive filters apply server‑side and work standalone.
  - Code: parser in `packages/frontend/src/lib/leaderboard/searchDirectives.ts` with 14 tests; `sourceBreakdown` added to period/group rows and tests updated.

<sup>Written for commit 1176054a4f5c7883cd896c7472555efe5708a4cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

