### PR TITLE
fix(submit): derive session metrics per device and harden the active-time guard

### DIFF
--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -1116,7 +1116,7 @@ describe("POST /api/submit auth path", () => {
     }));
   });
 
-  it("sets all-time active time from all submitted device daily rows", async () => {
+  it("sums per-device session metrics across devices instead of taking a max", async () => {
     mockState.authenticatePersonalToken.mockResolvedValue({
       status: "valid",
       tokenId: "token-1",
@@ -1216,12 +1216,22 @@ describe("POST /api/submit auth path", () => {
         dateEnd: "2026-04-30",
         activeDays: 1,
         rowCount: 3,
+      }],
+      // deviceTotals: this desktop contributed 4_000ms / 1 session and a second
+      // machine previously contributed 6_000ms / 2 sessions. Session counts are
+      // additive across devices (independent local sessions); the shape metrics
+      // are a max because concurrency and streak length are per-machine.
+      [{
         totalActiveTimeMs: 10_000,
+        sessionCount: 3,
+        longestContinuousMs: 6_000,
+        maxConcurrentSessions: 2,
       }],
       [{ sourceBreakdown: insertedBreakdown }],
     ];
 
     const submissionUpdateSets: Array<Record<string, unknown>> = [];
+    const selectFields: Array<Record<string, unknown>> = [];
     let insertCall = 0;
     const tx = {
       update: vi.fn((table: unknown) => {
@@ -1236,7 +1246,10 @@ describe("POST /api/submit auth path", () => {
         };
         return builder;
       }),
-      select: vi.fn(() => makeAwaitableBuilder(selectResults.shift() ?? [])),
+      select: vi.fn((fields?: Record<string, unknown>) => {
+        if (fields) selectFields.push(fields);
+        return makeAwaitableBuilder(selectResults.shift() ?? []);
+      }),
       insert: vi.fn(() => {
         insertCall += 1;
         if (insertCall === 1) {
@@ -1287,12 +1300,44 @@ describe("POST /api/submit auth path", () => {
         4_000,
       ]),
     );
+    // 3, not 1: the submitting device reported sessionCount 1, so a
+    // max-across-devices merge would report 1 and drop the other machine.
     expect(submissionUpdateSets.at(-1)).toEqual(expect.objectContaining({
       totalActiveTimeMs: 10_000,
-      longestContinuousMs: 4_000,
-      maxConcurrentSessions: 1,
-      sessionCount: 1,
+      longestContinuousMs: 6_000,
+      maxConcurrentSessions: 2,
+      sessionCount: 3,
     }));
+
+    // deviceTotals is a mocked row, so the assertion above cannot tell SUM from
+    // MAX -- it only proves the route reads the aggregate instead of the
+    // submitting device's own snapshot. Pin the aggregate functions directly:
+    // counts are additive across machines, shape metrics are not.
+    const deviceAggregate = selectFields.find(
+      (fields) => !("id" in fields) && "sessionCount" in fields,
+    );
+    expect(deviceAggregate).toBeDefined();
+    expect(flattenSqlChunks(deviceAggregate!.sessionCount)).toEqual(
+      expect.arrayContaining([expect.stringContaining("SUM(")]),
+    );
+    expect(flattenSqlChunks(deviceAggregate!.totalActiveTimeMs)).toEqual(
+      expect.arrayContaining([expect.stringContaining("SUM(")]),
+    );
+    expect(flattenSqlChunks(deviceAggregate!.maxConcurrentSessions)).toEqual(
+      expect.arrayContaining([expect.stringContaining("MAX(")]),
+    );
+    expect(flattenSqlChunks(deviceAggregate!.longestContinuousMs)).toEqual(
+      expect.arrayContaining([expect.stringContaining("MAX(")]),
+    );
+
+    // The ON CONFLICT arm is unreachable while the per-user submissions row
+    // lock holds, but it must not be a silent hole in the monotonic guard if
+    // that ever changes (or if duplicate dates straddle an INSERT chunk).
+    expect(flattenSqlChunks(tx.execute.mock.calls[1][0])).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("GREATEST(daily_breakdown.active_time_ms"),
+      ]),
+    );
   });
 
   it("preserves same-device active time and session metrics when local history shrinks", async () => {
@@ -1398,6 +1443,7 @@ describe("POST /api/submit auth path", () => {
     const selectResults = [
       [{
         id: "submission-1",
+        totalActiveTimeMs: 13_000,
         longestContinuousMs: 9_000,
         maxConcurrentSessions: 4,
         sessionCount: 12,
@@ -1418,7 +1464,16 @@ describe("POST /api/submit auth path", () => {
         dateEnd: "2026-04-30",
         activeDays: 1,
         rowCount: 2,
-        totalActiveTimeMs: 13_000,
+      }],
+      // deviceTotals deliberately LOWER than the stored submission values, the
+      // shape of the migration transition: device rows start with NULL metrics,
+      // so until every device submits again the SUM under-reports. The stored
+      // value must act as a floor or the account total would drop.
+      [{
+        totalActiveTimeMs: 5_000,
+        sessionCount: 1,
+        longestContinuousMs: 5_000,
+        maxConcurrentSessions: 1,
       }],
       [{ sourceBreakdown: mergedBreakdown }],
     ];
@@ -1471,16 +1526,243 @@ describe("POST /api/submit auth path", () => {
     expect(response.status).toBe(200);
     expect(tx.insert).toHaveBeenCalledTimes(1);
     expect(tx.execute).toHaveBeenCalledTimes(1);
-    expect(flattenSqlChunks(tx.execute.mock.calls[0][0])).toEqual(
-      expect.arrayContaining([7_000]),
+    const updateChunks = flattenSqlChunks(tx.execute.mock.calls[0][0]);
+    expect(updateChunks).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("UPDATE daily_breakdown"),
+        "daily-1",
+        456,
+        7_000,
+      ]),
     );
+    // The VALUES tuple is (id, tokens, cost, input, output, timestamp_ms,
+    // active_time_ms, source_breakdown). arrayContaining is order-blind, so it
+    // alone cannot catch timestamp_ms and active_time_ms being transposed --
+    // which would write an epoch millisecond into active_time_ms. Pin the
+    // relative order of the two bound parameters.
+    expect(updateChunks.indexOf(456)).toBeGreaterThan(updateChunks.indexOf("daily-1"));
+    expect(updateChunks.indexOf(7_000)).toBeGreaterThan(updateChunks.indexOf(456));
     expect(submissionUpdateSets.at(-1)).toEqual(expect.objectContaining({
       totalActiveTimeMs: 13_000,
       longestContinuousMs: 9_000,
       maxConcurrentSessions: 4,
       sessionCount: 12,
     }));
+    // The preservation is silent otherwise: the CLI prints these warnings, so
+    // the user's only signal that their local scan came back short.
+    const body = await response.json();
+    expect(body.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Preserved 7000ms active time"),
+      ]),
+    );
   });
+  it("accepts a larger incoming active time and keeps the device upsert monotonic", async () => {
+    mockState.authenticatePersonalToken.mockResolvedValue({
+      status: "valid",
+      tokenId: "token-1",
+      userId: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      expiresAt: null,
+    });
+
+    mockState.validateSubmission.mockReturnValue({
+      valid: true,
+      data: {
+        device: {
+          id: "dev_laptop",
+        },
+        meta: {
+          version: "2.0.0",
+          dateRange: { start: "2026-04-30", end: "2026-04-30" },
+        },
+        summary: {
+          clients: ["codex"],
+        },
+        contributions: [
+          {
+            date: "2026-04-30",
+            timestampMs: 789,
+            activeTimeMs: 9_000,
+            clients: [
+              {
+                client: "codex",
+                modelId: "gpt-5.5",
+                tokens: 15,
+                cost: 0.75,
+                input: 10,
+                output: 5,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+                messages: 1,
+              },
+            ],
+          },
+        ],
+        timeMetrics: {
+          totalActiveTimeMs: 9_000,
+          longestContinuousMs: 9_000,
+          maxConcurrentSessions: 1,
+          sessionCount: 1,
+        },
+      },
+      errors: [],
+      warnings: [],
+    });
+
+    const incomingBreakdown = {
+      tokens: 15,
+      cost: 0.75,
+      input: 10,
+      output: 5,
+      cacheRead: 0,
+      cacheWrite: 0,
+      reasoning: 0,
+      messages: 1,
+    };
+    const existingBreakdown = {
+      codex: {
+        tokens: 12,
+        cost: 0.5,
+        input: 7,
+        output: 5,
+        cacheRead: 0,
+        cacheWrite: 0,
+        reasoning: 0,
+        messages: 1,
+        models: { "gpt-5.5": { tokens: 12 } },
+      },
+    };
+    const mergedBreakdown = {
+      codex: {
+        ...incomingBreakdown,
+        models: { "gpt-5.5": incomingBreakdown },
+      },
+    };
+
+    mockState.clientContributionToBreakdownData.mockReturnValue(incomingBreakdown);
+    mockState.mergeClientBreakdownsWithRegressionGuard.mockReturnValue({
+      merged: mergedBreakdown,
+      warnings: [],
+      foldPreservedClients: new Set<string>(),
+    });
+    mockState.recalculateDayTotals.mockReturnValue({
+      tokens: 15,
+      cost: 0.75,
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+    mockState.mergeTimestampMs.mockReturnValue(789);
+
+    const selectResults = [
+      [{ id: "submission-1" }],
+      [{
+        id: "daily-1",
+        date: "2026-04-30",
+        timestampMs: 123,
+        // Smaller than the incoming 9_000: growth must not be clamped.
+        activeTimeMs: 2_000,
+        sourceBreakdown: existingBreakdown,
+      }],
+      [{
+        totalTokens: 27,
+        totalCost: "1.2500",
+        inputTokens: 17,
+        outputTokens: 10,
+        dateStart: "2026-04-30",
+        dateEnd: "2026-04-30",
+        activeDays: 1,
+        rowCount: 2,
+      }],
+      [{
+        totalActiveTimeMs: 9_000,
+        sessionCount: 1,
+        longestContinuousMs: 9_000,
+        maxConcurrentSessions: 1,
+      }],
+      [{ sourceBreakdown: mergedBreakdown }],
+    ];
+
+    const submissionUpdateSets: Array<Record<string, unknown>> = [];
+    const deviceUpsertSets: Array<Record<string, unknown>> = [];
+    const tx = {
+      update: vi.fn((table: unknown) => {
+        const builder = {
+          set: vi.fn((values: Record<string, unknown>) => {
+            if ((table as { id?: unknown }).id === "submissions.id") {
+              submissionUpdateSets.push(values);
+            }
+            return builder;
+          }),
+          where: vi.fn(() => Promise.resolve()),
+        };
+        return builder;
+      }),
+      select: vi.fn(() => makeAwaitableBuilder(selectResults.shift() ?? [])),
+      insert: vi.fn(() => {
+        const builder = {
+          values: vi.fn(() => builder),
+          onConflictDoUpdate: vi.fn((config: { set?: Record<string, unknown> }) => {
+            if (config?.set) deviceUpsertSets.push(config.set);
+            return builder;
+          }),
+          returning: vi.fn(() => Promise.resolve([{ id: "submitted-device-1" }])),
+        };
+        return builder;
+      }),
+      execute: vi.fn((..._args: unknown[]) => Promise.resolve()),
+      transaction: vi.fn(async (callback: (sp: typeof tx) => Promise<unknown>) =>
+        callback(tx)
+      ),
+    };
+    type MockTransaction = typeof tx;
+
+    mockState.db.transaction.mockImplementation(async (callback: (tx: MockTransaction) => Promise<unknown>) =>
+      callback(tx)
+    );
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ meta: {}, contributions: [] }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    // 9_000, not the stored 2_000: the monotonic guard preserves the LARGER
+    // value, it does not freeze the row at whatever landed first.
+    const updateChunks = flattenSqlChunks(tx.execute.mock.calls[0][0]);
+    expect(updateChunks).toEqual(expect.arrayContaining([9_000]));
+    expect(updateChunks).not.toEqual(expect.arrayContaining([2_000]));
+
+    // Nothing was preserved, so the shrink warning must stay silent.
+    const body = await response.json();
+    expect(body.warnings ?? []).not.toEqual(
+      expect.arrayContaining([expect.stringContaining("Preserved")]),
+    );
+
+    // The per-device high-water mark is enforced in SQL, so assert the upsert
+    // actually carries GREATEST rather than a plain overwrite.
+    const deviceSet = deviceUpsertSets.at(-1) ?? {};
+    for (const column of [
+      "totalActiveTimeMs",
+      "longestContinuousMs",
+      "maxConcurrentSessions",
+      "sessionCount",
+    ]) {
+      expect(flattenSqlChunks(deviceSet[column])).toEqual(
+        expect.arrayContaining([expect.stringContaining("GREATEST")]),
+      );
+    }
+  });
+
   it("adopts legacy daily rows into the first modern device instead of duplicating totals", async () => {
     mockState.authenticatePersonalToken.mockResolvedValue({
       status: "valid",

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -1330,6 +1330,17 @@ describe("POST /api/submit auth path", () => {
       expect.arrayContaining([expect.stringContaining("MAX(")]),
     );
 
+    // Only the SUM columns need the clamp: SUM() widens its input, so casting
+    // back to the column type overflows once the per-device values total past
+    // it, aborting the submit. Pin the bounds too -- a wrong constant is as
+    // broken as a missing LEAST().
+    const sessionCountSql = flattenSqlChunks(deviceAggregate!.sessionCount).join(" ");
+    expect(sessionCountSql).toContain("LEAST(");
+    expect(sessionCountSql).toContain("2147483647");
+    const activeTimeSql = flattenSqlChunks(deviceAggregate!.totalActiveTimeMs).join(" ");
+    expect(activeTimeSql).toContain("LEAST(");
+    expect(activeTimeSql).toContain("9223372036854775807");
+
     // The ON CONFLICT arm is unreachable while the per-user submissions row
     // lock holds, but it must not be a silent hole in the monotonic guard if
     // that ever changes (or if duplicate dates straddle an INSERT chunk).

--- a/packages/frontend/__tests__/lib/submissionDuplicateDates.test.ts
+++ b/packages/frontend/__tests__/lib/submissionDuplicateDates.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { validateSubmission } from "@/lib/validation/submission";
+
+// A repeated date in `contributions` used to reach the submit route intact.
+// The route builds its INSERT batch from a date-keyed map of EXISTING rows that
+// is never updated as the loop runs, so both entries miss the map and both are
+// queued as inserts -- two rows sharing (submission_id, submitted_device_id,
+// date). Postgres then either aborts the statement ("ON CONFLICT DO UPDATE
+// command cannot affect row a second time") or, when the duplicates straddle an
+// INSERT_CHUNK_SIZE boundary, lets the second row overwrite the first through
+// the ON CONFLICT arm -- which is the one path that bypasses the monotonic
+// active-time guard. Rejecting at validation turns both into a clean 400.
+
+const tokens = {
+  input: 100,
+  output: 100,
+  cacheRead: 100,
+  cacheWrite: 0,
+  reasoning: 0,
+};
+
+function buildDay(date: string): Record<string, unknown> {
+  return {
+    date,
+    totals: { tokens: 300, cost: 1.5, messages: 0 },
+    intensity: 4,
+    tokenBreakdown: tokens,
+    clients: [{ client: "codex", modelId: "gpt-5.5", tokens, cost: 1.5, messages: 0 }],
+  };
+}
+
+function buildSubmission(dates: string[]): Record<string, unknown> {
+  return {
+    meta: {
+      generatedAt: "2026-07-14T00:00:00.000Z",
+      version: "4.5.3",
+      dateRange: { start: "2026-05-11", end: "2026-05-11" },
+    },
+    summary: {
+      totalTokens: 300 * dates.length,
+      totalCost: 1.5 * dates.length,
+      totalDays: dates.length,
+      activeDays: dates.length,
+      averagePerDay: 1.5,
+      maxCostInSingleDay: 1.5,
+      clients: ["codex"],
+      models: ["gpt-5.5"],
+    },
+    years: [
+      {
+        year: "2026",
+        totalTokens: 300 * dates.length,
+        totalCost: 1.5 * dates.length,
+        range: { start: "2026-05-11", end: "2026-05-11" },
+      },
+    ],
+    contributions: dates.map(buildDay),
+  };
+}
+
+const DUPLICATE_MESSAGE = "Duplicate dates in contributions";
+
+describe("submission duplicate-date guard", () => {
+  it("accepts distinct contribution dates", () => {
+    const result = validateSubmission(buildSubmission(["2026-05-11"]));
+
+    expect(result.errors).not.toEqual(
+      expect.arrayContaining([expect.stringContaining(DUPLICATE_MESSAGE)]),
+    );
+  });
+
+  it("rejects a submission repeating the same contribution date", () => {
+    const result = validateSubmission(
+      buildSubmission(["2026-05-11", "2026-05-11"]),
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([expect.stringContaining(DUPLICATE_MESSAGE)]),
+    );
+  });
+
+  it("rejects duplicates that are not adjacent in the array", () => {
+    const result = validateSubmission(
+      buildSubmission(["2026-05-11", "2026-05-12", "2026-05-11"]),
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([expect.stringContaining(DUPLICATE_MESSAGE)]),
+    );
+  });
+});

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -767,8 +767,18 @@ export async function POST(request: Request) {
       // survive a TZ change unchanged.
       const [deviceTotals] = await tx
         .select({
-          totalActiveTimeMs: sql<number>`COALESCE(SUM(${submittedDevices.totalActiveTimeMs}), 0)::bigint`,
-          sessionCount: sql<number>`COALESCE(SUM(${submittedDevices.sessionCount}), 0)::int`,
+          // LEAST() clamps rather than aborting the submit. SUM() widens its
+          // input (int4 -> bigint, int8 -> numeric), so the casts back down to
+          // the column type raise "out of range" as soon as the per-device
+          // values total past it. TimeMetricsSchema bounds these at min(0)
+          // with no maximum, so a client reporting ~2.1B sessions on one
+          // device would otherwise make every submit from a SECOND device
+          // fail: the aggregate reads both rows, overflows ::int, and rolls
+          // the transaction back. Clamping keeps a dishonest payload from
+          // locking a real device out. MAX() needs no clamp -- it returns a
+          // value that already fit the column.
+          totalActiveTimeMs: sql<number>`LEAST(COALESCE(SUM(${submittedDevices.totalActiveTimeMs}), 0), 9223372036854775807)::bigint`,
+          sessionCount: sql<number>`LEAST(COALESCE(SUM(${submittedDevices.sessionCount}), 0), 2147483647)::int`,
           longestContinuousMs: sql<number>`COALESCE(MAX(${submittedDevices.longestContinuousMs}), 0)::bigint`,
           maxConcurrentSessions: sql<number>`COALESCE(MAX(${submittedDevices.maxConcurrentSessions}), 0)::int`,
         })

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -303,6 +303,7 @@ export async function POST(request: Request) {
       const [existingSubmission] = await tx
         .select({
           id: submissions.id,
+          totalActiveTimeMs: submissions.totalActiveTimeMs,
           longestContinuousMs: submissions.longestContinuousMs,
           maxConcurrentSessions: submissions.maxConcurrentSessions,
           sessionCount: submissions.sessionCount,
@@ -352,6 +353,7 @@ export async function POST(request: Request) {
           const [racedSubmission] = await tx
             .select({
               id: submissions.id,
+              totalActiveTimeMs: submissions.totalActiveTimeMs,
               longestContinuousMs: submissions.longestContinuousMs,
               maxConcurrentSessions: submissions.maxConcurrentSessions,
               sessionCount: submissions.sessionCount,
@@ -372,6 +374,19 @@ export async function POST(request: Request) {
 
       const submitDevice = getSubmitDevice(data);
       const submittedAt = new Date();
+      // Session-shape metrics are recorded PER DEVICE as monotonic high-water
+      // marks. The per-device max still protects against a truncated local
+      // rescan (the d9df8c9c case), but keeping the metrics device-scoped is
+      // what lets the submission-level values be derived additively below
+      // instead of one device's snapshot overwriting another's.
+      const incomingDeviceMetrics = data.timeMetrics
+        ? {
+            totalActiveTimeMs: data.timeMetrics.totalActiveTimeMs,
+            longestContinuousMs: data.timeMetrics.longestContinuousMs,
+            maxConcurrentSessions: data.timeMetrics.maxConcurrentSessions,
+            sessionCount: data.timeMetrics.sessionCount,
+          }
+        : null;
       const [submittedDevice] = await tx
         .insert(submittedDevices)
         .values({
@@ -380,6 +395,7 @@ export async function POST(request: Request) {
           displayName: submitDevice.name,
           lastSubmittedAt: submittedAt,
           updatedAt: submittedAt,
+          ...(incomingDeviceMetrics ?? {}),
         })
         .onConflictDoUpdate({
           target: [submittedDevices.userId, submittedDevices.deviceKey],
@@ -387,6 +403,18 @@ export async function POST(request: Request) {
             displayName: sql`COALESCE(EXCLUDED.display_name, ${submittedDevices.displayName})`,
             lastSubmittedAt: submittedAt,
             updatedAt: submittedAt,
+            // A submit filtered by --clients/--date reports metrics for only
+            // that slice, so it must never lower the device's stored value.
+            // GREATEST ignores NULLs in Postgres, so a first-time metric write
+            // onto a pre-migration row adopts the incoming value cleanly.
+            ...(incomingDeviceMetrics
+              ? {
+                  totalActiveTimeMs: sql`GREATEST(${submittedDevices.totalActiveTimeMs}, EXCLUDED.total_active_time_ms)`,
+                  longestContinuousMs: sql`GREATEST(${submittedDevices.longestContinuousMs}, EXCLUDED.longest_continuous_ms)`,
+                  maxConcurrentSessions: sql`GREATEST(${submittedDevices.maxConcurrentSessions}, EXCLUDED.max_concurrent_sessions)`,
+                  sessionCount: sql`GREATEST(${submittedDevices.sessionCount}, EXCLUDED.session_count)`,
+                }
+              : {}),
           },
         })
         .returning({ id: submittedDevices.id });
@@ -673,7 +701,10 @@ export async function POST(request: Request) {
             input_tokens = EXCLUDED.input_tokens,
             output_tokens = EXCLUDED.output_tokens,
             timestamp_ms = EXCLUDED.timestamp_ms,
-            active_time_ms = EXCLUDED.active_time_ms,
+            -- Mirrors mergeActiveTimeMs(): this arm must not be a hole in the
+            -- monotonic guard the in-memory merge path applies. GREATEST
+            -- ignores NULLs in Postgres, matching the helper's null handling.
+            active_time_ms = GREATEST(daily_breakdown.active_time_ms, EXCLUDED.active_time_ms),
             source_breakdown = EXCLUDED.source_breakdown
         `);
       }
@@ -717,11 +748,32 @@ export async function POST(request: Request) {
           dateStart: sql<string>`MIN(${dailyBreakdown.date})`,
           dateEnd: sql<string>`MAX(${dailyBreakdown.date})`,
           activeDays: sql<number>`COUNT(DISTINCT CASE WHEN ${dailyBreakdown.tokens} > 0 THEN ${dailyBreakdown.date} END)::int`,
-          totalActiveTimeMs: sql<number>`COALESCE(SUM(${dailyBreakdown.activeTimeMs}), 0)::bigint`,
           rowCount: sql<number>`COUNT(*)::int`,
         })
         .from(dailyBreakdown)
         .where(eq(dailyBreakdown.submissionId, submissionId));
+
+      // Session-shape totals come from the PER-DEVICE high-water marks, not
+      // from SUM(daily_breakdown.active_time_ms).
+      //
+      // Two reasons. (1) Additivity: sessionCount is a count of independent
+      // local sessions, so two devices reporting 100 and 40 total 140 -- taking
+      // a max across devices would report 100 and silently drop the second
+      // machine. (2) Timezone stability: the daily rows apportion each interval
+      // across LOCAL calendar days, so rescanning the same history under a
+      // different TZ re-splits it; combined with the monotonic per-day merge
+      // that permanently inflates SUM(daily). The CLI's timeMetrics totals are
+      // plain sums of interval durations and carry no date bucketing, so they
+      // survive a TZ change unchanged.
+      const [deviceTotals] = await tx
+        .select({
+          totalActiveTimeMs: sql<number>`COALESCE(SUM(${submittedDevices.totalActiveTimeMs}), 0)::bigint`,
+          sessionCount: sql<number>`COALESCE(SUM(${submittedDevices.sessionCount}), 0)::int`,
+          longestContinuousMs: sql<number>`COALESCE(MAX(${submittedDevices.longestContinuousMs}), 0)::bigint`,
+          maxConcurrentSessions: sql<number>`COALESCE(MAX(${submittedDevices.maxConcurrentSessions}), 0)::int`,
+        })
+        .from(submittedDevices)
+        .where(eq(submittedDevices.userId, tokenRecord.userId));
 
       const allDays = await tx
         .select({
@@ -781,22 +833,36 @@ export async function POST(request: Request) {
           ...(isBackfill ? { hasBackfill: true } : {}),
           submitCount: sql`COALESCE(submit_count, 0) + 1`,
           schemaVersion: sql`GREATEST(COALESCE(${submissions.schemaVersion}, 0), ${submitDevice.schemaVersion})`,
-          totalActiveTimeMs: aggregates.totalActiveTimeMs,
-          // Session-shape metrics cannot be safely recomputed from daily active-time buckets.
-          ...(data.timeMetrics ? {
-            longestContinuousMs: Math.max(
-              storedSessionMetrics?.longestContinuousMs ?? 0,
-              data.timeMetrics.longestContinuousMs,
-            ),
-            maxConcurrentSessions: Math.max(
-              storedSessionMetrics?.maxConcurrentSessions ?? 0,
-              data.timeMetrics.maxConcurrentSessions,
-            ),
-            sessionCount: Math.max(
-              storedSessionMetrics?.sessionCount ?? 0,
-              data.timeMetrics.sessionCount,
-            ),
-          } : {}),
+          // Derived from the per-device high-water marks (see deviceTotals
+          // above), floored by whatever is already stored.
+          //
+          // The floor exists for the migration transition: every device row
+          // starts with NULL metrics, so until a device submits again its
+          // contribution to the SUM is 0. Without the floor a user's first
+          // post-migration submit from one of two machines would drop the
+          // account total -- exactly the regression d9df8c9c fixed. It also
+          // preserves monotonicity generally.
+          //
+          // Consequence worth knowing: a total that was already inflated by a
+          // pre-migration TZ re-split stays frozen at the inflated value; the
+          // floor can only hold it, never correct it down. New inflation is
+          // prevented, historical inflation is not repaired.
+          totalActiveTimeMs: Math.max(
+            deviceTotals?.totalActiveTimeMs ?? 0,
+            storedSessionMetrics?.totalActiveTimeMs ?? 0,
+          ),
+          longestContinuousMs: Math.max(
+            deviceTotals?.longestContinuousMs ?? 0,
+            storedSessionMetrics?.longestContinuousMs ?? 0,
+          ),
+          maxConcurrentSessions: Math.max(
+            deviceTotals?.maxConcurrentSessions ?? 0,
+            storedSessionMetrics?.maxConcurrentSessions ?? 0,
+          ),
+          sessionCount: Math.max(
+            deviceTotals?.sessionCount ?? 0,
+            storedSessionMetrics?.sessionCount ?? 0,
+          ),
           mcpServers: mcpServers && mcpServers.length > 0 ? mcpServers : null,
           updatedAt: new Date(),
         })

--- a/packages/frontend/src/lib/db/migrations/0019_add_device_session_metrics.sql
+++ b/packages/frontend/src/lib/db/migrations/0019_add_device_session_metrics.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "submitted_devices" ADD COLUMN "total_active_time_ms" bigint;--> statement-breakpoint
+ALTER TABLE "submitted_devices" ADD COLUMN "longest_continuous_ms" bigint;--> statement-breakpoint
+ALTER TABLE "submitted_devices" ADD COLUMN "max_concurrent_sessions" integer;--> statement-breakpoint
+ALTER TABLE "submitted_devices" ADD COLUMN "session_count" integer;

--- a/packages/frontend/src/lib/db/migrations/meta/0019_snapshot.json
+++ b/packages/frontend/src/lib/db/migrations/meta/0019_snapshot.json
@@ -1,0 +1,1555 @@
+{
+  "id": "b0a6f8ac-2031-4385-965e-3979cf3d093c",
+  "prevId": "ffee8557-f4bf-4ada-b5c1-a7085c515ae7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_api_tokens_token": {
+          "name": "idx_api_tokens_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_tokens_user_id": {
+          "name": "idx_api_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_unique": {
+          "name": "api_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        },
+        "api_tokens_user_name_unique": {
+          "name": "api_tokens_user_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_breakdown": {
+      "name": "daily_breakdown",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(14, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_breakdown": {
+          "name": "source_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_time_ms": {
+          "name": "active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_daily_breakdown_submission_id": {
+          "name": "idx_daily_breakdown_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_submitted_device_id": {
+          "name": "idx_daily_breakdown_submitted_device_id",
+          "columns": [
+            {
+              "expression": "submitted_device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_date": {
+          "name": "idx_daily_breakdown_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_breakdown_submission_id_submissions_id_fk": {
+          "name": "daily_breakdown_submission_id_submissions_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_breakdown_submitted_device_id_submitted_devices_id_fk": {
+          "name": "daily_breakdown_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_breakdown_submission_device_date_unique": {
+          "name": "daily_breakdown_submission_device_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "submission_id",
+            "submitted_device_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_codes_device_code": {
+          "name": "idx_device_codes_device_code",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_code": {
+          "name": "idx_device_codes_user_code",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_id": {
+          "name": "idx_device_codes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_expires_at": {
+          "name": "idx_device_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_codes_user_id_users_id_fk": {
+          "name": "device_codes_user_id_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_invites": {
+      "name": "group_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_username": {
+          "name": "invited_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_username_normalized": {
+          "name": "invited_username_normalized",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_user_id": {
+          "name": "invited_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_group_invites_group_status": {
+          "name": "idx_group_invites_group_status",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_user_status": {
+          "name": "idx_group_invites_invited_user_status",
+          "columns": [
+            {
+              "expression": "invited_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_username_status": {
+          "name": "idx_group_invites_invited_username_status",
+          "columns": [
+            {
+              "expression": "invited_username_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_expires_at": {
+          "name": "idx_group_invites_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_by": {
+          "name": "idx_group_invites_invited_by",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_invites_group_id_groups_id_fk": {
+          "name": "group_invites_group_id_groups_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_invites_invited_user_id_users_id_fk": {
+          "name": "group_invites_invited_user_id_users_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_invites_invited_by_users_id_fk": {
+          "name": "group_invites_invited_by_users_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_invites_token_hash_unique": {
+          "name": "group_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_members": {
+      "name": "group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_group_members_user_id": {
+          "name": "idx_group_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_members_invited_by": {
+          "name": "idx_group_members_invited_by",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_members_group_id_groups_id_fk": {
+          "name": "group_members_group_id_groups_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_members_user_id_users_id_fk": {
+          "name": "group_members_user_id_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_members_invited_by_users_id_fk": {
+          "name": "group_members_invited_by_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_members_group_user_unique": {
+          "name": "group_members_group_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_created_by": {
+          "name": "idx_groups_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_groups_visibility_updated": {
+          "name": "idx_groups_visibility_updated",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_created_by_users_id_fk": {
+          "name": "groups_created_by_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_slug_unique": {
+          "name": "groups_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_token_hash": {
+          "name": "idx_sessions_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sources_used": {
+          "name": "sources_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "models_used": {
+          "name": "models_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_version": {
+          "name": "cli_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_hash": {
+          "name": "submission_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submit_count": {
+          "name": "submit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_backfill": {
+          "name": "has_backfill",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_active_time_ms": {
+          "name": "total_active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longest_continuous_ms": {
+          "name": "longest_continuous_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_sessions": {
+          "name": "max_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_servers": {
+          "name": "mcp_servers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_submissions_created_at": {
+          "name": "idx_submissions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_leaderboard": {
+          "name": "idx_submissions_leaderboard",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_tokens",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_cost",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submissions_user_id_unique": {
+          "name": "submissions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submitted_devices": {
+      "name": "submitted_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_key": {
+          "name": "device_key",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_active_time_ms": {
+          "name": "total_active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longest_continuous_ms": {
+          "name": "longest_continuous_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_sessions": {
+          "name": "max_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_submitted_devices_user_id": {
+          "name": "idx_submitted_devices_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submitted_devices_user_id_users_id_fk": {
+          "name": "submitted_devices_user_id_users_id_fk",
+          "tableFrom": "submitted_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submitted_devices_user_device_key_unique": {
+          "name": "submitted_devices_user_device_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_lower_unique": {
+          "name": "users_username_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_github_id": {
+          "name": "idx_users_github_id",
+          "columns": [
+            {
+              "expression": "github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1784611194680,
       "tag": "0018_add_has_backfill",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1784927483081,
+      "tag": "0019_add_device_session_metrics",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -251,6 +251,26 @@ export const submittedDevices = pgTable(
       .notNull()
       .defaultNow(),
     lastSubmittedAt: timestamp("last_submitted_at", { withTimezone: true }),
+
+    /**
+     * Per-device session-shape metrics, kept as monotonic high-water marks.
+     *
+     * These mirror the identically-named columns on `submissions`, but at the
+     * scope the CLI actually measures: one machine's local session files. The
+     * submission-level values are DERIVED from these (SUM for additive metrics,
+     * MAX for shape metrics) so a second device no longer overwrites the first.
+     *
+     * `totalActiveTimeMs` here comes from the CLI's `timeMetrics`, which sums
+     * raw interval durations and is therefore TIMEZONE-INVARIANT. The daily
+     * `active_time_ms` rows are not: they apportion each interval across LOCAL
+     * calendar days, so re-scanning under a different TZ re-splits them and
+     * their monotonic merge inflates the sum. Deriving the submission total
+     * from these columns instead of SUM(daily) avoids that.
+     */
+    totalActiveTimeMs: bigint("total_active_time_ms", { mode: "number" }),
+    longestContinuousMs: bigint("longest_continuous_ms", { mode: "number" }),
+    maxConcurrentSessions: integer("max_concurrent_sessions"),
+    sessionCount: integer("session_count"),
   },
   (table) => [
     index("idx_submitted_devices_user_id").on(table.userId),

--- a/packages/frontend/src/lib/publicProfileData.ts
+++ b/packages/frontend/src/lib/publicProfileData.ts
@@ -152,6 +152,16 @@ export async function getPublicProfileResponse(
             submissionCount: sql<number>`COALESCE(MAX(${submissions.submitCount}), 0)`,
             earliestDate: sql<string>`MIN(${submissions.dateStart})`,
             latestDate: sql<string>`MAX(${submissions.dateEnd})`,
+            // `submissions` is unique per user, so this SUM reads a single row.
+            // That row's sessionCount is itself derived in the submit route by
+            // summing PER-DEVICE counts, which is what makes the "all-time"
+            // label defensible for multi-device users -- before that it was one
+            // device's snapshot overwriting another's.
+            //
+            // Still an approximate historical maximum, not an exact count: each
+            // device's stored value is a high-water mark, so a submit filtered
+            // by --clients/--date can never lower it, and a re-sessionization
+            // that legitimately merges two intervals cannot correct it down.
             sessionCount: sql<number>`COALESCE(SUM(${submissions.sessionCount}), 0)`,
           })
           .from(submissions)

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -213,7 +213,19 @@ const SubmissionDataSchema = z.preprocess(normalizeLegacySources, z.object({
   device: SubmitDeviceSchema.optional(),
   summary: DataSummarySchema,
   years: z.array(YearSummarySchema),
-  contributions: z.array(DailyContributionSchema),
+  // Each date must appear at most once. The submit route builds its insert
+  // batch from a date-keyed map of EXISTING rows that is not updated as the
+  // loop runs, so a repeated date produces two rows with the same
+  // (submission_id, submitted_device_id, date). Postgres then either aborts
+  // the statement ("ON CONFLICT DO UPDATE command cannot affect row a second
+  // time") or, if the duplicates land in different INSERT chunks, lets the
+  // second silently overwrite the first through the ON CONFLICT arm --
+  // bypassing the monotonic active-time guard. Rejecting up front turns both
+  // into a clear 400.
+  contributions: z.array(DailyContributionSchema).refine(
+    (days) => new Set(days.map((day) => day.date)).size === days.length,
+    { message: "Duplicate dates in contributions: each date may appear at most once" }
+  ),
   timeMetrics: TimeMetricsSchema.optional(),
   provenance: SubmissionProvenanceSchema.optional(),
 }));


### PR DESCRIPTION
Follow-ups to d9df8c9c, from a review of that commit plus an adversarial second pass.

d9df8c9c was right to stop a truncated local rescan from erasing history. These are the three things it left open.

## 1. Session metrics were scoped wrong

The values live on `submissions` (per user) but the CLI measures per machine, so `Math.max` against one device's snapshot reported the **largest device, not the account**: two machines reporting 100 and 40 sessions showed 100, not 140.

`sessionCount` is the only ratcheted metric users can see — "Sessions (all-time)" on public profiles — so the number contradicted its label. The other four (`totalActiveTimeMs`, daily `active_time_ms`, `longestContinuousMs`, `maxConcurrentSessions`) are write-only today.

Now stored per device (migration `0019`, four nullable columns), still monotonic per device so a `--clients`/`--date` filtered submit can't lower them, with the submission row derived: **SUM** for counts (additive across independent machines), **MAX** for concurrency and streak length (not additive).

A stored-value floor is kept because device rows start `NULL` — without it, the first post-migration submit from one of two machines would drop the account total, which is the regression d9df8c9c fixed.

## 2. Timezone re-split inflation

Daily `active_time_ms` apportions each interval across **local** calendar days (`compute_daily_active_time` → `chrono::Local`). Rescanning under a different TZ re-splits it, and the monotonic per-day merge then cements both splits — a 4h session straddling midnight settles at **7h**, permanently.

The CLI already sends a timezone-invariant total (`sessionize.rs:191`, a plain sum of interval durations with no date bucketing); the route discarded it in favour of `SUM(daily)`. Reading the per-device totals sidesteps the re-split entirely.

Not just a traveller's edge case: devcontainers bind-mounting `$HOME` keep the same device UUID, and cron/launchd never see a `TZ` exported in a shell rc.

> **Note:** this stops *new* inflation. Totals already inflated pre-migration stay frozen — the floor holds them and cannot correct them down. Token/cost totals inflate the same way via the older breakdown ratchet and are **not** addressed here; that needs the CLI to send its timezone.

## 3. ON CONFLICT bypassed the guard

The arm overwrote `active_time_ms` with `EXCLUDED`, a hole in the monotonic merge. Now `GREATEST(...)`, which matches `mergeActiveTimeMs` null-for-null in Postgres.

It's unreachable via concurrency (the per-user `submissions` row lock serializes submits, including the first-submit 23505 retry), but duplicate dates in a payload *did* reach it — `contributions` had no uniqueness constraint, and the merge loop never updates its date map. Past `INSERT_CHUNK_SIZE` the second row silently overwrote the first. Now rejected at validation with a clear 400.

## Testing

The premise of this PR is that the old tests didn't constrain the code, so correctness is argued by mutation testing rather than by test count. All five mutations that survived d9df8c9c's suite now fail, plus three for the new behavior:

| Mutation | Before | After |
|---|---|---|
| `mergeActiveTimeMs` → `return existing` | survived | caught |
| session metrics → `?? incoming` | survived | caught |
| transpose `timestamp_ms`/`active_time_ms` in VALUES | survived | caught |
| delete shrink-warning block | survived | caught |
| delete `storedSessionMetrics = racedSubmission` | survived | caught |
| device `SUM` → `MAX` | — | caught |
| ON CONFLICT `GREATEST` → `EXCLUDED` | — | caught |
| drop duplicate-date refine | — | caught |

The transposition one mattered: the previous `arrayContaining([7_000])` assertion is order-blind, and both columns are `::bigint`, so writing an epoch millisecond into `active_time_ms` passed. Pinned by relative parameter order now.

658 tests pass, `tsc` clean, eslint 0 errors.

**Not verified locally:** `check-migrations.ts` (needs `DATABASE_URL`; CI runs it), and a real two-device account against Postgres — the per-device `GREATEST` runs in SQL and is asserted structurally, not executed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives session metrics per device and aggregates them for the user to fix wrong all‑time totals and remove timezone‑driven active‑time inflation. Adds overflow clamps to prevent SUM casts from aborting submits, hardens the active‑time guard, and rejects duplicate contribution dates.

- **Bug Fixes**
  - Record per‑device high‑water marks in `submitted_devices`; derive `submissions` from them: SUM `totalActiveTimeMs`/`sessionCount`, MAX `longestContinuousMs`/`maxConcurrentSessions`, floored by stored values to stay monotonic.
  - Clamp per‑device aggregates to column types to avoid overflow aborts: `LEAST(SUM(...), 9223372036854775807)::bigint` and `LEAST(SUM(...), 2147483647)::int` (MAX needs no clamp).
  - Use per‑device `timeMetrics` totals (timezone‑invariant) instead of `SUM(daily_breakdown.active_time_ms)` to stop TZ re‑split inflation.
  - In `daily_breakdown` upserts, set `active_time_ms = GREATEST(existing, excluded)` to close the guard bypass.
  - Validate `contributions` to reject duplicate dates with a clear 400.
  - Public profile `sessionCount` now reflects multi‑device totals.
  - Tests cover device aggregation (SUM/MAX), clamp bounds, guard behavior, and duplicate‑date validation.

- **Migration**
  - Add nullable columns to `submitted_devices`: `total_active_time_ms`, `longest_continuous_ms`, `max_concurrent_sessions`, `session_count`.

<sup>Written for commit 62974001a89cc960c0e6d6765e7e78b7bbfa6ff1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

