### PR TITLE
fix(kimi): preserve larger saturated updates

### DIFF
--- a/crates/tokscale-core/src/sessions/kimi.rs
+++ b/crates/tokscale-core/src/sessions/kimi.rs
@@ -321,11 +321,23 @@ pub fn parse_kimi_file(path: &Path) -> Vec<UnifiedMessage> {
 }
 
 fn should_replace_status_update(existing: &UnifiedMessage, candidate: &UnifiedMessage) -> bool {
-    let existing_total = existing.tokens.total();
-    let candidate_total = candidate.tokens.total();
+    let existing_total = exact_token_total(&existing.tokens);
+    let candidate_total = exact_token_total(&candidate.tokens);
 
     candidate_total > existing_total
         || (candidate_total == existing_total && candidate.timestamp >= existing.timestamp)
+}
+
+/// Compare Kimi progress updates without collapsing distinct large totals.
+///
+/// `TokenBreakdown::total` saturates for reporting, while five i64 buckets fit
+/// safely in i128 for this ordering decision.
+fn exact_token_total(tokens: &TokenBreakdown) -> i128 {
+    i128::from(tokens.input)
+        + i128::from(tokens.output)
+        + i128::from(tokens.cache_read)
+        + i128::from(tokens.cache_write)
+        + i128::from(tokens.reasoning)
 }
 
 fn push_or_replace_status_update(
@@ -487,6 +499,22 @@ mod tests {
         assert_eq!(messages[0].tokens.output, 30);
         assert_eq!(messages[0].tokens.cache_read, 5);
         assert_eq!(messages[0].timestamp, 1770983420000);
+    }
+
+    #[test]
+    fn test_parse_kimi_deduplication_preserves_larger_extreme_usage() {
+        let content = r#"{"type": "metadata", "protocol_version": "1.3"}
+{"timestamp": 1770983410.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 9223372036854775807, "output": 9223372036854775807, "input_cache_read": 2, "input_cache_creation": 0}, "message_id": "msg-extreme"}}}
+{"timestamp": 1770983420.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 9223372036854775807, "output": 0, "input_cache_read": 0, "input_cache_creation": 0}, "message_id": "msg-extreme"}}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_kimi_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, i64::MAX);
+        assert_eq!(messages[0].tokens.output, i64::MAX);
+        assert_eq!(messages[0].tokens.cache_read, 2);
+        assert_eq!(messages[0].timestamp, 1770983410000);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Rank duplicate legacy Kimi `StatusUpdate` records with an exact `i128` token total.
- Keep the existing saturating total for reporting paths.
- Add a regression for a later smaller same-ID update that previously replaced a larger extreme usage record.

## Root cause
`TokenBreakdown::total()` saturates at `i64::MAX`. After #923 retained extreme Kimi buckets, different actual totals could tie during deduplication and the later timestamp could replace the larger breakdown.

## Validation
- `cargo test --locked -p tokscale-core test_parse_kimi_deduplication_preserves_larger_extreme_usage`
- `cargo test --locked --release -p tokscale-core test_parse_kimi_deduplication_preserves_larger_extreme_usage`
- `cargo fmt --all -- --check`
- `git diff --check`

Follow-up to #923.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Kimi StatusUpdate dedup so the larger extreme-usage record is kept when totals saturate. Prevents a later smaller update with the same ID from replacing the real larger one.

- Bug Fixes
  - Rank duplicate Kimi `StatusUpdate` records with an exact i128 sum of the five token buckets to avoid `i64::MAX` ties.
  - Keep the saturating total only for reporting paths; existing progress ordering stays the same.
  - Added a regression test to ensure larger extreme-usage updates aren’t replaced by later smaller ones.

<sup>Written for commit 860b42d3ed5f3160883b45d3ccb52d9e7dd799e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

