### PR TITLE
fix(moderation): drop the implied-rate floor that flagged 38 innocent accounts

### DIFF
--- a/packages/frontend/__tests__/lib/moderationHeuristics.test.ts
+++ b/packages/frontend/__tests__/lib/moderationHeuristics.test.ts
@@ -87,18 +87,41 @@ describe("scoreCandidate", () => {
     expect(signalKeys(scored)).not.toContain("dailyMismatch");
   });
 
-  it("flags an implied per-token price outside provider pricing", () => {
+  it("flags an implied per-token price above every provider's list price", () => {
     const tooExpensive = scoreCandidate(
       row({ totalTokens: 1_000, totalCost: 500 }),
       CONTEXT
     );
-    const tooCheap = scoreCandidate(
-      row({ totalTokens: 1_000_000_000_000, totalCost: 1 }),
-      CONTEXT
-    );
 
     expect(signalKeys(tooExpensive)).toContain("impliedRate");
-    expect(signalKeys(tooCheap)).toContain("impliedRate");
+  });
+
+  it("does not flag a very low implied rate, which local and free models produce", () => {
+    // Measured against production: a 1e-7 floor flagged 38 ordinary accounts
+    // against 3 genuine ones. Ollama and LM Studio cost nothing, free tiers
+    // cost nothing, and cache reads are far cheaper than input tokens, so a
+    // low blended rate is normal heavy usage rather than evidence of anything.
+    // @adheizal's real figures, with the real median (~5.8e9, derived from
+    // grenadeoftacoss reporting 1,550,270x it) and daily rows that agree with
+    // the stored total, so this isolates the implied-rate signal alone.
+    const localModels = scoreCandidate(
+      row({
+        totalTokens: 87_931_302_128,
+        totalCost: 6_232,
+        dailyTokens: 87_931_302_128,
+      }),
+      { siteTokens: 9_078_292_663_926_388, medianTokens: 5_822_000_000 }
+    );
+    const nearlyFree = scoreCandidate(
+      row({ totalTokens: 1_000_000_000, totalCost: 1, dailyTokens: 1_000_000_000 }),
+      { siteTokens: 9_078_292_663_926_388, medianTokens: 5_822_000_000 }
+    );
+
+    expect(signalKeys(localModels)).not.toContain("impliedRate");
+    expect(signalKeys(nearlyFree)).not.toContain("impliedRate");
+    // Drops out of the queue entirely rather than sitting there as permanent
+    // noise — which is what the old floor did to 38 accounts like this one.
+    expect(localModels.signals).toEqual([]);
   });
 
   it("never divides by zero on an empty site or a zero-token user", () => {

--- a/packages/frontend/__tests__/lib/moderationHeuristics.test.ts
+++ b/packages/frontend/__tests__/lib/moderationHeuristics.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  SLOP_MODEL_REGEX,
   rankCandidates,
   scoreCandidate,
   type CandidateContext,
@@ -221,5 +222,40 @@ describe("rankCandidates", () => {
     );
 
     expect(ranked.map((c) => c.username)).toEqual(["adam", "zoe"]);
+  });
+});
+
+describe("SLOP_MODEL_REGEX", () => {
+  // The pattern is interpolated into a Postgres `~*` comparison, so this is a
+  // JS approximation of that operator. Both are POSIX-flavoured and the
+  // constructs used here -- alternation, a negated class, an anchor -- behave
+  // identically, which is enough to pin the boundary this test is about.
+  const matches = (name: string) => new RegExp(SLOP_MODEL_REGEX, "i").test(name);
+
+  it("matches an invented name with no delimiter before the marker", () => {
+    // The case the pattern list exists for. Requiring delimiters on BOTH sides
+    // would silently stop catching it, which is why only the left is anchored.
+    expect(matches("slopllm")).toBe(true);
+    expect(matches("SlopLLM")).toBe(true);
+  });
+
+  it("matches the marker at a segment boundary", () => {
+    expect(matches("slop-llm")).toBe(true);
+    expect(matches("slopai/slopllm:5m")).toBe(true);
+    expect(matches("gpt-4-fake")).toBe(true);
+    expect(matches("my_dummy_model")).toBe(true);
+  });
+
+  it("does not match a marker buried inside a longer word", () => {
+    // The false-positive class: a future legitimate id that merely contains
+    // one of these words should not enter the queue.
+    expect(matches("notaslopname")).toBe(false);
+    expect(matches("xfakey")).toBe(false);
+  });
+
+  it("leaves ordinary model ids alone", () => {
+    expect(matches("claude-sonnet-4-5")).toBe(false);
+    expect(matches("deepseek-v3")).toBe(false);
+    expect(matches("gpt-5.4")).toBe(false);
   });
 });

--- a/packages/frontend/__tests__/lib/moderationHeuristics.test.ts
+++ b/packages/frontend/__tests__/lib/moderationHeuristics.test.ts
@@ -32,6 +32,7 @@ function row(overrides: Partial<CandidateRow> = {}): CandidateRow {
     hasBackfill: false,
     dailyTokens: 1_200_000,
     nearDuplicateCount: 0,
+    slopModels: [],
     ...overrides,
   };
 }
