### PR TITLE
fix(autosubmit): verify macOS launchd activation before reporting success

### DIFF
--- a/crates/tokscale-cli/src/commands/autosubmit.rs
+++ b/crates/tokscale-cli/src/commands/autosubmit.rs
@@ -11,11 +11,17 @@ use std::fs::{self, OpenOptions};
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 const JOB_ID: &str = "ai.tokscale.autosubmit";
 const CRON_MARKER_BEGIN: &str = "# BEGIN TOKSCALE AUTOSUBMIT";
 const CRON_MARKER_END: &str = "# END TOKSCALE AUTOSUBMIT";
 const SKIP_SCHEDULER_ENV: &str = "TOKSCALE_AUTOSUBMIT_SKIP_SCHEDULER";
+const MANAGED_EXECUTABLE_NAME: &str = if cfg!(target_os = "windows") {
+    "tokscale.exe"
+} else {
+    "tokscale"
+};
 
 #[derive(Subcommand)]
 pub enum AutosubmitSubcommand {
@@ -122,8 +128,9 @@ struct StatusOutput {
 pub fn enable(args: AutosubmitEnableArgs) -> Result<()> {
     let interval_minutes = parse_interval_minutes(&args.interval)?;
     let scheduler = args.scheduler.unwrap_or_else(default_scheduler_kind);
-    let exe = std::env::current_exe().context("Could not resolve current tokscale executable")?;
-    validate_scheduler_executable(&exe)?;
+    let source_exe =
+        std::env::current_exe().context("Could not resolve current tokscale executable")?;
+    let exe = prepare_managed_scheduler_executable(&source_exe)?;
 
     let mut settings = crate::tui::settings::Settings::load();
     settings.autosubmit = AutosubmitSettings {
@@ -200,6 +207,7 @@ pub fn disable() -> Result<()> {
 
     if settings.autosubmit.enabled && !skip_scheduler_install() {
         uninstall_scheduler(scheduler)?;
+        remove_managed_scheduler_executable()?;
     }
 
     settings.autosubmit.enabled = false;
@@ -419,16 +427,20 @@ fn uninstall_scheduler(scheduler: SchedulerKind) -> Result<()> {
         interval_minutes: DEFAULT_AUTOSUBMIT_INTERVAL_MINUTES,
         ..AutosubmitSettings::default()
     };
-    let exe = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("tokscale"));
+    let exe = managed_scheduler_executable_path()?;
     let spec = render_scheduler_spec(scheduler, &exe, &dummy)?;
     for (program, args) in spec.uninstall_commands {
-        let _ = Command::new(&program).args(&args).status();
+        run_status_command(&program, &args)?;
     }
     if scheduler == SchedulerKind::Cron {
-        let _ = uninstall_cron_block();
+        uninstall_cron_block()?;
     }
     for (path, _) in spec.files {
-        let _ = fs::remove_file(path);
+        match fs::remove_file(path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == ErrorKind::NotFound => {}
+            Err(err) => return Err(err.into()),
+        }
     }
     Ok(())
 }
@@ -720,16 +732,113 @@ fn run_status_command(program: &str, args: &[String]) -> Result<()> {
     Ok(())
 }
 
-fn autosubmit_log_path() -> Result<PathBuf> {
+fn autosubmit_dir() -> Result<PathBuf> {
     let dir = crate::paths::get_config_dir().join("autosubmit");
     fs::create_dir_all(&dir)?;
-    Ok(dir.join("autosubmit.log"))
+    Ok(dir)
+}
+
+fn autosubmit_log_path() -> Result<PathBuf> {
+    Ok(autosubmit_dir()?.join("autosubmit.log"))
 }
 
 fn autosubmit_lock_path() -> Result<PathBuf> {
-    let dir = crate::paths::get_config_dir().join("autosubmit");
-    fs::create_dir_all(&dir)?;
-    Ok(dir.join("autosubmit.lock"))
+    Ok(autosubmit_dir()?.join("autosubmit.lock"))
+}
+
+fn managed_scheduler_executable_path() -> Result<PathBuf> {
+    Ok(autosubmit_dir()?.join(MANAGED_EXECUTABLE_NAME))
+}
+
+fn prepare_managed_scheduler_executable(source: &Path) -> Result<PathBuf> {
+    validate_scheduler_executable(source)?;
+    let source_metadata = fs::metadata(source)
+        .with_context(|| format!("Could not read tokscale executable at {}", source.display()))?;
+    if !source_metadata.is_file() {
+        bail!(
+            "Tokscale executable is not a regular file: {}",
+            source.display()
+        );
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if source_metadata.permissions().mode() & 0o111 == 0 {
+            bail!(
+                "Tokscale executable is not executable: {}",
+                source.display()
+            );
+        }
+    }
+
+    let managed = managed_scheduler_executable_path()?;
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let temporary = managed.with_file_name(format!(
+        ".{MANAGED_EXECUTABLE_NAME}.{}.{}.tmp",
+        std::process::id(),
+        timestamp
+    ));
+
+    let result = (|| -> Result<()> {
+        fs::copy(source, &temporary).with_context(|| {
+            format!(
+                "Could not copy tokscale executable from {} to {}",
+                source.display(),
+                temporary.display()
+            )
+        })?;
+        fs::set_permissions(&temporary, source_metadata.permissions())?;
+        OpenOptions::new()
+            .write(true)
+            .open(&temporary)?
+            .sync_all()?;
+        tokscale_core::fs_atomic::replace_file(&temporary, &managed)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result?;
+
+    validate_managed_scheduler_executable(&managed)?;
+    Ok(managed)
+}
+
+fn remove_managed_scheduler_executable() -> Result<()> {
+    let managed = managed_scheduler_executable_path()?;
+    match fs::remove_file(managed) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn validate_managed_scheduler_executable(path: &Path) -> Result<()> {
+    validate_scheduler_executable(path)?;
+    let metadata = fs::metadata(path)
+        .with_context(|| format!("Managed tokscale executable is missing: {}", path.display()))?;
+    if !metadata.is_file() {
+        bail!(
+            "Managed tokscale executable is not a regular file: {}",
+            path.display()
+        );
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if metadata.permissions().mode() & 0o111 == 0 {
+            bail!(
+                "Managed tokscale executable is not executable: {}",
+                path.display()
+            );
+        }
+    }
+    Ok(())
 }
 
 fn validate_scheduler_executable(path: &Path) -> Result<()> {
@@ -978,6 +1087,87 @@ mod tests {
         assert!(err.to_string().contains("whole-day multiples"));
     }
 
+    #[test]
+    #[serial_test::serial]
+    fn scheduler_specs_use_the_managed_executable() {
+        let temp = TempDir::new().unwrap();
+        let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+        let managed = managed_scheduler_executable_path().unwrap();
+        let process_executable = Path::new("/workspace/node_modules/.bin/tokscale");
+        let settings = AutosubmitSettings {
+            interval_minutes: 60,
+            ..AutosubmitSettings::default()
+        };
+
+        for scheduler in [
+            SchedulerKind::Launchd,
+            SchedulerKind::Systemd,
+            SchedulerKind::Cron,
+            SchedulerKind::WindowsTaskScheduler,
+        ] {
+            let spec = render_scheduler_spec(scheduler, &managed, &settings).unwrap();
+            let rendered = format!("{spec:?}");
+            assert!(rendered.contains(managed.to_string_lossy().as_ref()));
+            assert!(!rendered.contains(process_executable.to_string_lossy().as_ref()));
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial]
+    fn managed_executable_refreshes_atomically_with_source_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+        let source = temp.path().join("tokscale-source");
+        fs::write(&source, "first binary").unwrap();
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let managed = prepare_managed_scheduler_executable(&source).unwrap();
+        assert_eq!(
+            managed,
+            temp.path().join("autosubmit").join(MANAGED_EXECUTABLE_NAME)
+        );
+        assert_eq!(fs::read_to_string(&managed).unwrap(), "first binary");
+        assert_eq!(
+            fs::metadata(&managed).unwrap().permissions().mode() & 0o777,
+            0o755
+        );
+
+        fs::write(&source, "second binary").unwrap();
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o711)).unwrap();
+        prepare_managed_scheduler_executable(&source).unwrap();
+
+        assert_eq!(fs::read_to_string(&managed).unwrap(), "second binary");
+        assert_eq!(
+            fs::metadata(&managed).unwrap().permissions().mode() & 0o777,
+            0o711
+        );
+        assert!(fs::read_dir(managed.parent().unwrap())
+            .unwrap()
+            .all(|entry| !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .ends_with(".tmp")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial]
+    fn managed_executable_rejects_nonexecutable_source() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+        let source = temp.path().join("tokscale-source");
+        fs::write(&source, "not executable").unwrap();
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let error = prepare_managed_scheduler_executable(&source).unwrap_err();
+        assert!(error.to_string().contains("not executable"));
+    }
     #[test]
     fn submit_filters_keep_absolute_date_filters() {
         let settings = AutosubmitSettings {

--- a/crates/tokscale-cli/src/commands/autosubmit.rs
+++ b/crates/tokscale-cli/src/commands/autosubmit.rs
@@ -3,7 +3,7 @@ use crate::tui::settings::{
     MIN_AUTOSUBMIT_INTERVAL_MINUTES,
 };
 use crate::{ClientFlags, DateRangeFlags};
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use clap::{Args, Subcommand, ValueEnum};
 use fs2::FileExt;
 use serde::Serialize;
@@ -105,6 +105,21 @@ struct SchedulerSpec {
     install_commands: Vec<(String, Vec<String>)>,
     uninstall_commands: Vec<(String, Vec<String>)>,
     cron_block: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LaunchdService {
+    domain: String,
+    target: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CapturedCommand {
+    command: String,
+    status: String,
+    success: bool,
+    stdout: String,
+    stderr: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -407,14 +422,23 @@ fn install_scheduler(
     settings: &AutosubmitSettings,
 ) -> Result<()> {
     let spec = render_scheduler_spec(scheduler, exe, settings)?;
-    for (path, content) in spec.files {
+    for (path, content) in &spec.files {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
         fs::write(path, content)?;
     }
-    for (program, args) in spec.install_commands {
-        run_status_command(&program, &args)?;
+    if scheduler == SchedulerKind::Launchd {
+        let plist = spec
+            .files
+            .first()
+            .map(|(path, _)| path)
+            .context("launchd scheduler is missing its plist")?;
+        activate_launchd_service(plist)?;
+    } else {
+        for (program, args) in spec.install_commands {
+            run_status_command(&program, &args)?;
+        }
     }
     if let Some(block) = spec.cron_block {
         install_cron_block(&block)?;
@@ -429,8 +453,12 @@ fn uninstall_scheduler(scheduler: SchedulerKind) -> Result<()> {
     };
     let exe = managed_scheduler_executable_path()?;
     let spec = render_scheduler_spec(scheduler, &exe, &dummy)?;
-    for (program, args) in spec.uninstall_commands {
-        run_status_command(&program, &args)?;
+    if scheduler == SchedulerKind::Launchd {
+        deactivate_launchd_service()?;
+    } else {
+        for (program, args) in spec.uninstall_commands {
+            run_status_command(&program, &args)?;
+        }
     }
     if scheduler == SchedulerKind::Cron {
         uninstall_cron_block()?;
@@ -492,22 +520,10 @@ fn render_launchd_spec(exe: &Path, settings: &AutosubmitSettings) -> Result<Sche
         log = xml_escape(&log_path.to_string_lossy())
     );
     Ok(SchedulerSpec {
-        files: vec![(plist_path.clone(), content)],
+        files: vec![(plist_path, content)],
         cron_block: None,
-        install_commands: vec![(
-            "launchctl".to_string(),
-            vec![
-                "load".to_string(),
-                plist_path.to_string_lossy().into_owned(),
-            ],
-        )],
-        uninstall_commands: vec![(
-            "launchctl".to_string(),
-            vec![
-                "unload".to_string(),
-                plist_path.to_string_lossy().into_owned(),
-            ],
-        )],
+        install_commands: Vec::new(),
+        uninstall_commands: Vec::new(),
     })
 }
 
@@ -730,6 +746,134 @@ fn run_status_command(program: &str, args: &[String]) -> Result<()> {
         bail!("{program} exited with status {status}");
     }
     Ok(())
+}
+
+#[cfg(target_os = "macos")]
+unsafe extern "C" {
+    fn geteuid() -> u32;
+}
+
+fn launchd_service_for_uid(uid: u32) -> LaunchdService {
+    let domain = format!("gui/{uid}");
+    let target = format!("{domain}/{JOB_ID}");
+    LaunchdService { domain, target }
+}
+
+#[cfg(target_os = "macos")]
+fn active_launchd_service() -> Result<LaunchdService> {
+    Ok(launchd_service_for_uid(unsafe { geteuid() }))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn active_launchd_service() -> Result<LaunchdService> {
+    bail!("launchd scheduler is only available on macOS")
+}
+
+fn launchd_bootstrap_command(service: &LaunchdService, plist: &Path) -> (String, Vec<String>) {
+    (
+        "launchctl".to_string(),
+        vec![
+            "bootstrap".to_string(),
+            service.domain.clone(),
+            plist.to_string_lossy().into_owned(),
+        ],
+    )
+}
+
+fn launchd_bootout_command(service: &LaunchdService) -> (String, Vec<String>) {
+    (
+        "launchctl".to_string(),
+        vec![
+            "bootout".to_string(),
+            "--wait".to_string(),
+            service.target.clone(),
+        ],
+    )
+}
+
+fn launchd_print_command(service: &LaunchdService) -> (String, Vec<String>) {
+    (
+        "launchctl".to_string(),
+        vec!["print".to_string(), service.target.clone()],
+    )
+}
+
+fn activate_launchd_service(plist: &Path) -> Result<()> {
+    let service = active_launchd_service()?;
+    let (program, args) = launchd_bootstrap_command(&service, plist);
+    let bootstrap = capture_command(&program, &args)?;
+    if !bootstrap.success {
+        return Err(command_failure("launchd bootstrap", &bootstrap));
+    }
+
+    let (program, args) = launchd_print_command(&service);
+    let verification = capture_command(&program, &args)?;
+    verify_launchd_service(&service, &verification)
+}
+
+fn deactivate_launchd_service() -> Result<()> {
+    let service = active_launchd_service()?;
+    let (program, args) = launchd_bootout_command(&service);
+    let bootout = capture_command(&program, &args)?;
+    if bootout.success {
+        return Ok(());
+    }
+
+    let (program, args) = launchd_print_command(&service);
+    let verification = capture_command(&program, &args)?;
+    if launchd_service_is_absent(&service, &verification) {
+        return Ok(());
+    }
+
+    Err(command_failure("launchd bootout", &bootout))
+}
+
+fn verify_launchd_service(service: &LaunchdService, captured: &CapturedCommand) -> Result<()> {
+    if !captured.success || !captured.stdout.contains(&service.target) {
+        return Err(command_failure("launchd print verification", captured));
+    }
+    Ok(())
+}
+
+fn launchd_service_is_absent(service: &LaunchdService, captured: &CapturedCommand) -> bool {
+    if captured.success {
+        return false;
+    }
+    let missing_service = format!("could not find service \"{}\"", service.target).to_lowercase();
+    let diagnostic = format!("{}\n{}", captured.stdout, captured.stderr).to_lowercase();
+    diagnostic.contains(&missing_service)
+}
+
+fn capture_command(program: &str, args: &[String]) -> Result<CapturedCommand> {
+    let command = command_display(program, args);
+    let output = Command::new(program)
+        .args(args)
+        .output()
+        .with_context(|| format!("Could not execute `{command}`"))?;
+    Ok(CapturedCommand {
+        command,
+        status: output.status.to_string(),
+        success: output.status.success(),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    })
+}
+
+fn command_display(program: &str, args: &[String]) -> String {
+    std::iter::once(program)
+        .chain(args.iter().map(String::as_str))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn command_failure(action: &str, captured: &CapturedCommand) -> anyhow::Error {
+    anyhow!(
+        "{action} failed: command `{}` exited with status {}; stdout: {}; stderr: {}",
+        captured.command,
+        captured.status,
+        captured.stdout.trim(),
+        captured.stderr.trim()
+    )
 }
 
 fn autosubmit_dir() -> Result<PathBuf> {
@@ -1000,7 +1144,98 @@ mod tests {
         assert!(content.contains("<string>/usr/local/bin/tokscale</string>"));
         assert!(content.contains("<string>autosubmit</string>"));
         assert!(content.contains("<string>run</string>"));
+        assert!(content.contains("<key>RunAtLoad</key><true/>"));
+        assert!(content.contains("<key>StartInterval</key><integer>3600</integer>"));
         assert!(!content.contains("/bin/sh"));
+        assert!(!content.contains("launchctl load"));
+        assert!(!content.contains("launchctl unload"));
+    }
+
+    #[test]
+    fn launchd_commands_target_the_active_user_domain() {
+        let service = launchd_service_for_uid(501);
+        let plist = Path::new("/Users/alice/Library/LaunchAgents/ai.tokscale.autosubmit.plist");
+
+        assert_eq!(service.domain, "gui/501");
+        assert_eq!(service.target, "gui/501/ai.tokscale.autosubmit");
+        assert_eq!(
+            launchd_bootstrap_command(&service, plist),
+            (
+                "launchctl".to_string(),
+                vec![
+                    "bootstrap".to_string(),
+                    "gui/501".to_string(),
+                    plist.to_string_lossy().into_owned()
+                ]
+            )
+        );
+        assert_eq!(
+            launchd_bootout_command(&service),
+            (
+                "launchctl".to_string(),
+                vec![
+                    "bootout".to_string(),
+                    "--wait".to_string(),
+                    "gui/501/ai.tokscale.autosubmit".to_string()
+                ]
+            )
+        );
+        assert_eq!(
+            launchd_print_command(&service),
+            (
+                "launchctl".to_string(),
+                vec![
+                    "print".to_string(),
+                    "gui/501/ai.tokscale.autosubmit".to_string()
+                ]
+            )
+        );
+    }
+
+    #[test]
+    fn launchd_verification_requires_the_exact_service_target() {
+        let service = launchd_service_for_uid(501);
+        let verified = CapturedCommand {
+            command: "launchctl print gui/501/ai.tokscale.autosubmit".to_string(),
+            status: "exit status: 0".to_string(),
+            success: true,
+            stdout: "gui/501/ai.tokscale.autosubmit = {\n}".to_string(),
+            stderr: String::new(),
+        };
+        verify_launchd_service(&service, &verified).unwrap();
+
+        let unverified = CapturedCommand {
+            command: "launchctl print gui/501/ai.tokscale.autosubmit".to_string(),
+            status: "exit status: 0".to_string(),
+            success: true,
+            stdout: "gui/501/another.service = {\n}".to_string(),
+            stderr: "target was not found".to_string(),
+        };
+        let error = verify_launchd_service(&service, &unverified).unwrap_err();
+        let rendered = error.to_string();
+        assert!(rendered.contains("launchctl print gui/501/ai.tokscale.autosubmit"));
+        assert!(rendered.contains("exit status: 0"));
+        assert!(rendered.contains("gui/501/another.service"));
+        assert!(rendered.contains("target was not found"));
+    }
+
+    #[test]
+    fn launchd_absence_is_idempotent_only_for_the_service_target() {
+        let service = launchd_service_for_uid(501);
+        let absent = CapturedCommand {
+            command: "launchctl print gui/501/ai.tokscale.autosubmit".to_string(),
+            status: "exit status: 3".to_string(),
+            success: false,
+            stdout: String::new(),
+            stderr: "Could not find service \"gui/501/ai.tokscale.autosubmit\"".to_string(),
+        };
+        assert!(launchd_service_is_absent(&service, &absent));
+
+        let unrelated = CapturedCommand {
+            stderr: "Could not find service \"gui/501/other.service\"".to_string(),
+            ..absent
+        };
+        assert!(!launchd_service_is_absent(&service, &unrelated));
     }
 
     #[test]

--- a/crates/tokscale-cli/src/commands/autosubmit.rs
+++ b/crates/tokscale-cli/src/commands/autosubmit.rs
@@ -122,6 +122,31 @@ struct CapturedCommand {
     stderr: String,
 }
 
+#[derive(Debug, Clone)]
+struct SchedulerArtifactSnapshot {
+    scheduler: SchedulerKind,
+    files: Vec<(PathBuf, Option<Vec<u8>>)>,
+    cron: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ManagedExecutableSnapshot {
+    path: PathBuf,
+    contents: Option<Vec<u8>>,
+    permissions: Option<fs::Permissions>,
+}
+
+struct EnableRollbackContext<'a> {
+    previous_settings: &'a crate::tui::settings::Settings,
+    previous_artifacts: Option<&'a SchedulerArtifactSnapshot>,
+    managed_snapshot: &'a ManagedExecutableSnapshot,
+    scheduler: SchedulerKind,
+    scheduler_started: bool,
+    previous_scheduler_was_displaced: bool,
+    exe: &'a Path,
+    next_settings: &'a AutosubmitSettings,
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct StatusOutput {
@@ -141,14 +166,30 @@ struct StatusOutput {
 }
 
 pub fn enable(args: AutosubmitEnableArgs) -> Result<()> {
+    enable_with_scheduler_operations(args, install_scheduler, |scheduler, _, _| {
+        uninstall_scheduler(scheduler)
+    })
+}
+
+fn enable_with_scheduler_operations<I, U>(
+    args: AutosubmitEnableArgs,
+    mut installer: I,
+    mut uninstaller: U,
+) -> Result<()>
+where
+    I: FnMut(SchedulerKind, &Path, &AutosubmitSettings) -> Result<()>,
+    U: FnMut(SchedulerKind, &Path, &AutosubmitSettings) -> Result<()>,
+{
     let interval_minutes = parse_interval_minutes(&args.interval)?;
     let scheduler = args.scheduler.unwrap_or_else(default_scheduler_kind);
-    let source_exe =
-        std::env::current_exe().context("Could not resolve current tokscale executable")?;
-    let exe = prepare_managed_scheduler_executable(&source_exe)?;
-
-    let mut settings = crate::tui::settings::Settings::load();
-    settings.autosubmit = AutosubmitSettings {
+    let previous_settings = crate::tui::settings::Settings::load();
+    let previous_scheduler = previous_settings
+        .autosubmit
+        .scheduler
+        .as_deref()
+        .and_then(SchedulerKind::from_str)
+        .unwrap_or_else(default_scheduler_kind);
+    let next_autosubmit = AutosubmitSettings {
         enabled: true,
         interval_minutes,
         clients: clients_for_settings(args.clients),
@@ -160,14 +201,91 @@ pub fn enable(args: AutosubmitEnableArgs) -> Result<()> {
         week: args.date.week,
         month: args.date.month,
         scheduler: Some(scheduler.as_str().to_string()),
-        last_run_at_ms: settings.autosubmit.last_run_at_ms,
+        last_run_at_ms: previous_settings.autosubmit.last_run_at_ms,
         last_error: None,
     };
+    let managed_snapshot = snapshot_managed_scheduler_executable()?;
+    let previous_artifacts = if previous_settings.autosubmit.enabled && !skip_scheduler_install() {
+        Some(snapshot_scheduler_artifacts(
+            previous_scheduler,
+            &previous_settings.autosubmit,
+        )?)
+    } else {
+        None
+    };
+    let source_exe =
+        std::env::current_exe().context("Could not resolve current tokscale executable")?;
+    let exe = match prepare_managed_scheduler_executable(&source_exe) {
+        Ok(exe) => exe,
+        Err(error) => match restore_managed_scheduler_executable(&managed_snapshot) {
+            Ok(()) => return Err(error),
+            Err(rollback_error) => {
+                return Err(anyhow!(
+                    "{error}; rollback failed while restoring managed executable: {rollback_error}"
+                ));
+            }
+        },
+    };
+
+    let mut next_settings = previous_settings.clone();
+    next_settings.autosubmit = next_autosubmit;
+    if let Err(error) = next_settings.save() {
+        return enable_failure_with_rollback(
+            error,
+            EnableRollbackContext {
+                previous_settings: &previous_settings,
+                previous_artifacts: previous_artifacts.as_ref(),
+                managed_snapshot: &managed_snapshot,
+                scheduler,
+                scheduler_started: false,
+                previous_scheduler_was_displaced: false,
+                exe: &exe,
+                next_settings: &next_settings.autosubmit,
+            },
+            &mut uninstaller,
+        );
+    }
 
     if !skip_scheduler_install() {
-        install_scheduler(scheduler, &exe, &settings.autosubmit)?;
+        let mut previous_scheduler_was_displaced = false;
+        if previous_settings.autosubmit.enabled {
+            previous_scheduler_was_displaced = true;
+            if let Err(error) = uninstaller(previous_scheduler, &exe, &previous_settings.autosubmit)
+            {
+                return enable_failure_with_rollback(
+                    error,
+                    EnableRollbackContext {
+                        previous_settings: &previous_settings,
+                        previous_artifacts: previous_artifacts.as_ref(),
+                        managed_snapshot: &managed_snapshot,
+                        scheduler,
+                        scheduler_started: false,
+                        previous_scheduler_was_displaced,
+                        exe: &exe,
+                        next_settings: &next_settings.autosubmit,
+                    },
+                    &mut uninstaller,
+                );
+            }
+        }
+
+        if let Err(error) = installer(scheduler, &exe, &next_settings.autosubmit) {
+            return enable_failure_with_rollback(
+                error,
+                EnableRollbackContext {
+                    previous_settings: &previous_settings,
+                    previous_artifacts: previous_artifacts.as_ref(),
+                    managed_snapshot: &managed_snapshot,
+                    scheduler,
+                    scheduler_started: true,
+                    previous_scheduler_was_displaced,
+                    exe: &exe,
+                    next_settings: &next_settings.autosubmit,
+                },
+                &mut uninstaller,
+            );
+        }
     }
-    settings.save()?;
 
     println!(
         "Autosubmit enabled: every {} minutes via {}.",
@@ -473,6 +591,175 @@ fn uninstall_scheduler(scheduler: SchedulerKind) -> Result<()> {
     Ok(())
 }
 
+fn snapshot_managed_scheduler_executable() -> Result<ManagedExecutableSnapshot> {
+    let path = managed_scheduler_executable_path()?;
+    match fs::read(&path) {
+        Ok(contents) => Ok(ManagedExecutableSnapshot {
+            permissions: Some(fs::metadata(&path)?.permissions()),
+            path,
+            contents: Some(contents),
+        }),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(ManagedExecutableSnapshot {
+            path,
+            contents: None,
+            permissions: None,
+        }),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn restore_managed_scheduler_executable(snapshot: &ManagedExecutableSnapshot) -> Result<()> {
+    let Some(contents) = &snapshot.contents else {
+        return match fs::remove_file(&snapshot.path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        };
+    };
+    let permissions = snapshot
+        .permissions
+        .as_ref()
+        .context("Managed executable snapshot is missing permissions")?;
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let temporary = snapshot.path.with_file_name(format!(
+        ".{MANAGED_EXECUTABLE_NAME}.restore.{}.{}.tmp",
+        std::process::id(),
+        timestamp
+    ));
+
+    let result = (|| -> Result<()> {
+        fs::write(&temporary, contents)?;
+        fs::set_permissions(&temporary, permissions.clone())?;
+        OpenOptions::new()
+            .write(true)
+            .open(&temporary)?
+            .sync_all()?;
+        tokscale_core::fs_atomic::replace_file(&temporary, &snapshot.path)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result?;
+    validate_managed_scheduler_executable(&snapshot.path)
+}
+
+fn snapshot_scheduler_artifacts(
+    scheduler: SchedulerKind,
+    settings: &AutosubmitSettings,
+) -> Result<SchedulerArtifactSnapshot> {
+    let exe = managed_scheduler_executable_path()?;
+    let spec = render_scheduler_spec(scheduler, &exe, settings)?;
+    let mut files = Vec::with_capacity(spec.files.len());
+    for (path, _) in spec.files {
+        let contents = match fs::read(&path) {
+            Ok(contents) => Some(contents),
+            Err(error) if error.kind() == ErrorKind::NotFound => None,
+            Err(error) => return Err(error.into()),
+        };
+        files.push((path, contents));
+    }
+    let cron = spec.cron_block.map(|_| read_crontab()).transpose()?;
+    Ok(SchedulerArtifactSnapshot {
+        scheduler,
+        files,
+        cron,
+    })
+}
+
+fn restore_scheduler_artifacts(snapshot: &SchedulerArtifactSnapshot) -> Result<()> {
+    for (path, contents) in &snapshot.files {
+        match contents {
+            Some(contents) => {
+                if let Some(parent) = path.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                fs::write(path, contents)?;
+            }
+            None => match fs::remove_file(path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == ErrorKind::NotFound => {}
+                Err(error) => return Err(error.into()),
+            },
+        }
+    }
+    if let Some(cron) = &snapshot.cron {
+        write_crontab(cron)?;
+    }
+    Ok(())
+}
+
+fn reactivate_scheduler(scheduler: SchedulerKind, settings: &AutosubmitSettings) -> Result<()> {
+    let exe = managed_scheduler_executable_path()?;
+    let spec = render_scheduler_spec(scheduler, &exe, settings)?;
+    if scheduler == SchedulerKind::Launchd {
+        let plist = spec
+            .files
+            .first()
+            .map(|(path, _)| path)
+            .context("launchd scheduler is missing its plist")?;
+        let service = active_launchd_service()?;
+        let (program, args) = launchd_print_command(&service);
+        let current = capture_command(&program, &args)?;
+        if verify_launchd_service(&service, &current).is_err() {
+            activate_launchd_service(plist)?;
+        }
+        return Ok(());
+    }
+    for (program, args) in spec.install_commands {
+        run_status_command(&program, &args)?;
+    }
+    Ok(())
+}
+
+fn enable_failure_with_rollback<U>(
+    error: anyhow::Error,
+    context: EnableRollbackContext<'_>,
+    uninstaller: &mut U,
+) -> Result<()>
+where
+    U: FnMut(SchedulerKind, &Path, &AutosubmitSettings) -> Result<()>,
+{
+    let mut rollback_errors = Vec::new();
+    if context.scheduler_started {
+        if let Err(rollback_error) =
+            uninstaller(context.scheduler, context.exe, context.next_settings)
+        {
+            rollback_errors.push(format!("removing new scheduler: {rollback_error}"));
+        }
+    }
+    if let Err(rollback_error) = context.previous_settings.save() {
+        rollback_errors.push(format!("restoring settings: {rollback_error}"));
+    }
+    if let Err(rollback_error) = restore_managed_scheduler_executable(context.managed_snapshot) {
+        rollback_errors.push(format!("restoring managed executable: {rollback_error}"));
+    }
+    if let Some(snapshot) = context.previous_artifacts {
+        if let Err(rollback_error) = restore_scheduler_artifacts(snapshot) {
+            rollback_errors.push(format!("restoring scheduler artifacts: {rollback_error}"));
+        }
+        if context.previous_scheduler_was_displaced {
+            if let Err(rollback_error) =
+                reactivate_scheduler(snapshot.scheduler, &context.previous_settings.autosubmit)
+            {
+                rollback_errors.push(format!("reactivating previous scheduler: {rollback_error}"));
+            }
+        }
+    }
+
+    if rollback_errors.is_empty() {
+        Err(error)
+    } else {
+        Err(anyhow!(
+            "{error}; rollback failed: {}",
+            rollback_errors.join("; ")
+        ))
+    }
+}
+
 fn render_scheduler_spec(
     scheduler: SchedulerKind,
     exe: &Path,
@@ -489,6 +776,14 @@ fn render_scheduler_spec(
 
 fn render_launchd_spec(exe: &Path, settings: &AutosubmitSettings) -> Result<SchedulerSpec> {
     let home = dirs::home_dir().context("Could not determine home directory")?;
+    render_launchd_spec_for_home(exe, settings, &home)
+}
+
+fn render_launchd_spec_for_home(
+    exe: &Path,
+    settings: &AutosubmitSettings,
+    home: &Path,
+) -> Result<SchedulerSpec> {
     let plist_path = home
         .join("Library")
         .join("LaunchAgents")
@@ -1134,14 +1429,25 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn launchd_spec_uses_program_arguments_without_shell() {
+        let temp = TempDir::new().unwrap();
+        let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
         let settings = AutosubmitSettings {
             interval_minutes: 60,
             ..AutosubmitSettings::default()
         };
-        let spec = render_launchd_spec(Path::new("/usr/local/bin/tokscale"), &settings).unwrap();
+        let managed = temp.path().join("autosubmit").join(MANAGED_EXECUTABLE_NAME);
+        let spec = render_launchd_spec_for_home(&managed, &settings, temp.path()).unwrap();
+        assert_eq!(
+            spec.files[0].0,
+            temp.path()
+                .join("Library")
+                .join("LaunchAgents")
+                .join("ai.tokscale.autosubmit.plist")
+        );
         let content = &spec.files[0].1;
-        assert!(content.contains("<string>/usr/local/bin/tokscale</string>"));
+        assert!(content.contains(&format!("<string>{}</string>", managed.display())));
         assert!(content.contains("<string>autosubmit</string>"));
         assert!(content.contains("<string>run</string>"));
         assert!(content.contains("<key>RunAtLoad</key><true/>"));
@@ -1402,6 +1708,89 @@ mod tests {
 
         let error = prepare_managed_scheduler_executable(&source).unwrap_err();
         assert!(error.to_string().contains("not executable"));
+    }
+
+    fn enable_args(scheduler: SchedulerKind) -> AutosubmitEnableArgs {
+        AutosubmitEnableArgs {
+            interval: "1h".to_string(),
+            clients: ClientFlags::default(),
+            date: DateRangeFlags::default(),
+            scheduler: Some(scheduler),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn enable_persists_settings_before_scheduler_installation() {
+        use std::cell::Cell;
+
+        let temp = TempDir::new().unwrap();
+        let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+        let observed_enabled = Cell::new(false);
+
+        enable_with_scheduler_operations(
+            enable_args(SchedulerKind::Cron),
+            |_, _, _| {
+                observed_enabled.set(crate::tui::settings::Settings::load().autosubmit.enabled);
+                Ok(())
+            },
+            |_, _, _| Ok(()),
+        )
+        .unwrap();
+
+        assert!(observed_enabled.get());
+        assert!(crate::tui::settings::Settings::load().autosubmit.enabled);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn enable_rolls_back_settings_and_managed_executable_after_activation_failure() {
+        use std::cell::Cell;
+
+        let temp = TempDir::new().unwrap();
+        let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+        let cleanup_calls = Cell::new(0);
+
+        let error = enable_with_scheduler_operations(
+            enable_args(SchedulerKind::Cron),
+            |_, _, _| Err(anyhow::anyhow!("scheduler activation failed")),
+            |_, _, _| {
+                cleanup_calls.set(cleanup_calls.get() + 1);
+                Ok(())
+            },
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("scheduler activation failed"));
+        assert_eq!(cleanup_calls.get(), 1);
+        let restored = crate::tui::settings::Settings::load().autosubmit;
+        assert!(!restored.enabled);
+        assert!(restored.scheduler.is_none());
+        assert!(!managed_scheduler_executable_path().unwrap().exists());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn enable_rolls_back_after_post_bootstrap_verification_failure() {
+        let temp = TempDir::new().unwrap();
+        let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+
+        let error = enable_with_scheduler_operations(
+            enable_args(SchedulerKind::Launchd),
+            |_, _, _| {
+                Err(anyhow::anyhow!(
+                    "launchd print verification failed: exact service target was absent"
+                ))
+            },
+            |_, _, _| Ok(()),
+        )
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("launchd print verification failed"));
+        assert!(!crate::tui::settings::Settings::load().autosubmit.enabled);
+        assert!(!managed_scheduler_executable_path().unwrap().exists());
     }
     #[test]
     fn submit_filters_keep_absolute_date_filters() {

--- a/crates/tokscale-cli/src/commands/autosubmit.rs
+++ b/crates/tokscale-cli/src/commands/autosubmit.rs
@@ -1,6 +1,5 @@
 use crate::tui::settings::{
-    AutosubmitSettings, DEFAULT_AUTOSUBMIT_INTERVAL_MINUTES, MAX_AUTOSUBMIT_INTERVAL_MINUTES,
-    MIN_AUTOSUBMIT_INTERVAL_MINUTES,
+    AutosubmitSettings, MAX_AUTOSUBMIT_INTERVAL_MINUTES, MIN_AUTOSUBMIT_INTERVAL_MINUTES,
 };
 use crate::{ClientFlags, DateRangeFlags};
 use anyhow::{anyhow, bail, Context, Result};
@@ -11,17 +10,26 @@ use std::fs::{self, OpenOptions};
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+#[cfg(target_os = "windows")]
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const JOB_ID: &str = "ai.tokscale.autosubmit";
 const CRON_MARKER_BEGIN: &str = "# BEGIN TOKSCALE AUTOSUBMIT";
 const CRON_MARKER_END: &str = "# END TOKSCALE AUTOSUBMIT";
 const SKIP_SCHEDULER_ENV: &str = "TOKSCALE_AUTOSUBMIT_SKIP_SCHEDULER";
+const SYSTEMD_TIMER_UNIT: &str = "tokscale-autosubmit.timer";
 const MANAGED_EXECUTABLE_NAME: &str = if cfg!(target_os = "windows") {
     "tokscale.exe"
 } else {
     "tokscale"
 };
+#[cfg(any(target_os = "windows", test))]
+const LEGACY_WINDOWS_MANAGED_EXECUTABLE_NAME: &str = "tokscale.exe";
+#[cfg(target_os = "windows")]
+static WINDOWS_MANAGED_EXECUTABLE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+#[cfg(target_os = "windows")]
+const WINDOWS_ERROR_SHARING_VIOLATION: i32 = 32;
 
 #[derive(Subcommand)]
 pub enum AutosubmitSubcommand {
@@ -127,6 +135,7 @@ struct SchedulerArtifactSnapshot {
     scheduler: SchedulerKind,
     files: Vec<(PathBuf, Option<Vec<u8>>)>,
     cron: Option<String>,
+    executable: PathBuf,
 }
 
 #[derive(Debug, Clone)]
@@ -166,8 +175,8 @@ struct StatusOutput {
 }
 
 pub fn enable(args: AutosubmitEnableArgs) -> Result<()> {
-    enable_with_scheduler_operations(args, install_scheduler, |scheduler, _, _| {
-        uninstall_scheduler(scheduler)
+    enable_with_scheduler_operations(args, install_scheduler, |scheduler, _, settings| {
+        uninstall_scheduler(scheduler, settings)
     })
 }
 
@@ -203,8 +212,12 @@ where
         scheduler: Some(scheduler.as_str().to_string()),
         last_run_at_ms: previous_settings.autosubmit.last_run_at_ms,
         last_error: None,
+        managed_executable: None,
     };
-    let managed_snapshot = snapshot_managed_scheduler_executable()?;
+    let source_exe =
+        std::env::current_exe().context("Could not resolve current tokscale executable")?;
+    let managed_destination = next_managed_scheduler_executable_path()?;
+    let managed_snapshot = snapshot_managed_scheduler_executable(&managed_destination)?;
     let previous_artifacts = if previous_settings.autosubmit.enabled && !skip_scheduler_install() {
         Some(snapshot_scheduler_artifacts(
             previous_scheduler,
@@ -213,9 +226,7 @@ where
     } else {
         None
     };
-    let source_exe =
-        std::env::current_exe().context("Could not resolve current tokscale executable")?;
-    let exe = match prepare_managed_scheduler_executable(&source_exe) {
+    let exe = match prepare_managed_scheduler_executable(&source_exe, managed_destination) {
         Ok(exe) => exe,
         Err(error) => match restore_managed_scheduler_executable(&managed_snapshot) {
             Ok(()) => return Err(error),
@@ -226,6 +237,8 @@ where
             }
         },
     };
+    let mut next_autosubmit = next_autosubmit;
+    next_autosubmit.managed_executable = Some(exe.to_string_lossy().into_owned());
 
     let mut next_settings = previous_settings.clone();
     next_settings.autosubmit = next_autosubmit;
@@ -247,8 +260,11 @@ where
     }
 
     if !skip_scheduler_install() {
+        let retargets_previous_windows_task = previous_settings.autosubmit.enabled
+            && previous_scheduler == SchedulerKind::WindowsTaskScheduler
+            && scheduler == SchedulerKind::WindowsTaskScheduler;
         let mut previous_scheduler_was_displaced = false;
-        if previous_settings.autosubmit.enabled {
+        if previous_settings.autosubmit.enabled && !retargets_previous_windows_task {
             previous_scheduler_was_displaced = true;
             if let Err(error) = uninstaller(previous_scheduler, &exe, &previous_settings.autosubmit)
             {
@@ -277,7 +293,7 @@ where
                     previous_artifacts: previous_artifacts.as_ref(),
                     managed_snapshot: &managed_snapshot,
                     scheduler,
-                    scheduler_started: true,
+                    scheduler_started: !retargets_previous_windows_task,
                     previous_scheduler_was_displaced,
                     exe: &exe,
                     next_settings: &next_settings.autosubmit,
@@ -330,6 +346,17 @@ pub fn status(json: bool) -> Result<()> {
 }
 
 pub fn disable() -> Result<()> {
+    disable_with_scheduler_operations(uninstall_scheduler, remove_managed_scheduler_executable)
+}
+
+fn disable_with_scheduler_operations<U, R>(
+    mut uninstaller: U,
+    mut executable_cleanup: R,
+) -> Result<()>
+where
+    U: FnMut(SchedulerKind, &AutosubmitSettings) -> Result<()>,
+    R: FnMut() -> Result<()>,
+{
     let mut settings = crate::tui::settings::Settings::load();
     let scheduler = settings
         .autosubmit
@@ -338,12 +365,15 @@ pub fn disable() -> Result<()> {
         .and_then(SchedulerKind::from_str)
         .unwrap_or_else(default_scheduler_kind);
 
-    if settings.autosubmit.enabled && !skip_scheduler_install() {
-        uninstall_scheduler(scheduler)?;
-        remove_managed_scheduler_executable()?;
+    if !skip_scheduler_install() {
+        if settings.autosubmit.enabled {
+            uninstaller(scheduler, &settings.autosubmit)?;
+        }
+        executable_cleanup()?;
     }
 
     settings.autosubmit.enabled = false;
+    settings.autosubmit.managed_executable = None;
     settings.autosubmit.last_error = None;
     settings.save()?;
     println!("Autosubmit disabled.");
@@ -564,18 +594,14 @@ fn install_scheduler(
     Ok(())
 }
 
-fn uninstall_scheduler(scheduler: SchedulerKind) -> Result<()> {
-    let dummy = AutosubmitSettings {
-        interval_minutes: DEFAULT_AUTOSUBMIT_INTERVAL_MINUTES,
-        ..AutosubmitSettings::default()
-    };
-    let exe = managed_scheduler_executable_path()?;
-    let spec = render_scheduler_spec(scheduler, &exe, &dummy)?;
+fn uninstall_scheduler(scheduler: SchedulerKind, settings: &AutosubmitSettings) -> Result<()> {
+    let exe = managed_scheduler_executable_for_settings(settings)?;
+    let spec = render_scheduler_spec(scheduler, &exe, settings)?;
     if scheduler == SchedulerKind::Launchd {
         deactivate_launchd_service()?;
     } else {
         for (program, args) in spec.uninstall_commands {
-            run_status_command(&program, &args)?;
+            run_scheduler_cleanup_command(scheduler, &program, &args)?;
         }
     }
     if scheduler == SchedulerKind::Cron {
@@ -591,8 +617,8 @@ fn uninstall_scheduler(scheduler: SchedulerKind) -> Result<()> {
     Ok(())
 }
 
-fn snapshot_managed_scheduler_executable() -> Result<ManagedExecutableSnapshot> {
-    let path = managed_scheduler_executable_path()?;
+fn snapshot_managed_scheduler_executable(path: &Path) -> Result<ManagedExecutableSnapshot> {
+    let path = path.to_path_buf();
     match fs::read(&path) {
         Ok(contents) => Ok(ManagedExecutableSnapshot {
             permissions: Some(fs::metadata(&path)?.permissions()),
@@ -651,7 +677,7 @@ fn snapshot_scheduler_artifacts(
     scheduler: SchedulerKind,
     settings: &AutosubmitSettings,
 ) -> Result<SchedulerArtifactSnapshot> {
-    let exe = managed_scheduler_executable_path()?;
+    let exe = managed_scheduler_executable_for_settings(settings)?;
     let spec = render_scheduler_spec(scheduler, &exe, settings)?;
     let mut files = Vec::with_capacity(spec.files.len());
     for (path, _) in spec.files {
@@ -664,6 +690,7 @@ fn snapshot_scheduler_artifacts(
     }
     let cron = spec.cron_block.map(|_| read_crontab()).transpose()?;
     Ok(SchedulerArtifactSnapshot {
+        executable: exe,
         scheduler,
         files,
         cron,
@@ -692,9 +719,12 @@ fn restore_scheduler_artifacts(snapshot: &SchedulerArtifactSnapshot) -> Result<(
     Ok(())
 }
 
-fn reactivate_scheduler(scheduler: SchedulerKind, settings: &AutosubmitSettings) -> Result<()> {
-    let exe = managed_scheduler_executable_path()?;
-    let spec = render_scheduler_spec(scheduler, &exe, settings)?;
+fn reactivate_scheduler(
+    scheduler: SchedulerKind,
+    exe: &Path,
+    settings: &AutosubmitSettings,
+) -> Result<()> {
+    let spec = render_scheduler_spec(scheduler, exe, settings)?;
     if scheduler == SchedulerKind::Launchd {
         let plist = spec
             .files
@@ -742,9 +772,11 @@ where
             rollback_errors.push(format!("restoring scheduler artifacts: {rollback_error}"));
         }
         if context.previous_scheduler_was_displaced {
-            if let Err(rollback_error) =
-                reactivate_scheduler(snapshot.scheduler, &context.previous_settings.autosubmit)
-            {
+            if let Err(rollback_error) = reactivate_scheduler(
+                snapshot.scheduler,
+                &snapshot.executable,
+                &context.previous_settings.autosubmit,
+            ) {
                 rollback_errors.push(format!("reactivating previous scheduler: {rollback_error}"));
             }
         }
@@ -825,7 +857,7 @@ fn render_launchd_spec_for_home(
 fn render_systemd_spec(exe: &Path, settings: &AutosubmitSettings) -> Result<SchedulerSpec> {
     let user_dir = systemd_user_dir()?;
     let service_path = user_dir.join("tokscale-autosubmit.service");
-    let timer_path = user_dir.join("tokscale-autosubmit.timer");
+    let timer_path = user_dir.join(SYSTEMD_TIMER_UNIT);
     let log_path = autosubmit_log_path()?;
     let service = format!(
         "[Unit]\nDescription=Tokscale autosubmit\n\n[Service]\nType=oneshot\nExecStart={} autosubmit run\nStandardOutput=append:{}\nStandardError=append:{}\n",
@@ -851,7 +883,7 @@ fn render_systemd_spec(exe: &Path, settings: &AutosubmitSettings) -> Result<Sche
                     "--user".to_string(),
                     "enable".to_string(),
                     "--now".to_string(),
-                    "tokscale-autosubmit.timer".to_string(),
+                    SYSTEMD_TIMER_UNIT.to_string(),
                 ],
             ),
         ],
@@ -862,7 +894,7 @@ fn render_systemd_spec(exe: &Path, settings: &AutosubmitSettings) -> Result<Sche
                     "--user".to_string(),
                     "disable".to_string(),
                     "--now".to_string(),
-                    "tokscale-autosubmit.timer".to_string(),
+                    SYSTEMD_TIMER_UNIT.to_string(),
                 ],
             ),
             (
@@ -1043,6 +1075,49 @@ fn run_status_command(program: &str, args: &[String]) -> Result<()> {
     Ok(())
 }
 
+fn run_scheduler_cleanup_command(
+    scheduler: SchedulerKind,
+    program: &str,
+    args: &[String],
+) -> Result<()> {
+    let captured = capture_command(program, args)?;
+    cleanup_scheduler_command_result(scheduler, "scheduler cleanup", &captured)
+}
+
+fn cleanup_scheduler_command_result(
+    scheduler: SchedulerKind,
+    action: &str,
+    captured: &CapturedCommand,
+) -> Result<()> {
+    if captured.success || scheduler_entry_is_absent(scheduler, captured) {
+        return Ok(());
+    }
+    Err(command_failure(action, captured))
+}
+
+fn scheduler_entry_is_absent(scheduler: SchedulerKind, captured: &CapturedCommand) -> bool {
+    if captured.success {
+        return false;
+    }
+
+    let diagnostic = format!("{}\n{}", captured.stdout, captured.stderr).to_lowercase();
+    let systemd_timer = SYSTEMD_TIMER_UNIT.to_ascii_lowercase();
+    let windows_task = JOB_ID.to_ascii_lowercase();
+    match scheduler {
+        SchedulerKind::Systemd => {
+            diagnostic.contains(&format!("unit {systemd_timer} not loaded"))
+                || diagnostic.contains(&format!("unit file {systemd_timer} does not exist"))
+        }
+        SchedulerKind::WindowsTaskScheduler => {
+            diagnostic.contains("error: the system cannot find the file specified.")
+                || diagnostic.contains(&format!(
+                "error: the specified task name \"{windows_task}\" does not exist in the system."
+            ))
+        }
+        SchedulerKind::Launchd | SchedulerKind::Cron => false,
+    }
+}
+
 #[cfg(target_os = "macos")]
 unsafe extern "C" {
     fn geteuid() -> u32;
@@ -1189,7 +1264,48 @@ fn managed_scheduler_executable_path() -> Result<PathBuf> {
     Ok(autosubmit_dir()?.join(MANAGED_EXECUTABLE_NAME))
 }
 
-fn prepare_managed_scheduler_executable(source: &Path) -> Result<PathBuf> {
+fn managed_scheduler_executable_for_settings(settings: &AutosubmitSettings) -> Result<PathBuf> {
+    let path = settings
+        .managed_executable
+        .as_deref()
+        .map(PathBuf::from)
+        .unwrap_or(managed_scheduler_executable_path()?);
+    validate_scheduler_executable(&path)?;
+    Ok(path)
+}
+
+fn next_managed_scheduler_executable_path() -> Result<PathBuf> {
+    let dir = autosubmit_dir()?;
+    #[cfg(target_os = "windows")]
+    {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0);
+        let sequence = WINDOWS_MANAGED_EXECUTABLE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        return Ok(versioned_windows_managed_executable_path(
+            &dir, timestamp, sequence,
+        ));
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        Ok(dir.join(MANAGED_EXECUTABLE_NAME))
+    }
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn versioned_windows_managed_executable_path(
+    autosubmit_dir: &Path,
+    timestamp: u128,
+    sequence: u64,
+) -> PathBuf {
+    autosubmit_dir.join(format!(
+        "tokscale-{}-{timestamp}-{sequence}.exe",
+        std::process::id()
+    ))
+}
+
+fn prepare_managed_scheduler_executable(source: &Path, managed: PathBuf) -> Result<PathBuf> {
     validate_scheduler_executable(source)?;
     let source_metadata = fs::metadata(source)
         .with_context(|| format!("Could not read tokscale executable at {}", source.display()))?;
@@ -1211,7 +1327,6 @@ fn prepare_managed_scheduler_executable(source: &Path) -> Result<PathBuf> {
         }
     }
 
-    let managed = managed_scheduler_executable_path()?;
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_nanos())
@@ -1247,12 +1362,41 @@ fn prepare_managed_scheduler_executable(source: &Path) -> Result<PathBuf> {
     Ok(managed)
 }
 
+#[cfg(any(target_os = "windows", test))]
+fn is_windows_managed_executable_name(name: &str) -> bool {
+    name == LEGACY_WINDOWS_MANAGED_EXECUTABLE_NAME
+        || (name.starts_with("tokscale-") && name.ends_with(".exe"))
+}
+
 fn remove_managed_scheduler_executable() -> Result<()> {
-    let managed = managed_scheduler_executable_path()?;
-    match fs::remove_file(managed) {
-        Ok(()) => Ok(()),
-        Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
-        Err(err) => Err(err.into()),
+    #[cfg(target_os = "windows")]
+    {
+        for entry in fs::read_dir(autosubmit_dir()?)? {
+            let path = entry?.path();
+            let is_managed_executable = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(is_windows_managed_executable_name);
+            if !is_managed_executable {
+                continue;
+            }
+            match fs::remove_file(path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == ErrorKind::NotFound => {}
+                Err(error) if error.raw_os_error() == Some(WINDOWS_ERROR_SHARING_VIOLATION) => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+        return Ok(());
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let managed = managed_scheduler_executable_path()?;
+        match fs::remove_file(managed) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        }
     }
 }
 
@@ -1665,7 +1809,8 @@ mod tests {
         fs::write(&source, "first binary").unwrap();
         fs::set_permissions(&source, fs::Permissions::from_mode(0o755)).unwrap();
 
-        let managed = prepare_managed_scheduler_executable(&source).unwrap();
+        let managed_destination = next_managed_scheduler_executable_path().unwrap();
+        let managed = prepare_managed_scheduler_executable(&source, managed_destination).unwrap();
         assert_eq!(
             managed,
             temp.path().join("autosubmit").join(MANAGED_EXECUTABLE_NAME)
@@ -1678,7 +1823,7 @@ mod tests {
 
         fs::write(&source, "second binary").unwrap();
         fs::set_permissions(&source, fs::Permissions::from_mode(0o711)).unwrap();
-        prepare_managed_scheduler_executable(&source).unwrap();
+        prepare_managed_scheduler_executable(&source, managed.clone()).unwrap();
 
         assert_eq!(fs::read_to_string(&managed).unwrap(), "second binary");
         assert_eq!(
@@ -1706,8 +1851,134 @@ mod tests {
         fs::write(&source, "not executable").unwrap();
         fs::set_permissions(&source, fs::Permissions::from_mode(0o644)).unwrap();
 
-        let error = prepare_managed_scheduler_executable(&source).unwrap_err();
+        let error = prepare_managed_scheduler_executable(
+            &source,
+            next_managed_scheduler_executable_path().unwrap(),
+        )
+        .unwrap_err();
         assert!(error.to_string().contains("not executable"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial]
+    fn windows_reenable_renders_a_new_versioned_managed_executable_path() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+        let managed_dir = temp.path().join("autosubmit");
+        let existing = versioned_windows_managed_executable_path(&managed_dir, 1, 1);
+        let replacement = versioned_windows_managed_executable_path(&managed_dir, 2, 2);
+        fs::create_dir_all(&managed_dir).unwrap();
+        fs::write(&existing, "old executable").unwrap();
+        let source = temp.path().join("tokscale-source");
+        fs::write(&source, "new executable").unwrap();
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let prepared = prepare_managed_scheduler_executable(&source, replacement.clone()).unwrap();
+        let settings = AutosubmitSettings {
+            interval_minutes: 60,
+            ..AutosubmitSettings::default()
+        };
+        let existing_task = render_windows_task_spec(&existing, &settings).unwrap();
+        let replacement_task = render_windows_task_spec(&prepared, &settings).unwrap();
+
+        assert_eq!(fs::read_to_string(&existing).unwrap(), "old executable");
+        assert_eq!(fs::read_to_string(&prepared).unwrap(), "new executable");
+        assert_ne!(existing, prepared);
+        assert!(existing.starts_with(&managed_dir));
+        assert!(prepared.starts_with(&managed_dir));
+        assert!(existing_task.install_commands[0]
+            .1
+            .iter()
+            .any(|arg| arg.contains(&existing.to_string_lossy().into_owned())));
+        assert!(replacement_task.install_commands[0]
+            .1
+            .iter()
+            .any(|arg| arg.contains(&prepared.to_string_lossy().into_owned())));
+        assert!(!replacement_task.install_commands[0]
+            .1
+            .iter()
+            .any(|arg| arg.contains(&existing.to_string_lossy().into_owned())));
+    }
+
+    #[test]
+    fn scheduler_cleanup_tolerates_only_known_absent_entries() {
+        let absent_windows_task = CapturedCommand {
+            command: format!("schtasks /Delete /F /TN {JOB_ID}"),
+            status: "exit status: 1".to_string(),
+            success: false,
+            stdout: String::new(),
+            stderr: "ERROR: The system cannot find the file specified.".to_string(),
+        };
+        assert!(scheduler_entry_is_absent(
+            SchedulerKind::WindowsTaskScheduler,
+            &absent_windows_task
+        ));
+        cleanup_scheduler_command_result(
+            SchedulerKind::WindowsTaskScheduler,
+            "schtasks delete",
+            &absent_windows_task,
+        )
+        .unwrap();
+
+        let absent_windows_task_by_name = CapturedCommand {
+            stderr: format!(
+                "ERROR: The specified task name \"{JOB_ID}\" does not exist in the system."
+            ),
+            ..absent_windows_task.clone()
+        };
+        assert!(scheduler_entry_is_absent(
+            SchedulerKind::WindowsTaskScheduler,
+            &absent_windows_task_by_name
+        ));
+
+        let absent_systemd_timer = CapturedCommand {
+            command: format!("systemctl --user disable --now {SYSTEMD_TIMER_UNIT}"),
+            status: "exit status: 1".to_string(),
+            success: false,
+            stdout: String::new(),
+            stderr: format!(
+                "Failed to disable unit: Unit file {SYSTEMD_TIMER_UNIT} does not exist."
+            ),
+        };
+        assert!(scheduler_entry_is_absent(
+            SchedulerKind::Systemd,
+            &absent_systemd_timer
+        ));
+
+        let invalid_task_name = CapturedCommand {
+            stderr: format!("ERROR: The specified task name \"{JOB_ID}\" is invalid."),
+            ..absent_windows_task.clone()
+        };
+        assert!(!scheduler_entry_is_absent(
+            SchedulerKind::WindowsTaskScheduler,
+            &invalid_task_name
+        ));
+
+        let cleanup_failure = CapturedCommand {
+            stderr: "Access is denied.".to_string(),
+            ..absent_windows_task
+        };
+        assert!(!scheduler_entry_is_absent(
+            SchedulerKind::WindowsTaskScheduler,
+            &cleanup_failure
+        ));
+        assert!(cleanup_scheduler_command_result(
+            SchedulerKind::WindowsTaskScheduler,
+            "schtasks delete",
+            &cleanup_failure,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn windows_managed_executable_cleanup_recognizes_versioned_and_legacy_names() {
+        assert!(is_windows_managed_executable_name("tokscale.exe"));
+        assert!(is_windows_managed_executable_name("tokscale-123-456-7.exe"));
+        assert!(!is_windows_managed_executable_name("tokscale.exe.tmp"));
+        assert!(!is_windows_managed_executable_name("unrelated.exe"));
     }
 
     fn enable_args(scheduler: SchedulerKind) -> AutosubmitEnableArgs {
@@ -1717,6 +1988,165 @@ mod tests {
             date: DateRangeFlags::default(),
             scheduler: Some(scheduler),
         }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn windows_reenable_failure_keeps_the_existing_task_intact() {
+        use std::cell::Cell;
+
+        let temp = TempDir::new().unwrap();
+        let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+        let mut settings = crate::tui::settings::Settings::load();
+        settings.autosubmit = AutosubmitSettings {
+            enabled: true,
+            scheduler: Some(SchedulerKind::WindowsTaskScheduler.as_str().to_string()),
+            ..AutosubmitSettings::default()
+        };
+        settings.save().unwrap();
+        let uninstall_calls = Cell::new(0);
+
+        let error = enable_with_scheduler_operations(
+            enable_args(SchedulerKind::WindowsTaskScheduler),
+            |_, _, _| Err(anyhow::anyhow!("schtasks replacement failed")),
+            |_, _, _| {
+                uninstall_calls.set(uninstall_calls.get() + 1);
+                Ok(())
+            },
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("schtasks replacement failed"));
+        assert_eq!(uninstall_calls.get(), 0);
+        let restored = crate::tui::settings::Settings::load().autosubmit;
+        assert!(restored.enabled);
+        assert_eq!(
+            restored.scheduler.as_deref(),
+            Some(SchedulerKind::WindowsTaskScheduler.as_str())
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn scheduler_snapshot_preserves_versioned_windows_executable_path() {
+        let temp = TempDir::new().unwrap();
+        let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+        let executable = temp
+            .path()
+            .join("autosubmit")
+            .join("tokscale-123-456-7.exe");
+        let settings = AutosubmitSettings {
+            scheduler: Some(SchedulerKind::WindowsTaskScheduler.as_str().to_string()),
+            managed_executable: Some(executable.to_string_lossy().into_owned()),
+            ..AutosubmitSettings::default()
+        };
+
+        let snapshot =
+            snapshot_scheduler_artifacts(SchedulerKind::WindowsTaskScheduler, &settings).unwrap();
+
+        assert_eq!(snapshot.executable, executable);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn disable_persists_settings_after_known_absent_scheduler_cleanup() {
+        use std::cell::Cell;
+
+        let temp = TempDir::new().unwrap();
+        let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+        let mut settings = crate::tui::settings::Settings::load();
+        settings.autosubmit = AutosubmitSettings {
+            enabled: true,
+            scheduler: Some(SchedulerKind::WindowsTaskScheduler.as_str().to_string()),
+            ..AutosubmitSettings::default()
+        };
+        settings.save().unwrap();
+        let executable_cleanup_calls = Cell::new(0);
+
+        disable_with_scheduler_operations(
+            |scheduler, _| {
+                let absent = CapturedCommand {
+                    command: format!("schtasks /Delete /F /TN {JOB_ID}"),
+                    status: "exit status: 1".to_string(),
+                    success: false,
+                    stdout: String::new(),
+                    stderr: "ERROR: The system cannot find the file specified.".to_string(),
+                };
+                cleanup_scheduler_command_result(scheduler, "schtasks delete", &absent)
+            },
+            || {
+                executable_cleanup_calls.set(executable_cleanup_calls.get() + 1);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert!(!crate::tui::settings::Settings::load().autosubmit.enabled);
+        assert_eq!(executable_cleanup_calls.get(), 1);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn disable_retries_executable_cleanup_after_a_previous_locked_run() {
+        use std::cell::Cell;
+
+        let temp = TempDir::new().unwrap();
+        let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+        let mut settings = crate::tui::settings::Settings::load();
+        settings.autosubmit = AutosubmitSettings {
+            enabled: false,
+            managed_executable: Some(
+                temp.path()
+                    .join("autosubmit")
+                    .join("tokscale-123-456-7.exe")
+                    .to_string_lossy()
+                    .into_owned(),
+            ),
+            ..AutosubmitSettings::default()
+        };
+        settings.save().unwrap();
+        let executable_cleanup_calls = Cell::new(0);
+
+        disable_with_scheduler_operations(
+            |_, _| panic!("disabled autosubmit must not uninstall a scheduler"),
+            || {
+                executable_cleanup_calls.set(executable_cleanup_calls.get() + 1);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(executable_cleanup_calls.get(), 1);
+        assert!(crate::tui::settings::Settings::load()
+            .autosubmit
+            .managed_executable
+            .is_none());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn disable_keeps_settings_enabled_after_scheduler_cleanup_failure() {
+        let temp = TempDir::new().unwrap();
+        let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+        let mut settings = crate::tui::settings::Settings::load();
+        settings.autosubmit = AutosubmitSettings {
+            enabled: true,
+            scheduler: Some(SchedulerKind::Systemd.as_str().to_string()),
+            last_error: Some("previous error".to_string()),
+            ..AutosubmitSettings::default()
+        };
+        settings.save().unwrap();
+
+        let error = disable_with_scheduler_operations(
+            |_, _| Err(anyhow::anyhow!("systemctl cleanup failed")),
+            || panic!("managed executable cleanup must not run after scheduler cleanup failure"),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("systemctl cleanup failed"));
+        let restored = crate::tui::settings::Settings::load().autosubmit;
+        assert!(restored.enabled);
+        assert_eq!(restored.last_error.as_deref(), Some("previous error"));
     }
 
     #[test]

--- a/crates/tokscale-cli/src/commands/autosubmit.rs
+++ b/crates/tokscale-cli/src/commands/autosubmit.rs
@@ -1123,6 +1123,7 @@ unsafe extern "C" {
     fn geteuid() -> u32;
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn launchd_service_for_uid(uid: u32) -> LaunchdService {
     let domain = format!("gui/{uid}");
     let target = format!("{domain}/{JOB_ID}");

--- a/crates/tokscale-cli/src/cursor.rs
+++ b/crates/tokscale-cli/src/cursor.rs
@@ -275,7 +275,9 @@ pub fn cursor_state_vscdb_candidates(home_dir: &Path) -> Vec<PathBuf> {
     {
         if let Ok(appdata) = std::env::var("APPDATA") {
             paths.push(
-                PathBuf::from(appdata).join("Cursor").join("User/globalStorage/state.vscdb"),
+                PathBuf::from(appdata)
+                    .join("Cursor")
+                    .join("User/globalStorage/state.vscdb"),
             );
         }
         paths.push(home_dir.join("AppData/Roaming/Cursor/User/globalStorage/state.vscdb"));
@@ -375,9 +377,7 @@ pub fn session_token_from_access_token(access_token: &str) -> Result<String> {
 pub fn read_local_cursor_session_token() -> Result<String> {
     let home = home_dir()?;
     let db_path = find_cursor_state_vscdb(&home).ok_or_else(|| {
-        anyhow::anyhow!(
-            "Cursor desktop state.vscdb not found (install Cursor and sign in first)"
-        )
+        anyhow::anyhow!("Cursor desktop state.vscdb not found (install Cursor and sign in first)")
     })?;
     let access_token = read_access_token_from_state_vscdb(&db_path)?;
     session_token_from_access_token(&access_token)
@@ -1232,7 +1232,10 @@ pub fn run_cursor_login(name: Option<String>) -> Result<()> {
     }
 
     // Prefer the local Cursor desktop accessToken (state.vscdb) when present.
-    println!("{}", "  Checking local Cursor desktop login...".bright_black());
+    println!(
+        "{}",
+        "  Checking local Cursor desktop login...".bright_black()
+    );
     let token = match read_local_cursor_session_token() {
         Ok(token) => {
             if let Some(user_id) = extract_user_id_from_session_token(&token) {

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -72,6 +72,8 @@ pub struct AutosubmitSettings {
     #[serde(default)]
     pub scheduler: Option<String>,
     #[serde(default)]
+    pub managed_executable: Option<String>,
+    #[serde(default)]
     pub last_run_at_ms: Option<i64>,
     #[serde(default)]
     pub last_error: Option<String>,
@@ -91,6 +93,7 @@ impl Default for AutosubmitSettings {
             week: false,
             month: false,
             scheduler: None,
+            managed_executable: None,
             last_run_at_ms: None,
             last_error: None,
         }


### PR DESCRIPTION
## Summary
- Copy the running Tokscale binary atomically into the config-root autosubmit directory and render every scheduler backend against that managed executable.
- Activate macOS LaunchAgents with `bootstrap gui/<uid>`, verify the exact service through `print gui/<uid>/ai.tokscale.autosubmit`, and use idempotent `bootout --wait` cleanup.
- Persist enabled settings before scheduler activation, snapshot prior artifacts, and restore settings, artifacts, and managed executable when replacement fails.

## Validation
- `cargo fmt --all -- --check` — passed
- `bash scripts/check-version-coherence.sh` — passed (`4.7.0`)
- `cargo clippy --locked --workspace --all-features -- -D warnings` — passed
- `cargo test -p tokscale-cli --bin tokscale autosubmit` — passed (24 tests)
- `cargo test -p tokscale-cli --all-features` — passed (1081 tests, 2 ignored)
- `cargo test --workspace --all-features` — passed (2392 tests, 5 ignored)
- Isolated launchd plist rendering test verifies the managed executable path, `RunAtLoad`, `StartInterval`, no shell wrapper, and no legacy `load` or `unload` path.

No real usage submission was triggered during validation.

Closes #970

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make autosubmit enablement safe, verifiable, and state-preserving. We persist a managed `tokscale` executable path, verify macOS `launchd` activation, and fully roll back on failure.

- **Bug Fixes**
  - macOS `launchd`: use `bootstrap gui/<uid>`, verify with `print gui/<uid>/ai.tokscale.autosubmit`, and clean up via `bootout --wait`; verification checks the exact service target; tests guard the `launchd` helper on non-macOS.
  - Managed executable: atomically copy and validate the running binary into the autosubmit dir, persist its path in settings, and render all schedulers against it; on Windows use versioned filenames and tolerate sharing violations.
  - Transactional enable: save settings before activation; snapshot prior files and crontab; on failure restore settings/artifacts/executable and reactivate the previous scheduler; Windows Task Scheduler re-enables by retargeting the existing task when unchanged.
  - Cleanup/disable: use the managed executable path; make systemd and Windows cleanup idempotent and keep `cron` uninstall idempotent; on disable, remove managed executables and clear `managed_executable` in settings.

- **Refactors**
  - Applied `rustfmt` formatting to `cursor.rs` (no functional changes).

<sup>Written for commit 18f7230b9c1f668cdd58b6d77384a58e256d1446. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

