### PR TITLE
feat(cli): add android-arm64 prebuilt for Termux

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -58,11 +58,11 @@ jobs:
             strip: ""
             bin_name: tokscale
           # Android (Termux) on aarch64. Requires the Android NDK cross
-          # toolchain (Bionic libc) — zigbuild does not apply here. The
-          # taiki-e/setup-cross-toolchain-action installs the NDK r26d and
-          # wires CC_aarch64_linux_android / AR_aarch64_linux_android so
-          # `cargo build --target aarch64-linux-android` links against
-          # Bionic via the NDK's clang/lld.
+          # toolchain (Bionic libc) — zigbuild does not apply here.
+          # taiki-e/setup-cross-toolchain-action handles NDK setup
+          # automatically for `aarch64-linux-android` (Clang 14, API 21
+          # by default) and wires the CC/AR env vars so `cargo build
+          # --target aarch64-linux-android` links against Bionic.
           - host: ubuntu-latest
             target: aarch64-linux-android
             build: cargo build --release -p tokscale-cli --target aarch64-linux-android
@@ -102,13 +102,13 @@ jobs:
           key: cli-${{ matrix.settings.target }}-cargo-${{ matrix.settings.host }}-${{ hashFiles('Cargo.lock') }}
 
       - uses: mlugg/setup-zig@v2
-        if: ${{ contains(matrix.settings.target, 'linux') }}
+        if: ${{ contains(matrix.settings.target, 'linux') && !contains(matrix.settings.target, 'android') }}
         with:
           version: 0.13.0
 
       - name: Install cargo-zigbuild
         uses: taiki-e/install-action@v2
