### PR TITLE
feat(tui): add sessions tab / feat(core): populate session title in opencode parser

### DIFF
--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -20,7 +20,7 @@ use super::codex_login::{
 };
 use super::data::{
     AgentUsage, DailyUsage, DataLoader, HourlyUsage, MinutelyUsage, ModelUsage, MonthlyUsage,
-    TokenBreakdown, UsageData,
+    SessionUsage, TokenBreakdown, UsageData,
 };
 use super::privacy::looks_like_email;
 use super::settings::Settings;
@@ -61,6 +61,7 @@ pub enum Tab {
     Hourly,
     Minutely,
     Monthly,
+    Sessions,
     Stats,
     Agents,
 }
@@ -75,6 +76,7 @@ impl Tab {
             Tab::Hourly,
             Tab::Minutely,
             Tab::Monthly,
+            Tab::Sessions,
             Tab::Stats,
             Tab::Agents,
         ]
@@ -89,6 +91,7 @@ impl Tab {
             Tab::Hourly => "Hourly",
             Tab::Minutely => "Minutely",
             Tab::Monthly => "Monthly",
+            Tab::Sessions => "Sessions",
             Tab::Stats => "Stats",
             Tab::Agents => "Agents",
         }
@@ -103,6 +106,7 @@ impl Tab {
             Tab::Hourly => "Hr",
             Tab::Minutely => "Min",
             Tab::Monthly => "Mon",
+            Tab::Sessions => "Ses",
             Tab::Stats => "Sta",
             Tab::Agents => "Agt",
         }
@@ -116,7 +120,8 @@ impl Tab {
             Tab::Daily => Tab::Hourly,
             Tab::Hourly => Tab::Minutely,
             Tab::Minutely => Tab::Monthly,
-            Tab::Monthly => Tab::Stats,
+            Tab::Monthly => Tab::Sessions,
+            Tab::Sessions => Tab::Stats,
             Tab::Stats => Tab::Agents,
             Tab::Agents => Tab::Overview,
         }
@@ -131,7 +136,8 @@ impl Tab {
             Tab::Hourly => Tab::Daily,
             Tab::Minutely => Tab::Hourly,
             Tab::Monthly => Tab::Minutely,
-            Tab::Stats => Tab::Monthly,
+            Tab::Sessions => Tab::Monthly,
+            Tab::Stats => Tab::Sessions,
             Tab::Agents => Tab::Stats,
         }
     }
