### PR TITLE
feat: read opencode model names from user config for TUI display

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -537,6 +537,10 @@ fn main() -> Result<()> {
     // Honors the global `--home` override exactly like scanner settings; an
     // empty or absent config is a strict no-op.
     tokscale_core::model_alias::set_global(&tui::settings::load_model_aliases_for_home(&cli.home));
+    let opencode_model_names = tokscale_core::opencode_model_name::load_for_home(
+        cli.home.as_deref().map(std::path::Path::new),
+    );
+    tokscale_core::opencode_model_name::set_global(opencode_model_names);
     let can_use_tui = std::io::stdin().is_terminal() && std::io::stdout().is_terminal();
 
     if cli.test_data {

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -2699,6 +2699,7 @@ mod tests {
         app.data.models = vec![
             ModelUsage {
                 model: "model1".to_string(),
+                color_key: "model1".to_string(),
                 provider: "provider1".to_string(),
                 client: "opencode".to_string(),
                 tokens: TokenBreakdown::default(),
@@ -2710,6 +2711,7 @@ mod tests {
             },
             ModelUsage {
                 model: "model2".to_string(),
+                color_key: "model2".to_string(),
                 provider: "provider2".to_string(),
                 client: "opencode".to_string(),
                 tokens: TokenBreakdown::default(),
@@ -2748,6 +2750,7 @@ mod tests {
         app.data.models = vec![
             ModelUsage {
                 model: "model1".to_string(),
+                color_key: "model1".to_string(),
                 provider: "provider1".to_string(),
                 client: "opencode".to_string(),
                 tokens: TokenBreakdown::default(),
@@ -2759,6 +2762,7 @@ mod tests {
             },
             ModelUsage {
                 model: "model2".to_string(),
+                color_key: "model2".to_string(),
                 provider: "provider2".to_string(),
                 client: "opencode".to_string(),
                 tokens: TokenBreakdown::default(),
@@ -2796,6 +2800,7 @@ mod tests {
         // Add some mock data
         app.data.models = vec![ModelUsage {
             model: "model1".to_string(),
+            color_key: "model1".to_string(),
             provider: "provider1".to_string(),
             client: "opencode".to_string(),
             tokens: TokenBreakdown::default(),
@@ -3097,6 +3102,7 @@ mod tests {
         app.data.models = (0..n)
             .map(|i| ModelUsage {
                 model: format!("model{}", i),
+                color_key: format!("model{}", i),
                 provider: "provider".to_string(),
                 client: "opencode".to_string(),
                 tokens: TokenBreakdown::default(),
@@ -4856,6 +4862,7 @@ mod tests {
     fn model_usage(name: &str, cost: f64, workspace: Option<&str>) -> ModelUsage {
         ModelUsage {
             model: name.to_string(),
+            color_key: name.to_string(),
             provider: "anthropic".to_string(),
             client: "claude".to_string(),
             workspace_key: workspace.map(String::from),
@@ -5006,6 +5013,7 @@ mod tests {
         app.data.models = vec![
             ModelUsage {
                 model: "claude-opus-4-5".to_string(),
+                color_key: "claude-opus-4-5".to_string(),
                 provider: "anthropic".to_string(),
                 client: "claude".to_string(),
                 workspace_key: None,
@@ -5017,6 +5025,7 @@ mod tests {
             },
             ModelUsage {
                 model: "gpt-5".to_string(),
+                color_key: "gpt-5".to_string(),
                 provider: "openai".to_string(),
                 client: "codex".to_string(),
                 workspace_key: None,
@@ -5073,6 +5082,7 @@ mod tests {
         app.data.models = vec![
             ModelUsage {
                 model: "sonnet-shared".to_string(),
+                color_key: "sonnet-shared".to_string(),
                 provider: "anthropic".to_string(),
                 client: "claude".to_string(),
                 workspace_key: None,
@@ -5084,6 +5094,7 @@ mod tests {
             },
             ModelUsage {
                 model: "sonnet-shared".to_string(),
+                color_key: "sonnet-shared".to_string(),
                 provider: "openai".to_string(),
                 client: "codex".to_string(),
                 workspace_key: None,
@@ -5119,6 +5130,7 @@ mod tests {
         let mut app = make_app();
         let copilot_fable = ModelUsage {
             model: "claude-fable-5".to_string(),
+            color_key: "claude-fable-5".to_string(),
             provider: "github-copilot".to_string(),
             client: "opencode".to_string(),
             workspace_key: None,
@@ -5130,6 +5142,8 @@ mod tests {
         };
         app.data.models = vec![
             ModelUsage {
+                model: "claude-fable-5".to_string(),
+                color_key: "claude-fable-5".to_string(),
                 provider: "anthropic".to_string(),
                 cost: 5.0,
                 ..copilot_fable.clone()

--- a/crates/tokscale-cli/src/tui/cache.rs
+++ b/crates/tokscale-cli/src/tui/cache.rs
@@ -128,6 +128,7 @@ struct CachedTokenBreakdown {
 #[serde(rename_all = "camelCase")]
 struct CachedModelUsage {
     model: String,
+    #[serde(default)]
     color_key: String,
     provider: String,
     client: String,
@@ -280,9 +281,14 @@ impl From<&ModelUsage> for CachedModelUsage {
 
 impl From<CachedModelUsage> for ModelUsage {
     fn from(m: CachedModelUsage) -> Self {
+        let color_key = if m.color_key.is_empty() {
+            m.model.clone()
+        } else {
+            m.color_key
+        };
         Self {
             model: m.model,
-            color_key: m.color_key,
+            color_key,
             provider: m.provider,
             client: m.client,
             workspace_key: m.workspace_key,

--- a/crates/tokscale-cli/src/tui/cache.rs
+++ b/crates/tokscale-cli/src/tui/cache.rs
@@ -128,6 +128,7 @@ struct CachedTokenBreakdown {
 #[serde(rename_all = "camelCase")]
 struct CachedModelUsage {
     model: String,
+    color_key: String,
     provider: String,
     client: String,
     #[serde(default)]
@@ -264,6 +265,7 @@ impl From<&ModelUsage> for CachedModelUsage {
     fn from(m: &ModelUsage) -> Self {
         Self {
             model: m.model.clone(),
+            color_key: m.color_key.clone(),
             provider: m.provider.clone(),
             client: m.client.clone(),
             workspace_key: m.workspace_key.clone(),
@@ -280,6 +282,7 @@ impl From<CachedModelUsage> for ModelUsage {
     fn from(m: CachedModelUsage) -> Self {
         Self {
             model: m.model,
+            color_key: m.color_key,
             provider: m.provider,
             client: m.client,
             workspace_key: m.workspace_key,

--- a/crates/tokscale-cli/src/tui/colors.rs
+++ b/crates/tokscale-cli/src/tui/colors.rs
@@ -177,6 +177,11 @@ mod tests {
             provider_color_key("github-copilot", "gpt-5.3-codex"),
             "openai"
         );
+        assert_eq!(provider_color_key("fireworks_ai", "GLM 5.2"), "zai");
+        assert_eq!(
+            provider_color_key("fireworks_ai", "Kimi K2.7 Code"),
+            "moonshotai"
+        );
         // Empty / mixed providers also defer to the model.
         assert_eq!(provider_color_key("", "claude-fable-5"), "anthropic");
         assert_eq!(

--- a/crates/tokscale-cli/src/tui/colors.rs
+++ b/crates/tokscale-cli/src/tui/colors.rs
@@ -25,12 +25,12 @@ pub fn model_shade_key(provider: &str, model: &str) -> String {
 pub fn build_model_shade_map(models: &[ModelUsage]) -> HashMap<String, Color> {
     let mut by_provider: HashMap<&str, HashMap<&str, f64>> = HashMap::new();
     for m in models {
-        let provider = provider_color_key(&m.provider, &m.model);
+        let provider = provider_color_key(&m.provider, &m.color_key);
         let cost = if m.cost.is_finite() { m.cost } else { 0.0 };
         *by_provider
             .entry(provider)
             .or_default()
-            .entry(m.model.as_str())
+            .entry(m.color_key.as_str())
             .or_insert(0.0) += cost;
     }
 
@@ -145,6 +145,7 @@ mod tests {
     fn usage(model: &str, provider: &str, cost: f64) -> ModelUsage {
         ModelUsage {
             model: model.to_string(),
+            color_key: model.to_string(),
             provider: provider.to_string(),
             client: "claude".to_string(),
             workspace_key: None,

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -7,7 +7,7 @@ use tokio::runtime::{Handle, Runtime};
 
 use tokscale_core::sessions::UnifiedMessage;
 use tokscale_core::{
-    normalize_model_for_grouping, parse_local_unified_messages, sessions, ClientId, GroupBy,
+    model_name_for_grouping, parse_local_unified_messages, sessions, ClientId, GroupBy,
     LocalParseOptions, ModelPerformance,
 };
 
@@ -457,7 +457,8 @@ impl DataLoader {
         let mut session_map: HashMap<String, SessionUsage> = HashMap::new();
 
         for msg in &messages {
-            let normalized_model = normalize_model_for_grouping(&msg.model_id);
+            let normalized_model =
+                model_name_for_grouping(&msg.client, &msg.provider_id, &msg.model_id);
             let (workspace_group_key, workspace_key, workspace_label) = workspace_bucket(msg);
             let key = match group_by {
                 GroupBy::Model => normalized_model.clone(),

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -7,8 +7,8 @@ use tokio::runtime::{Handle, Runtime};
 
 use tokscale_core::sessions::UnifiedMessage;
 use tokscale_core::{
-    model_name_for_grouping, parse_local_unified_messages, sessions, ClientId, GroupBy,
-    LocalParseOptions, ModelPerformance,
+    model_name_for_grouping, normalize_model_for_grouping, parse_local_unified_messages, sessions,
+    ClientId, GroupBy, LocalParseOptions, ModelPerformance,
 };
 
 /// Returns the scanner settings that `DataLoader` should use when building
@@ -459,6 +459,7 @@ impl DataLoader {
         for msg in &messages {
             let normalized_model =
                 model_name_for_grouping(&msg.client, &msg.provider_id, &msg.model_id);
+            let model_key = normalize_model_for_grouping(&msg.model_id);
             let (workspace_group_key, workspace_key, workspace_label) = workspace_bucket(msg);
             let key = match group_by {
                 GroupBy::Model => normalized_model.clone(),
@@ -684,7 +685,7 @@ impl DataLoader {
                             &msg.provider_id,
                             &normalized_model,
                         ),
-                        color_key: model_color_key(group_by, &msg.provider_id, &normalized_model),
+                        color_key: model_color_key(group_by, &msg.provider_id, &model_key),
                         tokens: TokenBreakdown::default(),
                         cost: 0.0,
                         messages: 0,
@@ -774,7 +775,7 @@ impl DataLoader {
                             &msg.provider_id,
                             &normalized_model,
                         ),
-                        color_key: model_color_key(group_by, &msg.provider_id, &normalized_model),
+                        color_key: model_color_key(group_by, &msg.provider_id, &model_key),
                         tokens: TokenBreakdown::default(),
                         cost: 0.0,
                     });
@@ -868,11 +869,7 @@ impl DataLoader {
                                 &msg.provider_id,
                                 &normalized_model,
                             ),
-                            color_key: model_color_key(
-                                group_by,
-                                &msg.provider_id,
-                                &normalized_model,
-                            ),
+                            color_key: model_color_key(group_by, &msg.provider_id, &model_key),
                             tokens: TokenBreakdown::default(),
                             cost: 0.0,
                         });

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -48,6 +48,7 @@ impl TokenBreakdown {
 #[derive(Debug, Clone)]
 pub struct ModelUsage {
     pub model: String,
+    pub color_key: String,
     pub provider: String,
     pub client: String,
     pub workspace_key: Option<String>,
@@ -479,6 +480,7 @@ impl DataLoader {
 
             let model_entry = model_map.entry(key.clone()).or_insert_with(|| ModelUsage {
                 model: normalized_model.clone(),
+                color_key: model_key.clone(),
                 provider: msg.provider_id.clone(),
                 client: msg.client.clone(),
                 workspace_key: if *group_by == GroupBy::WorkspaceModel {

--- a/crates/tokscale-cli/src/tui/ui/models.rs
+++ b/crates/tokscale-cli/src/tui/ui/models.rs
@@ -149,7 +149,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             let is_selected = idx == selected_index;
             let is_striped = idx % 2 == 1;
 
-            let model_color = app.model_color_for(&model.provider, &model.model);
+            let model_color = app.model_color_for(&model.provider, &model.color_key);
             let display_name = model_display_name(model, &group_by);
 
             let cells: Vec<Cell> = if is_very_narrow {

--- a/crates/tokscale-cli/src/tui/ui/overview.rs
+++ b/crates/tokscale-cli/src/tui/ui/overview.rs
@@ -8,6 +8,7 @@ use tokscale_core::GroupBy;
 
 struct ModelRowData {
     model: String,
+    color_key: String,
     provider: String,
     workspace_label: Option<String>,
     tokens_input: u64,
@@ -154,7 +155,7 @@ fn render_legend(frame: &mut Frame, app: &App, area: Rect) {
         .map(|m| {
             (
                 overview_model_label(&group_by, &m.model, m.workspace_label.as_deref()),
-                app.model_color_for(&m.provider, &m.model),
+                app.model_color_for(&m.provider, &m.color_key),
             )
         })
         .collect();
@@ -205,6 +206,7 @@ fn render_top_models(frame: &mut Frame, app: &mut App, area: Rect, items_per_pag
         .iter()
         .map(|m| ModelRowData {
             model: m.model.clone(),
+            color_key: m.color_key.clone(),
             provider: m.provider.clone(),
             workspace_label: m.workspace_label.clone(),
             tokens_input: m.tokens.input,
@@ -287,7 +289,7 @@ fn render_top_models(frame: &mut Frame, app: &mut App, area: Rect, items_per_pag
             Style::default()
         };
 
-        let model_color = app.model_color_for(&model.provider, &model.model);
+        let model_color = app.model_color_for(&model.provider, &model.color_key);
         let display_name =
             overview_model_label(&group_by, &model.model, model.workspace_label.as_deref());
         let name = truncate_string(&display_name, max_name_width);

--- a/crates/tokscale-cli/src/tui/ui/stats.rs
+++ b/crates/tokscale-cli/src/tui/ui/stats.rs
@@ -268,7 +268,7 @@ fn render_stats_panel(frame: &mut Frame, app: &App, area: Rect) {
     });
     let favorite_model_name = favorite_model.map(|m| m.model.as_str()).unwrap_or("N/A");
     let model_color = favorite_model
-        .map(|m| app.model_color_for(&m.provider, &m.model))
+        .map(|m| app.model_color_for(&m.provider, &m.color_key))
         .unwrap_or_else(|| app.model_color("N/A"));
     let sessions: u32 = app.data.models.iter().map(|m| m.session_count).sum();
 

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -366,7 +366,7 @@ fn is_delimited_model_family(model_lower: &str, family: &str) -> bool {
                 || token
                     .strip_prefix(family)
                     .and_then(|suffix| suffix.chars().next())
-                    .map_or(false, |c| c.is_ascii_digit())
+                    .is_some_and(|c| c.is_ascii_digit())
         })
 }
 

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -190,6 +190,8 @@ fn known_provider_palette(provider_lower: &str) -> Option<&'static [(u8, u8, u8)
         s if s.contains("google") || s.contains("gemini") => &GOOGLE_SHADES,
         s if s.contains("deepseek") => &DEEPSEEK_SHADES,
         s if s.contains("xai") || s.contains("grok") => &XAI_SHADES,
+        s if s.contains("zai") || s.contains("z_ai") || s.contains("zhipu") => &ZAI_SHADES,
+        s if s.contains("moonshot") || s.contains("kimi") => &MOONSHOT_SHADES,
         s if s.contains("meta") || s.contains("llama") => &META_SHADES,
         s if s.contains("cursor") => &CURSOR_SHADES,
         s if s.contains("sakana") || s.contains("fugu") => &SAKANA_SHADES,
@@ -293,6 +295,26 @@ const XAI_SHADES: [(u8, u8, u8); 7] = [
     (251, 221, 129), // #FBDD81
 ];
 
+const ZAI_SHADES: [(u8, u8, u8); 7] = [
+    (168, 85, 247),  // #A855F7
+    (181, 110, 249), // #B56EF9
+    (193, 132, 250), // #C184FA
+    (204, 153, 251), // #CC99FB
+    (214, 172, 252), // #D6ACFC
+    (224, 192, 253), // #E0C0FD
+    (235, 213, 254), // #EBD5FE
+];
+
+const MOONSHOT_SHADES: [(u8, u8, u8); 7] = [
+    (20, 184, 166),  // #14B8A6
+    (35, 197, 178),  // #23C5B2
+    (58, 207, 190),  // #3ACFBE
+    (85, 216, 202),  // #55D8CA
+    (112, 224, 212), // #70E0D4
+    (143, 232, 222), // #8FE8DE
+    (174, 240, 232), // #AEF0E8
+];
+
 const META_SHADES: [(u8, u8, u8); 7] = [
     (99, 102, 241),  // #6366F1
     (122, 125, 243), // #7A7DF3
@@ -367,6 +389,10 @@ pub fn get_provider_from_model(model: &str) -> &'static str {
         "deepseek"
     } else if model_lower.contains("grok") {
         "xai"
+    } else if model_lower.contains("glm") {
+        "zai"
+    } else if model_lower.contains("kimi") {
+        "moonshotai"
     } else if model_lower.contains("llama") {
         "meta"
     } else if model_lower.contains("mixtral") {
@@ -651,6 +677,20 @@ mod tests {
     }
 
     #[test]
+    fn glm_and_kimi_use_their_vendor_color_ramps() {
+        assert_eq!(get_provider_from_model("glm-5.2"), "zai");
+        assert_eq!(get_provider_from_model("kimi-k2.7-code"), "moonshotai");
+        assert_ne!(
+            get_provider_shade("zai", 0),
+            get_provider_shade("unknown", 0)
+        );
+        assert_ne!(
+            get_provider_shade("moonshotai", 0),
+            get_provider_shade("unknown", 0)
+        );
+    }
+
+    #[test]
     fn fable_gets_same_base_color_as_opus() {
         // Fable is a flagship Claude model and must render in the Anthropic
         // palette at the same base level as Opus — not the gray UNKNOWN shade.
@@ -810,6 +850,8 @@ mod tests {
         assert!(provider_has_palette("anthropic"));
         assert!(provider_has_palette("openai"));
         assert!(provider_has_palette("openrouter-gemini-prod"));
+        assert!(provider_has_palette("zai"));
+        assert!(provider_has_palette("moonshotai"));
         // Gateway/reseller providers do not — callers must color by the
         // model's own vendor instead of the neutral "unknown" gray.
         assert!(!provider_has_palette("github-copilot"));

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -358,6 +358,18 @@ const UNKNOWN_SHADES: [(u8, u8, u8); 7] = [
     (244, 244, 244), // #F4F4F4
 ];
 
+fn is_delimited_model_family(model_lower: &str, family: &str) -> bool {
+    model_lower
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .any(|token| {
+            token == family
+                || token
+                    .strip_prefix(family)
+                    .and_then(|suffix| suffix.chars().next())
+                    .map_or(false, |c| c.is_ascii_digit())
+        })
+}
+
 pub fn get_provider_from_model(model: &str) -> &'static str {
     let model_lower = model.to_lowercase();
 
@@ -389,9 +401,9 @@ pub fn get_provider_from_model(model: &str) -> &'static str {
         "deepseek"
     } else if model_lower.contains("grok") {
         "xai"
-    } else if model_lower.contains("glm") {
+    } else if is_delimited_model_family(&model_lower, "glm") {
         "zai"
-    } else if model_lower.contains("kimi") {
+    } else if is_delimited_model_family(&model_lower, "kimi") {
         "moonshotai"
     } else if model_lower.contains("llama") {
         "meta"
@@ -680,14 +692,10 @@ mod tests {
     fn glm_and_kimi_use_their_vendor_color_ramps() {
         assert_eq!(get_provider_from_model("glm-5.2"), "zai");
         assert_eq!(get_provider_from_model("kimi-k2.7-code"), "moonshotai");
-        assert_ne!(
-            get_provider_shade("zai", 0),
-            get_provider_shade("unknown", 0)
-        );
-        assert_ne!(
-            get_provider_shade("moonshotai", 0),
-            get_provider_shade("unknown", 0)
-        );
+        assert!(provider_has_palette("zai"));
+        assert!(provider_has_palette("moonshotai"));
+        assert_eq!(get_provider_from_model("glmish-1"), "unknown");
+        assert_eq!(get_provider_from_model("kimiko-1"), "unknown");
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod fs_atomic;
 pub mod mcp;
 mod message_cache;
 pub mod model_alias;
+pub mod opencode_model_name;
 mod parser;
 pub mod paths;
 pub mod pricing;
@@ -88,6 +89,22 @@ pub fn canonical_model_id(model_id: &str) -> String {
 /// empty/unset alias config makes this identical to [`canonical_model_id`].
 pub fn normalize_model_for_grouping(model_id: &str) -> String {
     model_alias::global().apply(normalize_syntactic(model_id))
+}
+
+/// Local display/grouping name with OpenCode's configured model label applied
+/// when one exists. The configured label is scoped to OpenCode and matched by
+/// provider plus raw model key; all other messages use the normal grouping
+/// name.
+pub fn model_name_for_grouping(client: &str, provider_id: &str, model_id: &str) -> String {
+    let fallback = normalize_model_for_grouping(model_id);
+    if client == "opencode" {
+        opencode_model_name::global()
+            .display_name(provider_id, model_id)
+            .map(str::to_string)
+            .unwrap_or(fallback)
+    } else {
+        fallback
+    }
 }
 
 /// Structural-only model-name normalization: lowercase, strip a
@@ -2193,7 +2210,7 @@ fn aggregate_model_usage_entries(
     let mut model_map: HashMap<String, ModelUsage> = HashMap::new();
 
     for msg in messages {
-        let normalized = normalize_model_for_grouping(&msg.model_id);
+        let normalized = model_name_for_grouping(&msg.client, &msg.provider_id, &msg.model_id);
         let (workspace_group_key, workspace_key, workspace_label) = workspace_bucket(&msg);
         let key = match group_by {
             GroupBy::Model => normalized.clone(),
@@ -2428,9 +2445,11 @@ pub async fn get_monthly_report(options: ReportOptions) -> Result<MonthlyReport,
 
         let entry = month_map.entry(month).or_default();
 
-        entry
-            .models
-            .insert(normalize_model_for_grouping(&msg.model_id));
+        entry.models.insert(model_name_for_grouping(
+            &msg.client,
+            &msg.provider_id,
+            &msg.model_id,
+        ));
         // saturating_add so clamped (i64::MAX) buckets from a corrupt source
         // can't overflow the fold.
         entry.input = entry.input.saturating_add(msg.tokens.input);
@@ -2530,9 +2549,11 @@ pub async fn get_hourly_report(options: ReportOptions) -> Result<HourlyReport, S
         let entry = hour_map.entry(hour_key).or_default();
 
         entry.clients.insert(msg.client.clone());
-        entry
-            .models
-            .insert(normalize_model_for_grouping(&msg.model_id));
+        entry.models.insert(model_name_for_grouping(
+            &msg.client,
+            &msg.provider_id,
+            &msg.model_id,
+        ));
         // saturating_add so clamped (i64::MAX) buckets from a corrupt source
         // can't overflow the fold.
         entry.input = entry.input.saturating_add(msg.tokens.input);

--- a/crates/tokscale-core/src/opencode_model_name.rs
+++ b/crates/tokscale-core/src/opencode_model_name.rs
@@ -50,7 +50,6 @@ impl OpenCodeModelNameResolver {
                 };
 
                 let name = name.to_string();
-                names.insert((provider.clone(), model_id.to_string()), name.clone());
                 names
                     .entry((provider.clone(), canonical_model_id(model_id)))
                     .or_insert(name);
@@ -68,8 +67,7 @@ impl OpenCodeModelNameResolver {
         let provider = provider_identity::canonical_provider(provider_id)
             .unwrap_or_else(|| provider_id.to_string());
         self.names
-            .get(&(provider.clone(), model_id.to_string()))
-            .or_else(|| self.names.get(&(provider, canonical_model_id(model_id))))
+            .get(&(provider, canonical_model_id(model_id)))
             .map(String::as_str)
     }
 }
@@ -459,27 +457,25 @@ mod tests {
     }
 
     #[test]
-    fn exact_model_id_match_takes_precedence_over_canonical_collision() {
+    fn colliding_canonical_ids_resolve_to_single_name() {
         let resolver = OpenCodeModelNameResolver::from_json(
             r#"{
                 "provider": {
                     "fireworks": {
                         "models": {
-                            "accounts/fireworks/models/glm-5p2": { "name": "Exact" },
-                            "fireworks/glm-5p2": { "name": "Alias" }
+                            "glm-5p2-20250701": { "name": "Dated" },
+                            "glm-5p2": { "name": "Short" }
                         }
                     }
                 }
             }"#,
         );
 
-        assert_eq!(
-            resolver.display_name("fireworks", "accounts/fireworks/models/glm-5p2"),
-            Some("Exact")
-        );
-        assert_eq!(
-            resolver.display_name("fireworks", "fireworks/glm-5p2"),
-            Some("Alias")
-        );
+        // Both keys canonicalize to "glm-5p2" (date suffix stripped),
+        // so both lookups return the same name.
+        let dated = resolver.display_name("fireworks", "glm-5p2-20250701");
+        let short = resolver.display_name("fireworks", "glm-5p2");
+        assert!(dated.is_some());
+        assert_eq!(dated, short);
     }
 }

--- a/crates/tokscale-core/src/opencode_model_name.rs
+++ b/crates/tokscale-core/src/opencode_model_name.rs
@@ -49,7 +49,11 @@ impl OpenCodeModelNameResolver {
                     continue;
                 };
 
-                names.insert((provider.clone(), model_id.to_string()), name.to_string());
+                let name = name.to_string();
+                names.insert((provider.clone(), model_id.to_string()), name.clone());
+                names
+                    .entry((provider.clone(), canonical_model_id(model_id)))
+                    .or_insert(name);
             }
         }
 
@@ -75,13 +79,55 @@ fn parse_jsonc(contents: &str) -> Option<serde_json::Value> {
         .ok()
         .or_else(|| serde_json::from_str(&strip_jsonc_syntax(contents)).ok())
 }
-
 fn strip_jsonc_syntax(contents: &str) -> String {
     let chars: Vec<char> = contents.chars().collect();
-    let mut out = String::with_capacity(contents.len());
+    let mut without_comments = String::with_capacity(contents.len());
+    let mut index = 0;
     let mut in_string = false;
     let mut escaped = false;
+
+    while index < chars.len() {
+        let ch = chars[index];
+        if in_string {
+            without_comments.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            index += 1;
+            continue;
+        }
+
+        if ch == '"' {
+            in_string = true;
+            without_comments.push(ch);
+            index += 1;
+        } else if ch == '/' && chars.get(index + 1) == Some(&'/') {
+            index += 2;
+            while index < chars.len() && chars[index] != '\n' {
+                index += 1;
+            }
+        } else if ch == '/' && chars.get(index + 1) == Some(&'*') {
+            without_comments.push(' ');
+            index += 2;
+            while index + 1 < chars.len() && !(chars[index] == '*' && chars[index + 1] == '/') {
+                index += 1;
+            }
+            index = (index + 2).min(chars.len());
+        } else {
+            without_comments.push(ch);
+            index += 1;
+        }
+    }
+
+    let chars: Vec<char> = without_comments.chars().collect();
+    let mut out = String::with_capacity(without_comments.len());
     let mut index = 0;
+    let mut in_string = false;
+    let mut escaped = false;
 
     while index < chars.len() {
         let ch = chars[index];
@@ -101,53 +147,15 @@ fn strip_jsonc_syntax(contents: &str) -> String {
         if ch == '"' {
             in_string = true;
             out.push(ch);
-            index += 1;
-        } else if ch == '/' && chars.get(index + 1) == Some(&'/') {
-            index += 2;
-            while index < chars.len() && chars[index] != '\n' {
-                index += 1;
-            }
-        } else if ch == '/' && chars.get(index + 1) == Some(&'*') {
-            out.push(' ');
-            index += 2;
-            while index + 1 < chars.len() && !(chars[index] == '*' && chars[index + 1] == '/') {
-                index += 1;
-            }
-            index = (index + 2).min(chars.len());
         } else if ch == ',' {
-            let mut peek = index + 1;
-            loop {
-                while peek < chars.len() && chars[peek].is_ascii_whitespace() {
-                    peek += 1;
-                }
-                if peek + 1 < chars.len() && chars[peek] == '/' && chars[peek + 1] == '/' {
-                    peek += 2;
-                    while peek < chars.len() && chars[peek] != '\n' {
-                        peek += 1;
-                    }
-                    continue;
-                }
-                if peek + 1 < chars.len() && chars[peek] == '/' && chars[peek + 1] == '*' {
-                    peek += 2;
-                    while peek + 1 < chars.len() && !(chars[peek] == '*' && chars[peek + 1] == '/')
-                    {
-                        peek += 1;
-                    }
-                    peek = (peek + 2).min(chars.len());
-                    continue;
-                }
-                break;
-            }
-            if peek < chars.len() && matches!(chars[peek], '}' | ']') {
-                index += 1;
-            } else {
+            let next = chars[index + 1..].iter().find(|c| !c.is_ascii_whitespace());
+            if !matches!(next, Some(&'}') | Some(&']')) {
                 out.push(ch);
-                index += 1;
             }
         } else {
             out.push(ch);
-            index += 1;
         }
+        index += 1;
     }
 
     out

--- a/crates/tokscale-core/src/opencode_model_name.rs
+++ b/crates/tokscale-core/src/opencode_model_name.rs
@@ -49,10 +49,7 @@ impl OpenCodeModelNameResolver {
                     continue;
                 };
 
-                names.insert(
-                    (provider.clone(), canonical_model_id(model_id)),
-                    name.to_string(),
-                );
+                names.insert((provider.clone(), model_id.to_string()), name.to_string());
             }
         }
 
@@ -67,7 +64,8 @@ impl OpenCodeModelNameResolver {
         let provider = provider_identity::canonical_provider(provider_id)
             .unwrap_or_else(|| provider_id.to_string());
         self.names
-            .get(&(provider, canonical_model_id(model_id)))
+            .get(&(provider.clone(), model_id.to_string()))
+            .or_else(|| self.names.get(&(provider, canonical_model_id(model_id))))
             .map(String::as_str)
     }
 }
@@ -117,8 +115,30 @@ fn strip_jsonc_syntax(contents: &str) -> String {
             }
             index = (index + 2).min(chars.len());
         } else if ch == ',' {
-            let next = chars[index + 1..].iter().find(|c| !c.is_ascii_whitespace());
-            if matches!(next, Some(&'}') | Some(&']')) {
+            let mut peek = index + 1;
+            loop {
+                while peek < chars.len() && chars[peek].is_ascii_whitespace() {
+                    peek += 1;
+                }
+                if peek + 1 < chars.len() && chars[peek] == '/' && chars[peek + 1] == '/' {
+                    peek += 2;
+                    while peek < chars.len() && chars[peek] != '\n' {
+                        peek += 1;
+                    }
+                    continue;
+                }
+                if peek + 1 < chars.len() && chars[peek] == '/' && chars[peek + 1] == '*' {
+                    peek += 2;
+                    while peek + 1 < chars.len() && !(chars[peek] == '*' && chars[peek + 1] == '/')
+                    {
+                        peek += 1;
+                    }
+                    peek = (peek + 2).min(chars.len());
+                    continue;
+                }
+                break;
+            }
+            if peek < chars.len() && matches!(chars[peek], '}' | ']') {
                 index += 1;
             } else {
                 out.push(ch);
@@ -405,6 +425,53 @@ mod tests {
         assert_eq!(
             resolver.display_name("fireworks", "accounts/fireworks/models/glm-5p2"),
             Some("Inline")
+        );
+    }
+
+    #[test]
+    fn trailing_comma_with_comment_then_close_brace_is_valid_jsonc() {
+        let resolver = OpenCodeModelNameResolver::from_json(
+            r#"{
+                "provider": {
+                    "fireworks-ai": {
+                        "models": {
+                            "accounts/fireworks/models/glm-5p2": {
+                                "name": "GLM 5.2", // model label comment
+                            },
+                        },
+                    },
+                },
+            }"#,
+        );
+
+        assert_eq!(
+            resolver.display_name("fireworks", "accounts/fireworks/models/glm-5p2"),
+            Some("GLM 5.2")
+        );
+    }
+
+    #[test]
+    fn exact_model_id_match_takes_precedence_over_canonical_collision() {
+        let resolver = OpenCodeModelNameResolver::from_json(
+            r#"{
+                "provider": {
+                    "fireworks": {
+                        "models": {
+                            "accounts/fireworks/models/glm-5p2": { "name": "Exact" },
+                            "fireworks/glm-5p2": { "name": "Alias" }
+                        }
+                    }
+                }
+            }"#,
+        );
+
+        assert_eq!(
+            resolver.display_name("fireworks", "accounts/fireworks/models/glm-5p2"),
+            Some("Exact")
+        );
+        assert_eq!(
+            resolver.display_name("fireworks", "fireworks/glm-5p2"),
+            Some("Alias")
         );
     }
 }

--- a/crates/tokscale-core/src/opencode_model_name.rs
+++ b/crates/tokscale-core/src/opencode_model_name.rs
@@ -1,0 +1,410 @@
+//! OpenCode-configured model display names.
+//!
+//! OpenCode lets providers assign a human-readable `name` to a model key in
+//! its user-level configuration. These names are presentation metadata:
+//! they are applied only while grouping local reports and never replace the
+//! model id used for pricing, caching, or exports.
+
+use crate::{canonical_model_id, provider_identity};
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::OnceLock;
+
+#[derive(Debug, Default)]
+pub struct OpenCodeModelNameResolver {
+    names: HashMap<(String, String), String>,
+}
+
+impl OpenCodeModelNameResolver {
+    fn from_json(contents: &str) -> Self {
+        let Some(config) = parse_jsonc(contents) else {
+            return Self::default();
+        };
+
+        let Some(providers) = config
+            .get("provider")
+            .and_then(serde_json::Value::as_object)
+        else {
+            return Self::default();
+        };
+
+        let mut names = HashMap::new();
+        for (provider, provider_config) in providers {
+            let Some(models) = provider_config
+                .get("models")
+                .and_then(serde_json::Value::as_object)
+            else {
+                continue;
+            };
+
+            let provider = provider_identity::canonical_provider(provider)
+                .unwrap_or_else(|| provider.to_string());
+            for (model_id, model_config) in models {
+                let Some(name) = model_config
+                    .get("name")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::trim)
+                    .filter(|name| !name.is_empty())
+                else {
+                    continue;
+                };
+
+                names.insert(
+                    (provider.clone(), canonical_model_id(model_id)),
+                    name.to_string(),
+                );
+            }
+        }
+
+        Self { names }
+    }
+
+    fn extend_from_json(&mut self, contents: &str) {
+        self.names.extend(Self::from_json(contents).names);
+    }
+
+    pub fn display_name(&self, provider_id: &str, model_id: &str) -> Option<&str> {
+        let provider = provider_identity::canonical_provider(provider_id)
+            .unwrap_or_else(|| provider_id.to_string());
+        self.names
+            .get(&(provider, canonical_model_id(model_id)))
+            .map(String::as_str)
+    }
+}
+
+fn parse_jsonc(contents: &str) -> Option<serde_json::Value> {
+    serde_json::from_str(contents)
+        .ok()
+        .or_else(|| serde_json::from_str(&strip_jsonc_syntax(contents)).ok())
+}
+
+fn strip_jsonc_syntax(contents: &str) -> String {
+    let chars: Vec<char> = contents.chars().collect();
+    let mut out = String::with_capacity(contents.len());
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut index = 0;
+
+    while index < chars.len() {
+        let ch = chars[index];
+        if in_string {
+            out.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            index += 1;
+            continue;
+        }
+
+        if ch == '"' {
+            in_string = true;
+            out.push(ch);
+            index += 1;
+        } else if ch == '/' && chars.get(index + 1) == Some(&'/') {
+            index += 2;
+            while index < chars.len() && chars[index] != '\n' {
+                index += 1;
+            }
+        } else if ch == '/' && chars.get(index + 1) == Some(&'*') {
+            out.push(' ');
+            index += 2;
+            while index + 1 < chars.len() && !(chars[index] == '*' && chars[index + 1] == '/') {
+                index += 1;
+            }
+            index = (index + 2).min(chars.len());
+        } else if ch == ',' {
+            let next = chars[index + 1..].iter().find(|c| !c.is_ascii_whitespace());
+            if matches!(next, Some(&'}') | Some(&']')) {
+                index += 1;
+            } else {
+                out.push(ch);
+                index += 1;
+            }
+        } else {
+            out.push(ch);
+            index += 1;
+        }
+    }
+
+    out
+}
+
+fn global_config_dir(home_dir: &Path, xdg_config_home: Option<&Path>) -> std::path::PathBuf {
+    if let Some(config_home) = xdg_config_home {
+        return config_home.join("opencode");
+    }
+    home_dir.join(".config/opencode")
+}
+
+#[derive(Default)]
+struct EnvironmentConfig {
+    xdg_config_home: Option<std::path::PathBuf>,
+    custom_config: Option<std::path::PathBuf>,
+    custom_config_dir: Option<std::path::PathBuf>,
+    inline_config: Option<String>,
+}
+
+impl EnvironmentConfig {
+    fn from_env() -> Self {
+        let path = |name| {
+            std::env::var_os(name)
+                .filter(|path| !path.is_empty())
+                .map(std::path::PathBuf::from)
+        };
+        Self {
+            xdg_config_home: path("XDG_CONFIG_HOME"),
+            custom_config: path("OPENCODE_CONFIG"),
+            custom_config_dir: path("OPENCODE_CONFIG_DIR"),
+            inline_config: std::env::var("OPENCODE_CONFIG_CONTENT").ok(),
+        }
+    }
+}
+
+fn load_with_environment(
+    home_dir: &Path,
+    environment: Option<&EnvironmentConfig>,
+) -> OpenCodeModelNameResolver {
+    let mut resolver = OpenCodeModelNameResolver::default();
+
+    let config_dir = global_config_dir(
+        home_dir,
+        environment.and_then(|config| config.xdg_config_home.as_deref()),
+    );
+    for filename in ["opencode.json", "opencode.jsonc"] {
+        if let Ok(contents) = std::fs::read_to_string(config_dir.join(filename)) {
+            resolver.extend_from_json(&contents);
+        }
+    }
+
+    // Mirror OpenCode's user-level source order. Project, remote, and managed
+    // configs are intentionally excluded because reports span many workspaces.
+    if let Some(path) = environment.and_then(|config| config.custom_config.as_deref()) {
+        if let Ok(contents) = std::fs::read_to_string(path) {
+            resolver.extend_from_json(&contents);
+        }
+    }
+
+    let legacy_dir = home_dir.join(".opencode");
+    for filename in ["opencode.json", "opencode.jsonc"] {
+        if let Ok(contents) = std::fs::read_to_string(legacy_dir.join(filename)) {
+            resolver.extend_from_json(&contents);
+        }
+    }
+
+    if let Some(environment) = environment {
+        if let Some(config_dir) = environment.custom_config_dir.as_deref() {
+            for filename in ["opencode.json", "opencode.jsonc"] {
+                if let Ok(contents) = std::fs::read_to_string(config_dir.join(filename)) {
+                    resolver.extend_from_json(&contents);
+                }
+            }
+        }
+        if let Some(contents) = environment.inline_config.as_deref() {
+            resolver.extend_from_json(contents);
+        }
+    }
+
+    resolver
+}
+
+/// Load configured model names from OpenCode's user-level configuration.
+///
+/// Normal runs honor OpenCode's XDG config root, custom config path and
+/// directory, inline config, and legacy `~/.opencode` directory. An explicit
+/// `--home` only reads paths under that home so reports stay hermetic. Invalid
+/// or unreadable config files are ignored so usage reporting remains available.
+pub fn load_for_home(home_dir: Option<&Path>) -> OpenCodeModelNameResolver {
+    let use_env_roots = home_dir.is_none();
+    let Some(home_dir) = home_dir.map(Path::to_path_buf).or_else(dirs::home_dir) else {
+        return OpenCodeModelNameResolver::default();
+    };
+
+    let environment = use_env_roots.then(EnvironmentConfig::from_env);
+    load_with_environment(&home_dir, environment.as_ref())
+}
+
+static GLOBAL: OnceLock<OpenCodeModelNameResolver> = OnceLock::new();
+static EMPTY: OnceLock<OpenCodeModelNameResolver> = OnceLock::new();
+
+/// Install the process-wide OpenCode name resolver. The first call wins, like
+/// the existing model-alias resolver.
+pub fn set_global(resolver: OpenCodeModelNameResolver) {
+    let _ = GLOBAL.set(resolver);
+}
+
+pub(crate) fn global() -> &'static OpenCodeModelNameResolver {
+    GLOBAL
+        .get()
+        .unwrap_or_else(|| EMPTY.get_or_init(OpenCodeModelNameResolver::default))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        global_config_dir, load_for_home, load_with_environment, EnvironmentConfig,
+        OpenCodeModelNameResolver,
+    };
+
+    fn config_with_name(name: &str) -> String {
+        format!(
+            r#"{{"provider":{{"fireworks-ai":{{"models":{{"accounts/fireworks/models/glm-5p2":{{"name":"{name}"}}}}}}}}}}"#
+        )
+    }
+
+    #[test]
+    fn uses_configured_name_for_matching_provider_and_model() {
+        let resolver = OpenCodeModelNameResolver::from_json(
+            r#"{
+                "provider": {
+                    "fireworks-ai": {
+                        "models": {
+                            "accounts/fireworks/models/glm-5p2": { "name": "GLM 5.2" }
+                        }
+                    }
+                }
+            }"#,
+        );
+
+        assert_eq!(
+            resolver.display_name("fireworks_ai", "accounts/fireworks/models/glm-5p2"),
+            Some("GLM 5.2")
+        );
+        assert_eq!(
+            resolver.display_name("fireworks_ai", "accounts/fireworks/models/glm-5p1"),
+            None
+        );
+    }
+
+    #[test]
+    fn skips_missing_or_blank_names_without_rejecting_other_models() {
+        let resolver = OpenCodeModelNameResolver::from_json(
+            r#"{
+                "provider": {
+                    "fireworks-ai": {
+                        "models": {
+                            "missing": {},
+                            "blank": { "name": "  " },
+                            "named": { "name": "DeepSeek V4 Flash" }
+                        }
+                    }
+                }
+            }"#,
+        );
+
+        assert_eq!(resolver.display_name("fireworks-ai", "missing"), None);
+        assert_eq!(resolver.display_name("fireworks-ai", "blank"), None);
+        assert_eq!(
+            resolver.display_name("fireworks-ai", "named"),
+            Some("DeepSeek V4 Flash")
+        );
+    }
+
+    #[test]
+    fn reads_jsonc_global_config_with_comments_and_trailing_commas() {
+        let home = tempfile::TempDir::new().unwrap();
+        let config_dir = home.path().join(".config/opencode");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(
+            config_dir.join("opencode.jsonc"),
+            r#"{
+                // Model labels are for display only.
+                "provider": {
+                    "fireworks-ai": {
+                        "models": {
+                            "accounts/fireworks/models/glm-5p2": {
+                                "name": "GLM 5.2",
+                            },
+                        },
+                    },
+                },
+            }"#,
+        )
+        .unwrap();
+
+        let resolver = load_for_home(Some(home.path()));
+
+        assert_eq!(
+            resolver.display_name("fireworks", "accounts/fireworks/models/glm-5p2"),
+            Some("GLM 5.2")
+        );
+    }
+
+    #[test]
+    fn explicit_home_ignores_environment_config_sources() {
+        let home = tempfile::TempDir::new().unwrap();
+        let home_config_dir = home.path().join(".config/opencode");
+        std::fs::create_dir_all(&home_config_dir).unwrap();
+        std::fs::write(
+            home_config_dir.join("opencode.json"),
+            r#"{"provider":{"fireworks-ai":{"models":{"accounts/fireworks/models/glm-5p2":{"name":"Home Config"}}}}}"#,
+        )
+        .unwrap();
+
+        let legacy_config_dir = home.path().join(".opencode");
+        std::fs::create_dir_all(&legacy_config_dir).unwrap();
+        std::fs::write(
+            legacy_config_dir.join("opencode.json"),
+            r#"{"provider":{"fireworks-ai":{"models":{"accounts/fireworks/models/glm-5p2":{"name":"Home Legacy"}}}}}"#,
+        )
+        .unwrap();
+
+        let resolver = load_with_environment(home.path(), None);
+
+        assert_eq!(
+            resolver.display_name("fireworks", "accounts/fireworks/models/glm-5p2"),
+            Some("Home Legacy")
+        );
+    }
+
+    #[test]
+    fn normal_runs_apply_xdg_and_environment_sources_in_opencode_order() {
+        let home = tempfile::TempDir::new().unwrap();
+        let xdg = tempfile::TempDir::new().unwrap();
+        let external = tempfile::TempDir::new().unwrap();
+        let xdg_config_dir = xdg.path().join("opencode");
+        let legacy_config_dir = home.path().join(".opencode");
+        let config_dir = external.path().join("config-dir");
+        let custom_config = external.path().join("custom.json");
+        std::fs::create_dir_all(&xdg_config_dir).unwrap();
+        std::fs::create_dir_all(&legacy_config_dir).unwrap();
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(
+            xdg_config_dir.join("opencode.json"),
+            config_with_name("XDG"),
+        )
+        .unwrap();
+        std::fs::write(&custom_config, config_with_name("Custom")).unwrap();
+        std::fs::write(
+            legacy_config_dir.join("opencode.json"),
+            config_with_name("Legacy"),
+        )
+        .unwrap();
+        std::fs::write(
+            config_dir.join("opencode.json"),
+            config_with_name("Config Dir"),
+        )
+        .unwrap();
+
+        let environment = EnvironmentConfig {
+            xdg_config_home: Some(xdg.path().to_path_buf()),
+            custom_config: Some(custom_config),
+            custom_config_dir: Some(config_dir),
+            inline_config: Some(config_with_name("Inline")),
+        };
+
+        assert_eq!(
+            global_config_dir(home.path(), environment.xdg_config_home.as_deref()),
+            xdg_config_dir
+        );
+        let resolver = load_with_environment(home.path(), Some(&environment));
+
+        assert_eq!(
+            resolver.display_name("fireworks", "accounts/fireworks/models/glm-5p2"),
+            Some("Inline")
+        );
+    }
+}


### PR DESCRIPTION
## Summary
OpenCode lets users assign a human-readable `name` to model keys in their provider config:

```jsonc
{
  "provider": {
    "fireworks-ai": {
      "models": {
        "accounts/fireworks/models/glm-5p2": { "name": "GLM 5.2" }
      }
    }
  }
}
```
These labels are now loaded from the user's opencode config files (XDG config dir, custom config, env overrides, legacy ~/.opencode) and used as display names in the TUI and reports. When no name is configured the existing normalized model name is used unchanged.

Also adds provider color ramps for Zhipu AI (zai/z_ai/zhipu — purple) and Moonshot AI (moonshot/kimi — teal), plus model-id detection so models like glm-5.2 and kimi-k2.7-code get their vendor colors instead of neutral gray.

## Screenshots

### Before
<img width="2028" height="981" alt="Screenshot 2026-07-21 at 3 37 57 PM" src="https://github.com/user-attachments/assets/e9aa847d-ca3f-4c0d-8fd8-6ce77ef53800" />
<img width="2026" height="983" alt="Screenshot 2026-07-21 at 3 38 10 PM" src="https://github.com/user-attachments/assets/1bca336a-be95-4b2c-bb08-1e99c130f76d" />

### After
<img width="1896" height="965" alt="Screenshot 2026-07-22 at 9 50 04 AM" src="https://github.com/user-attachments/assets/d2cb4439-4318-455f-b5a6-4e9903cc2da2" />
<img width="1910" height="978" alt="Screenshot 2026-07-22 at 9 49 47 AM" src="https://github.com/user-attachments/assets/174dd527-0737-4169-b7fb-9ca86eb4394f" />

## Changes
- New opencode_model_name module in tokscale-core — reads config files, resolves display names
- model_name_for_grouping wraps the resolver, scoped to opencode messages only
- Wired into both TUI data loader and report aggregation
- Color palette + model detection for Zhipu AI and Moonshot AI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use model display names from the user’s OpenCode config in the TUI and reports, falling back to the normalized model id when no name is set. Adds vendor color palettes and detection for Zhipu AI and Moonshot AI so GLM and Kimi models render with correct colors.

- New Features
  - Load model names from OpenCode config files (opencode.json/jsonc in XDG config dir, `OPENCODE_CONFIG`, `OPENCODE_CONFIG_DIR`, `OPENCODE_CONFIG_CONTENT`, legacy `~/.opencode`); `--home` scopes reads to that home.
  - Apply names only to OpenCode messages when grouping/displaying; others keep the normalized name.
  - Wire into `tokscale-cli` TUI and `tokscale-core` data/report aggregation; add `opencode_model_name` resolver with global load.
  - Add color ramps and model/vendor detection for Zhipu AI (`glm*`) and Moonshot AI (`kimi*`).

- Bug Fixes
  - Assign colors by a stable normalized `color_key` so vendor palettes remain correct when a display name is shown; cache updated accordingly.

<sup>Written for commit a1410b4fd20af68a4997920b703f8e738aa190a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

