### PR TITLE
fix(core): saturate cross-day token totals in summary, years, and import reconciliation

### DIFF
--- a/crates/tokscale-cli/src/commands/import.rs
+++ b/crates/tokscale-cli/src/commands/import.rs
@@ -243,10 +243,10 @@ pub fn parse_clawdboard_export(json: &str) -> Result<ImportOutcome> {
                     suspect_cost_rows += 1;
                 }
 
-                mb_input += tokens.input;
-                mb_output += tokens.output;
-                mb_cache_read += tokens.cache_read;
-                mb_cache_write += tokens.cache_write;
+                mb_input = mb_input.saturating_add(tokens.input);
+                mb_output = mb_output.saturating_add(tokens.output);
+                mb_cache_read = mb_cache_read.saturating_add(tokens.cache_read);
+                mb_cache_write = mb_cache_write.saturating_add(tokens.cache_write);
                 mb_cost += cost;
 
                 add_row(day, &client, &mb.model_name, tokens, cost);
@@ -261,11 +261,16 @@ pub fn parse_clawdboard_export(json: &str) -> Result<ImportOutcome> {
                 || agg.cache_read_tokens != 0
                 || agg.cache_creation_tokens != 0;
             if agg_tokens_present {
-                let agg_total = agg.input_tokens.max(0)
-                    + agg.output_tokens.max(0)
-                    + agg.cache_read_tokens.max(0)
-                    + agg.cache_creation_tokens.max(0);
-                let mb_total = mb_input + mb_output + mb_cache_read + mb_cache_write;
+                let agg_total = agg
+                    .input_tokens
+                    .max(0)
+                    .saturating_add(agg.output_tokens.max(0))
+                    .saturating_add(agg.cache_read_tokens.max(0))
+                    .saturating_add(agg.cache_creation_tokens.max(0));
+                let mb_total = mb_input
+                    .saturating_add(mb_output)
+                    .saturating_add(mb_cache_read)
+                    .saturating_add(mb_cache_write);
                 if tokens_diverge(mb_total, agg_total) {
                     breakdown_reconciliation_warnings.push(format!(
                         "{} {}: modelBreakdowns sum to {} token(s) but aggregate totals report {}",
@@ -526,6 +531,46 @@ mod tests {
         }
       ]
     }"#;
+
+    #[test]
+    fn extreme_token_counts_saturate_without_panicking() {
+        // Two model breakdowns each at i64::MAX must saturate the per-day
+        // reconciliation accumulators instead of overflowing (debug panic /
+        // release wrap), and must not produce a spurious mismatch warning
+        // when the aggregate totals are equally extreme.
+        let max = i64::MAX;
+        let sample = format!(
+            r#"{{
+              "exportedAt": "2026-07-14T17:45:44.315Z",
+              "profile": {{ "name": "example", "githubUsername": "example" }},
+              "dailyAggregates": [
+                {{
+                  "date": "2026-05-11",
+                  "source": "codex",
+                  "machineId": "m1",
+                  "inputTokens": {max},
+                  "outputTokens": {max},
+                  "modelsUsed": ["gpt-5.5"],
+                  "modelBreakdowns": [
+                    {{ "modelName": "gpt-5.5", "cost": 1.0, "inputTokens": {max},
+                      "outputTokens": 0, "cacheReadTokens": 0, "cacheCreationTokens": 0 }},
+                    {{ "modelName": "gpt-5.5-mini", "cost": 1.0, "inputTokens": {max},
+                      "outputTokens": 0, "cacheReadTokens": 0, "cacheCreationTokens": 0 }}
+                  ]
+                }}
+              ]
+            }}"#
+        );
+
+        let out = parse_clawdboard_export(&sample).unwrap();
+        assert_eq!(out.graph.contributions.len(), 1);
+        assert_eq!(out.graph.contributions[0].totals.tokens, i64::MAX);
+        assert!(
+            out.breakdown_reconciliation_warnings.is_empty(),
+            "saturated totals on both sides must not be reported as divergent: {:?}",
+            out.breakdown_reconciliation_warnings
+        );
+    }
 
     #[test]
     fn parses_dates_and_client_rows() {

--- a/crates/tokscale-core/src/aggregator.rs
+++ b/crates/tokscale-core/src/aggregator.rs
@@ -102,7 +102,12 @@ pub fn aggregate_by_session(messages: Vec<UnifiedMessage>) -> Vec<SessionContrib
 
 /// Calculate summary statistics
 pub fn calculate_summary(contributions: &[DailyContribution]) -> DataSummary {
-    let total_tokens: i64 = contributions.iter().map(|c| c.totals.tokens).sum();
+    // Daily totals already saturate at i64::MAX (clamped extreme inputs), so
+    // summing several such days must saturate too rather than overflow.
+    let total_tokens: i64 = contributions
+        .iter()
+        .map(|c| c.totals.tokens)
+        .fold(0i64, i64::saturating_add);
     let total_cost: f64 = contributions.iter().map(|c| c.totals.cost).sum();
     let active_days = contributions
         .iter()
@@ -162,7 +167,7 @@ pub fn calculate_years(contributions: &[DailyContribution]) -> Vec<YearSummary> 
         }
         let year = &c.date[0..4];
         let entry = years_map.entry(year.to_string()).or_default();
-        entry.tokens += c.totals.tokens;
+        entry.tokens = entry.tokens.saturating_add(c.totals.tokens);
         entry.cost += c.totals.cost;
 
         if entry.start.is_empty() || c.date < entry.start {
@@ -995,6 +1000,32 @@ mod tests {
         assert_eq!(summary.total_days, 3);
         assert_eq!(summary.active_days, 2);
         assert!((summary.average_per_day - 0.65).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_extreme_day_totals_saturate_in_summary_and_years() {
+        // Daily totals clamp extreme inputs to i64::MAX; summing several such
+        // days must saturate rather than overflow (debug panic / release wrap).
+        let saturated_day = |date: &str| DailyContribution {
+            date: date.to_string(),
+            totals: DailyTotals {
+                tokens: i64::MAX,
+                cost: 1.0,
+                messages: 1,
+            },
+            intensity: 0,
+            token_breakdown: TokenBreakdown::default(),
+            clients: Vec::new(),
+            active_time_ms: None,
+        };
+        let contributions = vec![saturated_day("2024-01-01"), saturated_day("2024-01-02")];
+
+        let summary = calculate_summary(&contributions);
+        assert_eq!(summary.total_tokens, i64::MAX);
+
+        let years = calculate_years(&contributions);
+        assert_eq!(years.len(), 1);
+        assert_eq!(years[0].total_tokens, i64::MAX);
     }
 
     #[test]


### PR DESCRIPTION
## Why

Follow-up from the post-merge Codex review of the 2026-07-21 PR batch. Per-day totals deliberately clamp extreme (corrupt-source) values to `i64::MAX` (#929/#927 lineage), which makes saturated daily totals reachable — but three downstream accumulations still used unchecked `i64` arithmetic and overflow once two saturated values meet (panic in debug, wrap to negative in release):

- `calculate_summary` — `.sum::<i64>()` over daily totals
- `calculate_years` — `entry.tokens +=`
- `tokscale import` reconciliation — `mb_* +=` and the `agg_total`/`mb_total` sums

## What

Saturating arithmetic at all three sites (matching the existing convention in `add_row`/`finalize_day`/TUI accumulators), plus regression tests: two `i64::MAX` days through summary+years, and two `i64::MAX` model breakdowns through import reconciliation (also asserting no spurious mismatch warning when both sides saturate equally).

## Validation

`cargo test -p tokscale-core --lib aggregator` (28 passed), `cargo test -p tokscale-cli import` (30+2 passed), `cargo clippy` clean, `cargo fmt` applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents integer overflow when combining saturated daily token totals by using saturating arithmetic in summaries, yearly aggregates, and import reconciliation. This stops debug panics and negative wraps, matching existing per-day clamping.

- **Bug Fixes**
  - `tokscale-core`: Use `saturating_add` for `total_tokens` in `calculate_summary` and yearly token accumulation in `calculate_years`.
  - `tokscale-cli` import: Saturate per-model breakdown accumulators and aggregate totals to avoid overflow and false divergence warnings when both sides saturate.
  - Regression tests added for two `i64::MAX` days and import reconciliation with extreme totals.

<sup>Written for commit 991c32aa1055d45bcc7f5a22c40e40bd5f8e496e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

