### PR TITLE
fix(profile): distinguish token mix categories

### DIFF
--- a/packages/frontend/src/components/profile/TokenBreakdown.tsx
+++ b/packages/frontend/src/components/profile/TokenBreakdown.tsx
@@ -10,6 +10,14 @@ export interface TokenBreakdownProps {
   className?: string;
 }
 
+const TOKEN_MIX_COLORS = {
+  input: "#56b4e9",
+  output: "#009e73",
+  cacheRead: "#cc79a7",
+  cacheWrite: "#e69f00",
+  reasoning: "#d7dde8",
+} as const;
+
 const BreakdownPanel = styled.section`
   overflow: hidden;
   border: 1px solid var(--service-border);
@@ -127,31 +135,29 @@ export function TokenBreakdown({ stats, className }: TokenBreakdownProps) {
     {
       label: "Input",
       value: finiteNonnegative(stats.inputTokens),
-      color: "var(--service-accent)",
+      color: TOKEN_MIX_COLORS.input,
     },
     {
       label: "Output",
       value: finiteNonnegative(stats.outputTokens),
-      color: "var(--service-accent-hover)",
+      color: TOKEN_MIX_COLORS.output,
     },
     {
       label: "Cache read",
       value: finiteNonnegative(stats.cacheReadTokens),
-      color:
-        "color-mix(in srgb, var(--service-accent) 55%, var(--service-text-muted))",
+      color: TOKEN_MIX_COLORS.cacheRead,
     },
     {
       label: "Cache write",
       value: finiteNonnegative(stats.cacheWriteTokens),
-      color:
-        "color-mix(in srgb, var(--service-accent) 30%, var(--service-text-muted))",
+      color: TOKEN_MIX_COLORS.cacheWrite,
     },
     ...(finiteNonnegative(stats.reasoningTokens) > 0
       ? [
           {
             label: "Reasoning",
             value: finiteNonnegative(stats.reasoningTokens),
-            color: "var(--service-text-muted)",
+            color: TOKEN_MIX_COLORS.reasoning,
           },
         ]
       : []),


### PR DESCRIPTION
## Summary

- Replaces the blue-only Token mix ramp with distinct sky-blue, green, purple, amber, and neutral categories.
- Preserves the existing layout, values, and accessible token-distribution description.

## Why

The previous accent variants were too similar to distinguish reliably in the segmented bar and matching metric markers.

## Validation

- `bun run lint` (passes with six existing warnings)
- `bun run typecheck`
- `bun run test` (601 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the profile token mix from a single blue ramp to a distinct categorical palette so each category is easy to tell apart in the segmented bar and metric list.

- **Bug Fixes**
  - Assigns unique colors for Input, Output, Cache read, Cache write, and Reasoning.
  - Keeps the existing layout, values, and accessible distribution text; no theme contract changes.
  - Colors tuned for the compact dark profile surface.

<sup>Written for commit f2f1de4b58beb8f5d62cd51a9bf5481e9949378a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

