### PR TITLE
fix(leaderboard): make current-user card navigate to own profile

### DIFF
--- a/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
@@ -478,6 +478,13 @@ const CurrentUserCard = styled.div`
   align-items: center;
   justify-content: space-between;
   gap: 16px;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--service-accent-soft);
+    border-color: var(--service-accent);
+    opacity: 0.9;
+  }
 
   @media (max-width: 640px) {
     flex-direction: column;
@@ -1206,7 +1213,17 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
       )}
 
       {currentUser && currentUserRank && (
-        <CurrentUserCard>
+        <CurrentUserCard
+          role="link"
+          tabIndex={0}
+          onClick={() => handleRowClick(currentUser.username)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              handleRowClick(currentUser.username);
+            }
+          }}
+        >
           <CurrentUserInfo>
             <CurrentUserAvatar
               src={currentUser.avatarUrl || `https://github.com/${currentUser.username}.png`}


### PR DESCRIPTION
## Summary
- The current-user summary card on the leaderboard (avatar, name, "Your Rank", Tokens, Cost) had no click handler — clicking it did nothing.
- Every other row already navigates to `/u/${username}` via `TableRow`'s `onClick={() => handleRowClick(username)}`. This wires the same `handleRowClick` callback onto `CurrentUserCard`, plus `role="link"` / `tabIndex={0}` / `onKeyDown` (Enter/Space) so a clickable `div` gets equivalent keyboard access to an actual link.
- Adds `cursor: pointer` + a subtle hover state to `CurrentUserCard`'s styled-component, matching `TableRow`'s existing affordance.

## Test plan
- [x] `bun run typecheck` clean
- [x] Local dev server: page still returns 200 and renders with the change (fails on `DATABASE_URL environment variable is not set` identically with or without this diff — pre-existing local-env limitation, not a regression)
- [ ] Click-through in a browser against real data/session — not verifiable locally, no `DATABASE_URL`/auth available in this environment. Logic is a direct copy of the already-shipped, working `TableRow`/`handleRowClick` pattern used for every other row in this same file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the current-user leaderboard card navigate to your profile and be keyboard accessible. Matches the behavior and affordance of other leaderboard rows.

- **Bug Fixes**
  - Wire `CurrentUserCard` to `handleRowClick` for `/u/${username}` navigation.
  - Add `role="link"`, `tabIndex={0}`, and Enter/Space key handling.
  - Add `cursor: pointer` and subtle hover styles to `CurrentUserCard`.

<sup>Written for commit 21565441c27c78fc93c79fb61dad9b2dbf53cc28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

