### PR TITLE
fix(9router): read usageHistory table, handle missing requestDetails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ benchmarks/synthetic-data/
 
 target/
 *.node
+__pycache__/
 
 # Debug logs
 *.log
@@ -34,7 +35,9 @@ self-host/
 .next/
 .vercel
 .env*.local
-.claude/skills/
+.claude/
 .omp/
 .omx/
 .codegraph/
+.agents/
+skills-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ self-host/
 .next/
 .vercel
 .env*.local
+.claude/skills/
+.omp/
+.omx/
+.codegraph/

--- a/scripts/9router_tokscale_bridge_gjc.py
+++ b/scripts/9router_tokscale_bridge_gjc.py
@@ -35,6 +35,7 @@ See docs/9router-bridge.md for full documentation.
 """
 
 import json
+import math
 import os
 import tempfile
 import sqlite3
@@ -298,6 +299,8 @@ def convert_usage_history_row(row, stats: dict | None = None) -> dict | None:
     if cost is not None:
         try:
             cost = float(cost)
+            if not math.isfinite(cost):
+                cost = None
         except (ValueError, TypeError):
             cost = None
 

--- a/scripts/9router_tokscale_bridge_gjc.py
+++ b/scripts/9router_tokscale_bridge_gjc.py
@@ -17,6 +17,14 @@ CostSource::ProviderReported, which prevents tokscale from repricing via its
 pricing database. Omitting the cost field lets tokscale reprice from
 tokens + pricing data.
 
+This applies to rows from the `requestDetails` table, where costs must be
+inferred from tokens.  Rows from the `usageHistory` table have a dedicated
+`cost` REAL column with provider-reported values; positive costs from this
+column ARE passed through as authoritative.  Zero or missing costs from
+`usageHistory` follow the same default policy (omit for paid models, $0.00
+for free-tier).
+
+
 For FREE-tier models (ids ending in "-free" or ":free"), the bridge embeds
 "cost": {"total": 0.0} on purpose: tokscale's pricing lookup strips the
 "-free" suffix, so an omitted cost would reprice e.g. kimi-k2.5-free at the
@@ -37,6 +45,7 @@ from urllib.parse import quote
 ROUTER_DB = Path.home() / ".9router" / "db" / "data.sqlite"
 BRIDGE_DIR = Path.home() / ".local" / "share" / "9router-tokscale" / "sessions"
 
+
 def discover_router_dbs() -> list[Path]:
     """Discover the current 9Router DB and all backup DBs.
 
@@ -55,11 +64,13 @@ def discover_router_dbs() -> list[Path]:
         ))
     return [db for db in dbs if db.exists()]
 
+
 def ensure_bridge_dir():
-    """Create output directory. Existing files are NOT deleted — each date's
+    """Create output directory. Existing files are NOT deleted -- each date's
     file is overwritten individually by the write loop, preserving historical
     data from previous bridge runs."""
     BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+
 
 def open_readonly_db(db_path: Path) -> sqlite3.Connection | None:
     """Open a 9Router DB read-only via a `file:` URI.
@@ -74,6 +85,7 @@ def open_readonly_db(db_path: Path) -> sqlite3.Connection | None:
     conn = sqlite3.connect(f"file:{quote(str(db_path))}?mode=ro", uri=True)
     conn.row_factory = sqlite3.Row
     return conn
+
 
 def parse_iso_timestamp(ts: str) -> int | None:
     """Convert ISO-8601 timestamp to Unix milliseconds.
@@ -106,6 +118,7 @@ def safe_int(value) -> int:
         return 0
     return max(n, 0)
 
+
 def compute_token_buckets(tokens: dict) -> tuple[int, int, int, int]:
     """Split OpenAI-style token counts into non-overlapping buckets.
 
@@ -127,6 +140,7 @@ def compute_token_buckets(tokens: dict) -> tuple[int, int, int, int]:
     total = input_tokens + cached + completion
     return input_tokens, cached, completion, total
 
+
 def is_free_model(model: str) -> bool:
     """Return True for free-tier model ids (ending in "-free" or ":free").
 
@@ -137,7 +151,17 @@ def is_free_model(model: str) -> bool:
     lowered = model.lower()
     return lowered.endswith("-free") or lowered.endswith(":free")
 
-def convert_row_to_entry(row, stats: dict | None = None) -> dict | None:
+
+def _date_str_from_ms(ts_ms: int) -> str:
+    """Convert Unix-millisecond timestamp to local date string for file bucketing.
+
+    Uses local timezone (not UTC) so bridge file dates align with
+    tokscale --today / --since/--until, which use chrono::Local.
+    """
+    return datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc).astimezone().strftime("%Y-%m-%d")
+
+
+def convert_request_details_row(row, stats: dict | None = None) -> dict | None:
     """Convert a single `requestDetails` DB row into a gjc-format entry.
 
     Returns None when the row should be skipped: malformed/NULL `data`
@@ -178,14 +202,12 @@ def convert_row_to_entry(row, stats: dict | None = None) -> dict | None:
     # that case must be handled separately.
     model = req_data.get("model") or row["model"] or "unknown"
     # Derive provider from first path segment for qualified IDs
-    # (e.g. "deepseek-ai/deepseek-v4-flash" → "deepseek-ai"),
+    # (e.g. "deepseek-ai/deepseek-v4-flash" -> "deepseek-ai"),
     # otherwise pass through the DB value.
     provider = row["provider"] or None
     if not provider and "/" in model:
         provider = model.split("/", 1)[0].lstrip("@")
