### PR TITLE
fix(copilot): preserve duplicate span metadata

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -809,7 +809,8 @@ fn parser_version(client: ClientId) -> u32 {
         // input_tokens before pricing and aggregation.
         ClientId::Jcode => 6,
         // v5->v6: merge same-dedup-key Copilot spans before emitting messages.
-        ClientId::Copilot => 6,
+        // v6->v7: stabilize duplicate agent attribution and partial timing boundaries.
+        ClientId::Copilot => 7,
         // Pi subagent sessions now derive agent attribution from session_info
         // names; version-1 caches carry those messages without agent metadata.
         ClientId::Pi => 2,
@@ -2048,8 +2049,12 @@ mod tests {
     #[test]
     fn test_codex_duration_parser_version_invalidates_v4_entries() {
         assert_eq!(parser_version(ClientId::Codex), 6);
-        assert_eq!(parser_version(ClientId::Copilot), 6);
         assert_eq!(parser_version(ClientId::Claude), 2);
+    }
+
+    #[test]
+    fn test_copilot_duplicate_metadata_parser_version_invalidates_v6_entries() {
+        assert_eq!(parser_version(ClientId::Copilot), 7);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/copilot.rs
+++ b/crates/tokscale-core/src/sessions/copilot.rs
@@ -160,12 +160,22 @@ impl CopilotUsageCandidate {
         });
 
         let duplicate_agent = duplicate.agent.filter(|agent| !agent.is_empty());
-        if duplicate.agent_is_direct && !self.agent_is_direct && duplicate_agent.is_some() {
+        // Direct attribution outranks fallback; equal-authority conflicts use a
+        // stable lexical tie-break so duplicate merging is order-independent.
+        let replace_agent = match (
+            self.agent.as_deref().filter(|agent| !agent.is_empty()),
+            duplicate_agent.as_deref(),
+        ) {
+            (None, Some(_)) => true,
+            (Some(_), Some(_)) if self.agent_is_direct != duplicate.agent_is_direct => {
+                duplicate.agent_is_direct
+            }
+            (Some(current), Some(candidate)) => candidate < current,
+            _ => false,
+        };
+        if replace_agent {
             self.agent = duplicate_agent;
-            self.agent_is_direct = true;
-        } else if self.agent.as_deref().is_none_or(|agent| agent.is_empty()) {
-            self.agent_is_direct = duplicate.agent_is_direct && duplicate_agent.is_some();
-            self.agent = duplicate_agent;
+            self.agent_is_direct = duplicate.agent_is_direct;
         }
     }
 }
@@ -1576,6 +1586,21 @@ mod tests {
         assert_eq!(message.duration_ms, Some(8_000));
         assert_eq!(message.agent.as_deref(), Some("agent-merge"));
         assert_eq!(message.dedup_key.as_deref(), Some("trace-merge:span-merge"));
+    }
+
+    #[test]
+    fn test_parse_copilot_duplicate_direct_agents_are_order_independent() {
+        let first = r#"{"type":"span","traceId":"trace-agent-merge","spanId":"span-agent-merge","name":"chat gpt-5.4-mini","startTime":[1775934260,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.agent.id":"agent-z","gen_ai.usage.input_tokens":100,"gen_ai.usage.output_tokens":10}}"#;
+        let second = r#"{"type":"span","traceId":"trace-agent-merge","spanId":"span-agent-merge","name":"chat gpt-5.4-mini","startTime":[1775934260,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.agent.id":"agent-a","gen_ai.usage.input_tokens":200,"gen_ai.usage.output_tokens":20}}"#;
+        let forward_file = create_test_file(&format!("{first}\n{second}\n"));
+        let reverse_file = create_test_file(&format!("{second}\n{first}\n"));
+
+        let forward = parse_copilot_file(forward_file.path());
+        let reverse = parse_copilot_file(reverse_file.path());
+
+        assert_eq!(forward, reverse);
+        assert_eq!(forward.len(), 1);
+        assert_eq!(forward[0].agent.as_deref(), Some("agent-a"));
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/copilot.rs
+++ b/crates/tokscale-core/src/sessions/copilot.rs
@@ -100,6 +100,8 @@ struct CopilotUsageCandidate {
     session_id: String,
     timestamp_ms: i64,
     duration_ms: Option<i64>,
+    start_timestamp_ms: Option<i64>,
+    end_timestamp_ms: Option<i64>,
     inclusive_input_tokens: i64,
     tokens: TokenBreakdown,
     dedup_key: String,
@@ -144,20 +146,22 @@ impl CopilotUsageCandidate {
             self.tokens.reasoning.max(duplicate.tokens.reasoning),
         );
 
-        let timestamp_ms = self.timestamp_ms.min(duplicate.timestamp_ms);
-        let end_timestamp_ms = self
-            .duration_ms
-            .map(|duration| self.timestamp_ms.saturating_add(duration))
-            .max(
-                duplicate
-                    .duration_ms
-                    .map(|duration| duplicate.timestamp_ms.saturating_add(duration)),
-            );
-        self.timestamp_ms = timestamp_ms;
-        self.duration_ms = end_timestamp_ms.and_then(|end_timestamp_ms| {
-            let duration_ms = end_timestamp_ms.saturating_sub(timestamp_ms);
-            (duration_ms > 0).then_some(duration_ms)
-        });
+        let fallback_timestamp_ms = self.timestamp_ms.min(duplicate.timestamp_ms);
+        let fallback_duration_ms = self.duration_ms.max(duplicate.duration_ms);
+        self.start_timestamp_ms = match (self.start_timestamp_ms, duplicate.start_timestamp_ms) {
+            (Some(current), Some(candidate)) => Some(current.min(candidate)),
+            (current, candidate) => current.or(candidate),
+        };
+        self.end_timestamp_ms = self.end_timestamp_ms.max(duplicate.end_timestamp_ms);
+        self.timestamp_ms = self.start_timestamp_ms.unwrap_or(fallback_timestamp_ms);
+        self.duration_ms = self
+            .start_timestamp_ms
+            .zip(self.end_timestamp_ms)
+            .and_then(|(start_timestamp_ms, end_timestamp_ms)| {
+                let duration_ms = end_timestamp_ms.saturating_sub(start_timestamp_ms);
+                (duration_ms > 0).then_some(duration_ms)
+            })
+            .or(fallback_duration_ms);
 
         let duplicate_agent = duplicate.agent.filter(|agent| !agent.is_empty());
         // Direct attribution outranks fallback; equal-authority conflicts use a
@@ -463,8 +467,21 @@ fn candidate_from_attributes(
         .or(trace_id.as_deref())
         .unwrap_or("unknown-session")
         .to_string();
-    let timestamp_ms = timestamp_ms_from_record(record).unwrap_or(fallback_timestamp);
+    let record_timestamp_ms = timestamp_ms_from_record(record);
+    let timestamp_ms = record_timestamp_ms.unwrap_or(fallback_timestamp);
     let duration_ms = duration_ms_from_record(record);
+    // Preserve explicit interval boundaries separately: an end-only exporter
+    // update uses endTime as its timestamp but must not treat that end as a start.
+    let explicit_start_ms = record.get("startTime").and_then(timestamp_ms_from_value);
+    let explicit_end_ms = record.get("endTime").and_then(timestamp_ms_from_value);
+    let start_timestamp_ms = explicit_start_ms.or_else(|| {
+        record_timestamp_ms.filter(|_| duration_ms.is_some() || explicit_end_ms.is_none())
+    });
+    let end_timestamp_ms = explicit_end_ms.or_else(|| {
+        record_timestamp_ms
+            .zip(duration_ms)
+            .map(|(start, duration)| start.saturating_add(duration))
+    });
     let dedup_key = dedup_key_for_record(
         source,
         record,
@@ -486,6 +503,8 @@ fn candidate_from_attributes(
         session_id,
         timestamp_ms,
         duration_ms,
+        start_timestamp_ms,
+        end_timestamp_ms,
         inclusive_input_tokens: input.max(0),
         tokens,
         dedup_key,
@@ -1589,6 +1608,68 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_copilot_duplicate_uses_end_only_update_for_interval() {
+        let content = concat!(
+            r#"{"type":"span","traceId":"trace-end-update","spanId":"span-end-update","name":"chat gpt-5.4-mini","startTime":[1775934260,0],"endTime":[1775934261,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.usage.input_tokens":100,"gen_ai.usage.output_tokens":10}}"#,
+            "\n",
+            r#"{"type":"span","traceId":"trace-end-update","spanId":"span-end-update","name":"chat gpt-5.4-mini","endTime":[1775934265,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.usage.input_tokens":200,"gen_ai.usage.output_tokens":20}}"#,
+        );
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].timestamp, 1_775_934_260_000);
+        assert_eq!(messages[0].duration_ms, Some(5_000));
+    }
+
+    #[test]
+    fn test_parse_copilot_duplicate_end_only_updates_do_not_invent_duration() {
+        let first = r#"{"type":"span","traceId":"trace-end-only","spanId":"span-end-only","name":"chat gpt-5.4-mini","endTime":[1775934261,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.usage.input_tokens":100,"gen_ai.usage.output_tokens":10}}"#;
+        let second = r#"{"type":"span","traceId":"trace-end-only","spanId":"span-end-only","name":"chat gpt-5.4-mini","endTime":[1775934265,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.usage.input_tokens":200,"gen_ai.usage.output_tokens":20}}"#;
+        let forward_file = create_test_file(&format!("{first}\n{second}\n"));
+        let reverse_file = create_test_file(&format!("{second}\n{first}\n"));
+
+        let forward = parse_copilot_file(forward_file.path());
+        let reverse = parse_copilot_file(reverse_file.path());
+
+        assert_eq!(forward, reverse);
+        assert_eq!(forward.len(), 1);
+        assert_eq!(forward[0].timestamp, 1_775_934_261_000);
+        assert_eq!(forward[0].duration_ms, None);
+    }
+
+    #[test]
+    fn test_parse_copilot_duplicate_fallback_timestamp_is_not_interval_start() {
+        let content = concat!(
+            r#"{"type":"span","traceId":"trace-fallback-time","spanId":"span-fallback-time","name":"chat gpt-5.4-mini","attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.usage.input_tokens":100,"gen_ai.usage.output_tokens":10}}"#,
+            "\n",
+            r#"{"type":"span","traceId":"trace-fallback-time","spanId":"span-fallback-time","name":"chat gpt-5.4-mini","endTime":[4102444800,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.usage.input_tokens":200,"gen_ai.usage.output_tokens":20}}"#,
+        );
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].duration_ms, None);
+    }
+
+    #[test]
+    fn test_parse_copilot_duplicate_duration_only_fallback_is_not_interval_start() {
+        let content = concat!(
+            r#"{"type":"span","traceId":"trace-fallback-duration","spanId":"span-fallback-duration","name":"chat gpt-5.4-mini","duration":[1,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.usage.input_tokens":100,"gen_ai.usage.output_tokens":10}}"#,
+            "\n",
+            r#"{"type":"span","traceId":"trace-fallback-duration","spanId":"span-fallback-duration","name":"chat gpt-5.4-mini","endTime":[4102444800,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.usage.input_tokens":200,"gen_ai.usage.output_tokens":20}}"#,
+        );
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].duration_ms, Some(1_000));
+    }
+
+    #[test]
     fn test_parse_copilot_duplicate_direct_agents_are_order_independent() {
         let first = r#"{"type":"span","traceId":"trace-agent-merge","spanId":"span-agent-merge","name":"chat gpt-5.4-mini","startTime":[1775934260,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.agent.id":"agent-z","gen_ai.usage.input_tokens":100,"gen_ai.usage.output_tokens":10}}"#;
         let second = r#"{"type":"span","traceId":"trace-agent-merge","spanId":"span-agent-merge","name":"chat gpt-5.4-mini","startTime":[1775934260,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.agent.id":"agent-a","gen_ai.usage.input_tokens":200,"gen_ai.usage.output_tokens":20}}"#;
@@ -1687,6 +1768,8 @@ mod tests {
             session_id: "primary-session".to_string(),
             timestamp_ms: 100,
             duration_ms: Some(20),
+            start_timestamp_ms: Some(100),
+            end_timestamp_ms: Some(120),
             inclusive_input_tokens: 40,
             tokens: TokenBreakdown {
                 input: 10,
@@ -1708,6 +1791,8 @@ mod tests {
             session_id: "duplicate-session".to_string(),
             timestamp_ms: 90,
             duration_ms: Some(30),
+            start_timestamp_ms: Some(90),
+            end_timestamp_ms: Some(120),
             inclusive_input_tokens: 60,
             tokens: TokenBreakdown {
                 input: 20,

--- a/crates/tokscale-core/src/sessions/copilot.rs
+++ b/crates/tokscale-core/src/sessions/copilot.rs
@@ -161,7 +161,7 @@ impl CopilotUsageCandidate {
                 let duration_ms = end_timestamp_ms.saturating_sub(start_timestamp_ms);
                 (duration_ms > 0).then_some(duration_ms)
             })
-            .or(fallback_duration_ms);
+            .max(fallback_duration_ms);
 
         let duplicate_agent = duplicate.agent.filter(|agent| !agent.is_empty());
         // Direct attribution outranks fallback; equal-authority conflicts use a
@@ -1667,6 +1667,22 @@ mod tests {
 
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].duration_ms, Some(1_000));
+    }
+
+    #[test]
+    fn test_parse_copilot_duplicate_keeps_larger_duration_only_update() {
+        let interval = r#"{"type":"span","traceId":"trace-duration-update","spanId":"span-duration-update","name":"chat gpt-5.4-mini","startTime":[1775934260,0],"endTime":[1775934261,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.usage.input_tokens":100,"gen_ai.usage.output_tokens":10}}"#;
+        let duration_only = r#"{"type":"span","traceId":"trace-duration-update","spanId":"span-duration-update","name":"chat gpt-5.4-mini","duration":[5,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.usage.input_tokens":200,"gen_ai.usage.output_tokens":20}}"#;
+        let forward_file = create_test_file(&format!("{interval}\n{duration_only}\n"));
+        let reverse_file = create_test_file(&format!("{duration_only}\n{interval}\n"));
+
+        let forward = parse_copilot_file(forward_file.path());
+        let reverse = parse_copilot_file(reverse_file.path());
+
+        assert_eq!(forward, reverse);
+        assert_eq!(forward.len(), 1);
+        assert_eq!(forward[0].timestamp, 1_775_934_260_000);
+        assert_eq!(forward[0].duration_ms, Some(5_000));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Completes the duplicate-span semantics added by #939 for conflicting direct agents and partial timing snapshots.

Equal-authority direct `gen_ai.agent.id` values now use a stable lexical tie-break, while direct attribution continues to outrank trace-level fallback. Each candidate also retains observed start and end boundaries separately from its display timestamp: an end-only exporter update can extend an interval with a valid start, completion timestamps and timestamp-free file-mtime fallback cannot become invented starts, and a larger duration-only update can extend a shorter explicit interval without supplying an absolute start.

The primary candidate's model, provider, session, source, trace, response, and dedup identity remain unchanged, as do the raw-token merge and source-priority semantics from #939. The Copilot parser cache version advances from 6 to 7 so unchanged exporter files cannot replay pre-fix agent or timing metadata.

Fixes #942

## Verification

- Hermetic forward/reverse fixture for conflicting direct agents
- Hermetic full-plus-end-only fixture extending one second to five seconds
- Hermetic forward/reverse end-only fixtures remaining durationless
- Hermetic timestamp-free plus end-only fixture preventing a file-mtime interval
- Hermetic one-second interval plus five-second duration-only update in both record orders
- Parser-version 6 stale-cache rejection and rebuild coverage
- Focused Copilot parser and cache tests
- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-features -- -D warnings`
- `cargo test --locked --workspace --all-features`
- `cargo build --locked --release -p tokscale-cli`
- `git diff --check`
