### PR TITLE
fix(kimi): treat a blank KIMI_CODE_HOME as unset

### DIFF
--- a/crates/tokscale-cli/src/commands/usage/kimi.rs
+++ b/crates/tokscale-cli/src/commands/usage/kimi.rs
@@ -61,10 +61,16 @@ struct Membership {
 fn credentials_paths() -> Vec<std::path::PathBuf> {
     let mut paths = Vec::new();
 
-    // 1) kimi-code (supports KIMI_CODE_HOME override)
+    // 1) kimi-code (supports KIMI_CODE_HOME override). A blank export means
+    // unset, matching the scanner: `PathBuf::from("")` makes the credentials
+    // path the relative `credentials/kimi-code.json`, so Kimi drops out of the
+    // table while the CLI probes -- and would read tokens from -- whatever
+    // happens to sit under the current directory.
     let kimi_code_home = std::env::var("KIMI_CODE_HOME")
+        .ok()
+        .filter(|home| !home.trim().is_empty())
         .map(std::path::PathBuf::from)
-        .unwrap_or_else(|_| {
+        .unwrap_or_else(|| {
             dirs::home_dir()
                 .map(|h| h.join(".kimi-code"))
                 .unwrap_or_else(|| std::path::PathBuf::from("."))
@@ -297,4 +303,101 @@ pub fn fetch() -> Result<UsageOutput> {
             spend_control: None,
         })
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    /// Restores KIMI_CODE_HOME even if the test unwinds, so one failure cannot
+    /// leak an override into the rest of the suite.
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe {
+                std::env::remove_var(key);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    /// The kimi-code candidate, which `credentials_paths` always lists first.
+    fn kimi_code_candidate() -> std::path::PathBuf {
+        credentials_paths().into_iter().next().unwrap()
+    }
+
+    /// A blank KIMI_CODE_HOME -- how a shell exports an optional variable that
+    /// was never given a value -- means unset. Without this the candidate is
+    /// the relative `credentials/kimi-code.json`, so the real tokens are never
+    /// found and lookup follows the current directory instead.
+    ///
+    /// Compared against the genuinely-unset lookup rather than against a
+    /// rebuilt `<home>/.kimi-code`, so the assertion cannot drift along with
+    /// the fallback it is meant to pin.
+    #[test]
+    #[serial]
+    fn credentials_path_falls_back_when_kimi_code_home_is_blank() {
+        let unset = {
+            let _guard = EnvVarGuard::remove("KIMI_CODE_HOME");
+            kimi_code_candidate()
+        };
+        assert!(
+            unset.ends_with(".kimi-code/credentials/kimi-code.json"),
+            "unset lookup no longer defaults to ~/.kimi-code: {unset:?}"
+        );
+
+        for blank in ["", "   ", "\t\n"] {
+            let _guard = EnvVarGuard::set("KIMI_CODE_HOME", blank);
+
+            assert_eq!(
+                kimi_code_candidate(),
+                unset,
+                "KIMI_CODE_HOME={blank:?} must resolve exactly as if unset"
+            );
+        }
+    }
+
+    /// Only blank values are reinterpreted: a non-blank override is used
+    /// verbatim, surrounding whitespace included, because a directory may
+    /// legitimately carry it.
+    #[test]
+    #[serial]
+    fn credentials_path_honors_kimi_code_home_verbatim() {
+        for root in ["/custom/kimi-code", " /padded/kimi-code "] {
+            let _guard = EnvVarGuard::set("KIMI_CODE_HOME", root);
+
+            assert_eq!(
+                kimi_code_candidate(),
+                std::path::PathBuf::from(root)
+                    .join("credentials")
+                    .join("kimi-code.json"),
+                "KIMI_CODE_HOME={root:?} must be used as supplied"
+            );
+        }
+    }
 }

--- a/crates/tokscale-cli/src/commands/usage/kimi.rs
+++ b/crates/tokscale-cli/src/commands/usage/kimi.rs
@@ -366,10 +366,22 @@ mod tests {
             let _guard = EnvVarGuard::remove("KIMI_CODE_HOME");
             kimi_code_candidate()
         };
-        assert!(
-            unset.ends_with(".kimi-code/credentials/kimi-code.json"),
-            "unset lookup no longer defaults to ~/.kimi-code: {unset:?}"
-        );
+        // Pinning the baseline is what stops this test from passing if the
+        // fallback expression itself changes, but it only holds where a home
+        // directory resolves: with none, `credentials_paths` intentionally
+        // yields the relative `./credentials/kimi-code.json`. Asserting the
+        // `.kimi-code` shape unconditionally would fail on a machine with no
+        // HOME while the code under test behaved exactly as documented.
+        //
+        // The blank-equals-unset assertion below needs no such guard -- both
+        // sides take the same branch whichever it is, which is the property
+        // this test actually exists to prove.
+        if dirs::home_dir().is_some() {
+            assert!(
+                unset.ends_with(".kimi-code/credentials/kimi-code.json"),
+                "unset lookup no longer defaults to ~/.kimi-code: {unset:?}"
+            );
+        }
 
         for blank in ["", "   ", "\t\n"] {
             let _guard = EnvVarGuard::set("KIMI_CODE_HOME", blank);

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -1344,9 +1344,19 @@ fn scan_all_clients_with_env_strategy_inner(
             .resolve_path_with_env_strategy(home_dir, use_env_roots);
         push_unique_scan_task(&mut tasks, &mut seen_scan_roots, ClientId::Kimi, kimi_path);
 
-        // Kimi Code: ~/.kimi-code/sessions/**/wire.jsonl (supports KIMI_CODE_HOME)
+        // Kimi Code: ~/.kimi-code/sessions/**/wire.jsonl (supports KIMI_CODE_HOME).
+        // Blank exports are treated as unset — matching PathRoot::EnvVar — because
+        // joining "sessions" onto "" yields the root-level /sessions, which both
+        // hides the real sessions and points the walker at an unrelated directory.
+        // Non-blank values are passed through verbatim, leading/trailing space
+        // included, since a path may legitimately contain it.
         let kimi_code_home = if use_env_roots {
-            std::env::var("KIMI_CODE_HOME").unwrap_or_else(|_| format!("{}/.kimi-code", home_dir))
+            let configured = std::env::var("KIMI_CODE_HOME").unwrap_or_default();
+            if configured.trim().is_empty() {
+                format!("{}/.kimi-code", home_dir)
+            } else {
+                configured
+            }
         } else {
             format!("{}/.kimi-code", home_dir)
         };
@@ -2458,6 +2468,19 @@ mod tests {
         let mut file = File::create(kimi_session.join("wire.jsonl")).unwrap();
         file.write_all(b"{\"type\": \"metadata\", \"protocol_version\": \"1.3\"}\n")
             .unwrap();
+    }
+
+    /// Kimi Code lays sessions out as
+    /// `<root>/sessions/WORKSPACE/SESSION/agents/AGENT/wire.jsonl`, where
+    /// `<root>` is `~/.kimi-code` or whatever KIMI_CODE_HOME points at.
+    fn setup_mock_kimi_code_dir(root: &std::path::Path) -> PathBuf {
+        let agent_dir = root.join("sessions/workspace-1/session-uuid-1/agents/main");
+        fs::create_dir_all(&agent_dir).unwrap();
+        let wire = agent_dir.join("wire.jsonl");
+        let mut file = File::create(&wire).unwrap();
+        file.write_all(b"{\"type\": \"metadata\", \"protocol_version\": \"1.3\"}\n")
+            .unwrap();
+        wire
     }
 
     fn setup_mock_grok_dir(base: &std::path::Path) {
@@ -4301,6 +4324,87 @@ mod tests {
         assert!(result.get(ClientId::Kimi)[0].ends_with("wire.jsonl"));
         assert!(result.get(ClientId::OpenCode).is_empty());
         assert!(result.get(ClientId::Claude).is_empty());
+    }
+
+    /// An explicit KIMI_CODE_HOME moves Kimi Code discovery to that root.
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_kimi_code_home_override() {
+        let mut env = EnvGuard::capture(&["KIMI_CODE_HOME"]);
+        let dir = TempDir::new().unwrap();
+        let home = dir.path().join("home");
+        let custom_root = dir.path().join("custom-kimi-code");
+        let wire = setup_mock_kimi_code_dir(&custom_root);
+        env.set("KIMI_CODE_HOME", &custom_root);
+
+        let result = scan_without_extra_dirs(home.to_str().unwrap(), &["kimi".to_string()]);
+
+        assert_eq!(result.get(ClientId::Kimi), &vec![wire]);
+    }
+
+    /// Only *blank* values are reinterpreted. A non-blank value is used
+    /// verbatim, so a root whose name carries surrounding whitespace still
+    /// resolves — trimming the value here would silently miss it.
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_kimi_code_home_override_is_not_trimmed() {
+        let mut env = EnvGuard::capture(&["KIMI_CODE_HOME"]);
+        let dir = TempDir::new().unwrap();
+        let home = dir.path().join("home");
+        let padded_root = dir.path().join(" padded-kimi-code ");
+        let wire = setup_mock_kimi_code_dir(&padded_root);
+        env.set("KIMI_CODE_HOME", &padded_root);
+
+        let result = scan_without_extra_dirs(home.to_str().unwrap(), &["kimi".to_string()]);
+
+        assert_eq!(result.get(ClientId::Kimi), &vec![wire]);
+    }
+
+    /// A blank KIMI_CODE_HOME — empty or whitespace-only, which is how
+    /// shells export an optional variable that was never given a value — means
+    /// "unset". Without this, `format!("{}/sessions", "")` walks the
+    /// root-level `/sessions` and the user's real sessions go unreported.
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_kimi_code_home_blank_falls_back_to_home() {
+        for blank in ["", "   ", "\t\n"] {
+            let mut env = EnvGuard::capture(&["KIMI_CODE_HOME"]);
+            let dir = TempDir::new().unwrap();
+            let home = dir.path();
+            let wire = setup_mock_kimi_code_dir(&home.join(".kimi-code"));
+            env.set("KIMI_CODE_HOME", blank);
+
+            let result = scan_without_extra_dirs(home.to_str().unwrap(), &["kimi".to_string()]);
+
+            assert_eq!(
+                result.get(ClientId::Kimi),
+                &vec![wire],
+                "KIMI_CODE_HOME={:?} must fall back to <home>/.kimi-code",
+                blank
+            );
+        }
+    }
+
+    /// use_env_roots=false keeps `--home` authoritative: KIMI_CODE_HOME is
+    /// never consulted, blank or not.
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_kimi_code_home_ignored_without_env_roots() {
+        let mut env = EnvGuard::capture(&["KIMI_CODE_HOME"]);
+        let dir = TempDir::new().unwrap();
+        let home = dir.path().join("home");
+        let conflicting = dir.path().join("conflicting-kimi-code");
+        let wire = setup_mock_kimi_code_dir(&home.join(".kimi-code"));
+        setup_mock_kimi_code_dir(&conflicting);
+        env.set("KIMI_CODE_HOME", &conflicting);
+
+        let result = scan_all_clients_with_env_strategy(
+            home.to_str().unwrap(),
+            &["kimi".to_string()],
+            false,
+        );
+
+        assert_eq!(result.get(ClientId::Kimi), &vec![wire]);
     }
 
     #[test]


### PR DESCRIPTION
Closes #963.

## The bug

Kimi Code root discovery accepted any successful `KIMI_CODE_HOME` lookup, including an empty string. Joining `"sessions"` onto `""` produces `/sessions` rather than falling back to `<home>/.kimi-code`, so normal sessions are missed and the scanner walks an unrelated root-level directory. Whitespace-only values do the same.

Environments routinely export optional variables as empty strings, so this is a real state, not a contrived one.

Missing, empty, and whitespace-only now all read as unset. Every other value is preserved **verbatim**, including surrounding whitespace — a padded path is a path the user meant.

## A second site, found by review

`crates/tokscale-cli/src/commands/usage/kimi.rs:69` read the same variable with the identical unguarded shape. Confirmed by execution before touching it:

```
KIMI_CODE_HOME=""     ->  "credentials/kimi-code.json"        (relative!)
KIMI_CODE_HOME="   "  ->  "   /credentials/kimi-code.json"    (relative!)
```

Both readers are fixed. A repo-wide grep confirms those are the only two production readers of the variable.

Supporting evidence that this is the settled rule rather than a new convention: `usage/codex.rs:364` already guards `CODEX_HOME` with the same `trim().is_empty()` check. The Kimi lookup was the outlier.

## No `parser_version` bump, deliberately

This changes *discovery*, not parsed output. `message_cache` keys entries by `CacheKey { namespace, path }` per file, not per scan root, and no env-derived input enters the fingerprint — identical bytes still parse identically. Newly discovered files simply have no cache entry yet.

A bump would force every Kimi user — overwhelmingly people who never set the variable — into a full re-parse. Under #960 a re-parse re-buckets days under the current timezone, so that would move real users' visible numbers for zero benefit.

## Deliberately out of scope

Five other env-root lookups share the shape and are **not** touched, because a partial sweep is worse than none: `scanner.rs:1375` (`CODEX_HOME`), `scanner.rs:1272/1455/1806` (`XDG_DATA_HOME`), `clients.rs:18` (`PathRoot::XdgData`), `scanner.rs:207` (`TOKSCALE_HEADLESS_DIR`). They are listed in the commit's `Directive:` trailer so a follow-up has concrete targets.

## Verification

`cargo test -p tokscale-core --lib` 1280 passed; `cargo test -p tokscale-cli --bin tokscale` 969 passed; clippy `--all-targets` and fmt clean on **both** crates.

`--all-targets` on both specifically: the new CLI tests are `#[cfg(test)]` and the usual invocation would never have linted them.

Mutation-checked, three separate mutations each killed by a different assertion — including one that the first draft of the test would have survived, because it mirrored the production fallback expression instead of pinning the behaviour independently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Kimi Code discovery when `KIMI_CODE_HOME` is blank. Blank or whitespace values now act as unset to avoid scanning `/sessions` or using a CWD‑relative credentials path.

- **Bug Fixes**
  - Scanner: blank `KIMI_CODE_HOME` falls back to `~/.kimi-code`; non-blank values are used verbatim (whitespace preserved).
  - CLI usage: applies the same rule to credentials lookup to avoid `credentials/kimi-code.json` relative paths.
  - Tests hardened (guard baseline pin when no resolvable home dir); no `parser_version` bump; `use_env_roots=false` continues to ignore environment overrides.

<sup>Written for commit a1743c69ffa764100ecf6dbc1e0f1fd75f57ffa6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