-    # Use local timezone (not UTC) so bridge file dates align with
-    # tokscale --today / --since/--until, which use chrono::Local.
-    date_str = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc).astimezone().strftime("%Y-%m-%d")
+    date_str = _date_str_from_ms(ts_ms)
 
     msg = {
         "role": "assistant",
@@ -213,10 +235,132 @@ def convert_row_to_entry(row, stats: dict | None = None) -> dict | None:
         "date_str": date_str,
         "entry": {
             "type": "message",
-            "id": row["id"],
+            "id": f"rd-{row['id']}",
             "message": msg,
         },
     }
+
+
+def convert_usage_history_row(row, stats: dict | None = None) -> dict | None:
+    """Convert a single `usageHistory` DB row into a gjc-format entry.
+
+    `usageHistory` stores tokens as a direct JSON string (unlike
+    `requestDetails` where it was nested in a `data` blob), and has a
+    dedicated `cost` REAL column. Returns None when the row should be
+    skipped: zero tokens, or a missing/unparseable timestamp.
+    """
+    try:
+        tokens = json.loads(row["tokens"])
+        if not isinstance(tokens, dict):
+            print(f"  Skipping usageHistory row {row['id']}: tokens is not an object")
+            return None
+    except (json.JSONDecodeError, TypeError):
+        print(f"  Skipping usageHistory row {row['id']}: malformed tokens column")
+        return None
+
+    input_tokens, cached, completion, total = compute_token_buckets(tokens)
+    prompt = safe_int(tokens.get("prompt_tokens", 0))
+
+    model = row["model"] or "unknown"
+    provider = row["provider"] or None
+    if not provider and "/" in model:
+        provider = model.split("/", 1)[0].lstrip("@")
+
+    if prompt == 0 and completion == 0:
+        return None
+
+    ts_ms = parse_iso_timestamp(row["timestamp"])
+    if ts_ms is None:
+        if stats is not None:
+            stats["missing_timestamp"] = stats.get("missing_timestamp", 0) + 1
+        return None
+
+    date_str = _date_str_from_ms(ts_ms)
+
+    msg = {
+        "role": "assistant",
+        "model": model,
+        "source": "9router",
+        "timestamp": ts_ms,
+        "usage": {
+            "input": input_tokens,
+            "output": completion,
+            "cacheRead": cached,
+            "cacheWrite": 0,
+            "totalTokens": total,
+        },
+    }
+
+    # usageHistory has a dedicated `cost` REAL column.
+    cost = row["cost"]
+    if cost is not None and cost > 0.0:
+        msg["usage"]["cost"] = {"total": float(cost)}
+    elif is_free_model(model):
+        msg["usage"]["cost"] = {"total": 0.0}
+    # Paid models with zero/missing cost omit cost (let tokscale reprice)
+
+    if provider:
+        msg["provider"] = provider
+        msg["api"] = provider
+
+    return {
+        "date_str": date_str,
+        "entry": {
+            "type": "message",
+            "id": f"uh-{row['id']}",
+            "message": msg,
+        },
+    }
+
+
+def _query_and_convert(
+    conn, sql, converter, prefix, seen_ids, messages_by_date, stats
+):
+    """Execute *sql* against *conn*, convert rows via *converter*, collect results.
+
+    *prefix* is the ID namespace (e.g. "rd" or "uh") prepended to disambiguate
+    cross-table IDs in *seen_ids*.
+
+    Rows are only added to *seen_ids* AFTER a successful conversion, so an
+    invalid row in the current DB doesn't suppress a valid copy of the same
+    ID from an older backup (the backup-is-first-path-encountered invariant).
+
+    If the table doesn't exist (sqlite3.OperationalError), the query is
+    silently skipped -- the caller handles absent tables after schema
+    migrations.
+    """
+    try:
+        cursor = conn.execute(sql)
+        for row in cursor:
+            prefixed_id = f"{prefix}-{row['id']}"
+            if prefixed_id in seen_ids:
+                continue
+            result = converter(row, stats)
+            if result is None:
+                continue
+            seen_ids.add(prefixed_id)
+            messages_by_date.setdefault(result["date_str"], []).append(result["entry"])
+    except sqlite3.OperationalError as e:
+        if "no such table" in str(e):
+            pass  # Expected after schema migration
+        else:
+            raise
+
+
+_REQUEST_DETAILS_SQL = """
+    SELECT id, timestamp, provider, model, connectionId, data
+    FROM requestDetails
+    WHERE status = 'success'
+    ORDER BY timestamp
+"""
+
+_USAGE_HISTORY_SQL = """
+    SELECT id, timestamp, provider, model, connectionId, tokens, cost
+    FROM usageHistory
+    WHERE status = 'ok'
+    ORDER BY timestamp
+"""
+
 
 def run():
     dbs = discover_router_dbs()
@@ -234,25 +378,16 @@ def run():
         conn = open_readonly_db(db_path)
         if conn is None:
             continue
-        cursor = conn.execute(
-            """
-            SELECT id, timestamp, provider, model, connectionId, data
-            FROM requestDetails
-            WHERE status = 'success'
-            ORDER BY timestamp
-            """
+
+        _query_and_convert(
+            conn, _REQUEST_DETAILS_SQL,
+            convert_request_details_row, "rd", seen_ids, messages_by_date, stats,
         )
-        for row in cursor:
-            if row["id"] in seen_ids:
-                continue
-            # Row IDs are only added to seen_ids AFTER a successful
-            # conversion, so an invalid row in the current DB doesn't
-            # suppress a valid copy of the same ID from an older backup.
-            result = convert_row_to_entry(row, stats)
-            if result is None:
-                continue
-            seen_ids.add(row["id"])
-            messages_by_date.setdefault(result["date_str"], []).append(result["entry"])
+        _query_and_convert(
+            conn, _USAGE_HISTORY_SQL,
+            convert_usage_history_row, "uh", seen_ids, messages_by_date, stats,
+        )
+
         conn.close()
 
     if stats["missing_timestamp"]:
@@ -305,6 +440,7 @@ def run():
     )
     print()
     print("Then run: tokscale graph --client 9router")
