### PR TITLE
fix: pricing, parser, and TUI fixes from adversarial bug hunt

### DIFF
--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -1020,7 +1020,13 @@ impl DataLoader {
                 .then_with(|| a.session_id.cmp(&b.session_id))
         });
 
-        let total_tokens: u64 = models.iter().map(|m| m.tokens.total()).sum();
+        // Plain `.sum()` panics (debug) / wraps (release) on overflow across
+        // many models; a single corrupt/huge bucket must not poison the
+        // whole total, so fold with saturating_add like `TokenBreakdown::total`.
+        let total_tokens: u64 = models
+            .iter()
+            .map(|m| m.tokens.total())
+            .fold(0u64, u64::saturating_add);
         let total_cost: f64 = models
             .iter()
             .map(|m| if m.cost.is_finite() { m.cost } else { 0.0 })
@@ -1994,6 +2000,40 @@ mod tests {
         assert_eq!(usage.agents[0].message_count, 2);
         assert!((usage.agents[0].cost - 4.0).abs() < f64::EPSILON);
         assert_eq!(usage.agents[0].tokens.total(), 45);
+    }
+
+    #[test]
+    fn total_tokens_saturates_across_corrupt_model_buckets() {
+        let loader = DataLoader::new(None);
+        // Three distinct models each carrying i64::MAX input tokens: no
+        // single model bucket overflows (TokenBreakdown::total saturates
+        // internally), but summing three of them plainly overflows u64.
+        let messages: Vec<UnifiedMessage> = (0..3)
+            .map(|i| {
+                UnifiedMessage::new(
+                    "claude",
+                    format!("model-{i}"),
+                    "anthropic",
+                    format!("session-{i}"),
+                    1_735_689_600_000,
+                    tokscale_core::TokenBreakdown {
+                        input: i64::MAX,
+                        output: 0,
+                        cache_read: 0,
+                        cache_write: 0,
+                        reasoning: 0,
+                    },
+                    0.0,
+                )
+            })
+            .collect();
+
+        let usage = loader
+            .aggregate_messages(messages, &GroupBy::Model)
+            .unwrap();
+
+        assert_eq!(usage.models.len(), 3);
+        assert_eq!(usage.total_tokens, u64::MAX);
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/ui/stats.rs
+++ b/crates/tokscale-cli/src/tui/ui/stats.rs
@@ -222,7 +222,11 @@ fn render_stats_panel(frame: &mut Frame, app: &App, area: Rect) {
                 .flat_map(|w| w.iter())
                 .filter_map(|d| d.as_ref())
                 .map(|d| d.tokens)
-                .sum()
+                // Plain `.sum()` panics (debug) / wraps (release) if a single
+                // corrupt/huge day's token count overflows u64 across the
+                // graph; saturate instead so one bad day doesn't poison the
+                // whole panel's total.
+                .fold(0u64, u64::saturating_add)
         })
         .unwrap_or(0);
 
