### PR TITLE
fix(grok): account for Grok Build's complete token usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@
 | <img width="48px" src=".github/assets/client-antigravity.png" alt="Antigravity CLI" /> | [Antigravity CLI](https://antigravity.google/) | `~/.gemini/antigravity-cli/conversations/*.db` (override the Gemini home via `GEMINI_CLI_HOME`; local SQLite, read directly — no `antigravity sync` needed) |
 | <img width="48px" src=".github/assets/client-trae.png" alt="Trae" /> | [Trae IDE](https://www.trae.ai/) / [Trae Solo](https://www.trae.ai/solo) (international) | Cached via `tokscale trae sync` to `~/.config/tokscale/trae-cache/sessions/*.json` (account-level usage from the official API) |
 | <img width="48px" src="https://github.com/warpdotdev.png" alt="Warp" /> | [Warp](https://www.warp.dev/) / Oz | Cached via `tokscale warp sync` to `~/.config/tokscale/warp-cache/usage.json` (aggregate requests and spend only; no token transcripts) |
-| <img width="48px" src="https://github.com/xai-org.png" alt="Grok Build" /> | Grok Build | `$GROK_HOME/sessions/*/*/updates.jsonl` (fallback: `~/.grok/sessions/*/*/updates.jsonl`) |
+| <img width="48px" src="https://github.com/xai-org.png" alt="Grok Build" /> | Grok Build | `$GROK_HOME/logs/unified.jsonl` (fallback: `~/.grok/logs/unified.jsonl`; legacy session-update fallback) |
 | <img width="48px" src=".github/assets/client-zed.webp" alt="Zed Agent" /> | [Zed Agent](https://zed.dev/docs/ai/agent-panel) | `~/.local/share/zed/threads/threads.db` (macOS: `~/Library/Application Support/Zed/threads/threads.db`; Windows: `%LOCALAPPDATA%/Zed/threads/threads.db`; hosted Zed models only, not external ACP agents) |
 | <img width="48px" src="https://github.com/kirodotdev.png" alt="Kiro" /> | Kiro | `~/.kiro/sessions/cli/*.json` (+ `*.jsonl`), `~/.local/share/kiro-cli/data.sqlite3` (macOS: `~/Library/Application Support/kiro-cli/data.sqlite3`), and Kiro IDE globalStorage snapshots (`Kiro/User/globalStorage/kiro.kiroagent`; macOS Application Support, Linux `~/.config/Kiro`, Windows `%APPDATA%\Kiro`) |
 | <img width="48px" src="https://github.com/cline.png" alt="Cline" /> | [Cline](https://github.com/cline/cline) | VS Code globalStorage tasks (Linux: `~/.config/Code/...`; macOS: `~/Library/Application Support/Code/...`; Windows: `%APPDATA%\Code\...`; server: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/`) |
@@ -1338,7 +1338,7 @@ AI coding tools store their session data in cross-platform locations. Most tools
 | Kiro | `~/.kiro/sessions/cli/` and `~/.local/share/kiro-cli/data.sqlite3` | `%USERPROFILE%\.kiro\sessions\cli\` and `%USERPROFILE%\.local\share\kiro-cli\data.sqlite3` | Parses Kiro session files plus the Kiro CLI SQLite database when present |
 | Trae | `~/.config/tokscale/trae-cache/sessions/` | `%APPDATA%\tokscale\trae-cache\sessions\` | Synced once via `tokscale trae sync`; credentials are auto-discovered from any installed Trae IDE or Trae Solo desktop app |
 | Warp/Oz | `~/.config/tokscale/warp-cache/usage.json` | `%APPDATA%\tokscale\warp-cache\usage.json` | Synced via `tokscale warp sync`; aggregate requests and spend only, no token transcripts |
-| Grok Build | `~/.grok/sessions/` | `%USERPROFILE%\.grok\sessions\` | Configurable via `GROK_HOME` env var; parses `updates.jsonl` session updates |
+| Grok Build | `~/.grok/logs/unified.jsonl` (legacy: `~/.grok/sessions/`) | `%USERPROFILE%\.grok\logs\unified.jsonl` (legacy: `%USERPROFILE%\.grok\sessions\`) | Configurable via `GROK_HOME`; parses unified per-inference usage and falls back to legacy `updates.jsonl` session updates |
 | Jcode | `~/.jcode/sessions/` | `%USERPROFILE%\.jcode\sessions\` | Configurable via `JCODE_HOME` env var; parses `session_*.json` snapshots plus `session_*.journal.jsonl` sidecars |
 | MiMo Code | `~/.local/share/mimocode/` | `%USERPROFILE%\.local\share\mimocode\` | Uses XDG data directory; SQLite database `mimocode.db` |
 | Gajae-Code | `~/.gjc/agent/sessions/` | `%USERPROFILE%\.gjc\agent\sessions\` | Configurable via `GJC_CODING_AGENT_DIR` (also `GJC_CONFIG_DIR`/`PI_CONFIG_DIR`; `$XDG_DATA_HOME/gjc/sessions/` flattens on Linux/macOS) |
@@ -1594,9 +1594,9 @@ Warp/Oz data is not fetched automatically by the root command. Run `tokscale war
 
 ### Grok Build
 
-Location: `$GROK_HOME/sessions/*/*/updates.jsonl` (fallback: `~/.grok/sessions/*/*/updates.jsonl`)
+Preferred location: `$GROK_HOME/logs/unified.jsonl` (fallback: `~/.grok/logs/unified.jsonl`); legacy fallback: `$GROK_HOME/sessions/*/*/updates.jsonl`.
 
-Grok Build data is parsed directly from local session updates. Current logs expose cumulative `totalTokens` counters without a stable input/output split, so Tokscale records positive per-turn deltas as input tokens. `grok-composer-2.5-fast` is temporarily mapped to the Composer 2.5 Fast pricing override until a dedicated public price is available.
+The unified log emits per-inference prompt, cached-prompt, completion, and reasoning counts. Tokscale records non-cached input, cache reads, visible output, and reasoning as non-overlapping buckets, then prefers this richer source over legacy updates for sessions it covers. Legacy updates expose only cumulative `totalTokens`, so their positive per-turn deltas remain input-only fallback data. `grok-composer-2.5-fast` is temporarily mapped to the Composer 2.5 Fast pricing override until a dedicated public price is available.
 
 ### Jcode
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1340,16 +1340,18 @@ fn parse_all_messages_with_pricing_with_env_strategy(
                 &source_cache,
                 pricing,
                 message_cache::SourceFingerprint::check_grok_path_samples_only,
-                sessions::grok::parse_grok_updates_file,
+                sessions::grok::parse_grok_file,
             )
         })
         .collect();
+    let mut grok_messages = Vec::new();
     for outcome in grok_outcomes {
-        all_messages.extend(outcome.messages);
+        grok_messages.extend(outcome.messages);
         if let Some(entry) = outcome.cache_entry {
             source_cache.insert(entry);
         }
     }
+    all_messages.extend(sessions::grok::prefer_unified_log_messages(grok_messages));
 
     let jcode_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::Jcode)
@@ -3530,15 +3532,14 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     counts.set(ClientId::WorkBuddy, workbuddy_count);
     messages.extend(workbuddy_msgs);
 
-    let grok_msgs: Vec<ParsedMessage> = scan_result
+    let grok_messages: Vec<UnifiedMessage> = scan_result
         .get(ClientId::Grok)
         .par_iter()
-        .flat_map(|path| {
-            sessions::grok::parse_grok_updates_file(path)
-                .into_iter()
-                .map(|msg| unified_to_parsed(&msg))
-                .collect::<Vec<_>>()
-        })
+        .flat_map(|path| sessions::grok::parse_grok_file(path))
+        .collect();
+    let grok_msgs: Vec<ParsedMessage> = sessions::grok::prefer_unified_log_messages(grok_messages)
+        .into_iter()
+        .map(|msg| unified_to_parsed(&msg))
         .collect();
     let grok_count = summed_parsed_message_count(&grok_msgs);
     counts.set(ClientId::Grok, grok_count);
@@ -4865,6 +4866,54 @@ mod tests {
 {"timestamp": 1770983450.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 8, "output": 1, "input_cache_read": 0, "input_cache_creation": 0}}}}"#,
         )
         .unwrap();
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parse_all_messages_with_pricing_prefers_grok_unified_log() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            let session_dir = source_home
+                .path()
+                .join(".grok/sessions/%2Ftmp%2Fproject/session-1");
+            std::fs::create_dir_all(&session_dir).unwrap();
+            std::fs::write(
+                session_dir.join("updates.jsonl"),
+                r#"{"method":"session/update","params":{"sessionId":"session-1","_meta":{"totalTokens":999,"agentTimestampMs":1700000000000}}}"#,
+            )
+            .unwrap();
+
+            let logs_dir = source_home.path().join(".grok/logs");
+            std::fs::create_dir_all(&logs_dir).unwrap();
+            std::fs::write(
+                logs_dir.join("unified.jsonl"),
+                r#"{"ts":"2023-11-14T22:13:19Z","pid":7,"sid":"session-1","msg":"model changed","ctx":{"model":"grok-build"}}
+{"ts":"2023-11-14T22:13:20Z","pid":7,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":100,"cached_prompt_tokens":60,"completion_tokens":25,"reasoning_tokens":5}}"#,
+            )
+            .unwrap();
+
+            let messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["grok".to_string()],
+                None,
+            );
+
+            assert_eq!(messages.len(), 1);
+            assert_eq!(messages[0].tokens.input, 40);
+            assert_eq!(messages[0].tokens.cache_read, 60);
+            assert_eq!(messages[0].tokens.output, 20);
+            assert_eq!(messages[0].tokens.reasoning, 5);
+            assert_eq!(messages[0].tokens.total(), 125);
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
     }
 
     #[test]

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -372,6 +372,7 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
                 "sessions.json" => file_name == "sessions.json",
                 "wire.jsonl" => file_name == "wire.jsonl",
                 "updates.jsonl" => file_name == "updates.jsonl",