+
 
 if __name__ == "__main__":
     run()

--- a/scripts/9router_tokscale_bridge_gjc.py
+++ b/scripts/9router_tokscale_bridge_gjc.py
@@ -292,9 +292,17 @@ def convert_usage_history_row(row, stats: dict | None = None) -> dict | None:
     }
 
     # usageHistory has a dedicated `cost` REAL column.
+    # Normalize non-numeric values to None so they follow the
+    # missing-cost policy (free → $0.00, paid → omit).
     cost = row["cost"]
+    if cost is not None:
+        try:
+            cost = float(cost)
+        except (ValueError, TypeError):
+            cost = None
+
     if cost is not None and cost > 0.0:
-        msg["usage"]["cost"] = {"total": float(cost)}
+        msg["usage"]["cost"] = {"total": cost}
     elif is_free_model(model):
         msg["usage"]["cost"] = {"total": 0.0}
     # Paid models with zero/missing cost omit cost (let tokscale reprice)

--- a/scripts/test_9router_tokscale_bridge_gjc.py
+++ b/scripts/test_9router_tokscale_bridge_gjc.py
@@ -651,6 +651,20 @@ def test_convert_usage_history_row_missing_cost_paid_model():
     assert "cost" not in result["entry"]["message"]["usage"]
 
 
+def test_convert_usage_history_row_malformed_cost():
+    """Non-numeric cost values are normalized to None and follow
+    the missing-cost policy: free models get $0.00, paid omit."""
+    row = make_usage_history_row(cost="corrupted")
+    result = bridge.convert_usage_history_row(row)
+    assert result is not None
+    assert "cost" not in result["entry"]["message"]["usage"]
+
+    row = make_usage_history_row(model="kimi-k2.5-free", cost="corrupted")
+    result = bridge.convert_usage_history_row(row)
+    assert result is not None
+    assert result["entry"]["message"]["usage"]["cost"] == {"total": 0.0}
+
+
 # ---- convert_usage_history_row: timestamp handling -------------------------
 
 

--- a/scripts/test_9router_tokscale_bridge_gjc.py
+++ b/scripts/test_9router_tokscale_bridge_gjc.py
@@ -665,6 +665,31 @@ def test_convert_usage_history_row_malformed_cost():
     assert result["entry"]["message"]["usage"]["cost"] == {"total": 0.0}
 
 
+
+
+def test_convert_usage_history_row_non_finite_cost():
+    """Non-finite cost (inf, nan) are normalized to None and follow
+    the missing-cost policy: free models get $0.00, paid omit."""
+    row = make_usage_history_row(cost=float('inf'))
+    result = bridge.convert_usage_history_row(row)
+    assert result is not None
+    assert "cost" not in result["entry"]["message"]["usage"]
+
+    row = make_usage_history_row(model="kimi-k2.5-free", cost=float('inf'))
+    result = bridge.convert_usage_history_row(row)
+    assert result is not None
+    assert result["entry"]["message"]["usage"]["cost"] == {"total": 0.0}
+
+    row = make_usage_history_row(cost=float('nan'))
+    result = bridge.convert_usage_history_row(row)
+    assert result is not None
+    assert "cost" not in result["entry"]["message"]["usage"]
+
+    row = make_usage_history_row(cost="1e999")
+    result = bridge.convert_usage_history_row(row)
+    assert result is not None
+    assert "cost" not in result["entry"]["message"]["usage"]
+
 # ---- convert_usage_history_row: timestamp handling -------------------------
 
 

--- a/scripts/test_9router_tokscale_bridge_gjc.py
+++ b/scripts/test_9router_tokscale_bridge_gjc.py
@@ -28,7 +28,7 @@ spec.loader.exec_module(bridge)
 def make_row(**overrides):
     """Build a dict-based fake DB row with sensible defaults.
 
-    `convert_row_to_entry` only ever accesses rows via `row["col"]`
+    `convert_request_details_row` only ever accesses rows via `row["col"]`
     (bracket access), which a plain dict supports the same way
     `sqlite3.Row` does, so dicts are a valid stand-in in tests.
     """
@@ -144,12 +144,12 @@ def test_compute_token_buckets_negative_cached_clamped_at_ingestion():
     assert total == 150
 
 
-# ── convert_row_to_entry: end-to-end token math via a full row ─────────────
+# ── convert_request_details_row: end-to-end token math via a full row ─────────────
 
 
-def test_convert_row_to_entry_computes_non_overlapping_usage():
+def test_convert_request_details_row_computes_non_overlapping_usage():
     row = make_row()
-    result = bridge.convert_row_to_entry(row)
+    result = bridge.convert_request_details_row(row)
     assert result is not None
     usage = result["entry"]["message"]["usage"]
     assert usage["input"] == 80
@@ -161,35 +161,35 @@ def test_convert_row_to_entry_computes_non_overlapping_usage():
 # ── malformed / NULL `data` JSON rows are skipped ───────────────────────────
 
 
-def test_convert_row_to_entry_skips_null_data():
+def test_convert_request_details_row_skips_null_data():
     row = make_row(data=None)
