### PR TITLE
fix(antigravity): resolve current IDE and CLI model aliases

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -8086,13 +8086,13 @@ mod tests {
             .unwrap();
 
         assert_eq!(graph.summary.clients, vec!["antigravity"]);
-        assert_eq!(graph.summary.models, vec!["model_placeholder_m84"]);
+        assert_eq!(graph.summary.models, vec!["gemini-3-flash-preview"]);
         assert_eq!(graph.summary.total_tokens, 19);
         assert_eq!(graph.contributions.len(), 1);
         assert_eq!(graph.contributions[0].clients[0].client, "antigravity");
         assert_eq!(
             graph.contributions[0].clients[0].model_id,
-            "model_placeholder_m84"
+            "gemini-3-flash-preview"
         );
     }
 

--- a/crates/tokscale-core/src/pricing/aliases.rs
+++ b/crates/tokscale-core/src/pricing/aliases.rs
@@ -19,16 +19,16 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     m.insert("model_placeholder_m36", "gemini-3.1-pro");
     m.insert("model_placeholder_m37", "gemini-3.1-pro");
     // Antigravity uses opaque placeholder IDs in IDE metadata and shorter
-    // responseModel aliases in CLI conversation protobufs. These mappings are
-    // cross-checked against two independent open-source integrations:
+    // responseModel aliases in CLI conversation protobufs. The evidence has
+    // two distinct roles:
     //
     // - Antigravity Manager is a third-party account/quota manager. Its quota
-    //   client shows that Antigravity obtains the available model IDs and
-    //   display names from Google Cloud Code Assist's fetchAvailableModels API:
+    //   client documents the server-side metadata source and response shape:
+    //   model IDs and display names come from Google Cloud Code Assist's
+    //   fetchAvailableModels API.
     //   https://github.com/lbjlaq/Antigravity-Manager/blob/dfe876548d572237da92fe4c3e070a9db33c0910/src-tauri/src/modules/quota.rs
-    // - Antigravity Context Window Monitor reads the running language server's
-    //   GetUserStatus model config and records the placeholder/responseModel
-    //   aliases observed in Antigravity session metadata:
+    // - The concrete placeholder and responseModel mappings below come from
+    //   Antigravity Context Window Monitor's GetUserStatus/session registry.
     //   https://github.com/AGI-is-going-to-arrive/Antigravity-Context-Window-Monitor/blob/603e3ea00a0ee94f1beecc162cf47a4ed68d3a6f/src/models.ts
     //
     // Keep these as machine-ID aliases. Do not use server-provided display
