### PR TITLE
fix(devin-desktop): show pre-dedup message count and Windows paths in clients command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1351,6 +1351,8 @@ AI coding tools store their session data in cross-platform locations. Most tools
 | Devin Desktop | Linux: `~/.config/Devin/User/acp-events/`; macOS: `~/Library/Application Support/Devin/User/acp-events/` | `%APPDATA%\Devin\User\acp-events\` | Parses ACP usage events; the CLI database resolves matching session titles when present |
 | Synthetic | Re-attributed from other sources | Re-attributed from other sources | Detects `hf:` model prefix + `synthetic` provider |
 
+> **Devin Desktop agent support**: Local usage parsing works for ACP-connected agents (e.g. Cascade/Windsurf, claude-code, opencode) that emit `usage_update` events in the NDJSON stream. The default **devin-cloud** agent does not emit local `usage_update` events — its usage stays server-side and cannot be tracked by tokscale without an account-level API.
+
 > **Note**: On Windows, `~` expands to `%USERPROFILE%` (e.g., `C:\Users\YourName`). These tools intentionally use Unix-style paths (like `.local/share`) even on Windows for cross-platform consistency, rather than Windows-native paths like `%APPDATA%`.
 
 #### Windows-Specific Configuration

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -3878,6 +3878,20 @@ fn run_clients_command(json: bool, home_dir: Option<String>) -> Result<()> {
                         exists: path.exists(),
                     });
                 }
+                if client == ClientId::DevinDesktop {
+                    for root in tokscale_core::scanner::devin_desktop_additional_roots(
+                        &home_dir_str,
+                        use_env_roots,
+                    ) {
+                        let path_str = root.to_string_lossy().to_string();
+                        if !additional_paths.iter().any(|p| p.path == path_str) {
+                            additional_paths.push(AdditionalPath {
+                                path: path_str,
+                                exists: root.exists(),
+                            });
+                        }
+                    }
+                }
                 let legacy_paths = if client == ClientId::OpenClaw {
                     vec![
                         LegacyPath {

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -7770,6 +7770,92 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_local_clients_devin_nonzero_cli_usage_dedups_desktop_row_but_keeps_raw_count() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let db_path = temp_dir.path().join(".local/share/devin/cli/sessions.db");
+        std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE sessions (
+                 id TEXT PRIMARY KEY,
+                 working_directory TEXT NOT NULL,
+                 backend_type TEXT NOT NULL,
+                 model TEXT NOT NULL,
+                 title TEXT,
+                 agent_mode TEXT NOT NULL,
+                 created_at INTEGER NOT NULL,
+                 last_activity_at INTEGER NOT NULL
+             );
+             CREATE TABLE message_nodes (
+                 row_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 session_id TEXT NOT NULL,
+                 node_id INTEGER NOT NULL,
+                 parent_node_id INTEGER,
+                 chat_message TEXT NOT NULL,
+                 created_at INTEGER NOT NULL,
+                 metadata TEXT
+             );",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions (id, working_directory, backend_type, model, title, agent_mode, created_at, last_activity_at) VALUES ('cli-session', '/tmp/project', 'windsurf', 'gpt-5', 'Desktop task', 'accept-edits', 1, 1)",
+            [],
+        )
+        .unwrap();
+        // Unlike the zero-usage regression test above, this CLI row carries
+        // real attributable usage, so it must NOT be filtered by
+        // `parse_devin_cli_sqlite`'s zero-metric guard. That means its
+        // session id lands in `cli_session_ids`, which is exactly the
+        // condition needed to exercise the dedup filter against the
+        // matching Desktop NDJSON session.
+        conn.execute(
+            "INSERT INTO message_nodes (session_id, node_id, chat_message, created_at) VALUES ('cli-session', 1, ?1, 1700000000)",
+            [r#"{"role":"assistant","metadata":{"metrics":{"input_tokens":50,"output_tokens":25}}}"#],
+        )
+        .unwrap();
+        drop(conn);
+
+        let desktop_dir = temp_dir
+            .path()
+            .join("Library/Application Support/Devin/User/acp-events");
+        std::fs::create_dir_all(&desktop_dir).unwrap();
+        std::fs::write(
+            desktop_dir.join("desktop-file.ndjson"),
+            concat!(
+                r#"{"notification":{"sessionUpdate":"session_info_update","title":"Desktop task"}}"#,
+                "\n",
+                r#"{"notification":{"sessionUpdate":"usage_update","_meta":{"cognition.ai/inputTokens":100,"cognition.ai/outputTokens":20,"cognition.ai/cachedReadTokens":10}}}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+
+        let parsed = parse_local_clients(LocalParseOptions {
+            home_dir: Some(temp_dir.path().to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(vec!["devin-cli".to_string(), "devin-desktop".to_string()]),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner::ScannerSettings::default(),
+        })
+        .unwrap();
+
+        // The Desktop row shares its resolved session id with the CLI row,
+        // so it must be deduped out of `messages` and attributed to
+        // devin-cli instead.
+        assert_eq!(parsed.messages.len(), 1);
+        assert_eq!(parsed.messages[0].client, "devin-cli");
+        assert_eq!(parsed.messages[0].session_id, "cli-session");
+
+        // But the `clients` command count must still reflect the raw,
+        // pre-dedup Desktop discovery so Desktop usage doesn't appear to
+        // vanish when it overlaps with a CLI session.
+        assert_eq!(parsed.counts.get(ClientId::DevinCli), 1);
+        assert!(parsed.counts.get(ClientId::DevinDesktop) > 0);
+    }
+
+    #[test]
     fn test_parse_local_clients_desktop_uses_configured_cli_lookup_without_cli_usage() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let external_dir = temp_dir.path().join("imports/devin/profile");

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -3445,7 +3445,7 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
         .iter()
         .map(|message| message.session_id.clone())
         .collect();
-    let devin_desktop_messages: Vec<UnifiedMessage> = if include_devin_desktop {
+    let devin_desktop_messages_raw: Vec<UnifiedMessage> = if include_devin_desktop {
         let devin_desktop_lookup =
             sessions::devin::load_devin_desktop_session_lookup(&scan_result.devin_dbs);
         scan_result
@@ -3454,11 +3454,20 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
             .flat_map(|path| {
                 sessions::devin::parse_devin_desktop_ndjson_with_lookup(path, &devin_desktop_lookup)
             })
-            .filter(|message| !cli_session_ids.contains(&message.session_id))
             .collect()
     } else {
         Vec::new()
     };
+    // Count before dedup so the `clients` command reflects how many Desktop
+    // sessions were actually found, even when they overlap with the CLI DB.
+    let devin_desktop_raw_count: i32 = devin_desktop_messages_raw
+        .iter()
+        .map(|msg| msg.message_count.max(0))
+        .sum();
+    let devin_desktop_messages: Vec<UnifiedMessage> = devin_desktop_messages_raw
+        .into_iter()
+        .filter(|message| !cli_session_ids.contains(&message.session_id))
+        .collect();
 
     let devin_cli_parsed: Vec<ParsedMessage> = devin_cli_messages
         .into_iter()
@@ -3469,7 +3478,10 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
         .map(|msg| unified_to_parsed(&msg))
         .collect();
     let devin_cli_count = summed_parsed_message_count(&devin_cli_parsed);
-    let devin_desktop_count = summed_parsed_message_count(&devin_desktop_parsed);
+    // Use the pre-dedup count for the `clients` command display so users see
+    // all discovered Desktop sessions. The dedup-filtered messages are still
+    // what gets added to the combined `messages` vector.
+    let devin_desktop_count = devin_desktop_raw_count;
     counts.set(ClientId::DevinCli, devin_cli_count);
     counts.set(ClientId::DevinDesktop, devin_desktop_count);
     messages.extend(devin_cli_parsed);

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -830,7 +830,7 @@ fn cline_additional_vscode_task_roots(home_dir: &str, use_env_roots: bool) -> Ve
     roots
 }
 
-fn devin_desktop_additional_roots(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
+pub fn devin_desktop_additional_roots(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
     let mut roots = vec![
         PathBuf::from(home_dir).join(".config/Devin/User/acp-events"),
         PathBuf::from(home_dir).join(".config/devin/User/acp-events"),


### PR DESCRIPTION
Closes #872.

The clients command showed 0 messages for Devin Desktop even when Cascade sessions were being parsed correctly, because the dedup filter suppressed messages matching CLI database session IDs.

Changes:
- Show pre-dedup message count for Devin Desktop in parse_local_clients
- Display devin-desktop additional scan paths (including Windows APPDATA) in clients command
- Make devin_desktop_additional_roots public for reuse in CLI display
- Add README note clarifying devin-cloud vs ACP-connected agent support

Test plan:
- cargo test -p tokscale-core: 1185 passed, 0 failed
- tokscale clients: Devin Desktop now shows messages: 1 (previously 0) and additional paths
- tokscale models --client devin-desktop: correctly reports Cascade session tokens

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Devin Desktop showing 0 messages in the `clients` command by using the pre-dedup count and listing Windows scan paths. Clarifies agent support in the README. Closes #872.

- **Bug Fixes**
  - Use pre-dedup Devin Desktop count in parse_local_clients so `clients` shows sessions even when they overlap with the CLI DB.
  - Display additional Devin Desktop scan roots in `clients`, including `%APPDATA%\Devin\User\acp-events\` on Windows.
  - Make `scanner::devin_desktop_additional_roots` public for CLI reuse.
  - README: clarify that `devin-cloud` doesn’t emit local `usage_update` events; ACP-connected agents (Cascade/Windsurf, `claude-code`, `opencode`) are supported.
  - Add regression test to pin pre-dedup Desktop count when a CLI session dedups the Desktop row.

<sup>Written for commit d897377df9647cad10e0dc98610789f7a1418008. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

