### PR TITLE
fix(submit): preserve local-date usage ahead of UTC

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -4950,34 +4950,6 @@ struct SubmitMetrics {
     sources: Option<Vec<String>>,
 }
 
-fn cap_graph_result_to_utc_today(
-    graph_result: &mut tokscale_core::GraphResult,
-    utc_today: &str,
-) -> bool {
-    let pre_cap_len = graph_result.contributions.len();
-    graph_result
-        .contributions
-        .retain(|c| c.date.as_str() <= utc_today);
-    if graph_result.contributions.len() == pre_cap_len {
-        return false;
-    }
-
-    graph_result.meta.date_range_start = graph_result
-        .contributions
-        .first()
-        .map(|c| c.date.clone())
-        .unwrap_or_default();
-    graph_result.meta.date_range_end = graph_result
-        .contributions
-        .last()
-        .map(|c| c.date.clone())
-        .unwrap_or_default();
-    graph_result.summary = tokscale_core::calculate_summary(&graph_result.contributions);
-    graph_result.years = tokscale_core::calculate_years(&graph_result.contributions);
-
-    true
-}
-
 /// A client row dropped from a submission because it carried cost without any
 /// token attribution. See [`exclude_tokenless_cost_contributions`].
 #[derive(Debug, Clone, PartialEq)]
