### PR TITLE
fix(pricing): resolve Kimi coding-plan model aliases

### DIFF
--- a/crates/tokscale-core/src/pricing/aliases.rs
+++ b/crates/tokscale-core/src/pricing/aliases.rs
@@ -13,6 +13,8 @@ static MODEL_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     m.insert("kimi-k2p6", "kimi-k2.6");
     m.insert("kimi-k2.5-thinking", "kimi-k2-thinking");
     m.insert("kimi-for-coding", "kimi-k2.5");
+    m.insert("kimi-for-coding-highspeed", "kimi-k2.7-code-highspeed");
+    m.insert("k3", "kimi-k3");
 
     m.insert("model_placeholder_m26", "claude-opus-4-6");
     m.insert("model_placeholder_m35", "claude-sonnet-4-6");
@@ -157,6 +159,18 @@ mod tests {
 
         assert_eq!(resolve_alias("k2p5"), Some("kimi-k2-thinking"));
         assert_eq!(resolve_alias("k2-p5"), Some("kimi-k2-thinking"));
+    }
+
+    #[test]
+    fn resolves_kimi_coding_plan_ids_to_underlying_models() {
+        // kimi-code writes `kimi-code/<id>`; the parser strips the prefix, so
+        // pricing sees the bare id. Without these, models.dev matches them under
+        // its `kimi-for-coding/*` subscription namespace at $0.00.
+        assert_eq!(
+            resolve_alias("kimi-for-coding-highspeed"),
+            Some("kimi-k2.7-code-highspeed")
+        );
+        assert_eq!(resolve_alias("k3"), Some("kimi-k3"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Kimi Code writes its configured model into `wire.jsonl` as `kimi-code/<id>`, and `normalize_kimi_code_model` strips the `kimi-code/` prefix, so pricing lookup receives the bare id. For coding-plan models that bare id is `kimi-for-coding-highspeed` or `k3`.

Neither id has a usable price. models.dev publishes both under a `kimi-for-coding/*` namespace with every cost field set to `0.0`, and `0.0` passes `is_valid_price_value`, so the lookup succeeds on that zero-priced entry instead of falling through to the underlying model. Real usage on those ids ends up reported at `$0.00`.

## Change

Two alias entries mapping the coding-plan ids to the models they actually run on, following the existing `k2p5` / `k2p6` entries directly above them.

## Verification

Resolution before and after, with `provider_id = "moonshot"` as the Kimi parser emits it:

| model id | before | after |
| --- | --- | --- |
| `kimi-for-coding-highspeed` | `kimi-for-coding/kimi-for-coding-highspeed` — $0.00 | `moonshotai/kimi-k2.7-code-highspeed` — $1.90 / $8.00 per 1M |
| `k3` | `kimi-for-coding/k3` — $0.00 | `moonshotai/kimi-k3` — $3.00 / $15.00 per 1M |

Both ids appear in real local usage (`tokscale models`), so this is not a speculative mapping.

`k3` is a short key, so I checked it for collisions: no other pricing key in the bundled LiteLLM, OpenRouter, or models.dev datasets has `k3` as its terminal model segment, and across local session logs for all scanned clients the string is emitted only by Kimi Code. This matches the precedent already set by the bare `k2p5` / `k2p6` keys.

## Out of scope

`kimi-for-coding` itself still resolves to `kimi-k2.5` and is deliberately left alone here. That id is a rolling pointer whose target has changed across model generations, so retargeting it is a separate decision from these two unambiguous ids and deserves its own change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix pricing for Kimi coding-plan models by resolving aliases so `kimi-for-coding-highspeed` and `k3` map to their real models instead of zero-priced subscription entries. This corrects cost reporting for Kimi Code sessions.

- **Bug Fixes**
  - Map `kimi-for-coding-highspeed` -> `kimi-k2.7-code-highspeed` and `k3` -> `kimi-k3`.
  - Avoids `models.dev` `kimi-for-coding/*` $0.00 matches; uses real rates.
  - Adds tests to verify alias resolution.

<sup>Written for commit ab71c91ee52032b036bb0ea4d3255658de6e6dda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