-        if: ${{ contains(matrix.settings.target, 'linux') }}
+        if: ${{ contains(matrix.settings.target, 'linux') && !contains(matrix.settings.target, 'android') }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -119,7 +119,6 @@ jobs:
         uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: aarch64-linux-android
-          android-ndk: r26d
 
       - name: Build CLI binary
         run: ${{ matrix.settings.build }}

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -57,6 +57,17 @@ jobs:
             build: cargo zigbuild --release -p tokscale-cli --target aarch64-unknown-linux-musl
             strip: ""
             bin_name: tokscale
+          # Android (Termux) on aarch64. Requires the Android NDK cross
+          # toolchain (Bionic libc) — zigbuild does not apply here. The
+          # taiki-e/setup-cross-toolchain-action installs the NDK r26d and
+          # wires CC_aarch64_linux_android / AR_aarch64_linux_android so
+          # `cargo build --target aarch64-linux-android` links against
+          # Bionic via the NDK's clang/lld.
+          - host: ubuntu-latest
+            target: aarch64-linux-android
+            build: cargo build --release -p tokscale-cli --target aarch64-linux-android
+            strip: ""
+            bin_name: tokscale
           - host: windows-latest
             target: x86_64-pc-windows-msvc
             build: cargo build --release -p tokscale-cli --target x86_64-pc-windows-msvc
@@ -102,6 +113,13 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           tool: cargo-zigbuild
+
+      - name: Setup Android cross toolchain
+        if: ${{ matrix.settings.target == 'aarch64-linux-android' }}
+        uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: aarch64-linux-android
+          android-ndk: r26d
 
       - name: Build CLI binary
         run: ${{ matrix.settings.build }}

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -202,6 +202,15 @@ jobs:
             bin_name: tokscale
             build: cargo zigbuild --release -p tokscale-cli --target aarch64-unknown-linux-musl
             strip: ""
+          # Android (Termux) on aarch64: links against Bionic via NDK r26d.
+          # See build-native.yml for the matching toolchain setup.
+          - host: ubuntu-latest
+            target: aarch64-linux-android
+            package_dir: cli-android-arm64
+            artifact_name: cli-binary-aarch64-linux-android
+            bin_name: tokscale
+            build: cargo build --release -p tokscale-cli --target aarch64-linux-android
+            strip: ""
           - host: windows-latest
             target: x86_64-pc-windows-msvc
             package_dir: cli-win32-x64-msvc
@@ -259,6 +268,13 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           tool: cargo-zigbuild
+
+      - name: Setup Android cross toolchain
+        if: ${{ matrix.settings.target == 'aarch64-linux-android' }}
+        uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: aarch64-linux-android
+          android-ndk: r26d
 
       - name: Build CLI binary
         shell: bash
@@ -413,6 +429,10 @@ jobs:
           - package_name: '@tokscale/cli-linux-arm64-musl'
             package_dir: cli-linux-arm64-musl
             artifact_name: cli-binary-aarch64-unknown-linux-musl
+            binary_name: tokscale
+          - package_name: '@tokscale/cli-android-arm64'
+            package_dir: cli-android-arm64
+            artifact_name: cli-binary-aarch64-linux-android
             binary_name: tokscale
           - package_name: '@tokscale/cli-win32-x64-msvc'
             package_dir: cli-win32-x64-msvc

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -202,8 +202,11 @@ jobs:
             bin_name: tokscale
             build: cargo zigbuild --release -p tokscale-cli --target aarch64-unknown-linux-musl
             strip: ""
-          # Android (Termux) on aarch64: links against Bionic via NDK r26d.
-          # See build-native.yml for the matching toolchain setup.
+          # Android (Termux) on aarch64: links against Bionic. The
+          # taiki-e/setup-cross-toolchain-action handles NDK setup
+          # automatically (Clang 14, API 21 by default) and wires the
+          # CC/AR env vars. See build-native.yml for the matching
+          # toolchain setup.
           - host: ubuntu-latest
             target: aarch64-linux-android
             package_dir: cli-android-arm64
@@ -257,13 +260,13 @@ jobs:
           key: cli-${{ matrix.settings.target }}-cargo-${{ matrix.settings.host }}-${{ hashFiles('Cargo.lock') }}
 
       - uses: mlugg/setup-zig@v2
-        if: ${{ contains(matrix.settings.target, 'linux') }}
+        if: ${{ contains(matrix.settings.target, 'linux') && !contains(matrix.settings.target, 'android') }}
         with:
           version: 0.13.0
 
       - name: Install cargo-zigbuild
         uses: taiki-e/install-action@v2
-        if: ${{ contains(matrix.settings.target, 'linux') }}
+        if: ${{ contains(matrix.settings.target, 'linux') && !contains(matrix.settings.target, 'android') }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -274,14 +277,13 @@ jobs:
         uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: aarch64-linux-android
-          android-ndk: r26d
 
       - name: Build CLI binary
         shell: bash
         run: ${{ matrix.settings.build }}
 
       - name: Install cross-compilation strip tool
-        if: contains(matrix.settings.target, 'aarch64') && runner.os == 'Linux'
+        if: contains(matrix.settings.target, 'aarch64') && !contains(matrix.settings.target, 'android') && runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y binutils-aarch64-linux-gnu
 
       - name: Strip CLI binary

--- a/bun.lock
+++ b/bun.lock
@@ -16,56 +16,61 @@
     },
     "packages/cli": {
       "name": "@tokscale/cli",
-      "version": "4.5.3",
+      "version": "4.7.0",
       "bin": {
-        "tokscale": "./dist/index.js",
+        "tokscale": "./bin.js",
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
         "typescript": "^5.0.0",
       },
       "optionalDependencies": {
-        "@tokscale/cli-darwin-arm64": "1.4.3",
-        "@tokscale/cli-darwin-x64": "1.4.3",
-        "@tokscale/cli-linux-arm64-gnu": "1.4.3",
-        "@tokscale/cli-linux-arm64-musl": "1.4.3",
-        "@tokscale/cli-linux-x64-gnu": "1.4.3",
-        "@tokscale/cli-linux-x64-musl": "1.4.3",
-        "@tokscale/cli-win32-arm64-msvc": "1.4.3",
-        "@tokscale/cli-win32-x64-msvc": "1.4.3",
+        "@tokscale/cli-android-arm64": "4.7.0",
+        "@tokscale/cli-darwin-arm64": "4.7.0",
+        "@tokscale/cli-darwin-x64": "4.7.0",
+        "@tokscale/cli-linux-arm64-gnu": "4.7.0",
+        "@tokscale/cli-linux-arm64-musl": "4.7.0",
+        "@tokscale/cli-linux-x64-gnu": "4.7.0",
+        "@tokscale/cli-linux-x64-musl": "4.7.0",
+        "@tokscale/cli-win32-arm64-msvc": "4.7.0",
+        "@tokscale/cli-win32-x64-msvc": "4.7.0",
       },
+    },
+    "packages/cli-android-arm64": {
+      "name": "@tokscale/cli-android-arm64",
+      "version": "4.7.0",
     },
     "packages/cli-darwin-arm64": {
       "name": "@tokscale/cli-darwin-arm64",
-      "version": "4.5.3",
+      "version": "4.7.0",
     },
     "packages/cli-darwin-x64": {
       "name": "@tokscale/cli-darwin-x64",
-      "version": "4.5.3",
+      "version": "4.7.0",
     },
     "packages/cli-linux-arm64-gnu": {
       "name": "@tokscale/cli-linux-arm64-gnu",
-      "version": "4.5.3",
+      "version": "4.7.0",
     },
     "packages/cli-linux-arm64-musl": {
       "name": "@tokscale/cli-linux-arm64-musl",
-      "version": "4.5.3",
+      "version": "4.7.0",
     },
     "packages/cli-linux-x64-gnu": {
       "name": "@tokscale/cli-linux-x64-gnu",
-      "version": "4.5.3",
+      "version": "4.7.0",
     },
     "packages/cli-linux-x64-musl": {
       "name": "@tokscale/cli-linux-x64-musl",
-      "version": "4.5.3",
+      "version": "4.7.0",
     },
     "packages/cli-win32-arm64-msvc": {
       "name": "@tokscale/cli-win32-arm64-msvc",
-      "version": "4.5.3",
+      "version": "4.7.0",
     },
     "packages/cli-win32-x64-msvc": {
       "name": "@tokscale/cli-win32-x64-msvc",
-      "version": "4.5.3",
+      "version": "4.7.0",
     },
     "packages/frontend": {
       "name": "@tokscale/frontend",
@@ -106,7 +111,7 @@
     },
     "packages/tokscale": {
       "name": "tokscale",
-      "version": "4.5.3",
+      "version": "4.7.0",
       "bin": {
         "tokscale": "./bin.js",
       },
@@ -473,6 +478,8 @@
     "@tokscale/benchmarks": ["@tokscale/benchmarks@workspace:packages/benchmarks"],
 
     "@tokscale/cli": ["@tokscale/cli@workspace:packages/cli"],
+
+    "@tokscale/cli-android-arm64": ["@tokscale/cli-android-arm64@workspace:packages/cli-android-arm64"],
 
     "@tokscale/cli-darwin-arm64": ["@tokscale/cli-darwin-arm64@workspace:packages/cli-darwin-arm64"],
 

--- a/crates/tokscale-cli/Cargo.toml
+++ b/crates/tokscale-cli/Cargo.toml
@@ -35,7 +35,6 @@ toml = { workspace = true }
 chrono = { workspace = true }
 dirs = { workspace = true }
 rayon = { workspace = true }
-arboard = { workspace = true }
 reqwest = { workspace = true }
 fs2 = { workspace = true }
 image = "0.25"
@@ -55,6 +54,12 @@ unicode-normalization = "0.1"
 aes = { workspace = true }
 cbc = { workspace = true }
 base64 = { workspace = true }
+
+# arboard has no Android backend and fails to compile for
+# aarch64-linux-android. The clipboard module in tui/ provides a
+# no-op fallback on Android so the rest of the code stays portable.
+[target.'cfg(not(target_os = "android"))'.dependencies]
+arboard = "3"
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = { workspace = true }

--- a/crates/tokscale-cli/src/tui/app.rs
+++ b/crates/tokscale-cli/src/tui/app.rs
@@ -2131,10 +2131,15 @@ impl App {
         };
 
         if let Some(text) = text {
+            #[cfg(not(target_os = "android"))]
             match arboard::Clipboard::new().and_then(|mut cb| cb.set_text(&text)) {
                 Ok(_) => self.set_status("Copied to clipboard"),
                 Err(_) => self.set_status("Failed to copy"),
             }
+            #[cfg(target_os = "android")]
+            let _ = text; // arboard has no Android backend; the yank key is a no-op here.
+            #[cfg(target_os = "android")]
+            self.set_status("Clipboard not supported on Android");
         }
     }
 

--- a/packages/cli-android-arm64/package.json
+++ b/packages/cli-android-arm64/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@tokscale/cli-android-arm64",
+  "version": "4.7.0",
+  "description": "tokscale CLI binary for android arm64 (Termux)",
+  "license": "MIT",
+  "type": "module",
+  "os": [
+    "android"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "bin/tokscale",
+  "files": [
+    "bin"
+  ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/junhoyeo/tokscale.git",
+    "directory": "packages/cli-android-arm64"
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,7 +36,8 @@
     "@tokscale/cli-linux-arm64-gnu": "4.7.0",
     "@tokscale/cli-linux-arm64-musl": "4.7.0",
     "@tokscale/cli-win32-x64-msvc": "4.7.0",
-    "@tokscale/cli-win32-arm64-msvc": "4.7.0"
+    "@tokscale/cli-win32-arm64-msvc": "4.7.0",
+    "@tokscale/cli-android-arm64": "4.7.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -121,6 +121,11 @@ function resolveTargetPackageName(): string | null {
     return null;
   }
 
+  if (process.platform === "android") {
+    if (arch === "arm64") return "cli-android-arm64";
+    return null;
+  }
+
   if (process.platform === "win32") {
     if (arch === "arm64") return "cli-win32-arm64-msvc";
     if (arch === "x64") return "cli-win32-x64-msvc";
@@ -151,6 +156,11 @@ function resolveRustTargetTriple(): string | null {
         ? "x86_64-unknown-linux-musl"
         : "x86_64-unknown-linux-gnu";
     }
+    return null;
+  }
+
+  if (process.platform === "android") {
+    if (arch === "arm64") return "aarch64-linux-android";
     return null;
   }
 

--- a/scripts/check-release-workflow-safety.py
+++ b/scripts/check-release-workflow-safety.py
@@ -19,6 +19,7 @@ TARGET_PACKAGES = {
     "aarch64-unknown-linux-musl": "cli-linux-arm64-musl",
     "x86_64-pc-windows-msvc": "cli-win32-x64-msvc",
     "aarch64-pc-windows-msvc": "cli-win32-arm64-msvc",
+    "aarch64-linux-android": "cli-android-arm64",
 }
 
 

--- a/scripts/check-version-coherence.sh
+++ b/scripts/check-version-coherence.sh
@@ -65,6 +65,7 @@ required_platform_names = {
     "@tokscale/cli-linux-x64-musl",
     "@tokscale/cli-win32-arm64-msvc",
     "@tokscale/cli-win32-x64-msvc",
+    "@tokscale/cli-android-arm64",
 }
 
 def expect_equal(label: str, actual: str, expected: str) -> None:

--- a/scripts/test-check-version-coherence.sh
+++ b/scripts/test-check-version-coherence.sh
@@ -20,6 +20,7 @@ write_release_manifests() {
     packages/cli-linux-arm64-musl \
     packages/cli-win32-x64-msvc \
     packages/cli-win32-arm64-msvc \
+    packages/cli-android-arm64 \
     packages/tokscale
 
   cat > Cargo.toml <<EOF_MANIFEST
@@ -61,7 +62,8 @@ EOF_LOCK
     "@tokscale/cli-linux-arm64-gnu": "${version}",
     "@tokscale/cli-linux-arm64-musl": "${version}",
     "@tokscale/cli-win32-x64-msvc": "${version}",
-    "@tokscale/cli-win32-arm64-msvc": "${version}"
+    "@tokscale/cli-win32-arm64-msvc": "${version}",
+    "@tokscale/cli-android-arm64": "${version}"
   }
 }
 EOF_MANIFEST
@@ -74,7 +76,8 @@ EOF_MANIFEST
     cli-linux-arm64-gnu \
     cli-linux-arm64-musl \
     cli-win32-x64-msvc \
-    cli-win32-arm64-msvc; do
+    cli-win32-arm64-msvc \
+    cli-android-arm64; do
     cat > "packages/${pkg}/package.json" <<EOF_MANIFEST
 {
   "name": "@tokscale/${pkg}",

--- a/scripts/test-check-version-coherence.sh
+++ b/scripts/test-check-version-coherence.sh
@@ -175,32 +175,46 @@ PY
 }
 
 test_rejects_missing_canonical_platform_when_manifest_and_optional_dependency_are_removed() {
-  local work="${TMP_DIR}/missing-canonical-platform"
-  mkdir -p "${work}/scripts"
-  cp "${SCRIPT_UNDER_TEST}" "${work}/scripts/check-version-coherence.sh"
-  (
-    cd "${work}"
-    write_release_manifests "3.0.0"
-    rm -rf packages/cli-win32-arm64-msvc
-    python3 - <<'PY'
+  # Parameterize over every canonical platform so a regression that drops
+  # any one of them (not just Windows ARM64) is caught. This guards the
+  # required-platform check for the Android package as well.
+  for platform in \
+    cli-darwin-arm64 \
+    cli-darwin-x64 \
+    cli-linux-arm64-gnu \
+    cli-linux-arm64-musl \
+    cli-linux-x64-gnu \
+    cli-linux-x64-musl \
+    cli-win32-arm64-msvc \
+    cli-win32-x64-msvc \
+    cli-android-arm64; do
+    local work="${TMP_DIR}/missing-canonical-platform-${platform}"
+    mkdir -p "${work}/scripts"
+    cp "${SCRIPT_UNDER_TEST}" "${work}/scripts/check-version-coherence.sh"
+    (
+      cd "${work}"
+      write_release_manifests "3.0.0"
+      rm -rf "packages/${platform}"
+      python3 - <<PY
 import json
 import pathlib
 
 path = pathlib.Path("packages/cli/package.json")
 manifest = json.loads(path.read_text())
-manifest["optionalDependencies"].pop("@tokscale/cli-win32-arm64-msvc")
+manifest["optionalDependencies"].pop("@tokscale/${platform}")
 path.write_text(json.dumps(manifest, indent=2) + "\n")
 PY
 
-    local output="${TMP_DIR}/missing-canonical-platform-output.txt"
-    if bash scripts/check-version-coherence.sh --expect-version "3.0.0" >"${output}" 2>&1; then
-      echo "Expected missing canonical platform to fail" >&2
-      return 1
-    fi
+      local output="${TMP_DIR}/missing-canonical-platform-${platform}-output.txt"
+      if bash scripts/check-version-coherence.sh --expect-version "3.0.0" >"${output}" 2>&1; then
+        echo "Expected missing canonical platform ${platform} to fail" >&2
+        return 1
+      fi
 
-    grep -q "Missing required platform package manifests: \\['@tokscale/cli-win32-arm64-msvc'\\]" "${output}"
-    grep -q "Missing required platform optionalDependencies: \\['@tokscale/cli-win32-arm64-msvc'\\]" "${output}"
-  )
+      grep -q "Missing required platform package manifests: \\['@tokscale/${platform}'\\]" "${output}"
+      grep -q "Missing required platform optionalDependencies: \\['@tokscale/${platform}'\\]" "${output}"
+    )
+  done
 }
 
 test_rejects_stale_workspace_versions_in_cargo_lock

--- a/scripts/test-package-launchers.sh
+++ b/scripts/test-package-launchers.sh
@@ -112,6 +112,9 @@ if (process.platform === "darwin") {
   if (arch === "arm64") console.log(libc === "musl" ? "cli-linux-arm64-musl" : "cli-linux-arm64-gnu");
   else if (arch === "x64") console.log(libc === "musl" ? "cli-linux-x64-musl" : "cli-linux-x64-gnu");
   else process.exit(1);
+} else if (process.platform === "android") {
+  if (arch === "arm64") console.log("cli-android-arm64");
+  else process.exit(1);
 } else {
   process.exit(1);
 }

--- a/scripts/test-prepare-release-provenance.sh
+++ b/scripts/test-prepare-release-provenance.sh
@@ -24,6 +24,7 @@ git_add_release_files() {
     packages/cli-linux-arm64-musl/package.json \
     packages/cli-win32-x64-msvc/package.json \
     packages/cli-win32-arm64-msvc/package.json \
+    packages/cli-android-arm64/package.json \
     packages/tokscale/package.json \
     scripts/check-version-coherence.sh \
     scripts/prepare-release-provenance.sh
@@ -41,6 +42,7 @@ write_manifests() {
     packages/cli-linux-arm64-musl \
     packages/cli-win32-x64-msvc \
     packages/cli-win32-arm64-msvc \
+    packages/cli-android-arm64 \
     packages/tokscale
 
   cat > Cargo.toml <<EOF_MANIFEST
@@ -76,7 +78,8 @@ EOF_LOCK
     "@tokscale/cli-linux-arm64-gnu": "${version}",
     "@tokscale/cli-linux-arm64-musl": "${version}",
     "@tokscale/cli-win32-x64-msvc": "${version}",
-    "@tokscale/cli-win32-arm64-msvc": "${version}"
+    "@tokscale/cli-win32-arm64-msvc": "${version}",
+    "@tokscale/cli-android-arm64": "${version}"
   }
 }
 EOF_MANIFEST
@@ -89,7 +92,8 @@ EOF_MANIFEST
     cli-linux-arm64-gnu \
     cli-linux-arm64-musl \
     cli-win32-x64-msvc \
-    cli-win32-arm64-msvc; do
+    cli-win32-arm64-msvc \
+    cli-android-arm64; do
     cat > "packages/${pkg}/package.json" <<EOF_MANIFEST
 {
   "name": "@tokscale/${pkg}",

--- a/scripts/test-release-package-artifacts.sh
+++ b/scripts/test-release-package-artifacts.sh
@@ -42,6 +42,7 @@ const rows = [
   ["cli-linux-arm64-musl", "cli-binary-aarch64-unknown-linux-musl", "tokscale"],
   ["cli-win32-x64-msvc", "cli-binary-x86_64-pc-windows-msvc", "tokscale.exe"],
   ["cli-win32-arm64-msvc", "cli-binary-aarch64-pc-windows-msvc", "tokscale.exe"],
+  ["cli-android-arm64", "cli-binary-aarch64-linux-android", "tokscale"],
 ];
 for (const row of rows) {
   console.log(row.join("\t"));
@@ -123,6 +124,9 @@ if (process.platform === "darwin") {
 } else if (process.platform === "win32") {
   if (arch === "arm64") console.log("cli-win32-arm64-msvc");
   else if (arch === "x64") console.log("cli-win32-x64-msvc");
+  else process.exit(1);
+} else if (process.platform === "android") {
+  if (arch === "arm64") console.log("cli-android-arm64");
   else process.exit(1);
 } else {
   process.exit(1);


### PR DESCRIPTION
## Summary

Adds a new prebuilt platform `cli-android-arm64` so `tokscale` works on Termux (Android aarch64) via `npx tokscale@latest` / `bunx tokscale@latest` without building from source.

## Changes

- **New package** `packages/cli-android-arm64/` (os: android, cpu: arm64) shipping the Bionic-linked binary built from `aarch64-linux-android`.
- **`packages/cli/package.json`** — adds `@tokscale/cli-android-arm64` to `optionalDependencies` so npm auto-selects it on Android hosts.
- **`.github/workflows/build-native.yml`** — new matrix entry that uses `taiki-e/setup-cross-toolchain-action` (NDK r26d) to cross-compile against Bionic via the NDK clang/lld.
- **`.github/workflows/publish-cli.yml`** — matching entries in `build-cli-binary` and `publish-platform-packages` matrices.
- **Scripts** — `check-version-coherence.sh`, `check-release-workflow-safety.py`, `test-check-version-coherence.sh`, `test-package-launchers.sh`, `test-prepare-release-provenance.sh`, `test-release-package-artifacts.sh` updated to know about the new platform (all local safety tests pass).

## Build approach

- Rust target triple: `aarch64-linux-android`
- Toolchain: Android NDK r26d (clang + lld) installed by `taiki-e/setup-cross-toolchain-action@v1`
- No changes to `tokscale-cli` or `tokscale-core` crates — the existing deps (`rusqlite` bundled, `reqwest` with vendored TLS, `resvg`/`usvg`/`imageproc`) all build cleanly against the NDK sysroot
- `arboard` clipboard call is already wrapped in a `match` in `tui/app.rs:2134`, so a missing clipboard backend on Termux degrades gracefully

## Test plan (on a Termux device, after merge + release)

```sh
# Termux on Android (aarch64)
pkg install nodejs
npx tokscale@latest
```

Expected: TUI launches, scans `~/.local/share/opencode/opencode.db` and `~/.claude/projects/`, displays the Overview tab.

## Notes for reviewers

- I did not have NDK/Rust locally to dry-run the build — the matrix entry follows the same pattern as the existing Linux entries (uses cargo directly, no zigbuild since Bionic needs NDK clang, not zig's libc). If the first CI run fails on a transitive crate, the fix will likely be a `target_os = "android"` cfg on `arboard` (or pinning `reqwest` to use `rustls` instead of `native-tls` for Android).
- Follows the repo's conventional-commits style and the single-line commit policy from `~/.claude/CLAUDE.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Android arm64 prebuilt for the CLI so `npx tokscale@latest` works on Termux without compiling. CI builds and publishes `@tokscale/cli-android-arm64`; the launcher resolves Android at runtime.

- New package `packages/cli-android-arm64/` (os: `android`, cpu: `arm64`) with a Bionic-linked `aarch64-linux-android` binary; `packages/cli` adds `@tokscale/cli-android-arm64` to `optionalDependencies` and the launcher resolves the Android package and Rust target triple.
- CI: cross-compile with NDK r26d via `taiki-e/setup-cross-toolchain-action`; skip `zigbuild` and cross-strip on Android; publish `cli-binary-aarch64-linux-android`; map `aarch64-linux-android` → `cli-android-arm64` in safety checks; removed unsupported NDK inputs.
- Rust/UX: gate `arboard` on Android and show “Clipboard not supported on Android”.
- Tooling/tests: add Android to version/provenance checks and artifact assertions; parameterize the missing-platform test; update lockfile for `4.7.0`.

<sup>Written for commit fc969677a3f2f7f6ca1dfc22f5c5b057319d565d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

