### PR TITLE
feat(landing): add a dedicated sponsor section

### DIFF
--- a/packages/frontend/src/app/layout.tsx
+++ b/packages/frontend/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata, Viewport } from "next";
-import Script from "next/script";
 import { JetBrains_Mono, Figtree } from "next/font/google";
 import NextTopLoader from "nextjs-toploader";
 import { ToastContainer } from "react-toastify";
@@ -70,7 +69,6 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
         </Providers>
         <ToastContainer position="top-right" />
         <Analytics />
-        <Script src="https://ui.sh/ui-picker.js" />
       </body>
     </html>
   );

--- a/packages/frontend/src/app/layout.tsx
+++ b/packages/frontend/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import Script from "next/script";
 import { JetBrains_Mono, Figtree } from "next/font/google";
 import NextTopLoader from "nextjs-toploader";
 import { ToastContainer } from "react-toastify";
@@ -69,6 +70,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
         </Providers>
         <ToastContainer position="top-right" />
         <Analytics />
+        <Script src="https://ui.sh/ui-picker.js" />
       </body>
     </html>
   );

--- a/packages/frontend/src/components/landing/LandingPage.tsx
+++ b/packages/frontend/src/components/landing/LandingPage.tsx
@@ -7,6 +7,7 @@ import {
   QuickstartSection,
   WorldwideSection,
   DescriptionSection,
+  SponsorSection,
   FollowSection,
   FooterSection,
 } from "./sections";
