### PR TITLE
fix(cache): complete atomic shard writes on Windows

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1356,8 +1356,10 @@ fn write_shard_with_limit(
             .map_err(std::io::Error::other)?;
         writer.flush()?;
         writer.get_ref().sync_all()?;
+        drop(writer);
         crate::fs_atomic::replace_file(&tmp_path, final_path)?;
-        File::open(final_path)?.sync_all()?;
+        let final_file = OpenOptions::new().read(true).write(true).open(final_path)?;
+        final_file.sync_all()?;
         Ok(())
     })();
 
@@ -2531,6 +2533,29 @@ mod tests {
         std::fs::write(file.path(), rewritten).unwrap();
 
         assert!(!codex_prefix_matches(file.path(), &incremental_cache));
+    }
+
+    #[test]
+    fn test_write_shard_round_trips_after_atomic_replace() {
+        let source = write_temp_file(b"{}\n");
+        let identity = CacheIdentity::for_client(ClientId::Claude);
+        let entry = test_entry(identity, source.path(), "session-1");
+        let shard_dir = TempDir::new().unwrap();
+        let shard_path = shard_dir.path().join("shard.bin");
+
+        write_shard_with_limit(
+            &shard_path,
+            identity,
+            std::slice::from_ref(&entry),
+            MAX_CACHE_SHARD_BYTES,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            read_shard(&shard_path, identity),
+            ShardReadStatus::Loaded(entries)
+                if entries.len() == 1 && entries[0].messages[0].session_id == "session-1"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #913

## Summary

- Release the temporary cache shard writer before atomic replacement so the cache does not keep its own source handle open across `MoveFileExW`.
- Reopen the installed shard with read and write access before the final durability sync, matching the access requirements of Windows `FlushFileBuffers`.
- Add a direct shard write/read regression without changing cache format, parser versions, shard identity, retry policy, or TUI warning behavior.

## Current-upstream adaptation

| Validated downstream behavior | Current upstream location | Adaptation |
|---|---|---|
| Flush and sync the monolithic temporary cache, then drop its writer before replacement | `write_shard_with_limit` temporary envelope writer | Apply the same handle ordering to each shard writer |
| Reopen the installed cache read/write before `sync_all()` | Final shard durability sync | Use `OpenOptions::new().read(true).write(true)` |
| Monolithic cache layout and schema | Sharded envelopes and per-parser versions | Deliberately excluded; no format or identity change |
| Atomic replacement implementation | Shared `fs_atomic::replace_file` with #906 retry behavior | Deliberately unchanged |

The source behavior was recovered into [TokenBar PR #59](https://github.com/Nanako0129/TokenBar/pull/59). The Windows validation ancestry and full downstream evidence are recorded in the [handoff comment](https://github.com/Nanako0129/TokenBar/issues/45#issuecomment-5002865759).

## Verification

- `cargo test -p tokscale-core test_write_shard_round_trips_after_atomic_replace -- --test-threads=1`
- `cargo test -p tokscale-core test_save_if_dirty_marks_cache_clean -- --test-threads=1`
- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo build --release -p tokscale-cli`
- `git diff --check`

## Windows evidence boundary

The downstream handle-ordering fix was executed and validated on Windows. This PR adapts that invariant to the current shard writer. Upstream `Build Native` checks Windows x64 and arm64 compilation only; it does not execute this regression on Windows. Unless an additional Windows runner runs the test, this PR does not claim independent upstream Windows runtime verification.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes atomic shard writes on Windows by closing the temp writer before replacement and reopening the final shard for a proper flush. Prevents handle conflicts and ensures cache durability after writes.

- **Bug Fixes**
  - Drop the temporary shard writer before atomic replace to avoid carrying an open source handle into `MoveFileExW`.
  - Reopen the installed shard with read+write before the final `sync_all()` to satisfy Windows `FlushFileBuffers`.
  - Add a regression test to verify shard write/read round-trip after replace.
  - No changes to cache format, shard identity, parser versions, retry policy, or TUI behavior.

<sup>Written for commit e15e66bd72052cc3c7b4d2782bd844d7f7c6b308. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

