### PR TITLE
fix(submit): clamp submission token aggregates to bigint

### DIFF
--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -1341,6 +1341,17 @@ describe("POST /api/submit auth path", () => {
     expect(activeTimeSql).toContain("LEAST(");
     expect(activeTimeSql).toContain("9223372036854775807");
 
+    // Same overflow shape on the daily-breakdown totals. These feed the
+    // leaderboard, so an unclamped SUM turns one inflated day into a 500 on
+    // every subsequent submit for that user.
+    const tokenAggregate = selectFields.find((fields) => "totalTokens" in fields);
+    expect(tokenAggregate).toBeDefined();
+    for (const column of ["totalTokens", "inputTokens", "outputTokens"] as const) {
+      const columnSql = flattenSqlChunks(tokenAggregate![column]).join(" ");
+      expect(columnSql).toContain("LEAST(");
+      expect(columnSql).toContain("9223372036854775807");
+    }
+
     // The ON CONFLICT arm is unreachable while the per-user submissions row
     // lock holds, but it must not be a silent hole in the monotonic guard if
     // that ever changes (or if duplicate dates straddle an INSERT chunk).

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -741,10 +741,17 @@ export async function POST(request: Request) {
       // ------------------------------------------
       const [aggregates] = await tx
         .select({
-          totalTokens: sql<number>`COALESCE(SUM(${dailyBreakdown.tokens}), 0)::bigint`,
+          // SUM(int8) returns numeric, so casting back to bigint raises "out of
+          // range" once the day rows total past int8 -- aborting the submit for
+          // a user whose history is otherwise fine. Clamp rather than abort;
+          // see the same treatment on the per-device aggregate below. The bound
+          // is int8 max (~9.2e18 tokens), orders of magnitude above any honest
+          // total, so this cannot alter a real ranking -- it only replaces a
+          // 500 with a saturated value.
+          totalTokens: sql<number>`LEAST(COALESCE(SUM(${dailyBreakdown.tokens}), 0), 9223372036854775807)::bigint`,
           totalCost: sql<string>`COALESCE(SUM(CAST(${dailyBreakdown.cost} AS DECIMAL(14,4))), 0)::text`,
-          inputTokens: sql<number>`COALESCE(SUM(${dailyBreakdown.inputTokens}), 0)::bigint`,
-          outputTokens: sql<number>`COALESCE(SUM(${dailyBreakdown.outputTokens}), 0)::bigint`,
+          inputTokens: sql<number>`LEAST(COALESCE(SUM(${dailyBreakdown.inputTokens}), 0), 9223372036854775807)::bigint`,
+          outputTokens: sql<number>`LEAST(COALESCE(SUM(${dailyBreakdown.outputTokens}), 0), 9223372036854775807)::bigint`,
           dateStart: sql<string>`MIN(${dailyBreakdown.date})`,
           dateEnd: sql<string>`MAX(${dailyBreakdown.date})`,
           activeDays: sql<number>`COUNT(DISTINCT CASE WHEN ${dailyBreakdown.tokens} > 0 THEN ${dailyBreakdown.date} END)::int`,


### PR DESCRIPTION
Follow-up to #955, split out because it touches the leaderboard's headline numbers rather than the session metrics #955 is about.

> Stacked on #955 for the test scaffolding only (the `selectFields` capture in `submitAuth.test.ts`). The route change itself is independent — `main`'s lines 744-747 versus #955's 768+. GitHub will retarget this to `main` when #955 merges.

## The bug

`route.ts:744,746,747` derive the submission totals as `COALESCE(SUM(...), 0)::bigint` over `daily_breakdown`. `SUM(int8)` returns `numeric`, so the cast back down raises `out of range` once the day rows *total* past int8 — with every individual row still perfectly valid.

That aborts the whole submit transaction. A user with a single inflated day cannot submit at all until that row is removed, and the endpoint gives them a 500 rather than anything actionable.

Nothing upstream prevents it: submission value caps were deliberately removed in v3.1.0, so incoming token counts are unbounded by design.

## Verified on postgres:16

```
-- two day rows, each individually valid for bigint
COALESCE(SUM(tokens), 0)::bigint                          -> ERROR: bigint out of range
LEAST(COALESCE(SUM(tokens), 0), 9223372036854775807)::bigint -> 9223372036854775807

-- realistic total, clamp inert
unclamped 4700000000  |  clamped 4700000000

-- empty set
0
```

## Why clamping is safe here

The bound is int8 max — about 9.2 quintillion tokens, orders of magnitude beyond any honest total. The clamp cannot engage for a real user, so it cannot move a real ranking. It only replaces a 500 with a saturated value for data that was already fabricated.

Not fixing this by adding Zod maxima: that would reverse the v3.1.0 removal of submission caps. The aggregate is the right place.

## Deliberately out of scope

`total_cost` (`:745`) has a different mechanism — its `SUM` casts to `::text`, which cannot overflow at query time. Its exposure is at *write* time against `numeric(18,4)`, so it needs its own fix rather than the same wrapper.

Migrations 0015/0016 contain the same idiom but are immutable once applied.

## Verification

- 4/4 mutations caught: clamp dropped on each of the three columns, and an int4 bound substituted for the int8 one
- 658 tests / 72 files pass, `tsc` exit 0, 0 lint errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp token aggregates in the submit route to `bigint` max so SUM over daily rows can’t overflow and abort submissions. Users with an inflated day can submit; real totals and rankings stay unchanged.

- **Bug Fixes**
  - Clamp `totalTokens`, `inputTokens`, and `outputTokens` with `LEAST(..., 9223372036854775807)::bigint` in `packages/frontend/src/app/api/submit/route.ts`.
  - Prevents `bigint out of range` when `SUM(int8)` returns `numeric`; inflated totals saturate instead of causing 500s.
  - Add tests in `packages/frontend/__tests__/api/submitAuth.test.ts` to assert the clamp; `totalCost` remains unchanged and will be addressed separately.

<sup>Written for commit d7f1ead627d4c0eaf6f05a610feb46dd84a7ad26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

