### PR TITLE
fix(sessionize): start-anchor duration timestamps in remaining parsers

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -815,12 +815,23 @@ fn parser_version(client: ClientId) -> u32 {
         // (end-anchored) timestampMs. Follow-up to #890.
         ClientId::Junie => 2,
         // zcode's model_usage timestamp now prefers `started_at` over
-        // `completed_at`. Follow-up to #890.
-        ClientId::Zcode => 2,
+        // `completed_at`. Follow-up to #890. v2->v3: rows with a NULL
+        // `started_at` now back-calculate `completed_at - duration_ms`
+        // instead of staying end-anchored at `completed_at`, and
+        // `is_turn_start` is now assigned to the earliest-STARTED request
+        // per turn instead of the first one seen in completed_at order.
+        // Second-round follow-up to #890.
+        ClientId::Zcode => 3,
         // opencodereview's llm_response timestamp is now back-calculated to
         // the call start (timestamp - duration_ms) instead of the recorded
         // (end-anchored) timestamp. Follow-up to #890.
         ClientId::OpenCodeReview => 2,
+        // Kiro's structured messages.jsonl turns now back-calculate the
+        // start anchor from `turn_end - elapsedTime` when the user prompt's
+        // own timestamp is missing/unparseable, instead of falling through
+        // to the (end-anchored) turn_end timestamp. Second-round follow-up
+        // to #890.
+        ClientId::Kiro => 2,
         _ => 1,
     }
 }
@@ -2029,15 +2040,21 @@ mod tests {
         // Follow-up to #890: junie, jcode, devin-cli, zcode, and
         // opencodereview were re-anchored to start-anchored duration
         // timestamps; their cache-invalidating parser versions must bump so
-        // stale end-anchored-timestamp cache entries are not reused. kiro was
-        // audited and found already start-anchored across all four of its
-        // data sources, so it is intentionally not bumped here.
+        // stale end-anchored-timestamp cache entries are not reused.
+        //
+        // Second-round review found gaps in that first pass: zcode's
+        // NULL-`started_at` fallback stayed end-anchored and its
+        // `is_turn_start` marking didn't follow the new start-anchored
+        // timestamps, and kiro's structured messages.jsonl turns stayed
+        // end-anchored when the prompt timestamp was missing. Both bump
+        // again here so those stale (start-anchored-but-still-wrong) v2/v1
+        // cache entries are also invalidated.
         assert_eq!(parser_version(ClientId::Junie), 2);
         assert_eq!(parser_version(ClientId::Jcode), 5);
         assert_eq!(parser_version(ClientId::DevinCli), 3);
-        assert_eq!(parser_version(ClientId::Zcode), 2);
+        assert_eq!(parser_version(ClientId::Zcode), 3);
         assert_eq!(parser_version(ClientId::OpenCodeReview), 2);
-        assert_eq!(parser_version(ClientId::Kiro), 1);
+        assert_eq!(parser_version(ClientId::Kiro), 2);
     }
 
     #[test]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -793,15 +793,34 @@ fn parser_version(client: ClientId) -> u32 {
         // global schema. Their independent counters start from those histories
         // so future changes have an obvious local version to increment.
         ClientId::Codex => 6,
-        ClientId::Jcode => 4,
+        // v4->v5: jcode's assistant-message timestamp is now back-calculated
+        // to the turn start (timestamp - tool_duration_ms) instead of using
+        // the recorded (end-anchored) timestamp directly. Follow-up to #890.
+        ClientId::Jcode => 5,
         ClientId::Copilot => 5,
         // Pi subagent sessions now derive agent attribution from session_info
         // names; version-1 caches carry those messages without agent metadata.
         ClientId::Pi => 2,
-        // Devin CLI v1 could stop at a malformed chat_message. Desktop v1
-        // parsed a non-ACP shape and did not track its CLI title lookup.
-        ClientId::DevinCli | ClientId::DevinDesktop => 2,
+        // Devin CLI v1 could stop at a malformed chat_message. v2->v3:
+        // message timestamp is now back-calculated to the turn start
+        // (created_at - total_time_ms) instead of the recorded (end-anchored)
+        // created_at. Follow-up to #890.
+        ClientId::DevinCli => 3,
+        // Desktop v1 parsed a non-ACP shape and did not track its CLI title
+        // lookup; its timestamp handling is unaffected by the #890 follow-up.
+        ClientId::DevinDesktop => 2,
         ClientId::Claude => 2,
+        // Junie's usage-event timestamp is now back-calculated to the call
+        // start (timestampMs - usage.time) instead of the recorded
+        // (end-anchored) timestampMs. Follow-up to #890.
+        ClientId::Junie => 2,
+        // zcode's model_usage timestamp now prefers `started_at` over
+        // `completed_at`. Follow-up to #890.
+        ClientId::Zcode => 2,
+        // opencodereview's llm_response timestamp is now back-calculated to
+        // the call start (timestamp - duration_ms) instead of the recorded
+        // (end-anchored) timestamp. Follow-up to #890.
+        ClientId::OpenCodeReview => 2,
         _ => 1,
     }
 }
