### PR TITLE
fix(leaderboard): align all-time directive filtering

### DIFF
--- a/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
@@ -40,6 +40,7 @@ const mockState = vi.hoisted(() => {
   const desc = vi.fn(() => "desc");
   const asc = vi.fn(() => "asc");
   const and = vi.fn(() => "and");
+  const or = vi.fn((...conditions: unknown[]) => ({ kind: "or", conditions }));
   const gte = vi.fn(() => "gte");
   const lte = vi.fn(() => "lte");
   const sql = Object.assign(
@@ -101,6 +102,7 @@ const mockState = vi.hoisted(() => {
     desc,
     asc,
     and,
+    or,
     gte,
     lte,
     sql,
@@ -116,6 +118,7 @@ const mockState = vi.hoisted(() => {
       desc.mockClear();
       asc.mockClear();
       and.mockClear();
+      or.mockClear();
       gte.mockClear();
       lte.mockClear();
       sql.mockClear();
@@ -149,6 +152,7 @@ vi.mock("drizzle-orm", () => ({
   desc: mockState.desc,
   asc: mockState.asc,
   and: mockState.and,
+  or: mockState.or,
   gte: mockState.gte,
   lte: mockState.lte,
   sql: mockState.sql,
@@ -326,5 +330,25 @@ describe("group leaderboard data", () => {
     });
 
     expectNoNarrowedCostCast(sqlTexts);
+  });
+
+  it("ORs repeated directives in all-time group leaderboards", async () => {
+    mockState.setAllTimeRows([]);
+
+    await getGroupLeaderboardData(
+      "group-1",
+      "all",
+      1,
+      50,
+      "tokens",
+      "client:opencode client:claude model:gpt-5"
+    );
+
+    expect(mockState.or).toHaveBeenCalledTimes(2);
+    expect(mockState.or.mock.calls.map((call) => call.length)).toEqual([2, 1]);
+    expect(mockState.and).toHaveBeenLastCalledWith(
+      mockState.or.mock.results[0]?.value,
+      mockState.or.mock.results[1]?.value
+    );
   });
 });

--- a/packages/frontend/__tests__/lib/getLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboard.test.ts
@@ -28,6 +28,7 @@ const mockState = vi.hoisted(() => {
   const eq = vi.fn(() => "eq");
   const desc = vi.fn(() => "desc");
   const and = vi.fn(() => "and");
+  const or = vi.fn((...conditions: unknown[]) => ({ kind: "or", conditions }));
   const gte = vi.fn(() => "gte");
   const lte = vi.fn(() => "lte");
   const sql = Object.assign(
@@ -43,17 +44,34 @@ const mockState = vi.hoisted(() => {
 
   const db = {
     select: vi.fn(() => {
+      let selectedTable: unknown;
       const builder = {
         from: vi.fn((table: unknown) => {
+          selectedTable = table;
           fromCalls.push(table);
           return builder;
         }),
         innerJoin: vi.fn(() => builder),
-        where: vi.fn(async () => [...periodRows]),
+        where: vi.fn(() => builder),
         groupBy: vi.fn(() => builder),
         orderBy: vi.fn(() => builder),
         limit: vi.fn(() => builder),
         offset: vi.fn(() => builder),
+        as: vi.fn(() => ({
+          rank: "ranked.rank",
+          userId: "ranked.userId",
+          username: "ranked.username",
+          displayName: "ranked.displayName",
+          avatarUrl: "ranked.avatarUrl",
+          totalTokens: "ranked.totalTokens",
+          totalCost: "ranked.totalCost",
+        })),
+        then: (resolve: (value: unknown) => unknown) => {
+          if (selectedTable === tables.dailyBreakdown) {
+            return resolve([...periodRows]);
+          }
+          return resolve([]);
+        },
       };
 
       return builder;
@@ -67,6 +85,7 @@ const mockState = vi.hoisted(() => {
     eq,
     desc,
     and,
+    or,
     gte,
     lte,
     sql,
@@ -77,6 +96,7 @@ const mockState = vi.hoisted(() => {
       eq.mockClear();
       desc.mockClear();
       and.mockClear();
+      or.mockClear();
       gte.mockClear();
       lte.mockClear();
       sql.mockClear();
@@ -122,6 +142,7 @@ vi.mock("drizzle-orm", () => ({
   eq: mockState.eq,
   desc: mockState.desc,
   and: mockState.and,
+  or: mockState.or,
   gte: mockState.gte,
   lte: mockState.lte,
   sql: mockState.sql,
@@ -334,5 +355,27 @@ describe("period leaderboard data", () => {
     await expect(getUserRank("alice", "week", "tokens")).rejects.toThrow(
       "Multiple users match username alice case-insensitively"
     );
+  });
+});
+
+describe("all-time leaderboard directives", () => {
+  it("ORs repeated directives within each type before combining types", async () => {
+    await getLeaderboardData(
+      "all",
+      1,
+      50,
+      "tokens",
+      "client:opencode client:claude model:gpt_5"
+    );
+
+    expect(mockState.or).toHaveBeenCalledTimes(2);
+    expect(mockState.or.mock.calls.map((call) => call.length)).toEqual([2, 1]);
+    expect(mockState.and).toHaveBeenCalledWith(
+      mockState.or.mock.results[0]?.value,
+      mockState.or.mock.results[1]?.value
+    );
+
+    const boundValues = mockState.sql.mock.calls.flatMap(([, ...values]) => values);
+    expect(boundValues).toContain("%gpt\\_5%");
   });
 });

--- a/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
@@ -30,6 +30,7 @@ const mockState = vi.hoisted(() => {
   const eq = vi.fn(() => "eq");
   const desc = vi.fn(() => "desc");
   const and = vi.fn(() => "and");
+  const or = vi.fn(() => "or");
   const gte = vi.fn(() => "gte");
   const lte = vi.fn(() => "lte");
   const sql = Object.assign(
@@ -72,6 +73,7 @@ const mockState = vi.hoisted(() => {
     eq,
     desc,
     and,
+    or,
     gte,
     lte,
     sql,
@@ -82,6 +84,7 @@ const mockState = vi.hoisted(() => {
       eq.mockClear();
       desc.mockClear();
       and.mockClear();
+      or.mockClear();
       gte.mockClear();
       lte.mockClear();
       sql.mockClear();
@@ -127,6 +130,7 @@ vi.mock("drizzle-orm", () => ({
   eq: mockState.eq,
   desc: mockState.desc,
   and: mockState.and,
+  or: mockState.or,
   gte: mockState.gte,
   lte: mockState.lte,
   sql: mockState.sql,

--- a/packages/frontend/__tests__/lib/searchDirectives.test.ts
+++ b/packages/frontend/__tests__/lib/searchDirectives.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { parseSearchDirectives, hasDirectives } from "@/lib/leaderboard/searchDirectives";
+import {
+  escapeLikePattern,
+  hasDirectives,
+  parseSearchDirectives,
+} from "@/lib/leaderboard/searchDirectives";
 
 describe("parseSearchDirectives", () => {
   it("returns empty directives and original text when no directives present", () => {
@@ -106,5 +110,11 @@ describe("hasDirectives", () => {
 
   it("returns true when both present", () => {
     expect(hasDirectives({ text: "", clients: ["claude"], models: ["gpt-5"] })).toBe(true);
+  });
+});
+
+describe("escapeLikePattern", () => {
+  it("escapes SQL LIKE wildcard and escape characters", () => {
+    expect(escapeLikePattern("gpt_5%\\")).toBe("gpt\\_5\\%\\\\");
   });
 });

--- a/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
+++ b/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
@@ -1,8 +1,12 @@
 import { unstable_cache } from "next/cache";
-import { and, asc, desc, eq, gte, lte, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gte, lte, or, sql } from "drizzle-orm";
 import { db, dailyBreakdown, groupMembers, submissions, users } from "@/lib/db";
 import type { LeaderboardUser, Period, SortBy } from "@/lib/leaderboard/types";
-import { parseSearchDirectives, hasDirectives } from "@/lib/leaderboard/searchDirectives";
+import {
+  escapeLikePattern,
+  hasDirectives,
+  parseSearchDirectives,
+} from "@/lib/leaderboard/searchDirectives";
 
 interface GroupLeaderboardPeriodRow {
   userId: string;
@@ -264,17 +268,16 @@ async function fetchAllTimeRows(groupId: string, sortBy: SortBy, search: string 
     ? sql`SUM(${submissions.totalTokens})`
     : sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`;
 
-  const conditions: ReturnType<typeof sql>[] = [];
-  for (const client of parsed.clients) {
-    conditions.push(
-      sql`EXISTS (SELECT 1 FROM unnest(${submissions.sourcesUsed}) AS s WHERE LOWER(s) LIKE ${`%${client}%`})`
-    );
-  }
-  for (const model of parsed.models) {
-    conditions.push(
-      sql`EXISTS (SELECT 1 FROM unnest(${submissions.modelsUsed}) AS m WHERE LOWER(m) LIKE ${`%${model}%`})`
-    );
-  }
+  const clientConditions = parsed.clients.map((client) =>
+    sql`EXISTS (SELECT 1 FROM unnest(${submissions.sourcesUsed}) AS s WHERE LOWER(s) LIKE ${`%${escapeLikePattern(client)}%`})`
+  );
+  const modelConditions = parsed.models.map((model) =>
+    sql`EXISTS (SELECT 1 FROM unnest(${submissions.modelsUsed}) AS m WHERE LOWER(m) LIKE ${`%${escapeLikePattern(model)}%`})`
+  );
+  const conditions = [
+    clientConditions.length > 0 ? or(...clientConditions) : undefined,
+    modelConditions.length > 0 ? or(...modelConditions) : undefined,
+  ].filter((condition): condition is ReturnType<typeof sql> => condition !== undefined);
 
   const rows = await db
     .select({

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -6,9 +6,13 @@ import {
   normalizeUsernameCacheKey,
   usernameEqualsIgnoreCase,
 } from "@/lib/db/usernameLookup";
-import { eq, desc, sql, and, gte, lte } from "drizzle-orm";
+import { eq, desc, sql, and, or, gte, lte } from "drizzle-orm";
 import type { LeaderboardData, LeaderboardUser, Period, SortBy } from "@/lib/leaderboard/types";
-import { parseSearchDirectives, hasDirectives } from "@/lib/leaderboard/searchDirectives";
+import {
+  escapeLikePattern,
+  hasDirectives,
+  parseSearchDirectives,
+} from "@/lib/leaderboard/searchDirectives";
 
 export type { LeaderboardData, LeaderboardUser, Period, SortBy } from "@/lib/leaderboard/types";
 
@@ -329,17 +333,16 @@ async function fetchLeaderboardData(
     ? sql`SUM(${submissions.totalTokens})`
     : sql`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`;
 
-  const directiveConditions: ReturnType<typeof sql>[] = [];
-  for (const client of parsed.clients) {
-    directiveConditions.push(
-      sql`EXISTS (SELECT 1 FROM unnest(${submissions.sourcesUsed}) AS s WHERE LOWER(s) LIKE ${`%${client}%`})`
-    );
-  }
-  for (const model of parsed.models) {
-    directiveConditions.push(
-      sql`EXISTS (SELECT 1 FROM unnest(${submissions.modelsUsed}) AS m WHERE LOWER(m) LIKE ${`%${model}%`})`
-    );
-  }
+  const clientConditions = parsed.clients.map((client) =>
+    sql`EXISTS (SELECT 1 FROM unnest(${submissions.sourcesUsed}) AS s WHERE LOWER(s) LIKE ${`%${escapeLikePattern(client)}%`})`
+  );
+  const modelConditions = parsed.models.map((model) =>
+    sql`EXISTS (SELECT 1 FROM unnest(${submissions.modelsUsed}) AS m WHERE LOWER(m) LIKE ${`%${escapeLikePattern(model)}%`})`
+  );
+  const directiveConditions = [
+    clientConditions.length > 0 ? or(...clientConditions) : undefined,
+    modelConditions.length > 0 ? or(...modelConditions) : undefined,
+  ].filter((condition): condition is ReturnType<typeof sql> => condition !== undefined);
 
   const hasTextSearch = parsed.text.length > 0;
   const hasDirectiveFilters = directiveConditions.length > 0;
@@ -366,7 +369,7 @@ async function fetchLeaderboardData(
 
     let textFilter: ReturnType<typeof sql> | undefined;
     if (hasTextSearch) {
-      const escapedSearch = parsed.text.toLowerCase().replace(/[%_\\]/g, "\\$&");
+      const escapedSearch = escapeLikePattern(parsed.text.toLowerCase());
       const searchPattern = `%${escapedSearch}%`;
       textFilter = sql`(LOWER(${rankedSubquery.username}) LIKE ${searchPattern} OR LOWER(COALESCE(${rankedSubquery.displayName}, '')) LIKE ${searchPattern})`;
     }

--- a/packages/frontend/src/lib/leaderboard/searchDirectives.ts
+++ b/packages/frontend/src/lib/leaderboard/searchDirectives.ts
@@ -26,6 +26,10 @@ export interface ParsedSearchDirectives {
 
 const DIRECTIVE_REGEX = /\b(client|model):([\w.:\-/]+)/gi;
 
+export function escapeLikePattern(value: string): string {
+  return value.replace(/[%_\\]/g, "\\$&");
+}
+
 export function parseSearchDirectives(raw: string): ParsedSearchDirectives {
   const clients: string[] = [];
   const models: string[] = [];


### PR DESCRIPTION
## Summary

- Make repeated client and model directives OR within their respective categories for all-time global and group leaderboards.
- Escape directive values before binding PostgreSQL `LIKE` patterns.
- Add regression coverage for all-time global/group directive composition and literal wildcard escaping.

Follow-up to #876.

## Validation

- `bun --cwd packages/frontend lint` (passes with six existing warnings outside this change)
- `bun --cwd packages/frontend typecheck`
- `bun --cwd packages/frontend test` (620 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns all-time leaderboard directive filtering with period behavior. Same-type directives are OR’d, then combined across types with AND. Literal LIKE escaping is used for directives and free-text so %, _, and \ don’t act as wildcards.

- **Bug Fixes**
  - All-time global and group queries OR multiple `client:` directives and OR multiple `model:` directives, then AND those groups.
  - Added `escapeLikePattern` and applied it to directive and text LIKE patterns; added tests for global/group directive composition and literal wildcard escaping.

<sup>Written for commit 25b11402a96118b5a6d50e5c1befa1c5d0e47dc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

