### PR TITLE
chore: ignore Claude Code worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,10 @@ self-host/
 .next/
 .vercel
 .env*.local
+
+# Ephemeral git worktrees created by Claude Code. These are real checkouts
+# containing their own .git file, so `git add -A` from the repo root stages
+# them as embedded-repository gitlinks rather than ignoring them. Only the
+# worktrees are ignored, not all of .claude/ -- project-level agent config
+# there is worth committing deliberately.
+.claude/worktrees/


### PR DESCRIPTION
One line, plus the reason it is one line and not two.

## Why

`.claude/worktrees/` holds real git checkouts, each with its own `.git` file. Because the path is not ignored, `git add -A` from the repo root stages them as **embedded-repository gitlinks** rather than skipping them:

```
warning: adding embedded git repository: .claude/worktrees/pr943
warning: adding embedded git repository: .claude/worktrees/wf_aacbce6c-c09-1
...
```

That happened on #973 — six of them landed in a commit before I caught it and amended them out. It will happen to anyone using Claude Code worktrees in this repo, and the warnings are easy to scroll past.

## Scope

Deliberately `.claude/worktrees/` rather than `.claude/`. That directory currently contains nothing else, but project-level agent config there (`settings.json`, agents, skills) is the sort of thing worth committing on purpose, and a blanket rule would silently prevent it later without anyone noticing why.

`.omc/` and `.omx/` are already ignored, so this is the only gap.

## Verification

```
$ git check-ignore -v .claude/worktrees/pr943
.gitignore:43:.claude/worktrees/	.claude/worktrees/pr943

$ git status --porcelain --untracked-files=all | grep -c '^?? .claude'
0        # was 1
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.claude/worktrees/` to `.gitignore` to prevent Claude Code worktrees from being staged as embedded git repositories when running `git add -A`. Only the worktrees are ignored; other `.claude/` content (e.g., project config) remains trackable.

<sup>Written for commit aa42c9a4f333106e8e72e1e9addf06d1a17f5bef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

