### PR TITLE
fix(tui): stop background cache-warning writes from corrupting TUI screen

### DIFF
--- a/crates/tokscale-cli/src/tui/mod.rs
+++ b/crates/tokscale-cli/src/tui/mod.rs
@@ -146,6 +146,13 @@ pub fn run(
         return Err(e.into());
     }
 
+    // From here on the TUI owns raw mode and the alternate screen for its
+    // whole run. Background diagnostics (e.g. cache save warnings) must not
+    // write raw stdio while this is set, or they corrupt the rendered
+    // display instead of being visible as a log line. Cleared in both
+    // `restore_terminal` and `restore_terminal_best_effort` below.
+    tokscale_core::tui_signal::set_tui_active(true);
+
     let backend = CrosstermBackend::new(stdout);
     let terminal_result = Terminal::new(backend);
     let mut terminal = match terminal_result {
@@ -233,6 +240,7 @@ pub fn run(
 }
 
 fn restore_terminal_best_effort() {
+    tokscale_core::tui_signal::set_tui_active(false);
     let _ = execute!(
         io::stdout(),
         LeaveAlternateScreen,
@@ -243,6 +251,7 @@ fn restore_terminal_best_effort() {
 }
 
 fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) {
+    tokscale_core::tui_signal::set_tui_active(false);
     let _ = disable_raw_mode();
     let _ = execute!(
         terminal.backend_mut(),

--- a/crates/tokscale-core/src/fs_atomic.rs
+++ b/crates/tokscale-core/src/fs_atomic.rs
@@ -36,18 +36,41 @@ fn windows_replace_file(tmp_path: &Path, final_path: &Path) -> io::Result<()> {
             .collect()
     }
 
+    // MoveFileExW replacing an existing file is a well-known source of
+    // transient ERROR_ACCESS_DENIED (5) / ERROR_SHARING_VIOLATION (32) on
+    // Windows: antivirus, indexing, and cloud-sync agents routinely hold a
+    // brief scan handle open on a just-written file. Retry a handful of
+    // times with a short backoff before giving up, rather than surfacing a
+    // one-shot failure for what is usually a few-millisecond lock.
+    const ERROR_ACCESS_DENIED: i32 = 5;
+    const ERROR_SHARING_VIOLATION: i32 = 32;
+    const MAX_ATTEMPTS: u32 = 5;
+
     let existing = encode(tmp_path);
     let new = encode(final_path);
-    let result = unsafe {
-        MoveFileExW(
-            existing.as_ptr(),
-            new.as_ptr(),
-            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
-        )
-    };
-    if result == 0 {
-        Err(io::Error::last_os_error())
-    } else {
-        Ok(())
+
+    for attempt in 1..=MAX_ATTEMPTS {
+        let result = unsafe {
+            MoveFileExW(
+                existing.as_ptr(),
+                new.as_ptr(),
+                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+            )
+        };
+        if result != 0 {
+            return Ok(());
+        }
+
+        let error = io::Error::last_os_error();
+        let is_retryable = matches!(
+            error.raw_os_error(),
+            Some(ERROR_ACCESS_DENIED) | Some(ERROR_SHARING_VIOLATION)
+        );
+        if !is_retryable || attempt == MAX_ATTEMPTS {
+            return Err(error);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10 * attempt as u64));
     }
+
+    unreachable!("loop always returns on its final attempt")
 }

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -15,6 +15,7 @@ mod provider_identity;
 pub mod scanner;
 pub mod sessionize;
 pub mod sessions;
+pub mod tui_signal;
 pub mod wiki;
 
 pub use aggregator::*;

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -102,10 +102,16 @@ fn warn_cache_failure_once(context: &'static str, path: &Path, error: &impl std:
 
     // Most non-TUI commands (including `submit`) do not install a tracing
     // subscriber. Surface persistence failures directly once per process so a
-    // permanently cold cache can never fail silently again.
+    // permanently cold cache can never fail silently again. The TUI owns raw
+    // mode and the alternate screen for its whole run, so a raw stdio write
+    // there corrupts the rendered display instead of being visible as a log
+    // line — suppress it in that case and rely on tracing::warn! (or the
+    // TUI's own status/error UI) instead.
     static WARNED_CONTEXTS: OnceLock<Mutex<HashSet<&'static str>>> = OnceLock::new();
     let warned = WARNED_CONTEXTS.get_or_init(|| Mutex::new(HashSet::new()));
-    if warned.lock().is_ok_and(|mut warned| warned.insert(context)) {
+    if warned.lock().is_ok_and(|mut warned| warned.insert(context))
+        && !crate::tui_signal::is_tui_active()
+    {
         eprintln!("tokscale: warning: {context} ({}): {error}", path.display());
     }
 }

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -2806,11 +2806,7 @@ mod tests {
                 "google/gemini-3.5-flash",
                 "Models.dev",
             ),
-            (
-                "gemini-3-flash-b",
-                "google/gemini-3.5-flash",
-                "Models.dev",
-            ),
+            ("gemini-3-flash-b", "google/gemini-3.5-flash", "Models.dev"),
             (
                 // Legacy CLI responseModel for M132, the retired predecessor
                 // of M133 — prices as the High tier, same catalog entry as

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -901,8 +901,7 @@ fn merge_claude_duplicate(
                 // streaming chunks), so never let a later-processed duplicate
                 // with an earlier completion timestamp shrink a duration
                 // already established by another duplicate.
-                existing.duration_ms =
-                    Some(existing.duration_ms.unwrap_or(0).max(new_duration));
+                existing.duration_ms = Some(existing.duration_ms.unwrap_or(0).max(new_duration));
             }
         }
     }

--- a/crates/tokscale-core/src/tui_signal.rs
+++ b/crates/tokscale-core/src/tui_signal.rs
@@ -1,0 +1,35 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+// Some diagnostics (e.g. cache save failures) fall back to a direct
+// eprintln! when no tracing subscriber is guaranteed to be installed, so
+// non-TUI commands still surface them. The TUI owns raw mode and the
+// crossterm alternate screen for its whole lifetime, and a stray stdio
+// write there corrupts the rendered display instead of being visible as a
+// normal log line. This flag lets that diagnostic code suppress the raw
+// stdio fallback while the TUI holds the terminal.
+static TUI_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+pub fn set_tui_active(active: bool) {
+    TUI_ACTIVE.store(active, Ordering::Relaxed);
+}
+
+pub fn is_tui_active() -> bool {
+    TUI_ACTIVE.load(Ordering::Relaxed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn round_trips() {
+        let previous = is_tui_active();
+        set_tui_active(true);
+        assert!(is_tui_active());
+        set_tui_active(false);
+        assert!(!is_tui_active());
+        set_tui_active(previous);
+    }
+}


### PR DESCRIPTION
Fixes #893

## Root causes

Two independent, stackable issues cause the TUI's screen to get corrupted when a background cache shard save fails:

1. **Why the write fails on Windows (`Access is denied (os error 5)`)**: `fs_atomic::windows_replace_file` calls `MoveFileExW(..., MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)` exactly once, with no retry. This is a well-known source of transient `ERROR_ACCESS_DENIED` (5) / `ERROR_SHARING_VIOLATION` (32) on Windows — antivirus, indexing, and cloud-sync agents routinely hold a brief scan handle open on a just-written file. `fs_atomic::replace_file` is the single shared atomic-rename primitive used by 10 call sites across both crates, so this failure mode isn't unique to the cache.

2. **Why the failure corrupts the TUI display**: `message_cache::warn_cache_failure_once` always calls `tracing::warn!`, then falls back to a raw `eprintln!` the first time each failure context is seen — because most non-TUI commands never install a tracing subscriber, so `tracing::warn!` alone would be silent. But the TUI only installs a subscriber under `--debug`. In normal (non-debug) use, that `eprintln!` writes directly to stdio while the TUI owns raw mode and the crossterm alternate screen, corrupting the rendered display exactly as reported.

## Fix

- `fs_atomic.rs`: wrap the Windows `MoveFileExW` call in a bounded retry loop (5 attempts, ~10ms × attempt backoff, ≤100ms worst case), retrying only on the two known-transient error codes. Benefits all 10 existing `replace_file` call sites with no call-site changes. Non-Windows path (`std::fs::rename`) is untouched.
- New `tui_signal.rs`: a small process-wide `AtomicBool` flag (`set_tui_active`/`is_tui_active`), mirroring the existing style of `paths::is_config_dir_overridden()`.
- `message_cache.rs`: gate the `eprintln!` fallback in `warn_cache_failure_once` on `!tui_signal::is_tui_active()`. `tracing::warn!` still fires unconditionally and is unchanged. Non-TUI command behavior is byte-for-byte unchanged.
- `tui/mod.rs`: toggle the flag to `true` right after the TUI successfully enters the alternate screen, and back to `false` in both terminal-restore paths (normal exit and the panic hook's best-effort restore), so it can never get stuck.

## Verification

- `cargo build -p tokscale-core -p tokscale-cli` — clean
- `cargo clippy -p tokscale-core -p tokscale-cli --all-targets -- -D warnings` — zero warnings
- `cargo test -p tokscale-core` — 1216 passed, 0 failed, including a new `tui_signal::tests::round_trips` test
- `cargo fmt --check` — clean
- Manual review of the `unsafe extern "system"` `MoveFileExW` retry loop — no Windows machine available locally to compile/run the `#[cfg(windows)]` path; relying on the existing `build-native.yml` Windows CI job plus this manual review

**Not tested**: actual Windows `MoveFileEx` retry behavior under real transient file-lock contention (AV/indexer/cloud-sync), since no Windows machine is available in this environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents TUI screen corruption when background cache save warnings fire by suppressing raw stderr during TUI and making Windows file replacement more resilient. Fixes #893.

- **Bug Fixes**
  - Windows: retry `MoveFileExW` in `fs_atomic::replace_file` (up to 5 attempts with short backoff) on transient `ERROR_ACCESS_DENIED`/`ERROR_SHARING_VIOLATION`. Non-Windows unchanged.
  - TUI: add `tokscale-core::tui_signal` and toggle it from `tokscale-cli` when entering/leaving the TUI; suppress `message_cache::warn_cache_failure_once` `eprintln!` while active. `tracing::warn!` unchanged; non-TUI behavior remains the same.

- **Refactors**
  - Run workspace-wide `cargo fmt` to satisfy CI; unrelated files only, no behavior changes.

<sup>Written for commit eb31d945992416ca0db0172c8acee2c2262bbcc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

