### PR TITLE
fix(migrations): auto-apply prod drizzle migrations via Vercel buildCommand

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "packages/cli": {
       "name": "@tokscale/cli",
-      "version": "2.1.3",
+      "version": "4.5.3",
       "bin": {
         "tokscale": "./dist/index.js",
       },
@@ -37,35 +37,35 @@
     },
     "packages/cli-darwin-arm64": {
       "name": "@tokscale/cli-darwin-arm64",
-      "version": "2.1.3",
+      "version": "4.5.3",
     },
     "packages/cli-darwin-x64": {
       "name": "@tokscale/cli-darwin-x64",
-      "version": "2.1.3",
+      "version": "4.5.3",
     },
     "packages/cli-linux-arm64-gnu": {
       "name": "@tokscale/cli-linux-arm64-gnu",
-      "version": "2.1.3",
+      "version": "4.5.3",
     },
     "packages/cli-linux-arm64-musl": {
       "name": "@tokscale/cli-linux-arm64-musl",
-      "version": "2.1.3",
+      "version": "4.5.3",
     },
     "packages/cli-linux-x64-gnu": {
       "name": "@tokscale/cli-linux-x64-gnu",
-      "version": "2.1.3",
+      "version": "4.5.3",
     },
     "packages/cli-linux-x64-musl": {
       "name": "@tokscale/cli-linux-x64-musl",
-      "version": "2.1.3",
+      "version": "4.5.3",
     },
     "packages/cli-win32-arm64-msvc": {
       "name": "@tokscale/cli-win32-arm64-msvc",
-      "version": "2.1.3",
+      "version": "4.5.3",
     },
     "packages/cli-win32-x64-msvc": {
       "name": "@tokscale/cli-win32-x64-msvc",
-      "version": "2.1.3",
+      "version": "4.5.3",
     },
     "packages/frontend": {
       "name": "@tokscale/frontend",
@@ -96,6 +96,7 @@
         "@types/react-dom": "^19",
         "@types/styled-components": "^5.1.36",
         "@vitest/coverage-v8": "4.0.16",
+        "bun-types": "^1.3.14",
         "drizzle-kit": "^0.30.1",
         "eslint": "^9",
         "eslint-config-next": "16.0.6",
@@ -105,7 +106,7 @@
     },
     "packages/tokscale": {
       "name": "tokscale",
-      "version": "2.1.3",
+      "version": "4.5.3",
       "bin": {
         "tokscale": "./bin.js",
       },
@@ -646,6 +647,8 @@
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 

--- a/packages/frontend/.gitignore
+++ b/packages/frontend/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.env*.local

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -42,6 +42,7 @@
     "@types/react-dom": "^19",
     "@types/styled-components": "^5.1.36",
     "@vitest/coverage-v8": "4.0.16",
+    "bun-types": "^1.3.14",
     "drizzle-kit": "^0.30.1",
     "eslint": "^9",
     "eslint-config-next": "16.0.6",

--- a/packages/frontend/scripts/migrate-prod.ts
+++ b/packages/frontend/scripts/migrate-prod.ts
@@ -1,0 +1,78 @@
+/// <reference types="bun-types" />
+import postgres from "postgres";
+
+// Vercel has no buildCommand-level distinction between "preview build for a
+// WIP branch" and "production build" other than VERCEL_ENV — and DATABASE_URL
+// is the SAME value across Production/Preview/Development in this project.
+// Without this gate, pushing an unreviewed migration to any branch would
+// apply it to prod the moment its preview build runs.
+if (process.env.VERCEL_ENV !== "production") {
+  console.log(
+    `skip - migrate-prod: VERCEL_ENV=${process.env.VERCEL_ENV ?? "(unset)"}, not production`
+  );
+  process.exit(0);
+}
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  throw new Error("DATABASE_URL is required");
+}
+
+// drizzle-kit/drizzle-orm take no advisory lock of their own, so concurrent
+// builds (rapid pushes, a manual redeploy overlapping an in-flight one) can
+// race two `drizzle-kit migrate` runs against each other. Hold a session
+// lock for the lifetime of this process to serialize them.
+const LOCK_KEY = "tokscale_drizzle_migrate";
+const MAX_ATTEMPTS = 5;
+const RETRY_DELAY_MS = 3000;
+
+const sql = postgres(databaseUrl, { max: 1 });
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function runMigrate(): Promise<{ ok: boolean; deadlock: boolean; stderr: string }> {
+  const proc = Bun.spawn(["bunx", "drizzle-kit", "migrate"], {
+    stdout: "inherit",
+    stderr: "pipe",
+  });
+  const stderr = await new Response(proc.stderr).text();
+  process.stderr.write(stderr);
+  const exitCode = await proc.exited;
+  if (exitCode === 0) {
+    return { ok: true, deadlock: false, stderr };
+  }
+  // Postgres deadlock_detected is SQLSTATE 40P01.
+  const deadlock = /40P01|deadlock detected/i.test(stderr);
+  return { ok: false, deadlock, stderr };
+}
+
+try {
+  await sql`SELECT pg_advisory_lock(hashtext(${LOCK_KEY}))`;
+  console.log(`ok - acquired advisory lock (${LOCK_KEY})`);
+
+  let lastResult: Awaited<ReturnType<typeof runMigrate>> | undefined;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    lastResult = await runMigrate();
+    if (lastResult.ok) {
+      console.log(`ok - drizzle-kit migrate succeeded (attempt ${attempt}/${MAX_ATTEMPTS})`);
+      break;
+    }
+    if (!lastResult.deadlock) {
+      throw new Error(
+        `drizzle-kit migrate failed (attempt ${attempt}/${MAX_ATTEMPTS}, not a deadlock — not retrying)`
+      );
+    }
+    console.warn(
+      `warn - drizzle-kit migrate hit a deadlock (attempt ${attempt}/${MAX_ATTEMPTS})`
+    );
+    if (attempt === MAX_ATTEMPTS) {
+      throw new Error(`drizzle-kit migrate deadlocked ${MAX_ATTEMPTS} times in a row`);
+    }
+    await sleep(RETRY_DELAY_MS);
+  }
+} finally {
+  await sql`SELECT pg_advisory_unlock(hashtext(${LOCK_KEY}))`;
+  await sql.end();
+}