+                "unified.jsonl" => file_name == "unified.jsonl",
                 "events.jsonl" => file_name == "events.jsonl",
                 "ui_messages.json" => file_name == "ui_messages.json",
                 "session-usage.json" => file_name == "session-usage.json",
@@ -1133,6 +1134,23 @@ fn scan_all_clients_with_env_strategy_inner(
         let def = client_id.data();
         let path = def.resolve_path_with_env_strategy(home_dir, use_env_roots);
         push_unique_scan_task(&mut tasks, &mut seen_scan_roots, *client_id, path);
+    }
+
+    if enabled.contains(&ClientId::Grok) {
+        let grok_sessions = PathBuf::from(
+            ClientId::Grok
+                .data()
+                .resolve_path_with_env_strategy(home_dir, use_env_roots),
+        );
+        if let Some(grok_home) = grok_sessions.parent() {
+            push_unique_scan_task_with_pattern(
+                &mut tasks,
+                &mut seen_scan_roots,
+                ClientId::Grok,
+                grok_home.join("logs"),
+                "unified.jsonl",
+            );
+        }
     }
 
     for (client_id, path) in extra_scan_paths_for(scanner_settings, &enabled_with_devin_lookup) {
@@ -4220,13 +4238,22 @@ mod tests {
         let home = dir.path();
         setup_mock_grok_dir(home);
 
+        let unified_dir = home.join(".grok/logs");
+        fs::create_dir_all(&unified_dir).unwrap();
+        let unified_log = unified_dir.join("unified.jsonl");
+        File::create(&unified_log).unwrap();
+
         let result = scan_all_clients_with_env_strategy(
             home.to_str().unwrap(),
             &["grok".to_string()],
             false,
         );
-        assert_eq!(result.get(ClientId::Grok).len(), 1);
-        assert!(result.get(ClientId::Grok)[0].ends_with("updates.jsonl"));
+        let grok_files = result.get(ClientId::Grok);
+        assert_eq!(grok_files.len(), 2);
+        assert!(grok_files
+            .iter()
+            .any(|path| path.ends_with("updates.jsonl")));
+        assert!(grok_files.iter().any(|path| path == &unified_log));
         assert!(result.get(ClientId::OpenCode).is_empty());
         assert!(result.get(ClientId::Claude).is_empty());
     }

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -1147,7 +1147,7 @@ fn scan_all_clients_with_env_strategy_inner(
                 &mut tasks,
                 &mut seen_scan_roots,
                 ClientId::Grok,
-                grok_home.join("logs"),
+                grok_home.join("logs/unified.jsonl"),
                 "unified.jsonl",
             );
         }
