### PR TITLE
test(provider): lock family matching for version-suffixed model ids

### DIFF
--- a/crates/tokscale-core/src/provider_identity.rs
+++ b/crates/tokscale-core/src/provider_identity.rs
@@ -332,6 +332,45 @@ mod tests {
         assert_eq!(inferred_provider_from_model("metamorphic-v1"), None);
     }
 
+    /// The families below are matched with plain `contains`, not
+    /// `contains_delimited`, and that asymmetry is load-bearing rather than an
+    /// oversight. Vendors append version digits directly to the family token
+    /// (`qwen3`, `mistral4`) and embed it mid-word (`chatgpt-4o-latest`,
+    /// `codellama`), all of which a delimited match rejects.
+    ///
+    /// Switching these to delimited matching drops the provider on 536 model ids
+    /// in the bundled models.dev/litellm/openrouter catalogs. `contains_delimited`
+    /// stays reserved for short tokens that collide inside ordinary words -- see
+    /// `test_inferred_provider_no_false_positives`.
+    #[test]
+    fn test_inferred_provider_matches_version_suffixed_and_embedded_families() {
+        for model in [
+            "qwen3-coder",
+            "qwen3.7-plus",
+            "qwen2-5-14b-instruct",
+            "qwen3-235b-a22b-instruct-2507",
+        ] {
+            assert_eq!(inferred_provider_from_model(model), Some("qwen"), "{model}");
+        }
+
+        for model in ["chatgpt-4o-latest", "chatgpt-image-latest"] {
+            assert_eq!(
+                inferred_provider_from_model(model),
+                Some("openai"),
+                "{model}"
+            );
+        }
+
+        assert_eq!(
+            inferred_provider_from_model("mistral4-119b"),
+            Some("mistral")
+        );
+        assert_eq!(
+            inferred_provider_from_model("CodeLlama-34b-Instruct-hf"),
+            Some("meta")
+        );
+    }
+
     #[test]
     fn test_inferred_provider_boundary_matches() {
         assert_eq!(inferred_provider_from_model("o1-preview"), Some("openai"));

--- a/crates/tokscale-core/src/sessions/senpi.rs
+++ b/crates/tokscale-core/src/sessions/senpi.rs
@@ -146,6 +146,26 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_senpi_provider_inference_wins_over_the_client_fallback() {
+        // given: a provider-less message whose model id carries a recognizable
+        // family token. Inference runs before the `senpi` fallback on purpose --
+        // an id that names a family is better attributed to that vendor than to
+        // the harness that recorded it, because pricing keys off the vendor.
+        let content = r#"{"type":"session","version":3,"id":"senpi_ses_precedence","timestamp":"2026-07-29T15:19:53.436Z","cwd":"/tmp"}
+{"type":"message","id":"b1","parentId":null,"timestamp":"2026-07-29T15:20:01.000Z","message":{"role":"assistant","model":"qwen3-coder","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":2}}}
+{"type":"message","id":"b2","parentId":"b1","timestamp":"2026-07-29T15:20:02.000Z","message":{"role":"assistant","model":"internal-house-model","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":2}}}"#;
+        let file = create_test_file(content);
+
+        // when
+        let messages = parse_senpi_file(file.path());
+
+        // then: only a genuinely unrecognizable id lands on the client fallback.
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].provider_id, "qwen");
+        assert_eq!(messages[1].provider_id, "senpi");
+    }
+
+    #[test]
     fn test_parse_senpi_ignores_custom_and_non_assistant_entries() {
         // given: omo injects `custom` records (e.g. the ultrawork directive)
         // and user turns carry no usage. Neither may produce a message.


### PR DESCRIPTION
Follow-up to #979, addressing the review comment left on `crates/tokscale-core/src/sessions/pi.rs:233`.

## The review comment

> Senpi sessions with omitted providers can be attributed to the wrong vendor when a custom model ID merely contains a family name, because the shared parser invokes substring-based provider inference before this fallback. Delimited family matching (including the existing version-suffix cases) would keep unknown/custom IDs on the fallback path and preserve pricing attribution.

The underlying observation is fair: `inferred_provider_from_model` matches some families with plain `contains` (`claude`, `gpt`, `gemini`, `qwen`, `llama`, `mistral`, …) and others with `contains_delimited` (`o1`, `o3`, `o4`, `meta`, `opus`, `sonnet`, `haiku`, `kimi`, `mimo`, `glm`). Nothing in the code said why, so the asymmetry reads like an oversight.

**It isn't, and the suggested change is a net regression.** I measured it rather than guessing, against the bundled models.dev / litellm / openrouter catalogs (8,392 model ids):

| variant | model ids whose provider attribution changes |
|---|---|
| delimited matching for all families | **536 lost** (`qwen3*` ×379, `llama*` ×117, `mistral*` ×35, `chatgpt-4o-latest` ×4, 1 reattributed) |
| delimited + version-suffix allowance | **19 lost** (`chatgpt-4o-latest`, `chatgpt-image-latest`, the `codellama` family) |
| inference scoped to the last path segment | 236 fixed, **631 lost** |

The cause is that vendors append version digits straight onto the family token (`qwen3-coder`, `qwen2-5-14b-instruct`, `mistral4-119b`) and embed it mid-word (`chatgpt-4o-latest`, `CodeLlama-34b-Instruct-hf`). A delimited match rejects every one of those.

On the other side of the ledger, the false-positive class the comment is guarding against does not appear: of the 535 ids that match only via an embedded token, **all 535 are correct attributions**. And across the 97 model ids actually observed in local session data on this machine — which is what this function is really fed, not catalog keys — all three variants are exact no-ops.

So there is no behavior change here. `contains_delimited` stays reserved for short tokens that collide inside ordinary words, which is what `test_inferred_provider_no_false_positives` (`protocol1`, `proto3`, `co4pilot`, `metadata`, `metamorphic`) already pins.

## What this PR adds

Tests only.

- `test_inferred_provider_matches_version_suffixed_and_embedded_families` pins the family ids that delimited matching would break, with a comment explaining why the asymmetry exists. Applying the suggested change fails it immediately: `qwen3-coder` → `left: None, right: Some("qwen")`.
- `test_parse_senpi_provider_inference_wins_over_the_client_fallback` makes the precedence the comment asked about explicit — a provider-less `qwen3-coder` message is attributed to `qwen`, and only a genuinely unrecognizable id (`internal-house-model`) falls back to `senpi`.

The gap the review found was real, just not the one it named: this behavior was undocumented and unpinned, so the next reader would have drawn the same conclusion. Now it fails loudly instead.

## One genuine issue found while measuring, not fixed here

Because `llama` is matched as a substring, **any `ollama/…` route id is attributed to `meta`** — `ollama/orca-mini` (Microsoft), `ollama/codegemma` (Google), `ollama/qwen3-coder` (Alibaba). That is a real misattribution, and it is the strongest version of the reviewer's concern.

It is out of scope here: no `ollama/…` id appears in the observed session data, the fix belongs with route-prefix handling rather than family matching (segment scoping alone costs 631 ids), and it affects every client that infers, not just Senpi. Worth its own change with its own evidence.

## Verification

`cargo test -p tokscale-core` — 1306 passed, 0 failed. `cargo fmt --check` clean, `cargo clippy --all-targets` 0 warnings.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests that lock provider inference for version-suffixed and embedded family tokens (e.g., qwen3, mistral4, chatgpt-4o-latest, CodeLlama) to preserve correct vendor attribution and pricing. Also pin Senpi precedence: inference runs before the client `senpi` fallback when a family is recognized.

<sup>Written for commit 985cc478252ae0f2d1439ea53e0a4e8e83fb177f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