--- a/packages/frontend/scripts/migrate-prod.ts
+++ b/packages/frontend/scripts/migrate-prod.ts
@@ -1,6 +1,19 @@
 /// <reference types="bun-types" />
 import postgres from "postgres";
 
+// This runs BEFORE `next build` in vercel.json's buildCommand
+// (`bun run scripts/migrate-prod.ts && next build`), intentionally — not after.
+// `src/app/(main)/page.tsx` (HomePage) has no dynamic rendering signal, so it's
+// statically prerendered at build time, and its render path calls
+// `getLeaderboardData`, which queries the DB directly (through an
+// `unstable_cache` wrapper — caching the fetch doesn't defer *when* it first
+// runs). Reordering to build-then-migrate would make `next build` fail
+// whenever a PR's new code depends on its own accompanying migration,
+// permanently blocking that deploy since the migration never gets a chance to
+// run. The residual risk of the current order (migrate succeeds, then build
+// fails for an unrelated reason, leaving new schema paired with old code) is
+// mitigated by this repo's convention of additive-only migrations.
+//
 // Vercel has no buildCommand-level distinction between "preview build for a
 // WIP branch" and "production build" other than VERCEL_ENV — and DATABASE_URL
 // is the SAME value across Production/Preview/Development in this project.
@@ -23,6 +36,7 @@ if (!databaseUrl) {
 // race two `drizzle-kit migrate` runs against each other. Hold a session
 // lock for the lifetime of this process to serialize them.
 const LOCK_KEY = "tokscale_drizzle_migrate";
+const MAX_LOCK_ATTEMPTS = 60;
 const MAX_ATTEMPTS = 5;
 const RETRY_DELAY_MS = 3000;
 
@@ -48,8 +62,32 @@ async function runMigrate(): Promise<{ ok: boolean; deadlock: boolean; stderr: s
   return { ok: false, deadlock, stderr };
 }
 
+let lockAcquired = false;
+
 try {
-  await sql`SELECT pg_advisory_lock(hashtext(${LOCK_KEY}))`;
+  for (let attempt = 1; attempt <= MAX_LOCK_ATTEMPTS; attempt++) {
+    const [result] = await sql<{ acquired: boolean }[]>`
+      SELECT pg_try_advisory_lock(hashtext(${LOCK_KEY})) AS acquired
+    `;
+    if (result?.acquired) {
+      lockAcquired = true;
+      break;
+    }
+
+    if (attempt < MAX_LOCK_ATTEMPTS) {
+      console.warn(
+        `warn - migration advisory lock unavailable (attempt ${attempt}/${MAX_LOCK_ATTEMPTS}); retrying in ${RETRY_DELAY_MS}ms`
+      );
+      await sleep(RETRY_DELAY_MS);
+    }
+  }
+
+  if (!lockAcquired) {
+    throw new Error(
+      `could not acquire migration advisory lock after ${MAX_LOCK_ATTEMPTS} attempts -- a concurrent build may be stuck`
+    );
+  }
+
   console.log(`ok - acquired advisory lock (${LOCK_KEY})`);
 
   let lastResult: Awaited<ReturnType<typeof runMigrate>> | undefined;
@@ -73,6 +111,17 @@ try {
     await sleep(RETRY_DELAY_MS);
   }
 } finally {
-  await sql`SELECT pg_advisory_unlock(hashtext(${LOCK_KEY}))`;
-  await sql.end();
+  if (lockAcquired) {
+    try {
+      await sql`SELECT pg_advisory_unlock(hashtext(${LOCK_KEY}))`;
+    } catch (error) {
+      console.error("warn - failed to release migration advisory lock", error);
+    }
+  }
+
+  try {
+    await sql.end();
+  } catch (error) {
+    console.error("warn - failed to close migration database connection", error);
+  }
 }

--- a/packages/frontend/vercel.json
+++ b/packages/frontend/vercel.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- . ../../bun.lock ../../package.json"
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- . ../../bun.lock ../../package.json",
+  "buildCommand": "bun run scripts/migrate-prod.ts && next build"
 }


