### PR TITLE
fix(provider): ignore Ollama route prefixes during inference

### DIFF
--- a/crates/tokscale-core/src/provider_identity.rs
+++ b/crates/tokscale-core/src/provider_identity.rs
@@ -124,6 +124,14 @@ fn contains_delimited(haystack: &str, needle: &str) -> bool {
 pub fn inferred_provider_from_model(model: &str) -> Option<&'static str> {
     let lower = model.to_lowercase();
 
+    // Ollama is a routing prefix, not part of the upstream model family. In
+    // particular, matching the `llama` in `ollama/...` would label every
+    // otherwise-unknown Ollama model as Meta. Re-run inference on the routed
+    // model so known families retain their actual providers.
+    if let Some(routed_model) = lower.strip_prefix("ollama/") {
+        return inferred_provider_from_model(routed_model);
+    }
+
     if lower.contains("claude")
         || lower.contains("anthropic")
         || contains_delimited(&lower, "opus")
@@ -308,6 +316,19 @@ mod tests {
         assert_eq!(inferred_provider_from_model("llama-3"), Some("meta"));
         assert_eq!(inferred_provider_from_model("qwen3-coder"), Some("qwen"));
         assert_eq!(inferred_provider_from_model("unknown-model"), None);
+    }
+
+    #[test]
+    fn test_inferred_provider_ignores_ollama_route_prefix() {
+        assert_eq!(inferred_provider_from_model("ollama/orca-mini"), None);
+        assert_eq!(
+            inferred_provider_from_model("ollama/qwen3-coder"),
+            Some("qwen")
+        );
+        assert_eq!(
+            inferred_provider_from_model("ollama/llama-3.3"),
+            Some("meta")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Prevents `ollama/` route prefixes from being treated as a Meta Llama model-family match during provider inference.

- `ollama/orca-mini` now remains unknown instead of being attributed to Meta solely because the route prefix contains `llama`.
- Known model families behind Ollama routing keep their provider: `ollama/qwen3-coder` resolves to Qwen and `ollama/llama-3.3` resolves to Meta.

## Verification

- `cargo test -p tokscale-core` — 1308 passed
- `cargo clippy -p tokscale-core --all-targets -- -D warnings`
- `cargo fmt --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents mislabeling Ollama-routed models as Meta by ignoring the `ollama/` route prefix during provider inference. Known families behind Ollama still resolve to the right provider.

- **Bug Fixes**
  - Ignore `ollama/` and re-run inference on the routed model.
  - Examples: `ollama/orca-mini` → unknown; `ollama/qwen3-coder` → Qwen; `ollama/llama-3.3` → Meta.

<sup>Written for commit b45a065f4e581c67443cea963f554df68ab776a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

