### PR TITLE
fix(migrations): retry prod migrate on transient connection drops, not just deadlocks

### DIFF
--- a/packages/frontend/__tests__/scripts/migrateRetry.test.ts
+++ b/packages/frontend/__tests__/scripts/migrateRetry.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { classifyFailure } from "../../scripts/migrate-retry";
+
+describe("classifyFailure", () => {
+  it("retries a Postgres deadlock (40P01)", () => {
+    expect(classifyFailure("error: deadlock detected")).toEqual({
+      retryable: true,
+      reason: "deadlock",
+    });
+    expect(classifyFailure("... (SQLSTATE 40P01) ...")).toEqual({
+      retryable: true,
+      reason: "deadlock",
+    });
+  });
+
+  it("retries a dropped DB connection", () => {
+    // The exact error that failed migration 0017's first production deploy:
+    // the managed-Postgres proxy severed the socket mid-migration.
+    expect(
+      classifyFailure("Error: write CONNECTION_CLOSED nozomi.proxy.rlwy.net:27021")
+    ).toEqual({ retryable: true, reason: "connection error" });
+    expect(classifyFailure("read ECONNRESET")).toEqual({
+      retryable: true,
+      reason: "connection error",
+    });
+    expect(classifyFailure("Connection terminated unexpectedly")).toEqual({
+      retryable: true,
+      reason: "connection error",
+    });
+    expect(classifyFailure("terminating connection due to administrator command")).toEqual({
+      retryable: true,
+      reason: "connection error",
+    });
+  });
+
+  it("does NOT retry a genuine SQL error", () => {
+    expect(classifyFailure('error: column "foo" does not exist')).toEqual({
+      retryable: false,
+      reason: "non-retryable error",
+    });
+    expect(
+      classifyFailure('relation "daily_breakdown" already exists')
+    ).toEqual({ retryable: false, reason: "non-retryable error" });
+    expect(classifyFailure("")).toEqual({
+      retryable: false,
+      reason: "non-retryable error",
+    });
+  });
+});

--- a/packages/frontend/__tests__/scripts/migrateRetry.test.ts
+++ b/packages/frontend/__tests__/scripts/migrateRetry.test.ts
@@ -51,4 +51,18 @@ describe("classifyFailure", () => {
       reason: "non-retryable error",
     });
   });
+
+  it("does NOT retry caller-initiated pool shutdowns", () => {
+    // postgres.js emits CONNECTION_ENDED / CONNECTION_DESTROYED when the pool is
+    // deliberately closed -- deterministic, not a transient outage. Pinned so a
+    // later regex edit can't silently start retrying shutdown errors.
+    expect(classifyFailure("Error: CONNECTION_ENDED")).toEqual({
+      retryable: false,
+      reason: "non-retryable error",
+    });
+    expect(classifyFailure("Error: CONNECTION_DESTROYED")).toEqual({
+      retryable: false,
+      reason: "non-retryable error",
+    });
+  });
 });

--- a/packages/frontend/__tests__/scripts/migrateRetry.test.ts
+++ b/packages/frontend/__tests__/scripts/migrateRetry.test.ts
@@ -31,6 +31,11 @@ describe("classifyFailure", () => {
       retryable: true,
       reason: "connection error",
     });