### PR DESCRIPTION
## Summary
- Three separate prod incidents (0012/0013 staleness, 0014, and the 0015 hard 500s on #903) all share the same root cause: `vercel.json` had no `buildCommand`, so a merged migration file never actually got applied to prod — someone had to remember to run it by hand.
- Adds `packages/frontend/scripts/migrate-prod.ts` and wires it into `vercel.json`'s `buildCommand` (`bun run scripts/migrate-prod.ts && next build`), so a failed/blocked migration keeps the *previous* deployment live instead of shipping schema-mismatched code.
- `VERCEL_ENV`-gated (no-ops on Preview/Development, which share the same `DATABASE_URL` as Production), advisory-lock-serialized against concurrent builds, and retries up to 5x on `40P01` deadlocks while failing fast on any other error.

## Why buildCommand over a GitHub Action
No prod-DB secret exists in `.github/workflows/*` today, and a post-merge Action would still race Vercel's independent auto-deploy trigger on the same push — it narrows the bad window, it doesn't close it. `buildCommand` gives a hard ordering guarantee: Vercel never cuts traffic to a build that failed.

## Test plan
- [x] `VERCEL_ENV` unset locally → script logs skip and exits 0 without connecting to any DB
- [x] `VERCEL_ENV=production` against a throwaway `postgres:16` Docker container → connects, acquires advisory lock, runs `drizzle-kit migrate`, releases lock, exits 0
- [x] Re-run against the same already-migrated container → idempotent no-op success
- [x] `bun run typecheck` clean
- [ ] First real Production deploy — watch build logs for the migrate step, then re-run the `pg_constraint` spot check against prod

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-run production Drizzle migrations during Vercel builds to prevent schema/code mismatches. If a migration fails, the deploy is blocked and the previous version stays live.

- **Bug Fixes**
  - Add `packages/frontend/scripts/migrate-prod.ts` to `vercel.json` `buildCommand`: `bun run scripts/migrate-prod.ts && next build` (runs before build to satisfy build-time DB reads).
  - Gate to `VERCEL_ENV=production` so previews/dev no-op (shared `DATABASE_URL`).
  - Serialize concurrent runs with a non-blocking Postgres advisory lock plus bounded retries; retry `40P01` deadlocks up to 5 times; guard unlock/connection close with try/catch; fail fast on other errors.

- **Dependencies**
  - Add `bun-types` for Bun type refs in the migration script.

<sup>Written for commit 0640a07594d87821eb690fe660792410a0648eb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