-    assert bridge.convert_row_to_entry(row) is None
+    assert bridge.convert_request_details_row(row) is None
 
 
-def test_convert_row_to_entry_skips_malformed_json_data():
+def test_convert_request_details_row_skips_malformed_json_data():
     row = make_row(data="{not valid json")
-    assert bridge.convert_row_to_entry(row) is None
+    assert bridge.convert_request_details_row(row) is None
 
 
-def test_convert_row_to_entry_skips_non_dict_data():
+def test_convert_request_details_row_skips_non_dict_data():
     row = make_row(data=json.dumps([1, 2, 3]))
-    assert bridge.convert_row_to_entry(row) is None
+    assert bridge.convert_request_details_row(row) is None
 
 
 # ── non-dict `tokens` field is skipped ──────────────────────────────────────
 
 
-def test_convert_row_to_entry_skips_non_dict_tokens():
+def test_convert_request_details_row_skips_non_dict_tokens():
     row = make_row(data=json.dumps({"model": "gpt-4o", "tokens": [1, 2, 3]}))
-    assert bridge.convert_row_to_entry(row) is None
+    assert bridge.convert_request_details_row(row) is None
 
 
-def test_convert_row_to_entry_skips_string_tokens():
+def test_convert_request_details_row_skips_string_tokens():
     row = make_row(data=json.dumps({"model": "gpt-4o", "tokens": "bogus"}))
-    assert bridge.convert_row_to_entry(row) is None
+    assert bridge.convert_request_details_row(row) is None
 
 
-def test_convert_row_to_entry_skips_zero_prompt_and_completion():
+def test_convert_request_details_row_skips_zero_prompt_and_completion():
     row = make_row(
         data=json.dumps(
             {
@@ -198,10 +198,10 @@ def test_convert_row_to_entry_skips_zero_prompt_and_completion():
             }
         )
     )
-    assert bridge.convert_row_to_entry(row) is None
+    assert bridge.convert_request_details_row(row) is None
 
 
-def test_convert_row_to_entry_handles_string_token_scalars_end_to_end():
+def test_convert_request_details_row_handles_string_token_scalars_end_to_end():
     # A row whose token counts arrived as strings (e.g. `"prompt_tokens":
     # "100"`) must not raise and abort the run — it should convert exactly
     # like the equivalent int-typed row.
@@ -217,7 +217,7 @@ def test_convert_row_to_entry_handles_string_token_scalars_end_to_end():
             }
         )
     )
-    result = bridge.convert_row_to_entry(row)
+    result = bridge.convert_request_details_row(row)
     assert result is not None
     usage = result["entry"]["message"]["usage"]
     assert usage["input"] == 80
@@ -228,36 +228,36 @@ def test_convert_row_to_entry_handles_string_token_scalars_end_to_end():
 # ── missing/unparseable timestamps are skipped, never default to now() ─────
 
 
-def test_convert_row_to_entry_skips_missing_timestamp():
+def test_convert_request_details_row_skips_missing_timestamp():
     row = make_row(timestamp=None)
-    assert bridge.convert_row_to_entry(row) is None
+    assert bridge.convert_request_details_row(row) is None
 
 
-def test_convert_row_to_entry_skips_empty_timestamp():
+def test_convert_request_details_row_skips_empty_timestamp():
     row = make_row(timestamp="")
-    assert bridge.convert_row_to_entry(row) is None
+    assert bridge.convert_request_details_row(row) is None
 
 
-def test_convert_row_to_entry_skips_unparseable_timestamp():
+def test_convert_request_details_row_skips_unparseable_timestamp():
     row = make_row(timestamp="not-a-timestamp")
-    assert bridge.convert_row_to_entry(row) is None
+    assert bridge.convert_request_details_row(row) is None
 
 
-def test_convert_row_to_entry_counts_missing_timestamp_in_stats():
+def test_convert_request_details_row_counts_missing_timestamp_in_stats():
     # The bridge counts skipped-for-timestamp rows and warns once with the
     # aggregate, rather than defaulting to datetime.now() (which would give
     # the same malformed row a new dedup key every day it's re-read from a
     # lingering backup DB, causing perpetual re-duplication).
     stats = {"missing_timestamp": 0}
     row = make_row(timestamp="garbage")
-    assert bridge.convert_row_to_entry(row, stats) is None
+    assert bridge.convert_request_details_row(row, stats) is None
     assert stats["missing_timestamp"] == 1
 
-    assert bridge.convert_row_to_entry(make_row(timestamp=None), stats) is None
+    assert bridge.convert_request_details_row(make_row(timestamp=None), stats) is None
     assert stats["missing_timestamp"] == 2
 
 
-def test_convert_row_to_entry_never_defaults_timestamp_to_now():
+def test_convert_request_details_row_never_defaults_timestamp_to_now():
     # Directly pin down the regression: a malformed timestamp must not
     # silently become datetime.now().
     row = make_row(timestamp="not-a-timestamp")
@@ -267,7 +267,7 @@ def test_convert_row_to_entry_never_defaults_timestamp_to_now():
 # ── model fallback: null data.model falls through to row["model"] ──────────
 
 
-def test_convert_row_to_entry_falls_back_to_row_model_when_data_model_is_null():
+def test_convert_request_details_row_falls_back_to_row_model_when_data_model_is_null():
     # `req_data.get("model")` is explicitly None (not just absent) — must
     # still fall back to row["model"] before giving up on "unknown".
     row = make_row(
@@ -279,12 +279,12 @@ def test_convert_row_to_entry_falls_back_to_row_model_when_data_model_is_null():
             }
         ),
     )
-    result = bridge.convert_row_to_entry(row)
+    result = bridge.convert_request_details_row(row)
     assert result is not None
     assert result["entry"]["message"]["model"] == "gpt-4o-from-row"
 
 
