### PR TITLE
fix(autosubmit): report when the scheduled copy is a stale build

### DIFF
--- a/crates/tokscale-cli/src/commands/autosubmit.rs
+++ b/crates/tokscale-cli/src/commands/autosubmit.rs
@@ -249,9 +249,14 @@ where
     };
     let mut next_autosubmit = next_autosubmit;
     next_autosubmit.managed_executable = Some(exe.to_string_lossy().into_owned());
-    // Stamped from the build doing the copying, not read back off the file, so
-    // it describes what the scheduler will actually run.
-    next_autosubmit.managed_executable_version = Some(RUNNING_VERSION.to_string());
+    // The version is deliberately NOT stamped here. This save happens before the
+    // scheduler is installed, and on Windows `exe` is a freshly versioned path
+    // while the task still points at the previous one. Recording the version now
+    // would mean that a re-enable killed between this save and the install below
+    // leaves settings claiming a build the scheduler is not running, and
+    // `managed_executable_is_stale` would report clean at exactly the moment it
+    // is wrong. It is stamped after installation succeeds instead; until then
+    // `None` reads as "unknown", which reports drift.
 
     let mut next_settings = previous_settings.clone();
     next_settings.autosubmit = next_autosubmit;
@@ -314,6 +319,20 @@ where
                 &mut uninstaller,
             );
         }
+    }
+
+    // Second phase of the version stamp: only now is the scheduler actually
+    // pointing at `exe`, so only now does recording its build describe reality.
+    //
+    // A failure here is not worth unwinding a correctly installed scheduler. The
+    // version stays `None`, status reports drift, and re-running `enable` clears
+    // it — the conservative direction, and self-healing.
+    next_settings.autosubmit.managed_executable_version = Some(RUNNING_VERSION.to_string());
+    if let Err(error) = next_settings.save() {
+        eprintln!(
+            "Warning: autosubmit is enabled, but the scheduled build could not be recorded: {error}\n         \
+             `tokscale autosubmit status` will report it as out of date until you re-run `enable`."
+        );
     }
 
     println!(
@@ -2456,6 +2475,50 @@ mod tests {
         assert!(
             output.managed_executable_stale,
             "scripted checks read the boolean rather than diffing versions themselves"
+        );
+    }
+
+    #[test]
+    fn enable_withholds_the_version_until_the_scheduler_is_installed() {
+        use std::cell::Cell;
+
+        // On Windows a re-enable writes a freshly versioned copy while the task
+        // still points at the previous one, so a process killed between the
+        // first settings save and the scheduler install would leave settings
+        // claiming a build the scheduler is not running -- and the stale check
+        // would report clean at exactly the moment it is wrong. Recording the
+        // version only after installation means an interrupted enable leaves
+        // `None`, which reads as unknown and reports drift.
+        let temp = TempDir::new().unwrap();
+        let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+        let observed = Cell::new(Some(String::new()));
+
+        enable_with_scheduler_operations(
+            enable_args(SchedulerKind::Cron),
+            |_, _, _| {
+                observed.set(
+                    crate::tui::settings::Settings::load()
+                        .autosubmit
+                        .managed_executable_version,
+                );
+                Ok(())
+            },
+            |_, _, _| Ok(()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            observed.take(),
+            None,
+            "the version must not be persisted before the scheduler points at the new copy"
+        );
+        assert_eq!(
+            crate::tui::settings::Settings::load()
+                .autosubmit
+                .managed_executable_version
+                .as_deref(),
+            Some(RUNNING_VERSION),
+            "and must be persisted once installation succeeds"
         );
     }
 

--- a/crates/tokscale-cli/src/commands/autosubmit.rs
+++ b/crates/tokscale-cli/src/commands/autosubmit.rs
@@ -15,6 +15,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const JOB_ID: &str = "ai.tokscale.autosubmit";
+/// Version of the build answering the current call, stamped into settings when
+/// the managed copy is written so later runs can tell whether it has drifted.
+const RUNNING_VERSION: &str = env!("CARGO_PKG_VERSION");
 const CRON_MARKER_BEGIN: &str = "# BEGIN TOKSCALE AUTOSUBMIT";
 const CRON_MARKER_END: &str = "# END TOKSCALE AUTOSUBMIT";
 const SKIP_SCHEDULER_ENV: &str = "TOKSCALE_AUTOSUBMIT_SKIP_SCHEDULER";
@@ -170,6 +173,12 @@ struct StatusOutput {
     yesterday: bool,
     week: bool,
     month: bool,
+    managed_executable: Option<String>,
+    managed_executable_version: Option<String>,
+    /// True when the scheduled copy came from a different build than the one
+    /// answering this call. Scripted health checks read this rather than
+    /// diffing the two version strings themselves.
+    managed_executable_stale: bool,
     last_run_at_ms: Option<i64>,
     last_error: Option<String>,
 }
@@ -213,6 +222,7 @@ where
         last_run_at_ms: previous_settings.autosubmit.last_run_at_ms,
         last_error: None,
         managed_executable: None,
+        managed_executable_version: None,
     };
     let source_exe =
         std::env::current_exe().context("Could not resolve current tokscale executable")?;
@@ -239,6 +249,9 @@ where
     };
     let mut next_autosubmit = next_autosubmit;
     next_autosubmit.managed_executable = Some(exe.to_string_lossy().into_owned());
