### PR TITLE
feat: add Augment Code (Auggie) local session client

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -96,6 +96,7 @@
 | <img width="48px" src="https://static.workbuddy.cn/web/agents/008054d6beaaf4a83e2d049e982e1244560726dc/assets/share-logo.png" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/**/*.jsonl` + SQLite フォールバック |
 | <img width="48px" src=".github/assets/client-devin.jpg" alt="Devin CLI" /> | [Devin CLI](https://devin.ai/) | `~/.local/share/devin/cli/sessions.db`（SQLite） |
 | <img width="48px" src=".github/assets/client-devin.jpg" alt="Devin Desktop" /> | [Devin Desktop](https://devin.ai/) | ACP イベント：macOS `~/Library/Application Support/Devin/User/acp-events/`、Linux `~/.config/Devin/User/acp-events/`、Windows `%APPDATA%\Devin\User\acp-events\` |
+| <img width="48px" src="https://github.com/augmentcode.png" alt="Augment Code" /> | [Augment Code](https://www.augmentcode.com/)（Auggie CLI） | `~/.augment/sessions/*.json` |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | `hf:`モデルや`synthetic`プロバイダを検出して他ソースから再帰属（+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`） |
 
 [🚅 LiteLLMの価格データ](https://github.com/BerriAI/litellm)を使用してリアルタイム価格計算を提供し、階層型価格モデルとキャッシュトークン割引をサポートしています。
@@ -170,7 +171,7 @@ AI支援開発の時代において、**トークンは新しいエネルギー*
   - 設定可能なカラーテーマのGitHubスタイル貢献グラフ
   - リアルタイムフィルタリングとソート
   - ゼロフリッカーレンダリング
-- **マルチプラットフォームサポート** - OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Synthetic全体の使用量追跡
+- **マルチプラットフォームサポート** - OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic全体の使用量追跡
 - **リアルタイム価格** - 1時間ディスクキャッシュ付きでLiteLLMから現在の価格を取得；OpenRouter自動フォールバックと新規モデル向けCursor価格サポート
 - **詳細な内訳** - 入力、出力、キャッシュ読み書き、推論トークン追跡
 - **ネイティブRustコア** - 10倍高速な処理のため、すべての解析と集計をRustで実行
@@ -381,7 +382,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-利用可能な値: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `synthetic`。
+利用可能な値: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `augment`, `synthetic`。
 
 > **破壊的変更 (v4.0.0)**: クライアント単位のブール型フラグ（`--opencode`、`--claude`、`--codex` など）は削除され、現在はエラーになります。代わりに正規の `--client`/`-c` フラグを使用してください — 例: `tokscale --client opencode,claude`。
 
@@ -1001,7 +1002,7 @@ tokscale sources --json
 - **インタラクティブツールチップ**: ホバーで詳細な日別内訳を表示
 - **日別内訳パネル**: クリックでソース別、モデル別の詳細を確認
 - **年別フィルタリング**: 年間を移動
-- **ソースフィルタリング**: プラットフォーム別フィルター（OpenCode、Claude、Codex、Copilot、Cursor、Gemini、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi、Qwen、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、Synthetic）
+- **ソースフィルタリング**: プラットフォーム別フィルター（OpenCode、Claude、Codex、Copilot、Cursor、Gemini、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi、Qwen、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic）
 - **統計パネル**: 総コスト、トークン、活動日数、連続記録
 - **FOUC防止**: Reactハイドレーション前にテーマを適用（フラッシュなし）
 
@@ -1342,6 +1343,7 @@ AIコーディングツールはクロスプラットフォームの場所にセ
 | OpenCodeReview | `~/.opencodereview/sessions/` | `%USERPROFILE%\.opencodereview\sessions\` | `*.jsonl` セッショントランスクリプトを解析；Alibaba の AI コードレビューツール |
 | CodeBuddy | `~/.codebuddy/projects/` + 拡張機能ログ | `%USERPROFILE%\.codebuddy\projects\` + CodeBuddy / VS Code 拡張機能ログ | CodeBuddy CLI・IDE・VS Code プラグインのトークン使用量を解析 |
 | WorkBuddy | `~/.workbuddy/projects/` + `~/.workbuddy/workbuddy.db` | `%USERPROFILE%\.workbuddy\projects\` + `%USERPROFILE%\.workbuddy\workbuddy.db` | WorkBuddy のトークン使用量を解析し、集約 SQLite データベースをフォールバックとして使用 |
+| Augment Code | `~/.augment/sessions/` | `%USERPROFILE%\.augment\sessions\` | Auggie CLI のセッション JSON スナップショット（`*.json`）を解析。結合キーはトップレベルの `sessionId` |
 | Synthetic | 他ソースから再帰属 | 他ソースから再帰属 | `hf:`モデル + `synthetic`プロバイダを検出 |
 
 > **注**: Windowsでは`~`は`%USERPROFILE%`に展開されます（例：`C:\Users\ユーザー名`）。これらのツールは`%APPDATA%`のようなWindowsネイティブパスではなく、クロスプラットフォームの一貫性のためにUnixスタイルのパス（`.local/share`など）を意図的に使用しています。
@@ -1556,6 +1558,12 @@ Grok Build データはローカルのセッション更新から直接解析さ
 場所: `$JCODE_HOME/sessions/session_*.json`（フォールバック: `~/.jcode/sessions/session_*.json`）と、対応する `session_*.journal.jsonl` サイドカー。
 
 Jcode データはローカルのセッションスナップショットから直接解析されます。Tokscale は別のクライアントの識別子を偽装することなく、アシスタントの `messages[].token_usage` フィールド（`input_tokens`、`output_tokens`、`cache_read_input_tokens`、`cache_creation_input_tokens`、`reasoning_output_tokens`）を読み取ります。対応するジャーナルサイドカーは重複排除の前に同じセッションストリームへマージされるため、Jcode がスナップショットにチェックポイントするまでの間も、最近追記されたメッセージが含まれます。リプレイの重複排除には安定したメッセージ ID を使用し、ID を持たない不正/カスタムなレコードにはスコープ付きのフォールバックキーを使用します。
+
+### Augment Code (Auggie CLI)
+
+場所: `~/.augment/sessions/<sessionId>.json`
+
+Augment Code / Auggie CLI はチャットセッションごとに 1 つの JSON スナップショットを書き出します。Tokscale は `chatHistory[]` の完了済みターンを読み取り、セッション既定の `agentState.modelId` より `exchange.model_id` を優先し、`exchange.response_nodes[]` 上の単一の `token_usage` 観測（`input_tokens`、`output_tokens`、`cache_read_input_tokens`、`cache_creation_input_tokens`）を使用します。トップレベルの `sessionId` はそのまま保持され、外部ツールが ACP セッション ID にコストを結合できます。
 
 ### OpenClaw
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -96,6 +96,7 @@
 | <img width="48px" src="https://static.workbuddy.cn/web/agents/008054d6beaaf4a83e2d049e982e1244560726dc/assets/share-logo.png" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/**/*.jsonl` + SQLite 폴백 |
 | <img width="48px" src=".github/assets/client-devin.jpg" alt="Devin CLI" /> | [Devin CLI](https://devin.ai/) | `~/.local/share/devin/cli/sessions.db` (SQLite) |
 | <img width="48px" src=".github/assets/client-devin.jpg" alt="Devin Desktop" /> | [Devin Desktop](https://devin.ai/) | ACP 이벤트: macOS `~/Library/Application Support/Devin/User/acp-events/`; Linux `~/.config/Devin/User/acp-events/`; Windows `%APPDATA%\Devin\User\acp-events\` |
+| <img width="48px" src="https://github.com/augmentcode.png" alt="Augment Code" /> | [Augment Code](https://www.augmentcode.com/) (Auggie CLI) | `~/.augment/sessions/*.json` |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | `hf:` 모델/`synthetic` provider 감지로 다른 소스에서 재귀속 (+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`) |
 
 [🚅 LiteLLM의 가격 데이터](https://github.com/BerriAI/litellm)를 사용해 **실시간 비용 계산**을 제공합니다. 구간별 가격 모델(대용량 컨텍스트 등)과 **캐시 토큰 할인**도 지원합니다.
@@ -168,7 +169,7 @@ AI 지원 개발 시대에 **토큰은 새로운 에너지**입니다. 토큰은
   - 설정 가능한 색상 테마의 GitHub 스타일 기여 그래프
   - 실시간 필터링 및 정렬
   - 깜빡임 없는 렌더링
-- **멀티 플랫폼 지원** - OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Synthetic 사용량 통합 추적
+- **멀티 플랫폼 지원** - OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic 사용량 통합 추적
 - **실시간 가격 반영** - LiteLLM에서 최신 가격을 가져와(디스크 캐시 1시간) 비용 계산; OpenRouter 자동 폴백 및 신규 모델용 Cursor 가격 지원
 - **상세 분석** - 입력, 출력, 캐시 읽기/쓰기, 추론 토큰까지 추적
 - **네이티브 Rust 코어** - 모든 파싱과 집계를 Rust로 처리해 최대 10배 빠른 성능
@@ -377,7 +378,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-가능한 값: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `synthetic`.
+가능한 값: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `augment`, `synthetic`.
 
 > **Breaking change (v4.0.0):** 클라이언트별 boolean 플래그(`--opencode`, `--claude`, `--codex` 등)는 제거되었으며 이제 오류를 발생시킵니다. 대신 정식 `--client`/`-c` 플래그를 사용하세요 — 예: `tokscale --client opencode,claude`.
 
@@ -1000,7 +1001,7 @@ tokscale sources --json
 - **인터랙티브 툴팁**: 호버 시 상세 일별 분석 표시
 - **일별 분석 패널**: 클릭하여 소스별, 모델별 세부사항 확인
 - **연도 필터링**: 연도 간 탐색
-- **소스 필터링**: 플랫폼별 필터 (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, Synthetic)
+- **소스 필터링**: 플랫폼별 필터 (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic)
 - **통계 패널**: 총 비용, 토큰, 활동 일수, 연속 기록
 - **FOUC 방지**: React 하이드레이션 전 테마 적용 (깜빡임 없음)
 
@@ -1343,6 +1344,7 @@ AI 코딩 도구들은 크로스 플랫폼 위치에 세션 데이터를 저장�
 | OpenCodeReview | `~/.opencodereview/sessions/` | `%USERPROFILE%\.opencodereview\sessions\` | `*.jsonl` 세션 트랜스크립트 파싱; Alibaba의 AI 코드 리뷰 도구 |
 | CodeBuddy | `~/.codebuddy/projects/` + 확장 프로그램 로그 | `%USERPROFILE%\.codebuddy\projects\` + CodeBuddy / VS Code 확장 프로그램 로그 | CodeBuddy CLI, IDE, VS Code 플러그인 토큰 사용량 파싱 |
 | WorkBuddy | `~/.workbuddy/projects/` + `~/.workbuddy/workbuddy.db` | `%USERPROFILE%\.workbuddy\projects\` + `%USERPROFILE%\.workbuddy\workbuddy.db` | WorkBuddy 토큰 사용량 파싱, 집계 SQLite 데이터베이스를 폴백으로 사용 |
+| Augment Code | `~/.augment/sessions/` | `%USERPROFILE%\.augment\sessions\` | Auggie CLI 세션 JSON 스냅샷(`*.json`) 파싱; 조인 키는 최상위 `sessionId` |
 | Synthetic | 다른 소스에서 재귀속 | 다른 소스에서 재귀속 | `hf:` 모델 접두사 + `synthetic` provider 감지 |
 
 > **참고**: Windows에서 `~`는 `%USERPROFILE%`로 확장됩니다 (예: `C:\Users\사용자이름`). 이러한 도구들은 `%APPDATA%`와 같은 Windows 기본 경로 대신 크로스 플랫폼 일관성을 위해 의도적으로 Unix 스타일 경로(`.local/share` 등)를 사용합니다.
@@ -1595,6 +1597,12 @@ Grok Build 데이터는 로컬 세션 업데이트에서 직접 파싱됩니다.
 위치: `$JCODE_HOME/sessions/session_*.json` (폴백: `~/.jcode/sessions/session_*.json`) 및 매칭되는 `session_*.journal.jsonl` 사이드카.
 
 Jcode 데이터는 로컬 세션 스냅샷에서 직접 파싱됩니다. Tokscale은 다른 클라이언트 신원을 위장하지 않고 어시스턴트의 `messages[].token_usage` 필드(`input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, `reasoning_output_tokens`)를 읽습니다. 매칭되는 저널 사이드카는 중복 제거 전에 동일한 세션 스트림으로 병합되므로, Jcode가 스냅샷에 체크포인트로 반영하기 전까지 최근에 추가된 메시지도 포함됩니다. 재생(replay) 중복 제거에는 안정적인 메시지 ID를 사용하며, ID가 없는 잘못된/커스텀 레코드는 범위가 한정된 폴백 키를 사용합니다.
+
+### Augment Code (Auggie CLI)
+
+위치: `~/.augment/sessions/<sessionId>.json`
+
+Augment Code / Auggie CLI는 채팅 세션마다 하나의 JSON 스냅샷을 기록합니다. Tokscale은 `chatHistory[]`의 완료된 턴을 읽고, 세션 기본값 `agentState.modelId`보다 `exchange.model_id`를 우선하며, `exchange.response_nodes[]`의 단일 `token_usage` 관측값(`input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`)을 사용합니다. 최상위 `sessionId`는 그대로 보존되어 외부 도구가 ACP 세션 ID에 비용을 조인할 수 있습니다.
 
 ### OpenClaw
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@
 | <img width="48px" src="https://static.workbuddy.cn/web/agents/008054d6beaaf4a83e2d049e982e1244560726dc/assets/share-logo.png" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/**/*.jsonl` + SQLite fallback |
 | <img width="48px" src=".github/assets/client-devin.jpg" alt="Devin CLI" /> | [Devin CLI](https://devin.ai/) | `~/.local/share/devin/cli/sessions.db` (SQLite) |
 | <img width="48px" src=".github/assets/client-devin.jpg" alt="Devin Desktop" /> | [Devin Desktop](https://devin.ai/) | ACP events: macOS `~/Library/Application Support/Devin/User/acp-events/`; Linux `~/.config/Devin/User/acp-events/`; Windows `%APPDATA%\Devin\User\acp-events\` |
+| <img width="48px" src="https://github.com/augmentcode.png" alt="Augment Code" /> | [Augment Code](https://www.augmentcode.com/) (Auggie CLI) | `~/.augment/sessions/*.json` |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | Re-attributed from other sources via `hf:` model prefix or `synthetic` provider (+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`) |
 
 Get real-time pricing calculations using [🚅 LiteLLM's pricing data](https://github.com/BerriAI/litellm), with support for tiered pricing models and cache token discounts.
@@ -379,7 +380,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-Possible values: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `synthetic`.
+Possible values: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `augment`, `synthetic`.
 
 > **Breaking change (v4.0.0):** The per-client boolean flags (`--opencode`, `--claude`, `--codex`, etc.) have been removed and now error. Use the canonical `--client`/`-c` flag instead — e.g. `tokscale --client opencode,claude`.
 
@@ -1359,6 +1360,7 @@ AI coding tools store their session data in cross-platform locations. Most tools
 | WorkBuddy | `~/.workbuddy/projects/` + `~/.workbuddy/workbuddy.db` | `%USERPROFILE%\.workbuddy\projects\` + `%USERPROFILE%\.workbuddy\workbuddy.db` | Parses WorkBuddy token usage, with the aggregate SQLite database as a fallback |
 | Devin CLI | `~/.local/share/devin/cli/sessions.db` | `%USERPROFILE%\.local\share\devin\cli\sessions.db` | Reads the authoritative local SQLite usage database |
 | Devin Desktop | Linux: `~/.config/Devin/User/acp-events/`; macOS: `~/Library/Application Support/Devin/User/acp-events/` | `%APPDATA%\Devin\User\acp-events\` | Parses ACP usage events; the CLI database resolves matching session titles when present |
+| Augment Code | `~/.augment/sessions/` | `%USERPROFILE%\.augment\sessions\` | Parses Auggie CLI session JSON snapshots (`*.json`); join key is top-level `sessionId` |
 | Synthetic | Re-attributed from other sources | Re-attributed from other sources | Detects `hf:` model prefix + `synthetic` provider |
 
 > **Devin Desktop agent support**: Local usage parsing works for ACP-connected agents (e.g. Cascade/Windsurf, claude-code, opencode) that emit `usage_update` events in the NDJSON stream. The default **devin-cloud** agent does not emit local `usage_update` events — its usage stays server-side and cannot be tracked by tokscale without an account-level API.
@@ -1613,6 +1615,12 @@ Grok Build data is parsed directly from local session updates. Current logs expo
 Location: `$JCODE_HOME/sessions/session_*.json` (fallback: `~/.jcode/sessions/session_*.json`) plus matching `session_*.journal.jsonl` sidecars.
 
 Jcode data is parsed directly from local session snapshots. Tokscale reads assistant `messages[].token_usage` fields (`input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, and `reasoning_output_tokens`) without spoofing another client identity. Matching journal sidecars are merged into the same session stream before deduplication so recent appended messages are included until Jcode checkpoints them into the snapshot. Stable message IDs are used for replay dedupe; malformed/custom records without IDs use a scoped fallback key.
+
+### Augment Code (Auggie CLI)
+
+Location: `~/.augment/sessions/<sessionId>.json`
+
+Augment Code / Auggie CLI writes one JSON snapshot per chat session. Tokscale reads each completed turn under `chatHistory[]`, prefers `exchange.model_id` over the session default `agentState.modelId`, and takes the single `token_usage` observation on `exchange.response_nodes[]` (`input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`). The top-level `sessionId` is preserved so external tools can join costs back to the ACP session id.
 
 ### OpenClaw
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
   - GitHub-style contribution graph with configurable color themes
   - Real-time filtering and sorting
   - Zero flicker rendering
-- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, and Synthetic
+- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, and Synthetic
 - **Real-time pricing** - Fetches current pricing from LiteLLM with 1-hour disk cache; automatic OpenRouter fallback and Cursor model pricing for newly released models
 - **Detailed breakdowns** - Input, output, cache read/write, and reasoning token tracking
 - **Native Rust core** - All parsing and aggregation done in Rust for 10x faster processing
@@ -1013,7 +1013,7 @@ The frontend provides a GitHub-style contribution graph visualization:
 - **Interactive tooltips**: Hover for detailed daily breakdowns
 - **Day breakdown panel**: Click to see per-source and per-model details
 - **Year filtering**: Navigate between years
-- **Source filtering**: Filter by platform (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Synthetic)
+- **Source filtering**: Filter by platform (OpenCode, Claude, Codex, Copilot, Cursor, Gemini, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi, Qwen, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic)
 - **Stats panel**: Total cost, tokens, active days, streaks
 - **FOUC prevention**: Theme applied before React hydrates (no flash)
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -97,6 +97,7 @@
 | <img width="48px" src="https://static.workbuddy.cn/web/agents/008054d6beaaf4a83e2d049e982e1244560726dc/assets/share-logo.png" alt="WorkBuddy" /> | WorkBuddy | `~/.workbuddy/projects/**/*.jsonl` + SQLite 回退 |
 | <img width="48px" src=".github/assets/client-devin.jpg" alt="Devin CLI" /> | [Devin CLI](https://devin.ai/) | `~/.local/share/devin/cli/sessions.db`（SQLite） |
 | <img width="48px" src=".github/assets/client-devin.jpg" alt="Devin Desktop" /> | [Devin Desktop](https://devin.ai/) | ACP 事件：macOS `~/Library/Application Support/Devin/User/acp-events/`；Linux `~/.config/Devin/User/acp-events/`；Windows `%APPDATA%\Devin\User\acp-events\` |
+| <img width="48px" src="https://github.com/augmentcode.png" alt="Augment Code" /> | [Augment Code](https://www.augmentcode.com/)（Auggie CLI） | `~/.augment/sessions/*.json` |
 | <img width="48px" src=".github/assets/client-synthetic.png" alt="Synthetic" /> | [Synthetic](https://synthetic.new/) | 通过 `hf:` 模型前缀或 `synthetic` provider 从其他来源重归属（+ [Octofriend](https://github.com/synthetic-lab/octofriend): `~/.local/share/octofriend/sqlite.db`） |
 
 使用 [🚅 LiteLLM 的价格数据](https://github.com/BerriAI/litellm)提供实时价格计算，支持分层定价模型和缓存 Token 折扣。
@@ -168,7 +169,7 @@
   - 支持可配置颜色主题的 GitHub 风格贡献图
   - 实时筛选和排序
   - 零闪烁渲染
-- **多平台支持** - 跟踪 OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop 和 Synthetic 的使用情况
+- **多平台支持** - 跟踪 OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code 和 Synthetic 的使用情况
 - **实时定价** - 从 LiteLLM 获取当前价格，带 1 小时磁盘缓存；OpenRouter 自动回退和新模型的 Cursor 定价支持
 - **详细分解** - 输入、输出、缓存读写和推理 Token 跟踪
 - **原生 Rust 核心** - 所有解析和聚合在 Rust 中完成，处理速度提升 10 倍
@@ -378,7 +379,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-可用值：`opencode`、`claude`、`codex`、`copilot`、`gemini`、`cursor`、`amp`、`codebuff`、`droid`、`openclaw`、`hermes`、`pi`、`kimi`、`qwen`、`roocode`、`kilocode`、`kilo`、`mux`、`crush`、`goose`、`antigravity`、`antigravity-cli`、`zed`、`kiro`、`trae`、`warp`、`cline`、`gjc`、`grok`、`jcode`、`micode`、`commandcode`、`junie`、`zcode`、`synthetic`。
+可用值：`opencode`、`claude`、`codex`、`copilot`、`gemini`、`cursor`、`amp`、`codebuff`、`droid`、`openclaw`、`hermes`、`pi`、`kimi`、`qwen`、`roocode`、`kilocode`、`kilo`、`mux`、`crush`、`goose`、`antigravity`、`antigravity-cli`、`zed`、`kiro`、`trae`、`warp`、`cline`、`gjc`、`grok`、`jcode`、`micode`、`commandcode`、`junie`、`zcode`、`opencodereview`、`codebuddy`、`augment`、`synthetic`。
 
 > **破坏性变更（v4.0.0）**：单客户端布尔选项（`--opencode`、`--claude`、`--codex` 等）已被移除，现在会直接报错。请改用规范的 `--client`/`-c` 选项——例如 `tokscale --client opencode,claude`。
 
@@ -1002,7 +1003,7 @@ tokscale sources --json
 - **交互式提示**：悬停查看详细的每日分解
 - **每日分解面板**：点击查看每个来源和模型的详情
 - **年份筛选**：在年份之间导航
-- **来源筛选**：按平台筛选（OpenCode、Claude、Codex、Copilot、Cursor、Gemini、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi、Qwen、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、Synthetic）
+- **来源筛选**：按平台筛选（OpenCode、Claude、Codex、Copilot、Cursor、Gemini、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi、Qwen、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic）
 - **统计面板**：总成本、Token、活跃天数、连续记录
 - **FOUC 防护**：在 React 水合前应用主题（无闪烁）
 
@@ -1341,6 +1342,7 @@ AI 编程工具将会话数据存储在跨平台位置。大多数工具在所�
 | OpenCodeReview | `~/.opencodereview/sessions/` | `%USERPROFILE%\.opencodereview\sessions\` | 解析 `*.jsonl` 会话记录；阿里巴巴的 AI 代码审查工具 |
 | CodeBuddy | `~/.codebuddy/projects/` + 扩展日志 | `%USERPROFILE%\.codebuddy\projects\` + CodeBuddy / VS Code 扩展日志 | 解析 CodeBuddy CLI、IDE 和 VS Code 插件的 token 用量 |
 | WorkBuddy | `~/.workbuddy/projects/` + `~/.workbuddy/workbuddy.db` | `%USERPROFILE%\.workbuddy\projects\` + `%USERPROFILE%\.workbuddy\workbuddy.db` | 解析 WorkBuddy token 用量，以聚合 SQLite 数据库作为回退 |
+| Augment Code | `~/.augment/sessions/` | `%USERPROFILE%\.augment\sessions\` | 解析 Auggie CLI 会话 JSON 快照（`*.json`）；关联键为顶层 `sessionId` |
 | Synthetic | 从其他来源重归属 | 从其他来源重归属 | 检测 `hf:` 模型前缀 + `synthetic` provider |
 
 > **注意**：在 Windows 上，`~` 扩展为 `%USERPROFILE%`（例如 `C:\Users\用户名`）。这些工具故意使用 Unix 风格的路径（如 `.local/share`）而不是 Windows 原生路径（如 `%APPDATA%`），以实现跨平台一致性。
@@ -1593,6 +1595,12 @@ Grok Build 数据直接从本地会话更新解析。当前日志只公开累积
 位置：`$JCODE_HOME/sessions/session_*.json`（回退：`~/.jcode/sessions/session_*.json`）以及匹配的 `session_*.journal.jsonl` sidecar。
 
 Jcode 数据直接从本地会话快照解析。Tokscale 读取助手消息的 `messages[].token_usage` 字段（`input_tokens`、`output_tokens`、`cache_read_input_tokens`、`cache_creation_input_tokens` 和 `reasoning_output_tokens`），不会伪造其他客户端的身份。匹配的 journal sidecar 会在去重前合并进同一会话流，因此在 Jcode 将其检查点写入快照之前，最近追加的消息也会被包含进来。去重使用稳定的消息 ID 进行重放去重；缺少 ID 的畸形/自定义记录则使用作用域内的回退 key。
+
+### Augment Code (Auggie CLI)
+
+位置：`~/.augment/sessions/<sessionId>.json`
+
+Augment Code / Auggie CLI 为每个聊天会话写入一份 JSON 快照。Tokscale 读取 `chatHistory[]` 中的已完成回合，优先使用 `exchange.model_id`（回退到会话默认的 `agentState.modelId`），并采用 `exchange.response_nodes[]` 上的单次 `token_usage` 观测（`input_tokens`、`output_tokens`、`cache_read_input_tokens`、`cache_creation_input_tokens`）。顶层 `sessionId` 会原样保留，便于外部工具按 ACP 会话 ID 关联费用。
 
 ### OpenClaw
 

--- a/crates/tokscale-cli/src/commands/wrapped.rs
+++ b/crates/tokscale-cli/src/commands/wrapped.rs
@@ -1470,6 +1470,7 @@ fn client_display_name(client: &str) -> Option<&'static str> {
         "gjc" => Some("Gajae-Code"),
         "jcode" => Some("Jcode"),
         "junie" => Some("Junie"),
+        "augment" => Some("Augment Code"),
         "synthetic" => Some("Synthetic"),
         _ => None,
     }
@@ -1513,6 +1514,7 @@ fn client_logo_url(client_name: &str) -> Option<&'static str> {
         ),
         "Jcode" => Some("https://raw.githubusercontent.com/junhoyeo/tokscale/main/.github/assets/client-jcode.png"),
         "Junie" => Some("https://github.com/JetBrains.png"),
+        "Augment Code" => Some("https://github.com/augmentcode.png"),
         "Synthetic" => Some("https://tokscale.ai/assets/logos/synthetic.png"),
         _ => None,
     }

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -997,6 +997,7 @@ pub enum ClientFilter {
     #[value(name = "devin-desktop")]
     DevinDesktop,
     Senpi,
+    #[value(alias = "auggie")]
     Augment,
     Synthetic,
 }
@@ -1161,6 +1162,12 @@ impl ClientFilter {
     /// any unknown id so callers can drop unrecognized settings entries
     /// without erroring.
     pub fn from_filter_str(s: &str) -> Option<Self> {
+        // Canonical ids match as_filter_str. A few product aliases map onto
+        // the same ClientFilter (e.g. "auggie" -> Augment).
+        match s {
+            "auggie" => return Some(Self::Augment),
+            _ => {}
+        }
         Self::value_variants()
             .iter()
             .copied()

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -997,6 +997,7 @@ pub enum ClientFilter {
     #[value(name = "devin-desktop")]
     DevinDesktop,
     Senpi,
+    Augment,
     Synthetic,
 }
 
@@ -1047,6 +1048,7 @@ impl ClientFilter {
             Self::DevinCli => "devin-cli",
             Self::DevinDesktop => "devin-desktop",
             Self::Senpi => "senpi",
+            Self::Augment => "augment",
             Self::Synthetic => "synthetic",
         }
     }
@@ -1100,6 +1102,7 @@ impl ClientFilter {
             Self::DevinCli => Some(ClientId::DevinCli),
             Self::DevinDesktop => Some(ClientId::DevinDesktop),
             Self::Senpi => Some(ClientId::Senpi),
+            Self::Augment => Some(ClientId::Augment),
             Self::Synthetic => None,
         }
     }
@@ -1149,6 +1152,7 @@ impl ClientFilter {
             ClientId::DevinCli => Self::DevinCli,
             ClientId::DevinDesktop => Self::DevinDesktop,
             ClientId::Senpi => Self::Senpi,
+            ClientId::Augment => Self::Augment,
         }
     }
 
@@ -3791,6 +3795,7 @@ fn capitalize_client(client: &str) -> String {
         "devin-cli" => "Devin CLI".to_string(),
         "devin-desktop" => "Devin Desktop".to_string(),
         "senpi" => "Senpi (OmO Native)".to_string(),
+        "augment" => "Augment Code".to_string(),
         other => other.to_string(),
     }
 }

--- a/crates/tokscale-cli/src/tui/client_ui.rs
+++ b/crates/tokscale-cli/src/tui/client_ui.rs
@@ -170,6 +170,12 @@ pub const CLIENT_UI: [ClientUi; ClientId::COUNT] = [
         display_name: "Senpi",
         hotkey: 'S',
     },
+    // Short form: full "Augment Code" fits the client column, but keep parity
+    // with other product-branded names used in capitalize_client.
+    ClientUi {
+        display_name: "Augment",
+        hotkey: 'A',
+    },
 ];
 
 pub fn display_name(client: ClientId) -> &'static str {

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -1609,6 +1609,10 @@ mod tests {
         assert_eq!(clients[34], ClientId::OpenCodeReview);
         assert_eq!(clients[35], ClientId::CodeBuddy);
         assert_eq!(clients[36], ClientId::WorkBuddy);
+        assert_eq!(clients[37], ClientId::DevinCli);
+        assert_eq!(clients[38], ClientId::DevinDesktop);
+        assert_eq!(clients[39], ClientId::Senpi);
+        assert_eq!(clients[40], ClientId::Augment);
     }
 
     #[test]
@@ -1712,6 +1716,10 @@ mod tests {
             crate::tui::client_ui::display_name(ClientId::WorkBuddy),
             "WorkBuddy"
         );
+        assert_eq!(
+            crate::tui::client_ui::display_name(ClientId::Augment),
+            "Augment"
+        );
     }
 
     #[test]
@@ -1747,6 +1755,7 @@ mod tests {
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Junie), 'p');
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::CodeBuddy), 'C');
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::WorkBuddy), 'B');
+        assert_eq!(crate::tui::client_ui::hotkey(ClientId::Augment), 'A');
     }
 
     #[test]
@@ -1854,6 +1863,10 @@ mod tests {
         assert_eq!(
             crate::tui::client_ui::from_hotkey('B'),
             Some(ClientId::WorkBuddy)
+        );
+        assert_eq!(
+            crate::tui::client_ui::from_hotkey('A'),
+            Some(ClientId::Augment)
         );
     }
 

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -566,6 +566,18 @@ define_clients!(
         headless: false,
         parse_local: true,
         submit_default: true
+    },
+    // Augment Code / Auggie CLI stores per-session JSON snapshots under
+    // `~/.augment/sessions/<sessionId>.json` with per-turn token_usage on
+    // exchange.response_nodes.
+    Augment = 40 => {
+        id: "augment",
+        root: PathRoot::Home,
+        relative: ".augment/sessions",
+        pattern: "*.json",
+        headless: false,
+        parse_local: true,
+        submit_default: true
     }
 );
 
@@ -618,7 +630,7 @@ mod tests {
 
     #[test]
     fn test_client_id_count() {
-        assert_eq!(ClientId::COUNT, 40);
+        assert_eq!(ClientId::COUNT, 41);
     }
 
     #[test]
@@ -626,6 +638,20 @@ mod tests {
         let client = ClientId::from_str("senpi").expect("senpi client should be registered");
         assert_eq!(client.data().relative_path, "sessions");
         assert_eq!(client.data().pattern, "*.jsonl");
+        assert!(client.data().parse_local);
+        assert!(client.data().submit_default);
+        assert!(!client.data().headless);
+    }
+
+    #[test]
+    fn test_augment_client_registered_as_local_session_source() {
+        let client = ClientId::from_str("augment").expect("augment client should be registered");
+        assert_eq!(
+            client.data().resolve_path("/tmp/home"),
+            "/tmp/home/.augment/sessions"
+        );
+        assert_eq!(client.data().relative_path, ".augment/sessions");
+        assert_eq!(client.data().pattern, "*.json");
         assert!(client.data().parse_local);
         assert!(client.data().submit_default);
         assert!(!client.data().headless);

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1516,6 +1516,32 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         }
     }
 
+    let augment_outcomes: Vec<CachedParseOutcome> = scan_result
+        .get(ClientId::Augment)
+        .par_iter()
+        .map(|path| {
+            load_or_parse_source(
+                message_cache::CacheIdentity::for_client(ClientId::Augment),
+                path,
+                &source_cache,
+                pricing,
+                sessions::augment::parse_augment_file,
+            )
+        })
+        .collect();
+    let mut augment_seen: HashSet<String> = HashSet::new();
+    for outcome in augment_outcomes {
+        all_messages.extend(
+            outcome
+                .messages
+                .into_iter()
+                .filter(|message| should_keep_deduped_message(&mut augment_seen, message)),
+        );
+        if let Some(entry) = outcome.cache_entry {
+            source_cache.insert(entry);
+        }
+    }
+
     // Command Code does not persist token usage or cost locally, so tokens are
     // estimated and priced. The model id comes from ~/.commandcode/config.json
     // (canonicalized, e.g. "MiniMaxAI/MiniMax-M3-Free" -> "MiniMax-M3"), not the
@@ -3155,6 +3181,21 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     let senpi_count = senpi_msgs.len() as i32;
     counts.set(ClientId::Senpi, senpi_count);
     messages.extend(senpi_msgs);
+
+    let augment_msgs_raw: Vec<UnifiedMessage> = scan_result
+        .get(ClientId::Augment)
+        .par_iter()
+        .flat_map(|path| sessions::augment::parse_augment_file(path))
+        .collect();
+    let mut augment_seen: HashSet<String> = HashSet::new();
+    let augment_msgs: Vec<ParsedMessage> = augment_msgs_raw
+        .into_iter()
+        .filter(|message| should_keep_deduped_message(&mut augment_seen, message))
+        .map(|msg| unified_to_parsed(&msg))
+        .collect();
+    let augment_count = augment_msgs.len() as i32;
+    counts.set(ClientId::Augment, augment_count);
+    messages.extend(augment_msgs);
 
     let commandcode_msgs: Vec<ParsedMessage> = scan_result
         .get(ClientId::CommandCode)

--- a/crates/tokscale-core/src/sessions/augment.rs
+++ b/crates/tokscale-core/src/sessions/augment.rs
@@ -1,11 +1,40 @@
 //! Augment Code (Auggie CLI) session parser
 //!
 //! Parses local session snapshots from `~/.augment/sessions/<sessionId>.json`.
+//!
+//! ## Token accounting
+//!
 //! Each completed turn stores one authoritative `token_usage` observation on a
-//! `response_nodes[]` entry. Verified against real sessions: turns never carry
-//! multiple usage nodes, so we take the first non-empty usage per turn rather
-//! than summing (which would double-count if the format ever repeated cumulative
-//! values).
+//! `response_nodes[]` entry. Verified against real sessions: turns almost never
+//! carry multiple usage nodes. If they do, we take the **last** non-empty usage
+//! (final streamed totals) rather than summing — summing would double-count if
+//! the format ever repeated cumulative values.
+//!
+//! Input and cache buckets are reported independently (Anthropic-style split
+//! accounting). Do not subtract `cache_read` from `input`.
+//!
+//! ## Completeness gate
+//!
+//! Only turns with `completed: true` are counted. Snapshots may retain
+//! in-progress or aborted turns that already carry a partial `token_usage`.
+//!
+//! ## Timestamps
+//!
+//! Auggie records `finishedAt` only — there is no per-turn start time or
+//! duration in the on-disk schema, so messages are **end-anchored**. Cost and
+//! token totals are unaffected; duration-based metrics stay empty.
+//!
+//! ## Cost
+//!
+//! This parser always emits `cost = 0`. Downstream pricing estimates public
+//! model API list prices from the model id. Augment credits /
+//! `subAgentCostUsd` are intentionally ignored.
+//!
+//! ## Turn shape
+//!
+//! One unified message is emitted per completed turn, so `is_turn_start` is
+//! always set. If a future format needs multiple messages per turn, revisit
+//! that flag before counting turns.
 
 use super::utils::{file_modified_timestamp_ms, parse_timestamp_str, read_file_or_none};
 use super::UnifiedMessage;
@@ -47,7 +76,14 @@ struct AugmentExchange {
     model_id: Option<String>,
     request_id: Option<String>,
     #[serde(default)]
-    response_nodes: Vec<serde_json::Value>,
+    response_nodes: Vec<AugmentResponseNode>,
+}
+
+/// Response node subset. Extra wire fields are ignored so unknown node shapes
+/// do not fail the turn.
+#[derive(Debug, Deserialize)]
+struct AugmentResponseNode {
+    token_usage: Option<AugmentTokenUsage>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -68,14 +104,14 @@ fn model_id(model: Option<&str>) -> String {
 }
 
 fn provider_for_model(model: &str) -> String {
+    // Unrecognized ids fall back to "augment". Pricing tables will not match
+    // that provider, so estimated cost stays $0 while tokens still count.
     provider_identity::inferred_provider_from_model(model)
         .unwrap_or("augment")
         .to_string()
 }
 
 fn tokens_from_usage(usage: &AugmentTokenUsage) -> TokenBreakdown {
-    // Augment reports input and cache buckets independently (Anthropic-style
-    // split accounting). Do not subtract cache_read from input.
     TokenBreakdown {
         input: usage.input_tokens.unwrap_or(0).max(0),
         output: usage.output_tokens.unwrap_or(0).max(0),
@@ -85,22 +121,17 @@ fn tokens_from_usage(usage: &AugmentTokenUsage) -> TokenBreakdown {
     }
 }
 
-fn first_token_usage(nodes: &[serde_json::Value]) -> Option<AugmentTokenUsage> {
-    for node in nodes {
-        if let Some(raw) = node.get("token_usage") {
-            if let Ok(usage) = serde_json::from_value::<AugmentTokenUsage>(raw.clone()) {
-                let tokens = tokens_from_usage(&usage);
-                if tokens.input > 0
-                    || tokens.output > 0
-                    || tokens.cache_read > 0
-                    || tokens.cache_write > 0
-                {
-                    return Some(usage);
-                }
-            }
-        }
-    }
-    None
+fn usage_is_nonzero(usage: &AugmentTokenUsage) -> bool {
+    tokens_from_usage(usage).total() > 0
+}
+
+/// Prefer the last non-empty observation so a later full total wins over an
+/// earlier partial if the format ever streams multiple usage nodes.
+fn last_token_usage(nodes: &[AugmentResponseNode]) -> Option<&AugmentTokenUsage> {
+    nodes
+        .iter()
+        .rev()
+        .find_map(|node| node.token_usage.as_ref().filter(|u| usage_is_nonzero(u)))
 }
 
 fn session_id_from_path(path: &Path) -> String {
@@ -132,6 +163,10 @@ fn turn_dedup_key(session_id: &str, turn: &AugmentTurn, index: usize) -> String 
 }
 
 /// Parse an Augment/Auggie session JSON file into unified messages (one per turn).
+///
+/// Best-effort: unreadable files, invalid JSON, and malformed turns yield no
+/// messages for that input rather than hard errors (same contract as peer
+/// local session parsers).
 pub fn parse_augment_file(path: &Path) -> Vec<UnifiedMessage> {
     let Some(data) = read_file_or_none(path) else {
         return vec![];
@@ -162,7 +197,7 @@ pub fn parse_augment_file(path: &Path) -> Vec<UnifiedMessage> {
     );
     let fallback_ts = file_modified_timestamp_ms(path);
 
-    let mut messages = Vec::new();
+    let mut messages = Vec::with_capacity(session.chat_history.len());
     for (index, raw_turn) in session.chat_history.into_iter().enumerate() {
         let turn: AugmentTurn = match serde_json::from_value(raw_turn) {
             Ok(t) => t,
@@ -174,22 +209,14 @@ pub fn parse_augment_file(path: &Path) -> Vec<UnifiedMessage> {
             continue;
         }
 
-        // Incomplete turns may lack usage; skip if no token observation.
         let Some(exchange) = turn.exchange.as_ref() else {
             continue;
         };
-        let Some(usage) = first_token_usage(&exchange.response_nodes) else {
+        let Some(usage) = last_token_usage(&exchange.response_nodes) else {
             continue;
         };
 
-        let tokens = tokens_from_usage(&usage);
-        if tokens.input == 0
-            && tokens.output == 0
-            && tokens.cache_read == 0
-            && tokens.cache_write == 0
-        {
-            continue;
-        }
+        let tokens = tokens_from_usage(usage);
 
         let model = model_id(
             exchange
@@ -215,6 +242,7 @@ pub fn parse_augment_file(path: &Path) -> Vec<UnifiedMessage> {
             0.0,
             Some(turn_dedup_key(&session_id, &turn, index)),
         );
+        // One message per completed turn (see module docs).
         msg.is_turn_start = true;
         messages.push(msg);
     }
@@ -226,6 +254,7 @@ pub fn parse_augment_file(path: &Path) -> Vec<UnifiedMessage> {
 mod tests {
     use super::*;
     use std::io::Write;
+    use std::time::{SystemTime, UNIX_EPOCH};
     use tempfile::NamedTempFile;
 
     fn write_temp_json(json: &str) -> NamedTempFile {
@@ -363,11 +392,54 @@ mod tests {
     }
 
     #[test]
-    fn test_does_not_double_count_multiple_usage_nodes() {
-        // Defensive: if a future format repeats usage on several nodes, take
-        // the first non-empty observation only.
+    fn test_prefers_last_nonempty_usage_node_when_totals_diverge() {
+        // If a future format streams a partial usage then a fuller final one,
+        // take the last non-empty observation (not the first, not the sum).
         let json = r#"{
             "sessionId": "s1",
+            "agentState": { "modelId": "grok-4-5" },
+            "chatHistory": [
+                {
+                    "completed": true,
+                    "finishedAt": "2026-07-20T13:33:00.000Z",
+                    "exchange": {
+                        "model_id": "grok-4-5",
+                        "request_id": "r1",
+                        "response_nodes": [
+                            {
+                                "token_usage": {
+                                    "input_tokens": 100,
+                                    "output_tokens": 10,
+                                    "cache_read_input_tokens": 50,
+                                    "cache_creation_input_tokens": 0
+                                }
+                            },
+                            {
+                                "token_usage": {
+                                    "input_tokens": 250,
+                                    "output_tokens": 40,
+                                    "cache_read_input_tokens": 75,
+                                    "cache_creation_input_tokens": 5
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }"#;
+        let f = write_temp_json(json);
+        let messages = parse_augment_file(f.path());
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 250);
+        assert_eq!(messages[0].tokens.output, 40);
+        assert_eq!(messages[0].tokens.cache_read, 75);
+        assert_eq!(messages[0].tokens.cache_write, 5);
+    }
+
+    #[test]
+    fn test_identical_multi_usage_nodes_still_count_once() {
+        let json = r#"{
+            "sessionId": "s1b",
             "agentState": { "modelId": "grok-4-5" },
             "chatHistory": [
                 {
@@ -493,4 +565,111 @@ mod tests {
         let f = write_temp_json(json);
         assert!(parse_augment_file(f.path()).is_empty());
     }
+
+    #[test]
+    fn test_missing_finished_at_falls_back_to_file_mtime() {
+        let json = r#"{
+            "sessionId": "s-mtime",
+            "agentState": { "modelId": "grok-4-5" },
+            "chatHistory": [
+                {
+                    "completed": true,
+                    "exchange": {
+                        "model_id": "grok-4-5",
+                        "request_id": "r-mtime",
+                        "response_nodes": [
+                            {
+                                "token_usage": {
+                                    "input_tokens": 3,
+                                    "output_tokens": 1,
+                                    "cache_read_input_tokens": 0,
+                                    "cache_creation_input_tokens": 0
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }"#;
+        let f = write_temp_json(json);
+        let messages = parse_augment_file(f.path());
+        assert_eq!(messages.len(), 1);
+        let mtime = file_modified_timestamp_ms(f.path());
+        // Allow small skew between metadata reads.
+        assert!((messages[0].timestamp - mtime).abs() < 5_000);
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
+        assert!(messages[0].timestamp > 0);
+        assert!(messages[0].timestamp <= now_ms + 5_000);
+    }
+
+    #[test]
+    fn test_empty_exchange_model_falls_back_then_unknown_provider() {
+        let json = r#"{
+            "sessionId": "s-unknown",
+            "agentState": { "modelId": "   " },
+            "chatHistory": [
+                {
+                    "completed": true,
+                    "finishedAt": "2026-07-20T13:33:00.000Z",
+                    "exchange": {
+                        "model_id": "",
+                        "request_id": "r-u",
+                        "response_nodes": [
+                            {
+                                "token_usage": {
+                                    "input_tokens": 7,
+                                    "output_tokens": 1,
+                                    "cache_read_input_tokens": 0,
+                                    "cache_creation_input_tokens": 0
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }"#;
+        let f = write_temp_json(json);
+        let messages = parse_augment_file(f.path());
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "unknown");
+        assert_eq!(messages[0].provider_id, "augment");
+    }
+
+    #[test]
+    fn test_numeric_sequence_id_dedup_key() {
+        let json = r#"{
+            "sessionId": "s-seq",
+            "agentState": { "modelId": "grok-4-5" },
+            "chatHistory": [
+                {
+                    "completed": true,
+                    "finishedAt": "2026-07-20T13:33:00.000Z",
+                    "sequenceId": 42,
+                    "exchange": {
+                        "response_nodes": [
+                            {
+                                "token_usage": {
+                                    "input_tokens": 2,
+                                    "output_tokens": 1,
+                                    "cache_read_input_tokens": 0,
+                                    "cache_creation_input_tokens": 0
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }"#;
+        let f = write_temp_json(json);
+        let messages = parse_augment_file(f.path());
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some("augment:s-seq:seq:42")
+        );
+    }
 }
+

--- a/crates/tokscale-core/src/sessions/augment.rs
+++ b/crates/tokscale-core/src/sessions/augment.rs
@@ -1,0 +1,440 @@
+//! Augment Code (Auggie CLI) session parser
+//!
+//! Parses local session snapshots from `~/.augment/sessions/<sessionId>.json`.
+//! Each completed turn stores one authoritative `token_usage` observation on a
+//! `response_nodes[]` entry. Verified against real sessions: turns never carry
+//! multiple usage nodes, so we take the first non-empty usage per turn rather
+//! than summing (which would double-count if the format ever repeated cumulative
+//! values).
+
+use super::utils::{file_modified_timestamp_ms, parse_timestamp_str, read_file_or_none};
+use super::UnifiedMessage;
+use crate::{provider_identity, TokenBreakdown};
+use serde::Deserialize;
+use std::path::Path;
+
+#[derive(Debug, Deserialize)]
+struct AugmentSession {
+    #[serde(rename = "sessionId")]
+    session_id: Option<String>,
+    #[serde(rename = "agentState")]
+    agent_state: Option<AugmentAgentState>,
+    #[serde(default, rename = "chatHistory")]
+    chat_history: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AugmentAgentState {
+    #[serde(rename = "modelId")]
+    model_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AugmentTurn {
+    #[serde(rename = "finishedAt")]
+    finished_at: Option<String>,
+    exchange: Option<AugmentExchange>,
+    #[serde(rename = "sequenceId")]
+    sequence_id: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AugmentExchange {
+    model_id: Option<String>,
+    request_id: Option<String>,
+    #[serde(default)]
+    response_nodes: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AugmentTokenUsage {
+    input_tokens: Option<i64>,
+    output_tokens: Option<i64>,
+    cache_read_input_tokens: Option<i64>,
+    cache_creation_input_tokens: Option<i64>,
+}
+
+fn model_id(model: Option<&str>) -> String {
+    let model = model.unwrap_or("unknown").trim();
+    if model.is_empty() {
+        "unknown".to_string()
+    } else {
+        model.to_string()
+    }
+}
+
+fn provider_for_model(model: &str) -> String {
+    provider_identity::inferred_provider_from_model(model)
+        .unwrap_or("augment")
+        .to_string()
+}
+
+fn tokens_from_usage(usage: &AugmentTokenUsage) -> TokenBreakdown {
+    // Augment reports input and cache buckets independently (Anthropic-style
+    // split accounting). Do not subtract cache_read from input.
+    TokenBreakdown {
+        input: usage.input_tokens.unwrap_or(0).max(0),
+        output: usage.output_tokens.unwrap_or(0).max(0),
+        cache_read: usage.cache_read_input_tokens.unwrap_or(0).max(0),
+        cache_write: usage.cache_creation_input_tokens.unwrap_or(0).max(0),
+        reasoning: 0,
+    }
+}
+
+fn first_token_usage(nodes: &[serde_json::Value]) -> Option<AugmentTokenUsage> {
+    for node in nodes {
+        if let Some(raw) = node.get("token_usage") {
+            if let Ok(usage) = serde_json::from_value::<AugmentTokenUsage>(raw.clone()) {
+                let tokens = tokens_from_usage(&usage);
+                if tokens.input > 0
+                    || tokens.output > 0
+                    || tokens.cache_read > 0
+                    || tokens.cache_write > 0
+                {
+                    return Some(usage);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn session_id_from_path(path: &Path) -> String {
+    path.file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
+fn turn_dedup_key(session_id: &str, turn: &AugmentTurn, index: usize) -> String {
+    if let Some(request_id) = turn
+        .exchange
+        .as_ref()
+        .and_then(|e| e.request_id.as_deref())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        return format!("augment:{session_id}:req:{request_id}");
+    }
+    if let Some(seq) = turn.sequence_id.as_ref() {
+        let seq_str = match seq {
+            serde_json::Value::String(s) => s.clone(),
+            other => other.to_string(),
+        };
+        if !seq_str.is_empty() && seq_str != "null" {
+            return format!("augment:{session_id}:seq:{seq_str}");
+        }
+    }
+    format!("augment:{session_id}:turn:{index}")
+}
+
+/// Parse an Augment/Auggie session JSON file into unified messages (one per turn).
+pub fn parse_augment_file(path: &Path) -> Vec<UnifiedMessage> {
+    let Some(data) = read_file_or_none(path) else {
+        return vec![];
+    };
+
+    let session: AugmentSession = match serde_json::from_slice(&data) {
+        Ok(s) => s,
+        Err(_) => return vec![],
+    };
+
+    let session_id = session
+        .session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| session_id_from_path(path));
+
+    if session_id.is_empty() {
+        return vec![];
+    }
+
+    let default_model = model_id(
+        session
+            .agent_state
+            .as_ref()
+            .and_then(|s| s.model_id.as_deref()),
+    );
+    let fallback_ts = file_modified_timestamp_ms(path);
+
+    let mut messages = Vec::new();
+    for (index, raw_turn) in session.chat_history.into_iter().enumerate() {
+        let turn: AugmentTurn = match serde_json::from_value(raw_turn) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+
+        // Incomplete turns may lack usage; skip if no token observation.
+        let Some(exchange) = turn.exchange.as_ref() else {
+            continue;
+        };
+        let Some(usage) = first_token_usage(&exchange.response_nodes) else {
+            continue;
+        };
+
+        let tokens = tokens_from_usage(&usage);
+        if tokens.input == 0
+            && tokens.output == 0
+            && tokens.cache_read == 0
+            && tokens.cache_write == 0
+        {
+            continue;
+        }
+
+        let model = model_id(
+            exchange
+                .model_id
+                .as_deref()
+                .filter(|m| !m.trim().is_empty())
+                .or(Some(default_model.as_str())),
+        );
+        let provider = provider_for_model(&model);
+        let timestamp = turn
+            .finished_at
+            .as_deref()
+            .and_then(parse_timestamp_str)
+            .unwrap_or(fallback_ts);
+
+        let mut msg = UnifiedMessage::new_with_dedup(
+            "augment",
+            model,
+            provider,
+            session_id.clone(),
+            timestamp,
+            tokens,
+            0.0,
+            Some(turn_dedup_key(&session_id, &turn, index)),
+        );
+        msg.is_turn_start = true;
+        messages.push(msg);
+    }
+
+    messages
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_temp_json(json: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(json.as_bytes()).unwrap();
+        f
+    }
+
+    #[test]
+    fn test_parse_valid_session_one_message_per_turn() {
+        let json = r#"{
+            "sessionId": "11111111-2222-3333-4444-555555555555",
+            "created": "2026-01-15T12:00:00.000Z",
+            "modified": "2026-01-15T12:10:00.000Z",
+            "agentState": { "modelId": "grok-4-5" },
+            "chatHistory": [
+                {
+                    "completed": true,
+                    "finishedAt": "2026-01-15T12:01:00.000Z",
+                    "sequenceId": 1,
+                    "exchange": {
+                        "model_id": "grok-4-5",
+                        "request_id": "req-1",
+                        "response_nodes": [
+                            { "type": 1 },
+                            {
+                                "type": 10,
+                                "token_usage": {
+                                    "input_tokens": 1000,
+                                    "output_tokens": 50,
+                                    "cache_read_input_tokens": 200,
+                                    "cache_creation_input_tokens": 0
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "completed": true,
+                    "finishedAt": "2026-01-15T12:05:00.000Z",
+                    "sequenceId": 2,
+                    "exchange": {
+                        "model_id": "claude-opus-4-8",
+                        "request_id": "req-2",
+                        "response_nodes": [
+                            {
+                                "token_usage": {
+                                    "input_tokens": 400,
+                                    "output_tokens": 100,
+                                    "cache_read_input_tokens": 800,
+                                    "cache_creation_input_tokens": 25
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "completed": false,
+                    "finishedAt": "2026-01-15T12:09:00.000Z",
+                    "exchange": {
+                        "model_id": "grok-4-5",
+                        "response_nodes": []
+                    }
+                }
+            ]
+        }"#;
+        let f = write_temp_json(json);
+        let messages = parse_augment_file(f.path());
+        assert_eq!(messages.len(), 2);
+
+        let first = &messages[0];
+        assert_eq!(first.client, "augment");
+        assert_eq!(first.session_id, "11111111-2222-3333-4444-555555555555");
+        assert_eq!(first.model_id, "grok-4-5");
+        assert_eq!(first.provider_id, "xai");
+        assert_eq!(first.tokens.input, 1000);
+        assert_eq!(first.tokens.output, 50);
+        assert_eq!(first.tokens.cache_read, 200);
+        assert_eq!(first.tokens.cache_write, 0);
+        assert!(first.is_turn_start);
+        assert_eq!(
+            first.dedup_key.as_deref(),
+            Some("augment:11111111-2222-3333-4444-555555555555:req:req-1")
+        );
+        assert_eq!(
+            first.timestamp,
+            parse_timestamp_str("2026-01-15T12:01:00.000Z").unwrap()
+        );
+
+        let second = &messages[1];
+        assert_eq!(second.model_id, "claude-opus-4-8");
+        assert_eq!(second.provider_id, "anthropic");
+        assert_eq!(second.tokens.input, 400);
+        assert_eq!(second.tokens.output, 100);
+        assert_eq!(second.tokens.cache_read, 800);
+        assert_eq!(second.tokens.cache_write, 25);
+    }
+
+    #[test]
+    fn test_falls_back_to_session_model_and_filename_session_id() {
+        let json = r#"{
+            "agentState": { "modelId": "gpt-5-4" },
+            "chatHistory": [
+                {
+                    "completed": true,
+                    "finishedAt": "2026-07-20T13:33:00.000Z",
+                    "sequenceId": "seq-a",
+                    "exchange": {
+                        "response_nodes": [
+                            {
+                                "token_usage": {
+                                    "input_tokens": 10,
+                                    "output_tokens": 5,
+                                    "cache_read_input_tokens": 0,
+                                    "cache_creation_input_tokens": 0
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }"#;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session-from-name.json");
+        std::fs::write(&path, json).unwrap();
+        let messages = parse_augment_file(&path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].session_id, "session-from-name");
+        assert_eq!(messages[0].model_id, "gpt-5-4");
+        assert_eq!(messages[0].provider_id, "openai");
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some("augment:session-from-name:seq:seq-a")
+        );
+    }
+
+    #[test]
+    fn test_does_not_double_count_multiple_usage_nodes() {
+        // Defensive: if a future format repeats usage on several nodes, take
+        // the first non-empty observation only.
+        let json = r#"{
+            "sessionId": "s1",
+            "agentState": { "modelId": "grok-4-5" },
+            "chatHistory": [
+                {
+                    "completed": true,
+                    "finishedAt": "2026-07-20T13:33:00.000Z",
+                    "exchange": {
+                        "model_id": "grok-4-5",
+                        "request_id": "r1",
+                        "response_nodes": [
+                            {
+                                "token_usage": {
+                                    "input_tokens": 100,
+                                    "output_tokens": 10,
+                                    "cache_read_input_tokens": 50,
+                                    "cache_creation_input_tokens": 0
+                                }
+                            },
+                            {
+                                "token_usage": {
+                                    "input_tokens": 100,
+                                    "output_tokens": 10,
+                                    "cache_read_input_tokens": 50,
+                                    "cache_creation_input_tokens": 0
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }"#;
+        let f = write_temp_json(json);
+        let messages = parse_augment_file(f.path());
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 100);
+        assert_eq!(messages[0].tokens.output, 10);
+        assert_eq!(messages[0].tokens.cache_read, 50);
+    }
+
+    #[test]
+    fn test_invalid_json_and_missing_file() {
+        let f = write_temp_json("not json");
+        assert!(parse_augment_file(f.path()).is_empty());
+        assert!(parse_augment_file(Path::new("/nonexistent/augment.json")).is_empty());
+    }
+
+    #[test]
+    fn test_skips_malformed_turns() {
+        let json = r#"{
+            "sessionId": "s2",
+            "agentState": { "modelId": "grok-4-5" },
+            "chatHistory": [
+                "bad-turn",
+                {
+                    "completed": true,
+                    "finishedAt": "2026-07-20T13:33:00.000Z",
+                    "exchange": {
+                        "model_id": "grok-4-5",
+                        "request_id": "ok",
+                        "response_nodes": [
+                            {
+                                "token_usage": {
+                                    "input_tokens": 1,
+                                    "output_tokens": 2,
+                                    "cache_read_input_tokens": 0,
+                                    "cache_creation_input_tokens": 0
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }"#;
+        let f = write_temp_json(json);
+        let messages = parse_augment_file(f.path());
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 1);
+        assert_eq!(messages[0].tokens.output, 2);
+    }
+}

--- a/crates/tokscale-core/src/sessions/augment.rs
+++ b/crates/tokscale-core/src/sessions/augment.rs
@@ -33,6 +33,10 @@ struct AugmentAgentState {
 struct AugmentTurn {
     #[serde(rename = "finishedAt")]
     finished_at: Option<String>,
+    /// Only completed turns are counted. Snapshots may retain in-progress or
+    /// aborted turns that already carry a partial `token_usage` observation.
+    #[serde(default)]
+    completed: Option<bool>,
     exchange: Option<AugmentExchange>,
     #[serde(rename = "sequenceId")]
     sequence_id: Option<serde_json::Value>,
@@ -164,6 +168,11 @@ pub fn parse_augment_file(path: &Path) -> Vec<UnifiedMessage> {
             Ok(t) => t,
             Err(_) => continue,
         };
+
+        // Skip incomplete/aborted turns even if a partial token_usage was streamed.
+        if turn.completed != Some(true) {
+            continue;
+        }
 
         // Incomplete turns may lack usage; skip if no token observation.
         let Some(exchange) = turn.exchange.as_ref() else {
@@ -436,5 +445,52 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].tokens.input, 1);
         assert_eq!(messages[0].tokens.output, 2);
+    }
+
+    #[test]
+    fn test_skips_incomplete_turns_even_with_token_usage() {
+        let json = r#"{
+            "sessionId": "s3",
+            "agentState": { "modelId": "grok-4-5" },
+            "chatHistory": [
+                {
+                    "completed": false,
+                    "finishedAt": "2026-01-15T12:01:00.000Z",
+                    "exchange": {
+                        "model_id": "grok-4-5",
+                        "request_id": "partial",
+                        "response_nodes": [
+                            {
+                                "token_usage": {
+                                    "input_tokens": 999,
+                                    "output_tokens": 50,
+                                    "cache_read_input_tokens": 0,
+                                    "cache_creation_input_tokens": 0
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "finishedAt": "2026-01-15T12:02:00.000Z",
+                    "exchange": {
+                        "model_id": "grok-4-5",
+                        "request_id": "missing-completed",
+                        "response_nodes": [
+                            {
+                                "token_usage": {
+                                    "input_tokens": 100,
+                                    "output_tokens": 10,
+                                    "cache_read_input_tokens": 0,
+                                    "cache_creation_input_tokens": 0
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }"#;
+        let f = write_temp_json(json);
+        assert!(parse_augment_file(f.path()).is_empty());
     }
 }

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -5,6 +5,7 @@
 pub mod amp;
 pub mod antigravity;
 pub mod antigravity_cli;
+pub mod augment;
 pub mod claudecode;
 pub mod cline;
 pub mod codebuddy;

--- a/packages/frontend/src/lib/constants.ts
+++ b/packages/frontend/src/lib/constants.ts
@@ -168,7 +168,7 @@ export const SOURCE_COLORS: Record<ClientType, string> = {
   "devin-cli": "#334155",
   "devin-desktop": "#334155",
   senpi: "#2F6F63",
-  augment: "#7C3AED",
+  augment: "#9333EA",
 };
 
 // Derived values

--- a/packages/frontend/src/lib/constants.ts
+++ b/packages/frontend/src/lib/constants.ts
@@ -69,6 +69,7 @@ export const SOURCE_DISPLAY_NAMES: Record<ClientType, string> = {
   "devin-cli": "Devin CLI",
   "devin-desktop": "Devin Desktop",
   senpi: "Senpi (OmO Native)",
+  augment: "Augment Code",
 };
 
 // Client logos from GitHub CDN (public repo)
@@ -121,6 +122,7 @@ export const SOURCE_LOGOS: Record<ClientType, string> = {
   "devin-cli": `${GITHUB_CDN_BASE}/client-devin.jpg`,
   "devin-desktop": `${GITHUB_CDN_BASE}/client-devin.jpg`,
   senpi: `${GITHUB_CDN_BASE}/client-senpi.png`,
+  augment: "https://github.com/augmentcode.png",
 };
 
 export const SOURCE_COLORS: Record<ClientType, string> = {
@@ -166,6 +168,7 @@ export const SOURCE_COLORS: Record<ClientType, string> = {
   "devin-cli": "#334155",
   "devin-desktop": "#334155",
   senpi: "#2F6F63",
+  augment: "#7C3AED",
 };
 
 // Derived values

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -41,6 +41,7 @@ export const SUPPORTED_CLIENT_TYPES = [
   "devin-cli",
   "devin-desktop",
   "senpi",
+  "augment",
 ] as const;
 
 export type CcMirrorClientType = `cc-mirror/${string}`;


### PR DESCRIPTION
## Summary

Adds native **Augment Code (Auggie CLI)** support so tokscale scans local session snapshots under ~/.augment/sessions/*.json, prices per-turn token usage, and preserves Auggie sessionId for external joins.

Closes https://github.com/junhoyeo/tokscale/issues/235

## Changes

- Register client augment -> ~/.augment/sessions / *.json (parse_local: true)
- New parser sessions/augment.rs:
  - one message per completed turn with token_usage
  - model from exchange.model_id (fallback agentState.modelId)
  - tokens: input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens
  - session id from top-level sessionId (filename fallback)
  - takes the first non-empty usage node per turn (avoids double-counting if a turn ever repeated usage)
- Wire into cached + parse_local_clients scan paths
- CLI filter / TUI UI / README / frontend client maps

## Validation

    cargo test -p tokscale-core augment
    cargo test -p tokscale-cli test_client_
    cargo build -p tokscale-cli --release

    ./target/release/tokscale clients --json
    # expect client augment with sessionsPath under ~/.augment/sessions

    ./target/release/tokscale --json --group-by session,model -c augment --week
    # expect non-empty entries with sessionId + model + tokens when local Auggie sessions exist
