### PR TITLE
chore(ci): prevent PR and release build drift

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -2,11 +2,29 @@ name: Build Native (Test Only)
 
 on:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      bumped-manifests:
+        description: "Artifact containing release-bumped manifests to overlay before building"
+        required: false
+        type: string
+        default: ""
   pull_request:
     paths:
+      - ".github/workflows/build-native.yml"
+      - ".github/workflows/publish-cli.yml"
       - "crates/**"
+      - "packages/cli-*/package.json"
+      - "scripts/check-release-workflow-safety.py"
       - "Cargo.toml"
       - "Cargo.lock"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-native-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   MACOSX_DEPLOYMENT_TARGET: "10.13"
@@ -23,6 +41,8 @@ jobs:
         settings:
           - host: macos-latest
             target: x86_64-apple-darwin
+            package_dir: cli-darwin-x64
+            artifact_name: cli-binary-x86_64-apple-darwin
             build: cargo build --release -p tokscale-cli --target x86_64-apple-darwin
             strip: strip -x target/x86_64-apple-darwin/release/tokscale
             bin_name: tokscale
@@ -34,26 +54,36 @@ jobs:
           # Apple-Silicon-only, so this is intentionally not enabled for x86_64.
           - host: macos-26
             target: aarch64-apple-darwin
+            package_dir: cli-darwin-arm64
+            artifact_name: cli-binary-aarch64-apple-darwin
             build: cargo build --release -p tokscale-cli --target aarch64-apple-darwin --features apple-fm
             strip: strip -x target/aarch64-apple-darwin/release/tokscale
             bin_name: tokscale
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            package_dir: cli-linux-x64-gnu
+            artifact_name: cli-binary-x86_64-unknown-linux-gnu
             build: cargo zigbuild --release -p tokscale-cli --target x86_64-unknown-linux-gnu
             strip: strip target/x86_64-unknown-linux-gnu/release/tokscale
             bin_name: tokscale
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl
+            package_dir: cli-linux-x64-musl
+            artifact_name: cli-binary-x86_64-unknown-linux-musl
             build: cargo zigbuild --release -p tokscale-cli --target x86_64-unknown-linux-musl
             strip: strip target/x86_64-unknown-linux-musl/release/tokscale
             bin_name: tokscale
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
+            package_dir: cli-linux-arm64-gnu
+            artifact_name: cli-binary-aarch64-unknown-linux-gnu
             build: cargo zigbuild --release -p tokscale-cli --target aarch64-unknown-linux-gnu
             strip: ""
             bin_name: tokscale
           - host: ubuntu-latest
             target: aarch64-unknown-linux-musl
+            package_dir: cli-linux-arm64-musl
+            artifact_name: cli-binary-aarch64-unknown-linux-musl
             build: cargo zigbuild --release -p tokscale-cli --target aarch64-unknown-linux-musl
             strip: ""
             bin_name: tokscale
@@ -65,22 +95,35 @@ jobs:
           # --target aarch64-linux-android` links against Bionic.
           - host: ubuntu-latest
             target: aarch64-linux-android
+            package_dir: cli-android-arm64
+            artifact_name: cli-binary-aarch64-linux-android
             build: cargo build --release -p tokscale-cli --target aarch64-linux-android
             strip: ""
             bin_name: tokscale
           - host: windows-latest
             target: x86_64-pc-windows-msvc
+            package_dir: cli-win32-x64-msvc
+            artifact_name: cli-binary-x86_64-pc-windows-msvc
             build: cargo build --release -p tokscale-cli --target x86_64-pc-windows-msvc
             strip: ""
             bin_name: tokscale.exe
           - host: windows-latest
             target: aarch64-pc-windows-msvc
+            package_dir: cli-win32-arm64-msvc
+            artifact_name: cli-binary-aarch64-pc-windows-msvc
             build: cargo build --release -p tokscale-cli --target aarch64-pc-windows-msvc
             strip: ""
             bin_name: tokscale.exe
 
     steps:
       - uses: actions/checkout@v5
+
+      - name: Download bumped release files
+        if: ${{ inputs.bumped-manifests != '' }}
+        uses: actions/download-artifact@v6
+        with:
+          name: ${{ inputs.bumped-manifests }}
+          path: .
 
       - name: Check release workflow safety
         run: python3 scripts/check-release-workflow-safety.py
@@ -124,14 +167,33 @@ jobs:
         run: ${{ matrix.settings.build }}
         shell: bash
 
+      - name: Smoke Android binary
+        if: ${{ matrix.settings.target == 'aarch64-linux-android' }}
+        run: cargo run --release -p tokscale-cli --target aarch64-linux-android -- --no-spinner --version
+        shell: bash
+
       - name: Strip CLI binary
         if: ${{ matrix.settings.strip != '' }}
         shell: bash
         run: ${{ matrix.settings.strip }}
 
-      - name: Upload artifact
+      # Keep release and PR artifacts identical. The Apple Silicon build may
+      # include a dynamically loaded Foundation Models sidecar.
+      - name: Stage CLI binary artifact
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp "target/${{ matrix.settings.target }}/release/${{ matrix.settings.bin_name }}" dist/
+          if [ -f "target/${{ matrix.settings.target }}/release/libFoundationModels.dylib" ]; then
+            cp "target/${{ matrix.settings.target }}/release/libFoundationModels.dylib" dist/
+            echo "staged sidecar libFoundationModels.dylib"
+          fi
+          ls -la dist
+
+      - name: Upload CLI binary artifact
         uses: actions/upload-artifact@v6
         with:
-          name: cli-binary-${{ matrix.settings.target }}
-          path: target/${{ matrix.settings.target }}/release/${{ matrix.settings.bin_name }}
+          name: ${{ matrix.settings.artifact_name }}
+          path: dist
           if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -162,6 +162,7 @@ jobs:
         uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: aarch64-linux-android
+          runner: qemu-user
 
       - name: Build CLI binary
         run: ${{ matrix.settings.build }}

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -14,6 +14,7 @@ on:
       - ".github/workflows/build-native.yml"
       - ".github/workflows/publish-cli.yml"
       - "crates/**"
+      - "packages/cli/package.json"
       - "packages/cli-*/package.json"
       - "scripts/check-release-workflow-safety.py"
       - "Cargo.toml"

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -24,13 +24,11 @@ on:
         default: false
 
 permissions:
-  contents: write
-  pull-requests: read
+  contents: read
 
-env:
-  MACOSX_DEPLOYMENT_TARGET: "10.13"
-  CARGO_TERM_COLOR: always
-  CARGO_INCREMENTAL: 0
+concurrency:
+  group: publish-cli
+  cancel-in-progress: false
 
 jobs:
   bump-versions:
@@ -147,171 +145,13 @@ jobs:
           retention-days: 1
 
   build-cli-binary:
-    name: Build CLI binary - ${{ matrix.settings.target }}
+    name: Build CLI binaries
     needs: bump-versions
