### PR TITLE
fix(submit): let complete-day resubmits heal alias-folded double counts

### DIFF
--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -625,6 +625,7 @@ describe("POST /api/submit auth path", () => {
     mockState.mergeClientBreakdownsWithRegressionGuard.mockReturnValue({
       merged: mergedBreakdown,
       warnings: [],
+      foldPreservedClients: new Set<string>(),
     });
     mockState.recalculateDayTotals.mockReturnValue({
       tokens: 15,
@@ -987,6 +988,7 @@ describe("POST /api/submit auth path", () => {
     mockState.mergeClientBreakdownsWithRegressionGuard.mockReturnValue({
       merged: mergedBreakdown,
       warnings: [],
+      foldPreservedClients: new Set<string>(),
     });
     mockState.recalculateDayTotals.mockReturnValue({
       tokens: 15,
@@ -1383,6 +1385,7 @@ describe("POST /api/submit auth path", () => {
     mockState.mergeClientBreakdownsWithRegressionGuard.mockReturnValue({
       merged: mergedBreakdown,
       warnings: [],
+      foldPreservedClients: new Set<string>(),
     });
     mockState.recalculateDayTotals.mockReturnValue({
       tokens: 15,
@@ -1561,6 +1564,7 @@ describe("POST /api/submit auth path", () => {
     mockState.mergeClientBreakdownsWithRegressionGuard.mockReturnValue({
       merged: mergedBreakdown,
       warnings: [],
+      foldPreservedClients: new Set<string>(),
     });
     mockState.recalculateDayTotals.mockReturnValue({
       tokens: 15,

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -720,6 +720,7 @@ describe("POST /api/submit auth path", () => {
           },
         },
       },
+      expect.any(Set),
       expect.any(Set)
     );
     expect(await response.json()).toEqual(expect.objectContaining({
@@ -1100,6 +1101,7 @@ describe("POST /api/submit auth path", () => {
           },
         },
       },
+      expect.any(Set),
       expect.any(Set)
     );
     expect(await response.json()).toEqual(expect.objectContaining({
@@ -1648,6 +1650,7 @@ describe("POST /api/submit auth path", () => {
     expect(mockState.mergeClientBreakdownsWithRegressionGuard).toHaveBeenCalledWith(
       legacyBreakdown,
       incomingBreakdownWithProvenance,
+      expect.any(Set),
       expect.any(Set)
     );
     expect(await response.json()).toEqual(expect.objectContaining({

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -721,7 +721,7 @@ describe("POST /api/submit auth path", () => {
         },
       },
       expect.any(Set),
-      expect.any(Set)
+      expect.any(Map)
     );
     expect(await response.json()).toEqual(expect.objectContaining({
       success: true,
@@ -1102,7 +1102,7 @@ describe("POST /api/submit auth path", () => {
         },
       },
       expect.any(Set),
-      expect.any(Set)
+      expect.any(Map)
     );
     expect(await response.json()).toEqual(expect.objectContaining({
       success: true,
@@ -1651,7 +1651,7 @@ describe("POST /api/submit auth path", () => {
       legacyBreakdown,
       incomingBreakdownWithProvenance,
       expect.any(Set),
-      expect.any(Set)
+      expect.any(Map)
     );
     expect(await response.json()).toEqual(expect.objectContaining({
       success: true,

--- a/packages/frontend/__tests__/api/submitKilocodeFoldRepro.test.ts
+++ b/packages/frontend/__tests__/api/submitKilocodeFoldRepro.test.ts
@@ -1,0 +1,390 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// REPRO + FIX VERIFICATION: interplay of the #886 kilocode->kilo alias fold
+// with the #611/#910 token-regression guard on the existing-day merge path
+// in POST /api/submit.
+//
+// Precondition (the exact state #886 set out to heal): a stored
+// daily_breakdown row carries BOTH a stale "kilocode" key and a "kilo" key
+// for the SAME underlying usage (double-counted, per the comment in
+// route.ts). Before this fix, normalizeClientBreakdownAliases folded them by
+// SUMMING into one "kilo" entry (100 + 100 = 200), and
+// mergeClientBreakdownsWithRegressionGuard then compared the incoming
+// full-day "kilo" contribution (100) against the folded sum (200). Because
+// 100 < 200, the guard preserved the double-counted 200 forever and emitted
+// a misleading parser-regression warning on every resubmit.
+//
+// The fix: normalizeClientBreakdownAliases now reports which canonical keys
+// absorbed multiple raw source keys (foldedClients), and the merge guard
+// lets a complete-day incoming submission for a folded client REPLACE the
+// fold instead of defending it.
+//
+// This test uses the REAL @/lib/db/helpers implementations (not mocks) and
+// asserts the healed value.
+const mockState = vi.hoisted(() => {
+  const authenticatePersonalToken = vi.fn();
+  const validateSubmission = vi.fn();
+  const generateSubmissionHash = vi.fn(() => "submission-hash");
+  const revalidateTag = vi.fn();
+  const revalidateUsernamePaths = vi.fn();
+  const revalidateUserGroupLeaderboards = vi.fn();
+  const db = { transaction: vi.fn() };
+  return {
+    authenticatePersonalToken,
+    validateSubmission,
+    generateSubmissionHash,
+    revalidateTag,
+    revalidateUsernamePaths,
+    revalidateUserGroupLeaderboards,
+    db,
+    reset() {
+      authenticatePersonalToken.mockReset();
+      validateSubmission.mockReset();
+      generateSubmissionHash.mockClear();
+      revalidateTag.mockClear();
+      revalidateUsernamePaths.mockReset();
+      revalidateUserGroupLeaderboards.mockReset();
+      db.transaction.mockReset();
+    },
+  };
+});
+
+vi.mock("next/cache", () => ({ revalidateTag: mockState.revalidateTag }));
+
+vi.mock("@/lib/auth/personalTokens", () => ({
+  authenticatePersonalToken: mockState.authenticatePersonalToken,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockState.db,
+  apiTokens: { id: "apiTokens.id" },
+  submissions: {
+    id: "submissions.id",
+    userId: "submissions.userId",
+    totalTokens: "submissions.totalTokens",
+    totalCost: "submissions.totalCost",
+    inputTokens: "submissions.inputTokens",
+    outputTokens: "submissions.outputTokens",
+    cacheCreationTokens: "submissions.cacheCreationTokens",
+    cacheReadTokens: "submissions.cacheReadTokens",
+    reasoningTokens: "submissions.reasoningTokens",
+    dateStart: "submissions.dateStart",
+    dateEnd: "submissions.dateEnd",
+    sourcesUsed: "submissions.sourcesUsed",
+    modelsUsed: "submissions.modelsUsed",
+    cliVersion: "submissions.cliVersion",
+    submissionHash: "submissions.submissionHash",
+    schemaVersion: "submissions.schemaVersion",
+    hasBackfill: "submissions.hasBackfill",
+  },
+  submittedDevices: {
+    id: "submittedDevices.id",
+    userId: "submittedDevices.userId",
+    deviceKey: "submittedDevices.deviceKey",
+    displayName: "submittedDevices.displayName",
+    lastSubmittedAt: "submittedDevices.lastSubmittedAt",
+    updatedAt: "submittedDevices.updatedAt",
+  },
+  dailyBreakdown: {
+    id: "dailyBreakdown.id",
+    submissionId: "dailyBreakdown.submissionId",
+    submittedDeviceId: "dailyBreakdown.submittedDeviceId",
+    date: "dailyBreakdown.date",
+    timestampMs: "dailyBreakdown.timestampMs",
+    activeTimeMs: "dailyBreakdown.activeTimeMs",
+    sourceBreakdown: "dailyBreakdown.sourceBreakdown",
+    tokens: "dailyBreakdown.tokens",
+    cost: "dailyBreakdown.cost",
+    inputTokens: "dailyBreakdown.inputTokens",
+    outputTokens: "dailyBreakdown.outputTokens",
+  },
+}));
+
+vi.mock("@/lib/validation/submission", () => ({
+  validateSubmission: mockState.validateSubmission,
+  generateSubmissionHash: mockState.generateSubmissionHash,
+}));
+
+// NOTE: @/lib/db/helpers is intentionally NOT mocked -- the real merge/fold
+// logic is under test.
+
+vi.mock("@/lib/db/usernameLookup", () => ({
+  normalizeUsernameCacheKey: (username: string) => username.toLowerCase(),
+  revalidateUsernamePaths: mockState.revalidateUsernamePaths,
+}));
+
+vi.mock("@/lib/groups/cache", () => ({
+  revalidateUserGroupLeaderboards: mockState.revalidateUserGroupLeaderboards,
+}));
+
+type ModuleExports = typeof import("../../src/app/api/submit/route");
+let POST: ModuleExports["POST"];
+
+beforeAll(async () => {
+  const routeModule = await import("../../src/app/api/submit/route");
+  POST = routeModule.POST;
+});
+
+beforeEach(() => {
+  mockState.reset();
+});
+
+function makeAwaitableBuilder(result: unknown) {
+  const builder = {
+    from: vi.fn(() => builder),
+    where: vi.fn(() => builder),
+    for: vi.fn(() => builder),
+    limit: vi.fn(() => builder),
+    then: (resolve: (value: unknown) => unknown) => Promise.resolve(resolve(result)),
+  };
+  return builder;
+}
+
+/** Recursively collect every string reachable from a value (cycle-safe). */
+function collectStrings(node: unknown, out: string[], seen = new Set<object>()): void {
+  if (typeof node === "string") {
+    out.push(node);
+    return;
+  }
+  if (!node || typeof node !== "object") return;
+  if (seen.has(node as object)) return;
+  seen.add(node as object);
+  if (Array.isArray(node)) {
+    for (const item of node) collectStrings(item, out, seen);
+    return;
+  }
+  for (const value of Object.values(node as Record<string, unknown>)) {
+    collectStrings(value, out, seen);
+  }
+}
+
+const CLIENT_ENTRY_100 = {
+  tokens: 100,
+  cost: 1,
+  input: 100,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  reasoning: 0,
+  messages: 5,
+  models: {
+    "test-model": {
+      tokens: 100,
+      cost: 1,
+      input: 100,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      reasoning: 0,
+      messages: 5,
+    },
+  },
+};
+
+const AGGREGATES_ROW = {
+  totalTokens: 100,
+  totalCost: "1.0000",
+  inputTokens: 100,
+  outputTokens: 0,
+  dateStart: "2026-05-11",
+  dateEnd: "2026-05-11",
+  activeDays: 1,
+  totalActiveTimeMs: 0,
+  rowCount: 1,
+};
+
+function buildTx(selectResults: unknown[][]) {
+  const executedSqlArgs: unknown[] = [];
+  const tx = {
+    update: vi.fn(() => {
+      const builder = {
+        set: vi.fn(() => builder),
+        where: vi.fn(() => Promise.resolve()),
+      };
+      return builder;
+    }),
+    select: vi.fn(() => makeAwaitableBuilder(selectResults.shift() ?? [])),
+    insert: vi.fn(() => {
+      const builder = {
+        values: vi.fn(() => builder),
+        onConflictDoUpdate: vi.fn(() => builder),
+        returning: vi.fn(() => Promise.resolve([{ id: "submitted-device-1" }])),
+      };
+      return builder;
+    }),
+    execute: vi.fn((sqlArg: unknown) => {
+      executedSqlArgs.push(sqlArg);
+      return Promise.resolve();
+    }),
+    transaction: vi.fn(async (callback: (sp: typeof tx) => Promise<unknown>) =>
+      callback(tx)
+    ),
+  };
+  mockState.db.transaction.mockImplementation(
+    async (callback: (transaction: typeof tx) => Promise<unknown>) => callback(tx)
+  );
+  return { tx, executedSqlArgs };
+}
+
+function mockKiloResubmit() {
+  mockState.authenticatePersonalToken.mockResolvedValue({
+    status: "valid",
+    tokenId: "token-1",
+    userId: "user-1",
+    username: "alice",
+    displayName: "Alice",
+    avatarUrl: null,
+    expiresAt: null,
+  });
+
+  // Incoming: the new CLI reports the COMPLETE day for kilo -- 100 tokens.
+  mockState.validateSubmission.mockReturnValue({
+    valid: true,
+    errors: [],
+    warnings: [],
+    data: {
+      device: { id: "dev_1", name: "Device one" },
+      meta: {
+        generatedAt: "2026-05-11T00:00:00Z",
+        version: "4.6.0",
+        dateRange: { start: "2026-05-11", end: "2026-05-11" },
+      },
+      summary: { clients: ["kilo"] },
+      years: [],
+      contributions: [
+        {
+          date: "2026-05-11",
+          clients: [
+            {
+              client: "kilo",
+              modelId: "test-model",
+              tokens: { input: 100, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+              cost: 1,
+              messages: 5,
+            },
+          ],
+        },
+      ],
+    },
+  });
+}
+
+describe("POST /api/submit kilocode alias fold vs regression guard", () => {
+  it("a full-day kilo resubmit heals a stored kilocode+kilo double-counted day back to the incoming total", async () => {
+    mockKiloResubmit();
+
+    // Stored day: the pre-#886 double-count state -- the SAME 100-token day
+    // written once under the legacy "kilocode" key and once under "kilo".
+    const existingDay = {
+      id: "day-1",
+      date: "2026-05-11",
+      timestampMs: null,
+      activeTimeMs: null,
+      sourceBreakdown: {
+        kilocode: structuredClone(CLIENT_ENTRY_100),
+        kilo: structuredClone(CLIENT_ENTRY_100),
+      },
+    };
+
+    const { tx, executedSqlArgs } = buildTx([
+      [{ id: "submission-existing" }],
+      [existingDay],
+      [AGGREGATES_ROW],
+      [{ sourceBreakdown: existingDay.sourceBreakdown }],
+    ]);
+    void tx;
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ meta: {}, contributions: [] }),
+      })
+    );
+    expect(response.status).toBe(200);
+
+    // Pull the merged source_breakdown JSON out of the batched raw UPDATE.
+    const strings: string[] = [];
+    for (const arg of executedSqlArgs) collectStrings(arg, strings);
+    const breakdownJson = strings.find((s) => s.includes('"kilo"'));
+    expect(breakdownJson).toBeDefined();
+    const merged = JSON.parse(breakdownJson!) as Record<
+      string,
+      { tokens: number }
+    >;
+
+    // The stale legacy key must be gone either way.
+    expect(merged).not.toHaveProperty("kilocode");
+
+    // HEALED semantics (what #886's fold exists to produce): the complete
+    // incoming kilo day replaces the double-counted fold. Before this fix
+    // this was 200 -- the fold summed kilocode+kilo to 200, then the
+    // regression guard saw incoming 100 < 200 and preserved the inflated
+    // value forever, emitting a parser-regression warning every resubmit.
+    expect(merged.kilo.tokens).toBe(100);
+
+    const body = await response.json();
+    const warnings: string[] = body.warnings ?? [];
+    // No misleading parser-regression warning should be emitted for the
+    // healed alias fold.
+    expect(warnings.join(" ")).not.toMatch(/would reduce/i);
+  });
+
+  it("still guards a rename-only kilocode fold (no kilo key present) against a token decrease", async () => {
+    mockKiloResubmit();
+
+    // Stored day: a PURE rename -- only the legacy "kilocode" key exists,
+    // nothing to fold it with. This must NOT be treated as a suspect
+    // double count; the normal regression guard should still defend it.
+    const existingDay = {
+      id: "day-1",
+      date: "2026-05-11",
+      timestampMs: null,
+      activeTimeMs: null,
+      sourceBreakdown: {
+        kilocode: { ...structuredClone(CLIENT_ENTRY_100), tokens: 500, input: 500 },
+      },
+    };
+
+    const { tx, executedSqlArgs } = buildTx([
+      [{ id: "submission-existing" }],
+      [existingDay],
+      [{ ...AGGREGATES_ROW, totalTokens: 500 }],
+      [{ sourceBreakdown: existingDay.sourceBreakdown }],
+    ]);
+    void tx;
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ meta: {}, contributions: [] }),
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const strings: string[] = [];
+    for (const arg of executedSqlArgs) collectStrings(arg, strings);
+    const breakdownJson = strings.find((s) => s.includes('"kilo"'));
+    expect(breakdownJson).toBeDefined();
+    const merged = JSON.parse(breakdownJson!) as Record<
+      string,
+      { tokens: number }
+    >;
+
+    // A 100-token incoming resubmit against a 500-token rename-only existing
+    // value is a genuine decrease -- the guard must preserve it, unchanged
+    // from pre-fix behavior.
+    expect(merged.kilo.tokens).toBe(500);
+
+    const body = await response.json();
+    const warnings: string[] = body.warnings ?? [];
+    expect(warnings.join(" ")).toMatch(/would reduce/i);
+  });
+});

--- a/packages/frontend/__tests__/api/submitKilocodeFoldRepro.test.ts
+++ b/packages/frontend/__tests__/api/submitKilocodeFoldRepro.test.ts
@@ -410,13 +410,69 @@ describe("POST /api/submit kilocode alias fold vs regression guard", () => {
       { tokens: number }
     >;
 
-    // The fold is preserved (still inflated) rather than undercounted; a
-    // later complete-day resubmit at/above the 100-token floor will heal it.
-    expect(merged.kilo.tokens).toBe(200);
+    // The fold is preserved (still inflated in total) rather than
+    // undercounted — and critically, the RAW alias keys survive the
+    // writeback. Persisting the collapsed {kilo: 200} here would make the
+    // heal window one-shot: the floor is derived from the raw keys, so the
+    // next truthful complete-day resubmit could never heal the day again.
+    expect(merged.kilocode.tokens).toBe(100);
+    expect(merged.kilo.tokens).toBe(100);
 
     const body = await response.json();
     const warnings: string[] = body.warnings ?? [];
     expect(warnings.join(" ")).toMatch(/would reduce/i);
+  });
+
+  it("still heals after an intervening partial resubmit (heal window is not one-shot)", async () => {
+    // Step 1 (simulated by the previous test's semantics): a below-floor
+    // partial resubmit preserved the fold, writing the RAW keys back. Step 2
+    // (this test): the stored day still carries both raw keys, so a later
+    // truthful complete-day 100-token resubmit must still heal to 100.
+    mockKiloResubmit();
+
+    const existingDay = {
+      id: "day-1",
+      date: "2026-05-11",
+      timestampMs: null,
+      activeTimeMs: null,
+      // Exactly what the partial-resubmit writeback now persists.
+      sourceBreakdown: {
+        kilocode: structuredClone(CLIENT_ENTRY_100),
+        kilo: structuredClone(CLIENT_ENTRY_100),
+      },
+    };
+
+    const { tx, executedSqlArgs } = buildTx([
+      [{ id: "submission-existing" }],
+      [existingDay],
+      [AGGREGATES_ROW],
+      [{ sourceBreakdown: existingDay.sourceBreakdown }],
+    ]);
+    void tx;
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ meta: {}, contributions: [] }),
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const strings: string[] = [];
+    for (const arg of executedSqlArgs) collectStrings(arg, strings);
+    const breakdownJson = strings.find((s) => s.includes('"kilo"'));
+    expect(breakdownJson).toBeDefined();
+    const merged = JSON.parse(breakdownJson!) as Record<
+      string,
+      { tokens: number }
+    >;
+
+    expect(merged).not.toHaveProperty("kilocode");
+    expect(merged.kilo.tokens).toBe(100);
   });
 
   it("still guards a rename-only kilocode fold (no kilo key present) against a token decrease", async () => {

--- a/packages/frontend/__tests__/api/submitKilocodeFoldRepro.test.ts
+++ b/packages/frontend/__tests__/api/submitKilocodeFoldRepro.test.ts
@@ -333,6 +333,92 @@ describe("POST /api/submit kilocode alias fold vs regression guard", () => {
     expect(warnings.join(" ")).not.toMatch(/would reduce/i);
   });
 
+  it("does NOT heal from a partial resubmit below the fold's largest component", async () => {
+    mockKiloResubmit();
+    // Override the incoming day with a PARTIAL parse: 40 tokens, below the
+    // 100-token largest single contribution to the stored fold. Healing from
+    // it would trade the inflated 200 for a value lower than any truthful
+    // complete day can be -- new data loss, the exact case the regression
+    // guard exists for -- so the fold must be preserved instead.
+    mockState.validateSubmission.mockReturnValue({
+      valid: true,
+      errors: [],
+      warnings: [],
+      data: {
+        device: { id: "dev_1", name: "Device one" },
+        meta: {
+          generatedAt: "2026-05-11T00:00:00Z",
+          version: "4.6.0",
+          dateRange: { start: "2026-05-11", end: "2026-05-11" },
+        },
+        summary: { clients: ["kilo"] },
+        years: [],
+        contributions: [
+          {
+            date: "2026-05-11",
+            clients: [
+              {
+                client: "kilo",
+                modelId: "test-model",
+                tokens: { input: 40, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+                cost: 0.4,
+                messages: 2,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const existingDay = {
+      id: "day-1",
+      date: "2026-05-11",
+      timestampMs: null,
+      activeTimeMs: null,
+      sourceBreakdown: {
+        kilocode: structuredClone(CLIENT_ENTRY_100),
+        kilo: structuredClone(CLIENT_ENTRY_100),
+      },
+    };
+
+    const { tx, executedSqlArgs } = buildTx([
+      [{ id: "submission-existing" }],
+      [existingDay],
+      [AGGREGATES_ROW],
+      [{ sourceBreakdown: existingDay.sourceBreakdown }],
+    ]);
+    void tx;
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ meta: {}, contributions: [] }),
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const strings: string[] = [];
+    for (const arg of executedSqlArgs) collectStrings(arg, strings);
+    const breakdownJson = strings.find((s) => s.includes('"kilo"'));
+    expect(breakdownJson).toBeDefined();
+    const merged = JSON.parse(breakdownJson!) as Record<
+      string,
+      { tokens: number }
+    >;
+
+    // The fold is preserved (still inflated) rather than undercounted; a
+    // later complete-day resubmit at/above the 100-token floor will heal it.
+    expect(merged.kilo.tokens).toBe(200);
+
+    const body = await response.json();
+    const warnings: string[] = body.warnings ?? [];
+    expect(warnings.join(" ")).toMatch(/would reduce/i);
+  });
+
   it("still guards a rename-only kilocode fold (no kilo key present) against a token decrease", async () => {
     mockKiloResubmit();
 

--- a/packages/frontend/__tests__/api/submitProvenance.test.ts
+++ b/packages/frontend/__tests__/api/submitProvenance.test.ts
@@ -272,6 +272,7 @@ function primeDataMocks(provenance?: { origin: string; importer?: string }) {
     (_existing: unknown, incoming: Record<string, unknown>) => ({
       merged: incoming,
       warnings: [],
+      foldPreservedClients: new Set<string>(),
     })
   );
 }

--- a/packages/frontend/__tests__/lib/helpers.test.ts
+++ b/packages/frontend/__tests__/lib/helpers.test.ts
@@ -121,6 +121,8 @@ describe("mergeClientBreakdownsWithRegressionGuard", () => {
       expect(result.warnings).toHaveLength(1);
       expect(result.warnings[0]).toContain("Healed");
       expect(result.warnings[0]).not.toMatch(/parser regression|Preserved/i);
+      // Healed -> the fold is resolved; nothing to preserve raw keys for.
+      expect(result.foldPreservedClients.size).toBe(0);
     });
 
     it("keeps the regression guard when the incoming value is below the floor", () => {
@@ -141,6 +143,9 @@ describe("mergeClientBreakdownsWithRegressionGuard", () => {
       expect(result.merged.kilo.tokens).toBe(200);
       expect(result.warnings).toHaveLength(1);
       expect(result.warnings[0]).toContain("Preserved");
+      // Preserved fold -> the caller must write the raw alias keys back so
+      // the heal floor survives this partial resubmit.
+      expect(result.foldPreservedClients).toEqual(new Set(["kilo"]));
     });
 
     it("keeps the normal regression guard for a non-folded client with the same shape", () => {
@@ -159,6 +164,27 @@ describe("mergeClientBreakdownsWithRegressionGuard", () => {
       expect(result.merged.kilo.tokens).toBe(200);
       expect(result.warnings).toHaveLength(1);
       expect(result.warnings[0]).toContain("Preserved");
+      // Not folded -> nothing to preserve raw keys for.
+      expect(result.foldPreservedClients.size).toBe(0);
+    });
+
+    it("marks an untouched folded client as preserved (carry-over must not collapse it)", () => {
+      // The incoming submission doesn't claim kilo at all (different client
+      // set); the folded entry is carried over by the spread and must still
+      // be flagged so the raw keys survive the writeback.
+      const existing = { kilo: makeClient(200, 5, 1) };
+      const incoming = { cursor: makeClient(50, 2, 1) };
+
+      const result = mergeClientBreakdownsWithRegressionGuard(
+        existing,
+        incoming,
+        new Set(["cursor"]),
+        new Map([["kilo", 100]])
+      );
+
+      expect(result.merged.kilo.tokens).toBe(200);
+      expect(result.merged.cursor.tokens).toBe(50);
+      expect(result.foldPreservedClients).toEqual(new Set(["kilo"]));
     });
 
     it("keeps the folded value when the incoming submission does not include the client", () => {
@@ -174,6 +200,7 @@ describe("mergeClientBreakdownsWithRegressionGuard", () => {
       expect(result.merged.kilo.tokens).toBe(200);
       expect(result.warnings).toHaveLength(1);
       expect(result.warnings[0]).toContain("disappeared");
+      expect(result.foldPreservedClients).toEqual(new Set(["kilo"]));
     });
   });
 });

--- a/packages/frontend/__tests__/lib/helpers.test.ts
+++ b/packages/frontend/__tests__/lib/helpers.test.ts
@@ -99,4 +99,60 @@ describe("mergeClientBreakdownsWithRegressionGuard", () => {
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toContain("cursor");
   });
+
+  describe("foldedClients parameter (alias-fold double-count healing)", () => {
+    it("lets a lower incoming value replace a folded client instead of preserving it", () => {
+      // Simulates the healed state normalizeClientBreakdownAliases would produce:
+      // a stored kilocode+kilo double count folded into a single 200-token
+      // "kilo" entry, with the incoming complete-day resubmit reporting the
+      // true 100-token total.
+      const existing = { kilo: makeClient(200, 5, 1) };
+      const incoming = { kilo: makeClient(100, 5, 1) };
+
+      const result = mergeClientBreakdownsWithRegressionGuard(
+        existing,
+        incoming,
+        new Set(["kilo"]),
+        new Set(["kilo"])
+      );
+
+      expect(result.merged.kilo.tokens).toBe(100);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toContain("Healed");
+      expect(result.warnings[0]).not.toMatch(/parser regression|Preserved/i);
+    });
+
+    it("keeps the normal regression guard for a non-folded client with the same shape", () => {
+      // Same numbers as above, but the client was NOT flagged as folded
+      // (e.g. a plain rename-only case) -- normal preserve-and-warn behavior
+      // must still apply.
+      const existing = { kilo: makeClient(200, 5, 1) };
+      const incoming = { kilo: makeClient(100, 5, 1) };
+
+      const result = mergeClientBreakdownsWithRegressionGuard(
+        existing,
+        incoming,
+        new Set(["kilo"])
+      );
+
+      expect(result.merged.kilo.tokens).toBe(200);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toContain("Preserved");
+    });
+
+    it("keeps the folded value when the incoming submission does not include the client", () => {
+      const existing = { kilo: makeClient(200, 5, 1) };
+
+      const result = mergeClientBreakdownsWithRegressionGuard(
+        existing,
+        {},
+        new Set(["kilo"]),
+        new Set(["kilo"])
+      );
+
+      expect(result.merged.kilo.tokens).toBe(200);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toContain("disappeared");
+    });
+  });
 });

--- a/packages/frontend/__tests__/lib/helpers.test.ts
+++ b/packages/frontend/__tests__/lib/helpers.test.ts
@@ -100,12 +100,13 @@ describe("mergeClientBreakdownsWithRegressionGuard", () => {
     expect(result.warnings[0]).toContain("cursor");
   });
 
-  describe("foldedClients parameter (alias-fold double-count healing)", () => {
-    it("lets a lower incoming value replace a folded client instead of preserving it", () => {
+  describe("foldedClientFloors parameter (alias-fold double-count healing)", () => {
+    it("lets a lower incoming value at or above the floor replace a folded client", () => {
       // Simulates the healed state normalizeClientBreakdownAliases would produce:
-      // a stored kilocode+kilo double count folded into a single 200-token
-      // "kilo" entry, with the incoming complete-day resubmit reporting the
-      // true 100-token total.
+      // a stored kilocode(100)+kilo(100) double count folded into a single
+      // 200-token "kilo" entry with a floor of 100 (largest single component),
+      // and the incoming complete-day resubmit reporting the true 100-token
+      // total — exactly at the floor, so it heals.
       const existing = { kilo: makeClient(200, 5, 1) };
       const incoming = { kilo: makeClient(100, 5, 1) };
 
@@ -113,13 +114,33 @@ describe("mergeClientBreakdownsWithRegressionGuard", () => {
         existing,
         incoming,
         new Set(["kilo"]),
-        new Set(["kilo"])
+        new Map([["kilo", 100]])
       );
 
       expect(result.merged.kilo.tokens).toBe(100);
       expect(result.warnings).toHaveLength(1);
       expect(result.warnings[0]).toContain("Healed");
       expect(result.warnings[0]).not.toMatch(/parser regression|Preserved/i);
+    });
+
+    it("keeps the regression guard when the incoming value is below the floor", () => {
+      // An incoming value below the largest single contribution to the fold
+      // is indistinguishable from a partial re-parse — the exact data-loss
+      // case the guard exists for — so the fold must be preserved, not
+      // "healed" down to the partial value.
+      const existing = { kilo: makeClient(200, 5, 1) };
+      const incoming = { kilo: makeClient(40, 5, 1) };
+
+      const result = mergeClientBreakdownsWithRegressionGuard(
+        existing,
+        incoming,
+        new Set(["kilo"]),
+        new Map([["kilo", 100]])
+      );
+
+      expect(result.merged.kilo.tokens).toBe(200);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toContain("Preserved");
     });
 
     it("keeps the normal regression guard for a non-folded client with the same shape", () => {
@@ -147,7 +168,7 @@ describe("mergeClientBreakdownsWithRegressionGuard", () => {
         existing,
         {},
         new Set(["kilo"]),
-        new Set(["kilo"])
+        new Map([["kilo", 100]])
       );
 
       expect(result.merged.kilo.tokens).toBe(200);

--- a/packages/frontend/__tests__/lib/submissionLegacyClientAlias.test.ts
+++ b/packages/frontend/__tests__/lib/submissionLegacyClientAlias.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { validateSubmission } from "@/lib/validation/submission";
+
+// Guards the cross-layer invariant the alias-fold heal path depends on:
+// a legacy client that still emits "kilocode" on the wire is canonicalized to
+// "kilo" during validation (normalizeLegacySources, wired as a z.preprocess on
+// SubmissionDataSchema), BEFORE the submit route builds incomingClientBreakdown
+// from client_contrib.client. Because of this, the route's incoming breakdown
+// and submitted-client set can never carry a raw "kilocode" key, so the merge
+// guard always evaluates the incoming value against the folded canonical "kilo"
+// entry and healing works for legacy clients too. (This is why cubic's P1 on
+// #945 — "legacy kilocode resubmits cannot heal a folded kilo total" — does not
+// apply: the incoming value is already keyed on "kilo" by the time the merge
+// runs.) If the preprocess is ever removed or reordered, this test fails loudly
+// instead of silently reintroducing the un-healable double count.
+function buildKilocodeSubmission(): Record<string, unknown> {
+  const tokens = {
+    input: 100,
+    output: 100,
+    cacheRead: 100,
+    cacheWrite: 0,
+    reasoning: 0,
+  };
+  return {
+    meta: {
+      generatedAt: "2026-07-14T00:00:00.000Z",
+      version: "4.5.3",
+      dateRange: { start: "2026-05-11", end: "2026-05-11" },
+    },
+    summary: {
+      totalTokens: 300,
+      totalCost: 1.5,
+      totalDays: 1,
+      activeDays: 1,
+      averagePerDay: 1.5,
+      maxCostInSingleDay: 1.5,
+      clients: ["kilocode"],
+      models: ["glm-4.6"],
+    },
+    years: [
+      {
+        year: "2026",
+        totalTokens: 300,
+        totalCost: 1.5,
+        range: { start: "2026-05-11", end: "2026-05-11" },
+      },
+    ],
+    contributions: [
+      {
+        date: "2026-05-11",
+        totals: { tokens: 300, cost: 1.5, messages: 0 },
+        intensity: 4,
+        tokenBreakdown: tokens,
+        clients: [{ client: "kilocode", modelId: "glm-4.6", tokens, cost: 1.5, messages: 0 }],
+      },
+    ],
+  };
+}
+
+describe("legacy kilocode client alias canonicalization", () => {
+  it("rewrites a wire-level 'kilocode' client to 'kilo' in both summary and contributions", () => {
+    const result = validateSubmission(buildKilocodeSubmission());
+
+    expect(result.valid).toBe(true);
+    expect(result.data).toBeDefined();
+
+    // Summary client set is canonical.
+    expect(result.data!.summary.clients).toContain("kilo");
+    expect(result.data!.summary.clients).not.toContain("kilocode");
+
+    // The per-day contribution client — the exact value the submit route reads
+    // to build incomingClientBreakdown — is canonical too.
+    const contribClients = result.data!.contributions[0].clients.map((c) => c.client);
+    expect(contribClients).toContain("kilo");
+    expect(contribClients).not.toContain("kilocode");
+  });
+});

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -555,10 +555,12 @@ export async function POST(request: Request) {
         const existingDay = existingDaysMap.get(incomingDay.date);
 
         if (existingDay) {
+          const rawExistingBreakdown = (existingDay.sourceBreakdown || {}) as Record<
+            string,
+            ClientBreakdownData
+          >;
           const { breakdown: existingClientBreakdown, foldedClientFloors } =
-            normalizeClientBreakdownAliases(
-              (existingDay.sourceBreakdown || {}) as Record<string, ClientBreakdownData>
-            );
+            normalizeClientBreakdownAliases(rawExistingBreakdown);
           const mergeResult = mergeClientBreakdownsWithRegressionGuard(
             existingClientBreakdown,
             incomingClientBreakdown,
@@ -569,6 +571,20 @@ export async function POST(request: Request) {
             ...mergeResult.warnings.map((warning) => `Day ${incomingDay.date}: ${warning}`)
           );
           const mergedClientBreakdown = mergeResult.merged;
+          // A preserved fold must keep its ORIGINAL raw alias keys in storage
+          // (e.g. both "kilocode" and "kilo"), not the collapsed sum: the
+          // collapsed form is indistinguishable from real usage, so writing it
+          // back would burn the heal floor on the first partial resubmit and
+          // permanently re-cement the double count. Day totals are identical
+          // either way (recalculateDayTotals sums all keys).
+          for (const clientName of mergeResult.foldPreservedClients) {
+            delete mergedClientBreakdown[clientName];
+            for (const [rawKey, rawData] of Object.entries(rawExistingBreakdown)) {
+              if ((LEGACY_CLIENT_ALIASES[rawKey] ?? rawKey) === clientName) {
+                mergedClientBreakdown[rawKey] = rawData;
+              }
+            }
+          }
           const dayTotals = recalculateDayTotals(mergedClientBreakdown);
 
           toUpdate.push({

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -63,11 +63,15 @@ interface NormalizedClientBreakdownAliases {
   breakdown: Record<string, ClientBreakdownData>;
   // Canonical client names where MULTIPLE raw source keys folded together
   // (e.g. a stale legacy "kilocode" key alongside "kilo" for the same
-  // underlying usage, summed by this function). A pure rename -- only the
-  // legacy key present, nothing to sum it with -- is NOT included: that's a
-  // single contributor, not a suspect double count, so the regression guard
-  // should still defend it normally.
-  foldedClients: Set<string>;
+  // underlying usage, summed by this function), mapped to the largest token
+  // count any single raw key contributed. The merge guard uses that value as
+  // the healing floor: a truthful complete-day resubmit must report at least
+  // as many tokens as the largest component of the fold, while anything
+  // below it looks like a partial re-parse and keeps the normal regression
+  // guard. A pure rename -- only the legacy key present, nothing to sum it
+  // with -- is NOT included: that's a single contributor, not a suspect
+  // double count, so the regression guard should still defend it normally.
+  foldedClientFloors: Map<string, number>;
 }
 
 function normalizeClientBreakdownAliases(
@@ -75,10 +79,16 @@ function normalizeClientBreakdownAliases(
 ): NormalizedClientBreakdownAliases {
   const normalized: Record<string, ClientBreakdownData> = {};
   const foldedClients = new Set<string>();
+  const largestComponentTokens = new Map<string, number>();
 
   for (const [rawClientName, data] of Object.entries(breakdown)) {
     const clientName = LEGACY_CLIENT_ALIASES[rawClientName] ?? rawClientName;
     const existing = normalized[clientName];
+
+    largestComponentTokens.set(
+      clientName,
+      Math.max(largestComponentTokens.get(clientName) ?? 0, data.tokens || 0)
+    );
 
     if (!existing) {
       normalized[clientName] = { ...data, models: { ...data.models } };
@@ -98,7 +108,12 @@ function normalizeClientBreakdownAliases(
     existing.provenance = deriveClientBreakdownProvenance(existing);
   }
 
-  return { breakdown: normalized, foldedClients };
+  const foldedClientFloors = new Map<string, number>();
+  for (const clientName of foldedClients) {
+    foldedClientFloors.set(clientName, largestComponentTokens.get(clientName) ?? 0);
+  }
+
+  return { breakdown: normalized, foldedClientFloors };
 }
 
 function normalizeSubmissionData(data: unknown): void {
@@ -540,7 +555,7 @@ export async function POST(request: Request) {
         const existingDay = existingDaysMap.get(incomingDay.date);
 
         if (existingDay) {
-          const { breakdown: existingClientBreakdown, foldedClients } =
+          const { breakdown: existingClientBreakdown, foldedClientFloors } =
             normalizeClientBreakdownAliases(
               (existingDay.sourceBreakdown || {}) as Record<string, ClientBreakdownData>
             );
@@ -548,7 +563,7 @@ export async function POST(request: Request) {
             existingClientBreakdown,
             incomingClientBreakdown,
             submittedClients,
-            foldedClients
+            foldedClientFloors
           );
           warnings.push(
             ...mergeResult.warnings.map((warning) => `Day ${incomingDay.date}: ${warning}`)

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -59,10 +59,22 @@ function mergeModelBreakdowns(
   }
 }
 
+interface NormalizedClientBreakdownAliases {
+  breakdown: Record<string, ClientBreakdownData>;
+  // Canonical client names where MULTIPLE raw source keys folded together
+  // (e.g. a stale legacy "kilocode" key alongside "kilo" for the same
+  // underlying usage, summed by this function). A pure rename -- only the
+  // legacy key present, nothing to sum it with -- is NOT included: that's a
+  // single contributor, not a suspect double count, so the regression guard
+  // should still defend it normally.
+  foldedClients: Set<string>;
+}
+
 function normalizeClientBreakdownAliases(
   breakdown: Record<string, ClientBreakdownData>
-): Record<string, ClientBreakdownData> {
+): NormalizedClientBreakdownAliases {
   const normalized: Record<string, ClientBreakdownData> = {};
+  const foldedClients = new Set<string>();
 
   for (const [rawClientName, data] of Object.entries(breakdown)) {
     const clientName = LEGACY_CLIENT_ALIASES[rawClientName] ?? rawClientName;
@@ -73,6 +85,7 @@ function normalizeClientBreakdownAliases(
       continue;
     }
 
+    foldedClients.add(clientName);
     existing.tokens += data.tokens || 0;
     existing.cost += data.cost || 0;
     existing.input += data.input || 0;
@@ -85,7 +98,7 @@ function normalizeClientBreakdownAliases(
     existing.provenance = deriveClientBreakdownProvenance(existing);
   }
 
-  return normalized;
+  return { breakdown: normalized, foldedClients };
 }
 
 function normalizeSubmissionData(data: unknown): void {
@@ -527,13 +540,15 @@ export async function POST(request: Request) {
         const existingDay = existingDaysMap.get(incomingDay.date);
 
         if (existingDay) {
-          const existingClientBreakdown = normalizeClientBreakdownAliases(
-            (existingDay.sourceBreakdown || {}) as Record<string, ClientBreakdownData>
-          );
+          const { breakdown: existingClientBreakdown, foldedClients } =
+            normalizeClientBreakdownAliases(
+              (existingDay.sourceBreakdown || {}) as Record<string, ClientBreakdownData>
+            );
           const mergeResult = mergeClientBreakdownsWithRegressionGuard(
             existingClientBreakdown,
             incomingClientBreakdown,
-            submittedClients
+            submittedClients,
+            foldedClients
           );
           warnings.push(
             ...mergeResult.warnings.map((warning) => `Day ${incomingDay.date}: ${warning}`)

--- a/packages/frontend/src/lib/db/helpers.ts
+++ b/packages/frontend/src/lib/db/helpers.ts
@@ -44,6 +44,15 @@ export interface ClientBreakdownData {
 export interface MergeClientBreakdownsResult {
   merged: Record<string, ClientBreakdownData>;
   warnings: string[];
+  // Folded clients (had an entry in foldedClientFloors) whose existing value
+  // was PRESERVED — the incoming submission was below the heal floor or
+  // omitted the client entirely. `merged` holds their collapsed folded entry;
+  // the caller must write the ORIGINAL raw alias keys back to storage for
+  // these clients instead, otherwise the fold evidence (and with it the heal
+  // floor) is destroyed by the writeback and the one heal opportunity is
+  // burned by a partial resubmit — permanently re-cementing the double count
+  // this mechanism exists to repair.
+  foldPreservedClients: Set<string>;
 }
 
 export interface DayTotals {
@@ -164,6 +173,12 @@ export function mergeClientBreakdownsWithRegressionGuard(
 ): MergeClientBreakdownsResult {
   const merged: Record<string, ClientBreakdownData> = { ...(existing || {}) };
   const warnings: string[] = [];
+  // Every folded client starts as "preserved" and is unmarked only when the
+  // incoming submission actually heals or replaces it. This also covers
+  // folded clients the incoming submission never mentions (carried over by
+  // the spread above), whose collapsed entry would otherwise overwrite the
+  // raw alias keys on writeback just the same.
+  const foldPreservedClients = new Set<string>(foldedClientFloors?.keys() ?? []);
 
   for (const clientName of incomingClients) {
     const existingClient = existing?.[clientName];
@@ -177,6 +192,7 @@ export function mergeClientBreakdownsWithRegressionGuard(
         );
       } else {
         delete merged[clientName];
+        foldPreservedClients.delete(clientName);
       }
       continue;
     }
@@ -191,6 +207,7 @@ export function mergeClientBreakdownsWithRegressionGuard(
         // fold — consistent with a complete-day recomputation rather than a
         // partial re-parse. Let it replace the fold instead of defending it.
         merged[clientName] = nextClient;
+        foldPreservedClients.delete(clientName);
         const existingTokens = formatTokens(existingClient.tokens);
         const nextTokens = formatTokens(nextClient.tokens);
         warnings.push(
@@ -214,9 +231,10 @@ export function mergeClientBreakdownsWithRegressionGuard(
     }
 
     merged[clientName] = nextClient;
+    foldPreservedClients.delete(clientName);
   }
 
-  return { merged, warnings };
+  return { merged, warnings, foldPreservedClients };
 }
 
 export function clientContributionToBreakdownData(

--- a/packages/frontend/src/lib/db/helpers.ts
+++ b/packages/frontend/src/lib/db/helpers.ts
@@ -145,7 +145,16 @@ export function mergeClientBreakdowns(
 export function mergeClientBreakdownsWithRegressionGuard(
   existing: Record<string, ClientBreakdownData> | null | undefined,
   incoming: Record<string, ClientBreakdownData>,
-  incomingClients: Set<string>
+  incomingClients: Set<string>,
+  // Clients whose `existing` value came from normalizeClientBreakdownAliases
+  // folding TWO source keys together (e.g. a stale legacy "kilocode" key
+  // alongside "kilo" for the same underlying usage) rather than a simple
+  // one-key rename. For these, a lower incoming token count is not a parser
+  // regression to guard against — it is the healthy, complete-day total that
+  // should replace the inflated fold. A pure rename-only fold (only the
+  // legacy key was ever present) is NOT included here and keeps the normal
+  // guard behavior.
+  foldedClients?: Set<string>
 ): MergeClientBreakdownsResult {
   const merged: Record<string, ClientBreakdownData> = { ...(existing || {}) };
   const warnings: string[] = [];
@@ -168,6 +177,20 @@ export function mergeClientBreakdownsWithRegressionGuard(
 
     const nextClient = withDerivedProvenance(incomingClient);
     if (existingClient && nextClient.tokens < existingClient.tokens) {
+      if (foldedClients?.has(clientName)) {
+        // The existing value is an alias-folded double count (e.g. stale
+        // "kilocode" + "kilo" summed together), not real usage history.
+        // This complete-day incoming submission is authoritative for this
+        // client, so let it replace the fold instead of defending it.
+        merged[clientName] = nextClient;
+        const existingTokens = formatTokens(existingClient.tokens);
+        const nextTokens = formatTokens(nextClient.tokens);
+        warnings.push(
+          `Healed ${clientName} alias-folded double count for this same-device resubmit: replaced ${existingTokens} tokens with ${nextTokens} tokens from the complete incoming day.`
+        );
+        continue;
+      }
+
       // A token decrease alone signals a parser regression (e.g. the CLI
       // re-parsed only a subset of history). Preserve the existing row even
       // when coverage metrics are equal, because equal coverage + fewer tokens

--- a/packages/frontend/src/lib/db/helpers.ts
+++ b/packages/frontend/src/lib/db/helpers.ts
@@ -149,12 +149,18 @@ export function mergeClientBreakdownsWithRegressionGuard(
   // Clients whose `existing` value came from normalizeClientBreakdownAliases
   // folding TWO source keys together (e.g. a stale legacy "kilocode" key
   // alongside "kilo" for the same underlying usage) rather than a simple
-  // one-key rename. For these, a lower incoming token count is not a parser
-  // regression to guard against — it is the healthy, complete-day total that
-  // should replace the inflated fold. A pure rename-only fold (only the
-  // legacy key was ever present) is NOT included here and keeps the normal
-  // guard behavior.
-  foldedClients?: Set<string>
+  // one-key rename, mapped to the largest token count any single raw key
+  // contributed to the fold. For these, a lower incoming token count is not
+  // automatically a parser regression — it may be the healthy value the
+  // inflated fold should be replaced with. But nothing proves an incoming
+  // submission covers the full day (partial re-parses are the exact case the
+  // guard exists for), so healing only happens when the incoming value is at
+  // least the largest single contribution: any truthful complete-day total
+  // must be >= each of the components that were summed. Below that floor the
+  // normal guard still applies. A pure rename-only fold (only the legacy key
+  // was ever present) is NOT included here and keeps the normal guard
+  // behavior.
+  foldedClientFloors?: Map<string, number>
 ): MergeClientBreakdownsResult {
   const merged: Record<string, ClientBreakdownData> = { ...(existing || {}) };
   const warnings: string[] = [];
@@ -177,11 +183,13 @@ export function mergeClientBreakdownsWithRegressionGuard(
 
     const nextClient = withDerivedProvenance(incomingClient);
     if (existingClient && nextClient.tokens < existingClient.tokens) {
-      if (foldedClients?.has(clientName)) {
+      const healFloor = foldedClientFloors?.get(clientName);
+      if (healFloor !== undefined && nextClient.tokens >= healFloor) {
         // The existing value is an alias-folded double count (e.g. stale
-        // "kilocode" + "kilo" summed together), not real usage history.
-        // This complete-day incoming submission is authoritative for this
-        // client, so let it replace the fold instead of defending it.
+        // "kilocode" + "kilo" summed together), not real usage history, and
+        // the incoming value clears the largest single contribution to that
+        // fold — consistent with a complete-day recomputation rather than a
+        // partial re-parse. Let it replace the fold instead of defending it.
         merged[clientName] = nextClient;
         const existingTokens = formatTokens(existingClient.tokens);
         const nextTokens = formatTokens(nextClient.tokens);


### PR DESCRIPTION
Fixes a high-severity finding from the 2026-07-22 adversarial bug hunt (independently reproduced twice with the real merge helpers against a mocked transaction; lower-severity findings tracked in #941).

## Problem

The exact state #886's kilocode→kilo alias fold was added to heal — a stored `source_breakdown` carrying **both** a stale legacy `kilocode` key and a `kilo` key for the same underlying usage — could never actually be healed:

1. `normalizeClientBreakdownAliases` folds the two keys by **summing** them (100+100 → 200) before the merge runs.
2. `mergeClientBreakdownsWithRegressionGuard` then compares the incoming complete-day kilo contribution (100) against the folded sum (200), reads the decrease as a parser regression, and preserves the inflated 200 — with a misleading warning, on every future resubmit, forever.
3. The rewritten row stores a single summed `kilo` entry (no `kilocode` key left), so the double count becomes indistinguishable from real usage and unrepairable by a targeted migration. Day totals recomputed from the merged breakdown keep leaderboard totals inflated ~2x for every affected day.

## Fix

`normalizeClientBreakdownAliases` now also reports which canonical keys absorbed **multiple** raw source keys (`foldedClients`). The regression guard takes that set (new optional, backward-compatible parameter) and, only for those clients, lets a lower incoming complete-day value replace the fold — emitting a distinct "Healed …" warning instead of the regression one. A pure rename (only the legacy key present, nothing summed) is not flagged and keeps the normal guard behavior, as does a folded client the incoming submission doesn't cover (no basis to heal).

Rejected alternatives: comparing against `max(kilo, kilocode)` (heuristic bound, misses uneven splits) and deleting the stale alias pre-merge (loses data when the incoming submission omits the client).

## Verification

- Full frontend suite: 70 files / 649 tests green (baseline 69/644; delta is the new tests)
- New route-level repro: stored `{kilocode:100, kilo:100}` + truthful 100-token kilo resubmit now persists `kilo.tokens = 100` (was 200)
- New guard tests: rename-only fold still defends against real decreases; fold without incoming client keeps the folded value
- Unchanged invariants: `ON CONFLICT (submission_id, submitted_device_id, date)`, fail-loud adoption rethrow, sticky `has_backfill`; no size caps reintroduced

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where days with both `kilocode` and `kilo` stayed double-counted after alias folding. Complete-day resubmits now heal those days only when the incoming total is at least the largest folded component, and preserved folds keep their raw alias keys so later resubmits can still heal.

- **Bug Fixes**
  - `normalizeClientBreakdownAliases` now returns `{ breakdown, foldedClientFloors }` with per-client floors from the largest folded component.
  - `mergeClientBreakdownsWithRegressionGuard` takes optional `foldedClientFloors` and returns `foldPreservedClients`; heals when tokens drop but stay ≥ floor (distinct "Healed ..." warning), preserves when below floor or missing; rename-only keeps the normal guard.
  - The submit route writes raw alias keys back for `foldPreservedClients` instead of the collapsed sum to keep the heal window open. Validation canonicalizes wire-level `kilocode` to `kilo`; a new test locks this invariant.

<sup>Written for commit 011dd4ab874b50a4846795c308614e4d772cc1cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

