### PR TITLE
fix(scanner): keep explicit-home scans isolated on Windows

### DIFF
--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -42,6 +42,14 @@ impl PathRoot {
                     }
                 }
 
+                #[cfg(target_os = "windows")]
+                if !use_env_roots {
+                    return std::path::Path::new(home_dir)
+                        .join("AppData/Roaming/tokscale")
+                        .to_string_lossy()
+                        .into_owned();
+                }
+
                 format!("{home_dir}/.config/tokscale")
             }
             PathRoot::EnvVar {
@@ -833,7 +841,15 @@ mod tests {
         }
 
         let resolved = PathRoot::Config.resolve_with_env_strategy("/tmp/home", false);
-        assert_eq!(resolved, "/tmp/home/.config/tokscale");
+        let expected = if cfg!(target_os = "windows") {
+            std::path::Path::new("/tmp/home")
+                .join("AppData/Roaming/tokscale")
+                .to_string_lossy()
+                .into_owned()
+        } else {
+            "/tmp/home/.config/tokscale".to_string()
+        };
+        assert_eq!(resolved, expected);
 
         restore_env("TOKSCALE_CONFIG_DIR", previous_override);
         restore_env("XDG_CONFIG_HOME", previous_xdg);

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -33,17 +33,10 @@ impl PathRoot {
                     if let Ok(xdg_config_home) = std::env::var("XDG_CONFIG_HOME") {
                         return format!("{xdg_config_home}/tokscale");
                     }
-                }
 
-                // Match paths::get_config_dir() platform branches so the
-                // scanner reads from the same root the writer (e.g.
-                // get_antigravity_cache_dir) targets. Hardcoding
-                // `{home}/.config/tokscale` everywhere would diverge from
-                // dirs::config_dir() on Windows (where it resolves to
-                // %APPDATA%\tokscale), causing synced data to land in
-                // %APPDATA% while the scanner looks in %USERPROFILE%.
-                #[cfg(target_os = "windows")]
-                {
+                    // Match paths::get_config_dir() so default Windows scans
+                    // read the same %APPDATA% root used by cache writers.
+                    #[cfg(target_os = "windows")]
                     if let Some(dir) = dirs::config_dir() {
                         return dir.join("tokscale").to_string_lossy().into_owned();
                     }

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -8100,9 +8100,9 @@ mod tests {
     #[test]
     fn test_parse_local_clients_honors_scanner_extra_scan_paths_for_zed_threads_db() {
         let temp_dir = tempfile::TempDir::new().unwrap();
-        let windows_threads_dir = temp_dir.path().join("AppData/Local/Zed/threads");
-        std::fs::create_dir_all(&windows_threads_dir).unwrap();
-        let threads_db = windows_threads_dir.join("threads.db");
+        let extra_threads_dir = temp_dir.path().join("custom-zed/threads");
+        std::fs::create_dir_all(&extra_threads_dir).unwrap();
+        let threads_db = extra_threads_dir.join("threads.db");
         let conn = create_zed_sqlite_db(&threads_db);
         insert_zed_thread(&conn, "zed-extra-thread", "claude-sonnet-4-5");
         drop(conn);
@@ -8121,7 +8121,7 @@ mod tests {
         assert!(parsed_default.messages.is_empty());
 
         let mut extra_scan_paths = std::collections::BTreeMap::new();
-        extra_scan_paths.insert("zed".to_string(), vec![windows_threads_dir]);
+        extra_scan_paths.insert("zed".to_string(), vec![extra_threads_dir]);
         let parsed_with_settings = parse_local_clients(LocalParseOptions {
             home_dir: Some(temp_dir.path().to_str().unwrap().to_string()),
             use_env_roots: false,

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -1607,6 +1607,12 @@ fn scan_all_clients_with_env_strategy_inner(
                 result.zed_db = Some(macos_path);
             }
         }
+        if !use_env_roots && result.zed_db.is_none() {
+            let windows_path = PathBuf::from(home_dir).join("AppData/Local/Zed/threads/threads.db");
+            if windows_path.is_file() {
+                result.zed_db = Some(windows_path);
+            }
+        }
         #[cfg(target_os = "windows")]
         if use_env_roots && result.zed_db.is_none() {
             if let Some(local_app_data) = dirs::data_local_dir() {
@@ -3087,6 +3093,26 @@ mod tests {
 
         assert_eq!(result.hermes_db.as_ref(), Some(&default_db));
         assert_eq!(result.hermes_db_paths(), vec![default_db, profile_db]);
+    }
+
+    #[test]
+    fn test_scan_all_clients_with_scanner_settings_discovers_zed_windows_local_appdata_home() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+
+        let windows_threads_dir = home.join("AppData/Local/Zed/threads");
+        fs::create_dir_all(&windows_threads_dir).unwrap();
+        let threads_db = windows_threads_dir.join("threads.db");
+        File::create(&threads_db).unwrap();
+
+        let result = scan_all_clients_with_scanner_settings(
+            home.to_str().unwrap(),
+            &["zed".to_string()],
+            false,
+            &ScannerSettings::default(),
+        );
+
+        assert_eq!(result.zed_db.as_ref(), Some(&threads_db));
     }
 
     #[test]

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -12,18 +12,16 @@ use crate::sessions::{normalize_workspace_key, workspace_label_from_key};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-/// Emit a one-time `tracing::warn!` if `path` does not start with the user's
-/// home directory. The scan is NOT blocked — this is a heads-up only.
-fn warn_if_escapes_home(client_id: ClientId, path: &Path) {
-    if let Some(home) = dirs::home_dir() {
-        if !path.starts_with(&home) {
-            tracing::warn!(
-                client = client_id.as_str(),
-                path = %path.display(),
-                home = %home.display(),
-                "extra scan path is outside $HOME — verify this is intentional"
-            );
-        }
+/// Emit a one-time `tracing::warn!` if `path` does not start with the scan's
+/// supplied home directory. The scan is NOT blocked — this is a heads-up only.
+fn warn_if_escapes_home(home: &Path, client_id: ClientId, path: &Path) {
+    if !path.starts_with(home) {
+        tracing::warn!(
+            client = client_id.as_str(),
+            path = %path.display(),
+            home = %home.display(),
+            "extra scan path is outside $HOME — verify this is intentional"
+        );
     }
 }
 
@@ -1138,7 +1136,7 @@ fn scan_all_clients_with_env_strategy_inner(
     }
 
     for (client_id, path) in extra_scan_paths_for(scanner_settings, &enabled_with_devin_lookup) {
-        warn_if_escapes_home(client_id, &path);
+        warn_if_escapes_home(Path::new(home_dir), client_id, &path);
         if client_id == ClientId::DevinCli {
             devin_cli_roots.push(path);
         } else {
@@ -1235,7 +1233,7 @@ fn scan_all_clients_with_env_strategy_inner(
     if use_env_roots {
         let extra_dirs_val = std::env::var("TOKSCALE_EXTRA_DIRS").unwrap_or_default();
         for (client_id, path) in parse_extra_dirs(&extra_dirs_val, &enabled_with_devin_lookup) {
-            warn_if_escapes_home(client_id, &PathBuf::from(&path));
+            warn_if_escapes_home(Path::new(home_dir), client_id, &PathBuf::from(&path));
             if client_id == ClientId::DevinCli {
                 devin_cli_roots.push(PathBuf::from(path));
             } else {
@@ -1610,7 +1608,7 @@ fn scan_all_clients_with_env_strategy_inner(
             }
         }
         #[cfg(target_os = "windows")]
-        if result.zed_db.is_none() {
+        if use_env_roots && result.zed_db.is_none() {
             if let Some(local_app_data) = dirs::data_local_dir() {
                 let windows_path = local_app_data.join("Zed/threads/threads.db");
                 if windows_path.is_file() {
@@ -4365,17 +4363,10 @@ mod tests {
     #[test]
     #[serial]
     fn test_extra_scan_path_outside_home_does_not_block_scan() {
-        // Use a tempdir that is guaranteed to be outside the real $HOME
-        // (tempfile creates dirs under /tmp on Unix, %TEMP% on Windows).
+        let fake_home = TempDir::new().unwrap();
         let outside_home = TempDir::new().unwrap();
         let outside_path = outside_home.path();
-
-        // Ensure it is truly outside home (skip the test if somehow inside).
-        if let Some(home) = dirs::home_dir() {
-            if outside_path.starts_with(&home) {
-                return; // unexpected environment — skip rather than false-fail
-            }
-        }
+        assert!(!outside_path.starts_with(fake_home.path()));
 
         // Populate with a valid session file so the scanner has something to find.
         let session_dir = outside_path.join("sessions");
@@ -4392,7 +4383,6 @@ mod tests {
         };
 
         // The scan must complete without panicking.
-        let fake_home = TempDir::new().unwrap();
         let _result = scan_all_clients_with_env_strategy(
             fake_home.path().to_str().unwrap(),
             &["claude".to_string()],


### PR DESCRIPTION
Fixes #915

## Summary

- Keep the process Windows config-root lookup inside `use_env_roots`, so explicit-home scans resolve to `<supplied-home>/AppData/Roaming/tokscale` instead of the process `%APPDATA%`.
- Gate the process Zed known-folder lookup on `use_env_roots` while probing `<supplied-home>/AppData/Local/Zed/threads/threads.db` for explicit-home scans.
- Evaluate extra-path warnings against the supplied scan home while preserving their warn-only behavior.
- Move the Zed extra-path fixture off the newly canonical supplied-home path so it continues testing configured extras independently.
- Keep default environment-aware Windows discovery and scanner-settings extra paths unchanged.

## Current-upstream adaptation

| Validated downstream behavior | Current upstream location | Adaptation |
|---|---|---|
| Explicit-home config roots do not read process `%APPDATA%` | `PathRoot::Config::resolve_with_env_strategy` and the CLI's existing `ExplicitHomeConfigLayout::WindowsRoaming` contract | Keep `dirs::config_dir()` inside `use_env_roots`; otherwise derive `AppData/Roaming/tokscale` from the supplied home |
| Explicit-home Zed scans do not use process `%LOCALAPPDATA%` | Windows Zed fallback in `scan_all_clients_with_env_strategy_inner` | Probe the supplied home's `AppData/Local` path when environment roots are disabled; retain the process known-folder lookup for default scans |
| Warning metadata uses the scan's trust boundary | `warn_if_escapes_home` and its settings/environment callers | Pass `Path::new(home_dir)` explicitly |
| Default Windows profile discovery | Same config and Zed paths with `use_env_roots = true` | Deliberately preserved |

The Windows downstream validation established the isolation invariant recovered into [TokenBar PR #59](https://github.com/Nanako0129/TokenBar/pull/59): explicit-home scans must not consume process-profile roots. This PR maps that invariant to current upstream and uses Tokscale's existing Windows roaming/local explicit-home layouts for the positive supplied-profile paths. The validation ancestry and full downstream evidence are recorded in the [handoff comment](https://github.com/Nanako0129/TokenBar/issues/45#issuecomment-5002865759).

## Verification

- `cargo test -p tokscale-core test_path_root_config_ignores_env_when_disabled -- --test-threads=1`
- `cargo test -p tokscale-core test_scan_all_clients_with_scanner_settings_discovers_zed_windows_local_appdata_home -- --test-threads=1`
- `cargo test -p tokscale-core test_scan_all_clients_with_scanner_settings_merges_zed_extra_threads_db -- --test-threads=1`
- `cargo test -p tokscale-core test_parse_local_clients_honors_scanner_extra_scan_paths_for_zed_threads_db -- --test-threads=1`
- `cargo test -p tokscale-core test_extra_scan_path_outside_home_does_not_block_scan -- --test-threads=1`
- `cargo test -p tokscale-core test_scan_all_clients_ignores_extra_dirs_when_env_roots_disabled -- --test-threads=1`
- `cargo test -p tokscale-cli explicit_home_config_path_uses_windows_roaming_layout -- --test-threads=1`
- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo build --release -p tokscale-cli`
- `bun run --cwd packages/frontend test -- __tests__/lib/clientRegistry.test.ts`
- `bun run --cwd packages/frontend typecheck`
- `git diff --check`

## Windows evidence boundary

The downstream fixes were executed and validated on Windows for the process-profile exclusion invariant. This PR maps that invariant to current upstream and derives the positive supplied-profile paths from Tokscale's existing Windows layout contracts. Upstream `Build Native` verifies Windows x64 and arm64 compilation only; it does not run the Rust tests. Unless an additional Windows runner executes them, this PR does not claim independent upstream Windows runtime verification.