@@ -1994,7 +2013,7 @@ mod tests {
 
     #[test]
     fn test_devin_parser_versions_invalidate_v1_entries() {
-        assert_eq!(parser_version(ClientId::DevinCli), 2);
+        assert_eq!(parser_version(ClientId::DevinCli), 3);
         assert_eq!(parser_version(ClientId::DevinDesktop), 2);
     }
 
@@ -2003,6 +2022,22 @@ mod tests {
         assert_eq!(parser_version(ClientId::Codex), 6);
         assert_eq!(parser_version(ClientId::Copilot), 5);
         assert_eq!(parser_version(ClientId::Claude), 2);
+    }
+
+    #[test]
+    fn test_duration_anchor_audit_remaining_parsers_bumps_versions() {
+        // Follow-up to #890: junie, jcode, devin-cli, zcode, and
+        // opencodereview were re-anchored to start-anchored duration
+        // timestamps; their cache-invalidating parser versions must bump so
+        // stale end-anchored-timestamp cache entries are not reused. kiro was
+        // audited and found already start-anchored across all four of its
+        // data sources, so it is intentionally not bumped here.
+        assert_eq!(parser_version(ClientId::Junie), 2);
+        assert_eq!(parser_version(ClientId::Jcode), 5);
+        assert_eq!(parser_version(ClientId::DevinCli), 3);
+        assert_eq!(parser_version(ClientId::Zcode), 2);
+        assert_eq!(parser_version(ClientId::OpenCodeReview), 2);
+        assert_eq!(parser_version(ClientId::Kiro), 1);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/devin.rs
+++ b/crates/tokscale-core/src/sessions/devin.rs
@@ -268,7 +268,21 @@ pub fn parse_devin_cli_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             continue;
         }
 
-        let timestamp = created_at_ms.unwrap_or(fallback_timestamp);
+        let recorded_timestamp = created_at_ms.unwrap_or(fallback_timestamp);
+        // `message_nodes.created_at` is stamped when the row is written, which
+        // happens once the assistant message (including `metrics`) is
+        // finalized, i.e. the turn's *end*, not its start. `total_time_ms` is
+        // that turn's elapsed generation time, so sessionize()'s
+        // `[timestamp, timestamp + duration_ms]` span would otherwise project
+        // forward past the actual completion into phantom idle time.
+        // Back-calculate the start anchor the same way #890 did for
+        // Copilot's `endTime`-only records.
+        let duration_ms = metrics
+            .and_then(|m| m.total_time_ms)
+            .map(|total_time_ms| total_time_ms.max(0));
+        let timestamp = duration_ms
+            .map(|duration| recorded_timestamp.saturating_sub(duration))
+            .unwrap_or(recorded_timestamp);
         let dedup_key = format!("devin-cli:{session_id}:{row_id}");
         let mut unified = UnifiedMessage::new_with_dedup(
             "devin-cli",
@@ -281,9 +295,7 @@ pub fn parse_devin_cli_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             Some(dedup_key),
         );
 
-        if let Some(total_time_ms) = metrics.and_then(|m| m.total_time_ms) {
-            unified.duration_ms = Some(total_time_ms.max(0));
-        }
+        unified.duration_ms = duration_ms;
 
         if let Some(ws) = workspace {
             let workspace_key = normalize_workspace_key(&ws);
@@ -692,9 +704,47 @@ mod tests {
         assert_eq!(msg.tokens.output, 147);
         assert_eq!(msg.tokens.cache_read, 8);
         assert_eq!(msg.tokens.cache_write, 0);
-        assert_eq!(msg.timestamp, 1_700_000_000_000);
+        // `created_at` is the message row's write time (the turn's end), so
+        // the message timestamp is back-calculated to the turn start:
+        // created_at_ms - total_time_ms. See #890 (follow-up).
+        assert_eq!(msg.timestamp, 1_700_000_000_000 - 2846);
         assert_eq!(msg.duration_ms, Some(2846));
         assert_eq!(msg.workspace_key.as_deref(), Some("/Users/alice/project"));
+    }
+
+    #[test]
+    fn test_total_time_ms_timestamp_is_start_anchored() {
+        // Regression (follow-up to #890): `message_nodes.created_at` is
+        // stamped when the row is written, which happens once the assistant
+        // message (including `metrics`) is finalized, i.e. the turn's *end*,
+        // not its start. `total_time_ms` is that turn's elapsed generation
+        // time, so sessionize()'s `[timestamp, timestamp + duration_ms]` span
+        // would otherwise project forward past the actual completion into
+        // phantom idle time. The parser must back-calculate the start anchor
+        // instead.
+        let dir = TempDir::new().unwrap();
+        let db_path = create_devin_cli_db(&dir);
+        let conn = Connection::open(&db_path).unwrap();
+
+        insert_session(&conn, "sess-1", "/Users/alice/project", "claude-sonnet-4");
+        let chat = r#"{"role":"assistant","content":"hello","metadata":{"generation_model":"claude-sonnet-4","metrics":{"input_tokens":100,"output_tokens":50,"total_time_ms":5000}}}"#;
+        insert_message(&conn, "sess-1", chat, 1_700_000_010);
+        drop(conn);
+
+        let messages = parse_devin_cli_sqlite(&db_path);
+        assert_eq!(messages.len(), 1);
+
+        let msg = &messages[0];
+        assert_eq!(
+            msg.timestamp,
+            1_700_000_010_000 - 5000,
+            "timestamp must be back-calculated to the turn start (end - duration)"
+        );
+        assert_eq!(
+            msg.duration_ms,
+            Some(5000),
+            "duration_ms must still span from start to the recorded end timestamp"
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/devin.rs
+++ b/crates/tokscale-core/src/sessions/devin.rs
@@ -4,7 +4,7 @@
 //! - Devin CLI SQLite database (`~/.local/share/devin/cli/sessions.db`)
 //! - Devin Desktop NDJSON event streams (`~/Library/Application Support/Devin/User/acp-events/*.ndjson`)
 
-use super::utils::{file_modified_timestamp_ms, open_readonly_sqlite};
+use super::utils::{back_anchor_timestamp, file_modified_timestamp_ms, open_readonly_sqlite};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::{provider_identity, TokenBreakdown};
 use serde::Deserialize;
@@ -280,9 +280,16 @@ pub fn parse_devin_cli_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
         let duration_ms = metrics
             .and_then(|m| m.total_time_ms)
             .map(|total_time_ms| total_time_ms.max(0));
-        let timestamp = duration_ms
-            .map(|duration| recorded_timestamp.saturating_sub(duration))
-            .unwrap_or(recorded_timestamp);
+        // Only back-calculate when `created_at_ms` is this row's own recorded
+        // completion time: when it's absent, `recorded_timestamp` is
+        // `fallback_timestamp` (the database file's mtime), not this
+        // message's own end time, and subtracting `total_time_ms` from it
+        // would shift the message into the wrong day rather than anchor it
+        // correctly.
+        let timestamp = match (created_at_ms, duration_ms.filter(|duration| *duration > 0)) {
+            (Some(end), Some(duration)) => back_anchor_timestamp(end, duration),
+            _ => recorded_timestamp,
+        };
         let dedup_key = format!("devin-cli:{session_id}:{row_id}");
         let mut unified = UnifiedMessage::new_with_dedup(
             "devin-cli",

--- a/crates/tokscale-core/src/sessions/jcode.rs
+++ b/crates/tokscale-core/src/sessions/jcode.rs
@@ -181,11 +181,22 @@ fn parse_jcode_messages(
             if tokens.total() <= 0 {
                 return None;
             }
-            let timestamp = message
+            let recorded_timestamp = message
                 .timestamp
                 .as_deref()
                 .and_then(parse_timestamp_str)
                 .unwrap_or(fallback_timestamp);
+            // The assistant message's `timestamp` is written once the message
+            // (including `token_usage`) is finalized, i.e. the turn's *end*,
+            // not its start. `tool_duration_ms` is that turn's elapsed time,
+            // so `sessionize()`'s `[timestamp, timestamp + duration_ms]` span
+            // would otherwise project forward past completion into phantom
+            // idle time. Back-calculate the start anchor the same way #890
+            // did for Copilot's `endTime`-only records.
+            let duration_ms = message.tool_duration_ms.filter(|duration| *duration > 0);
+            let timestamp = duration_ms
+                .map(|duration| recorded_timestamp.saturating_sub(duration))
+                .unwrap_or(recorded_timestamp);
             let mut unified = UnifiedMessage::new_with_dedup(
                 "jcode",
                 context.model.clone(),
@@ -196,7 +207,7 @@ fn parse_jcode_messages(
                 0.0,
                 Some(dedup_key),
             );
-            unified.duration_ms = message.tool_duration_ms.filter(|duration| *duration > 0);
+            unified.duration_ms = duration_ms;
             if !is_replacement
                 && message.role.as_deref() == Some("assistant")
                 && context.pending_turn_start
@@ -659,5 +670,41 @@ mod tests {
         assert!(messages[1].is_turn_start);
         let turn_count = messages.iter().filter(|m| m.is_turn_start).count();
         assert_eq!(turn_count, 2);
+    }
+
+    #[test]
+    fn test_tool_duration_timestamp_is_start_anchored() {
+        // Regression (follow-up to #890): an assistant message's `timestamp`
+        // is written once the message (including `token_usage`) is
+        // finalized, i.e. the turn's *end*, not its start. `tool_duration_ms`
+        // is that turn's elapsed time, so sessionize()'s
+        // `[timestamp, timestamp + duration_ms]` span would otherwise project
+        // forward past the actual completion into phantom idle time. The
+        // parser must back-calculate the start anchor instead.
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            file.path(),
+            r#"{
+  "id":"session_test",
+  "model":"snapshot-model",
+  "messages":[
+    {"id":"assistant_1","role":"assistant","timestamp":"2026-06-16T12:00:05Z","token_usage":{"input_tokens":100,"output_tokens":10},"tool_duration_ms":2000}
+  ]
+}"#,
+        )
+        .unwrap();
+
+        let messages = parse_jcode_file(file.path());
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].timestamp,
+            parse_timestamp_str("2026-06-16T12:00:03Z").unwrap(),
+            "timestamp must be back-calculated to the turn start (end - duration)"
+        );
+        assert_eq!(
+            messages[0].duration_ms,
+            Some(2000),
+            "duration_ms must still span from start to the recorded end timestamp"
+        );
     }
 }

--- a/crates/tokscale-core/src/sessions/jcode.rs
+++ b/crates/tokscale-core/src/sessions/jcode.rs
@@ -4,7 +4,7 @@
 //! Jcode stores authoritative assistant token usage on messages under
 //! `token_usage`; user/tool messages without usage are skipped.
 
-use super::utils::{file_modified_timestamp_ms, parse_timestamp_str};
+use super::utils::{back_anchor_timestamp, file_modified_timestamp_ms, parse_timestamp_str};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::{provider_identity, TokenBreakdown};
 use serde::Deserialize;
@@ -181,11 +181,11 @@ fn parse_jcode_messages(
             if tokens.total() <= 0 {
                 return None;
             }
-            let recorded_timestamp = message
-                .timestamp
-                .as_deref()
-                .and_then(parse_timestamp_str)
-                .unwrap_or(fallback_timestamp);
+            // `explicit_timestamp` is the message's own recorded `timestamp`
+            // field, as opposed to `fallback_timestamp` (a session/file-level
+            // fallback used when it's absent or unparseable).
+            let explicit_timestamp = message.timestamp.as_deref().and_then(parse_timestamp_str);
+            let recorded_timestamp = explicit_timestamp.unwrap_or(fallback_timestamp);
             // The assistant message's `timestamp` is written once the message
             // (including `token_usage`) is finalized, i.e. the turn's *end*,
             // not its start. `tool_duration_ms` is that turn's elapsed time,
@@ -193,10 +193,17 @@ fn parse_jcode_messages(
             // would otherwise project forward past completion into phantom
             // idle time. Back-calculate the start anchor the same way #890
             // did for Copilot's `endTime`-only records.
+            //
+            // Only do this when `explicit_timestamp` is a real recorded end
+            // timestamp: when it's absent, `recorded_timestamp` is the
+            // session/file-level fallback, not this message's own completion
+            // time, and subtracting `tool_duration_ms` from it would shift
+            // the message into the wrong day rather than anchor it correctly.
             let duration_ms = message.tool_duration_ms.filter(|duration| *duration > 0);
-            let timestamp = duration_ms
-                .map(|duration| recorded_timestamp.saturating_sub(duration))
-                .unwrap_or(recorded_timestamp);
+            let timestamp = match (explicit_timestamp, duration_ms) {
+                (Some(end), Some(duration)) => back_anchor_timestamp(end, duration),
+                _ => recorded_timestamp,
+            };
             let mut unified = UnifiedMessage::new_with_dedup(
                 "jcode",
                 context.model.clone(),

--- a/crates/tokscale-core/src/sessions/junie.rs
+++ b/crates/tokscale-core/src/sessions/junie.rs
@@ -113,18 +113,30 @@ pub fn parse_junie_file(path: &Path) -> Vec<UnifiedMessage> {
                 continue;
             }
 
+            // `timestampMs` is recorded when the LlmResponseMetadataEvent (the
+            // response) is logged, i.e. the call's *end*, not its start.
+            // `usage.time` is that call's latency, so `sessionize()`'s
+            // `[timestamp, timestamp + duration_ms]` span would otherwise
+            // project forward past the actual completion into phantom idle
+            // time. Back-calculate the start anchor the same way #890 did for
+            // Copilot's `endTime`-only records.
+            let duration_ms = number_field(usage, "time").filter(|duration| *duration > 0);
+            let start_timestamp = duration_ms
+                .map(|duration| timestamp.saturating_sub(duration))
+                .unwrap_or(timestamp);
+
             let mut message = UnifiedMessage::new_with_agent(
                 "junie",
                 model_id,
                 provider_id,
                 &session_id,
-                timestamp,
+                start_timestamp,
                 tokens,
                 cost,
                 agent.clone(),
             );
             message.dedup_key = Some(dedup_key);
-            message.duration_ms = number_field(usage, "time").filter(|duration| *duration > 0);
+            message.duration_ms = duration_ms;
             if pending_turn_start && !turn_start_assigned {
                 message.is_turn_start = true;
                 turn_start_assigned = true;
@@ -428,5 +440,29 @@ mod tests {
         // Only the genuine usage event counts; the snapshot tagged with a
         // skipped top-level kind is ignored even though it embeds a usage shape.
         assert_eq!(messages.len(), 1);
+    }
+
+    #[test]
+    fn test_usage_timestamp_is_start_anchored() {
+        // Regression (follow-up to #890): `timestampMs` on a
+        // LlmResponseMetadataEvent is recorded when the response is logged
+        // (the call's *end*), and `usage.time` is that call's latency. If the
+        // message's timestamp were left at `timestampMs`, sessionize()'s
+        // `[timestamp, timestamp + duration_ms]` span would project forward
+        // past the actual completion into phantom idle time. The parser must
+        // back-calculate the start anchor instead.
+        let content = r#"{"timestampMs":1750000005000,"event":{"agentEvent":{"kind":"LlmResponseMetadataEvent","modelUsage":[{"model":"gpt-5","inputTokens":100,"outputTokens":50,"time":2000}]}}}"#;
+        let messages = parse_events(content);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].timestamp, 1_750_000_003_000,
+            "timestamp must be back-calculated to the call start (end - duration)"
+        );
+        assert_eq!(
+            messages[0].duration_ms,
+            Some(2000),
+            "duration_ms must still span from start to the logged end timestamp"
+        );
     }
 }

--- a/crates/tokscale-core/src/sessions/junie.rs
+++ b/crates/tokscale-core/src/sessions/junie.rs
@@ -2,7 +2,7 @@
 //!
 //! Junie stores local sessions under `~/.junie/sessions/<session-id>/events.jsonl`.
 
-use super::utils::file_modified_timestamp_ms;
+use super::utils::{back_anchor_timestamp, file_modified_timestamp_ms};
 use super::UnifiedMessage;
 use crate::{pricing, provider_identity, TokenBreakdown};
 use chrono::{Local, LocalResult, NaiveDateTime, TimeZone};
@@ -67,9 +67,15 @@ pub fn parse_junie_file(path: &Path) -> Vec<UnifiedMessage> {
             continue;
         };
 
-        let timestamp = number_field(&value, "timestampMs")
-            .filter(|timestamp| *timestamp > 0)
-            .unwrap_or(default_timestamp);
+        // `explicit_timestamp` is the recorded `timestampMs` for this event, as
+        // opposed to `default_timestamp` (a session-derived or file-mtime
+        // fallback used when it's absent). Only an explicit end timestamp is a
+        // valid anchor to back-calculate from below — subtracting `usage.time`
+        // from the fallback would shift the message into the wrong
+        // day/session-window rather than the call's actual start.
+        let explicit_timestamp =
+            number_field(&value, "timestampMs").filter(|timestamp| *timestamp > 0);
+        let timestamp = explicit_timestamp.unwrap_or(default_timestamp);
         let agent = agent_name(agent_event);
         let Some(usages) = agent_event.get("modelUsage").and_then(Value::as_array) else {
             continue;
@@ -120,10 +126,17 @@ pub fn parse_junie_file(path: &Path) -> Vec<UnifiedMessage> {
             // project forward past the actual completion into phantom idle
             // time. Back-calculate the start anchor the same way #890 did for
             // Copilot's `endTime`-only records.
+            //
+            // Only do this when `explicit_timestamp` is a real recorded end
+            // timestamp: when it's absent, `timestamp` is `default_timestamp`
+            // (session-ID-derived or file mtime), not a per-event completion
+            // time, and subtracting `usage.time` from it would shift the
+            // message into the wrong day rather than anchor it correctly.
             let duration_ms = number_field(usage, "time").filter(|duration| *duration > 0);
-            let start_timestamp = duration_ms
-                .map(|duration| timestamp.saturating_sub(duration))
-                .unwrap_or(timestamp);
+            let start_timestamp = match (explicit_timestamp, duration_ms) {
+                (Some(end), Some(duration)) => back_anchor_timestamp(end, duration),
+                _ => timestamp,
+            };
 
             let mut message = UnifiedMessage::new_with_agent(
                 "junie",
@@ -464,5 +477,26 @@ mod tests {
             Some(2000),
             "duration_ms must still span from start to the logged end timestamp"
         );
+    }
+
+    #[test]
+    fn missing_timestamp_ms_does_not_subtract_from_session_fallback() {
+        // Second-round review fix: when `timestampMs` is absent (only
+        // `usage.time` latency is recorded), `timestamp` falls back to
+        // `default_timestamp` (session-ID-derived, or file mtime) — not a
+        // per-event recorded end time. Back-calculating
+        // `default_timestamp - usage.time` in that case would shift the
+        // message into the wrong day rather than anchor it correctly, since
+        // the fallback was never the call's actual completion time.
+        let content = r#"{"event":{"agentEvent":{"kind":"LlmResponseMetadataEvent","modelUsage":[{"model":"gpt-5","inputTokens":100,"outputTokens":50,"time":2000}]}}}"#;
+        let messages = parse_events(content);
+
+        assert_eq!(messages.len(), 1);
+        let expected_fallback = session_timestamp_from_id("session-250622-101010").unwrap();
+        assert_eq!(
+            messages[0].timestamp, expected_fallback,
+            "timestamp must stay at the session-derived fallback, not be back-calculated from it"
+        );
+        assert_eq!(messages[0].duration_ms, Some(2000));
     }
 }

--- a/crates/tokscale-core/src/sessions/kiro.rs
+++ b/crates/tokscale-core/src/sessions/kiro.rs
@@ -13,7 +13,7 @@
 //! estimated from context_usage_percentage * context_window (input) and
 //! response_size / 4 (output).
 
-use super::utils::file_modified_timestamp_ms;
+use super::utils::{back_anchor_timestamp, file_modified_timestamp_ms};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
 use rusqlite::Connection;
@@ -615,13 +615,28 @@ fn parse_kiro_ide_session_file(path: &Path) -> Vec<UnifiedMessage> {
                     return None;
                 }
 
-                let timestamp = turn
-                    .prompt_timestamp_ms
-                    .or(turn.end_timestamp_ms)
-                    .unwrap_or(fallback_timestamp);
                 let duration_ms = turn.elapsed_ms.or_else(|| {
                     duration_between_ms(turn.prompt_timestamp_ms, turn.end_timestamp_ms)
                 });
+                // Prefer the user prompt's own timestamp. When it's absent or
+                // unparseable (e.g. `usage_summary.elapsedTime` supplied
+                // `duration_ms` but the prompt timestamp couldn't be
+                // resolved), back-calculate the start anchor from
+                // `turn_end - elapsed` instead of falling through to
+                // `end_timestamp_ms` directly — otherwise sessionize()'s
+                // `[timestamp, timestamp + duration_ms]` span would project
+                // forward past the turn's actual end into phantom idle time.
+                // The back-calculation is guarded against a non-positive
+                // result (which sessionize() silently drops) by falling back
+                // to the unadjusted `end_timestamp_ms`.
+                let timestamp = turn
+                    .prompt_timestamp_ms
+                    .or_else(|| match (turn.end_timestamp_ms, duration_ms) {
+                        (Some(end), Some(elapsed)) => Some(back_anchor_timestamp(end, elapsed)),
+                        _ => None,
+                    })
+                    .or(turn.end_timestamp_ms)
+                    .unwrap_or(fallback_timestamp);
 
                 let mut message = UnifiedMessage::new_with_dedup(
                     CLIENT_ID,
@@ -2191,6 +2206,46 @@ not valid json at all
         assert_eq!(messages[0].message_count, 2);
         assert!(messages[0].tokens.input > 0);
         assert!(messages[0].tokens.output > 0);
+    }
+
+    #[test]
+    fn test_structured_turn_missing_prompt_timestamp_back_calculates_from_elapsed_time() {
+        // Second-round review fix: in the structured `messages.jsonl` layout,
+        // `usage_summary.elapsedTime` can supply `duration_ms` while the user
+        // prompt's own timestamp is absent (or unparseable). Previously the
+        // message timestamp fell back to the `turn_end` event's own
+        // timestamp, leaving the message end-anchored — sessionize()'s
+        // `[timestamp, timestamp + duration_ms]` span would then project
+        // forward past the turn's actual end into phantom idle time. The
+        // parser must back-calculate `turn_end - elapsedTime` as the anchor
+        // instead.
+        let session_json = r#"{
+            "schemaVersion": "1.0.0",
+            "id": "sess_structured"
+        }"#;
+        let messages_jsonl = concat!(
+            "{\"payload\":{\"type\":\"user\",\"content\":\"hello world\"}}\n",
+            "{\"payload\":{\"type\":\"assistant\",\"content\":\"response text\"}}\n",
+            "{\"payload\":{\"type\":\"usage_summary\",\"elapsedTime\":5000}}\n",
+            "{\"payload\":{\"type\":\"turn_end\"},\"timestamp\":\"2026-06-20T10:00:05Z\"}\n",
+        );
+
+        let dir = TempDir::new().unwrap();
+        let path =
+            create_ide_session_files(&dir, "ws", "sess_structured", session_json, messages_jsonl);
+
+        let messages = parse_kiro_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        let expected_end = chrono::DateTime::parse_from_rfc3339("2026-06-20T10:00:05Z")
+            .unwrap()
+            .timestamp_millis();
+        assert_eq!(
+            messages[0].timestamp,
+            expected_end - 5000,
+            "timestamp must be back-calculated from turn_end - elapsedTime when the prompt timestamp is missing"
+        );
+        assert_eq!(messages[0].duration_ms, Some(5000));
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/opencodereview.rs
+++ b/crates/tokscale-core/src/sessions/opencodereview.rs
@@ -3,7 +3,7 @@
 //! OpenCodeReview stores sessions as JSONL files under
 //! `~/.opencodereview/sessions/<encoded-repo-path>/<session-id>.jsonl`.
 
-use super::utils::{file_modified_timestamp_ms, parse_timestamp_value};
+use super::utils::{back_anchor_timestamp, file_modified_timestamp_ms, parse_timestamp_value};
 use super::UnifiedMessage;
 use crate::{pricing, provider_identity, TokenBreakdown};
 use serde_json::Value;
@@ -58,10 +58,11 @@ pub fn parse_opencodereview_file(path: &Path) -> Vec<UnifiedMessage> {
             continue;
         }
 
-        let recorded_timestamp = value
-            .get("timestamp")
-            .and_then(parse_timestamp_value)
-            .unwrap_or(fallback_timestamp);
+        // `explicit_timestamp` is this record's own recorded `timestamp`
+        // field, as opposed to `fallback_timestamp` (a file-mtime fallback
+        // used when it's absent or unparseable).
+        let explicit_timestamp = value.get("timestamp").and_then(parse_timestamp_value);
+        let recorded_timestamp = explicit_timestamp.unwrap_or(fallback_timestamp);
 
         let model_raw = value
             .get("model")
@@ -87,9 +88,16 @@ pub fn parse_opencodereview_file(path: &Path) -> Vec<UnifiedMessage> {
         // project forward past the actual completion into phantom idle time.
         // Back-calculate the start anchor the same way #890 did for
         // Copilot's `endTime`-only records.
-        let timestamp = duration_ms
-            .map(|duration| recorded_timestamp.saturating_sub(duration))
-            .unwrap_or(recorded_timestamp);
+        //
+        // Only do this when `explicit_timestamp` is a real recorded end
+        // timestamp: when it's absent, `recorded_timestamp` is
+        // `fallback_timestamp` (the file's mtime), not this record's own end
+        // time, and subtracting `duration_ms` from it would shift the
+        // message into the wrong day rather than anchor it correctly.
+        let timestamp = match (explicit_timestamp, duration_ms) {
+            (Some(end), Some(duration)) => back_anchor_timestamp(end, duration),
+            _ => recorded_timestamp,
+        };
 
         let dedup_key = format!(
             "opencodereview:{session_id}:{recorded_timestamp}:{model_id}:{}:{}:{}:{}",

--- a/crates/tokscale-core/src/sessions/opencodereview.rs
+++ b/crates/tokscale-core/src/sessions/opencodereview.rs
@@ -58,7 +58,7 @@ pub fn parse_opencodereview_file(path: &Path) -> Vec<UnifiedMessage> {
             continue;
         }
 
-        let timestamp = value
+        let recorded_timestamp = value
             .get("timestamp")
             .and_then(parse_timestamp_value)
             .unwrap_or(fallback_timestamp);
@@ -80,8 +80,19 @@ pub fn parse_opencodereview_file(path: &Path) -> Vec<UnifiedMessage> {
             .and_then(Value::as_i64)
             .filter(|d| *d > 0);
 
+        // The `llm_response` record's `timestamp` is written when the
+        // response is logged, i.e. the call's *end*, not its start.
+        // `duration_ms` is that call's elapsed time, so sessionize()'s
+        // `[timestamp, timestamp + duration_ms]` span would otherwise
+        // project forward past the actual completion into phantom idle time.
+        // Back-calculate the start anchor the same way #890 did for
+        // Copilot's `endTime`-only records.
+        let timestamp = duration_ms
+            .map(|duration| recorded_timestamp.saturating_sub(duration))
+            .unwrap_or(recorded_timestamp);
+
         let dedup_key = format!(
-            "opencodereview:{session_id}:{timestamp}:{model_id}:{}:{}:{}:{}",
+            "opencodereview:{session_id}:{recorded_timestamp}:{model_id}:{}:{}:{}:{}",
             tokens.input, tokens.output, tokens.cache_read, tokens.cache_write,
         );
         if !seen.insert(dedup_key.clone()) {
@@ -288,5 +299,32 @@ mod tests {
         let msgs = parse_opencodereview_file(&path);
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].session_id, "my-unique-session");
+    }
+
+    #[test]
+    fn test_llm_response_timestamp_is_start_anchored() {
+        // Regression (follow-up to #890): an `llm_response` record's
+        // `timestamp` is written when the response is logged, i.e. the
+        // call's *end*, not its start. `duration_ms` is that call's elapsed
+        // time, so sessionize()'s `[timestamp, timestamp + duration_ms]`
+        // span would otherwise project forward past the actual completion
+        // into phantom idle time. The parser must back-calculate the start
+        // anchor instead.
+        let content = llm_response("2026-01-15T10:00:05Z", "gpt-4o", 100, 50, 0, 0);
+        let msgs = parse_events(&format!("{content}\n"));
+
+        assert_eq!(msgs.len(), 1);
+        let expected_end =
+            parse_timestamp_value(&Value::String("2026-01-15T10:00:05Z".to_string())).unwrap();
+        assert_eq!(
+            msgs[0].timestamp,
+            expected_end - 1500,
+            "timestamp must be back-calculated to the call start (end - duration)"
+        );
+        assert_eq!(
+            msgs[0].duration_ms,
+            Some(1500),
+            "duration_ms must still span from start to the recorded end timestamp"
+        );
     }
 }

--- a/crates/tokscale-core/src/sessions/utils.rs
+++ b/crates/tokscale-core/src/sessions/utils.rs
@@ -98,6 +98,26 @@ pub(crate) fn read_file_or_none(path: &Path) -> Option<Vec<u8>> {
     std::fs::read(path).ok()
 }
 
+/// Back-calculate a start anchor from a recorded end timestamp and an elapsed
+/// duration: `end - duration`.
+///
+/// Several session sources only record the timestamp at which a call/turn
+/// *finished*, plus its elapsed duration. Anchoring the message at that end
+/// timestamp directly would make `sessionize()`'s
+/// `[timestamp, timestamp + duration_ms]` span project forward past the
+/// actual completion into phantom idle time (see #890), so callers
+/// back-calculate the start instead. That subtraction can itself produce a
+/// non-positive result when `duration` exceeds `end` (e.g. a corrupt or
+/// clock-skewed duration value) — `sessionize()` silently drops any message
+/// with `timestamp <= 0`, so this guards against that by falling back to the
+/// unadjusted `end` timestamp when the back-calculated candidate would not
+/// be positive.
+pub(crate) fn back_anchor_timestamp(end: i64, duration: i64) -> i64 {
+    end.checked_sub(duration)
+        .filter(|candidate| *candidate > 0)
+        .unwrap_or(end)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tokscale-core/src/sessions/zcode.rs
+++ b/crates/tokscale-core/src/sessions/zcode.rs
@@ -409,9 +409,15 @@ pub fn parse_zcode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             .as_deref()
             .map(canonicalize_model)
             .unwrap_or_else(|| UNKNOWN_MODEL.to_string());
+        // `model_usage` records both endpoints of the call: prefer
+        // `started_at` so the message timestamp anchors to the call's start,
+        // matching `duration_ms`'s own start-to-end span. Anchoring at
+        // `completed_at` instead would make sessionize()'s
+        // `[timestamp, timestamp + duration_ms]` span project forward past
+        // the actual completion into phantom idle time (see #890).
         let timestamp = row
-            .completed_at
-            .or(row.started_at)
+            .started_at
+            .or(row.completed_at)
             .unwrap_or(fallback_timestamp);
 
         let raw_input = row.input_tokens.unwrap_or(0);
@@ -866,7 +872,9 @@ mod tests {
         assert_eq!(msg.provider_id, "zhipu");
         assert_eq!(msg.model_id, "glm-5.2");
         assert_eq!(msg.session_id, "sess_1");
-        assert_eq!(msg.timestamp, 1_782_718_001_000_i64);
+        // Timestamp anchors to `started_at` (the call's start), not
+        // `completed_at` (the call's end). See #890 (follow-up).
+        assert_eq!(msg.timestamp, 1_782_718_000_000_i64);
         assert_eq!(msg.duration_ms, Some(1000));
         assert_eq!(msg.tokens.input, 90);
         assert_eq!(msg.tokens.output, 15);
@@ -911,6 +919,52 @@ mod tests {
         assert_eq!(messages.len(), 2);
         assert!(messages[0].is_turn_start);
         assert!(!messages[1].is_turn_start);
+    }
+
+    #[test]
+    fn test_model_usage_timestamp_is_start_anchored() {
+        // Regression (follow-up to #890): `model_usage` records both
+        // `started_at` and `completed_at` for a call, plus an explicit
+        // `duration_ms`. Anchoring the message timestamp at `completed_at`
+        // would make sessionize()'s `[timestamp, timestamp + duration_ms]`
+        // span project forward past the actual completion into phantom idle
+        // time. The parser must prefer `started_at`.
+        let dir = TempDir::new().unwrap();
+        let db_path = create_zcode_sqlite_db(&dir);
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            r#"
+            INSERT INTO model_usage (
+                id, session_id, turn_id, model_id, started_at, completed_at,
+                duration_ms, input_tokens, output_tokens
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+            "#,
+            params![
+                "usage_1",
+                "sess_1",
+                "turn_1",
+                "glm-5.2",
+                1_782_718_000_000_i64,
+                1_782_718_005_000_i64,
+                5000_i64,
+                10_i64,
+                1_i64,
+            ],
+        )
+        .unwrap();
+
+        let messages = parse_zcode_sqlite(&db_path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].timestamp, 1_782_718_000_000_i64,
+            "timestamp must anchor at started_at, not completed_at"
+        );
+        assert_eq!(
+            messages[0].duration_ms,
+            Some(5000),
+            "duration_ms must still span from start to completion"
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/zcode.rs
+++ b/crates/tokscale-core/src/sessions/zcode.rs
@@ -13,11 +13,11 @@
 //! counts are used. When absent, tokens are estimated at ~4 chars/token,
 //! consistent with tokscale's other estimated sources (see CommandCode, Kiro).
 
-use super::utils::{file_modified_timestamp_ms, open_readonly_sqlite};
+use super::utils::{back_anchor_timestamp, file_modified_timestamp_ms, open_readonly_sqlite};
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
 use serde::Deserialize;
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 
@@ -395,7 +395,10 @@ pub fn parse_zcode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
     };
 
     let mut messages = Vec::new();
-    let mut seen_turns: HashSet<String> = HashSet::new();
+    // Parallel to `messages`: each row's turn_id (if any), so is_turn_start
+    // can be assigned in a second pass once every row's start-anchored
+    // timestamp is known (see below).
+    let mut turn_ids: Vec<Option<String>> = Vec::new();
 
     for row_result in rows {
         let row = match row_result {
@@ -409,16 +412,12 @@ pub fn parse_zcode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             .as_deref()
             .map(canonicalize_model)
             .unwrap_or_else(|| UNKNOWN_MODEL.to_string());
-        // `model_usage` records both endpoints of the call: prefer
-        // `started_at` so the message timestamp anchors to the call's start,
-        // matching `duration_ms`'s own start-to-end span. Anchoring at
-        // `completed_at` instead would make sessionize()'s
-        // `[timestamp, timestamp + duration_ms]` span project forward past
-        // the actual completion into phantom idle time (see #890).
-        let timestamp = row
-            .started_at
-            .or(row.completed_at)
-            .unwrap_or(fallback_timestamp);
+        let timestamp = resolve_zcode_timestamp(
+            row.started_at,
+            row.completed_at,
+            row.duration_ms,
+            fallback_timestamp,
+        );
 
         let raw_input = row.input_tokens.unwrap_or(0);
         let raw_output = row.output_tokens.unwrap_or(0);
@@ -489,19 +488,76 @@ pub fn parse_zcode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
         );
         message.dedup_key = Some(format!("zcode-sqlite:{}", row.id));
         message.duration_ms = row.duration_ms.filter(|duration| *duration > 0);
-        if let Some(turn_id) = row.turn_id.as_deref().filter(|id| !id.is_empty()) {
-            message.is_turn_start = seen_turns.insert(turn_id.to_string());
-        }
 
         let workspace_root = row.session_directory.or(row.session_path);
         let workspace_key = workspace_root.as_deref().and_then(normalize_workspace_key);
         let workspace_label = workspace_key.as_deref().and_then(workspace_label_from_key);
         message.set_workspace(workspace_key, workspace_label);
 
+        turn_ids.push(
+            row.turn_id
+                .as_deref()
+                .filter(|id| !id.is_empty())
+                .map(str::to_string),
+        );
         messages.push(message);
     }
 
+    // Assign is_turn_start to the earliest-STARTED request per turn, not the
+    // first one encountered in query order (which is ordered by
+    // completed_at). Timestamps are now start-anchored (see above), so a
+    // later-started-but-earlier-completed request could otherwise win the
+    // flag and land the turn in the wrong hour/day bucket downstream (see
+    // lib.rs's hourly turn_count aggregation).
+    let mut earliest_index_per_turn: HashMap<&str, usize> = HashMap::new();
+    for (index, turn_id) in turn_ids.iter().enumerate() {
+        let Some(turn_id) = turn_id.as_deref() else {
+            continue;
+        };
+        earliest_index_per_turn
+            .entry(turn_id)
+            .and_modify(|current| {
+                if messages[index].timestamp < messages[*current].timestamp {
+                    *current = index;
+                }
+            })
+            .or_insert(index);
+    }
+    for index in earliest_index_per_turn.into_values() {
+        messages[index].is_turn_start = true;
+    }
+
     messages
+}
+
+/// Resolve the anchor timestamp for a `model_usage` row.
+///
+/// Prefers `started_at` when it's a positive epoch, since it anchors the
+/// message at the call's actual start, matching `duration_ms`'s own
+/// start-to-end span. When `started_at` is missing or non-positive, falls
+/// back to `completed_at`, back-calculating the start anchor from
+/// `completed_at - duration_ms` when a positive `duration_ms` is available
+/// — anchoring at `completed_at` directly would make sessionize()'s
+/// `[timestamp, timestamp + duration_ms]` span project forward past the
+/// actual completion into phantom idle time (see #890). The back-calculation
+/// is guarded against a non-positive result (which sessionize() silently
+/// drops) by falling back to the unadjusted `completed_at`.
+fn resolve_zcode_timestamp(
+    started_at: Option<i64>,
+    completed_at: Option<i64>,
+    duration_ms: Option<i64>,
+    fallback_timestamp: i64,
+) -> i64 {
+    if let Some(started) = started_at.filter(|value| *value > 0) {
+        return started;
+    }
+    match completed_at {
+        Some(completed) => match duration_ms.filter(|duration| *duration > 0) {
+            Some(duration) => back_anchor_timestamp(completed, duration),
+            None => completed,
+        },
+        None => fallback_timestamp,
+    }
 }
 
 struct ZcodeUsageRow {
@@ -965,6 +1021,46 @@ mod tests {
             Some(5000),
             "duration_ms must still span from start to completion"
         );
+    }
+
+    #[test]
+    fn test_model_usage_missing_started_at_back_calculates_from_completed_at() {
+        // Second-round review fix: when `started_at` is NULL but
+        // `completed_at` and a positive `duration_ms` are present, the row
+        // must not stay end-anchored at `completed_at` (a phantom forward
+        // projection past the call's actual completion). Back-calculate the
+        // start anchor from `completed_at - duration_ms` instead.
+        let dir = TempDir::new().unwrap();
+        let db_path = create_zcode_sqlite_db(&dir);
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            r#"
+            INSERT INTO model_usage (
+                id, session_id, turn_id, model_id, completed_at,
+                duration_ms, input_tokens, output_tokens
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+            "#,
+            params![
+                "usage_1",
+                "sess_1",
+                "turn_1",
+                "glm-5.2",
+                1_782_718_005_000_i64,
+                5000_i64,
+                10_i64,
+                1_i64,
+            ],
+        )
+        .unwrap();
+
+        let messages = parse_zcode_sqlite(&db_path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].timestamp, 1_782_718_000_000_i64,
+            "timestamp must be back-calculated from completed_at - duration_ms when started_at is missing"
+        );
+        assert_eq!(messages[0].duration_ms, Some(5000));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #890, which fixed the Claude Code, Codex CLI, and Copilot parsers to anchor a message's `timestamp` to activity **start** rather than **end** — since `sessionize()` computes each activity span as `[timestamp, timestamp + duration_ms]`, an end-anchored timestamp with a forward-extending `duration_ms` inflates active-duration metrics with phantom idle time.

That PR explicitly scoped out six other duration-emitting parsers as follow-up work. This PR audits and fixes all six.

## Per-parser audit

| Parser | Verdict | Fix |
|---|---|---|
| **junie** | End-anchored | `LlmResponseMetadataEvent.timestampMs` is logged at response completion; `usage.time` is that call's latency. Back-calculate `start = timestampMs - time`. |
| **jcode** | End-anchored | An assistant message's `timestamp` is written once `token_usage` is finalized (post-completion); `tool_duration_ms` is that turn's elapsed time. Back-calculate `start = timestamp - tool_duration_ms`. |
| **devin** (CLI) | End-anchored | `message_nodes.created_at` is stamped when the row is written (post-completion); `metrics.total_time_ms` is the turn's generation time. Back-calculate `start = created_at - total_time_ms`. (Devin Desktop's NDJSON path never emits `duration_ms` — no change needed there.) |
| **kiro** | Partially end-anchored | Three of four data sources already anchor at an explicit prompt/request/start timestamp field. The fourth — the structured IDE `messages.jsonl` layout — could fall through to the (end-anchored) `turn_end` timestamp when the user prompt's own timestamp was missing/unparseable, even though `usage_summary.elapsedTime` supplied a duration. Back-calculate `start = turn_end - elapsedTime` in that case. |
| **zcode** | End-anchored | The SQLite `model_usage` table has an explicit `started_at` column alongside `completed_at` and `duration_ms`, but the parser preferred `completed_at`. Now prefers `started_at` (when positive), falling back to `completed_at - duration_ms` when `started_at` is NULL. |
| **opencodereview** | End-anchored | The `llm_response` record's `timestamp` is logged when the response is written; `duration_ms` is the call's elapsed time. Back-calculate `start = timestamp - duration_ms`. |

## Changes

- Re-anchored timestamps in `junie.rs`, `jcode.rs`, `devin.rs` (Devin CLI path), `zcode.rs` (SQLite path), and `opencodereview.rs`, mirroring the back-calculation approach `#890` used for Copilot's `endTime`-only records.
- Bumped `parser_version` in `message_cache.rs` for `Junie`, `Jcode`, `DevinCli`, `Zcode`, `OpenCodeReview`, and `Kiro` to invalidate stale end-anchored-timestamp cache entries, the same mechanism `#890` used. `DevinDesktop` is intentionally left unbumped since its behavior is unchanged.
- Added a start-anchoring regression test per fixed parser, following `test_token_count_timestamp_is_start_anchored` in `codex.rs` as the template, and updated existing fixtures/assertions that encoded the old end-anchored behavior.

## Second-round review fixes

An independent review of the first pass above found six gaps, all fixed in a follow-up commit:

1. **zcode** — when `started_at` was NULL but `completed_at` and a positive `duration_ms` existed, the row stayed end-anchored (a phantom forward projection) instead of falling back to `completed_at - duration_ms`.
2. **kiro** — the structured IDE `messages.jsonl` branch could stay end-anchored at the `turn_end` timestamp when the user prompt's timestamp was absent/unparseable, even though `usage_summary.elapsedTime` supplied a duration. Now back-calculates `turn_end - elapsedTime` in that case; `Kiro`'s `parser_version` is bumped (1 → 2) to invalidate stale caches.
3. **zcode** — `is_turn_start` was assigned to the first-COMPLETED request in a turn (query order), which could disagree with the now-start-anchored timestamps and land the turn in the wrong hour/day bucket in hourly turn-count aggregation. Now assigned to the earliest-STARTED request per turn.
4. **junie/jcode/devin/opencodereview** — the `end - duration` back-calculation was also applied when "end" was a fallback timestamp (session-ID-derived or file mtime), not a recorded per-event completion time, which could shift messages into the wrong day. Now the subtraction only happens when an explicit per-event end timestamp was parsed; fallback timestamps are emitted unchanged.
5. **junie/jcode/devin/opencodereview/zcode/kiro** — the back-calculation could itself produce a non-positive timestamp (e.g. a duration exceeding the end timestamp), which `sessionize()` silently drops. All back-calculations now guard against this and fall back to the unadjusted end timestamp when the candidate would be `<= 0`.
6. **zcode** — a zero/negative `started_at` was preferred over a valid `completed_at`, emitting timestamp `0` (silently dropped by `sessionize()`). `started_at` is now only preferred when it's a positive epoch.

`zcode`'s `parser_version` is also bumped again (2 → 3) to cover fixes 1, 3, and 6 above, which change its output beyond the first-pass `started_at`-preference change.

## Test plan

- [x] `cargo test -p tokscale-core --lib` — see latest run in CI/PR checks
- [x] `cargo test -p tokscale-core start_anchored` — first-pass regression tests pass (junie, jcode, devin, zcode, opencodereview, plus codex's existing one)
- [x] New second-round regression tests: zcode NULL-`started_at` back-calculation, kiro structured-turn missing-prompt-timestamp back-calculation, junie missing-`timestampMs` fallback (no subtraction)
- [x] `cargo clippy -- -D warnings` on touched crates — clean

Follow-up to #890.

https://claude.ai/code/session_01DyvMebVbf1r4rZP7U5hUF4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchors duration timestamps to activity start to remove phantom idle time in session metrics. Covers `junie`, `jcode`, `devin-cli`, `zcode` (SQLite), `opencodereview`, and `kiro` (structured IDE turns), and fixes edge cases found in review.

- **Bug Fixes**
  - `junie`: start = `timestampMs - usage.time` (only when `timestampMs` is recorded).
  - `jcode`: start = `timestamp - tool_duration_ms` (only when `timestamp` is recorded).
  - `devin-cli`: start = `created_at - metrics.total_time_ms` (only when `created_at` is recorded).
  - `zcode` (SQLite): prefer positive `started_at`; else use `completed_at - duration_ms`; assign `is_turn_start` to the earliest-started request per turn.
  - `opencodereview`: start = `timestamp - duration_ms` (only when `timestamp` is recorded).
  - `kiro` (structured IDE turns): when the prompt timestamp is missing, start = `turn_end - elapsedTime`.
  - Back-calculations skip fallback timestamps (e.g. file mtime) and guard against non-positive results; added a shared `back_anchor_timestamp` helper.
  - Bumped parser versions for affected clients to invalidate caches and added regression tests.

<sup>Written for commit 3fc4e00911196b9d969632d311476db8d00f335d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