+    // Stamped from the build doing the copying, not read back off the file, so
+    // it describes what the scheduler will actually run.
+    next_autosubmit.managed_executable_version = Some(RUNNING_VERSION.to_string());
 
     let mut next_settings = previous_settings.clone();
     next_settings.autosubmit = next_autosubmit;
@@ -333,6 +346,17 @@ pub fn status(json: bool) -> Result<()> {
         } else {
             println!("  Clients: default submit clients");
         }
+        if managed_executable_is_stale(&autosubmit) {
+            let scheduled = autosubmit
+                .managed_executable_version
+                .as_deref()
+                .unwrap_or("unknown");
+            println!(
+                "  Scheduled binary: {scheduled} (this build is {RUNNING_VERSION})\n    \
+                 The scheduler runs its own copy, which upgrades do not replace. \
+                 Re-run `tokscale autosubmit enable` to refresh it."
+            );
+        }
     } else {
         println!("Autosubmit is disabled.");
     }
@@ -374,6 +398,7 @@ where
 
     settings.autosubmit.enabled = false;
     settings.autosubmit.managed_executable = None;
+    settings.autosubmit.managed_executable_version = None;
     settings.autosubmit.last_error = None;
     settings.save()?;
     println!("Autosubmit disabled.");
@@ -450,6 +475,53 @@ pub fn try_acquire_run_lock() -> Result<Option<AutosubmitRunLock>> {
     }
 }
 
