### PR TITLE
feat(sponsors): make project funding discoverable

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [junhoyeo]

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,6 +16,7 @@
 > | [<img alt="GitHub Follow" src="https://img.shields.io/github/followers/junhoyeo?style=flat-square&logo=github&labelColor=black&color=24292f" width="156px" />](https://github.com/junhoyeo) | GitHubで[@junhoyeo](https://github.com/junhoyeo)をフォローして、他のプロジェクトもチェックしてください。AI、インフラ、その他様々な分野で開発しています。 |
 > | :-----| :----- |
 > [<img alt="Discord link" src="https://img.shields.io/discord/1480206352755458110?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=flat-square" width="156px" />](https://discord.gg/h6DUGWdBbm) | [Discord](https://discord.gg/h6DUGWdBbm)に参加しよう — 世界最高のバイバーたちと一緒に。 |
+> [<img alt="Sponsor Tokscale" src="https://img.shields.io/badge/sponsor-Tokscale-EA4AAA?style=flat-square&logo=githubsponsors&logoColor=white&labelColor=black" width="156px" />](https://github.com/sponsors/junhoyeo) | [GitHub Sponsors](https://github.com/sponsors/junhoyeo)を通じて、Tokscaleの継続的な開発をご支援ください。 |
 
 <div align="center">
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -16,6 +16,7 @@
 > | [<img alt="GitHub Follow" src="https://img.shields.io/github/followers/junhoyeo?style=flat-square&logo=github&labelColor=black&color=24292f" width="156px" />](https://github.com/junhoyeo) | GitHub에서 [@junhoyeo](https://github.com/junhoyeo)를 팔로우하고 더 많은 프로젝트를 만나보세요. AI, 인프라 등 다양한 분야를 다룹니다. |
 > | :-----| :----- |
 > [<img alt="Discord link" src="https://img.shields.io/discord/1480206352755458110?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=flat-square" width="156px" />](https://discord.gg/h6DUGWdBbm) | [Discord](https://discord.gg/h6DUGWdBbm)에서 함께해요 — 세계 최고의 바이버들과 어울리세요. |
+> [<img alt="Sponsor Tokscale" src="https://img.shields.io/badge/sponsor-Tokscale-EA4AAA?style=flat-square&logo=githubsponsors&logoColor=white&labelColor=black" width="156px" />](https://github.com/sponsors/junhoyeo) | [GitHub Sponsors](https://github.com/sponsors/junhoyeo)를 통해 Tokscale의 지속적인 개발을 후원해 주세요. |
 
 <div align="center">
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 > | [<img alt="GitHub Follow" src="https://img.shields.io/github/followers/junhoyeo?style=flat-square&logo=github&labelColor=black&color=24292f" width="156px" />](https://github.com/junhoyeo) | Follow [@junhoyeo](https://github.com/junhoyeo) on GitHub for more projects. Hacking on AI, infra, and everything in between. |
 > | :-----| :----- |
 > [<img alt="Discord link" src="https://img.shields.io/discord/1480206352755458110?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=flat-square" width="156px" />](https://discord.gg/h6DUGWdBbm) | Come hang out in our [Discord](https://discord.gg/h6DUGWdBbm) — and surround yourself with the world's top-tier vibers. |
+> [<img alt="Sponsor Tokscale" src="https://img.shields.io/badge/sponsor-Tokscale-EA4AAA?style=flat-square&logo=githubsponsors&logoColor=white&labelColor=black" width="156px" />](https://github.com/sponsors/junhoyeo) | Support Tokscale's continued development through [GitHub Sponsors](https://github.com/sponsors/junhoyeo). |
 
 <div align="center">
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -16,6 +16,7 @@
 > | [<img alt="GitHub Follow" src="https://img.shields.io/github/followers/junhoyeo?style=flat-square&logo=github&labelColor=black&color=24292f" width="156px" />](https://github.com/junhoyeo) | 在 GitHub 上关注 [@junhoyeo](https://github.com/junhoyeo) 获取更多项目。涉及 AI、基础设施等各个领域。 |
 > | :-----| :----- |
 > [<img alt="Discord link" src="https://img.shields.io/discord/1480206352755458110?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=flat-square" width="156px" />](https://discord.gg/h6DUGWdBbm) | 加入我们的 [Discord](https://discord.gg/h6DUGWdBbm) — 与全球顶尖的开发者一起交流。 |
+> [<img alt="Sponsor Tokscale" src="https://img.shields.io/badge/sponsor-Tokscale-EA4AAA?style=flat-square&logo=githubsponsors&logoColor=white&labelColor=black" width="156px" />](https://github.com/sponsors/junhoyeo) | 通过 [GitHub Sponsors](https://github.com/sponsors/junhoyeo) 支持 Tokscale 的持续开发。 |
 
 <div align="center">
 

--- a/packages/frontend/src/components/landing/sections/FollowSection.tsx
+++ b/packages/frontend/src/components/landing/sections/FollowSection.tsx
@@ -29,13 +29,22 @@ export function FollowSection() {
                 <br />
                 Don&#39;t miss the next one.
               </HeadingText>
-              <FollowLink
-                href="https://github.com/junhoyeo"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Follow @junhoyeo on GitHub
-              </FollowLink>
+              <Actions>
+                <FollowLink
+                  href="https://github.com/junhoyeo"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Follow @junhoyeo on GitHub
+                </FollowLink>
+                <SponsorLink
+                  href="https://github.com/sponsors/junhoyeo"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Sponsor Tokscale
+                </SponsorLink>
+              </Actions>
             </TextGroup>
           </MiddleContentInner>
         </MiddleContentOuter>
@@ -183,7 +192,24 @@ const HeadingText = styled.p`
   }
 `;
 
+const Actions = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  min-width: 0;
+
+  @media (max-width: 480px) {
+    flex-direction: column;
+    width: 100%;
+  }
+`;
+
 const FollowLink = styled.a`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
   font-family: var(--font-figtree), "Figtree", sans-serif;
   font-weight: 600;
   font-size: 24px;
@@ -192,10 +218,14 @@ const FollowLink = styled.a`
   text-align: center;
   color: #b6c0d4;
   text-decoration: none;
-  transition: color 0.15s;
 
   &:hover {
     color: #ffffff;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #75b6ff;
+    outline-offset: 3px;
   }
 
   @media (max-width: 768px) {
@@ -203,7 +233,42 @@ const FollowLink = styled.a`
   }
 
   @media (max-width: 480px) {
+    min-height: 48px;
     font-size: 18px;
+  }
+`;
+
+const SponsorLink = styled.a`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 18px;
+  flex-shrink: 0;
+  border: 1px solid rgba(135, 240, 242, 0.32);
+  border-radius: 12px;
+  background: rgba(0, 115, 255, 0.08);
+  font-family: var(--font-figtree), "Figtree", sans-serif;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 1.2em;
+  color: #d8f8ff;
+  text-decoration: none;
+
+  &:hover {
+    border-color: rgba(135, 240, 242, 0.56);
+    background: rgba(0, 115, 255, 0.16);
+  }
+
+  &:focus-visible {
+    outline: 2px solid #75b6ff;
+    outline-offset: 3px;
+  }
+
+  @media (max-width: 480px) {
+    width: 100%;
+    max-width: 240px;
+    min-height: 48px;
   }
 `;
 

--- a/packages/frontend/src/components/landing/sections/FooterSection.tsx
+++ b/packages/frontend/src/components/landing/sections/FooterSection.tsx
@@ -6,6 +6,22 @@ export function FooterSection() {
   return (
     <LandingFooter>
       <FooterInner>
+        <FooterNav aria-label="Footer links">
+          <FooterLink
+            href="https://github.com/junhoyeo/tokscale"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            GitHub
+          </FooterLink>
+          <FooterLink
+            href="https://github.com/sponsors/junhoyeo"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Sponsor Tokscale
+          </FooterLink>
+        </FooterNav>
         <FooterCopyright>© 2026 STROKE</FooterCopyright>
       </FooterInner>
     </LandingFooter>
@@ -13,7 +29,7 @@ export function FooterSection() {
 }
 
 /* ── Footer Styled Components ── */
-const LandingFooter = styled.div`
+const LandingFooter = styled.footer`
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -32,6 +48,43 @@ const FooterInner = styled.div`
   gap: 20px;
   padding-top: 16px;
   border-top: 1px solid rgba(255, 255, 255, 0.1);
+`;
+
+const FooterNav = styled.nav`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+
+  @media (max-width: 480px) {
+    flex-direction: column;
+    gap: 4px;
+  }
+`;
+
+const FooterLink = styled.a`
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  font-family: "Wanted Sans", system-ui, -apple-system, sans-serif;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.5em;
+  color: #99a1af;
+  text-decoration: none;
+
+  &:hover {
+    color: #ffffff;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #75b6ff;
+    outline-offset: 3px;
+  }
+
+  @media (max-width: 480px) {
+    min-height: 48px;
+  }
 `;
 
 const FooterCopyright = styled.p`


### PR DESCRIPTION
## Summary

- Enable GitHub's native Sponsor button through repository funding metadata.
- Add a GitHub Sponsors badge and localized call to action to the English, Korean, Japanese, and Simplified Chinese READMEs.
- Add responsive, keyboard-accessible sponsor actions to the landing follow card and footer while keeping the hero's GitHub star action visually primary.

## Design

- Reuse Tokscale's existing dark blue and cyan visual language instead of introducing a competing pink landing-page treatment.
- Keep the sponsor action as a compact secondary outline control with visible focus styles and 44–48px touch targets.
- Verified the rendered landing page at 1440×1100 and 390×844; structured visual verdict: 94/100, pass.

## Testing

- `bun run lint` (passes with 15 existing warnings in untouched files)
- `bun run typecheck`
- `bun run test` (71 files, 654 tests)
- `bun run build`
- Verified the GitHub Sponsors page and shields.io badge endpoint both return HTTP 200.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable GitHub Sponsors and make funding easy to find across the repo and site. Adds README badges and accessible Sponsor actions on the landing follow card and footer while keeping the star CTA primary.

- Turn on the GitHub Sponsors button via `.github/FUNDING.yml` targeting https://github.com/sponsors/junhoyeo.
- Add a Sponsors badge and localized CTA to README (English, Korean, Japanese, Simplified Chinese).
- Add a secondary Sponsor control next to Follow in the landing `FollowSection`, and a Sponsor link in the footer nav; both are keyboard-accessible, responsive, and meet 44–48px touch targets.
- Use existing dark-blue/cyan styles and keep Sponsor secondary; sponsor URL is consistent across metadata, READMEs, and UI.

<sup>Written for commit 7e0097961a3f5f5161128fa46b030d2388b055e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

