### PR TITLE
fix(tui): stop forcing Terminal.app into compatible color mode

### DIFF
--- a/crates/tokscale-cli/src/tui/themes.rs
+++ b/crates/tokscale-cli/src/tui/themes.rs
@@ -14,7 +14,6 @@ impl TerminalColorMode {
         V: AsRef<str>,
     {
         let mut term = String::new();
-        let mut term_program = String::new();
         let mut colorterm = String::new();
         let mut no_color = false;
 
@@ -23,14 +22,19 @@ impl TerminalColorMode {
             let value = value.as_ref();
             match key {
                 "TERM" => term = value.to_ascii_lowercase(),
-                "TERM_PROGRAM" => term_program = value.to_ascii_lowercase(),
                 "COLORTERM" => colorterm = value.to_ascii_lowercase(),
                 "NO_COLOR" => no_color = true,
                 _ => {}
             }
         }
 
-        if no_color || term == "dumb" || term_program == "apple_terminal" {
+        // `TERM_PROGRAM == "Apple_Terminal"` used to land here too. Terminal.app
+        // does render 24-bit SGR colors (verified: `ESC[38;2;255;80;0m` paints
+        // its own orange, distinct from indexed 208), and it never sets
+        // COLORTERM, so blacklisting it dropped Terminal.app to `Compatible`,
+        // which overwrites every theme with one palette and made theme
+        // switching a no-op there. Re-test before reinstating it.
+        if no_color || term == "dumb" {
             return Self::Compatible;
         }
 
@@ -540,13 +544,20 @@ mod tests {
     }
 
     #[test]
-    fn apple_terminal_uses_compatible_color_mode() {
+    fn apple_terminal_keeps_full_color_and_per_theme_palettes() {
         let mode = TerminalColorMode::from_env(env(&[
             ("TERM_PROGRAM", "Apple_Terminal"),
             ("TERM", "xterm-256color"),
         ]));
 
-        assert_eq!(mode, TerminalColorMode::Compatible);
+        assert_eq!(mode, TerminalColorMode::FullColor);
+
+        // The regression this guards: in `Compatible` mode every theme collapses
+        // onto one grey/cyan palette, so cycling themes changed the footer label
+        // and nothing else.
+        let green = Theme::from_name_with_color_mode(ThemeName::Green, mode);
+        let blue = Theme::from_name_with_color_mode(ThemeName::Blue, mode);
+        assert_ne!(green.colors, blue.colors);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Switching themes does nothing visible in macOS Terminal.app. Cycling with `p` updates the theme name, but every theme renders in the same grey/cyan palette.

The cause is a hardcoded terminal blacklist in `TerminalColorMode::from_env`:

```rust
if no_color || term == "dumb" || term_program == "apple_terminal" {
    return Self::Compatible;
}
```

Terminal.app sets `TERM_PROGRAM=Apple_Terminal`, so it always resolves to `Compatible`. That mode does more than reduce colour depth — it discards each theme's palette entirely and substitutes one fixed set:

```rust
theme.colors = [Color::Black, Color::DarkGray, Color::Gray, Color::White, Color::Cyan];
theme.accent = Color::Cyan;
// ... background / foreground / border / selection are all overwritten too
```

So all themes collapse onto the same colours, and theme switching becomes a no-op for anyone using the default macOS terminal.

## Why the blacklist is no longer correct

Terminal.app renders 24-bit SGR colour correctly. Running this in Terminal.app prints two visibly different oranges — the truecolour word in `rgb(255, 80, 0)` and the indexed word in palette entry 208 (`#ff8700`):

```sh
printf '\033[38;2;255;80;0mTRUECOLOR\033[0m  \033[38;5;208mINDEXED256\033[0m\n'
```

If the 24-bit form were unsupported the sequence would be dropped and the first word would fall back to the default foreground colour. It does not, and the two words are distinguishable shades, which is only possible if the RGB triple is honoured.

Terminal.app also never sets `COLORTERM`, so it cannot satisfy the positive truecolour check further down the function. Removing the blacklist lets it fall through to the `FullColor` default, which is the correct outcome.

## Change

Drop the `term_program == "apple_terminal"` condition, along with the `term_program` binding and its match arm, which have no other reader. `NO_COLOR` and `TERM=dumb` still resolve to `Compatible`, and the `COLORTERM` / `TERM` truecolour checks are untouched.

The existing `apple_terminal_uses_compatible_color_mode` test asserted the behaviour being removed, so it is inverted and renamed. It now also asserts that two themes keep distinct palettes under the resolved mode, which is the user-visible symptom rather than just the enum value.

A comment records the verification above so the blacklist is not reintroduced without re-testing.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- Manually confirmed in Terminal.app that cycling themes with `p` now changes the rendered colours. The degraded paths are unaffected: `TERM=dumb` still resolves to the compatible palette, and `NO_COLOR=1` still renders monochrome (crossterm strips colour output itself under `NO_COLOR`, independently of the resolved theme).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes theme switching in macOS Terminal.app so themes render distinct colors instead of a fixed grey/cyan palette.

- **Bug Fixes**
  - Removed `TERM_PROGRAM=Apple_Terminal` blacklist in color-mode detection so Terminal.app resolves to FullColor (it supports 24‑bit SGR).
  - Updated test to assert FullColor and that themes keep distinct palettes in Terminal.app.
  - `NO_COLOR` and `TERM=dumb` still resolve to Compatible.

<sup>Written for commit afbf12ec3a7fc3d97cf6beede1e9d1606ace7fa1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

