### PR TITLE
feat(cursor): auto-login from local Cursor desktop state.vscdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3458,6 +3458,7 @@ dependencies = [
  "reqwest",
  "resvg",
  "rpassword",
+ "rusqlite",
  "serde",
  "serde_json",
  "serial_test",

--- a/README.ja.md
+++ b/README.ja.md
@@ -63,7 +63,7 @@
 | <img width="48px" src=".github/assets/client-copilot.jpg" alt="Copilot" /> | [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-the-github-copilot-coding-agent-in-cli) | `~/.copilot/otel/*.jsonl` (+ `COPILOT_OTEL_FILE_EXPORTER_PATH`) |
 | <img width="48px" src=".github/assets/client-hermes.png" alt="Hermes Agent" /> | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `$HERMES_HOME/state.db` および `$HERMES_HOME/profiles/*/state.db`（フォールバック: `~/.hermes/...`） |
 | <img width="48px" src=".github/assets/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `$GEMINI_CLI_HOME/tmp/*/chats/*.json`（フォールバック: `~/.gemini/tmp/*/chats/*.json`） |
-| <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | Cursor API のエクスポートを `~/.config/tokscale/cursor-cache/usage*.csv` にキャッシュ（`~/.cursor` ではない） |
+| <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | Cursor API のエクスポートを `~/.config/tokscale/cursor-cache/usage*.csv` にキャッシュ（デスクトップ自動ログインまたは Cookie 貼り付け；`~/.cursor` ではない） |
 | <img width="48px" src=".github/assets/client-amp.png" alt="Amp" /> | [Amp (AmpCode)](https://ampcode.com/) | `~/.local/share/amp/threads/` |
 | <img width="48px" src=".github/assets/client-codebuff.png" alt="Codebuff" /> | [Codebuff](https://codebuff.com/) | `~/.config/manicode/` (+ `manicode-dev`、`manicode-staging`; `CODEBUFF_DATA_DIR` でオーバーライド可能) |
 | <img width="48px" src=".github/assets/client-droid.png" alt="Droid" /> | [Droid (Factory Droid)](https://factory.ai/) | `~/.factory/sessions/` |
@@ -554,10 +554,27 @@ tokscale autosubmit disable
 
 ### Cursor IDEコマンド
 
-Cursor IDEはセッショントークンによる別途認証が必要です（ソーシャルプラットフォームのログインとは異なる）：
+Cursor IDE は Cursor のウェブ用量エクスポート API を使い、Tokscale が `~/.config/tokscale/cursor-cache/usage*.csv` にキャッシュします。Tokscale は `~/.cursor` 配下の Cursor Agent CLI ローカル状態を解析しません。また、デスクトップの SQLite DB を使用量台帳としては扱いません。
+
+Cursor デスクトップアプリがインストール済みでサインイン済みの場合、`tokscale cursor login` は Cursor の `state.vscdb` から `cursorAuth/accessToken` を優先して読み取り、セッション Cookie を自動構築します。`tokscale cursor sync` も利用可能ならそのトークンを更新します。使用量行は引き続き Cursor の usage-export API からのみ取得します。
+
+セットアップ（デスクトップ自動ログイン）:
+
+1. Cursor デスクトップアプリにサインインする。
+2. `tokscale cursor login --name work` を実行する（ローカルデスクトップセッションがあれば自動検出）。
+3. `tokscale cursor sync --json` を実行して `~/.config/tokscale/cursor-cache/usage.csv` を埋める。
+4. `tokscale --client cursor` または任意のレポートコマンドを実行する。
+
+フォールバック（手動でブラウザ Cookie を貼り付け）— デスクトップログインが使えない場合:
+
+1. ブラウザで https://www.cursor.com/settings を開く
+2. 開発者ツールを開く（F12）
+3. **オプションA - Networkタブ**: ページで何らかのアクションを行い、`cursor.com/api/*`へのリクエストを見つけ、Request Headersの`Cookie`ヘッダーを確認し、`WorkosCursorSessionToken=`の後の値のみをコピー
+4. **オプションB - Applicationタブ**: Application → Cookies → `https://www.cursor.com`に移動し、`WorkosCursorSessionToken`クッキーを見つけてその値をコピー（クッキー名ではなく値）
+5. `tokscale cursor login --name work` を実行し、求められたらトークンを貼り付け、続けて `tokscale cursor sync --json` を実行する
 
 ```bash
-# Cursorにログイン（ブラウザからセッショントークンが必要）
+# Cursorにログイン（デスクトップログインを自動検出；失敗時はブラウザ Cookie 貼り付け）
 # --name は任意で、後でアカウントを識別するためのラベルです
 tokscale cursor login --name work
 
@@ -591,12 +608,6 @@ tokscale cursor logout --all --purge-cache
 デフォルトでは、tokscale は **保存済みのすべての Cursor アカウントの使用量を合算**します（`cursor-cache/usage*.csv`）。後方互換のため、アクティブアカウントは `cursor-cache/usage.csv` に同期されます。
 
 ログアウト時はキャッシュされた履歴を `cursor-cache/archive/` に移動して保持します（そのため集計には含まれません）。完全に削除したい場合は `--purge-cache` を使ってください。
-
-**Cursorセッショントークンの取得方法:**
-1. ブラウザで https://www.cursor.com/settings を開く
-2. 開発者ツールを開く（F12）
-3. **オプションA - Networkタブ**: ページで何らかのアクションを行い、`cursor.com/api/*`へのリクエストを見つけ、Request Headersの`Cookie`ヘッダーを確認し、`WorkosCursorSessionToken=`の後の値のみをコピー
-4. **オプションB - Applicationタブ**: Application → Cookies → `https://www.cursor.com`に移動し、`WorkosCursorSessionToken`クッキーを見つけてその値をコピー（クッキー名ではなく値）
 
 > ⚠️ **セキュリティ警告**: セッショントークンはパスワードのように扱ってください。公開したり、バージョン管理にコミットしたりしないでください。トークンはCursorアカウントへの完全なアクセス権を付与します。
 
@@ -1513,7 +1524,7 @@ Tokscaleは `chat` spanをトークン集計の信頼源として扱い、ツー
 
 場所: `~/.config/tokscale/cursor-cache/`（Cursor API経由で同期）
 
-CursorデータはセッショントークンでCursor APIから取得され、ローカルにキャッシュされます。認証するには`tokscale cursor login`を実行してください。セットアップ手順は[Cursor IDEコマンド](#cursor-ideコマンド)を参照。
+CursorデータはセッショントークンでCursor APIから取得され、ローカルにキャッシュされます。認証は Cursor デスクトップの `state.vscdb`（`cursorAuth/accessToken` のみ）から取り込むか、ブラウザ Cookie を貼り付けできます。Tokscale はレポート用に API キャッシュを読みます。ローカルの `~/.cursor` セッションデータやデスクトップの使用量テーブルは解析しません。セットアップ手順は[Cursor IDEコマンド](#cursor-ideコマンド)を参照。
 
 ### Antigravity
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -1313,7 +1313,7 @@ AIコーディングツールはクロスプラットフォームの場所にセ
 | Hermes Agent | `~/.hermes/` | `%USERPROFILE%\.hermes\` | `HERMES_HOME`環境変数で設定可能（[ソース](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/developer-guide/session-storage.md)） |
 | Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | `GEMINI_CLI_HOME`環境変数で設定可能 |
 | Amp | `~/.local/share/amp/` | `%USERPROFILE%\.local\share\amp\` | OpenCodeと同様に`xdg-basedir`を使用 |
-| Cursor | API同期 | API同期 | Cursor API から取得したデータを `usage*.csv` としてキャッシュ；ローカルの `~/.cursor` セッションデータは解析しない |
+| Cursor | API同期 | API同期 | Cursor API から取得したデータを `usage*.csv` としてキャッシュ；デスクトップ自動ログインは `state.vscdb` の認証のみ；ローカルの `~/.cursor` セッションデータは解析しない |
 | Droid | `~/.factory/` | `%USERPROFILE%\.factory\` | すべてのプラットフォームで同じパス |
 | Pi | `~/.pi/` and `~/.omp/` | `%USERPROFILE%\.pi\` and `%USERPROFILE%\.omp\` | すべてのプラットフォームで同じパス（Pi と [Oh My Pi](https://github.com/can1357/oh-my-pi) の両方をサポート） |
 | Kimi CLI | `~/.kimi/` | `%USERPROFILE%\.kimi\` | すべてのプラットフォームで同じパス |

--- a/README.ko.md
+++ b/README.ko.md
@@ -63,7 +63,7 @@
 | <img width="48px" src=".github/assets/client-copilot.jpg" alt="Copilot" /> | [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-the-github-copilot-coding-agent-in-cli) | `~/.copilot/otel/*.jsonl` (+ `COPILOT_OTEL_FILE_EXPORTER_PATH`) |
 | <img width="48px" src=".github/assets/client-hermes.png" alt="Hermes Agent" /> | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `$HERMES_HOME/state.db` 및 `$HERMES_HOME/profiles/*/state.db` (폴백: `~/.hermes/...`) |
 | <img width="48px" src=".github/assets/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `$GEMINI_CLI_HOME/tmp/*/chats/*.json` (폴백: `~/.gemini/tmp/*/chats/*.json`) |
-| <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | Cursor API 내보내기를 `~/.config/tokscale/cursor-cache/usage*.csv`에 캐싱 (`~/.cursor` 아님) |
+| <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | Cursor API 내보내기를 `~/.config/tokscale/cursor-cache/usage*.csv`에 캐싱 (데스크톱 자동 로그인 또는 쿠키 붙여넣기; `~/.cursor` 아님) |
 | <img width="48px" src=".github/assets/client-amp.png" alt="Amp" /> | [Amp (AmpCode)](https://ampcode.com/) | `~/.local/share/amp/threads/` |
 | <img width="48px" src=".github/assets/client-codebuff.png" alt="Codebuff" /> | [Codebuff](https://codebuff.com/) | `~/.config/manicode/` (+ `manicode-dev`, `manicode-staging`; `CODEBUFF_DATA_DIR`로 오버라이드 가능) |
 | <img width="48px" src=".github/assets/client-droid.png" alt="Droid" /> | [Droid (Factory Droid)](https://factory.ai/) | `~/.factory/sessions/` |
@@ -550,22 +550,30 @@ tokscale autosubmit disable
 
 ### Cursor IDE 명령어
 
-Cursor IDE 지원은 Cursor의 웹 API 내보내기를 사용하며, Tokscale이 `~/.config/tokscale/cursor-cache/usage*.csv`에 캐싱합니다. Tokscale은 `~/.cursor` 아래의 로컬 Cursor Agent CLI 상태를 파싱하지 않습니다.
+Cursor IDE 지원은 Cursor의 웹 API 내보내기를 사용하며, Tokscale이 `~/.config/tokscale/cursor-cache/usage*.csv`에 캐싱합니다. Tokscale은 `~/.cursor` 아래의 로컬 Cursor Agent CLI 상태를 파싱하지 않으며, 데스크톱 SQLite DB를 사용량 원장으로 취급하지도 않습니다.
 
-설정:
+Cursor 데스크톱 앱이 설치되어 있고 로그인되어 있으면, `tokscale cursor login`은 Cursor의 `state.vscdb`에서 `cursorAuth/accessToken`을 우선 읽어 세션 쿠키를 자동으로 만듭니다. `tokscale cursor sync`도 가능할 때 이 토큰을 갱신합니다. 사용량 행은 계속 Cursor usage-export API에서만 가져옵니다.
+
+설정 (데스크톱 자동 로그인):
+
+1. Cursor 데스크톱 앱에 로그인하세요.
+2. `tokscale cursor login --name work`를 실행하세요 (로컬 데스크톱 세션이 있으면 자동 감지).
+3. `tokscale cursor sync --json`을 실행해 `~/.config/tokscale/cursor-cache/usage.csv`를 채우세요.
+4. `tokscale --client cursor` 또는 아무 리포트 명령을 실행하세요.
+
+대체 방법 (브라우저 쿠키 수동 붙여넣기) — 데스크톱 로그인을 쓸 수 없을 때:
 
 1. 브라우저에서 https://www.cursor.com/settings 를 열고 로그인하세요.
 2. `WorkosCursorSessionToken` 쿠키 값을 복사하세요:
    - Network 탭: `cursor.com/api/*`로 아무 요청이나 보낸 뒤, `Cookie` 요청 헤더에서 `WorkosCursorSessionToken=` 뒤의 값을 복사합니다.
    - Application 탭: Cookies → `https://www.cursor.com`을 열고 `WorkosCursorSessionToken` 값을 복사합니다.
-3. `tokscale cursor login --name work`를 실행하고 토큰을 붙여 넣으세요.
-4. `tokscale cursor sync --json`을 실행해 `~/.config/tokscale/cursor-cache/usage.csv`를 채우세요.
-5. `tokscale --client cursor` 또는 아무 리포트 명령을 실행하세요.
+3. `tokscale cursor login --name work`를 실행하고 프롬프트에서 토큰을 붙여 넣으세요.
+4. 위와 같이 `tokscale cursor sync --json`을 계속 진행하세요.
 
 세션 토큰은 비밀번호처럼 취급하세요. 토큰은 `~/.config/tokscale/cursor-credentials.json`에 로컬로 저장됩니다.
 
 ```bash
-# Cursor 로그인 (브라우저에서 세션 토큰 필요)
+# Cursor 로그인 (데스크톱 로그인 자동 감지; 실패 시 브라우저 쿠키 붙여넣기)
 # --name은 선택이며, 나중에 계정을 구분하는 데만 도움이 됩니다
 tokscale cursor login --name work
 
@@ -1555,7 +1563,7 @@ Tokscale은 `chat` span을 토큰 집계의 출처로 취급하고, 도구 span�
 
 위치: `~/.config/tokscale/cursor-cache/usage*.csv` (Cursor API를 통해 동기화)
 
-Cursor 데이터는 세션 토큰을 사용하여 Cursor API에서 가져와 로컬에 캐시됩니다. Tokscale은 리포트를 위해 해당 캐시 파일을 읽으며, 로컬 `~/.cursor` 세션 데이터는 파싱하지 않습니다. 설정 안내는 [Cursor IDE 명령어](#cursor-ide-명령어)를 참조하세요.
+Cursor 데이터는 세션 토큰을 사용하여 Cursor API에서 가져와 로컬에 캐시됩니다. 인증은 Cursor 데스크톱 `state.vscdb`(`cursorAuth/accessToken`만)에서 가져오거나 브라우저 쿠키를 붙여 넣을 수 있습니다. Tokscale은 리포트를 위해 API 캐시 파일을 읽으며, 로컬 `~/.cursor` 세션 데이터나 데스크톱 사용량 테이블은 파싱하지 않습니다. 설정 안내는 [Cursor IDE 명령어](#cursor-ide-명령어)를 참조하세요.
 
 ### Antigravity
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1314,7 +1314,7 @@ AI 코딩 도구들은 크로스 플랫폼 위치에 세션 데이터를 저장�
 | Hermes Agent | `~/.hermes/` | `%USERPROFILE%\.hermes\` | `HERMES_HOME` 환경변수로 설정 가능 ([소스](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/developer-guide/session-storage.md)) |
 | Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | `GEMINI_CLI_HOME` 환경변수로 설정 가능 |
 | Amp | `~/.local/share/amp/` | `%USERPROFILE%\.local\share\amp\` | OpenCode와 동일하게 `xdg-basedir` 사용 |
-| Cursor | API 동기화 | API 동기화 | API를 통해 데이터 가져오기, `%USERPROFILE%\.config\tokscale\cursor-cache\`에 캐시 |
+| Cursor | API 동기화 | API 동기화 | API로 가져와 `usage*.csv`로 캐시; 데스크톱 자동 로그인은 `state.vscdb` 인증만 읽음; 로컬 `~/.cursor` 세션 데이터는 파싱하지 않음 |
 | Droid | `~/.factory/` | `%USERPROFILE%\.factory\` | 모든 플랫폼에서 동일한 경로 |
 | Pi | `~/.pi/` and `~/.omp/` | `%USERPROFILE%\.pi\` and `%USERPROFILE%\.omp\` | 모든 플랫폼에서 동일한 경로 (Pi 및 [Oh My Pi](https://github.com/can1357/oh-my-pi) 모두 지원) |
 | Kimi CLI | `~/.kimi/` | `%USERPROFILE%\.kimi\` | 모든 플랫폼에서 동일한 경로 |

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@
 | <img width="48px" src=".github/assets/client-copilot.jpg" alt="Copilot" /> | [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-the-github-copilot-coding-agent-in-cli) | `~/.copilot/otel/*.jsonl` (+ `COPILOT_OTEL_FILE_EXPORTER_PATH`) |
 | <img width="48px" src=".github/assets/client-hermes.png" alt="Hermes Agent" /> | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `$HERMES_HOME/state.db` and `$HERMES_HOME/profiles/*/state.db` (fallback: `~/.hermes/...`) |
 | <img width="48px" src=".github/assets/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `$GEMINI_CLI_HOME/tmp/*/chats/*.json` (fallback: `~/.gemini/tmp/*/chats/*.json`) |
-| <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | Cursor API export cached at `~/.config/tokscale/cursor-cache/usage*.csv` (not `~/.cursor`) |
+| <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | Cursor API export cached at `~/.config/tokscale/cursor-cache/usage*.csv` (desktop auto-login or cookie paste; not `~/.cursor`) |
 | <img width="48px" src=".github/assets/client-amp.png" alt="Amp" /> | [Amp (AmpCode)](https://ampcode.com/) | `~/.local/share/amp/threads/` |
 | <img width="48px" src=".github/assets/client-codebuff.png" alt="Codebuff" /> | [Codebuff](https://codebuff.com/) | `~/.config/manicode/` (+ `manicode-dev`, `manicode-staging`; override via `CODEBUFF_DATA_DIR`) |
 | <img width="48px" src=".github/assets/client-droid.png" alt="Droid" /> | [Droid (Factory Droid)](https://factory.ai/) | `~/.factory/sessions/` |
@@ -552,22 +552,30 @@ Scheduled runs are non-interactive: they never prompt for GitHub auth or star co
 
 ### Cursor IDE Commands
 
-Cursor IDE support uses Cursor's web API export, cached by Tokscale at `~/.config/tokscale/cursor-cache/usage*.csv`. Tokscale does not parse local Cursor Agent CLI state under `~/.cursor`.
+Cursor IDE support uses Cursor's web API export, cached by Tokscale at `~/.config/tokscale/cursor-cache/usage*.csv`. Tokscale does not parse local Cursor Agent CLI state under `~/.cursor`, and it does not treat the desktop SQLite DB as a usage ledger.
 
-Setup:
+When the Cursor desktop app is installed and signed in, `tokscale cursor login` prefers the local `cursorAuth/accessToken` from Cursor's `state.vscdb` and builds the session cookie automatically. `tokscale cursor sync` also refreshes that token when available. Usage rows still come only from Cursor's usage-export API.
+
+Setup (desktop auto-login):
+
+1. Sign in to the Cursor desktop app.
+2. Run `tokscale cursor login --name work` (auto-detects the local desktop session when available).
+3. Run `tokscale cursor sync --json` to populate `~/.config/tokscale/cursor-cache/usage.csv`.
+4. Run `tokscale --client cursor` or any report command.
+
+Fallback (manual browser cookie), if desktop login is unavailable:
 
 1. Open https://www.cursor.com/settings in your browser and sign in.
 2. Copy the `WorkosCursorSessionToken` cookie value:
    - Network tab: make any request to `cursor.com/api/*`, then copy the value after `WorkosCursorSessionToken=` from the `Cookie` request header.
    - Application tab: open Cookies -> `https://www.cursor.com`, then copy the `WorkosCursorSessionToken` value.
-3. Run `tokscale cursor login --name work` and paste the token.
-4. Run `tokscale cursor sync --json` to populate `~/.config/tokscale/cursor-cache/usage.csv`.
-5. Run `tokscale --client cursor` or any report command.
+3. Run `tokscale cursor login --name work` and paste the token when prompted.
+4. Continue with `tokscale cursor sync --json` as above.
 
 Treat the session token like a password. It is stored locally in `~/.config/tokscale/cursor-credentials.json`.
 
 ```bash
-# Login to Cursor (requires session token from browser)
+# Login to Cursor (auto-detects Cursor desktop login; falls back to browser cookie paste)
 # --name is optional; it just helps you identify accounts later
 tokscale cursor login --name work
 
@@ -1320,7 +1328,7 @@ AI coding tools store their session data in cross-platform locations. Most tools
 | Hermes Agent | `~/.hermes/` | `%USERPROFILE%\.hermes\` | Configurable via `HERMES_HOME` env var ([source](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/developer-guide/session-storage.md)) |
 | Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | Configurable via `GEMINI_CLI_HOME` env var |
 | Amp | `~/.local/share/amp/` | `%USERPROFILE%\.local\share\amp\` | Uses `xdg-basedir` like OpenCode |
-| Cursor | API sync | API sync | Data fetched from Cursor API and cached as `usage*.csv`; local `~/.cursor` session data is not parsed |
+| Cursor | API sync | API sync | Data fetched from Cursor API and cached as `usage*.csv`; desktop auto-login reads auth only from `state.vscdb`; local `~/.cursor` session data is not parsed |
 | Droid | `~/.factory/` | `%USERPROFILE%\.factory\` | Same path on all platforms |
 | Pi | `~/.pi/` and `~/.omp/` | `%USERPROFILE%\.pi\` and `%USERPROFILE%\.omp\` | Same path on all platforms (supports both Pi and [Oh My Pi](https://github.com/can1357/oh-my-pi)) |
 | Kimi CLI | `~/.kimi/` | `%USERPROFILE%\.kimi\` | Same path on all platforms |
@@ -1573,7 +1581,7 @@ Session files containing message arrays:
 
 Location: `~/.config/tokscale/cursor-cache/usage*.csv` (synced via Cursor API)
 
-Cursor data is fetched from the Cursor API using your session token and cached locally. Tokscale reads those cache files for reports; it does not parse local `~/.cursor` session data. See [Cursor IDE Commands](#cursor-ide-commands) for setup.
+Cursor usage is fetched from the Cursor API using a session token and cached locally. Auth can be imported from the Cursor desktop `state.vscdb` (`cursorAuth/accessToken` only) or pasted as a browser cookie. Tokscale reads the API cache files for reports; it does not parse local `~/.cursor` session data or desktop usage tables. See [Cursor IDE Commands](#cursor-ide-commands) for setup.
 
 ### Antigravity
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -1312,7 +1312,7 @@ AI 编程工具将会话数据存储在跨平台位置。大多数工具在所�
 | Hermes Agent | `~/.hermes/` | `%USERPROFILE%\.hermes\` | 可通过 `HERMES_HOME` 环境变量配置（[源码](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/developer-guide/session-storage.md)） |
 | Gemini CLI | `~/.gemini/` | `%USERPROFILE%\.gemini\` | 可通过 `GEMINI_CLI_HOME` 环境变量配置 |
 | Amp | `~/.local/share/amp/` | `%USERPROFILE%\.local\share\amp\` | 与 OpenCode 一样使用 `xdg-basedir` |
-| Cursor | API 同步 | API 同步 | 通过 API 获取数据，缓存在 `%USERPROFILE%\.config\tokscale\cursor-cache\` |
+| Cursor | API 同步 | API 同步 | 通过 API 获取并缓存为 `usage*.csv`；桌面端自动登录仅读取 `state.vscdb` 认证；不解析本地 `~/.cursor` 会话数据 |
 | Droid | `~/.factory/` | `%USERPROFILE%\.factory\` | 所有平台使用相同路径 |
 | Pi | `~/.pi/` and `~/.omp/` | `%USERPROFILE%\.pi\` and `%USERPROFILE%\.omp\` | 所有平台使用相同路径（支持 Pi 和 [Oh My Pi](https://github.com/can1357/oh-my-pi)） |
 | Kimi CLI | `~/.kimi/` | `%USERPROFILE%\.kimi\` | 所有平台使用相同路径 |

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -64,7 +64,7 @@
 | <img width="48px" src=".github/assets/client-copilot.jpg" alt="Copilot" /> | [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-the-github-copilot-coding-agent-in-cli) | `~/.copilot/otel/*.jsonl` (+ `COPILOT_OTEL_FILE_EXPORTER_PATH`) |
 | <img width="48px" src=".github/assets/client-hermes.png" alt="Hermes Agent" /> | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `$HERMES_HOME/state.db` 和 `$HERMES_HOME/profiles/*/state.db`（回退：`~/.hermes/...`） |
 | <img width="48px" src=".github/assets/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `$GEMINI_CLI_HOME/tmp/*/chats/*.json`（回退：`~/.gemini/tmp/*/chats/*.json`） |
-| <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | Cursor API 导出缓存于 `~/.config/tokscale/cursor-cache/usage*.csv`（而非 `~/.cursor`） |
+| <img width="48px" src=".github/assets/client-cursor.jpg" alt="Cursor" /> | [Cursor IDE](https://cursor.com/) | Cursor API 导出缓存于 `~/.config/tokscale/cursor-cache/usage*.csv`（桌面端自动登录或粘贴 cookie；而非 `~/.cursor`） |
 | <img width="48px" src=".github/assets/client-amp.png" alt="Amp" /> | [Amp (AmpCode)](https://ampcode.com/) | `~/.local/share/amp/threads/` |
 | <img width="48px" src=".github/assets/client-codebuff.png" alt="Codebuff" /> | [Codebuff](https://codebuff.com/) | `~/.config/manicode/`（+ `manicode-dev`、`manicode-staging`；可通过 `CODEBUFF_DATA_DIR` 覆盖） |
 | <img width="48px" src=".github/assets/client-droid.png" alt="Droid" /> | [Droid (Factory Droid)](https://factory.ai/) | `~/.factory/sessions/` |
@@ -550,10 +550,27 @@ tokscale autosubmit disable
 
 ### Cursor IDE 命令
 
-Cursor IDE 需要通过会话令牌进行单独认证（与社交平台登录不同）：
+Cursor IDE 通过 Cursor 的网页用量导出 API 获取数据，并缓存在 `~/.config/tokscale/cursor-cache/usage*.csv`。Tokscale **不会**解析 `~/.cursor` 下的 Cursor Agent CLI 本地会话，也不会把桌面端 SQLite 当作用量账本。
+
+若本机已安装并登录 Cursor 桌面端，`tokscale cursor login` 会优先从 Cursor 的 `state.vscdb` 读取 `cursorAuth/accessToken` 并自动构造会话 cookie；`tokscale cursor sync` 在可用时也会刷新该 token。用量数据仍只来自 Cursor 的 usage-export API。
+
+设置（桌面端自动登录）：
+
+1. 登录 Cursor 桌面端。
+2. 运行 `tokscale cursor login --name work`（有本地桌面会话时会自动检测）。
+3. 运行 `tokscale cursor sync --json`，填充 `~/.config/tokscale/cursor-cache/usage.csv`。
+4. 运行 `tokscale --client cursor` 或任意报告命令。
+
+回退（手动粘贴浏览器 cookie）：桌面端不可用时：
+
+1. 在浏览器中打开 https://www.cursor.com/settings
+2. 打开开发者工具（F12）
+3. **选项 A - Network 标签**：在页面上执行任何操作，找到对 `cursor.com/api/*` 的请求，在 Request Headers 中查看 `Cookie` 头，仅复制 `WorkosCursorSessionToken=` 后面的值
+4. **选项 B - Application 标签**：转到 Application → Cookies → `https://www.cursor.com`，找到 `WorkosCursorSessionToken` cookie，复制其值（不是 cookie 名称）
+5. 运行 `tokscale cursor login --name work`，在提示时粘贴令牌，然后继续 `tokscale cursor sync --json`
 
 ```bash
-# 登录 Cursor（需要从浏览器获取会话令牌）
+# 登录 Cursor（优先自动检测桌面端登录；失败再粘贴浏览器 cookie）
 # --name 是可选的，用于之后区分账户的标签
 tokscale cursor login --name work
 
@@ -562,6 +579,9 @@ tokscale cursor status
 
 # 列出已保存的 Cursor 账户
 tokscale cursor accounts
+
+# 手动刷新缓存的 Cursor 使用量
+tokscale cursor sync --json
 
 # 切换活动账户（同步到 cursor-cache/usage.csv 的账户）
 tokscale cursor switch work
@@ -584,12 +604,6 @@ tokscale cursor logout --all --purge-cache
 默认情况下，tokscale 会 **合并统计所有已保存 Cursor 账户的使用量**（`cursor-cache/usage*.csv`）。为保持兼容性，活动账户会同步到 `cursor-cache/usage.csv`。
 
 登出时，tokscale 会将缓存的历史记录移动到 `cursor-cache/archive/`（因此不会参与合并统计）。如需彻底删除缓存，请使用 `--purge-cache`。
-
-**获取 Cursor 会话令牌的方法：**
-1. 在浏览器中打开 https://www.cursor.com/settings
-2. 打开开发者工具（F12）
-3. **选项 A - Network 标签**：在页面上执行任何操作，找到对 `cursor.com/api/*` 的请求，在 Request Headers 中查看 `Cookie` 头，仅复制 `WorkosCursorSessionToken=` 后面的值
-4. **选项 B - Application 标签**：转到 Application → Cookies → `https://www.cursor.com`，找到 `WorkosCursorSessionToken` cookie，复制其值（不是 cookie 名称）
 
 > ⚠️ **安全警告**：像对待密码一样对待您的会话令牌。切勿公开分享或提交到版本控制。该令牌授予对您 Cursor 账户的完全访问权限。
 
@@ -1547,7 +1561,7 @@ Tokscale 将 `chat` span 作为 Token 统计的真实来源，并在第一阶段
 
 位置：`~/.config/tokscale/cursor-cache/usage*.csv`（通过 Cursor API 同步）
 
-Cursor 数据使用您的会话令牌从 Cursor API 获取并本地缓存。Tokscale 读取这些缓存文件来生成报告；它不会解析本地的 `~/.cursor` 会话数据。设置说明请参阅 [Cursor IDE 命令](#cursor-ide-命令)。
+Cursor 数据使用会话令牌从 Cursor API 获取并本地缓存。认证可从 Cursor 桌面端 `state.vscdb`（仅 `cursorAuth/accessToken`）导入，或粘贴浏览器 cookie。Tokscale 读取 API 缓存文件生成报告；不会解析本地 `~/.cursor` 会话数据或桌面端用量表。设置说明请参阅 [Cursor IDE 命令](#cursor-ide-命令)。
 
 ### Antigravity
 

--- a/crates/tokscale-cli/Cargo.toml
+++ b/crates/tokscale-cli/Cargo.toml
@@ -55,6 +55,9 @@ aes = { workspace = true }
 cbc = { workspace = true }
 base64 = { workspace = true }
 
+# Cursor desktop state.vscdb accessToken import
+rusqlite = { workspace = true }
+
 # arboard has no Android backend and fails to compile for
 # aarch64-linux-android. The clipboard module in tui/ provides a
 # no-op fallback on Android so the rest of the code stays portable.

--- a/crates/tokscale-cli/src/commands/wrapped.rs
+++ b/crates/tokscale-cli/src/commands/wrapped.rs
@@ -3050,7 +3050,7 @@ fn cursor_setup_warning_for_wrapped(
     let action = if cursor_logged_in {
         "run `tokscale cursor sync --json`"
     } else {
-        "run `tokscale cursor login` and `tokscale cursor sync --json`"
+        "run `tokscale cursor login` (auto-detects Cursor desktop when signed in) and `tokscale cursor sync --json`"
     };
 
     Some(format!(

--- a/crates/tokscale-cli/src/cursor.rs
+++ b/crates/tokscale-cli/src/cursor.rs
@@ -257,6 +257,193 @@ fn extract_user_id_from_session_token(token: &str) -> Option<String> {
     None
 }
 
+/// Candidate paths for Cursor desktop `state.vscdb` (VS Code globalStorage).
+///
+/// Mirrors the layout used by Cursor Usage Agent on Windows, plus the standard
+/// Electron/Chromium config dirs on Linux and macOS.
+pub fn cursor_state_vscdb_candidates(home_dir: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    #[cfg(target_os = "macos")]
+    {
+        paths.push(
+            home_dir.join("Library/Application Support/Cursor/User/globalStorage/state.vscdb"),
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(appdata) = std::env::var("APPDATA") {
+            paths.push(
+                PathBuf::from(appdata).join("Cursor").join("User/globalStorage/state.vscdb"),
+            );
+        }
+        paths.push(home_dir.join("AppData/Roaming/Cursor/User/globalStorage/state.vscdb"));
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        paths.push(home_dir.join(".config/Cursor/User/globalStorage/state.vscdb"));
+    }
+
+    paths
+}
+
+fn find_cursor_state_vscdb(home_dir: &Path) -> Option<PathBuf> {
+    cursor_state_vscdb_candidates(home_dir)
+        .into_iter()
+        .find(|path| path.is_file())
+}
+
+/// Read `cursorAuth/accessToken` from a Cursor `state.vscdb` SQLite DB.
+pub fn read_access_token_from_state_vscdb(db_path: &Path) -> Result<String> {
+    use rusqlite::{Connection, OpenFlags};
+
+    // Prefer URI read-only so a running Cursor IDE holding a write lock does
+    // not block us (WAL readers are allowed while the app is open).
+    let uri = format!("file:{}?mode=ro", db_path.display());
+    let conn = Connection::open_with_flags(
+        &uri,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
+    )
+    .with_context(|| format!("Failed to open Cursor state DB at {}", db_path.display()))?;
+
+    let token: String = conn
+        .query_row(
+            "SELECT value FROM ItemTable WHERE key = 'cursorAuth/accessToken'",
+            [],
+            |row| row.get(0),
+        )
+        .context("cursorAuth/accessToken not found in Cursor state DB (is Cursor logged in?)")?;
+
+    if token.trim().is_empty() {
+        anyhow::bail!("cursorAuth/accessToken is empty");
+    }
+    Ok(token)
+}
+
+/// Extract the Cursor `user_…` id from a JWT `sub` claim (e.g. `auth0|user_abc`).
+fn user_id_from_access_token_jwt(access_token: &str) -> Result<String> {
+    use base64::Engine;
+
+    let payload_b64 = access_token
+        .split('.')
+        .nth(1)
+        .ok_or_else(|| anyhow::anyhow!("Invalid Cursor access token JWT"))?;
+    let padded = match payload_b64.len() % 4 {
+        2 => format!("{}==", payload_b64),
+        3 => format!("{}=", payload_b64),
+        _ => payload_b64.to_string(),
+    };
+    let bytes = base64::engine::general_purpose::URL_SAFE
+        .decode(padded.as_bytes())
+        .or_else(|_| {
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(payload_b64.as_bytes())
+        })
+        .context("Failed to decode Cursor access token JWT payload")?;
+    let payload: serde_json::Value =
+        serde_json::from_slice(&bytes).context("Failed to parse Cursor access token JWT")?;
+    let sub = payload
+        .get("sub")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("Cursor access token JWT missing sub claim"))?;
+
+    if let Some(idx) = sub.find("user_") {
+        let rest = &sub[idx..];
+        let end = rest
+            .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+            .unwrap_or(rest.len());
+        let user_id = &rest[..end];
+        if user_id.len() > "user_".len() {
+            return Ok(user_id.to_string());
+        }
+    }
+
+    anyhow::bail!("Cannot parse Cursor user id from JWT sub: {sub}");
+}
+
+/// Build the `WorkosCursorSessionToken` cookie value from a desktop access token.
+///
+/// Format matches browser cookies and Cursor Usage Agent:
+/// `{user_id}%3A%3A{access_token}` (`%3A%3A` is URL-encoded `::`).
+pub fn session_token_from_access_token(access_token: &str) -> Result<String> {
+    let user_id = user_id_from_access_token_jwt(access_token)?;
+    Ok(format!("{user_id}%3A%3A{access_token}"))
+}
+
+/// Read the local Cursor desktop login and build a session token cookie value.
+pub fn read_local_cursor_session_token() -> Result<String> {
+    let home = home_dir()?;
+    let db_path = find_cursor_state_vscdb(&home).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Cursor desktop state.vscdb not found (install Cursor and sign in first)"
+        )
+    })?;
+    let access_token = read_access_token_from_state_vscdb(&db_path)?;
+    session_token_from_access_token(&access_token)
+}
+
+/// Save credentials while preserving an existing account label / created_at when
+/// the caller does not supply a new label (used by local desktop refresh).
+fn upsert_credentials(token: &str, label: Option<&str>) -> Result<String> {
+    let account_id = derive_account_id(token);
+    let user_id = extract_user_id_from_session_token(token);
+
+    let mut store = load_credentials_store().unwrap_or_else(|| CursorCredentialsStore {
+        version: 1,
+        active_account_id: account_id.clone(),
+        accounts: HashMap::new(),
+    });
+
+    if let Some(lbl) = label {
+        let needle = lbl.trim().to_lowercase();
+        if !needle.is_empty() {
+            for (id, acct) in &store.accounts {
+                if id == &account_id {
+                    continue;
+                }
+                if let Some(existing_label) = &acct.label {
+                    if existing_label.trim().to_lowercase() == needle {
+                        anyhow::bail!("Cursor account label already exists: {}", lbl);
+                    }
+                }
+            }
+        }
+    }
+
+    let existing = store.accounts.get(&account_id);
+    let created_at = existing
+        .map(|c| c.created_at.clone())
+        .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
+    let resolved_label = label
+        .map(|s| s.to_string())
+        .or_else(|| existing.and_then(|c| c.label.clone()));
+
+    let credentials = CursorCredentials {
+        session_token: token.to_string(),
+        user_id,
+        created_at,
+        expires_at: None,
+        label: resolved_label,
+    };
+
+    store.accounts.insert(account_id.clone(), credentials);
+    store.active_account_id = account_id.clone();
+    save_credentials_store(&store)?;
+    Ok(account_id)
+}
+
+/// Best-effort: refresh saved Cursor credentials from the desktop `state.vscdb`.
+///
+/// Used before sync so tokscale picks up tokens refreshed by the Cursor app
+/// without requiring a manual cookie paste.
+fn ensure_credentials_from_local_cursor() -> Result<Option<String>> {
+    match read_local_cursor_session_token() {
+        Ok(token) => Ok(Some(upsert_credentials(&token, None)?)),
+        Err(_) => Ok(None),
+    }
+}
+
 fn derive_account_id(session_token: &str) -> String {
     if let Some(user_id) = extract_user_id_from_session_token(session_token) {
         return user_id;
@@ -441,45 +628,7 @@ pub fn find_account(name_or_id: &str) -> Option<AccountInfo> {
 }
 
 pub fn save_credentials(token: &str, label: Option<&str>) -> Result<String> {
-    let account_id = derive_account_id(token);
-    let user_id = extract_user_id_from_session_token(token);
-
-    let mut store = load_credentials_store().unwrap_or_else(|| CursorCredentialsStore {
-        version: 1,
-        active_account_id: account_id.clone(),
-        accounts: HashMap::new(),
-    });
-
-    if let Some(lbl) = label {
-        let needle = lbl.trim().to_lowercase();
-        if !needle.is_empty() {
-            for (id, acct) in &store.accounts {
-                if id == &account_id {
-                    continue;
-                }
-                if let Some(existing_label) = &acct.label {
-                    if existing_label.trim().to_lowercase() == needle {
-                        anyhow::bail!("Cursor account label already exists: {}", lbl);
-                    }
-                }
-            }
-        }
-    }
-
-    let credentials = CursorCredentials {
-        session_token: token.to_string(),
-        user_id,
-        created_at: chrono::Utc::now().to_rfc3339(),
-        expires_at: None,
-        label: label.map(|s| s.to_string()),
-    };
-
-    store.accounts.insert(account_id.clone(), credentials);
-    store.active_account_id = account_id.clone();
-
-    save_credentials_store(&store)?;
-
-    Ok(account_id)
+    upsert_credentials(token, label)
 }
 
 pub fn remove_account(name_or_id: &str, purge_cache: bool) -> Result<()> {
@@ -1030,6 +1179,10 @@ where
 }
 
 pub async fn sync_cursor_cache() -> SyncCursorResult {
+    // Prefer a fresh token from the local Cursor desktop login when available.
+    // This avoids stale manually-pasted cookies after Cursor refreshes its JWT.
+    let _ = ensure_credentials_from_local_cursor();
+
     sync_cursor_cache_with_fetcher(|session_token| async move {
         fetch_cursor_usage_csv(&session_token).await
     })
@@ -1078,15 +1231,36 @@ pub fn run_cursor_login(name: Option<String>) -> Result<()> {
         }
     }
 
-    print!("  Enter Cursor WorkosCursorSessionToken value: ");
-    std::io::stdout().flush()?;
-    let token = rpassword::read_password().context("Failed to read session token")?;
-    let token = token.trim().to_string();
-
-    if token.is_empty() {
-        println!("\n  {}\n", "No token provided.".yellow());
-        return Ok(());
-    }
+    // Prefer the local Cursor desktop accessToken (state.vscdb) when present.
+    println!("{}", "  Checking local Cursor desktop login...".bright_black());
+    let token = match read_local_cursor_session_token() {
+        Ok(token) => {
+            if let Some(user_id) = extract_user_id_from_session_token(&token) {
+                println!(
+                    "{}",
+                    format!("  Found local Cursor session ({user_id}).").bright_black()
+                );
+            } else {
+                println!("{}", "  Found local Cursor session.".bright_black());
+            }
+            token
+        }
+        Err(local_err) => {
+            println!(
+                "{}",
+                format!("  Local desktop login unavailable: {local_err}").bright_black()
+            );
+            print!("  Enter Cursor WorkosCursorSessionToken value: ");
+            std::io::stdout().flush()?;
+            let pasted = rpassword::read_password().context("Failed to read session token")?;
+            let pasted = pasted.trim().to_string();
+            if pasted.is_empty() {
+                println!("\n  {}\n", "No token provided.".yellow());
+                return Ok(());
+            }
+            pasted
+        }
+    };
 
     println!();
     println!("{}", "  Validating session token...".bright_black());
@@ -1350,6 +1524,48 @@ mod tests {
         assert_eq!(extract_user_id_from_session_token(""), None);
         // Whitespace only
         assert_eq!(extract_user_id_from_session_token("   "), None);
+    }
+
+    fn make_access_token_jwt(sub: &str) -> String {
+        use base64::Engine;
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"{\"alg\":\"none\"}");
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(format!(r#"{{"sub":"{sub}"}}"#).as_bytes());
+        format!("{header}.{payload}.sig")
+    }
+
+    #[test]
+    fn test_session_token_from_access_token_builds_cookie_value() {
+        let access = make_access_token_jwt("auth0|user_01ABCXYZ");
+        let session = session_token_from_access_token(&access).unwrap();
+        assert_eq!(session, format!("user_01ABCXYZ%3A%3A{access}"));
+        assert_eq!(
+            extract_user_id_from_session_token(&session),
+            Some("user_01ABCXYZ".to_string())
+        );
+    }
+
+    #[test]
+    fn test_read_access_token_from_state_vscdb() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let db_path = temp_dir.path().join("state.vscdb");
+        let access = make_access_token_jwt("auth0|user_LOCAL123");
+
+        {
+            let conn = rusqlite::Connection::open(&db_path)?;
+            conn.execute(
+                "CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO ItemTable (key, value) VALUES (?1, ?2)",
+                rusqlite::params!["cursorAuth/accessToken", access],
+            )?;
+        }
+
+        let read = read_access_token_from_state_vscdb(&db_path)?;
+        assert_eq!(read, access);
+        Ok(())
     }
 
     #[test]

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -386,7 +386,7 @@ enum Commands {
 
 #[derive(Subcommand)]
 enum CursorSubcommand {
-    #[command(about = "Login to Cursor with a browser session token")]
+    #[command(about = "Login to Cursor (auto-detect desktop session, or paste browser token)")]
     Login {
         #[arg(long, help = "Label for this Cursor account (e.g., work, personal)")]
         name: Option<String>,

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1353,7 +1353,7 @@ fn cursor_setup_warnings_for_report(
 
     let Some(state) = cursor_setup_state(home_dir) else {
         return vec![
-            "Cursor usage requires Tokscale's Cursor API cache, but the home directory could not be resolved. Run `tokscale cursor login` and `tokscale cursor sync --json`. Tokscale does not parse local `~/.cursor` session data.".to_string(),
+            "Cursor usage requires Tokscale's Cursor API cache, but the home directory could not be resolved. Run `tokscale cursor login` (auto-detects Cursor desktop when signed in) and `tokscale cursor sync --json`. Tokscale does not parse local `~/.cursor` session data.".to_string(),
         ];
     };
     if state.has_cache {
@@ -1361,11 +1361,11 @@ fn cursor_setup_warnings_for_report(
     }
 
     let action = if state.home_override {
-        "run `tokscale cursor login` and `tokscale cursor sync --json`, or populate that cache before running a report with --home"
+        "run `tokscale cursor login` (auto-detects Cursor desktop when signed in) and `tokscale cursor sync --json`, or populate that cache before running a report with --home"
     } else if state.has_credentials {
         "run `tokscale cursor sync --json`"
     } else {
-        "run `tokscale cursor login` and `tokscale cursor sync --json`"
+        "run `tokscale cursor login` (auto-detects Cursor desktop when signed in) and `tokscale cursor sync --json`"
     };
 
     vec![format!(


### PR DESCRIPTION
## Summary
  Cursor usage in Tokscale still requires pasting a `WorkosCursorSessionToken` from the browser. That flow is easy to miss, and the cookie expires, so reports often look empty even when Cursor desktop is already signed in.
  This PR keeps the existing Cursor **API export → `cursor-cache/usage*.csv`** path, but adds desktop auto-login:
  1. Read `cursorAuth/accessToken` from Cursor IDE `state.vscdb`
  2. Build `WorkosCursorSessionToken={user_id}%3A%3A{access_token}`
  3. Use it in `tokscale cursor login` (preferred) and refresh it before `cursor sync`
  Manual cookie paste remains as a fallback when the desktop DB is missing or Cursor is not logged in.
  ## Why this is different from existing issues / PRs
  Related history in the repo:
  - https://github.com/junhoyeo/tokscale/issues/586 — explicit Cursor reports silently showed zero when unauthenticated / cache missing
  - https://github.com/junhoyeo/tokscale/issues/587 — docs clarified Cursor uses Tokscale's API cache, not local `~/.cursor` session data
  - https://github.com/junhoyeo/tokscale/issues/588 — asked for Cursor Agent CLI local session support **or** an explicit unsupported marker
  - https://github.com/junhoyeo/tokscale/pull/556 — proposed parsing `state.vscdb` `cursorDiskKV` bubbles as a separate best-effort `cursorcli` usage client (closed, unmerged)
  | Approach | Data source | What it does | Status / outcome |
  |---|---|---|---|
  | Current main | Browser cookie + Cursor usage CSV API | Accurate billed usage via `cursor-cache` | Supported |
  | #588 / docs path | `~/.cursor` transcripts / local CLI state | Local ledger like Claude/Codex | Explicitly unsupported (no durable token fields) |
  | #556 | `state.vscdb` bubble metadata | Best-effort local token estimates as `cursorcli` | Closed without merge |
  | **This PR** | `state.vscdb` `cursorAuth/accessToken` | Auth only; still syncs official CSV usage | Proposed |
  So this is **not** another attempt to invent local Cursor CLI accounting. It only removes the cookie-paste friction for the supported API sync flow, which is the same friction behind #586 / #587.
  ## Screenshots

<img width="2852" height="2186" alt="1" src="https://github.com/user-attachments/assets/9406f7d9-386d-404b-a82a-a282b9101a3e" />

<img width="1950" height="1134" alt="图片" src="https://github.com/user-attachments/assets/826ba7f6-068e-4a8a-98d8-678df12dfdd7" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-login to Cursor using the desktop `state.vscdb`, so you no longer need to paste the browser `WorkosCursorSessionToken`. Sync now refreshes the token from the desktop app when available to prevent stale auth and empty reports; READMEs across locales were updated to reflect this flow.

- **New Features**
  - Auto-detect `state.vscdb` on macOS/Windows/Linux and read `cursorAuth/accessToken` in read-only mode.
  - Build `WorkosCursorSessionToken` as `{user_id}%3A%3A{access_token}` from the JWT `sub`.
  - `tokscale cursor login` prefers the desktop session; falls back to a pasted token. CLI help and setup warnings updated.
  - `tokscale cursor sync` refreshes credentials from the desktop before fetching the usage CSV. Docs clarify usage still comes from the API export and Tokscale does not parse `~/.cursor` or desktop usage tables.

- **Dependencies**
  - Added `rusqlite` for reading the Cursor desktop SQLite DB.

<sup>Written for commit 84041178aaf2f47ff8f29958c144bbfbe97ad430. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

