### PR TITLE
feat(sessions): query session_model_usage for per-model token breakdown in Hermes parser

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -4021,6 +4021,27 @@ mod tests {
                 billing_provider TEXT,
                 estimated_cost_usd REAL,
                 actual_cost_usd REAL
+            );
+            CREATE TABLE session_model_usage (
+                session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+                model TEXT NOT NULL,
+                billing_provider TEXT NOT NULL DEFAULT '',
+                billing_base_url TEXT NOT NULL DEFAULT '',
+                billing_mode TEXT NOT NULL DEFAULT '',
+                task TEXT NOT NULL DEFAULT '',
+                api_call_count INTEGER NOT NULL DEFAULT 0,
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+                reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+                estimated_cost_usd REAL NOT NULL DEFAULT 0,
+                actual_cost_usd REAL NOT NULL DEFAULT 0,
+                cost_status TEXT,
+                cost_source TEXT,
+                first_seen REAL,
+                last_seen REAL,
+                PRIMARY KEY (session_id, model, billing_provider, billing_base_url, billing_mode, task)
             );",
         )
         .unwrap();
@@ -4089,6 +4110,21 @@ mod tests {
                 id,
                 model,
                 message_count,
+                input_tokens,
+                output_tokens,
+                actual_cost_usd
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_model_usage (
+                session_id, model, billing_provider, billing_base_url, billing_mode, task,
+                input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
+                estimated_cost_usd, actual_cost_usd
+            ) VALUES (?1, ?2, 'anthropic', '', '', '', ?3, ?4, 0, 0, 0, 0, ?5)",
+            rusqlite::params![
+                id,
+                model,
                 input_tokens,
                 output_tokens,
                 actual_cost_usd

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -857,6 +857,10 @@ fn parser_version(client: ClientId) -> u32 {
         // Kimi now checks each token bucket independently when deciding
         // whether a usage record is empty, avoiding an overflowing sum.
         ClientId::Kimi => 2,
+        // v1->v2: per-model token attribution now comes from
+        // session_model_usage instead of crediting the whole session to
+        // sessions.model, and dedup keys are namespaced per (session, model).
+        ClientId::Hermes => 2,
         _ => 1,
     }
 }
@@ -2091,6 +2095,11 @@ mod tests {
     #[test]
     fn test_kimi_parser_version_invalidates_v1_entries() {
         assert_eq!(parser_version(ClientId::Kimi), 2);
+    }
+
+    #[test]
+    fn test_hermes_parser_version_invalidates_v1_entries() {
+        assert_eq!(parser_version(ClientId::Hermes), 2);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/hermes.rs
+++ b/crates/tokscale-core/src/sessions/hermes.rs
@@ -7,6 +7,7 @@
 use super::UnifiedMessage;
 use crate::{provider_identity, TokenBreakdown};
 use rusqlite::Connection;
+use std::collections::HashSet;
 use std::path::Path;
 use tracing::warn;
 
@@ -30,11 +31,18 @@ fn resolved_provider(billing_provider: Option<String>, model_id: &str) -> String
 
 /// Per-model breakdown, available once Hermes started recording
 /// `session_model_usage`.
+///
+/// Grouping keeps `billing_provider` because the composite primary key lets a
+/// single (session, model) pair span several providers; collapsing them would
+/// erase one provider from the breakdown and credit its tokens to the other.
+/// Cost is resolved per row (actual when non-zero, otherwise estimated) before
+/// the SUM, so a reconciled sibling row cannot discard estimate-only siblings.
+/// `ORDER BY` makes the message_count credit below deterministic.
 const PER_MODEL_QUERY: &str = r#"
         SELECT
             smu.session_id,
             smu.model,
-            MAX(smu.billing_provider) AS billing_provider,
+            smu.billing_provider,
             s.started_at,
             CASE WHEN smu.model = s.model THEN COALESCE(s.message_count, 0) ELSE 0 END AS message_count,
             SUM(smu.input_tokens)        AS input_tokens,
@@ -42,24 +50,24 @@ const PER_MODEL_QUERY: &str = r#"
             SUM(smu.cache_read_tokens)   AS cache_read_tokens,
             SUM(smu.cache_write_tokens)  AS cache_write_tokens,
             SUM(smu.reasoning_tokens)    AS reasoning_tokens,
-            SUM(smu.estimated_cost_usd)  AS estimated_cost_usd,
-            SUM(smu.actual_cost_usd)     AS actual_cost_usd
+            SUM(COALESCE(NULLIF(smu.actual_cost_usd, 0), smu.estimated_cost_usd, 0)) AS cost_usd
         FROM session_model_usage smu
         JOIN sessions s ON s.id = smu.session_id
         WHERE smu.model IS NOT NULL
           AND TRIM(smu.model) != ''
-        GROUP BY smu.session_id, smu.model, s.started_at, s.message_count
+        GROUP BY smu.session_id, smu.model, smu.billing_provider, s.started_at, s.message_count
         HAVING SUM(smu.input_tokens) > 0
             OR SUM(smu.output_tokens) > 0
             OR SUM(smu.cache_read_tokens) > 0
             OR SUM(smu.cache_write_tokens) > 0
             OR SUM(smu.reasoning_tokens) > 0
-            OR MAX(smu.actual_cost_usd) > 0
-            OR MAX(smu.estimated_cost_usd) > 0
+            OR SUM(COALESCE(NULLIF(smu.actual_cost_usd, 0), smu.estimated_cost_usd, 0)) > 0
+        ORDER BY smu.session_id, smu.model, smu.billing_provider
 "#;
 
-/// Session-level totals credited to `sessions.model`. Used by Hermes builds
-/// that predate `session_model_usage`; column order matches `PER_MODEL_QUERY`.
+/// Session-level totals credited to `sessions.model`. Covers Hermes builds that
+/// predate `session_model_usage` and, on builds that have it, sessions with no
+/// child rows in it; column order matches `PER_MODEL_QUERY`.
 const SESSION_TOTALS_QUERY: &str = r#"
         SELECT
             id,
@@ -72,8 +80,7 @@ const SESSION_TOTALS_QUERY: &str = r#"
             cache_read_tokens,
             cache_write_tokens,
             reasoning_tokens,
-            estimated_cost_usd,
-            actual_cost_usd
+            COALESCE(actual_cost_usd, estimated_cost_usd, 0) AS cost_usd
         FROM sessions
         WHERE model IS NOT NULL
           AND TRIM(model) != ''
@@ -86,6 +93,104 @@ const SESSION_TOTALS_QUERY: &str = r#"
             COALESCE(actual_cost_usd, estimated_cost_usd, 0) > 0
           )
 "#;
+
+/// One usage row, decoded from either query — both project the same columns.
+struct HermesUsageRow {
+    session_id: String,
+    model_id: String,
+    billing_provider: Option<String>,
+    started_at: f64,
+    message_count: i32,
+    input: i64,
+    output: i64,
+    cache_read: i64,
+    cache_write: i64,
+    reasoning: i64,
+    cost: f64,
+}
+
+fn decode_usage_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<HermesUsageRow> {
+    Ok(HermesUsageRow {
+        session_id: row.get(0)?,
+        model_id: row.get(1)?,
+        billing_provider: row.get(2)?,
+        started_at: row.get(3)?,
+        message_count: row.get::<_, Option<i32>>(4)?.unwrap_or(0),
+        input: row.get::<_, Option<i64>>(5)?.unwrap_or(0),
+        output: row.get::<_, Option<i64>>(6)?.unwrap_or(0),
+        cache_read: row.get::<_, Option<i64>>(7)?.unwrap_or(0),
+        cache_write: row.get::<_, Option<i64>>(8)?.unwrap_or(0),
+        reasoning: row.get::<_, Option<i64>>(9)?.unwrap_or(0),
+        cost: row.get::<_, Option<f64>>(10)?.unwrap_or(0.0),
+    })
+}
+
+/// Runs one of the usage queries. Returns `None` when the query cannot run at
+/// all (prepare or execute failure) so the caller can fall back, and `Some` —
+/// possibly empty — when it ran and simply matched nothing.
+fn query_usage_rows(db_path: &Path, conn: &Connection, query: &str) -> Option<Vec<HermesUsageRow>> {
+    let mut stmt = match conn.prepare(query) {
+        Ok(stmt) => stmt,
+        Err(err) => {
+            warn!(
+                db_path = %db_path.display(),
+                error = %err,
+                "Failed to prepare Hermes session query"
+            );
+            return None;
+        }
+    };
+
+    let rows = match stmt.query_map([], decode_usage_row) {
+        Ok(rows) => rows,
+        Err(err) => {
+            warn!(
+                db_path = %db_path.display(),
+                error = %err,
+                "Failed to execute Hermes session query"
+            );
+            return None;
+        }
+    };
+
+    Some(
+        rows.filter_map(|row| match row {
+            Ok(row) => Some(row),
+            Err(err) => {
+                warn!(
+                    db_path = %db_path.display(),
+                    error = %err,
+                    "Failed to decode Hermes session row"
+                );
+                None
+            }
+        })
+        .collect(),
+    )
+}
+
+fn build_message(row: HermesUsageRow, dedup_key: String) -> UnifiedMessage {
+    let provider = resolved_provider(row.billing_provider, &row.model_id);
+    let mut msg = UnifiedMessage::new_with_agent(
+        "hermes",
+        row.model_id,
+        provider,
+        row.session_id,
+        timestamp_secs_to_ms(row.started_at),
+        TokenBreakdown {
+            input: row.input.max(0),
+            output: row.output.max(0),
+            cache_read: row.cache_read.max(0),
+            cache_write: row.cache_write.max(0),
+            reasoning: row.reasoning.max(0),
+        },
+        row.cost.max(0.0),
+        Some(HERMES_AGENT_NAME.to_string()),
+    );
+    msg.message_count = row.message_count.max(0);
+    msg.dedup_key = Some(dedup_key);
+    msg
+}
 
 fn has_session_model_usage(db_path: &Path, conn: &Connection) -> bool {
     match conn.query_row(
@@ -122,115 +227,63 @@ pub fn parse_hermes_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
         }
     };
 
-    // Hermes builds that predate `session_model_usage` would fail to prepare
-    // the per-model query and report zero usage, so probe for the table and
-    // fall back to the session-level totals when it is missing.
-    let per_model = has_session_model_usage(db_path, &conn);
-    let query = if per_model {
-        PER_MODEL_QUERY
+    // Hermes builds that predate `session_model_usage` cannot run the per-model
+    // query at all; probing first keeps that expected case quiet instead of
+    // logging a prepare failure for every such install. When the table does
+    // exist but the query still fails to prepare — schema drift, e.g. an older
+    // `session_model_usage` without `reasoning_tokens` — `query_usage_rows`
+    // returns None and the session totals below carry the whole database, so
+    // drift degrades to coarser data instead of losing all of it.
+    let per_model_rows = if has_session_model_usage(db_path, &conn) {
+        query_usage_rows(db_path, &conn, PER_MODEL_QUERY)
     } else {
-        SESSION_TOTALS_QUERY
+        None
     };
 
-    let mut stmt = match conn.prepare(query) {
-        Ok(s) => s,
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to prepare Hermes session query"
-            );
-            return Vec::new();
-        }
-    };
+    let mut messages: Vec<UnifiedMessage> = Vec::new();
+    // Sessions the per-model pass emitted at least one row for.
+    let mut covered_sessions: HashSet<String> = HashSet::new();
+    // Sessions whose `message_count` has already been handed to a row.
+    let mut counted_sessions: HashSet<String> = HashSet::new();
 
-    let rows = match stmt.query_map([], |row| {
-        Ok((
-            row.get::<_, String>(0)?,
-            row.get::<_, String>(1)?,
-            row.get::<_, Option<String>>(2)?,
-            row.get::<_, f64>(3)?,
-            row.get::<_, Option<i32>>(4)?.unwrap_or(0),
-            row.get::<_, Option<i64>>(5)?.unwrap_or(0),
-            row.get::<_, Option<i64>>(6)?.unwrap_or(0),
-            row.get::<_, Option<i64>>(7)?.unwrap_or(0),
-            row.get::<_, Option<i64>>(8)?.unwrap_or(0),
-            row.get::<_, Option<i64>>(9)?.unwrap_or(0),
-            row.get::<_, Option<f64>>(10)?,
-            row.get::<_, Option<f64>>(11)?,
-        ))
-    }) {
-        Ok(r) => r,
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to execute Hermes session query"
-            );
-            return Vec::new();
+    for mut row in per_model_rows.unwrap_or_default() {
+        covered_sessions.insert(row.session_id.clone());
+        // `sessions.message_count` is a per-session total that the query credits
+        // to the row whose model matches `sessions.model`. Grouping by
+        // billing_provider can split that model across several rows, so credit
+        // only the first of them; ORDER BY makes "first" deterministic.
+        if row.message_count > 0 && !counted_sessions.insert(row.session_id.clone()) {
+            row.message_count = 0;
         }
-    };
+        let dedup_key = format!(
+            "hermes:{}:{}:{}",
+            row.session_id,
+            row.model_id,
+            row.billing_provider.as_deref().unwrap_or_default()
+        );
+        messages.push(build_message(row, dedup_key));
+    }
 