@@ -32,6 +33,7 @@ export function LandingPage({
           topUsersByTokens={topUsersByTokens}
         />
         <DescriptionSection />
+        <SponsorSection />
         <FollowSection />
         <FooterSection />
       </PageInner>

--- a/packages/frontend/src/components/landing/sections/FollowSection.tsx
+++ b/packages/frontend/src/components/landing/sections/FollowSection.tsx
@@ -7,72 +7,26 @@ const SPONSOR_URL = "https://github.com/sponsors/junhoyeo";
 
 export function SponsorSection() {
   return (
-    <PickerContents data-uidotsh-pick="Sponsor section style" className="contents">
-      <PickerOption data-uidotsh-option="Signal strip" className="contents">
-        <SponsorSectionShell>
-          <SignalPanel>
-            <SignalAccent aria-hidden="true" />
-            <SponsorCopy>
-              <SponsorEyebrow>Open source, sustained</SponsorEyebrow>
-              <SponsorTitle>Keep Tokscale independent.</SponsorTitle>
-              <SponsorDescription>
-                Sponsor ongoing releases, platform support, and the work that keeps token tracking open.
-              </SponsorDescription>
-            </SponsorCopy>
-            <SponsorAction href={SPONSOR_URL} target="_blank" rel="noopener noreferrer">
-              <SponsorActionText>Sponsor on GitHub</SponsorActionText>
-              <SponsorActionArrow aria-hidden="true">↗</SponsorActionArrow>
-            </SponsorAction>
-          </SignalPanel>
-        </SponsorSectionShell>
-      </PickerOption>
-
-      <PickerOption data-uidotsh-option="Blueprint split" className="contents" hidden>
-        <SponsorSectionShell>
-          <BlueprintPanel>
-            <BlueprintHeader>
-              <SponsorEyebrow>Back the project</SponsorEyebrow>
-              <BlueprintMeta>GitHub Sponsors</BlueprintMeta>
-            </BlueprintHeader>
-            <BlueprintBody>
-              <SponsorCopy>
-                <SponsorTitle>Help ship the next release.</SponsorTitle>
-                <SponsorDescription>
-                  Your support gives maintenance, integrations, and cross-platform builds more dedicated time.
-                </SponsorDescription>
-              </SponsorCopy>
-              <SponsorAction href={SPONSOR_URL} target="_blank" rel="noopener noreferrer">
-                <SponsorActionText>Sponsor on GitHub</SponsorActionText>
-                <SponsorActionArrow aria-hidden="true">↗</SponsorActionArrow>
-              </SponsorAction>
-            </BlueprintBody>
-          </BlueprintPanel>
-        </SponsorSectionShell>
-      </PickerOption>
-
-      <PickerOption data-uidotsh-option="Support ledger" className="contents" hidden>
-        <SponsorSectionShell>
-          <LedgerPanel>
-            <LedgerCopy>
-              <SponsorEyebrow>Fund the work</SponsorEyebrow>
-              <SponsorTitle>Make open-source time sustainable.</SponsorTitle>
-              <SponsorDescription>
-                Support the maintenance behind every Tokscale release.
-              </SponsorDescription>
-            </LedgerCopy>
-            <LedgerItems role="list" aria-label="Work supported by sponsorship">
-              <LedgerItem role="listitem">CLI maintenance</LedgerItem>
-              <LedgerItem role="listitem">Platform builds</LedgerItem>
-              <LedgerItem role="listitem">Community support</LedgerItem>
-            </LedgerItems>
-            <SponsorAction href={SPONSOR_URL} target="_blank" rel="noopener noreferrer">
-              <SponsorActionText>Sponsor on GitHub</SponsorActionText>
-              <SponsorActionArrow aria-hidden="true">↗</SponsorActionArrow>
-            </SponsorAction>
-          </LedgerPanel>
-        </SponsorSectionShell>
-      </PickerOption>
-    </PickerContents>
+    <SponsorSectionShell>
+      <BlueprintPanel>
+        <BlueprintHeader>
+          <SponsorEyebrow>Back the project</SponsorEyebrow>
+          <BlueprintMeta>GitHub Sponsors</BlueprintMeta>
+        </BlueprintHeader>
+        <BlueprintBody>
+          <SponsorCopy>
+            <SponsorTitle>Help ship the next release.</SponsorTitle>
+            <SponsorDescription>
+              Your support gives maintenance, integrations, and cross-platform builds more dedicated time.
+            </SponsorDescription>
+          </SponsorCopy>
+          <SponsorAction href={SPONSOR_URL} target="_blank" rel="noopener noreferrer">
+            <SponsorActionText>Sponsor on GitHub</SponsorActionText>
+            <SponsorActionArrow aria-hidden="true">↗</SponsorActionArrow>
+          </SponsorAction>
+        </BlueprintBody>
+      </BlueprintPanel>
+    </SponsorSectionShell>
   );
 }
 
@@ -125,23 +79,7 @@ export function FollowSection() {
   );
 }
 
-/* ── Sponsor Picker Styled Components ── */
-
-const PickerContents = styled.div`
-  display: contents;
-
-  &[hidden] {
-    display: none;
-  }
-`;
-
-const PickerOption = styled.div`
-  display: contents;
-
-  &[hidden] {
-    display: none;
-  }
-`;
+/* ── Sponsor Section Styled Components ── */
 
 const SponsorSectionShell = styled.section`
   width: 100%;
@@ -237,33 +175,6 @@ const SponsorActionArrow = styled.span`
   color: #87f0f2;
 `;
 
-const SignalPanel = styled.div`
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 40px;
-  overflow: hidden;
-  padding: 40px 48px;
-  border: 1px solid rgba(0, 115, 255, 0.48);
-  border-radius: 16px;
-  background: #01070f;
-
-  @media (max-width: 768px) {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 28px;
-    padding: 32px 24px 32px 28px;
-  }
-`;
-
-const SignalAccent = styled.div`
-  position: absolute;
-  inset: 0 auto 0 0;
-  width: 4px;
-  background: #0073ff;
-`;
-
 const BlueprintPanel = styled.div`
   overflow: hidden;
   border: 1px solid rgba(0, 115, 255, 0.48);
@@ -311,56 +222,6 @@ const BlueprintBody = styled.div`
     gap: 28px;
     padding: 32px 24px;
   }
-`;
-
-const LedgerPanel = styled.div`
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 40px;
-  padding: 40px 48px;
-  border-top: 1px solid rgba(0, 115, 255, 0.48);
-  border-bottom: 1px solid rgba(0, 115, 255, 0.48);
-  background: #01070f;
-
-  @media (max-width: 900px) {
-    grid-template-columns: minmax(0, 1fr) auto;
-  }
-
-  @media (max-width: 768px) {
-    grid-template-columns: 1fr;
-    align-items: stretch;
-    gap: 28px;
-    padding: 32px 24px;
-  }
-`;
-
-const LedgerCopy = styled(SponsorCopy)`
-  @media (min-width: 769px) and (max-width: 900px) {
-    grid-column: 1 / -1;
-  }
-`;
-
-const LedgerItems = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-  min-width: 0;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
-
-  @media (min-width: 769px) and (max-width: 900px) {
-    grid-column: 1;
-  }
-`;
-
-const LedgerItem = styled.div`
-  padding: 10px 0;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  font-family: var(--font-mono), monospace;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 1.4em;
-  color: #b6c0d4;
 `;
 
 /* ── Follow Section Styled Components ── */

--- a/packages/frontend/src/components/landing/sections/FollowSection.tsx
+++ b/packages/frontend/src/components/landing/sections/FollowSection.tsx
@@ -3,6 +3,79 @@
 import Image from "next/image";
 import styled from "styled-components";
 
+const SPONSOR_URL = "https://github.com/sponsors/junhoyeo";
+
+export function SponsorSection() {
+  return (
+    <PickerContents data-uidotsh-pick="Sponsor section style" className="contents">
+      <PickerOption data-uidotsh-option="Signal strip" className="contents">
+        <SponsorSectionShell>
+          <SignalPanel>
+            <SignalAccent aria-hidden="true" />
+            <SponsorCopy>
+              <SponsorEyebrow>Open source, sustained</SponsorEyebrow>
+              <SponsorTitle>Keep Tokscale independent.</SponsorTitle>
+              <SponsorDescription>
+                Sponsor ongoing releases, platform support, and the work that keeps token tracking open.
+              </SponsorDescription>
+            </SponsorCopy>
+            <SponsorAction href={SPONSOR_URL} target="_blank" rel="noopener noreferrer">
+              <SponsorActionText>Sponsor on GitHub</SponsorActionText>
+              <SponsorActionArrow aria-hidden="true">↗</SponsorActionArrow>
+            </SponsorAction>
+          </SignalPanel>
+        </SponsorSectionShell>
+      </PickerOption>
+
+      <PickerOption data-uidotsh-option="Blueprint split" className="contents" hidden>
+        <SponsorSectionShell>
+          <BlueprintPanel>
+            <BlueprintHeader>
+              <SponsorEyebrow>Back the project</SponsorEyebrow>
+              <BlueprintMeta>GitHub Sponsors</BlueprintMeta>
+            </BlueprintHeader>
+            <BlueprintBody>
+              <SponsorCopy>
+                <SponsorTitle>Help ship the next release.</SponsorTitle>
+                <SponsorDescription>
+                  Your support gives maintenance, integrations, and cross-platform builds more dedicated time.
+                </SponsorDescription>
+              </SponsorCopy>
+              <SponsorAction href={SPONSOR_URL} target="_blank" rel="noopener noreferrer">
+                <SponsorActionText>Sponsor on GitHub</SponsorActionText>
+                <SponsorActionArrow aria-hidden="true">↗</SponsorActionArrow>
+              </SponsorAction>
+            </BlueprintBody>
+          </BlueprintPanel>
+        </SponsorSectionShell>
+      </PickerOption>
+
+      <PickerOption data-uidotsh-option="Support ledger" className="contents" hidden>
+        <SponsorSectionShell>
+          <LedgerPanel>
+            <LedgerCopy>
+              <SponsorEyebrow>Fund the work</SponsorEyebrow>
+              <SponsorTitle>Make open-source time sustainable.</SponsorTitle>
+              <SponsorDescription>
+                Support the maintenance behind every Tokscale release.
+              </SponsorDescription>
+            </LedgerCopy>
+            <LedgerItems role="list" aria-label="Work supported by sponsorship">
+              <LedgerItem role="listitem">CLI maintenance</LedgerItem>
+              <LedgerItem role="listitem">Platform builds</LedgerItem>
+              <LedgerItem role="listitem">Community support</LedgerItem>
+            </LedgerItems>
+            <SponsorAction href={SPONSOR_URL} target="_blank" rel="noopener noreferrer">
+              <SponsorActionText>Sponsor on GitHub</SponsorActionText>
+              <SponsorActionArrow aria-hidden="true">↗</SponsorActionArrow>
+            </SponsorAction>
+          </LedgerPanel>
+        </SponsorSectionShell>
+      </PickerOption>
+    </PickerContents>
+  );
+}
+
 export function FollowSection() {
   return (
     <FollowSectionWrapper>
@@ -29,22 +102,13 @@ export function FollowSection() {
                 <br />
                 Don&#39;t miss the next one.
               </HeadingText>
-              <Actions>
-                <FollowLink
-                  href="https://github.com/junhoyeo"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Follow @junhoyeo on GitHub
-                </FollowLink>
-                <SponsorLink
-                  href="https://github.com/sponsors/junhoyeo"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Sponsor Tokscale
-                </SponsorLink>
-              </Actions>
+              <FollowLink
+                href="https://github.com/junhoyeo"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Follow @junhoyeo on GitHub
+              </FollowLink>
             </TextGroup>
           </MiddleContentInner>
         </MiddleContentOuter>
@@ -60,6 +124,244 @@ export function FollowSection() {
     </FollowSectionWrapper>
   );
 }
+
+/* ── Sponsor Picker Styled Components ── */
+
+const PickerContents = styled.div`
+  display: contents;
+
+  &[hidden] {
+    display: none;
+  }
+`;
+
+const PickerOption = styled.div`
+  display: contents;
+
+  &[hidden] {
+    display: none;
+  }
+`;
+
+const SponsorSectionShell = styled.section`
+  width: 100%;
+  padding: 0 0 64px;
+
+  @media (max-width: 768px) {
+    padding-bottom: 48px;
+  }
+`;
+
+const SponsorCopy = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  min-width: 0;
+`;
+
+const SponsorEyebrow = styled.p`
+  font-family: var(--font-mono), monospace;
+  font-weight: 600;
+  font-size: 13px;
+  line-height: 1.4em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #85caff;
+`;
+
+const SponsorTitle = styled.h2`
+  max-width: 35ch;
+  font-family: var(--font-figtree), "Figtree", sans-serif;
+  font-weight: 600;
+  font-size: 36px;
+  letter-spacing: -0.03em;
+  color: #f4f8ff;
+
+  @media (max-width: 768px) {
+    font-size: 28px;
+  }
+`;
+
+const SponsorDescription = styled.p`
+  max-width: 56ch;
+  font-family: var(--font-figtree), "Figtree", sans-serif;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.5em;
+  color: #a8b3c7;
+`;
+
+const SponsorAction = styled.a`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-height: 48px;
+  padding: 0 14px 0 18px;
+  flex-shrink: 0;
+  border: 1px solid rgba(135, 240, 242, 0.48);
+  border-radius: 12px;
+  background: rgba(0, 115, 255, 0.12);
+  color: #f4fbff;
+  text-decoration: none;
+
+  &:hover {
+    border-color: rgba(135, 240, 242, 0.8);
+    background: rgba(0, 115, 255, 0.2);
+  }
+
+  &:focus-visible {
+    outline: 2px solid #75b6ff;
+    outline-offset: 3px;
+  }
+
+  @media (max-width: 480px) {
+    width: 100%;
+  }
+`;
+
+const SponsorActionText = styled.span`
+  font-family: var(--font-figtree), "Figtree", sans-serif;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 1.2em;
+  white-space: nowrap;
+`;
+
+const SponsorActionArrow = styled.span`
+  font-family: var(--font-figtree), "Figtree", sans-serif;
+  font-weight: 600;
+  font-size: 18px;
+  line-height: 1em;
+  color: #87f0f2;
+`;
+
+const SignalPanel = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 40px;
+  overflow: hidden;
+  padding: 40px 48px;
+  border: 1px solid rgba(0, 115, 255, 0.48);
+  border-radius: 16px;
+  background: #01070f;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 28px;
+    padding: 32px 24px 32px 28px;
+  }
+`;
+
+const SignalAccent = styled.div`
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4px;
+  background: #0073ff;
+`;
+
+const BlueprintPanel = styled.div`
+  overflow: hidden;
+  border: 1px solid rgba(0, 115, 255, 0.48);
+  border-radius: 16px;
+  background: #01070f;
+`;
+
+const BlueprintHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 16px 32px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  background-image: url("/assets/landing/separator-pattern-slash@gray.svg");
+  background-size: 24px 24px;
+
+  @media (max-width: 480px) {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+    padding: 16px 24px;
+  }
+`;
+
+const BlueprintMeta = styled.p`
+  font-family: var(--font-mono), monospace;
+  font-weight: 500;
+  font-size: 13px;
+  line-height: 1.4em;
+  letter-spacing: 0.04em;
+  color: #8292b1;
+`;
+
+const BlueprintBody = styled.div`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 48px;
+  padding: 40px 48px;
+
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+    gap: 28px;
+    padding: 32px 24px;
+  }
+`;
+
+const LedgerPanel = styled.div`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 40px;
+  padding: 40px 48px;
+  border-top: 1px solid rgba(0, 115, 255, 0.48);
+  border-bottom: 1px solid rgba(0, 115, 255, 0.48);
+  background: #01070f;
+
+  @media (max-width: 900px) {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+    gap: 28px;
+    padding: 32px 24px;
+  }
+`;
+
+const LedgerCopy = styled(SponsorCopy)`
+  @media (min-width: 769px) and (max-width: 900px) {
+    grid-column: 1 / -1;
+  }
+`;
+
+const LedgerItems = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  min-width: 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+
+  @media (min-width: 769px) and (max-width: 900px) {
+    grid-column: 1;
+  }
+`;
+
+const LedgerItem = styled.div`
+  padding: 10px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  font-family: var(--font-mono), monospace;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 1.4em;
+  color: #b6c0d4;
+`;
 
 /* ── Follow Section Styled Components ── */
 
@@ -192,19 +494,6 @@ const HeadingText = styled.p`
   }
 `;
 
-const Actions = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 12px;
-  min-width: 0;
-
-  @media (max-width: 480px) {
-    flex-direction: column;
-    width: 100%;
-  }
-`;
-
 const FollowLink = styled.a`
   display: inline-flex;
   align-items: center;
@@ -235,40 +524,6 @@ const FollowLink = styled.a`
   @media (max-width: 480px) {
     min-height: 48px;
     font-size: 18px;
-  }
-`;
-
-const SponsorLink = styled.a`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 44px;
-  padding: 0 18px;
-  flex-shrink: 0;
-  border: 1px solid rgba(135, 240, 242, 0.32);
-  border-radius: 12px;
-  background: rgba(0, 115, 255, 0.08);
-  font-family: var(--font-figtree), "Figtree", sans-serif;
-  font-weight: 600;
-  font-size: 16px;
-  line-height: 1.2em;
-  color: #d8f8ff;
-  text-decoration: none;
-
-  &:hover {
-    border-color: rgba(135, 240, 242, 0.56);
-    background: rgba(0, 115, 255, 0.16);
-  }
-
-  &:focus-visible {
-    outline: 2px solid #75b6ff;
-    outline-offset: 3px;
-  }
-
-  @media (max-width: 480px) {
-    width: 100%;
-    max-width: 240px;
-    min-height: 48px;
   }
 `;
 

--- a/packages/frontend/src/components/landing/sections/index.ts
+++ b/packages/frontend/src/components/landing/sections/index.ts
@@ -2,5 +2,5 @@ export { HeroSection } from "./HeroSection";
 export { QuickstartSection } from "./QuickstartSection";
 export { WorldwideSection } from "./WorldwideSection";
 export { DescriptionSection } from "./DescriptionSection";
-export { FollowSection } from "./FollowSection";
+export { FollowSection, SponsorSection } from "./FollowSection";
 export { FooterSection } from "./FooterSection";


### PR DESCRIPTION
## Summary

- Move the sponsor CTA out of the maintainer follow card and into a dedicated landing-page section.
- Add the selected Blueprint split layout with a patterned sponsorship header and responsive split content.
- Upgrade the Sponsor on GitHub action with clearer wording, a stronger secondary treatment, visible focus styling, and full-width mobile behavior.

## Design

- Keep sponsorship distinct from the maintainer follow card and from the product-adoption trust strip.
- Preserve the hero GitHub action as the page's strongest CTA while giving sponsorship a clear standalone destination.
- Remove all temporary ui.sh picker markup, hidden variants, and script loading after selection.

## Testing

- `bun run lint -- src/app/layout.tsx src/components/landing/LandingPage.tsx src/components/landing/sections/FollowSection.tsx src/components/landing/sections/index.ts`
- `bun run typecheck`
- `bun run test` (71 files, 654 tests)
- `bun run build`
- Browser QA at 1440×1100 and 390×844
- Final structured visual verdict: 95/100, pass
