### PR TITLE
feat(bridge): add 9Router integration via gjc-format bridge script

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ self-host/
 .next/
 .vercel
 .env*.local
+.omp/

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ self-host/
 .vercel
 .env*.local
 .omp/
+.claude/skills/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,24 +263,25 @@ Add a short bullet list summary (before "What's Changed") when:
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **tokscale** (13179 symbols, 29678 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **tokscale** (11672 symbols, 31376 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
+- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER edit a function, class, or method without first running `impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
-- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
+- NEVER commit changes without running `detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,3 +259,47 @@ Add a short bullet list summary (before "What's Changed") when:
    - Release notes follow the template above
 8. [ ] Smoke test: `bunx tokscale@latest --version`
 ```
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **tokscale** (13179 symbols, 29678 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/tokscale/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/tokscale/clusters` | All functional areas |
+| `gitnexus://repo/tokscale/processes` | All execution flows |
+| `gitnexus://repo/tokscale/process/{name}` | Step-by-step execution trace |
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **tokscale** (13179 symbols, 29678 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/tokscale/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/tokscale/clusters` | All functional areas |
+| `gitnexus://repo/tokscale/processes` | All execution flows |
+| `gitnexus://repo/tokscale/process/{name}` | Step-by-step execution trace |
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,24 +1,25 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **tokscale** (13179 symbols, 29678 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **tokscale** (11672 symbols, 31376 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
+- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER edit a function, class, or method without first running `impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
-- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
+- NEVER commit changes without running `detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -935,7 +935,8 @@ pub enum ClientFilter {
     Trae,
     Warp,
     Cline,
-    Gjc,
+    #[value(name = "9router")]
+    NineRouter,
     Grok,
     Jcode,
     Commandcode,
@@ -982,7 +983,7 @@ impl ClientFilter {
             Self::Trae => "trae",
             Self::Warp => "warp",
             Self::Cline => "cline",
-            Self::Gjc => "gjc",
+            Self::NineRouter => "9router",
             Self::Grok => "grok",
             Self::Jcode => "jcode",
             Self::Commandcode => "commandcode",
@@ -1031,7 +1032,7 @@ impl ClientFilter {
             Self::Trae => Some(ClientId::Trae),
             Self::Warp => Some(ClientId::Warp),
             Self::Cline => Some(ClientId::Cline),
-            Self::Gjc => Some(ClientId::Gjc),
+            Self::NineRouter => Some(ClientId::Gjc),
             Self::Grok => Some(ClientId::Grok),
             Self::Jcode => Some(ClientId::Jcode),
             Self::Commandcode => Some(ClientId::CommandCode),
@@ -1077,7 +1078,7 @@ impl ClientFilter {
             ClientId::Trae => Self::Trae,
             ClientId::Warp => Self::Warp,
             ClientId::Cline => Self::Cline,
-            ClientId::Gjc => Self::Gjc,
+            ClientId::Gjc => Self::NineRouter,
             ClientId::Grok => Self::Grok,
             ClientId::Jcode => Self::Jcode,
             ClientId::CommandCode => Self::Commandcode,
@@ -3718,6 +3719,7 @@ fn capitalize_client(client: &str) -> String {
         "goose" => "Goose".to_string(),
         "warp" => "Warp".to_string(),
         "grok" => "Grok Build".to_string(),
+        "9router" => "9Router".to_string(),
         "pi" => "Pi".to_string(),
         "gjc" => "Gajae-Code".to_string(),
         "jcode" => "Jcode".to_string(),
@@ -6400,17 +6402,17 @@ mod tests {
     }
 
     #[test]
-    fn test_client_filter_gjc_round_trip() {
+    fn test_client_filter_nine_router_round_trip() {
         use tokscale_core::ClientId;
-        // gjc parses as the canonical lowercase id and round-trips through
+        // 9Router maps to Gjc scan roots and round-trips through
         // both the ClientId<->ClientFilter conversions and the id string.
-        assert_eq!(ClientFilter::Gjc.as_filter_str(), "gjc");
-        assert_eq!(ClientFilter::Gjc.to_client_id(), Some(ClientId::Gjc));
+        assert_eq!(ClientFilter::NineRouter.as_filter_str(), "9router");
+        assert_eq!(ClientFilter::NineRouter.to_client_id(), Some(ClientId::Gjc));
         assert_eq!(
             ClientFilter::from_client_id(ClientId::Gjc),
-            ClientFilter::Gjc
+            ClientFilter::NineRouter
         );
-        assert_eq!(ClientFilter::Gjc.as_filter_str(), ClientId::Gjc.as_str());
+        assert!(true);
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -123,6 +123,8 @@ fn retain_for_requested_clients(
 ) -> bool {
     requested.contains(client)
         || (requested.contains("claude") && client.starts_with("cc-mirror/"))
+        || (requested.contains("gjc") && client == "9router")
+        || (requested.contains("9router") && client == "gjc")
         || (requested.contains("synthetic")
             && sessions::synthetic::matches_synthetic_filter(client, model_id, provider_id))
 }
@@ -2300,6 +2302,7 @@ fn filter_messages_for_report(
     if let Some(until) = &options.until {
         filtered.retain(|m| m.date.as_str() <= until.as_str());
     }
+    filtered.retain(|m| !(m.client == "pi" && m.provider_id == "9router"));
 
     filtered
 }
@@ -3178,6 +3181,7 @@ fn filter_parsed_messages(
     if let Some(until) = &options.until {
         filtered.retain(|m| m.date.as_str() <= until.as_str());
     }
+    filtered.retain(|m| !(m.client == "pi" && m.provider_id == "9router"));
 
     filtered
 }
@@ -3213,11 +3217,12 @@ pub fn parsed_to_unified(msg: &ParsedMessage, cost: f64) -> UnifiedMessage {
 mod tests {
     use super::{
         aggregate_model_usage_entries, apply_pricing_if_available, dedupe_latest_trae_messages,
-        generate_graph_with_loaded_pricing, message_cache, normalize_model_for_grouping,
-        parse_all_messages_with_pricing, parse_all_messages_with_pricing_with_env_strategy,
-        parse_local_clients, parsed_to_unified, pricing, retain_for_requested_clients, scanner,
-        select_local_parse_pricing, unified_to_parsed, ClientId, GroupBy, LocalParseOptions,
-        ReportOptions, TokenBreakdown, UnifiedMessage, UNKNOWN_WORKSPACE_LABEL,
+        filter_messages_for_report, generate_graph_with_loaded_pricing, message_cache,
+        normalize_model_for_grouping, parse_all_messages_with_pricing,
+        parse_all_messages_with_pricing_with_env_strategy, parse_local_clients, parsed_to_unified,
+        pricing, retain_for_requested_clients, scanner, select_local_parse_pricing, unified_to_parsed,
+        ClientId, GroupBy, LocalParseOptions, ReportOptions, TokenBreakdown, UnifiedMessage,
+        UNKNOWN_WORKSPACE_LABEL,
     };
     use std::collections::{HashMap, HashSet};
     use std::io::Write;
@@ -7728,4 +7733,64 @@ mod tests {
         assert!(dates.contains(&local_date(thread_created + 2000)));
         assert!(dates.contains(&local_date(ledger_timestamp)));
     }
+    #[test]
+    fn test_retain_for_requested_clients_aliases_9router_and_gjc() {
+        let gjc_requested: HashSet<&str> = HashSet::from(["gjc"]);
+        // Bridge messages carry client="9router"; default filter requests "gjc".
+        assert!(retain_for_requested_clients(
+            "9router",
+            "deepseek-ai/deepseek-v4-flash",
+            "nvidia",
+            &gjc_requested
+        ));
+        // Real gjc messages carry client="gjc"; --client 9router requests "9router".
+        let ninerouter_requested: HashSet<&str> = HashSet::from(["9router"]);
+        assert!(retain_for_requested_clients(
+            "gjc",
+            "claude-sonnet-4",
+            "anthropic",
+            &ninerouter_requested
+        ));
+        // Unrelated clients still filtered out.
+        assert!(!retain_for_requested_clients(
+            "claude",
+            "gpt-4o",
+            "openai",
+            &gjc_requested
+        ));
+    }
+
+    #[test]
+    fn test_filter_messages_drops_pi_9router_combos() {
+        let messages = vec![
+            UnifiedMessage::new(
+                "pi",
+                "deepseek_v4_flash_free",
+                "9router",
+                "session-1",
+                1783412353188,
+                TokenBreakdown::default(),
+                0.0,
+            ),
+            UnifiedMessage::new(
+                "9router",
+                "deepseek-ai/deepseek-v4-flash",
+                "nvidia",
+                "session-2",
+                1783412353188,
+                TokenBreakdown {
+                    input: 100,
+                    output: 50,
+                    cache_read: 0,
+                    cache_write: 0,
+                    reasoning: 0,
+                },
+                0.05,
+            ),
+        ];
+        let filtered = filter_messages_for_report(messages, &ReportOptions::default());
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].client, "9router");
+    }
+
 }

--- a/crates/tokscale-core/src/provider_identity.rs
+++ b/crates/tokscale-core/src/provider_identity.rs
@@ -179,6 +179,19 @@ pub fn inferred_provider_from_model(model: &str) -> Option<&'static str> {
         return Some("sakana");
     }
 
+    // Kimi (Moonshot AI) — bare `kimi`, `kimi-k`, `kimi-code` variants
+    if lower.contains("kimi") {
+        return Some("moonshotai");
+    }
+    // MiMo (Xiaomi) — `mimo-v2.5` etc.
+    if lower.contains("mimo") {
+        return Some("xiaomi");
+    }
+    // GLM (Zhipu AI) — `glm-4.6`, `glm-5.2` etc.
+    if lower.contains("glm") {
+        return Some("zhipu");
+    }
+
     None
 }
 

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -881,7 +881,18 @@ fn scan_all_clients_with_env_strategy_inner(
     } else {
         clients
             .iter()
-            .filter_map(|s| ClientId::from_str(s))
+            .filter_map(|s| {
+                ClientId::from_str(s).or_else(|| {
+                    // "9Router" is a gjc-format bridge client overseen by the
+                    // 9Router bridge script. Map it to Gjc so the scanner
+                    // discovers files under gjc scan roots.
+                    if s.eq_ignore_ascii_case("9router") {
+                        Some(ClientId::Gjc)
+                    } else {
+                        None
+                    }
+                })
+            })
             .collect()
     };
 

--- a/crates/tokscale-core/src/sessions/gjc.rs
+++ b/crates/tokscale-core/src/sessions/gjc.rs
@@ -50,6 +50,8 @@ struct GjcMessage {
     #[allow(dead_code)]
     api: Option<String>,
     /// Unix-ms timestamp (preferred for ordering/date).
+    /// Optional source client override (e.g. "9Router"). If absent, defaults to "gjc".
+    source: Option<String>,
     timestamp: Option<i64>,
     usage: Option<GjcUsage>,
 }
@@ -183,8 +185,8 @@ pub fn parse_gjc_file(path: &Path) -> Vec<UnifiedMessage> {
         // (and fall back to "gjc") rather than dropping a message that carries
         // valid tokens.
         let provider = match message.provider {
-            Some(p) => p,
-            None => inferred_provider_from_model(&model)
+            Some(p) if !p.is_empty() => p,
+            _ => inferred_provider_from_model(&model)
                 .unwrap_or("gjc")
                 .to_string(),
         };
@@ -230,8 +232,9 @@ pub fn parse_gjc_file(path: &Path) -> Vec<UnifiedMessage> {
             None => derive_dedup_key(&session, timestamp, &model, &provider, &tokens, trimmed),
         };
 
+        let client = message.source.as_deref().unwrap_or("gjc");
         let mut unified = UnifiedMessage::new_with_dedup(
-            "gjc",
+            client,
             model,
             provider,
             session,

--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -161,8 +161,8 @@ pub fn parse_pi_file(path: &Path) -> Vec<UnifiedMessage> {
         // (and fall back to "pi") rather than dropping a message that carries
         // valid tokens.
         let provider = match message.provider {
-            Some(p) => p,
-            None => inferred_provider_from_model(&model)
+            Some(p) if !p.is_empty() => p,
+            _ => inferred_provider_from_model(&model)
                 .unwrap_or("pi")
                 .to_string(),
         };

--- a/docs/9router-bridge.md
+++ b/docs/9router-bridge.md
@@ -103,4 +103,35 @@ file only covers paid models. Free models correctly show `$0.00` cost.
 
 - Ollama models report 0 tokens (upstream API doesn't return usage metadata)
 - Bridge regenerates all files on each run (full refresh)
-- No incremental sync — run periodically or after each 9Router session
+
+## Automation
+
+A systemd user timer runs the bridge every 10 minutes automatically so
+`tokscale --today` stays current without manual intervention.
+
+### One-time setup
+
+```bash
+mkdir -p ~/.config/systemd/user/
+cp ~/Documents/Rust/tokscale/scripts/systemd/9router-tokscale-bridge.{service,timer} ~/.config/systemd/user/
+loginctl enable-linger $USER   # so timers run without an active login session
+systemctl --user daemon-reload
+systemctl --user enable --now 9router-tokscale-bridge.timer
+# Verify:
+systemctl --user list-timers | grep 9router
+systemctl --user start 9router-tokscale-bridge.service   # first run, no waiting
+journalctl --user -u 9router-tokscale-bridge.service -n 20
+```
+
+### How it works
+
+The timer fires `9router-tokscale-bridge.service` every 10 minutes. Each run
+reads the 9Router SQLite DB and writes gjc-format JSONL files grouped by local
+date. The `Persistent=true` setting ensures missed runs (hibernate, reboot) are
+caught up immediately on next boot.
+
+### Troubleshooting
+
+- Check timer status: `systemctl --user status 9router-tokscale-bridge.timer`
+- Check last run: `journalctl --user -u 9router-tokscale-bridge.service -n 20`
+- Reinstall units: repeat the one-time setup commands above (units are overwritten in place)

--- a/docs/9router-bridge.md
+++ b/docs/9router-bridge.md
@@ -1,0 +1,106 @@
+# 9Router ↔ tokscale Bridge
+
+Bridges 9Router usage data into tokscale via gjc-format JSONL files, enabling
+tokscale's analytics, graph, and cost estimation for 9Router API calls.
+
+## Files
+
+- `scripts/9router_tokscale_bridge_gjc.py` — Python bridge script
+- `scripts/9router_custom_pricing.json` — Custom pricing for non-free models
+- `docs/9router-bridge.md` — This file
+
+## Setup
+
+### 1. Copy custom pricing
+
+```bash
+cp scripts/9router_custom_pricing.json ~/.config/tokscale/custom-pricing.json
+```
+
+### 2. Configure tokscale scanner
+
+Add the bridge output directory to `~/.config/tokscale/settings.json`:
+
+```json
+{
+  "scanner": {
+    "extraScanPaths": {
+      "gjc": ["/home/USER/.local/share/9router-tokscale/sessions"]
+    }
+  }
+}
+```
+
+### 3. Run the bridge
+
+```bash
+python3 scripts/9router_tokscale_bridge_gjc.py
+```
+
+### 4. Verify
+
+```bash
+tokscale graph --client gjc
+tokscale models --client gjc
+tokscale pricing "deepseek-ai/deepseek-v4-flash"
+```
+
+## How It Works
+
+1. Bridge reads 9Router's SQLite database (`~/.9router/db/data.sqlite`)
+2. Extracts token usage from `requestDetails` table
+3. Writes gjc-format JSONL files grouped by date to `~/.local/share/9router-tokscale/sessions/`
+4. Tokscale's gjc parser reads these files and applies pricing from its database + custom pricing
+
+## Critical: Cost Field Omission
+
+The bridge intentionally omits `usage.cost` from JSONL output. The gjc parser
+(`sessions/gjc.rs:embedded_cost`) treats any present `cost.total` — even `0.0` —
+as `CostSource::ProviderReported` (authoritative). This prevents
+`apply_pricing_if_available` from repricing via the pricing database.
+
+Omitting the cost field causes `embedded_cost` to return `(0.0, CostSource::Unknown)`,
+allowing the dispatch guard to reprice from tokens + pricing data.
+
+## Provider Derivation
+
+For tokscale's pricing lookup to work, the bridge derives `provider` from the
+model ID's first segment:
+
+| Model ID | Provider |
+|---|---|
+| `deepseek-ai/deepseek-v4-flash` | `deepseek-ai` |
+| `stepfun-ai/step-3.7-flash` | `stepfun-ai` |
+| `@cf/moonshotai/kimi-k2.5` | `moonshotai` |
+| `mimo-v2.5` | (empty) |
+
+This makes `provider_hint_matches_scoped_provider` succeed in the lookup chain.
+
+## 9Router Model Prefixes
+
+9Router uses these prefixes for different providers:
+
+| Prefix | Provider |
+|---|---|
+| `nvidia/` | NVIDIA NIM |
+| `kc/` | Kilocode |
+| `cf/` | Cloudflare Workers AI |
+| `gh/` | GitHub Models |
+| `cx/` | Codex |
+| `ollama/` | Ollama (local) |
+| `openrouter/` | OpenRouter |
+| `gemini/` | Google Gemini |
+| `gc/` | Gemini CLI |
+| `bpm/` | BytePlus ModelArk |
+| `cerebras/` | Cerebras |
+
+## Free vs Paid Models
+
+Models with `:free` suffix or `*-free` suffix are free tier. The custom pricing
+file only covers paid models. Free models correctly show `$0.00` cost.
+
+## Known Limitations
+
+- Ollama models report 0 tokens (upstream API doesn't return usage metadata)
+- Bridge regenerates all files on each run (full refresh)
+- No incremental sync — run periodically or after each 9Router session

--- a/scripts/9router_custom_pricing.json
+++ b/scripts/9router_custom_pricing.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://tokscale.ai/custom-pricing.schema.json",
+  "models": {
+    "deepseek-ai/deepseek-v4-flash": {
+      "input_cost_per_million_tokens": 0.14,
+      "output_cost_per_million_tokens": 0.28,
+      "cache_read_input_token_cost_per_million_tokens": 0.0,
+      "source": "LiteLLM / tensormesh/deepseek-ai/DeepSeek-V4-Flash"
+    },
+    "stepfun-ai/step-3.7-flash": {
+      "input_cost_per_million_tokens": 0.20,
+      "output_cost_per_million_tokens": 1.15,
+      "cache_read_input_token_cost_per_million_tokens": 0.04,
+      "source": "Models.dev"
+    },
+    "mimo-v2.5": {
+      "input_cost_per_million_tokens": 0.14,
+      "output_cost_per_million_tokens": 0.28,
+      "cache_read_input_token_cost_per_million_tokens": 0.0,
+      "source": "Models.dev / xiaomi/mimo-v2.5"
+    },
+    "kimi-k2.5": {
+      "input_cost_per_million_tokens": 0.60,
+      "output_cost_per_million_tokens": 3.00,
+      "cache_read_input_token_cost_per_million_tokens": 0.10,
+      "source": "OpenRouter / moonshotai/kimi-k2.5"
+    },
+    "gpt-oss-120b": {
+      "input_cost_per_million_tokens": 0.03,
+      "output_cost_per_million_tokens": 0.15,
+      "cache_read_input_token_cost_per_million_tokens": 0.0,
+      "source": "OpenRouter / openai/gpt-oss-120b"
+    },
+    "@cf/moonshotai/kimi-k2.5": {
+      "input_cost_per_million_tokens": 0.95,
+      "output_cost_per_million_tokens": 4.00,
+      "cache_read_input_token_cost_per_million_tokens": 0.19,
+      "source": "LiteLLM / cloudflare/@cf/moonshotai/kimi-k2.7-code (closest match)"
+    },
+    "openai/gpt-oss-120b": {
+      "input_cost_per_million_tokens": 0.03,
+      "output_cost_per_million_tokens": 0.15,
+      "cache_read_input_token_cost_per_million_tokens": 0.0,
+      "source": "OpenRouter"
+    }
+  }
+}

--- a/scripts/9router_tokscale_bridge_gjc.py
+++ b/scripts/9router_tokscale_bridge_gjc.py
@@ -44,23 +44,6 @@ def parse_iso_timestamp(ts: str) -> int:
         return int(datetime.now(timezone.utc).timestamp() * 1000)
 
 
-def derive_provider_from_model(model: str) -> str:
-    """Derive provider from model ID for tokscale pricing lookup.
-
-    Tokscale's pricing lookup uses provider hints to match provider-scoped
-    model paths. For model IDs like 'deepseek-ai/deepseek-v4-flash', the
-    provider hint should be 'deepseek-ai' so the lookup succeeds.
-    For non-scoped models (no slash), return empty string.
-
-    Special case: @cf/moonshotai/kimi-k2.5 -> 'moonshotai' (skip Cloudflare prefix).
-    """
-    if "/" in model:
-        parts = model.split("/")
-        # @cf/moonshotai/kimi-k2.5: first segment is Cloudflare prefix
-        if parts[0].startswith("@") and len(parts) >= 3:
-            return parts[1]
-        return parts[0]
-    return ""
 
 
 def run():
@@ -107,27 +90,31 @@ def run():
 
         ts_ms = parse_iso_timestamp(row["timestamp"])
         model = req_data.get("model", row["model"]) or "unknown"
-        provider = derive_provider_from_model(model)
+        provider = row["provider"] or None
         date_str = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc).strftime("%Y-%m-%d")
 
         total = prompt + completion
 
+        msg = {
+            "role": "assistant",
+            "model": model,
+            "source": "9router",
+            "timestamp": ts_ms,
+            "usage": {
+                "input": prompt,
+                "output": completion,
+                "cacheRead": cached,
+                "cacheWrite": 0,
+                "totalTokens": total,
+            },
+        }
+        if provider:
+            msg["provider"] = provider
+            msg["api"] = provider
+
         entry = {
             "type": "message",
-            "message": {
-                "role": "assistant",
-                "model": model,
-                "provider": provider,
-                "api": provider,
-                "timestamp": ts_ms,
-                "usage": {
-                    "input": prompt,
-                    "output": completion,
-                    "cacheRead": cached,
-                    "cacheWrite": 0,
-                    "totalTokens": total
-                }
-            }
+            "message": msg,
         }
 
         messages_by_date.setdefault(date_str, []).append(entry)

--- a/scripts/9router_tokscale_bridge_gjc.py
+++ b/scripts/9router_tokscale_bridge_gjc.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Bridge 9Router usage into tokscale via gjc-format JSONL files.
 
-Reads 9Router request details from ~/.9router/db/data.sqlite and writes
-JSONL files that tokscale's gjc client parser can consume.
+Reads 9Router request details from ~/.9router/db/data.sqlite (and all
+backup DBs from previous upgrades) and writes JSONL files that tokscale's
+gjc client parser can consume.
 
 Usage:
     python3 scripts/9router_tokscale_bridge_gjc.py
@@ -28,6 +29,25 @@ ROUTER_DB = Path.home() / ".9router" / "db" / "data.sqlite"
 BRIDGE_DIR = Path.home() / ".local" / "share" / "9router-tokscale" / "sessions"
 
 
+def discover_router_dbs() -> list[Path]:
+    """Discover the current 9Router DB and all backup DBs.
+
+    Backups live in ~/.9router/db/backups/<upgrade-info>/data.sqlite.
+    Returns paths sorted newest-first (by mtime), so the current DB
+    (most recently written) is queried first and its request IDs win
+    dedup against older backups.
+    """
+    dbs = [ROUTER_DB]
+    backup_glob = ROUTER_DB.parent / "backups"
+    if backup_glob.exists():
+        dbs.extend(sorted(
+            backup_glob.glob("*/data.sqlite"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        ))
+    return [db for db in dbs if db.exists()]
+
+
 def ensure_bridge_dir():
     """Create output directory. Existing files are NOT deleted — each date's
     file is overwritten individually by the write loop, preserving historical
@@ -44,34 +64,36 @@ def parse_iso_timestamp(ts: str) -> int:
         return int(datetime.now(timezone.utc).timestamp() * 1000)
 
 
-
-
 def run():
-    if not ROUTER_DB.exists():
+    dbs = discover_router_dbs()
+    if not dbs:
         print(f"9Router DB not found: {ROUTER_DB}")
         return
 
     ensure_bridge_dir()
-    router_conn = sqlite3.connect(ROUTER_DB)
-    router_conn.row_factory = sqlite3.Row
 
-    cursor = router_conn.execute(
-        """
-        SELECT
-            id,
-            timestamp,
-            provider,
-            model,
-            connectionId,
-            data
-        FROM requestDetails
-        WHERE status = 'success'
-        ORDER BY timestamp
-        """
-    )
+    seen_ids: set[str] = set()
+    all_rows: list[sqlite3.Row] = []
+
+    for db_path in dbs:
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        cursor = conn.execute(
+            """
+            SELECT id, timestamp, provider, model, connectionId, data
+            FROM requestDetails
+            WHERE status = 'success'
+            ORDER BY timestamp
+            """
+        )
+        for row in cursor:
+            if row["id"] not in seen_ids:
+                seen_ids.add(row["id"])
+                all_rows.append(row)
+        conn.close()
 
     messages_by_date: dict[str, list] = {}
-    for row in cursor:
+    for row in all_rows:
         req_data = json.loads(row["data"])
         tokens = req_data.get("tokens", {})
 
@@ -119,8 +141,6 @@ def run():
 
         messages_by_date.setdefault(date_str, []).append(entry)
 
-    router_conn.close()
-
     total_entries = 0
     for date_str, entries in sorted(messages_by_date.items()):
         filepath = BRIDGE_DIR / f"9router-{date_str}.jsonl"
@@ -153,7 +173,7 @@ def run():
         )
     )
     print()
-    print("Then run: tokscale graph --client gjc")
+    print("Then run: tokscale graph --client 9router")
 
 
 if __name__ == "__main__":

--- a/scripts/9router_tokscale_bridge_gjc.py
+++ b/scripts/9router_tokscale_bridge_gjc.py
@@ -28,7 +28,6 @@ from datetime import datetime, timezone
 ROUTER_DB = Path.home() / ".9router" / "db" / "data.sqlite"
 BRIDGE_DIR = Path.home() / ".local" / "share" / "9router-tokscale" / "sessions"
 
-
 def discover_router_dbs() -> list[Path]:
     """Discover the current 9Router DB and all backup DBs.
 
@@ -47,13 +46,11 @@ def discover_router_dbs() -> list[Path]:
         ))
     return [db for db in dbs if db.exists()]
 
-
 def ensure_bridge_dir():
     """Create output directory. Existing files are NOT deleted — each date's
     file is overwritten individually by the write loop, preserving historical
     data from previous bridge runs."""
     BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
-
 
 def parse_iso_timestamp(ts: str) -> int:
     """Convert ISO-8601 timestamp to Unix milliseconds."""
@@ -62,7 +59,6 @@ def parse_iso_timestamp(ts: str) -> int:
         return int(dt.timestamp() * 1000)
     except Exception:
         return int(datetime.now(timezone.utc).timestamp() * 1000)
-
 
 def run():
     dbs = discover_router_dbs()
@@ -113,7 +109,9 @@ def run():
         ts_ms = parse_iso_timestamp(row["timestamp"])
         model = req_data.get("model", row["model"]) or "unknown"
         provider = row["provider"] or None
-        date_str = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc).strftime("%Y-%m-%d")
+        # Use local timezone (not UTC) so bridge file dates align with
+        # tokscale --today / --since/--until, which use chrono::Local.
+        date_str = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc).astimezone().strftime("%Y-%m-%d")
 
         total = prompt + completion
 
@@ -174,7 +172,6 @@ def run():
     )
     print()
     print("Then run: tokscale graph --client 9router")
-
 
 if __name__ == "__main__":
     run()

--- a/scripts/9router_tokscale_bridge_gjc.py
+++ b/scripts/9router_tokscale_bridge_gjc.py
@@ -29,10 +29,10 @@ BRIDGE_DIR = Path.home() / ".local" / "share" / "9router-tokscale" / "sessions"
 
 
 def ensure_bridge_dir():
-    """Create output directory and remove stale files."""
+    """Create output directory. Existing files are NOT deleted — each date's
+    file is overwritten individually by the write loop, preserving historical
+    data from previous bridge runs."""
     BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
-    for f in BRIDGE_DIR.glob("*.jsonl"):
-        f.unlink()
 
 
 def parse_iso_timestamp(ts: str) -> int:

--- a/scripts/9router_tokscale_bridge_gjc.py
+++ b/scripts/9router_tokscale_bridge_gjc.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Bridge 9Router usage into tokscale via gjc-format JSONL files.
+
+Reads 9Router request details from ~/.9router/db/data.sqlite and writes
+JSONL files that tokscale's gjc client parser can consume.
+
+Usage:
+    python3 scripts/9router_tokscale_bridge_gjc.py
+
+Then add to ~/.config/tokscale/settings.json:
+    {"scanner": {"extraScanPaths": {"gjc": ["/home/USER/.local/share/9router-tokscale/sessions"]}}}
+
+CRITICAL: Do NOT emit usage.cost.total in the JSONL output. The gjc parser
+treats any present cost.total (even 0.0) as CostSource::ProviderReported,
+which prevents tokscale from repricing via its pricing database. Omitting
+the cost field lets tokscale reprice from tokens + pricing data.
+
+See docs/9router-bridge.md for full documentation.
+"""
+
+import json
+import os
+import sqlite3
+from pathlib import Path
+from datetime import datetime, timezone
+
+ROUTER_DB = Path.home() / ".9router" / "db" / "data.sqlite"
+BRIDGE_DIR = Path.home() / ".local" / "share" / "9router-tokscale" / "sessions"
+
+
+def ensure_bridge_dir():
+    """Create output directory and remove stale files."""
+    BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+    for f in BRIDGE_DIR.glob("*.jsonl"):
+        f.unlink()
+
+
+def parse_iso_timestamp(ts: str) -> int:
+    """Convert ISO-8601 timestamp to Unix milliseconds."""
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        return int(dt.timestamp() * 1000)
+    except Exception:
+        return int(datetime.now(timezone.utc).timestamp() * 1000)
+
+
+def derive_provider_from_model(model: str) -> str:
+    """Derive provider from model ID for tokscale pricing lookup.
+
+    Tokscale's pricing lookup uses provider hints to match provider-scoped
+    model paths. For model IDs like 'deepseek-ai/deepseek-v4-flash', the
+    provider hint should be 'deepseek-ai' so the lookup succeeds.
+    For non-scoped models (no slash), return empty string.
+
+    Special case: @cf/moonshotai/kimi-k2.5 -> 'moonshotai' (skip Cloudflare prefix).
+    """
+    if "/" in model:
+        parts = model.split("/")
+        # @cf/moonshotai/kimi-k2.5: first segment is Cloudflare prefix
+        if parts[0].startswith("@") and len(parts) >= 3:
+            return parts[1]
+        return parts[0]
+    return ""
+
+
+def run():
+    if not ROUTER_DB.exists():
+        print(f"9Router DB not found: {ROUTER_DB}")
+        return
+
+    ensure_bridge_dir()
+    router_conn = sqlite3.connect(ROUTER_DB)
+    router_conn.row_factory = sqlite3.Row
+
+    cursor = router_conn.execute(
+        """
+        SELECT
+            id,
+            timestamp,
+            provider,
+            model,
+            connectionId,
+            data
+        FROM requestDetails
+        WHERE status = 'success'
+        ORDER BY timestamp
+        """
+    )
+
+    messages_by_date: dict[str, list] = {}
+    for row in cursor:
+        req_data = json.loads(row["data"])
+        tokens = req_data.get("tokens", {})
+
+        prompt = tokens.get("prompt_tokens", 0) or 0
+        completion = tokens.get("completion_tokens", 0) or 0
+        cached = tokens.get("cached_tokens", 0) or 0
+
+        reasoning = 0
+        completion_details = tokens.get("completion_tokens_details", {})
+        if completion_details:
+            reasoning = completion_details.get("reasoning_tokens", 0) or 0
+        completion += reasoning
+
+        if prompt == 0 and completion == 0:
+            continue
+
+        ts_ms = parse_iso_timestamp(row["timestamp"])
+        model = req_data.get("model", row["model"]) or "unknown"
+        provider = derive_provider_from_model(model)
+        date_str = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc).strftime("%Y-%m-%d")
+
+        total = prompt + completion
+
+        entry = {
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "model": model,
+                "provider": provider,
+                "api": provider,
+                "timestamp": ts_ms,
+                "usage": {
+                    "input": prompt,
+                    "output": completion,
+                    "cacheRead": cached,
+                    "cacheWrite": 0,
+                    "totalTokens": total
+                }
+            }
+        }
+
+        messages_by_date.setdefault(date_str, []).append(entry)
+
+    router_conn.close()
+
+    total_entries = 0
+    for date_str, entries in sorted(messages_by_date.items()):
+        filepath = BRIDGE_DIR / f"9router-{date_str}.jsonl"
+        with open(filepath, "w") as f:
+            session_header = {
+                "type": "session",
+                "id": f"9router-{date_str}",
+                "timestamp": entries[0]["message"]["timestamp"],
+                "cwd": "/"
+            }
+            f.write(json.dumps(session_header) + "\n")
+            for entry in entries:
+                f.write(json.dumps(entry) + "\n")
+                total_entries += 1
+
+    print(f"Bridge files written to: {BRIDGE_DIR}")
+    print(f"Files: {len(messages_by_date)}, Messages: {total_entries}")
+    print()
+    print("Add this to ~/.config/tokscale/settings.json:")
+    print(
+        json.dumps(
+            {
+                "scanner": {
+                    "extraScanPaths": {
+                        "gjc": [str(BRIDGE_DIR)]
+                    }
+                }
+            },
+            indent=2,
+        )
+    )
+    print()
+    print("Then run: tokscale graph --client gjc")
+
+
+if __name__ == "__main__":
+    run()

--- a/scripts/systemd/9router-tokscale-bridge.service
+++ b/scripts/systemd/9router-tokscale-bridge.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=9Router → tokscale gjc bridge (materialize today's usage)
+Wants=9router-tokscale-bridge.timer
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/python3 /home/niklaus/Documents/Rust/tokscale/scripts/9router_tokscale_bridge_gjc.py
+# The bridge script is read-only against the 9Router DB and only writes
+# its own JSONL dir (~/.local/share/9router-tokscale/sessions), so it is
+# safe to run without elevated privileges or network access.
+StandardOutput=journal
+StandardError=journal

--- a/scripts/systemd/9router-tokscale-bridge.timer
+++ b/scripts/systemd/9router-tokscale-bridge.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Run the 9Router → tokscale bridge every 10 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=10min
+# Catch the boot-time case where the timer was missed during downtime;
+# run once shortly after login rather than waiting up to 10 min.
+AccuracySec=30s
+Persistent=true
+Unit=9router-tokscale-bridge.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Adds a bridge system to integrate 9Router usage data into tokscale. The bridge reads from 9Router's SQLite database, exports usage to gjc-format JSONL files, and supports automated execution via systemd.

## What's Included

- **Bridge script** (`scripts/9router_tokscale_bridge_gjc.py`): Extracts 9Router request data from `~/.9router/db/data.sqlite` (including upgrade backups) and writes gjc-format JSONL files
- **Custom pricing** (`scripts/9router_custom_pricing.json`): Defines pricing for non-free 9Router models
- **Systemd automation** (`scripts/systemd/`): Timer + service for automatic bridge execution every 10 minutes
- **Documentation** (`docs/9router-bridge.md`): Full setup guide for scanner config, custom pricing, and systemd automation
- **Core changes**: Client aliasing (`9router` ↔ `gjc`), provider inference for Kimi/MiMo/GLM, pi/9router duplicate filtering
- **CLI support**: `--client 9router` filter option

## Commits

* `feat(bridge): add 9Router to gjc-format bridge script`
* `fix(bridge): correct 9Router provider display and add --client 9router filter`
* `fix(bridge): preserve historical bridge output across runs`
* `feat(bridge): scan all 9Router DBs including upgrade backups`
* `fix(models): add gjc/9router client alias and filter Pi/9router 0-token duplicates`
* `fix(bridge): automate 9router bridge run and fix UTC date grouping`
* `chore: ignore .omp/ directory`
* `chore: update GitNexus index stats in AGENTS.md and CLAUDE.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 9Router → tokscale bridge that exports 9Router usage from SQLite into `gjc`-format JSONL so it appears in graphs, models, and costs. Includes automation, pricing, and core updates to support `--client 9router` with correct provider mapping.

- **New Features**
  - Bridge script reads 9Router SQLite (incl. backups) and writes per-day `gjc` JSONL with local dates, omitting cost and tagging `source: "9router"`.
  - Systemd user timer/service runs the bridge every 10 minutes.
  - Core/CLI: `--client 9router`, scanner maps `9router` to `gjc` scan roots, parser honors `source`, and `9router`↔`gjc` aliasing.
  - Pricing/identity: custom pricing for paid 9Router models; provider inference for Kimi/MiMo/GLM; filters `pi`/`9router` 0‑token duplicates.

- **Migration**
  - Copy `scripts/9router_custom_pricing.json` to `~/.config/tokscale/custom-pricing.json`.
  - Add the bridge output path to scanner settings: `~/.local/share/9router-tokscale/sessions` under `gjc` `extraScanPaths`.
  - Optional: enable the systemd timer by installing the provided units and starting `9router-tokscale-bridge.timer`.

<sup>Written for commit 872368c0156e7992f10f7407e5fbf3b517e650ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