@@ -4242,6 +4242,10 @@ mod tests {
         fs::create_dir_all(&unified_dir).unwrap();
         let unified_log = unified_dir.join("unified.jsonl");
         File::create(&unified_log).unwrap();
+        let nested_dir = unified_dir.join("archive");
+        fs::create_dir_all(&nested_dir).unwrap();
+        let nested_log = nested_dir.join("unified.jsonl");
+        File::create(&nested_log).unwrap();
 
         let result = scan_all_clients_with_env_strategy(
             home.to_str().unwrap(),
@@ -4254,6 +4258,7 @@ mod tests {
             .iter()
             .any(|path| path.ends_with("updates.jsonl")));
         assert!(grok_files.iter().any(|path| path == &unified_log));
+        assert!(!grok_files.iter().any(|path| path == &nested_log));
         assert!(result.get(ClientId::OpenCode).is_empty());
         assert!(result.get(ClientId::Claude).is_empty());
     }

--- a/crates/tokscale-core/src/sessions/grok.rs
+++ b/crates/tokscale-core/src/sessions/grok.rs
@@ -3,11 +3,12 @@
 //! Grok Build writes JSON-RPC session updates under
 //! `~/.grok/sessions/<urlencoded-workspace>/<session-id>/updates.jsonl`.
 //! Session rollups also land in sibling `signals.json` (including
-//! `totalTokensBeforeCompaction` and `contextTokensUsed`). Current update
-//! logs expose cumulative `totalTokens` counters without a stable
-//! input/output split, so this parser records per-turn positive total-token
-//! deltas as input tokens and reconciles any remaining `signals.json` total
-//! so compacted sessions are not under-counted.
+//! `totalTokensBeforeCompaction` and `contextTokensUsed`). Legacy update logs
+//! expose cumulative `totalTokens` counters without a stable input/output
+//! split, so this parser records per-turn positive total-token deltas as input
+//! tokens and reconciles any remaining `signals.json` total so compacted
+//! sessions are not under-counted. Recent Grok Build releases additionally
+//! write per-inference token breakdowns to `~/.grok/logs/unified.jsonl`.
 
 use super::utils::{
     extract_i64, extract_string, file_modified_timestamp_ms, parse_timestamp_value,
@@ -16,12 +17,14 @@ use super::utils::{
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
 use serde_json::Value;
+use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
 const CLIENT_ID: &str = "grok";
 const PROVIDER_ID: &str = "xai";
 const UNKNOWN_MODEL: &str = "grok-unknown";
+const UNIFIED_LOG_DEDUP_PREFIX: &str = "grok-unified:";
 
 #[derive(Debug, Clone)]
 struct GrokMetadata {
@@ -217,6 +220,194 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
 
     append_signals_reconciliation(path, &metadata, &mut messages, &current_model);
     messages
+}
+
+/// Parses Grok Build's append-only unified log. Each `shell.turn.inference_done`
+/// record reports a prompt total that includes cached prompt tokens and a
+/// completion total that includes reasoning tokens. Tokscale stores the
+/// non-overlapping component buckets so their sum remains the source total.
+pub fn parse_grok_unified_log_file(path: &Path) -> Vec<UnifiedMessage> {
+    if path.file_name().and_then(|name| name.to_str()) != Some("unified.jsonl") {
+        return Vec::new();
+    }
+
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(_) => return Vec::new(),
+    };
+
+    let fallback_timestamp = file_modified_timestamp_ms(path);
+    let mut fallback_model_by_pid = HashMap::new();
+    let mut model_by_pid_and_session = HashMap::new();
+    let mut seen = HashSet::new();
+    let mut messages = Vec::new();
+
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+
+        if let Some((pid, model_session_id, model_id)) = unified_log_model_change(&value) {
+            if let Some(model_session_id) = model_session_id {
+                model_by_pid_and_session.insert((pid, model_session_id), model_id);
+            } else {
+                fallback_model_by_pid.insert(pid, model_id);
+            }
+            continue;
+        }
+
+        if value.get("msg").and_then(Value::as_str) != Some("shell.turn.inference_done") {
+            continue;
+        }
+
+        let Some(session_id) =
+            extract_string(value.get("sid")).filter(|session_id| !session_id.trim().is_empty())
+        else {
+            continue;
+        };
+        let Some(context) = value.get("ctx") else {
+            continue;
+        };
+        let Some(prompt_tokens) = required_non_negative_i64(context.get("prompt_tokens")) else {
+            continue;
+        };
+        let Some(cached_prompt_tokens) =
+            optional_non_negative_i64(context.get("cached_prompt_tokens"))
+        else {
+            continue;
+        };
+        let Some(completion_tokens) = required_non_negative_i64(context.get("completion_tokens"))
+        else {
+            continue;
+        };
+        let Some(reasoning_tokens) = optional_non_negative_i64(context.get("reasoning_tokens"))
+        else {
+            continue;
+        };
+        if cached_prompt_tokens > prompt_tokens {
+            continue;
+        }
+
+        let Some(loop_index) = optional_non_negative_i64(context.get("loop_index")) else {
+            continue;
+        };
+        let Some(pid) = optional_non_negative_i64(value.get("pid")) else {
+            continue;
+        };
+        let timestamp = value
+            .get("ts")
+            .and_then(parse_timestamp_value)
+            .unwrap_or(fallback_timestamp);
+        let reasoning = reasoning_tokens.min(completion_tokens);
+        let dedup_key =
+            format!("{UNIFIED_LOG_DEDUP_PREFIX}{session_id}:{timestamp}:{pid}:{loop_index}");
+        if !seen.insert(dedup_key.clone()) {
+            continue;
+        }
+
+        let model_id = model_by_pid_and_session
+            .get(&(pid, session_id.clone()))
+            .or_else(|| fallback_model_by_pid.get(&pid))
+            .cloned()
+            .unwrap_or_else(|| UNKNOWN_MODEL.to_string());
+        let mut message = UnifiedMessage::new_with_dedup(
+            CLIENT_ID,
+            model_id,
+            PROVIDER_ID,
+            session_id,
+            timestamp,
+            TokenBreakdown {
+                input: prompt_tokens.saturating_sub(cached_prompt_tokens),
+                output: completion_tokens.saturating_sub(reasoning),
+                cache_read: cached_prompt_tokens,
+                cache_write: 0,
+                reasoning,
+            },
+            0.0,
+            Some(dedup_key),
+        );
+        // The unified log records one inference for each tool-loop iteration.
+        // In observed Grok logs, loop one starts the user turn; later loops do
+        // not represent additional user interactions.
+        message.is_turn_start = loop_index == 1;
+        messages.push(message);
+    }
+
+    messages
+}
+
+/// Dispatches between Grok's legacy per-session updates and its newer unified
+/// log without accepting unrelated JSONL files under the Grok home directory.
+pub fn parse_grok_file(path: &Path) -> Vec<UnifiedMessage> {
+    match path.file_name().and_then(|name| name.to_str()) {
+        Some("updates.jsonl") => parse_grok_updates_file(path),
+        Some("unified.jsonl") => parse_grok_unified_log_file(path),
+        _ => Vec::new(),
+    }
+}
+
+/// Uses the richer, per-inference unified log for sessions it covers. Legacy
+/// updates remain a fallback for sessions absent from that log, avoiding an
+/// additive merge of two representations of the same activity.
+pub fn prefer_unified_log_messages(messages: Vec<UnifiedMessage>) -> Vec<UnifiedMessage> {
+    let unified_sessions: HashSet<String> = messages
+        .iter()
+        .filter(|message| is_unified_log_message(message))
+        .map(|message| message.session_id.clone())
+        .collect();
+
+    if unified_sessions.is_empty() {
+        return messages;
+    }
+
+    messages
+        .into_iter()
+        .filter(|message| {
+            is_unified_log_message(message) || !unified_sessions.contains(&message.session_id)
+        })
+        .collect()
+}
+
+fn is_unified_log_message(message: &UnifiedMessage) -> bool {
+    message
+        .dedup_key
+        .as_deref()
+        .is_some_and(|key| key.starts_with(UNIFIED_LOG_DEDUP_PREFIX))
+}
+
+fn unified_log_model_change(value: &Value) -> Option<(i64, Option<String>, String)> {
+    let pid = required_non_negative_i64(value.get("pid"))?;
+    let context = value.get("ctx")?;
+    let model_id = match value.get("msg").and_then(Value::as_str)? {
+        "model changed" => extract_string(context.get("model")),
+        "model catalog: notifying clients" => extract_string(context.get("current_model_id")),
+        "backend_search: model switch" => extract_string(context.get("new_model"))
+            .or_else(|| extract_string(context.get("model")))
+            .or_else(|| extract_string(context.get("current_model_id"))),
+        "subagent model resolved" => {
+            extract_string(context.get("model_id")).or_else(|| extract_string(context.get("model")))
+        }
+        _ => None,
+    }?;
+
+    let session_id =
+        extract_string(value.get("sid")).filter(|session_id| !session_id.trim().is_empty());
+    (!model_id.trim().is_empty()).then_some((pid, session_id, model_id))
+}
+
+fn required_non_negative_i64(value: Option<&Value>) -> Option<i64> {
+    extract_i64(value).filter(|value| *value >= 0)
+}
+
+fn optional_non_negative_i64(value: Option<&Value>) -> Option<i64> {
+    match value {
+        Some(value) => required_non_negative_i64(Some(value)),
+        None => Some(0),
+    }
 }
 
 fn non_negative_i64(value: Option<&Value>) -> i64 {
@@ -533,6 +724,87 @@ mod tests {
             std::fs::write(session_dir.join("signals.json"), signals_json).unwrap();
         }
         (temp, updates_path)
+    }
+
+    fn write_unified_fixture(unified_jsonl: &str) -> (tempfile::TempDir, PathBuf) {
+        let temp = tempfile::TempDir::new().unwrap();
+        let logs_dir = temp.path().join(".grok/logs");
+        std::fs::create_dir_all(&logs_dir).unwrap();
+        let path = logs_dir.join("unified.jsonl");
+        std::fs::write(&path, unified_jsonl).unwrap();
+        (temp, path)
+    }
+
+    fn test_message(session_id: &str, dedup_key: &str) -> UnifiedMessage {
+        UnifiedMessage::new_with_dedup(
+            CLIENT_ID,
+            "grok-build",
+            PROVIDER_ID,
+            session_id,
+            1_700_000_000_000,
+            TokenBreakdown::default(),
+            0.0,
+            Some(dedup_key.to_string()),
+        )
+    }
+
+    #[test]
+    fn parses_unified_log_token_breakdown_without_double_counting_reasoning() {
+        let (_temp, path) = write_unified_fixture(
+            r#"{"ts":"2023-11-14T22:13:19Z","pid":17,"sid":"session-1","msg":"model changed","ctx":{"model":"grok-composer-2.5-fast"}}
+{"ts":"2023-11-14T22:13:19Z","pid":17,"msg":"model catalog: notifying clients","ctx":{"current_model_id":"grok-4.5"}}
+{"ts":"2023-11-14T22:13:20Z","pid":17,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":100,"cached_prompt_tokens":60,"completion_tokens":25,"reasoning_tokens":5}}
+{"ts":"2023-11-14T22:13:21Z","pid":17,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":2,"prompt_tokens":80,"cached_prompt_tokens":0,"completion_tokens":12,"reasoning_tokens":0}}
+{"ts":"2023-11-14T22:13:20Z","pid":17,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":100,"cached_prompt_tokens":60,"completion_tokens":25,"reasoning_tokens":5}}
+{"ts":"2023-11-14T22:13:22Z","pid":17,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":3,"prompt_tokens":10,"cached_prompt_tokens":11,"completion_tokens":1,"reasoning_tokens":0}}"#,
+        );
+
+        let messages = parse_grok_unified_log_file(&path);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].client, CLIENT_ID);
+        assert_eq!(messages[0].model_id, "grok-composer-2.5-fast");
+        assert_eq!(messages[0].session_id, "session-1");
+        assert_eq!(messages[0].tokens.input, 40);
+        assert_eq!(messages[0].tokens.cache_read, 60);
+        assert_eq!(messages[0].tokens.output, 20);
+        assert_eq!(messages[0].tokens.reasoning, 5);
+        assert_eq!(messages[0].tokens.total(), 125);
+        assert!(messages[0].is_turn_start);
+        assert_eq!(messages[1].tokens.input, 80);
+        assert_eq!(messages[1].tokens.output, 12);
+        assert!(!messages[1].is_turn_start);
+    }
+
+    #[test]
+    fn unified_log_uses_catalog_model_only_as_a_session_fallback() {
+        let (_temp, path) = write_unified_fixture(
+            r#"{"ts":"2023-11-14T22:13:19Z","pid":17,"msg":"model catalog: notifying clients","ctx":{"current_model_id":"grok-4.5"}}
+{"ts":"2023-11-14T22:13:20Z","pid":17,"sid":"session-without-model-event","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":10,"completion_tokens":1}}"#,
+        );
+
+        let messages = parse_grok_unified_log_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "grok-4.5");
+    }
+
+    #[test]
+    fn unified_log_replaces_legacy_messages_only_for_covered_sessions() {
+        let covered_legacy = test_message("covered", "grok:covered:0");
+        let uncovered_legacy = test_message("fallback", "grok:fallback:0");
+        let covered_unified = test_message("covered", "grok-unified:covered:1:1:1");
+
+        let messages =
+            prefer_unified_log_messages(vec![covered_legacy, uncovered_legacy, covered_unified]);
+
+        assert_eq!(messages.len(), 2);
+        assert!(messages
+            .iter()
+            .any(|message| { message.session_id == "covered" && is_unified_log_message(message) }));
+        assert!(messages
+            .iter()
+            .any(|message| message.session_id == "fallback"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #849

Grok Build now exposes per-inference usage in `logs/unified.jsonl`. This change discovers that file under the resolved Grok home while retaining the legacy session `updates.jsonl` files as a fallback, so recent sessions can report the complete token breakdown without losing older sessions.

The unified parser records `prompt_tokens - cached_prompt_tokens` as input, `cached_prompt_tokens` as cache reads, `completion_tokens - reasoning_tokens` as visible output, and reasoning as the bounded portion of completion tokens. These buckets are non-overlapping and preserve the reported total. Malformed, negative, inconsistent, and duplicate rows are ignored safely.

Model resolution prefers session-scoped model-change events over PID-only catalog events, then falls back to the existing unknown-model value. When unified rows cover a session, those rows are authoritative and legacy messages for that session are removed; legacy messages are retained only for sessions not covered by the unified log. Both materialized core parsing flows use the same parser and authority-selection logic.

The first branch commit cherry-picks @junhoyeo's original commit, preserving the original author and commit message: https://github.com/junhoyeo/tokscale/commit/ed7986425efb8bad8df62e16269e30c15a82801a. It targets base `366ce64395594abf111e0409581d91016561b25a`; all 388 changed lines in that commit are identical to the original patch. The stable patch ID differs because current main changes hunk layout and surrounding context, with the current scanner helper signature retained. A separate follow-up commit limits discovery to the exact `logs/unified.jsonl` path after a regression showed that recursively scanning `logs` also accepted nested archive files. Credit to @junhoyeo for the original implementation and to reporter @entrptaher for the report.

Non-goals: this does not add a cumulative-counter epoch heuristic, combine unified and legacy rows additively, change streaming or reporting behavior, or introduce TokenBar-specific cache, FFI, cohort, or reporting architecture.

Tests run:

- `cargo fmt --all -- --check`
- `cargo test -p tokscale-core -- --nocapture` — 1231 passed, 1 ignored
- `cargo test -p tokscale-core sessions::grok::tests -- --nocapture` — 12 passed
- `cargo test -p tokscale-core scanner::tests::test_scan_all_clients_grok -- --nocapture` — 1 passed, including canonical-path acceptance and nested archive rejection
- `cargo test -p tokscale-core tests::test_parse_all_messages_with_pricing_prefers_grok_unified_log -- --nocapture` — 1 passed
- `cargo clippy -p tokscale-core --all-targets -- -D warnings`
- `git diff --check upstream/main...HEAD`
- Fresh verifier on the corrected two-commit head — `CONFIRMED`

The locked workspace all-feature Clippy and test suites, release `tokscale-cli` build, and final diff check all pass. A live Grok Build installation and CI were not exercised locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parse Grok Build’s new `logs/unified.jsonl` and prefer it over legacy `updates.jsonl` so token usage shows accurate input, cache reads, output, and reasoning without double counting. The scanner now targets only the canonical unified log path and ignores nested archives.

- New Features
  - Parse per-inference usage from `~/.grok/logs/unified.jsonl`; fallback to session `updates.jsonl` when unified is missing.
  - Non-overlapping buckets: input = `prompt_tokens - cached_prompt_tokens`, cache reads = `cached_prompt_tokens`, output = `completion_tokens - reasoning_tokens`, reasoning bounded by completion.
  - Prefer session-scoped model-change events over PID-only catalog events; default to `grok-unknown` if none.
  - When unified rows cover a session, they replace legacy rows for that session; otherwise, legacy data remains.
  - Shared entry point `parse_grok_file` and `prefer_unified_log_messages` used in both local and priced parse flows; README updated.

- Bug Fixes
  - Scan only `$GROK_HOME/logs/unified.jsonl` (not the whole `logs` directory) to avoid picking up archived or nested files.

<sup>Written for commit 9e4bd94d98efd47f93c0bb0dffa36289d016490f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