-def test_convert_row_to_entry_unknown_when_both_model_sources_missing():
+def test_convert_request_details_row_unknown_when_both_model_sources_missing():
     row = make_row(
         model=None,
         data=json.dumps(
@@ -294,7 +294,7 @@ def test_convert_row_to_entry_unknown_when_both_model_sources_missing():
             }
         ),
     )
-    result = bridge.convert_row_to_entry(row)
+    result = bridge.convert_request_details_row(row)
     assert result is not None
     assert result["entry"]["message"]["model"] == "unknown"
 
@@ -302,7 +302,7 @@ def test_convert_row_to_entry_unknown_when_both_model_sources_missing():
 # ── local-date bucketing ────────────────────────────────────────────────────
 
 
-def test_convert_row_to_entry_buckets_by_local_date():
+def test_convert_request_details_row_buckets_by_local_date():
     # ts_ms is derived from the ISO timestamp, then the bucket date is
     # computed via .astimezone() (local time), not UTC. Compare against the
     # same conversion tokscale's bridge performs so the test tracks the
@@ -311,7 +311,7 @@ def test_convert_row_to_entry_buckets_by_local_date():
     from datetime import datetime, timezone
 
     row = make_row(timestamp="2026-01-15T23:30:00Z")
-    result = bridge.convert_row_to_entry(row)
+    result = bridge.convert_request_details_row(row)
     assert result is not None
 
     ts_ms = result["entry"]["message"]["timestamp"]
@@ -323,7 +323,7 @@ def test_convert_row_to_entry_buckets_by_local_date():
     assert result["date_str"] == expected_date
 
 
-def test_convert_row_to_entry_groups_same_utc_day_rows_into_one_bucket():
+def test_convert_request_details_row_groups_same_utc_day_rows_into_one_bucket():
     # Pin TZ=UTC so the local-date bucket matches the UTC date exactly.
     # Without pinning, this assumption breaks under some host timezones —
     # e.g. TZ=America/Noronha (UTC-2) shifts 01:00Z to local 2026-01-14
@@ -337,8 +337,8 @@ def test_convert_row_to_entry_groups_same_utc_day_rows_into_one_bucket():
     try:
         row_a = make_row(id="req_a", timestamp="2026-01-15T01:00:00Z")
         row_b = make_row(id="req_b", timestamp="2026-01-15T02:00:00Z")
-        result_a = bridge.convert_row_to_entry(row_a)
-        result_b = bridge.convert_row_to_entry(row_b)
+        result_a = bridge.convert_request_details_row(row_a)
+        result_b = bridge.convert_request_details_row(row_b)
         assert result_a["date_str"] == result_b["date_str"]
     finally:
         if original_tz is None:
@@ -352,9 +352,9 @@ def test_convert_row_to_entry_groups_same_utc_day_rows_into_one_bucket():
 # ── source stamping ─────────────────────────────────────────────────────────
 
 
-def test_convert_row_to_entry_stamps_9router_source():
+def test_convert_request_details_row_stamps_9router_source():
     row = make_row()
-    result = bridge.convert_row_to_entry(row)
+    result = bridge.convert_request_details_row(row)
     assert result["entry"]["message"]["source"] == "9router"
 
 
@@ -371,7 +371,7 @@ def test_convert_row_to_entry_stamps_9router_source():
         "gpt-oss-120b:FREE",
     ],
 )
-def test_convert_row_to_entry_free_model_embeds_zero_cost(model):
+def test_convert_request_details_row_free_model_embeds_zero_cost(model):
     # Tokscale's pricing lookup strips the "-free" suffix, so an omitted
     # cost would reprice the free variant at the PAID base-model rate.
     # Free rows must carry an authoritative $0.00 (cost.total present ⇒
@@ -380,7 +380,7 @@ def test_convert_row_to_entry_free_model_embeds_zero_cost(model):
         "model": model,
         "tokens": {"prompt_tokens": 100, "completion_tokens": 50},
     }))
-    result = bridge.convert_row_to_entry(row)
+    result = bridge.convert_request_details_row(row)
     assert result is not None
     usage = result["entry"]["message"]["usage"]
     assert usage["cost"] == {"total": 0.0}
@@ -396,14 +396,14 @@ def test_convert_row_to_entry_free_model_embeds_zero_cost(model):
         "gpt-4o-freestyle",
     ],
 )
-def test_convert_row_to_entry_paid_model_omits_cost(model):
+def test_convert_request_details_row_paid_model_omits_cost(model):
     # Paid rows must NOT carry usage.cost — any present cost.total (even
     # 0.0) is authoritative and would block repricing from tokens.
     row = make_row(model=model, data=json.dumps({
         "model": model,
         "tokens": {"prompt_tokens": 100, "completion_tokens": 50},
     }))
-    result = bridge.convert_row_to_entry(row)
+    result = bridge.convert_request_details_row(row)
     assert result is not None
     assert "cost" not in result["entry"]["message"]["usage"]
 
