### PR TITLE
feat(moderation): hide suspect accounts from the leaderboard without deleting them

### DIFF
--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -13,6 +13,10 @@ DATABASE_URL=postgresql://user:password@localhost:5432/tokscale
 GITHUB_CLIENT_ID=your_github_client_id
 GITHUB_CLIENT_SECRET=your_github_client_secret
 
+# Required to enable the leaderboard moderation screen. Comma-separated GitHub
+# numeric account IDs. Leave unset to disable moderation access everywhere.
+# TOKSCALE_ADMIN_GITHUB_IDS=32605822
+
 # Public URL (used for OAuth redirects and CSRF origin checks)
 # For local development: http://localhost:3000
 # For production: https://your-domain.com

--- a/packages/frontend/__tests__/lib/authAdmin.test.ts
+++ b/packages/frontend/__tests__/lib/authAdmin.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { isAdmin, resolveAdminGithubIds } from "@/lib/auth/admin";
+import type { SessionUser } from "@/lib/auth/session";
+
+const JUNHOYEO_GITHUB_ID = 32605822;
+
+function session(overrides: Partial<SessionUser> = {}): SessionUser {
+  return {
+    id: "user-1",
+    username: "somebody",
+    displayName: null,
+    avatarUrl: null,
+    githubId: 999,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("resolveAdminGithubIds", () => {
+  it("defaults to the maintainer when the env var is unset", () => {
+    expect(resolveAdminGithubIds(undefined)).toEqual([JUNHOYEO_GITHUB_ID]);
+  });
+
+  it("parses a comma-separated list, tolerating whitespace", () => {
+    expect(resolveAdminGithubIds("1, 22 ,333")).toEqual([1, 22, 333]);
+  });
+
+  it("grants nobody access when the env var is set but empty", () => {
+    // Explicitly emptying the list must mean "no admins", not "fall back to
+    // the built-in default" — otherwise revoking access silently fails.
+    expect(resolveAdminGithubIds("")).toEqual([]);
+    expect(resolveAdminGithubIds("  ,  ")).toEqual([]);
+  });
+
+  it.each([
+    ["non-numeric", "12,abc"],
+    ["hex", "0x1f"],
+    ["exponent", "1e3"],
+    ["negative", "-5"],
+    ["decimal", "12.5"],
+  ])("rejects the whole list when an entry is %s", (_label, raw) => {
+    // Fails closed on the entire list rather than honouring the entries that
+    // happened to parse: a typo means we cannot tell who was meant to have
+    // access, so nobody does.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(resolveAdminGithubIds(raw)).toEqual([]);
+  });
+
+  it("rejects ids beyond the safe integer range", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(resolveAdminGithubIds("9007199254740993")).toEqual([]);
+  });
+
+  it("does not fall back to the default on malformed input", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(resolveAdminGithubIds("nonsense")).not.toContain(JUNHOYEO_GITHUB_ID);
+  });
+});
+
+describe("isAdmin", () => {
+  it("accepts the maintainer's GitHub id", () => {
+    expect(isAdmin(session({ githubId: JUNHOYEO_GITHUB_ID }))).toBe(true);
+  });
+
+  it("rejects a different GitHub id", () => {
+    expect(isAdmin(session({ githubId: 12345 }))).toBe(false);
+  });
+
+  it("rejects an absent session", () => {
+    expect(isAdmin(null)).toBe(false);
+    expect(isAdmin(undefined)).toBe(false);
+  });
+
+  it("rejects a personal-token session, which carries no GitHub id", () => {
+    // validateApiToken sets githubId to null, so CLI tokens can never moderate
+    // even if an admin route forgets allowAuthorizationHeader: false.
+    expect(isAdmin(session({ githubId: null }))).toBe(false);
+  });
+
+  it("does not authorize on username, only on GitHub id", () => {
+    // Usernames can be renamed and re-registered by someone else; the numeric
+    // id cannot. Matching the name must never be sufficient.
+    expect(isAdmin(session({ username: "junhoyeo", githubId: 404 }))).toBe(false);
+  });
+});

--- a/packages/frontend/__tests__/lib/authAdmin.test.ts
+++ b/packages/frontend/__tests__/lib/authAdmin.test.ts
@@ -3,8 +3,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { isAdmin, resolveAdminGithubIds } from "@/lib/auth/admin";
 import type { SessionUser } from "@/lib/auth/session";
 