+/// Whether the scheduled copy came from a different build than the one running
+/// now, meaning the scheduler is submitting with stale code.
+///
+/// `enable` is the only writer of the managed copy, so replacing the installed
+/// binary — `npm update -g tokscale`, brew, or dropping in a new binary — does
+/// not touch it and the scheduled job silently keeps the old build.
+///
+/// Compared by version rather than by content. Hashing would additionally catch
+/// same-version rebuilds, which only developers produce, at the cost of reading
+/// the whole binary on every status call.
+///
+/// Any difference counts, not just an older recorded version: a deliberate
+/// downgrade is drift too. The question being answered is "what is the
+/// scheduler actually running", not "which build is newer".
+fn managed_executable_is_stale(settings: &AutosubmitSettings) -> bool {
+    if !settings.enabled {
+        return false;
+    }
+    let Some(managed) = settings.managed_executable.as_deref() else {
+        return false;
+    };
+    // Invoking the managed copy directly compares it against itself, which
+    // always matches and says nothing. Report no drift rather than a spurious
+    // clean bill of health from a binary that cannot observe its own staleness.
+    if running_executable_is(managed) {
+        return false;
+    }
+    // `None` predates this field, so the recorded build is genuinely unknown
+    // and reported as drift. It resolves on the next enable.
+    settings.managed_executable_version.as_deref() != Some(RUNNING_VERSION)
+}
+
+/// Whether the process answering this call is the binary at `path`, compared
+/// through the filesystem so a symlinked or relative path still matches.
+fn running_executable_is(path: &str) -> bool {
+    let Ok(current) = std::env::current_exe() else {
+        return false;
+    };
+    let candidate = Path::new(path);
+    match (current.canonicalize(), candidate.canonicalize()) {
+        (Ok(current), Ok(candidate)) => current == candidate,
+        // A managed copy that no longer exists cannot be the running process,
+        // and is a separate problem from drift.
+        _ => current == candidate,
+    }
+}
+
 fn status_output(settings: &AutosubmitSettings) -> StatusOutput {
     StatusOutput {
         enabled: settings.enabled,
@@ -463,6 +535,9 @@ fn status_output(settings: &AutosubmitSettings) -> StatusOutput {
         yesterday: settings.yesterday,
         week: settings.week,
         month: settings.month,
+        managed_executable: settings.managed_executable.clone(),
+        managed_executable_version: settings.managed_executable_version.clone(),
+        managed_executable_stale: managed_executable_is_stale(settings),
         last_run_at_ms: settings.last_run_at_ms,
         last_error: settings.last_error.clone(),
     }
@@ -1498,16 +1573,44 @@ mod tests {
     use std::ffi::{OsStr, OsString};
     use tempfile::TempDir;
 
+    /// Serializes every test that redirects `TOKSCALE_CONFIG_DIR`.
+    ///
+    /// The env is process-global while cargo runs tests on parallel threads, so
+    /// two such tests otherwise read each other's config directory: one saves
+    /// settings, the other's guard restores the variable underneath it, and the
+    /// first then loads from the wrong place. That was latent rather than
+    /// theoretical — the suite passed only because of scheduling luck, and
+    /// adding two more config-directory tests was enough to make it fail
+    /// differently on every run.
+    ///
+    /// Holding the lock inside the guard means every existing caller is
+    /// serialized without changing a single test body. No test takes two guards
+    /// at once, so this cannot deadlock.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     struct EnvVarGuard {
         key: &'static str,
         previous: Option<OsString>,
+        // Released on drop, after the variable is restored below.
+        _lock: std::sync::MutexGuard<'static, ()>,
     }
 
     impl EnvVarGuard {
         fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+            // A test that panicked while holding the lock poisons it. The env
+            // is restored by the guard's Drop regardless, so the data is not
+            // actually corrupt and recovering keeps one failure from cascading
+            // into every later test.
+            let lock = ENV_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
             let previous = env::var_os(key);
             env::set_var(key, value);
-            Self { key, previous }
+            Self {
+                key,
+                previous,
+                _lock: lock,
+            }
         }
     }
 
@@ -2265,5 +2368,139 @@ mod tests {
         assert!(try_acquire_run_lock().unwrap().is_none());
         drop(first);
         assert!(try_acquire_run_lock().unwrap().is_some());
+    }
+    /// The scheduler runs its own copy, so an upgrade that replaces the
+    /// installed binary leaves it behind. These pin the detection, because the
+    /// drift itself is silent by construction.
+    #[test]
+    fn managed_executable_stale_reports_a_version_change() {
+        let settings = AutosubmitSettings {
+            enabled: true,
+            managed_executable: Some("/nonexistent/managed/tokscale".to_string()),
+            managed_executable_version: Some("0.0.1-old".to_string()),
+            ..AutosubmitSettings::default()
+        };
+        assert!(managed_executable_is_stale(&settings));
+    }
+
+    #[test]
+    fn managed_executable_stale_is_quiet_when_versions_match() {
+        let settings = AutosubmitSettings {
+            enabled: true,
+            managed_executable: Some("/nonexistent/managed/tokscale".to_string()),
+            managed_executable_version: Some(RUNNING_VERSION.to_string()),
+            ..AutosubmitSettings::default()
+        };
+        assert!(!managed_executable_is_stale(&settings));
+    }
+
+    #[test]
+    fn managed_executable_stale_is_quiet_when_autosubmit_is_disabled() {
+        // Nothing is scheduled, so a stale copy submits nothing and warning
+        // about it would be noise.
+        let settings = AutosubmitSettings {
+            enabled: false,
+            managed_executable: Some("/nonexistent/managed/tokscale".to_string()),
+            managed_executable_version: Some("0.0.1-old".to_string()),
+            ..AutosubmitSettings::default()
+        };
+        assert!(!managed_executable_is_stale(&settings));
+    }
+
+    #[test]
+    fn managed_executable_stale_treats_a_missing_version_as_drift() {
+        // Configs written before the field existed. The recorded build is
+        // genuinely unknown, so claiming it is current would be a guess.
+        let settings = AutosubmitSettings {
+            enabled: true,
+            managed_executable: Some("/nonexistent/managed/tokscale".to_string()),
+            managed_executable_version: None,
+            ..AutosubmitSettings::default()
+        };
+        assert!(managed_executable_is_stale(&settings));
+    }
+
+    #[test]
+    fn managed_executable_stale_ignores_self_invocation() {
+        // Running the managed copy compares it against itself, which always
+        // matches and proves nothing -- a binary cannot observe its own
+        // staleness. Deliberately reports no drift rather than a false all-clear
+        // derived from the version mismatch below.
+        let running = std::env::current_exe().unwrap();
+        let settings = AutosubmitSettings {
+            enabled: true,
+            managed_executable: Some(running.to_string_lossy().into_owned()),
+            managed_executable_version: Some("0.0.1-old".to_string()),
+            ..AutosubmitSettings::default()
+        };
+        assert!(!managed_executable_is_stale(&settings));
+    }
+
+    #[test]
+    fn status_output_surfaces_the_scheduled_build() {
+        let settings = AutosubmitSettings {
+            enabled: true,
+            managed_executable: Some("/nonexistent/managed/tokscale".to_string()),
+            managed_executable_version: Some("0.0.1-old".to_string()),
+            ..AutosubmitSettings::default()
+        };
+        let output = status_output(&settings);
+        assert_eq!(
+            output.managed_executable.as_deref(),
+            Some("/nonexistent/managed/tokscale")
+        );
+        assert_eq!(
+            output.managed_executable_version.as_deref(),
+            Some("0.0.1-old")
+        );
+        assert!(
+            output.managed_executable_stale,
+            "scripted checks read the boolean rather than diffing versions themselves"
+        );
+    }
+
+    #[test]
+    fn enable_records_the_running_version_beside_the_managed_copy() {
+        let temp = TempDir::new().unwrap();
+        let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+
+        enable_with_scheduler_operations(
+            enable_args(SchedulerKind::Cron),
+            |_, _, _| Ok(()),
+            |_, _, _| Ok(()),
+        )
+        .unwrap();
+
+        let saved = crate::tui::settings::Settings::load().autosubmit;
+        assert_eq!(
+            saved.managed_executable_version.as_deref(),
+            Some(RUNNING_VERSION),
+            "without this the next run cannot tell a stale scheduled job from a current one"
+        );
+        assert!(saved.managed_executable.is_some());
+    }
+
+    #[test]
+    fn disable_clears_the_recorded_managed_version() {
+        let temp = TempDir::new().unwrap();
+        let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+        let mut settings = crate::tui::settings::Settings::load();
+        settings.autosubmit = AutosubmitSettings {
+            enabled: true,
+            scheduler: Some(SchedulerKind::Cron.as_str().to_string()),
+            managed_executable: Some("/nonexistent/managed/tokscale".to_string()),
+            managed_executable_version: Some("0.0.1-old".to_string()),
+            ..AutosubmitSettings::default()
+        };
+        settings.save().unwrap();
+
+        disable_with_scheduler_operations(|_, _| Ok(()), || Ok(())).unwrap();
+
+        let saved = crate::tui::settings::Settings::load().autosubmit;
+        assert_eq!(saved.managed_executable, None);
+        assert_eq!(
+            saved.managed_executable_version, None,
+            "a stale version left behind would make the next enable look like drift"
+        );
     }
 }