@@ -89,58 +89,32 @@ mod tests {
 
     #[test]
     fn resolves_antigravity_placeholders() {
-        assert_eq!(
-            resolve_alias("MODEL_PLACEHOLDER_M26"),
-            Some("claude-opus-4-6")
-        );
-        assert_eq!(
-            resolve_alias("model_placeholder_m37"),
-            Some("gemini-3.1-pro")
-        );
-        assert_eq!(
-            resolve_alias("model_placeholder_m16"),
-            Some("gemini-3.1-pro")
-        );
-        assert_eq!(
-            resolve_alias("MODEL_PLACEHOLDER_M84"),
-            Some("gemini-3-flash-preview")
-        );
-        assert_eq!(
-            resolve_alias("model_placeholder_m133"),
-            Some("gemini-3.5-flash-high")
-        );
-        assert_eq!(
-            resolve_alias("gemini-3-flash-agent"),
-            Some("gemini-3.5-flash-high")
-        );
-        assert_eq!(
-            resolve_alias("gemini-3.5-flash-low"),
-            Some("gemini-3.5-flash-medium")
-        );
-        assert_eq!(
-            resolve_alias("MODEL_OPENAI_GPT_OSS_120B_MEDIUM"),
-            Some("gpt-oss-120b-medium")
-        );
-        assert_eq!(
-            resolve_alias("gemini-3-flash-c"),
-            Some("gemini-3-flash-preview")
-        );
-        assert_eq!(
-            resolve_alias("gemini-3-flash-a"),
-            Some("gemini-3-flash-preview")
-        );
-        assert_eq!(
-            resolve_alias("claude-opus-4.6-thinking"),
-            Some("claude-opus-4-6")
-        );
-        assert_eq!(
-            resolve_alias("anthropic/claude-4-5-haiku"),
-            Some("claude-haiku-4-5")
-        );
-        assert_eq!(
-            resolve_alias("anthropic/claude-4-6-sonnet"),
-            Some("claude-sonnet-4-6")
-        );
+        let cases = [
+            ("MODEL_PLACEHOLDER_M26", "claude-opus-4-6"),
+            ("model_placeholder_m37", "gemini-3.1-pro"),
+            ("model_placeholder_m16", "gemini-3.1-pro"),
+            ("model_placeholder_m18", "gemini-3-flash-preview"),
+            ("MODEL_PLACEHOLDER_M84", "gemini-3-flash-preview"),
+            ("model_placeholder_m132", "gemini-3.5-flash-high"),
+            ("model_placeholder_m133", "gemini-3.5-flash-high"),
+            ("model_placeholder_m187", "gemini-3.5-flash-low"),
+            ("model_placeholder_m20", "gemini-3.5-flash-medium"),
+            ("gemini-pro-default", "gemini-3.1-pro"),
+            ("gemini-pro-agent", "gemini-3.1-pro"),
+            ("gemini-3-flash-agent", "gemini-3.5-flash-high"),
+            ("gemini-3-flash-b", "gemini-3.5-flash-high"),
+            ("gemini-3.5-flash-low", "gemini-3.5-flash-medium"),
+            ("MODEL_OPENAI_GPT_OSS_120B_MEDIUM", "gpt-oss-120b-medium"),
+            ("gemini-3-flash-c", "gemini-3-flash-preview"),
+            ("gemini-3-flash-a", "gemini-3-flash-preview"),
+            ("claude-opus-4.6-thinking", "claude-opus-4-6"),
+            ("anthropic/claude-4-5-haiku", "claude-haiku-4-5"),
+            ("anthropic/claude-4-6-sonnet", "claude-sonnet-4-6"),
+        ];
+
+        for (raw, expected) in cases {
+            assert_eq!(resolve_alias(raw), Some(expected), "raw model: {raw}");
+        }
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/aliases.rs
+++ b/crates/tokscale-core/src/pricing/aliases.rs
@@ -34,9 +34,10 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     // Keep these as machine-ID aliases. Do not use server-provided display
     // labels as pricing keys because labels may be renamed or localized.
     //
-    // M133/`gemini-3-flash-b` and M187/raw `gemini-3.5-flash-low` are two
-    // cases where the obvious mapping is wrong, verified against the pinned
-    // Antigravity Context Window Monitor SHA above (models.ts@603e3ea):
+    // M133/`gemini-3-flash-b`, `gemini-3-flash-a`, and M187/raw
+    // `gemini-3.5-flash-low` are cases where the obvious mapping is wrong,
+    // verified against the pinned Antigravity Context Window Monitor SHA
+    // above (models.ts@603e3ea):
     //
     // - M133 was renamed from "Gemini 3 Flash" to "Gemini 3.5 Flash (High)"
     //   ("MODEL_PLACEHOLDER_M133": 'Gemini 3.5 Flash (High)', // gemini-3-flash-agent
@@ -44,22 +45,30 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     //   BOTH `gemini-3-flash-agent` and `gemini-3-flash-b` to M133. So M133
     //   and `gemini-3-flash-b` must resolve identically to `gemini-3-flash-agent`
     //   (gemini-3.5-flash-high), not to the retired gemini-3-flash-preview tier.
-    // - The raw CLI responseModel string `gemini-3.5-flash-low` is, per the
-    //   same pinned source, literally `responseModelAliases['gemini-3.5-flash-low']
-    //   = 'MODEL_PLACEHOLDER_M20' // model_id for M20 (3.5 Flash Medium)` — i.e.
-    //   despite the name, that wire string identifies the Medium tier, not the
-    //   Low tier (M187). resolve_alias is single-hop, so M187 must resolve
-    //   directly to the same final target as the raw `gemini-3.5-flash-low`
-    //   key instead of to the string `gemini-3.5-flash-low` itself (which
-    //   would otherwise re-enter this table on a second hop and collapse to
-    //   a different result depending on whether it came from the IDE or the
-    //   CLI).
+    // - `responseModelAliases['gemini-3-flash-a'] = 'MODEL_PLACEHOLDER_M132'`
+    //   ("legacy responseModel for 3.5 Flash"), and
+    //   `STATIC_MODEL_NAME_FALLBACKS['MODEL_PLACEHOLDER_M132'] =
+    //   'Gemini 3.5 Flash (High)' // retired predecessor of M133`. So
+    //   `gemini-3-flash-a` prices as the retired-predecessor High tier
+    //   (gemini-3.5-flash-high) — the same catalog entry as M133/M132/
+    //   `gemini-3-flash-b` — not as the unrelated gemini-3-flash-preview
+    //   family (M18/M84), which is a different, older backend command model.
+    // - M20's `activeModelSpecs` entry has `modelId: 'gemini-3.5-flash-low'`
+    //   with `displayName: 'Gemini 3.5 Flash (Medium)'` — the wire string
+    //   says "low" but the tier is actually Medium. M187 is a distinct
+    //   placeholder whose own `activeModelSpecs` entry has
+    //   `modelId: 'gemini-3.5-flash-extra-low'` and
+    //   `displayName: 'Gemini 3.5 Flash (Low)'` — the true Low tier. M187
+    //   and M20/raw `gemini-3.5-flash-low` must NOT collapse to the same
+    //   canonical alias target: M187 maps to `gemini-3.5-flash-extra-low`
+    //   (its own machine ID), while M20 and the raw wire string map to
+    //   `gemini-3.5-flash-medium`.
     m.insert("model_placeholder_m16", "gemini-3.1-pro");
     m.insert("model_placeholder_m18", "gemini-3-flash-preview");
     m.insert("model_placeholder_m84", "gemini-3-flash-preview");
     m.insert("model_placeholder_m132", "gemini-3.5-flash-high");
     m.insert("model_placeholder_m133", "gemini-3.5-flash-high");
-    m.insert("model_placeholder_m187", "gemini-3.5-flash-medium");
+    m.insert("model_placeholder_m187", "gemini-3.5-flash-extra-low");
     m.insert("model_placeholder_m20", "gemini-3.5-flash-medium");
     m.insert("gemini-pro-default", "gemini-3.1-pro");
     m.insert("gemini-pro-agent", "gemini-3.1-pro");
@@ -90,7 +99,7 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     m.insert("gemini-3-pro-low", "gemini-3-pro");
     m.insert("gemini-3-flash", "gemini-3-flash-preview");
     m.insert("gemini-3-flash-c", "gemini-3-flash-preview");
-    m.insert("gemini-3-flash-a", "gemini-3-flash-preview");
+    m.insert("gemini-3-flash-a", "gemini-3.5-flash-high");
     m.insert("grok-composer-2.5", "composer-2.5");
     m.insert("grok-composer-2.5-fast", "composer-2.5-fast");
 
@@ -119,7 +128,7 @@ mod tests {
             ("MODEL_PLACEHOLDER_M84", "gemini-3-flash-preview"),
             ("model_placeholder_m132", "gemini-3.5-flash-high"),
             ("model_placeholder_m133", "gemini-3.5-flash-high"),
-            ("model_placeholder_m187", "gemini-3.5-flash-medium"),
+            ("model_placeholder_m187", "gemini-3.5-flash-extra-low"),
             ("model_placeholder_m20", "gemini-3.5-flash-medium"),
             ("gemini-pro-default", "gemini-3.1-pro"),
             ("gemini-pro-agent", "gemini-3.1-pro"),
@@ -128,7 +137,7 @@ mod tests {
             ("gemini-3.5-flash-low", "gemini-3.5-flash-medium"),
             ("MODEL_OPENAI_GPT_OSS_120B_MEDIUM", "gpt-oss-120b-medium"),
             ("gemini-3-flash-c", "gemini-3-flash-preview"),
-            ("gemini-3-flash-a", "gemini-3-flash-preview"),
+            ("gemini-3-flash-a", "gemini-3.5-flash-high"),
             ("claude-opus-4.6-thinking", "claude-opus-4-6"),
             ("anthropic/claude-4-5-haiku", "claude-haiku-4-5"),
             ("anthropic/claude-4-6-sonnet", "claude-sonnet-4-6"),
@@ -160,42 +169,57 @@ mod tests {
     }
 
     #[test]
-    fn ide_and_cli_low_tier_aliases_price_to_the_same_catalog_entry() {
-        // Two-stage regression for the collapsed M187 chain: the IDE emits
-        // the opaque placeholder `model_placeholder_m187`, while the CLI
-        // emits the raw responseModel string `gemini-3.5-flash-low`. Both
-        // must resolve (single-hop) to the same canonical id, and that id
-        // must land on the identical priced catalog entry so the two
-        // sources merge into one cost bucket instead of splitting.
-        let ide_canonical = resolve_alias("model_placeholder_m187").unwrap();
-        let cli_canonical = resolve_alias("gemini-3.5-flash-low").unwrap();
-        assert_eq!(ide_canonical, "gemini-3.5-flash-medium");
-        assert_eq!(ide_canonical, cli_canonical);
+    fn m187_and_m20_resolve_to_distinct_tiers_but_both_still_price() {
+        // M187 (true Low tier, machine id `gemini-3.5-flash-extra-low`) and
+        // M20/raw CLI `gemini-3.5-flash-low` (actually the Medium tier) must
+        // NOT collapse to the same canonical alias target — that would
+        // silently merge two different-priced tiers into one cost bucket.
+        // Verified against the pinned Antigravity Context Window Monitor SHA
+        // (models.ts@603e3ea): M187's own `activeModelSpecs` entry has
+        // `modelId: 'gemini-3.5-flash-extra-low'`, distinct from M20's
+        // `modelId: 'gemini-3.5-flash-low'`.
+        let m187_canonical = resolve_alias("model_placeholder_m187").unwrap();
+        let m20_canonical = resolve_alias("model_placeholder_m20").unwrap();
+        let cli_low_canonical = resolve_alias("gemini-3.5-flash-low").unwrap();
 
-        let mut litellm = HashMap::new();
-        litellm.insert(
-            "gemini-3.5-flash-medium".to_string(),
+        assert_eq!(m187_canonical, "gemini-3.5-flash-extra-low");
+        assert_eq!(m20_canonical, "gemini-3.5-flash-medium");
+        assert_ne!(
+            m187_canonical, m20_canonical,
+            "M187 (Low) and M20 (Medium) must not resolve to the same tier"
+        );
+        // The raw CLI wire string tracks M20 (Medium), not M187 (Low).
+        assert_eq!(cli_low_canonical, m20_canonical);
+
+        // Both tiers must still reach a priced catalog entry: the pricing
+        // dataset only carries one generic `google/gemini-3.5-flash` entry,
+        // and the lookup's suffix-stripping normalization must land both the
+        // `-extra-low` and `-medium` canonical ids on it.
+        let mut models_dev = HashMap::new();
+        models_dev.insert(
+            "google/gemini-3.5-flash".to_string(),
             super::super::litellm::ModelPricing {
-                input_cost_per_token: Some(0.0000005),
-                output_cost_per_token: Some(0.000003),
+                input_cost_per_token: Some(0.0000015),
+                output_cost_per_token: Some(0.000009),
                 ..Default::default()
             },
         );
-        let lookup =
-            super::super::lookup::PricingLookup::new(litellm, HashMap::new(), HashMap::new());
-
-        let ide_result = lookup.lookup(ide_canonical).expect("IDE path must price");
-        let cli_result = lookup.lookup(cli_canonical).expect("CLI path must price");
-
-        assert_eq!(ide_result.matched_key, "gemini-3.5-flash-medium");
-        assert_eq!(ide_result.matched_key, cli_result.matched_key);
-        assert_eq!(
-            ide_result.pricing.input_cost_per_token,
-            cli_result.pricing.input_cost_per_token
+        let lookup = super::super::lookup::PricingLookup::new_with_models_dev(
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            models_dev,
         );
-        assert_eq!(
-            ide_result.pricing.output_cost_per_token,
-            cli_result.pricing.output_cost_per_token
-        );
+
+        let m187_result = lookup
+            .lookup(m187_canonical)
+            .expect("M187 target must still price via lookup normalization");
+        let m20_result = lookup
+            .lookup(m20_canonical)
+            .expect("M20 target must still price via lookup normalization");
+
+        assert_eq!(m187_result.matched_key, "google/gemini-3.5-flash");
+        assert_eq!(m20_result.matched_key, "google/gemini-3.5-flash");
     }
 }

--- a/crates/tokscale-core/src/pricing/aliases.rs
+++ b/crates/tokscale-core/src/pricing/aliases.rs
@@ -18,11 +18,21 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     m.insert("model_placeholder_m35", "claude-sonnet-4-6");
     m.insert("model_placeholder_m36", "gemini-3.1-pro");
     m.insert("model_placeholder_m37", "gemini-3.1-pro");
-    // Antigravity's language server emits placeholder IDs in IDE metadata and
-    // response-model aliases in CLI conversation protobufs. The current
-    // server-provided labels/mappings are documented by the Antigravity model
-    // monitor, while Antigravity Manager confirms model metadata itself comes
-    // from fetchAvailableModels rather than a stable local model list.
+    // Antigravity uses opaque placeholder IDs in IDE metadata and shorter
+    // responseModel aliases in CLI conversation protobufs. These mappings are
+    // cross-checked against two independent open-source integrations:
+    //
+    // - Antigravity Manager is a third-party account/quota manager. Its quota
+    //   client shows that Antigravity obtains the available model IDs and
+    //   display names from Google Cloud Code Assist's fetchAvailableModels API:
+    //   https://github.com/lbjlaq/Antigravity-Manager/blob/dfe876548d572237da92fe4c3e070a9db33c0910/src-tauri/src/modules/quota.rs
+    // - Antigravity Context Window Monitor reads the running language server's
+    //   GetUserStatus model config and records the placeholder/responseModel
+    //   aliases observed in Antigravity session metadata:
+    //   https://github.com/AGI-is-going-to-arrive/Antigravity-Context-Window-Monitor/blob/603e3ea00a0ee94f1beecc162cf47a4ed68d3a6f/src/models.ts
+    //
+    // Keep these as machine-ID aliases. Do not use server-provided display
+    // labels as pricing keys because labels may be renamed or localized.
     m.insert("model_placeholder_m16", "gemini-3.1-pro");
     m.insert("model_placeholder_m18", "gemini-3-flash-preview");
     m.insert("model_placeholder_m84", "gemini-3-flash-preview");

--- a/crates/tokscale-core/src/pricing/aliases.rs
+++ b/crates/tokscale-core/src/pricing/aliases.rs
@@ -37,13 +37,13 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     m.insert("model_placeholder_m18", "gemini-3-flash-preview");
     m.insert("model_placeholder_m84", "gemini-3-flash-preview");
     m.insert("model_placeholder_m132", "gemini-3.5-flash-high");
-    m.insert("model_placeholder_m133", "gemini-3.5-flash-high");
+    m.insert("model_placeholder_m133", "gemini-3-flash-preview");
     m.insert("model_placeholder_m187", "gemini-3.5-flash-low");
     m.insert("model_placeholder_m20", "gemini-3.5-flash-medium");
     m.insert("gemini-pro-default", "gemini-3.1-pro");
     m.insert("gemini-pro-agent", "gemini-3.1-pro");
     m.insert("gemini-3-flash-agent", "gemini-3.5-flash-high");
-    m.insert("gemini-3-flash-b", "gemini-3.5-flash-high");
+    m.insert("gemini-3-flash-b", "gemini-3-flash-preview");
     m.insert("gemini-3.5-flash-low", "gemini-3.5-flash-medium");
     m.insert("model_placeholder_m47", "gemini-3-flash-preview");
     m.insert("model_openai_gpt_oss_120b_medium", "gpt-oss-120b-medium");
@@ -96,13 +96,13 @@ mod tests {
             ("model_placeholder_m18", "gemini-3-flash-preview"),
             ("MODEL_PLACEHOLDER_M84", "gemini-3-flash-preview"),
             ("model_placeholder_m132", "gemini-3.5-flash-high"),
-            ("model_placeholder_m133", "gemini-3.5-flash-high"),
+            ("model_placeholder_m133", "gemini-3-flash-preview"),
             ("model_placeholder_m187", "gemini-3.5-flash-low"),
             ("model_placeholder_m20", "gemini-3.5-flash-medium"),
             ("gemini-pro-default", "gemini-3.1-pro"),
             ("gemini-pro-agent", "gemini-3.1-pro"),
             ("gemini-3-flash-agent", "gemini-3.5-flash-high"),
-            ("gemini-3-flash-b", "gemini-3.5-flash-high"),
+            ("gemini-3-flash-b", "gemini-3-flash-preview"),
             ("gemini-3.5-flash-low", "gemini-3.5-flash-medium"),
             ("MODEL_OPENAI_GPT_OSS_120B_MEDIUM", "gpt-oss-120b-medium"),
             ("gemini-3-flash-c", "gemini-3-flash-preview"),

--- a/crates/tokscale-core/src/pricing/aliases.rs
+++ b/crates/tokscale-core/src/pricing/aliases.rs
@@ -18,6 +18,23 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     m.insert("model_placeholder_m35", "claude-sonnet-4-6");
     m.insert("model_placeholder_m36", "gemini-3.1-pro");
     m.insert("model_placeholder_m37", "gemini-3.1-pro");
+    // Antigravity's language server emits placeholder IDs in IDE metadata and
+    // response-model aliases in CLI conversation protobufs. The current
+    // server-provided labels/mappings are documented by the Antigravity model
+    // monitor, while Antigravity Manager confirms model metadata itself comes
+    // from fetchAvailableModels rather than a stable local model list.
+    m.insert("model_placeholder_m16", "gemini-3.1-pro");
+    m.insert("model_placeholder_m18", "gemini-3-flash-preview");
+    m.insert("model_placeholder_m84", "gemini-3-flash-preview");
+    m.insert("model_placeholder_m132", "gemini-3.5-flash-high");
+    m.insert("model_placeholder_m133", "gemini-3.5-flash-high");
+    m.insert("model_placeholder_m187", "gemini-3.5-flash-low");
+    m.insert("model_placeholder_m20", "gemini-3.5-flash-medium");
+    m.insert("gemini-pro-default", "gemini-3.1-pro");
+    m.insert("gemini-pro-agent", "gemini-3.1-pro");
+    m.insert("gemini-3-flash-agent", "gemini-3.5-flash-high");
+    m.insert("gemini-3-flash-b", "gemini-3.5-flash-high");
+    m.insert("gemini-3.5-flash-low", "gemini-3.5-flash-medium");
     m.insert("model_placeholder_m47", "gemini-3-flash-preview");
     m.insert("model_openai_gpt_oss_120b_medium", "gpt-oss-120b-medium");
     m.insert("claude-opus-4-6-thinking", "claude-opus-4-6");
@@ -71,6 +88,26 @@ mod tests {
             Some("gemini-3.1-pro")
         );
         assert_eq!(
+            resolve_alias("model_placeholder_m16"),
+            Some("gemini-3.1-pro")
+        );
+        assert_eq!(
+            resolve_alias("MODEL_PLACEHOLDER_M84"),
+            Some("gemini-3-flash-preview")
+        );
+        assert_eq!(
+            resolve_alias("model_placeholder_m133"),
+            Some("gemini-3.5-flash-high")
+        );
+        assert_eq!(
+            resolve_alias("gemini-3-flash-agent"),
+            Some("gemini-3.5-flash-high")
+        );
+        assert_eq!(
+            resolve_alias("gemini-3.5-flash-low"),
+            Some("gemini-3.5-flash-medium")
+        );
+        assert_eq!(
             resolve_alias("MODEL_OPENAI_GPT_OSS_120B_MEDIUM"),
             Some("gpt-oss-120b-medium")
         );
@@ -94,8 +131,6 @@ mod tests {
             resolve_alias("anthropic/claude-4-6-sonnet"),
             Some("claude-sonnet-4-6")
         );
-        assert_eq!(resolve_alias("model_placeholder_m84"), None);
-        assert_eq!(resolve_alias("model_placeholder_m16"), None);
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/aliases.rs
+++ b/crates/tokscale-core/src/pricing/aliases.rs
@@ -33,17 +33,38 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     //
     // Keep these as machine-ID aliases. Do not use server-provided display
     // labels as pricing keys because labels may be renamed or localized.
+    //
+    // M133/`gemini-3-flash-b` and M187/raw `gemini-3.5-flash-low` are two
+    // cases where the obvious mapping is wrong, verified against the pinned
+    // Antigravity Context Window Monitor SHA above (models.ts@603e3ea):
+    //
+    // - M133 was renamed from "Gemini 3 Flash" to "Gemini 3.5 Flash (High)"
+    //   ("MODEL_PLACEHOLDER_M133": 'Gemini 3.5 Flash (High)', // gemini-3-flash-agent
+    //   (renamed from "Gemini 3 Flash")"), and `responseModelAliases` maps
+    //   BOTH `gemini-3-flash-agent` and `gemini-3-flash-b` to M133. So M133
+    //   and `gemini-3-flash-b` must resolve identically to `gemini-3-flash-agent`
+    //   (gemini-3.5-flash-high), not to the retired gemini-3-flash-preview tier.
+    // - The raw CLI responseModel string `gemini-3.5-flash-low` is, per the
+    //   same pinned source, literally `responseModelAliases['gemini-3.5-flash-low']
+    //   = 'MODEL_PLACEHOLDER_M20' // model_id for M20 (3.5 Flash Medium)` — i.e.
+    //   despite the name, that wire string identifies the Medium tier, not the
+    //   Low tier (M187). resolve_alias is single-hop, so M187 must resolve
+    //   directly to the same final target as the raw `gemini-3.5-flash-low`
+    //   key instead of to the string `gemini-3.5-flash-low` itself (which
+    //   would otherwise re-enter this table on a second hop and collapse to
+    //   a different result depending on whether it came from the IDE or the
+    //   CLI).
     m.insert("model_placeholder_m16", "gemini-3.1-pro");
     m.insert("model_placeholder_m18", "gemini-3-flash-preview");
     m.insert("model_placeholder_m84", "gemini-3-flash-preview");
     m.insert("model_placeholder_m132", "gemini-3.5-flash-high");
-    m.insert("model_placeholder_m133", "gemini-3-flash-preview");
-    m.insert("model_placeholder_m187", "gemini-3.5-flash-low");
+    m.insert("model_placeholder_m133", "gemini-3.5-flash-high");
+    m.insert("model_placeholder_m187", "gemini-3.5-flash-medium");
     m.insert("model_placeholder_m20", "gemini-3.5-flash-medium");
     m.insert("gemini-pro-default", "gemini-3.1-pro");
     m.insert("gemini-pro-agent", "gemini-3.1-pro");
     m.insert("gemini-3-flash-agent", "gemini-3.5-flash-high");
-    m.insert("gemini-3-flash-b", "gemini-3-flash-preview");
+    m.insert("gemini-3-flash-b", "gemini-3.5-flash-high");
     m.insert("gemini-3.5-flash-low", "gemini-3.5-flash-medium");
     m.insert("model_placeholder_m47", "gemini-3-flash-preview");
     m.insert("model_openai_gpt_oss_120b_medium", "gpt-oss-120b-medium");
@@ -86,6 +107,7 @@ pub fn resolve_alias(model_id: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::resolve_alias;
+    use std::collections::HashMap;
 
     #[test]
     fn resolves_antigravity_placeholders() {
@@ -96,13 +118,13 @@ mod tests {
             ("model_placeholder_m18", "gemini-3-flash-preview"),
             ("MODEL_PLACEHOLDER_M84", "gemini-3-flash-preview"),
             ("model_placeholder_m132", "gemini-3.5-flash-high"),
-            ("model_placeholder_m133", "gemini-3-flash-preview"),
-            ("model_placeholder_m187", "gemini-3.5-flash-low"),
+            ("model_placeholder_m133", "gemini-3.5-flash-high"),
+            ("model_placeholder_m187", "gemini-3.5-flash-medium"),
             ("model_placeholder_m20", "gemini-3.5-flash-medium"),
             ("gemini-pro-default", "gemini-3.1-pro"),
             ("gemini-pro-agent", "gemini-3.1-pro"),
             ("gemini-3-flash-agent", "gemini-3.5-flash-high"),
-            ("gemini-3-flash-b", "gemini-3-flash-preview"),
+            ("gemini-3-flash-b", "gemini-3.5-flash-high"),
             ("gemini-3.5-flash-low", "gemini-3.5-flash-medium"),
             ("MODEL_OPENAI_GPT_OSS_120B_MEDIUM", "gpt-oss-120b-medium"),
             ("gemini-3-flash-c", "gemini-3-flash-preview"),
@@ -134,6 +156,46 @@ mod tests {
         assert_eq!(
             resolve_alias("GROK-COMPOSER-2.5-FAST"),
             Some("composer-2.5-fast")
+        );
+    }
+
+    #[test]
+    fn ide_and_cli_low_tier_aliases_price_to_the_same_catalog_entry() {
+        // Two-stage regression for the collapsed M187 chain: the IDE emits
+        // the opaque placeholder `model_placeholder_m187`, while the CLI
+        // emits the raw responseModel string `gemini-3.5-flash-low`. Both
+        // must resolve (single-hop) to the same canonical id, and that id
+        // must land on the identical priced catalog entry so the two
+        // sources merge into one cost bucket instead of splitting.
+        let ide_canonical = resolve_alias("model_placeholder_m187").unwrap();
+        let cli_canonical = resolve_alias("gemini-3.5-flash-low").unwrap();
+        assert_eq!(ide_canonical, "gemini-3.5-flash-medium");
+        assert_eq!(ide_canonical, cli_canonical);
+
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "gemini-3.5-flash-medium".to_string(),
+            super::super::litellm::ModelPricing {
+                input_cost_per_token: Some(0.0000005),
+                output_cost_per_token: Some(0.000003),
+                ..Default::default()
+            },
+        );
+        let lookup =
+            super::super::lookup::PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        let ide_result = lookup.lookup(ide_canonical).expect("IDE path must price");
+        let cli_result = lookup.lookup(cli_canonical).expect("CLI path must price");
+
+        assert_eq!(ide_result.matched_key, "gemini-3.5-flash-medium");
+        assert_eq!(ide_result.matched_key, cli_result.matched_key);
+        assert_eq!(
+            ide_result.pricing.input_cost_per_token,
+            cli_result.pricing.input_cost_per_token
+        );
+        assert_eq!(
+            ide_result.pricing.output_cost_per_token,
+            cli_result.pricing.output_cost_per_token
         );
     }
 }

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -2798,8 +2798,8 @@ mod tests {
             ),
             (
                 "MODEL_PLACEHOLDER_M133",
-                "vertex_ai/gemini-3-flash-preview",
-                "LiteLLM",
+                "google/gemini-3.5-flash",
+                "Models.dev",
             ),
             (
                 "gemini-3-flash-agent",
@@ -2808,8 +2808,8 @@ mod tests {
             ),
             (
                 "gemini-3-flash-b",
-                "vertex_ai/gemini-3-flash-preview",
-                "LiteLLM",
+                "google/gemini-3.5-flash",
+                "Models.dev",
             ),
             (
                 "MODEL_PLACEHOLDER_M187",

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -2798,13 +2798,18 @@ mod tests {
             ),
             (
                 "MODEL_PLACEHOLDER_M133",
-                "google/gemini-3.5-flash",
-                "Models.dev",
+                "vertex_ai/gemini-3-flash-preview",
+                "LiteLLM",
             ),
             (
                 "gemini-3-flash-agent",
                 "google/gemini-3.5-flash",
                 "Models.dev",
+            ),
+            (
+                "gemini-3-flash-b",
+                "vertex_ai/gemini-3-flash-preview",
+                "LiteLLM",
             ),
             (
                 "MODEL_PLACEHOLDER_M187",

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -2812,6 +2812,15 @@ mod tests {
                 "Models.dev",
             ),
             (
+                // Legacy CLI responseModel for M132, the retired predecessor
+                // of M133 — prices as the High tier, same catalog entry as
+                // `gemini-3-flash-agent`/`gemini-3-flash-b` above (see
+                // aliases.rs source-citation comment, models.ts@603e3ea).
+                "gemini-3-flash-a",
+                "google/gemini-3.5-flash",
+                "Models.dev",
+            ),
+            (
                 "MODEL_PLACEHOLDER_M187",
                 "google/gemini-3.5-flash",
                 "Models.dev",

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -2760,6 +2760,76 @@ mod tests {
         assert_eq!(result.source, "LiteLLM");
     }
 
+    #[test]
+    fn antigravity_model_aliases_reach_priced_catalog_entries() {
+        let mut litellm = mock_litellm();
+        litellm.insert(
+            "gemini-3.1-pro".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000002),
+                output_cost_per_token: Some(0.000012),
+                ..Default::default()
+            },
+        );
+        let mut models_dev = HashMap::new();
+        models_dev.insert(
+            "google/gemini-3.5-flash".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0000015),
+                output_cost_per_token: Some(0.000009),
+                cache_read_input_token_cost: Some(0.00000015),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new_with_models_dev(
+            litellm,
+            mock_openrouter(),
+            HashMap::new(),
+            HashMap::new(),
+            models_dev,
+        );
+
+        let cases = [
+            ("MODEL_PLACEHOLDER_M16", "gemini-3.1-pro", "LiteLLM"),
+            (
+                "MODEL_PLACEHOLDER_M84",
+                "vertex_ai/gemini-3-flash-preview",
+                "LiteLLM",
+            ),
+            (
+                "MODEL_PLACEHOLDER_M133",
+                "google/gemini-3.5-flash",
+                "Models.dev",
+            ),
+            (
+                "gemini-3-flash-agent",
+                "google/gemini-3.5-flash",
+                "Models.dev",
+            ),
+            (
+                "MODEL_PLACEHOLDER_M187",
+                "google/gemini-3.5-flash",
+                "Models.dev",
+            ),
+            (
+                "MODEL_PLACEHOLDER_M20",
+                "google/gemini-3.5-flash",
+                "Models.dev",
+            ),
+        ];
+
+        for (raw, expected_key, expected_source) in cases {
+            let result = lookup
+                .lookup(raw)
+                .unwrap_or_else(|| panic!("unpriced alias: {raw}"));
+            assert_eq!(result.matched_key, expected_key, "raw model: {raw}");
+            assert_eq!(result.source, expected_source, "raw model: {raw}");
+        }
+
+        let cost = lookup.calculate_cost("gemini-3-flash-agent", 1_000_000, 100_000, 50_000, 0, 0);
+        assert!((cost - 2.4075).abs() < 1e-10);
+    }
+
     // =========================================================================
     // OPENCODE ZEN MODELS - KIMI FAMILY
     // =========================================================================

--- a/crates/tokscale-core/src/sessions/antigravity.rs
+++ b/crates/tokscale-core/src/sessions/antigravity.rs
@@ -157,7 +157,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_usage_row_preserves_unmapped_placeholder_models() {
+    fn parse_usage_row_resolves_current_placeholder_models() {
         let input = r#"{"type":"usage","sessionId":"abc","modelId":"model_placeholder_m84","timestamp":1711200000000,"input":12,"output":4,"cacheRead":2,"cacheWrite":0,"reasoning":1}
 {"type":"usage","sessionId":"abc","modelId":"model_placeholder_m16","timestamp":1711200000001,"input":8,"output":3,"cacheRead":0,"cacheWrite":0,"reasoning":0}
 "#;
@@ -167,9 +167,9 @@ mod tests {
 
         let messages = parse_antigravity_file(path.path());
         assert_eq!(messages.len(), 2);
-        assert_eq!(messages[0].model_id, "model_placeholder_m84");
-        assert_eq!(messages[0].provider_id, "antigravity");
-        assert_eq!(messages[1].model_id, "model_placeholder_m16");
-        assert_eq!(messages[1].provider_id, "antigravity");
+        assert_eq!(messages[0].model_id, "gemini-3-flash-preview");
+        assert_eq!(messages[0].provider_id, "google");
+        assert_eq!(messages[1].model_id, "gemini-3.1-pro");
+        assert_eq!(messages[1].provider_id, "google");
     }
 }

--- a/crates/tokscale-core/src/sessions/antigravity_cli.rs
+++ b/crates/tokscale-core/src/sessions/antigravity_cli.rs
@@ -496,7 +496,10 @@ mod tests {
         assert_eq!(message.client, "antigravity-cli");
         // `gemini-3-flash-a` (raw #19 responseModel) is alias-resolved to the
         // priced canonical model so cost lookups don't fall through to 0.
-        assert_eq!(message.model_id, "gemini-3-flash-preview");
+        // Per upstream (models.ts@603e3ea), `gemini-3-flash-a` is the legacy
+        // responseModel for M132, the retired predecessor of M133 — i.e. the
+        // High tier, not the unrelated gemini-3-flash-preview family.
+        assert_eq!(message.model_id, "gemini-3.5-flash-high");
         assert_eq!(message.provider_id, "google");
         assert_eq!(message.session_id, "session-test");
         assert_eq!(message.tokens.input, 1632); // 1132 + 500
@@ -615,7 +618,7 @@ mod tests {
         // dataset, which is unavailable in unit tests).
         assert_eq!(
             pricing::aliases::resolve_alias("gemini-3-flash-a"),
-            Some("gemini-3-flash-preview")
+            Some("gemini-3.5-flash-high")
         );
     }
 

--- a/crates/tokscale-core/src/sessions/antigravity_cli.rs
+++ b/crates/tokscale-core/src/sessions/antigravity_cli.rs
@@ -410,6 +410,10 @@ mod tests {
     }
 
     fn build_gen_metadata() -> Vec<u8> {
+        build_gen_metadata_with_model("gemini-3-flash-a")
+    }
+
+    fn build_gen_metadata_with_model(model: &str) -> Vec<u8> {
         // usage message (#4 of chatModel)
         let mut usage = Vec::new();
         usage.extend(enc_varint(1, 1132)); // fixed system prompt
@@ -422,7 +426,7 @@ mod tests {
         // chatModel message (#1 of gen_metadata)
         let mut chat_model = Vec::new();
         chat_model.extend(enc_len(4, &usage));
-        chat_model.extend(enc_len(19, b"gemini-3-flash-a"));
+        chat_model.extend(enc_len(19, model.as_bytes()));
 
         enc_len(1, &chat_model)
     }
@@ -506,6 +510,17 @@ mod tests {
             Some("C:/Users/Frank/obsidian-vault")
         );
         assert_eq!(message.workspace_label.as_deref(), Some("obsidian-vault"));
+    }
+
+    #[test]
+    fn resolves_current_antigravity_cli_response_model() {
+        let blob = build_gen_metadata_with_model("gemini-3-flash-agent");
+        let mut seen = HashSet::new();
+
+        let message = parse_gen_metadata(&blob, "session", 1_000, &mut seen).unwrap();
+
+        assert_eq!(message.model_id, "gemini-3.5-flash-high");
+        assert_eq!(message.provider_id, "google");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Normalize current Antigravity IDE placeholder IDs and Antigravity CLI `responseModel` aliases into normalized Tokscale model identifiers.

This prevents Tokscale reports from exposing opaque internal values such as `MODEL_PLACEHOLDER_M84` and ensures that provider inference, aggregation, and pricing lookup reach the corresponding model family.

## Problem

Antigravity does not always persist the public model name directly.

The two supported Antigravity sources expose different internal identifiers:

- Antigravity IDE sync artifacts can contain placeholder IDs such as `MODEL_PLACEHOLDER_M16`, `MODEL_PLACEHOLDER_M84`, and `MODEL_PLACEHOLDER_M133`.
- Antigravity CLI conversation databases store `chatModel.responseModel` aliases such as `gemini-pro-agent` and `gemini-3-flash-agent` in protobuf field 19.

Tokscale already extracted these values correctly, but its shared alias table only recognized part of the current Antigravity model set. Unrecognized identifiers therefore passed through unchanged.

This caused several user-visible problems:

- Reports displayed opaque implementation IDs instead of recognizable model names.
- Provider inference fell back to `antigravity` instead of identifying Google models.
- Equivalent model variants could be split into separate aggregation rows.
- Pricing lookup could miss the canonical model and report zero or incomplete cost.
- The same underlying model could appear differently depending on whether usage came from the IDE or `antigravity-cli`.

For example, cached IDE usage containing `MODEL_PLACEHOLDER_M84` previously remained `model_placeholder_m84`; it now resolves to `gemini-3-flash-preview`. Similarly, the current Antigravity CLI response alias `gemini-3-flash-agent` now resolves to `gemini-3.5-flash-high`.

## Why these mappings are needed

Antigravity model metadata is server-driven rather than defined by a stable local model list.

Antigravity Manager documents the server-side source and response shape: it obtains available model IDs and display names from Google Cloud Code Assist's internal `fetchAvailableModels` endpoint. The concrete placeholder and `responseModel` mappings come from the Antigravity Context Window Monitor's language-server and session model registry.

The language server exposes model IDs and labels through `GetUserStatus` at `userStatus.cascadeModelConfigData.clientModelConfigs[]`, using `modelOrAlias.model` for the internal ID and `label` for its display name.

- [Antigravity Manager quota/model discovery](https://github.com/lbjlaq/Antigravity-Manager/blob/dfe876548d572237da92fe4c3e070a9db33c0910/src-tauri/src/modules/quota.rs)
- [Antigravity Manager quota model](https://github.com/lbjlaq/Antigravity-Manager/blob/dfe876548d572237da92fe4c3e070a9db33c0910/src-tauri/src/models/quota.rs)
- [Antigravity language-server model config parsing](https://github.com/AGI-is-going-to-arrive/Antigravity-Context-Window-Monitor/blob/603e3ea00a0ee94f1beecc162cf47a4ed68d3a6f/src/tracker.ts#L568-L612)
- [Current Antigravity placeholder and response-model aliases](https://github.com/AGI-is-going-to-arrive/Antigravity-Context-Window-Monitor/blob/603e3ea00a0ee94f1beecc162cf47a4ed68d3a6f/src/models.ts)

Display labels are not used directly as pricing keys because they may be renamed or localized. This change only adds source-verified machine-ID aliases.

## Changes

Extended the shared model alias resolver with current Antigravity identifiers:

| Antigravity identifier | Tokscale model ID |
|---|---|
| `MODEL_PLACEHOLDER_M16` | `gemini-3.1-pro` |
| `MODEL_PLACEHOLDER_M18` | `gemini-3-flash-preview` |
| `MODEL_PLACEHOLDER_M84` | `gemini-3-flash-preview` |
| `MODEL_PLACEHOLDER_M132` | `gemini-3.5-flash-high` |
| `MODEL_PLACEHOLDER_M133` | `gemini-3.5-flash-high` |
| `MODEL_PLACEHOLDER_M187` | `gemini-3.5-flash-low` |
| `MODEL_PLACEHOLDER_M20` | `gemini-3.5-flash-medium` |
| `gemini-pro-default` | `gemini-3.1-pro` |
| `gemini-pro-agent` | `gemini-3.1-pro` |
| `gemini-3-flash-agent` | `gemini-3.5-flash-high` |
| `gemini-3-flash-b` | `gemini-3.5-flash-high` |
| `gemini-3.5-flash-low` | `gemini-3.5-flash-medium` |

Because both Antigravity parsers already use the shared alias resolver, the mappings apply consistently to IDE JSONL artifacts created by `tokscale antigravity sync` and Antigravity CLI SQLite conversation databases.

Unknown future IDs are still preserved unchanged. The parsers do not guess a model or discard usage when no verified mapping exists.

## Tests

Added or updated coverage for every added Antigravity alias, current IDE and CLI parser outputs, provider inference, submitted graph identity, exact pricing-catalog matches, and nonzero Gemini 3.5 Flash cost calculation.

```text
cargo test -p tokscale-core antigravity -- --nocapture
26 passed

cargo test -p tokscale-core antigravity_model_aliases_reach_priced_catalog_entries -- --nocapture
1 passed

cargo build -p tokscale-cli
passed

cargo fmt --all -- --check
passed
```

The pricing regression verifies representative Pro, Gemini 3 Flash, and Gemini 3.5 Flash identifiers against controlled LiteLLM/models.dev fixtures. Gemini 3.5 tier slugs resolve to the priced `google/gemini-3.5-flash` catalog entry.

A local report over existing Antigravity cache data also produced canonical model rows including `gemini-3.1-pro`, `gemini-3-flash-preview`, `gemini-3.5-flash-high`, `claude-opus-4-6`, and `claude-sonnet-4-6`.

## Compatibility

- No scanner path changes
- No client ID or CLI changes
- No Antigravity OAuth or network dependency added
- No changes to the submission schema
- Antigravity CLI remains an offline, read-only SQLite integration
- Unknown model identifiers continue to pass through unchanged