+    // postgres.js connect/startup timeout is reported as CONNECT_TIMEOUT.
+    expect(classifyFailure("Error: CONNECT_TIMEOUT")).toEqual({
+      retryable: true,
+      reason: "connection error",
+    });
   });
 
   it("does NOT retry a genuine SQL error", () => {

--- a/packages/frontend/__tests__/scripts/migrateRetry.test.ts
+++ b/packages/frontend/__tests__/scripts/migrateRetry.test.ts
@@ -36,6 +36,15 @@ describe("classifyFailure", () => {
       retryable: true,
       reason: "connection error",
     });
+    // Transient DNS failures (Node getaddrinfo errnos).
+    expect(classifyFailure("Error: getaddrinfo EAI_AGAIN db.host")).toEqual({
+      retryable: true,
+      reason: "connection error",
+    });
+    expect(classifyFailure("Error: getaddrinfo ENOTFOUND db.host")).toEqual({
+      retryable: true,
+      reason: "connection error",
+    });
   });
 
   it("does NOT retry a genuine SQL error", () => {

--- a/packages/frontend/scripts/migrate-prod.ts
+++ b/packages/frontend/scripts/migrate-prod.ts
@@ -116,11 +116,33 @@ try {
       );
     }
     await sleep(RETRY_DELAY_MS);
+
+    // A retryable connection failure may have severed not just the child
+    // drizzle-kit connection but also the parent session that holds the
+    // advisory lock -- advisory locks are session-scoped and released the
+    // moment their connection closes. Without re-checking, we could launch
+    // the next migration attempt while believing we still hold the lock,
+    // racing a concurrent build. Re-acquire before retrying: postgres.js
+    // reconnects for this query and pg_try_advisory_lock re-grabs the lock if
+    // it was released (a harmless re-entrant grab if the session survived).
+    // If a concurrent build has taken it, bail rather than race -- that build
+    // will apply the pending migrations.
+    const [reacquired] = await sql<{ acquired: boolean }[]>`
+      SELECT pg_try_advisory_lock(hashtext(${LOCK_KEY})) AS acquired
+    `;
+    if (!reacquired?.acquired) {
+      throw new Error(
+        "lost the migration advisory lock during a transient failure and a concurrent build now holds it — aborting to avoid a racing migration"
+      );
+    }
   }
 } finally {
   if (lockAcquired) {
     try {
-      await sql`SELECT pg_advisory_unlock(hashtext(${LOCK_KEY}))`;
+      // Release every level held -- the retry path's re-acquire is re-entrant,
+      // so the session can hold the lock more than once. pg_advisory_unlock_all
+      // clears them all regardless of depth.
+      await sql`SELECT pg_advisory_unlock_all()`;
     } catch (error) {
       console.error("warn - failed to release migration advisory lock", error);
     }

--- a/packages/frontend/scripts/migrate-prod.ts
+++ b/packages/frontend/scripts/migrate-prod.ts
@@ -67,32 +67,51 @@ async function runMigrate(): Promise<{
   return { ok: false, retryable, reason, stderr };
 }
 
-let lockAcquired = false;
-
-try {
+// Acquire (or re-acquire) the session-scoped advisory lock that serializes
+// concurrent `drizzle-kit migrate` runs across overlapping builds. Loops on
+// two conditions so it survives a wobbly database:
+//   - the query itself fails (DB still unreachable, e.g. mid-outage): keep
+//     retrying so a transient blip doesn't abort a deploy;
+//   - the lock is held by another build: wait for that build to finish, then
+//     re-check -- we never run a migration without holding the lock.
+// Throws only after MAX_LOCK_ATTEMPTS. Safe to call again on the migrate-retry
+// path: a transient connection drop can sever the session and silently release
+// the lock (advisory locks die with their connection), so re-establishing it
+// before each retry is what prevents two builds from migrating at once.
+async function acquireAdvisoryLock(): Promise<void> {
   for (let attempt = 1; attempt <= MAX_LOCK_ATTEMPTS; attempt++) {
-    const [result] = await sql<{ acquired: boolean }[]>`
-      SELECT pg_try_advisory_lock(hashtext(${LOCK_KEY})) AS acquired
-    `;
-    if (result?.acquired) {
-      lockAcquired = true;
-      break;
+    let acquired = false;
+    try {
+      const [row] = await sql<{ acquired: boolean }[]>`
+        SELECT pg_try_advisory_lock(hashtext(${LOCK_KEY})) AS acquired
+      `;
+      acquired = row?.acquired ?? false;
+    } catch (error) {
+      if (attempt === MAX_LOCK_ATTEMPTS) throw error;
+      console.warn(
+        `warn - could not reach DB to acquire migration advisory lock (attempt ${attempt}/${MAX_LOCK_ATTEMPTS}); retrying in ${RETRY_DELAY_MS}ms`
+      );
+      await sleep(RETRY_DELAY_MS);
+      continue;
     }
-
+    if (acquired) return;
     if (attempt < MAX_LOCK_ATTEMPTS) {
       console.warn(
-        `warn - migration advisory lock unavailable (attempt ${attempt}/${MAX_LOCK_ATTEMPTS}); retrying in ${RETRY_DELAY_MS}ms`
+        `warn - migration advisory lock held by another build (attempt ${attempt}/${MAX_LOCK_ATTEMPTS}); retrying in ${RETRY_DELAY_MS}ms`
       );
       await sleep(RETRY_DELAY_MS);
     }
   }
+  throw new Error(
+    `could not acquire migration advisory lock after ${MAX_LOCK_ATTEMPTS} attempts -- a concurrent build may be stuck`
+  );
+}
 
-  if (!lockAcquired) {
-    throw new Error(
-      `could not acquire migration advisory lock after ${MAX_LOCK_ATTEMPTS} attempts -- a concurrent build may be stuck`
-    );
-  }
+let lockAcquired = false;
 
+try {
+  await acquireAdvisoryLock();
+  lockAcquired = true;
   console.log(`ok - acquired advisory lock (${LOCK_KEY})`);
 
   let lastResult: Awaited<ReturnType<typeof runMigrate>> | undefined;
@@ -117,24 +136,11 @@ try {
     }
     await sleep(RETRY_DELAY_MS);
 
-    // A retryable connection failure may have severed not just the child
-    // drizzle-kit connection but also the parent session that holds the
-    // advisory lock -- advisory locks are session-scoped and released the
-    // moment their connection closes. Without re-checking, we could launch
-    // the next migration attempt while believing we still hold the lock,
-    // racing a concurrent build. Re-acquire before retrying: postgres.js
-    // reconnects for this query and pg_try_advisory_lock re-grabs the lock if
-    // it was released (a harmless re-entrant grab if the session survived).
-    // If a concurrent build has taken it, bail rather than race -- that build
-    // will apply the pending migrations.
-    const [reacquired] = await sql<{ acquired: boolean }[]>`
-      SELECT pg_try_advisory_lock(hashtext(${LOCK_KEY})) AS acquired
-    `;
-    if (!reacquired?.acquired) {
-      throw new Error(
-        "lost the migration advisory lock during a transient failure and a concurrent build now holds it — aborting to avoid a racing migration"
-      );
-    }
+    // The retryable failure may have severed the parent session holding the
+    // advisory lock (see acquireAdvisoryLock). Re-establish it before the next
+    // attempt so we never migrate without the lock -- waiting through both a
+    // still-recovering DB and a concurrent holder rather than aborting.
+    await acquireAdvisoryLock();
   }
 } finally {
   if (lockAcquired) {

--- a/packages/frontend/scripts/migrate-prod.ts
+++ b/packages/frontend/scripts/migrate-prod.ts
@@ -1,5 +1,6 @@
 /// <reference types="bun-types" />
 import postgres from "postgres";
+import { classifyFailure } from "./migrate-retry";
 
 // This runs BEFORE `next build` in vercel.json's buildCommand
 // (`bun run scripts/migrate-prod.ts && next build`), intentionally — not after.
@@ -46,7 +47,12 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function runMigrate(): Promise<{ ok: boolean; deadlock: boolean; stderr: string }> {
+async function runMigrate(): Promise<{
+  ok: boolean;
+  retryable: boolean;
+  reason: string;
+  stderr: string;
+}> {
   const proc = Bun.spawn(["bunx", "drizzle-kit", "migrate"], {
     stdout: "inherit",
     stderr: "pipe",
@@ -55,11 +61,10 @@ async function runMigrate(): Promise<{ ok: boolean; deadlock: boolean; stderr: s
   process.stderr.write(stderr);
   const exitCode = await proc.exited;
   if (exitCode === 0) {
-    return { ok: true, deadlock: false, stderr };
+    return { ok: true, retryable: false, reason: "", stderr };
   }
-  // Postgres deadlock_detected is SQLSTATE 40P01.
-  const deadlock = /40P01|deadlock detected/i.test(stderr);
-  return { ok: false, deadlock, stderr };
+  const { retryable, reason } = classifyFailure(stderr);
+  return { ok: false, retryable, reason, stderr };
 }
 
 let lockAcquired = false;
@@ -97,16 +102,18 @@ try {
       console.log(`ok - drizzle-kit migrate succeeded (attempt ${attempt}/${MAX_ATTEMPTS})`);
       break;
     }
-    if (!lastResult.deadlock) {
+    if (!lastResult.retryable) {
       throw new Error(
-        `drizzle-kit migrate failed (attempt ${attempt}/${MAX_ATTEMPTS}, not a deadlock — not retrying)`
+        `drizzle-kit migrate failed (attempt ${attempt}/${MAX_ATTEMPTS}, ${lastResult.reason} — not retrying)`
       );
     }
     console.warn(
-      `warn - drizzle-kit migrate hit a deadlock (attempt ${attempt}/${MAX_ATTEMPTS})`
+      `warn - drizzle-kit migrate hit a transient ${lastResult.reason} (attempt ${attempt}/${MAX_ATTEMPTS})`
     );
     if (attempt === MAX_ATTEMPTS) {
-      throw new Error(`drizzle-kit migrate deadlocked ${MAX_ATTEMPTS} times in a row`);
+      throw new Error(
+        `drizzle-kit migrate failed with a transient ${lastResult.reason} ${MAX_ATTEMPTS} times in a row`
+      );
     }
     await sleep(RETRY_DELAY_MS);
   }

--- a/packages/frontend/scripts/migrate-prod.ts
+++ b/packages/frontend/scripts/migrate-prod.ts
@@ -87,7 +87,14 @@ async function acquireAdvisoryLock(): Promise<void> {
       `;
       acquired = row?.acquired ?? false;
     } catch (error) {
-      if (attempt === MAX_LOCK_ATTEMPTS) throw error;
+      // Only wait out a TRANSIENT connectivity failure (same classifier as the
+      // migrate retry). A permanent error -- bad credentials, unreachable host,
+      // a missing function -- won't fix itself, so fail the deploy immediately
+      // instead of burning ~MAX_LOCK_ATTEMPTS of pointless waits.
+      const errorText = `${error} ${(error as { code?: unknown })?.code ?? ""}`;
+      if (attempt === MAX_LOCK_ATTEMPTS || !classifyFailure(errorText).retryable) {
+        throw error;
+      }
       console.warn(
         `warn - could not reach DB to acquire migration advisory lock (attempt ${attempt}/${MAX_LOCK_ATTEMPTS}); retrying in ${RETRY_DELAY_MS}ms`
       );

--- a/packages/frontend/scripts/migrate-retry.ts
+++ b/packages/frontend/scripts/migrate-retry.ts
@@ -18,7 +18,10 @@ export function classifyFailure(stderr: string): { retryable: boolean; reason: s
     return { retryable: true, reason: "deadlock" };
   }
   if (
-    /CONNECTION_CLOSED|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|connection closed|connection terminated|terminating connection|server closed the connection|Connection ended/i.test(
+    // postgres.js surfaces dropped/failed connections via these error codes
+    // (CONNECTION_* / CONNECT_TIMEOUT) and Node's socket errnos (ECONN* etc.);
+    // the text variants cover server-initiated terminations.
+    /CONNECTION_CLOSED|CONNECTION_ENDED|CONNECTION_DESTROYED|CONNECT_TIMEOUT|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|connection closed|connection terminated|terminating connection|server closed the connection|Connection ended/i.test(
       stderr
     )
   ) {

--- a/packages/frontend/scripts/migrate-retry.ts
+++ b/packages/frontend/scripts/migrate-retry.ts
@@ -21,11 +21,13 @@ export function classifyFailure(stderr: string): { retryable: boolean; reason: s
     // Transient loss of connectivity worth reconnecting for: postgres.js
     // surfaces an unexpectedly dropped socket as CONNECTION_CLOSED and a
     // failed connect as CONNECT_TIMEOUT; Node reports socket-level failures
-    // via these errnos; the text variants are server-initiated terminations
-    // (restart / failover). Deliberately excluded are CONNECTION_ENDED /
-    // CONNECTION_DESTROYED -- postgres.js emits those on a caller-initiated
-    // pool shutdown, i.e. deterministic, not a transient outage.
-    /CONNECTION_CLOSED|CONNECT_TIMEOUT|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|connection terminated|terminating connection|server closed the connection/i.test(
+    // (ECONN* / ETIMEDOUT / EPIPE) and transient DNS failures (ENOTFOUND /
+    // EAI_AGAIN) via these errnos; the text variants are server-initiated
+    // terminations (restart / failover). Deliberately excluded are
+    // CONNECTION_ENDED / CONNECTION_DESTROYED -- postgres.js emits those on a
+    // caller-initiated pool shutdown, i.e. deterministic, not a transient
+    // outage.
+    /CONNECTION_CLOSED|CONNECT_TIMEOUT|ECONNRESET|ECONNREFUSED|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|EPIPE|connection terminated|terminating connection|server closed the connection/i.test(
       stderr
     )
   ) {

--- a/packages/frontend/scripts/migrate-retry.ts
+++ b/packages/frontend/scripts/migrate-retry.ts
@@ -18,10 +18,14 @@ export function classifyFailure(stderr: string): { retryable: boolean; reason: s
     return { retryable: true, reason: "deadlock" };
   }
   if (
-    // postgres.js surfaces dropped/failed connections via these error codes
-    // (CONNECTION_* / CONNECT_TIMEOUT) and Node's socket errnos (ECONN* etc.);
-    // the text variants cover server-initiated terminations.
-    /CONNECTION_CLOSED|CONNECTION_ENDED|CONNECTION_DESTROYED|CONNECT_TIMEOUT|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|connection closed|connection terminated|terminating connection|server closed the connection|Connection ended/i.test(
+    // Transient loss of connectivity worth reconnecting for: postgres.js
+    // surfaces an unexpectedly dropped socket as CONNECTION_CLOSED and a
+    // failed connect as CONNECT_TIMEOUT; Node reports socket-level failures
+    // via these errnos; the text variants are server-initiated terminations
+    // (restart / failover). Deliberately excluded are CONNECTION_ENDED /
+    // CONNECTION_DESTROYED -- postgres.js emits those on a caller-initiated
+    // pool shutdown, i.e. deterministic, not a transient outage.
+    /CONNECTION_CLOSED|CONNECT_TIMEOUT|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|connection terminated|terminating connection|server closed the connection/i.test(
       stderr
     )
   ) {

--- a/packages/frontend/scripts/migrate-retry.ts
+++ b/packages/frontend/scripts/migrate-retry.ts
@@ -1,0 +1,28 @@
+// Classify a failed `drizzle-kit migrate` run as transient (worth retrying
+// with a fresh process/connection) or not. Extracted from migrate-prod.ts so
+// the classification is unit-testable without running the migration side
+// effects that module performs on import.
+//
+// Two transient classes:
+//   - Postgres deadlock_detected (SQLSTATE 40P01).
+//   - A dropped/reset DB connection. drizzle-kit runs each migration inside a
+//     transaction, so a mid-flight connection loss (e.g. a managed-Postgres
+//     proxy severing the socket during a slow index build / ADD CONSTRAINT)
+//     rolls the migration back with no partial state -- the postgres driver
+//     surfaces it as CONNECTION_CLOSED / ECONNRESET / "Connection terminated"
+//     rather than a SQLSTATE. Re-running from a fresh process reconnects and
+//     re-attempts the still-pending migration idempotently.
+// Anything else (a real SQL error) is non-retryable and fails the build.
+export function classifyFailure(stderr: string): { retryable: boolean; reason: string } {
+  if (/40P01|deadlock detected/i.test(stderr)) {
+    return { retryable: true, reason: "deadlock" };
+  }
+  if (
+    /CONNECTION_CLOSED|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|connection closed|connection terminated|terminating connection|server closed the connection|Connection ended/i.test(
+      stderr
+    )
+  ) {
+    return { retryable: true, reason: "connection error" };
+  }
+  return { retryable: false, reason: "non-retryable error" };
+}


### PR DESCRIPTION
## Why

Migration 0017's first production deploy (#910) failed on a **transient database connection drop**, not a code or SQL defect. `migrate-prod.ts` runs before `next build` in the Vercel buildCommand, so this failed the whole production deploy. Redeploying with no changes then succeeded — confirming it was a one-off.

The exact failure, ~47s into applying 0017:

```
Error: write CONNECTION_CLOSED nozomi.proxy.rlwy.net:27021
...
error: drizzle-kit migrate failed (attempt 1/5, not a deadlock — not retrying)
```

`migrate-prod.ts` retried **only** Postgres deadlocks (`40P01`) and threw on everything else, so the dropped connection bailed after a single attempt even though it would have self-healed on a retry.

## What

Widen the retry classification to also treat **dropped/reset DB connections** as transient (`CONNECTION_CLOSED`, `ECONNRESET`, `ECONNREFUSED`, `ETIMEDOUT`, `EPIPE`, "connection terminated", "terminating connection", "server closed the connection", …).

This is safe: drizzle-kit wraps each migration in a transaction, so a mid-flight connection loss rolls back with **no partial state** — re-running from a fresh process reconnects and re-attempts the still-pending migration idempotently. Genuine SQL errors remain **non-retryable** and fail the build immediately, exactly as before.

The classifier is extracted into `scripts/migrate-retry.ts` so it's unit-testable without triggering `migrate-prod.ts`'s on-import migration side effects.

## Tests

New `__tests__/scripts/migrateRetry.test.ts` pins:
- the exact `CONNECTION_CLOSED` string that failed 0017 → retryable
- deadlock (40P01) → retryable
- `ECONNRESET` / "connection terminated" → retryable
- a genuine SQL error and empty stderr → **not** retryable

3 tests + `tsc --noEmit` pass. Note: `migrate-prod.ts` runs only in the production build, not in CI's Migration Replay, so behavior is unchanged for CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make production migrations more resilient by retrying transient DB connection and DNS errors, and re-acquiring the advisory lock between attempts. Fail fast on permanent lock errors to avoid stalled deploys when `migrate-prod.ts` runs before `next build`.

- **Bug Fixes**
  - Retry `drizzle-kit migrate` on dropped/reset connections, timeouts, and transient DNS failures in addition to deadlocks (`CONNECTION_CLOSED`, `CONNECT_TIMEOUT`, `ECONNRESET`, `ECONNREFUSED`, `ETIMEDOUT`, `EPIPE`, `ENOTFOUND`, `EAI_AGAIN`, and common “connection terminated/closed” messages); exclude `CONNECTION_ENDED`/`CONNECTION_DESTROYED`. Classifier extracted to `scripts/migrate-retry.ts` with unit tests and negative assertions; genuine SQL errors still fail fast.
  - Re-acquire the Postgres advisory lock before each retry with a retry/wait loop that handles both DB-unreachable and lock-held cases. Only transient connectivity/DNS errors wait; permanent errors rethrow immediately. We never migrate without the lock; release via `pg_advisory_unlock_all()`.

<sup>Written for commit b9e4442e6347d43ab52c2638a4f98d309735bbd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

