### PR TITLE
fix(jcode): avoid double-counting cached input tokens

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -805,7 +805,9 @@ fn parser_version(client: ClientId) -> u32 {
         // v4->v5: jcode's assistant-message timestamp is now back-calculated
         // to the turn start (timestamp - tool_duration_ms) instead of using
         // the recorded (end-anchored) timestamp directly. Follow-up to #890.
-        ClientId::Jcode => 5,
+        // v5->v6: OpenAI-style Jcode usage now removes cache-read overlap from
+        // input_tokens before pricing and aggregation.
+        ClientId::Jcode => 6,
         ClientId::Copilot => 5,
         // Pi subagent sessions now derive agent attribution from session_info
         // names; version-1 caches carry those messages without agent metadata.
@@ -2064,7 +2066,7 @@ mod tests {
         // again here so those stale (start-anchored-but-still-wrong) v2/v1
         // cache entries are also invalidated.
         assert_eq!(parser_version(ClientId::Junie), 2);
-        assert_eq!(parser_version(ClientId::Jcode), 5);
+        assert_eq!(parser_version(ClientId::Jcode), 6);
         assert_eq!(parser_version(ClientId::DevinCli), 3);
         assert_eq!(parser_version(ClientId::Zcode), 3);
         assert_eq!(parser_version(ClientId::OpenCodeReview), 2);

--- a/crates/tokscale-core/src/sessions/jcode.rs
+++ b/crates/tokscale-core/src/sessions/jcode.rs
@@ -71,12 +71,33 @@ fn model_id(model: Option<&str>) -> String {
     }
 }
 
+fn uses_split_cache_accounting(usage: &JcodeTokenUsage, input: i64, cache_read: i64) -> bool {
+    // Jcode stores provider/model only at session scope, so either value may
+    // describe a later route after a mid-session switch. Use message-local usage
+    // shape instead. Anthropic-style reports preserve the cache-creation field
+    // even when its value is zero; OpenAI/OpenRouter cached_tokens omit it and
+    // report cache reads as a subset of input_tokens.
+    usage.cache_creation_input_tokens.is_some() || cache_read > input
+}
+
 fn tokens_from_usage(usage: &JcodeTokenUsage) -> TokenBreakdown {
+    let reported_input = usage.input_tokens.unwrap_or(0).max(0);
+    let cache_read = usage.cache_read_input_tokens.unwrap_or(0).max(0);
+    let cache_write = usage.cache_creation_input_tokens.unwrap_or(0).max(0);
+    let input = if uses_split_cache_accounting(usage, reported_input, cache_read) {
+        reported_input
+    } else {
+        // OpenAI-style APIs report cached tokens as a subset of input_tokens.
+        // Tokscale prices input and cache buckets independently, so remove that
+        // overlap here rather than charging cached reads twice.
+        reported_input.saturating_sub(cache_read.min(reported_input))
+    };
+
     TokenBreakdown {
-        input: usage.input_tokens.unwrap_or(0).max(0),
+        input,
         output: usage.output_tokens.unwrap_or(0).max(0),
-        cache_read: usage.cache_read_input_tokens.unwrap_or(0).max(0),
-        cache_write: usage.cache_creation_input_tokens.unwrap_or(0).max(0),
+        cache_read,
+        cache_write,
         reasoning: usage.reasoning_output_tokens.unwrap_or(0).max(0),
     }
 }
@@ -371,6 +392,74 @@ mod tests {
     }
 
     #[test]
+    fn subtracts_subset_cache_reads_from_openai_input_tokens() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            file.path(),
+            r#"{
+  "id":"session_openai_cache",
+  "provider_key":"openai",
+  "model":"gpt-5.6-sol",
+  "messages":[
+    {"id":"assistant_1","role":"assistant","timestamp":"2026-06-16T12:00:01Z","token_usage":{"input_tokens":19347,"output_tokens":71,"cache_read_input_tokens":15872}}
+  ]
+}"#,
+        )
+        .unwrap();
+
+        let messages = parse_jcode_file(file.path());
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 3_475);
+        assert_eq!(messages[0].tokens.cache_read, 15_872);
+        assert_eq!(messages[0].tokens.output, 71);
+    }
+
+    #[test]
+    fn preserves_split_cache_reads_for_anthropic_input_tokens() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            file.path(),
+            r#"{
+  "id":"session_anthropic_cache",
+  "provider_key":"anthropic-api-key",
+  "model":"claude-sonnet-4-5",
+  "messages":[
+    {"id":"assistant_1","role":"assistant","timestamp":"2026-06-16T12:00:01Z","token_usage":{"input_tokens":20000,"output_tokens":71,"cache_read_input_tokens":15872,"cache_creation_input_tokens":0}}
+  ]
+}"#,
+        )
+        .unwrap();
+
+        let messages = parse_jcode_file(file.path());
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 20_000);
+        assert_eq!(messages[0].tokens.cache_read, 15_872);
+        assert_eq!(messages[0].tokens.output, 71);
+    }
+
+    #[test]
+    fn subtracts_openrouter_cache_for_routed_claude_models() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            file.path(),
+            r#"{
+  "id":"session_openrouter_claude",
+  "provider_key":"openrouter",
+  "model":"anthropic/claude-sonnet-4",
+  "messages":[
+    {"id":"assistant_1","role":"assistant","timestamp":"2026-06-16T12:00:01Z","token_usage":{"input_tokens":1000,"output_tokens":71,"cache_read_input_tokens":800}}
+  ]
+}"#,
+        )
+        .unwrap();
+
+        let messages = parse_jcode_file(file.path());
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 200);
+        assert_eq!(messages[0].tokens.cache_read, 800);
+    }
+
+    #[test]
     fn marks_only_first_assistant_after_user_as_turn_start() {
         let file = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(
@@ -426,7 +515,7 @@ mod tests {
         assert_eq!(messages[0].tokens.input, 100);
         assert_eq!(messages[1].model_id, "journal-model");
         assert_eq!(messages[1].provider_id, "openai");
-        assert_eq!(messages[1].tokens.input, 200);
+        assert_eq!(messages[1].tokens.input, 150);
         assert_eq!(messages[1].tokens.cache_read, 50);
         assert_eq!(
             messages[1].workspace_label.as_deref(),
@@ -519,7 +608,7 @@ mod tests {
         // Exactly one entry for the repeated id (no double-counting).
         assert_eq!(messages.len(), 1);
         // Journal value wins over the stale snapshot value.
-        assert_eq!(messages[0].tokens.input, 900);
+        assert_eq!(messages[0].tokens.input, 860);
         assert_eq!(messages[0].tokens.output, 300);
         assert_eq!(messages[0].tokens.cache_read, 40);
     }


### PR DESCRIPTION
## Summary

- normalize Jcode usage so OpenAI/OpenRouter cached input is not counted again as paid input
- preserve Anthropic-style split accounting using message-local cache-creation presence, including an explicit zero value
- invalidate cached Jcode parse results by bumping the source parser version

## Problem

Jcode stores provider-reported `input_tokens` and cache buckets on assistant messages. OpenAI-style providers report `cache_read_input_tokens` as a subset of `input_tokens`, while Anthropic-style providers report separate buckets. The parser previously copied both fields directly into Tokscale, so cached input was included in the regular input bucket and then charged again through the cache-read bucket.

The normalization intentionally uses message-local usage shape rather than session-level provider/model metadata because Jcode sessions can switch routes and the top-level metadata may describe a later turn.

## Validation

- `cargo test -p tokscale-core`
- Jcode parser regression test run three consecutive times
- frozen local-history comparison: input `492,295,743` → `36,180,031`, cache read remained `456,115,712`, output/message totals were unchanged, and estimated cost changed from `$2,670.69` to `$456.24`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `Jcode` token accounting in `tokscale-core` to stop double-charging cached input for OpenAI/OpenRouter routes, while keeping Anthropic-style split accounting. Also bumps the `Jcode` parser version to invalidate stale caches.

- **Bug Fixes**
  - For OpenAI/OpenRouter-style reports, subtract `cache_read_input_tokens` from `input_tokens` before pricing/aggregation.
  - Preserve Anthropic-style split when `cache_creation_input_tokens` is present (including zero).
  - Use message-local usage shape to handle mid-session route switches.

- **Migration**
  - `Jcode` parser version bumped to v6; existing cached parse results are invalidated automatically.

<sup>Written for commit 4b60cc136de7106d4b99261be5de098faff1a9d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