-    rows.filter_map(|row| match row {
-        Ok(row) => Some(row),
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to decode Hermes session row"
-            );
-            None
+    // Reconcile per session, not per table: a Hermes upgrade can create
+    // `session_model_usage` without backfilling older sessions, and those
+    // sessions still carry their totals on `sessions`. Emit totals only for
+    // sessions the per-model pass did not cover, which makes the two result
+    // sets disjoint by construction — they cannot double count.
+    //
+    // Deliberately no "top up" of a session whose smu rows only partially cover
+    // its session totals: if a session has ANY smu row we trust smu, because
+    // adding the difference would double count the models smu did record. Do
+    // not "fix" this into a per-column reconciliation.
+    for row in query_usage_rows(db_path, &conn, SESSION_TOTALS_QUERY).unwrap_or_default() {
+        if covered_sessions.contains(&row.session_id) {
+            continue;
         }
-    })
-    .map(
-        |(
-            session_id,
-            model_id,
-            billing_provider,
-            started_at,
-            message_count,
-            input,
-            output,
-            cache_read,
-            cache_write,
-            reasoning,
-            estimated_cost,
-            actual_cost,
-        )| {
-            let provider = resolved_provider(billing_provider, &model_id);
-            // The per-model path emits one message per (session, model), so it
-            // needs a namespaced dedup key; the session-totals path emits at
-            // most one message per session and keeps the bare session id.
-            let (cost, dedup_key) = if per_model {
-                (
-                    actual_cost
-                        .filter(|c| *c > 0.0)
-                        .or(estimated_cost.filter(|c| *c > 0.0)),
-                    format!("hermes:{session_id}:{model_id}"),
-                )
-            } else {
-                (actual_cost.or(estimated_cost), session_id.clone())
-            };
-            let mut msg = UnifiedMessage::new_with_agent(
-                "hermes",
-                model_id,
-                provider,
-                session_id.clone(),
-                timestamp_secs_to_ms(started_at),
-                TokenBreakdown {
-                    input: input.max(0),
-                    output: output.max(0),
-                    cache_read: cache_read.max(0),
-                    cache_write: cache_write.max(0),
-                    reasoning: reasoning.max(0),
-                },
-                cost.unwrap_or(0.0).max(0.0),
-                Some(HERMES_AGENT_NAME.to_string()),
-            );
-            msg.message_count = message_count.max(0);
-            msg.dedup_key = Some(dedup_key);
-            msg
-        },
-    )
-    .collect()
+        // This path emits at most one message per session, so it keeps the bare
+        // session id as its dedup key; the per-model keys are namespaced and
+        // cannot collide with it.
+        let dedup_key = row.session_id.clone();
+        messages.push(build_message(row, dedup_key));
+    }
+
+    messages
 }

--- a/crates/tokscale-core/src/sessions/hermes.rs
+++ b/crates/tokscale-core/src/sessions/hermes.rs
@@ -46,29 +46,30 @@ pub fn parse_hermes_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
 
     let query = r#"
         SELECT
-            id,
-            model,
-            billing_provider,
-            started_at,
-            message_count,
-            input_tokens,
-            output_tokens,
-            cache_read_tokens,
-            cache_write_tokens,
-            reasoning_tokens,
-            estimated_cost_usd,
-            actual_cost_usd
-        FROM sessions
-        WHERE model IS NOT NULL
-          AND TRIM(model) != ''
-          AND (
-            COALESCE(input_tokens, 0) > 0 OR
-            COALESCE(output_tokens, 0) > 0 OR
-            COALESCE(cache_read_tokens, 0) > 0 OR
-            COALESCE(cache_write_tokens, 0) > 0 OR
-            COALESCE(reasoning_tokens, 0) > 0 OR
-            COALESCE(actual_cost_usd, estimated_cost_usd, 0) > 0
-          )
+            smu.session_id,
+            smu.model,
+            MAX(smu.billing_provider) AS billing_provider,
+            s.started_at,
+            CASE WHEN smu.model = s.model THEN COALESCE(s.message_count, 0) ELSE 0 END AS message_count,
+            SUM(smu.input_tokens)        AS input_tokens,
+            SUM(smu.output_tokens)       AS output_tokens,
+            SUM(smu.cache_read_tokens)   AS cache_read_tokens,
+            SUM(smu.cache_write_tokens)  AS cache_write_tokens,
+            SUM(smu.reasoning_tokens)    AS reasoning_tokens,
+            SUM(smu.estimated_cost_usd)  AS estimated_cost_usd,
+            SUM(smu.actual_cost_usd)     AS actual_cost_usd
+        FROM session_model_usage smu
+        JOIN sessions s ON s.id = smu.session_id
+        WHERE smu.model IS NOT NULL
+          AND TRIM(smu.model) != ''
+        GROUP BY smu.session_id, smu.model, s.started_at, s.message_count
+        HAVING SUM(smu.input_tokens) > 0
+            OR SUM(smu.output_tokens) > 0
+            OR SUM(smu.cache_read_tokens) > 0
+            OR SUM(smu.cache_write_tokens) > 0
+            OR SUM(smu.reasoning_tokens) > 0
+            OR MAX(smu.actual_cost_usd) > 0
+            OR MAX(smu.estimated_cost_usd) > 0
     "#;
 
     let mut stmt = match conn.prepare(query) {
@@ -137,6 +138,7 @@ pub fn parse_hermes_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             actual_cost,
         )| {
             let provider = resolved_provider(billing_provider, &model_id);
+            let dedup_key = format!("hermes:{session_id}:{model_id}");
             let mut msg = UnifiedMessage::new_with_agent(
                 "hermes",
                 model_id,
@@ -150,11 +152,15 @@ pub fn parse_hermes_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
                     cache_write: cache_write.max(0),
                     reasoning: reasoning.max(0),
                 },
-                actual_cost.or(estimated_cost).unwrap_or(0.0).max(0.0),
+                actual_cost
+                    .filter(|c| *c > 0.0)
+                    .or(estimated_cost.filter(|c| *c > 0.0))
+                    .unwrap_or(0.0)
+                    .max(0.0),
                 Some(HERMES_AGENT_NAME.to_string()),
             );
             msg.message_count = message_count.max(0);