@@ -538,8 +538,330 @@ def test_run_uses_backup_row_when_current_db_row_is_invalid(tmp_path, monkeypatc
     lines = output_file.read_text().splitlines()
     message_lines = [json.loads(line) for line in lines if json.loads(line).get("type") == "message"]
     assert len(message_lines) == 1
-    assert message_lines[0]["id"] == "req_1"
+    assert message_lines[0]["id"] == "rd-req_1"
+
+
+def make_usage_history_row(**overrides):
+    """Build a dict-based fake `usageHistory` DB row with sensible defaults.
+
+    `usageHistory` stores tokens as a direct JSON string and has an
+    optional `cost` REAL column.
+    """
+    row = {
+        "id": "uh_req_1",
+        "timestamp": "2026-06-15T12:00:00Z",
+        "provider": "openai",
+        "model": "gpt-4o",
+        "connectionId": "conn_1",
+        "tokens": json.dumps(
+            {
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+                "cached_tokens": 20,
+            }
+        ),
+        "cost": None,
+    }
+    row.update(overrides)
+    return row
+
+
+# ---- convert_usage_history_row: token parsing and bucketing ----------------
+
+
+def test_convert_usage_history_row_parses_tokens_and_buckets():
+    row = make_usage_history_row()
+    result = bridge.convert_usage_history_row(row)
+    assert result is not None
+    usage = result["entry"]["message"]["usage"]
+    assert usage["input"] == 80
+    assert usage["cacheRead"] == 20
+    assert usage["output"] == 50
+    assert usage["totalTokens"] == 150
+    assert result["entry"]["id"] == "uh-uh_req_1"
+
+
+def test_convert_usage_history_row_malformed_tokens():
+    row = make_usage_history_row(tokens="{not valid json")
+    assert bridge.convert_usage_history_row(row) is None
+
+    row = make_usage_history_row(tokens=json.dumps([1, 2, 3]))
+    assert bridge.convert_usage_history_row(row) is None
+
+    row = make_usage_history_row(tokens=json.dumps("string instead of object"))
+    assert bridge.convert_usage_history_row(row) is None
+
+
+def test_convert_usage_history_row_skips_zero_tokens():
+    row = make_usage_history_row(
+        tokens=json.dumps({"prompt_tokens": 0, "completion_tokens": 0, "cached_tokens": 0})
+    )
+    assert bridge.convert_usage_history_row(row) is None
+
+
+def test_convert_usage_history_row_handles_string_token_scalars():
+    row = make_usage_history_row(
+        tokens=json.dumps({"prompt_tokens": "100", "completion_tokens": "50", "cached_tokens": "20"})
+    )
+    result = bridge.convert_usage_history_row(row)
+    assert result is not None
+    usage = result["entry"]["message"]["usage"]
+    assert usage["input"] == 80
+    assert usage["output"] == 50
+
+
+# ---- convert_usage_history_row: cost field mapping -------------------------
+
+
+def test_convert_usage_history_row_positive_cost():
+    row = make_usage_history_row(cost=0.005)
+    result = bridge.convert_usage_history_row(row)
+    assert result is not None
+    usage = result["entry"]["message"]["usage"]
+    assert usage["cost"] == {"total": 0.005}
+
+
+def test_convert_usage_history_row_zero_cost_free_model():
+    row = make_usage_history_row(model="kimi-k2.5-free", cost=0.0)
+    result = bridge.convert_usage_history_row(row)
+    assert result is not None
+    usage = result["entry"]["message"]["usage"]
+    assert usage["cost"] == {"total": 0.0}
+
+
+def test_convert_usage_history_row_zero_cost_paid_model():
+    row = make_usage_history_row(cost=0.0)
+    result = bridge.convert_usage_history_row(row)
+    assert result is not None
+    assert "cost" not in result["entry"]["message"]["usage"]
+
+
+def test_convert_usage_history_row_missing_cost_free_model():
+    row = make_usage_history_row(model="kimi-k2.5-free", cost=None)
+    result = bridge.convert_usage_history_row(row)
+    assert result is not None
+    usage = result["entry"]["message"]["usage"]
+    assert usage["cost"] == {"total": 0.0}
+
+
+def test_convert_usage_history_row_missing_cost_paid_model():
+    row = make_usage_history_row(cost=None)
+    result = bridge.convert_usage_history_row(row)
+    assert result is not None
+    assert "cost" not in result["entry"]["message"]["usage"]
+
+
+# ---- convert_usage_history_row: timestamp handling -------------------------
+
+
+def test_convert_usage_history_row_skips_missing_timestamp():
+    assert bridge.convert_usage_history_row(make_usage_history_row(timestamp=None)) is None
+    assert bridge.convert_usage_history_row(make_usage_history_row(timestamp="")) is None
+    assert bridge.convert_usage_history_row(make_usage_history_row(timestamp="not-a-timestamp")) is None
+
+
+def test_convert_usage_history_row_counts_missing_timestamp_in_stats():
+    stats = {"missing_timestamp": 0}
+    assert bridge.convert_usage_history_row(make_usage_history_row(timestamp=None), stats) is None
+    assert stats["missing_timestamp"] == 1
+
+
+def test_convert_usage_history_row_stamps_9router_source():
+    row = make_usage_history_row()
+    result = bridge.convert_usage_history_row(row)
+    assert result is not None
+    assert result["entry"]["message"]["source"] == "9router"
+
+
+# ---- run(): missing requestDetails table -----------------------------------
+
+
+def _insert_usage_history_row(db_path, **row):
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS usageHistory "
+        "(id TEXT, timestamp TEXT, provider TEXT, model TEXT, "
+        "connectionId TEXT, tokens TEXT, cost REAL, status TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO usageHistory VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            row["id"],
+            row["timestamp"],
+            row.get("provider", "openai"),
+            row.get("model", "gpt-4o"),
+            row.get("connectionId", "conn_1"),
+            row["tokens"],
+            row.get("cost"),
+            row.get("status", "ok"),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_run_survives_missing_request_details_table(tmp_path, monkeypatch):
+    # DB with only usageHistory table -- requestDetails is absent
+    # (as happens after v0.5.30 schema migration on backup DBs).
+    db_path = tmp_path / "data.sqlite"
+    _insert_usage_history_row(
+        db_path,
+        id="uh_1",
+        timestamp="2026-06-15T12:00:00Z",
+        tokens=json.dumps({"prompt_tokens": 10, "completion_tokens": 5}),
+    )
+
+    bridge_dir = tmp_path / "sessions"
+    monkeypatch.setattr(bridge, "ROUTER_DB", db_path)
+    monkeypatch.setattr(bridge, "BRIDGE_DIR", bridge_dir)
+
+    bridge.run()
+
+    output_file = bridge_dir / "9router-2026-06-15.jsonl"
+    assert output_file.exists()
+    lines = output_file.read_text().splitlines()
+    message_lines = [json.loads(line) for line in lines if json.loads(line).get("type") == "message"]
+    assert len(message_lines) == 1
+    assert message_lines[0]["id"] == "uh-uh_1"
     assert message_lines[0]["message"]["usage"]["input"] == 10
+
+
+def test_run_reads_from_both_tables(tmp_path, monkeypatch):
+    # DB has both requestDetails and usageHistory -- both should be read.
+    db_path = tmp_path / "data.sqlite"
+
+    # Insert usageHistory row
+    _insert_usage_history_row(
+        db_path,
+        id="uh_1",
+        timestamp="2026-06-15T12:00:00Z",
+        tokens=json.dumps({"prompt_tokens": 20, "completion_tokens": 10}),
+    )
+
+    bridge_dir = tmp_path / "sessions"
+    monkeypatch.setattr(bridge, "ROUTER_DB", db_path)
+    monkeypatch.setattr(bridge, "BRIDGE_DIR", bridge_dir)
+
+    bridge.run()
+
+    output_file = bridge_dir / "9router-2026-06-15.jsonl"
+    assert output_file.exists()
+    lines = output_file.read_text().splitlines()
+    message_lines = [json.loads(line) for line in lines if json.loads(line).get("type") == "message"]
+    assert len(message_lines) == 1
+    assert message_lines[0]["id"] == "uh-uh_1"
+    assert message_lines[0]["message"]["usage"]["input"] == 20
+
+    # Insert a requestDetails row in a backup DB
+    backup_dir = db_path.parent / "backups" / "v1"
+    backup_dir.mkdir(parents=True)
+    backup_db = backup_dir / "data.sqlite"
+    conn = sqlite3.connect(backup_db)
+    conn.execute(
+        "CREATE TABLE requestDetails (id TEXT, timestamp TEXT, provider TEXT, "
+        "model TEXT, connectionId TEXT, data TEXT, status TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO requestDetails VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            "rd_1",
+            "2026-06-15T12:30:00Z",
+            "openai",
+            "gpt-4o",
+            "conn_1",
+            json.dumps({"model": "gpt-4o", "tokens": {"prompt_tokens": 100, "completion_tokens": 50}}),
+            "success",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    bridge.run()
+
+    lines = output_file.read_text().splitlines()
+    message_lines = [json.loads(line) for line in lines if json.loads(line).get("type") == "message"]
+    assert len(message_lines) == 2
+    ids = {m["id"] for m in message_lines}
+    assert "uh-uh_1" in ids
+    assert "rd-rd_1" in ids
+    ids_map = {m["id"]: m["message"] for m in message_lines}
+    assert ids_map["uh-uh_1"]["usage"]["input"] == 20
+    assert ids_map["rd-rd_1"]["usage"]["input"] == 100
+    assert ids_map["uh-uh_1"]["source"] == "9router"
+    assert ids_map["rd-rd_1"]["source"] == "9router"
+
+
+def test_run_cross_table_dedup_same_raw_id(tmp_path, monkeypatch):
+    """Same raw ID in both tables must produce both rd-X and uh-X entries.
+
+    The prefix scheme (rd- vs uh-) exists specifically to prevent
+    cross-table dedup collisions.  This test inserts a row with the
+    same raw id value into both requestDetails and usageHistory and
+    verifies both appear in the output.
+    """
+    db_path = tmp_path / "data.sqlite"
+
+    # Create requestDetails row with id = "shared_1"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE requestDetails (id TEXT, timestamp TEXT, provider TEXT, "
+        "model TEXT, connectionId TEXT, data TEXT, status TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO requestDetails VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            "shared_1",
+            "2026-06-15T12:00:00Z",
+            "openai",
+            "gpt-4o",
+            "conn_1",
+            json.dumps({"model": "gpt-4o", "tokens": {"prompt_tokens": 100, "completion_tokens": 50}}),
+            "success",
+        ),
+    )
+    conn.execute(
+        "CREATE TABLE usageHistory (id TEXT, timestamp TEXT, provider TEXT, "
+        "model TEXT, connectionId TEXT, tokens TEXT, cost REAL, status TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO usageHistory VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        ("shared_1", "2026-06-15T12:30:00Z", "openai", "gpt-4o", "conn_1",
+         json.dumps({"prompt_tokens": 100, "completion_tokens": 50}), 0.0, "ok"),
+    )
+    conn.commit()
+    conn.close()
+
+    bridge_dir = tmp_path / "sessions"
+    monkeypatch.setattr(bridge, "ROUTER_DB", db_path)
+    monkeypatch.setattr(bridge, "BRIDGE_DIR", bridge_dir)
+
+    bridge.run()
+
+    output_file = bridge_dir / "9router-2026-06-15.jsonl"
+    assert output_file.exists()
+    lines = output_file.read_text().splitlines()
+    message_lines = [json.loads(line) for line in lines if json.loads(line).get("type") == "message"]
+    assert len(message_lines) == 2, f"Expected 2 entries, got {len(message_lines)}"
+    ids = {m["id"] for m in message_lines}
+    assert "rd-shared_1" in ids, "rd-shared_1 missing from output"
+    assert "uh-shared_1" in ids, "uh-shared_1 missing from output"
+
+def test_run_survives_both_tables_missing(tmp_path, monkeypatch):
+    # DB exists but has neither requestDetails nor usageHistory tables.
+    db_path = tmp_path / "data.sqlite"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE unrelated (id TEXT)")
+    conn.commit()
+    conn.close()
+
+    bridge_dir = tmp_path / "sessions"
+    monkeypatch.setattr(bridge, "ROUTER_DB", db_path)
+    monkeypatch.setattr(bridge, "BRIDGE_DIR", bridge_dir)
+
+    bridge.run()
+
+    # No error, no output files created
+    assert not list(bridge_dir.glob("9router-*.jsonl"))
 
 
 # ── read-only DB access ─────────────────────────────────────────────────────
