### PR TITLE
fix(frontend): format currency in millions/billions instead of huge K values

### DIFF
--- a/packages/frontend/__tests__/lib/formatCurrency.test.ts
+++ b/packages/frontend/__tests__/lib/formatCurrency.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { formatCurrency } from "../../src/lib/utils";
+
+describe("formatCurrency", () => {
+  it("formats sub-thousand amounts as plain dollars", () => {
+    expect(formatCurrency(0)).toBe("$0.00");
+    expect(formatCurrency(42.5)).toBe("$42.50");
+    expect(formatCurrency(999.99)).toBe("$999.99");
+  });
+
+  it("formats thousands with K suffix", () => {
+    expect(formatCurrency(1_000)).toBe("$1.00K");
+    expect(formatCurrency(1_500)).toBe("$1.50K");
+    expect(formatCurrency(123_456)).toBe("$123.46K");
+  });
+
+  it("formats millions with M suffix", () => {
+    expect(formatCurrency(1_000_000)).toBe("$1.00M");
+    expect(formatCurrency(2_345_678)).toBe("$2.35M");
+    // Regression: production leaderboard total rendered as "$391803.96K"
+    expect(formatCurrency(391_803_960)).toBe("$391.80M");
+  });
+
+  it("formats billions with B suffix", () => {
+    expect(formatCurrency(1_000_000_000)).toBe("$1.00B");
+    expect(formatCurrency(2_500_000_000)).toBe("$2.50B");
+  });
+
+  // Values near unit boundaries should promote to the next unit instead of
+  // displaying "$1000.00K" / "$1000.00M" (same guard as formatTokenCount).
+  it("promotes 999_995 to $1.00M instead of $1000.00K", () => {
+    expect(formatCurrency(999_995)).toBe("$1.00M");
+  });
+
+  it("promotes 999_995_000 to $1.00B instead of $1000.00M", () => {
+    expect(formatCurrency(999_995_000)).toBe("$1.00B");
+  });
+
+  it("does not promote values well below the boundary", () => {
+    expect(formatCurrency(999_994)).toBe("$999.99K");
+  });
+});

--- a/packages/frontend/src/components/landing/sections/WorldwideSection.tsx
+++ b/packages/frontend/src/components/landing/sections/WorldwideSection.tsx
@@ -23,6 +23,10 @@ function formatCompactNumber(n: number): string {
 }
 
 function formatCompactCurrency(n: number): string {
+  if (n >= 1_000_000_000)
+    return "$" + (n / 1_000_000_000).toFixed(1).replace(/\.0$/, "") + "B";
+  if (n >= 1_000_000)
+    return "$" + (n / 1_000_000).toFixed(1).replace(/\.0$/, "") + "M";
   if (n >= 1_000)
     return "$" + (n / 1_000).toFixed(1).replace(/\.0$/, "") + "K";
   if (n >= 1) return "$" + n.toFixed(2);

--- a/packages/frontend/src/lib/utils.ts
+++ b/packages/frontend/src/lib/utils.ts
@@ -254,7 +254,22 @@ export function formatTokenCount(count: number): string {
 export const formatNumber = formatTokenCount;
 
 export function formatCurrency(amount: number): string {
-  if (amount >= 1000) return `$${(amount / 1000).toFixed(2)}K`;
+  if (amount >= 1_000_000_000) {
+    return `$${(amount / 1_000_000_000).toFixed(2)}B`;
+  }
+  if (amount >= 1_000_000) {
+    const val = amount / 1_000_000;
+    // toFixed(2) rounds 999.995+ to "1000.00"; promote to next unit instead
+    return val >= 999.995
+      ? `$${(val / 1000).toFixed(2)}B`
+      : `$${val.toFixed(2)}M`;
+  }
+  if (amount >= 1000) {
+    const val = amount / 1000;
+    return val >= 999.995
+      ? `$${(val / 1000).toFixed(2)}M`
+      : `$${val.toFixed(2)}K`;
+  }
   return `$${amount.toFixed(2)}`;
 }
 


### PR DESCRIPTION
## Problem

The production leaderboard's total cost renders as **\$391803.96K** — `formatCurrency` in `src/lib/utils.ts` caps out at the `K` tier, so anything ≥ \$1M displays as thousands with an absurd mantissa.

## Fix

- **`formatCurrency`**: add `M` and `B` tiers, keeping two decimals (`$391.80M` for the current prod total). Uses the same near-boundary promotion guard as `formatTokenCount` (#474): `toFixed(2)` rounds 999.995+ up to `"1000.00"`, so those values promote to the next unit instead of rendering `$1000.00K` / `$1000.00M`.
- **`formatCompactCurrency`** (landing `WorldwideSection`): same bug shape — added matching `M`/`B` tiers in its existing one-decimal style.

Sub-\$1M output is byte-identical to before, so leaderboard, groups, settings, StatsPanel, and tooltip call sites only change where they were already broken.

## Tests

New `__tests__/lib/formatCurrency.test.ts` covering all tiers, the exact prod regression value (`391_803_960` → `$391.80M`), and boundary promotion. `bunx vitest run` (16 tests) and `tsc --noEmit` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes currency formatting to show millions and billions instead of huge K values. Leaderboard total now renders as $391.80M instead of $391803.96K.

- **Bug Fixes**
  - `formatCurrency`: add `M`/`B` tiers with 2 decimals and near-boundary promotion to avoid `$1000.00K`/`$1000.00M`.
  - `WorldwideSection`’s `formatCompactCurrency`: add `M`/`B` tiers with 1-decimal style.
  - Sub-$1M output stays identical across all call sites; regression value `391,803,960` now formats as `$391.80M`.

<sup>Written for commit f86f1a89b9e3b76c0bc7a93636c3d1675b1ceafd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

