### PR TITLE
feat(frontend): add display timezone preference for profile charts

### DIFF
--- a/packages/frontend/__tests__/api/usersProfile.test.ts
+++ b/packages/frontend/__tests__/api/usersProfile.test.ts
@@ -8,6 +8,7 @@ import {
   vi,
 } from "vitest";
 
+import { createContributionCalendar } from "../../src/components/profile/ProfileContributionGraph";
 import { expectNoNarrowedCostCast } from "../support/costCastWidths";
 
 const mockState = vi.hoisted(() => {
@@ -579,6 +580,194 @@ describe("GET /api/users/[username]", () => {
     expect(body.chartRange).toEqual({
       start: "2023-02-28",
       end: "2024-02-29",
+    });
+  });
+
+  it("ends the lifetime range on the newest submitted date when it is ahead of UTC today", async () => {
+    // 2026-07-23T16:00Z is still the 23rd in UTC — and in America/Los_Angeles —
+    // but already the 24th in Asia/Seoul. The owner's CLI bucketed that session
+    // into their local 2026-07-24 and submitted it. The range is resolved here,
+    // on the server, from the data: no viewer's clock is an input, so the day
+    // is visible to a Los Angeles reader exactly as it is to a Seoul one.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-23T16:00:00.000Z"));
+
+    mockState.pushSelectResult([
+      {
+        id: "user-ahead-of-utc",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        totalTokens: 35,
+        totalCost: 3.5,
+        inputTokens: 20,
+        outputTokens: 15,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        reasoningTokens: 0,
+        submissionCount: 2,
+        earliestDate: "2026-07-22",
+        latestDate: "2026-07-24",
+        sessionCount: 2,
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        sourcesUsed: ["codex"],
+        modelsUsed: ["gpt-5.5"],
+        updatedAt: new Date("2026-07-23T15:00:00.000Z"),
+        cliVersion: "2.0.0",
+        schemaVersion: 2,
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        date: "2026-07-22",
+        timestampMs: 100,
+        tokens: 10,
+        cost: "1.0000",
+        inputTokens: 6,
+        outputTokens: 4,
+        sourceBreakdown: {
+          codex: {
+            tokens: 10,
+            cost: 1,
+            input: 6,
+            output: 4,
+            cacheRead: 0,
+            cacheWrite: 0,
+            reasoning: 0,
+            messages: 1,
+            models: {
+              "gpt-5.5": {
+                tokens: 10,
+                cost: 1,
+                input: 6,
+                output: 4,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+                messages: 1,
+              },
+            },
+          },
+        },
+      },
+      {
+        date: "2026-07-24",
+        timestampMs: 200,
+        tokens: 25,
+        cost: "2.5000",
+        inputTokens: 14,
+        outputTokens: 11,
+        sourceBreakdown: {
+          codex: {
+            tokens: 25,
+            cost: 2.5,
+            input: 14,
+            output: 11,
+            cacheRead: 0,
+            cacheWrite: 0,
+            reasoning: 0,
+            messages: 2,
+            models: {
+              "gpt-5.5": {
+                tokens: 25,
+                cost: 2.5,
+                input: 14,
+                output: 11,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+                messages: 2,
+              },
+            },
+          },
+        },
+      },
+    ]);
+    mockState.pushExecuteResult([{ rank: 1 }]);
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/users/alice"),
+      { params: Promise.resolve({ username: "alice" }) },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.chartRange).toEqual({
+      start: "2025-07-24",
+      end: "2026-07-24",
+    });
+    expect(body.dateRange.end).toBe("2026-07-24");
+
+    // The graph clips the payload's contributions to the payload's chartRange,
+    // so building the calendar the way the client does is the check that the
+    // newest day actually renders.
+    const calendar = createContributionCalendar(
+      body.contributions,
+      body.chartRange.start,
+      body.chartRange.end,
+    );
+    expect(calendar.endDate).toBe("2026-07-24");
+    expect(calendar.cells.find(({ date }) => date === "2026-07-24")).toEqual(
+      expect.objectContaining({ inRange: true, tokens: 25 }),
+    );
+
+    // ProfileOverview's "Active days (1y)" and the graph's own count sit on the
+    // same screen; both must be scoped to the same window.
+    expect(body.stats.activeDays).toBe(2);
+    expect(calendar.activeDays).toBe(body.stats.activeDays);
+  });
+
+  it("falls back to UTC today when the newest submitted date is unusable", async () => {
+    // A `date` column cannot hold this, but the anchor now feeds a Date
+    // constructor, and a public profile must not 500 on a malformed value.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-23T16:00:00.000Z"));
+
+    mockState.pushSelectResult([
+      {
+        id: "user-bad-date",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        totalTokens: 0,
+        totalCost: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        reasoningTokens: 0,
+        submissionCount: 0,
+        earliestDate: "2026-07-22",
+        latestDate: "2026-13-45",
+      },
+    ]);
+    mockState.pushSelectResult([]);
+    mockState.pushSelectResult([]);
+    mockState.pushExecuteResult([]);
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/users/alice"),
+      { params: Promise.resolve({ username: "alice" }) },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.chartRange).toEqual({
+      start: "2025-07-23",
+      end: "2026-07-23",
     });
   });
 

--- a/packages/frontend/__tests__/api/usersProfile.test.ts
+++ b/packages/frontend/__tests__/api/usersProfile.test.ts
@@ -771,6 +771,164 @@ describe("GET /api/users/[username]", () => {
     });
   });
 
+  it("ends the 7d window on the newest submitted date when it is ahead of UTC today", async () => {
+    // Same owner-ahead-of-UTC case as the lifetime range, on the 7d tab. The
+    // anchor is not known when the daily query is built, so the query reaches
+    // back from UTC today and the window trims the front: seven days ending on
+    // 2026-07-24, not seven days ending on 2026-07-23 with the newest day cut.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-23T16:00:00.000Z"));
+
+    const breakdownFor = (
+      client: string,
+      model: string,
+      tokens: number,
+      cost: number,
+      input: number,
+      output: number,
+    ) => ({
+      [client]: {
+        tokens,
+        cost,
+        input,
+        output,
+        cacheRead: 0,
+        cacheWrite: 0,
+        reasoning: 0,
+        messages: 1,
+        models: {
+          [model]: {
+            tokens,
+            cost,
+            input,
+            output,
+            cacheRead: 0,
+            cacheWrite: 0,
+            reasoning: 0,
+            messages: 1,
+          },
+        },
+      },
+    });
+
+    mockState.pushSelectResult([
+      {
+        id: "user-ahead-of-utc",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        totalTokens: 125,
+        totalCost: 13.5,
+        inputTokens: 74,
+        outputTokens: 51,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        reasoningTokens: 0,
+        submissionCount: 3,
+        earliestDate: "2026-07-17",
+        latestDate: "2026-07-24",
+        sessionCount: 3,
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        sourcesUsed: ["codex", "claude"],
+        modelsUsed: ["gpt-5.5", "gpt-legacy"],
+        updatedAt: new Date("2026-07-23T15:00:00.000Z"),
+        cliVersion: "2.0.0",
+        schemaVersion: 2,
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        // Fetched (the query reaches back from UTC today) but one day before the
+        // anchored window starts. Its cost is the largest of the three, so an
+        // intensity scale that still saw it would flatten the two days that do
+        // render.
+        date: "2026-07-17",
+        timestampMs: 50,
+        tokens: 90,
+        cost: "10.0000",
+        inputTokens: 54,
+        outputTokens: 36,
+        sourceBreakdown: breakdownFor("claude", "gpt-legacy", 90, 10, 54, 36),
+      },
+      {
+        date: "2026-07-22",
+        timestampMs: 100,
+        tokens: 10,
+        cost: "1.0000",
+        inputTokens: 6,
+        outputTokens: 4,
+        sourceBreakdown: breakdownFor("codex", "gpt-5.5", 10, 1, 6, 4),
+      },
+      {
+        date: "2026-07-24",
+        timestampMs: 200,
+        tokens: 25,
+        cost: "2.5000",
+        inputTokens: 14,
+        outputTokens: 11,
+        sourceBreakdown: breakdownFor("codex", "gpt-5.5", 25, 2.5, 14, 11),
+      },
+    ]);
+    mockState.pushExecuteResult([{ rank: 1 }]);
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/users/alice?period=week"),
+      { params: Promise.resolve({ username: "alice" }) },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockState.gte).toHaveBeenCalledWith(
+      mockState.tables.dailyBreakdown.date,
+      "2026-07-17",
+    );
+    expect(mockState.lte).not.toHaveBeenCalled();
+    expect(body.chartRange).toEqual({
+      start: "2026-07-18",
+      end: "2026-07-24",
+    });
+    expect(body.dateRange).toEqual({ start: "2026-07-18", end: "2026-07-24" });
+    expect(body.stats).toEqual(
+      expect.objectContaining({
+        totalTokens: 35,
+        totalCost: 3.5,
+        inputTokens: 20,
+        outputTokens: 15,
+        activeDays: 2,
+      }),
+    );
+
+    // Everything scoped to the window agrees with it: the payload's days, the
+    // intensity scale built from them, and the period-scoped metadata.
+    expect(body.contributions.map((day: { date: string }) => day.date)).toEqual(
+      ["2026-07-22", "2026-07-24"],
+    );
+    expect(
+      body.contributions.map((day: { intensity: number }) => day.intensity),
+    ).toEqual([2, 4]);
+    expect(body.clients).toEqual(["codex"]);
+    expect(body.models).toEqual(["gpt-5.5"]);
+
+    const calendar = createContributionCalendar(
+      body.contributions,
+      body.chartRange.start,
+      body.chartRange.end,
+    );
+    expect(calendar.endDate).toBe("2026-07-24");
+    expect(calendar.cells.find(({ date }) => date === "2026-07-24")).toEqual(
+      expect.objectContaining({ inRange: true, tokens: 25 }),
+    );
+    expect(calendar.activeDays).toBe(body.stats.activeDays);
+  });
+
   it("recalculates profile overview stats from daily rows for rolling periods", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-28T12:00:00.000Z"));
@@ -887,10 +1045,9 @@ describe("GET /api/users/[username]", () => {
       mockState.tables.dailyBreakdown.date,
       "2026-06-22",
     );
-    expect(mockState.lte).toHaveBeenCalledWith(
-      mockState.tables.dailyBreakdown.date,
-      "2026-06-28",
-    );
+    // No upper bound in SQL: the window's end is the anchor, which is not known
+    // when the query is built, and no row can sit above it anyway.
+    expect(mockState.lte).not.toHaveBeenCalled();
     expect(body.period).toBe("week");
     expect(body.dateRange).toEqual({ start: "2026-06-22", end: "2026-06-28" });
     expect(body.stats).toEqual(

--- a/packages/frontend/__tests__/components/profileHeader.test.ts
+++ b/packages/frontend/__tests__/components/profileHeader.test.ts
@@ -4,7 +4,7 @@
 process.env.TZ = "America/New_York";
 
 import { describe, expect, it } from "vitest";
-import { formatLastUpdated } from "../../src/components/profile";
+import { formatJoined, formatLastUpdated } from "../../src/components/profile";
 
 // A fixed instant, 2026-07-10 15:30:00 UTC.
 const ISO_A = "2026-07-10T15:30:00.000Z";
@@ -40,6 +40,18 @@ describe("formatLastUpdated", () => {
     expect(localA).not.toBe(UTC_A);
   });
 
+  it("passes the caller's zone through instead of the host's", () => {
+    // ProfileOverview supplies "UTC" before mount and the viewer's display zone
+    // after, so an ignored third argument would silently reintroduce the
+    // hydration mismatch the isMounted branch exists to prevent.
+    expect(formatLastUpdated(ISO_A, true, "UTC")).toBe(UTC_A);
+    expect(formatLastUpdated(ISO_A, true, "Asia/Seoul")).toBe(
+      "7/11/2026, 12:30:00 AM",
+    );
+    // Pre-mount stays UTC no matter what zone is handed in.
+    expect(formatLastUpdated(ISO_A, false, "Asia/Seoul")).toBe(UTC_A);
+  });
+
   it("derives the label from the current timestamp with no stale carry-over", () => {
     // Regression guard for the previous implementation, which stashed the
     // formatted string in useState and refreshed it from a useEffect keyed on
@@ -53,5 +65,38 @@ describe("formatLastUpdated", () => {
     expect(formatLastUpdated(ISO_B, true)).toBe(LOCAL_B);
     // And back again — still tracks the current argument exactly.
     expect(formatLastUpdated(ISO_A, true)).toBe(LOCAL_A);
+  });
+});
+
+// 2026-01-01 00:30 UTC: still December in the Americas, already January in Asia.
+const JOINED_BOUNDARY = "2026-01-01T00:30:00.000Z";
+
+describe("formatJoined", () => {
+  it("returns null when there is no usable timestamp", () => {
+    expect(formatJoined(undefined)).toBeNull();
+    expect(formatJoined(null)).toBeNull();
+    expect(formatJoined("")).toBeNull();
+    expect(formatJoined("not-a-date")).toBeNull();
+  });
+
+  it("formats in UTC when the caller pins UTC, matching the server render", () => {
+    // ProfileOverview passes "UTC" until it has mounted, so this is the string
+    // the SSR markup carries; anything else here is a hydration mismatch.
+    expect(formatJoined(JOINED_BOUNDARY, "UTC")).toBe("Jan 2026");
+  });
+
+  it("renders the joined instant in the zone it is given", () => {
+    // "Joined" is an absolute instant, not a calendar bucket, so two viewers
+    // straddling a UTC boundary reading different months is the intended
+    // behavior of the display-timezone preference — not a bug to pin to UTC.
+    expect(formatJoined(JOINED_BOUNDARY, "Asia/Seoul")).toBe("Jan 2026");
+    expect(formatJoined(JOINED_BOUNDARY, "America/Los_Angeles")).toBe(
+      "Dec 2025",
+    );
+  });
+
+  it("falls back to the host zone when no zone is given", () => {
+    // TZ is pinned to America/New_York at the top of this file.
+    expect(formatJoined(JOINED_BOUNDARY)).toBe("Dec 2025");
   });
 });

--- a/packages/frontend/__tests__/lib/timezone.test.ts
+++ b/packages/frontend/__tests__/lib/timezone.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  calendarInstantInTimeZone,
+  extendDateRangeEndToToday,
+  getTodayInTimeZone,
+  isValidTimeZone,
+  resolveEffectiveTimeZone,
+} from "@/lib/timezone";
+
+// 2026-07-23T16:00:00Z — still the 23rd in UTC and New York, already the
+// 24th in Seoul. This is the case where a KST user's early-morning usage is
+// bucketed as the 24th while the server's UTC "today" is still the 23rd.
+const NOW = new Date("2026-07-23T16:00:00.000Z");
+
+function formatInTimeZone(timestamp: number, timeZone: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    weekday: "long",
+  }).format(new Date(timestamp));
+}
+
+describe("isValidTimeZone", () => {
+  it("accepts IANA zones and rejects garbage", () => {
+    expect(isValidTimeZone("UTC")).toBe(true);
+    expect(isValidTimeZone("Asia/Seoul")).toBe(true);
+    expect(isValidTimeZone("America/New_York")).toBe(true);
+    expect(isValidTimeZone("Not/AZone")).toBe(false);
+    expect(isValidTimeZone("auto")).toBe(false);
+    expect(isValidTimeZone("")).toBe(false);
+  });
+});
+
+describe("resolveEffectiveTimeZone", () => {
+  it("keeps an explicit valid zone", () => {
+    expect(resolveEffectiveTimeZone("Asia/Seoul")).toBe("Asia/Seoul");
+  });
+
+  it("resolves auto and invalid values to the browser zone", () => {
+    const browserZone =
+      Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC";
+    expect(resolveEffectiveTimeZone("auto")).toBe(browserZone);
+    expect(resolveEffectiveTimeZone("Not/AZone")).toBe(browserZone);
+  });
+});
+
+describe("getTodayInTimeZone", () => {
+  it("returns the calendar date in the requested zone, not UTC", () => {
+    expect(getTodayInTimeZone("UTC", NOW)).toBe("2026-07-23");
+    expect(getTodayInTimeZone("Asia/Seoul", NOW)).toBe("2026-07-24");
+    expect(getTodayInTimeZone("America/New_York", NOW)).toBe("2026-07-23");
+  });
+});
+
+describe("extendDateRangeEndToToday", () => {
+  it("extends a UTC-bucketed end when local today is ahead", () => {
+    expect(extendDateRangeEndToToday("2026-07-23", "Asia/Seoul", NOW)).toBe(
+      "2026-07-24",
+    );
+  });
+
+  it("keeps the end when local today is not ahead", () => {
+    expect(extendDateRangeEndToToday("2026-07-23", "UTC", NOW)).toBe(
+      "2026-07-23",
+    );
+    expect(
+      extendDateRangeEndToToday("2026-12-31", "Asia/Seoul", NOW),
+    ).toBe("2026-12-31");
+  });
+
+  it("passes through a missing end", () => {
+    expect(extendDateRangeEndToToday(null, "Asia/Seoul", NOW)).toBeNull();
+    expect(extendDateRangeEndToToday(undefined, "Asia/Seoul", NOW)).toBeNull();
+  });
+});
+
+describe("calendarInstantInTimeZone", () => {
+  const UTC_MIDNIGHT = Date.UTC(2026, 6, 24); // 2026-07-24, a Friday
+
+  it("returns the input unchanged for UTC", () => {
+    expect(calendarInstantInTimeZone(UTC_MIDNIGHT, "UTC")).toBe(UTC_MIDNIGHT);
+  });
+
+  it("anchors the instant so formatters label the intended calendar day", () => {
+    for (const timeZone of [
+      "Asia/Seoul",
+      "America/New_York",
+      "Pacific/Auckland",
+      "Pacific/Kiritimati",
+    ]) {
+      const instant = calendarInstantInTimeZone(UTC_MIDNIGHT, timeZone);
+      expect(formatInTimeZone(instant, timeZone)).toBe("Friday, 07/24/2026");
+    }
+  });
+});

