### PR TITLE
feat(tui): show model names with family-shade colors in Sessions tab

### DIFF
--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -170,7 +170,7 @@ pub struct SessionUsage {
 
 /// A model entry within a session, retaining the provider and color_key
 /// needed for correct family-shade color lookup alongside the display name.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SessionModel {
     pub display_name: String,
     pub provider: String,
@@ -2815,6 +2815,76 @@ after"#,
             },
             cost,
         )
+    }
+
+    /// The Sessions tab's Model column reads `SessionUsage.models`. Each entry
+    /// keeps the provider and color key its family-shade lookup needs, and the
+    /// list is deduped by display name so a model reached under two spellings
+    /// (here a dated id and its normalized form) lands once, in first-seen order.
+    #[test]
+    fn test_session_models_dedup_by_display_name_and_retain_provider() {
+        let loader = DataLoader::new(None);
+        let base_ms = 1_735_689_600_000_i64;
+        let tokens = || tokscale_core::TokenBreakdown {
+            input: 10,
+            output: 5,
+            cache_read: 0,
+            cache_write: 0,
+            reasoning: 0,
+        };
+        let usage = loader
+            .aggregate_messages(
+                vec![
+                    UnifiedMessage::new(
+                        "claude",
+                        "claude-sonnet-4-5-20250929",
+                        "anthropic",
+                        "session-1",
+                        base_ms,
+                        tokens(),
+                        1.0,
+                    ),
+                    UnifiedMessage::new(
+                        "claude",
+                        "gpt-5",
+                        "openai",
+                        "session-1",
+                        base_ms + 1_000,
+                        tokens(),
+                        1.0,
+                    ),
+                    // Same model as the first message, spelled without the date
+                    // and served through a gateway: must not add a second entry.
+                    UnifiedMessage::new(
+                        "claude",
+                        "claude-sonnet-4-5",
+                        "github-copilot",
+                        "session-1",
+                        base_ms + 2_000,
+                        tokens(),
+                        1.0,
+                    ),
+                ],
+                &GroupBy::Model,
+            )
+            .unwrap();
+
+        assert_eq!(usage.sessions.len(), 1, "expected a single session bucket");
+        assert_eq!(
+            usage.sessions[0].models,
+            vec![
+                SessionModel {
+                    display_name: "claude-sonnet-4-5".to_string(),
+                    provider: "anthropic".to_string(),
+                    color_key: "claude-sonnet-4-5".to_string(),
+                },
+                SessionModel {
+                    display_name: "gpt-5".to_string(),
+                    provider: "openai".to_string(),
+                    color_key: "gpt-5".to_string(),
+                },
+            ]
+        );
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -153,10 +153,9 @@ pub struct SessionUsage {
     /// (e.g. OpenCode's `session.title` column). `None` for clients that
     /// don't record a title.
     pub title: Option<String>,
-    /// Distinct model display names used across messages in this session,
-    /// in first-seen order. Most sessions use a single model; a few switch
-    /// mid-conversation and show multiple entries.
-    pub models: Vec<String>,
+    /// Distinct models used across messages in this session, in first-seen
+    /// order. Most sessions use a single model; a few switch mid-conversation.
+    pub models: Vec<SessionModel>,
     pub tokens: TokenBreakdown,
     pub cost: f64,
     pub message_count: u32,
@@ -167,6 +166,15 @@ pub struct SessionUsage {
     /// Unix-ms timestamp of the most recent message observed in this session.
     /// `0` when every message lacked a usable timestamp.
     pub last_active_ms: i64,
+}
+
+/// A model entry within a session, retaining the provider and color_key
+/// needed for correct family-shade color lookup alongside the display name.
+#[derive(Debug, Clone)]
+pub struct SessionModel {
+    pub display_name: String,
+    pub provider: String,
+    pub color_key: String,
 }
 
 #[derive(Debug, Clone)]
@@ -975,9 +983,18 @@ impl DataLoader {
                     }
                 }
 
-                // Track distinct model display names in first-seen order.
-                if !session_entry.models.contains(&normalized_model) {
-                    session_entry.models.push(normalized_model.clone());
+                // Track distinct models in first-seen order, retaining
+                // provider and color_key for correct shade-map lookups.
+                if !session_entry
+                    .models
+                    .iter()
+                    .any(|m| m.color_key == model_key)
+                {
+                    session_entry.models.push(SessionModel {
+                        display_name: normalized_model.clone(),
+                        provider: msg.provider_id.clone(),
+                        color_key: model_key.clone(),
+                    });
                 }
             }
         }

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -988,7 +988,7 @@ impl DataLoader {
                 if !session_entry
                     .models
                     .iter()
-                    .any(|m| m.color_key == model_key)
+                    .any(|m| m.display_name == normalized_model)
                 {
                     session_entry.models.push(SessionModel {
                         display_name: normalized_model.clone(),

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -2821,6 +2821,15 @@ after"#,
     /// keeps the provider and color key its family-shade lookup needs, and the
     /// list is deduped by display name so a model reached under two spellings
     /// (here a dated id and its normalized form) lands once, in first-seen order.
+    ///
+    /// The dedup below relies on `model_name_for_grouping` ignoring `provider_id`
+    /// for this input: it consults the provider only when `client == "opencode"`
+    /// (to apply an OpenCode-configured label), and every other client falls
+    /// through to `normalize_model_for_grouping`, which is a pure function of the
+    /// model id. That is why the third message can carry a different provider
+    /// (`github-copilot` vs `anthropic`) and still collapse onto the same display
+    /// name. If that scoping ever widens beyond OpenCode, this assertion is the
+    /// one that should start failing.
     #[test]
     fn test_session_models_dedup_by_display_name_and_retain_provider() {
         let loader = DataLoader::new(None);

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -153,6 +153,10 @@ pub struct SessionUsage {
     /// (e.g. OpenCode's `session.title` column). `None` for clients that
     /// don't record a title.
     pub title: Option<String>,
+    /// Distinct model display names used across messages in this session,
+    /// in first-seen order. Most sessions use a single model; a few switch
+    /// mid-conversation and show multiple entries.
+    pub models: Vec<String>,
     pub tokens: TokenBreakdown,
     pub cost: f64,
     pub message_count: u32,
@@ -912,6 +916,7 @@ impl DataLoader {
                             session_id: msg.session_id.clone(),
                             client: msg.client.clone(),
                             title: None,
+                            models: Vec::new(),
                             tokens: TokenBreakdown::default(),
                             cost: 0.0,
                             message_count: 0,
@@ -968,6 +973,11 @@ impl DataLoader {
                             session_entry.title = Some(trimmed.to_string());
                         }
                     }
+                }
+
+                // Track distinct model display names in first-seen order.
+                if !session_entry.models.contains(&normalized_model) {
+                    session_entry.models.push(normalized_model.clone());
                 }
             }
         }

--- a/crates/tokscale-cli/src/tui/ui/sessions.rs
+++ b/crates/tokscale-cli/src/tui/ui/sessions.rs
@@ -11,10 +11,34 @@ use super::widgets::{
 use crate::tui::app::{App, SortDirection, SortField};
 use crate::tui::data::SessionModel;
 
-/// Terminal width at which the Sessions table starts showing the Model column.
-/// The wide layout kicks in at 80 columns but its constraints already exceed the
-/// space available there, so Model waits for a terminal that can absorb it.
-const MODEL_COLUMN_MIN_WIDTH: u16 = 120;
+/// Narrowest Model column worth showing. Below this the names are cut so short
+/// that the column carries no information, so it stays hidden instead.
+const MODEL_COLUMN_MIN_CHARS: u16 = 18;
+
+/// Widest the Model column ever grows; surplus past this goes to Session.
+const MODEL_COLUMN_MAX_CHARS: u16 = 36;
+
+/// Cells the wide Sessions layout needs *before* a Model column: Session (20),
+/// Client (12), the optional Turn (5), Msgs (5 or 6), the ten trailing metric
+/// columns, and one separator cell between every pair.
+///
+/// The wide layout kicks in at 80 columns but is heavily over-subscribed there:
+/// ratatui shrinks every column to fit, which truncates the header labels and
+/// clips the sort indicator off whichever column carries it. Model is gated on
+/// this budget rather than a magic terminal width so it only appears once the
+/// rest of the table renders at its natural size.
+fn wide_layout_fixed_width(has_turn: bool) -> u16 {
+    // Input, Output, Cache R, Cache W, Cache×, Total, Cost, Cost/1M, Duration,
+    // Last Active.
+    const TRAILING: u16 = 10 + 10 + 10 + 10 + 8 + 10 + 10 + 10 + 9 + 17;
+    if has_turn {
+        // 14 columns, so 13 separators.
+        20 + 12 + 5 + 5 + TRAILING + 13
+    } else {
+        // 13 columns, so 12 separators.
+        20 + 12 + 6 + TRAILING + 12
+    }
+}
 
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default()
@@ -67,12 +91,17 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         "%Y-%m-%d %H:%M"
     };
 
-    // The wide layout is already over-subscribed at its own 80-column threshold, so
-    // Model gets a threshold of its own rather than riding along with `!is_narrow`.
-    let show_model = !is_narrow && !is_very_narrow && app.terminal_width >= MODEL_COLUMN_MIN_WIDTH;
+    // What the wide layout can spare for Model once every other column has its
+    // natural width, including the separator Model itself would add. Measured
+    // against `inner` rather than the terminal so the budget matches the width
+    // ratatui actually divides up, which keeps `build_model_cell`'s ellipsis
+    // budget equal to the rendered cell instead of being re-cut by the solver.
+    let model_budget = inner
+        .width
+        .saturating_sub(wide_layout_fixed_width(has_turn_data) + 1);
 
-    // Model column grows on wide terminals: base 18, +1 per 8 chars past 80, capped at 36.
-    let model_col_width = (18 + (app.terminal_width as usize).saturating_sub(80) / 8).min(36);
+    let show_model = !is_narrow && !is_very_narrow && model_budget >= MODEL_COLUMN_MIN_CHARS;
+    let model_col_width = model_budget.min(MODEL_COLUMN_MAX_CHARS);
 
     let header_cells = if is_very_narrow {
         vec!["Session", "Cost"]
@@ -249,7 +278,11 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                         .style(Style::default().fg(theme_muted)),
                 );
                 if show_model {
-                    cells.push(build_model_cell(&session.models, model_col_width, app));
+                    cells.push(build_model_cell(
+                        &session.models,
+                        model_col_width as usize,
+                        app,
+                    ));
                 }
                 if has_turn_data {
                     let turn_str = if session.turn_count > 0 {
@@ -320,7 +353,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     } else {
         let mut widths = vec![Constraint::Min(20), Constraint::Length(12)];
         if show_model {
-            widths.push(Constraint::Length(model_col_width as u16));
+            widths.push(Constraint::Length(model_col_width));
         }
         if has_turn_data {
             widths.push(Constraint::Length(5));
@@ -642,38 +675,98 @@ mod tests {
         );
     }
 
+    /// Narrowest terminal that still shows the Model column, derived the way
+    /// `render` derives it: the fixed wide-layout budget, Model's own separator
+    /// and minimum width, plus the two block borders `inner` strips off.
+    fn model_gate_width(has_turn: bool) -> u16 {
+        wide_layout_fixed_width(has_turn) + 1 + MODEL_COLUMN_MIN_CHARS + 2
+    }
+
     #[test]
     fn model_column_hidden_below_its_width_threshold() {
-        // 119 is still the wide layout (>= 80) but one short of the Model gate.
-        let mut app = make_app(119);
-        app.data.sessions = vec![session("abc-123", "opencode", 1.5, 1_736_000_000_000)];
-        let body = render_body(&mut app, 119, 12);
-        assert!(
-            !body.contains("Model"),
-            "Model header should be gated off at 119 columns\n{body}"
-        );
-        assert!(
-            !body.contains("test-model"),
-            "Model cell should be gated off at 119 columns\n{body}"
-        );
-        // The rest of the wide layout is still intact.
-        assert!(body.contains("Client"), "expected Client header\n{body}");
-        assert!(body.contains("Cache×"), "expected Cache× header\n{body}");
+        for has_turn in [true, false] {
+            let width = model_gate_width(has_turn) - 1;
+            let mut app = make_app(width);
+            let mut s = session("abc-123", "opencode", 1.5, 1_736_000_000_000);
+            if !has_turn {
+                s.turn_count = 0;
+            }
+            app.data.sessions = vec![s];
+            let body = render_body(&mut app, width, 12);
+            assert!(
+                !body.contains("Model"),
+                "Model header should be gated off at {width} columns (turn={has_turn})\n{body}"
+            );
+            assert!(
+                !body.contains("test-model"),
+                "Model cell should be gated off at {width} columns (turn={has_turn})\n{body}"
+            );
+            // The rest of the wide layout is still intact.
+            assert!(body.contains("Client"), "expected Client header\n{body}");
+            assert!(body.contains("Cache×"), "expected Cache× header\n{body}");
+        }
     }
 
     #[test]
     fn model_column_appears_at_its_width_threshold() {
-        let mut app = make_app(120);
-        app.data.sessions = vec![session("abc-123", "opencode", 1.5, 1_736_000_000_000)];
-        let body = render_body(&mut app, 120, 12);
-        assert!(
-            body.contains("Model"),
-            "expected Model header at 120 columns\n{body}"
-        );
-        assert!(
-            body.contains("test-model"),
-            "expected model name at 120 columns\n{body}"
-        );
+        for has_turn in [true, false] {
+            let width = model_gate_width(has_turn);
+            let mut app = make_app(width);
+            let mut s = session("abc-123", "opencode", 1.5, 1_736_000_000_000);
+            if !has_turn {
+                s.turn_count = 0;
+            }
+            app.data.sessions = vec![s];
+            let body = render_body(&mut app, width, 12);
+            assert!(
+                body.contains("Model"),
+                "expected Model header at {width} columns (turn={has_turn})\n{body}"
+            );
+            assert!(
+                body.contains("test-model"),
+                "expected model name at {width} columns (turn={has_turn})\n{body}"
+            );
+        }
+    }
+
+    /// The gate exists so the Model column never squeezes the rest of the table.
+    /// At the exact width where Model first appears every other header must still
+    /// render in full, indicator included — the previous fixed 120-column gate
+    /// clipped the Cost indicator the moment Model showed up.
+    #[test]
+    fn model_column_gate_keeps_the_rest_of_the_header_legible() {
+        for has_turn in [true, false] {
+            let width = model_gate_width(has_turn);
+            for (expected, field) in [
+                ("Cost ▼", SortField::Cost),
+                ("Total ▼", SortField::Tokens),
+                ("Last Active ▼", SortField::Date),
+            ] {
+                let mut app = make_app(width);
+                let mut s = session("abc-123", "opencode", 1.5, 1_736_000_000_000);
+                if !has_turn {
+                    s.turn_count = 0;
+                }
+                app.data.sessions = vec![s];
+                app.sort_field = field;
+                let header = header_line(&mut app, width);
+                assert!(
+                    header.contains("Model"),
+                    "Model should be shown at its gate width {width} (turn={has_turn})\n{header}"
+                );
+                for label in ["Cache R", "Cache W", "Cost/1M", "Duration", "Last Active"] {
+                    assert!(
+                        header.contains(label),
+                        "header {label} was squeezed at width {width} (turn={has_turn})\n{header}"
+                    );
+                }
+                assert!(
+                    header.contains(expected),
+                    "sort indicator {expected} was clipped at the Model gate width {width} \
+                     (turn={has_turn})\n{header}"
+                );
+            }
+        }
     }
 
     /// The Cost/Tokens/Date sort indicators are placed by hand-computed column
@@ -684,8 +777,11 @@ mod tests {
         for (width, expect_model, has_turn) in [
             (200u16, true, true),
             (200, true, false),
-            (119, false, true),
-            (119, false, false),
+            // Straddle the gate itself, where the indicator is most at risk.
+            (model_gate_width(true), true, true),
+            (model_gate_width(false), true, false),
+            (model_gate_width(true) - 1, false, true),
+            (model_gate_width(false) - 1, false, false),
         ] {
             let mut app = make_app(width);
             let mut s = session("abc-123", "opencode", 1.5, 1_736_000_000_000);

--- a/crates/tokscale-cli/src/tui/ui/sessions.rs
+++ b/crates/tokscale-cli/src/tui/ui/sessions.rs
@@ -405,13 +405,19 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
 /// models are joined with `", "`. The total width is truncated to `max_chars`
 /// with an ellipsis when it overflows, counted in `chars()` to match
 /// `truncate_text`, which measures the Session and Client cells in this table.
+///
+/// A multi-model session always ends in an ellipsis when some of its models did
+/// not fit, so a session that switched models never renders as a single-model
+/// one. One cell is held back for that marker when there is more than one model.
 fn build_model_cell(models: &[SessionModel], max_chars: usize, app: &App) -> Cell<'static> {
     if models.is_empty() {
         return Cell::from("\u{2014}".to_string()).style(Style::default().fg(app.theme.muted));
     }
 
     let mut spans: Vec<Span<'static>> = Vec::new();
-    let mut budget = max_chars;
+    let mut budget = max_chars.saturating_sub(usize::from(models.len() > 1));
+    let mut shown = 0usize;
+    let mut ellipsis = false;
 
     for (i, model) in models.iter().enumerate() {
         if i > 0 {
@@ -436,6 +442,7 @@ fn build_model_cell(models: &[SessionModel], max_chars: usize, app: &App) -> Cel
         } else if budget <= 1 {
             spans.push(Span::styled("…".to_string(), Style::default().fg(color)));
             budget = 0;
+            ellipsis = true;
         } else {
             let head: String = name.chars().take(budget - 1).collect();
             spans.push(Span::styled(
@@ -443,7 +450,18 @@ fn build_model_cell(models: &[SessionModel], max_chars: usize, app: &App) -> Cel
                 Style::default().fg(color),
             ));
             budget = 0;
+            ellipsis = true;
         }
+        shown += 1;
+    }
+
+    // Dropping whole models silently would misreport the session; a truncated
+    // name already carries its own ellipsis, so only mark the clean-break case.
+    if shown < models.len() && !ellipsis {
+        spans.push(Span::styled(
+            "…".to_string(),
+            Style::default().fg(app.theme.muted),
+        ));
     }
 
     Cell::from(Line::from(spans))
@@ -834,6 +852,67 @@ mod tests {
                 "date sort indicator misplaced (turn={has_turn})\n{header}"
             );
         }
+    }
+
+    /// A session that switched models must never render as a single-model
+    /// session. When the next name cannot fit, a trailing "…" marks that models
+    /// were dropped instead of them vanishing silently.
+    #[test]
+    fn multi_model_cell_marks_models_that_did_not_fit() {
+        // Width chosen so the Model column is 22 cells: exactly the 21-char
+        // first name plus the reserved marker cell, with nothing left for the
+        // ", " separator the second name would need.
+        let width = wide_layout_fixed_width(false) + 1 + 22 + 2;
+        let mut app = make_app(width);
+        let mut s = session("abc-123", "opencode", 1.5, 1_736_000_000_000);
+        s.turn_count = 0;
+        s.models = vec![
+            SessionModel {
+                display_name: "gemini-2-5-flash-lite".to_string(),
+                provider: "google".to_string(),
+                color_key: "gemini-2-5-flash-lite".to_string(),
+            },
+            SessionModel {
+                display_name: "claude-sonnet-4-5".to_string(),
+                provider: "anthropic".to_string(),
+                color_key: "claude-sonnet-4-5".to_string(),
+            },
+        ];
+        app.data.sessions = vec![s];
+        let body = render_body(&mut app, width, 12);
+        assert!(
+            body.contains("gemini-2-5-flash-lite…"),
+            "expected a truncation marker after the model that did fit\n{body}"
+        );
+        assert!(
+            !body.contains("claude"),
+            "second model was not supposed to fit at width {width}\n{body}"
+        );
+    }
+
+    /// A single model that overflows carries its own ellipsis, so the
+    /// dropped-model marker must not double up on it.
+    #[test]
+    fn single_model_cell_truncates_without_a_second_ellipsis() {
+        let width = wide_layout_fixed_width(false) + 1 + 22 + 2;
+        let mut app = make_app(width);
+        let mut s = session("abc-123", "opencode", 1.5, 1_736_000_000_000);
+        s.turn_count = 0;
+        s.models = vec![SessionModel {
+            display_name: "a-very-long-model-name-that-overflows".to_string(),
+            provider: "anthropic".to_string(),
+            color_key: "a-very-long-model-name-that-overflows".to_string(),
+        }];
+        app.data.sessions = vec![s];
+        let body = render_body(&mut app, width, 12);
+        assert!(
+            body.contains("a-very-long-model-nam…"),
+            "expected a single trailing ellipsis on the truncated name\n{body}"
+        );
+        assert!(
+            !body.contains("……"),
+            "truncated name must not pick up a second ellipsis\n{body}"
+        );
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/ui/sessions.rs
+++ b/crates/tokscale-cli/src/tui/ui/sessions.rs
@@ -61,6 +61,9 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         "%Y-%m-%d %H:%M"
     };
 
+    // Model column grows on wide terminals: base 18, +1 per 8 chars past 80, capped at 36.
+    let model_col_width = (18 + (app.terminal_width as usize).saturating_sub(80) / 8).min(36);
+
     let header_cells = if is_very_narrow {
         vec!["Session", "Cost"]
     } else if is_narrow {
@@ -73,6 +76,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         vec![
             "Session",
             "Client",
+            "Model",
             "Turn",
             "Msgs",
             "Input",
@@ -90,6 +94,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         vec![
             "Session",
             "Client",
+            "Model",
             "Msgs",
             "Input",
             "Output",
@@ -127,9 +132,9 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                     // narrow drops last-active entirely; Date sort has no header indicator
                     usize::MAX
                 } else if has_turn_data {
-                    13
+                    14
                 } else {
-                    12
+                    13
                 };
                 let total_idx = if is_very_narrow {
                     usize::MAX
@@ -140,9 +145,9 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                         3
                     }
                 } else if has_turn_data {
-                    9
+                    10
                 } else {
-                    8
+                    9
                 };
                 let cost_idx = if is_very_narrow {
                     1
@@ -153,9 +158,9 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                         4
                     }
                 } else if has_turn_data {
-                    10
+                    11
                 } else {
-                    9
+                    10
                 };
                 let indicator = if i == last_active_idx {
                     sort_indicator(SortField::Date)
@@ -249,6 +254,8 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                     Cell::from(get_client_display_name(&session.client))
                         .style(Style::default().fg(theme_muted)),
                 );
+                let model_cell = build_model_cell(&session.models, model_col_width, app);
+                cells.push(model_cell);
                 if has_turn_data {
                     let turn_str = if session.turn_count > 0 {
                         session.turn_count.to_string()
@@ -319,6 +326,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         vec![
             Constraint::Min(20),
             Constraint::Length(12),
+            Constraint::Length(model_col_width as u16),
             Constraint::Length(5),
             Constraint::Length(5),
             Constraint::Length(10),
@@ -336,6 +344,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         vec![
             Constraint::Min(20),
             Constraint::Length(12),
+            Constraint::Length(model_col_width as u16),
             Constraint::Length(6),
             Constraint::Length(10),
             Constraint::Length(10),
@@ -373,6 +382,53 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             &mut scrollbar_state,
         );
     }
+}
+
+/// Build a table cell for the Model column with each model name colored by the
+/// same family-shade system used in the Overview and Models tabs. Multiple
+/// models are joined with `", "`. The total display width is truncated to
+/// `max_chars` with an ellipsis when it overflows.
+fn build_model_cell(models: &[String], max_chars: usize, app: &App) -> Cell<'static> {
+    if models.is_empty() {
+        return Cell::from("\u{2014}".to_string()).style(Style::default().fg(app.theme.muted));
+    }
+
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    let mut budget = max_chars;
+
+    for (i, model) in models.iter().enumerate() {
+        if i > 0 {
+            if budget < 3 {
+                break;
+            }
+            spans.push(Span::raw(", "));
+            budget -= 2;
+        }
+
+        if budget == 0 {
+            break;
+        }
+
+        let color = app.model_color(model);
+        let model_len = model.chars().count();
+
+        if model_len <= budget {
+            spans.push(Span::styled(model.clone(), Style::default().fg(color)));
+            budget -= model_len;
+        } else if budget <= 1 {
+            spans.push(Span::styled("…".to_string(), Style::default().fg(color)));
+            budget = 0;
+        } else {
+            let head: String = model.chars().take(budget - 1).collect();
+            spans.push(Span::styled(
+                format!("{}…", head),
+                Style::default().fg(color),
+            ));
+            budget = 0;
+        }
+    }
+
+    Cell::from(Line::from(spans))
 }
 
 /// Convert Unix-ms to a local NaiveDateTime for display.
@@ -424,6 +480,7 @@ mod tests {
             session_id: id.to_string(),
             client: client.to_string(),
             title: None,
+            models: vec!["test-model".to_string()],
             tokens: TokenBreakdown {
                 input: 1000,
                 output: 500,
@@ -498,6 +555,33 @@ mod tests {
     }
 
     #[test]
+    fn model_column_shows_model_names() {
+        let mut app = make_app(200);
+        let mut s = session("abc-123", "opencode", 1.5, 1_736_000_000_000);
+        s.models = vec!["claude-sonnet-4".to_string()];
+        app.data.sessions = vec![s];
+        let body = render_body(&mut app, 200, 12);
+        assert!(body.contains("Model"), "expected Model header\n{body}");
+        assert!(
+            body.contains("claude-sonnet-4"),
+            "expected model name in body\n{body}"
+        );
+    }
+
+    #[test]
+    fn model_column_shows_multiple_models() {
+        let mut app = make_app(220);
+        let mut s = session("abc-123", "opencode", 1.5, 1_736_000_000_000);
+        s.models = vec!["gpt-4o".to_string(), "o3-mini".to_string()];
+        app.data.sessions = vec![s];
+        let body = render_body(&mut app, 220, 12);
+        assert!(
+            body.contains("gpt-4o") && body.contains("o3-mini"),
+            "expected both model names in body\n{body}"
+        );
+    }
+
+    #[test]
     fn session_title_displayed_when_available() {
         let mut app = make_app(200);
         let mut s = session("ses_09d2eac0", "opencode", 1.5, 1_736_000_000_000);
@@ -512,11 +596,11 @@ mod tests {
 
     #[test]
     fn session_column_expands_on_wide_terminal() {
-        let mut app = make_app(220);
+        let mut app = make_app(260);
         let mut s = session("ses_09d2eac0", "opencode", 1.5, 1_736_000_000_000);
         s.title = Some("This is a long title for a session that could be used".to_string());
         app.data.sessions = vec![s];
-        let body = render_body(&mut app, 220, 12);
+        let body = render_body(&mut app, 260, 12);
         assert!(
             body.contains("This is a long title for a session that could be used"),
             "expected full title on wide terminal\n{body}"

--- a/crates/tokscale-cli/src/tui/ui/sessions.rs
+++ b/crates/tokscale-cli/src/tui/ui/sessions.rs
@@ -9,6 +9,7 @@ use super::widgets::{
     get_client_display_name, total_tokens_cell, truncate_text, viewport_scrollbar_state,
 };
 use crate::tui::app::{App, SortDirection, SortField};
+use crate::tui::data::SessionModel;
 
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default()
@@ -388,7 +389,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
 /// same family-shade system used in the Overview and Models tabs. Multiple
 /// models are joined with `", "`. The total display width is truncated to
 /// `max_chars` with an ellipsis when it overflows.
-fn build_model_cell(models: &[String], max_chars: usize, app: &App) -> Cell<'static> {
+fn build_model_cell(models: &[SessionModel], max_chars: usize, app: &App) -> Cell<'static> {
     if models.is_empty() {
         return Cell::from("\u{2014}".to_string()).style(Style::default().fg(app.theme.muted));
     }
@@ -409,17 +410,18 @@ fn build_model_cell(models: &[String], max_chars: usize, app: &App) -> Cell<'sta
             break;
         }
 
-        let color = app.model_color(model);
-        let model_len = model.chars().count();
+        let color = app.model_color_for(&model.provider, &model.color_key);
+        let name = &model.display_name;
+        let model_len = name.chars().count();
 
         if model_len <= budget {
-            spans.push(Span::styled(model.clone(), Style::default().fg(color)));
+            spans.push(Span::styled(name.clone(), Style::default().fg(color)));
             budget -= model_len;
         } else if budget <= 1 {
             spans.push(Span::styled("…".to_string(), Style::default().fg(color)));
             budget = 0;
         } else {
-            let head: String = model.chars().take(budget - 1).collect();
+            let head: String = name.chars().take(budget - 1).collect();
             spans.push(Span::styled(
                 format!("{}…", head),
                 Style::default().fg(color),
@@ -480,7 +482,11 @@ mod tests {
             session_id: id.to_string(),
             client: client.to_string(),
             title: None,
-            models: vec!["test-model".to_string()],
+            models: vec![SessionModel {
+                display_name: "test-model".to_string(),
+                provider: "test".to_string(),
+                color_key: "test-model".to_string(),
+            }],
             tokens: TokenBreakdown {
                 input: 1000,
                 output: 500,
@@ -558,7 +564,11 @@ mod tests {
     fn model_column_shows_model_names() {
         let mut app = make_app(200);
         let mut s = session("abc-123", "opencode", 1.5, 1_736_000_000_000);
-        s.models = vec!["claude-sonnet-4".to_string()];
+        s.models = vec![SessionModel {
+            display_name: "claude-sonnet-4".to_string(),
+            provider: "anthropic".to_string(),
+            color_key: "claude-sonnet-4".to_string(),
+        }];
         app.data.sessions = vec![s];
         let body = render_body(&mut app, 200, 12);
         assert!(body.contains("Model"), "expected Model header\n{body}");
@@ -572,7 +582,18 @@ mod tests {
     fn model_column_shows_multiple_models() {
         let mut app = make_app(220);
         let mut s = session("abc-123", "opencode", 1.5, 1_736_000_000_000);
-        s.models = vec!["gpt-4o".to_string(), "o3-mini".to_string()];
+        s.models = vec![
+            SessionModel {
+                display_name: "gpt-4o".to_string(),
+                provider: "openai".to_string(),
+                color_key: "gpt-4o".to_string(),
+            },
+            SessionModel {
+                display_name: "o3-mini".to_string(),
+                provider: "openai".to_string(),
+                color_key: "o3-mini".to_string(),
+            },
+        ];
         app.data.sessions = vec![s];
         let body = render_body(&mut app, 220, 12);
         assert!(

--- a/crates/tokscale-cli/src/tui/ui/sessions.rs
+++ b/crates/tokscale-cli/src/tui/ui/sessions.rs
@@ -11,6 +11,11 @@ use super::widgets::{
 use crate::tui::app::{App, SortDirection, SortField};
 use crate::tui::data::SessionModel;
 
+/// Terminal width at which the Sessions table starts showing the Model column.
+/// The wide layout kicks in at 80 columns but its constraints already exceed the
+/// space available there, so Model waits for a terminal that can absorb it.
+const MODEL_COLUMN_MIN_WIDTH: u16 = 120;
+
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
@@ -62,6 +67,10 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         "%Y-%m-%d %H:%M"
     };
 
+    // The wide layout is already over-subscribed at its own 80-column threshold, so
+    // Model gets a threshold of its own rather than riding along with `!is_narrow`.
+    let show_model = !is_narrow && !is_very_narrow && app.terminal_width >= MODEL_COLUMN_MIN_WIDTH;
+
     // Model column grows on wide terminals: base 18, +1 per 8 chars past 80, capped at 36.
     let model_col_width = (18 + (app.terminal_width as usize).saturating_sub(80) / 8).min(36);
 
@@ -73,29 +82,15 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         } else {
             vec!["Session", "Client", "Msgs", "Tokens", "Cost"]
         }
-    } else if has_turn_data {
-        vec![
-            "Session",
-            "Client",
-            "Model",
-            "Turn",
-            "Msgs",
-            "Input",
-            "Output",
-            "Cache R",
-            "Cache W",
-            "Cache×",
-            "Total",
-            "Cost",
-            "Cost/1M",
-            "Duration",
-            "Last Active",
-        ]
     } else {
-        vec![
-            "Session",
-            "Client",
-            "Model",
+        let mut cells = vec!["Session", "Client"];
+        if show_model {
+            cells.push("Model");
+        }
+        if has_turn_data {
+            cells.push("Turn");
+        }
+        cells.extend([
             "Msgs",
             "Input",
             "Output",
@@ -107,7 +102,8 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             "Cost/1M",
             "Duration",
             "Last Active",
-        ]
+        ]);
+        cells
     };
 
     let sort_indicator = |field: SortField| -> &'static str {
@@ -121,48 +117,45 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         }
     };
 
+    // Every wide-layout column after Client shifts right by one for each optional
+    // column that is present, so the sort indicators must track both gates.
+    let optional_cols = usize::from(show_model) + usize::from(has_turn_data);
+
+    // "Last Active" column index is the sort target for Date.
+    let last_active_idx = if is_very_narrow || is_narrow {
+        // neither narrow layout keeps a last-active column, so Date sort has no indicator
+        usize::MAX
+    } else {
+        12 + optional_cols
+    };
+    let total_idx = if is_very_narrow {
+        usize::MAX
+    } else if is_narrow {
+        if has_turn_data {
+            4
+        } else {
+            3
+        }
+    } else {
+        8 + optional_cols
+    };
+    let cost_idx = if is_very_narrow {
+        1
+    } else if is_narrow {
+        if has_turn_data {
+            5
+        } else {
+            4
+        }
+    } else {
+        9 + optional_cols
+    };
+
     let header = Row::new(
         header_cells
             .iter()
             .enumerate()
             .map(|(i, h)| {
-                // "Last Active" column index is the sort target for Date.
-                let last_active_idx = if is_very_narrow {
-                    usize::MAX // no last-active column in very narrow mode
-                } else if is_narrow {
-                    // narrow drops last-active entirely; Date sort has no header indicator
-                    usize::MAX
-                } else if has_turn_data {
-                    14
-                } else {
-                    13
-                };
-                let total_idx = if is_very_narrow {
-                    usize::MAX
-                } else if is_narrow {
-                    if has_turn_data {
-                        4
-                    } else {
-                        3
-                    }
-                } else if has_turn_data {
-                    10
-                } else {
-                    9
-                };
-                let cost_idx = if is_very_narrow {
-                    1
-                } else if is_narrow {
-                    if has_turn_data {
-                        5
-                    } else {
-                        4
-                    }
-                } else if has_turn_data {
-                    11
-                } else {
-                    10
-                };
                 let indicator = if i == last_active_idx {
                     sort_indicator(SortField::Date)
                 } else if i == total_idx {
@@ -255,8 +248,9 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                     Cell::from(get_client_display_name(&session.client))
                         .style(Style::default().fg(theme_muted)),
                 );
-                let model_cell = build_model_cell(&session.models, model_col_width, app);
-                cells.push(model_cell);
+                if show_model {
+                    cells.push(build_model_cell(&session.models, model_col_width, app));
+                }
                 if has_turn_data {
                     let turn_str = if session.turn_count > 0 {
                         session.turn_count.to_string()
@@ -323,30 +317,17 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             Constraint::Percentage(18),
             Constraint::Percentage(20),
         ]
-    } else if has_turn_data {
-        vec![
-            Constraint::Min(20),
-            Constraint::Length(12),
-            Constraint::Length(model_col_width as u16),
-            Constraint::Length(5),
-            Constraint::Length(5),
-            Constraint::Length(10),
-            Constraint::Length(10),
-            Constraint::Length(10),
-            Constraint::Length(10),
-            Constraint::Length(8),
-            Constraint::Length(10),
-            Constraint::Length(10),
-            Constraint::Length(10),
-            Constraint::Length(9),
-            Constraint::Length(17),
-        ]
     } else {
-        vec![
-            Constraint::Min(20),
-            Constraint::Length(12),
-            Constraint::Length(model_col_width as u16),
-            Constraint::Length(6),
+        let mut widths = vec![Constraint::Min(20), Constraint::Length(12)];
+        if show_model {
+            widths.push(Constraint::Length(model_col_width as u16));
+        }
+        if has_turn_data {
+            widths.push(Constraint::Length(5));
+        }
+        // Msgs borrows a column from Turn when both are shown.
+        widths.push(Constraint::Length(if has_turn_data { 5 } else { 6 }));
+        widths.extend([
             Constraint::Length(10),
             Constraint::Length(10),
             Constraint::Length(10),
@@ -357,7 +338,8 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             Constraint::Length(10),
             Constraint::Length(9),
             Constraint::Length(17),
-        ]
+        ]);
+        widths
     };
 
     let table = Table::new(rows, widths)
@@ -387,8 +369,9 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
 
 /// Build a table cell for the Model column with each model name colored by the
 /// same family-shade system used in the Overview and Models tabs. Multiple
-/// models are joined with `", "`. The total display width is truncated to
-/// `max_chars` with an ellipsis when it overflows.
+/// models are joined with `", "`. The total width is truncated to `max_chars`
+/// with an ellipsis when it overflows, counted in `chars()` to match
+/// `truncate_text`, which measures the Session and Client cells in this table.
 fn build_model_cell(models: &[SessionModel], max_chars: usize, app: &App) -> Cell<'static> {
     if models.is_empty() {
         return Cell::from("\u{2014}".to_string()).style(Style::default().fg(app.theme.muted));
@@ -402,7 +385,7 @@ fn build_model_cell(models: &[SessionModel], max_chars: usize, app: &App) -> Cel
             if budget < 3 {
                 break;
             }
-            spans.push(Span::raw(", "));
+            spans.push(Span::styled(", ", Style::default().fg(app.theme.muted)));
             budget -= 2;
         }
 
@@ -541,6 +524,15 @@ mod tests {
             .join("\n")
     }
 
+    /// The header is the first line inside the block border.
+    fn header_line(app: &mut App, width: u16) -> String {
+        render_body(app, width, 6)
+            .lines()
+            .nth(1)
+            .unwrap_or_default()
+            .to_string()
+    }
+
     #[test]
     fn wide_terminal_renders_session_and_duration_columns() {
         let mut app = make_app(200);
@@ -648,6 +640,104 @@ mod tests {
             body.contains("No session usage data"),
             "expected empty message\n{body}"
         );
+    }
+
+    #[test]
+    fn model_column_hidden_below_its_width_threshold() {
+        // 119 is still the wide layout (>= 80) but one short of the Model gate.
+        let mut app = make_app(119);
+        app.data.sessions = vec![session("abc-123", "opencode", 1.5, 1_736_000_000_000)];
+        let body = render_body(&mut app, 119, 12);
+        assert!(
+            !body.contains("Model"),
+            "Model header should be gated off at 119 columns\n{body}"
+        );
+        assert!(
+            !body.contains("test-model"),
+            "Model cell should be gated off at 119 columns\n{body}"
+        );
+        // The rest of the wide layout is still intact.
+        assert!(body.contains("Client"), "expected Client header\n{body}");
+        assert!(body.contains("Cache×"), "expected Cache× header\n{body}");
+    }
+
+    #[test]
+    fn model_column_appears_at_its_width_threshold() {
+        let mut app = make_app(120);
+        app.data.sessions = vec![session("abc-123", "opencode", 1.5, 1_736_000_000_000)];
+        let body = render_body(&mut app, 120, 12);
+        assert!(
+            body.contains("Model"),
+            "expected Model header at 120 columns\n{body}"
+        );
+        assert!(
+            body.contains("test-model"),
+            "expected model name at 120 columns\n{body}"
+        );
+    }
+
+    /// The Cost/Tokens/Date sort indicators are placed by hand-computed column
+    /// indices, which shift for every optional column. Walk all four
+    /// Model x Turn combinations and confirm the indicator still lands on Cost.
+    #[test]
+    fn cost_sort_indicator_tracks_model_and_turn_gating() {
+        for (width, expect_model, has_turn) in [
+            (200u16, true, true),
+            (200, true, false),
+            (119, false, true),
+            (119, false, false),
+        ] {
+            let mut app = make_app(width);
+            let mut s = session("abc-123", "opencode", 1.5, 1_736_000_000_000);
+            if !has_turn {
+                s.turn_count = 0;
+            }
+            app.data.sessions = vec![s];
+            let header = header_line(&mut app, width);
+            assert_eq!(
+                header.contains("Model"),
+                expect_model,
+                "Model gating wrong at width {width}\n{header}"
+            );
+            assert_eq!(
+                header.contains("Turn"),
+                has_turn,
+                "Turn gating wrong at width {width}\n{header}"
+            );
+            assert!(
+                header.contains("Cost ▼"),
+                "cost sort indicator landed on the wrong column at width {width} \
+                 (model={expect_model}, turn={has_turn})\n{header}"
+            );
+        }
+    }
+
+    #[test]
+    fn tokens_and_date_sort_indicators_land_on_their_columns() {
+        for has_turn in [true, false] {
+            let mut s = session("abc-123", "opencode", 1.5, 1_736_000_000_000);
+            if !has_turn {
+                s.turn_count = 0;
+            }
+
+            let mut app = make_app(200);
+            app.data.sessions = vec![s.clone()];
+            app.sort_field = SortField::Tokens;
+            let header = header_line(&mut app, 200);
+            assert!(
+                header.contains("Total ▼"),
+                "tokens sort indicator misplaced (turn={has_turn})\n{header}"
+            );
+
+            let mut app = make_app(200);
+            app.data.sessions = vec![s];
+            app.sort_field = SortField::Date;
+            let header = header_line(&mut app, 200);
+            assert!(
+                header.contains("Last Active ▼"),
+                "date sort indicator misplaced (turn={has_turn})\n{header}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add a **Model** column to the Sessions tab showing which model(s) were used per session
- Model names are colored using the same provider family-shade system as the Overview and Models tabs (Anthropic orange, OpenAI green, Google blue, etc.)
- Column width expands dynamically on wide terminals (18 chars at 80w → +1 per 8 extra chars, capped at 36)
- Multi-model sessions show each name in its own color, joined by `", "`, with per-span truncation that preserves colors when cut off

## Context

Model data was already present on every `UnifiedMessage` (`model_id` field) but discarded during session aggregation into `SessionUsage`. This change collects distinct model display names (via the existing `model_name_for_grouping` function) into a new `SessionUsage.models: Vec<String>` field and renders them with `app.model_color()` — the same shade-map lookup used across the TUI.

## Changes

- **`tui/data/mod.rs`**: Added `models: Vec<String>` to `SessionUsage`; collect distinct model display names during session aggregation in first-seen order
- **`tui/ui/sessions.rs`**: Added Model column to the wide layout (after Client), with `build_model_cell` rendering per-model colored `Span`s joined by `", "`; dynamic column width; updated sort indicator indices for the shifted column layout

<img width="2386" height="1191" alt="Screenshot 2026-07-23 at 10 15 27 AM" src="https://github.com/user-attachments/assets/adcbdba9-96bc-418c-bd16-7d0683f94aae" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Model column to the Sessions tab showing distinct model(s) per session with family-shade colors. The column appears only when there’s room, keeps headers and sort arrows intact, and truncates cleanly with clear markers.

- **New Features**
  - Collects distinct models into `SessionUsage.models: Vec<SessionModel>` (`display_name`, `provider`, `color_key`) in first-seen order.
  - Renders colored model names; supports multiple models with muted ", "; truncates per name and adds a trailing "…" when more models were dropped.
  - Shows the Model column only when the layout can spare ≥18 chars; width uses the remaining budget up to 36.

- **Bug Fixes**
  - Correct per-model colors via `app.model_color_for(provider, color_key)`; fixes wrong/gray colors for custom-labeled models.
  - Dedupes by `display_name` (not `color_key`) so distinct displayed models aren’t collapsed across providers.
  - Gates the column on actual layout budget and derives sort-indicator indices from optional columns so headers and arrows stay correct at all widths.

<sup>Written for commit 89dec8ff04bbcf734e82c809ca651ecfae0f1614. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