@@ -5263,7 +5235,7 @@ fn run_submit_command(
     println!("{}", "  Scanning local session data...".bright_black());
 
     let rt = Runtime::new()?;
-    let graph_result = rt
+    let mut graph_result = rt
         .block_on(async {
             generate_graph(ReportOptions {
                 home_dir: None,
@@ -5279,17 +5251,9 @@ fn run_submit_command(
         })
         .map_err(|e| anyhow::anyhow!(e))?;
 
-    // Cap contributions to UTC today to prevent timezone-related future-date
-    // rejections. The CLI generates dates using chrono::Local, but the server
-    // validates against UTC. In UTC+ timezones the local date can be ahead of
-    // UTC around midnight, causing valid same-day data to be flagged as
-    // "future dates". Capped contributions will be included in the next
-    // submission once the UTC date catches up.
-    // See: https://github.com/junhoyeo/tokscale/issues/318
-    let utc_today = chrono::Utc::now().format("%Y-%m-%d").to_string();
-    let mut graph_result = graph_result;
-    cap_graph_result_to_utc_today(&mut graph_result, &utc_today);
-
+    // Preserve local-calendar contributions here. The API validator owns the
+    // UTC+ timezone buffer; client-side UTC capping silently drops current-day
+    // usage for users east of UTC. See #318 and #360.
     // Drop cost-only rows the server would reject (Cursor historical exports
     // record per-request cost with empty token columns) and report what was
     // left out, so a single legacy charge can't block the whole submission.
@@ -6036,7 +6000,7 @@ mod tests {
     use reqwest::StatusCode;
     use tokscale_core::{
         calculate_summary, calculate_years, ClientContribution, DailyContribution, DailyTotals,
-        GraphMeta, GraphResult, TokenBreakdown, YearSummary,
+        GraphMeta, GraphResult, TokenBreakdown,
     };
 
     #[test]
@@ -6228,15 +6192,6 @@ mod tests {
             contributions,
             time_metrics: None,
         }
-    }
-
-    fn year_summary(graph: &GraphResult, year: &str) -> YearSummary {
-        graph
-            .years
-            .iter()
-            .find(|entry| entry.year == year)
-            .cloned()
-            .unwrap()
     }
 
     // Tests below call `build_client_filter_with_defaults` directly with
@@ -7358,79 +7313,6 @@ mod tests {
         let (position2, forward2) = LightSpinner::scanner_state(54);
         assert_eq!(position1, position2);
         assert_eq!(forward1, forward2);
-    }
-
-    #[test]
-    fn test_cap_graph_result_to_utc_today_recalculates_all_derived_fields() {
-        let mut graph = graph_result_with_contributions(vec![
-            daily_contribution("2026-12-30", 10, 1.25, "codex", "model-a"),
-            daily_contribution("2026-12-31", 20, 2.50, "codex", "model-b"),
-            daily_contribution("2027-01-01", 30, 3.75, "cursor", "model-c"),
-        ]);
-
-        let changed = cap_graph_result_to_utc_today(&mut graph, "2026-12-31");
-
-        assert!(changed);
-        assert_eq!(graph.meta.date_range_start, "2026-12-30");
-        assert_eq!(graph.meta.date_range_end, "2026-12-31");
-        assert_eq!(graph.contributions.len(), 2);
-        assert_eq!(graph.summary.total_tokens, 30);
-        assert_eq!(graph.summary.total_cost, 3.75);
-        assert_eq!(graph.summary.total_days, 2);
-        assert_eq!(graph.summary.active_days, 2);
-        assert_eq!(graph.summary.clients, vec!["codex".to_string()]);
-        assert_eq!(
-            graph.summary.models,
-            vec!["model-a".to_string(), "model-b".to_string()]
-        );
-        assert_eq!(graph.years.len(), 1);
-        assert_eq!(year_summary(&graph, "2026").total_tokens, 30);
-    }
-
-    #[test]
-    fn test_cap_graph_result_to_utc_today_clears_empty_post_cap_state() {
-        let mut graph = graph_result_with_contributions(vec![daily_contribution(
-            "2027-01-01",
-            30,
-            3.75,
-            "cursor",
-            "model-c",
-        )]);
-
-        let changed = cap_graph_result_to_utc_today(&mut graph, "2026-12-31");
-
-        assert!(changed);
-        assert!(graph.contributions.is_empty());
-        assert_eq!(graph.meta.date_range_start, "");
-        assert_eq!(graph.meta.date_range_end, "");
-        assert_eq!(graph.summary.total_tokens, 0);
-        assert_eq!(graph.summary.total_cost, 0.0);
-        assert_eq!(graph.summary.total_days, 0);
-        assert_eq!(graph.summary.active_days, 0);
-        assert!(graph.summary.clients.is_empty());
-        assert!(graph.summary.models.is_empty());
-        assert!(graph.years.is_empty());
-    }
-
-    #[test]
-    fn test_cap_graph_result_to_utc_today_is_noop_when_all_dates_are_in_range() {
-        let mut graph = graph_result_with_contributions(vec![
-            daily_contribution("2026-12-30", 10, 1.25, "codex", "model-a"),
-            daily_contribution("2026-12-31", 20, 2.50, "codex", "model-b"),
-        ]);
-        let original_summary = graph.summary.clone();
-        let original_years = graph.years.clone();
-
-        let changed = cap_graph_result_to_utc_today(&mut graph, "2026-12-31");
-
-        assert!(!changed);
-        assert_eq!(graph.meta.date_range_start, "2026-12-30");
-        assert_eq!(graph.meta.date_range_end, "2026-12-31");
-        assert_eq!(graph.summary.total_tokens, original_summary.total_tokens);
-        assert_eq!(graph.summary.total_cost, original_summary.total_cost);
-        assert_eq!(graph.summary.clients, original_summary.clients);
-        assert_eq!(graph.summary.models, original_summary.models);
-        assert_eq!(graph.years.len(), original_years.len());
     }
 
     fn client_contribution(

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -298,6 +298,37 @@ fn create_timezone_boundary_fixture_dir() -> TempDir {
     tmp
 }
 
+fn create_positive_utc_offset_submit_fixture_dir() -> (TempDir, String) {
+    let tmp = TempDir::new().expect("failed to create temp dir");
+    let base = tmp.path();
+    prime_pricing_cache(base);
+
+    let utc_today = chrono::Utc::now().date_naive();
+    let utc_noon = utc_today.and_hms_opt(12, 0, 0).unwrap().and_utc();
+    let local_date = utc_today.succ_opt().unwrap().format("%Y-%m-%d").to_string();
+    let session = base.join(".local/share/opencode/storage/message/session1");
+    fs::create_dir_all(&session).unwrap();
+
+    let message = serde_json::json!({
+        "id": "msg_ahead_of_utc",
+        "sessionID": "session1",
+        "role": "assistant",
+        "modelID": "gpt-4o",
+        "providerID": "openai",
+        "cost": 0.02,
+        "tokens": {
+            "input": 1000,
+            "output": 500,
+            "reasoning": 0,
+            "cache": { "read": 200, "write": 50 }
+        },
+        "time": { "created": utc_noon.timestamp_millis() as f64 }
+    });
+    fs::write(session.join("msg_ahead_of_utc.json"), message.to_string()).unwrap();
+
+    (tmp, local_date)
+}
+
 fn create_qwen_workspace_fixture_dir() -> TempDir {
     let tmp = TempDir::new().expect("failed to create temp dir");
     let base = tmp.path();
@@ -1637,6 +1668,22 @@ fn test_submit_cursor_explicit_missing_cache_reports_setup_warning_text() {
         .success()
         .stderr(predicate::str::contains("Cursor usage requires"))
         .stderr(predicate::str::contains("tokscale cursor login"));
+}
+
+#[test]
+fn test_submit_dry_run_preserves_local_date_ahead_of_utc() {
+    let (tmp, expected_local_date) = create_positive_utc_offset_submit_fixture_dir();
+
+    cmd_with_home(tmp.path())
+        .env("TZ", "Pacific/Kiritimati")
+        .env("TOKSCALE_API_TOKEN", "test-token")
+        .args(["submit", "--client", "opencode", "--dry-run"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "Date range: {expected_local_date} to {expected_local_date}"
+        )))
+        .stdout(predicate::str::contains("Total tokens: 1,750"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- remove the CLI-side UTC date cap from `submit`
- preserve locally aggregated current-day contributions in positive UTC offsets
- add an end-to-end `submit --dry-run` regression test using `Pacific/Kiritimati` (UTC+14)

## Problem

Tokscale aggregates contribution dates with the user's local timezone, but `submit` then discarded every contribution whose local date was later than the current UTC date. Users east of UTC therefore saw stale submission totals between local midnight and UTC midnight even though `models` and `graph` already included the completed usage.

The API validator already owns this boundary and accepts a two-day future-date buffer for timezone and clock-skew handling, so the client-side cap is now both redundant and lossy. This follows up on #318 and #360.

The regression test fixes UTC noon as the fixture timestamp and runs the CLI under `Pacific/Kiritimati`, producing a deterministic local date one day ahead of UTC. It asserts that `submit --dry-run` retains the date and all 1,750 fixture tokens.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p tokscale-cli` (869 passed, 1 ignored; 131 integration tests passed)
- `cargo clippy --locked --workspace -- -D warnings`
- `cargo test -p tokscale-cli --test cli_tests test_submit_dry_run_preserves_local_date_ahead_of_utc -- --exact`

`cargo test -p tokscale-cli --all-features` could not run on this macOS host because the vendored Foundation Models Swift package requires Swift 6.2 while the installed toolchain is Swift 6.1; the default feature suite and Clippy pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves local-calendar contributions in `submit` by removing the CLI’s UTC date cap, so UTC+ users see correct same-day totals. Validation stays on the API, which already allows a small future-date buffer.

- **Bug Fixes**
  - Removed UTC cap in `submit` to avoid dropping current-day usage for positive UTC offsets.
  - Added an end-to-end `submit --dry-run` test under `Pacific/Kiritimati` (UTC+14) to verify the local date is kept and 1,750 tokens are included.

<sup>Written for commit 609295872f09d1e6f79d91ec871ff6acaf07b683. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