--- a/packages/frontend/__tests__/lib/timezone.test.ts
+++ b/packages/frontend/__tests__/lib/timezone.test.ts
@@ -1,3 +1,9 @@
+// Pin a non-UTC timezone BEFORE any Date/Intl usage so the fallback assertions
+// name a literal zone instead of re-deriving it from the code under test. CI
+// often runs in UTC, where a `getBrowserTimeZone()` that ignored the host and
+// returned "UTC" outright would look correct.
+process.env.TZ = "America/New_York";
+
 import { describe, expect, it } from "vitest";
 import {
   getBrowserTimeZone,
@@ -16,13 +22,19 @@ describe("isValidTimeZone", () => {
   });
 });
 
+describe("getBrowserTimeZone", () => {
+  it("reports the host zone", () => {
+    expect(getBrowserTimeZone()).toBe("America/New_York");
+  });
+});
+
 describe("resolveEffectiveTimeZone", () => {
   it("keeps an explicit valid zone", () => {
     expect(resolveEffectiveTimeZone("Asia/Seoul")).toBe("Asia/Seoul");
   });
 
-  it("resolves auto and invalid values to the browser zone", () => {
-    expect(resolveEffectiveTimeZone("auto")).toBe(getBrowserTimeZone());
-    expect(resolveEffectiveTimeZone("Not/AZone")).toBe(getBrowserTimeZone());
+  it("resolves auto and invalid values to the host zone", () => {
+    expect(resolveEffectiveTimeZone("auto")).toBe("America/New_York");
+    expect(resolveEffectiveTimeZone("Not/AZone")).toBe("America/New_York");
   });
 });

--- a/packages/frontend/__tests__/lib/timezone.test.ts
+++ b/packages/frontend/__tests__/lib/timezone.test.ts
@@ -1,26 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
-  calendarInstantInTimeZone,
-  extendDateRangeEndToToday,
-  getTodayInTimeZone,
+  getBrowserTimeZone,
   isValidTimeZone,
   resolveEffectiveTimeZone,
 } from "@/lib/timezone";
-
-// 2026-07-23T16:00:00Z — still the 23rd in UTC and New York, already the
-// 24th in Seoul. This is the case where a KST user's early-morning usage is
-// bucketed as the 24th while the server's UTC "today" is still the 23rd.
-const NOW = new Date("2026-07-23T16:00:00.000Z");
-
-function formatInTimeZone(timestamp: number, timeZone: string): string {
-  return new Intl.DateTimeFormat("en-US", {
-    timeZone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    weekday: "long",
-  }).format(new Date(timestamp));
-}
 
 describe("isValidTimeZone", () => {
   it("accepts IANA zones and rejects garbage", () => {
@@ -39,71 +22,7 @@ describe("resolveEffectiveTimeZone", () => {
   });
 
   it("resolves auto and invalid values to the browser zone", () => {
-    const browserZone =
-      Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC";
-    expect(resolveEffectiveTimeZone("auto")).toBe(browserZone);
-    expect(resolveEffectiveTimeZone("Not/AZone")).toBe(browserZone);
-  });
-});
-
-describe("getTodayInTimeZone", () => {
-  it("returns the calendar date in the requested zone, not UTC", () => {
-    expect(getTodayInTimeZone("UTC", NOW)).toBe("2026-07-23");
-    expect(getTodayInTimeZone("Asia/Seoul", NOW)).toBe("2026-07-24");
-    expect(getTodayInTimeZone("America/New_York", NOW)).toBe("2026-07-23");
-  });
-});
-
-describe("extendDateRangeEndToToday", () => {
-  it("extends a UTC-bucketed end when local today is ahead", () => {
-    expect(extendDateRangeEndToToday("2026-07-23", "Asia/Seoul", NOW)).toBe(
-      "2026-07-24",
-    );
-  });
-
-  it("keeps the end when local today is not ahead", () => {
-    expect(extendDateRangeEndToToday("2026-07-23", "UTC", NOW)).toBe(
-      "2026-07-23",
-    );
-    expect(
-      extendDateRangeEndToToday("2026-12-31", "Asia/Seoul", NOW),
-    ).toBe("2026-12-31");
-  });
-
-  it("passes through a missing end", () => {
-    expect(extendDateRangeEndToToday(null, "Asia/Seoul", NOW)).toBeNull();
-    expect(extendDateRangeEndToToday(undefined, "Asia/Seoul", NOW)).toBeNull();
-  });
-});
-
-describe("calendarInstantInTimeZone", () => {
-  const UTC_MIDNIGHT = Date.UTC(2026, 6, 24); // 2026-07-24, a Friday
-
-  it("returns the input unchanged for UTC", () => {
-    expect(calendarInstantInTimeZone(UTC_MIDNIGHT, "UTC")).toBe(UTC_MIDNIGHT);
-  });
-
-  it("anchors the instant so formatters label the intended calendar day", () => {
-    for (const timeZone of [
-      "Asia/Seoul",
-      "America/New_York",
-      "Pacific/Auckland",
-      "Pacific/Kiritimati",
-    ]) {
-      const instant = calendarInstantInTimeZone(UTC_MIDNIGHT, timeZone);
-      expect(formatInTimeZone(instant, timeZone)).toBe("Friday, 07/24/2026");
-    }
-  });
-
-  it("keeps skipped-midnight DST dates on their requested calendar day", () => {
-    const UTC_MIDNIGHT_ON_SANTIAGO_TRANSITION = Date.UTC(2026, 8, 6);
-    const instant = calendarInstantInTimeZone(
-      UTC_MIDNIGHT_ON_SANTIAGO_TRANSITION,
-      "America/Santiago",
-    );
-
-    expect(formatInTimeZone(instant, "America/Santiago")).toBe(
-      "Sunday, 09/06/2026",
-    );
+    expect(resolveEffectiveTimeZone("auto")).toBe(getBrowserTimeZone());
+    expect(resolveEffectiveTimeZone("Not/AZone")).toBe(getBrowserTimeZone());
   });
 });

--- a/packages/frontend/__tests__/lib/timezone.test.ts
+++ b/packages/frontend/__tests__/lib/timezone.test.ts
@@ -94,4 +94,16 @@ describe("calendarInstantInTimeZone", () => {
       expect(formatInTimeZone(instant, timeZone)).toBe("Friday, 07/24/2026");
     }
   });
+
+  it("keeps skipped-midnight DST dates on their requested calendar day", () => {
+    const UTC_MIDNIGHT_ON_SANTIAGO_TRANSITION = Date.UTC(2026, 8, 6);
+    const instant = calendarInstantInTimeZone(
+      UTC_MIDNIGHT_ON_SANTIAGO_TRANSITION,
+      "America/Santiago",
+    );
+
+    expect(formatInTimeZone(instant, "America/Santiago")).toBe(
+      "Sunday, 09/06/2026",
+    );
+  });
 });

