### PR TITLE
fix(tui): budget the Sessions columns instead of over-subscribing them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3469,6 +3469,7 @@ dependencies = [
  "toml",
  "tracing-subscriber",
  "unicode-normalization",
+ "unicode-segmentation",
  "unicode-width 0.2.0",
  "usvg",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3469,6 +3469,7 @@ dependencies = [
  "toml",
  "tracing-subscriber",
  "unicode-normalization",
+ "unicode-width 0.2.0",
  "usvg",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,11 @@ clap = { version = "4.5", features = ["derive", "cargo"] }
 ratatui = { version = "0.29", features = ["all-widgets"] }
 crossterm = { version = "0.28", features = ["event-stream"] }
 
+# Terminal cell width of a grapheme. ratatui lays tables out in cells and
+# already depends on this crate to do it, so measuring table content with
+# anything else (`chars().count()`) disagrees with the solver on CJK and emoji.
+unicode-width = "0.2"
+
 # Async utilities
 tokio-stream = "0.1"
 futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,12 @@ crossterm = { version = "0.28", features = ["event-stream"] }
 # anything else (`chars().count()`) disagrees with the solver on CJK and emoji.
 unicode-width = "0.2"
 
+# Grapheme cluster boundaries. `char_indices()` only respects UTF-8 character
+# boundaries, so truncating on it splits a flag (two regional indicators) or a
+# ZWJ family emoji mid-sequence and renders garbage. Already in the tree
+# transitively, so this adds no new dependency.
+unicode-segmentation = "1.12"
+
 # Async utilities
 tokio-stream = "0.1"
 futures = "0.3"

--- a/crates/tokscale-cli/Cargo.toml
+++ b/crates/tokscale-cli/Cargo.toml
@@ -49,6 +49,7 @@ rpassword = "7.0"
 sha2 = "0.10"
 csv = "1.3"
 unicode-normalization = "0.1"
+unicode-width = { workspace = true }
 
 # Trae iCubeAuthInfo decryption (Electron globalStorage)
 aes = { workspace = true }

--- a/crates/tokscale-cli/Cargo.toml
+++ b/crates/tokscale-cli/Cargo.toml
@@ -50,6 +50,7 @@ sha2 = "0.10"
 csv = "1.3"
 unicode-normalization = "0.1"
 unicode-width = { workspace = true }
+unicode-segmentation = { workspace = true }
 
 # Trae iCubeAuthInfo decryption (Electron globalStorage)
 aes = { workspace = true }

--- a/crates/tokscale-cli/src/tui/ui/sessions.rs
+++ b/crates/tokscale-cli/src/tui/ui/sessions.rs
@@ -1651,10 +1651,12 @@ mod tests {
                 let mut app = app_with(width, vec![s]);
                 let row = first_row_line(&mut app, width);
                 let cells = row.chars().filter(|c| *c == '모').count() * 2;
+                // Strictly less than the budget: the name has to leave room for
+                // the one ellipsis cell that marks what was dropped.
                 assert!(
-                    cells + 1 <= layout.model_width as usize,
-                    "model took {cells} cells plus an ellipsis out of a {} cell budget at width \
-                     {width} (turn={has_turn})\n{row}",
+                    cells < layout.model_width as usize,
+                    "model took {cells} cells, leaving no room for the ellipsis in a {} cell \
+                     budget at width {width} (turn={has_turn})\n{row}",
                     layout.model_width
                 );
                 assert!(

--- a/crates/tokscale-cli/src/tui/ui/sessions.rs
+++ b/crates/tokscale-cli/src/tui/ui/sessions.rs
@@ -5,8 +5,9 @@ use ratatui::widgets::{
 };
 
 use super::widgets::{
-    format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens,
-    get_client_display_name, total_tokens_cell, truncate_text, viewport_scrollbar_state,
+    display_width, format_cache_hit_rate, format_cost, format_cost_per_million, format_tokens,
+    get_client_display_name, prefix_to_width, total_tokens_cell, truncate_text, truncate_to_width,
+    viewport_scrollbar_state,
 };
 use crate::tui::app::{App, SortDirection, SortField};
 use crate::tui::data::{SessionModel, SessionUsage};
@@ -17,7 +18,9 @@ const MODEL_COLUMN_MAX_CHARS: u16 = 36;
 /// Session title width that slack distribution buys before Model gets any.
 /// Model's 18-cell minimum already renders most model names in full, while
 /// session titles routinely run 40–80 characters, so the marginal cell is worth
-/// more to the title. (Decision B in `docs/sessions-column-budget.md`.)
+/// more to the title. (Decision B in `docs/sessions-column-budget.md`, which is
+/// #965 and lands with it — the path does not resolve in this tree until it
+/// does, which is why the PR number is here too.)
 const SESSION_COLUMN_COMFORTABLE_CHARS: u16 = 40;
 
 /// One column of the wide Sessions layout.
@@ -53,10 +56,17 @@ enum SessionColumn {
 }
 
 /// Every variant, exactly once. `WIDE_ORDER` and `WIDE_PRIORITY` are checked
-/// against this by `every_column_is_ordered_and_prioritized` — the compiler
-/// never looks at those two arrays, so that test is the only thing standing
-/// between a new column and silently never rendering. It lives here rather than
-/// in the test module because it belongs beside the arrays it audits.
+/// against this by `every_column_is_ordered_and_prioritized`, because the
+/// compiler never looks at those two arrays. It lives here rather than in the
+/// test module because it belongs beside the arrays it audits.
+///
+/// Note what that test cannot see: it compares the three arrays *to each other*,
+/// and `ALL` is hand-maintained too, so a variant missing from all three passes
+/// it — verified, with the whole suite green. That shape is caught by the
+/// compiler instead: these arrays are the only places a variant is ever
+/// constructed and `ALL` is `#[cfg(test)]`, so a column absent from all three
+/// is `dead_code` in the non-test build, which CI compiles with `-D warnings`.
+/// The property holds, but by two mechanisms and neither one alone.
 #[cfg(test)]
 const ALL: [SessionColumn; 15] = [
     SessionColumn::Session,
@@ -103,8 +113,8 @@ const WIDE_ORDER: [SessionColumn; 15] = [
 /// The core is one group rather than six so admission can never stop *inside*
 /// it: the wide layout always shows at least the column set the narrow layout
 /// shows, which makes crossing 80 columns widen the table instead of reshaping
-/// it. The tail order is decision A in `docs/sessions-column-budget.md`, ranked
-/// by whether a column helps you find and compare sessions in a list.
+/// it. The tail order is decision A in `docs/sessions-column-budget.md` (#965),
+/// ranked by whether a column helps you find and compare sessions in a list.
 const WIDE_PRIORITY: [&[SessionColumn]; 8] = [
     &[
         SessionColumn::Session,
@@ -214,10 +224,20 @@ impl SessionColumn {
     /// only width input to admission. `Constraint`s are *derived* from this
     /// rather than written beside it: a second literal is exactly the
     /// budget-versus-layout divergence this design exists to kill.
+    ///
+    /// "Realistic" is doing real work in that sentence, so `fit()` enforces
+    /// these numbers on the cell as well rather than trusting them.
     fn natural(self, ctx: &WideCtx) -> u16 {
         match self {
             Self::Session => 20,
-            Self::Client => 12,
+            // The widest name the client registry can produce
+            // (`Antigravity CLI`), pinned by
+            // `client_column_fits_every_registered_client`. At 12 this column
+            // clipped three shipped clients with no marker, and it rendered
+            // `Antigravity CLI` and `Antigravity` identically — a
+            // misattribution in the column whose only job is saying which tool
+            // the session came from.
+            Self::Client => 15,
             Self::Model => 18,
             Self::Turn => 5,
             // Msgs borrows the cell Turn gives up. Keyed on the data rather
@@ -271,7 +291,7 @@ impl SessionColumn {
         layout: &WideLayout,
     ) -> Cell<'static> {
         match self {
-            Self::Session => Cell::from(truncate_text(
+            Self::Session => Cell::from(truncate_to_width(
                 session_label(s),
                 layout.session_width as usize,
             ))
@@ -280,44 +300,74 @@ impl SessionColumn {
                     .fg(app.theme.muted)
                     .add_modifier(Modifier::BOLD),
             ),
-            Self::Client => Cell::from(get_client_display_name(&s.client))
+            Self::Client => Cell::from(self.fit(get_client_display_name(&s.client), ctx))
                 .style(Style::default().fg(app.theme.muted)),
             Self::Model => build_model_cell(&s.models, layout.model_width as usize, app),
-            Self::Turn => Cell::from(if s.turn_count > 0 {
-                s.turn_count.to_string()
-            } else {
-                "\u{2014}".to_string()
-            }),
-            Self::Msgs => Cell::from(s.message_count.to_string()),
-            Self::Input => {
-                Cell::from(format_tokens(s.tokens.input)).style(app.theme.metric_input_style())
-            }
-            Self::Output => {
-                Cell::from(format_tokens(s.tokens.output)).style(app.theme.metric_output_style())
-            }
-            Self::CacheRead => Cell::from(format_tokens(s.tokens.cache_read))
+            Self::Turn => Cell::from(self.fit(
+                if s.turn_count > 0 {
+                    s.turn_count.to_string()
+                } else {
+                    "\u{2014}".to_string()
+                },
+                ctx,
+            )),
+            Self::Msgs => Cell::from(self.fit(s.message_count.to_string(), ctx)),
+            Self::Input => Cell::from(self.fit(format_tokens(s.tokens.input), ctx))
+                .style(app.theme.metric_input_style()),
+            Self::Output => Cell::from(self.fit(format_tokens(s.tokens.output), ctx))
+                .style(app.theme.metric_output_style()),
+            Self::CacheRead => Cell::from(self.fit(format_tokens(s.tokens.cache_read), ctx))
                 .style(app.theme.metric_cache_read_style()),
-            Self::CacheWrite => Cell::from(format_tokens(s.tokens.cache_write))
+            Self::CacheWrite => Cell::from(self.fit(format_tokens(s.tokens.cache_write), ctx))
                 .style(app.theme.metric_cache_write_style()),
-            Self::CacheHit => Cell::from(format_cache_hit_rate(
-                s.tokens.cache_read,
-                s.tokens.input,
-                s.tokens.cache_write,
+            Self::CacheHit => Cell::from(self.fit(
+                format_cache_hit_rate(s.tokens.cache_read, s.tokens.input, s.tokens.cache_write),
+                ctx,
             ))
             .style(Style::default().fg(Color::Cyan)),
-            Self::Total => total_tokens_cell(s.tokens.total(), &app.theme),
-            Self::Cost => Cell::from(format_cost(s.cost)).style(Style::default().fg(Color::Green)),
-            Self::CostPerMillion => Cell::from(format_cost_per_million(s.cost, s.tokens.total()))
-                .style(Style::default().fg(Color::Rgb(150, 200, 150))),
-            Self::Duration => Cell::from(format_duration(s.first_active_ms, s.last_active_ms))
-                .style(Style::default().fg(Color::Yellow)),
+            // Spelled out rather than `total_tokens_cell` — same style, but the
+            // helper has no width to clamp against.
+            Self::Total => Cell::from(self.fit(format_tokens(s.tokens.total()), ctx))
+                .style(app.theme.metric_total_style()),
+            Self::Cost => Cell::from(self.fit(format_cost(s.cost), ctx))
+                .style(Style::default().fg(Color::Green)),
+            Self::CostPerMillion => {
+                Cell::from(self.fit(format_cost_per_million(s.cost, s.tokens.total()), ctx))
+                    .style(Style::default().fg(Color::Rgb(150, 200, 150)))
+            }
+            Self::Duration => {
+                Cell::from(self.fit(format_duration(s.first_active_ms, s.last_active_ms), ctx))
+                    .style(Style::default().fg(Color::Yellow))
+            }
             Self::LastActive => Cell::from(
-                ms_to_local_naive(s.last_active_ms)
-                    .map(|dt| dt.format(ctx.last_active_fmt).to_string())
-                    .unwrap_or_else(|| "\u{2014}".to_string()),
+                self.fit(
+                    ms_to_local_naive(s.last_active_ms)
+                        .map(|dt| dt.format(ctx.last_active_fmt).to_string())
+                        .unwrap_or_else(|| "\u{2014}".to_string()),
+                    ctx,
+                ),
             )
             .style(Style::default().fg(app.theme.muted)),
         }
+    }
+
+    /// Clamp a fixed-width column's text to the width it was laid out with.
+    ///
+    /// A no-op on every value the column was sized for — `natural()` is the
+    /// widest *realistic* one — but "realistic" is an assumption about parsed
+    /// data, not a guarantee about it, and the failure mode when it is wrong is
+    /// the one this whole file exists to remove: 1,234,567 messages rendering
+    /// as `12345`, a bad `first_active_ms` rendering `20092d 14h` as
+    /// `20092d 14`. Clipped by ratatui those are plausible wrong numbers;
+    /// clipped here they are `12...` and `20092d...`, which are visibly
+    /// incomplete. `TokscaleConfig` client names are the one case that is
+    /// user-controlled rather than absurd.
+    ///
+    /// Session and Model are absent because their width comes from the
+    /// resolved `WideLayout` rather than from `natural()`; they clamp against
+    /// `session_width` and `model_width` at their own call sites.
+    fn fit(self, text: String, ctx: &WideCtx) -> String {
+        truncate_to_width(&text, self.natural(ctx) as usize)
     }
 }
 
@@ -365,6 +415,12 @@ fn order_index(c: SessionColumn) -> usize {
 /// Cells a column set occupies: the widths themselves plus one separator
 /// between every pair (ratatui's `column_spacing`, which defaults to 1).
 /// Measured against `inner`, which already has the block borders removed.
+///
+/// The `1` is not a free-floating assumption: at every group threshold the
+/// admitted set exactly fills `inner`, so a second cell of spacing pushes the
+/// last column past the border and
+/// `admitted_columns_render_header_and_value_in_full` goes red. Setting
+/// `.column_spacing(2)` on the table fails six of the tests below.
 fn required(set: &[SessionColumn], ctx: &WideCtx) -> u16 {
     let widths: u16 = set.iter().map(|c| c.natural(ctx)).sum();
     widths + set.len().saturating_sub(1) as u16
@@ -474,14 +530,24 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     // The wide layout is budget-driven: a column is admitted at its natural
     // width or it is not shown. Measured against `inner` rather than the
     // terminal so the budget equals the width ratatui actually divides up.
-    let wide = (!is_narrow && !is_very_narrow).then(|| {
-        let ctx = WideCtx {
-            has_turn: has_turn_data,
-            last_active_fmt,
-        };
-        let layout = admit_and_distribute(inner.width, &ctx);
-        (ctx, layout)
-    });
+    let wide = (!is_narrow && !is_very_narrow)
+        .then(|| {
+            let ctx = WideCtx {
+                has_turn: has_turn_data,
+                last_active_fmt,
+            };
+            let layout = admit_and_distribute(inner.width, &ctx);
+            (ctx, layout)
+        })
+        // The core group is atomic, so an `inner` narrower than its budget
+        // admits nothing at all and the table would render as an empty block —
+        // no header, no rows, no message. The gate above makes that
+        // unreachable through `ui::render`, which passes an `area` as wide as
+        // the terminal, but `render` is `pub` and takes `area` from its caller,
+        // so the precondition is one call site away rather than impossible.
+        // Falling back to the narrow layout costs nothing: it is
+        // percentage-based and renders something at any width.
+        .filter(|(_, layout)| !layout.chosen.is_empty());
 
     let sort_indicator = |field: SortField| -> &'static str {
         if sort_field == field {
@@ -672,20 +738,21 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
 
 /// Build a table cell for the Model column with each model name colored by the
 /// same family-shade system used in the Overview and Models tabs. Multiple
-/// models are joined with `", "`. The total width is truncated to `max_chars`
-/// with an ellipsis when it overflows, counted in `chars()` to match
-/// `truncate_text`, which measures the Session and Client cells in this table.
+/// models are joined with `", "`. The total width is truncated to `max_cells`
+/// with an ellipsis when it overflows, counted in terminal cells to match
+/// `truncate_to_width`, which measures the Session and Client cells in this
+/// table, and to match the unit ratatui lays the column out in.
 ///
 /// A multi-model session always ends in an ellipsis when some of its models did
 /// not fit, so a session that switched models never renders as a single-model
 /// one. One cell is held back for that marker when there is more than one model.
-fn build_model_cell(models: &[SessionModel], max_chars: usize, app: &App) -> Cell<'static> {
+fn build_model_cell(models: &[SessionModel], max_cells: usize, app: &App) -> Cell<'static> {
     if models.is_empty() {
         return Cell::from("\u{2014}".to_string()).style(Style::default().fg(app.theme.muted));
     }
 
     let mut spans: Vec<Span<'static>> = Vec::new();
-    let mut budget = max_chars.saturating_sub(usize::from(models.len() > 1));
+    let mut budget = max_cells.saturating_sub(usize::from(models.len() > 1));
     let mut shown = 0usize;
     let mut ellipsis = false;
 
@@ -704,7 +771,7 @@ fn build_model_cell(models: &[SessionModel], max_chars: usize, app: &App) -> Cel
 
         let color = app.model_color_for(&model.provider, &model.color_key);
         let name = &model.display_name;
-        let model_len = name.chars().count();
+        let model_len = display_width(name);
 
         if model_len <= budget {
             spans.push(Span::styled(name.clone(), Style::default().fg(color)));
@@ -714,7 +781,7 @@ fn build_model_cell(models: &[SessionModel], max_chars: usize, app: &App) -> Cel
             budget = 0;
             ellipsis = true;
         } else {
-            let head: String = name.chars().take(budget - 1).collect();
+            let head = prefix_to_width(name, budget - 1);
             spans.push(Span::styled(
                 format!("{}…", head),
                 Style::default().fg(color),
@@ -779,6 +846,7 @@ mod tests {
     use crate::tui::app::{Tab, TuiConfig};
     use crate::tui::data::TokenBreakdown;
     use ratatui::{backend::TestBackend, Terminal};
+    use tokscale_core::ClientId;
 
     /// Terminal width at which each priority group first appears.
     ///
@@ -787,9 +855,14 @@ mod tests {
     /// the old `model_gate_width` helper never caught that the wide layout asked
     /// for 161 columns and turned on at 80. Amending decision A moves these
     /// numbers, and the diff then names which threshold moved and by how much.
+    ///
+    /// Every number here is three higher than the first draft of this table:
+    /// `natural(Client)` went 12 → 15 so `Antigravity CLI` stops rendering as
+    /// `Antigravity`, and a widened column pushes every later group right by
+    /// exactly its three cells.
     const THRESHOLDS_WITH_TURN: [(u16, &[SessionColumn]); 8] = [
         (
-            69,
+            72,
             &[
                 SessionColumn::Session,
                 SessionColumn::Client,
@@ -799,20 +872,20 @@ mod tests {
                 SessionColumn::Cost,
             ],
         ),
-        (87, &[SessionColumn::LastActive]),
-        (106, &[SessionColumn::Model]),
-        (128, &[SessionColumn::Input, SessionColumn::Output]),
-        (150, &[SessionColumn::CacheRead, SessionColumn::CacheWrite]),
-        (160, &[SessionColumn::Duration]),
-        (169, &[SessionColumn::CacheHit]),
-        (180, &[SessionColumn::CostPerMillion]),
+        (90, &[SessionColumn::LastActive]),
+        (109, &[SessionColumn::Model]),
+        (131, &[SessionColumn::Input, SessionColumn::Output]),
+        (153, &[SessionColumn::CacheRead, SessionColumn::CacheWrite]),
+        (163, &[SessionColumn::Duration]),
+        (172, &[SessionColumn::CacheHit]),
+        (183, &[SessionColumn::CostPerMillion]),
     ];
 
     /// Same table without turn data. Every threshold is five narrower: Turn's
     /// five cells and its separator go away, and Msgs takes one of them back.
     const THRESHOLDS_NO_TURN: [(u16, &[SessionColumn]); 8] = [
         (
-            64,
+            67,
             &[
                 SessionColumn::Session,
                 SessionColumn::Client,
@@ -821,16 +894,16 @@ mod tests {
                 SessionColumn::Cost,
             ],
         ),
-        (82, &[SessionColumn::LastActive]),
-        (101, &[SessionColumn::Model]),
-        (123, &[SessionColumn::Input, SessionColumn::Output]),
-        (145, &[SessionColumn::CacheRead, SessionColumn::CacheWrite]),
-        (155, &[SessionColumn::Duration]),
-        (164, &[SessionColumn::CacheHit]),
-        (175, &[SessionColumn::CostPerMillion]),
+        (85, &[SessionColumn::LastActive]),
+        (104, &[SessionColumn::Model]),
+        (126, &[SessionColumn::Input, SessionColumn::Output]),
+        (148, &[SessionColumn::CacheRead, SessionColumn::CacheWrite]),
+        (158, &[SessionColumn::Duration]),
+        (167, &[SessionColumn::CacheHit]),
+        (178, &[SessionColumn::CostPerMillion]),
     ];
 
-    /// Widest terminal the sweeps cover. Past the last threshold (180) nothing
+    /// Widest terminal the sweeps cover. Past the last threshold (183) nothing
     /// changes but the Session column's share of the slack.
     const SWEEP_MAX: u16 = 240;
 
@@ -983,11 +1056,19 @@ mod tests {
     }
 
     fn render_body(app: &mut App, width: u16, height: u16) -> String {
+        render_into(app, width, height, Rect::new(0, 0, width, height))
+    }
+
+    /// `render_body` with the drawing area decoupled from the terminal, which is
+    /// the only way to reach an `area` narrower than `app.terminal_width`.
+    ///
+    /// A wide grapheme occupies two cells and ratatui stores its symbol in the
+    /// first and an empty string in the second, so a returned line has one
+    /// `char` per grapheme, not one per cell.
+    fn render_into(app: &mut App, width: u16, height: u16, area: Rect) -> String {
         let backend = TestBackend::new(width, height);
         let mut terminal = Terminal::new(backend).unwrap();
-        terminal
-            .draw(|frame| render(frame, app, Rect::new(0, 0, width, height)))
-            .unwrap();
+        terminal.draw(|frame| render(frame, app, area)).unwrap();
         terminal
             .backend()
             .buffer()
@@ -1107,7 +1188,7 @@ mod tests {
         for has_turn in [true, false] {
             let ctx = wide_ctx(has_turn);
             let core = thresholds(has_turn)[0].1;
-            let floor = if has_turn { 67 } else { 62 };
+            let floor = if has_turn { 70 } else { 65 };
             assert_eq!(
                 required(core, &ctx),
                 floor,
@@ -1124,6 +1205,33 @@ mod tests {
                     );
                 }
             }
+        }
+    }
+
+    /// Admission takes whole groups, so an area narrower than the core group's
+    /// budget admits nothing and the wide branch would draw an empty block —
+    /// no header, no rows, no message. `ui::render` cannot produce that, but
+    /// `render` takes `area` from its caller and asserts the precondition
+    /// nowhere, so the fallback is what makes the blank panel unreachable
+    /// rather than merely unreached.
+    #[test]
+    fn an_area_below_the_core_budget_falls_back_instead_of_rendering_nothing() {
+        for area_width in [30u16, 40, 50, 60, 68, 71] {
+            let mut app = app_with(200, vec![fat_session()]);
+            let body = render_into(&mut app, 200, 6, Rect::new(0, 0, area_width, 6));
+            let mut lines = body.lines().skip(1);
+            let header = lines.next().unwrap_or_default();
+            let row = lines.next().unwrap_or_default();
+            // Cost is the last column of every narrow variant, so its header
+            // and its value are present whichever one the fallback picked.
+            assert!(
+                header.contains("Cost"),
+                "blank Sessions header at area width {area_width}\n{body}"
+            );
+            assert!(
+                row.contains("$12"),
+                "blank Sessions row at area width {area_width}\n{body}"
+            );
         }
     }
 
@@ -1221,34 +1329,53 @@ mod tests {
     /// The active sort arrow is legible whenever its column is admitted, and
     /// absent from the whole header when it is not. Today `Last Active ▼` is
     /// missing at 77 of 121 widths.
+    ///
+    /// Both directions, because `make_app` fixes the sort to descending and an
+    /// ascending-only clipping bug would otherwise pass. Placement is
+    /// direction-independent by construction — `sort_indicator` picks the glyph
+    /// and the header is formatted the same either way — so this is coverage of
+    /// the glyph, not of a second code path.
     #[test]
     fn sort_indicator_is_legible_exactly_when_its_column_is_admitted() {
         for width in 80u16..=SWEEP_MAX {
             for has_turn in [true, false] {
-                for (field, column) in [
-                    (SortField::Cost, SessionColumn::Cost),
-                    (SortField::Tokens, SessionColumn::Total),
-                    (SortField::Date, SessionColumn::LastActive),
+                for (direction, arrow) in [
+                    (SortDirection::Descending, '▼'),
+                    (SortDirection::Ascending, '▲'),
                 ] {
-                    let mut s = fat_session();
-                    if !has_turn {
-                        s.turn_count = 0;
-                    }
-                    let mut app = app_with(width, vec![s]);
-                    app.sort_field = field;
-                    let header = header_line(&mut app, width);
-                    if expected_columns(width, has_turn).contains(&column) {
+                    for (field, column) in [
+                        (SortField::Cost, SessionColumn::Cost),
+                        (SortField::Tokens, SessionColumn::Total),
+                        (SortField::Date, SessionColumn::LastActive),
+                    ] {
+                        let mut s = fat_session();
+                        if !has_turn {
+                            s.turn_count = 0;
+                        }
+                        let mut app = app_with(width, vec![s]);
+                        app.sort_field = field;
+                        app.sort_direction = direction;
+                        let header = header_line(&mut app, width);
+                        if expected_columns(width, has_turn).contains(&column) {
+                            assert!(
+                                header.contains(&format!("{} {arrow}", column.header())),
+                                "{:?} {arrow} clipped at width {width} (turn={has_turn})\n{header}",
+                                field
+                            );
+                        } else {
+                            assert!(
+                                !header.contains(arrow),
+                                "{:?} drew {arrow} with its column unadmitted at width {width} \
+                                 (turn={has_turn})\n{header}",
+                                field
+                            );
+                        }
+                        // The other glyph must never appear at all — one active
+                        // sort, one arrow.
+                        let other = if arrow == '▼' { '▲' } else { '▼' };
                         assert!(
-                            header.contains(&format!("{} ▼", column.header())),
-                            "{:?} indicator clipped at width {width} (turn={has_turn})\n{header}",
-                            field
-                        );
-                    } else {
-                        assert!(
-                            !header.contains('▼'),
-                            "{:?} drew an arrow with its column unadmitted at width {width} \
-                             (turn={has_turn})\n{header}",
-                            field
+                            !header.contains(other),
+                            "both arrows drawn at width {width} (turn={has_turn})\n{header}"
                         );
                     }
                 }
@@ -1321,6 +1448,110 @@ mod tests {
         }
     }
 
+    /// `natural()` is sized for realistic values, and every one of these is
+    /// unrealistic — a `first_active_ms` of 1, a session that paid for one
+    /// input token and read 45M from cache, a six-digit message count. None of
+    /// them is reachable through an honest session; all of them are reachable
+    /// through a bad timestamp or a bad token count, and this file exists
+    /// because of what ratatui does to a value that does not fit.
+    ///
+    /// Each line below names what the value rendered as before `fit()`: a
+    /// number that looks like a number and is wrong by two to five orders of
+    /// magnitude, which is #964 again in a column nobody was looking at.
+    #[test]
+    fn absurd_values_are_marked_rather_than_clipped_to_plausible_ones() {
+        let width = 240;
+        let mut s = fat_session();
+        s.first_active_ms = 1; // "20092d 14h" in nine cells -> `20092d 14`
+        s.tokens.input = 1;
+        s.tokens.cache_write = 0;
+        s.tokens.cache_read = 45_678_901; // "45678901.0x" in eight -> `45678901`
+        s.message_count = 1_234_567; // in five -> `12345`
+        s.turn_count = 999_999; // in five -> `99999`
+        let mut app = app_with(width, vec![s]);
+        let row = first_row_line(&mut app, width);
+        for plausible in ["12345", "99999", "45678901", "20092d 14"] {
+            assert!(
+                !row.contains(plausible),
+                "{plausible:?} is a clipped value passing for a whole one\n{row}"
+            );
+        }
+        // What they render as instead, so this test fails if the marker moves.
+        for marked in ["12...", "99...", "45678...", "20092d..."] {
+            assert!(
+                row.contains(marked),
+                "expected {marked:?} in the row\n{row}"
+            );
+        }
+    }
+
+    // ---- the Client budget is a claim about the client registry ------------
+
+    /// `natural(Client)` asserts something about `clients.rs`, so check it
+    /// against `clients.rs` rather than against a fixture. Every name the
+    /// registry can produce has to fit at its natural width, or the column that
+    /// says which tool a session came from starts answering with a prefix.
+    ///
+    /// Adding a client with a longer display name fails here. The fix is to
+    /// raise `natural(Client)` and move every threshold in the tables above by
+    /// the same number of cells — not to lower the budget back down.
+    #[test]
+    fn client_column_fits_every_registered_client() {
+        let budget = SessionColumn::Client.natural(&wide_ctx(true)) as usize;
+        for client in ClientId::iter() {
+            let name = get_client_display_name(client.as_str());
+            assert!(
+                display_width(&name) <= budget,
+                "{client:?} renders {name:?} ({} cells) in a {budget}-cell Client column",
+                display_width(&name)
+            );
+        }
+    }
+
+    /// The concrete failure the budget above prevents: at 12 cells these two
+    /// rows were byte-identical at every width, which is a misattribution and
+    /// not a cosmetic clip. `🦞 OpenClaw` is here because its emoji is one char
+    /// and two cells, so a code-point budget gets it wrong in the other
+    /// direction.
+    #[test]
+    fn clients_sharing_a_prefix_render_distinguishably() {
+        let width = 200;
+        for (a, b) in [
+            ("antigravity-cli", "antigravity"),
+            ("opencodereview", "opencode"),
+            ("devin-desktop", "devin"),
+            ("openclaw", "opencode"),
+        ] {
+            let render_one = |client: &str| {
+                let mut s = fat_session();
+                s.client = client.to_string();
+                let mut app = app_with(width, vec![s]);
+                first_row_line(&mut app, width)
+            };
+            assert_ne!(
+                render_one(a),
+                render_one(b),
+                "{a} and {b} render the same row at width {width}"
+            );
+        }
+    }
+
+    /// `TokscaleConfig` lets a user name a client anything, and an unrecognised
+    /// id is echoed through verbatim, so the budget has to be enforced at the
+    /// cell instead of trusted. Past it the name is marked, not silently cut.
+    #[test]
+    fn an_over_long_client_name_is_marked_truncated() {
+        let width = 200;
+        let mut s = fat_session();
+        s.client = "a-client-with-a-very-long-name".to_string();
+        let mut app = app_with(width, vec![s]);
+        let row = first_row_line(&mut app, width);
+        assert!(
+            row.contains("a-client-wit..."),
+            "an over-long client name must carry an ellipsis\n{row}"
+        );
+    }
+
     // ---- slack distribution ------------------------------------------------
 
     /// Session is the sole `Min` column, so ratatui hands it every cell that
@@ -1357,20 +1588,98 @@ mod tests {
         }
     }
 
+    /// The same claim with a title whose graphemes are two cells wide. A
+    /// code-point budget calls 28 Hangul syllables comfortable in a 34-cell
+    /// column, returns them untouched, and ratatui clips them at 17 with no
+    /// marker — the exact silent truncation this change exists to remove, in
+    /// the one column that was still measuring in the wrong unit.
+    #[test]
+    fn a_full_width_title_is_budgeted_in_cells_not_code_points() {
+        let title = "가".repeat(60);
+        for width in 80u16..=SWEEP_MAX {
+            for has_turn in [true, false] {
+                let ctx = wide_ctx(has_turn);
+                let layout = admit_and_distribute(width - 2, &ctx);
+                let mut s = fat_session();
+                s.title = Some(title.clone());
+                if !has_turn {
+                    s.turn_count = 0;
+                }
+                let mut app = app_with(width, vec![s]);
+                let row = first_row_line(&mut app, width);
+                // One `char` per grapheme, and ratatui blanks the second cell
+                // of a wide one, so each syllable shows up as "가 ".
+                let cells = row.chars().filter(|c| *c == '가').count() * 2;
+                assert!(
+                    cells + 3 <= layout.session_width as usize,
+                    "title took {cells} cells plus an ellipsis out of a {} cell budget at width \
+                     {width} (turn={has_turn})\n{row}",
+                    layout.session_width
+                );
+                // The marker has to sit in the Session cell, before Client.
+                let marker = row.find("...").unwrap_or(usize::MAX);
+                let client = row.find("OpenCode").unwrap_or(0);
+                assert!(
+                    marker < client,
+                    "an over-long full-width title must be marked as truncated at width \
+                     {width} (turn={has_turn})\n{row}"
+                );
+            }
+        }
+    }
+
+    /// `build_model_cell` measures in cells for the same reason the Session and
+    /// Client cells do, and needs its own fixture because every other model in
+    /// this file is ASCII. On a code-point budget a full-width name fills 17
+    /// graphemes of an 18-cell column, and the "…" it appends is the first
+    /// thing the solver cuts — a truncated name that does not look truncated.
+    #[test]
+    fn a_full_width_model_name_is_budgeted_in_cells_not_code_points() {
+        for width in [120u16, 160, 220] {
+            for has_turn in [true, false] {
+                let ctx = wide_ctx(has_turn);
+                let layout = admit_and_distribute(width - 2, &ctx);
+                let mut s = fat_session();
+                if !has_turn {
+                    s.turn_count = 0;
+                }
+                s.models = vec![SessionModel {
+                    display_name: "모".repeat(30),
+                    provider: "test".to_string(),
+                    color_key: "test-model".to_string(),
+                }];
+                let mut app = app_with(width, vec![s]);
+                let row = first_row_line(&mut app, width);
+                let cells = row.chars().filter(|c| *c == '모').count() * 2;
+                assert!(
+                    cells + 1 <= layout.model_width as usize,
+                    "model took {cells} cells plus an ellipsis out of a {} cell budget at width \
+                     {width} (turn={has_turn})\n{row}",
+                    layout.model_width
+                );
+                assert!(
+                    row.contains('…'),
+                    "an over-long full-width model name must be marked as truncated at width \
+                     {width} (turn={has_turn})\n{row}"
+                );
+            }
+        }
+    }
+
     /// Decision B: the session title gets slack up to 40 cells before Model gets
     /// any, then Model grows to 36, then the rest lands back on Session.
     #[test]
     fn slack_goes_to_the_session_title_before_the_model_column() {
         for (width, has_turn, session_width, model_width) in [
-            (120u16, true, 34, 18), // Model admitted, all slack to the title
-            (149, true, 40, 19),    // title comfortable, Model starts growing
-            (150, true, 20, 18),    // Cache R/W admitted, slack reclaimed
-            (199, true, 39, 18),
+            (120u16, true, 31, 18), // Model admitted, all slack to the title
+            (152, true, 40, 19),    // title comfortable, Model starts growing
+            (153, true, 20, 18),    // Cache R/W admitted, slack reclaimed
+            (199, true, 36, 18),
             // The width the model-truncation tests pin: without turn data every
-            // group is admitted at 175, so 199 leaves 24 cells of slack — 20 to
+            // group is admitted at 178, so 202 leaves 24 cells of slack — 20 to
             // the title, 4 to Model, which lands it on exactly 22.
-            (199, false, 40, 22),
-            (260, true, 82, 36), // Model capped, remainder back to the title
+            (202, false, 40, 22),
+            (260, true, 79, 36), // Model capped, remainder back to the title
         ] {
             let ctx = wide_ctx(has_turn);
             let layout = admit_and_distribute(width - 2, &ctx);
@@ -1658,7 +1967,7 @@ mod tests {
     /// left for the ", " a second name would need. Under decision B Session
     /// takes the first 20 cells of slack, so this sits 20 columns above where
     /// the Model-first rule put it. Pinned by `slack_goes_to_the_session_title_*`.
-    const MODEL_WIDTH_22_TERMINAL: u16 = 199;
+    const MODEL_WIDTH_22_TERMINAL: u16 = 202;
 
     /// A session that switched models must never render as a single-model
     /// session. When the next name cannot fit, a trailing "…" marks that models

--- a/crates/tokscale-cli/src/tui/ui/sessions.rs
+++ b/crates/tokscale-cli/src/tui/ui/sessions.rs
@@ -9,35 +9,419 @@ use super::widgets::{
     get_client_display_name, total_tokens_cell, truncate_text, viewport_scrollbar_state,
 };
 use crate::tui::app::{App, SortDirection, SortField};
-use crate::tui::data::SessionModel;
-
-/// Narrowest Model column worth showing. Below this the names are cut so short
-/// that the column carries no information, so it stays hidden instead.
-const MODEL_COLUMN_MIN_CHARS: u16 = 18;
+use crate::tui::data::{SessionModel, SessionUsage};
 
 /// Widest the Model column ever grows; surplus past this goes to Session.
 const MODEL_COLUMN_MAX_CHARS: u16 = 36;
 
-/// Cells the wide Sessions layout needs *before* a Model column: Session (20),
-/// Client (12), the optional Turn (5), Msgs (5 or 6), the ten trailing metric
-/// columns, and one separator cell between every pair.
+/// Session title width that slack distribution buys before Model gets any.
+/// Model's 18-cell minimum already renders most model names in full, while
+/// session titles routinely run 40–80 characters, so the marginal cell is worth
+/// more to the title. (Decision B in `docs/sessions-column-budget.md`.)
+const SESSION_COLUMN_COMFORTABLE_CHARS: u16 = 40;
+
+/// One column of the wide Sessions layout.
 ///
-/// The wide layout kicks in at 80 columns but is heavily over-subscribed there:
-/// ratatui shrinks every column to fit, which truncates the header labels and
-/// clips the sort indicator off whichever column carries it. Model is gated on
-/// this budget rather than a magic terminal width so it only appears once the
-/// rest of the table renders at its natural size.
-fn wide_layout_fixed_width(has_turn: bool) -> u16 {
-    // Input, Output, Cache R, Cache W, Cache×, Total, Cost, Cost/1M, Duration,
-    // Last Active.
-    const TRAILING: u16 = 10 + 10 + 10 + 10 + 8 + 10 + 10 + 10 + 9 + 17;
-    if has_turn {
-        // 14 columns, so 13 separators.
-        20 + 12 + 5 + 5 + TRAILING + 13
-    } else {
-        // 13 columns, so 12 separators.
-        20 + 12 + 6 + TRAILING + 12
+/// The wide layout used to be six hand-synced vectors — headers, cells,
+/// constraints, sort indices, a duplicated width sum, and a truncation limit —
+/// none of which the compiler checked against each other. It also asked for 161
+/// columns while turning on at 80, so across the whole 80–160 band ratatui
+/// shrank every column and clipped cell *content* with no ellipsis: 234K tokens
+/// rendered as `234`, $12.35 as `$12.`. Plausible numbers, wrong by 1000x.
+///
+/// Now every per-column fact hangs off this enum and a column is either
+/// admitted at its natural width or not shown at all. Each method below is an
+/// exhaustive `match` with no `_` arm, so adding a variant fails to compile
+/// until every one of them has an answer for it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionColumn {
+    Session,
+    Client,
+    Model,
+    Turn,
+    Msgs,
+    Input,
+    Output,
+    CacheRead,
+    CacheWrite,
+    CacheHit,
+    Total,
+    Cost,
+    CostPerMillion,
+    Duration,
+    LastActive,
+}
+
+/// Every variant, exactly once. `WIDE_ORDER` and `WIDE_PRIORITY` are checked
+/// against this by `every_column_is_ordered_and_prioritized` — the compiler
+/// never looks at those two arrays, so that test is the only thing standing
+/// between a new column and silently never rendering. It lives here rather than
+/// in the test module because it belongs beside the arrays it audits.
+#[cfg(test)]
+const ALL: [SessionColumn; 15] = [
+    SessionColumn::Session,
+    SessionColumn::Client,
+    SessionColumn::Model,
+    SessionColumn::Turn,
+    SessionColumn::Msgs,
+    SessionColumn::Input,
+    SessionColumn::Output,
+    SessionColumn::CacheRead,
+    SessionColumn::CacheWrite,
+    SessionColumn::CacheHit,
+    SessionColumn::Total,
+    SessionColumn::Cost,
+    SessionColumn::CostPerMillion,
+    SessionColumn::Duration,
+    SessionColumn::LastActive,
+];
+
+/// Left-to-right display order. Cosmetic: reshuffling it never changes what
+/// fits, only where it sits.
+const WIDE_ORDER: [SessionColumn; 15] = [
+    SessionColumn::Session,
+    SessionColumn::Client,
+    SessionColumn::Model,
+    SessionColumn::Turn,
+    SessionColumn::Msgs,
+    SessionColumn::Input,
+    SessionColumn::Output,
+    SessionColumn::CacheRead,
+    SessionColumn::CacheWrite,
+    SessionColumn::CacheHit,
+    SessionColumn::Total,
+    SessionColumn::Cost,
+    SessionColumn::CostPerMillion,
+    SessionColumn::Duration,
+    SessionColumn::LastActive,
+];
+
+/// Admission order: earlier groups are admitted first and dropped last. Each
+/// group is all-or-nothing — `Input` without `Output` invites a reader to take
+/// Input for a total, and `Cache R` without `Cache W` is the same trap.
+///
+/// The core is one group rather than six so admission can never stop *inside*
+/// it: the wide layout always shows at least the column set the narrow layout
+/// shows, which makes crossing 80 columns widen the table instead of reshaping
+/// it. The tail order is decision A in `docs/sessions-column-budget.md`, ranked
+/// by whether a column helps you find and compare sessions in a list.
+const WIDE_PRIORITY: [&[SessionColumn]; 8] = [
+    &[
+        SessionColumn::Session,
+        SessionColumn::Client,
+        SessionColumn::Total,
+        SessionColumn::Cost,
+        SessionColumn::Msgs,
+        SessionColumn::Turn,
+    ],
+    &[SessionColumn::LastActive],
+    &[SessionColumn::Model],
+    &[SessionColumn::Input, SessionColumn::Output],
+    &[SessionColumn::CacheRead, SessionColumn::CacheWrite],
+    &[SessionColumn::Duration],
+    &[SessionColumn::CacheHit],
+    &[SessionColumn::CostPerMillion],
+];
+
+/// Everything known *before* admission runs. Widths that depend on the admitted
+/// set are deliberately absent: `natural()` is what the budget sums, so it has
+/// to be answerable before anything has been admitted.
+struct WideCtx {
+    has_turn: bool,
+    last_active_fmt: &'static str,
+}
+
+/// Produced by admission, consumed by rendering. Every width that depends on
+/// the chosen set lives here and nowhere else.
+struct WideLayout {
+    chosen: Vec<SessionColumn>,
+    /// Cells the Model column is laid out with, `natural(Model)` plus its share
+    /// of the slack. `build_model_cell`'s ellipsis budget must equal this or
+    /// multi-model sessions get re-cut by the solver and render as single-model.
+    model_width: u16,
+    /// What `Session`'s cell truncates its title to. Session is the sole `Min`
+    /// column, so ratatui hands it every cell slack distribution did not give
+    /// Model; this has to match that or the title is clipped without an ellipsis.
+    session_width: u16,
+}
+
+impl SessionColumn {
+    fn header(self) -> &'static str {
+        match self {
+            Self::Session => "Session",
+            Self::Client => "Client",
+            Self::Model => "Model",
+            Self::Turn => "Turn",
+            Self::Msgs => "Msgs",
+            Self::Input => "Input",
+            Self::Output => "Output",
+            Self::CacheRead => "Cache R",
+            Self::CacheWrite => "Cache W",
+            Self::CacheHit => "Cache×",
+            Self::Total => "Total",
+            Self::Cost => "Cost",
+            Self::CostPerMillion => "Cost/1M",
+            Self::Duration => "Duration",
+            Self::LastActive => "Last Active",
+        }
     }
+
+    /// Whether the data supports this column at all, independent of width.
+    fn available(self, ctx: &WideCtx) -> bool {
+        match self {
+            Self::Turn => ctx.has_turn,
+            Self::Session
+            | Self::Client
+            | Self::Model
+            | Self::Msgs
+            | Self::Input
+            | Self::Output
+            | Self::CacheRead
+            | Self::CacheWrite
+            | Self::CacheHit
+            | Self::Total
+            | Self::Cost
+            | Self::CostPerMillion
+            | Self::Duration
+            | Self::LastActive => true,
+        }
+    }
+
+    /// The sort this column is the target of, so the indicator is placed by
+    /// identity rather than by a computed index. When the sorted column is not
+    /// admitted nothing matches and no arrow is drawn.
+    fn sort_field(self) -> Option<SortField> {
+        match self {
+            Self::Total => Some(SortField::Tokens),
+            Self::Cost => Some(SortField::Cost),
+            Self::LastActive => Some(SortField::Date),
+            Self::Session
+            | Self::Client
+            | Self::Model
+            | Self::Turn
+            | Self::Msgs
+            | Self::Input
+            | Self::Output
+            | Self::CacheRead
+            | Self::CacheWrite
+            | Self::CacheHit
+            | Self::CostPerMillion
+            | Self::Duration => None,
+        }
+    }
+
+    /// Cells this column needs to render its widest realistic value, and the
+    /// only width input to admission. `Constraint`s are *derived* from this
+    /// rather than written beside it: a second literal is exactly the
+    /// budget-versus-layout divergence this design exists to kill.
+    fn natural(self, ctx: &WideCtx) -> u16 {
+        match self {
+            Self::Session => 20,
+            Self::Client => 12,
+            Self::Model => 18,
+            Self::Turn => 5,
+            // Msgs borrows the cell Turn gives up. Keyed on the data rather
+            // than on whether Turn was admitted, so the answer exists before
+            // admission runs — and every no-turn threshold depends on it.
+            Self::Msgs => {
+                if ctx.has_turn {
+                    5
+                } else {
+                    6
+                }
+            }
+            Self::Input | Self::Output | Self::CacheRead | Self::CacheWrite => 10,
+            Self::CacheHit => 8,
+            // `format_cost` switches to `${:.1}K` past $1000 and
+            // `format_cost_per_million` has no compact branch at all, so
+            // neither of these tightens below 10 without truncating.
+            Self::Total | Self::Cost | Self::CostPerMillion => 10,
+            Self::Duration => 9,
+            Self::LastActive => 17,
+        }
+    }
+
+    /// Whether leftover cells may flow here. Session is the sole sink, which is
+    /// what turns admission's slack into session-title width.
+    fn grows(self) -> bool {
+        match self {
+            Self::Session => true,
+            Self::Client
+            | Self::Model
+            | Self::Turn
+            | Self::Msgs
+            | Self::Input
+            | Self::Output
+            | Self::CacheRead
+            | Self::CacheWrite
+            | Self::CacheHit
+            | Self::Total
+            | Self::Cost
+            | Self::CostPerMillion
+            | Self::Duration
+            | Self::LastActive => false,
+        }
+    }
+
+    fn cell(
+        self,
+        s: &SessionUsage,
+        app: &App,
+        ctx: &WideCtx,
+        layout: &WideLayout,
+    ) -> Cell<'static> {
+        match self {
+            Self::Session => Cell::from(truncate_text(
+                session_label(s),
+                layout.session_width as usize,
+            ))
+            .style(
+                Style::default()
+                    .fg(app.theme.muted)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Self::Client => Cell::from(get_client_display_name(&s.client))
+                .style(Style::default().fg(app.theme.muted)),
+            Self::Model => build_model_cell(&s.models, layout.model_width as usize, app),
+            Self::Turn => Cell::from(if s.turn_count > 0 {
+                s.turn_count.to_string()
+            } else {
+                "\u{2014}".to_string()
+            }),
+            Self::Msgs => Cell::from(s.message_count.to_string()),
+            Self::Input => {
+                Cell::from(format_tokens(s.tokens.input)).style(app.theme.metric_input_style())
+            }
+            Self::Output => {
+                Cell::from(format_tokens(s.tokens.output)).style(app.theme.metric_output_style())
+            }
+            Self::CacheRead => Cell::from(format_tokens(s.tokens.cache_read))
+                .style(app.theme.metric_cache_read_style()),
+            Self::CacheWrite => Cell::from(format_tokens(s.tokens.cache_write))
+                .style(app.theme.metric_cache_write_style()),
+            Self::CacheHit => Cell::from(format_cache_hit_rate(
+                s.tokens.cache_read,
+                s.tokens.input,
+                s.tokens.cache_write,
+            ))
+            .style(Style::default().fg(Color::Cyan)),
+            Self::Total => total_tokens_cell(s.tokens.total(), &app.theme),
+            Self::Cost => Cell::from(format_cost(s.cost)).style(Style::default().fg(Color::Green)),
+            Self::CostPerMillion => Cell::from(format_cost_per_million(s.cost, s.tokens.total()))
+                .style(Style::default().fg(Color::Rgb(150, 200, 150))),
+            Self::Duration => Cell::from(format_duration(s.first_active_ms, s.last_active_ms))
+                .style(Style::default().fg(Color::Yellow)),
+            Self::LastActive => Cell::from(
+                ms_to_local_naive(s.last_active_ms)
+                    .map(|dt| dt.format(ctx.last_active_fmt).to_string())
+                    .unwrap_or_else(|| "\u{2014}".to_string()),
+            )
+            .style(Style::default().fg(app.theme.muted)),
+        }
+    }
+}
+
+impl WideLayout {
+    /// The constraint a column is laid out with, derived from `natural()`.
+    /// Model is the one fixed column that absorbs slack, so its length comes
+    /// from the resolved layout; Session is `Min` and takes the remainder.
+    fn constraint(&self, c: SessionColumn, ctx: &WideCtx) -> Constraint {
+        let width = match c {
+            SessionColumn::Model => self.model_width,
+            SessionColumn::Session
+            | SessionColumn::Client
+            | SessionColumn::Turn
+            | SessionColumn::Msgs
+            | SessionColumn::Input
+            | SessionColumn::Output
+            | SessionColumn::CacheRead
+            | SessionColumn::CacheWrite
+            | SessionColumn::CacheHit
+            | SessionColumn::Total
+            | SessionColumn::Cost
+            | SessionColumn::CostPerMillion
+            | SessionColumn::Duration
+            | SessionColumn::LastActive => c.natural(ctx),
+        };
+        if c.grows() {
+            Constraint::Min(width)
+        } else {
+            Constraint::Length(width)
+        }
+    }
+}
+
+/// Position in the display order. Total rather than `unwrap()`: a column
+/// missing from `WIDE_ORDER` sorts last instead of panicking inside the draw
+/// loop, which would leave the terminal in raw mode. The permutation test is
+/// what actually catches it.
+fn order_index(c: SessionColumn) -> usize {
+    WIDE_ORDER
+        .iter()
+        .position(|o| *o == c)
+        .unwrap_or(usize::MAX)
+}
+
+/// Cells a column set occupies: the widths themselves plus one separator
+/// between every pair (ratatui's `column_spacing`, which defaults to 1).
+/// Measured against `inner`, which already has the block borders removed.
+fn required(set: &[SessionColumn], ctx: &WideCtx) -> u16 {
+    let widths: u16 = set.iter().map(|c| c.natural(ctx)).sum();
+    widths + set.len().saturating_sub(1) as u16
+}
+
+/// Admit whole priority groups while they fit, then resolve the slack.
+fn admit_and_distribute(available: u16, ctx: &WideCtx) -> WideLayout {
+    let mut chosen: Vec<SessionColumn> = Vec::new();
+    for group in WIDE_PRIORITY {
+        let admissible: Vec<SessionColumn> =
+            group.iter().copied().filter(|c| c.available(ctx)).collect();
+        if admissible.is_empty() {
+            continue; // e.g. Turn with no turn data
+        }
+        let mut next = chosen.clone();
+        next.extend(&admissible);
+        if required(&next, ctx) <= available {
+            chosen = next;
+        } else {
+            // Stop, don't skip. Trying the next (narrower) group packs more
+            // columns in but makes the admitted set non-monotonic in width —
+            // Cache× at W, Duration and no Cache× at W+1 — which is the same
+            // disorientation the ratatui solver produces today.
+            break;
+        }
+    }
+    chosen.sort_by_key(|c| order_index(*c));
+
+    let slack = available.saturating_sub(required(&chosen, ctx));
+    let session_min = SessionColumn::Session.natural(ctx);
+    let model_min = SessionColumn::Model.natural(ctx);
+    // Saturating because the caps are constants and the minima come from
+    // `natural()`: raising a minimum past its cap should cost that column its
+    // growth, not panic inside the draw loop.
+    let session_extra = slack.min(SESSION_COLUMN_COMFORTABLE_CHARS.saturating_sub(session_min));
+    let model_extra = if chosen.contains(&SessionColumn::Model) {
+        (slack - session_extra).min(MODEL_COLUMN_MAX_CHARS.saturating_sub(model_min))
+    } else {
+        0
+    };
+
+    WideLayout {
+        model_width: model_min + model_extra,
+        // Whatever Model did not take lands on Session through its `Min`
+        // constraint, so this is what ratatui will actually hand the column.
+        session_width: session_min + slack - model_extra,
+        chosen,
+    }
+}
+
+/// The human-readable title when the source client stored one, falling back to
+/// the session ID for clients that don't.
+fn session_label(s: &SessionUsage) -> &str {
+    s.title
+        .as_deref()
+        .filter(|t| !t.is_empty())
+        .unwrap_or(&s.session_id)
 }
 
 pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
@@ -77,63 +461,27 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let theme_accent = app.theme.accent;
     let theme_muted = app.theme.muted;
     let theme_selection = app.theme.selection;
-    let metric_input_style = app.theme.metric_input_style();
-    let metric_output_style = app.theme.metric_output_style();
-    let metric_cache_read_style = app.theme.metric_cache_read_style();
-    let metric_cache_write_style = app.theme.metric_cache_write_style();
     let striped_row_style = app.theme.striped_row_style();
 
     // Timestamp format adapts to width: full date+time when there's room,
     // compact "mm-dd HH:MM" when the full layout would overflow.
-    let last_active_fmt: &str = if is_narrow || is_very_narrow {
+    let last_active_fmt: &'static str = if is_narrow || is_very_narrow {
         "%m-%d %H:%M"
     } else {
         "%Y-%m-%d %H:%M"
     };
 
-    // What the wide layout can spare for Model once every other column has its
-    // natural width, including the separator Model itself would add. Measured
-    // against `inner` rather than the terminal so the budget matches the width
-    // ratatui actually divides up, which keeps `build_model_cell`'s ellipsis
-    // budget equal to the rendered cell instead of being re-cut by the solver.
-    let model_budget = inner
-        .width
-        .saturating_sub(wide_layout_fixed_width(has_turn_data) + 1);
-
-    let show_model = !is_narrow && !is_very_narrow && model_budget >= MODEL_COLUMN_MIN_CHARS;
-    let model_col_width = model_budget.min(MODEL_COLUMN_MAX_CHARS);
-
-    let header_cells = if is_very_narrow {
-        vec!["Session", "Cost"]
-    } else if is_narrow {
-        if has_turn_data {
-            vec!["Session", "Client", "Turn", "Msgs", "Tokens", "Cost"]
-        } else {
-            vec!["Session", "Client", "Msgs", "Tokens", "Cost"]
-        }
-    } else {
-        let mut cells = vec!["Session", "Client"];
-        if show_model {
-            cells.push("Model");
-        }
-        if has_turn_data {
-            cells.push("Turn");
-        }
-        cells.extend([
-            "Msgs",
-            "Input",
-            "Output",
-            "Cache R",
-            "Cache W",
-            "Cache×",
-            "Total",
-            "Cost",
-            "Cost/1M",
-            "Duration",
-            "Last Active",
-        ]);
-        cells
-    };
+    // The wide layout is budget-driven: a column is admitted at its natural
+    // width or it is not shown. Measured against `inner` rather than the
+    // terminal so the budget equals the width ratatui actually divides up.
+    let wide = (!is_narrow && !is_very_narrow).then(|| {
+        let ctx = WideCtx {
+            has_turn: has_turn_data,
+            last_active_fmt,
+        };
+        let layout = admit_and_distribute(inner.width, &ctx);
+        (ctx, layout)
+    });
 
     let sort_indicator = |field: SortField| -> &'static str {
         if sort_field == field {
@@ -146,64 +494,60 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         }
     };
 
-    // Every wide-layout column after Client shifts right by one for each optional
-    // column that is present, so the sort indicators must track both gates.
-    let optional_cols = usize::from(show_model) + usize::from(has_turn_data);
-
-    // "Last Active" column index is the sort target for Date.
-    let last_active_idx = if is_very_narrow || is_narrow {
-        // neither narrow layout keeps a last-active column, so Date sort has no indicator
-        usize::MAX
+    let header_cells: Vec<String> = if let Some((_, layout)) = &wide {
+        // Headers carry the sort arrow, so this is one derivation and not two.
+        // Nothing computes a column index at all, so the arrow cannot land on
+        // the wrong column, and a sorted-but-unadmitted column simply has no
+        // descriptor to match — which is what the narrow branches fake with a
+        // `usize::MAX` sentinel below.
+        layout
+            .chosen
+            .iter()
+            .map(|c| {
+                let indicator = c.sort_field().map(sort_indicator).unwrap_or("");
+                format!("{}{}", c.header(), indicator)
+            })
+            .collect()
     } else {
-        12 + optional_cols
-    };
-    let total_idx = if is_very_narrow {
-        usize::MAX
-    } else if is_narrow {
-        if has_turn_data {
-            4
+        let labels: &[&str] = if is_very_narrow {
+            &["Session", "Cost"]
+        } else if has_turn_data {
+            &["Session", "Client", "Turn", "Msgs", "Tokens", "Cost"]
         } else {
-            3
-        }
-    } else {
-        8 + optional_cols
-    };
-    let cost_idx = if is_very_narrow {
-        1
-    } else if is_narrow {
-        if has_turn_data {
-            5
+            &["Session", "Client", "Msgs", "Tokens", "Cost"]
+        };
+        // The narrow layouts keep their hand-picked indices, and `usize::MAX`
+        // still stands for "this sort has no column here".
+        let (total_idx, cost_idx) = if is_very_narrow {
+            (usize::MAX, 1)
+        } else if has_turn_data {
+            (4, 5)
         } else {
-            4
-        }
-    } else {
-        9 + optional_cols
-    };
-
-    let header = Row::new(
-        header_cells
+            (3, 4)
+        };
+        labels
             .iter()
             .enumerate()
             .map(|(i, h)| {
-                let indicator = if i == last_active_idx {
-                    sort_indicator(SortField::Date)
-                } else if i == total_idx {
+                let indicator = if i == total_idx {
                     sort_indicator(SortField::Tokens)
                 } else if i == cost_idx {
                     sort_indicator(SortField::Cost)
                 } else {
                     ""
                 };
-                Cell::from(format!("{}{}", h, indicator))
+                format!("{}{}", h, indicator)
             })
-            .collect::<Vec<_>>(),
-    )
-    .style(
-        Style::default()
-            .fg(theme_accent)
-            .add_modifier(Modifier::BOLD),
-    )
-    .height(1);
+            .collect()
+    };
+
+    let header = Row::new(header_cells.into_iter().map(Cell::from).collect::<Vec<_>>())
+        .style(
+            Style::default()
+                .fg(theme_accent)
+                .add_modifier(Modifier::BOLD),
+        )
+        .height(1);
 
     let sessions_len = sessions.len();
     let start = scroll_offset.min(sessions_len);
@@ -221,54 +565,23 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             let is_selected = idx == selected_index;
             let is_striped = idx % 2 == 1;
 
-            let last_active_str = ms_to_local_naive(session.last_active_ms)
-                .map(|dt| dt.format(last_active_fmt).to_string())
-                .unwrap_or_else(|| "\u{2014}".to_string());
-            let duration_str = format_duration(session.first_active_ms, session.last_active_ms);
-
-            // Show the human-readable title when the source client stored one,
-            // falling back to the session ID for clients that don't.
-            let session_label = session
-                .title
-                .as_deref()
-                .filter(|t| !t.is_empty())
-                .unwrap_or(&session.session_id);
-
-            let cells: Vec<Cell> = if is_very_narrow {
+            let cells: Vec<Cell> = if let Some((ctx, layout)) = &wide {
+                layout
+                    .chosen
+                    .iter()
+                    .map(|c| c.cell(session, app, ctx, layout))
+                    .collect()
+            } else if is_very_narrow {
                 vec![
-                    Cell::from(truncate_text(session_label, 20)).style(
+                    Cell::from(truncate_text(session_label(session), 20)).style(
                         Style::default()
                             .fg(theme_muted)
                             .add_modifier(Modifier::BOLD),
                     ),
                     Cell::from(format_cost(session.cost)).style(Style::default().fg(Color::Green)),
                 ]
-            } else if is_narrow {
-                let mut cells = vec![Cell::from(truncate_text(session_label, 24)).style(
-                    Style::default()
-                        .fg(theme_muted)
-                        .add_modifier(Modifier::BOLD),
-                )];
-                cells.push(
-                    Cell::from(get_client_display_name(&session.client))
-                        .style(Style::default().fg(theme_muted)),
-                );
-                if has_turn_data {
-                    let turn_str = if session.turn_count > 0 {
-                        session.turn_count.to_string()
-                    } else {
-                        "\u{2014}".to_string()
-                    };
-                    cells.push(Cell::from(turn_str));
-                }
-                cells.extend([
-                    Cell::from(session.message_count.to_string()),
-                    total_tokens_cell(session.tokens.total(), &app.theme),
-                    Cell::from(format_cost(session.cost)).style(Style::default().fg(Color::Green)),
-                ]);
-                cells
             } else {
-                let mut cells = vec![Cell::from(truncate_text(session_label, 60)).style(
+                let mut cells = vec![Cell::from(truncate_text(session_label(session), 24)).style(
                     Style::default()
                         .fg(theme_muted)
                         .add_modifier(Modifier::BOLD),
@@ -277,13 +590,6 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                     Cell::from(get_client_display_name(&session.client))
                         .style(Style::default().fg(theme_muted)),
                 );
-                if show_model {
-                    cells.push(build_model_cell(
-                        &session.models,
-                        model_col_width as usize,
-                        app,
-                    ));
-                }
                 if has_turn_data {
                     let turn_str = if session.turn_count > 0 {
                         session.turn_count.to_string()
@@ -294,27 +600,8 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                 }
                 cells.extend([
                     Cell::from(session.message_count.to_string()),
-                    Cell::from(format_tokens(session.tokens.input)).style(metric_input_style),
-                    Cell::from(format_tokens(session.tokens.output)).style(metric_output_style),
-                    Cell::from(format_tokens(session.tokens.cache_read))
-                        .style(metric_cache_read_style),
-                    Cell::from(format_tokens(session.tokens.cache_write))
-                        .style(metric_cache_write_style),
-                    Cell::from(format_cache_hit_rate(
-                        session.tokens.cache_read,
-                        session.tokens.input,
-                        session.tokens.cache_write,
-                    ))
-                    .style(Style::default().fg(Color::Cyan)),
                     total_tokens_cell(session.tokens.total(), &app.theme),
                     Cell::from(format_cost(session.cost)).style(Style::default().fg(Color::Green)),
-                    Cell::from(format_cost_per_million(
-                        session.cost,
-                        session.tokens.total(),
-                    ))
-                    .style(Style::default().fg(Color::Rgb(150, 200, 150))),
-                    Cell::from(duration_str).style(Style::default().fg(Color::Yellow)),
-                    Cell::from(last_active_str).style(Style::default().fg(theme_muted)),
                 ]);
                 cells
             };
@@ -331,9 +618,15 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         })
         .collect();
 
-    let widths = if is_very_narrow {
+    let widths: Vec<Constraint> = if let Some((ctx, layout)) = &wide {
+        layout
+            .chosen
+            .iter()
+            .map(|c| layout.constraint(*c, ctx))
+            .collect()
+    } else if is_very_narrow {
         vec![Constraint::Percentage(60), Constraint::Percentage(40)]
-    } else if is_narrow && has_turn_data {
+    } else if has_turn_data {
         vec![
             Constraint::Percentage(28),
             Constraint::Percentage(16),
@@ -342,7 +635,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             Constraint::Percentage(16),
             Constraint::Percentage(16),
         ]
-    } else if is_narrow {
+    } else {
         vec![
             Constraint::Percentage(32),
             Constraint::Percentage(18),
@@ -350,29 +643,6 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
             Constraint::Percentage(18),
             Constraint::Percentage(20),
         ]
-    } else {
-        let mut widths = vec![Constraint::Min(20), Constraint::Length(12)];
-        if show_model {
-            widths.push(Constraint::Length(model_col_width));
-        }
-        if has_turn_data {
-            widths.push(Constraint::Length(5));
-        }
-        // Msgs borrows a column from Turn when both are shown.
-        widths.push(Constraint::Length(if has_turn_data { 5 } else { 6 }));
-        widths.extend([
-            Constraint::Length(10),
-            Constraint::Length(10),
-            Constraint::Length(10),
-            Constraint::Length(10),
-            Constraint::Length(8),
-            Constraint::Length(10),
-            Constraint::Length(10),
-            Constraint::Length(10),
-            Constraint::Length(9),
-            Constraint::Length(17),
-        ]);
-        widths
     };
 
     let table = Table::new(rows, widths)
@@ -503,13 +773,112 @@ fn format_duration(first_ms: i64, last_ms: i64) -> String {
         format!("{}s", s)
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::tui::app::{Tab, TuiConfig};
-    use crate::tui::data::{SessionUsage, TokenBreakdown};
+    use crate::tui::data::TokenBreakdown;
     use ratatui::{backend::TestBackend, Terminal};
+
+    /// Terminal width at which each priority group first appears.
+    ///
+    /// **Literals, never derived from `admit_and_distribute`.** A test that
+    /// recomputes the formula it is testing cannot fail — which is exactly why
+    /// the old `model_gate_width` helper never caught that the wide layout asked
+    /// for 161 columns and turned on at 80. Amending decision A moves these
+    /// numbers, and the diff then names which threshold moved and by how much.
+    const THRESHOLDS_WITH_TURN: [(u16, &[SessionColumn]); 8] = [
+        (
+            69,
+            &[
+                SessionColumn::Session,
+                SessionColumn::Client,
+                SessionColumn::Turn,
+                SessionColumn::Msgs,
+                SessionColumn::Total,
+                SessionColumn::Cost,
+            ],
+        ),
+        (87, &[SessionColumn::LastActive]),
+        (106, &[SessionColumn::Model]),
+        (128, &[SessionColumn::Input, SessionColumn::Output]),
+        (150, &[SessionColumn::CacheRead, SessionColumn::CacheWrite]),
+        (160, &[SessionColumn::Duration]),
+        (169, &[SessionColumn::CacheHit]),
+        (180, &[SessionColumn::CostPerMillion]),
+    ];
+
+    /// Same table without turn data. Every threshold is five narrower: Turn's
+    /// five cells and its separator go away, and Msgs takes one of them back.
+    const THRESHOLDS_NO_TURN: [(u16, &[SessionColumn]); 8] = [
+        (
+            64,
+            &[
+                SessionColumn::Session,
+                SessionColumn::Client,
+                SessionColumn::Msgs,
+                SessionColumn::Total,
+                SessionColumn::Cost,
+            ],
+        ),
+        (82, &[SessionColumn::LastActive]),
+        (101, &[SessionColumn::Model]),
+        (123, &[SessionColumn::Input, SessionColumn::Output]),
+        (145, &[SessionColumn::CacheRead, SessionColumn::CacheWrite]),
+        (155, &[SessionColumn::Duration]),
+        (164, &[SessionColumn::CacheHit]),
+        (175, &[SessionColumn::CostPerMillion]),
+    ];
+
+    /// Widest terminal the sweeps cover. Past the last threshold (180) nothing
+    /// changes but the Session column's share of the slack.
+    const SWEEP_MAX: u16 = 240;
+
+    fn thresholds(has_turn: bool) -> &'static [(u16, &'static [SessionColumn])] {
+        if has_turn {
+            &THRESHOLDS_WITH_TURN
+        } else {
+            &THRESHOLDS_NO_TURN
+        }
+    }
+
+    /// Columns the reviewed threshold table says a terminal of `width` shows.
+    fn expected_columns(width: u16, has_turn: bool) -> Vec<SessionColumn> {
+        let mut columns: Vec<SessionColumn> = Vec::new();
+        for (threshold, group) in thresholds(has_turn) {
+            if width < *threshold {
+                break;
+            }
+            columns.extend(*group);
+        }
+        columns.sort_by_key(|c| *c as usize);
+        columns
+    }
+
+    /// Columns whose header label appears in a rendered header line. `Cost` is a
+    /// substring of `Cost/1M`, so the longer label is stripped before looking for
+    /// the shorter one; no other pair of labels overlaps.
+    fn header_columns(header: &str) -> Vec<SessionColumn> {
+        let without_cost_per_million = header.replace(SessionColumn::CostPerMillion.header(), "");
+        ALL.iter()
+            .copied()
+            .filter(|c| {
+                let haystack = if *c == SessionColumn::Cost {
+                    without_cost_per_million.as_str()
+                } else {
+                    header
+                };
+                haystack.contains(c.header())
+            })
+            .collect()
+    }
+
+    fn wide_ctx(has_turn: bool) -> WideCtx {
+        WideCtx {
+            has_turn,
+            last_active_fmt: "%Y-%m-%d %H:%M",
+        }
+    }
 
     fn session(id: &str, client: &str, cost: f64, last_ms: i64) -> SessionUsage {
         SessionUsage {
@@ -536,6 +905,58 @@ mod tests {
         }
     }
 
+    const FAT_SESSION_LAST_MS: i64 = 1_736_000_000_000;
+
+    /// A session whose every column has a value long enough that clipping it
+    /// would still look like a number. This is the shape of the original bug:
+    /// at 80 columns Output rendered `234` for 234,567 tokens.
+    fn fat_session() -> SessionUsage {
+        let mut s = session("my-session", "opencode", 12.3456, FAT_SESSION_LAST_MS);
+        s.models = vec![SessionModel {
+            display_name: "claude-sonnet-4".to_string(),
+            provider: "anthropic".to_string(),
+            color_key: "claude-sonnet-4".to_string(),
+        }];
+        s.tokens = TokenBreakdown {
+            input: 1_234_567,
+            output: 234_567,
+            cache_read: 45_678_901,
+            cache_write: 2_345_678,
+            reasoning: 0,
+        };
+        s.message_count = 428;
+        s.turn_count = 137;
+        s
+    }
+
+    /// What `fat_session()` must render, in full, in every column that is
+    /// admitted. Exhaustive so a new column cannot skip this assertion.
+    fn expected_value(c: SessionColumn) -> String {
+        match c {
+            SessionColumn::Session => "my-session".to_string(),
+            SessionColumn::Client => "OpenCode".to_string(),
+            SessionColumn::Model => "claude-sonnet-4".to_string(),
+            SessionColumn::Turn => "137".to_string(),
+            SessionColumn::Msgs => "428".to_string(),
+            SessionColumn::Input => "1.2M".to_string(),
+            SessionColumn::Output => "234K".to_string(),
+            SessionColumn::CacheRead => "45.7M".to_string(),
+            SessionColumn::CacheWrite => "2.3M".to_string(),
+            SessionColumn::CacheHit => "12.8x".to_string(),
+            SessionColumn::Total => "49.5M".to_string(),
+            SessionColumn::Cost => "$12.35".to_string(),
+            SessionColumn::CostPerMillion => "$0.25".to_string(),
+            SessionColumn::Duration => "1h 0m".to_string(),
+            // The one value that depends on the machine's time zone, so it is
+            // formatted rather than hardcoded. Still catches clipping: the claim
+            // is that all sixteen characters survive the layout.
+            SessionColumn::LastActive => ms_to_local_naive(FAT_SESSION_LAST_MS)
+                .expect("fixture timestamp is in range")
+                .format("%Y-%m-%d %H:%M")
+                .to_string(),
+        }
+    }
+
     fn make_app(width: u16) -> App {
         let config = TuiConfig {
             theme: "blue".to_string(),
@@ -552,6 +973,12 @@ mod tests {
         app.current_tab = Tab::Sessions;
         app.sort_field = SortField::Cost;
         app.sort_direction = SortDirection::Descending;
+        app
+    }
+
+    fn app_with(width: u16, sessions: Vec<SessionUsage>) -> App {
+        let mut app = make_app(width);
+        app.data.sessions = sessions;
         app
     }
 
@@ -584,13 +1011,512 @@ mod tests {
             .to_string()
     }
 
+    /// The first data row, directly under the header.
+    fn first_row_line(app: &mut App, width: u16) -> String {
+        render_body(app, width, 6)
+            .lines()
+            .nth(2)
+            .unwrap_or_default()
+            .to_string()
+    }
+
+    // ---- the descriptor arrays -------------------------------------------
+
+    /// The exhaustive `match`es cover the six descriptor methods and stop there:
+    /// `WIDE_ORDER` and `WIDE_PRIORITY` are hand-maintained arrays of column
+    /// names that compile fine while missing a variant. Absent from
+    /// `WIDE_PRIORITY` a column is never admitted at any width and silently
+    /// never renders; absent from `WIDE_ORDER` its sort key has no answer. This
+    /// is the only assertion that enforces the no-drift property the whole
+    /// design is sold on.
+    #[test]
+    fn every_column_is_ordered_and_prioritized() {
+        let mut order = WIDE_ORDER.to_vec();
+        let mut priority: Vec<SessionColumn> = WIDE_PRIORITY.concat();
+        let mut all = ALL.to_vec();
+        for v in [&mut order, &mut priority, &mut all] {
+            v.sort_by_key(|c| *c as usize);
+        }
+        assert_eq!(order, all, "WIDE_ORDER is not a permutation of ALL");
+        assert_eq!(priority, all, "WIDE_PRIORITY is not a permutation of ALL");
+    }
+
+    // ---- the budget -------------------------------------------------------
+
+    #[test]
+    fn group_thresholds_are_where_the_review_put_them() {
+        for has_turn in [true, false] {
+            let ctx = wide_ctx(has_turn);
+            for (threshold, group) in thresholds(has_turn) {
+                let at = admit_and_distribute(threshold - 2, &ctx).chosen;
+                for column in *group {
+                    assert!(
+                        at.contains(column),
+                        "{:?} should be admitted at {threshold} columns (turn={has_turn}), got {at:?}",
+                        column
+                    );
+                }
+                let below = admit_and_distribute(threshold - 3, &ctx).chosen;
+                for column in *group {
+                    assert!(
+                        !below.contains(column),
+                        "{:?} should not be admitted at {} columns (turn={has_turn}), got {below:?}",
+                        column,
+                        threshold - 1
+                    );
+                }
+            }
+        }
+    }
+
+    /// Every threshold above the wide layout's 80-column entry point, checked
+    /// through an actual render rather than through `admit_and_distribute`.
+    #[test]
+    fn group_thresholds_hold_when_actually_rendered() {
+        for has_turn in [true, false] {
+            for (threshold, group) in thresholds(has_turn) {
+                if *threshold <= 80 {
+                    continue; // below the wide layout's entry condition
+                }
+                for (width, want) in [(threshold - 1, false), (*threshold, true)] {
+                    let mut s = fat_session();
+                    if !has_turn {
+                        s.turn_count = 0;
+                    }
+                    let mut app = app_with(width, vec![s]);
+                    let header = header_line(&mut app, width);
+                    for column in *group {
+                        assert_eq!(
+                            header.contains(column.header()),
+                            want,
+                            "{:?} at width {width} (turn={has_turn}) should be {}\n{header}",
+                            column,
+                            if want { "shown" } else { "hidden" }
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// The wide core is the narrow column set, so crossing 80 columns widens the
+    /// table instead of reshaping it. The core is one atomic priority group
+    /// precisely so admission can never stop inside it.
+    #[test]
+    fn wide_layout_never_drops_below_the_narrow_column_set() {
+        for has_turn in [true, false] {
+            let ctx = wide_ctx(has_turn);
+            let core = thresholds(has_turn)[0].1;
+            let floor = if has_turn { 67 } else { 62 };
+            assert_eq!(
+                required(core, &ctx),
+                floor,
+                "the core column set costs {floor} cells (turn={has_turn})"
+            );
+            // 78 is the narrowest `inner` the wide path ever sees (80 - borders).
+            for available in floor..=SWEEP_MAX {
+                let chosen = admit_and_distribute(available, &ctx).chosen;
+                for column in core {
+                    assert!(
+                        chosen.contains(column),
+                        "{:?} dropped from the core at inner width {available} (turn={has_turn})",
+                        column
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn the_admitted_set_always_fits_the_terminal() {
+        for width in 80u16..=SWEEP_MAX {
+            for has_turn in [true, false] {
+                let ctx = wide_ctx(has_turn);
+                let available = width - 2;
+                let chosen = admit_and_distribute(available, &ctx).chosen;
+                assert!(
+                    required(&chosen, &ctx) <= available,
+                    "admitted set overflows at width {width} (turn={has_turn}): {chosen:?}"
+                );
+            }
+        }
+    }
+
+    // ---- the invariants over a full width sweep ---------------------------
+
+    /// Every admitted column renders its header *and* its value in full, at
+    /// every width. This is the assertion that would have turned #964 into a red
+    /// test: today it fails from 80 to 154 with turn data, because ratatui clips
+    /// cell content with no ellipsis and 234,567 tokens render as `234`.
+    #[test]
+    fn admitted_columns_render_header_and_value_in_full() {
+        for width in 80u16..=SWEEP_MAX {
+            for has_turn in [true, false] {
+                let mut s = fat_session();
+                if !has_turn {
+                    s.turn_count = 0;
+                }
+                let mut app = app_with(width, vec![s]);
+                let body = render_body(&mut app, width, 6);
+                let mut lines = body.lines().skip(1);
+                let header = lines.next().unwrap_or_default();
+                let row = lines.next().unwrap_or_default();
+                for column in expected_columns(width, has_turn) {
+                    assert!(
+                        header.contains(column.header()),
+                        "header {:?} squeezed at width {width} (turn={has_turn})\n{header}",
+                        column
+                    );
+                    // Turn renders an em-dash when the session has no turns.
+                    if column == SessionColumn::Turn && !has_turn {
+                        continue;
+                    }
+                    assert!(
+                        row.contains(&expected_value(column)),
+                        "value for {:?} truncated at width {width} (turn={has_turn}); \
+                         expected {:?}\n{header}\n{row}",
+                        column,
+                        expected_value(column)
+                    );
+                }
+            }
+        }
+    }
+
+    /// A column that is not admitted leaves nothing behind — no stub header and,
+    /// more importantly, no half of a number.
+    #[test]
+    fn unadmitted_columns_leave_no_trace() {
+        for width in 80u16..=SWEEP_MAX {
+            for has_turn in [true, false] {
+                let mut s = fat_session();
+                if !has_turn {
+                    s.turn_count = 0;
+                }
+                let mut app = app_with(width, vec![s]);
+                let body = render_body(&mut app, width, 6);
+                let mut lines = body.lines().skip(1);
+                let header = lines.next().unwrap_or_default();
+                let row = lines.next().unwrap_or_default();
+                let admitted = expected_columns(width, has_turn);
+                for column in ALL {
+                    if admitted.contains(&column) {
+                        continue;
+                    }
+                    assert!(
+                        !header.contains(column.header()),
+                        "{:?} header showed at width {width} (turn={has_turn})\n{header}",
+                        column
+                    );
+                    assert!(
+                        !row.contains(&expected_value(column)),
+                        "{:?} value showed at width {width} (turn={has_turn})\n{row}",
+                        column
+                    );
+                }
+            }
+        }
+    }
+
+    /// The active sort arrow is legible whenever its column is admitted, and
+    /// absent from the whole header when it is not. Today `Last Active ▼` is
+    /// missing at 77 of 121 widths.
+    #[test]
+    fn sort_indicator_is_legible_exactly_when_its_column_is_admitted() {
+        for width in 80u16..=SWEEP_MAX {
+            for has_turn in [true, false] {
+                for (field, column) in [
+                    (SortField::Cost, SessionColumn::Cost),
+                    (SortField::Tokens, SessionColumn::Total),
+                    (SortField::Date, SessionColumn::LastActive),
+                ] {
+                    let mut s = fat_session();
+                    if !has_turn {
+                        s.turn_count = 0;
+                    }
+                    let mut app = app_with(width, vec![s]);
+                    app.sort_field = field;
+                    let header = header_line(&mut app, width);
+                    if expected_columns(width, has_turn).contains(&column) {
+                        assert!(
+                            header.contains(&format!("{} ▼", column.header())),
+                            "{:?} indicator clipped at width {width} (turn={has_turn})\n{header}",
+                            field
+                        );
+                    } else {
+                        assert!(
+                            !header.contains('▼'),
+                            "{:?} drew an arrow with its column unadmitted at width {width} \
+                             (turn={has_turn})\n{header}",
+                            field
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Widening the terminal never removes a column. `break` in the admission
+    /// loop is what buys this: skipping a group that does not fit and trying the
+    /// next, narrower one would show Cache× at W and Duration instead at W+1.
+    ///
+    /// Note what this does **not** cover: it compares header *sets*, so it stays
+    /// green through the Session sawtooth (Session is 40 cells at 149 and 20 at
+    /// 150). That is accepted, but it means this test is not evidence that
+    /// widening never costs the user anything.
+    #[test]
+    fn admitted_columns_are_monotonic_in_width() {
+        for has_turn in [true, false] {
+            let mut previous: Vec<SessionColumn> = Vec::new();
+            for width in 80u16..=SWEEP_MAX {
+                let mut s = fat_session();
+                if !has_turn {
+                    s.turn_count = 0;
+                }
+                let mut app = app_with(width, vec![s]);
+                let header = header_line(&mut app, width);
+                let current = header_columns(&header);
+                for column in &previous {
+                    assert!(
+                        current.contains(column),
+                        "{:?} disappeared going from {} to {width} columns (turn={has_turn})\n{header}",
+                        column,
+                        width - 1
+                    );
+                }
+                previous = current;
+            }
+        }
+    }
+
+    /// Headers, cells and constraints are all derived from the same `chosen`
+    /// vector, so this should be impossible to fail — which is the reason to
+    /// assert it. If it can fail, they are not actually derived.
+    #[test]
+    fn header_cell_and_constraint_counts_agree() {
+        for width in 80u16..=SWEEP_MAX {
+            for has_turn in [true, false] {
+                let ctx = wide_ctx(has_turn);
+                let layout = admit_and_distribute(width - 2, &ctx);
+                let constraints: Vec<Constraint> = layout
+                    .chosen
+                    .iter()
+                    .map(|c| layout.constraint(*c, &ctx))
+                    .collect();
+                assert_eq!(constraints.len(), layout.chosen.len());
+
+                let mut s = fat_session();
+                if !has_turn {
+                    s.turn_count = 0;
+                }
+                let mut app = app_with(width, vec![s]);
+                let header = header_line(&mut app, width);
+                assert_eq!(
+                    header_columns(&header).len(),
+                    layout.chosen.len(),
+                    "rendered header does not match the admitted set at width {width} \
+                     (turn={has_turn})\n{header}"
+                );
+            }
+        }
+    }
+
+    // ---- slack distribution ------------------------------------------------
+
+    /// Session is the sole `Min` column, so ratatui hands it every cell that
+    /// slack distribution did not give Model. `session_width` has to equal that
+    /// or the title is clipped by the solver with no ellipsis — the same silent
+    /// truncation this change exists to remove, one column over.
+    #[test]
+    fn session_cell_truncates_to_the_width_it_is_actually_given() {
+        let title = "X".repeat(200);
+        for width in 80u16..=SWEEP_MAX {
+            for has_turn in [true, false] {
+                let ctx = wide_ctx(has_turn);
+                let layout = admit_and_distribute(width - 2, &ctx);
+                let mut s = fat_session();
+                s.title = Some(title.clone());
+                if !has_turn {
+                    s.turn_count = 0;
+                }
+                let mut app = app_with(width, vec![s]);
+                let row = first_row_line(&mut app, width);
+                let rendered = row.chars().filter(|c| *c == 'X').count();
+                assert_eq!(
+                    rendered as u16 + 3,
+                    layout.session_width,
+                    "Session rendered {rendered} title chars but the layout budgeted \
+                     {} at width {width} (turn={has_turn})\n{row}",
+                    layout.session_width
+                );
+                assert!(
+                    row.contains("X..."),
+                    "an over-long title must be marked as truncated at width {width}\n{row}"
+                );
+            }
+        }
+    }
+
+    /// Decision B: the session title gets slack up to 40 cells before Model gets
+    /// any, then Model grows to 36, then the rest lands back on Session.
+    #[test]
+    fn slack_goes_to_the_session_title_before_the_model_column() {
+        for (width, has_turn, session_width, model_width) in [
+            (120u16, true, 34, 18), // Model admitted, all slack to the title
+            (149, true, 40, 19),    // title comfortable, Model starts growing
+            (150, true, 20, 18),    // Cache R/W admitted, slack reclaimed
+            (199, true, 39, 18),
+            // The width the model-truncation tests pin: without turn data every
+            // group is admitted at 175, so 199 leaves 24 cells of slack — 20 to
+            // the title, 4 to Model, which lands it on exactly 22.
+            (199, false, 40, 22),
+            (260, true, 82, 36), // Model capped, remainder back to the title
+        ] {
+            let ctx = wide_ctx(has_turn);
+            let layout = admit_and_distribute(width - 2, &ctx);
+            assert_eq!(
+                (layout.session_width, layout.model_width),
+                (session_width, model_width),
+                "slack split wrong at width {width} (turn={has_turn})"
+            );
+        }
+    }
+
+    // ---- narrow and very narrow must not move ------------------------------
+
+    /// The narrow branches keep their percentage constraints, their hardcoded
+    /// sort indices and their `usize::MAX` sentinel. These lines are byte-for-byte
+    /// what the pre-budget implementation rendered.
+    #[test]
+    fn narrow_layouts_render_exactly_as_before() {
+        for (width, has_turn, field, expected_header, expected_row) in [
+            (
+                59u16,
+                true,
+                SortField::Cost,
+                "│Session                           Cost ▼                 │",
+                "│A fairly long ses...              $12.35                 │",
+            ),
+            (
+                59,
+                true,
+                SortField::Date,
+                "│Session                           Cost                   │",
+                "│A fairly long ses...              $12.35                 │",
+            ),
+            (
+                60,
+                true,
+                SortField::Cost,
+                "│Session     Client     Turn   Msgs    Tokens     Cost ▼   │",
+                "│A fairly lo OpenCode   137    428     49.5M      $12.35   │",
+            ),
+            (
+                60,
+                false,
+                SortField::Tokens,
+                "│Session         Client     Msgs    Tokens ▼   Cost        │",
+                "│A fairly long s OpenCode   428     49.5M      $12.35      │",
+            ),
+            (
+                79,
+                true,
+                SortField::Tokens,
+                "│Session           Client       Turn      Msgs      Tokens ▼      Cost        │",
+                "│A fairly long ses OpenCode     137       428       49.5M         $12.35      │",
+            ),
+            (
+                79,
+                false,
+                SortField::Date,
+                "│Session               Client         Msgs      Tokens         Cost           │",
+                "│A fairly long session OpenCode       428       49.5M          $12.35         │",
+            ),
+        ] {
+            let mut s = fat_session();
+            s.session_id = "ses_09d2eac0-long-id".to_string();
+            s.title = Some("A fairly long session title here".to_string());
+            if !has_turn {
+                s.turn_count = 0;
+            }
+            let mut app = app_with(width, vec![s]);
+            app.sort_field = field;
+            let body = render_body(&mut app, width, 6);
+            let mut lines = body.lines().skip(1);
+            assert_eq!(
+                lines.next().unwrap_or_default(),
+                expected_header,
+                "narrow header moved at width {width} (turn={has_turn}, sort={field:?})"
+            );
+            assert_eq!(
+                lines.next().unwrap_or_default(),
+                expected_row,
+                "narrow row moved at width {width} (turn={has_turn}, sort={field:?})"
+            );
+        }
+    }
+
+    /// Neither narrow layout ever grows a wide-only column, at any width below
+    /// the 80-column entry point.
+    #[test]
+    fn narrow_layouts_never_show_wide_only_columns() {
+        for width in 20u16..80 {
+            for has_turn in [true, false] {
+                let mut s = fat_session();
+                if !has_turn {
+                    s.turn_count = 0;
+                }
+                let mut app = app_with(width, vec![s]);
+                let header = header_line(&mut app, width);
+                for label in [
+                    "Model",
+                    "Input",
+                    "Output",
+                    "Cache R",
+                    "Cache W",
+                    "Cache×",
+                    "Total",
+                    "Cost/1M",
+                    "Duration",
+                    "Last Active",
+                ] {
+                    assert!(
+                        !header.contains(label),
+                        "wide-only header {label} leaked into the narrow layout at width \
+                         {width} (turn={has_turn})\n{header}"
+                    );
+                }
+                if width >= 60 {
+                    assert!(
+                        header.contains("Tokens"),
+                        "expected narrow Tokens\n{header}"
+                    );
+                    assert_eq!(
+                        header.contains("Turn "),
+                        has_turn,
+                        "narrow Turn gating wrong at width {width}\n{header}"
+                    );
+                } else {
+                    assert!(
+                        !header.contains("Client"),
+                        "very narrow keeps two columns\n{header}"
+                    );
+                }
+            }
+        }
+    }
+
+    // ---- behavioral tests that predate the budget --------------------------
+
     #[test]
     fn wide_terminal_renders_session_and_duration_columns() {
-        let mut app = make_app(200);
-        app.data.sessions = vec![
-            session("abc-123", "opencode", 1.5, 1_736_000_000_000),
-            session("def-456", "claude", 0.25, 1_736_000_000_000),
-        ];
+        let mut app = app_with(
+            200,
+            vec![
+                session("abc-123", "opencode", 1.5, 1_736_000_000_000),
+                session("def-456", "claude", 0.25, 1_736_000_000_000),
+            ],
+        );
         let body = render_body(&mut app, 200, 12);
         assert!(body.contains("abc-123"), "expected session id\n{body}");
         assert!(
@@ -605,14 +1531,13 @@ mod tests {
 
     #[test]
     fn model_column_shows_model_names() {
-        let mut app = make_app(200);
         let mut s = session("abc-123", "opencode", 1.5, 1_736_000_000_000);
         s.models = vec![SessionModel {
             display_name: "claude-sonnet-4".to_string(),
             provider: "anthropic".to_string(),
             color_key: "claude-sonnet-4".to_string(),
         }];
-        app.data.sessions = vec![s];
+        let mut app = app_with(200, vec![s]);
         let body = render_body(&mut app, 200, 12);
         assert!(body.contains("Model"), "expected Model header\n{body}");
         assert!(
@@ -623,7 +1548,6 @@ mod tests {
 
     #[test]
     fn model_column_shows_multiple_models() {
-        let mut app = make_app(220);
         let mut s = session("abc-123", "opencode", 1.5, 1_736_000_000_000);
         s.models = vec![
             SessionModel {
@@ -637,7 +1561,7 @@ mod tests {
                 color_key: "o3-mini".to_string(),
             },
         ];
-        app.data.sessions = vec![s];
+        let mut app = app_with(220, vec![s]);
         let body = render_body(&mut app, 220, 12);
         assert!(
             body.contains("gpt-4o") && body.contains("o3-mini"),
@@ -647,10 +1571,9 @@ mod tests {
 
     #[test]
     fn session_title_displayed_when_available() {
-        let mut app = make_app(200);
         let mut s = session("ses_09d2eac0", "opencode", 1.5, 1_736_000_000_000);
         s.title = Some("This is a long title for a session that could be used".to_string());
-        app.data.sessions = vec![s];
+        let mut app = app_with(200, vec![s]);
         let body = render_body(&mut app, 200, 12);
         assert!(
             body.contains("This is a long"),
@@ -658,23 +1581,34 @@ mod tests {
         );
     }
 
+    /// The Session column is the sole sink for leftover cells, so a wide
+    /// terminal shows the whole title. What it truncates to is
+    /// `WideLayout::session_width`, not a hardcoded 60.
     #[test]
     fn session_column_expands_on_wide_terminal() {
-        let mut app = make_app(260);
+        let title = "This is a long title for a session that could be used";
         let mut s = session("ses_09d2eac0", "opencode", 1.5, 1_736_000_000_000);
-        s.title = Some("This is a long title for a session that could be used".to_string());
-        app.data.sessions = vec![s];
+        s.title = Some(title.to_string());
+        let mut app = app_with(260, vec![s]);
         let body = render_body(&mut app, 260, 12);
         assert!(
-            body.contains("This is a long title for a session that could be used"),
+            body.contains(title),
             "expected full title on wide terminal\n{body}"
+        );
+        let layout = admit_and_distribute(258, &wide_ctx(true));
+        assert!(
+            layout.session_width as usize >= title.chars().count(),
+            "the layout must budget at least the title it renders, got {}",
+            layout.session_width
         );
     }
 
     #[test]
     fn narrow_terminal_drops_token_breakdown_columns() {
-        let mut app = make_app(70);
-        app.data.sessions = vec![session("abc-123", "opencode", 1.5, 1_736_000_000_000)];
+        let mut app = app_with(
+            70,
+            vec![session("abc-123", "opencode", 1.5, 1_736_000_000_000)],
+        );
         let body = render_body(&mut app, 70, 12);
         assert!(body.contains("abc-123"), "expected session id\n{body}");
         assert!(
@@ -693,139 +1627,6 @@ mod tests {
         );
     }
 
-    /// Narrowest terminal that still shows the Model column, derived the way
-    /// `render` derives it: the fixed wide-layout budget, Model's own separator
-    /// and minimum width, plus the two block borders `inner` strips off.
-    fn model_gate_width(has_turn: bool) -> u16 {
-        wide_layout_fixed_width(has_turn) + 1 + MODEL_COLUMN_MIN_CHARS + 2
-    }
-
-    #[test]
-    fn model_column_hidden_below_its_width_threshold() {
-        for has_turn in [true, false] {
-            let width = model_gate_width(has_turn) - 1;
-            let mut app = make_app(width);
-            let mut s = session("abc-123", "opencode", 1.5, 1_736_000_000_000);
-            if !has_turn {
-                s.turn_count = 0;
-            }
-            app.data.sessions = vec![s];
-            let body = render_body(&mut app, width, 12);
-            assert!(
-                !body.contains("Model"),
-                "Model header should be gated off at {width} columns (turn={has_turn})\n{body}"
-            );
-            assert!(
-                !body.contains("test-model"),
-                "Model cell should be gated off at {width} columns (turn={has_turn})\n{body}"
-            );
-            // The rest of the wide layout is still intact.
-            assert!(body.contains("Client"), "expected Client header\n{body}");
-            assert!(body.contains("Cache×"), "expected Cache× header\n{body}");
-        }
-    }
-
-    #[test]
-    fn model_column_appears_at_its_width_threshold() {
-        for has_turn in [true, false] {
-            let width = model_gate_width(has_turn);
-            let mut app = make_app(width);
-            let mut s = session("abc-123", "opencode", 1.5, 1_736_000_000_000);
-            if !has_turn {
-                s.turn_count = 0;
-            }
-            app.data.sessions = vec![s];
-            let body = render_body(&mut app, width, 12);
-            assert!(
-                body.contains("Model"),
-                "expected Model header at {width} columns (turn={has_turn})\n{body}"
-            );
-            assert!(
-                body.contains("test-model"),
-                "expected model name at {width} columns (turn={has_turn})\n{body}"
-            );
-        }
-    }
-
-    /// The gate exists so the Model column never squeezes the rest of the table.
-    /// At the exact width where Model first appears every other header must still
-    /// render in full, indicator included — the previous fixed 120-column gate
-    /// clipped the Cost indicator the moment Model showed up.
-    #[test]
-    fn model_column_gate_keeps_the_rest_of_the_header_legible() {
-        for has_turn in [true, false] {
-            let width = model_gate_width(has_turn);
-            for (expected, field) in [
-                ("Cost ▼", SortField::Cost),
-                ("Total ▼", SortField::Tokens),
-                ("Last Active ▼", SortField::Date),
-            ] {
-                let mut app = make_app(width);
-                let mut s = session("abc-123", "opencode", 1.5, 1_736_000_000_000);
-                if !has_turn {
-                    s.turn_count = 0;
-                }
-                app.data.sessions = vec![s];
-                app.sort_field = field;
-                let header = header_line(&mut app, width);
-                assert!(
-                    header.contains("Model"),
-                    "Model should be shown at its gate width {width} (turn={has_turn})\n{header}"
-                );
-                for label in ["Cache R", "Cache W", "Cost/1M", "Duration", "Last Active"] {
-                    assert!(
-                        header.contains(label),
-                        "header {label} was squeezed at width {width} (turn={has_turn})\n{header}"
-                    );
-                }
-                assert!(
-                    header.contains(expected),
-                    "sort indicator {expected} was clipped at the Model gate width {width} \
-                     (turn={has_turn})\n{header}"
-                );
-            }
-        }
-    }
-
-    /// The Cost/Tokens/Date sort indicators are placed by hand-computed column
-    /// indices, which shift for every optional column. Walk all four
-    /// Model x Turn combinations and confirm the indicator still lands on Cost.
-    #[test]
-    fn cost_sort_indicator_tracks_model_and_turn_gating() {
-        for (width, expect_model, has_turn) in [
-            (200u16, true, true),
-            (200, true, false),
-            // Straddle the gate itself, where the indicator is most at risk.
-            (model_gate_width(true), true, true),
-            (model_gate_width(false), true, false),
-            (model_gate_width(true) - 1, false, true),
-            (model_gate_width(false) - 1, false, false),
-        ] {
-            let mut app = make_app(width);
-            let mut s = session("abc-123", "opencode", 1.5, 1_736_000_000_000);
-            if !has_turn {
-                s.turn_count = 0;
-            }
-            app.data.sessions = vec![s];
-            let header = header_line(&mut app, width);
-            assert_eq!(
-                header.contains("Model"),
-                expect_model,
-                "Model gating wrong at width {width}\n{header}"
-            );
-            assert_eq!(
-                header.contains("Turn"),
-                has_turn,
-                "Turn gating wrong at width {width}\n{header}"
-            );
-            assert!(
-                header.contains("Cost ▼"),
-                "cost sort indicator landed on the wrong column at width {width} \
-                 (model={expect_model}, turn={has_turn})\n{header}"
-            );
-        }
-    }
-
     #[test]
     fn tokens_and_date_sort_indicators_land_on_their_columns() {
         for has_turn in [true, false] {
@@ -834,8 +1635,7 @@ mod tests {
                 s.turn_count = 0;
             }
 
-            let mut app = make_app(200);
-            app.data.sessions = vec![s.clone()];
+            let mut app = app_with(200, vec![s.clone()]);
             app.sort_field = SortField::Tokens;
             let header = header_line(&mut app, 200);
             assert!(
@@ -843,8 +1643,7 @@ mod tests {
                 "tokens sort indicator misplaced (turn={has_turn})\n{header}"
             );
 
-            let mut app = make_app(200);
-            app.data.sessions = vec![s];
+            let mut app = app_with(200, vec![s]);
             app.sort_field = SortField::Date;
             let header = header_line(&mut app, 200);
             assert!(
@@ -854,16 +1653,19 @@ mod tests {
         }
     }
 
+    /// Terminal width at which the Model column is exactly 22 cells with no turn
+    /// data: the 21-char first name plus the reserved marker cell, with nothing
+    /// left for the ", " a second name would need. Under decision B Session
+    /// takes the first 20 cells of slack, so this sits 20 columns above where
+    /// the Model-first rule put it. Pinned by `slack_goes_to_the_session_title_*`.
+    const MODEL_WIDTH_22_TERMINAL: u16 = 199;
+
     /// A session that switched models must never render as a single-model
     /// session. When the next name cannot fit, a trailing "…" marks that models
     /// were dropped instead of them vanishing silently.
     #[test]
     fn multi_model_cell_marks_models_that_did_not_fit() {
-        // Width chosen so the Model column is 22 cells: exactly the 21-char
-        // first name plus the reserved marker cell, with nothing left for the
-        // ", " separator the second name would need.
-        let width = wide_layout_fixed_width(false) + 1 + 22 + 2;
-        let mut app = make_app(width);
+        let width = MODEL_WIDTH_22_TERMINAL;
         let mut s = session("abc-123", "opencode", 1.5, 1_736_000_000_000);
         s.turn_count = 0;
         s.models = vec![
@@ -878,7 +1680,7 @@ mod tests {
                 color_key: "claude-sonnet-4-5".to_string(),
             },
         ];
-        app.data.sessions = vec![s];
+        let mut app = app_with(width, vec![s]);
         let body = render_body(&mut app, width, 12);
         assert!(
             body.contains("gemini-2-5-flash-lite…"),
@@ -894,8 +1696,7 @@ mod tests {
     /// dropped-model marker must not double up on it.
     #[test]
     fn single_model_cell_truncates_without_a_second_ellipsis() {
-        let width = wide_layout_fixed_width(false) + 1 + 22 + 2;
-        let mut app = make_app(width);
+        let width = MODEL_WIDTH_22_TERMINAL;
         let mut s = session("abc-123", "opencode", 1.5, 1_736_000_000_000);
         s.turn_count = 0;
         s.models = vec![SessionModel {
@@ -903,7 +1704,7 @@ mod tests {
             provider: "anthropic".to_string(),
             color_key: "a-very-long-model-name-that-overflows".to_string(),
         }];
-        app.data.sessions = vec![s];
+        let mut app = app_with(width, vec![s]);
         let body = render_body(&mut app, width, 12);
         assert!(
             body.contains("a-very-long-model-nam…"),

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -1,7 +1,8 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Cell, ScrollbarState};
 use tokscale_core::ClientId;
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
 
 use crate::tui::client_ui;
 use crate::tui::config::TokscaleConfig;
@@ -137,8 +138,13 @@ pub fn display_width(s: &str) -> usize {
 /// than one over it.
 pub fn prefix_to_width(s: &str, max_cells: usize) -> &str {
     let mut used = 0usize;
-    for (offset, ch) in s.char_indices() {
-        let w = UnicodeWidthChar::width(ch).unwrap_or(0);
+    // Grapheme clusters, not chars. A flag is two regional indicators and a
+    // family emoji is a ZWJ sequence, so cutting on a char boundary can leave
+    // half a flag or a dangling ZWJ -- and the width of the pieces does not
+    // add up to the width of the whole, so the cut would not even respect the
+    // budget it was measuring against.
+    for (offset, cluster) in s.grapheme_indices(true) {
+        let w = UnicodeWidthStr::width(cluster);
         if used + w > max_cells {
             return &s[..offset];
         }
@@ -645,6 +651,31 @@ mod tests {
         assert_eq!(prefix_to_width("세션제목", 6), "세션제");
         assert_eq!(prefix_to_width("abc", 10), "abc");
         assert_eq!(prefix_to_width("abc", 0), "");
+
+        // The cases the name actually promises. Hangul is one char per
+        // grapheme, so the assertions above hold under char iteration too and
+        // never exercised the claim. These are multi-char graphemes: a flag is
+        // two regional indicators and a family is a ZWJ sequence, so char-wise
+        // truncation yields half a flag or a dangling ZWJ.
+        let flag = "\u{1F1F0}\u{1F1F7}"; // KR
+        let family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}";
+
+        for (label, s) in [("flag", flag), ("family", family)] {
+            assert_eq!(
+                prefix_to_width(s, 1),
+                "",
+                "{label}: a 2-cell grapheme must not be halved to fit 1 cell"
+            );
+            assert_eq!(prefix_to_width(s, 2), s, "{label}: fits whole at 2 cells");
+            // 'a' and 'b' take 2 of the 3 cells, leaving 1 — not enough for the
+            // 2-cell cluster, which must therefore be dropped whole rather than
+            // contributing a leading component.
+            assert_eq!(
+                prefix_to_width(&format!("ab{s}"), 3),
+                "ab",
+                "{label}: a cluster that does not fit is dropped, not split"
+            );
+        }
     }
 
     #[test]

--- a/crates/tokscale-cli/src/tui/ui/widgets.rs
+++ b/crates/tokscale-cli/src/tui/ui/widgets.rs
@@ -1,6 +1,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Cell, ScrollbarState};
 use tokscale_core::ClientId;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::tui::client_ui;
 use crate::tui::config::TokscaleConfig;
@@ -103,6 +104,14 @@ pub fn viewport_scrollbar_state(
 /// truncation occurs. Returns the original string when it fits, and an empty
 /// string when `max_chars` is 0. Shared across all table-style tabs (Daily,
 /// Monthly, Sessions, Models, Agents) so ellipsis behavior stays consistent.
+///
+/// Counts code points, not terminal cells, so a CJK or emoji string it calls
+/// short is twice as wide as the column that asked for it and gets clipped by
+/// the solver with no marker. Every caller passes a column width, so cells are
+/// the unit they all actually want: prefer [`truncate_to_width`] for anything
+/// that can hold a non-ASCII name. Kept as-is only because the Daily, Models
+/// and Agents tables are pinned by golden renders that this commit does not
+/// touch.
 pub fn truncate_text(s: &str, max_chars: usize) -> String {
     if max_chars == 0 {
         return String::new();
@@ -116,6 +125,44 @@ pub fn truncate_text(s: &str, max_chars: usize) -> String {
         let head: String = s.chars().take(max_chars - 3).collect();
         format!("{}...", head)
     }
+}
+
+/// Terminal cells `s` occupies, which is the unit ratatui lays tables out in.
+pub fn display_width(s: &str) -> usize {
+    UnicodeWidthStr::width(s)
+}
+
+/// Longest prefix of `s` that fits in `max_cells` terminal cells. Never splits
+/// a grapheme, so the result can come in one cell short of the budget rather
+/// than one over it.
+pub fn prefix_to_width(s: &str, max_cells: usize) -> &str {
+    let mut used = 0usize;
+    for (offset, ch) in s.char_indices() {
+        let w = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + w > max_cells {
+            return &s[..offset];
+        }
+        used += w;
+    }
+    s
+}
+
+/// [`truncate_text`] measured in terminal cells instead of code points: the
+/// result never occupies more than `max_cells`, and carries a "..." whenever
+/// anything was dropped. Use this wherever the text can hold a full-width
+/// grapheme — a session title, a client display name — because those are the
+/// cases where a code-point count and the ratatui solver disagree.
+pub fn truncate_to_width(s: &str, max_cells: usize) -> String {
+    if max_cells == 0 {
+        return String::new();
+    }
+    if display_width(s) <= max_cells {
+        return s.to_string();
+    }
+    if max_cells <= 3 {
+        return prefix_to_width(s, max_cells).to_string();
+    }
+    format!("{}...", prefix_to_width(s, max_cells - 3))
 }
 
 fn scrollbar_position(scroll_offset: usize, content_len: usize, viewport_len: usize) -> usize {
@@ -560,6 +607,52 @@ fn capitalize_first(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn truncate_to_width_never_exceeds_its_budget() {
+        // The case `truncate_text` gets wrong: 8 code points, 16 cells.
+        let cjk = "세션제목한글로";
+        assert_eq!(truncate_text(cjk, 10), cjk, "code points say it fits");
+        assert!(
+            display_width(&truncate_to_width(cjk, 10)) <= 10,
+            "cells say it does not"
+        );
+        for budget in 0..=20 {
+            for s in [cjk, "ascii-session-title", "🦞 OpenClaw", ""] {
+                assert!(
+                    display_width(&truncate_to_width(s, budget)) <= budget,
+                    "{s:?} overflowed a {budget}-cell budget"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn truncate_to_width_marks_what_it_dropped() {
+        assert_eq!(truncate_to_width("abcdefghij", 10), "abcdefghij");
+        assert_eq!(truncate_to_width("abcdefghijk", 10), "abcdefg...");
+        assert_eq!(truncate_to_width("abcdefghijk", 3), "abc");
+        assert_eq!(truncate_to_width("abcdefghijk", 0), "");
+        // 7 cells of budget, 3 for the marker: two syllables (4 cells) fit and
+        // the third would overshoot, so the result is one cell short, not one
+        // cell over.
+        assert_eq!(truncate_to_width("세션제목", 7), "세션...");
+    }
+
+    #[test]
+    fn prefix_to_width_never_splits_a_grapheme() {
+        assert_eq!(prefix_to_width("세션제목", 5), "세션");
+        assert_eq!(prefix_to_width("세션제목", 6), "세션제");
+        assert_eq!(prefix_to_width("abc", 10), "abc");
+        assert_eq!(prefix_to_width("abc", 0), "");
+    }
+
+    #[test]
+    fn display_width_counts_cells_not_code_points() {
+        assert_eq!(display_width("OpenCode"), 8);
+        assert_eq!(display_width("🦞 OpenClaw"), 11);
+        assert_eq!("🦞 OpenClaw".chars().count(), 10, "the disagreement");
+    }
 
     #[test]
     fn scrollbar_position_maps_bottom_offset_to_last_position() {


### PR DESCRIPTION
Implements the design in #965. Fixes #964.

## The bug, before and after

The wide layout activates at 80 columns but asks for 161, so ratatui shrank every column — and it clips cell **content** with no ellipsis. Rendered through the existing `render_body` helper at width 80:

```
before  │abc-123    Ope 2  4  876K 234 0  0  0.0x 1.1 $12. $11 1h 0 202│
after   │abc-123    OpenCode  2  4  1.1M  $100.00                      │
```

`234` is 234K. `1.1` is 1.1M. Both are plausible-looking numbers wrong by 1000×, with nothing to signal truncation. The `Cost ▼` sort indicator was also gone below ~113 columns.

After: six columns at 80, every value complete, sort indicator present. Columns are admitted in priority order while the budget allows, so nothing is ever narrowed below the width it needs.

| width | columns |
|---|---|
| 80 | Session, Client, Turn, Msgs, Total, Cost |
| 100 | + Last Active |
| 120 | + Model *(was 180 before)* |
| 161 | + Input, Output, Cache R, Cache W |
| 183 | + Cache×, Duration, Cost/1M — the full table |

## A second silent-truncation bug found on the way

`Client` at 12 cells clips three shipped client names with no marker, and renders **`Antigravity CLI` and `Antigravity` identically** — a misattribution in the one column whose job is naming which tool a session came from. Its natural width is now 15, the widest the registry can produce, pinned by a test that enumerates the registry so a new client cannot reintroduce it.

That is the +3 that moves the full table from 180 to **183**. #965 has been updated to match; the threshold was verified by rendering, not arithmetic — `Cost/1M` is absent at 182 and present at 183.

## Structure

One `SessionColumn` enum with exhaustive matches and no `_` arm, so adding a variant fails to compile until every sync point exists. `natural()` is the single width source and `Constraint` is derived from it. Sort indices are `chosen.iter().position(…)` rather than literals — the class of bug #956 had to hand-maintain across four places. `MODEL_COLUMN_MIN_CHARS` and `wide_layout_fixed_width` are deleted.

Cell content is now measured in **terminal cells**, not code points, via a new `unicode-width` workspace dependency. `truncate_text` is left in place, with a comment, because the Daily/Models/Agents tables are pinned by golden renders this change does not touch.

## Verification

- `cargo test -p tokscale-cli` — **937 bin + 133 integration**, 0 failed (+20 tests)
- `cargo clippy -- -D warnings` and `cargo fmt --check` clean
- Narrow (<80) and very-narrow (<60) layouts confirmed unchanged
- I re-rendered the table myself across 80–220 rather than relying on the implementation's own report; the before/after rows above are from that run

## Still open, deliberately

`format_cost_per_million` is a bare `format!("${:.2}", per_m)` with no compact branch, so `(100.0, 100)` yields `$1000000.00` — 11 cells for a 10-cell column, even at full width. Reviewers caught this on #965 and it is listed there as decision 5. Cells are clamped so it can no longer be *silently* wrong, but the formatter still wants a compact branch; that is a separate, small change.

The four decisions in #965 (priority order, slack distribution, `has_model_data`, and whether trading breadth for correctness at ~120 is the right call) remain open — this implements the document's recommended answers, and each is a one-array edit to amend.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Budgets the Sessions table columns so each column is either fully shown or hidden, removing silent value truncation and keeping sort indicators stable. Implements #965 and fixes #964.

- **Bug Fixes**
  - Eliminates clipped numbers in `ratatui` wide layout; values now truncate with ellipses within column width.
  - Sort arrows render only when their column is admitted; never clipped or misplaced.
  - Falls back to the narrow layout if a too-small area would admit no wide columns.
  - Widens Client to 15 cells to avoid misattribution (e.g., `Antigravity CLI` vs `Antigravity`); thresholds updated accordingly.
  - Truncation is grapheme-safe; never splits emoji or flags, preventing garbage glyphs and width overruns.

- **Refactors**
  - Replaces hand-synced vectors with a single `SessionColumn` enum; headers, cells, sort mapping, and `Constraint`s derive from one `natural()` width source.
  - Admits columns in priority groups and stops at the first that doesn’t fit; crossing 80 cols only widens the table. Full set appears at 183 cols; Model ~109; narrow and very narrow renders are unchanged.
  - Distributes slack: Session title to 40 cells, then Model to 36, then back to Session.
  - Measures and truncates in terminal cells and on grapheme boundaries; adds `truncate_to_width`, `display_width`, and `prefix_to_width`; new deps `unicode-width` and `unicode-segmentation`.
  - Clamps fixed-width cells to their column to prevent plausible-but-wrong numbers on bad data.

<sup>Written for commit 6263a1771d0490bfc89bdb10cfa1aef6395e8a7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

