### PR TITLE
fix(submit): make daily_breakdown upsert conflict-target-agnostic (migration bridge)

### DIFF
--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -506,7 +506,8 @@ describe("POST /api/submit auth path", () => {
       displayName: "Test device",
     }));
     expect(tx.execute).toHaveBeenCalledTimes(1);
-    expect(flattenSqlChunks(tx.execute.mock.calls[0][0])).toEqual(
+    const insertChunks = flattenSqlChunks(tx.execute.mock.calls[0][0]);
+    expect(insertChunks).toEqual(
       expect.arrayContaining([
         expect.stringContaining("INSERT INTO daily_breakdown"),
         "submission-1",
@@ -514,6 +515,20 @@ describe("POST /api/submit auth path", () => {
         "2026-04-30",
       ]),
     );
+    // Expand/contract bridge invariant: the daily_breakdown INSERT must use an
+    // UNQUALIFIED `ON CONFLICT DO NOTHING` (no named constraint) so it survives
+    // the migration that swaps the table's unique key from (submission_id, date)
+    // to (submission_id, submitted_device_id, date). Naming either column set
+    // would throw 42P10 against the other schema during the deploy window.
+    expect(insertChunks).toEqual(
+      expect.arrayContaining([expect.stringContaining("ON CONFLICT DO NOTHING")]),
+    );
+    expect(
+      insertChunks.some(
+        (chunk) =>
+          typeof chunk === "string" && chunk.includes("ON CONFLICT (submission_id, date)"),
+      ),
+    ).toBe(false);
     expect(submissionUpdateValues).toEqual(
       expect.objectContaining({
         mcpServers: ["github", "slack"],

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -370,11 +370,11 @@ export async function POST(request: Request) {
         // Race note: two concurrent submits from the same user can both reach
         // this branch before either has committed. The second UPDATE will try
         // to re-stamp submitted_device_id on rows the first already claimed,
-        // which can violate the (submission_id, submitted_device_id, date)
-        // unique constraint. The ON CONFLICT DO NOTHING below makes the UPDATE
-        // skip conflicting rows rather than throw, and the outer try/catch falls
-        // through to the normal insert path if a unique violation still escapes
-        // (e.g. via a concurrent INSERT racing the UPDATE window).
+        // which can violate a daily_breakdown unique constraint. The UPDATE's
+        // own NOT EXISTS dup predicate below skips rows that would collide, and
+        // the savepoint + outer try/catch fall through to the normal insert
+        // path if a unique violation still escapes (e.g. via a concurrent
+        // INSERT racing the UPDATE window).
         try {
           // Wrap the UPDATE in a savepoint so a unique-constraint violation
           // from a concurrent submit does not poison the enclosing

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -562,11 +562,27 @@ export async function POST(request: Request) {
       // Batch INSERT new days via raw SQL VALUES list, chunked to stay under
       // PostgreSQL's 65,535 bound-parameter limit (10 params/row here --
       // a large historical backfill can otherwise exceed it in one statement).
-      // ON CONFLICT (submission_id, date) DO UPDATE is a defensive fallback
-      // for a concurrent submit racing this one between the SELECT above and
-      // this INSERT -- existingDaysMap already covers every device for this
-      // submission, so under normal (non-racing) conditions every row here is
-      // a genuinely new date.
+      //
+      // The conflict clause is intentionally UN-QUALIFIED (`ON CONFLICT DO
+      // NOTHING`, no column/constraint target). This is an expand/contract
+      // migration bridge: an upcoming migration swaps daily_breakdown's unique
+      // key from (submission_id, date) to (submission_id, submitted_device_id,
+      // date). Because prod applies migrations before the new build promotes,
+      // THIS code must run correctly against BOTH keys during the deploy window
+      // -- naming either column set would make the other schema throw 42P10
+      // ("no unique or exclusion constraint matching the ON CONFLICT
+      // specification") for the duration of that build. An unqualified target
+      // matches whichever unique constraint currently exists.
+      //
+      // DO NOTHING (not DO UPDATE) is correct here: existingDaysMap already
+      // routed every date that has a row for this submission to the toUpdate
+      // path above (an UPDATE keyed by row id, itself constraint-agnostic), so
+      // toInsert holds only genuinely-new dates. The conflict clause is purely
+      // a race net for a concurrent submit that inserted the same key between
+      // the SELECT ... FOR UPDATE above and this INSERT. Skipping the raced row
+      // is safe: STEP 3d below recomputes the submission's denormalized totals
+      // by summing the surviving daily_breakdown rows, so the winner's row is
+      // still counted.
       for (let i = 0; i < toInsert.length; i += INSERT_CHUNK_SIZE) {
         const chunk = toInsert.slice(i, i + INSERT_CHUNK_SIZE);
         const insertValuesClauses = chunk.map(
@@ -582,15 +598,7 @@ export async function POST(request: Request) {
             input_tokens, output_tokens, timestamp_ms, active_time_ms, source_breakdown
           )
           VALUES ${insertValuesList}
-          ON CONFLICT (submission_id, date) DO UPDATE SET
-            submitted_device_id = EXCLUDED.submitted_device_id,
-            tokens = EXCLUDED.tokens,
-            cost = EXCLUDED.cost,
-            input_tokens = EXCLUDED.input_tokens,
-            output_tokens = EXCLUDED.output_tokens,
-            timestamp_ms = EXCLUDED.timestamp_ms,
-            active_time_ms = EXCLUDED.active_time_ms,
-            source_breakdown = EXCLUDED.source_breakdown
+          ON CONFLICT DO NOTHING
         `);
       }
 


### PR DESCRIPTION
## Why

**Phase 1 of an expand/contract rollout** for the `daily_breakdown` unique-key change in #910.

#910 swaps the table's unique key from `(submission_id, date)` to `(submission_id, submitted_device_id, date)` via migration 0017. But production applies migrations **before** `next build` (`vercel.json` buildCommand → `migrate-prod.ts`), and the **old** deployment keeps serving for the entire build. So the moment 0017 drops the `(submission_id, date)` constraint, the currently-deployed route's `ON CONFLICT (submission_id, date) DO UPDATE` throws Postgres **42P10** ("no unique or exclusion constraint matching the ON CONFLICT specification") on every insert-containing submit — for the whole build window, and indefinitely if that build later fails.

A Codex review of #910 (high effort) flagged this as a real availability + client-side-delivery-gap risk, not merely a few stray 500s. This PR removes the coupling so #910 can deploy cleanly.

## What

Replace the qualified conflict target on the `daily_breakdown` INSERT with an **unqualified `ON CONFLICT DO NOTHING`**, which matches whichever unique constraint currently exists — so this code runs correctly against **both** the pre-0017 and post-0017 schemas.

`DO NOTHING` (vs the old `DO UPDATE`) is behavior-preserving:
- `existingDaysMap` already routes every date that has a row for the submission to the `toUpdate` path — an `UPDATE ... WHERE d.id = batch.id`, itself constraint-agnostic.
- So `toInsert` holds only genuinely-new dates; the conflict clause is purely a **concurrent-insert race net** (another submit inserting the same key between the `SELECT ... FOR UPDATE` and this INSERT).
- On that rare race, skipping is safe because **STEP 3d recomputes the submission's denormalized totals by summing the surviving daily rows**, so the winning row is still counted.

No migration, no schema change, no other `daily_breakdown` upsert exists (verified). The legacy-adoption path already uses a plain UPDATE.

## Rollout order

1. **Merge + deploy THIS PR** → prod now runs conflict-target-agnostic code.
2. Then merge #910 (migration 0017 + device-scoped merge). Its build window is served by this code, which tolerates both schemas → **no submit 500s, no delivery gap, no transient #909 regression**.

## Tests

Existing 13 submit-auth tests pass unchanged. Added an assertion locking in the bridge invariant: the INSERT must emit an unqualified `ON CONFLICT DO NOTHING` and must **not** name `(submission_id, date)`. `tsc --noEmit` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the `daily_breakdown` insert conflict clause schema-agnostic by using `ON CONFLICT DO NOTHING`, so submits work during the unique-key migration and avoid Postgres 42P10 errors. Also clarifies race-handling comments to reflect the actual protection path.

- **Bug Fixes**
  - Replace `ON CONFLICT (submission_id, date) DO UPDATE` with `ON CONFLICT DO NOTHING` in `packages/frontend/src/app/api/submit/route.ts` to work with both `(submission_id, date)` and `(submission_id, submitted_device_id, date)`.
  - Add a test in `packages/frontend/__tests__/api/submitAuth.test.ts` asserting the unqualified conflict clause, and update comments to attribute race handling to the UPDATE’s `NOT EXISTS` check plus savepoint (not the insert).

- **Migration**
  - Deploy this before the key change to `(submission_id, submitted_device_id, date)` (in #910 / migration 0017) to prevent submit failures during the build window.

<sup>Written for commit 221f6a4aa720eebb6f6ee5b9e494e3543b324c5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