--- a/packages/frontend/src/app/settings/SettingsClient.tsx
+++ b/packages/frontend/src/app/settings/SettingsClient.tsx
@@ -707,7 +707,11 @@ async function fetchDevices(username: string): Promise<SettingsDevice[]> {
 
 export default function SettingsClient() {
   const router = useRouter();
-  const { timezone, setTimezone } = useSettings();
+  const { timezone, setTimezone, mounted } = useSettings();
+  // Use the server-safe UTC label for the first render. The browser's zone can
+  // differ from the server's, so reading it before hydration would make the
+  // Auto option's text disagree with the SSR markup.
+  const browserTimeZone = mounted ? getBrowserTimeZone() : "UTC";
   const [user, setUser] = useState<User | null>(null);
   const [tokens, setTokens] = useState<ApiToken[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -973,7 +977,7 @@ export default function SettingsClient() {
             onChange={(event) => setTimezone(event.target.value)}
           >
             <option value="auto">
-              Auto (browser) — {getBrowserTimeZone()}
+              Auto (browser) — {browserTimeZone}
             </option>
             {COMMON_TIMEZONE_GROUPS.map((group) => (
               <optgroup key={group.region} label={group.region}>

--- a/packages/frontend/src/app/settings/SettingsClient.tsx
+++ b/packages/frontend/src/app/settings/SettingsClient.tsx
@@ -960,9 +960,12 @@ export default function SettingsClient() {
             Timezone
           </SectionTitle>
           <Description style={{ color: "var(--color-fg-muted)" }}>
-            Used to display dates on profile pages, including the contribution
-            graph. Stored only in this browser; the leaderboard always uses
-            UTC.
+            Renders the timestamps on profile pages — &ldquo;Updated&rdquo; and
+            &ldquo;Joined&rdquo; — in the zone you pick, and is stored only in
+            this browser. It does not move usage between days: which day a
+            session counts toward is decided by the machine that scanned it,
+            from that machine&rsquo;s own clock, so the contribution graph,
+            daily totals, and the leaderboard are unaffected.
           </Description>
 
           <FieldLabel

--- a/packages/frontend/src/app/settings/SettingsClient.tsx
+++ b/packages/frontend/src/app/settings/SettingsClient.tsx
@@ -9,6 +9,8 @@ import { Footer } from "@/components/layout/Footer";
 import { deviceDisplayLabel } from "@/lib/devices/shared";
 import { formatNumber, formatCurrency } from "@/lib/utils";
 import { formatRelativeTime } from "@/lib/format";
+import { useSettings } from "@/lib/useSettings";
+import { COMMON_TIMEZONE_GROUPS, getBrowserTimeZone } from "@/lib/timezone";
 
 interface User {
   id: string;
@@ -149,6 +151,17 @@ const ActionRow = styled.div`
 
 const TextInput = styled.input`
   height: 40px;
+  padding: 0 12px;
+  border-radius: 6px;
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-default);
+  color: var(--color-fg-default);
+  font-size: 14px;
+`;
+
+const SelectInput = styled.select`
+  height: 40px;
+  max-width: 360px;
   padding: 0 12px;
   border-radius: 6px;
   border: 1px solid var(--color-border-default);
@@ -694,6 +707,7 @@ async function fetchDevices(username: string): Promise<SettingsDevice[]> {
 
 export default function SettingsClient() {
   const router = useRouter();
+  const { timezone, setTimezone } = useSettings();
   const [user, setUser] = useState<User | null>(null);
   const [tokens, setTokens] = useState<ApiToken[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -933,6 +947,50 @@ export default function SettingsClient() {
           <InfoBanner style={{ marginTop: 16 }}>
             Profile information is synced from GitHub and cannot be edited here.
           </InfoBanner>
+        </Section>
+
+        <Section
+          style={{ backgroundColor: "var(--color-bg-default)", borderColor: "var(--color-border-default)" }}
+        >
+          <SectionTitle style={{ color: "var(--color-fg-default)" }}>
+            Timezone
+          </SectionTitle>
+          <Description style={{ color: "var(--color-fg-muted)" }}>
+            Used to display dates on profile pages, including the contribution
+            graph. Stored only in this browser; the leaderboard always uses
+            UTC.
+          </Description>
+
+          <FieldLabel
+            htmlFor="timezone-select"
+            style={{ color: "var(--color-fg-default)" }}
+          >
+            Display timezone
+          </FieldLabel>
+          <SelectInput
+            id="timezone-select"
+            value={timezone}
+            onChange={(event) => setTimezone(event.target.value)}
+          >
+            <option value="auto">
+              Auto (browser) — {getBrowserTimeZone()}
+            </option>
+            {COMMON_TIMEZONE_GROUPS.map((group) => (
+              <optgroup key={group.region} label={group.region}>
+                {group.zones.map((zone) => (
+                  <option key={zone} value={zone}>
+                    {zone.replace(/_/g, " ")}
+                  </option>
+                ))}
+              </optgroup>
+            ))}
+            {timezone !== "auto" &&
+              !COMMON_TIMEZONE_GROUPS.some((group) =>
+                group.zones.includes(timezone),
+              ) && (
+                <option value={timezone}>{timezone.replace(/_/g, " ")}</option>
+              )}
+          </SelectInput>
         </Section>
 
         <Section

--- a/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
+++ b/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useId, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import Link from "next/link";
 import styled from "styled-components";
 import { Navigation } from "@/components/layout/Navigation";
@@ -100,6 +100,12 @@ export default function ProfilePageClient({
   const [activeTab, setActiveTab] = useState<ProfileTab>("activity");
   const [contributionView, setContributionView] =
     useState<ProfileContributionView>("2d");
+  const [timeZoneData, setTimeZoneData] = useState<{
+    data: ProfileData;
+    period: ProfilePeriod;
+    timeZone: string;
+    username: string;
+  } | null>(null);
   const {
     paletteName: contributionPalette,
     setPalette: setContributionPalette,
@@ -107,25 +113,68 @@ export default function ProfilePageClient({
     mounted,
   } = useSettings();
   const contributionBreakdownId = useId();
-  const data = initialData;
-  const period = data.period ?? "all";
-  // Server chart ranges end at UTC "today", which clips contributions the CLI
-  // bucketed into the viewer's local-tomorrow date. Extend the display end to
-  // today in the effective timezone — only after mount, so the first client
-  // render matches the server-rendered range, and only for the lifetime view:
-  // week/month contributions are filtered by the UTC range server-side, so a
-  // local-today cell there could never carry data.
+  const period = initialData.period ?? "all";
+  // Server rendering uses UTC because the localStorage preference is only
+  // available in the browser. Once mounted, reload the complete profile
+  // payload for the selected zone so every period-scoped panel agrees on the
+  // same calendar-day boundaries.
   const effectiveTimeZone = mounted
     ? resolveEffectiveTimeZone(timezonePreference)
     : "UTC";
+  const hasMatchingTimeZoneData =
+    mounted &&
+    effectiveTimeZone !== "UTC" &&
+    timeZoneData?.timeZone === effectiveTimeZone &&
+    timeZoneData.username === username &&
+    timeZoneData.period === period;
+  const data = hasMatchingTimeZoneData ? timeZoneData.data : initialData;
+  useEffect(() => {
+    if (!mounted || effectiveTimeZone === "UTC") return;
+
+    const controller = new AbortController();
+    const query = new URLSearchParams({ tz: effectiveTimeZone });
+    if (period !== "all") query.set("period", period);
+
+    void fetch(`/api/users/${encodeURIComponent(username)}?${query}`, {
+      signal: controller.signal,
+    })
+      .then(async (response) => (response.ok ? response.json() : null))
+      .then((profile: ProfileData | null) => {
+        if (!controller.signal.aborted && profile) {
+          setTimeZoneData({
+            data: profile,
+            period,
+            timeZone: effectiveTimeZone,
+            username,
+          });
+        }
+      })
+      .catch(() => {
+        // Keep the server-rendered UTC payload if the timezone refresh fails.
+      });
+
+    return () => controller.abort();
+  }, [effectiveTimeZone, initialData, mounted, period, username]);
   const rollingChartRange = useMemo(() => {
     const range = getProfileChartRange(period, data.dateRange, data.chartRange);
-    if (!mounted || period !== "all") return range;
+    // Period payloads are filtered at the data boundary. Keep their UTC range
+    // until the matching timezone payload has arrived, rather than drawing an
+    // empty local-today cell while the refresh is in flight or unavailable.
+    if (!mounted || (period !== "all" && !hasMatchingTimeZoneData)) {
+      return range;
+    }
     return {
       start: range.start,
       end: extendDateRangeEndToToday(range.end, effectiveTimeZone),
     };
-  }, [period, data.chartRange, data.dateRange, mounted, effectiveTimeZone]);
+  }, [
+    period,
+    data.chartRange,
+    data.dateRange,
+    mounted,
+    hasMatchingTimeZoneData,
+    effectiveTimeZone,
+  ]);
   const contributionRangeOptions = useMemo(
     () =>
       period === "all"

--- a/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
+++ b/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
@@ -29,10 +29,7 @@ import {
 } from "@/components/profile";
 import type { DailyContribution } from "@/lib/types";
 import { useSettings } from "@/lib/useSettings";
-import {
-  extendDateRangeEndToToday,
-  resolveEffectiveTimeZone,
-} from "@/lib/timezone";
+import { resolveEffectiveTimeZone } from "@/lib/timezone";
 
 type ProfilePeriod = "all" | "week" | "month";
 
@@ -76,6 +73,10 @@ export interface ProfileData {
   period?: ProfilePeriod;
 }
 
+// Both branches already end on or after the newest submitted date: the server
+// anchors the lifetime `chartRange` to it, and `apiRange.end` is that date.
+// Nothing here may depend on the viewer's clock — contribution dates are
+// calendar buckets the submitting machine already resolved.
 function getProfileChartRange(
   period: ProfilePeriod,
   apiRange: ProfileData["dateRange"],
@@ -109,23 +110,16 @@ export default function ProfilePageClient({
   const contributionBreakdownId = useId();
   const data = initialData;
   const period = data.period ?? "all";
-  // Server chart ranges end at UTC "today", which clips contributions the CLI
-  // bucketed into the viewer's local-tomorrow date. Extend the display end to
-  // today in the effective timezone — only after mount, so the first client
-  // render matches the server-rendered range, and only for the lifetime view:
-  // week/month contributions are filtered by the UTC range server-side, so a
-  // local-today cell there could never carry data.
+  // Absolute instants ("Updated", "Joined") render in the viewer's display
+  // timezone; calendar-day buckets never do — see resolveEffectiveTimeZone.
+  // UTC before mount so the first client render matches the server markup.
   const effectiveTimeZone = mounted
     ? resolveEffectiveTimeZone(timezonePreference)
     : "UTC";
-  const rollingChartRange = useMemo(() => {
-    const range = getProfileChartRange(period, data.dateRange, data.chartRange);
-    if (!mounted || period !== "all") return range;
-    return {
-      start: range.start,
-      end: extendDateRangeEndToToday(range.end, effectiveTimeZone),
-    };
-  }, [period, data.chartRange, data.dateRange, mounted, effectiveTimeZone]);
+  const rollingChartRange = useMemo(
+    () => getProfileChartRange(period, data.dateRange, data.chartRange),
+    [period, data.chartRange, data.dateRange],
+  );
   const contributionRangeOptions = useMemo(
     () =>
       period === "all"
@@ -307,7 +301,6 @@ export default function ProfilePageClient({
                         selectableRangeEnd={contributionSelectionEnd}
                         selectedDate={selectedContributionDate}
                         showBreakdown={false}
-                        timeZone={effectiveTimeZone}
                         view={contributionView}
                         description={
                           period === "all"
@@ -326,7 +319,6 @@ export default function ProfilePageClient({
                           day={selectedContributionDay}
                           id={contributionBreakdownId}
                           paletteName={contributionPalette}
-                          timeZone={effectiveTimeZone}
                         />
                       </BreakdownArea>
                     )}

--- a/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
+++ b/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
@@ -74,9 +74,10 @@ export interface ProfileData {
 }
 
 // Both branches already end on or after the newest submitted date: the server
-// anchors the lifetime `chartRange` to it, and `apiRange.end` is that date.
-// Nothing here may depend on the viewer's clock — contribution dates are
-// calendar buckets the submitting machine already resolved.
+// anchors every window to it, so `chartRange.end` and the period `apiRange.end`
+// it also fills are both that anchor. Nothing here may depend on the viewer's
+// clock — contribution dates are calendar buckets the submitting machine
+// already resolved.
 function getProfileChartRange(
   period: ProfilePeriod,
   apiRange: ProfileData["dateRange"],

--- a/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
+++ b/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useId, useMemo, useState } from "react";
+import { useId, useMemo, useState } from "react";
 import Link from "next/link";
 import styled from "styled-components";
 import { Navigation } from "@/components/layout/Navigation";
@@ -100,12 +100,6 @@ export default function ProfilePageClient({
   const [activeTab, setActiveTab] = useState<ProfileTab>("activity");
   const [contributionView, setContributionView] =
     useState<ProfileContributionView>("2d");
-  const [timeZoneData, setTimeZoneData] = useState<{
-    data: ProfileData;
-    period: ProfilePeriod;
-    timeZone: string;
-    username: string;
-  } | null>(null);
   const {
     paletteName: contributionPalette,
     setPalette: setContributionPalette,
@@ -113,68 +107,25 @@ export default function ProfilePageClient({
     mounted,
   } = useSettings();
   const contributionBreakdownId = useId();
-  const period = initialData.period ?? "all";
-  // Server rendering uses UTC because the localStorage preference is only
-  // available in the browser. Once mounted, reload the complete profile
-  // payload for the selected zone so every period-scoped panel agrees on the
-  // same calendar-day boundaries.
+  const data = initialData;
+  const period = data.period ?? "all";
+  // Server chart ranges end at UTC "today", which clips contributions the CLI
+  // bucketed into the viewer's local-tomorrow date. Extend the display end to
+  // today in the effective timezone — only after mount, so the first client
+  // render matches the server-rendered range, and only for the lifetime view:
+  // week/month contributions are filtered by the UTC range server-side, so a
+  // local-today cell there could never carry data.
   const effectiveTimeZone = mounted
     ? resolveEffectiveTimeZone(timezonePreference)
     : "UTC";
-  const hasMatchingTimeZoneData =
-    mounted &&
-    effectiveTimeZone !== "UTC" &&
-    timeZoneData?.timeZone === effectiveTimeZone &&
-    timeZoneData.username === username &&
-    timeZoneData.period === period;
-  const data = hasMatchingTimeZoneData ? timeZoneData.data : initialData;
-  useEffect(() => {
-    if (!mounted || effectiveTimeZone === "UTC") return;
-
-    const controller = new AbortController();
-    const query = new URLSearchParams({ tz: effectiveTimeZone });
-    if (period !== "all") query.set("period", period);
-
-    void fetch(`/api/users/${encodeURIComponent(username)}?${query}`, {
-      signal: controller.signal,
-    })
-      .then(async (response) => (response.ok ? response.json() : null))
-      .then((profile: ProfileData | null) => {
-        if (!controller.signal.aborted && profile) {
-          setTimeZoneData({
-            data: profile,
-            period,
-            timeZone: effectiveTimeZone,
-            username,
-          });
-        }
-      })
-      .catch(() => {
-        // Keep the server-rendered UTC payload if the timezone refresh fails.
-      });
-
-    return () => controller.abort();
-  }, [effectiveTimeZone, initialData, mounted, period, username]);
   const rollingChartRange = useMemo(() => {
     const range = getProfileChartRange(period, data.dateRange, data.chartRange);
-    // Period payloads are filtered at the data boundary. Keep their UTC range
-    // until the matching timezone payload has arrived, rather than drawing an
-    // empty local-today cell while the refresh is in flight or unavailable.
-    if (!mounted || (period !== "all" && !hasMatchingTimeZoneData)) {
-      return range;
-    }
+    if (!mounted || period !== "all") return range;
     return {
       start: range.start,
       end: extendDateRangeEndToToday(range.end, effectiveTimeZone),
     };
-  }, [
-    period,
-    data.chartRange,
-    data.dateRange,
-    mounted,
-    hasMatchingTimeZoneData,
-    effectiveTimeZone,
-  ]);
+  }, [period, data.chartRange, data.dateRange, mounted, effectiveTimeZone]);
   const contributionRangeOptions = useMemo(
     () =>
       period === "all"

--- a/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
+++ b/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
@@ -29,6 +29,10 @@ import {
 } from "@/components/profile";
 import type { DailyContribution } from "@/lib/types";
 import { useSettings } from "@/lib/useSettings";
+import {
+  extendDateRangeEndToToday,
+  resolveEffectiveTimeZone,
+} from "@/lib/timezone";
 
 type ProfilePeriod = "all" | "week" | "month";
 
@@ -99,14 +103,29 @@ export default function ProfilePageClient({
   const {
     paletteName: contributionPalette,
     setPalette: setContributionPalette,
+    timezone: timezonePreference,
+    mounted,
   } = useSettings();
   const contributionBreakdownId = useId();
   const data = initialData;
   const period = data.period ?? "all";
-  const rollingChartRange = useMemo(
-    () => getProfileChartRange(period, data.dateRange, data.chartRange),
-    [period, data.chartRange, data.dateRange],
-  );
+  // Server chart ranges end at UTC "today", which clips contributions the CLI
+  // bucketed into the viewer's local-tomorrow date. Extend the display end to
+  // today in the effective timezone — only after mount, so the first client
+  // render matches the server-rendered range, and only for the lifetime view:
+  // week/month contributions are filtered by the UTC range server-side, so a
+  // local-today cell there could never carry data.
+  const effectiveTimeZone = mounted
+    ? resolveEffectiveTimeZone(timezonePreference)
+    : "UTC";
+  const rollingChartRange = useMemo(() => {
+    const range = getProfileChartRange(period, data.dateRange, data.chartRange);
+    if (!mounted || period !== "all") return range;
+    return {
+      start: range.start,
+      end: extendDateRangeEndToToday(range.end, effectiveTimeZone),
+    };
+  }, [period, data.chartRange, data.dateRange, mounted, effectiveTimeZone]);
   const contributionRangeOptions = useMemo(
     () =>
       period === "all"
@@ -236,6 +255,7 @@ export default function ProfilePageClient({
             stats={stats}
             lastUpdated={data.updatedAt ?? undefined}
             period={period}
+            timeZone={effectiveTimeZone}
           />
 
           {data.hasBackfill && (
@@ -287,6 +307,7 @@ export default function ProfilePageClient({
                         selectableRangeEnd={contributionSelectionEnd}
                         selectedDate={selectedContributionDate}
                         showBreakdown={false}
+                        timeZone={effectiveTimeZone}
                         view={contributionView}
                         description={
                           period === "all"
@@ -305,6 +326,7 @@ export default function ProfilePageClient({
                           day={selectedContributionDay}
                           id={contributionBreakdownId}
                           paletteName={contributionPalette}
+                          timeZone={effectiveTimeZone}
                         />
                       </BreakdownArea>
                     )}

--- a/packages/frontend/src/components/profile/ProfileContributionGraph.tsx
+++ b/packages/frontend/src/components/profile/ProfileContributionGraph.tsx
@@ -32,6 +32,7 @@ import {
   type GraphColorPalette,
 } from "@/lib/themes";
 import { formatCurrency, formatTokenCount } from "@/lib/utils";
+import { calendarInstantInTimeZone } from "@/lib/timezone";
 
 export interface ProfileContributionGraphProps {
   breakdownId?: string;
@@ -51,6 +52,7 @@ export interface ProfileContributionGraphProps {
   selectableRangeEnd?: string | null;
   selectedDate?: string | null;
   showBreakdown?: boolean;
+  timeZone?: string;
   view?: ProfileContributionView;
 }
 
@@ -132,6 +134,7 @@ export interface ProfileContributionBreakdownProps {
   id: string;
   onClose?: () => void;
   paletteName?: ColorPaletteName;
+  timeZone?: string;
 }
 
 export interface ContributionCalendar {
@@ -198,25 +201,49 @@ export function isContributionDateHit(target: Element | null): boolean {
   return Boolean(target?.closest("[data-contribution-date]"));
 }
 
-const dayFormatter = new Intl.DateTimeFormat("en-US", {
-  day: "numeric",
-  month: "short",
-  timeZone: "UTC",
-  year: "numeric",
-});
+type CalendarDateFormat = "day" | "fullDay" | "month";
 
-const fullDayFormatter = new Intl.DateTimeFormat("en-US", {
-  day: "numeric",
-  month: "long",
-  timeZone: "UTC",
-  weekday: "long",
-  year: "numeric",
-});
+const CALENDAR_DATE_FORMAT_OPTIONS: Record<
+  CalendarDateFormat,
+  Intl.DateTimeFormatOptions
+> = {
+  day: { day: "numeric", month: "short", year: "numeric" },
+  fullDay: { day: "numeric", month: "long", weekday: "long", year: "numeric" },
+  month: { month: "short" },
+};
 
-const monthFormatter = new Intl.DateTimeFormat("en-US", {
-  month: "short",
-  timeZone: "UTC",
-});
+const calendarDateFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function getCalendarDateFormatter(
+  format: CalendarDateFormat,
+  timeZone: string,
+): Intl.DateTimeFormat {
+  const key = `${format}:${timeZone}`;
+  let formatter = calendarDateFormatters.get(key);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat("en-US", {
+      ...CALENDAR_DATE_FORMAT_OPTIONS[format],
+      timeZone,
+    });
+    calendarDateFormatters.set(key, formatter);
+  }
+  return formatter;
+}
+
+/**
+ * Format a calendar date (as its UTC-midnight timestamp) for display. The
+ * instant is shifted to that date's midnight in `timeZone` first, so the
+ * label always names the intended calendar day regardless of the zone offset.
+ */
+function formatCalendarDate(
+  format: CalendarDateFormat,
+  utcMidnight: number,
+  timeZone: string,
+): string {
+  return getCalendarDateFormatter(format, timeZone).format(
+    calendarInstantInTimeZone(utcMidnight, timeZone),
+  );
+}
 
 const tokenFormatter = new Intl.NumberFormat("en-US", {
   maximumFractionDigits: 0,
@@ -579,6 +606,7 @@ export function createContributionCalendar(
   rangeStart?: string | null,
   rangeEnd?: string | null,
   selectableRangeEnd?: string | null,
+  timeZone = "UTC",
 ): ContributionCalendar {
   const contributionsByDate = new Map<
     string,
@@ -685,7 +713,7 @@ export function createContributionCalendar(
       const month = date.getUTCMonth();
       const marker = {
         compactVisible: monthMarkers.length === 0 || month % 3 === 0,
-        label: monthFormatter.format(date),
+        label: formatCalendarDate("month", cursor, timeZone),
         weekIndex,
       };
       const previous = monthMarkers.at(-1);
@@ -905,19 +933,26 @@ export function getNearestContributionDate(
   return nearestDistanceSquared <= maximumDistance ** 2 ? nearestDate : null;
 }
 
-function formatRange(startDate: string | null, endDate: string | null): string {
+function formatRange(
+  startDate: string | null,
+  endDate: string | null,
+  timeZone = "UTC",
+): string {
   if (!startDate || !endDate) return "No activity yet";
 
   const start = parseUtcDate(startDate);
   const end = parseUtcDate(endDate);
   if (start === null || end === null) return "No activity yet";
-  if (start === end) return dayFormatter.format(start);
-  return `${dayFormatter.format(start)} – ${dayFormatter.format(end)}`;
+  if (start === end) return formatCalendarDate("day", start, timeZone);
+  return `${formatCalendarDate("day", start, timeZone)} – ${formatCalendarDate("day", end, timeZone)}`;
 }
 
-function cellTitle(cell: ContributionCell): string {
+function cellTitle(cell: ContributionCell, timeZone = "UTC"): string {
   const timestamp = parseUtcDate(cell.date);
-  const date = timestamp === null ? cell.date : dayFormatter.format(timestamp);
+  const date =
+    timestamp === null
+      ? cell.date
+      : formatCalendarDate("day", timestamp, timeZone);
   const tokenLabel = cell.tokens === 1 ? "token" : "tokens";
   return `${date}: ${tokenFormatter.format(cell.tokens)} ${tokenLabel}`;
 }
@@ -1823,9 +1858,11 @@ const NoDayActivity = styled.p`
   font-size: 0.75rem;
 `;
 
-function formatFullDay(date: string): string {
+function formatFullDay(date: string, timeZone = "UTC"): string {
   const timestamp = parseUtcDate(date);
-  return timestamp === null ? date : fullDayFormatter.format(timestamp);
+  return timestamp === null
+    ? date
+    : formatCalendarDate("fullDay", timestamp, timeZone);
 }
 
 function getClientName(client: ClientType): string {
@@ -1855,7 +1892,13 @@ function modelMeta(model: ContributionModelDetail): string {
   return metrics.join(" · ");
 }
 
-function ContributionDayTooltip({ day }: { day: DailyContribution }) {
+function ContributionDayTooltip({
+  day,
+  timeZone = "UTC",
+}: {
+  day: DailyContribution;
+  timeZone?: string;
+}) {
   const clients = createContributionClientDetails(day);
   const messageCount = getContributionDayMessageCount(day, clients);
   const visibleCategories = TOKEN_CATEGORIES.filter(
@@ -1864,7 +1907,7 @@ function ContributionDayTooltip({ day }: { day: DailyContribution }) {
 
   return (
     <>
-      <CellTooltipDate>{formatFullDay(day.date)}</CellTooltipDate>
+      <CellTooltipDate>{formatFullDay(day.date, timeZone)}</CellTooltipDate>
       <TooltipTotal>
         <TooltipTotalLabel>Total tokens</TooltipTotalLabel>
         <CellTooltipValue>
@@ -1931,6 +1974,7 @@ function ContributionDayBreakdown({
   onClose,
   palette,
   standalone = false,
+  timeZone = "UTC",
 }: {
   className?: string;
   day: DailyContribution;
@@ -1938,6 +1982,7 @@ function ContributionDayBreakdown({
   onClose?: () => void;
   palette: GraphColorPalette;
   standalone?: boolean;
+  timeZone?: string;
 }) {
   const headingId = `${id}-heading`;
   const clients = createContributionClientDetails(day);
@@ -1953,7 +1998,9 @@ function ContributionDayBreakdown({
       <DetailHeader>
         <div>
           <DetailEyebrow>Day breakdown</DetailEyebrow>
-          <DetailTitle id={headingId}>{formatFullDay(day.date)}</DetailTitle>
+          <DetailTitle id={headingId}>
+            {formatFullDay(day.date, timeZone)}
+          </DetailTitle>
         </div>
         {onClose && (
           <DetailClose
@@ -2084,6 +2131,7 @@ export function ProfileContributionBreakdown({
   id,
   onClose,
   paletteName = DEFAULT_PALETTE,
+  timeZone = "UTC",
 }: ProfileContributionBreakdownProps) {
   return (
     <ContributionDayBreakdown
@@ -2093,6 +2141,7 @@ export function ProfileContributionBreakdown({
       onClose={onClose}
       palette={getPalette(paletteName)}
       standalone
+      timeZone={timeZone}
     />
   );
 }
@@ -2134,6 +2183,7 @@ export function ProfileContributionGraph({
   selectableRangeEnd,
   selectedDate: providedSelectedDate,
   showBreakdown = true,
+  timeZone = "UTC",
   view: providedView,
 }: ProfileContributionGraphProps) {
   const titleId = useId();
@@ -2172,14 +2222,15 @@ export function ProfileContributionGraph({
         rangeStart,
         rangeEnd,
         selectableRangeEnd,
+        timeZone,
       ),
-    [contributions, rangeStart, rangeEnd, selectableRangeEnd],
+    [contributions, rangeStart, rangeEnd, selectableRangeEnd, timeZone],
   );
   const activeDayLabel = `${calendar.activeDays.toLocaleString("en-US")} active ${
     calendar.activeDays === 1 ? "day" : "days"
   }`;
   const accessibleDetail = calendar.highestDay
-    ? `Highest activity: ${cellTitle(calendar.highestDay)}. ${calendar.freeTokenDays.toLocaleString(
+    ? `Highest activity: ${cellTitle(calendar.highestDay, timeZone)}. ${calendar.freeTokenDays.toLocaleString(
         "en-US",
       )} active days used tokens with no recorded cost.`
     : "No active contribution days are available.";
@@ -2468,7 +2519,9 @@ export function ProfileContributionGraph({
           </ViewToggle>
           <Summary aria-live="polite">
             <ActiveDays>{activeDayLabel}</ActiveDays>
-            <Range>{formatRange(calendar.startDate, calendar.endDate)}</Range>
+            <Range>
+              {formatRange(calendar.startDate, calendar.endDate, timeZone)}
+            </Range>
           </Summary>
         </HeaderAside>
       </Header>
@@ -2517,7 +2570,7 @@ export function ProfileContributionGraph({
                         cell.selectable && cell.date === tabbableDate ? 0 : -1
                       }
                       aria-hidden={cell.inRange ? undefined : true}
-                      aria-label={cell.inRange ? cellTitle(cell) : undefined}
+                      aria-label={cell.inRange ? cellTitle(cell, timeZone) : undefined}
                       aria-current={
                         cell.selectable && cell.date === selectedDate
                           ? "date"
@@ -2586,7 +2639,7 @@ export function ProfileContributionGraph({
                         interactive && cell.date === tabbableDate ? 0 : -1
                       }
                       aria-hidden={interactive ? undefined : true}
-                      aria-label={interactive ? cellTitle(cell) : undefined}
+                      aria-label={interactive ? cellTitle(cell, timeZone) : undefined}
                       aria-current={
                         interactive && selected ? "date" : undefined
                       }
@@ -2644,7 +2697,7 @@ export function ProfileContributionGraph({
               $left={tooltip.left}
               $top={tooltip.top}
             >
-              <ContributionDayTooltip day={tooltip.day} />
+              <ContributionDayTooltip day={tooltip.day} timeZone={timeZone} />
             </CellTooltip>
           )}
           <Footer>
@@ -2695,6 +2748,7 @@ export function ProfileContributionGraph({
               id={breakdownId}
               onClose={closeSelectedDay}
               palette={palette}
+              timeZone={timeZone}
             />
           )}
         </>

--- a/packages/frontend/src/components/profile/ProfileContributionGraph.tsx
+++ b/packages/frontend/src/components/profile/ProfileContributionGraph.tsx
@@ -32,7 +32,6 @@ import {
   type GraphColorPalette,
 } from "@/lib/themes";
 import { formatCurrency, formatTokenCount } from "@/lib/utils";
-import { calendarInstantInTimeZone } from "@/lib/timezone";
 
 export interface ProfileContributionGraphProps {
   breakdownId?: string;
@@ -52,7 +51,6 @@ export interface ProfileContributionGraphProps {
   selectableRangeEnd?: string | null;
   selectedDate?: string | null;
   showBreakdown?: boolean;
-  timeZone?: string;
   view?: ProfileContributionView;
 }
 
@@ -134,7 +132,6 @@ export interface ProfileContributionBreakdownProps {
   id: string;
   onClose?: () => void;
   paletteName?: ColorPaletteName;
-  timeZone?: string;
 }
 
 export interface ContributionCalendar {
@@ -201,49 +198,25 @@ export function isContributionDateHit(target: Element | null): boolean {
   return Boolean(target?.closest("[data-contribution-date]"));
 }
 
-type CalendarDateFormat = "day" | "fullDay" | "month";
+const dayFormatter = new Intl.DateTimeFormat("en-US", {
+  day: "numeric",
+  month: "short",
+  timeZone: "UTC",
+  year: "numeric",
+});
 
-const CALENDAR_DATE_FORMAT_OPTIONS: Record<
-  CalendarDateFormat,
-  Intl.DateTimeFormatOptions
-> = {
-  day: { day: "numeric", month: "short", year: "numeric" },
-  fullDay: { day: "numeric", month: "long", weekday: "long", year: "numeric" },
-  month: { month: "short" },
-};
+const fullDayFormatter = new Intl.DateTimeFormat("en-US", {
+  day: "numeric",
+  month: "long",
+  timeZone: "UTC",
+  weekday: "long",
+  year: "numeric",
+});
 
-const calendarDateFormatters = new Map<string, Intl.DateTimeFormat>();
-
-function getCalendarDateFormatter(
-  format: CalendarDateFormat,
-  timeZone: string,
-): Intl.DateTimeFormat {
-  const key = `${format}:${timeZone}`;
-  let formatter = calendarDateFormatters.get(key);
-  if (!formatter) {
-    formatter = new Intl.DateTimeFormat("en-US", {
-      ...CALENDAR_DATE_FORMAT_OPTIONS[format],
-      timeZone,
-    });
-    calendarDateFormatters.set(key, formatter);
-  }
-  return formatter;
-}
-
-/**
- * Format a calendar date (as its UTC-midnight timestamp) for display. The
- * instant is shifted to that date's midnight in `timeZone` first, so the
- * label always names the intended calendar day regardless of the zone offset.
- */
-function formatCalendarDate(
-  format: CalendarDateFormat,
-  utcMidnight: number,
-  timeZone: string,
-): string {
-  return getCalendarDateFormatter(format, timeZone).format(
-    calendarInstantInTimeZone(utcMidnight, timeZone),
-  );
-}
+const monthFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  timeZone: "UTC",
+});
 
 const tokenFormatter = new Intl.NumberFormat("en-US", {
   maximumFractionDigits: 0,
@@ -606,7 +579,6 @@ export function createContributionCalendar(
   rangeStart?: string | null,
   rangeEnd?: string | null,
   selectableRangeEnd?: string | null,
-  timeZone = "UTC",
 ): ContributionCalendar {
   const contributionsByDate = new Map<
     string,
@@ -713,7 +685,7 @@ export function createContributionCalendar(
       const month = date.getUTCMonth();
       const marker = {
         compactVisible: monthMarkers.length === 0 || month % 3 === 0,
-        label: formatCalendarDate("month", cursor, timeZone),
+        label: monthFormatter.format(date),
         weekIndex,
       };
       const previous = monthMarkers.at(-1);
@@ -933,26 +905,19 @@ export function getNearestContributionDate(
   return nearestDistanceSquared <= maximumDistance ** 2 ? nearestDate : null;
 }
 
-function formatRange(
-  startDate: string | null,
-  endDate: string | null,
-  timeZone = "UTC",
-): string {
+function formatRange(startDate: string | null, endDate: string | null): string {
   if (!startDate || !endDate) return "No activity yet";
 
   const start = parseUtcDate(startDate);
   const end = parseUtcDate(endDate);
   if (start === null || end === null) return "No activity yet";
-  if (start === end) return formatCalendarDate("day", start, timeZone);
-  return `${formatCalendarDate("day", start, timeZone)} – ${formatCalendarDate("day", end, timeZone)}`;
+  if (start === end) return dayFormatter.format(start);
+  return `${dayFormatter.format(start)} – ${dayFormatter.format(end)}`;
 }
 
-function cellTitle(cell: ContributionCell, timeZone = "UTC"): string {
+function cellTitle(cell: ContributionCell): string {
   const timestamp = parseUtcDate(cell.date);
-  const date =
-    timestamp === null
-      ? cell.date
-      : formatCalendarDate("day", timestamp, timeZone);
+  const date = timestamp === null ? cell.date : dayFormatter.format(timestamp);
   const tokenLabel = cell.tokens === 1 ? "token" : "tokens";
   return `${date}: ${tokenFormatter.format(cell.tokens)} ${tokenLabel}`;
 }
@@ -1858,11 +1823,9 @@ const NoDayActivity = styled.p`
   font-size: 0.75rem;
 `;
 
-function formatFullDay(date: string, timeZone = "UTC"): string {
+function formatFullDay(date: string): string {
   const timestamp = parseUtcDate(date);
-  return timestamp === null
-    ? date
-    : formatCalendarDate("fullDay", timestamp, timeZone);
+  return timestamp === null ? date : fullDayFormatter.format(timestamp);
 }
 
 function getClientName(client: ClientType): string {
@@ -1892,13 +1855,7 @@ function modelMeta(model: ContributionModelDetail): string {
   return metrics.join(" · ");
 }
 
-function ContributionDayTooltip({
-  day,
-  timeZone = "UTC",
-}: {
-  day: DailyContribution;
-  timeZone?: string;
-}) {
+function ContributionDayTooltip({ day }: { day: DailyContribution }) {
   const clients = createContributionClientDetails(day);
   const messageCount = getContributionDayMessageCount(day, clients);
   const visibleCategories = TOKEN_CATEGORIES.filter(
@@ -1907,7 +1864,7 @@ function ContributionDayTooltip({
 
   return (
     <>
-      <CellTooltipDate>{formatFullDay(day.date, timeZone)}</CellTooltipDate>
+      <CellTooltipDate>{formatFullDay(day.date)}</CellTooltipDate>
       <TooltipTotal>
         <TooltipTotalLabel>Total tokens</TooltipTotalLabel>
         <CellTooltipValue>
@@ -1974,7 +1931,6 @@ function ContributionDayBreakdown({
   onClose,
   palette,
   standalone = false,
-  timeZone = "UTC",
 }: {
   className?: string;
   day: DailyContribution;
@@ -1982,7 +1938,6 @@ function ContributionDayBreakdown({
   onClose?: () => void;
   palette: GraphColorPalette;
   standalone?: boolean;
-  timeZone?: string;
 }) {
   const headingId = `${id}-heading`;
   const clients = createContributionClientDetails(day);
@@ -1998,9 +1953,7 @@ function ContributionDayBreakdown({
       <DetailHeader>
         <div>
           <DetailEyebrow>Day breakdown</DetailEyebrow>
-          <DetailTitle id={headingId}>
-            {formatFullDay(day.date, timeZone)}
-          </DetailTitle>
+          <DetailTitle id={headingId}>{formatFullDay(day.date)}</DetailTitle>
         </div>
         {onClose && (
           <DetailClose
@@ -2131,7 +2084,6 @@ export function ProfileContributionBreakdown({
   id,
   onClose,
   paletteName = DEFAULT_PALETTE,
-  timeZone = "UTC",
 }: ProfileContributionBreakdownProps) {
   return (
     <ContributionDayBreakdown
@@ -2141,7 +2093,6 @@ export function ProfileContributionBreakdown({
       onClose={onClose}
       palette={getPalette(paletteName)}
       standalone
-      timeZone={timeZone}
     />
   );
 }
@@ -2183,7 +2134,6 @@ export function ProfileContributionGraph({
   selectableRangeEnd,
   selectedDate: providedSelectedDate,
   showBreakdown = true,
-  timeZone = "UTC",
   view: providedView,
 }: ProfileContributionGraphProps) {
   const titleId = useId();
@@ -2222,15 +2172,14 @@ export function ProfileContributionGraph({
         rangeStart,
         rangeEnd,
         selectableRangeEnd,
-        timeZone,
       ),
-    [contributions, rangeStart, rangeEnd, selectableRangeEnd, timeZone],
+    [contributions, rangeStart, rangeEnd, selectableRangeEnd],
   );
   const activeDayLabel = `${calendar.activeDays.toLocaleString("en-US")} active ${
     calendar.activeDays === 1 ? "day" : "days"
   }`;
   const accessibleDetail = calendar.highestDay
-    ? `Highest activity: ${cellTitle(calendar.highestDay, timeZone)}. ${calendar.freeTokenDays.toLocaleString(
+    ? `Highest activity: ${cellTitle(calendar.highestDay)}. ${calendar.freeTokenDays.toLocaleString(
         "en-US",
       )} active days used tokens with no recorded cost.`
     : "No active contribution days are available.";
@@ -2519,9 +2468,7 @@ export function ProfileContributionGraph({
           </ViewToggle>
           <Summary aria-live="polite">
             <ActiveDays>{activeDayLabel}</ActiveDays>
-            <Range>
-              {formatRange(calendar.startDate, calendar.endDate, timeZone)}
-            </Range>
+            <Range>{formatRange(calendar.startDate, calendar.endDate)}</Range>
           </Summary>
         </HeaderAside>
       </Header>
@@ -2570,7 +2517,7 @@ export function ProfileContributionGraph({
                         cell.selectable && cell.date === tabbableDate ? 0 : -1
                       }
                       aria-hidden={cell.inRange ? undefined : true}
-                      aria-label={cell.inRange ? cellTitle(cell, timeZone) : undefined}
+                      aria-label={cell.inRange ? cellTitle(cell) : undefined}
                       aria-current={
                         cell.selectable && cell.date === selectedDate
                           ? "date"
@@ -2639,7 +2586,7 @@ export function ProfileContributionGraph({
                         interactive && cell.date === tabbableDate ? 0 : -1
                       }
                       aria-hidden={interactive ? undefined : true}
-                      aria-label={interactive ? cellTitle(cell, timeZone) : undefined}
+                      aria-label={interactive ? cellTitle(cell) : undefined}
                       aria-current={
                         interactive && selected ? "date" : undefined
                       }
@@ -2697,7 +2644,7 @@ export function ProfileContributionGraph({
               $left={tooltip.left}
               $top={tooltip.top}
             >
-              <ContributionDayTooltip day={tooltip.day} timeZone={timeZone} />
+              <ContributionDayTooltip day={tooltip.day} />
             </CellTooltip>
           )}
           <Footer>
@@ -2748,7 +2695,6 @@ export function ProfileContributionGraph({
               id={breakdownId}
               onClose={closeSelectedDay}
               palette={palette}
-              timeZone={timeZone}
             />
           )}
         </>

--- a/packages/frontend/src/components/profile/ProfileOverview.tsx
+++ b/packages/frontend/src/components/profile/ProfileOverview.tsx
@@ -13,7 +13,11 @@ export interface ProfileOverviewProps {
   stats: ProfileStatsData;
   lastUpdated?: string | null;
   period?: "all" | "month" | "week";
-  /** Display timezone for user-facing dates; defaults to the viewer's zone. */
+  /**
+   * Zone for the two absolute instants rendered here — "Updated" and "Joined".
+   * Defaults to the viewer's browser zone. Never applies to contribution
+   * dates: those are calendar buckets the submitting machine already resolved.
+   */
   timeZone?: string;
   className?: string;
 }

--- a/packages/frontend/src/components/profile/ProfileOverview.tsx
+++ b/packages/frontend/src/components/profile/ProfileOverview.tsx
@@ -318,7 +318,13 @@ export function formatLastUpdated(
     : date.toLocaleString("en-US", { timeZone: "UTC" });
 }
 
-function formatJoined(
+/**
+ * "Joined" is an absolute instant (`users.createdAt`), so projecting it into the
+ * viewer's chosen zone is meaningful and two viewers may legitimately read a
+ * different month across a UTC boundary. Contribution dates never take this
+ * path — see src/lib/timezone.ts.
+ */
+export function formatJoined(
   createdAt: string | null | undefined,
   timeZone?: string,
 ): string | null {

--- a/packages/frontend/src/components/profile/ProfileOverview.tsx
+++ b/packages/frontend/src/components/profile/ProfileOverview.tsx
@@ -13,6 +13,8 @@ export interface ProfileOverviewProps {
   stats: ProfileStatsData;
   lastUpdated?: string | null;
   period?: "all" | "month" | "week";
+  /** Display timezone for user-facing dates; defaults to the viewer's zone. */
+  timeZone?: string;
   className?: string;
 }
 
@@ -303,15 +305,19 @@ const subscribeNoop = () => () => {};
 export function formatLastUpdated(
   lastUpdated: string | null | undefined,
   isMounted: boolean,
+  timeZone?: string,
 ): string | null {
   if (!lastUpdated) return null;
   const date = new Date(lastUpdated);
   return isMounted
-    ? date.toLocaleString("en-US")
+    ? date.toLocaleString("en-US", timeZone ? { timeZone } : undefined)
     : date.toLocaleString("en-US", { timeZone: "UTC" });
 }
 
-function formatJoined(createdAt: string | null | undefined): string | null {
+function formatJoined(
+  createdAt: string | null | undefined,
+  timeZone = "UTC",
+): string | null {
   if (!createdAt) return null;
   const date = new Date(createdAt);
   if (Number.isNaN(date.getTime())) return null;
@@ -319,7 +325,7 @@ function formatJoined(createdAt: string | null | undefined): string | null {
   return date.toLocaleDateString("en-US", {
     month: "short",
     year: "numeric",
-    timeZone: "UTC",
+    timeZone,
   });
 }
 
@@ -328,6 +334,7 @@ export function ProfileOverview({
   stats,
   lastUpdated,
   period = "all",
+  timeZone,
   className,
 }: ProfileOverviewProps) {
   const [isEmbedDialogOpen, setIsEmbedDialogOpen] = useState(false);
@@ -337,10 +344,13 @@ export function ProfileOverview({
     () => false,
   );
   const formattedLastUpdated = useMemo(
-    () => formatLastUpdated(lastUpdated, isMounted),
-    [isMounted, lastUpdated],
+    () => formatLastUpdated(lastUpdated, isMounted, timeZone),
+    [isMounted, lastUpdated, timeZone],
   );
-  const joined = useMemo(() => formatJoined(user.createdAt), [user.createdAt]);
+  const joined = useMemo(
+    () => formatJoined(user.createdAt, isMounted ? timeZone : undefined),
+    [user.createdAt, isMounted, timeZone],
+  );
   const displayName = user.displayName || user.username;
   const avatarUrl = user.avatarUrl || `https://github.com/${user.username}.png`;
 

--- a/packages/frontend/src/components/profile/ProfileOverview.tsx
+++ b/packages/frontend/src/components/profile/ProfileOverview.tsx
@@ -316,17 +316,18 @@ export function formatLastUpdated(
 
 function formatJoined(
   createdAt: string | null | undefined,
-  timeZone = "UTC",
+  timeZone?: string,
 ): string | null {
   if (!createdAt) return null;
   const date = new Date(createdAt);
   if (Number.isNaN(date.getTime())) return null;
 
-  return date.toLocaleDateString("en-US", {
+  const options: Intl.DateTimeFormatOptions = {
     month: "short",
     year: "numeric",
-    timeZone,
-  });
+  };
+  if (timeZone) options.timeZone = timeZone;
+  return date.toLocaleDateString("en-US", options);
 }
 
 export function ProfileOverview({
@@ -348,7 +349,7 @@ export function ProfileOverview({
     [isMounted, lastUpdated, timeZone],
   );
   const joined = useMemo(
-    () => formatJoined(user.createdAt, isMounted ? timeZone : undefined),
+    () => formatJoined(user.createdAt, isMounted ? timeZone : "UTC"),
     [user.createdAt, isMounted, timeZone],
   );
   const displayName = user.displayName || user.username;

--- a/packages/frontend/src/components/profile/index.tsx
+++ b/packages/frontend/src/components/profile/index.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-export { ProfileOverview, formatLastUpdated } from "./ProfileOverview";
+export {
+  ProfileOverview,
+  formatJoined,
+  formatLastUpdated,
+} from "./ProfileOverview";
 export type { ProfileOverviewProps } from "./ProfileOverview";
 
 export { ProfileTabBar } from "./ProfileTabBar";

--- a/packages/frontend/src/lib/publicProfileData.ts
+++ b/packages/frontend/src/lib/publicProfileData.ts
@@ -10,6 +10,7 @@ import {
   usernameEqualsIgnoreCase,
 } from "@/lib/db/usernameLookup";
 import { buildSubmissionFreshness } from "@/lib/submissionFreshness";
+import { getTodayInTimeZone, isValidTimeZone } from "@/lib/timezone";
 
 const LEGACY_CLIENT_ALIASES: Record<string, string> = { kilocode: "kilo" };
 function normalizeClientId(id: string): string {
@@ -38,43 +39,56 @@ function parseProfilePeriod(value: string | null): ProfilePeriod {
 
 function getProfilePeriodDateRange(
   period: ProfilePeriod,
+  timeZone = "UTC",
   now: Date = new Date(),
 ): ProfilePeriodDateRange | null {
   if (period === "all") {
     return null;
   }
 
-  const end = new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
-  );
-  const start = new Date(end);
-  start.setUTCDate(start.getUTCDate() - (period === "week" ? 6 : 29));
+  const end = getProfileRangeEnd(timeZone, now);
 
   return {
-    start: toUtcDateString(start),
-    end: toUtcDateString(end),
+    start: shiftDateKey(end, period === "week" ? -6 : -29),
+    end,
   };
 }
 
 function getRollingProfileDateRange(
+  timeZone = "UTC",
   now: Date = new Date(),
 ): ProfilePeriodDateRange {
-  const end = new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
-  );
-  const targetYear = end.getUTCFullYear() - 1;
-  const month = end.getUTCMonth();
+  const end = getProfileRangeEnd(timeZone, now);
+  const endDate = new Date(`${end}T00:00:00.000Z`);
+  const targetYear = endDate.getUTCFullYear() - 1;
+  const month = endDate.getUTCMonth();
   const lastValidDay = new Date(
     Date.UTC(targetYear, month + 1, 0),
   ).getUTCDate();
   const start = new Date(
-    Date.UTC(targetYear, month, Math.min(end.getUTCDate(), lastValidDay)),
+    Date.UTC(
+      targetYear,
+      month,
+      Math.min(endDate.getUTCDate(), lastValidDay),
+    ),
   );
 
   return {
     start: toUtcDateString(start),
-    end: toUtcDateString(end),
+    end,
   };
+}
+
+function shiftDateKey(date: string, days: number): string {
+  const shifted = new Date(`${date}T00:00:00.000Z`);
+  shifted.setUTCDate(shifted.getUTCDate() + days);
+  return toUtcDateString(shifted);
+}
+
+function getProfileRangeEnd(timeZone: string, now: Date): string {
+  const utcToday = toUtcDateString(now);
+  const localToday = getTodayInTimeZone(timeZone, now);
+  return localToday > utcToday ? localToday : utcToday;
 }
 
 function serializeUpdatedAt(
@@ -101,8 +115,13 @@ export async function getPublicProfileResponse(
     const { username } = await params;
     const { searchParams } = new URL(request.url);
     const period = parseProfilePeriod(searchParams.get("period"));
-    const periodRange = getProfilePeriodDateRange(period);
-    const chartRange = periodRange ?? getRollingProfileDateRange();
+    const requestedTimeZone = searchParams.get("tz");
+    const timeZone =
+      requestedTimeZone && isValidTimeZone(requestedTimeZone)
+        ? requestedTimeZone
+        : "UTC";
+    const periodRange = getProfilePeriodDateRange(period, timeZone);
+    const chartRange = periodRange ?? getRollingProfileDateRange(timeZone);
 
     // Find user
     const matchingUsers = await db
@@ -126,6 +145,9 @@ export async function getPublicProfileResponse(
       const canonicalUrl = new URL(`/api/users/${user.username}`, request.url);
       if (period !== "all") {
         canonicalUrl.searchParams.set("period", period);
+      }
+      if (requestedTimeZone && timeZone !== "UTC") {
+        canonicalUrl.searchParams.set("tz", timeZone);
       }
       return NextResponse.redirect(canonicalUrl, 308);
     }

--- a/packages/frontend/src/lib/publicProfileData.ts
+++ b/packages/frontend/src/lib/publicProfileData.ts
@@ -10,7 +10,6 @@ import {
   usernameEqualsIgnoreCase,
 } from "@/lib/db/usernameLookup";
 import { buildSubmissionFreshness } from "@/lib/submissionFreshness";
-import { getTodayInTimeZone, isValidTimeZone } from "@/lib/timezone";
 
 const LEGACY_CLIENT_ALIASES: Record<string, string> = { kilocode: "kilo" };
 function normalizeClientId(id: string): string {
@@ -39,56 +38,43 @@ function parseProfilePeriod(value: string | null): ProfilePeriod {
 
 function getProfilePeriodDateRange(
   period: ProfilePeriod,
-  timeZone = "UTC",
   now: Date = new Date(),
 ): ProfilePeriodDateRange | null {
   if (period === "all") {
     return null;
   }
 
-  const end = getProfileRangeEnd(timeZone, now);
+  const end = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - (period === "week" ? 6 : 29));
 
   return {
-    start: shiftDateKey(end, period === "week" ? -6 : -29),
-    end,
+    start: toUtcDateString(start),
+    end: toUtcDateString(end),
   };
 }
 
 function getRollingProfileDateRange(
-  timeZone = "UTC",
   now: Date = new Date(),
 ): ProfilePeriodDateRange {
-  const end = getProfileRangeEnd(timeZone, now);
-  const endDate = new Date(`${end}T00:00:00.000Z`);
-  const targetYear = endDate.getUTCFullYear() - 1;
-  const month = endDate.getUTCMonth();
+  const end = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+  const targetYear = end.getUTCFullYear() - 1;
+  const month = end.getUTCMonth();
   const lastValidDay = new Date(
     Date.UTC(targetYear, month + 1, 0),
   ).getUTCDate();
   const start = new Date(
-    Date.UTC(
-      targetYear,
-      month,
-      Math.min(endDate.getUTCDate(), lastValidDay),
-    ),
+    Date.UTC(targetYear, month, Math.min(end.getUTCDate(), lastValidDay)),
   );
 
   return {
     start: toUtcDateString(start),
-    end,
+    end: toUtcDateString(end),
   };
-}
-
-function shiftDateKey(date: string, days: number): string {
-  const shifted = new Date(`${date}T00:00:00.000Z`);
-  shifted.setUTCDate(shifted.getUTCDate() + days);
-  return toUtcDateString(shifted);
-}
-
-function getProfileRangeEnd(timeZone: string, now: Date): string {
-  const utcToday = toUtcDateString(now);
-  const localToday = getTodayInTimeZone(timeZone, now);
-  return localToday > utcToday ? localToday : utcToday;
 }
 
 function serializeUpdatedAt(
@@ -115,13 +101,8 @@ export async function getPublicProfileResponse(
     const { username } = await params;
     const { searchParams } = new URL(request.url);
     const period = parseProfilePeriod(searchParams.get("period"));
-    const requestedTimeZone = searchParams.get("tz");
-    const timeZone =
-      requestedTimeZone && isValidTimeZone(requestedTimeZone)
-        ? requestedTimeZone
-        : "UTC";
-    const periodRange = getProfilePeriodDateRange(period, timeZone);
-    const chartRange = periodRange ?? getRollingProfileDateRange(timeZone);
+    const periodRange = getProfilePeriodDateRange(period);
+    const chartRange = periodRange ?? getRollingProfileDateRange();
 
     // Find user
     const matchingUsers = await db
@@ -145,9 +126,6 @@ export async function getPublicProfileResponse(
       const canonicalUrl = new URL(`/api/users/${user.username}`, request.url);
       if (period !== "all") {
         canonicalUrl.searchParams.set("period", period);
-      }
-      if (requestedTimeZone && timeZone !== "UTC") {
-        canonicalUrl.searchParams.set("tz", timeZone);
       }
       return NextResponse.redirect(canonicalUrl, 308);
     }

--- a/packages/frontend/src/lib/publicProfileData.ts
+++ b/packages/frontend/src/lib/publicProfileData.ts
@@ -56,12 +56,34 @@ function getProfilePeriodDateRange(
   };
 }
 
+const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/** `YYYY-MM-DD` to its UTC midnight; null for anything that is not one. */
+function parseDateKey(value: string | null | undefined): Date | null {
+  if (!value || !DATE_KEY_PATTERN.test(value)) return null;
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+/**
+ * Rolling twelve-month window for the lifetime chart.
+ *
+ * The end is anchored to the later of UTC today and the newest date the data
+ * itself carries. Contribution dates are calendar-day buckets computed by the
+ * CLI in the *submitting* machine's local timezone, so a user ahead of UTC
+ * legitimately reports a date that is still tomorrow here. Anchoring to the
+ * data keeps that day inside the window for every viewer, wherever they are,
+ * and keeps the range-scoped stats on the same window the chart draws.
+ */
 function getRollingProfileDateRange(
+  latestDate?: string | null,
   now: Date = new Date(),
 ): ProfilePeriodDateRange {
-  const end = new Date(
+  const utcToday = new Date(
     Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
   );
+  const latest = parseDateKey(latestDate);
+  const end = latest && latest > utcToday ? latest : utcToday;
   const targetYear = end.getUTCFullYear() - 1;
   const month = end.getUTCMonth();
   const lastValidDay = new Date(
@@ -102,7 +124,6 @@ export async function getPublicProfileResponse(
     const { searchParams } = new URL(request.url);
     const period = parseProfilePeriod(searchParams.get("period"));
     const periodRange = getProfilePeriodDateRange(period);
-    const chartRange = periodRange ?? getRollingProfileDateRange();
 
     // Find user
     const matchingUsers = await db
@@ -211,6 +232,10 @@ export async function getPublicProfileResponse(
     const [stats] = statsResult;
     const [latestSubmission] = latestSubmissionResult;
     const rank = (rankResult as unknown as { rank: number }[])[0]?.rank || null;
+    // Resolved only once the newest submitted date is known, so the lifetime
+    // window can end on the data instead of on UTC "today".
+    const chartRange =
+      periodRange ?? getRollingProfileDateRange(stats?.latestDate);
 
     type ModelData = {
       tokens: number;

--- a/packages/frontend/src/lib/publicProfileData.ts
+++ b/packages/frontend/src/lib/publicProfileData.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { unstable_cache } from "next/cache";
 import { db, users, submissions, dailyBreakdown } from "@/lib/db";
-import { eq, desc, sql, and, gte, lte } from "drizzle-orm";
+import { eq, desc, sql, and, gte } from "drizzle-orm";
 import {
   AmbiguousUsernameError,
   USERNAME_LOOKUP_LIMIT,
@@ -30,30 +30,16 @@ function toUtcDateString(date: Date): string {
   return date.toISOString().slice(0, 10);
 }
 
+function getUtcToday(now: Date): Date {
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+}
+
 function parseProfilePeriod(value: string | null): ProfilePeriod {
   return PROFILE_PERIODS.includes(value as ProfilePeriod)
     ? (value as ProfilePeriod)
     : "all";
-}
-
-function getProfilePeriodDateRange(
-  period: ProfilePeriod,
-  now: Date = new Date(),
-): ProfilePeriodDateRange | null {
-  if (period === "all") {
-    return null;
-  }
-
-  const end = new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
-  );
-  const start = new Date(end);
-  start.setUTCDate(start.getUTCDate() - (period === "week" ? 6 : 29));
-
-  return {
-    start: toUtcDateString(start),
-    end: toUtcDateString(end),
-  };
 }
 
 const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
@@ -66,24 +52,46 @@ function parseDateKey(value: string | null | undefined): Date | null {
 }
 
 /**
- * Rolling twelve-month window for the lifetime chart.
+ * The day every profile window ends on: the later of UTC today and the newest
+ * date the data itself carries.
  *
- * The end is anchored to the later of UTC today and the newest date the data
- * itself carries. Contribution dates are calendar-day buckets computed by the
- * CLI in the *submitting* machine's local timezone, so a user ahead of UTC
- * legitimately reports a date that is still tomorrow here. Anchoring to the
- * data keeps that day inside the window for every viewer, wherever they are,
- * and keeps the range-scoped stats on the same window the chart draws.
+ * Contribution dates are calendar-day buckets computed by the CLI in the
+ * *submitting* machine's local timezone, so a user ahead of UTC legitimately
+ * reports a date that is still tomorrow here. Anchoring to the data keeps that
+ * day inside every window for every viewer, wherever they are, and keeps the
+ * range-scoped stats on the same window the chart draws. Validation caps
+ * contribution dates at UTC today + 2 days, so the anchor can never run more
+ * than two days past the present.
  */
-function getRollingProfileDateRange(
-  latestDate?: string | null,
-  now: Date = new Date(),
-): ProfilePeriodDateRange {
-  const utcToday = new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
-  );
+function getProfileRangeAnchor(
+  latestDate: string | null | undefined,
+  now: Date,
+): Date {
+  const utcToday = getUtcToday(now);
   const latest = parseDateKey(latestDate);
-  const end = latest && latest > utcToday ? latest : utcToday;
+  return latest && latest > utcToday ? latest : utcToday;
+}
+
+/** Trailing seven- or thirty-day window ending on `end`; null for lifetime. */
+function getProfilePeriodDateRange(
+  period: ProfilePeriod,
+  end: Date,
+): ProfilePeriodDateRange | null {
+  if (period === "all") {
+    return null;
+  }
+
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - (period === "week" ? 6 : 29));
+
+  return {
+    start: toUtcDateString(start),
+    end: toUtcDateString(end),
+  };
+}
+
+/** Rolling twelve-month window for the lifetime chart, ending on `end`. */
+function getRollingProfileDateRange(end: Date): ProfilePeriodDateRange {
   const targetYear = end.getUTCFullYear() - 1;
   const month = end.getUTCMonth();
   const lastValidDay = new Date(
@@ -123,7 +131,18 @@ export async function getPublicProfileResponse(
     const { username } = await params;
     const { searchParams } = new URL(request.url);
     const period = parseProfilePeriod(searchParams.get("period"));
-    const periodRange = getProfilePeriodDateRange(period);
+    // One clock reading for the whole request, so a UTC midnight crossed
+    // mid-request cannot put the query and the window on different days.
+    const now = new Date();
+    // The window a period request draws ends on the anchor, which is only known
+    // once the stats query returns. The anchor can only move *forward* of UTC
+    // today, so a window measured back from UTC today starts on or before the
+    // real one — fetching from there is a superset that `scopedContributions`
+    // trims to the anchored window.
+    const periodFetchStart = getProfilePeriodDateRange(
+      period,
+      getUtcToday(now),
+    )?.start;
 
     // Find user
     const matchingUsers = await db
@@ -151,11 +170,14 @@ export async function getPublicProfileResponse(
       return NextResponse.redirect(canonicalUrl, 308);
     }
 
-    const dailyBreakdownFilter = periodRange
+    // Deliberately unbounded above: `submissions.dateEnd` is
+    // `MAX(dailyBreakdown.date)`, so the anchor already dominates every row this
+    // user has and an upper bound could only ever drop the newest day of an
+    // owner whose calendar runs ahead of UTC.
+    const dailyBreakdownFilter = periodFetchStart
       ? and(
           eq(submissions.userId, user.id),
-          gte(dailyBreakdown.date, periodRange.start),
-          lte(dailyBreakdown.date, periodRange.end),
+          gte(dailyBreakdown.date, periodFetchStart),
         )
       : eq(submissions.userId, user.id);
 
@@ -232,10 +254,11 @@ export async function getPublicProfileResponse(
     const [stats] = statsResult;
     const [latestSubmission] = latestSubmissionResult;
     const rank = (rankResult as unknown as { rank: number }[])[0]?.rank || null;
-    // Resolved only once the newest submitted date is known, so the lifetime
-    // window can end on the data instead of on UTC "today".
-    const chartRange =
-      periodRange ?? getRollingProfileDateRange(stats?.latestDate);
+    // Resolved only once the newest submitted date is known, so every window —
+    // lifetime and period alike — ends on the data instead of on UTC "today".
+    const rangeAnchor = getProfileRangeAnchor(stats?.latestDate, now);
+    const periodRange = getProfilePeriodDateRange(period, rangeAnchor);
+    const chartRange = periodRange ?? getRollingProfileDateRange(rangeAnchor);
 
     type ModelData = {
       tokens: number;
@@ -480,7 +503,14 @@ export async function getPublicProfileResponse(
     const scopedContributions = contributions.filter(
       ({ date }) => date >= chartRange.start && date <= chartRange.end,
     );
-    const maxCost = Math.max(...contributions.map((c) => c.cost), 0);
+    // A lifetime request ships every day it holds — the graph's year dropdown
+    // reads them. A period request ships only its window: the query fetches a
+    // day or two more than the anchored window draws, and neither the intensity
+    // scale nor the graph may see past the window's edge.
+    const visibleContributions = periodRange
+      ? scopedContributions
+      : contributions;
+    const maxCost = Math.max(...visibleContributions.map((c) => c.cost), 0);
     const periodTotals = scopedContributions.reduce(
       (totals, day) => {
         totals.totalTokens += day.tokens;
@@ -508,7 +538,7 @@ export async function getPublicProfileResponse(
     );
 
     // Build contribution graph data
-    const graphContributions = contributions.map((day) => {
+    const graphContributions = visibleContributions.map((day) => {
       const intensity =
         maxCost === 0
           ? 0

--- a/packages/frontend/src/lib/timezone.ts
+++ b/packages/frontend/src/lib/timezone.ts
@@ -193,6 +193,15 @@ function getTimeZoneOffsetMs(timeZone: string, utcMs: number): number {
   return asUtcMs - utcMs;
 }
 
+function dateKeyInTimeZone(timeZone: string, timestamp: number): string {
+  const parts = getDayPartsFormatter(timeZone).formatToParts(
+    new Date(timestamp),
+  );
+  const part = (type: string) =>
+    parts.find((candidate) => candidate.type === type)?.value ?? "";
+  return `${part("year")}-${part("month")}-${part("day")}`;
+}
+
 /**
  * Shift a UTC-midnight calendar timestamp to the instant of that same
  * calendar midnight in `timeZone`, so timezone-aware formatters label the
@@ -204,10 +213,17 @@ export function calendarInstantInTimeZone(
 ): number {
   if (timeZone === "UTC") return utcMidnightMs;
   const offset = getTimeZoneOffsetMs(timeZone, utcMidnightMs);
-  let timestamp = utcMidnightMs - offset;
+  const timestamp = utcMidnightMs - offset;
   // Refine once: the offset at UTC midnight can differ from the offset at
-  // local midnight around DST transitions.
+  // local midnight around DST transitions. Some zones skip local midnight at
+  // spring-forward, though; retain the first valid instant on the requested
+  // calendar day rather than moving the label into the prior day.
   const refined = getTimeZoneOffsetMs(timeZone, timestamp);
-  if (refined !== offset) timestamp = utcMidnightMs - refined;
-  return timestamp;
+  if (refined === offset) return timestamp;
+
+  const refinedTimestamp = utcMidnightMs - refined;
+  const targetDate = new Date(utcMidnightMs).toISOString().slice(0, 10);
+  return dateKeyInTimeZone(timeZone, refinedTimestamp) === targetDate
+    ? refinedTimestamp
+    : timestamp;
 }

--- a/packages/frontend/src/lib/timezone.ts
+++ b/packages/frontend/src/lib/timezone.ts
@@ -1,11 +1,12 @@
 /**
  * Display-timezone helpers for the web dashboard.
  *
- * Contribution dates are calendar-day buckets (`YYYY-MM-DD`) submitted in the
- * user's local timezone, while the server computes chart ranges against UTC
- * "today". These helpers resolve the viewer's display timezone preference and
- * anchor calendar dates to it so freshly submitted local-today data renders
- * immediately. Display-only: the leaderboard stays UTC-based.
+ * Scope is deliberately narrow: the preference resolved here renders *absolute
+ * instants* — "Updated", "Joined" — in a zone the viewer chooses. It must never
+ * touch contribution dates. Those are calendar-day buckets (`YYYY-MM-DD`) that
+ * the CLI already resolved in the submitting machine's local timezone, so
+ * re-projecting them through a viewer's zone would move a day's usage onto a
+ * day its owner never worked. See #960 for the scan-timezone side of that split.
  */
 
 /** A modest list of common IANA zones for the settings select, by region. */
@@ -112,118 +113,4 @@ export function resolveEffectiveTimeZone(preference: string): string {
   return preference !== "auto" && isValidTimeZone(preference)
     ? preference
     : getBrowserTimeZone();
-}
-
-const dayPartsFormatters = new Map<string, Intl.DateTimeFormat>();
-
-function getDayPartsFormatter(timeZone: string): Intl.DateTimeFormat {
-  let formatter = dayPartsFormatters.get(timeZone);
-  if (!formatter) {
-    formatter = new Intl.DateTimeFormat("en-US", {
-      timeZone,
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-    });
-    dayPartsFormatters.set(timeZone, formatter);
-  }
-  return formatter;
-}
-
-/** "Today" as `YYYY-MM-DD` in the given timezone (never `toISOString`, which is UTC). */
-export function getTodayInTimeZone(
-  timeZone: string,
-  now: Date = new Date(),
-): string {
-  const parts = getDayPartsFormatter(timeZone).formatToParts(now);
-  const part = (type: string) =>
-    parts.find((candidate) => candidate.type === type)?.value ?? "";
-  return `${part("year")}-${part("month")}-${part("day")}`;
-}
-
-/**
- * Extend a range end to "today" in the effective timezone when the local day
- * is ahead of the (UTC-bucketed) end, so same-day contributions are not
- * clipped from profile charts. Never shortens the range.
- */
-export function extendDateRangeEndToToday(
-  rangeEnd: string | null | undefined,
-  timeZone: string,
-  now: Date = new Date(),
-): string | null {
-  if (!rangeEnd) return null;
-  const today = getTodayInTimeZone(timeZone, now);
-  return today > rangeEnd ? today : rangeEnd;
-}
-
-const offsetPartsFormatters = new Map<string, Intl.DateTimeFormat>();
-
-function getOffsetPartsFormatter(timeZone: string): Intl.DateTimeFormat {
-  let formatter = offsetPartsFormatters.get(timeZone);
-  if (!formatter) {
-    formatter = new Intl.DateTimeFormat("en-US", {
-      timeZone,
-      hourCycle: "h23",
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-    });
-    offsetPartsFormatters.set(timeZone, formatter);
-  }
-  return formatter;
-}
-
-function getTimeZoneOffsetMs(timeZone: string, utcMs: number): number {
-  const parts = getOffsetPartsFormatter(timeZone).formatToParts(
-    new Date(utcMs),
-  );
-  const part = (type: string) =>
-    Number(parts.find((candidate) => candidate.type === type)?.value ?? 0);
-  const asUtcMs = Date.UTC(
-    part("year"),
-    part("month") - 1,
-    part("day"),
-    part("hour"),
-    part("minute"),
-    part("second"),
-  );
-  return asUtcMs - utcMs;
-}
-
-function dateKeyInTimeZone(timeZone: string, timestamp: number): string {
-  const parts = getDayPartsFormatter(timeZone).formatToParts(
-    new Date(timestamp),
-  );
-  const part = (type: string) =>
-    parts.find((candidate) => candidate.type === type)?.value ?? "";
-  return `${part("year")}-${part("month")}-${part("day")}`;
-}
-
-/**
- * Shift a UTC-midnight calendar timestamp to the instant of that same
- * calendar midnight in `timeZone`, so timezone-aware formatters label the
- * intended date instead of the previous/next UTC day.
- */
-export function calendarInstantInTimeZone(
-  utcMidnightMs: number,
-  timeZone: string,
-): number {
-  if (timeZone === "UTC") return utcMidnightMs;
-  const offset = getTimeZoneOffsetMs(timeZone, utcMidnightMs);
-  const timestamp = utcMidnightMs - offset;
-  // Refine once: the offset at UTC midnight can differ from the offset at
-  // local midnight around DST transitions. Some zones skip local midnight at
-  // spring-forward, though; retain the first valid instant on the requested
-  // calendar day rather than moving the label into the prior day.
-  const refined = getTimeZoneOffsetMs(timeZone, timestamp);
-  if (refined === offset) return timestamp;
-
-  const refinedTimestamp = utcMidnightMs - refined;
-  const targetDate = new Date(utcMidnightMs).toISOString().slice(0, 10);
-  return dateKeyInTimeZone(timeZone, refinedTimestamp) === targetDate
-    ? refinedTimestamp
-    : timestamp;
 }

--- a/packages/frontend/src/lib/timezone.ts
+++ b/packages/frontend/src/lib/timezone.ts
@@ -1,0 +1,213 @@
+/**
+ * Display-timezone helpers for the web dashboard.
+ *
+ * Contribution dates are calendar-day buckets (`YYYY-MM-DD`) submitted in the
+ * user's local timezone, while the server computes chart ranges against UTC
+ * "today". These helpers resolve the viewer's display timezone preference and
+ * anchor calendar dates to it so freshly submitted local-today data renders
+ * immediately. Display-only: the leaderboard stays UTC-based.
+ */
+
+/** A modest list of common IANA zones for the settings select, by region. */
+export const COMMON_TIMEZONE_GROUPS: ReadonlyArray<{
+  region: string;
+  zones: readonly string[];
+}> = [
+  {
+    region: "Americas",
+    zones: [
+      "America/New_York",
+      "America/Chicago",
+      "America/Denver",
+      "America/Los_Angeles",
+      "America/Anchorage",
+      "Pacific/Honolulu",
+      "America/Toronto",
+      "America/Vancouver",
+      "America/Mexico_City",
+      "America/Sao_Paulo",
+      "America/Argentina/Buenos_Aires",
+    ],
+  },
+  {
+    region: "Europe",
+    zones: [
+      "Europe/London",
+      "Europe/Dublin",
+      "Europe/Paris",
+      "Europe/Berlin",
+      "Europe/Madrid",
+      "Europe/Rome",
+      "Europe/Amsterdam",
+      "Europe/Stockholm",
+      "Europe/Warsaw",
+      "Europe/Athens",
+      "Europe/Helsinki",
+      "Europe/Istanbul",
+      "Europe/Moscow",
+    ],
+  },
+  {
+    region: "Africa",
+    zones: [
+      "Africa/Cairo",
+      "Africa/Lagos",
+      "Africa/Nairobi",
+      "Africa/Johannesburg",
+    ],
+  },
+  {
+    region: "Asia",
+    zones: [
+      "Asia/Dubai",
+      "Asia/Karachi",
+      "Asia/Kolkata",
+      "Asia/Dhaka",
+      "Asia/Bangkok",
+      "Asia/Jakarta",
+      "Asia/Shanghai",
+      "Asia/Singapore",
+      "Asia/Hong_Kong",
+      "Asia/Taipei",
+      "Asia/Seoul",
+      "Asia/Tokyo",
+    ],
+  },
+  {
+    region: "Oceania",
+    zones: [
+      "Australia/Perth",
+      "Australia/Melbourne",
+      "Australia/Sydney",
+      "Pacific/Auckland",
+      "Pacific/Fiji",
+    ],
+  },
+  {
+    region: "Other",
+    zones: ["UTC", "Atlantic/Reykjavik", "Atlantic/Azores"],
+  },
+];
+
+export function isValidTimeZone(value: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: value });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function getBrowserTimeZone(): string {
+  try {
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return timeZone && isValidTimeZone(timeZone) ? timeZone : "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
+/** Resolve a stored preference (`"auto"` or an IANA zone) to a usable zone. */
+export function resolveEffectiveTimeZone(preference: string): string {
+  return preference !== "auto" && isValidTimeZone(preference)
+    ? preference
+    : getBrowserTimeZone();
+}
+
+const dayPartsFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function getDayPartsFormatter(timeZone: string): Intl.DateTimeFormat {
+  let formatter = dayPartsFormatters.get(timeZone);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+    dayPartsFormatters.set(timeZone, formatter);
+  }
+  return formatter;
+}
+
+/** "Today" as `YYYY-MM-DD` in the given timezone (never `toISOString`, which is UTC). */
+export function getTodayInTimeZone(
+  timeZone: string,
+  now: Date = new Date(),
+): string {
+  const parts = getDayPartsFormatter(timeZone).formatToParts(now);
+  const part = (type: string) =>
+    parts.find((candidate) => candidate.type === type)?.value ?? "";
+  return `${part("year")}-${part("month")}-${part("day")}`;
+}
+
+/**
+ * Extend a range end to "today" in the effective timezone when the local day
+ * is ahead of the (UTC-bucketed) end, so same-day contributions are not
+ * clipped from profile charts. Never shortens the range.
+ */
+export function extendDateRangeEndToToday(
+  rangeEnd: string | null | undefined,
+  timeZone: string,
+  now: Date = new Date(),
+): string | null {
+  if (!rangeEnd) return null;
+  const today = getTodayInTimeZone(timeZone, now);
+  return today > rangeEnd ? today : rangeEnd;
+}
+
+const offsetPartsFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function getOffsetPartsFormatter(timeZone: string): Intl.DateTimeFormat {
+  let formatter = offsetPartsFormatters.get(timeZone);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hourCycle: "h23",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+    offsetPartsFormatters.set(timeZone, formatter);
+  }
+  return formatter;
+}
+
+function getTimeZoneOffsetMs(timeZone: string, utcMs: number): number {
+  const parts = getOffsetPartsFormatter(timeZone).formatToParts(
+    new Date(utcMs),
+  );
+  const part = (type: string) =>
+    Number(parts.find((candidate) => candidate.type === type)?.value ?? 0);
+  const asUtcMs = Date.UTC(
+    part("year"),
+    part("month") - 1,
+    part("day"),
+    part("hour"),
+    part("minute"),
+    part("second"),
+  );
+  return asUtcMs - utcMs;
+}
+
+/**
+ * Shift a UTC-midnight calendar timestamp to the instant of that same
+ * calendar midnight in `timeZone`, so timezone-aware formatters label the
+ * intended date instead of the previous/next UTC day.
+ */
+export function calendarInstantInTimeZone(
+  utcMidnightMs: number,
+  timeZone: string,
+): number {
+  if (timeZone === "UTC") return utcMidnightMs;
+  const offset = getTimeZoneOffsetMs(timeZone, utcMidnightMs);
+  let timestamp = utcMidnightMs - offset;
+  // Refine once: the offset at UTC midnight can differ from the offset at
+  // local midnight around DST transitions.
+  const refined = getTimeZoneOffsetMs(timeZone, timestamp);
+  if (refined !== offset) timestamp = utcMidnightMs - refined;
+  return timestamp;
+}

--- a/packages/frontend/src/lib/useSettings.ts
+++ b/packages/frontend/src/lib/useSettings.ts
@@ -8,17 +8,21 @@ import {
   SORT_BY_COOKIE_NAME,
   isValidSortBy,
 } from "./leaderboard/constants";
+import { isValidTimeZone } from "./timezone";
 
 export type { LeaderboardSortBy };
 
 export interface Settings {
   paletteName: ColorPaletteName;
   leaderboardSortBy: LeaderboardSortBy;
+  /** Display timezone for profile charts: "auto" (browser) or an IANA zone. */
+  timezone: string;
 }
 
 const DEFAULT_SETTINGS: Settings = {
   paletteName: DEFAULT_PALETTE,
   leaderboardSortBy: "tokens",
+  timezone: "auto",
 };
 
 const STORAGE_KEY = "tokscale-settings";
@@ -54,6 +58,11 @@ function getStoredSettings(): Settings {
       leaderboardSortBy: isValidSortBy(parsed.leaderboardSortBy)
         ? parsed.leaderboardSortBy
         : DEFAULT_SETTINGS.leaderboardSortBy,
+      timezone:
+        typeof parsed.timezone === "string" &&
+        (parsed.timezone === "auto" || isValidTimeZone(parsed.timezone))
+          ? parsed.timezone
+          : DEFAULT_SETTINGS.timezone,
     };
     return cachedSettings;
   } catch {
@@ -134,11 +143,17 @@ export function useSettings() {
     saveSettings({ ...getStoredSettings(), leaderboardSortBy: sortBy });
   }, []);
 
+  const setTimezone = useCallback((timezone: string) => {
+    saveSettings({ ...getStoredSettings(), timezone });
+  }, []);
+
   return {
     paletteName: settings.paletteName,
     setPalette,
     leaderboardSortBy: settings.leaderboardSortBy,
     setLeaderboardSort,
+    timezone: settings.timezone,
+    setTimezone,
     mounted,
   };
 }

--- a/packages/frontend/src/lib/useSettings.ts
+++ b/packages/frontend/src/lib/useSettings.ts
@@ -15,7 +15,7 @@ export type { LeaderboardSortBy };
 export interface Settings {
   paletteName: ColorPaletteName;
   leaderboardSortBy: LeaderboardSortBy;
-  /** Display timezone for profile charts: "auto" (browser) or an IANA zone. */
+  /** Zone for profile timestamps: "auto" (browser) or an IANA zone. */
   timezone: string;
 }
 


### PR DESCRIPTION
## Problem

The CLI buckets daily contributions by the user's **local** timezone, so a KST user's early-morning usage is submitted under a date that is still "tomorrow" in UTC. The web dashboard computes profile chart ranges against UTC "today" (`toUtcDateString` in `src/lib/publicProfileData.ts`), so freshly submitted local-today data is clipped from the contribution graph until UTC midnight rolls over. Related local-timezone date context: #318, #334 (CLI-side submit validation, already fixed).

## What changed

Display-only, client-side fix — no DB or API changes:

- **`src/lib/useSettings.ts`** — new `timezone` setting in `localStorage["tokscale-settings"]`: `"auto"` (default) or an IANA zone, validated with `Intl.DateTimeFormat` in the parser (invalid values fall back to `"auto"`).
- **`src/lib/timezone.ts`** (new) — resolves the effective timezone (`"auto"` → browser zone), computes "today" as `YYYY-MM-DD` in that zone via `Intl.DateTimeFormat` parts (never `toISOString()`, which is UTC), extends a range end to local today without ever shortening it, and anchors calendar dates to a zone for label formatting.
- **`/settings` page** — new "Timezone" section with an "Auto (browser)" option plus a modest grouped list of common IANA zones (~45, not the full database).
- **Profile page** (`ProfilePageClient.tsx`) — after mount, the rolling chart range end becomes `max(server end, today-in-effective-tz)`, so local-today contributions render immediately on the lifetime view. The extension is mount-gated so the first client render matches SSR, and limited to `period=all` because week/month contributions are filtered by the UTC range server-side.
- **`ProfileContributionGraph.tsx`** — the hardcoded `timeZone: "UTC"` formatters are now cached per effective timezone; calendar-date labels (month markers, cell titles, tooltips, range summary, day breakdown) are formatted at the date's midnight *in the effective zone*, so labels always name the intended calendar day (no off-by-one for negative offsets).
- **`ProfileOverview.tsx`** — "Joined" and "Updated" dates use the effective timezone after hydration (previously viewer-default / hardcoded UTC).

## Deliberately NOT changed

- **Leaderboard stays UTC** — `src/lib/leaderboard/` untouched, as is embed SVG rendering (`src/lib/embed/`).
- **No DB migrations, no API changes** — the preference lives in localStorage only.
- **Week/month profile periods** — the server filters those contributions by the UTC range (`dailyBreakdownFilter`), so a client-side extension there could only render an empty trailing day; left as-is.

## Verification

- `tsc --noEmit` passes; `eslint` reports 0 errors (15 pre-existing warnings, identical on `main`).
- `vitest run`: 663 tests pass, including 9 new ones in `__tests__/lib/timezone.test.ts` covering zone validation, today-in-zone, range extension, and calendar anchoring (incl. `Pacific/Kiritimati` +14 edge).
- `next build` succeeds.
- Manual check: with `now = 2026-07-23T16:00Z`, a Seoul viewer's range end extends `2026-07-23` → `2026-07-24` while a UTC viewer's stays put, and `2026-07-24` still labels as "Fri, Jul 24" in `America/New_York`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a display timezone preference for profile timestamps and anchors all profile chart windows on the newest submitted date so local‑today contributions render consistently for everyone. This is display-only; charts and totals are driven by data on the server, not the viewer’s clock.

- **New Features**
  - New `timezone` in `useSettings` (`"auto"` or IANA zone) with a selector on `/settings`; stored in `localStorage` and validated via `lib/timezone`.
  - Profile overview timestamps (“Updated”, “Joined”) render in the effective timezone after hydration; SSR uses UTC to avoid hydration mismatches.

- **Bug Fixes**
  - Server now ends lifetime, 7d, and 30d windows at the latest submitted date (`MAX(submissions.dateEnd)`), falling back to UTC today; period queries remove the upper `lte` bound and trim results to the anchored window; intensity scaling uses only visible days.
  - Removed the no-op calendar timezone path; contribution graph labels and buckets remain stable and viewer‑timezone independent.
  - No API or DB changes; leaderboard and embeds remain UTC.

<sup>Written for commit 405cf0b6a5f320a605dc17a99937c0f926afe34e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