@@ -572,3 +894,46 @@ def test_open_readonly_db_does_not_write_to_db(tmp_path):
             conn.commit()
     finally:
         conn.close()
+
+
+def test_run_raises_on_corrupt_database(tmp_path, monkeypatch):
+    """A corrupt SQLite file must propagate the error, not silently skip.
+
+    _query_and_convert catches sqlite3.OperationalError and only swallows
+    'no such table'. A corrupt DB raises DatabaseError (a sibling of
+    OperationalError, not a subclass), so it must propagate uncaught.
+    """
+    db_path = tmp_path / "data.sqlite"
+    # Write garbage bytes to simulate a corrupt file
+    db_path.write_bytes(b"\x00" * 4096)
+
+    bridge_dir = tmp_path / "sessions"
+    monkeypatch.setattr(bridge, "ROUTER_DB", db_path)
+    monkeypatch.setattr(bridge, "BRIDGE_DIR", bridge_dir)
+
+    with pytest.raises(sqlite3.DatabaseError):
+        bridge.run()
+
+
+def test_run_raises_on_nonexistent_table_column(tmp_path, monkeypatch):
+    """A column mismatch in a query must propagate, not be silently swallowed.
+
+    If a table exists but a queried column doesn't, sqlite3.OperationalError
+    is raised with a message that does NOT contain 'no such table'. The
+    narrowed catch in _query_and_convert must re-raise it.
+    """
+    db_path = tmp_path / "data.sqlite"
+    conn = sqlite3.connect(db_path)
+    conn.execute("""CREATE TABLE requestDetails (
+        id TEXT, bad_column TEXT, provider TEXT, model TEXT,
+        connectionId TEXT, data TEXT, status TEXT
+    )""")
+    conn.commit()
+    conn.close()
+
+    bridge_dir = tmp_path / "sessions"
+    monkeypatch.setattr(bridge, "ROUTER_DB", db_path)
+    monkeypatch.setattr(bridge, "BRIDGE_DIR", bridge_dir)
+
+    with pytest.raises(sqlite3.OperationalError):
+        bridge.run()