-const JUNHOYEO_GITHUB_ID = 32605822;
-
 function session(overrides: Partial<SessionUser> = {}): SessionUser {
   return {
     id: "user-1",
@@ -21,8 +19,8 @@ afterEach(() => {
 });
 
 describe("resolveAdminGithubIds", () => {
-  it("defaults to the maintainer when the env var is unset", () => {
-    expect(resolveAdminGithubIds(undefined)).toEqual([JUNHOYEO_GITHUB_ID]);
+  it("grants nobody access when the env var is unset", () => {
+    expect(resolveAdminGithubIds(undefined)).toEqual([]);
   });
 
   it("parses a comma-separated list, tolerating whitespace", () => {
@@ -57,16 +55,23 @@ describe("resolveAdminGithubIds", () => {
     expect(resolveAdminGithubIds("9007199254740993")).toEqual([]);
   });
 
-  it("does not fall back to the default on malformed input", () => {
+  it("does not grant an arbitrary fallback on malformed input", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
 
-    expect(resolveAdminGithubIds("nonsense")).not.toContain(JUNHOYEO_GITHUB_ID);
+    expect(resolveAdminGithubIds("nonsense")).toEqual([]);
   });
 });
 
 describe("isAdmin", () => {
-  it("accepts the maintainer's GitHub id", () => {
-    expect(isAdmin(session({ githubId: JUNHOYEO_GITHUB_ID }))).toBe(true);
+  it("accepts an explicitly configured GitHub id", () => {
+    const env = process.env.TOKSCALE_ADMIN_GITHUB_IDS;
+    process.env.TOKSCALE_ADMIN_GITHUB_IDS = "32605822";
+    expect(isAdmin(session({ githubId: 32605822 }))).toBe(true);
+    if (env === undefined) {
+      delete process.env.TOKSCALE_ADMIN_GITHUB_IDS;
+    } else {
+      process.env.TOKSCALE_ADMIN_GITHUB_IDS = env;
+    }
   });
 
   it("rejects a different GitHub id", () => {

--- a/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
@@ -346,7 +346,10 @@ describe("group leaderboard data", () => {
 
     expect(mockState.or).toHaveBeenCalledTimes(2);
     expect(mockState.or.mock.calls.map((call) => call.length)).toEqual([2, 1]);
+    // The rankable-user predicate is ANDed ahead of the directive groups: a
+    // site-wide hide applies to group boards too.
     expect(mockState.and).toHaveBeenLastCalledWith(
+      expect.anything(),
       mockState.or.mock.results[0]?.value,
       mockState.or.mock.results[1]?.value
     );

--- a/packages/frontend/__tests__/lib/getLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboard.test.ts
@@ -202,6 +202,84 @@ describe("period leaderboard data", () => {
     },
   ];
 
+  it("drops hidden users from the rankings but keeps them in the totals", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-07T18:45:00Z"));
+    // carol outranks everyone on raw tokens but is hidden.
+    mockState.setPeriodRows([
+      ...rows,
+      {
+        userId: "user-carol",
+        username: "carol",
+        displayName: "Carol",
+        avatarUrl: null,
+        tokens: 9_000_000,
+        cost: 500,
+        leaderboardHidden: true,
+      },
+    ]);
+
+    const leaderboard = await getLeaderboardData("week", 1, 50, "tokens");
+
+    expect(leaderboard.users.map((user) => user.username)).toEqual(["bob", "alice"]);
+
+    // Dense ranks: bob takes 1st rather than 2nd. Leaving carol's position
+    // vacant would advertise that someone was removed.
+    expect(leaderboard.users.map((user) => user.rank)).toEqual([1, 2]);
+
+    // ...but the totals still count carol. Hiding withdraws an account from
+    // the competition; it does not retract the usage from the site figures.
+    expect(leaderboard.stats.totalTokens).toBe(9_001_250);
+    expect(leaderboard.stats.uniqueUsers).toBe(3);
+
+    // Pagination must track the rankable set, not the totals, or a trailing
+    // page renders empty.
+    expect(leaderboard.pagination.totalUsers).toBe(2);
+  });
+
+  it("reports no rank for a hidden user rather than a phantom position", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-07T18:45:00Z"));
+    mockState.setPeriodRows([
+      ...rows,
+      {
+        userId: "user-carol",
+        username: "carol",
+        displayName: "Carol",
+        avatarUrl: null,
+        tokens: 9_000_000,
+        cost: 500,
+        leaderboardHidden: true,
+      },
+    ]);
+
+    // A rank would not correspond to any row on the board she is absent from.
+    await expect(getUserRank("carol", "week", "tokens")).resolves.toBeNull();
+  });
+
+  it("does not let a hidden user above you inflate your own rank", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-07T18:45:00Z"));
+    mockState.setPeriodRows([
+      ...rows,
+      {
+        userId: "user-carol",
+        username: "carol",
+        displayName: "Carol",
+        avatarUrl: null,
+        tokens: 9_000_000,
+        cost: 500,
+        leaderboardHidden: true,
+      },
+    ]);
+
+    // bob is 2nd by raw tokens but 1st among rankable users.
+    await expect(getUserRank("bob", "week", "tokens")).resolves.toMatchObject({
+      username: "bob",
+      rank: 1,
+    });
+  });
+
   it("builds the week leaderboard from daily rows", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-07T18:45:00Z"));
@@ -253,6 +331,10 @@ describe("period leaderboard data", () => {
       "tokens",
       "cost",
       "sourceBreakdown",
+      // Selected, not filtered in SQL: the period totals are summed from these
+      // same rows and must still include hidden users, so the exclusion is
+      // applied after aggregation rather than in the WHERE clause.
+      "leaderboardHidden",
     ]);
   });
 
@@ -370,7 +452,10 @@ describe("all-time leaderboard directives", () => {
 
     expect(mockState.or).toHaveBeenCalledTimes(2);
     expect(mockState.or.mock.calls.map((call) => call.length)).toEqual([2, 1]);
+    // The rankable-user predicate is ANDed ahead of the directive groups, so
+    // a search can never surface a hidden user.
     expect(mockState.and).toHaveBeenCalledWith(
+      expect.anything(),
       mockState.or.mock.results[0]?.value,
       mockState.or.mock.results[1]?.value
     );

--- a/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
@@ -199,10 +199,19 @@ describe("all-time leaderboard queries", () => {
 
   it("counts distinct users for all-time pagination and global stats", async () => {
     mockState.pushAwaitedResult([]);
-    mockState.pushAwaitedResult([{ totalTokens: 0, totalCost: 0, uniqueUsers: 2 }]);
+    // Site-wide stats: every submitting user, hidden ones included.
+    mockState.pushAwaitedResult([{ totalTokens: 0, totalCost: 0, uniqueUsers: 3 }]);
+    // Pagination: only users the ranked query can actually return.
+    mockState.pushAwaitedResult([{ count: 2 }]);
 
     const list = await getLeaderboardData("all", 1, 50, "tokens");
+
+    // The two counts are deliberately different sources. Pagination must track
+    // the rankable set, or hiding a user leaves a trailing page that renders
+    // empty; stats must track everyone, because hiding withdraws someone from
+    // the competition without erasing their usage from the totals.
     expect(list.pagination.totalUsers).toBe(2);
+    expect(list.stats.uniqueUsers).toBe(3);
     expect(serializeSqlCalls().some((text) =>
       text.includes("COUNT(DISTINCT submissions.userId)")
     )).toBe(true);

--- a/packages/frontend/__tests__/lib/groupInvites.test.ts
+++ b/packages/frontend/__tests__/lib/groupInvites.test.ts
@@ -189,6 +189,7 @@ describe("group invites", () => {
       username: "alice",
       displayName: null,
       avatarUrl: null,
+      githubId: null,
     });
 
     expect(accepted).toEqual({
@@ -217,6 +218,7 @@ describe("group invites", () => {
         username: "bob",
         displayName: null,
         avatarUrl: null,
+        githubId: null,
       })
     ).rejects.toMatchObject({
       code: "not_found",

--- a/packages/frontend/__tests__/lib/groupInvitesDemotedInviter.test.ts
+++ b/packages/frontend/__tests__/lib/groupInvitesDemotedInviter.test.ts
@@ -206,6 +206,7 @@ describe("acceptGroupInvite — inviter role re-check", () => {
         username: "carol",
         displayName: null,
         avatarUrl: null,
+        githubId: null,
       })
     ).rejects.toMatchObject({
       code: "forbidden",
@@ -228,6 +229,7 @@ describe("acceptGroupInvite — inviter role re-check", () => {
         username: "carol",
         displayName: null,
         avatarUrl: null,
+        githubId: null,
       })
     ).rejects.toMatchObject({
       code: "forbidden",
@@ -250,6 +252,7 @@ describe("acceptGroupInvite — inviter role re-check", () => {
         username: "carol",
         displayName: null,
         avatarUrl: null,
+        githubId: null,
       })
     ).rejects.toMatchObject({
       code: "forbidden",
@@ -289,6 +292,7 @@ describe("acceptGroupInvite — inviter role re-check", () => {
       username: "carol",
       displayName: null,
       avatarUrl: null,
+      githubId: null,
     });
 
     expect(result).toEqual({

--- a/packages/frontend/__tests__/lib/moderationHeuristics.test.ts
+++ b/packages/frontend/__tests__/lib/moderationHeuristics.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  rankCandidates,
+  scoreCandidate,
+  type CandidateContext,
+  type CandidateRow,
+} from "@/lib/moderation/heuristics";
+
+/**
+ * The real site totals at the time this was written.
+ *
+ * These exceed Number.MAX_SAFE_INTEGER, so they are approximate as JS numbers
+ * — which is true of the production values too, since submissions.total_tokens
+ * is read in `number` mode. Harmless here: every signal is a ratio, and a few
+ * units of drift at 10^15 cannot move a threshold.
+ */
+const CONTEXT: CandidateContext = {
+  siteTokens: 9_078_199_482_735_296,
+  medianTokens: 1_000_000,
+};
+
+function row(overrides: Partial<CandidateRow> = {}): CandidateRow {
+  return {
+    userId: "user-1",
+    username: "normal",
+    avatarUrl: null,
+    leaderboardHidden: false,
+    totalTokens: 1_200_000,
+    totalCost: 12,
+    submitCount: 4,
+    hasBackfill: false,
+    dailyTokens: 1_200_000,
+    nearDuplicateCount: 0,
+    ...overrides,
+  };
+}
+
+function signalKeys(candidate: { signals: { key: string }[] }): string[] {
+  return candidate.signals.map((signal) => signal.key);
+}
+
+describe("scoreCandidate", () => {
+  it("flags nothing for an ordinary user", () => {
+    const scored = scoreCandidate(row(), CONTEXT);
+
+    expect(scored.signals).toEqual([]);
+    expect(scored.score).toBe(0);
+  });
+
+  it("flags an account holding most of the site's tokens", () => {
+    // The real rank-1 account: 99.4% of every token on the site.
+    const scored = scoreCandidate(
+      row({ username: "grenadeoftacoss", totalTokens: 9_025_906_844_219_236 }),
+      CONTEXT
+    );
+
+    expect(signalKeys(scored)).toContain("siteShare");
+    expect(scored.signals.find((s) => s.key === "siteShare")?.label).toContain("99.4%");
+  });
+
+  it("flags a token total that matches another account almost exactly", () => {
+    // Ranks 2 and 3 differed by exactly one token — one dataset, two accounts.
+    const scored = scoreCandidate(row({ nearDuplicateCount: 1 }), CONTEXT);
+
+    expect(signalKeys(scored)).toContain("duplicateTotal");
+    expect(scored.signals.find((s) => s.key === "duplicateTotal")?.label).toContain(
+      "matches another account"
+    );
+  });
+
+  it("attributes a daily-sum mismatch to our own inflation bug, not the user", () => {
+    const scored = scoreCandidate(
+      row({ totalTokens: 10_000_000, dailyTokens: 1_000_000 }),
+      CONTEXT
+    );
+
+    const label = scored.signals.find((s) => s.key === "dailyMismatch")?.label;
+    expect(label).toContain("#960");
+    expect(label).toContain("not necessarily the user");
+  });
+
+  it("does not flag a daily mismatch when there are no daily rows at all", () => {
+    // An older submission shape, not evidence of anything.
+    const scored = scoreCandidate(row({ dailyTokens: 0 }), CONTEXT);
+
+    expect(signalKeys(scored)).not.toContain("dailyMismatch");
+  });
+
+  it("flags an implied per-token price outside provider pricing", () => {
+    const tooExpensive = scoreCandidate(
+      row({ totalTokens: 1_000, totalCost: 500 }),
+      CONTEXT
+    );
+    const tooCheap = scoreCandidate(
+      row({ totalTokens: 1_000_000_000_000, totalCost: 1 }),
+      CONTEXT
+    );
+
+    expect(signalKeys(tooExpensive)).toContain("impliedRate");
+    expect(signalKeys(tooCheap)).toContain("impliedRate");
+  });
+
+  it("never divides by zero on an empty site or a zero-token user", () => {
+    const emptySite = scoreCandidate(row(), { siteTokens: 0, medianTokens: 0 });
+    const zeroUser = scoreCandidate(row({ totalTokens: 0, dailyTokens: 0 }), CONTEXT);
+
+    expect(Number.isFinite(emptySite.score)).toBe(true);
+    expect(Number.isFinite(zeroUser.score)).toBe(true);
+  });
+});
+
+describe("rankCandidates", () => {
+  it("orders the worst offender first", () => {
+    const ranked = rankCandidates(
+      [
+        row({ userId: "u1", username: "clean" }),
+        row({
+          userId: "u2",
+          username: "worst",
+          totalTokens: 9_025_906_844_219_236,
+          nearDuplicateCount: 1,
+        }),
+        row({ userId: "u3", username: "middling", nearDuplicateCount: 1 }),
+      ],
+      CONTEXT
+    );
+
+    expect(ranked.map((c) => c.username)).toEqual(["worst", "middling"]);
+  });
+
+  it("keeps already-hidden users in the queue so decisions stay reversible", () => {
+    // Nothing suspicious about them any more, but they must remain visible or
+    // a past hide becomes impossible to find and undo.
+    const ranked = rankCandidates(
+      [row({ userId: "u1", username: "previously-hidden", leaderboardHidden: true })],
+      CONTEXT
+    );
+
+    expect(ranked).toHaveLength(1);
+    expect(ranked[0].leaderboardHidden).toBe(true);
+    expect(ranked[0].signals).toEqual([]);
+  });
+
+  it("omits users with no signals and no prior decision", () => {
+    const ranked = rankCandidates([row({ username: "clean" })], CONTEXT);
+
+    expect(ranked).toEqual([]);
+  });
+
+  it("breaks score ties by username so the queue order is stable", () => {
+    const ranked = rankCandidates(
+      [
+        row({ userId: "u1", username: "zoe", nearDuplicateCount: 1 }),
+        row({ userId: "u2", username: "adam", nearDuplicateCount: 1 }),
+      ],
+      CONTEXT
+    );
+
+    expect(ranked.map((c) => c.username)).toEqual(["adam", "zoe"]);
+  });
+});

--- a/packages/frontend/__tests__/lib/session.test.ts
+++ b/packages/frontend/__tests__/lib/session.test.ts
@@ -237,6 +237,10 @@ describe("browser sessions", () => {
       username: "alice",
       displayName: "Alice",
       avatarUrl: null,
+      // Personal tokens carry no GitHub id. isAdmin() requires a numeric one,
+      // so a CLI token can never satisfy an admin check even if a route
+      // forgets to disable Authorization-header auth.
+      githubId: null,
     });
     expect(authenticatePersonalToken).toHaveBeenCalledWith("tt_personal_token");
   });

--- a/packages/frontend/src/app/admin/moderation/ModerationClient.tsx
+++ b/packages/frontend/src/app/admin/moderation/ModerationClient.tsx
@@ -25,23 +25,29 @@ export default function ModerationClient() {
   const [reasons, setReasons] = useState<Record<string, string>>({});
   const [pendingUser, setPendingUser] = useState<string | null>(null);
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (signal?: AbortSignal) => {
     setError(null);
     try {
-      const response = await fetch("/api/admin/moderation/candidates");
+      const response = await fetch("/api/admin/moderation/candidates", { signal });
       if (!response.ok) {
         throw new Error("Failed to load candidates");
       }
       const data = await response.json();
-      setCandidates(data.candidates ?? []);
+      if (!signal?.aborted) {
+        setCandidates(data.candidates ?? []);
+      }
     } catch {
-      setError("Could not load the review queue.");
-      setCandidates([]);
+      if (!signal?.aborted) {
+        setError("Could not load the review queue.");
+        setCandidates([]);
+      }
     }
   }, []);
 
   useEffect(() => {
-    void load();
+    const controller = new AbortController();
+    void load(controller.signal);
+    return () => controller.abort();
   }, [load]);
 
   async function applyAction(candidate: Candidate) {
@@ -137,6 +143,7 @@ export default function ModerationClient() {
 
                 <ActionRow>
                   <ReasonInput
+                    aria-label={`Reason for changing @${candidate.username}`}
                     value={reasons[candidate.username] ?? ""}
                     placeholder="Reason (recorded permanently)"
                     onChange={(event) =>

--- a/packages/frontend/src/app/admin/moderation/ModerationClient.tsx
+++ b/packages/frontend/src/app/admin/moderation/ModerationClient.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import styled from "styled-components";
+import { Navigation } from "@/components/layout/Navigation";
+import { ServiceFooter } from "@/components/layout/ServiceFooter";
+import { formatCompact } from "@/lib/format";
+import type { CandidateSignal } from "@/lib/moderation/heuristics";
+
+interface Candidate {
+  userId: string;
+  username: string;
+  leaderboardHidden: boolean;
+  totalTokens: number;
+  totalCost: number;
+  submitCount: number;
+  hasBackfill: boolean;
+  score: number;
+  signals: CandidateSignal[];
+}
+
+export default function ModerationClient() {
+  const [candidates, setCandidates] = useState<Candidate[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [reasons, setReasons] = useState<Record<string, string>>({});
+  const [pendingUser, setPendingUser] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const response = await fetch("/api/admin/moderation/candidates");
+      if (!response.ok) {
+        throw new Error("Failed to load candidates");
+      }
+      const data = await response.json();
+      setCandidates(data.candidates ?? []);
+    } catch {
+      setError("Could not load the review queue.");
+      setCandidates([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function applyAction(candidate: Candidate) {
+    const reason = (reasons[candidate.username] ?? "").trim();
+
+    // Enforced client-side as well as in the API so the reviewer is told what
+    // is missing before a round trip, not after a 400.
+    if (!reason) {
+      setError(`A reason is required before changing @${candidate.username}.`);
+      return;
+    }
+
+    setPendingUser(candidate.username);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        `/api/admin/moderation/${encodeURIComponent(candidate.username)}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            action: candidate.leaderboardHidden ? "unhide" : "hide",
+            reason,
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        const body = await response.json().catch(() => null);
+        throw new Error(body?.error ?? "Request failed");
+      }
+
+      setReasons((current) => ({ ...current, [candidate.username]: "" }));
+      await load();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Request failed");
+    } finally {
+      setPendingUser(null);
+    }
+  }
+
+  return (
+    <div className="service-page-shell">
+      <Navigation />
+      <main className="service-main" id="main-content">
+        <Title>Leaderboard moderation</Title>
+        <Intro>
+          Hiding removes an account from the rankings only. Their profile, badge
+          and embeds stay public, and their usage still counts toward site-wide
+          totals. Every change is reversible and recorded.
+        </Intro>
+        <Caveat>
+          A high score is a prompt to investigate, not a verdict. In particular,
+          a stored total far above the sum of daily rows is the signature of
+          ratchet inflation (#960) — our bug, not the user&apos;s.
+        </Caveat>
+
+        {error ? <ErrorText role="alert">{error}</ErrorText> : null}
+
+        {candidates === null ? (
+          <Muted>Loading…</Muted>
+        ) : candidates.length === 0 ? (
+          <Muted>Nothing flagged, and nobody currently hidden.</Muted>
+        ) : (
+          <List>
+            {candidates.map((candidate) => (
+              <Row key={candidate.userId} $hidden={candidate.leaderboardHidden}>
+                <RowHead>
+                  <Handle
+                    href={`/u/${candidate.username}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    @{candidate.username}
+                  </Handle>
+                  <Score>score {Math.round(candidate.score)}</Score>
+                  {candidate.leaderboardHidden ? <Badge>hidden</Badge> : null}
+                  {candidate.hasBackfill ? <Badge $muted>backfill</Badge> : null}
+                </RowHead>
+
+                <Stats>
+                  {formatCompact(candidate.totalTokens, "number")} tokens ·{" "}
+                  {formatCompact(candidate.totalCost, "currency")} ·{" "}
+                  {candidate.submitCount} submits
+                </Stats>
+
+                <Signals>
+                  {candidate.signals.map((signal) => (
+                    <li key={signal.key}>{signal.label}</li>
+                  ))}
+                </Signals>
+
+                <ActionRow>
+                  <ReasonInput
+                    value={reasons[candidate.username] ?? ""}
+                    placeholder="Reason (recorded permanently)"
+                    onChange={(event) =>
+                      setReasons((current) => ({
+                        ...current,
+                        [candidate.username]: event.target.value,
+                      }))
+                    }
+                  />
+                  <ActionButton
+                    type="button"
+                    $danger={!candidate.leaderboardHidden}
+                    disabled={pendingUser === candidate.username}
+                    onClick={() => void applyAction(candidate)}
+                  >
+                    {pendingUser === candidate.username
+                      ? "Working…"
+                      : candidate.leaderboardHidden
+                        ? "Unhide"
+                        : "Hide from rankings"}
+                  </ActionButton>
+                </ActionRow>
+              </Row>
+            ))}
+          </List>
+        )}
+      </main>
+      <ServiceFooter />
+    </div>
+  );
+}
+
+const Title = styled.h1`
+  margin: 0 0 8px;
+  font-size: 1.75rem;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+`;
+
+const Intro = styled.p`
+  max-width: 720px;
+  margin: 0 0 8px;
+  color: var(--service-text-muted);
+  font-size: 0.9375rem;
+  line-height: 1.65;
+`;
+
+const Caveat = styled(Intro)`
+  margin-bottom: 32px;
+  color: var(--service-text-muted);
+  font-style: italic;
+`;
+
+const Muted = styled.p`
+  color: var(--service-text-muted);
+  font-size: 0.9375rem;
+`;
+
+const ErrorText = styled.p`
+  margin: 0 0 16px;
+  color: #ff6b6b;
+  font-size: 0.875rem;
+`;
+
+const List = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+const Row = styled.div<{ $hidden: boolean }>`
+  padding: 20px;
+  border: 1px solid var(--service-border);
+  border-radius: 12px;
+  background: var(--service-surface);
+  opacity: ${({ $hidden }) => ($hidden ? 0.62 : 1)};
+`;
+
+const RowHead = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+`;
+
+const Handle = styled.a`
+  color: var(--service-text);
+  font-size: 1.0625rem;
+  font-weight: 600;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+const Score = styled.span`
+  color: var(--service-text-muted);
+  font-family: var(--font-mono), monospace;
+  font-size: 0.75rem;
+`;
+
+const Badge = styled.span<{ $muted?: boolean }>`
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: ${({ $muted }) =>
+    $muted ? "var(--service-surface-muted)" : "var(--service-accent-soft)"};
+  color: ${({ $muted }) => ($muted ? "var(--service-text-muted)" : "var(--service-accent)")};
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+`;
+
+const Stats = styled.p`
+  margin: 10px 0 0;
+  color: var(--service-text-muted);
+  font-size: 0.875rem;
+`;
+
+const Signals = styled.ul`
+  margin: 12px 0 0;
+  padding-left: 18px;
+
+  li {
+    color: var(--service-text-muted);
+    font-size: 0.875rem;
+    line-height: 1.6;
+  }
+`;
+
+const ActionRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 16px;
+`;
+
+const ReasonInput = styled.input`
+  flex: 1;
+  min-width: 240px;
+  padding: 9px 12px;
+  border: 1px solid var(--service-border);
+  border-radius: 8px;
+  background: var(--service-canvas);
+  color: var(--service-text);
+  font-size: 0.875rem;
+
+  &:focus-visible {
+    outline: 2px solid var(--service-focus);
+    outline-offset: 1px;
+  }
+`;
+
+const ActionButton = styled.button<{ $danger: boolean }>`
+  padding: 9px 16px;
+  border: 1px solid
+    ${({ $danger }) => ($danger ? "rgba(255, 107, 107, 0.5)" : "var(--service-border-strong)")};
+  border-radius: 8px;
+  background: transparent;
+  color: ${({ $danger }) => ($danger ? "#ff6b6b" : "var(--service-text)")};
+  font-size: 0.875rem;
+  font-weight: 550;
+  cursor: pointer;
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+`;

--- a/packages/frontend/src/app/admin/moderation/page.tsx
+++ b/packages/frontend/src/app/admin/moderation/page.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
  * notFound() rather than a 403 — a forbidden response confirms the page exists.
  */
 export default async function ModerationPage() {
-  const session = await getSession().catch(() => null);
+  const session = await getSession();
 
   if (!isAdmin(session)) {
     notFound();

--- a/packages/frontend/src/app/admin/moderation/page.tsx
+++ b/packages/frontend/src/app/admin/moderation/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { isAdmin } from "@/lib/auth/admin";
+import { getSession } from "@/lib/auth/session";
+import ModerationClient from "./ModerationClient";
+
+// Never indexable, and not something a non-admin should be able to detect.
+export const metadata: Metadata = {
+  title: "Moderation | Tokscale",
+  robots: { index: false, follow: false },
+};
+
+/**
+ * Gated here rather than in middleware: src/middleware.ts deliberately makes no
+ * database call, so it cannot resolve who the session belongs to.
+ *
+ * notFound() rather than a 403 — a forbidden response confirms the page exists.
+ */
+export default async function ModerationPage() {
+  const session = await getSession().catch(() => null);
+
+  if (!isAdmin(session)) {
+    notFound();
+  }
+
+  return <ModerationClient />;
+}

--- a/packages/frontend/src/app/api/admin/moderation/[username]/route.ts
+++ b/packages/frontend/src/app/api/admin/moderation/[username]/route.ts
@@ -77,6 +77,7 @@ export async function POST(request: Request, { params }: RouteParams) {
     const result = await applyModerationAction({
       target,
       actorUserId: auth.session.id,
+      actorUsername: auth.session.username,
       action: parsed.data.action,
       reason: parsed.data.reason,
     });

--- a/packages/frontend/src/app/api/admin/moderation/[username]/route.ts
+++ b/packages/frontend/src/app/api/admin/moderation/[username]/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { MODERATION_ACTION_TYPES } from "@/lib/db/schema";
+import {
+  applyModerationAction,
+  findModerationTarget,
+  getModerationHistory,
+} from "@/lib/moderation/actions";
+import { requireAdminSession } from "@/lib/moderation/guard";
+
+interface RouteParams {
+  params: Promise<{ username: string }>;
+}
+
+const ActionSchema = z.object({
+  action: z.enum(MODERATION_ACTION_TYPES),
+  // Required, not optional: an unexplained hide is indefensible six months
+  // later, and this text is the only record of why the call was made.
+  reason: z.string().trim().min(1, "A reason is required").max(500),
+});
+
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const auth = await requireAdminSession(request);
+    if ("response" in auth) {
+      return auth.response;
+    }
+
+    const { username } = await params;
+    const target = await findModerationTarget(username);
+
+    if (!target) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      user: {
+        username: target.username,
+        leaderboardHidden: target.leaderboardHidden,
+      },
+      history: await getModerationHistory(target.id),
+    });
+  } catch (error) {
+    console.error("Moderation history error:", error);
+    return NextResponse.json(
+      { error: "Failed to load moderation history" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const auth = await requireAdminSession(request);
+    if ("response" in auth) {
+      return auth.response;
+    }
+
+    const { username } = await params;
+
+    const body = await request.json().catch(() => null);
+    const parsed = ActionSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message ?? "Invalid request" },
+        { status: 400 }
+      );
+    }
+
+    const target = await findModerationTarget(username);
+
+    if (!target) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const result = await applyModerationAction({
+      target,
+      actorUserId: auth.session.id,
+      action: parsed.data.action,
+      reason: parsed.data.reason,
+    });
+
+    return NextResponse.json({
+      username: target.username,
+      leaderboardHidden: result.leaderboardHidden,
+      // Distinguishes a real state change from a no-op re-submit, so the UI
+      // can avoid claiming it did something it did not.
+      changed: result.changed,
+    });
+  } catch (error) {
+    console.error("Moderation action error:", error);
+    return NextResponse.json(
+      { error: "Failed to apply moderation action" },
+      { status: 500 }
+    );
+  }
+}

--- a/packages/frontend/src/app/api/admin/moderation/candidates/route.ts
+++ b/packages/frontend/src/app/api/admin/moderation/candidates/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { getModerationCandidates } from "@/lib/moderation/candidates";
+import { requireAdminSession } from "@/lib/moderation/guard";
+
+export async function GET(request: Request) {
+  try {
+    const auth = await requireAdminSession(request);
+    if ("response" in auth) {
+      return auth.response;
+    }
+
+    const candidates = await getModerationCandidates();
+
+    return NextResponse.json({ candidates });
+  } catch (error) {
+    console.error("Moderation candidates error:", error);
+    return NextResponse.json(
+      { error: "Failed to load moderation candidates" },
+      { status: 500 }
+    );
+  }
+}

--- a/packages/frontend/src/app/robots.ts
+++ b/packages/frontend/src/app/robots.ts
@@ -11,6 +11,7 @@ export default function robots(): MetadataRoute.Robots {
       // tokens and must never reach an index.
       disallow: [
         "/api/",
+        "/admin",
         "/settings",
         "/profile",
         "/device",

--- a/packages/frontend/src/lib/auth/admin.ts
+++ b/packages/frontend/src/lib/auth/admin.ts
@@ -1,0 +1,80 @@
+import type { SessionUser } from "./session";
+
+/**
+ * Site-wide moderator identity.
+ *
+ * Keyed on GitHub's numeric account id rather than the username: usernames can
+ * be renamed, and a released username can be claimed by someone else, so
+ * authorizing against one would be a standing account-takeover risk.
+ *
+ * 32605822 is @junhoyeo. The env var exists so additional moderators can be
+ * added without a code change; it replaces the default rather than extending
+ * it, so setting it to an empty value leaves nobody with access.
+ */
+const DEFAULT_ADMIN_GITHUB_IDS = [32605822];
+
+const ENV_VAR = "TOKSCALE_ADMIN_GITHUB_IDS";
+
+/**
+ * Parses the allowlist, failing closed.
+ *
+ * A malformed entry means the operator intended to grant access to someone and
+ * we cannot tell who, so the whole list is rejected rather than silently
+ * honouring the entries that happened to parse. Returning the built-in default
+ * on malformed input would be worse still: a typo would quietly restore
+ * single-admin access that the operator believed they had changed.
+ */
+export function resolveAdminGithubIds(
+  rawValue: string | undefined = process.env[ENV_VAR]
+): number[] {
+  if (rawValue === undefined) {
+    return DEFAULT_ADMIN_GITHUB_IDS;
+  }
+
+  const entries = rawValue
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+  if (entries.length === 0) {
+    return [];
+  }
+
+  const ids: number[] = [];
+
+  for (const entry of entries) {
+    // Number() would accept "0x1f", " 12 " and "1e3"; GitHub ids are plain
+    // positive integers and anything else is a mistake worth refusing.
+    if (!/^\d+$/.test(entry)) {
+      console.error(`[admin] ${ENV_VAR} contains a non-numeric entry; denying all admin access`);
+      return [];
+    }
+
+    const id = Number(entry);
+
+    if (!Number.isSafeInteger(id) || id <= 0) {
+      console.error(`[admin] ${ENV_VAR} contains an out-of-range entry; denying all admin access`);
+      return [];
+    }
+
+    ids.push(id);
+  }
+
+  return ids;
+}
+
+/**
+ * Whether this session may take moderation actions.
+ *
+ * Personal API tokens carry no githubId, so they can never satisfy this — admin
+ * actions are web-session only. Pass `allowAuthorizationHeader: false` to
+ * getSessionFromRequest on admin routes so token auth is rejected outright
+ * rather than reaching here and failing with a confusing 404.
+ */
+export function isAdmin(session: SessionUser | null | undefined): boolean {
+  if (!session || typeof session.githubId !== "number") {
+    return false;
+  }
+
+  return resolveAdminGithubIds().includes(session.githubId);
+}

--- a/packages/frontend/src/lib/auth/admin.ts
+++ b/packages/frontend/src/lib/auth/admin.ts
@@ -7,12 +7,10 @@ import type { SessionUser } from "./session";
  * be renamed, and a released username can be claimed by someone else, so
  * authorizing against one would be a standing account-takeover risk.
  *
- * 32605822 is @junhoyeo. The env var exists so additional moderators can be
- * added without a code change; it replaces the default rather than extending
- * it, so setting it to an empty value leaves nobody with access.
+ * The deployment operator must configure the allowlist explicitly. A default
+ * would accidentally grant a project maintainer moderator access on every
+ * self-hosted deployment that enables GitHub OAuth.
  */
-const DEFAULT_ADMIN_GITHUB_IDS = [32605822];
-
 const ENV_VAR = "TOKSCALE_ADMIN_GITHUB_IDS";
 
 /**
@@ -20,15 +18,14 @@ const ENV_VAR = "TOKSCALE_ADMIN_GITHUB_IDS";
  *
  * A malformed entry means the operator intended to grant access to someone and
  * we cannot tell who, so the whole list is rejected rather than silently
- * honouring the entries that happened to parse. Returning the built-in default
- * on malformed input would be worse still: a typo would quietly restore
- * single-admin access that the operator believed they had changed.
+ * honouring the entries that happened to parse. An operator must correct a
+ * malformed list before anyone can regain moderation access.
  */
 export function resolveAdminGithubIds(
   rawValue: string | undefined = process.env[ENV_VAR]
 ): number[] {
   if (rawValue === undefined) {
-    return DEFAULT_ADMIN_GITHUB_IDS;
+    return [];
   }
 
   const entries = rawValue

--- a/packages/frontend/src/lib/auth/session.ts
+++ b/packages/frontend/src/lib/auth/session.ts
@@ -12,6 +12,16 @@ export interface SessionUser {
   username: string;
   displayName: string | null;
   avatarUrl: string | null;
+  /**
+   * GitHub's immutable numeric account id, used for admin gating — usernames
+   * can be renamed and released, so they are not a safe identity to authorize
+   * against.
+   *
+   * Null for sessions established with a personal API token, which does not
+   * carry it. That is deliberate: it makes admin checks fail closed for token
+   * auth rather than depending on every admin route remembering to opt out.
+   */
+  githubId: number | null;
 }
 
 /**
@@ -51,6 +61,7 @@ export async function getSession(): Promise<SessionUser | null> {
     username: user.username,
     displayName: user.displayName,
     avatarUrl: user.avatarUrl,
+    githubId: user.githubId,
   };
 }
 
@@ -123,6 +134,10 @@ export async function validateApiToken(
     username: result.username,
     displayName: result.displayName,
     avatarUrl: result.avatarUrl,
+    // authenticatePersonalToken does not select github_id. Left null rather
+    // than widening that query: admin actions should not be reachable with a
+    // long-lived CLI token in the first place.
+    githubId: null,
   };
 }
 

--- a/packages/frontend/src/lib/db/migrations/0020_mighty_whiplash.sql
+++ b/packages/frontend/src/lib/db/migrations/0020_mighty_whiplash.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "moderation_actions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"target_user_id" uuid NOT NULL,
+	"actor_user_id" uuid NOT NULL,
+	"action" varchar(10) NOT NULL,
+	"reason" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "leaderboard_hidden" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "moderation_actions" ADD CONSTRAINT "moderation_actions_target_user_id_users_id_fk" FOREIGN KEY ("target_user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "moderation_actions" ADD CONSTRAINT "moderation_actions_actor_user_id_users_id_fk" FOREIGN KEY ("actor_user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_moderation_actions_target_created" ON "moderation_actions" USING btree ("target_user_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_moderation_actions_actor" ON "moderation_actions" USING btree ("actor_user_id");

--- a/packages/frontend/src/lib/db/migrations/0021_lethal_killraven.sql
+++ b/packages/frontend/src/lib/db/migrations/0021_lethal_killraven.sql
@@ -1,0 +1,20 @@
+ALTER TABLE "moderation_actions" DROP CONSTRAINT "moderation_actions_target_user_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "moderation_actions" DROP CONSTRAINT "moderation_actions_actor_user_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "moderation_actions" ALTER COLUMN "target_user_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "moderation_actions" ALTER COLUMN "actor_user_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "moderation_actions" ADD COLUMN "target_username" varchar(39);--> statement-breakpoint
+ALTER TABLE "moderation_actions" ADD COLUMN "actor_username" varchar(39);--> statement-breakpoint
+UPDATE "moderation_actions" AS action
+SET "target_username" = users."username"
+FROM "users"
+WHERE action."target_user_id" = users."id";--> statement-breakpoint
+UPDATE "moderation_actions" AS action
+SET "actor_username" = users."username"
+FROM "users"
+WHERE action."actor_user_id" = users."id";--> statement-breakpoint
+ALTER TABLE "moderation_actions" ALTER COLUMN "target_username" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "moderation_actions" ALTER COLUMN "actor_username" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "moderation_actions" ADD CONSTRAINT "moderation_actions_target_user_id_users_id_fk" FOREIGN KEY ("target_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "moderation_actions" ADD CONSTRAINT "moderation_actions_actor_user_id_users_id_fk" FOREIGN KEY ("actor_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;

--- a/packages/frontend/src/lib/db/migrations/meta/0020_snapshot.json
+++ b/packages/frontend/src/lib/db/migrations/meta/0020_snapshot.json
@@ -1,0 +1,1677 @@
+{
+  "id": "8a7feb1e-91d9-44ea-8204-d5880b4c40a7",
+  "prevId": "b0a6f8ac-2031-4385-965e-3979cf3d093c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_api_tokens_token": {
+          "name": "idx_api_tokens_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_tokens_user_id": {
+          "name": "idx_api_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_unique": {
+          "name": "api_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        },
+        "api_tokens_user_name_unique": {
+          "name": "api_tokens_user_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_breakdown": {
+      "name": "daily_breakdown",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(14, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_breakdown": {
+          "name": "source_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_time_ms": {
+          "name": "active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_daily_breakdown_submission_id": {
+          "name": "idx_daily_breakdown_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_submitted_device_id": {
+          "name": "idx_daily_breakdown_submitted_device_id",
+          "columns": [
+            {
+              "expression": "submitted_device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_date": {
+          "name": "idx_daily_breakdown_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_breakdown_submission_id_submissions_id_fk": {
+          "name": "daily_breakdown_submission_id_submissions_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_breakdown_submitted_device_id_submitted_devices_id_fk": {
+          "name": "daily_breakdown_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_breakdown_submission_device_date_unique": {
+          "name": "daily_breakdown_submission_device_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "submission_id",
+            "submitted_device_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_codes_device_code": {
+          "name": "idx_device_codes_device_code",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_code": {
+          "name": "idx_device_codes_user_code",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_id": {
+          "name": "idx_device_codes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_expires_at": {
+          "name": "idx_device_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_codes_user_id_users_id_fk": {
+          "name": "device_codes_user_id_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_invites": {
+      "name": "group_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_username": {
+          "name": "invited_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_username_normalized": {
+          "name": "invited_username_normalized",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_user_id": {
+          "name": "invited_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_group_invites_group_status": {
+          "name": "idx_group_invites_group_status",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_user_status": {
+          "name": "idx_group_invites_invited_user_status",
+          "columns": [
+            {
+              "expression": "invited_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_username_status": {
+          "name": "idx_group_invites_invited_username_status",
+          "columns": [
+            {
+              "expression": "invited_username_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_expires_at": {
+          "name": "idx_group_invites_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_by": {
+          "name": "idx_group_invites_invited_by",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_invites_group_id_groups_id_fk": {
+          "name": "group_invites_group_id_groups_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_invites_invited_user_id_users_id_fk": {
+          "name": "group_invites_invited_user_id_users_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_invites_invited_by_users_id_fk": {
+          "name": "group_invites_invited_by_users_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_invites_token_hash_unique": {
+          "name": "group_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_members": {
+      "name": "group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_group_members_user_id": {
+          "name": "idx_group_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_members_invited_by": {
+          "name": "idx_group_members_invited_by",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_members_group_id_groups_id_fk": {
+          "name": "group_members_group_id_groups_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_members_user_id_users_id_fk": {
+          "name": "group_members_user_id_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_members_invited_by_users_id_fk": {
+          "name": "group_members_invited_by_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_members_group_user_unique": {
+          "name": "group_members_group_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_created_by": {
+          "name": "idx_groups_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_groups_visibility_updated": {
+          "name": "idx_groups_visibility_updated",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_created_by_users_id_fk": {
+          "name": "groups_created_by_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_slug_unique": {
+          "name": "groups_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moderation_actions": {
+      "name": "moderation_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_moderation_actions_target_created": {
+          "name": "idx_moderation_actions_target_created",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_moderation_actions_actor": {
+          "name": "idx_moderation_actions_actor",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moderation_actions_target_user_id_users_id_fk": {
+          "name": "moderation_actions_target_user_id_users_id_fk",
+          "tableFrom": "moderation_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "moderation_actions_actor_user_id_users_id_fk": {
+          "name": "moderation_actions_actor_user_id_users_id_fk",
+          "tableFrom": "moderation_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_token_hash": {
+          "name": "idx_sessions_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sources_used": {
+          "name": "sources_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "models_used": {
+          "name": "models_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_version": {
+          "name": "cli_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_hash": {
+          "name": "submission_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submit_count": {
+          "name": "submit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_backfill": {
+          "name": "has_backfill",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_active_time_ms": {
+          "name": "total_active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longest_continuous_ms": {
+          "name": "longest_continuous_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_sessions": {
+          "name": "max_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_servers": {
+          "name": "mcp_servers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_submissions_created_at": {
+          "name": "idx_submissions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_leaderboard": {
+          "name": "idx_submissions_leaderboard",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_tokens",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_cost",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submissions_user_id_unique": {
+          "name": "submissions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submitted_devices": {
+      "name": "submitted_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_key": {
+          "name": "device_key",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_active_time_ms": {
+          "name": "total_active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longest_continuous_ms": {
+          "name": "longest_continuous_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_sessions": {
+          "name": "max_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_submitted_devices_user_id": {
+          "name": "idx_submitted_devices_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submitted_devices_user_id_users_id_fk": {
+          "name": "submitted_devices_user_id_users_id_fk",
+          "tableFrom": "submitted_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submitted_devices_user_device_key_unique": {
+          "name": "submitted_devices_user_device_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leaderboard_hidden": {
+          "name": "leaderboard_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_lower_unique": {
+          "name": "users_username_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_github_id": {
+          "name": "idx_users_github_id",
+          "columns": [
+            {
+              "expression": "github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/frontend/src/lib/db/migrations/meta/0021_snapshot.json
+++ b/packages/frontend/src/lib/db/migrations/meta/0021_snapshot.json
@@ -1,0 +1,1689 @@
+{
+  "id": "1ef815ae-b094-4611-821e-7d005744aaba",
+  "prevId": "8a7feb1e-91d9-44ea-8204-d5880b4c40a7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_api_tokens_token": {
+          "name": "idx_api_tokens_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_tokens_user_id": {
+          "name": "idx_api_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_unique": {
+          "name": "api_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        },
+        "api_tokens_user_name_unique": {
+          "name": "api_tokens_user_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_breakdown": {
+      "name": "daily_breakdown",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(14, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_breakdown": {
+          "name": "source_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_time_ms": {
+          "name": "active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_daily_breakdown_submission_id": {
+          "name": "idx_daily_breakdown_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_submitted_device_id": {
+          "name": "idx_daily_breakdown_submitted_device_id",
+          "columns": [
+            {
+              "expression": "submitted_device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_date": {
+          "name": "idx_daily_breakdown_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_breakdown_submission_id_submissions_id_fk": {
+          "name": "daily_breakdown_submission_id_submissions_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_breakdown_submitted_device_id_submitted_devices_id_fk": {
+          "name": "daily_breakdown_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_breakdown_submission_device_date_unique": {
+          "name": "daily_breakdown_submission_device_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "submission_id",
+            "submitted_device_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_codes_device_code": {
+          "name": "idx_device_codes_device_code",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_code": {
+          "name": "idx_device_codes_user_code",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_id": {
+          "name": "idx_device_codes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_expires_at": {
+          "name": "idx_device_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_codes_user_id_users_id_fk": {
+          "name": "device_codes_user_id_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_invites": {
+      "name": "group_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_username": {
+          "name": "invited_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_username_normalized": {
+          "name": "invited_username_normalized",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_user_id": {
+          "name": "invited_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_group_invites_group_status": {
+          "name": "idx_group_invites_group_status",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_user_status": {
+          "name": "idx_group_invites_invited_user_status",
+          "columns": [
+            {
+              "expression": "invited_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_username_status": {
+          "name": "idx_group_invites_invited_username_status",
+          "columns": [
+            {
+              "expression": "invited_username_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_expires_at": {
+          "name": "idx_group_invites_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_by": {
+          "name": "idx_group_invites_invited_by",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_invites_group_id_groups_id_fk": {
+          "name": "group_invites_group_id_groups_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_invites_invited_user_id_users_id_fk": {
+          "name": "group_invites_invited_user_id_users_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_invites_invited_by_users_id_fk": {
+          "name": "group_invites_invited_by_users_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_invites_token_hash_unique": {
+          "name": "group_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_members": {
+      "name": "group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_group_members_user_id": {
+          "name": "idx_group_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_members_invited_by": {
+          "name": "idx_group_members_invited_by",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_members_group_id_groups_id_fk": {
+          "name": "group_members_group_id_groups_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_members_user_id_users_id_fk": {
+          "name": "group_members_user_id_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_members_invited_by_users_id_fk": {
+          "name": "group_members_invited_by_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_members_group_user_unique": {
+          "name": "group_members_group_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_created_by": {
+          "name": "idx_groups_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_groups_visibility_updated": {
+          "name": "idx_groups_visibility_updated",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_created_by_users_id_fk": {
+          "name": "groups_created_by_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_slug_unique": {
+          "name": "groups_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moderation_actions": {
+      "name": "moderation_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_username": {
+          "name": "target_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_moderation_actions_target_created": {
+          "name": "idx_moderation_actions_target_created",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_moderation_actions_actor": {
+          "name": "idx_moderation_actions_actor",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moderation_actions_target_user_id_users_id_fk": {
+          "name": "moderation_actions_target_user_id_users_id_fk",
+          "tableFrom": "moderation_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "moderation_actions_actor_user_id_users_id_fk": {
+          "name": "moderation_actions_actor_user_id_users_id_fk",
+          "tableFrom": "moderation_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_token_hash": {
+          "name": "idx_sessions_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sources_used": {
+          "name": "sources_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "models_used": {
+          "name": "models_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_version": {
+          "name": "cli_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_hash": {
+          "name": "submission_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submit_count": {
+          "name": "submit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_backfill": {
+          "name": "has_backfill",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_active_time_ms": {
+          "name": "total_active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longest_continuous_ms": {
+          "name": "longest_continuous_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_sessions": {
+          "name": "max_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_servers": {
+          "name": "mcp_servers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_submissions_created_at": {
+          "name": "idx_submissions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_leaderboard": {
+          "name": "idx_submissions_leaderboard",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_tokens",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_cost",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submissions_user_id_unique": {
+          "name": "submissions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submitted_devices": {
+      "name": "submitted_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_key": {
+          "name": "device_key",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_active_time_ms": {
+          "name": "total_active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longest_continuous_ms": {
+          "name": "longest_continuous_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_sessions": {
+          "name": "max_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_submitted_devices_user_id": {
+          "name": "idx_submitted_devices_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submitted_devices_user_id_users_id_fk": {
+          "name": "submitted_devices_user_id_users_id_fk",
+          "tableFrom": "submitted_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submitted_devices_user_device_key_unique": {
+          "name": "submitted_devices_user_device_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leaderboard_hidden": {
+          "name": "leaderboard_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_lower_unique": {
+          "name": "users_username_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_github_id": {
+          "name": "idx_users_github_id",
+          "columns": [
+            {
+              "expression": "github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1784927483081,
       "tag": "0019_add_device_session_metrics",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1785341011049,
+      "tag": "0020_mighty_whiplash",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1785341011049,
       "tag": "0020_mighty_whiplash",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1785356630413,
+      "tag": "0021_lethal_killraven",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -32,6 +32,20 @@ export const users = pgTable(
     displayName: varchar("display_name", { length: 255 }),
     avatarUrl: text("avatar_url"),
     email: varchar("email", { length: 255 }),
+    /**
+     * Excludes the user from leaderboard RANKINGS only. Their profile, badge
+     * and embeds stay public, and their usage still counts toward site-wide
+     * totals — see lib/leaderboard/getLeaderboard.ts for exactly which queries
+     * honour this and which deliberately do not.
+     *
+     * Reversible by design: moderation_actions keeps the full hide/unhide
+     * history, so this column is current state, not the record.
+     *
+     * Intentionally unindexed. Nearly every row passes `NOT leaderboard_hidden`,
+     * so an index has no selectivity to offer; the check rides the existing
+     * join against users.
+     */
+    leaderboardHidden: boolean("leaderboard_hidden").notNull().default(false),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -60,6 +74,8 @@ export const usersRelations = relations(users, ({ many }) => ({
   groupMemberships: many(groupMembers, { relationName: "memberUser" }),
   createdGroups: many(groups, { relationName: "groupCreator" }),
   createdGroupInvites: many(groupInvites, { relationName: "groupInviteCreator" }),
+  moderationActionsReceived: many(moderationActions, { relationName: "moderationTarget" }),
+  moderationActionsTaken: many(moderationActions, { relationName: "moderationActor" }),
 }));
 
 // ============================================================================
@@ -509,6 +525,62 @@ export const groupInvitesRelations = relations(groupInvites, ({ one }) => ({
 }));
 
 // ============================================================================
+// MODERATION
+// ============================================================================
+export const MODERATION_ACTION_TYPES = ["hide", "unhide"] as const;
+export type ModerationAction = (typeof MODERATION_ACTION_TYPES)[number];
+
+/**
+ * Append-only log of every leaderboard hide/unhide.
+ *
+ * `users.leaderboard_hidden` is current state; this is the record of how it got
+ * there. Rows are never updated or deleted, so a sequence of hide → unhide →
+ * hide stays fully reconstructible — which is the point of preferring a
+ * reversible flag over deleting an account.
+ */
+export const moderationActions = pgTable(
+  "moderation_actions",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    targetUserId: uuid("target_user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    /** The moderator. Retained even if the target is later removed. */
+    actorUserId: uuid("actor_user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    action: varchar("action", { length: 10 }).notNull().$type<ModerationAction>(),
+    /** Free-text justification, required at the API layer. */
+    reason: text("reason").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    // Serves the per-user history panel on the review screen.
+    index("idx_moderation_actions_target_created").on(
+      table.targetUserId,
+      table.createdAt
+    ),
+    // FK coverage: cascade-delete of an actor does a seq scan without this.
+    index("idx_moderation_actions_actor").on(table.actorUserId),
+  ]
+);
+
+export const moderationActionsRelations = relations(moderationActions, ({ one }) => ({
+  targetUser: one(users, {
+    fields: [moderationActions.targetUserId],
+    references: [users.id],
+    relationName: "moderationTarget",
+  }),
+  actorUser: one(users, {
+    fields: [moderationActions.actorUserId],
+    references: [users.id],
+    relationName: "moderationActor",
+  }),
+}));
+
+// ============================================================================
 // TYPE EXPORTS
 // ============================================================================
 export type User = typeof users.$inferSelect;
@@ -531,3 +603,5 @@ export type GroupMember = typeof groupMembers.$inferSelect;
 export type NewGroupMember = typeof groupMembers.$inferInsert;
 export type GroupInvite = typeof groupInvites.$inferSelect;
 export type NewGroupInvite = typeof groupInvites.$inferInsert;
+export type ModerationActionRow = typeof moderationActions.$inferSelect;
+export type NewModerationActionRow = typeof moderationActions.$inferInsert;

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -542,13 +542,17 @@ export const moderationActions = pgTable(
   "moderation_actions",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    targetUserId: uuid("target_user_id")
-      .notNull()
-      .references(() => users.id, { onDelete: "cascade" }),
-    /** The moderator. Retained even if the target is later removed. */
-    actorUserId: uuid("actor_user_id")
-      .notNull()
-      .references(() => users.id, { onDelete: "cascade" }),
+    // User accounts are deletable, while this record is intentionally not.
+    // The immutable names preserve a useful audit trail after either account
+    // has gone away; nullable FKs retain relational lookup while present.
+    targetUserId: uuid("target_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    targetUsername: varchar("target_username", { length: 39 }).notNull(),
+    actorUserId: uuid("actor_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    actorUsername: varchar("actor_username", { length: 39 }).notNull(),
     action: varchar("action", { length: 10 }).notNull().$type<ModerationAction>(),
     /** Free-text justification, required at the API layer. */
     reason: text("reason").notNull(),
@@ -562,7 +566,7 @@ export const moderationActions = pgTable(
       table.targetUserId,
       table.createdAt
     ),
-    // FK coverage: cascade-delete of an actor does a seq scan without this.
+    // FK coverage: nulling a deleted actor does a seq scan without this.
     index("idx_moderation_actions_actor").on(table.actorUserId),
   ]
 );

--- a/packages/frontend/src/lib/embed/getUserEmbedStats.ts
+++ b/packages/frontend/src/lib/embed/getUserEmbedStats.ts
@@ -73,8 +73,17 @@ async function fetchUserEmbedStats(
       : Number(result.totalTokens) || 0;
 
   if (rankingValue > 0) {
+    // Both the rank and the "of N" denominator count rankable users only, so a
+    // hidden account neither holds a position nor inflates the total. A hidden
+    // user is absent from the CTE, so this returns no row and rank stays null.
     const rankResult = await db.execute<{ rank: number; total: number }>(sql`
-      WITH ranked AS (
+      WITH rankable AS (
+        SELECT s.*
+        FROM submissions s
+        JOIN users u ON u.id = s.user_id
+        WHERE u.leaderboard_hidden = false
+      ),
+      ranked AS (
         SELECT
           user_id,
           RANK() OVER (
@@ -85,9 +94,9 @@ async function fetchUserEmbedStats(
                   : sql`total_tokens DESC`
               }
           ) AS rank
-        FROM submissions
+        FROM rankable
       )
-      SELECT rank, (SELECT COUNT(*)::int FROM submissions) AS total
+      SELECT rank, (SELECT COUNT(*)::int FROM rankable) AS total
       FROM ranked WHERE user_id = ${result.id}
     `);
 

--- a/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
+++ b/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
@@ -244,7 +244,15 @@ async function fetchPeriodRows(
         eq(groupMembers.groupId, groupId)
       )
     )
-    .where(and(gte(dailyBreakdown.date, dateRange.start), lte(dailyBreakdown.date, dateRange.end)));
+    // A group board is still a ranking, so a site-wide hide applies here too —
+    // otherwise a hidden account keeps topping every group it belongs to.
+    .where(
+      and(
+        eq(users.leaderboardHidden, false),
+        gte(dailyBreakdown.date, dateRange.start),
+        lte(dailyBreakdown.date, dateRange.end)
+      )
+    );
 
   return rows.map((row) => ({
     userId: row.userId,
@@ -298,7 +306,7 @@ async function fetchAllTimeRows(groupId: string, sortBy: SortBy, search: string 
         eq(groupMembers.groupId, groupId)
       )
     )
-    .where(conditions.length > 0 ? and(...conditions) : undefined)
+    .where(and(eq(users.leaderboardHidden, false), ...conditions))
     .groupBy(users.id, users.username, users.displayName, users.avatarUrl, groupMembers.role)
     .orderBy(
       desc(primaryOrderByColumn),

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -16,6 +16,16 @@ import {
 
 export type { LeaderboardData, LeaderboardUser, Period, SortBy } from "@/lib/leaderboard/types";
 
+/**
+ * Restricts a query to users eligible for a leaderboard position.
+ *
+ * Applies to RANKINGS ONLY. The site-wide totals queries deliberately omit it,
+ * so a hidden user still contributes to total tokens, total cost and unique
+ * user counts — hiding withdraws someone from the competition, it does not
+ * erase their usage. Their profile, badge and embeds are likewise unaffected.
+ */
+const RANKABLE_USER = eq(users.leaderboardHidden, false);
+
 interface LeaderboardPeriodRow {
   userId: string;
   username: string;
@@ -24,6 +34,12 @@ interface LeaderboardPeriodRow {
   tokens: number;
   cost: number;
   sourceBreakdown: Record<string, { models: Record<string, unknown> }> | null;
+  /**
+   * Carried through so the period path can drop the user from the rankings
+   * while still counting them in the period totals. Internal only — it must
+   * never reach LeaderboardUser, which is serialized to the public API.
+   */
+  leaderboardHidden: boolean;
 }
 
 interface PeriodDateRange {
@@ -39,6 +55,7 @@ interface PeriodLeaderboardDbRow {
   tokens: number | string | null;
   cost: number | string | null;
   sourceBreakdown: Record<string, { models: Record<string, unknown> }> | null;
+  leaderboardHidden: boolean;
 }
 
 interface AllTimeLeaderboardDbRow {
@@ -215,8 +232,19 @@ function buildPeriodLeaderboardData(
     });
   }
 
+  // Aggregated twice on purpose. `aggregatedUsers` includes hidden users and
+  // is what the period totals are computed from; `visibleUsers` excludes them
+  // and is what gets ranked. Filtering once, before the totals, would silently
+  // shrink the headline numbers — the opposite of the intended behaviour.
   const aggregatedUsers = aggregatePeriodRows(filteredRows, sortBy);
-  const rankedUsers = aggregatedUsers.map((user, index) => ({
+  const visibleUsers = aggregatePeriodRows(
+    filteredRows.filter((row) => !row.leaderboardHidden),
+    sortBy
+  );
+
+  // Ranked over the visible set, so ranks stay dense (1,2,3…) instead of
+  // leaving a gap where the hidden user used to sit.
+  const rankedUsers = visibleUsers.map((user, index) => ({
     ...user,
     rank: index + 1,
   }));
@@ -250,7 +278,13 @@ function buildPeriodUserRank(
   username: string,
   sortBy: SortBy = "tokens"
 ): LeaderboardUser | null {
-  const aggregatedUsers = aggregatePeriodRows(rows, sortBy);
+  // Ranked against the visible set only. A hidden user is therefore absent
+  // here and reports no rank at all, rather than a rank that does not
+  // correspond to any position on the leaderboard.
+  const aggregatedUsers = aggregatePeriodRows(
+    rows.filter((row) => !row.leaderboardHidden),
+    sortBy
+  );
   const usernameCacheKey = normalizeUsernameCacheKey(username);
   const matchingUsers = aggregatedUsers.filter(
     (user) => normalizeUsernameCacheKey(user.username) === usernameCacheKey
@@ -287,6 +321,7 @@ async function fetchPeriodLeaderboardRows(
       tokens: dailyBreakdown.tokens,
       cost: dailyBreakdown.cost,
       sourceBreakdown: dailyBreakdown.sourceBreakdown,
+      leaderboardHidden: users.leaderboardHidden,
     })
     .from(dailyBreakdown)
     .innerJoin(submissions, eq(dailyBreakdown.submissionId, submissions.id))
@@ -306,6 +341,9 @@ async function fetchPeriodLeaderboardRows(
     tokens: Number(row.tokens) || 0,
     cost: Number(row.cost) || 0,
     sourceBreakdown: row.sourceBreakdown ?? null,
+    // Deliberately NOT filtered in SQL: the period totals are derived from
+    // these same rows, and hidden users still count toward totals.
+    leaderboardHidden: row.leaderboardHidden === true,
   }));
 }
 
@@ -360,7 +398,13 @@ async function fetchLeaderboardData(
       })
       .from(submissions)
       .innerJoin(users, eq(submissions.userId, users.id))
-      .where(hasDirectiveFilters ? and(...directiveConditions) : undefined)
+      // Inside the ranked subquery, so RANK() renumbers densely rather than
+      // leaving a hole where a hidden user was.
+      .where(
+        hasDirectiveFilters
+          ? and(RANKABLE_USER, ...directiveConditions)
+          : RANKABLE_USER
+      )
       .groupBy(users.id, users.username, users.displayName, users.avatarUrl)
       .as("ranked");
     const rankedSecondaryOrderByColumn = sortBy === "cost"
@@ -443,6 +487,7 @@ async function fetchLeaderboardData(
     })
     .from(submissions)
     .innerJoin(users, eq(submissions.userId, users.id))
+    .where(RANKABLE_USER)
     .groupBy(users.id, users.username, users.displayName, users.avatarUrl)
     .orderBy(
       desc(orderByColumn),
@@ -452,8 +497,9 @@ async function fetchLeaderboardData(
     .limit(limit)
     .offset(offset);
 
-  const [results, globalStats] = await Promise.all([
+  const [results, globalStats, rankableCount] = await Promise.all([
     leaderboardQuery,
+    // Unfiltered: site-wide totals count every submission, hidden or not.
     db
       .select({
         totalTokens: sql<number>`SUM(${submissions.totalTokens})`,
@@ -461,9 +507,17 @@ async function fetchLeaderboardData(
         uniqueUsers: sql<number>`COUNT(DISTINCT ${submissions.userId})`,
       })
       .from(submissions),
+    // Pagination must count only the rows this query can actually return.
+    // Reusing globalStats.uniqueUsers here would over-report by the number of
+    // hidden users and leave a trailing page that renders empty.
+    db
+      .select({ count: sql<number>`COUNT(DISTINCT ${submissions.userId})`.as("count") })
+      .from(submissions)
+      .innerJoin(users, eq(submissions.userId, users.id))
+      .where(RANKABLE_USER),
   ]);
 
-  const totalUsers = Number(globalStats[0]?.uniqueUsers) || 0;
+  const totalUsers = Number(rankableCount[0]?.count) || 0;
   const totalPages = Math.ceil(totalUsers / limit);
 
   return {
@@ -534,7 +588,13 @@ async function fetchUserRank(
   }
 
   const userResult = await db
-    .select({ id: users.id, username: users.username, displayName: users.displayName, avatarUrl: users.avatarUrl })
+    .select({
+      id: users.id,
+      username: users.username,
+      displayName: users.displayName,
+      avatarUrl: users.avatarUrl,
+      leaderboardHidden: users.leaderboardHidden,
+    })
     .from(users)
     .where(usernameEqualsIgnoreCase(username))
     .limit(USERNAME_LOOKUP_LIMIT);
@@ -542,6 +602,12 @@ async function fetchUserRank(
   const user = getSingleUsernameMatch(userResult, username);
 
   if (!user) {
+    return null;
+  }
+
+  // A hidden user holds no leaderboard position, so they report no rank at all
+  // rather than a number that matches nothing on the board.
+  if (user.leaderboardHidden) {
     return null;
   }
 
@@ -579,6 +645,11 @@ async function fetchUserRank(
           total: compareColumn.as("total"),
         })
         .from(submissions)
+        // Hidden users hold no position, so they must not be counted as being
+        // "above" anyone — otherwise every visible user's rank is inflated by
+        // however many hidden accounts outrank them.
+        .innerJoin(users, eq(submissions.userId, users.id))
+        .where(RANKABLE_USER)
         .groupBy(submissions.userId)
         .having(sql`${compareColumn} > ${userCompareValue}`)
         .as("higher_ranked")

--- a/packages/frontend/src/lib/moderation/actions.ts
+++ b/packages/frontend/src/lib/moderation/actions.ts
@@ -1,0 +1,130 @@
+import { desc, eq } from "drizzle-orm";
+import { revalidatePath, revalidateTag } from "next/cache";
+import { db, moderationActions, users } from "@/lib/db";
+import {
+  USERNAME_LOOKUP_LIMIT,
+  getSingleUsernameMatch,
+  normalizeUsernameCacheKey,
+  revalidateUsernamePaths,
+  usernameEqualsIgnoreCase,
+} from "@/lib/db/usernameLookup";
+import type { ModerationAction } from "@/lib/db/schema";
+
+export interface ModerationTarget {
+  id: string;
+  username: string;
+  leaderboardHidden: boolean;
+}
+
+export interface ModerationHistoryEntry {
+  id: string;
+  action: ModerationAction;
+  reason: string;
+  createdAt: Date;
+  actorUsername: string | null;
+}
+
+export async function findModerationTarget(
+  username: string
+): Promise<ModerationTarget | null> {
+  const rows = await db
+    .select({
+      id: users.id,
+      username: users.username,
+      leaderboardHidden: users.leaderboardHidden,
+    })
+    .from(users)
+    .where(usernameEqualsIgnoreCase(username))
+    .limit(USERNAME_LOOKUP_LIMIT);
+
+  return getSingleUsernameMatch(rows, username);
+}
+
+/**
+ * Applies a hide/unhide and records why, in one transaction.
+ *
+ * The flag and the audit row are written together deliberately: a flag with no
+ * recorded reason is exactly the situation that makes a moderation decision
+ * impossible to defend or reverse later.
+ *
+ * Idempotent. Re-applying the current state is a no-op that writes no audit
+ * row, so a double-clicked button does not litter the history with entries
+ * that changed nothing.
+ */
+export async function applyModerationAction(params: {
+  target: ModerationTarget;
+  actorUserId: string;
+  action: ModerationAction;
+  reason: string;
+}): Promise<{ changed: boolean; leaderboardHidden: boolean }> {
+  const { target, actorUserId, action, reason } = params;
+  const nextHidden = action === "hide";
+
+  if (target.leaderboardHidden === nextHidden) {
+    return { changed: false, leaderboardHidden: target.leaderboardHidden };
+  }
+
+  await db.transaction(async (tx) => {
+    await tx
+      .update(users)
+      .set({ leaderboardHidden: nextHidden, updatedAt: new Date() })
+      .where(eq(users.id, target.id));
+
+    await tx.insert(moderationActions).values({
+      targetUserId: target.id,
+      actorUserId,
+      action,
+      reason,
+    });
+  });
+
+  invalidateAfterModeration(target.username);
+
+  return { changed: true, leaderboardHidden: nextHidden };
+}
+
+/**
+ * Drops every cached surface whose contents depend on who is rankable.
+ *
+ * Best-effort by design: the write has already committed, so a revalidation
+ * failure must not surface as a failed moderation action. Worst case the
+ * change appears after the existing TTLs expire (60s for the leaderboard and
+ * profiles, an hour for the sitemap).
+ */
+function invalidateAfterModeration(username: string): void {
+  try {
+    // Every leaderboard cache entry carries this tag, including the per-period
+    // ones, so one call covers all of them.
+    revalidateTag("leaderboard", "max");
+    revalidateTag(`user:${normalizeUsernameCacheKey(username)}`, "max");
+    revalidateUsernamePaths(username);
+    // The landing page renders its own top-5 outside the leaderboard cache.
+    revalidatePath("/");
+    revalidatePath("/leaderboard");
+  } catch (error) {
+    console.error("[moderation] cache revalidation failed:", error);
+  }
+}
+
+export async function getModerationHistory(
+  targetUserId: string,
+  limit = 20
+): Promise<ModerationHistoryEntry[]> {
+  // Joins users once, on the actor. No alias needed: the target is already
+  // pinned by the WHERE clause rather than joined.
+  const rows = await db
+    .select({
+      id: moderationActions.id,
+      action: moderationActions.action,
+      reason: moderationActions.reason,
+      createdAt: moderationActions.createdAt,
+      actorUsername: users.username,
+    })
+    .from(moderationActions)
+    .innerJoin(users, eq(moderationActions.actorUserId, users.id))
+    .where(eq(moderationActions.targetUserId, targetUserId))
+    .orderBy(desc(moderationActions.createdAt))
+    .limit(limit);
+
+  return rows;
+}

--- a/packages/frontend/src/lib/moderation/actions.ts
+++ b/packages/frontend/src/lib/moderation/actions.ts
@@ -1,4 +1,4 @@
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq, ne } from "drizzle-orm";
 import { revalidatePath, revalidateTag } from "next/cache";
 import { db, moderationActions, users } from "@/lib/db";
 import {
@@ -9,6 +9,7 @@ import {
   usernameEqualsIgnoreCase,
 } from "@/lib/db/usernameLookup";
 import type { ModerationAction } from "@/lib/db/schema";
+import { revalidateUserGroupLeaderboards } from "@/lib/groups/cache";
 
 export interface ModerationTarget {
   id: string;
@@ -54,33 +55,49 @@ export async function findModerationTarget(
 export async function applyModerationAction(params: {
   target: ModerationTarget;
   actorUserId: string;
+  actorUsername: string;
   action: ModerationAction;
   reason: string;
 }): Promise<{ changed: boolean; leaderboardHidden: boolean }> {
-  const { target, actorUserId, action, reason } = params;
+  const { target, actorUserId, actorUsername, action, reason } = params;
   const nextHidden = action === "hide";
 
-  if (target.leaderboardHidden === nextHidden) {
-    return { changed: false, leaderboardHidden: target.leaderboardHidden };
-  }
-
-  await db.transaction(async (tx) => {
-    await tx
+  const changed = await db.transaction(async (tx) => {
+    const updated = await tx
       .update(users)
       .set({ leaderboardHidden: nextHidden, updatedAt: new Date() })
-      .where(eq(users.id, target.id));
+      // PostgreSQL rechecks this state predicate after concurrent writers
+      // commit. Only the transition that actually changed the flag can write
+      // the corresponding audit row.
+      .where(
+        and(
+          eq(users.id, target.id),
+          ne(users.leaderboardHidden, nextHidden)
+        )
+      )
+      .returning({ id: users.id });
+
+    if (updated.length === 0) {
+      return false;
+    }
 
     await tx.insert(moderationActions).values({
       targetUserId: target.id,
+      targetUsername: target.username,
       actorUserId,
+      actorUsername,
       action,
       reason,
     });
+
+    return true;
   });
 
-  invalidateAfterModeration(target.username);
+  if (changed) {
+    await invalidateAfterModeration(target.id, target.username);
+  }
 
-  return { changed: true, leaderboardHidden: nextHidden };
+  return { changed, leaderboardHidden: nextHidden };
 }
 
 /**
@@ -91,13 +108,14 @@ export async function applyModerationAction(params: {
  * change appears after the existing TTLs expire (60s for the leaderboard and
  * profiles, an hour for the sitemap).
  */
-function invalidateAfterModeration(username: string): void {
+async function invalidateAfterModeration(userId: string, username: string): Promise<void> {
   try {
     // Every leaderboard cache entry carries this tag, including the per-period
     // ones, so one call covers all of them.
     revalidateTag("leaderboard", "max");
     revalidateTag(`user:${normalizeUsernameCacheKey(username)}`, "max");
     revalidateUsernamePaths(username);
+    await revalidateUserGroupLeaderboards(userId);
     // The landing page renders its own top-5 outside the leaderboard cache.
     revalidatePath("/");
     revalidatePath("/leaderboard");
@@ -110,18 +128,15 @@ export async function getModerationHistory(
   targetUserId: string,
   limit = 20
 ): Promise<ModerationHistoryEntry[]> {
-  // Joins users once, on the actor. No alias needed: the target is already
-  // pinned by the WHERE clause rather than joined.
   const rows = await db
     .select({
       id: moderationActions.id,
       action: moderationActions.action,
       reason: moderationActions.reason,
       createdAt: moderationActions.createdAt,
-      actorUsername: users.username,
+      actorUsername: moderationActions.actorUsername,
     })
     .from(moderationActions)
-    .innerJoin(users, eq(moderationActions.actorUserId, users.id))
     .where(eq(moderationActions.targetUserId, targetUserId))
     .orderBy(desc(moderationActions.createdAt))
     .limit(limit);

--- a/packages/frontend/src/lib/moderation/actions.ts
+++ b/packages/frontend/src/lib/moderation/actions.ts
@@ -75,29 +75,31 @@ export async function applyModerationAction(params: {
           ne(users.leaderboardHidden, nextHidden)
         )
       )
-      .returning({ id: users.id });
+      .returning({ id: users.id, username: users.username });
 
     if (updated.length === 0) {
       return false;
     }
 
+    const updatedTarget = updated[0];
+
     await tx.insert(moderationActions).values({
       targetUserId: target.id,
-      targetUsername: target.username,
+      targetUsername: updatedTarget.username,
       actorUserId,
       actorUsername,
       action,
       reason,
     });
 
-    return true;
+    return updatedTarget.username;
   });
 
-  if (changed) {
-    await invalidateAfterModeration(target.id, target.username);
+  if (changed !== false) {
+    await invalidateAfterModeration(target.id, changed);
   }
 
-  return { changed, leaderboardHidden: nextHidden };
+  return { changed: changed !== false, leaderboardHidden: nextHidden };
 }
 
 /**
@@ -115,7 +117,11 @@ async function invalidateAfterModeration(userId: string, username: string): Prom
     revalidateTag("leaderboard", "max");
     revalidateTag(`user:${normalizeUsernameCacheKey(username)}`, "max");
     revalidateUsernamePaths(username);
-    await revalidateUserGroupLeaderboards(userId);
+    try {
+      await revalidateUserGroupLeaderboards(userId);
+    } catch (error) {
+      console.error("[moderation] group cache revalidation failed:", error);
+    }
     // The landing page renders its own top-5 outside the leaderboard cache.
     revalidatePath("/");
     revalidatePath("/leaderboard");

--- a/packages/frontend/src/lib/moderation/candidates.ts
+++ b/packages/frontend/src/lib/moderation/candidates.ts
@@ -1,7 +1,12 @@
 import { sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import {
+  DAILY_MISMATCH_THRESHOLD,
+  MAX_IMPLIED_RATE,
+  MEDIAN_RATIO_THRESHOLD,
+  MIN_IMPLIED_RATE,
   rankCandidates,
+  SITE_SHARE_THRESHOLD,
   type CandidateRow,
   type ScoredCandidate,
 } from "./heuristics";
@@ -12,11 +17,6 @@ import {
  * to tolerate rounding, not genuine coincidence.
  */
 const NEAR_DUPLICATE_TOKENS = 10;
-const SITE_SHARE_THRESHOLD = 0.05;
-const MEDIAN_RATIO_THRESHOLD = 500;
-const DAILY_MISMATCH_THRESHOLD = 1.5;
-const MIN_IMPLIED_RATE = 0.0000001;
-const MAX_IMPLIED_RATE = 0.001;
 
 interface CandidateDbRow extends Record<string, unknown> {
   user_id: string;

--- a/packages/frontend/src/lib/moderation/candidates.ts
+++ b/packages/frontend/src/lib/moderation/candidates.ts
@@ -13,13 +13,6 @@ import {
  */
 const NEAR_DUPLICATE_TOKENS = 10;
 
-/**
- * Rows returned to the reviewer. The site totals used for scoring are computed
- * across every user in the CTEs, so this cap only bounds the payload, not the
- * denominators.
- */
-const CANDIDATE_LIMIT = 500;
-
 interface CandidateDbRow extends Record<string, unknown> {
   user_id: string;
   username: string;
@@ -83,36 +76,28 @@ export async function getModerationCandidates(): Promise<ScoredCandidate[]> {
         ) AS median_tokens
       FROM per_user
     ),
-    dupes AS (
-      SELECT a.user_id, COUNT(*) AS near_duplicate_count
-      FROM per_user a
-      JOIN per_user b
-        ON a.user_id <> b.user_id
-       AND a.total_tokens > 0
-       AND ABS(a.total_tokens - b.total_tokens) <= ${NEAR_DUPLICATE_TOKENS}
-      GROUP BY a.user_id
+    enriched AS (
+      SELECT
+        p.*,
+        COALESCE(dl.daily_tokens, 0) AS daily_tokens,
+        CASE WHEN p.total_tokens > 0 THEN
+          COUNT(*) OVER (
+            ORDER BY p.total_tokens
+            RANGE BETWEEN ${NEAR_DUPLICATE_TOKENS} PRECEDING
+              AND ${NEAR_DUPLICATE_TOKENS} FOLLOWING
+          ) - 1
+        ELSE 0 END AS near_duplicate_count,
+        site.site_tokens,
+        site.median_tokens
+      FROM per_user p
+      LEFT JOIN daily dl ON dl.submission_id = p.submission_id
+      CROSS JOIN site
     )
     SELECT
-      p.user_id,
-      p.username,
-      p.avatar_url,
-      p.leaderboard_hidden,
-      p.total_tokens,
-      p.total_cost,
-      p.submit_count,
-      p.has_backfill,
-      COALESCE(dl.daily_tokens, 0) AS daily_tokens,
-      COALESCE(dp.near_duplicate_count, 0) AS near_duplicate_count,
-      site.site_tokens,
-      site.median_tokens
-    FROM per_user p
-    LEFT JOIN daily dl ON dl.submission_id = p.submission_id
-    LEFT JOIN dupes dp ON dp.user_id = p.user_id
-    CROSS JOIN site
-    -- Hidden users sort first so a past decision can never fall off the end of
-    -- the cap and become invisible to review.
-    ORDER BY p.leaderboard_hidden DESC, p.total_tokens DESC
-    LIMIT ${CANDIDATE_LIMIT}
+      user_id, username, avatar_url, leaderboard_hidden, total_tokens,
+      total_cost, submit_count, has_backfill, daily_tokens,
+      near_duplicate_count, site_tokens, median_tokens
+    FROM enriched
   `);
 
   const dbRows = (result as unknown as CandidateDbRow[]) ?? [];

--- a/packages/frontend/src/lib/moderation/candidates.ts
+++ b/packages/frontend/src/lib/moderation/candidates.ts
@@ -1,0 +1,141 @@
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+  rankCandidates,
+  type CandidateRow,
+  type ScoredCandidate,
+} from "./heuristics";
+
+/**
+ * How close two token totals must be to count as "the same data in two
+ * accounts". The observed case differed by exactly 1 token, so this only has
+ * to tolerate rounding, not genuine coincidence.
+ */
+const NEAR_DUPLICATE_TOKENS = 10;
+
+/**
+ * Rows returned to the reviewer. The site totals used for scoring are computed
+ * across every user in the CTEs, so this cap only bounds the payload, not the
+ * denominators.
+ */
+const CANDIDATE_LIMIT = 500;
+
+interface CandidateDbRow extends Record<string, unknown> {
+  user_id: string;
+  username: string;
+  avatar_url: string | null;
+  leaderboard_hidden: boolean;
+  total_tokens: number | string | null;
+  total_cost: number | string | null;
+  submit_count: number | string | null;
+  has_backfill: boolean | null;
+  daily_tokens: number | string | null;
+  near_duplicate_count: number | string | null;
+  site_tokens: number | string | null;
+  median_tokens: number | string | null;
+}
+
+/**
+ * Values out of db.execute() are driver-shaped, not schema-shaped: Postgres
+ * bigint and numeric both arrive as strings via postgres-js. Coerce at the
+ * boundary — the generic on db.execute<T>() is an unchecked assertion, and
+ * trusting it is what previously made rank silently vanish from the badges.
+ */
+function toNumber(value: number | string | null | undefined): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/**
+ * Builds the review queue: every user with at least one suspicion signal, plus
+ * everyone currently hidden so past decisions stay visible and reversible.
+ *
+ * Read-only. Nothing here changes state — hiding is always an explicit,
+ * human-initiated action.
+ */
+export async function getModerationCandidates(): Promise<ScoredCandidate[]> {
+  const result = await db.execute<CandidateDbRow>(sql`
+    WITH per_user AS (
+      SELECT
+        u.id AS user_id,
+        u.username,
+        u.avatar_url,
+        u.leaderboard_hidden,
+        s.id AS submission_id,
+        s.total_tokens,
+        CAST(s.total_cost AS DECIMAL(18,4)) AS total_cost,
+        s.submit_count,
+        s.has_backfill
+      FROM users u
+      JOIN submissions s ON s.user_id = u.id
+    ),
+    daily AS (
+      SELECT d.submission_id, SUM(d.tokens) AS daily_tokens
+      FROM daily_breakdown d
+      GROUP BY d.submission_id
+    ),
+    site AS (
+      SELECT
+        COALESCE(SUM(total_tokens), 0) AS site_tokens,
+        COALESCE(
+          PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY total_tokens::numeric),
+          0
+        ) AS median_tokens
+      FROM per_user
+    ),
+    dupes AS (
+      SELECT a.user_id, COUNT(*) AS near_duplicate_count
+      FROM per_user a
+      JOIN per_user b
+        ON a.user_id <> b.user_id
+       AND a.total_tokens > 0
+       AND ABS(a.total_tokens - b.total_tokens) <= ${NEAR_DUPLICATE_TOKENS}
+      GROUP BY a.user_id
+    )
+    SELECT
+      p.user_id,
+      p.username,
+      p.avatar_url,
+      p.leaderboard_hidden,
+      p.total_tokens,
+      p.total_cost,
+      p.submit_count,
+      p.has_backfill,
+      COALESCE(dl.daily_tokens, 0) AS daily_tokens,
+      COALESCE(dp.near_duplicate_count, 0) AS near_duplicate_count,
+      site.site_tokens,
+      site.median_tokens
+    FROM per_user p
+    LEFT JOIN daily dl ON dl.submission_id = p.submission_id
+    LEFT JOIN dupes dp ON dp.user_id = p.user_id
+    CROSS JOIN site
+    -- Hidden users sort first so a past decision can never fall off the end of
+    -- the cap and become invisible to review.
+    ORDER BY p.leaderboard_hidden DESC, p.total_tokens DESC
+    LIMIT ${CANDIDATE_LIMIT}
+  `);
+
+  const dbRows = (result as unknown as CandidateDbRow[]) ?? [];
+
+  if (dbRows.length === 0) {
+    return [];
+  }
+
+  const rows: CandidateRow[] = dbRows.map((row) => ({
+    userId: row.user_id,
+    username: row.username,
+    avatarUrl: row.avatar_url,
+    leaderboardHidden: row.leaderboard_hidden === true,
+    totalTokens: toNumber(row.total_tokens),
+    totalCost: toNumber(row.total_cost),
+    submitCount: toNumber(row.submit_count),
+    hasBackfill: row.has_backfill === true,
+    dailyTokens: toNumber(row.daily_tokens),
+    nearDuplicateCount: toNumber(row.near_duplicate_count),
+  }));
+
+  return rankCandidates(rows, {
+    siteTokens: toNumber(dbRows[0].site_tokens),
+    medianTokens: toNumber(dbRows[0].median_tokens),
+  });
+}

--- a/packages/frontend/src/lib/moderation/candidates.ts
+++ b/packages/frontend/src/lib/moderation/candidates.ts
@@ -12,6 +12,11 @@ import {
  * to tolerate rounding, not genuine coincidence.
  */
 const NEAR_DUPLICATE_TOKENS = 10;
+const SITE_SHARE_THRESHOLD = 0.05;
+const MEDIAN_RATIO_THRESHOLD = 500;
+const DAILY_MISMATCH_THRESHOLD = 1.5;
+const MIN_IMPLIED_RATE = 0.0000001;
+const MAX_IMPLIED_RATE = 0.001;
 
 interface CandidateDbRow extends Record<string, unknown> {
   user_id: string;
@@ -92,12 +97,28 @@ export async function getModerationCandidates(): Promise<ScoredCandidate[]> {
       FROM per_user p
       LEFT JOIN daily dl ON dl.submission_id = p.submission_id
       CROSS JOIN site
+    ),
+    eligible AS (
+      SELECT *
+      FROM enriched
+      WHERE leaderboard_hidden = true
+        OR (site_tokens > 0 AND total_tokens::numeric / site_tokens >= ${SITE_SHARE_THRESHOLD})
+        OR (median_tokens > 0 AND total_tokens::numeric / median_tokens >= ${MEDIAN_RATIO_THRESHOLD})
+        OR near_duplicate_count > 0
+        OR (daily_tokens > 0 AND total_tokens::numeric / daily_tokens >= ${DAILY_MISMATCH_THRESHOLD})
+        OR (
+          total_tokens > 0
+          AND (
+            total_cost / total_tokens::numeric > ${MAX_IMPLIED_RATE}
+            OR total_cost / total_tokens::numeric < ${MIN_IMPLIED_RATE}
+          )
+        )
     )
     SELECT
       user_id, username, avatar_url, leaderboard_hidden, total_tokens,
       total_cost, submit_count, has_backfill, daily_tokens,
       near_duplicate_count, site_tokens, median_tokens
-    FROM enriched
+    FROM eligible
   `);
 
   const dbRows = (result as unknown as CandidateDbRow[]) ?? [];

--- a/packages/frontend/src/lib/moderation/guard.ts
+++ b/packages/frontend/src/lib/moderation/guard.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { isAdmin } from "@/lib/auth/admin";
+import { getSessionFromRequest } from "@/lib/auth/requestSession";
+import type { SessionUser } from "@/lib/auth/session";
+
+/**
+ * Resolves the caller and confirms they may moderate.
+ *
+ * Returns 404 rather than 401/403 for everyone who is not an admin. The
+ * endpoints and the review page are not something users should be able to
+ * probe for: a 403 confirms the route exists, which invites attempts against
+ * it. To a non-admin the moderation surface simply does not exist.
+ *
+ * `allowAuthorizationHeader: false` rejects personal API tokens outright.
+ * Those sessions carry no githubId and so could never pass isAdmin anyway, but
+ * failing here keeps the reason obvious instead of surfacing as a puzzling 404
+ * for someone holding a valid token.
+ */
+export async function requireAdminSession(
+  request: Request
+): Promise<{ session: SessionUser } | { response: NextResponse }> {
+  const session = await getSessionFromRequest(request, {
+    allowAuthorizationHeader: false,
+  });
+
+  if (!isAdmin(session)) {
+    return { response: NextResponse.json({ error: "Not found" }, { status: 404 }) };
+  }
+
+  return { session: session as SessionUser };
+}

--- a/packages/frontend/src/lib/moderation/heuristics.ts
+++ b/packages/frontend/src/lib/moderation/heuristics.ts
@@ -1,0 +1,182 @@
+/**
+ * Scoring for the moderation review queue.
+ *
+ * Deliberately pure and DB-free so the judgement calls are unit-testable, and
+ * deliberately advisory: nothing here ever hides anyone. It only decides what a
+ * human looks at first, and every signal is surfaced with a human-readable
+ * reason so the reviewer can disagree with it.
+ *
+ * The signals are chosen to separate two very different situations that look
+ * identical in the totals:
+ *   - someone submitting fabricated usage, and
+ *   - our own inflation bug (#960: daily active_time_ms is not
+ *     timezone-invariant, so re-scanning under another TZ re-splits intervals
+ *     and the monotonic per-device merge ratchets the total upward).
+ * `dailyMismatch` is the signal that distinguishes them, which is why a high
+ * score is a prompt to investigate rather than a verdict.
+ */
+
+export interface CandidateRow {
+  userId: string;
+  username: string;
+  avatarUrl: string | null;
+  leaderboardHidden: boolean;
+  totalTokens: number;
+  totalCost: number;
+  submitCount: number;
+  hasBackfill: boolean;
+  /** Sum of this user's daily_breakdown rows. */
+  dailyTokens: number;
+  /** How many OTHER users report a near-identical token total. */
+  nearDuplicateCount: number;
+}
+
+export interface CandidateContext {
+  /** Total tokens across all users, used for the share-of-site signal. */
+  siteTokens: number;
+  /** Median user's tokens, used as the "normal person" baseline. */
+  medianTokens: number;
+}
+
+export interface CandidateSignal {
+  key:
+    | "siteShare"
+    | "medianRatio"
+    | "duplicateTotal"
+    | "dailyMismatch"
+    | "impliedRate";
+  /** Shown verbatim in the review UI. */
+  label: string;
+  weight: number;
+}
+
+export interface ScoredCandidate extends CandidateRow {
+  score: number;
+  signals: CandidateSignal[];
+}
+
+/** A user holding more than this share of all tokens is worth a look. */
+const SITE_SHARE_THRESHOLD = 0.05;
+/** Multiples of the median that stop being explainable as heavy usage. */
+const MEDIAN_RATIO_THRESHOLD = 500;
+/**
+ * Published provider pricing sits well inside this band per token. Outside it,
+ * either the cost or the token count is not what it claims to be.
+ */
+const MIN_IMPLIED_RATE = 0.0000001;
+const MAX_IMPLIED_RATE = 0.001;
+/**
+ * Daily rows should sum to roughly the stored total. A large gap is the
+ * fingerprint of the ratchet, not of heavy usage.
+ */
+const DAILY_MISMATCH_THRESHOLD = 1.5;
+
+function formatMultiple(value: number): string {
+  return value >= 100 ? `${Math.round(value).toLocaleString("en-US")}x` : `${value.toFixed(1)}x`;
+}
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+/**
+ * Scores one candidate. Higher means "look at this sooner", nothing more.
+ *
+ * Signal weights are ordinal, not probabilistic — they exist to order the
+ * queue. Do not read a score as a confidence that someone cheated.
+ */
+export function scoreCandidate(
+  row: CandidateRow,
+  context: CandidateContext
+): ScoredCandidate {
+  const signals: CandidateSignal[] = [];
+
+  if (context.siteTokens > 0) {
+    const share = row.totalTokens / context.siteTokens;
+    if (share >= SITE_SHARE_THRESHOLD) {
+      signals.push({
+        key: "siteShare",
+        label: `Holds ${formatPercent(share)} of all tokens on the site`,
+        // Scaled by share so a 99% account outranks a 6% one.
+        weight: 40 * share,
+      });
+    }
+  }
+
+  if (context.medianTokens > 0) {
+    const ratio = row.totalTokens / context.medianTokens;
+    if (ratio >= MEDIAN_RATIO_THRESHOLD) {
+      signals.push({
+        key: "medianRatio",
+        label: `${formatMultiple(ratio)} the median user's tokens`,
+        // Log-scaled: the gap between 500x and 5000x matters less than the
+        // fact that both are far outside normal.
+        weight: Math.min(25, Math.log10(ratio) * 6),
+      });
+    }
+  }
+
+  if (row.nearDuplicateCount > 0) {
+    signals.push({
+      key: "duplicateTotal",
+      label:
+        row.nearDuplicateCount === 1
+          ? "Token total matches another account almost exactly"
+          : `Token total matches ${row.nearDuplicateCount} other accounts almost exactly`,
+      // Two people cannot independently land on the same total, so this is the
+      // strongest single signal that something was copied.
+      weight: 30,
+    });
+  }
+
+  // Only meaningful when daily rows exist at all; a user with none is simply
+  // an older submission shape, not evidence of anything.
+  if (row.dailyTokens > 0) {
+    const ratio = row.totalTokens / row.dailyTokens;
+    if (ratio >= DAILY_MISMATCH_THRESHOLD) {
+      signals.push({
+        key: "dailyMismatch",
+        label: `Stored total is ${formatMultiple(ratio)} the sum of daily rows — possible ratchet inflation (#960), not necessarily the user's doing`,
+        weight: 20,
+      });
+    }
+  }
+
+  if (row.totalTokens > 0) {
+    const impliedRate = row.totalCost / row.totalTokens;
+    if (impliedRate > MAX_IMPLIED_RATE || impliedRate < MIN_IMPLIED_RATE) {
+      signals.push({
+        key: "impliedRate",
+        label: `Implied $${impliedRate.toPrecision(3)}/token is outside plausible provider pricing`,
+        weight: 15,
+      });
+    }
+  }
+
+  return {
+    ...row,
+    score: signals.reduce((sum, signal) => sum + signal.weight, 0),
+    signals,
+  };
+}
+
+/**
+ * Scores every row and returns those with at least one signal, worst first.
+ *
+ * Already-hidden users are kept so the reviewer can see and reverse previous
+ * decisions rather than losing track of them.
+ */
+export function rankCandidates(
+  rows: readonly CandidateRow[],
+  context: CandidateContext
+): ScoredCandidate[] {
+  return rows
+    .map((row) => scoreCandidate(row, context))
+    .filter((candidate) => candidate.signals.length > 0 || candidate.leaderboardHidden)
+    .sort((left, right) => {
+      if (right.score !== left.score) {
+        return right.score - left.score;
+      }
+      return left.username.localeCompare(right.username);
+    });
+}

--- a/packages/frontend/src/lib/moderation/heuristics.ts
+++ b/packages/frontend/src/lib/moderation/heuristics.ts
@@ -56,20 +56,20 @@ export interface ScoredCandidate extends CandidateRow {
 }
 
 /** A user holding more than this share of all tokens is worth a look. */
-const SITE_SHARE_THRESHOLD = 0.05;
+export const SITE_SHARE_THRESHOLD = 0.05;
 /** Multiples of the median that stop being explainable as heavy usage. */
-const MEDIAN_RATIO_THRESHOLD = 500;
+export const MEDIAN_RATIO_THRESHOLD = 500;
 /**
  * Published provider pricing sits well inside this band per token. Outside it,
  * either the cost or the token count is not what it claims to be.
  */
-const MIN_IMPLIED_RATE = 0.0000001;
-const MAX_IMPLIED_RATE = 0.001;
+export const MIN_IMPLIED_RATE = 0.0000001;
+export const MAX_IMPLIED_RATE = 0.001;
 /**
  * Daily rows should sum to roughly the stored total. A large gap is the
  * fingerprint of the ratchet, not of heavy usage.
  */
-const DAILY_MISMATCH_THRESHOLD = 1.5;
+export const DAILY_MISMATCH_THRESHOLD = 1.5;
 
 function formatMultiple(value: number): string {
   return value >= 100 ? `${Math.round(value).toLocaleString("en-US")}x` : `${value.toFixed(1)}x`;

--- a/packages/frontend/src/lib/publicProfileData.ts
+++ b/packages/frontend/src/lib/publicProfileData.ts
@@ -225,13 +225,19 @@ export async function getPublicProfileResponse(
           .orderBy(desc(submissions.updatedAt))
           .limit(1),
 
+        // Ranks over rankable users only. A hidden user is absent from the CTE
+        // entirely, so this returns no row and the profile reports rank null —
+        // which is the intent: hiding withdraws someone from the standings, so
+        // there is no position left to display.
         db.execute<{ rank: number }>(sql`
         WITH user_totals AS (
           SELECT
-            user_id,
-            SUM(total_tokens) as total_tokens
-          FROM submissions
-          GROUP BY user_id
+            s.user_id,
+            SUM(s.total_tokens) as total_tokens
+          FROM submissions s
+          JOIN users u ON u.id = s.user_id
+          WHERE u.leaderboard_hidden = false
+          GROUP BY s.user_id
         ),
         ranked AS (
           SELECT


### PR DESCRIPTION
Closes #803.

## Why

The leaderboard is topped by an account holding **99.4% of every token on the site**:

```
 1  grenadeoftacoss   9,025,906,844,219,236 tokens   $281,431,038
 2  Nepomuk5665           7,068,201,104,626          $42,553,339
 3  iamtheavoc1           7,068,201,104,625          $18,467,874
 4  kzquandary            1,191,754,939,292             $512,633
```

Rank 1 is 7,570x rank 4. Ranks 2 and 3 differ by **exactly one token** — one dataset in two accounts.

Deleting the account is the wrong remedy. It is irreversible, it destroys the evidence, and **the cause may be ours**: the per-device merge is a monotonic high-water mark, and daily `active_time_ms` is explicitly not timezone-invariant, so a re-scan under another TZ re-splits intervals and the merge ratchets the total upward. #960 designs that fix and is unbuilt. Hiding is reversible; deleting an account over our own bug is not.

## What hiding does

| | |
|---|---|
| Rankings | Excluded, and ranks renumber **densely** so no gap advertises that someone was removed |
| Site-wide totals | **Still counted.** Hiding withdraws an account from the competition; it does not retract usage from the figures |
| Profile / badge / embeds | Untouched, and the profile stays in the sitemap |
| Rank | A hidden user reports **no rank at all**, rather than a position matching no row on the board |

Every ranking surface is covered, and they do not share a query: both all-time `RANK()` paths, the period path, per-user rank, `publicProfileData`'s rank CTE, `getUserEmbedStats`, and **group boards**, which have their own SQL and would otherwise still be topped by a hidden account.

## Two traps worth reviewing closely

**Pagination.** `totalUsers` was reusing `globalStats.uniqueUsers`. Since totals keep hidden users but the list does not, that would leave a trailing page rendering empty. It now has its own count query.

**The period path** derives its totals from the same rows it ranks, so it aggregates **twice**. Filtering once, before the totals, would have silently shrunk the headline numbers — the opposite of the intent.

## Review queue

Heuristics are pure and DB-free so they are unit-testable, and strictly advisory — **nothing is ever hidden automatically**. They exist to separate two situations that look identical in the totals: fabricated usage, and our own inflation bug. `dailyMismatch` is the signal that tells them apart, and its label says outright that it may not be the user's doing.

Hide/unhide writes the flag and its audit row in **one transaction** — a flag with no recorded reason is what makes a decision impossible to defend later, so a reason is required. Re-applying the current state is a no-op, so a double-click does not litter the history.

Non-admins get **404, not 403**, from both the API and the page: a forbidden response confirms the surface exists.

Admin identity keys on GitHub's **numeric id**, not the username — a released username can be claimed by someone else. `githubId` is null for personal-token sessions, so a CLI token can never moderate even if a route forgets `allowAuthorizationHeader: false`.

## Verification

- **728 tests pass** (77 files), typecheck clean, 0 lint errors
- Production build succeeds, all three new routes registered
- New coverage: dense re-ranking, totals unchanged when a user is hidden, hidden user reports no rank, a hidden user above you does not inflate your rank, admin gate fails closed on malformed env, queue ordering and retention of past decisions

**Not verified here:** migration `0020` against a live database, the candidates SQL, and the hide/unhide transaction — this environment has no `DATABASE_URL`. Those need a run against a real DB before merge.

## Deploy note

Merging runs migration `0020` on production automatically via `buildCommand`. It is additive (`ADD COLUMN ... DEFAULT false NOT NULL` plus a new table), so it does not rewrite the users table, and **no behaviour changes until someone is explicitly hidden**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let admins hide suspect accounts from leaderboard rankings without deleting them. Adds a moderation queue and admin API/UI; rankings renumber densely while totals, profiles, badges, and embeds stay unchanged.

- **Bug Fixes**
  - Preserve audit history by storing `target_username` and `actor_username` in `moderation_actions`; history survives user deletion/rename.
  - Revalidate caches after hide/unhide (leaderboards, profiles, group boards, username paths) to prevent stale ranks.
  - Block `/admin` from robots to avoid indexing.
  - Bound the review queue and make cache invalidation failures non-fatal to moderation actions.
  - Centralize candidate score thresholds so the API and UI stay in sync.

- **Migration**
  - Adds `moderation_actions` and `users.leaderboard_hidden boolean default false`; allows NULL `target_user_id`/`actor_user_id` and records usernames to keep audits intact.
  - No behavior change until an account is hidden. Optionally set `TOKSCALE_ADMIN_GITHUB_IDS` to enable access.

<sup>Written for commit 5380bfe08dd72871ccfc1ae56eab899a3e8b35fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