@@ -57,6 +58,45 @@ describe("scoreCandidate", () => {
 
     expect(signalKeys(scored)).toContain("siteShare");
     expect(scored.signals.find((s) => s.key === "siteShare")?.label).toContain("99.4%");
+  });
+
+  it("flags invented model names and quotes them verbatim", () => {
+    // The real three variants on the rank-1 account.
+    const scored = scoreCandidate(
+      row({
+        slopModels: ["slopllm-5m", "slopai/slopllm-5m", "slopai/slopllm:5m"],
+      }),
+      CONTEXT
+    );
+
+    expect(signalKeys(scored)).toContain("slopModelName");
+    // Quoted so the reviewer judges the string itself rather than trusting the
+    // match — the name is the evidence.
+    expect(scored.signals.find((s) => s.key === "slopModelName")?.label).toContain(
+      '"slopllm-5m"'
+    );
+  });
+
+  it("outweighs every other single signal, since a name cannot be innocent", () => {
+    const slop = scoreCandidate(row({ slopModels: ["slopllm-5m"] }), CONTEXT);
+    const duplicate = scoreCandidate(row({ nearDuplicateCount: 1 }), CONTEXT);
+
+    expect(slop.score).toBeGreaterThan(duplicate.score);
+  });
+
+  it("summarises rather than listing every match", () => {
+    const scored = scoreCandidate(
+      row({ slopModels: ["a-slop", "b-slop", "c-slop", "d-slop", "e-slop"] }),
+      CONTEXT
+    );
+
+    expect(scored.signals[0].label).toContain("and 2 more");
+  });
+
+  it("does not flag an account with no invented names", () => {
+    expect(signalKeys(scoreCandidate(row({ slopModels: [] }), CONTEXT))).not.toContain(
+      "slopModelName"
+    );
   });
 
   it("flags a token total that matches another account almost exactly", () => {

--- a/packages/frontend/src/app/admin/moderation/ModerationClient.tsx
+++ b/packages/frontend/src/app/admin/moderation/ModerationClient.tsx
@@ -42,7 +42,17 @@ const HIDE_REASONS = [
   "Data issue on our side",
 ] as const;
 
-const UNHIDE_REASONS = ["Restored"] as const;
+/**
+ * Mirrors the ours-versus-theirs distinction above. A single "Restored" made
+ * the audit trail lossy in exactly the direction that matters: clearing an
+ * account we hid because of our own ratchet inflation looked identical to
+ * clearing one a human reviewed and disagreed with. Both are the same button
+ * press; only the record can tell them apart later.
+ */
+const UNHIDE_REASONS = [
+  "Restored after review",
+  "Restored — data issue on our side",
+] as const;
 
 export default function ModerationClient() {
   const [candidates, setCandidates] = useState<Candidate[] | null>(null);

--- a/packages/frontend/src/app/admin/moderation/ModerationClient.tsx
+++ b/packages/frontend/src/app/admin/moderation/ModerationClient.tsx
@@ -19,6 +19,32 @@ interface Candidate {
   signals: CandidateSignal[];
 }
 
+/**
+ * Fixed reasons rather than free text.
+ *
+ * These strings land verbatim in moderation_actions and are the only record of
+ * why a decision was made, so they need to still be legible to someone reading
+ * the audit log months later. A typed sentence would drift in wording and
+ * detail between entries; a closed set stays comparable.
+ *
+ * The wording separates the two cases the heuristics exist to distinguish:
+ * fabricated data, versus our own ratchet inflation (#960). Never record the
+ * latter as if the user did something wrong.
+ */
+const HIDE_REASONS = [
+  "Fabricated usage — reports invented model names",
+  "Duplicate dataset — token total matches another account almost exactly",
+  "Implausible magnitude — usage inconsistent with any real workload",
+  "Suspected ratchet inflation (#960) — our bug, hidden pending correction",
+  "Under investigation — withheld from rankings until reviewed",
+] as const;
+
+const UNHIDE_REASONS = [
+  "Reviewed — no evidence of fabrication, restored",
+  "Resolved — inflation corrected upstream, restored",
+  "Hidden in error — restored",
+] as const;
+
 export default function ModerationClient() {
   const [candidates, setCandidates] = useState<Candidate[] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -56,7 +82,7 @@ export default function ModerationClient() {
     // Enforced client-side as well as in the API so the reviewer is told what
     // is missing before a round trip, not after a 400.
     if (!reason) {
-      setError(`A reason is required before changing @${candidate.username}.`);
+      setError(`Select a reason before changing @${candidate.username}.`);
       return;
     }
 
@@ -142,17 +168,25 @@ export default function ModerationClient() {
                 </Signals>
 
                 <ActionRow>
-                  <ReasonInput
+                  <ReasonSelect
                     aria-label={`Reason for changing @${candidate.username}`}
                     value={reasons[candidate.username] ?? ""}
-                    placeholder="Reason (recorded permanently)"
                     onChange={(event) =>
                       setReasons((current) => ({
                         ...current,
                         [candidate.username]: event.target.value,
                       }))
                     }
-                  />
+                  >
+                    <option value="">Select a reason (recorded permanently)…</option>
+                    {(candidate.leaderboardHidden ? UNHIDE_REASONS : HIDE_REASONS).map(
+                      (reason) => (
+                        <option key={reason} value={reason}>
+                          {reason}
+                        </option>
+                      )
+                    )}
+                  </ReasonSelect>
                   <ActionButton
                     type="button"
                     $danger={!candidate.leaderboardHidden}
@@ -281,9 +315,9 @@ const ActionRow = styled.div`
   margin-top: 16px;
 `;
 
-const ReasonInput = styled.input`
+const ReasonSelect = styled.select`
   flex: 1;
-  min-width: 240px;
+  min-width: 320px;
   padding: 9px 12px;
   border: 1px solid var(--service-border);
   border-radius: 8px;

--- a/packages/frontend/src/app/admin/moderation/ModerationClient.tsx
+++ b/packages/frontend/src/app/admin/moderation/ModerationClient.tsx
@@ -20,30 +20,29 @@ interface Candidate {
 }
 
 /**
- * Fixed reasons rather than free text.
+ * Fixed reasons rather than free text, and deliberately vague ones.
  *
- * These strings land verbatim in moderation_actions and are the only record of
- * why a decision was made, so they need to still be legible to someone reading
- * the audit log months later. A typed sentence would drift in wording and
- * detail between entries; a closed set stays comparable.
+ * An earlier draft spelled out which signal fired ("reports invented model
+ * names", "token total matches another account"). That is a detection
+ * playbook: anyone who reads it learns exactly what to avoid next time. These
+ * strings are stored, and anything stored can end up shown, so they say
+ * nothing about how the account was found.
  *
- * The wording separates the two cases the heuristics exist to distinguish:
- * fabricated data, versus our own ratchet inflation (#960). Never record the
- * latter as if the user did something wrong.
+ * Nothing is lost by being vague. The review screen recomputes the signals
+ * live from current data, so the specific evidence is always reconstructible —
+ * the audit row only needs to record the decision and who made it.
+ *
+ * The one distinction kept is ours-versus-theirs. It leaks no method, and
+ * without it a hide caused by our own ratchet inflation would be recorded
+ * identically to genuine abuse.
  */
 const HIDE_REASONS = [
-  "Fabricated usage — reports invented model names",
-  "Duplicate dataset — token total matches another account almost exactly",
-  "Implausible magnitude — usage inconsistent with any real workload",
-  "Suspected ratchet inflation (#960) — our bug, hidden pending correction",
-  "Under investigation — withheld from rankings until reviewed",
+  "Abuse",
+  "Under investigation",
+  "Data issue on our side",
 ] as const;
 
-const UNHIDE_REASONS = [
-  "Reviewed — no evidence of fabrication, restored",
-  "Resolved — inflation corrected upstream, restored",
-  "Hidden in error — restored",
-] as const;
+const UNHIDE_REASONS = ["Restored"] as const;
 
 export default function ModerationClient() {
   const [candidates, setCandidates] = useState<Candidate[] | null>(null);

--- a/packages/frontend/src/lib/moderation/candidates.ts
+++ b/packages/frontend/src/lib/moderation/candidates.ts
@@ -4,6 +4,7 @@ import {
   DAILY_MISMATCH_THRESHOLD,
   MAX_IMPLIED_RATE,
   MEDIAN_RATIO_THRESHOLD,
+  SLOP_MODEL_REGEX,
   rankCandidates,
   SITE_SHARE_THRESHOLD,
   type CandidateRow,
@@ -28,6 +29,7 @@ interface CandidateDbRow extends Record<string, unknown> {
   has_backfill: boolean | null;
   daily_tokens: number | string | null;
   near_duplicate_count: number | string | null;
+  slop_models: string[] | null;
   site_tokens: number | string | null;
   median_tokens: number | string | null;
 }
@@ -62,7 +64,17 @@ export async function getModerationCandidates(): Promise<ScoredCandidate[]> {
         s.total_tokens,
         CAST(s.total_cost AS DECIMAL(18,4)) AS total_cost,
         s.submit_count,
-        s.has_backfill
+        s.has_backfill,
+        -- Pre-filtered here rather than shipping the whole array: the busiest
+        -- account reports 141 models and only the matches are of interest.
+        COALESCE(
+          (
+            SELECT array_agg(DISTINCT m)
+            FROM unnest(s.models_used) AS m
+            WHERE m ~* ${SLOP_MODEL_REGEX}
+          ),
+          ARRAY[]::text[]
+        ) AS slop_models
       FROM users u
       JOIN submissions s ON s.user_id = u.id
     ),
@@ -104,6 +116,7 @@ export async function getModerationCandidates(): Promise<ScoredCandidate[]> {
         OR (site_tokens > 0 AND total_tokens::numeric / site_tokens >= ${SITE_SHARE_THRESHOLD})
         OR (median_tokens > 0 AND total_tokens::numeric / median_tokens >= ${MEDIAN_RATIO_THRESHOLD})
         OR near_duplicate_count > 0
+        OR cardinality(slop_models) > 0
         OR (daily_tokens > 0 AND total_tokens::numeric / daily_tokens >= ${DAILY_MISMATCH_THRESHOLD})
         OR (
           total_tokens > 0
@@ -113,7 +126,7 @@ export async function getModerationCandidates(): Promise<ScoredCandidate[]> {
     SELECT
       user_id, username, avatar_url, leaderboard_hidden, total_tokens,
       total_cost, submit_count, has_backfill, daily_tokens,
-      near_duplicate_count, site_tokens, median_tokens
+      near_duplicate_count, slop_models, site_tokens, median_tokens
     FROM eligible
   `);
 
@@ -134,6 +147,7 @@ export async function getModerationCandidates(): Promise<ScoredCandidate[]> {
     hasBackfill: row.has_backfill === true,
     dailyTokens: toNumber(row.daily_tokens),
     nearDuplicateCount: toNumber(row.near_duplicate_count),
+    slopModels: Array.isArray(row.slop_models) ? row.slop_models : [],
   }));
 
   return rankCandidates(rows, {

--- a/packages/frontend/src/lib/moderation/candidates.ts
+++ b/packages/frontend/src/lib/moderation/candidates.ts
@@ -4,7 +4,6 @@ import {
   DAILY_MISMATCH_THRESHOLD,
   MAX_IMPLIED_RATE,
   MEDIAN_RATIO_THRESHOLD,
-  MIN_IMPLIED_RATE,
   rankCandidates,
   SITE_SHARE_THRESHOLD,
   type CandidateRow,
@@ -108,10 +107,7 @@ export async function getModerationCandidates(): Promise<ScoredCandidate[]> {
         OR (daily_tokens > 0 AND total_tokens::numeric / daily_tokens >= ${DAILY_MISMATCH_THRESHOLD})
         OR (
           total_tokens > 0
-          AND (
-            total_cost / total_tokens::numeric > ${MAX_IMPLIED_RATE}
-            OR total_cost / total_tokens::numeric < ${MIN_IMPLIED_RATE}
-          )
+          AND total_cost / total_tokens::numeric > ${MAX_IMPLIED_RATE}
         )
     )
     SELECT

--- a/packages/frontend/src/lib/moderation/heuristics.ts
+++ b/packages/frontend/src/lib/moderation/heuristics.ts
@@ -91,8 +91,18 @@ export const SLOP_MODEL_PATTERNS = [
   "madeup",
 ] as const;
 
-/** Case-insensitive alternation for the SQL-side pre-filter. */
-export const SLOP_MODEL_REGEX = `(${SLOP_MODEL_PATTERNS.join("|")})`;
+/**
+ * Case-insensitive alternation for the SQL-side pre-filter, anchored to the
+ * start of a name or of a segment within it.
+ *
+ * Unanchored, the pattern matched anywhere inside an id, so any future
+ * legitimate name that merely contains one of these words would be flagged.
+ * Anchoring only the left side is deliberate: requiring a delimiter on BOTH
+ * sides would stop matching `slopllm`, which is the exact shape the list is
+ * written to catch. `slop-llm`, `slop/llm` and `slopllm` all still match;
+ * `notaslopname` no longer does.
+ */
+export const SLOP_MODEL_REGEX = `(^|[^a-z0-9])(${SLOP_MODEL_PATTERNS.join("|")})`;
 
 /** A user holding more than this share of all tokens is worth a look. */
 export const SITE_SHARE_THRESHOLD = 0.05;
@@ -171,8 +181,15 @@ export function scoreCandidate(
     signals.push({
       key: "slopModelName",
       label: `Reports invented model names: ${shown}${extra > 0 ? ` and ${extra} more` : ""}`,
-      // The strongest signal available. Magnitude and duplication can both have
-      // innocent explanations; a model called "slopllm" cannot.
+      // The heaviest FIXED weight: magnitude and duplication can both have
+      // innocent explanations, and a model called "slopllm" cannot.
+      //
+      // Not the highest possible score, though — siteShare is 40 * share, so an
+      // account holding more than 87.5% of every token on the site outranks
+      // this. That ordering is correct and left alone: one account owning
+      // essentially the whole site is a bigger thing to look at than a bad
+      // model name, and it is the sort of claim worth stating accurately since
+      // the weights are what the queue order rests on.
       weight: 35,
     });
   }

--- a/packages/frontend/src/lib/moderation/heuristics.ts
+++ b/packages/frontend/src/lib/moderation/heuristics.ts
@@ -63,7 +63,18 @@ export const MEDIAN_RATIO_THRESHOLD = 500;
  * Published provider pricing sits well inside this band per token. Outside it,
  * either the cost or the token count is not what it claims to be.
  */
-export const MIN_IMPLIED_RATE = 0.0000001;
+/**
+ * Only an upper bound. There is deliberately no floor.
+ *
+ * A low implied rate carries no signal: local models via Ollama or LM Studio
+ * cost nothing, free tiers cost nothing, and cache reads are an order of
+ * magnitude cheaper than input tokens — so ordinary heavy users legitimately
+ * land far below any floor worth setting. Measured against real data, a
+ * 1e-7 floor flagged 38 innocent accounts against 3 genuine ones, which is a
+ * queue nobody would keep reading.
+ *
+ * The ceiling still means something: nobody pays above list price.
+ */
 export const MAX_IMPLIED_RATE = 0.001;
 /**
  * Daily rows should sum to roughly the stored total. A large gap is the
@@ -144,10 +155,10 @@ export function scoreCandidate(
 
   if (row.totalTokens > 0) {
     const impliedRate = row.totalCost / row.totalTokens;
-    if (impliedRate > MAX_IMPLIED_RATE || impliedRate < MIN_IMPLIED_RATE) {
+    if (impliedRate > MAX_IMPLIED_RATE) {
       signals.push({
         key: "impliedRate",
-        label: `Implied $${impliedRate.toPrecision(3)}/token is outside plausible provider pricing`,
+        label: `Implied $${impliedRate.toPrecision(3)}/token is above any provider's list price`,
         weight: 15,
       });
     }

--- a/packages/frontend/src/lib/moderation/heuristics.ts
+++ b/packages/frontend/src/lib/moderation/heuristics.ts
@@ -29,6 +29,12 @@ export interface CandidateRow {
   dailyTokens: number;
   /** How many OTHER users report a near-identical token total. */
   nearDuplicateCount: number;
+  /**
+   * This user's model names that match SLOP_MODEL_PATTERNS. Pre-filtered in SQL
+   * rather than sent whole: the busiest account reports 141 models, and only
+   * the matches are of any interest.
+   */
+  slopModels: string[];
 }
 
 export interface CandidateContext {
@@ -44,7 +50,8 @@ export interface CandidateSignal {
     | "medianRatio"
     | "duplicateTotal"
     | "dailyMismatch"
-    | "impliedRate";
+    | "impliedRate"
+    | "slopModelName";
   /** Shown verbatim in the review UI. */
   label: string;
   weight: number;
@@ -55,14 +62,42 @@ export interface ScoredCandidate extends CandidateRow {
   signals: CandidateSignal[];
 }
 
+/**
+ * Substrings that only appear in a model name someone invented.
+ *
+ * Deliberately tiny, and every entry was checked against production before
+ * being included. Two things are NOT here on purpose:
+ *
+ * - `test` — `test-model` is reported by 4 separate accounts, so it is someone
+ *   genuinely testing rather than a fabrication.
+ * - `hack` — the only hit was a tool name, and the word appears in enough
+ *   legitimate contexts to be a false-positive risk.
+ *
+ * Statistical alternatives were measured and rejected. Model *count* looked
+ * promising until the distribution came back at p50=20, p99=140, max=206 with
+ * 51 accounts above 100 models — the 141-model account is unremarkable on that
+ * axis. Counting models nobody else reports fails too, because the
+ * one-user-only set is mostly parser debris (`*`, `{`, `│`, bare UUIDs).
+ *
+ * So this is a content signal, not a statistical one: a name that declares
+ * itself fake is evidence in a way that an unusual count is not.
+ */
+export const SLOP_MODEL_PATTERNS = [
+  "slop",
+  "fake",
+  "dummy",
+  "bogus",
+  "notreal",
+  "madeup",
+] as const;
+
+/** Case-insensitive alternation for the SQL-side pre-filter. */
+export const SLOP_MODEL_REGEX = `(${SLOP_MODEL_PATTERNS.join("|")})`;
+
 /** A user holding more than this share of all tokens is worth a look. */
 export const SITE_SHARE_THRESHOLD = 0.05;
 /** Multiples of the median that stop being explainable as heavy usage. */
 export const MEDIAN_RATIO_THRESHOLD = 500;
-/**
- * Published provider pricing sits well inside this band per token. Outside it,
- * either the cost or the token count is not what it claims to be.
- */
 /**
  * Only an upper bound. There is deliberately no floor.
  *
@@ -125,6 +160,21 @@ export function scoreCandidate(
         weight: Math.min(25, Math.log10(ratio) * 6),
       });
     }
+  }
+
+  if (row.slopModels.length > 0) {
+    // Quoted verbatim so the reviewer judges the actual string rather than
+    // trusting the match — the whole point is that the name speaks for itself.
+    const shown = row.slopModels.slice(0, 3).map((name) => `"${name}"`).join(", ");
+    const extra = row.slopModels.length - 3;
+
+    signals.push({
+      key: "slopModelName",
+      label: `Reports invented model names: ${shown}${extra > 0 ? ` and ${extra} more` : ""}`,
+      // The strongest signal available. Magnitude and duplication can both have
+      // innocent explanations; a model called "slopllm" cannot.
+      weight: 35,
+    });
   }
 
   if (row.nearDuplicateCount > 0) {


### PR DESCRIPTION
Follow-up to #980, found by running the review queue against production for the first time.

## The problem

The queue returned **41 candidates and only 3 were real**. The other 38 all tripped one signal: an implied cost-per-token below the `1e-7` floor.

```
@adheizal        87.9B tokens / $6,232   → $7.09e-8/token   → flagged
@adolphrui-beep  12.0B tokens / $1,164   → $9.63e-8/token   → flagged
@287252681-ctrl  737M tokens  / $41      → $5.62e-8/token   → flagged
```

These are ordinary accounts. The floor was wrong in principle: **a low implied rate carries no information.** Local models via Ollama or LM Studio cost nothing, free tiers cost nothing, and cache reads are an order of magnitude cheaper than input tokens — so heavy legitimate users land far below any floor worth setting.

The ceiling still means something, because nobody pays *above* list price. So the fix keeps only that direction.

## Result

**41 candidates → 4**, all genuine:

```
@grenadeoftacoss  65  99.4% of all tokens · 1,550,270x median
@Nepomuk5665      49  1,214x median · matches another account almost exactly
@iamtheavoc1      49  1,214x median · matches another account almost exactly
@CollabVMgamez    15  Implied $0.00714/token is above any provider's list price
```

A queue that is 90% noise is one nobody keeps reading, which would have made the whole review surface pointless.

## Incidental finding

`dailyMismatch` fires on **none** of the four. The stored totals agree with the sum of daily rows, so the #960 ratchet-inflation fingerprint is absent for `grenadeoftacoss` — evidence pointing at the submitted data rather than our merge bug. Not conclusive (daily rows inflated in lockstep would also look clean), but the simplest ratchet story does not hold.

## Verification

- 729 tests pass, typecheck clean, 0 lint errors
- Queue re-run **read-only** against the production database: 41 → 4
- Test fixtures corrected to use the real median (~5.8e9, derived from `grenadeoftacoss` reporting 1,550,270x it) instead of an invented 1e6, which was masking how the thresholds actually behave

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the implied per-token rate floor and improved invented-name detection by anchoring the regex; also switched moderation reasons to a fixed, non-revealing select with distinct unhide options. In production the queue fell from 41 to 4 real candidates, then 6 with the name signal.

- **New Features**
  - Detect invented model names (e.g., `slop`, `fake`, `dummy`), quoted verbatim and summarized; prefiltered in SQL via `SLOP_MODEL_REGEX`; signal outweighs other singles.
  - Replace free-text reason with a fixed select that doesn’t reveal detection methods; options: “Abuse”, “Under investigation”, “Data issue on our side”; unhide: “Restored after review”, “Restored — data issue on our side” (client-side required).

- **Bug Fixes**
  - Dropped `MIN_IMPLIED_RATE`; kept `MAX_IMPLIED_RATE` and updated the label to “above any provider’s list price”; removed the lower-bound rate check from SQL and scoring; tests ensure very low implied rates aren’t flagged.
  - Anchored `SLOP_MODEL_REGEX` to the start of a name or segment to avoid substring false positives; continues to catch undelimited cases like `slopllm` while excluding `notaslopname`.

<sup>Written for commit 452cf920b6f5ac891dd6f8720808c323faf28302. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

