### PR TITLE
fix(kimi): resolve symbolic usage models from requests

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -854,9 +854,9 @@ fn parser_version(client: ClientId) -> u32 {
         // to the (end-anchored) turn_end timestamp. Second-round follow-up
         // to #890.
         ClientId::Kiro => 2,
-        // Kimi now checks each token bucket independently when deciding
-        // whether a usage record is empty, avoiding an overflowing sum.
-        ClientId::Kimi => 2,
+        // Kimi v2 checks token buckets without an overflowing sum. v2->v3:
+        // symbolic usage-record models now resolve from the latest llm.request.
+        ClientId::Kimi => 3,
         // v1->v2: per-model token attribution now comes from
         // session_model_usage instead of crediting the whole session to
         // sessions.model, and dedup keys are namespaced per (session, model).
@@ -2093,8 +2093,8 @@ mod tests {
     }
 
     #[test]
-    fn test_kimi_parser_version_invalidates_v1_entries() {
-        assert_eq!(parser_version(ClientId::Kimi), 2);
+    fn test_kimi_parser_version_invalidates_v2_entries() {
+        assert_eq!(parser_version(ClientId::Kimi), 3);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/kimi.rs
+++ b/crates/tokscale-core/src/sessions/kimi.rs
@@ -155,9 +155,8 @@ fn normalize_kimi_code_model(model: &str) -> String {
 fn concrete_kimi_code_model(model: &str) -> Option<String> {
     let normalized = normalize_kimi_code_model(model.trim());
     let normalized = normalized.trim();
-    let symbolic = normalized.len() >= 4
-        && normalized.starts_with("__")
-        && normalized.ends_with("__");
+    let symbolic =
+        normalized.len() >= 4 && normalized.starts_with("__") && normalized.ends_with("__");
     (!normalized.is_empty() && !symbolic).then(|| normalized.to_string())
 }
 
@@ -687,11 +686,9 @@ not valid json at all
         let messages = parse_kimi_code_file(&fake_path);
 
         assert_eq!(messages.len(), 4);
-        assert!(
-            messages
-                .iter()
-                .all(|message| message.model_id == DEFAULT_MODEL)
-        );
+        assert!(messages
+            .iter()
+            .all(|message| message.model_id == DEFAULT_MODEL));
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/kimi.rs
+++ b/crates/tokscale-core/src/sessions/kimi.rs
@@ -150,6 +150,17 @@ fn normalize_kimi_code_model(model: &str) -> String {
         .to_string()
 }
 
+/// Normalize a Kimi Code model, excluding symbolic config references such as
+/// `__kimi_env_model__` that do not identify the model sent to the provider.
+fn concrete_kimi_code_model(model: &str) -> Option<String> {
+    let normalized = normalize_kimi_code_model(model.trim());
+    let normalized = normalized.trim();
+    let symbolic = normalized.len() >= 4
+        && normalized.starts_with("__")
+        && normalized.ends_with("__");
+    (!normalized.is_empty() && !symbolic).then(|| normalized.to_string())
+}
+
 /// Kimi Code wire.jsonl line structure.
 #[derive(Debug, Deserialize)]
 struct KimiCodeWireLine {
@@ -174,6 +185,7 @@ pub fn parse_kimi_code_file(path: &Path) -> Vec<UnifiedMessage> {
 
     let reader = BufReader::new(file);
     let mut messages: Vec<UnifiedMessage> = Vec::new();
+    let mut latest_request_model: Option<String> = None;
 
     for line in reader.lines() {
         let line = match line {
@@ -191,6 +203,19 @@ pub fn parse_kimi_code_file(path: &Path) -> Vec<UnifiedMessage> {
             Ok(wl) => wl,
             Err(_) => continue,
         };
+
+        // usage.record can contain only a symbolic config reference, while the
+        // preceding llm.request records the concrete model sent to the provider.
+        if wire_line.line_type == "llm.request" {
+            if let Some(model) = wire_line
+                .model
+                .as_deref()
+                .and_then(concrete_kimi_code_model)
+            {
+                latest_request_model = Some(model);
+            }
+            continue;
+        }
 
         // Only process usage.record lines.
         // step.end also carries usage, but it duplicates the same usage.record
@@ -216,7 +241,8 @@ pub fn parse_kimi_code_file(path: &Path) -> Vec<UnifiedMessage> {
         let model = wire_line
             .model
             .as_deref()
-            .map(normalize_kimi_code_model)
+            .and_then(concrete_kimi_code_model)
+            .or_else(|| latest_request_model.clone())
             .unwrap_or_else(|| DEFAULT_MODEL.to_string());
 
         let timestamp_ms = wire_line.time.unwrap_or(fallback_timestamp);
@@ -614,6 +640,58 @@ not valid json at all
         assert_eq!(messages[0].tokens.cache_read, 13312);
         assert_eq!(messages[0].tokens.cache_write, 0);
         assert_eq!(messages[0].timestamp, 1780319377014);
+    }
+
+    #[test]
+    fn test_parse_kimi_code_keeps_latest_concrete_model_across_invalid_requests() {
+        let content = r#"{"type":"llm.request","model":"k3","time":1780319377000}
+{"type":"llm.request","time":1780319377001}
+{"type":"llm.request","model":" ","time":1780319377002}
+{"type":"llm.request","model":"__runtime_model__","time":1780319377003}
+{"type":"llm.request","model":"kimi-code/   ","time":1780319377004}
+{"type":"llm.request","model":"kimi-code/ __runtime_model__ ","time":1780319377005}
+{"type":"usage.record","model":"kimi-code/__kimi_env_model__","usage":{"inputOther":100,"output":50,"inputCacheRead":25,"inputCacheCreation":0},"usageScope":"turn","time":1780319377010}"#;
+        let (_dir, fake_path) = create_kimi_code_test_file(content);
+
+        let messages = parse_kimi_code_file(&fake_path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "k3");
+    }
+
+    #[test]
+    fn test_parse_kimi_code_prefers_concrete_usage_model_and_tracks_requests() {
+        let content = r#"{"type":"llm.request","model":"k3","time":1780319377000}
+{"type":"usage.record","model":"__runtime_model__","usage":{"inputOther":100,"output":50,"inputCacheRead":0,"inputCacheCreation":0},"usageScope":"turn","time":1780319377010}
+{"type":"llm.request","model":"kimi-code/k3-256k","time":1780319377020}
+{"type":"usage.record","model":"kimi-code/kimi-for-coding","usage":{"inputOther":200,"output":75,"inputCacheRead":0,"inputCacheCreation":0},"usageScope":"turn","time":1780319377030}
+{"type":"usage.record","model":"__another_model_alias__","usage":{"inputOther":300,"output":100,"inputCacheRead":0,"inputCacheCreation":0},"usageScope":"turn","time":1780319377040}"#;
+        let (_dir, fake_path) = create_kimi_code_test_file(content);
+
+        let messages = parse_kimi_code_file(&fake_path);
+
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0].model_id, "k3");
+        assert_eq!(messages[1].model_id, "kimi-for-coding");
+        assert_eq!(messages[2].model_id, "k3-256k");
+    }
+
+    #[test]
+    fn test_parse_kimi_code_invalid_usage_without_request_uses_default_model() {
+        let content = r#"{"type":"usage.record","model":"__kimi_env_model__","usage":{"inputOther":100,"output":50,"inputCacheRead":0,"inputCacheCreation":0},"usageScope":"turn","time":1780319377010}
+{"type":"usage.record","model":"kimi-code/__runtime_model__","usage":{"inputOther":100,"output":50,"inputCacheRead":0,"inputCacheCreation":0},"usageScope":"turn","time":1780319377020}
+{"type":"usage.record","model":"kimi-code/ __runtime_model__ ","usage":{"inputOther":100,"output":50,"inputCacheRead":0,"inputCacheCreation":0},"usageScope":"turn","time":1780319377030}
+{"type":"usage.record","model":"kimi-code/   ","usage":{"inputOther":100,"output":50,"inputCacheRead":0,"inputCacheCreation":0},"usageScope":"turn","time":1780319377040}"#;
+        let (_dir, fake_path) = create_kimi_code_test_file(content);
+
+        let messages = parse_kimi_code_file(&fake_path);
+
+        assert_eq!(messages.len(), 4);
+        assert!(
+            messages
+                .iter()
+                .all(|message| message.model_id == DEFAULT_MODEL)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Resolve symbolic Kimi Code usage models such as `__kimi_env_model__` from the latest concrete `llm.request` model.
- Preserve concrete `usage.record` models when present and retain `kimi-for-coding` as the fallback when no concrete request has been observed.
- Bump the Kimi parser cache version so existing cached placeholder values are reparsed.

## Problem

Recent Kimi Code `wire.jsonl` sessions can record the actual provider model on an `llm.request` line while the corresponding `usage.record` contains only a symbolic configuration reference:

```json
{"type":"llm.request","model":"k3"}
{"type":"usage.record","model":"__kimi_env_model__", ...}
```

The parser previously copied the usage model directly, so reports displayed `__kimi_env_model__` instead of the concrete model (`k3` in this example).

## Implementation

The Kimi Code parser now tracks the latest concrete model from preceding `llm.request` records. A usage record uses its own model when that value is concrete; otherwise it falls back to the latest concrete request model, then to the existing default.

Symbolic references are detected structurally as trimmed `__...__` values rather than by hard-coding a specific sentinel. Model normalization strips the existing `kimi-code/` prefix before classification, and invalid request values (missing, blank, symbolic, prefixed blank, or whitespace-wrapped symbolic aliases) do not erase a previously observed concrete model.

The Kimi cache parser version is incremented from 2 to 3 to invalidate stale parsed entries.

## Safety and scope

- Changes are limited to the Kimi Code wire parser and its cache-version fingerprint.
- The legacy Kimi CLI parser is unchanged.
- Concrete `usage.record` models continue to take precedence over request context.
- Existing zero-token, turn-scope, timestamp, and session-id behavior is unchanged.
- Regression coverage includes model changes, concrete usage precedence, invalid requests after a concrete request, prefixed symbolic aliases, whitespace edge cases, and invalid usage aliases before any request.

## Verification

- `cargo test -p tokscale-core sessions::kimi::tests --lib` — 23 passed
- `cargo test -p tokscale-core test_kimi_parser_version_invalidates_v2_entries --lib` — passed
- `cargo test -p tokscale-core --lib` — 1277 passed, 1 ignored
- `bun run build` — passed
- `git diff --check` — passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Kimi Code parsing to replace symbolic usage models with the real provider model from the latest `llm.request`. Reports now show concrete models (e.g., `k3`) instead of placeholders.

- **Bug Fixes**
  - Resolve symbolic `usage.record` models (e.g., `__kimi_env_model__`) from the latest concrete `llm.request` using `__...__` detection.
  - Preserve concrete `usage.record` models; otherwise fall back to the last concrete request model, then `kimi-for-coding`. Invalid request values do not reset the last concrete model.
  - Bump Kimi parser cache to v3 to invalidate and reparse stale entries.

<sup>Written for commit 831b1d907ac08c8278b3dcd98b7d2beb42d8d83c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

