### PR TITLE
fix(opencodereview): clamp oversized unsigned tokens

### DIFF
--- a/crates/tokscale-core/src/sessions/opencodereview.rs
+++ b/crates/tokscale-core/src/sessions/opencodereview.rs
@@ -153,7 +153,10 @@ fn tokens_from_usage(usage: &Value) -> TokenBreakdown {
 fn number_field(value: &Value, field: &str) -> i64 {
     value
         .get(field)
-        .and_then(|v| v.as_i64().or_else(|| v.as_u64().map(|u| u as i64)))
+        .and_then(|v| {
+            v.as_i64()
+                .or_else(|| v.as_u64().map(|u| i64::try_from(u).unwrap_or(i64::MAX)))
+        })
         .unwrap_or(0)
         .max(0)
 }
@@ -220,6 +223,26 @@ mod tests {
         assert_eq!(msgs[0].duration_ms, Some(1500));
         assert_eq!(msgs[0].session_id, "test-session-123");
         assert!(msgs[0].workspace_key.is_some());
+    }
+
+    #[test]
+    fn clamps_extreme_unsigned_usage_and_keeps_the_message() {
+        let content = format!(
+            "{}\n{}\n",
+            session_start("/home/user/project"),
+            r#"{"type":"llm_response","sessionId":"test-session-123","timestamp":"2026-01-15T10:00:05Z","model":"gpt-4o","duration_ms":1500,"usage":{"prompt_tokens":18446744073709551615,"completion_tokens":9223372036854775807,"cache_read_tokens":-1,"cache_write_tokens":0}}"#,
+        );
+        let msgs = parse_events(&content);
+
+        assert_eq!(
+            msgs.len(),
+            1,
+            "one extreme bucket must not drop the message"
+        );
+        assert_eq!(msgs[0].tokens.input, i64::MAX);
+        assert_eq!(msgs[0].tokens.output, i64::MAX);
+        assert_eq!(msgs[0].tokens.cache_read, 0);
+        assert_eq!(msgs[0].tokens.cache_write, 0);
     }
 
     #[test]


### PR DESCRIPTION
TITLE: fix(opencodereview): clamp oversized unsigned tokens

Closes #928

## Problem

OpenCodeReview usage fields are parsed from JSON with an unsigned-to-signed cast that wraps values above `i64::MAX`. The existing non-negative clamp then turns the wrapped value into zero, silently erasing a token bucket and potentially dropping the message.

## Behavior

Convert unsigned usage fields with checked conversion and clamp values above `i64::MAX` to `i64::MAX`. Preserve existing behavior for valid signed and unsigned values, negative signed values, missing fields, and the rest of OpenCodeReview parsing.

## Cache contract

OpenCodeReview parses directly and does not use the source-message cache. Do not change any parser version, cache format, or cache wiring.

## Non-goals

This change does not alter cross-message or report-level token folds, aggregation, pricing, timestamps, workspace parsing, or dependency requirements. It does not add OpenCodeReview source-cache wiring.

## Test evidence

Focused OpenCodeReview tests: 8 passed, including `u64::MAX`, `i64::MAX`, negative signed usage, and retention of a message with an extreme bucket. Full gates passed: `cargo fmt --all -- --check`, locked workspace tests, all-feature Clippy, release CLI checks, and `git diff --check`.

Fresh verifier: CONFIRMED.

Base: `940c1cb54c55cb5111b5503570601d7bb91399d0`.

No TokenBar-local architecture is involved; this is an upstream tokscale OpenCodeReview parser change only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp oversized unsigned OpenCodeReview usage tokens to `i64::MAX` to prevent wraparound to zero and dropped messages. Preserves existing parsing behavior; no cache or versioning changes.

- Bug Fixes
  - Use checked conversion for unsigned usage fields and clamp values above `i64::MAX` to `i64::MAX` instead of wrapping.
  - Keep existing handling for valid signed/unsigned values, negatives, and missing fields.
  - Add regression test covering `u64::MAX`, `i64::MAX`, and negative usage; message is retained.

<sup>Written for commit 96f1b36076079a465a1c941ffb9badcc49b4fcce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

