### PR TITLE
fix(kimi): preserve larger saturated status updates

### DIFF
--- a/crates/tokscale-core/src/sessions/kimi.rs
+++ b/crates/tokscale-core/src/sessions/kimi.rs
@@ -320,9 +320,17 @@ pub fn parse_kimi_file(path: &Path) -> Vec<UnifiedMessage> {
     messages
 }
 
+fn exact_token_total(tokens: &TokenBreakdown) -> i128 {
+    i128::from(tokens.input)
+        + i128::from(tokens.output)
+        + i128::from(tokens.cache_read)
+        + i128::from(tokens.cache_write)
+        + i128::from(tokens.reasoning)
+}
+
 fn should_replace_status_update(existing: &UnifiedMessage, candidate: &UnifiedMessage) -> bool {
-    let existing_total = existing.tokens.total();
-    let candidate_total = candidate.tokens.total();
+    let existing_total = exact_token_total(&existing.tokens);
+    let candidate_total = exact_token_total(&candidate.tokens);
 
     candidate_total > existing_total
         || (candidate_total == existing_total && candidate.timestamp >= existing.timestamp)
@@ -487,6 +495,25 @@ mod tests {
         assert_eq!(messages[0].tokens.output, 30);
         assert_eq!(messages[0].tokens.cache_read, 5);
         assert_eq!(messages[0].timestamp, 1770983420000);
+    }
+
+    #[test]
+    fn test_parse_kimi_keeps_larger_extreme_status_update() {
+        // Both saturating totals equal i64::MAX, but the first exact total is larger.
+        let content = r#"{"type": "metadata", "protocol_version": "1.3"}
+{"timestamp": 1770983410.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 9223372036854775807, "output": 9223372036854775807, "input_cache_read": 2, "input_cache_creation": 0}, "message_id": "msg-extreme"}}}
+{"timestamp": 1770983420.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 9223372036854775807, "output": 0, "input_cache_read": 1, "input_cache_creation": 0}, "message_id": "msg-extreme"}}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_kimi_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].dedup_key.as_deref(), Some("msg-extreme"));
+        assert_eq!(messages[0].tokens.input, i64::MAX);
+        assert_eq!(messages[0].tokens.output, i64::MAX);
+        assert_eq!(messages[0].tokens.cache_read, 2);
+        assert_eq!(messages[0].tokens.cache_write, 0);
+        assert_eq!(messages[0].timestamp, 1770983410000);
     }
 
     #[test]


### PR DESCRIPTION
TITLE: fix(kimi): preserve larger saturated status updates

Closes #926

## Problem

PR #923 preserves extreme nonzero Kimi buckets, but repeated legacy `StatusUpdate` rows are still ordered by `TokenBreakdown::total()`. Different extreme breakdowns can both saturate to `i64::MAX`, allowing a later smaller progress row to replace the larger usage through the timestamp tie-break.

## Behavior

Compare repeated same-`message_id` Kimi rows with an exact `i128` token total before applying the existing timestamp tie-break. Preserve ordinary larger-total replacement and exact-total timestamp ordering.

## Scope

This changes only `crates/tokscale-core/src/sessions/kimi.rs`. It does not alter deduplication keys, Kimi Code replay behavior, parser versions, cache formats, source authority, pricing, or other clients.

## Verification

The regression reproduces on upstream `940c1cb5` and passes on the candidate. All 20 focused Kimi parser tests pass. Locked workspace all-feature Clippy and tests pass (`1232 passed`, `1 ignored` in `tokscale-core`), the release `tokscale-cli` build and `git diff --check` pass, and fresh parent-fail/candidate-pass verification is confirmed.

Base: `940c1cb54c55cb5111b5503570601d7bb91399d0`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Kimi StatusUpdate dedupe so a larger extreme update is kept when totals saturate, by comparing exact `i128` token totals before the timestamp tie-break. Closes #926.

- Bug Fixes
  - Compare repeated same-`message_id` rows using an exact `i128` sum (not saturated `TokenBreakdown::total()`), then apply timestamp tie-break on exact ties.
  - Preserves ordinary behavior for non-extreme totals; no changes to dedup keys or other clients. Adds a focused regression test.

<sup>Written for commit e573e3f532d55397d542a70e2c58bf519a9c05cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