--- a/crates/tokscale-cli/src/commands/autosubmit.rs
+++ b/crates/tokscale-cli/src/commands/autosubmit.rs
@@ -1630,14 +1630,14 @@ fn build_date_filter_for_date(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serial_test::serial;
     use std::env;
     use std::ffi::{OsStr, OsString};
     use tempfile::TempDir;
 
     /// `TOKSCALE_CONFIG_DIR` is process-global while cargo runs tests on
-    /// parallel threads, so every test that redirects it is `#[serial]`.
-    /// Without that they read each other's config directory: one saves
+    /// parallel threads, so every test that redirects it needs
+    /// `#[serial_test::serial]` — the spelling already used throughout this
+    /// module. Without it they read each other's config directory: one saves
     /// settings, another's guard restores the variable underneath it, and the
     /// first then loads from the wrong place.
     ///
@@ -1646,9 +1646,13 @@ mod tests {
     /// it fail differently on every run.
     ///
     /// `serial_test` rather than a mutex local to this module, because
-    /// `device.rs`, `paths.rs` and `auth.rs` redirect the same variable and
-    /// already use `#[serial]`. A module-local lock coordinates none of those,
+    /// `device.rs`, `paths.rs` and `auth.rs` redirect the same variable and are
+    /// serialized the same way. A module-local lock coordinates none of those,
     /// so it would leave exactly the race it appears to fix.
+    ///
+    /// Use one spelling, not both: stacking the bare and qualified forms on the
+    /// same test serializes it twice for no benefit and risks it waiting on a
+    /// lock it already holds.
     struct EnvVarGuard {
         key: &'static str,
         previous: Option<OsString>,
@@ -1725,7 +1729,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     #[serial_test::serial]
     fn launchd_spec_uses_program_arguments_without_shell() {
         let temp = TempDir::new().unwrap();
@@ -1855,7 +1858,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     #[serial_test::serial]
     fn systemd_spec_honors_xdg_config_home() {
         let temp = TempDir::new().unwrap();
@@ -1927,7 +1929,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     #[serial_test::serial]
     fn scheduler_specs_use_the_managed_executable() {
         let temp = TempDir::new().unwrap();
@@ -1954,7 +1955,6 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    #[serial]
     #[serial_test::serial]
     fn managed_executable_refreshes_atomically_with_source_permissions() {
         use std::os::unix::fs::PermissionsExt;
@@ -1997,7 +1997,6 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    #[serial]
     #[serial_test::serial]
     fn managed_executable_rejects_nonexecutable_source() {
         use std::os::unix::fs::PermissionsExt;
@@ -2018,7 +2017,6 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    #[serial]
     #[serial_test::serial]
     fn windows_reenable_renders_a_new_versioned_managed_executable_path() {
         use std::os::unix::fs::PermissionsExt;
@@ -2149,7 +2147,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     #[serial_test::serial]
     fn windows_reenable_failure_keeps_the_existing_task_intact() {
         use std::cell::Cell;
@@ -2186,7 +2183,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     #[serial_test::serial]
     fn scheduler_snapshot_preserves_versioned_windows_executable_path() {
         let temp = TempDir::new().unwrap();
@@ -2208,7 +2204,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     #[serial_test::serial]
     fn disable_persists_settings_after_known_absent_scheduler_cleanup() {
         use std::cell::Cell;
@@ -2247,7 +2242,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     #[serial_test::serial]
     fn disable_retries_executable_cleanup_after_a_previous_locked_run() {
         use std::cell::Cell;
@@ -2286,7 +2280,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     #[serial_test::serial]
     fn disable_keeps_settings_enabled_after_scheduler_cleanup_failure() {
         let temp = TempDir::new().unwrap();
@@ -2313,7 +2306,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     #[serial_test::serial]
     fn enable_persists_settings_before_scheduler_installation() {
         use std::cell::Cell;
@@ -2337,7 +2329,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     #[serial_test::serial]
     fn enable_rolls_back_settings_and_managed_executable_after_activation_failure() {
         use std::cell::Cell;
@@ -2365,7 +2356,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     #[serial_test::serial]
     fn enable_rolls_back_after_post_bootstrap_verification_failure() {
         let temp = TempDir::new().unwrap();
@@ -2421,7 +2411,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     #[serial_test::serial]
     fn run_lock_blocks_concurrent_holder() {
         let temp = TempDir::new().unwrap();
@@ -2558,7 +2547,7 @@ mod tests {
     }
 
     #[test]
-    #[serial]
+    #[serial_test::serial]
     fn enable_withholds_the_version_until_the_scheduler_is_installed() {
         use std::cell::Cell;
 
@@ -2603,7 +2592,7 @@ mod tests {
     }
 
     #[test]
-    #[serial]
+    #[serial_test::serial]
     fn enable_records_the_running_version_beside_the_managed_copy() {
         let temp = TempDir::new().unwrap();
         let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
@@ -2625,7 +2614,7 @@ mod tests {
     }
 
     #[test]
-    #[serial]
+    #[serial_test::serial]
     fn disable_clears_the_recorded_managed_version() {
         let temp = TempDir::new().unwrap();
         let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());

--- a/crates/tokscale-cli/src/commands/autosubmit.rs
+++ b/crates/tokscale-cli/src/commands/autosubmit.rs
@@ -373,7 +373,8 @@ pub fn status(json: bool) -> Result<()> {
             println!(
                 "  Scheduled binary: {scheduled} (this build is {RUNNING_VERSION})\n    \
                  The scheduler runs its own copy, which upgrades do not replace. \
-                 Re-run `tokscale autosubmit enable` to refresh it."
+                 Refresh it with:\n      {}",
+                enable_command_for(&autosubmit)
             );
         }
     } else {
@@ -524,6 +525,47 @@ fn managed_executable_is_stale(settings: &AutosubmitSettings) -> bool {
     // `None` predates this field, so the recorded build is genuinely unknown
     // and reported as drift. It resolves on the next enable.
     settings.managed_executable_version.as_deref() != Some(RUNNING_VERSION)
+}
+
+/// The `enable` invocation that reproduces the configuration already in
+/// settings.
+///
+/// `enable` rebuilds every field from its arguments — only `last_run_at_ms`
+/// survives — and `--interval` defaults to `24h`. So telling somebody to
+/// "re-run `tokscale autosubmit enable`" after an upgrade would silently reset
+/// a 30m interval to 24h and drop any client or date filter. Printing what they
+/// actually configured makes the advice safe to follow verbatim.
+fn enable_command_for(settings: &AutosubmitSettings) -> String {
+    let mut parts = vec![
+        "tokscale autosubmit enable".to_string(),
+        format!("--interval {}m", settings.interval_minutes),
+    ];
+    if !settings.clients.is_empty() {
+        parts.push(format!("--client {}", settings.clients.join(",")));
+    }
+    if let Some(since) = settings.since.as_deref() {
+        parts.push(format!("--since {since}"));
+    }
+    if let Some(until) = settings.until.as_deref() {
+        parts.push(format!("--until {until}"));
+    }
+    if let Some(year) = settings.year.as_deref() {
+        parts.push(format!("--year {year}"));
+    }
+    for (flag, enabled) in [
+        ("--today", settings.today),
+        ("--yesterday", settings.yesterday),
+        ("--week", settings.week),
+        ("--month", settings.month),
+    ] {
+        if enabled {
+            parts.push(flag.to_string());
+        }
+    }
+    if let Some(scheduler) = settings.scheduler.as_deref() {
+        parts.push(format!("--scheduler {scheduler}"));
+    }
+    parts.join(" ")
 }
 
 /// Whether the process answering this call is the binary at `path`, compared
@@ -1588,48 +1630,35 @@ fn build_date_filter_for_date(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::env;
     use std::ffi::{OsStr, OsString};
     use tempfile::TempDir;
 
-    /// Serializes every test that redirects `TOKSCALE_CONFIG_DIR`.
+    /// `TOKSCALE_CONFIG_DIR` is process-global while cargo runs tests on
+    /// parallel threads, so every test that redirects it is `#[serial]`.
+    /// Without that they read each other's config directory: one saves
+    /// settings, another's guard restores the variable underneath it, and the
+    /// first then loads from the wrong place.
     ///
-    /// The env is process-global while cargo runs tests on parallel threads, so
-    /// two such tests otherwise read each other's config directory: one saves
-    /// settings, the other's guard restores the variable underneath it, and the
-    /// first then loads from the wrong place. That was latent rather than
-    /// theoretical — the suite passed only because of scheduling luck, and
-    /// adding two more config-directory tests was enough to make it fail
-    /// differently on every run.
+    /// That was latent rather than theoretical -- this suite passed only
+    /// through scheduling luck, and adding two more config-directory tests made
+    /// it fail differently on every run.
     ///
-    /// Holding the lock inside the guard means every existing caller is
-    /// serialized without changing a single test body. No test takes two guards
-    /// at once, so this cannot deadlock.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
+    /// `serial_test` rather than a mutex local to this module, because
+    /// `device.rs`, `paths.rs` and `auth.rs` redirect the same variable and
+    /// already use `#[serial]`. A module-local lock coordinates none of those,
+    /// so it would leave exactly the race it appears to fix.
     struct EnvVarGuard {
         key: &'static str,
         previous: Option<OsString>,
-        // Released on drop, after the variable is restored below.
-        _lock: std::sync::MutexGuard<'static, ()>,
     }
 
     impl EnvVarGuard {
         fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
-            // A test that panicked while holding the lock poisons it. The env
-            // is restored by the guard's Drop regardless, so the data is not
-            // actually corrupt and recovering keeps one failure from cascading
-            // into every later test.
-            let lock = ENV_LOCK
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
             let previous = env::var_os(key);
             env::set_var(key, value);
-            Self {
-                key,
-                previous,
-                _lock: lock,
-            }
+            Self { key, previous }
         }
     }
 
@@ -1696,6 +1725,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[serial_test::serial]
     fn launchd_spec_uses_program_arguments_without_shell() {
         let temp = TempDir::new().unwrap();
@@ -1825,6 +1855,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[serial_test::serial]
     fn systemd_spec_honors_xdg_config_home() {
         let temp = TempDir::new().unwrap();
@@ -1896,6 +1927,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[serial_test::serial]
     fn scheduler_specs_use_the_managed_executable() {
         let temp = TempDir::new().unwrap();
@@ -1922,6 +1954,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    #[serial]
     #[serial_test::serial]
     fn managed_executable_refreshes_atomically_with_source_permissions() {
         use std::os::unix::fs::PermissionsExt;
@@ -1964,6 +1997,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    #[serial]
     #[serial_test::serial]
     fn managed_executable_rejects_nonexecutable_source() {
         use std::os::unix::fs::PermissionsExt;
@@ -1984,6 +2018,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    #[serial]
     #[serial_test::serial]
     fn windows_reenable_renders_a_new_versioned_managed_executable_path() {
         use std::os::unix::fs::PermissionsExt;
@@ -2114,6 +2149,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[serial_test::serial]
     fn windows_reenable_failure_keeps_the_existing_task_intact() {
         use std::cell::Cell;
@@ -2150,6 +2186,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[serial_test::serial]
     fn scheduler_snapshot_preserves_versioned_windows_executable_path() {
         let temp = TempDir::new().unwrap();
@@ -2171,6 +2208,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[serial_test::serial]
     fn disable_persists_settings_after_known_absent_scheduler_cleanup() {
         use std::cell::Cell;
@@ -2209,6 +2247,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[serial_test::serial]
     fn disable_retries_executable_cleanup_after_a_previous_locked_run() {
         use std::cell::Cell;
@@ -2247,6 +2286,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[serial_test::serial]
     fn disable_keeps_settings_enabled_after_scheduler_cleanup_failure() {
         let temp = TempDir::new().unwrap();
@@ -2273,6 +2313,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[serial_test::serial]
     fn enable_persists_settings_before_scheduler_installation() {
         use std::cell::Cell;
@@ -2296,6 +2337,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[serial_test::serial]
     fn enable_rolls_back_settings_and_managed_executable_after_activation_failure() {
         use std::cell::Cell;
@@ -2323,6 +2365,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[serial_test::serial]
     fn enable_rolls_back_after_post_bootstrap_verification_failure() {
         let temp = TempDir::new().unwrap();
@@ -2378,6 +2421,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[serial_test::serial]
     fn run_lock_blocks_concurrent_holder() {
         let temp = TempDir::new().unwrap();
@@ -2479,6 +2523,42 @@ mod tests {
     }
 
     #[test]
+    fn refresh_command_preserves_a_non_default_configuration() {
+        // `enable` rebuilds every field from its arguments and `--interval`
+        // defaults to 24h, so advising a bare re-run would turn a 30m interval
+        // into 24h and drop the filters. The printed command has to be safe to
+        // paste verbatim.
+        let settings = AutosubmitSettings {
+            enabled: true,
+            interval_minutes: 30,
+            clients: vec!["codex".to_string(), "claude".to_string()],
+            since: Some("2026-01-01".to_string()),
+            week: true,
+            scheduler: Some(SchedulerKind::Launchd.as_str().to_string()),
+            ..AutosubmitSettings::default()
+        };
+        assert_eq!(
+            enable_command_for(&settings),
+            "tokscale autosubmit enable --interval 30m --client codex,claude \
+             --since 2026-01-01 --week --scheduler launchd"
+        );
+    }
+
+    #[test]
+    fn refresh_command_omits_unset_options() {
+        let settings = AutosubmitSettings {
+            enabled: true,
+            interval_minutes: 1440,
+            ..AutosubmitSettings::default()
+        };
+        assert_eq!(
+            enable_command_for(&settings),
+            "tokscale autosubmit enable --interval 1440m"
+        );
+    }
+
+    #[test]
+    #[serial]
     fn enable_withholds_the_version_until_the_scheduler_is_installed() {
         use std::cell::Cell;
 
@@ -2523,6 +2603,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn enable_records_the_running_version_beside_the_managed_copy() {
         let temp = TempDir::new().unwrap();
         let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
@@ -2544,6 +2625,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn disable_clears_the_recorded_managed_version() {
         let temp = TempDir::new().unwrap();
         let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -73,6 +73,16 @@ pub struct AutosubmitSettings {
     pub scheduler: Option<String>,
     #[serde(default)]
     pub managed_executable: Option<String>,
+    /// Version of the build that `managed_executable` was copied from.
+    ///
+    /// The copy is written only by `autosubmit enable`, so upgrading the
+    /// installed binary leaves the scheduled job on the old build. Without this
+    /// there is no way to tell a stale scheduled job from a current one, and
+    /// the drift is silent. `None` on configs written before this field
+    /// existed, and on those the version is reported as unknown rather than
+    /// assumed current.
+    #[serde(default)]
+    pub managed_executable_version: Option<String>,
     #[serde(default)]
     pub last_run_at_ms: Option<i64>,
     #[serde(default)]
@@ -94,6 +104,7 @@ impl Default for AutosubmitSettings {
             month: false,
             scheduler: None,
             managed_executable: None,
+            managed_executable_version: None,
             last_run_at_ms: None,
             last_error: None,
         }


### PR DESCRIPTION
Closes #972. Follow-up to #971 (`3ce29f97`), and strictly additive — #971 was right to land as-is.

## The problem

#971 renders every scheduler backend against a copy of the binary under the config root, and only `enable` writes that copy. Replacing the installed binary — `npm update -g tokscale`, brew, dropping one in — does not touch it, so the scheduled job keeps submitting with the old build until the user happens to re-run `enable`.

**The failure is that it is invisible, more than that it happens.** Settings recorded the copy's path but not its version, and neither status surface mentioned it. Someone upgrading specifically to pick up a parser fix had no signal that their scheduled submissions still used the old parser — and `main` currently carries `parser_version` bumps for Kimi (#967) and Hermes (#961), so the next release is exactly that case.

Not a regression from #971: `main` already rendered against `current_exe()`. The difference is that the old path was the installed binary, which an upgrade replaces, and the new one is a copy, which it does not.

## What this does

Records the version beside the path and reports drift in both status surfaces.

```
$ tokscale autosubmit status
Autosubmit is enabled.
  Interval: 60 minutes
  Scheduler: launchd
  Clients: default submit clients
  Scheduled binary: 4.6.1 (this build is 4.7.0)
    The scheduler runs its own copy, which upgrades do not replace. Re-run `tokscale autosubmit enable` to refresh it.

$ tokscale autosubmit status --json
{"managedExecutable": "…/autosubmit/tokscale", "managedExecutableVersion": "4.6.1", "managedExecutableStale": true}
```

Both, because scripted health checks read the boolean and would miss a human-only warning.

## Detection only, deliberately

Refreshing stays manual. On Unix it would be an atomic replace at a fixed path — no scheduler interaction at all, since the plist already points there. On **Windows** the copy is versioned to dodge the executable lock (`versioned_windows_managed_executable_path`), so a refresh means writing a new file, re-rendering the spec, and reaping the old one — a scheduler transaction carrying #971's rollback concerns. Bundling those two would hide the asymmetry. #972 has the design if you want it next.

## Decisions worth reviewing

- **Any difference counts, including a downgrade.** No semver parsing, and the question is what the scheduler is *running*, not which build is newer — someone who pinned an older version should see that reflected.
- **A missing version reads as drift, not as current.** It predates the field, so the build is genuinely unknown; assuming current would under-report. Resolves on the next `enable`.
- **Running the managed copy reports no drift.** It would compare against itself and always match. A binary cannot observe its own staleness, so this returns "no drift" rather than a false all-clear.
- **Version, not hash.** Hashing catches only same-version rebuilds that developers produce, at the cost of reading the whole binary on every status call.

## A latent test race this surfaced

Adding two config-directory tests made the autosubmit suite fail **differently on every run**. `EnvVarGuard` had no lock, so every test redirecting `TOKSCALE_CONFIG_DIR` raced every other — one saves settings while another's guard restores the variable underneath it. `main` passed only through scheduling luck; I confirmed it is clean there across three runs, and that my branch passed 40/40 single-threaded while failing varied subsets in parallel.

Fixed by holding a mutex inside the guard, so every existing caller is serialised without touching a single test body. No test takes two guards at once, so it cannot deadlock, and poisoning is recovered because `Drop` restores the variable regardless. Five consecutive parallel runs now pass 40/40.

## Verification

- `cargo test -p tokscale-cli` — 964 bin + 133 integration, 0 failed (8 new)
- `cargo clippy -p tokscale-cli --all-targets -- -D warnings` exit 0, `cargo fmt --check` clean
- **End-to-end against the built binary**, not just unit tests: `enable` records `4.7.0`, an edited `4.6.1` surfaces in both status paths with `managedExecutableStale: true`

`--all-targets` because the usual invocation omits it and therefore never lints `#[cfg(test)]` code — that gap let a real violation through on #966.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects and reports when autosubmit’s scheduled binary is stale, and now prints a safe `enable` command that preserves your config. The scheduled build version is stamped only after the scheduler installs, and status/JSON clearly surface drift.

- **Bug Fixes**
  - `autosubmit status` shows scheduled vs current and prints an exact refresh command that keeps interval, clients, date filters, and scheduler. `--json` adds `managedExecutableStale` plus `managedExecutable` and `managedExecutableVersion`.
  - Version is recorded only after scheduler installation; any version difference (including downgrades) or a missing version counts as drift; running the managed copy reports no drift.
  - `autosubmit disable` clears the recorded version; if the post-install save fails, we warn and status reports drift until the next `enable`.
  - Serialized `TOKSCALE_CONFIG_DIR` tests using `serial_test`’s `#[serial]` across modules; removed duplicate `#[serial]` attributes to avoid double-lock deadlocks.

- **Migration**
  - If status reports a stale scheduled binary, run the printed `tokscale autosubmit enable ...` command to refresh the managed copy.

<sup>Written for commit 26005e9a85cc56737663527ced1ede04f05e3b02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

