### PR TITLE
fix(submit): prevent duplicate daily_breakdown rows on device change

### DIFF
--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -154,6 +154,21 @@ function makeAwaitableBuilder(result: unknown) {
   return builder;
 }
 
+// Drizzle's `sql` template composes nested SQL/StringChunk objects (and
+// `sql.join` adds another nesting level for batched VALUES lists). Rather
+// than assert on the exact nesting shape -- which shifts whenever the query
+// is restructured -- flatten every chunk's raw values into one array so
+// assertions only care that the expected params were embedded somewhere.
+function flattenSqlChunks(node: unknown): unknown[] {
+  if (node && typeof node === "object" && Array.isArray((node as { queryChunks?: unknown }).queryChunks)) {
+    return (node as { queryChunks: unknown[] }).queryChunks.flatMap(flattenSqlChunks);
+  }
+  if (node && typeof node === "object" && Array.isArray((node as { value?: unknown }).value)) {
+    return (node as { value: unknown[] }).value;
+  }
+  return [node];
+}
+
 describe("POST /api/submit auth path", () => {
   it("rejects invalid API tokens through the shared auth service", async () => {
     mockState.authenticatePersonalToken.mockResolvedValue({ status: "invalid" });
@@ -380,6 +395,7 @@ describe("POST /api/submit auth path", () => {
     const selectResults = [
       [],
       [],
+      [],
       [{
         totalTokens: 12,
         totalCost: "0.5000",
@@ -450,7 +466,7 @@ describe("POST /api/submit auth path", () => {
           values: vi.fn(() => Promise.resolve()),
         };
       }),
-      execute: vi.fn(() => Promise.resolve()),
+      execute: vi.fn((..._args: unknown[]) => Promise.resolve()),
       // Nested transaction (Postgres SAVEPOINT). Mock just invokes the
       // callback with the same tx so calls inside the savepoint still
       // count toward tx.execute / tx.update / etc.
@@ -490,20 +506,13 @@ describe("POST /api/submit auth path", () => {
       displayName: "Test device",
     }));
     expect(tx.execute).toHaveBeenCalledTimes(1);
-    expect(tx.execute).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        queryChunks: expect.arrayContaining([
-          expect.objectContaining({
-            value: expect.arrayContaining([
-              expect.stringContaining("INSERT INTO daily_breakdown"),
-            ]),
-          }),
-          "submission-1",
-          "submitted-device-1",
-          "2026-04-30",
-        ]),
-      }),
+    expect(flattenSqlChunks(tx.execute.mock.calls[0][0])).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("INSERT INTO daily_breakdown"),
+        "submission-1",
+        "submitted-device-1",
+        "2026-04-30",
+      ]),
     );
     expect(submissionUpdateValues).toEqual(
       expect.objectContaining({
@@ -619,6 +628,12 @@ describe("POST /api/submit auth path", () => {
         sourceBreakdown: existingBreakdown,
       }],
       [{
+        id: "daily-1",
+        date: "2026-04-30",
+        timestampMs: 123,
+        sourceBreakdown: existingBreakdown,
+      }],
+      [{
         totalTokens: 15,
         totalCost: "0.7500",
         inputTokens: 10,
@@ -648,7 +663,7 @@ describe("POST /api/submit auth path", () => {
         };
         return builder;
       }),
-      execute: vi.fn(() => Promise.resolve()),
+      execute: vi.fn((..._args: unknown[]) => Promise.resolve()),
       // Nested transaction (Postgres SAVEPOINT). Mock just invokes the
       // callback with the same tx so calls inside the savepoint still
       // count toward tx.execute / tx.update / etc.
@@ -806,6 +821,13 @@ describe("POST /api/submit auth path", () => {
         sourceBreakdown: existingBreakdown,
       }],
       [{
+        id: "daily-1",
+        date: "2026-04-30",
+        timestampMs: 123,
+        activeTimeMs: null,
+        sourceBreakdown: existingBreakdown,
+      }],
+      [{
         totalTokens: 15,
         totalCost: "0.7500",
         inputTokens: 10,
@@ -863,7 +885,7 @@ describe("POST /api/submit auth path", () => {
         };
         return builder;
       }),
-      execute: vi.fn(() => Promise.resolve()),
+      execute: vi.fn((..._args: unknown[]) => Promise.resolve()),
       transaction: vi.fn(async (callback: (sp: typeof tx) => Promise<unknown>) =>
         callback(tx)
       ),
@@ -1003,6 +1025,7 @@ describe("POST /api/submit auth path", () => {
       [{ id: "submission-1" }],
       [],
       [],
+      [],
       [{
         totalTokens: 42,
         totalCost: "1.7500",
@@ -1049,7 +1072,7 @@ describe("POST /api/submit auth path", () => {
         };
         return builder;
       }),
-      execute: vi.fn(() => Promise.resolve()),
+      execute: vi.fn((..._args: unknown[]) => Promise.resolve()),
       transaction: vi.fn(async (callback: (sp: typeof tx) => Promise<unknown>) =>
         callback(tx)
       ),
@@ -1074,21 +1097,14 @@ describe("POST /api/submit auth path", () => {
     expect(response.status).toBe(200);
     expect(tx.insert).toHaveBeenCalledTimes(1);
     expect(tx.execute).toHaveBeenCalledTimes(2);
-    expect(tx.execute).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        queryChunks: expect.arrayContaining([
-          expect.objectContaining({
-            value: expect.arrayContaining([
-              expect.stringContaining("INSERT INTO daily_breakdown"),
-            ]),
-          }),
-          "submission-1",
-          "submitted-device-2",
-          "2026-04-30",
-          4_000,
-        ]),
-      }),
+    expect(flattenSqlChunks(tx.execute.mock.calls[1][0])).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("INSERT INTO daily_breakdown"),
+        "submission-1",
+        "submitted-device-2",
+        "2026-04-30",
+        4_000,
+      ]),
     );
     expect(submissionUpdateSets.at(-1)).toEqual(expect.objectContaining({
       totalActiveTimeMs: 10_000,
@@ -1207,6 +1223,13 @@ describe("POST /api/submit auth path", () => {
         sourceBreakdown: existingBreakdown,
       }],
       [{
+        id: "daily-1",
+        date: "2026-04-30",
+        timestampMs: 123,
+        activeTimeMs: 2_000,
+        sourceBreakdown: existingBreakdown,
+      }],
+      [{
         totalTokens: 27,
         totalCost: "1.2500",
         inputTokens: 17,
@@ -1243,7 +1266,7 @@ describe("POST /api/submit auth path", () => {
         };
         return builder;
       }),
-      execute: vi.fn(() => Promise.resolve()),
+      execute: vi.fn((..._args: unknown[]) => Promise.resolve()),
       transaction: vi.fn(async (callback: (sp: typeof tx) => Promise<unknown>) =>
         callback(tx)
       ),
@@ -1386,6 +1409,13 @@ describe("POST /api/submit auth path", () => {
         sourceBreakdown: legacyBreakdown,
       }],
       [{
+        id: "daily-legacy",
+        date: "2026-04-30",
+        timestampMs: 123,
+        activeTimeMs: null,
+        sourceBreakdown: legacyBreakdown,
+      }],
+      [{
         totalTokens: 15,
         totalCost: "0.7500",
         inputTokens: 10,
@@ -1424,7 +1454,7 @@ describe("POST /api/submit auth path", () => {
         };
         return builder;
       }),
-      execute: vi.fn(() => Promise.resolve()),
+      execute: vi.fn((..._args: unknown[]) => Promise.resolve()),
       // Nested transaction (Postgres SAVEPOINT). Mock just invokes the
       // callback with the same tx so calls inside the savepoint still
       // count toward tx.execute / tx.update / etc.
@@ -1551,6 +1581,7 @@ describe("POST /api/submit auth path", () => {
       [{ id: "submission-1" }],
       [],
       [],
+      [],
       [{
         totalTokens: 42,
         totalCost: "1.7500",
@@ -1590,7 +1621,7 @@ describe("POST /api/submit auth path", () => {
         };
         return builder;
       }),
-      execute: vi.fn(() => Promise.resolve()),
+      execute: vi.fn((..._args: unknown[]) => Promise.resolve()),
       // Nested transaction (Postgres SAVEPOINT). Mock just invokes the
       // callback with the same tx so calls inside the savepoint still
       // count toward tx.execute / tx.update / etc.
@@ -1618,22 +1649,15 @@ describe("POST /api/submit auth path", () => {
     expect(response.status).toBe(200);
     expect(tx.insert).toHaveBeenCalledTimes(1);
     expect(tx.execute).toHaveBeenCalledTimes(2);
-    expect(tx.execute).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        queryChunks: expect.arrayContaining([
-          expect.objectContaining({
-            value: expect.arrayContaining([
-              expect.stringContaining("INSERT INTO daily_breakdown"),
-            ]),
-          }),
-          "submission-1",
-          "submitted-device-2",
-          "2026-04-30",
-          15,
-          JSON.stringify(insertedBreakdown),
-        ]),
-      }),
+    expect(flattenSqlChunks(tx.execute.mock.calls[1][0])).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("INSERT INTO daily_breakdown"),
+        "submission-1",
+        "submitted-device-2",
+        "2026-04-30",
+        15,
+        JSON.stringify(insertedBreakdown),
+      ]),
     );
     expect(mockState.mergeClientBreakdownsWithRegressionGuard).not.toHaveBeenCalled();
     expect(await response.json()).toEqual(expect.objectContaining({

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -405,7 +405,6 @@ describe("POST /api/submit auth path", () => {
 
     let insertCall = 0;
     let submittedDeviceValues: unknown;
-    let dailyInsertValues: unknown;
     let submissionUpdateValues: unknown;
     const tx = {
       update: vi.fn((table: unknown) => {
@@ -448,10 +447,7 @@ describe("POST /api/submit auth path", () => {
         }
 
         return {
-          values: vi.fn((values: unknown) => {
-            dailyInsertValues = values;
-            return Promise.resolve();
-          }),
+          values: vi.fn(() => Promise.resolve()),
         };
       }),
       execute: vi.fn(() => Promise.resolve()),
@@ -484,6 +480,7 @@ describe("POST /api/submit auth path", () => {
     );
 
     expect(response.status).toBe(200);
+    expect(tx.insert).toHaveBeenCalledTimes(2);
     expect(tx.insert).toHaveBeenNthCalledWith(2, expect.objectContaining({
       id: "submittedDevices.id",
     }));
@@ -492,13 +489,22 @@ describe("POST /api/submit auth path", () => {
       deviceKey: "dev_test",
       displayName: "Test device",
     }));
-    expect(dailyInsertValues).toEqual([
+    expect(tx.execute).toHaveBeenCalledTimes(1);
+    expect(tx.execute).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
-        submissionId: "submission-1",
-        submittedDeviceId: "submitted-device-1",
-        date: "2026-04-30",
+        queryChunks: expect.arrayContaining([
+          expect.objectContaining({
+            value: expect.arrayContaining([
+              expect.stringContaining("INSERT INTO daily_breakdown"),
+            ]),
+          }),
+          "submission-1",
+          "submitted-device-1",
+          "2026-04-30",
+        ]),
       }),
-    ]);
+    );
     expect(submissionUpdateValues).toEqual(
       expect.objectContaining({
         mcpServers: ["github", "slack"],
@@ -1013,7 +1019,6 @@ describe("POST /api/submit auth path", () => {
 
     const submissionUpdateSets: Array<Record<string, unknown>> = [];
     let insertCall = 0;
-    let dailyInsertValues: unknown;
     const tx = {
       update: vi.fn((table: unknown) => {
         const builder = {
@@ -1040,10 +1045,7 @@ describe("POST /api/submit auth path", () => {
         }
 
         const builder = {
-          values: vi.fn((values: unknown) => {
-            dailyInsertValues = values;
-            return Promise.resolve();
-          }),
+          values: vi.fn(() => Promise.resolve()),
         };
         return builder;
       }),
@@ -1070,9 +1072,24 @@ describe("POST /api/submit auth path", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(dailyInsertValues).toEqual([expect.objectContaining({
-      activeTimeMs: 4_000,
-    })]);
+    expect(tx.insert).toHaveBeenCalledTimes(1);
+    expect(tx.execute).toHaveBeenCalledTimes(2);
+    expect(tx.execute).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        queryChunks: expect.arrayContaining([
+          expect.objectContaining({
+            value: expect.arrayContaining([
+              expect.stringContaining("INSERT INTO daily_breakdown"),
+            ]),
+          }),
+          "submission-1",
+          "submitted-device-2",
+          "2026-04-30",
+          4_000,
+        ]),
+      }),
+    );
     expect(submissionUpdateSets.at(-1)).toEqual(expect.objectContaining({
       totalActiveTimeMs: 10_000,
       longestContinuousMs: 4_000,
@@ -1382,7 +1399,6 @@ describe("POST /api/submit auth path", () => {
     ];
 
     let insertCall = 0;
-    let dailyInsertValues: unknown;
     const tx = {
       update: vi.fn(() => {
         const builder = {
@@ -1404,10 +1420,7 @@ describe("POST /api/submit auth path", () => {
         }
 
         const builder = {
-          values: vi.fn((values: unknown) => {
-            dailyInsertValues = values;
-            return Promise.resolve();
-          }),
+          values: vi.fn(() => Promise.resolve()),
         };
         return builder;
       }),
@@ -1438,7 +1451,6 @@ describe("POST /api/submit auth path", () => {
 
     expect(response.status).toBe(200);
     expect(tx.insert).toHaveBeenCalledTimes(1);
-    expect(dailyInsertValues).toBeUndefined();
     expect(tx.execute).toHaveBeenCalledTimes(2);
     expect(mockState.mergeClientBreakdownsWithRegressionGuard).toHaveBeenCalledWith(
       legacyBreakdown,
@@ -1553,7 +1565,6 @@ describe("POST /api/submit auth path", () => {
     ];
 
     let insertCall = 0;
-    let dailyInsertValues: unknown;
     const tx = {
       update: vi.fn(() => {
         const builder = {
@@ -1575,10 +1586,7 @@ describe("POST /api/submit auth path", () => {
         }
 
         const builder = {
-          values: vi.fn((values: unknown) => {
-            dailyInsertValues = values;
-            return Promise.resolve();
-          }),
+          values: vi.fn(() => Promise.resolve()),
         };
         return builder;
       }),
@@ -1608,14 +1616,25 @@ describe("POST /api/submit auth path", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(tx.insert).toHaveBeenCalledTimes(2);
-    expect(tx.execute).toHaveBeenCalledTimes(1);
-    expect(dailyInsertValues).toEqual([expect.objectContaining({
-      submittedDeviceId: "submitted-device-2",
-      date: "2026-04-30",
-      tokens: 15,
-      sourceBreakdown: insertedBreakdown,
-    })]);
+    expect(tx.insert).toHaveBeenCalledTimes(1);
+    expect(tx.execute).toHaveBeenCalledTimes(2);
+    expect(tx.execute).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        queryChunks: expect.arrayContaining([
+          expect.objectContaining({
+            value: expect.arrayContaining([
+              expect.stringContaining("INSERT INTO daily_breakdown"),
+            ]),
+          }),
+          "submission-1",
+          "submitted-device-2",
+          "2026-04-30",
+          15,
+          JSON.stringify(insertedBreakdown),
+        ]),
+      }),
+    );
     expect(mockState.mergeClientBreakdownsWithRegressionGuard).not.toHaveBeenCalled();
     expect(await response.json()).toEqual(expect.objectContaining({
       success: true,

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -694,6 +694,12 @@ describe("POST /api/submit auth path", () => {
       id: "submittedDevices.id",
     }));
     expect(tx.execute).toHaveBeenCalledTimes(1);
+    // Batch UPDATE must re-attribute the merged row to the submitting
+    // device, not leave it stamped with whichever device's row happened to
+    // survive the SELECT.
+    expect(flattenSqlChunks(tx.execute.mock.calls[0][0])).toEqual(
+      expect.arrayContaining(["submitted-device-1"]),
+    );
     expect(mockState.mergeClientBreakdownsWithRegressionGuard).toHaveBeenCalledWith(
       existingBreakdown,
       {
@@ -716,6 +722,186 @@ describe("POST /api/submit auth path", () => {
       }),
       mode: "merge",
     }));
+  });
+
+  it("attributes a merged day to the new device on a replacement-device submit", async () => {
+    // Regression for cubic P2 review: a replacement-device submit (dev_phone
+    // taking over from a previously-submitting device on an overlapping
+    // date) must stamp submitted_device_id on the batch UPDATE, otherwise
+    // the merged row keeps pointing at the old device.
+    mockState.authenticatePersonalToken.mockResolvedValue({
+      status: "valid",
+      tokenId: "token-1",
+      userId: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      expiresAt: null,
+    });
+
+    mockState.validateSubmission.mockReturnValue({
+      valid: true,
+      data: {
+        device: {
+          id: "dev_phone",
+        },
+        meta: {
+          version: "2.0.0",
+          dateRange: { start: "2026-04-30", end: "2026-04-30" },
+        },
+        summary: {
+          clients: ["codex"],
+        },
+        contributions: [
+          {
+            date: "2026-04-30",
+            timestampMs: 456,
+            clients: [
+              {
+                client: "codex",
+                modelId: "gpt-5.5",
+                tokens: 15,
+                cost: 0.75,
+                input: 10,
+                output: 5,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+                messages: 1,
+              },
+            ],
+          },
+        ],
+      },
+      errors: [],
+      warnings: [],
+    });
+
+    const incomingBreakdown = {
+      tokens: 15,
+      cost: 0.75,
+      input: 10,
+      output: 5,
+      cacheRead: 0,
+      cacheWrite: 0,
+      reasoning: 0,
+      messages: 1,
+    };
+    const existingBreakdown = {
+      codex: {
+        tokens: 12,
+        cost: 0.5,
+        input: 7,
+        output: 5,
+        cacheRead: 0,
+        cacheWrite: 0,
+        reasoning: 0,
+        messages: 1,
+        models: { "gpt-5.5": { tokens: 12 } },
+      },
+    };
+    const mergedBreakdown = {
+      codex: {
+        ...incomingBreakdown,
+        models: { "gpt-5.5": incomingBreakdown },
+      },
+    };
+
+    mockState.clientContributionToBreakdownData.mockReturnValue(incomingBreakdown);
+    mockState.mergeClientBreakdownsWithRegressionGuard.mockReturnValue({
+      merged: mergedBreakdown,
+      warnings: [],
+    });
+    mockState.recalculateDayTotals.mockReturnValue({
+      tokens: 15,
+      cost: 0.75,
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+    mockState.mergeTimestampMs.mockReturnValue(456);
+
+    const selectResults = [
+      [{ id: "submission-1" }],
+      // fetchExistingDeviceDays() for dev_phone: a row already visible under
+      // this device key (non-empty, so the legacy-adoption branch is
+      // skipped) -- what matters for this test is that the merged row gets
+      // re-stamped with the *current* submitting device's id below.
+      [{
+        id: "daily-old-device",
+        date: "2026-04-30",
+        timestampMs: 123,
+        activeTimeMs: null,
+        sourceBreakdown: existingBreakdown,
+      }],
+      // existingDays across the WHOLE submission.
+      [{
+        id: "daily-old-device",
+        date: "2026-04-30",
+        timestampMs: 123,
+        activeTimeMs: null,
+        sourceBreakdown: existingBreakdown,
+      }],
+      [{
+        totalTokens: 15,
+        totalCost: "0.7500",
+        inputTokens: 10,
+        outputTokens: 5,
+        dateStart: "2026-04-30",
+        dateEnd: "2026-04-30",
+        activeDays: 1,
+        rowCount: 1,
+      }],
+      [{ sourceBreakdown: mergedBreakdown }],
+    ];
+
+    const tx = {
+      update: vi.fn(() => {
+        const builder = {
+          set: vi.fn(() => builder),
+          where: vi.fn(() => Promise.resolve()),
+        };
+        return builder;
+      }),
+      select: vi.fn(() => makeAwaitableBuilder(selectResults.shift() ?? [])),
+      insert: vi.fn(() => {
+        const builder = {
+          values: vi.fn(() => builder),
+          onConflictDoUpdate: vi.fn(() => builder),
+          returning: vi.fn(() => Promise.resolve([{ id: "submitted-device-phone" }])),
+        };
+        return builder;
+      }),
+      execute: vi.fn((..._args: unknown[]) => Promise.resolve()),
+      transaction: vi.fn(async (callback: (sp: typeof tx) => Promise<unknown>) =>
+        callback(tx)
+      ),
+    };
+    type MockTransaction = typeof tx;
+
+    mockState.db.transaction.mockImplementation(async (callback: (tx: MockTransaction) => Promise<unknown>) =>
+      callback(tx)
+    );
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ meta: {}, contributions: [] }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(tx.execute).toHaveBeenCalledTimes(1);
+    expect(flattenSqlChunks(tx.execute.mock.calls[0][0])).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("UPDATE daily_breakdown"),
+        "daily-old-device",
+        "submitted-device-phone",
+      ]),
+    );
   });
 
   it("merges after a concurrent first submit creates the submission first", async () => {

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -28,6 +28,66 @@ const LEGACY_SUBMIT_DEVICE_NAME = "Legacy submissions";
 // across multiple INSERT statements to stay well under that limit.
 const INSERT_CHUNK_SIZE = 1000;
 
+// "kilocode" is a legacy alias of "kilo" (mirrors LEGACY_CLIENT_ALIASES in
+// lib/validation/submission.ts and lib/publicProfileData.ts). Incoming
+// contributions are already normalized to "kilo" by validateSubmission's
+// preprocessing, but a daily_breakdown row's stored source_breakdown JSON
+// can still carry a "kilocode" key written before that normalization
+// existed. Fold it into "kilo" before merging so the day-level merge treats
+// the two as the SAME client instead of summing them as disjoint clients
+// (which would double-count the same underlying usage).
+const LEGACY_CLIENT_ALIASES: Record<string, string> = { kilocode: "kilo" };
+
+function mergeModelBreakdowns(
+  target: Record<string, ClientBreakdownData["models"][string]>,
+  incoming: Record<string, ClientBreakdownData["models"][string]>
+): void {
+  for (const [modelId, modelData] of Object.entries(incoming)) {
+    const existingModel = target[modelId];
+    if (existingModel) {
+      existingModel.tokens += modelData.tokens || 0;
+      existingModel.cost += modelData.cost || 0;
+      existingModel.input += modelData.input || 0;
+      existingModel.output += modelData.output || 0;
+      existingModel.cacheRead += modelData.cacheRead || 0;
+      existingModel.cacheWrite += modelData.cacheWrite || 0;
+      existingModel.reasoning = (existingModel.reasoning || 0) + (modelData.reasoning || 0);
+      existingModel.messages += modelData.messages || 0;
+    } else {
+      target[modelId] = { ...modelData };
+    }
+  }
+}
+
+function normalizeClientBreakdownAliases(
+  breakdown: Record<string, ClientBreakdownData>
+): Record<string, ClientBreakdownData> {
+  const normalized: Record<string, ClientBreakdownData> = {};
+
+  for (const [rawClientName, data] of Object.entries(breakdown)) {
+    const clientName = LEGACY_CLIENT_ALIASES[rawClientName] ?? rawClientName;
+    const existing = normalized[clientName];
+
+    if (!existing) {
+      normalized[clientName] = { ...data, models: { ...data.models } };
+      continue;
+    }
+
+    existing.tokens += data.tokens || 0;
+    existing.cost += data.cost || 0;
+    existing.input += data.input || 0;
+    existing.output += data.output || 0;
+    existing.cacheRead += data.cacheRead || 0;
+    existing.cacheWrite += data.cacheWrite || 0;
+    existing.reasoning = (existing.reasoning || 0) + (data.reasoning || 0);
+    existing.messages += data.messages || 0;
+    mergeModelBreakdowns(existing.models, data.models || {});
+    existing.provenance = deriveClientBreakdownProvenance(existing);
+  }
+
+  return normalized;
+}
+
 function normalizeSubmissionData(data: unknown): void {
   if (!data || typeof data !== "object") return;
   const obj = data as Record<string, unknown>;
@@ -456,10 +516,9 @@ export async function POST(request: Request) {
         const existingDay = existingDaysMap.get(incomingDay.date);
 
         if (existingDay) {
-          const existingClientBreakdown = (existingDay.sourceBreakdown || {}) as Record<
-            string,
-            ClientBreakdownData
-          >;
+          const existingClientBreakdown = normalizeClientBreakdownAliases(
+            (existingDay.sourceBreakdown || {}) as Record<string, ClientBreakdownData>
+          );
           const mergeResult = mergeClientBreakdownsWithRegressionGuard(
             existingClientBreakdown,
             incomingClientBreakdown,

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -476,9 +476,30 @@ export async function POST(request: Request) {
         }
       }
 
-      // Batch INSERT new days
       if (toInsert.length > 0) {
-        await tx.insert(dailyBreakdown).values(toInsert);
+        for (const row of toInsert) {
+          await tx.execute(sql`
+            INSERT INTO daily_breakdown (
+              submission_id, submitted_device_id, date, tokens, cost,
+              input_tokens, output_tokens, timestamp_ms, active_time_ms, source_breakdown
+            ) VALUES (
+              ${row.submissionId}::uuid, ${row.submittedDeviceId}::uuid, ${row.date},
+              ${row.tokens}::bigint, ${row.cost}::numeric(14,4),
+              ${row.inputTokens}::bigint, ${row.outputTokens}::bigint,
+              ${row.timestampMs}::bigint, ${row.activeTimeMs}::bigint,
+              ${JSON.stringify(row.sourceBreakdown)}::jsonb
+            )
+            ON CONFLICT (submission_id, date) DO UPDATE SET
+              submitted_device_id = EXCLUDED.submitted_device_id,
+              tokens = EXCLUDED.tokens,
+              cost = EXCLUDED.cost,
+              input_tokens = EXCLUDED.input_tokens,
+              output_tokens = EXCLUDED.output_tokens,
+              timestamp_ms = EXCLUDED.timestamp_ms,
+              active_time_ms = EXCLUDED.active_time_ms,
+              source_breakdown = EXCLUDED.source_breakdown
+          `);
+        }
       }
 
       // Batch UPDATE existing days via raw SQL VALUES list

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -291,10 +291,10 @@ export async function POST(request: Request) {
           )
           .for('update');
 
-      let existingDays = await fetchExistingDeviceDays();
+      let existingDeviceDays = await fetchExistingDeviceDays();
 
       if (
-        existingDays.length === 0 &&
+        existingDeviceDays.length === 0 &&
         !isNewSubmission &&
         submitDevice.key !== LEGACY_SUBMIT_DEVICE_KEY
       ) {
@@ -356,8 +356,26 @@ export async function POST(request: Request) {
           // re-adopt.
           console.warn("Legacy adoption conflict (concurrent submit), falling through:", adoptionErr);
         }
-        existingDays = await fetchExistingDeviceDays();
+        existingDeviceDays = await fetchExistingDeviceDays();
       }
+
+      // Fetch existing days across the WHOLE submission (every device), not
+      // just the submitting device. A date already recorded by another
+      // device must flow through the toUpdate merge path below (which runs
+      // mergeClientBreakdownsWithRegressionGuard) instead of falling into
+      // toInsert, where ON CONFLICT DO UPDATE would blindly overwrite the
+      // other device's row with this device's raw values.
+      const existingDays = await tx
+        .select({
+          id: dailyBreakdown.id,
+          date: dailyBreakdown.date,
+          timestampMs: dailyBreakdown.timestampMs,
+          activeTimeMs: dailyBreakdown.activeTimeMs,
+          sourceBreakdown: dailyBreakdown.sourceBreakdown,
+        })
+        .from(dailyBreakdown)
+        .where(eq(dailyBreakdown.submissionId, submissionId))
+        .for('update');
 
       const existingDaysMap = new Map(
         existingDays.map((d) => [d.date, d])
@@ -476,30 +494,35 @@ export async function POST(request: Request) {
         }
       }
 
+      // Batch INSERT new days via raw SQL VALUES list. ON CONFLICT (submission_id, date)
+      // DO UPDATE is a defensive fallback for a concurrent submit racing this one
+      // between the SELECT above and this INSERT -- existingDaysMap already covers
+      // every device for this submission, so under normal (non-racing) conditions
+      // every row here is a genuinely new date.
       if (toInsert.length > 0) {
-        for (const row of toInsert) {
-          await tx.execute(sql`
-            INSERT INTO daily_breakdown (
-              submission_id, submitted_device_id, date, tokens, cost,
-              input_tokens, output_tokens, timestamp_ms, active_time_ms, source_breakdown
-            ) VALUES (
-              ${row.submissionId}::uuid, ${row.submittedDeviceId}::uuid, ${row.date},
-              ${row.tokens}::bigint, ${row.cost}::numeric(14,4),
-              ${row.inputTokens}::bigint, ${row.outputTokens}::bigint,
-              ${row.timestampMs}::bigint, ${row.activeTimeMs}::bigint,
-              ${JSON.stringify(row.sourceBreakdown)}::jsonb
-            )
-            ON CONFLICT (submission_id, date) DO UPDATE SET
-              submitted_device_id = EXCLUDED.submitted_device_id,
-              tokens = EXCLUDED.tokens,
-              cost = EXCLUDED.cost,
-              input_tokens = EXCLUDED.input_tokens,
-              output_tokens = EXCLUDED.output_tokens,
-              timestamp_ms = EXCLUDED.timestamp_ms,
-              active_time_ms = EXCLUDED.active_time_ms,
-              source_breakdown = EXCLUDED.source_breakdown
-          `);
-        }
+        const insertValuesClauses = toInsert.map(
+          (row) =>
+            sql`(${row.submissionId}::uuid, ${row.submittedDeviceId}::uuid, ${row.date}, ${row.tokens}::bigint, ${row.cost}::numeric(14,4), ${row.inputTokens}::bigint, ${row.outputTokens}::bigint, ${row.timestampMs}::bigint, ${row.activeTimeMs}::bigint, ${JSON.stringify(row.sourceBreakdown)}::jsonb)`
+        );
+
+        const insertValuesList = sql.join(insertValuesClauses, sql`, `);
+
+        await tx.execute(sql`
+          INSERT INTO daily_breakdown (
+            submission_id, submitted_device_id, date, tokens, cost,
+            input_tokens, output_tokens, timestamp_ms, active_time_ms, source_breakdown
+          )
+          VALUES ${insertValuesList}
+          ON CONFLICT (submission_id, date) DO UPDATE SET
+            submitted_device_id = EXCLUDED.submitted_device_id,
+            tokens = EXCLUDED.tokens,
+            cost = EXCLUDED.cost,
+            input_tokens = EXCLUDED.input_tokens,
+            output_tokens = EXCLUDED.output_tokens,
+            timestamp_ms = EXCLUDED.timestamp_ms,
+            active_time_ms = EXCLUDED.active_time_ms,
+            source_breakdown = EXCLUDED.source_breakdown
+        `);
       }
 
       // Batch UPDATE existing days via raw SQL VALUES list

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -23,6 +23,10 @@ import { LEGACY_DEVICE_KEY } from "@/lib/devices/shared";
 
 const LEGACY_SUBMIT_DEVICE_KEY = LEGACY_DEVICE_KEY;
 const LEGACY_SUBMIT_DEVICE_NAME = "Legacy submissions";
+// PostgreSQL caps a single statement at 65,535 bound parameters. Each
+// inserted row binds 10 params, so chunk large backfills (e.g. ~6,500+ days)
+// across multiple INSERT statements to stay well under that limit.
+const INSERT_CHUNK_SIZE = 1000;
 
 function normalizeSubmissionData(data: unknown): void {
   if (!data || typeof data !== "object") return;
@@ -399,6 +403,7 @@ export async function POST(request: Request) {
 
       const toUpdate: Array<{
         id: string;
+        submittedDeviceId: string;
         tokens: number;
         cost: string;
         inputTokens: number;
@@ -468,6 +473,7 @@ export async function POST(request: Request) {
 
           toUpdate.push({
             id: existingDay.id,
+            submittedDeviceId: submittedDevice.id,
             tokens: dayTotals.tokens,
             cost: dayTotals.cost.toFixed(4),
             inputTokens: dayTotals.inputTokens,
@@ -494,13 +500,17 @@ export async function POST(request: Request) {
         }
       }
 
-      // Batch INSERT new days via raw SQL VALUES list. ON CONFLICT (submission_id, date)
-      // DO UPDATE is a defensive fallback for a concurrent submit racing this one
-      // between the SELECT above and this INSERT -- existingDaysMap already covers
-      // every device for this submission, so under normal (non-racing) conditions
-      // every row here is a genuinely new date.
-      if (toInsert.length > 0) {
-        const insertValuesClauses = toInsert.map(
+      // Batch INSERT new days via raw SQL VALUES list, chunked to stay under
+      // PostgreSQL's 65,535 bound-parameter limit (10 params/row here --
+      // a large historical backfill can otherwise exceed it in one statement).
+      // ON CONFLICT (submission_id, date) DO UPDATE is a defensive fallback
+      // for a concurrent submit racing this one between the SELECT above and
+      // this INSERT -- existingDaysMap already covers every device for this
+      // submission, so under normal (non-racing) conditions every row here is
+      // a genuinely new date.
+      for (let i = 0; i < toInsert.length; i += INSERT_CHUNK_SIZE) {
+        const chunk = toInsert.slice(i, i + INSERT_CHUNK_SIZE);
+        const insertValuesClauses = chunk.map(
           (row) =>
             sql`(${row.submissionId}::uuid, ${row.submittedDeviceId}::uuid, ${row.date}, ${row.tokens}::bigint, ${row.cost}::numeric(14,4), ${row.inputTokens}::bigint, ${row.outputTokens}::bigint, ${row.timestampMs}::bigint, ${row.activeTimeMs}::bigint, ${JSON.stringify(row.sourceBreakdown)}::jsonb)`
         );
@@ -525,17 +535,23 @@ export async function POST(request: Request) {
         `);
       }
 
-      // Batch UPDATE existing days via raw SQL VALUES list
-      if (toUpdate.length > 0) {
-        const valuesClauses = toUpdate.map(
+      // Batch UPDATE existing days via raw SQL VALUES list, chunked for the
+      // same parameter-limit reason as the INSERT above. Includes
+      // submitted_device_id so a replacement-device submit re-attributes the
+      // merged row to the submitting device instead of leaving it stamped
+      // with the previous device that first created the row.
+      for (let i = 0; i < toUpdate.length; i += INSERT_CHUNK_SIZE) {
+        const chunk = toUpdate.slice(i, i + INSERT_CHUNK_SIZE);
+        const valuesClauses = chunk.map(
           (row) =>
-            sql`(${row.id}::uuid, ${row.tokens}::bigint, ${row.cost}::numeric(14,4), ${row.inputTokens}::bigint, ${row.outputTokens}::bigint, ${row.timestampMs}::bigint, ${row.activeTimeMs}::bigint, ${JSON.stringify(row.sourceBreakdown)}::jsonb)`
+            sql`(${row.id}::uuid, ${row.submittedDeviceId}::uuid, ${row.tokens}::bigint, ${row.cost}::numeric(14,4), ${row.inputTokens}::bigint, ${row.outputTokens}::bigint, ${row.timestampMs}::bigint, ${row.activeTimeMs}::bigint, ${JSON.stringify(row.sourceBreakdown)}::jsonb)`
         );
 
         const valuesList = sql.join(valuesClauses, sql`, `);
 
         await tx.execute(sql`
           UPDATE daily_breakdown AS d SET
+            submitted_device_id = batch.submitted_device_id,
             tokens = batch.tokens,
             cost = batch.cost,
             input_tokens = batch.input_tokens,
@@ -544,7 +560,7 @@ export async function POST(request: Request) {
             active_time_ms = batch.active_time_ms,
             source_breakdown = batch.source_breakdown
           FROM (VALUES ${valuesList})
-            AS batch(id, tokens, cost, input_tokens, output_tokens, timestamp_ms, active_time_ms, source_breakdown)
+            AS batch(id, submitted_device_id, tokens, cost, input_tokens, output_tokens, timestamp_ms, active_time_ms, source_breakdown)
           WHERE d.id = batch.id
         `);
       }

--- a/packages/frontend/src/lib/db/migrations/0015_restore_submission_date_unique.sql
+++ b/packages/frontend/src/lib/db/migrations/0015_restore_submission_date_unique.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "daily_breakdown" ADD CONSTRAINT "daily_breakdown_submission_id_date_key" UNIQUE ("submission_id", "date");

--- a/packages/frontend/src/lib/db/migrations/0015_restore_submission_date_unique.sql
+++ b/packages/frontend/src/lib/db/migrations/0015_restore_submission_date_unique.sql
@@ -6,10 +6,21 @@
 -- ADD CONSTRAINT UNIQUE (submission_id, date) would abort at deploy time.
 --
 -- Before restoring the (submission_id, date) uniqueness, merge any existing
--- duplicate (submission_id, date) rows into a single row: sum the numeric
--- totals, deep-merge source_breakdown per client/model, keep the row
--- belonging to whichever device most recently submitted, and delete the
--- rest.
+-- duplicate (submission_id, date) rows into a single row and delete the
+-- rest. The merge is per-client-key aware, not a blind sum of row totals:
+-- the PR's core scenario is a DEVICE CHANGE, where the same local history is
+-- resubmitted under a new device id, so two duplicate rows commonly carry
+-- the *same* client keys describing the *same* underlying usage. Summing
+-- those would double the user's daily usage. Instead, within
+-- source_breakdown, a client key that appears in more than one row keeps
+-- only the newest-submitting device's version of that client (the same
+-- "latest snapshot wins" semantics the route's
+-- mergeClientBreakdownsWithRegressionGuard applies to same-device
+-- resubmits). A client key that appears in exactly one row (a genuine
+-- two-machine duplicate with distinct client usage) is kept as-is. Row
+-- totals (tokens, cost, input, output) are then recomputed from the merged
+-- per-client breakdown rather than summed across rows, so they can never
+-- double-count a device-change duplicate.
 DO $$
 DECLARE
   dup RECORD;
@@ -25,10 +36,6 @@ DECLARE
   keep_device_id UUID;
   client_key TEXT;
   client_val JSONB;
-  existing_client_val JSONB;
-  model_key TEXT;
-  model_val JSONB;
-  existing_model_val JSONB;
 BEGIN
   FOR dup IN
     SELECT submission_id, date
@@ -37,10 +44,6 @@ BEGIN
     HAVING COUNT(*) > 1
   LOOP
     merged_source := '{}'::jsonb;
-    merged_tokens := 0;
-    merged_cost := 0;
-    merged_input := 0;
-    merged_output := 0;
     merged_timestamp_ms := NULL;
     merged_active_time_ms := NULL;
     keep_id := NULL;
@@ -48,11 +51,12 @@ BEGIN
 
     -- Rows for this (submission_id, date), most-recently-submitting device
     -- first. The first row visited becomes the row we keep (its id and
-    -- submitted_device_id survive); every row's numeric/JSON data is folded
-    -- into the merged totals regardless of visit order.
+    -- submitted_device_id survive). Client keys are folded in newest-first:
+    -- the first (newest) occurrence of a given client key wins outright, and
+    -- later (older) occurrences of the same key are skipped rather than
+    -- summed in.
     FOR device_row IN
-      SELECT db."id", db."submitted_device_id", db."tokens", db."cost",
-             db."input_tokens", db."output_tokens", db."timestamp_ms",
+      SELECT db."id", db."submitted_device_id", db."timestamp_ms",
              db."active_time_ms", db."source_breakdown"
       FROM daily_breakdown db
       LEFT JOIN submitted_devices sd ON sd."id" = db."submitted_device_id"
@@ -65,10 +69,6 @@ BEGIN
         keep_device_id := device_row."submitted_device_id";
       END IF;
 
-      merged_tokens := merged_tokens + COALESCE(device_row."tokens", 0);
-      merged_cost := merged_cost + COALESCE(device_row."cost", 0);
-      merged_input := merged_input + COALESCE(device_row."input_tokens", 0);
-      merged_output := merged_output + COALESCE(device_row."output_tokens", 0);
       merged_active_time_ms := COALESCE(merged_active_time_ms, 0) + COALESCE(device_row."active_time_ms", 0);
       merged_timestamp_ms := LEAST(
         COALESCE(merged_timestamp_ms, device_row."timestamp_ms"),
@@ -79,64 +79,22 @@ BEGIN
         FOR client_key, client_val IN
           SELECT key, value FROM jsonb_each(device_row."source_breakdown")
         LOOP
-          existing_client_val := merged_source -> client_key;
-
-          IF existing_client_val IS NULL THEN
+          IF NOT (merged_source ? client_key) THEN
             merged_source := jsonb_set(merged_source, ARRAY[client_key], client_val, true);
-          ELSE
-            existing_client_val := jsonb_set(existing_client_val, '{tokens}',
-              to_jsonb(COALESCE((existing_client_val->>'tokens')::numeric, 0) + COALESCE((client_val->>'tokens')::numeric, 0)));
-            existing_client_val := jsonb_set(existing_client_val, '{cost}',
-              to_jsonb(COALESCE((existing_client_val->>'cost')::numeric, 0) + COALESCE((client_val->>'cost')::numeric, 0)));
-            existing_client_val := jsonb_set(existing_client_val, '{input}',
-              to_jsonb(COALESCE((existing_client_val->>'input')::numeric, 0) + COALESCE((client_val->>'input')::numeric, 0)));
-            existing_client_val := jsonb_set(existing_client_val, '{output}',
-              to_jsonb(COALESCE((existing_client_val->>'output')::numeric, 0) + COALESCE((client_val->>'output')::numeric, 0)));
-            existing_client_val := jsonb_set(existing_client_val, '{cacheRead}',
-              to_jsonb(COALESCE((existing_client_val->>'cacheRead')::numeric, 0) + COALESCE((client_val->>'cacheRead')::numeric, 0)));
-            existing_client_val := jsonb_set(existing_client_val, '{cacheWrite}',
-              to_jsonb(COALESCE((existing_client_val->>'cacheWrite')::numeric, 0) + COALESCE((client_val->>'cacheWrite')::numeric, 0)));
-            existing_client_val := jsonb_set(existing_client_val, '{reasoning}',
-              to_jsonb(COALESCE((existing_client_val->>'reasoning')::numeric, 0) + COALESCE((client_val->>'reasoning')::numeric, 0)));
-            existing_client_val := jsonb_set(existing_client_val, '{messages}',
-              to_jsonb(COALESCE((existing_client_val->>'messages')::numeric, 0) + COALESCE((client_val->>'messages')::numeric, 0)));
-
-            IF client_val ? 'models' THEN
-              FOR model_key, model_val IN
-                SELECT key, value FROM jsonb_each(client_val -> 'models')
-              LOOP
-                existing_model_val := existing_client_val #> ARRAY['models', model_key];
-
-                IF existing_model_val IS NULL THEN
-                  existing_client_val := jsonb_set(existing_client_val, ARRAY['models', model_key], model_val, true);
-                ELSE
-                  existing_model_val := jsonb_set(existing_model_val, '{tokens}',
-                    to_jsonb(COALESCE((existing_model_val->>'tokens')::numeric, 0) + COALESCE((model_val->>'tokens')::numeric, 0)));
-                  existing_model_val := jsonb_set(existing_model_val, '{cost}',
-                    to_jsonb(COALESCE((existing_model_val->>'cost')::numeric, 0) + COALESCE((model_val->>'cost')::numeric, 0)));
-                  existing_model_val := jsonb_set(existing_model_val, '{input}',
-                    to_jsonb(COALESCE((existing_model_val->>'input')::numeric, 0) + COALESCE((model_val->>'input')::numeric, 0)));
-                  existing_model_val := jsonb_set(existing_model_val, '{output}',
-                    to_jsonb(COALESCE((existing_model_val->>'output')::numeric, 0) + COALESCE((model_val->>'output')::numeric, 0)));
-                  existing_model_val := jsonb_set(existing_model_val, '{cacheRead}',
-                    to_jsonb(COALESCE((existing_model_val->>'cacheRead')::numeric, 0) + COALESCE((model_val->>'cacheRead')::numeric, 0)));
-                  existing_model_val := jsonb_set(existing_model_val, '{cacheWrite}',
-                    to_jsonb(COALESCE((existing_model_val->>'cacheWrite')::numeric, 0) + COALESCE((model_val->>'cacheWrite')::numeric, 0)));
-                  existing_model_val := jsonb_set(existing_model_val, '{reasoning}',
-                    to_jsonb(COALESCE((existing_model_val->>'reasoning')::numeric, 0) + COALESCE((model_val->>'reasoning')::numeric, 0)));
-                  existing_model_val := jsonb_set(existing_model_val, '{messages}',
-                    to_jsonb(COALESCE((existing_model_val->>'messages')::numeric, 0) + COALESCE((model_val->>'messages')::numeric, 0)));
-
-                  existing_client_val := jsonb_set(existing_client_val, ARRAY['models', model_key], existing_model_val, true);
-                END IF;
-              END LOOP;
-            END IF;
-
-            merged_source := jsonb_set(merged_source, ARRAY[client_key], existing_client_val, true);
           END IF;
         END LOOP;
       END IF;
     END LOOP;
+
+    -- Recompute row totals from the merged per-client breakdown rather than
+    -- summing row totals across duplicate rows.
+    SELECT
+      COALESCE(SUM((value->>'tokens')::numeric), 0),
+      COALESCE(SUM((value->>'cost')::numeric), 0),
+      COALESCE(SUM((value->>'input')::numeric), 0),
+      COALESCE(SUM((value->>'output')::numeric), 0)
+    INTO merged_tokens, merged_cost, merged_input, merged_output
+    FROM jsonb_each(merged_source);
 
     UPDATE daily_breakdown
     SET "submitted_device_id" = keep_device_id,

--- a/packages/frontend/src/lib/db/migrations/0015_restore_submission_date_unique.sql
+++ b/packages/frontend/src/lib/db/migrations/0015_restore_submission_date_unique.sql
@@ -13,14 +13,92 @@
 -- the *same* client keys describing the *same* underlying usage. Summing
 -- those would double the user's daily usage. Instead, within
 -- source_breakdown, a client key that appears in more than one row keeps
--- only the newest-submitting device's version of that client (the same
--- "latest snapshot wins" semantics the route's
--- mergeClientBreakdownsWithRegressionGuard applies to same-device
--- resubmits). A client key that appears in exactly one row (a genuine
--- two-machine duplicate with distinct client usage) is kept as-is. Row
--- totals (tokens, cost, input, output) are then recomputed from the merged
--- per-client breakdown rather than summed across rows, so they can never
--- double-count a device-change duplicate.
+-- only ONE row's version of that client -- preferring the most-recently-
+-- submitting device's snapshot UNLESS it would regress (lower token total)
+-- relative to another duplicate's snapshot of the same client, in which
+-- case the larger-token version is kept. This mirrors the runtime's
+-- mergeClientBreakdownsWithRegressionGuard (lib/db/helpers.ts), which
+-- likewise refuses to let a fresher-but-smaller snapshot silently erase a
+-- larger one, e.g. an incomplete newer local history export. A client key
+-- that appears in exactly one row (a genuine two-machine duplicate with
+-- distinct client usage) is kept as-is.
+--
+-- "kilocode" is a legacy alias of "kilo" (see LEGACY_CLIENT_ALIASES in
+-- lib/validation/submission.ts and lib/publicProfileData.ts): older CLI
+-- versions wrote source_breakdown entries keyed "kilocode" for the same
+-- client newer versions key "kilo". Both keys are normalized to "kilo"
+-- before folding, so a pre-alias duplicate and a post-alias duplicate of
+-- the same underlying usage collide onto one key (subject to the same
+-- newest-wins-unless-regression rule above) instead of being summed as if
+-- they were two disjoint clients.
+--
+-- A duplicate row can also have source_breakdown = NULL: this is legacy
+-- schemaVersion 0/1 data written before the CLI tracked a per-client
+-- breakdown at all -- the row only carries a row-level total (tokens,
+-- cost, input_tokens, output_tokens). It has no client key to fold into
+-- source_breakdown, but its usage must never be silently dropped just
+-- because it lacks JSON attribution. It is folded in as an anonymous
+-- "pseudo-client" contribution using the same newest-wins-unless-regression
+-- rule (compared only against other NULL-breakdown duplicates for that
+-- day, since there's no way to tell whether it overlaps with any specific
+-- real client's usage), added into the row's numeric totals but kept out
+-- of the persisted source_breakdown JSON since it has no real client
+-- identity to attribute it to. If every duplicate for a day was
+-- NULL-breakdown, the merged row's source_breakdown stays NULL, preserving
+-- the original "row-total-only, no per-client attribution" semantics.
+--
+-- Row totals (tokens, cost, input, output) are recomputed from the merged
+-- per-client breakdown (plus any legacy pseudo-client contribution) rather
+-- than summed across rows, so they can never double-count a device-change
+-- duplicate.
+--
+-- active_time_ms is tracked at the row level only (there is no per-client
+-- active-time breakdown), so duplicate rows cannot be disambiguated into
+-- "overlapping" vs. "genuinely additional" active time the way per-client
+-- token data can. Unconditionally summing it across duplicates would
+-- always double it for this migration's core device-change-duplicate
+-- scenario, so the merge takes the MAX active_time_ms across duplicates
+-- instead -- a safe value that never fabricates time beyond what any
+-- single duplicate actually reported for the day, and never drops it
+-- either.
+--
+-- Because this merge can shrink a submission's daily_breakdown rows (and
+-- therefore its true totals), any submissions that had at least one
+-- duplicate merged have their denormalized `submissions` totals (total
+-- tokens/cost/input/output, cache/reasoning tokens, date range, active
+-- time, sources_used, models_used) recomputed from the now-deduplicated
+-- daily_breakdown rows at the end of this migration, mirroring the
+-- aggregation route.ts performs on every submit (STEP 3d/3e in
+-- app/api/submit/route.ts). Without this, a duplicate's tokens that were
+-- already counted into `submissions.total_tokens` at submit time would
+-- stay inflated forever for a user who never submits again.
+--
+-- Finally, an old-version CLI/writer could otherwise insert a new
+-- (submission_id, date) duplicate between this migration's scan and the
+-- ADD CONSTRAINT below, aborting the migration. LOCK TABLE daily_breakdown
+-- IN SHARE ROW EXCLUSIVE MODE at the top of this transaction blocks any
+-- concurrent WRITE to daily_breakdown -- INSERT/UPDATE/DELETE, including
+-- the submit route's raw INSERT ... ON CONFLICT / UPDATE statements, all of
+-- which need at least ROW EXCLUSIVE -- until this transaction commits.
+-- (Verified: SHARE ROW EXCLUSIVE does NOT block ACCESS SHARE (plain reads,
+-- e.g. leaderboard/profile pages) or ROW SHARE (SELECT ... FOR UPDATE, used
+-- by the submit route to lock candidate rows before deciding whether to
+-- insert or update); it only blocks the actual write once one is attempted,
+-- which is exactly what closes the race here -- a FOR UPDATE read alone
+-- cannot create a duplicate row.) The stronger EXCLUSIVE MODE was
+-- considered but rejected: it would additionally block SELECT ... FOR
+-- UPDATE/FOR SHARE reads (needless extra blocking of the submit route's
+-- read step) without closing any race that SHARE ROW EXCLUSIVE doesn't
+-- already close, since the write itself is what must be serialized against.
+LOCK TABLE daily_breakdown IN SHARE ROW EXCLUSIVE MODE;
+--> statement-breakpoint
+-- Tracks which submissions actually had a duplicate merged, so the totals
+-- recompute at the end of this migration only touches submissions whose
+-- denormalized totals could actually have gone stale.
+DROP TABLE IF EXISTS affected_submissions_0015;
+--> statement-breakpoint
+CREATE TEMP TABLE affected_submissions_0015 (submission_id uuid PRIMARY KEY);
+--> statement-breakpoint
 DO $$
 DECLARE
   dup RECORD;
@@ -32,10 +110,15 @@ DECLARE
   merged_output NUMERIC;
   merged_timestamp_ms BIGINT;
   merged_active_time_ms BIGINT;
+  active_time_seen BOOLEAN;
   keep_id UUID;
   keep_device_id UUID;
   client_key TEXT;
   client_val JSONB;
+  legacy_tokens NUMERIC;
+  legacy_cost NUMERIC;
+  legacy_input NUMERIC;
+  legacy_output NUMERIC;
 BEGIN
   FOR dup IN
     SELECT submission_id, date
@@ -45,19 +128,30 @@ BEGIN
   LOOP
     merged_source := '{}'::jsonb;
     merged_timestamp_ms := NULL;
-    merged_active_time_ms := NULL;
+    merged_active_time_ms := 0;
+    active_time_seen := FALSE;
     keep_id := NULL;
     keep_device_id := NULL;
+    legacy_tokens := NULL;
+    legacy_cost := NULL;
+    legacy_input := NULL;
+    legacy_output := NULL;
+
+    INSERT INTO affected_submissions_0015 (submission_id)
+    VALUES (dup.submission_id)
+    ON CONFLICT DO NOTHING;
 
     -- Rows for this (submission_id, date), most-recently-submitting device
     -- first. The first row visited becomes the row we keep (its id and
-    -- submitted_device_id survive). Client keys are folded in newest-first:
-    -- the first (newest) occurrence of a given client key wins outright, and
-    -- later (older) occurrences of the same key are skipped rather than
-    -- summed in.
+    -- submitted_device_id survive). Client keys (and the legacy NULL
+    -- pseudo-client, and active_time_ms) are folded in newest-first: the
+    -- first (newest) occurrence of a given key wins by default, but a later
+    -- (older) occurrence can still override it under the regression guard
+    -- below.
     FOR device_row IN
       SELECT db."id", db."submitted_device_id", db."timestamp_ms",
-             db."active_time_ms", db."source_breakdown"
+             db."active_time_ms", db."source_breakdown",
+             db."tokens", db."cost", db."input_tokens", db."output_tokens"
       FROM daily_breakdown db
       LEFT JOIN submitted_devices sd ON sd."id" = db."submitted_device_id"
       WHERE db."submission_id" = dup.submission_id
@@ -69,7 +163,11 @@ BEGIN
         keep_device_id := device_row."submitted_device_id";
       END IF;
 
-      merged_active_time_ms := COALESCE(merged_active_time_ms, 0) + COALESCE(device_row."active_time_ms", 0);
+      IF device_row."active_time_ms" IS NOT NULL THEN
+        active_time_seen := TRUE;
+        merged_active_time_ms := GREATEST(merged_active_time_ms, device_row."active_time_ms");
+      END IF;
+
       merged_timestamp_ms := LEAST(
         COALESCE(merged_timestamp_ms, device_row."timestamp_ms"),
         COALESCE(device_row."timestamp_ms", merged_timestamp_ms)
@@ -79,15 +177,37 @@ BEGIN
         FOR client_key, client_val IN
           SELECT key, value FROM jsonb_each(device_row."source_breakdown")
         LOOP
+          IF client_key = 'kilocode' THEN
+            client_key := 'kilo';
+          END IF;
+
           IF NOT (merged_source ? client_key) THEN
+            merged_source := jsonb_set(merged_source, ARRAY[client_key], client_val, true);
+          ELSIF COALESCE((client_val->>'tokens')::numeric, 0) >
+                COALESCE((merged_source->client_key->>'tokens')::numeric, 0) THEN
+            -- Regression guard: prefer the newest row's version of a client
+            -- UNLESS it has fewer tokens than another duplicate's version of
+            -- the same client, in which case keep the larger one.
             merged_source := jsonb_set(merged_source, ARRAY[client_key], client_val, true);
           END IF;
         END LOOP;
+      ELSE
+        -- Legacy pseudo-client contribution (see header comment). Only
+        -- overridden by another NULL-breakdown duplicate with a strictly
+        -- larger row total, same regression-guard rule as real client keys.
+        IF legacy_tokens IS NULL OR COALESCE(device_row."tokens", 0) > legacy_tokens THEN
+          legacy_tokens := COALESCE(device_row."tokens", 0);
+          legacy_cost := COALESCE(device_row."cost", 0);
+          legacy_input := COALESCE(device_row."input_tokens", 0);
+          legacy_output := COALESCE(device_row."output_tokens", 0);
+        END IF;
       END IF;
     END LOOP;
 
     -- Recompute row totals from the merged per-client breakdown rather than
-    -- summing row totals across duplicate rows.
+    -- summing row totals across duplicate rows, then add back any legacy
+    -- pseudo-client contribution so a NULL-breakdown duplicate's usage is
+    -- preserved even though it has no client key of its own.
     SELECT
       COALESCE(SUM((value->>'tokens')::numeric), 0),
       COALESCE(SUM((value->>'cost')::numeric), 0),
@@ -96,6 +216,11 @@ BEGIN
     INTO merged_tokens, merged_cost, merged_input, merged_output
     FROM jsonb_each(merged_source);
 
+    merged_tokens := merged_tokens + COALESCE(legacy_tokens, 0);
+    merged_cost := merged_cost + COALESCE(legacy_cost, 0);
+    merged_input := merged_input + COALESCE(legacy_input, 0);
+    merged_output := merged_output + COALESCE(legacy_output, 0);
+
     UPDATE daily_breakdown
     SET "submitted_device_id" = keep_device_id,
         "tokens" = merged_tokens,
@@ -103,8 +228,11 @@ BEGIN
         "input_tokens" = merged_input,
         "output_tokens" = merged_output,
         "timestamp_ms" = merged_timestamp_ms,
-        "active_time_ms" = merged_active_time_ms,
-        "source_breakdown" = merged_source
+        "active_time_ms" = CASE WHEN active_time_seen THEN merged_active_time_ms ELSE NULL END,
+        "source_breakdown" = CASE
+          WHEN merged_source = '{}'::jsonb AND legacy_tokens IS NOT NULL THEN NULL
+          ELSE merged_source
+        END
     WHERE "id" = keep_id;
 
     DELETE FROM daily_breakdown
@@ -128,3 +256,82 @@ BEGIN
     ALTER TABLE "daily_breakdown" ADD CONSTRAINT "daily_breakdown_submission_id_date_key" UNIQUE ("submission_id", "date");
   END IF;
 END $$;
+--> statement-breakpoint
+-- Recompute denormalized `submissions` totals for every submission that had
+-- at least one duplicate merged above (see header comment). On a re-run
+-- where no duplicates remain, affected_submissions_0015 is empty and this
+-- is a no-op, keeping the migration idempotent.
+WITH client_rows AS (
+  SELECT
+    db.submission_id,
+    CASE WHEN c.key = 'kilocode' THEN 'kilo' ELSE c.key END AS client_name,
+    c.value AS client_value
+  FROM daily_breakdown db
+  CROSS JOIN LATERAL jsonb_each(COALESCE(db.source_breakdown, '{}'::jsonb)) AS c(key, value)
+  WHERE db.submission_id IN (SELECT submission_id FROM affected_submissions_0015)
+),
+model_rows AS (
+  -- Mirrors route.ts STEP 3d: use a client's `models` map when present (even
+  -- if empty), falling back to the legacy singular `modelId` field only when
+  -- `models` is absent entirely.
+  SELECT cr.submission_id, m.key AS model_id
+  FROM client_rows cr
+  CROSS JOIN LATERAL jsonb_object_keys(COALESCE(cr.client_value->'models', '{}'::jsonb)) AS m(key)
+  WHERE cr.client_value ? 'models'
+  UNION ALL
+  SELECT cr.submission_id, cr.client_value->>'modelId' AS model_id
+  FROM client_rows cr
+  WHERE NOT (cr.client_value ? 'models') AND cr.client_value ? 'modelId'
+),
+client_agg AS (
+  SELECT
+    submission_id,
+    COALESCE(SUM((client_value->>'cacheRead')::numeric), 0)::bigint AS cache_read_tokens,
+    COALESCE(SUM((client_value->>'cacheWrite')::numeric), 0)::bigint AS cache_creation_tokens,
+    COALESCE(SUM((client_value->>'reasoning')::numeric), 0)::bigint AS reasoning_tokens,
+    array_agg(DISTINCT client_name) AS sources_used
+  FROM client_rows
+  GROUP BY submission_id
+),
+model_agg AS (
+  SELECT
+    submission_id,
+    array_agg(DISTINCT model_id) FILTER (WHERE model_id IS NOT NULL) AS models_used
+  FROM model_rows
+  GROUP BY submission_id
+),
+day_agg AS (
+  SELECT
+    db.submission_id,
+    COALESCE(SUM(db.tokens), 0)::bigint AS total_tokens,
+    COALESCE(SUM(db.cost), 0) AS total_cost,
+    COALESCE(SUM(db.input_tokens), 0)::bigint AS input_tokens,
+    COALESCE(SUM(db.output_tokens), 0)::bigint AS output_tokens,
+    MIN(db.date) AS date_start,
+    MAX(db.date) AS date_end,
+    COALESCE(SUM(db.active_time_ms), 0)::bigint AS total_active_time_ms
+  FROM daily_breakdown db
+  WHERE db.submission_id IN (SELECT submission_id FROM affected_submissions_0015)
+  GROUP BY db.submission_id
+)
+UPDATE submissions s
+SET
+  total_tokens = da.total_tokens,
+  total_cost = da.total_cost,
+  input_tokens = da.input_tokens,
+  output_tokens = da.output_tokens,
+  cache_read_tokens = COALESCE(ca.cache_read_tokens, 0),
+  cache_creation_tokens = COALESCE(ca.cache_creation_tokens, 0),
+  reasoning_tokens = COALESCE(ca.reasoning_tokens, 0),
+  date_start = da.date_start,
+  date_end = da.date_end,
+  total_active_time_ms = da.total_active_time_ms,
+  sources_used = COALESCE(ca.sources_used, '{}'::text[]),
+  models_used = COALESCE(ma.models_used, '{}'::text[]),
+  updated_at = now()
+FROM day_agg da
+LEFT JOIN client_agg ca ON ca.submission_id = da.submission_id
+LEFT JOIN model_agg ma ON ma.submission_id = da.submission_id
+WHERE s.id = da.submission_id;
+--> statement-breakpoint
+DROP TABLE IF EXISTS affected_submissions_0015;

--- a/packages/frontend/src/lib/db/migrations/0015_restore_submission_date_unique.sql
+++ b/packages/frontend/src/lib/db/migrations/0015_restore_submission_date_unique.sql
@@ -1,1 +1,172 @@
-ALTER TABLE "daily_breakdown" ADD CONSTRAINT "daily_breakdown_submission_id_date_key" UNIQUE ("submission_id", "date");
+-- Migration 0007 deliberately dropped the (submission_id, date) unique
+-- constraint in favor of (submission_id, submitted_device_id, date) so that
+-- multi-device users could hold one daily_breakdown row per device per day.
+-- That means production can already contain multiple rows sharing the same
+-- (submission_id, date) across different devices, so a bare
+-- ADD CONSTRAINT UNIQUE (submission_id, date) would abort at deploy time.
+--
+-- Before restoring the (submission_id, date) uniqueness, merge any existing
+-- duplicate (submission_id, date) rows into a single row: sum the numeric
+-- totals, deep-merge source_breakdown per client/model, keep the row
+-- belonging to whichever device most recently submitted, and delete the
+-- rest.
+DO $$
+DECLARE
+  dup RECORD;
+  device_row RECORD;
+  merged_source JSONB;
+  merged_tokens NUMERIC;
+  merged_cost NUMERIC;
+  merged_input NUMERIC;
+  merged_output NUMERIC;
+  merged_timestamp_ms BIGINT;
+  merged_active_time_ms BIGINT;
+  keep_id UUID;
+  keep_device_id UUID;
+  client_key TEXT;
+  client_val JSONB;
+  existing_client_val JSONB;
+  model_key TEXT;
+  model_val JSONB;
+  existing_model_val JSONB;
+BEGIN
+  FOR dup IN
+    SELECT submission_id, date
+    FROM daily_breakdown
+    GROUP BY submission_id, date
+    HAVING COUNT(*) > 1
+  LOOP
+    merged_source := '{}'::jsonb;
+    merged_tokens := 0;
+    merged_cost := 0;
+    merged_input := 0;
+    merged_output := 0;
+    merged_timestamp_ms := NULL;
+    merged_active_time_ms := NULL;
+    keep_id := NULL;
+    keep_device_id := NULL;
+
+    -- Rows for this (submission_id, date), most-recently-submitting device
+    -- first. The first row visited becomes the row we keep (its id and
+    -- submitted_device_id survive); every row's numeric/JSON data is folded
+    -- into the merged totals regardless of visit order.
+    FOR device_row IN
+      SELECT db."id", db."submitted_device_id", db."tokens", db."cost",
+             db."input_tokens", db."output_tokens", db."timestamp_ms",
+             db."active_time_ms", db."source_breakdown"
+      FROM daily_breakdown db
+      LEFT JOIN submitted_devices sd ON sd."id" = db."submitted_device_id"
+      WHERE db."submission_id" = dup.submission_id
+        AND db."date" = dup.date
+      ORDER BY sd."last_submitted_at" DESC NULLS LAST, db."id" DESC
+    LOOP
+      IF keep_id IS NULL THEN
+        keep_id := device_row."id";
+        keep_device_id := device_row."submitted_device_id";
+      END IF;
+
+      merged_tokens := merged_tokens + COALESCE(device_row."tokens", 0);
+      merged_cost := merged_cost + COALESCE(device_row."cost", 0);
+      merged_input := merged_input + COALESCE(device_row."input_tokens", 0);
+      merged_output := merged_output + COALESCE(device_row."output_tokens", 0);
+      merged_active_time_ms := COALESCE(merged_active_time_ms, 0) + COALESCE(device_row."active_time_ms", 0);
+      merged_timestamp_ms := LEAST(
+        COALESCE(merged_timestamp_ms, device_row."timestamp_ms"),
+        COALESCE(device_row."timestamp_ms", merged_timestamp_ms)
+      );
+
+      IF device_row."source_breakdown" IS NOT NULL THEN
+        FOR client_key, client_val IN
+          SELECT key, value FROM jsonb_each(device_row."source_breakdown")
+        LOOP
+          existing_client_val := merged_source -> client_key;
+
+          IF existing_client_val IS NULL THEN
+            merged_source := jsonb_set(merged_source, ARRAY[client_key], client_val, true);
+          ELSE
+            existing_client_val := jsonb_set(existing_client_val, '{tokens}',
+              to_jsonb(COALESCE((existing_client_val->>'tokens')::numeric, 0) + COALESCE((client_val->>'tokens')::numeric, 0)));
+            existing_client_val := jsonb_set(existing_client_val, '{cost}',
+              to_jsonb(COALESCE((existing_client_val->>'cost')::numeric, 0) + COALESCE((client_val->>'cost')::numeric, 0)));
+            existing_client_val := jsonb_set(existing_client_val, '{input}',
+              to_jsonb(COALESCE((existing_client_val->>'input')::numeric, 0) + COALESCE((client_val->>'input')::numeric, 0)));
+            existing_client_val := jsonb_set(existing_client_val, '{output}',
+              to_jsonb(COALESCE((existing_client_val->>'output')::numeric, 0) + COALESCE((client_val->>'output')::numeric, 0)));
+            existing_client_val := jsonb_set(existing_client_val, '{cacheRead}',
+              to_jsonb(COALESCE((existing_client_val->>'cacheRead')::numeric, 0) + COALESCE((client_val->>'cacheRead')::numeric, 0)));
+            existing_client_val := jsonb_set(existing_client_val, '{cacheWrite}',
+              to_jsonb(COALESCE((existing_client_val->>'cacheWrite')::numeric, 0) + COALESCE((client_val->>'cacheWrite')::numeric, 0)));
+            existing_client_val := jsonb_set(existing_client_val, '{reasoning}',
+              to_jsonb(COALESCE((existing_client_val->>'reasoning')::numeric, 0) + COALESCE((client_val->>'reasoning')::numeric, 0)));
+            existing_client_val := jsonb_set(existing_client_val, '{messages}',
+              to_jsonb(COALESCE((existing_client_val->>'messages')::numeric, 0) + COALESCE((client_val->>'messages')::numeric, 0)));
+
+            IF client_val ? 'models' THEN
+              FOR model_key, model_val IN
+                SELECT key, value FROM jsonb_each(client_val -> 'models')
+              LOOP
+                existing_model_val := existing_client_val #> ARRAY['models', model_key];
+
+                IF existing_model_val IS NULL THEN
+                  existing_client_val := jsonb_set(existing_client_val, ARRAY['models', model_key], model_val, true);
+                ELSE
+                  existing_model_val := jsonb_set(existing_model_val, '{tokens}',
+                    to_jsonb(COALESCE((existing_model_val->>'tokens')::numeric, 0) + COALESCE((model_val->>'tokens')::numeric, 0)));
+                  existing_model_val := jsonb_set(existing_model_val, '{cost}',
+                    to_jsonb(COALESCE((existing_model_val->>'cost')::numeric, 0) + COALESCE((model_val->>'cost')::numeric, 0)));
+                  existing_model_val := jsonb_set(existing_model_val, '{input}',
+                    to_jsonb(COALESCE((existing_model_val->>'input')::numeric, 0) + COALESCE((model_val->>'input')::numeric, 0)));
+                  existing_model_val := jsonb_set(existing_model_val, '{output}',
+                    to_jsonb(COALESCE((existing_model_val->>'output')::numeric, 0) + COALESCE((model_val->>'output')::numeric, 0)));
+                  existing_model_val := jsonb_set(existing_model_val, '{cacheRead}',
+                    to_jsonb(COALESCE((existing_model_val->>'cacheRead')::numeric, 0) + COALESCE((model_val->>'cacheRead')::numeric, 0)));
+                  existing_model_val := jsonb_set(existing_model_val, '{cacheWrite}',
+                    to_jsonb(COALESCE((existing_model_val->>'cacheWrite')::numeric, 0) + COALESCE((model_val->>'cacheWrite')::numeric, 0)));
+                  existing_model_val := jsonb_set(existing_model_val, '{reasoning}',
+                    to_jsonb(COALESCE((existing_model_val->>'reasoning')::numeric, 0) + COALESCE((model_val->>'reasoning')::numeric, 0)));
+                  existing_model_val := jsonb_set(existing_model_val, '{messages}',
+                    to_jsonb(COALESCE((existing_model_val->>'messages')::numeric, 0) + COALESCE((model_val->>'messages')::numeric, 0)));
+
+                  existing_client_val := jsonb_set(existing_client_val, ARRAY['models', model_key], existing_model_val, true);
+                END IF;
+              END LOOP;
+            END IF;
+
+            merged_source := jsonb_set(merged_source, ARRAY[client_key], existing_client_val, true);
+          END IF;
+        END LOOP;
+      END IF;
+    END LOOP;
+
+    UPDATE daily_breakdown
+    SET "submitted_device_id" = keep_device_id,
+        "tokens" = merged_tokens,
+        "cost" = merged_cost,
+        "input_tokens" = merged_input,
+        "output_tokens" = merged_output,
+        "timestamp_ms" = merged_timestamp_ms,
+        "active_time_ms" = merged_active_time_ms,
+        "source_breakdown" = merged_source
+    WHERE "id" = keep_id;
+
+    DELETE FROM daily_breakdown
+    WHERE "submission_id" = dup.submission_id
+      AND "date" = dup.date
+      AND "id" <> keep_id;
+  END LOOP;
+END $$;
+--> statement-breakpoint
+-- The (submission_id, submitted_device_id, date) constraint is strictly
+-- subsumed by the new (submission_id, date) constraint below, so drop it.
+ALTER TABLE "daily_breakdown" DROP CONSTRAINT IF EXISTS "daily_breakdown_submission_device_date_unique";
+--> statement-breakpoint
+-- Guarded so this migration is safe to re-run (e.g. if it partially applied
+-- before a deploy retry).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'daily_breakdown_submission_id_date_key'
+  ) THEN
+    ALTER TABLE "daily_breakdown" ADD CONSTRAINT "daily_breakdown_submission_id_date_key" UNIQUE ("submission_id", "date");
+  END IF;
+END $$;

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1780915651573,
       "tag": "0014_widen_cost_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1784069000000,
+      "tag": "0015_restore_submission_date_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -323,11 +323,6 @@ export const dailyBreakdown = pgTable(
       table.submissionId,
       table.date
     ),
-    unique("daily_breakdown_submission_device_date_unique").on(
-      table.submissionId,
-      table.submittedDeviceId,
-      table.date
-    ),
   ]
 );
 

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -319,6 +319,10 @@ export const dailyBreakdown = pgTable(
     index("idx_daily_breakdown_submission_id").on(table.submissionId),
     index("idx_daily_breakdown_submitted_device_id").on(table.submittedDeviceId),
     index("idx_daily_breakdown_date").on(table.date),
+    unique("daily_breakdown_submission_id_date_key").on(
+      table.submissionId,
+      table.date
+    ),
     unique("daily_breakdown_submission_device_date_unique").on(
       table.submissionId,
       table.submittedDeviceId,


### PR DESCRIPTION
When a user switches machines, the CLI generates a new device ID but submits the same local session data. The bare INSERT hits the `(submission_id, date)` unique constraint and returns HTTP 500 "Internal server error".

Replace the batch INSERT with per-row `INSERT ... ON CONFLICT (submission_id, date) DO UPDATE`, so the existing row is updated in-place with the latest device and merged source breakdown. This makes submit idempotent across device changes without requiring the multi-step legacy-adoption logic to succeed.

Fixes the "Internal server error" reported by users after PC replacement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate `daily_breakdown` rows when users switch devices and makes submit idempotent across device changes. Restores `(submission_id, date)` uniqueness and merges cross‑device days without double‑counting or losing legacy data.

- **Bug Fixes**
  - Fetch existing days across the whole submission; merge per‑client with alias normalization (`kilocode`→`kilo`), newest‑wins with a “never regress” guard; recompute day totals.
  - Batch `INSERT`/`UPDATE` with chunking and `ON CONFLICT (submission_id, date) DO UPDATE`; include `submitted_device_id` in batch `UPDATE` so merged rows are re‑attributed to the submitting device; stay under Postgres parameter limits.

- **Migration**
  - Deduplicate `(submission_id, date)` by alias‑aware per‑client newest‑wins merge with regression guard; preserve NULL‑breakdown usage in totals; take max `active_time_ms`; keep the most recent device’s row.
  - Lock `daily_breakdown` with SHARE ROW EXCLUSIVE; recompute affected parent `submissions` totals; drop the triple‑column unique; add the `(submission_id, date)` unique constraint idempotently.

<sup>Written for commit c4399414a41f683ff38e6059cf11c35fffa356b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