-            msg.dedup_key = Some(session_id);
+            msg.dedup_key = Some(dedup_key);
             msg
         },
     )

--- a/crates/tokscale-core/src/sessions/hermes.rs
+++ b/crates/tokscale-core/src/sessions/hermes.rs
@@ -13,6 +13,10 @@ use tracing::warn;
 
 const HERMES_AGENT_NAME: &str = "Hermes Agent";
 
+/// Stands in for a NULL `billing_provider` inside a per-model dedup key. Angle
+/// brackets keep it out of the slug space real provider ids live in.
+const NULL_PROVIDER_KEY: &str = "<null>";
+
 fn timestamp_secs_to_ms(timestamp: f64) -> i64 {
     if timestamp > 1e12 {
         timestamp as i64
@@ -37,14 +41,17 @@ fn resolved_provider(billing_provider: Option<String>, model_id: &str) -> String
 /// erase one provider from the breakdown and credit its tokens to the other.
 /// Cost is resolved per row (actual when non-zero, otherwise estimated) before
 /// the SUM, so a reconciled sibling row cannot discard estimate-only siblings.
-/// `ORDER BY` makes the message_count credit below deterministic.
+/// `ORDER BY` sorts the row matching `sessions.model` first within each session
+/// and is otherwise total, so the caller can hand `sessions.message_count` to
+/// the first row it sees per session and get the primary model whenever one
+/// survives grouping — and a deterministic row when none does.
 const PER_MODEL_QUERY: &str = r#"
         SELECT
             smu.session_id,
             smu.model,
             smu.billing_provider,
             s.started_at,
-            CASE WHEN smu.model = s.model THEN COALESCE(s.message_count, 0) ELSE 0 END AS message_count,
+            COALESCE(s.message_count, 0) AS message_count,
             SUM(smu.input_tokens)        AS input_tokens,
             SUM(smu.output_tokens)       AS output_tokens,
             SUM(smu.cache_read_tokens)   AS cache_read_tokens,
@@ -62,7 +69,10 @@ const PER_MODEL_QUERY: &str = r#"
             OR SUM(smu.cache_write_tokens) > 0
             OR SUM(smu.reasoning_tokens) > 0
             OR SUM(COALESCE(NULLIF(smu.actual_cost_usd, 0), smu.estimated_cost_usd, 0)) > 0
-        ORDER BY smu.session_id, smu.model, smu.billing_provider
+        ORDER BY smu.session_id,
+                 CASE WHEN smu.model = s.model THEN 0 ELSE 1 END,
+                 smu.model,
+                 smu.billing_provider
 "#;
 
 /// Session-level totals credited to `sessions.model`. Covers Hermes builds that
@@ -248,18 +258,26 @@ pub fn parse_hermes_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
 
     for mut row in per_model_rows.unwrap_or_default() {
         covered_sessions.insert(row.session_id.clone());
-        // `sessions.message_count` is a per-session total that the query credits
-        // to the row whose model matches `sessions.model`. Grouping by
-        // billing_provider can split that model across several rows, so credit
-        // only the first of them; ORDER BY makes "first" deterministic.
-        if row.message_count > 0 && !counted_sessions.insert(row.session_id.clone()) {
+        // `sessions.message_count` is a per-session total, so exactly one row
+        // per session may carry it. ORDER BY sorts the row matching
+        // `sessions.model` first, so "the first row of the session" is that
+        // primary model when it survives grouping, and a deterministic
+        // stand-in when it does not — a NULL `sessions.model`, a rename
+        // between the two tables, or a primary model whose rows were all zero
+        // and got filtered out. Zeroing every later row keeps the per-session
+        // sum equal to `sessions.message_count` instead of dropping it.
+        if !counted_sessions.insert(row.session_id.clone()) {
             row.message_count = 0;
         }
+        // SQLite groups NULL and '' separately, so one (session, model) can
+        // reach this loop as two rows that differ only in a NULL vs empty
+        // billing_provider. Rendering NULL as a sentinel keeps their keys
+        // apart; folding NULL to "" would collide and the caller's dedup pass
+        // would then drop the second row's tokens outright.
+        let provider_key = row.billing_provider.as_deref().unwrap_or(NULL_PROVIDER_KEY);
         let dedup_key = format!(
             "hermes:{}:{}:{}",
-            row.session_id,
-            row.model_id,
-            row.billing_provider.as_deref().unwrap_or_default()
+            row.session_id, row.model_id, provider_key
         );
         messages.push(build_message(row, dedup_key));
     }

--- a/crates/tokscale-core/src/sessions/hermes.rs
+++ b/crates/tokscale-core/src/sessions/hermes.rs
@@ -28,23 +28,9 @@ fn resolved_provider(billing_provider: Option<String>, model_id: &str) -> String
         .unwrap_or_else(|| "hermes".to_string())
 }
 
-pub fn parse_hermes_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
-    let conn = match Connection::open_with_flags(
-        db_path,
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    ) {
-        Ok(c) => c,
-        Err(err) => {
-            warn!(
-                db_path = %db_path.display(),
-                error = %err,
-                "Failed to open Hermes state database"
-            );
-            return Vec::new();
-        }
-    };
-
-    let query = r#"
+/// Per-model breakdown, available once Hermes started recording
+/// `session_model_usage`.
+const PER_MODEL_QUERY: &str = r#"
         SELECT
             smu.session_id,
             smu.model,
@@ -70,7 +56,81 @@ pub fn parse_hermes_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             OR SUM(smu.reasoning_tokens) > 0
             OR MAX(smu.actual_cost_usd) > 0
             OR MAX(smu.estimated_cost_usd) > 0
-    "#;
+"#;
+
+/// Session-level totals credited to `sessions.model`. Used by Hermes builds
+/// that predate `session_model_usage`; column order matches `PER_MODEL_QUERY`.
+const SESSION_TOTALS_QUERY: &str = r#"
+        SELECT
+            id,
+            model,
+            billing_provider,
+            started_at,
+            message_count,
+            input_tokens,
+            output_tokens,
+            cache_read_tokens,
+            cache_write_tokens,
+            reasoning_tokens,
+            estimated_cost_usd,
+            actual_cost_usd
+        FROM sessions
+        WHERE model IS NOT NULL
+          AND TRIM(model) != ''
+          AND (
+            COALESCE(input_tokens, 0) > 0 OR
+            COALESCE(output_tokens, 0) > 0 OR
+            COALESCE(cache_read_tokens, 0) > 0 OR
+            COALESCE(cache_write_tokens, 0) > 0 OR
+            COALESCE(reasoning_tokens, 0) > 0 OR
+            COALESCE(actual_cost_usd, estimated_cost_usd, 0) > 0
+          )
+"#;
+
+fn has_session_model_usage(db_path: &Path, conn: &Connection) -> bool {
+    match conn.query_row(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'session_model_usage'",
+        [],
+        |row| row.get::<_, i64>(0),
+    ) {
+        Ok(_) => true,
+        Err(rusqlite::Error::QueryReturnedNoRows) => false,
+        Err(err) => {
+            warn!(
+                db_path = %db_path.display(),
+                error = %err,
+                "Failed to probe Hermes session_model_usage table; using session totals"
+            );
+            false
+        }
+    }
+}
+
+pub fn parse_hermes_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
+    let conn = match Connection::open_with_flags(
+        db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    ) {
+        Ok(c) => c,
+        Err(err) => {
+            warn!(
+                db_path = %db_path.display(),
+                error = %err,
+                "Failed to open Hermes state database"
+            );
+            return Vec::new();
+        }
+    };
+
+    // Hermes builds that predate `session_model_usage` would fail to prepare
+    // the per-model query and report zero usage, so probe for the table and
+    // fall back to the session-level totals when it is missing.
+    let per_model = has_session_model_usage(db_path, &conn);
+    let query = if per_model {
+        PER_MODEL_QUERY
+    } else {
+        SESSION_TOTALS_QUERY
+    };
 
     let mut stmt = match conn.prepare(query) {
         Ok(s) => s,
@@ -138,7 +198,19 @@ pub fn parse_hermes_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             actual_cost,
         )| {
             let provider = resolved_provider(billing_provider, &model_id);
-            let dedup_key = format!("hermes:{session_id}:{model_id}");
+            // The per-model path emits one message per (session, model), so it
+            // needs a namespaced dedup key; the session-totals path emits at
+            // most one message per session and keeps the bare session id.
+            let (cost, dedup_key) = if per_model {
+                (
+                    actual_cost
+                        .filter(|c| *c > 0.0)
+                        .or(estimated_cost.filter(|c| *c > 0.0)),
+                    format!("hermes:{session_id}:{model_id}"),
+                )
+            } else {
+                (actual_cost.or(estimated_cost), session_id.clone())
+            };
             let mut msg = UnifiedMessage::new_with_agent(
                 "hermes",
                 model_id,
@@ -152,11 +224,7 @@ pub fn parse_hermes_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
                     cache_write: cache_write.max(0),
                     reasoning: reasoning.max(0),
                 },
-                actual_cost
-                    .filter(|c| *c > 0.0)
-                    .or(estimated_cost.filter(|c| *c > 0.0))
-                    .unwrap_or(0.0)
-                    .max(0.0),
+                cost.unwrap_or(0.0).max(0.0),
                 Some(HERMES_AGENT_NAME.to_string()),
             );
             msg.message_count = message_count.max(0);

--- a/crates/tokscale-core/tests/hermes.rs
+++ b/crates/tokscale-core/tests/hermes.rs
@@ -22,6 +22,27 @@ fn create_test_db(dir: &TempDir) -> std::path::PathBuf {
             estimated_cost_usd REAL,
             actual_cost_usd REAL
         );
+        CREATE TABLE session_model_usage (
+            session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+            model TEXT NOT NULL,
+            billing_provider TEXT NOT NULL DEFAULT '',
+            billing_base_url TEXT NOT NULL DEFAULT '',
+            billing_mode TEXT NOT NULL DEFAULT '',
+            task TEXT NOT NULL DEFAULT '',
+            api_call_count INTEGER NOT NULL DEFAULT 0,
+            input_tokens INTEGER NOT NULL DEFAULT 0,
+            output_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+            reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+            estimated_cost_usd REAL NOT NULL DEFAULT 0,
+            actual_cost_usd REAL NOT NULL DEFAULT 0,
+            cost_status TEXT,
+            cost_source TEXT,
+            first_seen REAL,
+            last_seen REAL,
+            PRIMARY KEY (session_id, model, billing_provider, billing_base_url, billing_mode, task)
+        );
         "#,
     )
     .unwrap();
@@ -34,13 +55,12 @@ fn test_parse_hermes_sqlite_reads_session_rows_and_preserves_message_count() {
     let db_path = create_test_db(&dir);
     let conn = Connection::open(&db_path).unwrap();
 
+    // Session row (needed for JOIN: started_at, message_count, model)
     conn.execute(
         r#"
         INSERT INTO sessions (
-            id, source, model, started_at, message_count,
-            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
-            billing_provider, estimated_cost_usd, actual_cost_usd
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+            id, source, model, started_at, message_count
+        ) VALUES (?1, ?2, ?3, ?4, ?5)
         "#,
         params![
             "session-1",
@@ -48,12 +68,31 @@ fn test_parse_hermes_sqlite_reads_session_rows_and_preserves_message_count() {
             "claude-sonnet-4",
             1_750_000_000.25_f64,
             42_i64,
+        ],
+    )
+    .unwrap();
+
+    // Per-model token data
+    conn.execute(
+        r#"
+        INSERT INTO session_model_usage (
+            session_id, model, billing_provider, billing_base_url, billing_mode, task,
+            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
+            estimated_cost_usd, actual_cost_usd
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+        "#,
+        params![
+            "session-1",
+            "claude-sonnet-4",
+            "anthropic",
+            "",
+            "",
+            "",
             1200_i64,
             300_i64,
             50_i64,
             20_i64,
             10_i64,
-            "anthropic",
             0.12_f64,
             0.34_f64,
         ],
@@ -77,7 +116,10 @@ fn test_parse_hermes_sqlite_reads_session_rows_and_preserves_message_count() {
     assert_eq!(msg.tokens.cache_write, 20);
     assert_eq!(msg.tokens.reasoning, 10);
     assert_eq!(msg.cost, 0.34);
-    assert_eq!(msg.dedup_key.as_deref(), Some("session-1"));
+    assert_eq!(
+        msg.dedup_key.as_deref(),
+        Some("hermes:session-1:claude-sonnet-4")
+    );
 }
 
 #[test]
@@ -87,13 +129,12 @@ fn test_parse_hermes_sqlite_skips_empty_sessions_and_falls_back_to_estimated_cos
     let db_path = create_test_db(&dir);
     let conn = Connection::open(&db_path).unwrap();
 
+    // Valid session with tokens
     conn.execute(
         r#"
         INSERT INTO sessions (
-            id, source, model, started_at, message_count,
-            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
-            billing_provider, estimated_cost_usd, actual_cost_usd
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+            id, source, model, started_at, message_count
+        ) VALUES (?1, ?2, ?3, ?4, ?5)
         "#,
         params![
             "session-valid",
@@ -101,25 +142,41 @@ fn test_parse_hermes_sqlite_skips_empty_sessions_and_falls_back_to_estimated_cos
             "gpt-5.4",
             1_775_001_102.0_f64,
             3_i64,
+        ],
+    )
+    .unwrap();
+    conn.execute(
+        r#"
+        INSERT INTO session_model_usage (
+            session_id, model, billing_provider, billing_base_url, billing_mode, task,
+            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
+            estimated_cost_usd, actual_cost_usd
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+        "#,
+        params![
+            "session-valid",
+            "gpt-5.4",
+            "",
+            "",
+            "",
+            "",
             100_i64,
             20_i64,
             0_i64,
             0_i64,
             5_i64,
-            Option::<String>::None,
             1.25_f64,
-            Option::<f64>::None,
+            0.0_f64,
         ],
     )
     .unwrap();
 
+    // Empty session (no smu row — excluded by JOIN, never reaches HAVING)
     conn.execute(
         r#"
         INSERT INTO sessions (
-            id, source, model, started_at, message_count,
-            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
-            billing_provider, estimated_cost_usd, actual_cost_usd
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+            id, source, model, started_at, message_count
+        ) VALUES (?1, ?2, ?3, ?4, ?5)
         "#,
         params![
             "session-empty",
@@ -127,25 +184,16 @@ fn test_parse_hermes_sqlite_skips_empty_sessions_and_falls_back_to_estimated_cos
             "gpt-5.4",
             1_775_001_103.0_f64,
             9_i64,
-            0_i64,
-            0_i64,
-            0_i64,
-            0_i64,
-            0_i64,
-            Option::<String>::None,
-            Option::<f64>::None,
-            Option::<f64>::None,
         ],
     )
     .unwrap();
 
+    // Session with no model — should be excluded by WHERE
     conn.execute(
         r#"
         INSERT INTO sessions (
-            id, source, model, started_at, message_count,
-            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
-            billing_provider, estimated_cost_usd, actual_cost_usd
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+            id, source, model, started_at, message_count
+        ) VALUES (?1, ?2, ?3, ?4, ?5)
         "#,
         params![
             "session-no-model",
@@ -153,14 +201,6 @@ fn test_parse_hermes_sqlite_skips_empty_sessions_and_falls_back_to_estimated_cos
             Option::<String>::None,
             1_775_001_104.0_f64,
             1_i64,
-            500_i64,
-            20_i64,
-            0_i64,
-            0_i64,
-            0_i64,
-            Some("openai".to_string()),
-            0.2_f64,
-            0.2_f64,
         ],
     )
     .unwrap();
@@ -184,10 +224,8 @@ fn test_parse_hermes_sqlite_ignores_unknown_billing_provider_and_falls_back_to_m
     conn.execute(
         r#"
         INSERT INTO sessions (
-            id, source, model, started_at, message_count,
-            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
-            billing_provider, estimated_cost_usd, actual_cost_usd
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+            id, source, model, started_at, message_count
+        ) VALUES (?1, ?2, ?3, ?4, ?5)
         "#,
         params![
             "session-unknown-provider",
@@ -195,14 +233,32 @@ fn test_parse_hermes_sqlite_ignores_unknown_billing_provider_and_falls_back_to_m
             "gpt-5.4",
             1_775_001_105.0_f64,
             2_i64,
+        ],
+    )
+    .unwrap();
+
+    conn.execute(
+        r#"
+        INSERT INTO session_model_usage (
+            session_id, model, billing_provider, billing_base_url, billing_mode, task,
+            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
+            estimated_cost_usd, actual_cost_usd
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+        "#,
+        params![
+            "session-unknown-provider",
+            "gpt-5.4",
+            "unknown",
+            "",
+            "",
+            "",
             100_i64,
             20_i64,
             0_i64,
             0_i64,
             0_i64,
-            Some("unknown".to_string()),
             0.5_f64,
-            Option::<f64>::None,
+            0.0_f64,
         ],
     )
     .unwrap();
@@ -210,4 +266,175 @@ fn test_parse_hermes_sqlite_ignores_unknown_billing_provider_and_falls_back_to_m
     let messages = parse_hermes_sqlite(&db_path);
     assert_eq!(messages.len(), 1);
     assert_eq!(messages[0].provider_id, "openai");
+}
+
+#[test]
+fn test_parse_hermes_sqlite_emits_per_model_rows_for_multi_model_session() {
+    let dir = TempDir::new().unwrap();
+    let db_path = create_test_db(&dir);
+    let conn = Connection::open(&db_path).unwrap();
+
+    // Single session with primary model "glm-5.2" and two smu models
+    conn.execute(
+        r#"
+        INSERT INTO sessions (
+            id, source, model, started_at, message_count
+        ) VALUES (?1, ?2, ?3, ?4, ?5)
+        "#,
+        params![
+            "session-multi",
+            "desktop",
+            "glm-5.2",
+            1_775_002_000.0_f64,
+            15_i64,
+        ],
+    )
+    .unwrap();
+
+    // Primary model (matches sessions.model) — should get message_count
+    conn.execute(
+        r#"
+        INSERT INTO session_model_usage (
+            session_id, model, billing_provider, billing_base_url, billing_mode, task,
+            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
+            estimated_cost_usd, actual_cost_usd
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+        "#,
+        params![
+            "session-multi",
+            "glm-5.2",
+            "kilocode",
+            "",
+            "",
+            "",
+            5000_i64,
+            800_i64,
+            100_i64,
+            0_i64,
+            200_i64,
+            0.0_f64,
+            0.0_f64,
+        ],
+    )
+    .unwrap();
+
+    // Secondary model — should get message_count = 0
+    conn.execute(
+        r#"
+        INSERT INTO session_model_usage (
+            session_id, model, billing_provider, billing_base_url, billing_mode, task,
+            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
+            estimated_cost_usd, actual_cost_usd
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+        "#,
+        params![
+            "session-multi",
+            "mimo-v2.5-free",
+            "opencode-zen",
+            "",
+            "",
+            "",
+            3000_i64,
+            500_i64,
+            0_i64,
+            0_i64,
+            0_i64,
+            0.0_f64,
+            0.0_f64,
+        ],
+    )
+    .unwrap();
+
+    // Third model with two task-variant rows — should be SUMmed
+    conn.execute(
+        r#"
+        INSERT INTO session_model_usage (
+            session_id, model, billing_provider, billing_base_url, billing_mode, task,
+            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
+            estimated_cost_usd, actual_cost_usd
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+        "#,
+        params![
+            "session-multi",
+            "cohere/north-mini-code:free",
+            "bifrost",
+            "",
+            "",
+            "",
+            900_i64,
+            100_i64,
+            0_i64,
+            0_i64,
+            0_i64,
+            0.0_f64,
+            0.0_f64,
+        ],
+    )
+    .unwrap();
+    conn.execute(
+        r#"
+        INSERT INTO session_model_usage (
+            session_id, model, billing_provider, billing_base_url, billing_mode, task,
+            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
+            estimated_cost_usd, actual_cost_usd
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+        "#,
+        params![
+            "session-multi",
+            "cohere/north-mini-code:free",
+            "bifrost",
+            "",
+            "",
+            "title_generation",
+            100_i64,
+            50_i64,
+            0_i64,
+            0_i64,
+            0_i64,
+            0.0_f64,
+            0.0_f64,
+        ],
+    )
+    .unwrap();
+
+    let mut messages = parse_hermes_sqlite(&db_path);
+    messages.sort_by(|a, b| a.model_id.cmp(&b.model_id));
+
+    assert_eq!(messages.len(), 3);
+
+    // cohere/north-mini-code:free: SUM of 2 rows (900+100=1000 input, 100+50=150 output)
+    let cohere = messages
+        .iter()
+        .find(|m| m.model_id == "cohere/north-mini-code:free")
+        .unwrap();
+    assert_eq!(cohere.tokens.input, 1000);
+    assert_eq!(cohere.tokens.output, 150);
+    assert_eq!(cohere.message_count, 0); // secondary model
+    assert_eq!(
+        cohere.dedup_key.as_deref(),
+        Some("hermes:session-multi:cohere/north-mini-code:free")
+    );
+
+    // glm-5.2: primary model, gets message_count
+    let glm = messages.iter().find(|m| m.model_id == "glm-5.2").unwrap();
+    assert_eq!(glm.tokens.input, 5000);
+    assert_eq!(glm.tokens.output, 800);
+    assert_eq!(glm.message_count, 15); // primary model
+    assert_eq!(
+        glm.dedup_key.as_deref(),
+        Some("hermes:session-multi:glm-5.2")
+    );
+
+    // mimo-v2.5-free: secondary model
+    let mimo = messages
+        .iter()
+        .find(|m| m.model_id == "mimo-v2.5-free")
+        .unwrap();
+    assert_eq!(mimo.tokens.input, 3000);
+    assert_eq!(mimo.tokens.output, 500);
+    assert_eq!(mimo.message_count, 0); // secondary model
+    assert_eq!(
+        mimo.dedup_key.as_deref(),
+        Some("hermes:session-multi:mimo-v2.5-free")
+    );
 }

--- a/crates/tokscale-core/tests/hermes.rs
+++ b/crates/tokscale-core/tests/hermes.rs
@@ -1,4 +1,5 @@
 use rusqlite::{params, Connection};
+use std::collections::HashSet;
 use tempfile::TempDir;
 use tokscale_core::sessions::hermes::parse_hermes_sqlite;
 
@@ -1099,4 +1100,124 @@ fn test_parse_hermes_sqlite_emits_cost_only_rows() {
     let messages = parse_hermes_sqlite(&db_path);
     assert_eq!(messages.len(), 1);
     assert!((messages[0].cost - 0.07).abs() < 1e-9);
+}
+
+/// `sessions.message_count` is credited to the row matching `sessions.model`,
+/// but nothing guarantees such a row exists — the session can have no model, or
+/// name one that `session_model_usage` never recorded. The count still belongs
+/// to the session, so a deterministic stand-in row has to carry it.
+#[test]
+fn test_parse_hermes_sqlite_keeps_message_count_when_no_row_matches_session_model() {
+    let dir = TempDir::new().unwrap();
+    let db_path = create_test_db(&dir);
+    let conn = Connection::open(&db_path).unwrap();
+
+    conn.execute(
+        r#"
+        INSERT INTO sessions (
+            id, source, model, started_at, message_count
+        ) VALUES (?1, ?2, ?3, ?4, ?5)
+        "#,
+        params![
+            "session-orphan-count",
+            "cli",
+            "glm-5.2",
+            1_775_007_000.0_f64,
+            11_i64,
+        ],
+    )
+    .unwrap();
+
+    for (model, input) in [("gpt-5.4", 2000_i64), ("mimo-v2.5-free", 1000_i64)] {
+        conn.execute(
+            r#"
+            INSERT INTO session_model_usage (
+                session_id, model, billing_provider, billing_base_url, billing_mode, task,
+                input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
+                estimated_cost_usd, actual_cost_usd
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+            "#,
+            params![
+                "session-orphan-count",
+                model,
+                "openai",
+                "",
+                "",
+                "",
+                input,
+                0_i64,
+                0_i64,
+                0_i64,
+                0_i64,
+                0.0_f64,
+                0.0_f64,
+            ],
+        )
+        .unwrap();
+    }
+
+    let messages = parse_hermes_sqlite(&db_path);
+    assert_eq!(messages.len(), 2);
+    assert_eq!(
+        messages.iter().map(|m| m.message_count).sum::<i32>(),
+        11,
+        "session message_count must survive, and exactly once"
+    );
+}
+
+/// A nullable `billing_provider` lets one (session, model) group twice — once
+/// under NULL, once under ''. Both rows carry real tokens, so their dedup keys
+/// must differ or the caller's dedup pass drops one of them.
+#[test]
+fn test_parse_hermes_sqlite_separates_null_and_empty_billing_providers() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("nullable-provider.db");
+    let conn = Connection::open(&db_path).unwrap();
+    conn.execute_batch(
+        r#"
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT NOT NULL,
+            model TEXT,
+            started_at REAL NOT NULL,
+            message_count INTEGER DEFAULT 0,
+            input_tokens INTEGER DEFAULT 0,
+            output_tokens INTEGER DEFAULT 0,
+            cache_read_tokens INTEGER DEFAULT 0,
+            cache_write_tokens INTEGER DEFAULT 0,
+            reasoning_tokens INTEGER DEFAULT 0,
+            billing_provider TEXT,
+            estimated_cost_usd REAL,
+            actual_cost_usd REAL
+        );
+        CREATE TABLE session_model_usage (
+            session_id TEXT NOT NULL,
+            model TEXT NOT NULL,
+            billing_provider TEXT,
+            input_tokens INTEGER NOT NULL DEFAULT 0,
+            output_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+            reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+            estimated_cost_usd REAL NOT NULL DEFAULT 0,
+            actual_cost_usd REAL NOT NULL DEFAULT 0
+        );
+        INSERT INTO sessions (id, source, model, started_at, message_count)
+        VALUES ('session-nullable', 'cli', 'glm-5.2', 1775008000.0, 3);
+        INSERT INTO session_model_usage (session_id, model, billing_provider, input_tokens)
+        VALUES ('session-nullable', 'glm-5.2', NULL, 2000),
+               ('session-nullable', 'glm-5.2', '',   1000);
+        "#,
+    )
+    .unwrap();
+
+    let messages = parse_hermes_sqlite(&db_path);
+    assert_eq!(messages.len(), 2);
+
+    let keys: HashSet<&str> = messages
+        .iter()
+        .filter_map(|m| m.dedup_key.as_deref())
+        .collect();
+    assert_eq!(keys.len(), 2, "NULL and '' must not share a dedup key");
+    assert_eq!(messages.iter().map(|m| m.tokens.input).sum::<i64>(), 3000);
 }

--- a/crates/tokscale-core/tests/hermes.rs
+++ b/crates/tokscale-core/tests/hermes.rs
@@ -49,6 +49,49 @@ fn create_test_db(dir: &TempDir) -> std::path::PathBuf {
     db_path
 }
 
+/// Schema of a Hermes build whose `session_model_usage` predates the
+/// `reasoning_tokens` column, so `PER_MODEL_QUERY` cannot even be prepared.
+fn create_drifted_test_db(dir: &TempDir) -> std::path::PathBuf {
+    let db_path = dir.path().join("drifted-state.db");
+    let conn = Connection::open(&db_path).unwrap();
+    conn.execute_batch(
+        r#"
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT NOT NULL,
+            model TEXT,
+            started_at REAL NOT NULL,
+            message_count INTEGER DEFAULT 0,
+            input_tokens INTEGER DEFAULT 0,
+            output_tokens INTEGER DEFAULT 0,
+            cache_read_tokens INTEGER DEFAULT 0,
+            cache_write_tokens INTEGER DEFAULT 0,
+            reasoning_tokens INTEGER DEFAULT 0,
+            billing_provider TEXT,
+            estimated_cost_usd REAL,
+            actual_cost_usd REAL
+        );
+        CREATE TABLE session_model_usage (
+            session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+            model TEXT NOT NULL,
+            billing_provider TEXT NOT NULL DEFAULT '',
+            billing_base_url TEXT NOT NULL DEFAULT '',
+            billing_mode TEXT NOT NULL DEFAULT '',
+            task TEXT NOT NULL DEFAULT '',
+            input_tokens INTEGER NOT NULL DEFAULT 0,
+            output_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+            estimated_cost_usd REAL NOT NULL DEFAULT 0,
+            actual_cost_usd REAL NOT NULL DEFAULT 0,
+            PRIMARY KEY (session_id, model, billing_provider, billing_base_url, billing_mode, task)
+        );
+        "#,
+    )
+    .unwrap();
+    db_path
+}
+
 /// Schema of a Hermes build that predates `session_model_usage`.
 fn create_legacy_test_db(dir: &TempDir) -> std::path::PathBuf {
     let db_path = dir.path().join("legacy-state.db");
@@ -145,7 +188,7 @@ fn test_parse_hermes_sqlite_reads_session_rows_and_preserves_message_count() {
     assert_eq!(msg.cost, 0.34);
     assert_eq!(
         msg.dedup_key.as_deref(),
-        Some("hermes:session-1:claude-sonnet-4")
+        Some("hermes:session-1:claude-sonnet-4:anthropic")
     );
 }
 
@@ -198,7 +241,8 @@ fn test_parse_hermes_sqlite_skips_empty_sessions_and_falls_back_to_estimated_cos
     )
     .unwrap();
 
-    // Empty session (no smu row — excluded by JOIN, never reaches HAVING)
+    // Empty session: no smu row, and no session totals either, so neither the
+    // per-model pass nor the session-totals reconciliation emits it.
     conn.execute(
         r#"
         INSERT INTO sessions (
@@ -439,7 +483,7 @@ fn test_parse_hermes_sqlite_emits_per_model_rows_for_multi_model_session() {
     assert_eq!(cohere.message_count, 0); // secondary model
     assert_eq!(
         cohere.dedup_key.as_deref(),
-        Some("hermes:session-multi:cohere/north-mini-code:free")
+        Some("hermes:session-multi:cohere/north-mini-code:free:bifrost")
     );
 
     // glm-5.2: primary model, gets message_count
@@ -449,7 +493,7 @@ fn test_parse_hermes_sqlite_emits_per_model_rows_for_multi_model_session() {
     assert_eq!(glm.message_count, 15); // primary model
     assert_eq!(
         glm.dedup_key.as_deref(),
-        Some("hermes:session-multi:glm-5.2")
+        Some("hermes:session-multi:glm-5.2:kilocode")
     );
 
     // mimo-v2.5-free: secondary model
@@ -462,7 +506,7 @@ fn test_parse_hermes_sqlite_emits_per_model_rows_for_multi_model_session() {
     assert_eq!(mimo.message_count, 0); // secondary model
     assert_eq!(
         mimo.dedup_key.as_deref(),
-        Some("hermes:session-multi:mimo-v2.5-free")
+        Some("hermes:session-multi:mimo-v2.5-free:opencode-zen")
     );
 }
 
@@ -595,4 +639,464 @@ fn test_parse_hermes_sqlite_legacy_skips_empty_sessions_and_falls_back_to_estima
     assert_eq!(msg.cost, 1.25);
     assert_eq!(msg.message_count, 3);
     assert_eq!(msg.dedup_key.as_deref(), Some("legacy-valid"));
+}
+
+/// A Hermes upgrade can create `session_model_usage` without backfilling
+/// existing sessions. Those sessions have real usage on `sessions` and no smu
+/// child row, so a table-level probe plus an inner JOIN drops them entirely.
+#[test]
+fn test_parse_hermes_sqlite_emits_session_totals_for_sessions_without_smu_rows() {
+    let dir = TempDir::new().unwrap();
+    let db_path = create_test_db(&dir);
+    let conn = Connection::open(&db_path).unwrap();
+
+    // Backfilled session: has smu rows, so smu is authoritative for it.
+    conn.execute(
+        r#"
+        INSERT INTO sessions (
+            id, source, model, started_at, message_count,
+            input_tokens, output_tokens, billing_provider, actual_cost_usd
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+        "#,
+        params![
+            "session-backfilled",
+            "cli",
+            "claude-sonnet-4",
+            1_775_003_000.0_f64,
+            5_i64,
+            1200_i64,
+            300_i64,
+            "anthropic",
+            0.10_f64,
+        ],
+    )
+    .unwrap();
+    conn.execute(
+        r#"
+        INSERT INTO session_model_usage (
+            session_id, model, billing_provider, billing_base_url, billing_mode, task,
+            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
+            estimated_cost_usd, actual_cost_usd
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+        "#,
+        params![
+            "session-backfilled",
+            "claude-sonnet-4",
+            "anthropic",
+            "",
+            "",
+            "",
+            1200_i64,
+            300_i64,
+            0_i64,
+            0_i64,
+            0_i64,
+            0.0_f64,
+            0.10_f64,
+        ],
+    )
+    .unwrap();
+
+    // Pre-upgrade session: substantial usage, no smu child row at all.
+    conn.execute(
+        r#"
+        INSERT INTO sessions (
+            id, source, model, started_at, message_count,
+            input_tokens, output_tokens, billing_provider, actual_cost_usd
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+        "#,
+        params![
+            "session-not-backfilled",
+            "desktop",
+            "claude-opus-4-6",
+            1_775_003_001.0_f64,
+            42_i64,
+            999_000_i64,
+            12_000_i64,
+            "anthropic",
+            2.50_f64,
+        ],
+    )
+    .unwrap();
+
+    let messages = parse_hermes_sqlite(&db_path);
+    assert_eq!(messages.len(), 2);
+
+    // The backfilled session is emitted exactly once — the two passes are
+    // disjoint, so it is not counted by both.
+    let backfilled: Vec<_> = messages
+        .iter()
+        .filter(|m| m.session_id == "session-backfilled")
+        .collect();
+    assert_eq!(backfilled.len(), 1);
+    assert_eq!(backfilled[0].tokens.input, 1200);
+    assert_eq!(
+        backfilled[0].dedup_key.as_deref(),
+        Some("hermes:session-backfilled:claude-sonnet-4:anthropic")
+    );
+
+    let recovered = messages
+        .iter()
+        .find(|m| m.session_id == "session-not-backfilled")
+        .expect("session without smu rows must still be reported");
+    assert_eq!(recovered.model_id, "claude-opus-4-6");
+    assert_eq!(recovered.provider_id, "anthropic");
+    assert_eq!(recovered.tokens.input, 999_000);
+    assert_eq!(recovered.tokens.output, 12_000);
+    assert_eq!(recovered.cost, 2.50);
+    assert_eq!(recovered.message_count, 42);
+    assert_eq!(
+        recovered.dedup_key.as_deref(),
+        Some("session-not-backfilled")
+    );
+}
+
+/// A session with *some* smu coverage is reported from smu alone. Topping it up
+/// from the session totals would double count whatever smu already recorded.
+#[test]
+fn test_parse_hermes_sqlite_does_not_top_up_partially_covered_sessions() {
+    let dir = TempDir::new().unwrap();
+    let db_path = create_test_db(&dir);
+    let conn = Connection::open(&db_path).unwrap();
+
+    conn.execute(
+        r#"
+        INSERT INTO sessions (
+            id, source, model, started_at, message_count, input_tokens, output_tokens
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+        "#,
+        params![
+            "session-partial",
+            "cli",
+            "glm-5.2",
+            1_775_003_100.0_f64,
+            9_i64,
+            5000_i64,
+            900_i64,
+        ],
+    )
+    .unwrap();
+    conn.execute(
+        r#"
+        INSERT INTO session_model_usage (
+            session_id, model, billing_provider, billing_base_url, billing_mode, task,
+            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
+            estimated_cost_usd, actual_cost_usd
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+        "#,
+        params![
+            "session-partial",
+            "glm-5.2",
+            "kilocode",
+            "",
+            "",
+            "",
+            3000_i64,
+            400_i64,
+            0_i64,
+            0_i64,
+            0_i64,
+            0.0_f64,
+            0.0_f64,
+        ],
+    )
+    .unwrap();
+
+    let messages = parse_hermes_sqlite(&db_path);
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].tokens.input, 3000);
+    assert_eq!(messages[0].tokens.output, 400);
+}
+
+/// Schema drift (here: a `session_model_usage` without `reasoning_tokens`)
+/// makes the per-model query fail to prepare. That must degrade to the session
+/// totals, not to reporting nothing at all.
+#[test]
+fn test_parse_hermes_sqlite_falls_back_to_session_totals_when_per_model_query_cannot_prepare() {
+    let dir = TempDir::new().unwrap();
+    let db_path = create_drifted_test_db(&dir);
+    let conn = Connection::open(&db_path).unwrap();
+
+    conn.execute(
+        r#"
+        INSERT INTO sessions (
+            id, source, model, started_at, message_count,
+            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
+            billing_provider, estimated_cost_usd, actual_cost_usd
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+        "#,
+        params![
+            "drifted-session",
+            "cli",
+            "claude-sonnet-4",
+            1_750_000_000.25_f64,
+            42_i64,
+            1200_i64,
+            300_i64,
+            50_i64,
+            20_i64,
+            10_i64,
+            "anthropic",
+            0.12_f64,
+            0.34_f64,
+        ],
+    )
+    .unwrap();
+    conn.execute(
+        r#"
+        INSERT INTO session_model_usage (
+            session_id, model, billing_provider, billing_base_url, billing_mode, task,
+            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+            estimated_cost_usd, actual_cost_usd
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+        "#,
+        params![
+            "drifted-session",
+            "claude-sonnet-4",
+            "anthropic",
+            "",
+            "",
+            "",
+            1200_i64,
+            300_i64,
+            50_i64,
+            20_i64,
+            0.12_f64,
+            0.34_f64,
+        ],
+    )
+    .unwrap();
+
+    let messages = parse_hermes_sqlite(&db_path);
+    assert_eq!(messages.len(), 1);
+
+    let msg = &messages[0];
+    assert_eq!(msg.session_id, "drifted-session");
+    assert_eq!(msg.tokens.input, 1200);
+    assert_eq!(msg.tokens.output, 300);
+    assert_eq!(msg.tokens.reasoning, 10);
+    assert_eq!(msg.cost, 0.34);
+    assert_eq!(msg.message_count, 42);
+    assert_eq!(msg.dedup_key.as_deref(), Some("drifted-session"));
+}
+
+/// The composite primary key lets one (session, model) span several billing
+/// providers. Collapsing them would credit every token to one provider and hide
+/// the other from the provider breakdown.
+#[test]
+fn test_parse_hermes_sqlite_keeps_billing_providers_separate_for_same_model() {
+    let dir = TempDir::new().unwrap();
+    let db_path = create_test_db(&dir);
+    let conn = Connection::open(&db_path).unwrap();
+
+    conn.execute(
+        r#"
+        INSERT INTO sessions (
+            id, source, model, started_at, message_count
+        ) VALUES (?1, ?2, ?3, ?4, ?5)
+        "#,
+        params![
+            "session-split",
+            "desktop",
+            "glm-5.2",
+            1_775_004_000.0_f64,
+            7_i64,
+        ],
+    )
+    .unwrap();
+
+    for (provider, input) in [("kilocode", 1000_i64), ("opencode-zen", 2000_i64)] {
+        conn.execute(
+            r#"
+            INSERT INTO session_model_usage (
+                session_id, model, billing_provider, billing_base_url, billing_mode, task,
+                input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
+                estimated_cost_usd, actual_cost_usd
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+            "#,
+            params![
+                "session-split",
+                "glm-5.2",
+                provider,
+                "",
+                "",
+                "",
+                input,
+                0_i64,
+                0_i64,
+                0_i64,
+                0_i64,
+                0.0_f64,
+                0.0_f64,
+            ],
+        )
+        .unwrap();
+    }
+
+    let messages = parse_hermes_sqlite(&db_path);
+    assert_eq!(messages.len(), 2);
+
+    let kilocode = messages
+        .iter()
+        .find(|m| m.provider_id == "kilocode")
+        .expect("kilocode must survive the grouping");
+    let opencode = messages
+        .iter()
+        .find(|m| m.provider_id == "opencode_zen")
+        .expect("opencode-zen must survive the grouping");
+
+    assert_eq!(kilocode.tokens.input, 1000);
+    assert_eq!(opencode.tokens.input, 2000);
+    assert_eq!(
+        kilocode.dedup_key.as_deref(),
+        Some("hermes:session-split:glm-5.2:kilocode")
+    );
+    assert_eq!(
+        opencode.dedup_key.as_deref(),
+        Some("hermes:session-split:glm-5.2:opencode-zen")
+    );
+
+    // `sessions.message_count` is a per-session total, so splitting the primary
+    // model across providers must not credit it twice.
+    assert_eq!(
+        kilocode.message_count + opencode.message_count,
+        7,
+        "session message_count must be credited exactly once"
+    );
+}
+
+/// Cost is resolved per row before summing: a row with a reconciled actual cost
+/// must not discard the estimated cost of its task-variant siblings.
+#[test]
+fn test_parse_hermes_sqlite_sums_actual_and_estimated_costs_per_row() {
+    let dir = TempDir::new().unwrap();
+    let db_path = create_test_db(&dir);
+    let conn = Connection::open(&db_path).unwrap();
+
+    conn.execute(
+        r#"
+        INSERT INTO sessions (
+            id, source, model, started_at, message_count
+        ) VALUES (?1, ?2, ?3, ?4, ?5)
+        "#,
+        params!["session-cost", "cli", "gpt-5.4", 1_775_005_000.0_f64, 4_i64,],
+    )
+    .unwrap();
+
+    // Reconciled row: actual cost known.
+    conn.execute(
+        r#"
+        INSERT INTO session_model_usage (
+            session_id, model, billing_provider, billing_base_url, billing_mode, task,
+            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
+            estimated_cost_usd, actual_cost_usd
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+        "#,
+        params![
+            "session-cost",
+            "gpt-5.4",
+            "openai",
+            "",
+            "",
+            "",
+            1000_i64,
+            200_i64,
+            0_i64,
+            0_i64,
+            0_i64,
+            0.0_f64,
+            0.50_f64,
+        ],
+    )
+    .unwrap();
+
+    // Task-variant sibling: only an estimate so far.
+    conn.execute(
+        r#"
+        INSERT INTO session_model_usage (
+            session_id, model, billing_provider, billing_base_url, billing_mode, task,
+            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
+            estimated_cost_usd, actual_cost_usd
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+        "#,
+        params![
+            "session-cost",
+            "gpt-5.4",
+            "openai",
+            "",
+            "",
+            "title_generation",
+            100_i64,
+            20_i64,
+            0_i64,
+            0_i64,
+            0_i64,
+            0.05_f64,
+            0.0_f64,
+        ],
+    )
+    .unwrap();
+
+    let messages = parse_hermes_sqlite(&db_path);
+    assert_eq!(messages.len(), 1);
+    assert!(
+        (messages[0].cost - 0.55).abs() < 1e-9,
+        "expected 0.50 actual + 0.05 estimated, got {}",
+        messages[0].cost
+    );
+    assert_eq!(messages[0].tokens.input, 1100);
+}
+
+/// A group whose only signal is cost still has to be emitted: the HAVING clause
+/// and the projection must agree on how cost is computed.
+#[test]
+fn test_parse_hermes_sqlite_emits_cost_only_rows() {
+    let dir = TempDir::new().unwrap();
+    let db_path = create_test_db(&dir);
+    let conn = Connection::open(&db_path).unwrap();
+
+    conn.execute(
+        r#"
+        INSERT INTO sessions (
+            id, source, model, started_at, message_count
+        ) VALUES (?1, ?2, ?3, ?4, ?5)
+        "#,
+        params![
+            "session-cost-only",
+            "cli",
+            "gpt-5.4",
+            1_775_006_000.0_f64,
+            1_i64,
+        ],
+    )
+    .unwrap();
+    conn.execute(
+        r#"
+        INSERT INTO session_model_usage (
+            session_id, model, billing_provider, billing_base_url, billing_mode, task,
+            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
+            estimated_cost_usd, actual_cost_usd
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+        "#,
+        params![
+            "session-cost-only",
+            "gpt-5.4",
+            "openai",
+            "",
+            "",
+            "",
+            0_i64,
+            0_i64,
+            0_i64,
+            0_i64,
+            0_i64,
+            0.07_f64,
+            0.0_f64,
+        ],
+    )
+    .unwrap();
+
+    let messages = parse_hermes_sqlite(&db_path);
+    assert_eq!(messages.len(), 1);
+    assert!((messages[0].cost - 0.07).abs() < 1e-9);
 }

--- a/crates/tokscale-core/tests/hermes.rs
+++ b/crates/tokscale-core/tests/hermes.rs
@@ -49,6 +49,33 @@ fn create_test_db(dir: &TempDir) -> std::path::PathBuf {
     db_path
 }
 
+/// Schema of a Hermes build that predates `session_model_usage`.
+fn create_legacy_test_db(dir: &TempDir) -> std::path::PathBuf {
+    let db_path = dir.path().join("legacy-state.db");
+    let conn = Connection::open(&db_path).unwrap();
+    conn.execute_batch(
+        r#"
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT NOT NULL,
+            model TEXT,
+            started_at REAL NOT NULL,
+            message_count INTEGER DEFAULT 0,
+            input_tokens INTEGER DEFAULT 0,
+            output_tokens INTEGER DEFAULT 0,
+            cache_read_tokens INTEGER DEFAULT 0,
+            cache_write_tokens INTEGER DEFAULT 0,
+            reasoning_tokens INTEGER DEFAULT 0,
+            billing_provider TEXT,
+            estimated_cost_usd REAL,
+            actual_cost_usd REAL
+        );
+        "#,
+    )
+    .unwrap();
+    db_path
+}
+
 #[test]
 fn test_parse_hermes_sqlite_reads_session_rows_and_preserves_message_count() {
     let dir = TempDir::new().unwrap();
@@ -437,4 +464,135 @@ fn test_parse_hermes_sqlite_emits_per_model_rows_for_multi_model_session() {
         mimo.dedup_key.as_deref(),
         Some("hermes:session-multi:mimo-v2.5-free")
     );
+}
+
+#[test]
+fn test_parse_hermes_sqlite_falls_back_to_session_totals_without_session_model_usage() {
+    let dir = TempDir::new().unwrap();
+    let db_path = create_legacy_test_db(&dir);
+    let conn = Connection::open(&db_path).unwrap();
+
+    conn.execute(
+        r#"
+        INSERT INTO sessions (
+            id, source, model, started_at, message_count,
+            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
+            billing_provider, estimated_cost_usd, actual_cost_usd
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+        "#,
+        params![
+            "legacy-session",
+            "cli",
+            "claude-sonnet-4",
+            1_750_000_000.25_f64,
+            42_i64,
+            1200_i64,
+            300_i64,
+            50_i64,
+            20_i64,
+            10_i64,
+            "anthropic",
+            0.12_f64,
+            0.34_f64,
+        ],
+    )
+    .unwrap();
+
+    let messages = parse_hermes_sqlite(&db_path);
+    assert_eq!(messages.len(), 1);
+
+    let msg = &messages[0];
+    assert_eq!(msg.client, "hermes");
+    assert_eq!(msg.agent.as_deref(), Some("Hermes Agent"));
+    assert_eq!(msg.session_id, "legacy-session");
+    assert_eq!(msg.model_id, "claude-sonnet-4");
+    assert_eq!(msg.provider_id, "anthropic");
+    assert_eq!(msg.timestamp, 1_750_000_000_250_i64);
+    assert_eq!(msg.message_count, 42);
+    assert_eq!(msg.tokens.input, 1200);
+    assert_eq!(msg.tokens.output, 300);
+    assert_eq!(msg.tokens.cache_read, 50);
+    assert_eq!(msg.tokens.cache_write, 20);
+    assert_eq!(msg.tokens.reasoning, 10);
+    assert_eq!(msg.cost, 0.34);
+    // The session-totals path emits one message per session, so it keeps the
+    // bare session id as the dedup key.
+    assert_eq!(msg.dedup_key.as_deref(), Some("legacy-session"));
+}
+
+#[test]
+fn test_parse_hermes_sqlite_legacy_skips_empty_sessions_and_falls_back_to_estimated_cost() {
+    let dir = TempDir::new().unwrap();
+    let db_path = create_legacy_test_db(&dir);
+    let conn = Connection::open(&db_path).unwrap();
+
+    // Valid session with tokens but no actual cost and no billing provider
+    conn.execute(
+        r#"
+        INSERT INTO sessions (
+            id, source, model, started_at, message_count,
+            input_tokens, output_tokens, reasoning_tokens,
+            billing_provider, estimated_cost_usd, actual_cost_usd
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+        "#,
+        params![
+            "legacy-valid",
+            "telegram",
+            "gpt-5.4",
+            1_775_001_102.0_f64,
+            3_i64,
+            100_i64,
+            20_i64,
+            5_i64,
+            Option::<String>::None,
+            1.25_f64,
+            Option::<f64>::None,
+        ],
+    )
+    .unwrap();
+
+    // Session with no usage at all — should be excluded by WHERE
+    conn.execute(
+        r#"
+        INSERT INTO sessions (
+            id, source, model, started_at, message_count
+        ) VALUES (?1, ?2, ?3, ?4, ?5)
+        "#,
+        params![
+            "legacy-empty",
+            "telegram",
+            "gpt-5.4",
+            1_775_001_103.0_f64,
+            9_i64,
+        ],
+    )
+    .unwrap();
+
+    // Session with no model — should be excluded by WHERE
+    conn.execute(
+        r#"
+        INSERT INTO sessions (
+            id, source, model, started_at, message_count, input_tokens
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+        "#,
+        params![
+            "legacy-no-model",
+            "cli",
+            Option::<String>::None,
+            1_775_001_104.0_f64,
+            1_i64,
+            500_i64,
+        ],
+    )
+    .unwrap();
+
+    let messages = parse_hermes_sqlite(&db_path);
+    assert_eq!(messages.len(), 1);
+
+    let msg = &messages[0];
+    assert_eq!(msg.session_id, "legacy-valid");
+    assert_eq!(msg.provider_id, "openai");
+    assert_eq!(msg.cost, 1.25);
+    assert_eq!(msg.message_count, 3);
+    assert_eq!(msg.dedup_key.as_deref(), Some("legacy-valid"));
 }


### PR DESCRIPTION
## What

Fix Hermes parser to use `session_model_usage` table for per-model token attribution, replacing the `sessions`-only query that misattributed all session tokens to the primary model.

## Why

For multi-model desktop sessions (common with fallback/routing), `sessions.model` stores only the primary model, and `sessions.input_tokens`/`output_tokens` store the **session total** — not the primary model's share. The old query emitted one `UnifiedMessage` per session under `sessions.model`, causing:

1. **Hidden secondary models** — models like `cohere/north-mini-code:free`, `glm-5.2-fp8`, `mimo-v2.5-free` never appeared in `tokscale models --client hermes`
2. **Misattribution** — the primary model was credited with the full session's tokens instead of its actual share

The `session_model_usage` table stores the correct per-model breakdown.

## Changes

- **`crates/tokscale-core/src/sessions/hermes.rs`** — Replace `SELECT ... FROM sessions` with `SELECT ... FROM session_model_usage smu JOIN sessions s ON s.id = smu.session_id GROUP BY smu.session_id, smu.model`. This emits one row per `(session_id, model)`, SUMming across task-variants (`title_generation`, `approval`, `compression`). Added `CASE WHEN smu.model = s.model` for `message_count` to avoid inflating it N× for multi-model sessions. Cost handling moved from `NULLIF` in SQL to `.filter(> 0.0)` in Rust for semantic correctness. `dedup_key` changed from `Some(session_id)` to `Some(format!("hermes:{session_id}:{model_id}"))` so per-model rows survive cross-client dedup.

- **`crates/tokscale-core/src/lib.rs`** — Updated `create_hermes_sqlite_db` and `insert_hermes_session` test helpers to create `session_model_usage` table and insert matching rows.

- **`crates/tokscale-core/tests/hermes.rs`** — Updated all 3 existing tests to use `session_model_usage` for token data. Added `test_parse_hermes_sqlite_emits_per_model_rows_for_multi_model_session` covering SUM across tasks, message_count on primary only, and dedup_key uniqueness.

## Verification

- 4/4 hermes tests pass
- 1273/1273 lib tests pass
- E2E: `tokscale models --client hermes` reports 24,094,685 input — matches `SELECT SUM(input_tokens) FROM session_model_usage` exactly
- Previously hidden models now visible: `cohere/north-mini-code:free`, `glm-5.2-fp8`, `mimo-v2.5-free`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Hermes parser to read per-model usage from `session_model_usage` joined to `sessions`. Fix token attribution in multi-model sessions, keep legacy installs working, and surface all models in `tokscale models --client hermes`.

- **Bug Fixes**
  - Emit one message per (session, model, billing_provider) and SUM task-variant rows; secondary models are included.
  - Credit message_count exactly once per session (primary if present), avoiding N× inflation and missing counts.
  - Reconcile per-model rows with session totals: emit totals for sessions not covered by `session_model_usage`, and fall back when the per-model query isn’t available; legacy schemas keep reporting totals.
  - Resolve cost per row (actual else estimated) before SUM and include cost-only rows; clamp negatives to 0.
  - Dedup key is now `hermes:{session}:{model}:{provider}` (NULL => `<null>`) for injective per-model dedup; bump Hermes parser version to 2 to invalidate v1 cache entries.

<sup>Written for commit 6705b67e821cce6707e0ea86c27aa429619c0fbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