@@ -1604,7 +1610,10 @@ impl App {
     }
 
     fn default_sort_for_tab(tab: Tab) -> (SortField, SortDirection) {
-        if matches!(tab, Tab::Hourly | Tab::Minutely | Tab::Monthly) {
+        if matches!(
+            tab,
+            Tab::Hourly | Tab::Minutely | Tab::Monthly | Tab::Sessions
+        ) {
             (SortField::Date, SortDirection::Descending)
         } else {
             (SortField::Cost, SortDirection::Descending)
@@ -1764,6 +1773,7 @@ impl App {
                 self.get_sorted_monthly_detail_days().len()
             }
             Tab::Monthly => self.data.monthly.len(),
+            Tab::Sessions => self.data.sessions.len(),
             Tab::Stats => {
                 if self.selected_graph_cell.is_some() {
                     self.stats_breakdown_total_lines
@@ -2100,6 +2110,23 @@ impl App {
                 .get_sorted_monthly()
                 .get(self.selected_index)
                 .map(|m| format!("{}: {} tokens, ${:.4}", m.month, m.tokens.total(), m.cost)),
+            Tab::Sessions => self
+                .get_sorted_sessions()
+                .get(self.selected_index)
+                .map(|s| {
+                    let label = s
+                        .title
+                        .as_deref()
+                        .filter(|t| !t.is_empty())
+                        .unwrap_or(&s.session_id);
+                    format!(
+                        "{} / {}: {} tokens, ${:.4}",
+                        s.client,
+                        label,
+                        s.tokens.total(),
+                        s.cost
+                    )
+                }),
             Tab::Stats | Tab::Usage => None,
         };
 
@@ -2492,6 +2519,59 @@ impl App {
     pub fn is_very_narrow(&self) -> bool {
         self.terminal_width < 60
     }
+
+    pub fn get_sorted_sessions(&self) -> Vec<&SessionUsage> {
+        let mut sessions: Vec<&SessionUsage> = self.data.sessions.iter().collect();
+
+        let tie_breaker = |a: &&SessionUsage, b: &&SessionUsage| {
+            a.client
+                .cmp(&b.client)
+                .then_with(|| a.session_id.cmp(&b.session_id))
+        };
+
+        match (self.sort_field, self.sort_direction) {
+            (SortField::Cost, SortDirection::Descending) => sessions.sort_by(|a, b| {
+                b.cost
+                    .total_cmp(&a.cost)
+                    .then_with(|| b.last_active_ms.cmp(&a.last_active_ms))
+                    .then_with(|| tie_breaker(a, b))
+            }),
+            (SortField::Cost, SortDirection::Ascending) => sessions.sort_by(|a, b| {
+                a.cost
+                    .total_cmp(&b.cost)
+                    .then_with(|| b.last_active_ms.cmp(&a.last_active_ms))
+                    .then_with(|| tie_breaker(a, b))
+            }),
+            (SortField::Tokens, SortDirection::Descending) => sessions.sort_by(|a, b| {
+                b.tokens
+                    .total()
+                    .cmp(&a.tokens.total())
+                    .then_with(|| b.last_active_ms.cmp(&a.last_active_ms))
+                    .then_with(|| tie_breaker(a, b))
+            }),
+            (SortField::Tokens, SortDirection::Ascending) => sessions.sort_by(|a, b| {
+                a.tokens
+                    .total()
+                    .cmp(&b.tokens.total())
+                    .then_with(|| b.last_active_ms.cmp(&a.last_active_ms))
+                    .then_with(|| tie_breaker(a, b))
+            }),
+            // "Date" maps to last_active for sessions: most recently active
+            // session first when descending, oldest active first when ascending.
+            (SortField::Date, SortDirection::Descending) => sessions.sort_by(|a, b| {
+                b.last_active_ms
+                    .cmp(&a.last_active_ms)
+                    .then_with(|| tie_breaker(a, b))
+            }),
+            (SortField::Date, SortDirection::Ascending) => sessions.sort_by(|a, b| {
+                a.last_active_ms
+                    .cmp(&b.last_active_ms)
+                    .then_with(|| tie_breaker(a, b))
+            }),
+        }
+
+        sessions
+    }
 }
 
 #[cfg(test)]
@@ -2509,7 +2589,7 @@ mod tests {
     #[test]
     fn test_tab_all() {
         let tabs = Tab::all();
-        assert_eq!(tabs.len(), 9);
+        assert_eq!(tabs.len(), 10);
         assert_eq!(tabs[0], Tab::Overview);
         assert_eq!(tabs[1], Tab::Usage);
         assert_eq!(tabs[2], Tab::Models);
@@ -2517,8 +2597,9 @@ mod tests {
         assert_eq!(tabs[4], Tab::Hourly);
         assert_eq!(tabs[5], Tab::Minutely);
         assert_eq!(tabs[6], Tab::Monthly);
-        assert_eq!(tabs[7], Tab::Stats);
-        assert_eq!(tabs[8], Tab::Agents);
+        assert_eq!(tabs[7], Tab::Sessions);
+        assert_eq!(tabs[8], Tab::Stats);
+        assert_eq!(tabs[9], Tab::Agents);
     }
 
     #[test]
@@ -2529,7 +2610,8 @@ mod tests {
         assert_eq!(Tab::Daily.next(), Tab::Hourly);
         assert_eq!(Tab::Hourly.next(), Tab::Minutely);
         assert_eq!(Tab::Minutely.next(), Tab::Monthly);
-        assert_eq!(Tab::Monthly.next(), Tab::Stats);
+        assert_eq!(Tab::Monthly.next(), Tab::Sessions);
+        assert_eq!(Tab::Sessions.next(), Tab::Stats);
         assert_eq!(Tab::Stats.next(), Tab::Agents);
         assert_eq!(Tab::Agents.next(), Tab::Overview);
     }
@@ -2543,7 +2625,8 @@ mod tests {
         assert_eq!(Tab::Hourly.prev(), Tab::Daily);
         assert_eq!(Tab::Minutely.prev(), Tab::Hourly);
         assert_eq!(Tab::Monthly.prev(), Tab::Minutely);
-        assert_eq!(Tab::Stats.prev(), Tab::Monthly);
+        assert_eq!(Tab::Sessions.prev(), Tab::Monthly);
+        assert_eq!(Tab::Stats.prev(), Tab::Sessions);
         assert_eq!(Tab::Agents.prev(), Tab::Stats);
     }
 
@@ -2556,6 +2639,7 @@ mod tests {
         assert_eq!(Tab::Hourly.as_str(), "Hourly");
         assert_eq!(Tab::Minutely.as_str(), "Minutely");
         assert_eq!(Tab::Monthly.as_str(), "Monthly");
+        assert_eq!(Tab::Sessions.as_str(), "Sessions");
         assert_eq!(Tab::Stats.as_str(), "Stats");
     }
 
@@ -2568,6 +2652,7 @@ mod tests {
         assert_eq!(Tab::Hourly.short_name(), "Hr");
         assert_eq!(Tab::Minutely.short_name(), "Min");
         assert_eq!(Tab::Monthly.short_name(), "Mon");
+        assert_eq!(Tab::Sessions.short_name(), "Ses");
         assert_eq!(Tab::Stats.short_name(), "Sta");
     }
 
@@ -3446,6 +3531,9 @@ mod tests {
         assert_eq!(app.current_tab, Tab::Monthly);
 
         app.handle_key_event(key(KeyCode::Tab));
+        assert_eq!(app.current_tab, Tab::Sessions);
+
+        app.handle_key_event(key(KeyCode::Tab));
         assert_eq!(app.current_tab, Tab::Stats);
 
         app.handle_key_event(key(KeyCode::Tab));
@@ -3465,6 +3553,9 @@ mod tests {
 
         app.handle_key_event(key(KeyCode::BackTab));
         assert_eq!(app.current_tab, Tab::Stats);
+
+        app.handle_key_event(key(KeyCode::BackTab));
+        assert_eq!(app.current_tab, Tab::Sessions);
 
         app.handle_key_event(key(KeyCode::BackTab));
         assert_eq!(app.current_tab, Tab::Monthly);
@@ -3498,6 +3589,7 @@ mod tests {
             Tab::Hourly,
             Tab::Minutely,
             Tab::Monthly,
+            Tab::Sessions,
             Tab::Stats,
             Tab::Agents,
             Tab::Overview,

--- a/crates/tokscale-cli/src/tui/cache.rs
+++ b/crates/tokscale-cli/src/tui/cache.rs
@@ -638,6 +638,10 @@ impl TryFrom<CachedUsageData> for UsageData {
             // first foreground refresh after cache hit will populate it.
             minutely: Vec::new(),
             monthly,
+            // Sessions are recomputed on each load (high cardinality, not
+            // worth round-tripping through the on-disk cache); the first
+            // foreground refresh after cache hit will populate it.
+            sessions: Vec::new(),
             graph: graph.transpose()?,
             total_tokens: u.total_tokens,
             total_cost: u.total_cost,

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -141,6 +141,29 @@ pub struct MonthlyUsage {
     pub turn_count: u32,
 }
 
+/// Per-session usage rollup. One row per `(client, session_id)` pair so the
+/// Sessions tab can show cost/tokens broken down by individual conversation
+/// alongside how long the session was active and when it last saw activity.
+#[derive(Debug, Clone)]
+pub struct SessionUsage {
+    pub session_id: String,
+    pub client: String,
+    /// Human-readable session title when the source client stores one
+    /// (e.g. OpenCode's `session.title` column). `None` for clients that
+    /// don't record a title.
+    pub title: Option<String>,
+    pub tokens: TokenBreakdown,
+    pub cost: f64,
+    pub message_count: u32,
+    pub turn_count: u32,
+    /// Unix-ms timestamp of the first message observed in this session.
+    /// `0` when every message lacked a usable timestamp.
+    pub first_active_ms: i64,
+    /// Unix-ms timestamp of the most recent message observed in this session.
+    /// `0` when every message lacked a usable timestamp.
+    pub last_active_ms: i64,
+}
+
 #[derive(Debug, Clone)]
 pub struct ContributionDay {
     pub date: NaiveDate,
@@ -162,6 +185,7 @@ pub struct UsageData {
     pub hourly: Vec<HourlyUsage>,
     pub minutely: Vec<MinutelyUsage>,
     pub monthly: Vec<MonthlyUsage>,
+    pub sessions: Vec<SessionUsage>,
     pub graph: Option<GraphData>,
     pub total_tokens: u64,
     pub total_cost: f64,
@@ -430,6 +454,7 @@ impl DataLoader {
         let mut hourly_map: HashMap<NaiveDateTime, HourlyUsage> = HashMap::new();
         let mut minutely_map: HashMap<NaiveDateTime, MinutelyUsage> = HashMap::new();
         let mut model_session_ids: HashMap<String, HashSet<String>> = HashMap::new();
+        let mut session_map: HashMap<String, SessionUsage> = HashMap::new();
 
         for msg in &messages {
             let normalized_model = normalize_model_for_grouping(&msg.model_id);
@@ -872,6 +897,79 @@ impl DataLoader {
                     .saturating_add(msg.tokens.reasoning.max(0) as u64);
                 m_model.cost += m_cost;
             }
+
+            // Session aggregation: one bucket per (client, session_id) so the
+            // Sessions tab can show cost/tokens per individual conversation.
+            // Skips messages with an empty session_id (some legacy/scanner
+            // records lack one) rather than lumping them into a single bogus
+            // "no-session" row.
+            if !msg.session_id.is_empty() {
+                let session_key = format!("{}:{}", msg.client, msg.session_id);
+                let session_entry =
+                    session_map
+                        .entry(session_key)
+                        .or_insert_with(|| SessionUsage {
+                            session_id: msg.session_id.clone(),
+                            client: msg.client.clone(),
+                            title: None,
+                            tokens: TokenBreakdown::default(),
+                            cost: 0.0,
+                            message_count: 0,
+                            turn_count: 0,
+                            first_active_ms: 0,
+                            last_active_ms: 0,
+                        });
+
+                session_entry.tokens.input = session_entry
+                    .tokens
+                    .input
+                    .saturating_add(msg.tokens.input.max(0) as u64);
+                session_entry.tokens.output = session_entry
+                    .tokens
+                    .output
+                    .saturating_add(msg.tokens.output.max(0) as u64);
+                session_entry.tokens.cache_read = session_entry
+                    .tokens
+                    .cache_read
+                    .saturating_add(msg.tokens.cache_read.max(0) as u64);
+                session_entry.tokens.cache_write = session_entry
+                    .tokens
+                    .cache_write
+                    .saturating_add(msg.tokens.cache_write.max(0) as u64);
+                session_entry.tokens.reasoning = session_entry
+                    .tokens
+                    .reasoning
+                    .saturating_add(msg.tokens.reasoning.max(0) as u64);
+                session_entry.cost += msg_cost;
+                session_entry.message_count = session_entry
+                    .message_count
+                    .saturating_add(msg.message_count.max(0) as u32);
+                if msg.is_turn_start {
+                    session_entry.turn_count += 1;
+                }
+
+                let ts = message_timestamp_ms(msg);
+                if ts > 0 {
+                    if session_entry.first_active_ms == 0 || ts < session_entry.first_active_ms {
+                        session_entry.first_active_ms = ts;
+                    }
+                    if ts > session_entry.last_active_ms {
+                        session_entry.last_active_ms = ts;
+                    }
+                }
+
+                // Adopt the first non-empty session_title seen across the
+                // session's messages. Parsers that don't populate the field
+                // leave it `None` and the Sessions tab falls back to the ID.
+                if session_entry.title.is_none() {
+                    if let Some(ref title) = msg.session_title {
+                        let trimmed = title.trim();
+                        if !trimmed.is_empty() {
+                            session_entry.title = Some(trimmed.to_string());
+                        }
+                    }
+                }
+            }
         }
 
         let mut models: Vec<ModelUsage> = model_map
@@ -913,6 +1011,15 @@ impl DataLoader {
 
         let monthly = aggregate_monthly_from_daily(&daily);
 
+        let mut sessions: Vec<SessionUsage> = session_map.into_values().collect();
+        sessions.sort_by(|a, b| {
+            b.cost
+                .total_cmp(&a.cost)
+                .then_with(|| b.last_active_ms.cmp(&a.last_active_ms))
+                .then_with(|| a.client.cmp(&b.client))
+                .then_with(|| a.session_id.cmp(&b.session_id))
+        });
+
         let total_tokens: u64 = models.iter().map(|m| m.tokens.total()).sum();
         let total_cost: f64 = models
             .iter()
@@ -929,6 +1036,7 @@ impl DataLoader {
             hourly,
             minutely,
             monthly,
+            sessions,
             graph: Some(graph),
             total_tokens,
             total_cost,
@@ -942,6 +1050,26 @@ impl DataLoader {
 
 fn parse_date(date_str: &str) -> Option<NaiveDate> {
     NaiveDate::parse_from_str(date_str, "%Y-%m-%d").ok()
+}
+
+/// Resolve a message to a Unix-ms timestamp, falling back to the `date`
+/// string's midnight (local) when `timestamp` is missing/zero. Mirrors the
+/// fallback semantics used by the hourly/minutely bucketing so sessions
+/// with only a date still contribute to first/last-active bounds.
+fn message_timestamp_ms(msg: &UnifiedMessage) -> i64 {
+    if msg.timestamp > 0 {
+        return msg.timestamp;
+    }
+    use chrono::TimeZone;
+    parse_date(&msg.date)
+        .and_then(|d| d.and_hms_opt(0, 0, 0))
+        .and_then(|dt| {
+            Local
+                .from_local_datetime(&dt)
+                .single()
+                .map(|dt| dt.timestamp_millis())
+        })
+        .unwrap_or(0)
 }
 
 /// Convert Unix ms timestamp to a NaiveDateTime truncated to the hour (local tz).

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -1053,19 +1053,25 @@ fn parse_date(date_str: &str) -> Option<NaiveDate> {
 }
 
 /// Resolve a message to a Unix-ms timestamp, falling back to the `date`
-/// string's midnight (UTC) when `timestamp` is missing/zero. UTC midnight is
-/// used instead of local midnight to avoid DST-transition ambiguity: a date
-/// that falls in a spring-forward gap or fall-back overlap would yield `None`
-/// from `Local.from_local_datetime(..).single()` and silently return 0,
-/// losing the session boundary. UTC is unambiguous and the fallback is only
-/// an approximation for boundary tracking.
+/// string's midnight when `timestamp` is missing/zero. Local midnight is
+/// preferred so the date renders on the same calendar day in the user's
+/// timezone. DST edge cases are handled explicitly:
+/// - Fall-back overlap (two valid midnights): take the earliest so the date
+///   stays on the correct day.
+/// - Spring-forward gap (midnight doesn't exist): fall back to UTC midnight
+///   rather than silently returning 0 and losing the session boundary.
 fn message_timestamp_ms(msg: &UnifiedMessage) -> i64 {
     if msg.timestamp > 0 {
         return msg.timestamp;
     }
+    use chrono::TimeZone;
     parse_date(&msg.date)
         .and_then(|d| d.and_hms_opt(0, 0, 0))
-        .map(|dt| dt.and_utc().timestamp_millis())
+        .map(|dt| match Local.from_local_datetime(&dt) {
+            chrono::LocalResult::Single(local) => local.timestamp_millis(),
+            chrono::LocalResult::Ambiguous(earliest, _) => earliest.timestamp_millis(),
+            chrono::LocalResult::None => dt.and_utc().timestamp_millis(),
+        })
         .unwrap_or(0)
 }
 

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -1053,22 +1053,19 @@ fn parse_date(date_str: &str) -> Option<NaiveDate> {
 }
 
 /// Resolve a message to a Unix-ms timestamp, falling back to the `date`
-/// string's midnight (local) when `timestamp` is missing/zero. Mirrors the
-/// fallback semantics used by the hourly/minutely bucketing so sessions
-/// with only a date still contribute to first/last-active bounds.
+/// string's midnight (UTC) when `timestamp` is missing/zero. UTC midnight is
+/// used instead of local midnight to avoid DST-transition ambiguity: a date
+/// that falls in a spring-forward gap or fall-back overlap would yield `None`
+/// from `Local.from_local_datetime(..).single()` and silently return 0,
+/// losing the session boundary. UTC is unambiguous and the fallback is only
+/// an approximation for boundary tracking.
 fn message_timestamp_ms(msg: &UnifiedMessage) -> i64 {
     if msg.timestamp > 0 {
         return msg.timestamp;
     }
-    use chrono::TimeZone;
     parse_date(&msg.date)
         .and_then(|d| d.and_hms_opt(0, 0, 0))
-        .and_then(|dt| {
-            Local
-                .from_local_datetime(&dt)
-                .single()
-                .map(|dt| dt.timestamp_millis())
-        })
+        .map(|dt| dt.and_utc().timestamp_millis())
         .unwrap_or(0)
 }
 

--- a/crates/tokscale-cli/src/tui/export.rs
+++ b/crates/tokscale-cli/src/tui/export.rs
@@ -62,6 +62,23 @@ pub fn build_export_json(data: &UsageData) -> Result<String> {
             "turnCount": m.turn_count,
             "cost": m.cost
         })).collect::<Vec<_>>(),
+        "sessions": data.sessions.iter().map(|s| json!({
+            "sessionId": s.session_id,
+            "client": s.client,
+            "title": s.title,
+            "tokens": {
+                "input": s.tokens.input,
+                "output": s.tokens.output,
+                "cacheRead": s.tokens.cache_read,
+                "cacheWrite": s.tokens.cache_write,
+                "total": s.tokens.total()
+            },
+            "messageCount": s.message_count,
+            "turnCount": s.turn_count,
+            "cost": s.cost,
+            "firstActiveMs": s.first_active_ms,
+            "lastActiveMs": s.last_active_ms
+        })).collect::<Vec<_>>(),
         "totals": {
             "tokens": data.total_tokens,
             "cost": data.total_cost

--- a/crates/tokscale-cli/src/tui/ui/agents.rs
+++ b/crates/tokscale-cli/src/tui/ui/agents.rs
@@ -4,7 +4,8 @@ use ratatui::widgets::{
 };
 
 use super::widgets::{
-    format_cost, get_client_display_name, total_tokens_cell, viewport_scrollbar_state,
+    format_cost, get_client_display_name, total_tokens_cell, truncate_text,
+    viewport_scrollbar_state,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 use crate::ClientFilter;
@@ -108,13 +109,13 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
 
             let cells: Vec<Cell> = if is_very_narrow {
                 vec![
-                    Cell::from(truncate(&agent.agent, 18))
+                    Cell::from(truncate_text(&agent.agent, 18))
                         .style(Style::default().fg(app.theme.foreground)),
                     Cell::from(format_cost(agent.cost)).style(Style::default().fg(Color::Green)),
                 ]
             } else if is_narrow {
                 vec![
-                    Cell::from(truncate(&agent.agent, 18))
+                    Cell::from(truncate_text(&agent.agent, 18))
                         .style(Style::default().fg(app.theme.foreground)),
                     total_tokens_cell(agent.tokens.total(), &app.theme),
                     Cell::from(format_cost(agent.cost)).style(Style::default().fg(Color::Green)),
@@ -122,12 +123,12 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             } else {
                 vec![
                     Cell::from(format!("{}", idx + 1)).style(Style::default().fg(theme_muted)),
-                    Cell::from(truncate(&agent.agent, 32)).style(
+                    Cell::from(truncate_text(&agent.agent, 32)).style(
                         Style::default()
                             .fg(app.theme.foreground)
                             .add_modifier(Modifier::BOLD),
                     ),
-                    Cell::from(truncate(&client_labels(&agent.clients), 24))
+                    Cell::from(truncate_text(&client_labels(&agent.clients), 24))
                         .style(Style::default().fg(theme_muted)),
                     total_tokens_cell(agent.tokens.total(), &app.theme),
                     Cell::from(format_cost(agent.cost)).style(Style::default().fg(Color::Green)),
@@ -214,21 +215,6 @@ fn client_labels(clients: &str) -> String {
         .map(get_client_display_name)
         .collect::<Vec<_>>()
         .join(", ")
-}
-
-fn truncate(s: &str, max_chars: usize) -> String {
-    if max_chars == 0 {
-        return String::new();
-    }
-    let char_count = s.chars().count();
-    if char_count <= max_chars {
-        s.to_string()
-    } else if max_chars <= 3 {
-        s.chars().take(max_chars).collect()
-    } else {
-        let head: String = s.chars().take(max_chars - 3).collect();
-        format!("{}...", head)
-    }
 }
 
 #[cfg(test)]

--- a/crates/tokscale-cli/src/tui/ui/daily.rs
+++ b/crates/tokscale-cli/src/tui/ui/daily.rs
@@ -6,7 +6,7 @@ use ratatui::widgets::{
 
 use super::widgets::{
     format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens,
-    get_client_display_name, get_provider_display_name, total_tokens_cell,
+    get_client_display_name, get_provider_display_name, total_tokens_cell, truncate_text,
     viewport_scrollbar_state,
 };
 use crate::tui::app::{App, SortDirection, SortField};
@@ -429,7 +429,7 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
 
             let cells: Vec<Cell> = if is_very_narrow {
                 vec![
-                    Cell::from(truncate(row.model, 18)).style(
+                    Cell::from(truncate_text(row.model, 18)).style(
                         Style::default()
                             .fg(model_color)
                             .add_modifier(Modifier::BOLD),
@@ -438,7 +438,7 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
                 ]
             } else if is_narrow {
                 vec![
-                    Cell::from(truncate(row.model, 24)).style(
+                    Cell::from(truncate_text(row.model, 24)).style(
                         Style::default()
                             .fg(model_color)
                             .add_modifier(Modifier::BOLD),
@@ -452,7 +452,7 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
             } else {
                 vec![
                     Cell::from(format!("{}", idx + 1)).style(Style::default().fg(theme_muted)),
-                    Cell::from(truncate(row.model, 30)).style(
+                    Cell::from(truncate_text(row.model, 30)).style(
                         Style::default()
                             .fg(model_color)
                             .add_modifier(Modifier::BOLD),
@@ -538,21 +538,6 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
             }),
             &mut scrollbar_state,
         );
-    }
-}
-
-fn truncate(s: &str, max_chars: usize) -> String {
-    if max_chars == 0 {
-        return String::new();
-    }
-    let char_count = s.chars().count();
-    if char_count <= max_chars {
-        s.to_string()
-    } else if max_chars <= 3 {
-        s.chars().take(max_chars).collect()
-    } else {
-        let head: String = s.chars().take(max_chars - 3).collect();
-        format!("{}...", head)
     }
 }
 

--- a/crates/tokscale-cli/src/tui/ui/footer.rs
+++ b/crates/tokscale-cli/src/tui/ui/footer.rs
@@ -162,6 +162,7 @@ fn current_count_label(app: &App) -> String {
             format!(" ({} days)", app.get_sorted_monthly_detail_days().len())
         }
         Tab::Monthly => format!(" ({} months)", app.data.monthly.len()),
+        Tab::Sessions => format!(" ({} sessions)", app.data.sessions.len()),
         Tab::Stats | Tab::Usage => String::new(),
     }
 }
@@ -435,6 +436,10 @@ mod tests {
         assert_eq!(
             current_count_label(&make_app_on(Tab::Monthly)),
             " (0 months)"
+        );
+        assert_eq!(
+            current_count_label(&make_app_on(Tab::Sessions)),
+            " (0 sessions)"
         );
         assert_eq!(current_count_label(&make_app_on(Tab::Stats)), "");
     }

--- a/crates/tokscale-cli/src/tui/ui/mod.rs
+++ b/crates/tokscale-cli/src/tui/ui/mod.rs
@@ -10,6 +10,7 @@ mod minutely;
 mod models;
 mod monthly;
 mod overview;
+mod sessions;
 pub mod spinner;
 mod stats;
 mod usage;
@@ -53,6 +54,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
             Tab::Hourly => hourly::render(frame, app, chunks[1]),
             Tab::Minutely => minutely::render(frame, app, chunks[1]),
             Tab::Monthly => monthly::render(frame, app, chunks[1]),
+            Tab::Sessions => sessions::render(frame, app, chunks[1]),
             Tab::Stats => stats::render(frame, app, chunks[1]),
             Tab::Usage => usage::render(frame, app, chunks[1]),
         }

--- a/crates/tokscale-cli/src/tui/ui/models.rs
+++ b/crates/tokscale-cli/src/tui/ui/models.rs
@@ -5,7 +5,7 @@ use ratatui::widgets::{
 
 use super::widgets::{
     format_cache_hit_rate, format_cost, format_cost_per_million, format_ms_per_1k, format_tokens,
-    get_client_display_name, get_provider_display_name, total_tokens_cell,
+    get_client_display_name, get_provider_display_name, total_tokens_cell, truncate_text,
     viewport_scrollbar_state,
 };
 use crate::tui::app::{App, SortDirection, SortField};
@@ -154,24 +154,26 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
 
             let cells: Vec<Cell> = if is_very_narrow {
                 vec![
-                    Cell::from(truncate(&display_name, 15)).style(Style::default().fg(model_color)),
+                    Cell::from(truncate_text(&display_name, 15))
+                        .style(Style::default().fg(model_color)),
                     Cell::from(format_cost(model.cost)).style(Style::default().fg(Color::Green)),
                 ]
             } else if is_narrow {
                 vec![
-                    Cell::from(truncate(&display_name, 25)).style(Style::default().fg(model_color)),
+                    Cell::from(truncate_text(&display_name, 25))
+                        .style(Style::default().fg(model_color)),
                     total_tokens_cell(model.tokens.total(), &app.theme),
                     Cell::from(format_cost(model.cost)).style(Style::default().fg(Color::Green)),
                 ]
             } else if group_by == GroupBy::WorkspaceModel {
                 vec![
                     Cell::from(format!("{}", idx + 1)).style(Style::default().fg(theme_muted)),
-                    Cell::from(truncate(workspace_label(model), 18)).style(
+                    Cell::from(truncate_text(workspace_label(model), 18)).style(
                         Style::default()
                             .fg(theme_accent)
                             .add_modifier(Modifier::BOLD),
                     ),
-                    Cell::from(truncate(&model.model, 24)).style(
+                    Cell::from(truncate_text(&model.model, 24)).style(
                         Style::default()
                             .fg(model_color)
                             .add_modifier(Modifier::BOLD),
@@ -195,7 +197,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             } else {
                 vec![
                     Cell::from(format!("{}", idx + 1)).style(Style::default().fg(theme_muted)),
-                    Cell::from(truncate(&model.model, 30)).style(
+                    Cell::from(truncate_text(&model.model, 30)).style(
                         Style::default()
                             .fg(model_color)
                             .add_modifier(Modifier::BOLD),
@@ -300,20 +302,5 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             }),
             &mut scrollbar_state,
         );
-    }
-}
-
-fn truncate(s: &str, max_chars: usize) -> String {
-    if max_chars == 0 {
-        return String::new();
-    }
-    let char_count = s.chars().count();
-    if char_count <= max_chars {
-        s.to_string()
-    } else if max_chars <= 3 {
-        s.chars().take(max_chars).collect()
-    } else {
-        let head: String = s.chars().take(max_chars - 3).collect();
-        format!("{}...", head)
     }
 }

--- a/crates/tokscale-cli/src/tui/ui/sessions.rs
+++ b/crates/tokscale-cli/src/tui/ui/sessions.rs
@@ -1,0 +1,583 @@
+use chrono::{Local, NaiveDateTime, TimeZone};
+use ratatui::prelude::*;
+use ratatui::widgets::{
+    Block, Borders, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, Table,
+};
+
+use super::widgets::{
+    format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens,
+    get_client_display_name, total_tokens_cell, viewport_scrollbar_state,
+};
+use crate::tui::app::{App, SortDirection, SortField};
+
+pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(app.theme.border))
+        .title(Span::styled(
+            " Sessions ",
+            Style::default()
+                .fg(app.theme.accent)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .style(Style::default().bg(app.theme.background));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let visible_height = inner.height.saturating_sub(1) as usize;
+    app.set_max_visible_items(visible_height);
+
+    let sessions = app.get_sorted_sessions();
+    if sessions.is_empty() {
+        let empty_msg = Paragraph::new("No session usage data found. Press 'r' to refresh.")
+            .style(Style::default().fg(app.theme.muted))
+            .alignment(Alignment::Center);
+        frame.render_widget(empty_msg, inner);
+        return;
+    }
+
+    let is_narrow = app.is_narrow();
+    let is_very_narrow = app.is_very_narrow();
+    let has_turn_data = sessions.iter().any(|s| s.turn_count > 0);
+    let sort_field = app.sort_field;
+    let sort_direction = app.sort_direction;
+    let scroll_offset = app.scroll_offset;
+    let selected_index = app.selected_index;
+    let theme_accent = app.theme.accent;
+    let theme_muted = app.theme.muted;
+    let theme_selection = app.theme.selection;
+    let metric_input_style = app.theme.metric_input_style();
+    let metric_output_style = app.theme.metric_output_style();
+    let metric_cache_read_style = app.theme.metric_cache_read_style();
+    let metric_cache_write_style = app.theme.metric_cache_write_style();
+    let striped_row_style = app.theme.striped_row_style();
+
+    // Timestamp format adapts to width: full date+time when there's room,
+    // compact "mm-dd HH:MM" when the full layout would overflow.
+    let last_active_fmt: &str = if is_narrow || is_very_narrow {
+        "%m-%d %H:%M"
+    } else {
+        "%Y-%m-%d %H:%M"
+    };
+
+    let header_cells = if is_very_narrow {
+        vec!["Session", "Cost"]
+    } else if is_narrow {
+        if has_turn_data {
+            vec!["Session", "Client", "Turn", "Msgs", "Tokens", "Cost"]
+        } else {
+            vec!["Session", "Client", "Msgs", "Tokens", "Cost"]
+        }
+    } else if has_turn_data {
+        vec![
+            "Session",
+            "Client",
+            "Turn",
+            "Msgs",
+            "Input",
+            "Output",
+            "Cache R",
+            "Cache W",
+            "Cache×",
+            "Total",
+            "Cost",
+            "Cost/1M",
+            "Duration",
+            "Last Active",
+        ]
+    } else {
+        vec![
+            "Session",
+            "Client",
+            "Msgs",
+            "Input",
+            "Output",
+            "Cache R",
+            "Cache W",
+            "Cache×",
+            "Total",
+            "Cost",
+            "Cost/1M",
+            "Duration",
+            "Last Active",
+        ]
+    };
+
+    let sort_indicator = |field: SortField| -> &'static str {
+        if sort_field == field {
+            match sort_direction {
+                SortDirection::Ascending => " ▲",
+                SortDirection::Descending => " ▼",
+            }
+        } else {
+            ""
+        }
+    };
+
+    let header = Row::new(
+        header_cells
+            .iter()
+            .enumerate()
+            .map(|(i, h)| {
+                // "Last Active" column index is the sort target for Date.
+                let last_active_idx = if is_very_narrow {
+                    usize::MAX // no last-active column in very narrow mode
+                } else if is_narrow {
+                    // narrow drops last-active entirely; Date sort has no header indicator
+                    usize::MAX
+                } else if has_turn_data {
+                    13
+                } else {
+                    12
+                };
+                let total_idx = if is_very_narrow {
+                    usize::MAX
+                } else if is_narrow {
+                    if has_turn_data {
+                        4
+                    } else {
+                        3
+                    }
+                } else if has_turn_data {
+                    9
+                } else {
+                    8
+                };
+                let cost_idx = if is_very_narrow {
+                    1
+                } else if is_narrow {
+                    if has_turn_data {
+                        5
+                    } else {
+                        4
+                    }
+                } else if has_turn_data {
+                    10
+                } else {
+                    9
+                };
+                let indicator = if i == last_active_idx {
+                    sort_indicator(SortField::Date)
+                } else if i == total_idx {
+                    sort_indicator(SortField::Tokens)
+                } else if i == cost_idx {
+                    sort_indicator(SortField::Cost)
+                } else {
+                    ""
+                };
+                Cell::from(format!("{}{}", h, indicator))
+            })
+            .collect::<Vec<_>>(),
+    )
+    .style(
+        Style::default()
+            .fg(theme_accent)
+            .add_modifier(Modifier::BOLD),
+    )
+    .height(1);
+
+    let sessions_len = sessions.len();
+    let start = scroll_offset.min(sessions_len);
+    let end = (start + visible_height).min(sessions_len);
+
+    if start >= sessions_len {
+        return;
+    }
+
+    let rows: Vec<Row> = sessions[start..end]
+        .iter()
+        .enumerate()
+        .map(|(i, session)| {
+            let idx = i + start;
+            let is_selected = idx == selected_index;
+            let is_striped = idx % 2 == 1;
+
+            let last_active_str = ms_to_local_naive(session.last_active_ms)
+                .map(|dt| dt.format(last_active_fmt).to_string())
+                .unwrap_or_else(|| "\u{2014}".to_string());
+            let duration_str = format_duration(session.first_active_ms, session.last_active_ms);
+
+            // Show the human-readable title when the source client stored one,
+            // falling back to the session ID for clients that don't.
+            let session_label = session
+                .title
+                .as_deref()
+                .filter(|t| !t.is_empty())
+                .unwrap_or(&session.session_id);
+
+            let cells: Vec<Cell> = if is_very_narrow {
+                vec![
+                    Cell::from(truncate(session_label, 20)).style(
+                        Style::default()
+                            .fg(theme_muted)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Cell::from(format_cost(session.cost)).style(Style::default().fg(Color::Green)),
+                ]
+            } else if is_narrow {
+                let mut cells = vec![Cell::from(truncate(session_label, 24)).style(
+                    Style::default()
+                        .fg(theme_muted)
+                        .add_modifier(Modifier::BOLD),
+                )];
+                cells.push(
+                    Cell::from(get_client_display_name(&session.client))
+                        .style(Style::default().fg(theme_muted)),
+                );
+                if has_turn_data {
+                    let turn_str = if session.turn_count > 0 {
+                        session.turn_count.to_string()
+                    } else {
+                        "\u{2014}".to_string()
+                    };
+                    cells.push(Cell::from(turn_str));
+                }
+                cells.extend([
+                    Cell::from(session.message_count.to_string()),
+                    total_tokens_cell(session.tokens.total(), &app.theme),
+                    Cell::from(format_cost(session.cost)).style(Style::default().fg(Color::Green)),
+                ]);
+                cells
+            } else {
+                let mut cells = vec![Cell::from(truncate(session_label, 60)).style(
+                    Style::default()
+                        .fg(theme_muted)
+                        .add_modifier(Modifier::BOLD),
+                )];
+                cells.push(
+                    Cell::from(get_client_display_name(&session.client))
+                        .style(Style::default().fg(theme_muted)),
+                );
+                if has_turn_data {
+                    let turn_str = if session.turn_count > 0 {
+                        session.turn_count.to_string()
+                    } else {
+                        "\u{2014}".to_string()
+                    };
+                    cells.push(Cell::from(turn_str));
+                }
+                cells.extend([
+                    Cell::from(session.message_count.to_string()),
+                    Cell::from(format_tokens(session.tokens.input)).style(metric_input_style),
+                    Cell::from(format_tokens(session.tokens.output)).style(metric_output_style),
+                    Cell::from(format_tokens(session.tokens.cache_read))
+                        .style(metric_cache_read_style),
+                    Cell::from(format_tokens(session.tokens.cache_write))
+                        .style(metric_cache_write_style),
+                    Cell::from(format_cache_hit_rate(
+                        session.tokens.cache_read,
+                        session.tokens.input,
+                        session.tokens.cache_write,
+                    ))
+                    .style(Style::default().fg(Color::Cyan)),
+                    total_tokens_cell(session.tokens.total(), &app.theme),
+                    Cell::from(format_cost(session.cost)).style(Style::default().fg(Color::Green)),
+                    Cell::from(format_cost_per_million(
+                        session.cost,
+                        session.tokens.total(),
+                    ))
+                    .style(Style::default().fg(Color::Rgb(150, 200, 150))),
+                    Cell::from(duration_str).style(Style::default().fg(Color::Yellow)),
+                    Cell::from(last_active_str).style(Style::default().fg(theme_muted)),
+                ]);
+                cells
+            };
+
+            let row_style = if is_selected {
+                Style::default().bg(theme_selection)
+            } else if is_striped {
+                striped_row_style
+            } else {
+                Style::default()
+            };
+
+            Row::new(cells).style(row_style).height(1)
+        })
+        .collect();
+
+    let widths = if is_very_narrow {
+        vec![Constraint::Percentage(60), Constraint::Percentage(40)]
+    } else if is_narrow && has_turn_data {
+        vec![
+            Constraint::Percentage(28),
+            Constraint::Percentage(16),
+            Constraint::Percentage(12),
+            Constraint::Percentage(12),
+            Constraint::Percentage(16),
+            Constraint::Percentage(16),
+        ]
+    } else if is_narrow {
+        vec![
+            Constraint::Percentage(32),
+            Constraint::Percentage(18),
+            Constraint::Percentage(12),
+            Constraint::Percentage(18),
+            Constraint::Percentage(20),
+        ]
+    } else if has_turn_data {
+        vec![
+            Constraint::Min(20),
+            Constraint::Length(12),
+            Constraint::Length(5),
+            Constraint::Length(5),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(8),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(9),
+            Constraint::Length(17),
+        ]
+    } else {
+        vec![
+            Constraint::Min(20),
+            Constraint::Length(12),
+            Constraint::Length(6),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(8),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(9),
+            Constraint::Length(17),
+        ]
+    };
+
+    let table = Table::new(rows, widths)
+        .header(header)
+        .row_highlight_style(Style::default().bg(theme_selection));
+
+    frame.render_widget(table, inner);
+
+    if sessions_len > visible_height {
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(Some("▲"))
+            .end_symbol(Some("▼"));
+
+        let mut scrollbar_state =
+            viewport_scrollbar_state(sessions_len, scroll_offset, visible_height);
+
+        frame.render_stateful_widget(
+            scrollbar,
+            area.inner(Margin {
+                horizontal: 0,
+                vertical: 1,
+            }),
+            &mut scrollbar_state,
+        );
+    }
+}
+
+/// Convert Unix-ms to a local NaiveDateTime for display.
+fn ms_to_local_naive(ms: i64) -> Option<NaiveDateTime> {
+    if ms <= 0 {
+        return None;
+    }
+    let secs = ms / 1000;
+    match Local.timestamp_opt(secs, 0) {
+        chrono::LocalResult::Single(dt) => Some(dt.naive_local()),
+        _ => None,
+    }
+}
+
+/// Human-readable elapsed time between first and last message in a session.
+/// Returns "—" when the bounds are missing or inverted.
+fn format_duration(first_ms: i64, last_ms: i64) -> String {
+    if first_ms <= 0 || last_ms <= 0 || last_ms < first_ms {
+        return "\u{2014}".to_string();
+    }
+    let secs = (last_ms - first_ms) / 1000;
+    if secs <= 0 {
+        return "0s".to_string();
+    }
+    let days = secs / 86400;
+    let hours = (secs % 86400) / 3600;
+    let mins = (secs % 3600) / 60;
+    let s = secs % 60;
+    if days > 0 {
+        format!("{}d {}h", days, hours)
+    } else if hours > 0 {
+        format!("{}h {}m", hours, mins)
+    } else if mins > 0 {
+        format!("{}m", mins)
+    } else {
+        format!("{}s", s)
+    }
+}
+
+fn truncate(s: &str, max_chars: usize) -> String {
+    if max_chars == 0 {
+        return String::new();
+    }
+    let char_count = s.chars().count();
+    if char_count <= max_chars {
+        s.to_string()
+    } else if max_chars <= 3 {
+        s.chars().take(max_chars).collect()
+    } else {
+        let head: String = s.chars().take(max_chars - 3).collect();
+        format!("{}...", head)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::app::{Tab, TuiConfig};
+    use crate::tui::data::{SessionUsage, TokenBreakdown};
+    use ratatui::{backend::TestBackend, Terminal};
+
+    fn session(id: &str, client: &str, cost: f64, last_ms: i64) -> SessionUsage {
+        SessionUsage {
+            session_id: id.to_string(),
+            client: client.to_string(),
+            title: None,
+            tokens: TokenBreakdown {
+                input: 1000,
+                output: 500,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            cost,
+            message_count: 4,
+            turn_count: 2,
+            first_active_ms: last_ms.saturating_sub(3_600_000),
+            last_active_ms: last_ms,
+        }
+    }
+
+    fn make_app(width: u16) -> App {
+        let config = TuiConfig {
+            theme: "blue".to_string(),
+            refresh: 0,
+            sessions_path: None,
+            clients: None,
+            since: None,
+            until: None,
+            year: None,
+            initial_tab: None,
+        };
+        let mut app = App::new_with_cached_data(config, None).unwrap();
+        app.terminal_width = width;
+        app.current_tab = Tab::Sessions;
+        app.sort_field = SortField::Cost;
+        app.sort_direction = SortDirection::Descending;
+        app
+    }
+
+    fn render_body(app: &mut App, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render(frame, app, Rect::new(0, 0, width, height)))
+            .unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .chunks(width as usize)
+            .map(|row| {
+                row.iter()
+                    .map(|c| c.symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn wide_terminal_renders_session_and_duration_columns() {
+        let mut app = make_app(200);
+        app.data.sessions = vec![
+            session("abc-123", "opencode", 1.5, 1_736_000_000_000),
+            session("def-456", "claude", 0.25, 1_736_000_000_000),
+        ];
+        let body = render_body(&mut app, 200, 12);
+        assert!(body.contains("abc-123"), "expected session id\n{body}");
+        assert!(
+            body.contains("Duration"),
+            "expected duration header\n{body}"
+        );
+        assert!(
+            body.contains("Last Active"),
+            "expected last active header\n{body}"
+        );
+    }
+
+    #[test]
+    fn session_title_displayed_when_available() {
+        let mut app = make_app(200);
+        let mut s = session("ses_09d2eac0", "opencode", 1.5, 1_736_000_000_000);
+        s.title = Some("This is a long title for a session that could be used".to_string());
+        app.data.sessions = vec![s];
+        let body = render_body(&mut app, 200, 12);
+        assert!(
+            body.contains("This is a long"),
+            "expected session title in body\n{body}"
+        );
+    }
+
+    #[test]
+    fn session_column_expands_on_wide_terminal() {
+        let mut app = make_app(220);
+        let mut s = session("ses_09d2eac0", "opencode", 1.5, 1_736_000_000_000);
+        s.title = Some("This is a long title for a session that could be used".to_string());
+        app.data.sessions = vec![s];
+        let body = render_body(&mut app, 220, 12);
+        assert!(
+            body.contains("This is a long title for a session that could be used"),
+            "expected full title on wide terminal\n{body}"
+        );
+    }
+
+    #[test]
+    fn narrow_terminal_drops_token_breakdown_columns() {
+        let mut app = make_app(70);
+        app.data.sessions = vec![session("abc-123", "opencode", 1.5, 1_736_000_000_000)];
+        let body = render_body(&mut app, 70, 12);
+        assert!(body.contains("abc-123"), "expected session id\n{body}");
+        assert!(
+            !body.contains("Cache×"),
+            "cache hit rate should be dropped in narrow mode\n{body}"
+        );
+    }
+
+    #[test]
+    fn empty_sessions_shows_refresh_message() {
+        let mut app = make_app(120);
+        let body = render_body(&mut app, 120, 12);
+        assert!(
+            body.contains("No session usage data"),
+            "expected empty message\n{body}"
+        );
+    }
+
+    #[test]
+    fn format_duration_handles_days_hours_minutes_seconds() {
+        assert_eq!(format_duration(0, 1000), "—");
+        assert_eq!(format_duration(1000, 500), "—");
+        assert_eq!(format_duration(1000, 1000), "0s");
+        assert_eq!(format_duration(0, 0), "—");
+        assert_eq!(format_duration(1000, 2000), "1s");
+        assert_eq!(format_duration(1000, 61_000), "1m");
+        assert_eq!(format_duration(1000, 3_661_000), "1h 1m");
+        assert_eq!(format_duration(1000, 90_061_000), "1d 1h");
+    }
+
+    #[test]
+    fn format_duration_boundary_units() {
+        // exactly one hour without extra minutes (use a real first_ms since
+        // first_ms == 0 short-circuits to "—")
+        assert_eq!(format_duration(1_000, 3_601_000), "1h 0m");
+        // exactly one day
+        assert_eq!(format_duration(1_000, 86_401_000), "1d 0h");
+    }
+}

--- a/crates/tokscale-cli/src/tui/ui/sessions.rs
+++ b/crates/tokscale-cli/src/tui/ui/sessions.rs
@@ -6,7 +6,7 @@ use ratatui::widgets::{
 
 use super::widgets::{
     format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens,
-    get_client_display_name, total_tokens_cell, viewport_scrollbar_state,
+    get_client_display_name, total_tokens_cell, truncate_text, viewport_scrollbar_state,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 
@@ -208,7 +208,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
 
             let cells: Vec<Cell> = if is_very_narrow {
                 vec![
-                    Cell::from(truncate(session_label, 20)).style(
+                    Cell::from(truncate_text(session_label, 20)).style(
                         Style::default()
                             .fg(theme_muted)
                             .add_modifier(Modifier::BOLD),
@@ -216,7 +216,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                     Cell::from(format_cost(session.cost)).style(Style::default().fg(Color::Green)),
                 ]
             } else if is_narrow {
-                let mut cells = vec![Cell::from(truncate(session_label, 24)).style(
+                let mut cells = vec![Cell::from(truncate_text(session_label, 24)).style(
                     Style::default()
                         .fg(theme_muted)
                         .add_modifier(Modifier::BOLD),
@@ -240,7 +240,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                 ]);
                 cells
             } else {
-                let mut cells = vec![Cell::from(truncate(session_label, 60)).style(
+                let mut cells = vec![Cell::from(truncate_text(session_label, 60)).style(
                     Style::default()
                         .fg(theme_muted)
                         .add_modifier(Modifier::BOLD),
@@ -409,21 +409,6 @@ fn format_duration(first_ms: i64, last_ms: i64) -> String {
         format!("{}m", mins)
     } else {
         format!("{}s", s)
-    }
-}
-
-fn truncate(s: &str, max_chars: usize) -> String {
-    if max_chars == 0 {
-        return String::new();
-    }
-    let char_count = s.chars().count();
-    if char_count <= max_chars {
-        s.to_string()
-    } else if max_chars <= 3 {
-        s.chars().take(max_chars).collect()
-    } else {
-        let head: String = s.chars().take(max_chars - 3).collect();
-        format!("{}...", head)
     }
 }
 

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -99,6 +99,25 @@ pub fn viewport_scrollbar_state(
         .viewport_content_length(viewport_len)
 }
 
+/// Truncate a string to `max_chars` Unicode code points, appending "..." when
+/// truncation occurs. Returns the original string when it fits, and an empty
+/// string when `max_chars` is 0. Shared across all table-style tabs (Daily,
+/// Monthly, Sessions, Models, Agents) so ellipsis behavior stays consistent.
+pub fn truncate_text(s: &str, max_chars: usize) -> String {
+    if max_chars == 0 {
+        return String::new();
+    }
+    let char_count = s.chars().count();
+    if char_count <= max_chars {
+        s.to_string()
+    } else if max_chars <= 3 {
+        s.chars().take(max_chars).collect()
+    } else {
+        let head: String = s.chars().take(max_chars - 3).collect();
+        format!("{}...", head)
+    }
+}
+
 fn scrollbar_position(scroll_offset: usize, content_len: usize, viewport_len: usize) -> usize {
     let max_scroll = content_len.saturating_sub(viewport_len);
     if max_scroll == 0 {

--- a/crates/tokscale-core/src/aggregator.rs
+++ b/crates/tokscale-core/src/aggregator.rs
@@ -773,6 +773,7 @@ mod tests {
             message_count: 1,
             agent: None,
             dedup_key: None,
+            session_title: None,
             is_turn_start: false,
         }
     }
@@ -1361,6 +1362,7 @@ mod tests {
             message_count: 1,
             agent: None,
             dedup_key: None,
+            session_title: None,
             is_turn_start: false,
             duration_ms: None,
         }

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -3692,6 +3692,7 @@ pub fn parsed_to_unified(msg: &ParsedMessage, cost: f64) -> UnifiedMessage {
         message_count: msg.message_count,
         agent: msg.agent.clone(),
         dedup_key: None,
+        session_title: None,
         is_turn_start: false,
     }
 }

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -20,7 +20,10 @@ use std::time::UNIX_EPOCH;
 // absent when cached. Claude sidechain parent candidates can therefore be
 // revalidated without reparsing the sidechain on every warm scan, while a
 // later-created parent transcript still invalidates the entry.
-const CACHE_FORMAT_VERSION: u32 = 2;
+// 3: UnifiedMessage gained session_title, changing the bincode payload layout.
+// Old shards must read as Stale (silent rebuild), not Invalid (corruption
+// warning), so the format version moves with the struct.
+const CACHE_FORMAT_VERSION: u32 = 3;
 // V2 intentionally starts cold and leaves source-message-cache.bin untouched:
 // the monolith did not record a trustworthy parser owner for migration.
 const CACHE_SHARD_DIRNAME: &str = "source-message-cache-v2";

--- a/crates/tokscale-core/src/sessionize.rs
+++ b/crates/tokscale-core/src/sessionize.rs
@@ -407,6 +407,7 @@ mod tests {
             message_count: 1,
             agent: None,
             dedup_key: None,
+            session_title: None,
             is_turn_start: false,
             duration_ms: None,
         }

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -77,6 +77,12 @@ pub struct UnifiedMessage {
     pub message_count: i32,
     pub agent: Option<String>,
     pub dedup_key: Option<String>,
+    /// Human-readable session title/name when the source client stores one
+    /// (e.g. OpenCode's `session.title` column). `None` for clients that
+    /// don't record a title; the Sessions tab falls back to showing just
+    /// the session ID in that case.
+    #[serde(default)]
+    pub session_title: Option<String>,
     /// True if this message is the first assistant response after a user turn.
     /// Used to count user interaction turns (as opposed to API message count).
     #[serde(default)]
@@ -356,6 +362,7 @@ impl UnifiedMessage {
             message_count: default_message_count(),
             agent,
             dedup_key,
+            session_title: None,
             is_turn_start: false,
         }
     }

--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -274,8 +274,8 @@ fn mark_opencode_cost_source(unified: &mut UnifiedMessage) {
 }
 
 /// Column layout shared by every OpenCode SQLite query variant:
-/// `(row_id, session_id, data_json, workspace_root)`.
-type OpenCodeSqliteRow = (String, String, String, Option<String>);
+/// `(row_id, session_id, data_json, workspace_root, session_title)`.
+type OpenCodeSqliteRow = (String, String, String, Option<String>, Option<String>);
 
 /// Accumulates parsed assistant messages across OpenCode's v1 (`message`) and
 /// v2 (`session_message`) tables, applying fingerprint-based deduplication so
@@ -294,7 +294,7 @@ impl OpenCodeSqliteAccumulator {
     /// Parse one SQLite row's JSON payload and merge it into the accumulator,
     /// deduplicating against previously ingested rows.
     fn ingest_row(&mut self, row: OpenCodeSqliteRow) {
-        let (row_id, session_id, data_json, row_workspace_root) = row;
+        let (row_id, session_id, data_json, row_workspace_root, row_session_title) = row;
 
         let mut bytes = data_json.into_bytes();
         let msg: OpenCodeMessage = match simd_json::from_slice(&mut bytes) {
@@ -374,6 +374,12 @@ impl OpenCodeSqliteAccumulator {
             .or(embedded_workspace_root.as_deref());
         set_workspace_from_root(&mut unified, workspace_root);
         mark_opencode_cost_source(&mut unified);
+        if let Some(ref title) = row_session_title {
+            let trimmed = title.trim();
+            if !trimmed.is_empty() {
+                unified.session_title = Some(trimmed.to_string());
+            }
+        }
 
         // Among entries sharing this fingerprint, merge into the first one that
         // is NOT a definitively-different message -- i.e. skip any whose stored
@@ -419,11 +425,11 @@ impl OpenCodeSqliteAccumulator {
     }
 }
 
-/// Run one query (whose columns are `id, session_id, data, workspace_root`)
-/// against `conn` and feed every row into `acc`. A prepare/query failure — for
-/// example a table that does not exist in this schema variant — is treated as
-/// "no rows", so callers can attempt several schema variants against the same
-/// database without an error aborting the scan.
+/// Run one query (whose columns are `id, session_id, data, workspace_root,
+/// session_title`) against `conn` and feed every row into `acc`. A prepare/query
+/// failure — for example a table that does not exist in this schema variant —
+/// is treated as "no rows", so callers can attempt several schema variants
+/// against the same database without an error aborting the scan.
 fn collect_opencode_rows(
     conn: &rusqlite::Connection,
     query: &str,
@@ -439,7 +445,8 @@ fn collect_opencode_rows(
         let session_id: String = row.get(1)?;
         let data_json: String = row.get(2)?;
         let workspace_root: Option<String> = row.get(3)?;
-        Ok((id, session_id, data_json, workspace_root))
+        let session_title: Option<String> = row.get(4)?;
+        Ok((id, session_id, data_json, workspace_root, session_title))
     }) {
         Ok(r) => r,
         Err(_) => return,
@@ -462,7 +469,7 @@ pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
     // under `$.model`. Absent in v1 databases, where the prepare fails and this
     // is a no-op.
     let v2_query = r#"
-        SELECT sm.id, sm.session_id, sm.data, NULLIF(s.directory, '') AS workspace_root
+        SELECT sm.id, sm.session_id, sm.data, NULLIF(s.directory, '') AS workspace_root, s.title AS session_title
         FROM session_message sm
         LEFT JOIN session s ON s.id = sm.session_id
         WHERE sm.type = 'assistant'
@@ -472,10 +479,11 @@ pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
     collect_opencode_rows(&conn, v2_query, &mut acc);
 
     // OpenCode v1 (`opencode.db`, 1.2+): per-message rows in `message`, role in
-    // the JSON `$.role`. The `session` join supplies the workspace directory;
-    // the legacy variant drops it for databases without a `session` table.
+    // the JSON `$.role`. The `session` join supplies the workspace directory
+    // and title; the legacy variant drops both for databases without a
+    // `session` table.
     let v1_modern_query = r#"
-        SELECT m.id, m.session_id, m.data, NULLIF(s.directory, '') AS workspace_root
+        SELECT m.id, m.session_id, m.data, NULLIF(s.directory, '') AS workspace_root, s.title AS session_title
         FROM message m
         LEFT JOIN session s ON s.id = m.session_id
         WHERE json_extract(m.data, '$.role') = 'assistant'
@@ -483,7 +491,7 @@ pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
         ORDER BY m.id, m.session_id
     "#;
     let v1_legacy_query = r#"
-        SELECT m.id, m.session_id, m.data, NULL AS workspace_root
+        SELECT m.id, m.session_id, m.data, NULL AS workspace_root, NULL AS session_title
         FROM message m
         WHERE json_extract(m.data, '$.role') = 'assistant'
           AND json_extract(m.data, '$.tokens') IS NOT NULL
@@ -660,7 +668,8 @@ mod tests {
             );
             CREATE TABLE session (
                 id TEXT PRIMARY KEY,
-                directory TEXT NOT NULL
+                directory TEXT NOT NULL,
+                title TEXT
             );
             CREATE TABLE session_message (
                 id TEXT PRIMARY KEY,
@@ -1405,7 +1414,8 @@ mod tests {
         conn.execute_batch(
             "CREATE TABLE session (
                 id TEXT PRIMARY KEY,
-                directory TEXT NOT NULL
+                directory TEXT NOT NULL,
+                title TEXT
             );",
         )
         .unwrap();
@@ -1499,7 +1509,8 @@ mod tests {
         conn.execute_batch(
             "CREATE TABLE session (
                 id TEXT PRIMARY KEY,
-                directory TEXT NOT NULL
+                directory TEXT NOT NULL,
+                title TEXT
             );",
         )
         .unwrap();

--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -468,6 +468,10 @@ pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
     // `session_message`, keyed by a `type` column, with model + provider nested
     // under `$.model`. Absent in v1 databases, where the prepare fails and this
     // is a no-op.
+    //
+    // Try the title-bearing query first; older v2 databases whose `session`
+    // table predates the `title` column fall back to a title-less variant so
+    // they still produce rows (the title is optional, not a gating column).
     let v2_query = r#"
         SELECT sm.id, sm.session_id, sm.data, NULLIF(s.directory, '') AS workspace_root, s.title AS session_title
         FROM session_message sm
@@ -476,14 +480,36 @@ pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
           AND json_extract(sm.data, '$.tokens') IS NOT NULL
         ORDER BY sm.id, sm.session_id
     "#;
-    collect_opencode_rows(&conn, v2_query, &mut acc);
+    let v2_query_no_title = r#"
+        SELECT sm.id, sm.session_id, sm.data, NULLIF(s.directory, '') AS workspace_root, NULL AS session_title
+        FROM session_message sm
+        LEFT JOIN session s ON s.id = sm.session_id
+        WHERE sm.type = 'assistant'
+          AND json_extract(sm.data, '$.tokens') IS NOT NULL
+        ORDER BY sm.id, sm.session_id
+    "#;
+    if conn.prepare(v2_query).is_ok() {
+        collect_opencode_rows(&conn, v2_query, &mut acc);
+    } else {
+        collect_opencode_rows(&conn, v2_query_no_title, &mut acc);
+    }
 
     // OpenCode v1 (`opencode.db`, 1.2+): per-message rows in `message`, role in
     // the JSON `$.role`. The `session` join supplies the workspace directory
-    // and title; the legacy variant drops both for databases without a
-    // `session` table.
+    // and title. Three fallback tiers:
+    //   1. modern: session table has both `directory` and `title`
+    //   2. directory-only: session table has `directory` but not `title`
+    //   3. legacy: no `session` table at all (drops workspace + title)
     let v1_modern_query = r#"
         SELECT m.id, m.session_id, m.data, NULLIF(s.directory, '') AS workspace_root, s.title AS session_title
+        FROM message m
+        LEFT JOIN session s ON s.id = m.session_id
+        WHERE json_extract(m.data, '$.role') = 'assistant'
+          AND json_extract(m.data, '$.tokens') IS NOT NULL
+        ORDER BY m.id, m.session_id
+    "#;
+    let v1_directory_query = r#"
+        SELECT m.id, m.session_id, m.data, NULLIF(s.directory, '') AS workspace_root, NULL AS session_title
         FROM message m
         LEFT JOIN session s ON s.id = m.session_id
         WHERE json_extract(m.data, '$.role') = 'assistant'
@@ -499,6 +525,8 @@ pub fn parse_opencode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
     "#;
     if conn.prepare(v1_modern_query).is_ok() {
         collect_opencode_rows(&conn, v1_modern_query, &mut acc);
+    } else if conn.prepare(v1_directory_query).is_ok() {
+        collect_opencode_rows(&conn, v1_directory_query, &mut acc);
     } else {
         collect_opencode_rows(&conn, v1_legacy_query, &mut acc);
     }


### PR DESCRIPTION
## feat(tui): add Sessions tab for per-session cost breakdown
Adds a new Sessions tab to the TUI that breaks down token usage and cost by individual conversation rather than by time bucket. Each row represents one (client, session_id) pair and shows the same token/cost columns as the Daily/Monthly tabs, plus three session-specific columns:
- Session — the human-readable session title when the source client stores one (e.g. OpenCode's session.title column like "Something Something dashboard"), falling back to the raw session ID for clients that don't record titles
- Duration — elapsed time between the first and last message in the session (e.g. 1h 0m, 2d 3h)
- Last Active — local timestamp of the most recent message in the session
The Session column uses Min(20) so it dynamically expands to fill leftover terminal width, letting longer titles render in full on wider terminals. The Last Active column is sized for the full %Y-%m-%d %H:%M format. Narrow and very-narrow layouts drop token breakdown columns progressively, matching the responsive behavior of the existing time-based tabs.
### Implementation
tokscale-core
- UnifiedMessage gains a session_title: Option<String> field, populated by the OpenCode SQLite parser via SELECT s.title from the session table join. Other parsers leave it None and the tab falls back to the session ID.
tokscale-cli
- New SessionUsage struct in tui/data/mod.rs aggregates per-session token/cost/timestamp bounds during the existing message loop (one HashMap pass, no separate scan)
- New tui/ui/sessions.rs render module with responsive column layouts and sort support (cost, tokens, and date — where "date" maps to last_active_ms)
- Tab::Sessions wired into the tab enum, header, footer count label, clipboard copy, and JSON export
- The tab is always visible (no settings gate) since the aggregation is a cheap HashMap grouping alongside the existing daily/hourly/minutely buckets
### Screenshots
<img width="1715" height="978" alt="Screenshot 2026-07-20 at 1 18 57 PM" src="https://github.com/user-attachments/assets/7b783cd7-2ed0-4209-bf42-58e616f13390" />

### Testing
- cargo fmt --all -- --check — clean
- cargo clippy --locked --workspace --all-features -- -D warnings — zero warnings
- cargo test --workspace --all-features — all tests pass
- New unit tests cover: render with/without session titles, column expansion on wide terminals, narrow-mode column dropping, empty-state message, and format_duration boundary cases
- Existing tab-ordering and tab-switch tests updated for the new tab position


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Sessions tab to the TUI for per-session token and cost breakdown. It shows session title or ID, client, counts, and on wide screens duration and last active; sorting by Cost, Tokens, or Date is supported. Also adds `session_title` to `UnifiedMessage` (populated from OpenCode with schema fallbacks) and bumps cache format for a clean rebuild.

- **New Features**
  - `tokscale-cli` TUI: Sessions tab with Session (title or ID), Client, Msgs, Tokens, Cost; optional Turn column; Duration and Last Active on wide screens; responsive columns; default sort by Date; sort by Cost/Tokens/Date.
  - Aggregation + Export: `SessionUsage` built during load (skips empty `session_id`), computes first/last active from timestamps or local-midnight of `date` with DST-safe fallback; adopts first non-empty `session_title`. JSON export adds a `sessions` array with tokens, cost, message/turn counts, and `firstActiveMs`/`lastActiveMs`; footer shows session count.
  - `tokscale-core`: `UnifiedMessage.session_title` added; OpenCode SQLite parser joins `session.title` with fallbacks across v2 (with/without title) and v1 (modern, directory-only, legacy) schemas.

- **Bug Fixes**
  - `tokscale-core`: Bumped `CACHE_FORMAT_VERSION` to 3 after adding `session_title` so old message-cache shards rebuild as stale instead of surfacing decode errors (prevents spurious corruption warnings).

<sup>Written for commit ab8ab84d9bc756b00d5b88903c979638dd903bb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