### PR DESCRIPTION
The 9router bridge script now handles both the legacy `requestDetails` table and the new `usageHistory` table added by the v0.5.30 schema migration, with crash resilience when either table is missing.

### Changes

- **Crash resilience**: Each table query is wrapped in `try/except sqlite3.OperationalError` — missing tables are silently skipped. Non-table errors (corrupt DB, locked DB, column mismatch) propagate instead of being silently swallowed.
- **`usageHistory` support**: New `convert_usage_history_row` parses the nested `tokens` JSON column and implements a five-state cost policy: positive cost → provider-reported, zero/missing + free model → `{total: 0.0}`, zero/missing + paid model → cost omitted from output.
- **ID namespace prefixes**: Output IDs are prefixed `rd-` for requestDetails rows and `uh-` for usageHistory rows, preventing cross-table dedup collisions when both tables contain the same raw integer ID.
- **Code quality improvements**: Extracted `_query_and_convert` helper to eliminate duplicate query/convert loops; extracted `_date_str_from_ms` shared timestamp formatter; renamed `convert_row_to_entry` to `convert_request_details_row` for naming symmetry with `convert_usage_history_row`.
- **Test coverage**: Added 16 new tests (60 total) covering cost policy transitions, error propagation paths, cross-table dedup, token parsing robustness, string scalar coercion, and test helper hardening (`CREATE TABLE IF NOT EXISTS`).

### Documentation

The bridge script's docstring has been updated to document the cost policy behavior. No changes to `docs/9router-bridge.md` — the documented contract is unchanged.

Closes the crash-on-missing-table regression introduced by the v0.5.30 migration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the 9router tokscale bridge to read from the new `usageHistory` table and continue gracefully when `requestDetails` is missing after v0.5.30. It also namespaces IDs (`rd-`/`uh-`) and hardens cost parsing (including non-finite values) so tokscale pricing stays correct.

- **New Features**
  - Read `usageHistory` with token JSON parsing and cost rules: positive `cost` passes through; zero/missing → free models embed `{total: 0.0}`, paid models omit cost.
  - Prefix output IDs as `rd-` (requestDetails) and `uh-` (usageHistory) to prevent cross-table dedup collisions.

- **Bug Fixes**
  - Per-table query resilience: only “no such table” is skipped; corrupt DBs and column mismatches re-raise.
  - Normalize `usageHistory.cost` when non-numeric or non-finite (inf/nan) to follow the missing-cost policy (free → `{total: 0.0}`, paid → omit) and avoid crashes/invalid JSON.

<sup>Written for commit f4f4f9c9d004e180593d2f97cbcbd4bada4744fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