-    runs-on: ${{ matrix.settings.host }}
-    strategy:
-      fail-fast: false
-      matrix:
-        settings:
-          - host: macos-latest
-            target: x86_64-apple-darwin
-            package_dir: cli-darwin-x64
-            artifact_name: cli-binary-x86_64-apple-darwin
-            bin_name: tokscale
-            build: cargo build --release -p tokscale-cli --target x86_64-apple-darwin
-            strip: strip -x target/x86_64-apple-darwin/release/tokscale
-          # Apple Silicon ships with the `apple-fm` feature (on-device Apple
-          # Foundation Models summarizer). Needs the macOS 26 SDK + Swift
-          # toolchain (Xcode 26 on macos-26) to build the vendored
-          # foundation-models-c shim; it is statically linked so the published
-          # binary stays self-contained. Not enabled for x86_64 — Apple
-          # Intelligence is Apple-Silicon-only (those installs use the heuristic).
-          - host: macos-26
-            target: aarch64-apple-darwin
-            package_dir: cli-darwin-arm64
-            artifact_name: cli-binary-aarch64-apple-darwin
-            bin_name: tokscale
-            build: cargo build --release -p tokscale-cli --target aarch64-apple-darwin --features apple-fm
-            strip: strip -x target/aarch64-apple-darwin/release/tokscale
-          - host: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            package_dir: cli-linux-x64-gnu
-            artifact_name: cli-binary-x86_64-unknown-linux-gnu
-            bin_name: tokscale
-            build: cargo zigbuild --release -p tokscale-cli --target x86_64-unknown-linux-gnu
-            strip: strip target/x86_64-unknown-linux-gnu/release/tokscale
-          - host: ubuntu-latest
-            target: x86_64-unknown-linux-musl
-            package_dir: cli-linux-x64-musl
-            artifact_name: cli-binary-x86_64-unknown-linux-musl
-            bin_name: tokscale
-            build: cargo zigbuild --release -p tokscale-cli --target x86_64-unknown-linux-musl
-            strip: strip target/x86_64-unknown-linux-musl/release/tokscale
-          - host: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            package_dir: cli-linux-arm64-gnu
-            artifact_name: cli-binary-aarch64-unknown-linux-gnu
-            bin_name: tokscale
-            build: cargo zigbuild --release -p tokscale-cli --target aarch64-unknown-linux-gnu
-            strip: ""
-          - host: ubuntu-latest
-            target: aarch64-unknown-linux-musl
-            package_dir: cli-linux-arm64-musl
-            artifact_name: cli-binary-aarch64-unknown-linux-musl
-            bin_name: tokscale
-            build: cargo zigbuild --release -p tokscale-cli --target aarch64-unknown-linux-musl
-            strip: ""
-          # Android (Termux) on aarch64: links against Bionic. The
-          # taiki-e/setup-cross-toolchain-action handles NDK setup
-          # automatically (Clang 14, API 21 by default) and wires the
-          # CC/AR env vars. See build-native.yml for the matching
-          # toolchain setup.
-          - host: ubuntu-latest
-            target: aarch64-linux-android
-            package_dir: cli-android-arm64
-            artifact_name: cli-binary-aarch64-linux-android
-            bin_name: tokscale
-            build: cargo build --release -p tokscale-cli --target aarch64-linux-android
-            strip: ""
-          - host: windows-latest
-            target: x86_64-pc-windows-msvc
-            package_dir: cli-win32-x64-msvc
-            artifact_name: cli-binary-x86_64-pc-windows-msvc
-            bin_name: tokscale.exe
-            build: cargo build --release -p tokscale-cli --target x86_64-pc-windows-msvc
-            strip: ""
-          - host: windows-latest
-            target: aarch64-pc-windows-msvc
-            package_dir: cli-win32-arm64-msvc
-            artifact_name: cli-binary-aarch64-pc-windows-msvc
-            bin_name: tokscale.exe
-            build: cargo build --release -p tokscale-cli --target aarch64-pc-windows-msvc
-            strip: ""
-
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Download bumped release files
-        uses: actions/download-artifact@v6
-        with:
-          name: bumped-manifests
-          path: .
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 20
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.settings.target }}
-
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: cli-${{ matrix.settings.target }}-cargo-${{ matrix.settings.host }}-${{ hashFiles('Cargo.lock') }}
-
-      - uses: mlugg/setup-zig@v2
-        if: ${{ contains(matrix.settings.target, 'linux') && !contains(matrix.settings.target, 'android') }}
-        with:
-          version: 0.13.0
-
-      - name: Install cargo-zigbuild
-        uses: taiki-e/install-action@v2
-        if: ${{ contains(matrix.settings.target, 'linux') && !contains(matrix.settings.target, 'android') }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          tool: cargo-zigbuild
-
-      - name: Setup Android cross toolchain
-        if: ${{ matrix.settings.target == 'aarch64-linux-android' }}
-        uses: taiki-e/setup-cross-toolchain-action@v1
-        with:
-          target: aarch64-linux-android
-
-      - name: Build CLI binary
-        shell: bash
-        run: ${{ matrix.settings.build }}
-
-      - name: Install cross-compilation strip tool
-        if: contains(matrix.settings.target, 'aarch64') && !contains(matrix.settings.target, 'android') && runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y binutils-aarch64-linux-gnu
-
-      - name: Strip CLI binary
-        if: ${{ matrix.settings.strip != '' }}
-        shell: bash
-        run: ${{ matrix.settings.strip }}
-
-      # Stage the binary plus, for the apple-fm arm64 build, the sidecar
-      # libFoundationModels.dylib that build.rs places next to it. The dylib is
-      # dlopen'd at runtime (never linked), so it must travel inside the npm
-      # package alongside tokscale. Other targets stage only the binary.
-      - name: Stage release artifact
-        shell: bash
-        run: |
-          mkdir -p dist
-          cp "target/${{ matrix.settings.target }}/release/${{ matrix.settings.bin_name }}" dist/
-          if [ -f "target/${{ matrix.settings.target }}/release/libFoundationModels.dylib" ]; then
-            cp "target/${{ matrix.settings.target }}/release/libFoundationModels.dylib" dist/
-            echo "staged sidecar libFoundationModels.dylib"
-          fi
-          ls -la dist
-
-      - name: Upload CLI binary artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: ${{ matrix.settings.artifact_name }}
-          path: dist
-          if-no-files-found: error
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-native.yml
+    with:
+      bumped-manifests: bumped-manifests
 
   smoke-release-artifacts:
     name: Smoke release artifacts
@@ -353,6 +193,8 @@ jobs:
     name: Commit release provenance
     needs: [bump-versions, build-cli-binary, smoke-release-artifacts]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       release_commit: ${{ steps.prepare.outputs.release_commit }}
 
@@ -450,11 +292,6 @@ jobs:
         with:
           ref: ${{ needs.prepare-release-provenance.outputs.release_commit }}
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.1.38
-
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
@@ -539,11 +376,6 @@ jobs:
         with:
           ref: ${{ needs.prepare-release-provenance.outputs.release_commit }}
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.1.38
-
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
@@ -562,6 +394,9 @@ jobs:
     name: Create release
     needs: [bump-versions, prepare-release-provenance, publish-alias]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
 
     steps:
       - uses: actions/checkout@v5

--- a/scripts/check-release-workflow-safety.py
+++ b/scripts/check-release-workflow-safety.py
@@ -8,6 +8,7 @@ import sys
 ROOT = pathlib.Path.cwd()
 PUBLISH_WORKFLOW = ROOT / ".github/workflows/publish-cli.yml"
 BUILD_NATIVE_WORKFLOW = ROOT / ".github/workflows/build-native.yml"
+CLI_PACKAGE_MANIFEST = ROOT / "packages/cli/package.json"
 REQUIRED_ENV_KEYS = ("MACOSX_DEPLOYMENT_TARGET", "CARGO_TERM_COLOR", "CARGO_INCREMENTAL")
 REQUIRED_BUILD_FIELDS = (
     "host",
@@ -146,6 +147,21 @@ def package_manifest_name(package_dir: str) -> str:
     return name
 
 
+def cli_platform_package_dirs() -> set[str]:
+    if not CLI_PACKAGE_MANIFEST.exists():
+        fail(f"Missing CLI package manifest: {CLI_PACKAGE_MANIFEST}")
+    manifest = json.loads(CLI_PACKAGE_MANIFEST.read_text(encoding="utf-8"))
+    optional_dependencies = manifest.get("optionalDependencies")
+    if not isinstance(optional_dependencies, dict):
+        fail(f"{CLI_PACKAGE_MANIFEST} missing optionalDependencies")
+    prefix = "@tokscale/"
+    return {
+        package_name.removeprefix(prefix)
+        for package_name in optional_dependencies
+        if package_name.startswith(f"{prefix}cli-")
+    }
+
+
 def block_contains(block: list[str], needle: str) -> bool:
     return any(needle in line for line in uncommented_lines(block))
 
@@ -200,10 +216,18 @@ def main() -> None:
 
     native_build = by_target(matrix_settings(native_lines, "build"), "build-native")
 
+    cli_package_dirs = cli_platform_package_dirs()
+    mapped_package_dirs = set(TARGET_PACKAGES.values())
+    unmapped_package_dirs = cli_package_dirs - mapped_package_dirs
+    if unmapped_package_dirs:
+        errors.append(
+            f"CLI optionalDependencies have unmapped platform packages: {sorted(unmapped_package_dirs)}"
+        )
+
     expected_targets = {
         target
         for target, package_dir in TARGET_PACKAGES.items()
-        if (ROOT / "packages" / package_dir / "package.json").exists()
+        if package_dir in cli_package_dirs
     }
     missing_targets = expected_targets - set(native_build)
     unknown_targets = set(native_build) - expected_targets
@@ -234,33 +258,35 @@ def main() -> None:
             )
 
     native_uncommented = uncommented_lines(native_lines)
+    native_build_uncommented = uncommented_lines(job_block(native_lines, "build"))
     if not any(line.strip() == "workflow_call:" for line in native_uncommented):
         errors.append("build-native workflow must expose workflow_call")
     if not any("bumped-manifests:" in line for line in native_uncommented):
         errors.append("build-native workflow must accept bumped-manifests input")
     if not any("name: ${{ inputs.bumped-manifests }}" in line for line in native_uncommented):
         errors.append("build-native workflow must download the bumped-manifests input")
-    android_runner = "\n".join(
-        [
-            "      - name: Setup Android cross toolchain",
-            "        if: ${{ matrix.settings.target == 'aarch64-linux-android' }}",
-            "        uses: taiki-e/setup-cross-toolchain-action@v1",
-            "        with:",
-            "          target: aarch64-linux-android",
-            "          runner: qemu-user",
-        ]
-    )
-    if android_runner not in "\n".join(native_uncommented):
-        errors.append("build-native workflow must configure the Android QEMU runner")
-    android_smoke = "\n".join(
-        [
-            "      - name: Smoke Android binary",
-            "        if: ${{ matrix.settings.target == 'aarch64-linux-android' }}",
-            "        run: cargo run --release -p tokscale-cli --target aarch64-linux-android -- --no-spinner --version",
-        ]
-    )
-    if android_smoke not in "\n".join(native_uncommented):
-        errors.append("build-native workflow must execute the Android binary smoke")
+    if "aarch64-linux-android" in native_build:
+        android_runner = "\n".join(
+            [
+                "      - name: Setup Android cross toolchain",
+                "        if: ${{ matrix.settings.target == 'aarch64-linux-android' }}",
+                "        uses: taiki-e/setup-cross-toolchain-action@v1",
+                "        with:",
+                "          target: aarch64-linux-android",
+                "          runner: qemu-user",
+            ]
+        )
+        if android_runner not in "\n".join(native_build_uncommented):
+            errors.append("build-native workflow must configure the Android QEMU runner")
+        android_smoke = "\n".join(
+            [
+                "      - name: Smoke Android binary",
+                "        if: ${{ matrix.settings.target == 'aarch64-linux-android' }}",
+                "        run: cargo run --release -p tokscale-cli --target aarch64-linux-android -- --no-spinner --version",
+            ]
+        )
+        if android_smoke not in "\n".join(native_build_uncommented):
+            errors.append("build-native workflow must execute the Android binary smoke")
 
     publish_build_block = job_block(publish_lines, "build-cli-binary")
     if not block_contains(

--- a/scripts/check-release-workflow-safety.py
+++ b/scripts/check-release-workflow-safety.py
@@ -282,12 +282,13 @@ def main() -> None:
     native_on_block = mapping_block(native_lines, "on", 0)
     native_workflow_call_block = mapping_block(native_on_block, "workflow_call", 2)
     native_pull_request_block = mapping_block(native_on_block, "pull_request", 2)
+    native_pull_request_paths = mapping_block(native_pull_request_block, "paths", 4)
     native_build_uncommented = uncommented_lines(job_block(native_lines, "build"))
     if not native_workflow_call_block:
         errors.append("build-native workflow must expose workflow_call")
     if not any(
         line.strip() == '- "packages/cli/package.json"'
-        for line in uncommented_lines(native_pull_request_block)
+        for line in uncommented_lines(native_pull_request_paths)
     ):
         errors.append("build-native workflow must run for CLI package manifest changes")
     if not any(

--- a/scripts/check-release-workflow-safety.py
+++ b/scripts/check-release-workflow-safety.py
@@ -240,6 +240,18 @@ def main() -> None:
         errors.append("build-native workflow must accept bumped-manifests input")
     if not any("name: ${{ inputs.bumped-manifests }}" in line for line in native_uncommented):
         errors.append("build-native workflow must download the bumped-manifests input")
+    android_runner = "\n".join(
+        [
+            "      - name: Setup Android cross toolchain",
+            "        if: ${{ matrix.settings.target == 'aarch64-linux-android' }}",
+            "        uses: taiki-e/setup-cross-toolchain-action@v1",
+            "        with:",
+            "          target: aarch64-linux-android",
+            "          runner: qemu-user",
+        ]
+    )
+    if android_runner not in "\n".join(native_uncommented):
+        errors.append("build-native workflow must configure the Android QEMU runner")
     android_smoke = "\n".join(
         [
             "      - name: Smoke Android binary",

--- a/scripts/check-release-workflow-safety.py
+++ b/scripts/check-release-workflow-safety.py
@@ -68,6 +68,28 @@ def top_level_env(lines: list[str]) -> dict[str, str]:
     return env
 
 
+def mapping_block(lines: list[str], key: str, indent: int) -> list[str]:
+    header = f"{' ' * indent}{key}:"
+    start = None
+    for index, line in enumerate(lines):
+        if line == header:
+            start = index + 1
+            break
+    if start is None:
+        return []
+
+    end = len(lines)
+    for index in range(start, len(lines)):
+        line = lines[index]
+        if not line.strip():
+            continue
+        line_indent = len(line) - len(line.lstrip(" "))
+        if line_indent <= indent:
+            end = index
+            break
+    return lines[start:end]
+
+
 def job_block(lines: list[str], job_name: str) -> list[str]:
     start = None
     for index, line in enumerate(lines):
@@ -257,13 +279,26 @@ def main() -> None:
                 f"build matrix {target} artifact drift: expected {expected_artifact}, found {native_entry.get('artifact_name')}"
             )
 
-    native_uncommented = uncommented_lines(native_lines)
+    native_on_block = mapping_block(native_lines, "on", 0)
+    native_workflow_call_block = mapping_block(native_on_block, "workflow_call", 2)
+    native_pull_request_block = mapping_block(native_on_block, "pull_request", 2)
     native_build_uncommented = uncommented_lines(job_block(native_lines, "build"))
-    if not any(line.strip() == "workflow_call:" for line in native_uncommented):
+    if not native_workflow_call_block:
         errors.append("build-native workflow must expose workflow_call")
-    if not any("bumped-manifests:" in line for line in native_uncommented):
+    if not any(
+        line.strip() == '- "packages/cli/package.json"'
+        for line in uncommented_lines(native_pull_request_block)
+    ):
+        errors.append("build-native workflow must run for CLI package manifest changes")
+    if not any(
+        "bumped-manifests:" in line
+        for line in uncommented_lines(native_workflow_call_block)
+    ):
         errors.append("build-native workflow must accept bumped-manifests input")
-    if not any("name: ${{ inputs.bumped-manifests }}" in line for line in native_uncommented):
+    if not any(
+        "name: ${{ inputs.bumped-manifests }}" in line
+        for line in native_build_uncommented
+    ):
         errors.append("build-native workflow must download the bumped-manifests input")
     if "aarch64-linux-android" in native_build:
         android_runner = "\n".join(

--- a/scripts/check-release-workflow-safety.py
+++ b/scripts/check-release-workflow-safety.py
@@ -9,7 +9,15 @@ ROOT = pathlib.Path.cwd()
 PUBLISH_WORKFLOW = ROOT / ".github/workflows/publish-cli.yml"
 BUILD_NATIVE_WORKFLOW = ROOT / ".github/workflows/build-native.yml"
 REQUIRED_ENV_KEYS = ("MACOSX_DEPLOYMENT_TARGET", "CARGO_TERM_COLOR", "CARGO_INCREMENTAL")
-COMMON_BUILD_FIELDS = ("host", "target", "build", "strip", "bin_name")
+REQUIRED_BUILD_FIELDS = (
+    "host",
+    "target",
+    "package_dir",
+    "artifact_name",
+    "build",
+    "strip",
+    "bin_name",
+)
 TARGET_PACKAGES = {
     "x86_64-apple-darwin": "cli-darwin-x64",
     "aarch64-apple-darwin": "cli-darwin-arm64",
@@ -185,52 +193,72 @@ def main() -> None:
     native_lines = read_lines(BUILD_NATIVE_WORKFLOW)
     errors: list[str] = []
 
-    publish_env = top_level_env(publish_lines)
     native_env = top_level_env(native_lines)
     for key in REQUIRED_ENV_KEYS:
-        publish_has_key = key in publish_env
-        native_has_key = key in native_env
-        if not publish_has_key:
-            errors.append(f"publish workflow missing required env {key}")
-        if not native_has_key:
+        if key not in native_env:
             errors.append(f"build-native workflow missing required env {key}")
-        if (
-            publish_has_key
-            and native_has_key
-            and publish_env.get(key) != native_env.get(key)
-        ):
-            errors.append(
-                f"env {key} differs: publish={publish_env.get(key)!r}, build-native={native_env.get(key)!r}"
-            )
 
-    publish_build = by_target(matrix_settings(publish_lines, "build-cli-binary"), "publish build")
     native_build = by_target(matrix_settings(native_lines, "build"), "build-native")
 
-    if list(publish_build) != list(native_build):
+    expected_targets = {
+        target
+        for target, package_dir in TARGET_PACKAGES.items()
+        if (ROOT / "packages" / package_dir / "package.json").exists()
+    }
+    missing_targets = expected_targets - set(native_build)
+    unknown_targets = set(native_build) - expected_targets
+    if missing_targets:
         errors.append(
-            f"build matrix targets differ: publish={list(publish_build)}, build-native={list(native_build)}"
+            f"canonical build matrix is missing targets: {sorted(missing_targets)}"
+        )
+    if unknown_targets:
+        errors.append(
+            f"canonical build matrix has unknown targets: {sorted(unknown_targets)}"
         )
 
-    for target, publish_entry in publish_build.items():
-        native_entry = native_build.get(target)
-        if native_entry is None:
-            continue
-        for field in COMMON_BUILD_FIELDS:
-            if publish_entry.get(field, "") != native_entry.get(field, ""):
-                errors.append(
-                    f"build matrix {target} field {field} differs: publish={publish_entry.get(field)!r}, build-native={native_entry.get(field)!r}"
-                )
-
-        expected_package_dir = TARGET_PACKAGES.get(target)
-        if publish_entry.get("package_dir") != expected_package_dir:
+    for target, native_entry in native_build.items():
+        missing_fields = [field for field in REQUIRED_BUILD_FIELDS if field not in native_entry]
+        if missing_fields:
             errors.append(
-                f"build matrix {target} package_dir drift: expected {expected_package_dir}, found {publish_entry.get('package_dir')}"
+                f"canonical build matrix {target} missing fields: {missing_fields}"
+            )
+        expected_package_dir = TARGET_PACKAGES.get(target)
+        if native_entry.get("package_dir") != expected_package_dir:
+            errors.append(
+                f"build matrix {target} package_dir drift: expected {expected_package_dir}, found {native_entry.get('package_dir')}"
             )
         expected_artifact = f"cli-binary-{target}"
-        if publish_entry.get("artifact_name") != expected_artifact:
+        if native_entry.get("artifact_name") != expected_artifact:
             errors.append(
-                f"build matrix {target} artifact drift: expected {expected_artifact}, found {publish_entry.get('artifact_name')}"
+                f"build matrix {target} artifact drift: expected {expected_artifact}, found {native_entry.get('artifact_name')}"
             )
+
+    native_uncommented = uncommented_lines(native_lines)
+    if not any(line.strip() == "workflow_call:" for line in native_uncommented):
+        errors.append("build-native workflow must expose workflow_call")
+    if not any("bumped-manifests:" in line for line in native_uncommented):
+        errors.append("build-native workflow must accept bumped-manifests input")
+    if not any("name: ${{ inputs.bumped-manifests }}" in line for line in native_uncommented):
+        errors.append("build-native workflow must download the bumped-manifests input")
+    android_smoke = "\n".join(
+        [
+            "      - name: Smoke Android binary",
+            "        if: ${{ matrix.settings.target == 'aarch64-linux-android' }}",
+            "        run: cargo run --release -p tokscale-cli --target aarch64-linux-android -- --no-spinner --version",
+        ]
+    )
+    if android_smoke not in "\n".join(native_uncommented):
+        errors.append("build-native workflow must execute the Android binary smoke")
+
+    publish_build_block = job_block(publish_lines, "build-cli-binary")
+    if not block_contains(
+        publish_build_block, "uses: ./.github/workflows/build-native.yml"
+    ):
+        errors.append("publish build must call the canonical build-native workflow")
+    if "bump-versions" not in parse_needs(publish_build_block):
+        errors.append("publish build must depend on bump-versions")
+    if not block_contains(publish_build_block, "bumped-manifests: bumped-manifests"):
+        errors.append("publish build must pass the bumped-manifests artifact")
 
     publish_platform = matrix_settings(publish_lines, "publish-platform-packages")
     platform_by_dir: dict[str, dict[str, str]] = {}
@@ -245,7 +273,7 @@ def main() -> None:
         platform_by_dir[package_dir] = entry
 
     expected_package_dirs = {
-        entry["package_dir"] for entry in publish_build.values() if entry.get("package_dir")
+        entry["package_dir"] for entry in native_build.values() if entry.get("package_dir")
     }
     if set(platform_by_dir) != expected_package_dirs:
         errors.append(
@@ -253,7 +281,7 @@ def main() -> None:
         )
 
     build_by_package_dir = {
-        entry["package_dir"]: entry for entry in publish_build.values() if entry.get("package_dir")
+        entry["package_dir"]: entry for entry in native_build.values() if entry.get("package_dir")
     }
     for package_dir, platform_entry in platform_by_dir.items():
         build_entry = build_by_package_dir.get(package_dir)

--- a/scripts/check-release-workflow-safety.py
+++ b/scripts/check-release-workflow-safety.py
@@ -43,8 +43,32 @@ def read_lines(path: pathlib.Path) -> list[str]:
     return path.read_text(encoding="utf-8").splitlines()
 
 
+def strip_yaml_comment(value: str) -> str:
+    quote: str | None = None
+    escaped = False
+    for index, char in enumerate(value):
+        if quote == '"':
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if quote == "'":
+            if char == quote:
+                quote = None
+            continue
+        if char in {'"', "'"}:
+            quote = char
+            continue
+        if char == "#" and (index == 0 or value[index - 1].isspace()):
+            return value[:index].rstrip()
+    return value.rstrip()
+
+
 def strip_yaml_scalar(value: str) -> str:
-    value = value.strip()
+    value = strip_yaml_comment(value).strip()
     if value in {'""', "''"}:
         return ""
     if (value.startswith('"') and value.endswith('"')) or (
@@ -72,7 +96,7 @@ def mapping_block(lines: list[str], key: str, indent: int) -> list[str]:
     header = f"{' ' * indent}{key}:"
     start = None
     for index, line in enumerate(lines):
-        if line == header:
+        if strip_yaml_comment(line) == header:
             start = index + 1
             break
     if start is None:
@@ -81,9 +105,10 @@ def mapping_block(lines: list[str], key: str, indent: int) -> list[str]:
     end = len(lines)
     for index in range(start, len(lines)):
         line = lines[index]
-        if not line.strip():
+        content = strip_yaml_comment(line)
+        if not content.strip():
             continue
-        line_indent = len(line) - len(line.lstrip(" "))
+        line_indent = len(content) - len(content.lstrip(" "))
         if line_indent <= indent:
             end = index
             break
@@ -192,6 +217,15 @@ def uncommented_lines(lines: list[str]) -> list[str]:
     return [line for line in lines if not line.lstrip().startswith("#")]
 
 
+def yaml_list_scalars(lines: list[str]) -> set[str]:
+    values: set[str] = set()
+    for line in lines:
+        item = strip_yaml_comment(line).strip()
+        if item.startswith("- "):
+            values.add(strip_yaml_scalar(item[2:]))
+    return values
+
+
 def parse_needs(block: list[str]) -> set[str]:
     lines = uncommented_lines(block)
     for index, line in enumerate(lines):
@@ -286,9 +320,8 @@ def main() -> None:
     native_build_uncommented = uncommented_lines(job_block(native_lines, "build"))
     if not native_workflow_call_block:
         errors.append("build-native workflow must expose workflow_call")
-    if not any(
-        line.strip() == '- "packages/cli/package.json"'
-        for line in uncommented_lines(native_pull_request_paths)
+    if "packages/cli/package.json" not in yaml_list_scalars(
+        native_pull_request_paths
     ):
         errors.append("build-native workflow must run for CLI package manifest changes")
     if not any(

--- a/scripts/test-release-workflow-safety.sh
+++ b/scripts/test-release-workflow-safety.sh
@@ -8,7 +8,16 @@ trap 'rm -rf "${TMP_DIR}"' EXIT
 
 write_good_workflows() {
   local work="$1"
-  mkdir -p "${work}/.github/workflows" "${work}/packages/cli-linux-x64-gnu"
+  mkdir -p \
+    "${work}/.github/workflows" \
+    "${work}/packages/cli-darwin-x64" \
+    "${work}/packages/cli-linux-x64-gnu"
+  cat > "${work}/packages/cli-darwin-x64/package.json" <<'EOF_MANIFEST'
+{
+  "name": "@tokscale/cli-darwin-x64",
+  "version": "3.0.0"
+}
+EOF_MANIFEST
   cat > "${work}/packages/cli-linux-x64-gnu/package.json" <<'EOF_MANIFEST'
 {
   "name": "@tokscale/cli-linux-x64-gnu",
@@ -17,6 +26,13 @@ write_good_workflows() {
 EOF_MANIFEST
   cat > "${work}/.github/workflows/build-native.yml" <<'EOF_YAML'
 name: Build Native (Test Only)
+
+on:
+  workflow_call:
+    inputs:
+      bumped-manifests:
+        type: string
+        default: ""
 
 env:
   MACOSX_DEPLOYMENT_TARGET: "10.13"
@@ -28,32 +44,37 @@ jobs:
     strategy:
       matrix:
         settings:
-          - host: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            build: cargo zigbuild --release -p tokscale-cli --target x86_64-unknown-linux-gnu
-            strip: strip target/x86_64-unknown-linux-gnu/release/tokscale
+          - host: macos-latest
+            target: x86_64-apple-darwin
+            package_dir: cli-darwin-x64
+            artifact_name: cli-binary-x86_64-apple-darwin
+            build: cargo build --release -p tokscale-cli --target x86_64-apple-darwin
+            strip: strip -x target/x86_64-apple-darwin/release/tokscale
             bin_name: tokscale
-EOF_YAML
-  cat > "${work}/.github/workflows/publish-cli.yml" <<'EOF_YAML'
-name: Publish
-
-env:
-  MACOSX_DEPLOYMENT_TARGET: "10.13"
-  CARGO_TERM_COLOR: always
-  CARGO_INCREMENTAL: 0
-
-jobs:
-  build-cli-binary:
-    strategy:
-      matrix:
-        settings:
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             package_dir: cli-linux-x64-gnu
             artifact_name: cli-binary-x86_64-unknown-linux-gnu
-            bin_name: tokscale
             build: cargo zigbuild --release -p tokscale-cli --target x86_64-unknown-linux-gnu
             strip: strip target/x86_64-unknown-linux-gnu/release/tokscale
+            bin_name: tokscale
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          name: ${{ inputs.bumped-manifests }}
+      - name: Smoke Android binary
+        if: ${{ matrix.settings.target == 'aarch64-linux-android' }}
+        run: cargo run --release -p tokscale-cli --target aarch64-linux-android -- --no-spinner --version
+EOF_YAML
+  cat > "${work}/.github/workflows/publish-cli.yml" <<'EOF_YAML'
+name: Publish
+
+jobs:
+  build-cli-binary:
+    needs: bump-versions
+    uses: ./.github/workflows/build-native.yml
+    with:
+      bumped-manifests: bumped-manifests
   smoke-release-artifacts:
     needs: [bump-versions, build-cli-binary]
     steps:
@@ -68,6 +89,10 @@ jobs:
     strategy:
       matrix:
         settings:
+          - package_name: '@tokscale/cli-darwin-x64'
+            package_dir: cli-darwin-x64
+            artifact_name: cli-binary-x86_64-apple-darwin
+            binary_name: tokscale
           - package_name: '@tokscale/cli-linux-x64-gnu'
             package_dir: cli-linux-x64-gnu
             artifact_name: cli-binary-x86_64-unknown-linux-gnu
@@ -104,13 +129,13 @@ test_reads_workflows_as_utf8_when_locale_is_non_utf8() {
 test_rejects_build_matrix_target_drift() {
   local work="${TMP_DIR}/target-drift"
   write_good_workflows "${work}"
-  python3 - "${work}/.github/workflows/publish-cli.yml" <<'PY'
+  python3 - "${work}/.github/workflows/build-native.yml" <<'PY'
 import pathlib
 import sys
 
 path = pathlib.Path(sys.argv[1])
 text = path.read_text()
-text = text.replace("target: x86_64-unknown-linux-gnu", "target: x86_64-unknown-linux-musl", 1)
+text = text.replace("target: x86_64-unknown-linux-gnu", "target: unsupported-target", 1)
 path.write_text(text)
 PY
 
@@ -120,34 +145,135 @@ PY
     return 1
   fi
 
-  grep -q "build matrix targets differ" "${output}"
+  grep -q "canonical build matrix has unknown targets" "${output}"
 }
 
-test_rejects_release_env_drift() {
-  local work="${TMP_DIR}/env-drift"
+test_rejects_missing_canonical_target() {
+  local work="${TMP_DIR}/missing-target"
+  write_good_workflows "${work}"
+  python3 - \
+    "${work}/.github/workflows/build-native.yml" \
+    "${work}/.github/workflows/publish-cli.yml" <<'PY'
+import pathlib
+import re
+import sys
+
+build_path = pathlib.Path(sys.argv[1])
+build_text = build_path.read_text()
+build_text, build_count = re.subn(
+    r"\n          - host: macos-latest\n"
+    r"            target: x86_64-apple-darwin\n"
+    r"(?:            .*\n){5}",
+    "\n",
+    build_text,
+    count=1,
+)
+if build_count != 1:
+    raise SystemExit("failed to remove canonical Darwin build target")
+build_path.write_text(build_text)
+
+publish_path = pathlib.Path(sys.argv[2])
+publish_text = publish_path.read_text()
+publish_text, publish_count = re.subn(
+    r"\n          - package_name: '@tokscale/cli-darwin-x64'\n"
+    r"(?:            .*\n){3}",
+    "\n",
+    publish_text,
+    count=1,
+)
+if publish_count != 1:
+    raise SystemExit("failed to remove Darwin publish target")
+publish_path.write_text(publish_text)
+PY
+
+  local output="${TMP_DIR}/missing-target-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to reject a missing canonical target" >&2
+    return 1
+  fi
+
+  grep -q "canonical build matrix is missing targets: \\['x86_64-apple-darwin'\\]" "${output}"
+}
+
+test_rejects_publish_build_call_drift() {
+  local work="${TMP_DIR}/call-drift"
   write_good_workflows "${work}"
   python3 - "${work}/.github/workflows/publish-cli.yml" <<'PY'
 import pathlib
 import sys
 
 path = pathlib.Path(sys.argv[1])
-text = path.read_text().replace('MACOSX_DEPLOYMENT_TARGET: "10.13"', 'MACOSX_DEPLOYMENT_TARGET: "11.0"')
+text = path.read_text().replace(
+    "uses: ./.github/workflows/build-native.yml",
+    "uses: ./.github/workflows/other.yml",
+)
 path.write_text(text)
 PY
 
-  local output="${TMP_DIR}/env-drift-output.txt"
+  local output="${TMP_DIR}/call-drift-output.txt"
   if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
-    echo "Expected workflow safety check to reject env drift" >&2
+    echo "Expected workflow safety check to reject reusable workflow drift" >&2
     return 1
   fi
 
-  grep -q "env MACOSX_DEPLOYMENT_TARGET differs" "${output}"
+  grep -q "publish build must call the canonical build-native workflow" "${output}"
+}
+
+test_rejects_missing_bumped_manifest_handoff() {
+  local work="${TMP_DIR}/missing-bumped-manifests"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/publish-cli.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace(
+    "bumped-manifests: bumped-manifests",
+    "bumped-manifests: stale-manifests",
+)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/missing-bumped-manifests-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to reject a stale manifest handoff" >&2
+    return 1
+  fi
+
+  grep -q "publish build must pass the bumped-manifests artifact" "${output}"
+}
+
+test_rejects_missing_android_smoke() {
+  local work="${TMP_DIR}/missing-android-smoke"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/build-native.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace(
+    """      - name: Smoke Android binary
+        if: ${{ matrix.settings.target == 'aarch64-linux-android' }}
+        run: cargo run --release -p tokscale-cli --target aarch64-linux-android -- --no-spinner --version
+""",
+    "",
+)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/missing-android-smoke-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to require the Android execution smoke" >&2
+    return 1
+  fi
+
+  grep -q "build-native workflow must execute the Android binary smoke" "${output}"
 }
 
 test_rejects_missing_required_release_env() {
   local work="${TMP_DIR}/missing-env"
   write_good_workflows "${work}"
-  python3 - "${work}/.github/workflows/publish-cli.yml" "${work}/.github/workflows/build-native.yml" <<'PY'
+  python3 - "${work}/.github/workflows/build-native.yml" <<'PY'
 import pathlib
 import sys
 
@@ -165,7 +291,6 @@ PY
     return 1
   fi
 
-  grep -q "publish workflow missing required env CARGO_INCREMENTAL" "${output}"
   grep -q "build-native workflow missing required env CARGO_INCREMENTAL" "${output}"
 }
 
@@ -287,7 +412,10 @@ PY
 test_accepts_matching_publish_and_native_workflows
 test_reads_workflows_as_utf8_when_locale_is_non_utf8
 test_rejects_build_matrix_target_drift
-test_rejects_release_env_drift
+test_rejects_missing_canonical_target
+test_rejects_publish_build_call_drift
+test_rejects_missing_bumped_manifest_handoff
+test_rejects_missing_android_smoke
 test_rejects_missing_required_release_env
 test_rejects_platform_publish_matrix_drift
 test_rejects_missing_release_artifact_smoke_job

--- a/scripts/test-release-workflow-safety.sh
+++ b/scripts/test-release-workflow-safety.sh
@@ -62,6 +62,12 @@ jobs:
       - uses: actions/download-artifact@v6
         with:
           name: ${{ inputs.bumped-manifests }}
+      - name: Setup Android cross toolchain
+        if: ${{ matrix.settings.target == 'aarch64-linux-android' }}
+        uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: aarch64-linux-android
+          runner: qemu-user
       - name: Smoke Android binary
         if: ${{ matrix.settings.target == 'aarch64-linux-android' }}
         run: cargo run --release -p tokscale-cli --target aarch64-linux-android -- --no-spinner --version
@@ -270,6 +276,27 @@ PY
   grep -q "build-native workflow must execute the Android binary smoke" "${output}"
 }
 
+test_rejects_missing_android_qemu_runner() {
+  local work="${TMP_DIR}/missing-android-runner"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/build-native.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace("          runner: qemu-user\n", "", 1)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/missing-android-runner-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to require the Android QEMU runner" >&2
+    return 1
+  fi
+
+  grep -q "build-native workflow must configure the Android QEMU runner" "${output}"
+}
+
 test_rejects_missing_required_release_env() {
   local work="${TMP_DIR}/missing-env"
   write_good_workflows "${work}"
@@ -416,6 +443,7 @@ test_rejects_missing_canonical_target
 test_rejects_publish_build_call_drift
 test_rejects_missing_bumped_manifest_handoff
 test_rejects_missing_android_smoke
+test_rejects_missing_android_qemu_runner
 test_rejects_missing_required_release_env
 test_rejects_platform_publish_matrix_drift
 test_rejects_missing_release_artifact_smoke_job

--- a/scripts/test-release-workflow-safety.sh
+++ b/scripts/test-release-workflow-safety.sh
@@ -215,6 +215,39 @@ PY
   grep -q "Release workflow safety OK" "${TMP_DIR}/without-android-output.txt"
 }
 
+test_accepts_yaml_comments_and_manifest_path_quote_styles() {
+  local work="${TMP_DIR}/yaml-comments"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/build-native.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text()
+text = text.replace("on:\n", "on: # workflow events\n", 1)
+text = text.replace("  workflow_call:\n", "  workflow_call: # reusable release build\n", 1)
+text = text.replace(
+    "  pull_request:\n",
+    "# Comments do not close the surrounding YAML mapping.\n  pull_request: # PR validation\n",
+    1,
+)
+text = text.replace("    paths:\n", "    paths: # relevant files\n", 1)
+text = text.replace(
+    '      - "packages/cli/package.json"\n',
+    "      - 'packages/cli/package.json' # release source of truth\n",
+    1,
+)
+path.write_text(text)
+PY
+
+  (
+    cd "${work}"
+    python3 "${SCRIPT_UNDER_TEST}" >"${TMP_DIR}/yaml-comments-output.txt" 2>&1
+  )
+
+  grep -q "Release workflow safety OK" "${TMP_DIR}/yaml-comments-output.txt"
+}
+
 test_reads_workflows_as_utf8_when_locale_is_non_utf8() {
   local work="${TMP_DIR}/utf8-locale"
   write_good_workflows "${work}"
@@ -614,6 +647,7 @@ PY
 
 test_accepts_matching_publish_and_native_workflows
 test_accepts_workflows_without_android_platform
+test_accepts_yaml_comments_and_manifest_path_quote_styles
 test_reads_workflows_as_utf8_when_locale_is_non_utf8
 test_rejects_build_matrix_target_drift
 test_rejects_unmapped_cli_platform_dependency

--- a/scripts/test-release-workflow-safety.sh
+++ b/scripts/test-release-workflow-safety.sh
@@ -52,6 +52,9 @@ on:
       bumped-manifests:
         type: string
         default: ""
+  pull_request:
+    paths:
+      - "packages/cli/package.json"
 
 env:
   MACOSX_DEPLOYMENT_TARGET: "10.13"
@@ -269,6 +272,28 @@ PY
   fi
 
   grep -q "CLI optionalDependencies have unmapped platform packages: \['cli-plan9-x64'\]" "${output}"
+}
+
+test_rejects_missing_cli_manifest_path_trigger() {
+  local work="${TMP_DIR}/missing-cli-manifest-trigger"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/build-native.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace('      - "packages/cli/package.json"\n', "", 1)
+text += '\nx-decoy:\n  - "packages/cli/package.json"\n'
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/missing-cli-manifest-trigger-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to require the CLI manifest path trigger" >&2
+    return 1
+  fi
+
+  grep -q "build-native workflow must run for CLI package manifest changes" "${output}"
 }
 
 test_rejects_missing_canonical_target() {
@@ -588,6 +613,7 @@ test_accepts_workflows_without_android_platform
 test_reads_workflows_as_utf8_when_locale_is_non_utf8
 test_rejects_build_matrix_target_drift
 test_rejects_unmapped_cli_platform_dependency
+test_rejects_missing_cli_manifest_path_trigger
 test_rejects_missing_canonical_target
 test_rejects_publish_build_call_drift
 test_rejects_missing_bumped_manifest_handoff

--- a/scripts/test-release-workflow-safety.sh
+++ b/scripts/test-release-workflow-safety.sh
@@ -283,7 +283,11 @@ import sys
 
 path = pathlib.Path(sys.argv[1])
 text = path.read_text().replace('      - "packages/cli/package.json"\n', "", 1)
-text += '\nx-decoy:\n  - "packages/cli/package.json"\n'
+text = text.replace(
+    "  pull_request:\n",
+    '  pull_request:\n    branches:\n      - "packages/cli/package.json"\n',
+    1,
+)
 path.write_text(text)
 PY
 

--- a/scripts/test-release-workflow-safety.sh
+++ b/scripts/test-release-workflow-safety.sh
@@ -10,8 +10,27 @@ write_good_workflows() {
   local work="$1"
   mkdir -p \
     "${work}/.github/workflows" \
+    "${work}/packages/cli" \
+    "${work}/packages/cli-android-arm64" \
     "${work}/packages/cli-darwin-x64" \
     "${work}/packages/cli-linux-x64-gnu"
+  cat > "${work}/packages/cli/package.json" <<'EOF_MANIFEST'
+{
+  "name": "@tokscale/cli",
+  "version": "3.0.0",
+  "optionalDependencies": {
+    "@tokscale/cli-android-arm64": "3.0.0",
+    "@tokscale/cli-darwin-x64": "3.0.0",
+    "@tokscale/cli-linux-x64-gnu": "3.0.0"
+  }
+}
+EOF_MANIFEST
+  cat > "${work}/packages/cli-android-arm64/package.json" <<'EOF_MANIFEST'
+{
+  "name": "@tokscale/cli-android-arm64",
+  "version": "3.0.0"
+}
+EOF_MANIFEST
   cat > "${work}/packages/cli-darwin-x64/package.json" <<'EOF_MANIFEST'
 {
   "name": "@tokscale/cli-darwin-x64",
@@ -58,6 +77,13 @@ jobs:
             build: cargo zigbuild --release -p tokscale-cli --target x86_64-unknown-linux-gnu
             strip: strip target/x86_64-unknown-linux-gnu/release/tokscale
             bin_name: tokscale
+          - host: ubuntu-latest
+            target: aarch64-linux-android
+            package_dir: cli-android-arm64
+            artifact_name: cli-binary-aarch64-linux-android
+            build: cargo build --release -p tokscale-cli --target aarch64-linux-android
+            strip: ""
+            bin_name: tokscale
     steps:
       - uses: actions/download-artifact@v6
         with:
@@ -103,6 +129,10 @@ jobs:
             package_dir: cli-linux-x64-gnu
             artifact_name: cli-binary-x86_64-unknown-linux-gnu
             binary_name: tokscale
+          - package_name: '@tokscale/cli-android-arm64'
+            package_dir: cli-android-arm64
+            artifact_name: cli-binary-aarch64-linux-android
+            binary_name: tokscale
 EOF_YAML
 }
 
@@ -116,6 +146,70 @@ test_accepts_matching_publish_and_native_workflows() {
   )
 
   grep -q "Release workflow safety OK" "${TMP_DIR}/good-output.txt"
+}
+
+test_accepts_workflows_without_android_platform() {
+  local work="${TMP_DIR}/without-android"
+  write_good_workflows "${work}"
+  python3 - \
+    "${work}/packages/cli/package.json" \
+    "${work}/.github/workflows/build-native.yml" \
+    "${work}/.github/workflows/publish-cli.yml" <<'PY'
+import json
+import pathlib
+import sys
+
+manifest_path = pathlib.Path(sys.argv[1])
+manifest = json.loads(manifest_path.read_text())
+manifest["optionalDependencies"].pop("@tokscale/cli-android-arm64")
+manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+
+build_path = pathlib.Path(sys.argv[2])
+build_text = build_path.read_text()
+build_text = build_text.replace(
+    """          - host: ubuntu-latest
+            target: aarch64-linux-android
+            package_dir: cli-android-arm64
+            artifact_name: cli-binary-aarch64-linux-android
+            build: cargo build --release -p tokscale-cli --target aarch64-linux-android
+            strip: ""
+            bin_name: tokscale
+""",
+    "",
+)
+build_text = build_text.replace(
+    """      - name: Setup Android cross toolchain
+        if: ${{ matrix.settings.target == 'aarch64-linux-android' }}
+        uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: aarch64-linux-android
+          runner: qemu-user
+      - name: Smoke Android binary
+        if: ${{ matrix.settings.target == 'aarch64-linux-android' }}
+        run: cargo run --release -p tokscale-cli --target aarch64-linux-android -- --no-spinner --version
+""",
+    "",
+)
+build_path.write_text(build_text)
+
+publish_path = pathlib.Path(sys.argv[3])
+publish_text = publish_path.read_text().replace(
+    """          - package_name: '@tokscale/cli-android-arm64'
+            package_dir: cli-android-arm64
+            artifact_name: cli-binary-aarch64-linux-android
+            binary_name: tokscale
+""",
+    "",
+)
+publish_path.write_text(publish_text)
+PY
+
+  (
+    cd "${work}"
+    python3 "${SCRIPT_UNDER_TEST}" >"${TMP_DIR}/without-android-output.txt" 2>&1
+  )
+
+  grep -q "Release workflow safety OK" "${TMP_DIR}/without-android-output.txt"
 }
 
 test_reads_workflows_as_utf8_when_locale_is_non_utf8() {
@@ -152,6 +246,29 @@ PY
   fi
 
   grep -q "canonical build matrix has unknown targets" "${output}"
+}
+
+test_rejects_unmapped_cli_platform_dependency() {
+  local work="${TMP_DIR}/unmapped-platform"
+  write_good_workflows "${work}"
+  python3 - "${work}/packages/cli/package.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+manifest = json.loads(path.read_text())
+manifest["optionalDependencies"]["@tokscale/cli-plan9-x64"] = "3.0.0"
+path.write_text(json.dumps(manifest, indent=2) + "\n")
+PY
+
+  local output="${TMP_DIR}/unmapped-platform-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to reject an unmapped CLI platform dependency" >&2
+    return 1
+  fi
+
+  grep -q "CLI optionalDependencies have unmapped platform packages: \['cli-plan9-x64'\]" "${output}"
 }
 
 test_rejects_missing_canonical_target() {
@@ -291,6 +408,36 @@ PY
   local output="${TMP_DIR}/missing-android-runner-output.txt"
   if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
     echo "Expected workflow safety check to require the Android QEMU runner" >&2
+    return 1
+  fi
+
+  grep -q "build-native workflow must configure the Android QEMU runner" "${output}"
+}
+
+test_rejects_android_runner_outside_build_job() {
+  local work="${TMP_DIR}/android-runner-outside-build"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/build-native.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text()
+runner = """      - name: Setup Android cross toolchain
+        if: ${{ matrix.settings.target == 'aarch64-linux-android' }}
+        uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: aarch64-linux-android
+          runner: qemu-user
+"""
+text = text.replace(runner, "", 1)
+text += "\n  decoy:\n    steps:\n" + runner
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/android-runner-outside-build-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to reject an Android runner outside the build job" >&2
     return 1
   fi
 
@@ -437,13 +584,16 @@ PY
 }
 
 test_accepts_matching_publish_and_native_workflows
+test_accepts_workflows_without_android_platform
 test_reads_workflows_as_utf8_when_locale_is_non_utf8
 test_rejects_build_matrix_target_drift
+test_rejects_unmapped_cli_platform_dependency
 test_rejects_missing_canonical_target
 test_rejects_publish_build_call_drift
 test_rejects_missing_bumped_manifest_handoff
 test_rejects_missing_android_smoke
 test_rejects_missing_android_qemu_runner
+test_rejects_android_runner_outside_build_job
 test_rejects_missing_required_release_env
 test_rejects_platform_publish_matrix_drift
 test_rejects_missing_release_artifact_smoke_job


### PR DESCRIPTION
## Summary

- reuse the native build workflow as the canonical PR and release target matrix
- stage identical sidecar-aware artifacts for validation and publishing
- add Android QEMU execution smoke coverage, safer concurrency, and narrower release permissions
- extend workflow safety checks to prevent missing targets or release handoff drift

## Validation

- `actionlint .github/workflows/build-native.yml .github/workflows/publish-cli.yml`
- `python3 scripts/check-release-workflow-safety.py`
- `bash scripts/test-release-workflow-safety.sh`
- version coherence and release provenance/recovery test suites
- npm release-state tests
- launcher smoke tests under Node and Bun
- `git diff --check`

Independent re-review completed with zero findings.
