### PR TITLE
fix(copilot): preserve trace-scoped parent hierarchy

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -794,7 +794,7 @@ fn parser_version(client: ClientId) -> u32 {
         // so future changes have an obvious local version to increment.
         ClientId::Codex => 4,
         ClientId::Jcode => 4,
-        ClientId::Copilot => 3,
+        ClientId::Copilot => 4,
         // Pi subagent sessions now derive agent attribution from session_info
         // names; version-1 caches carry those messages without agent metadata.
         ClientId::Pi => 2,
@@ -2617,6 +2617,118 @@ mod tests {
         assert!(SourceMessageCache::load()
             .get(claude, source.path())
             .is_some());
+
+        restore_cache_env(prev_env);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_copilot_v3_cache_is_rejected_and_rebuilt_with_root_agent() {
+        let temp_home = TempDir::new().unwrap();
+        let prev_env = sandbox_cache_env(temp_home.path());
+        let source_dir = TempDir::new().unwrap();
+        let source_path = source_dir.path().join("copilot-otel.jsonl");
+        std::fs::write(
+            &source_path,
+            concat!(
+                r#"{"type":"span","traceId":"trace-cache","spanId":"invoke-sub","parentSpanId":"tool-task","name":"invoke_agent","attributes":{"gen_ai.operation.name":"invoke_agent","gen_ai.agent.id":"github.copilot.subagent"}}"#,
+                "\n",
+                r#"{"type":"span","traceId":"trace-cache","spanId":"tool-task","parentSpanId":"invoke-root","name":"execute_tool task"}"#,
+                "\n",
+                r#"{"type":"span","traceId":"trace-cache","spanId":"invoke-root","name":"invoke_agent","attributes":{"gen_ai.operation.name":"invoke_agent","gen_ai.agent.id":"github.copilot.default"}}"#,
+                "\n",
+                r#"{"type":"span","traceId":"trace-cache","spanId":"chat","parentSpanId":"invoke-root","name":"chat gpt-5.4-mini","attributes":{"gen_ai.operation.name":"chat","gen_ai.request.model":"gpt-5.4-mini","gen_ai.response.model":"gpt-5.4-mini","gen_ai.usage.input_tokens":1,"gen_ai.usage.output_tokens":1}}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+
+        let current_identity = CacheIdentity::for_client(ClientId::Copilot);
+        let stale_identity = CacheIdentity {
+            namespace: current_identity.namespace,
+            parser_version: 3,
+        };
+        let mut stale_message = UnifiedMessage::new(
+            "copilot",
+            "gpt-5.4-mini",
+            "github-copilot",
+            "trace-cache",
+            1,
+            TokenBreakdown {
+                input: 1,
+                output: 1,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            0.0,
+        );
+        stale_message.agent = Some("github.copilot.subagent".to_string());
+        let fingerprint = SourceFingerprint::from_path(&source_path).unwrap();
+        let stale_entry = CachedSourceEntry::new(
+            stale_identity,
+            &source_path,
+            fingerprint.clone(),
+            vec![stale_message],
+            Vec::new(),
+            None,
+        );
+        let shard_key = CacheKey::new(current_identity, &source_path).shard();
+        let stale_path = shard_path(&cache_shard_dir().unwrap(), &shard_key);
+        ensure_cache_dir(stale_path.parent().unwrap()).unwrap();
+        write_shard_with_limit(
+            &stale_path,
+            stale_identity,
+            &[stale_entry],
+            MAX_CACHE_SHARD_BYTES,
+        )
+        .unwrap();
+
+        let mut loaded = SourceMessageCache::load();
+        assert!(
+            loaded.get(current_identity, &source_path).is_none(),
+            "a v3 Copilot cache entry must not be served after the parser output change"
+        );
+        assert!(loaded.rewrite_shards.contains(&shard_key));
+        assert_eq!(
+            SourceFingerprint::from_path(&source_path).unwrap(),
+            fingerprint,
+            "the source fingerprint must remain unchanged; parser version causes invalidation"
+        );
+
+        let rebuilt = crate::sessions::copilot::parse_copilot_file(&source_path);
+        assert_eq!(rebuilt.len(), 1);
+        assert_eq!(
+            rebuilt[0].agent.as_deref(),
+            Some("github.copilot.default"),
+            "a cold rebuild must use the root invoke_agent attribution"
+        );
+        loaded.insert(CachedSourceEntry::new(
+            current_identity,
+            &source_path,
+            fingerprint,
+            rebuilt,
+            Vec::new(),
+            None,
+        ));
+        loaded.save_if_dirty();
+
+        let reloaded = SourceMessageCache::load();
+        let cached = reloaded
+            .get(current_identity, &source_path)
+            .expect("rebuilt Copilot cache entry should survive reload");
+        assert_eq!(cached.parser_version, current_identity.parser_version);
+        assert_eq!(
+            cached.messages[0].agent.as_deref(),
+            Some("github.copilot.default")
+        );
+        assert!(matches!(
+            read_shard(&stale_path, current_identity),
+            ShardReadStatus::Loaded(entries)
+                if entries.len() == 1
+                    && entries[0].messages[0].agent.as_deref()
+                        == Some("github.copilot.default")
+        ));
 
         restore_cache_env(prev_env);
     }

--- a/crates/tokscale-core/src/sessions/copilot.rs
+++ b/crates/tokscale-core/src/sessions/copilot.rs
@@ -187,11 +187,11 @@ fn collect_trace_contexts(records: &[Value]) -> HashMap<String, TraceContext> {
 /// has no invoke_agent span, fall back to the first non-empty gen_ai.agent.id
 /// seen in the trace (input order).
 fn resolve_trace_fallback_agents(records: &[Value]) -> HashMap<String, String> {
-    // spanId -> parentSpanId across every span that declares both. OTel span
-    // ids are globally unique, so a single flat map is safe across traces.
-    let mut parent_of: HashMap<&str, &str> = HashMap::new();
+    // Span ids are unique only within a trace, so keep the OTel structural
+    // identity scoped by both ids.
+    let mut parent_of: HashMap<(&str, &str), &str> = HashMap::new();
     // Span ids of every invoke_agent span, used to detect a nested invoke.
-    let mut invoke_agent_span_ids: HashSet<&str> = HashSet::new();
+    let mut invoke_agent_span_ids: HashSet<(&str, &str)> = HashSet::new();
     // Per trace: invoke_agent spans in input order, each with its agent id.
     let mut trace_invoke_agents: HashMap<&str, Vec<(&str, Option<&str>)>> = HashMap::new();
     // Per trace: first non-empty agent id seen on any record (ultimate fallback
@@ -202,22 +202,26 @@ fn resolve_trace_fallback_agents(records: &[Value]) -> HashMap<String, String> {
         let Some(trace_id) = trace_id_from_record(record) else {
             continue;
         };
-        let Some(attributes) = record.get("attributes").and_then(Value::as_object) else {
-            continue;
-        };
 
+        // Parent edges are OTel structure, not attributes. Collect them before
+        // the attributes gate so attribute-less intermediary spans still link
+        // nested invokes back to the root.
         let span_id = span_id_from_record(record);
         if let Some(span_id) = span_id {
             if let Some(parent_span_id) = parent_span_id_from_record(record) {
-                parent_of.insert(span_id, parent_span_id);
+                parent_of.insert((trace_id, span_id), parent_span_id);
             }
         }
+
+        let Some(attributes) = record.get("attributes").and_then(Value::as_object) else {
+            continue;
+        };
 
         let agent_id = first_non_empty_attr(attributes, &["gen_ai.agent.id"]);
 
         if is_agent_summary_span_record(record, attributes) {
             if let Some(span_id) = span_id {
-                invoke_agent_span_ids.insert(span_id);
+                invoke_agent_span_ids.insert((trace_id, span_id));
                 trace_invoke_agents
                     .entry(trace_id)
                     .or_default()
@@ -240,7 +244,7 @@ fn resolve_trace_fallback_agents(records: &[Value]) -> HashMap<String, String> {
         let resolved = invokes
             .iter()
             .filter(|(span_id, _)| {
-                is_root_invoke_agent(span_id, &parent_of, &invoke_agent_span_ids)
+                is_root_invoke_agent(trace_id, span_id, &parent_of, &invoke_agent_span_ids)
             })
             .find_map(|(_, agent_id)| *agent_id)
             .or_else(|| invokes.iter().find_map(|(_, agent_id)| *agent_id));
@@ -263,21 +267,22 @@ fn resolve_trace_fallback_agents(records: &[Value]) -> HashMap<String, String> {
 /// An invoke_agent span is a ROOT when no span in its parent chain is itself an
 /// invoke_agent span. Nested task/sub-agent invokes therefore resolve to false.
 fn is_root_invoke_agent(
+    trace_id: &str,
     span_id: &str,
-    parent_of: &HashMap<&str, &str>,
-    invoke_agent_span_ids: &HashSet<&str>,
+    parent_of: &HashMap<(&str, &str), &str>,
+    invoke_agent_span_ids: &HashSet<(&str, &str)>,
 ) -> bool {
-    let mut current = parent_of.get(span_id).copied();
-    let mut visited: HashSet<&str> = HashSet::new();
+    let mut current = parent_of.get(&(trace_id, span_id)).copied();
+    let mut visited: HashSet<(&str, &str)> = HashSet::new();
     while let Some(parent) = current {
-        if invoke_agent_span_ids.contains(parent) {
+        if invoke_agent_span_ids.contains(&(trace_id, parent)) {
             return false;
         }
-        if !visited.insert(parent) {
+        if !visited.insert((trace_id, parent)) {
             // Guard against malformed/cyclic parent references.
             break;
         }
-        current = parent_of.get(parent).copied();
+        current = parent_of.get(&(trace_id, parent)).copied();
     }
     true
 }
@@ -1107,6 +1112,56 @@ mod tests {
             .find(|message| message.model_id == "gpt-5.4-mini")
             .unwrap();
         assert_eq!(plain.agent.as_deref(), Some("github.copilot.default"));
+    }
+
+    #[test]
+    fn test_parse_copilot_cli_trace_agent_links_through_attribute_less_intermediary() {
+        let content = r#"{"type":"span","traceId":"trace-attrless","spanId":"invoke-sub","parentSpanId":"tool-task","name":"invoke_agent","endTime":[1775934261,0],"attributes":{"gen_ai.operation.name":"invoke_agent","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.agent.id":"github.copilot.subagent"}}
+{"type":"span","traceId":"trace-attrless","spanId":"chat-sub","parentSpanId":"invoke-sub","name":"chat claude-sonnet-4.6","endTime":[1775934262,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.response.model":"claude-sonnet-4.6","gen_ai.response.id":"resp-sub","gen_ai.agent.id":"github.copilot.subagent","gen_ai.usage.input_tokens":100,"gen_ai.usage.output_tokens":10}}
+{"type":"span","traceId":"trace-attrless","spanId":"tool-task","parentSpanId":"invoke-root","name":"execute_tool task"}
+{"type":"span","traceId":"trace-attrless","spanId":"invoke-root","name":"invoke_agent","endTime":[1775934260,0],"attributes":{"gen_ai.operation.name":"invoke_agent","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.agent.id":"github.copilot.default"}}
+{"type":"span","traceId":"trace-attrless","spanId":"chat-plain","parentSpanId":"invoke-root","name":"chat gpt-5.4-mini","endTime":[1775934264,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.request.model":"gpt-5.4-mini","gen_ai.response.model":"gpt-5.4-mini","gen_ai.response.id":"resp-plain","gen_ai.usage.input_tokens":200,"gen_ai.usage.output_tokens":20}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        let sub = messages
+            .iter()
+            .find(|message| message.model_id == "claude-sonnet-4.6")
+            .unwrap();
+        assert_eq!(sub.agent.as_deref(), Some("github.copilot.subagent"));
+
+        let plain = messages
+            .iter()
+            .find(|message| message.model_id == "gpt-5.4-mini")
+            .unwrap();
+        assert_eq!(plain.agent.as_deref(), Some("github.copilot.default"));
+    }
+
+    #[test]
+    fn test_parse_copilot_cli_trace_agent_scopes_reused_span_ids_per_trace() {
+        let content = r#"{"type":"span","traceId":"trace-scope-a","spanId":"invoke-nested-a","parentSpanId":"tool-a","name":"invoke_agent","endTime":[1775934261,0],"attributes":{"gen_ai.operation.name":"invoke_agent","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.agent.id":"github.copilot.subagent-a"}}
+{"type":"span","traceId":"trace-scope-a","spanId":"tool-a","parentSpanId":"invoke-shared","name":"execute_tool task","endTime":[1775934262,0],"attributes":{"gen_ai.operation.name":"execute_tool","gen_ai.tool.name":"task"}}
+{"type":"span","traceId":"trace-scope-a","spanId":"invoke-shared","name":"invoke_agent","endTime":[1775934260,0],"attributes":{"gen_ai.operation.name":"invoke_agent","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.agent.id":"github.copilot.root-a"}}
+{"type":"span","traceId":"trace-scope-a","spanId":"chat-a","parentSpanId":"invoke-shared","name":"chat gpt-5.4-mini","endTime":[1775934264,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.request.model":"gpt-5.4-mini","gen_ai.response.model":"gpt-5.4-mini","gen_ai.response.id":"resp-a","gen_ai.usage.input_tokens":200,"gen_ai.usage.output_tokens":20}}
+{"type":"span","traceId":"trace-scope-b","spanId":"invoke-outer-b","name":"invoke_agent","endTime":[1775934260,0],"attributes":{"gen_ai.operation.name":"invoke_agent","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.agent.id":"github.copilot.root-b"}}
+{"type":"span","traceId":"trace-scope-b","spanId":"invoke-shared","parentSpanId":"invoke-outer-b","name":"invoke_agent","endTime":[1775934261,0],"attributes":{"gen_ai.operation.name":"invoke_agent","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.agent.id":"github.copilot.subagent-b"}}
+{"type":"span","traceId":"trace-scope-b","spanId":"chat-b","parentSpanId":"invoke-outer-b","name":"chat gpt-5.4-mini","endTime":[1775934264,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.request.model":"gpt-5.4-mini","gen_ai.response.model":"gpt-5.4-mini","gen_ai.response.id":"resp-b","gen_ai.usage.input_tokens":300,"gen_ai.usage.output_tokens":30}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        let chat_a = messages
+            .iter()
+            .find(|message| message.dedup_key.as_deref() == Some("trace-scope-a:chat-a"))
+            .unwrap();
+        assert_eq!(chat_a.agent.as_deref(), Some("github.copilot.root-a"));
+
+        let chat_b = messages
+            .iter()
+            .find(|message| message.dedup_key.as_deref() == Some("trace-scope-b:chat-b"))
+            .unwrap();
+        assert_eq!(chat_b.agent.as_deref(), Some("github.copilot.root-b"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #879.

This keeps the Copilot root-agent resolver from losing structural parent links on spans without `attributes` and from mixing hierarchies when separate OpenTelemetry traces reuse the same `spanId`. It also advances the Copilot parser cache version so previously cached mis-attribution is reparsed.

## Root cause

`resolve_trace_fallback_agents` previously collected `parentSpanId` only after requiring an `attributes` object. An attribute-less task or tool span could therefore remove the only edge connecting a nested `invoke_agent` to the real root. The hierarchy maps were also keyed by bare `spanId`, although OpenTelemetry only requires span IDs to be unique within a trace.

## Changes

| Change | Result |
|---|---|
| Collect structural parent edges before the attributes gate | Attribute-less intermediary spans remain part of the root walk. |
| Key parent edges and invocation membership by `(traceId, spanId)` | Separate traces cannot overwrite or satisfy each other's hierarchy entries. |
| Increment the Copilot parser cache version from 3 to 4 | Existing shards carrying the old fallback attribution are rejected and rebuilt. |
| Keep the existing root-first fallback, per-record precedence, and cycle guard | The correction does not change the intended #834 attribution policy. |

## Regression coverage

| Scenario | Expected result |
|---|---|
| Nested invocation behind an attribute-less intermediary | The nested chat keeps its sub-agent, while an agentless chat inherits the real root agent. |
| Two traces reuse the same span ID | Each trace resolves its own root independently. |
| Parser-version 3 shard with the old attribution | The stale entry is rejected, reparsed through the real Copilot parser, saved as version 4, and reloaded with the root attribution intact. |
| Existing single invocation | Behavior remains unchanged. |

## Verification

| Gate | Result |
|---|---|
| Pre-fix attribute-less intermediary regression | Failed as expected: selected `github.copilot.subagent` instead of `github.copilot.default`. |
| Pre-fix cross-trace span collision regression | Failed as expected: selected `github.copilot.subagent-a` instead of `github.copilot.root-a`. |
| Pre-fix parser-version 3 cache regression | Failed as expected: the unchanged-fingerprint stale entry was served. |
| Copilot hierarchy targeted tests | 5 passed. |
| Stale-v3 cache rebuild regression | Passed. |
| `cargo test -p tokscale-core` | 1,180 passed, 1 ignored. |
| `cargo test --workspace --all-features` | Passed. |
| `cargo fmt --all -- --check` | Passed. |
| `cargo clippy --locked --workspace --all-features -- -D warnings` | Passed with no lint findings. |
| `git diff --check origin/main...HEAD` | Passed. |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Copilot agent attribution by preserving trace-scoped parent links and avoiding cross-trace span ID collisions. Also bumps the Copilot parser cache to v4 to invalidate stale v3 entries.

- **Bug Fixes**
  - Collect OTel parent edges before the attributes gate so attribute-less spans keep nested invoke_agent chains linked to the root.
  - Scope parent and invoke identities by (traceId, spanId) and traverse within the current trace to prevent hierarchy mixing when span IDs are reused.
  - Keep existing root-first fallback, per-record precedence, and cycle guard.
  - Bump the Copilot parser cache to v4; stale v3 shards are rejected and rebuilt.

<sup>Written for commit 20d9096a68a40d4a4e83581b0e0dd308aadc5ab7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