@@ -670,5 +674,67 @@ fn truncate_model_name(s: &str, max_chars: usize) -> String {
     } else {
         let head: String = s.chars().take(max_chars - 1).collect();
         format!("{}…", head)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::app::TuiConfig;
+    use crate::tui::data::{ContributionDay, GraphData};
+    use chrono::NaiveDate;
+    use ratatui::{backend::TestBackend, Terminal};
+
+    fn make_app() -> App {
+        let config = TuiConfig {
+            theme: "blue".to_string(),
+            refresh: 0,
+            sessions_path: None,
+            clients: None,
+            since: None,
+            until: None,
+            year: None,
+            initial_tab: None,
+        };
+        App::new_with_cached_data(config, None).unwrap()
+    }
+
+    fn corrupt_day(date: NaiveDate) -> ContributionDay {
+        ContributionDay {
+            date,
+            tokens: u64::MAX,
+            cost: 0.0,
+            intensity: 1.0,
+        }
+    }
+
+    #[test]
+    fn saturated_graph_days_render_without_overflowing_total() {
+        let mut app = make_app();
+        // Three days each at u64::MAX: no single day overflows, but a plain
+        // `.sum()` across them does. render_stats_panel must saturate
+        // instead of panicking (debug) or wrapping (release).
+        app.data.graph = Some(GraphData {
+            weeks: vec![vec![
+                Some(corrupt_day(NaiveDate::from_ymd_opt(2026, 5, 27).unwrap())),
+                Some(corrupt_day(NaiveDate::from_ymd_opt(2026, 5, 28).unwrap())),
+                Some(corrupt_day(NaiveDate::from_ymd_opt(2026, 5, 29).unwrap())),
+            ]],
+        });
+
+        let backend = TestBackend::new(80, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_stats_panel(frame, &app, Rect::new(0, 0, 80, 20)))
+            .unwrap();
+
+        let body = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol().to_string())
+            .collect::<String>();
+        assert!(!body.trim().is_empty());
     }
 }

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -813,7 +813,11 @@ fn parser_version(client: ClientId) -> u32 {
         // no longer re-arms pending_turn_start and mints a spurious turn.
         ClientId::Jcode => 7,
         // v5->v6: merge same-dedup-key Copilot spans before emitting messages.
-        ClientId::Copilot => 6,
+        // v6->v7: all-zero trace/span ids (the W3C sentinel for "no recording
+        // span context") are now treated as absent instead of as a real,
+        // shared identity, and a valid span_id alone (no trace_id) is now a
+        // stable dedup key instead of falling through to the line-index key.
+        ClientId::Copilot => 7,
         // Pi subagent sessions now derive agent attribution from session_info
         // names; version-1 caches carry those messages without agent metadata.
         ClientId::Pi => 2,
@@ -2052,7 +2056,7 @@ mod tests {
     #[test]
     fn test_codex_duration_parser_version_invalidates_v4_entries() {
         assert_eq!(parser_version(ClientId::Codex), 6);
-        assert_eq!(parser_version(ClientId::Copilot), 6);
+        assert_eq!(parser_version(ClientId::Copilot), 7);
         assert_eq!(parser_version(ClientId::Claude), 2);
     }
 

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -807,7 +807,11 @@ fn parser_version(client: ClientId) -> u32 {
         // the recorded (end-anchored) timestamp directly. Follow-up to #890.
         // v5->v6: OpenAI-style Jcode usage now removes cache-read overlap from
         // input_tokens before pricing and aggregation.
-        ClientId::Jcode => 6,
+        // v6->v7: the snapshot's messages array is now parsed leniently
+        // (a single wrong-typed token_usage no longer drops the whole
+        // session), and a journal replay of an already-seen user message id
+        // no longer re-arms pending_turn_start and mints a spurious turn.
+        ClientId::Jcode => 7,
         // v5->v6: merge same-dedup-key Copilot spans before emitting messages.
         ClientId::Copilot => 6,
         // Pi subagent sessions now derive agent attribution from session_info
@@ -2067,7 +2071,7 @@ mod tests {
         // again here so those stale (start-anchored-but-still-wrong) v2/v1
         // cache entries are also invalidated.
         assert_eq!(parser_version(ClientId::Junie), 2);
-        assert_eq!(parser_version(ClientId::Jcode), 6);
+        assert_eq!(parser_version(ClientId::Jcode), 7);
         assert_eq!(parser_version(ClientId::DevinCli), 3);
         assert_eq!(parser_version(ClientId::Zcode), 3);
         assert_eq!(parser_version(ClientId::OpenCodeReview), 2);

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -807,10 +807,11 @@ fn parser_version(client: ClientId) -> u32 {
         // the recorded (end-anchored) timestamp directly. Follow-up to #890.
         // v5->v6: OpenAI-style Jcode usage now removes cache-read overlap from
         // input_tokens before pricing and aggregation.
-        // v6->v7: the snapshot's messages array is now parsed leniently
-        // (a single wrong-typed token_usage no longer drops the whole
-        // session), and a journal replay of an already-seen user message id
-        // no longer re-arms pending_turn_start and mints a spurious turn.
+        // v6->v7: snapshot and journal message arrays are now parsed
+        // leniently (a single wrong-typed token_usage no longer drops the
+        // whole session or its journal line), and a journal replay of an
+        // already-seen user message id no longer re-arms pending_turn_start
+        // and mints a spurious turn.
         ClientId::Jcode => 7,
         // v5->v6: merge same-dedup-key Copilot spans before emitting messages.
         // v6->v7: all-zero trace/span ids (the W3C sentinel for "no recording

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -1205,6 +1205,11 @@ fn should_prefer_openai_tiered_litellm(
         && litellm.is_some_and(|result| has_complete_openai_272k_pricing(&result.pricing))
 }
 
+// A fully-absent cache_read pair used to count as "complete" here (only a
+// present-but-partial pair failed), which let the 272k LiteLLM preference
+// fire over an OpenRouter entry that actually had cache-read pricing,
+// silently dropping it. cache_read is now required present+valid like
+// input/output, symmetric with them, for this preference decision only.
 fn has_complete_openai_272k_pricing(pricing: &ModelPricing) -> bool {
     let valid_pair = |base: Option<f64>, above: Option<f64>| {
         base.is_some_and(is_valid_price_value) && above.is_some_and(is_valid_price_value)
@@ -1216,12 +1221,10 @@ fn has_complete_openai_272k_pricing(pricing: &ModelPricing) -> bool {
     ) && valid_pair(
         pricing.output_cost_per_token,
         pricing.output_cost_per_token_above_272k_tokens,
-    ) && pricing.cache_read_input_token_cost.is_none_or(|base| {
-        is_valid_price_value(base)
-            && pricing
-                .cache_read_input_token_cost_above_272k_tokens
-                .is_some_and(is_valid_price_value)
-    })
+    ) && valid_pair(
+        pricing.cache_read_input_token_cost,
+        pricing.cache_read_input_token_cost_above_272k_tokens,
+    )
 }
 
 fn uses_openai_full_request_272k_pricing(result: &LookupResult, provider_id: Option<&str>) -> bool {
@@ -4914,10 +4917,54 @@ mod tests {
             assert!(!has_complete_openai_272k_pricing(&incomplete));
         }
 
+        // A fully-absent cache_read pair is now incomplete too: this used to
+        // pass leniently, letting the 272k preference silently drop an
+        // OpenRouter entry's cache-read pricing (see
+        // openai_272k_preference_prefers_openrouter_cache_read_pricing_over_incomplete_litellm).
         let mut without_cache_read = pricing;
         without_cache_read.cache_read_input_token_cost = None;
         without_cache_read.cache_read_input_token_cost_above_272k_tokens = None;
-        assert!(has_complete_openai_272k_pricing(&without_cache_read));
+        assert!(!has_complete_openai_272k_pricing(&without_cache_read));
+    }
+
+    #[test]
+    fn openai_272k_preference_prefers_openrouter_cache_read_pricing_over_incomplete_litellm() {
+        let mut litellm_pricing = openai_272k_result("gpt-5.6-sol", "LiteLLM").pricing;
+        litellm_pricing.cache_read_input_token_cost = None;
+        litellm_pricing.cache_read_input_token_cost_above_272k_tokens = None;
+
+        let openrouter_pricing = openai_272k_result("openai/gpt-5.6-sol", "OpenRouter").pricing;
+
+        let lookup = PricingLookup::new(
+            HashMap::from([("gpt-5.6-sol".into(), litellm_pricing)]),
+            HashMap::from([("openai/gpt-5.6-sol".into(), openrouter_pricing)]),
+            HashMap::new(),
+        );
+
+        let result = lookup
+            .lookup_with_provider("gpt-5.6-sol", Some("openai"))
+            .unwrap();
+        assert_eq!(result.source, "OpenRouter");
+        assert_eq!(result.matched_key, "openai/gpt-5.6-sol");
+        assert!(result.pricing.cache_read_input_token_cost.is_some());
+    }
+
+    #[test]
+    fn openai_272k_preference_still_prefers_complete_litellm_pricing() {
+        let litellm_pricing = openai_272k_result("gpt-5.6-sol", "LiteLLM").pricing;
+        let openrouter_pricing = openai_272k_result("openai/gpt-5.6-sol", "OpenRouter").pricing;
+
+        let lookup = PricingLookup::new(
+            HashMap::from([("gpt-5.6-sol".into(), litellm_pricing)]),
+            HashMap::from([("openai/gpt-5.6-sol".into(), openrouter_pricing)]),
+            HashMap::new(),
+        );
+
+        let result = lookup
+            .lookup_with_provider("gpt-5.6-sol", Some("openai"))
+            .unwrap();
+        assert_eq!(result.source, "LiteLLM");
+        assert_eq!(result.matched_key, "gpt-5.6-sol");
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -1182,6 +1182,9 @@ fn is_openai_full_request_272k_model(model_id: &str) -> bool {
         "gpt-5.4",
         "gpt-5.4-pro",
         "gpt-5.5",
+        // Priced identically to gpt-5.4-pro in LiteLLM ($30/$180 base,
+        // $60/$270 above 272k) with the same full-request semantics.
+        "gpt-5.5-pro",
         "gpt-5.6",
         "gpt-5.6-sol",
         "gpt-5.6-terra",
@@ -4923,6 +4926,8 @@ mod tests {
             "gpt-5.4",
             "openai/gpt-5.4-pro-2026-03-05",
             "gpt-5.5-2026-04-23",
+            "gpt-5.5-pro",
+            "gpt-5.5-pro-2026-04-23",
             "gpt-5.6",
             "gpt-5.6-sol",
             "gpt-5.6-terra-2026-07-01",
@@ -4940,7 +4945,7 @@ mod tests {
         for key in [
             "gpt-5.4-mini",
             "gpt-5.4-nano",
-            "gpt-5.5-pro",
+            "gpt-5.5-promax",
             "gpt-5.2",
             "fugu-ultra",
             "custom/gpt-5.5-pro",

--- a/crates/tokscale-core/src/sessions/copilot.rs
+++ b/crates/tokscale-core/src/sessions/copilot.rs
@@ -657,24 +657,42 @@ fn is_span_record(value: &Value) -> bool {
     has_name && (has_span_identity || has_span_timing || value.get("kind").is_some())
 }
 
+// A W3C Trace Context id (trace or span) is INVALID when it is all-zero hex
+// (32 zero chars for a trace id, 16 for a span id) — the sentinel a
+// non-recording span context carries. Empty behaves the same way. Records
+// without a recording span context carry these sentinel ids, so treat both
+// as absent rather than as a real (and, worse, shared-with-other-records)
+// identity.
+fn is_valid_span_identity_id(id: &str) -> bool {
+    !id.is_empty() && !id.chars().all(|c| c == '0')
+}
+
 fn trace_id_from_record(value: &Value) -> Option<&str> {
-    value.get("traceId").and_then(Value::as_str).or_else(|| {
-        value
-            .get("spanContext")
-            .and_then(Value::as_object)
-            .and_then(|context| context.get("traceId"))
-            .and_then(Value::as_str)
-    })
+    value
+        .get("traceId")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            value
+                .get("spanContext")
+                .and_then(Value::as_object)
+                .and_then(|context| context.get("traceId"))
+                .and_then(Value::as_str)
+        })
+        .filter(|trace_id| is_valid_span_identity_id(trace_id))
 }
 
 fn span_id_from_record(value: &Value) -> Option<&str> {
-    value.get("spanId").and_then(Value::as_str).or_else(|| {
-        value
-            .get("spanContext")
-            .and_then(Value::as_object)
-            .and_then(|context| context.get("spanId"))
-            .and_then(Value::as_str)
-    })
+    value
+        .get("spanId")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            value
+                .get("spanContext")
+                .and_then(Value::as_object)
+                .and_then(|context| context.get("spanId"))
+                .and_then(Value::as_str)
+        })
+        .filter(|span_id| is_valid_span_identity_id(span_id))
 }
 
 fn parent_span_id_from_record(value: &Value) -> Option<&str> {
@@ -690,7 +708,7 @@ fn parent_span_id_from_record(value: &Value) -> Option<&str> {
         })
         // OTel exporters may emit an empty (or absent) parent for a root span;
         // treat empty as "no parent" so it never matches a real span id.
-        .filter(|parent_span_id| !parent_span_id.is_empty())
+        .filter(|parent_span_id| is_valid_span_identity_id(parent_span_id))
 }
 
 fn dedup_key_for_record(
@@ -708,6 +726,10 @@ fn dedup_key_for_record(
         CopilotUsageSource::ChatSpan | CopilotUsageSource::AgentSummarySpan => {
             match (trace_id, span_id) {
                 (Some(trace_id), Some(span_id)) => format!("{trace_id}:{span_id}"),
+                // No trace id, but a valid span id is still a stable identity
+                // (unlike the line-index fallback below): key on it directly
+                // so duplicate span-id-only snapshots collapse to one entry.
+                (None, Some(span_id)) => format!("span:{session_id}:{span_id}"),
                 _ => format!("span:{session_id}:{timestamp_ms}:{index}"),
             }
         }
@@ -1713,5 +1735,59 @@ mod tests {
         assert_eq!(candidate.tokens.cache_write, 8);
         assert_eq!(candidate.tokens.reasoning, 6);
         assert_eq!(candidate.agent.as_deref(), Some("recovered-agent"));
+    }
+
+    #[test]
+    fn adversarial_zero_span_identity_spans_are_not_collapsed() {
+        // W3C/OTel "invalid" ids are all-zeros. Two UNRELATED chat spans that
+        // both carry the invalid all-zero traceId/spanId must not be merged
+        // into one message: they are distinct requests whose exporter simply
+        // had no recording span context. Expected: 2 messages, totals summed.
+        let content = concat!(
+            r#"{"type":"span","traceId":"00000000000000000000000000000000","spanId":"0000000000000000","name":"chat gpt-5.4-mini","startTime":[1775934260,0],"endTime":[1775934261,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.conversation.id":"conv-zero","gen_ai.usage.input_tokens":100,"gen_ai.usage.output_tokens":10}}"#,
+            "\n",
+            r#"{"type":"span","traceId":"00000000000000000000000000000000","spanId":"0000000000000000","name":"chat claude-sonnet-4.5","startTime":[1775934300,0],"endTime":[1775934301,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"claude-sonnet-4.5","gen_ai.conversation.id":"conv-zero","gen_ai.usage.input_tokens":200,"gen_ai.usage.output_tokens":20}}"#,
+        );
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        let total_input: i64 = messages.iter().map(|m| m.tokens.input).sum();
+        let total_output: i64 = messages.iter().map(|m| m.tokens.output).sum();
+        assert_eq!(
+            (messages.len(), total_input, total_output),
+            (2, 300, 30),
+            "unrelated zero-id spans were collapsed: {:?}",
+            messages
+                .iter()
+                .map(|m| (m.model_id.clone(), m.tokens.input))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn adversarial_spanid_only_duplicates_do_merge() {
+        // Duplicate exporter snapshots of the SAME span (same spanId) that lack
+        // a traceId. Per the #939 intent these should merge into one message,
+        // but the fallback dedup key previously ignored span_id and appended
+        // the line index, so they stayed distinct -> double count.
+        let content = concat!(
+            r#"{"type":"span","spanId":"span-dup","name":"chat gpt-5.4-mini","startTime":[1775934260,0],"endTime":[1775934261,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.conversation.id":"conv-dup","gen_ai.usage.input_tokens":100,"gen_ai.usage.output_tokens":10}}"#,
+            "\n",
+            r#"{"type":"span","spanId":"span-dup","name":"chat gpt-5.4-mini","startTime":[1775934260,0],"endTime":[1775934262,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.conversation.id":"conv-dup","gen_ai.usage.input_tokens":150,"gen_ai.usage.output_tokens":12}}"#,
+        );
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(
+            messages.len(),
+            1,
+            "spanId-only duplicate snapshots were not merged: keys {:?}",
+            messages
+                .iter()
+                .map(|m| m.dedup_key.clone())
+                .collect::<Vec<_>>()
+        );
     }
 }

--- a/crates/tokscale-core/src/sessions/copilot.rs
+++ b/crates/tokscale-core/src/sessions/copilot.rs
@@ -668,47 +668,54 @@ fn is_valid_span_identity_id(id: &str) -> bool {
 }
 
 fn trace_id_from_record(value: &Value) -> Option<&str> {
+    // Filter each candidate individually: a zero/empty top-level sentinel must
+    // fall through to a valid nested `spanContext` id instead of masking it.
     value
         .get("traceId")
         .and_then(Value::as_str)
+        .filter(|trace_id| is_valid_span_identity_id(trace_id))
         .or_else(|| {
             value
                 .get("spanContext")
                 .and_then(Value::as_object)
                 .and_then(|context| context.get("traceId"))
                 .and_then(Value::as_str)
+                .filter(|trace_id| is_valid_span_identity_id(trace_id))
         })
-        .filter(|trace_id| is_valid_span_identity_id(trace_id))
 }
 
 fn span_id_from_record(value: &Value) -> Option<&str> {
     value
         .get("spanId")
         .and_then(Value::as_str)
+        .filter(|span_id| is_valid_span_identity_id(span_id))
         .or_else(|| {
             value
                 .get("spanContext")
                 .and_then(Value::as_object)
                 .and_then(|context| context.get("spanId"))
                 .and_then(Value::as_str)
+                .filter(|span_id| is_valid_span_identity_id(span_id))
         })
-        .filter(|span_id| is_valid_span_identity_id(span_id))
 }
 
 fn parent_span_id_from_record(value: &Value) -> Option<&str> {
+    // OTel exporters may emit an empty, absent, or all-zero parent for a root
+    // span; treat those as "no parent" so they never match a real span id —
+    // filtering each candidate so a top-level sentinel can't mask a valid
+    // nested `spanContext` value.
     value
         .get("parentSpanId")
         .and_then(Value::as_str)
+        .filter(|parent_span_id| is_valid_span_identity_id(parent_span_id))
         .or_else(|| {
             value
                 .get("spanContext")
                 .and_then(Value::as_object)
                 .and_then(|context| context.get("parentSpanId"))
                 .and_then(Value::as_str)
+                .filter(|parent_span_id| is_valid_span_identity_id(parent_span_id))
         })
-        // OTel exporters may emit an empty (or absent) parent for a root span;
-        // treat empty as "no parent" so it never matches a real span id.
-        .filter(|parent_span_id| is_valid_span_identity_id(parent_span_id))
 }
 
 fn dedup_key_for_record(
@@ -1763,6 +1770,33 @@ mod tests {
                 .map(|m| (m.model_id.clone(), m.tokens.input))
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn zero_top_level_ids_fall_through_to_valid_span_context_ids() {
+        // A zero top-level sentinel must not mask a valid nested spanContext
+        // identity: duplicate snapshots of the SAME span, identified only via
+        // spanContext, must still merge instead of falling back to the
+        // line-index key and double counting.
+        let content = concat!(
+            r#"{"type":"span","traceId":"00000000000000000000000000000000","spanId":"0000000000000000","spanContext":{"traceId":"aaaabbbbccccddddaaaabbbbccccdddd","spanId":"1122334455667788"},"name":"chat gpt-5.4-mini","startTime":[1775934260,0],"endTime":[1775934261,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.conversation.id":"conv-ctx","gen_ai.usage.input_tokens":100,"gen_ai.usage.output_tokens":10}}"#,
+            "\n",
+            r#"{"type":"span","traceId":"00000000000000000000000000000000","spanId":"0000000000000000","spanContext":{"traceId":"aaaabbbbccccddddaaaabbbbccccdddd","spanId":"1122334455667788"},"name":"chat gpt-5.4-mini","startTime":[1775934260,0],"endTime":[1775934262,0],"attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"gpt-5.4-mini","gen_ai.conversation.id":"conv-ctx","gen_ai.usage.input_tokens":150,"gen_ai.usage.output_tokens":12}}"#,
+        );
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(
+            messages.len(),
+            1,
+            "duplicate snapshots with valid spanContext ids behind zero top-level ids must merge: keys {:?}",
+            messages
+                .iter()
+                .map(|m| m.dedup_key.clone())
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(messages[0].tokens.input, 150);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/jcode.rs
+++ b/crates/tokscale-core/src/sessions/jcode.rs
@@ -35,8 +35,21 @@ struct JcodeSessionEnvelope {
 #[derive(Debug, Deserialize)]
 struct JcodeJournalEntry {
     meta: Option<JcodeJournalMeta>,
+    // Raw values for the same reason as `JcodeSessionEnvelope::messages`: one
+    // malformed sibling in a journal batch must not drop the line's valid
+    // messages (or its meta).
     #[serde(default)]
-    append_messages: Vec<JcodeMessage>,
+    append_messages: Vec<serde_json::Value>,
+}
+
+/// Parse each raw message independently: a single wrong-typed field (e.g. a
+/// string `token_usage`) must only drop that message, not its whole snapshot
+/// or journal batch, mirroring how kimi/opencodereview skip bad lines.
+fn lenient_jcode_messages(values: Vec<serde_json::Value>) -> Vec<JcodeMessage> {
+    values
+        .into_iter()
+        .filter_map(|value| serde_json::from_value(value).ok())
+        .collect()
 }
 
 #[derive(Debug, Deserialize)]
@@ -284,14 +297,7 @@ pub fn parse_jcode_file(path: &Path) -> Vec<UnifiedMessage> {
         Ok(envelope) => envelope,
         Err(_) => return Vec::new(),
     };
-    // Parse each message independently: a single wrong-typed field (e.g. a
-    // string `token_usage`) must only drop that message, not the whole
-    // session's usage, mirroring how kimi/opencodereview skip bad lines.
-    let messages: Vec<JcodeMessage> = envelope
-        .messages
-        .into_iter()
-        .filter_map(|value| serde_json::from_value(value).ok())
-        .collect();
+    let messages = lenient_jcode_messages(envelope.messages);
     let session = JcodeSession {
         id: envelope.id,
         provider_key: envelope.provider_key,
@@ -357,7 +363,7 @@ pub fn parse_jcode_file(path: &Path) -> Vec<UnifiedMessage> {
                 context.apply_meta(meta);
             }
             let journal_messages = parse_jcode_messages(
-                entry.append_messages,
+                lenient_jcode_messages(entry.append_messages),
                 &mut context,
                 journal_fallback_timestamp,
                 &format!("journal:{line_index}"),
@@ -841,6 +847,41 @@ mod tests {
         let total_output: i64 = messages.iter().map(|m| m.tokens.output).sum();
         assert_eq!(total_input, 300);
         assert_eq!(total_output, 30);
+    }
+
+    #[test]
+    fn one_malformed_journal_sibling_does_not_drop_the_lines_valid_messages() {
+        // Same leniency as the snapshot: a malformed sibling inside a journal
+        // line's append_messages batch must only drop that element, not the
+        // valid messages (or meta) sharing the line.
+        let dir = tempfile::TempDir::new().unwrap();
+        let snapshot = dir.path().join("session_test.json");
+        std::fs::write(
+            &snapshot,
+            r#"{
+  "id":"session_test",
+  "model":"snapshot-model",
+  "messages":[
+    {"id":"assistant_good","role":"assistant","timestamp":"2026-06-16T12:00:01Z","token_usage":{"input_tokens":100,"output_tokens":10}}
+  ]
+}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("session_test.journal.jsonl"),
+            r#"{"append_messages":[{"id":"assistant_journal","role":"assistant","timestamp":"2026-06-16T12:00:03Z","token_usage":{"input_tokens":200,"output_tokens":20}},{"id":"assistant_bad","role":"assistant","timestamp":"2026-06-16T12:00:04Z","token_usage":"corrupt"}]}
+"#,
+        )
+        .unwrap();
+
+        let messages = parse_jcode_file(&snapshot);
+        assert_eq!(
+            messages.len(),
+            2,
+            "a valid journal message must survive a malformed sibling on its line"
+        );
+        let total_input: i64 = messages.iter().map(|m| m.tokens.input).sum();
+        assert_eq!(total_input, 300);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/jcode.rs
+++ b/crates/tokscale-core/src/sessions/jcode.rs
@@ -20,6 +20,18 @@ struct JcodeSession {
     messages: Vec<JcodeMessage>,
 }
 
+/// Same envelope, but with `messages` left as raw JSON so a single malformed
+/// element can be skipped instead of failing the whole snapshot deserialize.
+#[derive(Debug, Deserialize)]
+struct JcodeSessionEnvelope {
+    id: Option<String>,
+    provider_key: Option<String>,
+    model: Option<String>,
+    working_dir: Option<String>,
+    #[serde(default)]
+    messages: Vec<serde_json::Value>,
+}
+
 #[derive(Debug, Deserialize)]
 struct JcodeJournalEntry {
     meta: Option<JcodeJournalMeta>,
@@ -110,6 +122,12 @@ struct JcodeSessionContext {
     workspace_key: Option<String>,
     workspace_label: Option<String>,
     pending_turn_start: bool,
+    // User messages never carry `token_usage`, so they never enter
+    // `index_by_dedup_key`/`known_dedup_keys` (which only track messages
+    // that were emitted). This seen-set spans the snapshot and journal
+    // passes so a journal replay of an already-seen user id can't re-arm
+    // `pending_turn_start` and mint a spurious extra turn.
+    seen_user_dedup_keys: std::collections::HashSet<String>,
 }
 
 impl JcodeSessionContext {
@@ -126,6 +144,7 @@ impl JcodeSessionContext {
             workspace_key,
             workspace_label,
             pending_turn_start: false,
+            seen_user_dedup_keys: std::collections::HashSet::new(),
         }
     }
 
@@ -193,8 +212,12 @@ fn parse_jcode_messages(
             // None for the snapshot pass, so snapshot parsing is unchanged.
             let is_replacement = known_dedup_keys.is_some_and(|keys| keys.contains_key(&dedup_key));
 
-            if !is_replacement && message.role.as_deref() == Some("user") {
-                context.pending_turn_start = true;
+            if message.role.as_deref() == Some("user") {
+                // Only a user id not already seen (snapshot or journal) arms a
+                // new turn; a replay of the same id is turn-neutral.
+                if context.seen_user_dedup_keys.insert(dedup_key.clone()) {
+                    context.pending_turn_start = true;
+                }
             }
 
             let usage = message.token_usage?;
@@ -257,9 +280,24 @@ pub fn parse_jcode_file(path: &Path) -> Vec<UnifiedMessage> {
         Ok(data) => data,
         Err(_) => return Vec::new(),
     };
-    let session: JcodeSession = match simd_json::from_slice(&mut data) {
-        Ok(session) => session,
+    let envelope: JcodeSessionEnvelope = match simd_json::from_slice(&mut data) {
+        Ok(envelope) => envelope,
         Err(_) => return Vec::new(),
+    };
+    // Parse each message independently: a single wrong-typed field (e.g. a
+    // string `token_usage`) must only drop that message, not the whole
+    // session's usage, mirroring how kimi/opencodereview skip bad lines.
+    let messages: Vec<JcodeMessage> = envelope
+        .messages
+        .into_iter()
+        .filter_map(|value| serde_json::from_value(value).ok())
+        .collect();
+    let session = JcodeSession {
+        id: envelope.id,
+        provider_key: envelope.provider_key,
+        model: envelope.model,
+        working_dir: envelope.working_dir,
+        messages,
     };
 
     let session_id = session.id.clone().unwrap_or_else(|| {
@@ -766,6 +804,81 @@ mod tests {
         assert!(messages[1].is_turn_start);
         let turn_count = messages.iter().filter(|m| m.is_turn_start).count();
         assert_eq!(turn_count, 2);
+    }
+
+    #[test]
+    fn one_malformed_token_usage_does_not_drop_the_whole_session() {
+        // A single malformed message (token_usage as a string) must not nuke
+        // every other valid message in the snapshot (and its journal).
+        let dir = tempfile::TempDir::new().unwrap();
+        let snapshot = dir.path().join("session_test.json");
+        std::fs::write(
+            &snapshot,
+            r#"{
+  "id":"session_test",
+  "model":"snapshot-model",
+  "messages":[
+    {"id":"assistant_good","role":"assistant","timestamp":"2026-06-16T12:00:01Z","token_usage":{"input_tokens":100,"output_tokens":10}},
+    {"id":"assistant_bad","role":"assistant","timestamp":"2026-06-16T12:00:02Z","token_usage":"corrupt"}
+  ]
+}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("session_test.journal.jsonl"),
+            r#"{"append_messages":[{"id":"assistant_journal","role":"assistant","timestamp":"2026-06-16T12:00:03Z","token_usage":{"input_tokens":200,"output_tokens":20}}]}
+"#,
+        )
+        .unwrap();
+
+        let messages = parse_jcode_file(&snapshot);
+        assert_eq!(
+            messages.len(),
+            2,
+            "valid snapshot + journal messages must survive one malformed sibling"
+        );
+        let total_input: i64 = messages.iter().map(|m| m.tokens.input).sum();
+        let total_output: i64 = messages.iter().map(|m| m.tokens.output).sum();
+        assert_eq!(total_input, 300);
+        assert_eq!(total_output, 30);
+    }
+
+    #[test]
+    fn journal_full_turn_replay_does_not_double_count_turns() {
+        // The journal replays a whole already-snapshotted turn (user + assistant
+        // correction), then appends a follow-up assistant step of the SAME turn.
+        // The user replay must not re-arm pending_turn_start: assistant ids are
+        // guarded via known_dedup_keys, but user messages never enter the index
+        // (no usage), so their replay is indistinguishable from a new turn.
+        let dir = tempfile::TempDir::new().unwrap();
+        let snapshot = dir.path().join("session_test.json");
+        std::fs::write(
+            &snapshot,
+            r#"{
+  "id":"session_test",
+  "model":"snapshot-model",
+  "messages":[
+    {"id":"user_1","role":"user","timestamp":"2026-06-16T12:00:00Z"},
+    {"id":"assistant_1","role":"assistant","timestamp":"2026-06-16T12:00:01Z","token_usage":{"input_tokens":100,"output_tokens":10}}
+  ]
+}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("session_test.journal.jsonl"),
+            r#"{"append_messages":[{"id":"user_1","role":"user","timestamp":"2026-06-16T12:00:00Z"},{"id":"assistant_1","role":"assistant","timestamp":"2026-06-16T12:00:01Z","token_usage":{"input_tokens":150,"output_tokens":15}}]}
+{"append_messages":[{"id":"assistant_1b","role":"assistant","timestamp":"2026-06-16T12:00:04Z","token_usage":{"input_tokens":50,"output_tokens":5}}]}
+"#,
+        )
+        .unwrap();
+
+        let messages = parse_jcode_file(&snapshot);
+        assert_eq!(messages.len(), 2);
+        let turn_count = messages.iter().filter(|m| m.is_turn_start).count();
+        assert_eq!(
+            turn_count, 1,
+            "a replayed user message must not mint a second turn"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to the 2026-07-22 PR batch (#936 / #937 / #939). One pricing-data gap found during that review, plus four findings from a six-lens adversarial bug hunt over recently merged code (each reproduced with a failing test by the finder and independently confirmed by two verifiers before being fixed here). Lower-severity findings from the same hunt are tracked in #941.

## Commits

- **`fix(pricing): include gpt-5.5-pro in 272k full-request repricing`** — `gpt-5.5-pro` carries the same above-272k tiers in LiteLLM as the already-listed `gpt-5.4-pro` ($60/$270 vs $30/$180 base) but was missing from the full-request family list in #936, so its long-context requests were underpriced ~2x. Adds it (plus a `gpt-5.5-promax` prefix-collision guard in the scope test). The `gpt-5.6-*-pro` ids are absent from LiteLLM entirely, so there is nothing to add for them.
- **`fix(jcode): parse messages leniently and stop replay from double-arming turns`** — one wrong-typed field (e.g. a string `token_usage`) in a snapshot previously failed the single strict whole-file deserialize and silently dropped the entire session's usage, journal included. Messages are now parsed per-element with bad elements skipped, matching kimi/opencodereview. Also: a journal replay of an already-seen user message no longer re-arms `pending_turn_start` and mints a spurious extra turn. Jcode parser_version 6→7.
- **`fix(copilot): treat all-zero trace/span ids as absent and dedup on span_id alone`** — the W3C invalid sentinel (all-zero trace/span ids, carried by records emitted without a recording span context) was treated as a real shared identity, so #939's merge collapsed unrelated spans into one message (silent undercount + model misattribution). Zero/empty ids are now filtered to `None` at extraction (parent id included). Also: a valid `spanId` without a `traceId` (a supported VS Code record shape) is now a stable dedup key instead of falling through to the line-index fallback, so spanId-only duplicate snapshots merge as #939 intended. Copilot parser_version 6→7.
- **`fix(pricing): require cache-read pricing for the 272k LiteLLM preference`** — a LiteLLM entry with no cache-read pricing at all still counted as "complete", letting the 272k preference beat an OpenRouter entry that had cache-read pricing — pricing cache reads at $0 for every request of that model. The preference now requires a valid cache-read pair, symmetric with input/output; per-bucket repricing leniency is unchanged.
- **`fix(tui): saturate cross-model and cross-day token totals in stats panel`** — two plain `.sum()` rollups (TUI header/export total and Stats-tab graph total) missed by the ca834052 saturation sweep; they panic in debug / wrap in release once per-bucket totals saturate at `u64::MAX` from corrupt sources. Both now fold with `saturating_add`.

## Interaction with #943

#943 (Nanako0129's own follow-up to #939) also bumps Copilot parser_version 6→7. Whichever lands second needs to bump to 8 instead — otherwise caches written between the two merges would not be invalidated for the later change's behavior. The `copilot.rs` changes themselves touch different functions (id extraction + dedup key here; merge metadata/timing there) and should compose.

## Verification

- `cargo test -p tokscale-core`: 1254 passed (+6 new regression tests) across all binaries
- `cargo test -p tokscale-cli`: 905 + 133 passed (+2 new tests)
- `cargo clippy --workspace --all-targets --no-deps`: clean
- Each fix's regression test was reproduced failing on unfixed code by the hunt finder and re-reproduced independently by two adversarial verifiers
- CACHE_FORMAT_VERSION stays 3 (no serialized-layout change); the pricing changes need no parser_version bump (costs are repriced from live PricingService on cache hit)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 272k pricing for `gpt-5.5-pro`, hardens Copilot/Jcode parsing (including lenient journal handling and better span identity extraction), and saturates TUI totals to avoid overflow.

- **Bug Fixes**
  - Pricing: add `gpt-5.5-pro` to OpenAI 272k full‑request repricing; require cache‑read pricing for the 272k `LiteLLM` preference so `OpenRouter` wins when it has valid cache‑read rates.
  - Copilot parser: treat all‑zero `traceId`/`spanId` as absent, accept valid `spanContext` ids when top‑level ids are zero, and dedup by `spanId` when `traceId` is missing; parser_version → 7.
  - Jcode parser: parse snapshot and journal message arrays per‑element and skip malformed ones; stop journal replay of a user message from starting a new turn; parser_version → 7.
  - TUI: use saturating adds for cross‑model and cross‑day token totals in the header and stats graph to prevent overflow.

<sup>Written for commit 9c66ec1a44dfcfe6d05f13c802c19a0ff3050560. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

