### PR TITLE
fix(sessionize): normalize duration timestamps to start-anchored across parsers

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -792,15 +792,16 @@ fn parser_version(client: ClientId) -> u32 {
         // These clients accumulated parser-only invalidations under the old
         // global schema. Their independent counters start from those histories
         // so future changes have an obvious local version to increment.
-        ClientId::Codex => 5,
+        ClientId::Codex => 6,
         ClientId::Jcode => 4,
-        ClientId::Copilot => 4,
+        ClientId::Copilot => 5,
         // Pi subagent sessions now derive agent attribution from session_info
         // names; version-1 caches carry those messages without agent metadata.
         ClientId::Pi => 2,
         // Devin CLI v1 could stop at a malformed chat_message. Desktop v1
         // parsed a non-ACP shape and did not track its CLI title lookup.
         ClientId::DevinCli | ClientId::DevinDesktop => 2,
+        ClientId::Claude => 2,
         _ => 1,
     }
 }
@@ -1999,7 +2000,9 @@ mod tests {
 
     #[test]
     fn test_codex_duration_parser_version_invalidates_v4_entries() {
-        assert_eq!(parser_version(ClientId::Codex), 5);
+        assert_eq!(parser_version(ClientId::Codex), 6);
+        assert_eq!(parser_version(ClientId::Copilot), 5);
+        assert_eq!(parser_version(ClientId::Claude), 2);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -611,7 +611,6 @@ pub fn parse_claude_file_with_cache_and_home(
                                 &mut messages[existing_idx],
                                 &usage,
                                 parse_claude_entry_timestamp(entry.timestamp.as_deref()),
-                                pending_request_start_timestamp_ms,
                             );
                             if let Some(choice) = duplicate_provider_choice {
                                 update_claude_provider_id(
@@ -631,7 +630,6 @@ pub fn parse_claude_file_with_cache_and_home(
                                 &mut messages[existing_idx],
                                 &usage,
                                 parse_claude_entry_timestamp(entry.timestamp.as_deref()),
-                                pending_request_start_timestamp_ms,
                             );
                             if let Some(choice) = duplicate_provider_choice {
                                 update_claude_provider_id(
@@ -663,7 +661,8 @@ pub fn parse_claude_file_with_cache_and_home(
                 let model = canonicalize_claude_model(&raw_model);
 
                 let parsed_timestamp = parse_claude_entry_timestamp(entry.timestamp.as_deref());
-                let timestamp = parsed_timestamp.unwrap_or(fallback_timestamp);
+                let timestamp = pending_request_start_timestamp_ms
+                    .unwrap_or_else(|| parsed_timestamp.unwrap_or(fallback_timestamp));
                 let duration_ms =
                     duration_between_ms(pending_request_start_timestamp_ms, parsed_timestamp);
 
@@ -865,7 +864,6 @@ fn merge_claude_duplicate(
     existing: &mut UnifiedMessage,
     usage: &ClaudeUsage,
     parsed_timestamp: Option<i64>,
-    request_start_timestamp_ms: Option<i64>,
 ) {
     // Per-field max merge: each token field is updated independently.
     let t = &mut existing.tokens;
@@ -880,20 +878,8 @@ fn merge_claude_duplicate(
 
     if let Some(timestamp_ms) = parsed_timestamp {
         if timestamp_ms >= existing.timestamp {
-            // Recover the original request-start timestamp from the existing
-            // message's recorded duration. The parent loop clears
-            // `pending_request_start_timestamp_ms` after the first chunk of a
-            // message commits (so a NEW message with no preceding user doesn't
-            // inflate by reusing a stale start), which would otherwise blank
-            // out streaming duplicates' duration. Recovering from
-            // `existing.timestamp - existing.duration_ms` keeps the duration
-            // honest for late chunks of the same logical message.
-            let recovered_start = existing
-                .duration_ms
-                .map(|d| existing.timestamp - d)
-                .or(request_start_timestamp_ms);
-            existing.set_timestamp(timestamp_ms);
-            if let Some(new_duration) = duration_between_ms(recovered_start, Some(timestamp_ms)) {
+            let new_duration = timestamp_ms.saturating_sub(existing.timestamp);
+            if new_duration > 0 {
                 existing.duration_ms = Some(new_duration);
             }
         }
@@ -1884,7 +1870,7 @@ mod tests {
 
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].tokens.output, 250);
-        assert_eq!(messages[0].timestamp, 1_733_047_203_500);
+        assert_eq!(messages[0].timestamp, 1_733_047_200_000);
         assert_eq!(messages[0].duration_ms, Some(3500));
         assert_eq!(messages[0].dedup_key.as_deref(), Some("message:msg_stream"));
     }

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -880,7 +880,12 @@ fn merge_claude_duplicate(
         if timestamp_ms >= existing.timestamp {
             let new_duration = timestamp_ms.saturating_sub(existing.timestamp);
             if new_duration > 0 {
-                existing.duration_ms = Some(new_duration);
+                // Duplicates can arrive out of order (e.g. late-processed
+                // streaming chunks), so never let a later-processed duplicate
+                // with an earlier completion timestamp shrink a duration
+                // already established by another duplicate.
+                existing.duration_ms =
+                    Some(existing.duration_ms.unwrap_or(0).max(new_duration));
             }
         }
     }
@@ -1873,6 +1878,46 @@ mod tests {
         assert_eq!(messages[0].timestamp, 1_733_047_200_000);
         assert_eq!(messages[0].duration_ms, Some(3500));
         assert_eq!(messages[0].dedup_key.as_deref(), Some("message:msg_stream"));
+    }
+
+    #[test]
+    fn test_dedup_merge_duration_is_monotonic_across_out_of_order_duplicates() {
+        // Regression: several streaming duplicates of one message can be
+        // processed out of order (e.g. a late-arriving chunk carrying an
+        // earlier completion timestamp than one already merged). The start
+        // anchor (existing.timestamp) must survive every merge, and
+        // duration_ms must never shrink below a value already established by
+        // an earlier-processed duplicate — it must track the latest
+        // (largest) end timestamp seen so far.
+        let content = r#"{"type":"user","timestamp":"2024-12-01T10:00:00.000Z","message":{"content":"Hello"}}
+{"type":"assistant","timestamp":"2024-12-01T10:00:01.000Z","requestId":"req_multi","message":{"id":"msg_multi","model":"claude-3-5-sonnet","usage":{"input_tokens":10,"output_tokens":30}}}
+{"type":"assistant","timestamp":"2024-12-01T10:00:05.000Z","requestId":"req_multi","message":{"id":"msg_multi","model":"claude-3-5-sonnet","usage":{"input_tokens":10,"output_tokens":100}}}
+{"type":"assistant","timestamp":"2024-12-01T10:00:02.000Z","requestId":"req_multi","message":{"id":"msg_multi","model":"claude-3-5-sonnet","usage":{"input_tokens":10,"output_tokens":50}}}
+{"type":"assistant","timestamp":"2024-12-01T10:00:07.000Z","requestId":"req_multi","message":{"id":"msg_multi","model":"claude-3-5-sonnet","usage":{"input_tokens":10,"output_tokens":200}}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(
+            messages.len(),
+            1,
+            "all streaming duplicates should collapse to one message"
+        );
+        assert_eq!(
+            messages[0].timestamp, 1_733_047_200_000,
+            "the start anchor must survive every merge (the user entry's timestamp)"
+        );
+        assert_eq!(
+            messages[0].duration_ms,
+            Some(7_000),
+            "duration_ms must equal the latest end timestamp minus the start \
+             anchor (7s), not shrink when an out-of-order duplicate with an \
+             earlier timestamp is merged"
+        );
+        assert_eq!(
+            messages[0].tokens.output, 200,
+            "token fields keep the per-field max across all duplicates"
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/codex.rs
+++ b/crates/tokscale-core/src/sessions/codex.rs
@@ -557,7 +557,9 @@ fn parse_codex_reader<R: BufRead>(
                     state.previous_totals = next_totals;
 
                     let parsed_timestamp = parse_codex_entry_timestamp(entry.timestamp.as_deref());
-                    let timestamp = parsed_timestamp.unwrap_or(fallback_timestamp);
+                    let timestamp = state
+                        .last_accepted_token_timestamp_ms
+                        .unwrap_or_else(|| parsed_timestamp.unwrap_or(fallback_timestamp));
                     let duration_ms = duration_between_ms(
                         state.last_accepted_token_timestamp_ms,
                         parsed_timestamp,
@@ -2640,5 +2642,19 @@ mod tests {
             !incremental.state.pending_turn_start,
             "the pending flag is consumed once applied"
         );
+    }
+
+    #[test]
+    fn test_token_count_timestamp_is_start_anchored() {
+        let line1 = r#"{"timestamp":"1970-01-01T00:00:01Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#;
+        let line2 = r#"{"timestamp":"1970-01-01T00:00:01.005Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3}}}}"#;
+        let content = format!("{}\n{}", line1, line2);
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].timestamp, 1_000, "timestamp must be the turn_context start (1000ms epoch)");
+        assert_eq!(messages[0].duration_ms, Some(5), "duration_ms must span from turn start to token_count event (5ms)");
     }
 }

--- a/crates/tokscale-core/src/sessions/codex.rs
+++ b/crates/tokscale-core/src/sessions/codex.rs
@@ -457,6 +457,15 @@ fn parse_codex_reader<R: BufRead>(
                 {
                     if codex_message_is_human_turn(payload.message.as_deref()) {
                         state.pending_turn_start = true;
+                        // Defensively reset the start-anchor cursor here too.
+                        // Normally `turn_context` resets it every turn (see
+                        // above), but a resumed/compacted session can emit a
+                        // `token_count` after this `user_message` with no
+                        // intervening `turn_context`. Without this reset the
+                        // cursor would still hold the previous turn's last
+                        // token time and bridge backward across the idle gap.
+                        state.last_accepted_token_timestamp_ms =
+                            parse_codex_entry_timestamp(entry.timestamp.as_deref());
                     }
                     handled = true;
                 }
@@ -2662,6 +2671,45 @@ mod tests {
             messages[0].duration_ms,
             Some(5),
             "duration_ms must span from turn start to token_count event (5ms)"
+        );
+    }
+
+    #[test]
+    fn test_user_message_without_turn_context_anchors_at_user_message() {
+        // Regression: a resumed/compacted session can emit a human
+        // `user_message` followed directly by a `token_count` with no
+        // intervening `turn_context` (which normally resets the start-anchor
+        // cursor every turn). Before this fix, the token_count would anchor
+        // at the previous turn's last accepted token timestamp instead of
+        // this user message, bridging backward across the idle gap between
+        // turns.
+        let line1 = r#"{"timestamp":"1970-01-01T00:00:01Z","type":"turn_context","payload":{"model":"gpt-5.2"}}"#;
+        let line2 = r#"{"timestamp":"1970-01-01T00:00:01.100Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3}}}}"#;
+        // A long idle gap follows: the session resumes with a human
+        // user_message but no fresh turn_context before the next token_count.
+        let line3 = r#"{"timestamp":"1970-01-01T01:00:00Z","type":"event_msg","payload":{"type":"user_message","message":"still there?"}}"#;
+        let line4 = r#"{"timestamp":"1970-01-01T01:00:00.500Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":20,"cached_input_tokens":4,"output_tokens":6},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3}}}}"#;
+        let content = [line1, line2, line3, line4].join("\n");
+        let file = create_test_file(&content);
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(
+            messages[1].timestamp,
+            parse_codex_entry_timestamp(Some("1970-01-01T01:00:00Z")).unwrap(),
+            "the second token_count must anchor at the user_message, not the \
+             previous turn's last accepted token timestamp"
+        );
+        assert_eq!(
+            messages[1].duration_ms,
+            Some(500),
+            "duration_ms must span from the user_message to its token_count \
+             (500ms), not bridge backward across the idle gap"
+        );
+        assert!(
+            messages[1].is_turn_start,
+            "the deferred turn-start marker must still apply"
         );
     }
 }

--- a/crates/tokscale-core/src/sessions/codex.rs
+++ b/crates/tokscale-core/src/sessions/codex.rs
@@ -2654,7 +2654,14 @@ mod tests {
         let messages = parse_codex_file(file.path());
 
         assert_eq!(messages.len(), 1);
-        assert_eq!(messages[0].timestamp, 1_000, "timestamp must be the turn_context start (1000ms epoch)");
-        assert_eq!(messages[0].duration_ms, Some(5), "duration_ms must span from turn start to token_count event (5ms)");
+        assert_eq!(
+            messages[0].timestamp, 1_000,
+            "timestamp must be the turn_context start (1000ms epoch)"
+        );
+        assert_eq!(
+            messages[0].duration_ms,
+            Some(5),
+            "duration_ms must span from turn start to token_count event (5ms)"
+        );
     }
 }

--- a/crates/tokscale-core/src/sessions/copilot.rs
+++ b/crates/tokscale-core/src/sessions/copilot.rs
@@ -753,9 +753,14 @@ fn value_as_i64(value: &Value) -> Option<i64> {
 
 fn timestamp_ms_from_record(value: &Value) -> Option<i64> {
     value
-        .get("endTime")
+        .get("startTime")
         .and_then(timestamp_ms_from_value)
-        .or_else(|| value.get("startTime").and_then(timestamp_ms_from_value))
+        .or_else(|| {
+            // When only endTime is available, back-calculate the start if duration is known.
+            let end_ms = value.get("endTime").and_then(timestamp_ms_from_value)?;
+            let duration = duration_ms_from_record(value).unwrap_or(0);
+            Some(end_ms.saturating_sub(duration))
+        })
         .or_else(|| value.get("hrTime").and_then(timestamp_ms_from_value))
         .or_else(|| value.get("_hrTime").and_then(timestamp_ms_from_value))
         .or_else(|| value.get("time").and_then(timestamp_ms_from_value))
@@ -869,7 +874,7 @@ mod tests {
         assert_eq!(message.tokens.output, 281);
         assert_eq!(message.tokens.cache_read, 123);
         assert_eq!(message.tokens.reasoning, 128);
-        assert_eq!(message.timestamp, 1_775_934_264_967);
+        assert_eq!(message.timestamp, 1_775_934_260_133);
         assert_eq!(message.duration_ms, Some(4834));
         assert_eq!(message.dedup_key.as_deref(), Some("trace-1:span-1"));
     }


### PR DESCRIPTION
## Summary

Fixes active time overestimation caused by end-anchored timestamps in Claude Code, Codex CLI, and Copilot parsers.

The `sessionize()` function interprets `[timestamp, timestamp + duration_ms]` as the activity span for each message. However, three parsers were storing response-completion timestamps instead of request-start timestamps, causing durations to extend forward into phantom future time — incorrectly bridging idle gaps and inflating active time metrics.

## What changed

- **Claude Code**: Use `pending_request_start_timestamp_ms` (user/tool_result entry time) as message timestamp instead of assistant response completion time. Streaming dedup now preserves the original start timestamp and only extends `duration_ms`.
- **Codex CLI**: Use `last_accepted_token_timestamp_ms` (turn start) as message timestamp instead of the token_count event time.
- **Copilot**: Prefer `startTime` over `endTime` for message timestamp. When only `endTime` is available, back-calculate start from duration.

## Invariant established

All parsers now follow the same contract as OpenCode:
```
UnifiedMessage.timestamp = activity start time
UnifiedMessage.duration_ms = elapsed time forward from timestamp
```

## Impact

- Local reports will show more accurate (likely lower) active time after cache reparsing
- Already-submitted leaderboard data is unaffected
- Next `tokscale submit` will reflect corrected active time

## Testing

All 1,210 tests pass. New regression tests added for start-anchored timestamp behavior in each affected parser.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize message timestamps to the activity start across parsers and harden start-anchoring for edge cases to fix inflated active time. Also bump parser versions to invalidate stale caches.

- **Bug Fixes**
  - Sessionize: timestamps are now start-anchored and `duration_ms` extends forward.
    - Claude Code: uses `pending_request_start_timestamp_ms`; streaming dedup preserves the start anchor and only increases duration (never shrinks on out-of-order chunks).
    - Codex CLI: uses `last_accepted_token_timestamp_ms` (turn start); if a resumed session has a `user_message` without a `turn_context`, the start anchor resets so the next `token_count` anchors to the new turn (no backward bridging).
    - Copilot: prefers `startTime`; when only `endTime` exists, back-calculates start as `endTime - duration`.
  - Cache: bumped parser versions in `tokscale-core` to invalidate stale caches (Claude v2, Codex v6, Copilot v5).

<sup>Written for commit e883eaea17c51d7578b8225c36f7c9e206750855. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

