### PR TITLE
fix(leaderboard): sum only the filtered client's tokens on period boards

### DIFF
--- a/packages/frontend/__tests__/lib/getLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboard.test.ts
@@ -440,6 +440,215 @@ describe("period leaderboard data", () => {
   });
 });
 
+describe("period leaderboard directive scoping", () => {
+  // One device, one day, two clients. The row total (1000/10) is the sum of
+  // both, which is exactly what a filtered search must not credit.
+  const mixedClientDay = {
+    userId: "user-dana",
+    username: "dana",
+    displayName: "Dana",
+    avatarUrl: null,
+    tokens: 1000,
+    cost: 10,
+    leaderboardHidden: false,
+    sourceBreakdown: {
+      codex: {
+        tokens: 300,
+        cost: 3,
+        models: {
+          "gpt-5-codex": { tokens: 200, cost: 2 },
+          "gpt-5-mini": { tokens: 100, cost: 1 },
+        },
+      },
+      "claude-code": {
+        tokens: 700,
+        cost: 7,
+        models: {
+          "claude-opus-4": { tokens: 700, cost: 7 },
+        },
+      },
+    },
+  };
+
+  function useWeekOf(rows: Array<Record<string, unknown>>) {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-07T18:45:00Z"));
+    mockState.setPeriodRows(rows);
+  }
+
+  it("counts only the filtered client's share of a row shared with other clients", async () => {
+    useWeekOf([mixedClientDay]);
+
+    const leaderboard = await getLeaderboardData("week", 1, 50, "tokens", "client:codex");
+
+    // 300/3, not the row's 1000/10: claude-code ran on the same day and
+    // device but was not asked for.
+    expect(leaderboard.users[0]).toMatchObject({
+      username: "dana",
+      totalTokens: 300,
+      totalCost: 3,
+    });
+    expect(leaderboard.stats).toMatchObject({
+      totalTokens: 300,
+      totalCost: 3,
+      uniqueUsers: 1,
+    });
+  });
+
+  it("counts only the filtered model's share, not every client in the row", async () => {
+    useWeekOf([mixedClientDay]);
+
+    const leaderboard = await getLeaderboardData("week", 1, 50, "tokens", "model:claude-opus-4");
+
+    expect(leaderboard.users[0]).toMatchObject({
+      username: "dana",
+      totalTokens: 700,
+      totalCost: 7,
+    });
+    expect(leaderboard.stats).toMatchObject({ totalTokens: 700, totalCost: 7 });
+  });
+
+  it("sums a model directive across every client that ran the model", async () => {
+    useWeekOf([
+      {
+        ...mixedClientDay,
+        sourceBreakdown: {
+          codex: {
+            tokens: 300,
+            cost: 3,
+            models: { "gpt-5-codex": { tokens: 300, cost: 3 } },
+          },
+          crush: {
+            tokens: 700,
+            cost: 7,
+            models: { "gpt-5-codex": { tokens: 500, cost: 5 }, "gpt-4o": { tokens: 200, cost: 2 } },
+          },
+        },
+      },
+    ]);
+
+    const leaderboard = await getLeaderboardData("week", 1, 50, "tokens", "model:gpt-5-codex");
+
+    expect(leaderboard.users[0]).toMatchObject({ totalTokens: 800, totalCost: 8 });
+  });
+
+  it("reads client:x model:y as an intersection inside one client", async () => {
+    useWeekOf([mixedClientDay]);
+
+    // claude-opus-4 exists in the row, but under claude-code, not codex. The
+    // union reading would have credited dana all 300 of her Codex tokens for
+    // Opus work she never did there.
+    const leaderboard = await getLeaderboardData(
+      "week",
+      1,
+      50,
+      "tokens",
+      "client:codex model:claude-opus-4"
+    );
+
+    expect(leaderboard.users).toHaveLength(0);
+    expect(leaderboard.stats).toMatchObject({ totalTokens: 0, totalCost: 0, uniqueUsers: 0 });
+  });
+
+  it("keeps client matching on case-insensitive substrings", async () => {
+    useWeekOf([mixedClientDay]);
+
+    // `claude` is not a client id — it is a prefix of `claude-code`, and has
+    // matched it since the directive shipped.
+    const leaderboard = await getLeaderboardData("week", 1, 50, "tokens", "client:CLAUDE");
+
+    expect(leaderboard.users[0]).toMatchObject({ totalTokens: 700, totalCost: 7 });
+  });
+
+  it("drops rows with no source breakdown when a directive is active", async () => {
+    useWeekOf([
+      mixedClientDay,
+      {
+        userId: "user-erin",
+        username: "erin",
+        displayName: "Erin",
+        avatarUrl: null,
+        tokens: 5000,
+        cost: 50,
+        leaderboardHidden: false,
+        sourceBreakdown: null,
+      },
+    ]);
+
+    const leaderboard = await getLeaderboardData("week", 1, 50, "tokens", "client:codex");
+
+    expect(leaderboard.users.map((user) => user.username)).toEqual(["dana"]);
+    expect(leaderboard.stats.totalTokens).toBe(300);
+  });
+
+  it("ranks on the filtered share, so a heavy unrelated client cannot buy a position", async () => {
+    useWeekOf([
+      mixedClientDay,
+      {
+        userId: "user-frank",
+        username: "frank",
+        displayName: "Frank",
+        avatarUrl: null,
+        tokens: 400,
+        cost: 4,
+        leaderboardHidden: false,
+        sourceBreakdown: {
+          codex: {
+            tokens: 400,
+            cost: 4,
+            models: { "gpt-5-codex": { tokens: 400, cost: 4 } },
+          },
+        },
+      },
+    ]);
+
+    const leaderboard = await getLeaderboardData("week", 1, 50, "tokens", "client:codex");
+
+    // dana's 1000-token row outweighs frank's 400 only because 700 of it is
+    // claude-code. On Codex alone frank is ahead.
+    expect(leaderboard.users.map((user) => user.username)).toEqual(["frank", "dana"]);
+    expect(leaderboard.users.map((user) => user.totalTokens)).toEqual([400, 300]);
+  });
+
+  it("still counts a hidden user's filtered share in the period totals", async () => {
+    useWeekOf([mixedClientDay, { ...mixedClientDay, userId: "user-gil", username: "gil", leaderboardHidden: true }]);
+
+    const leaderboard = await getLeaderboardData("week", 1, 50, "tokens", "client:codex");
+
+    expect(leaderboard.users.map((user) => user.username)).toEqual(["dana"]);
+    // Both users' Codex share, neither user's claude-code share.
+    expect(leaderboard.stats).toMatchObject({ totalTokens: 600, uniqueUsers: 2 });
+    expect(leaderboard.pagination.totalUsers).toBe(1);
+  });
+
+  it("leaves the unfiltered path on the row totals", async () => {
+    useWeekOf([mixedClientDay]);
+
+    const leaderboard = await getLeaderboardData("week", 1, 50, "tokens");
+
+    // No directive, so sourceBreakdown is never consulted and the whole row
+    // counts, exactly as before.
+    expect(leaderboard.users[0]).toMatchObject({
+      username: "dana",
+      totalTokens: 1000,
+      totalCost: 10,
+    });
+    expect(leaderboard.stats).toMatchObject({
+      totalTokens: 1000,
+      totalCost: 10,
+      uniqueUsers: 1,
+    });
+  });
+
+  it("leaves a plain text search on the row totals", async () => {
+    useWeekOf([mixedClientDay]);
+
+    const leaderboard = await getLeaderboardData("week", 1, 50, "tokens", "dana");
+
+    expect(leaderboard.users[0]).toMatchObject({ totalTokens: 1000, totalCost: 10 });
+  });
+});
+
 describe("all-time leaderboard directives", () => {
   it("ORs repeated directives within each type before combining types", async () => {
     await getLeaderboardData(

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -12,6 +12,7 @@ import {
   escapeLikePattern,
   hasDirectives,
   parseSearchDirectives,
+  type ParsedSearchDirectives,
 } from "@/lib/leaderboard/searchDirectives";
 
 export type { LeaderboardData, LeaderboardUser, Period, SortBy } from "@/lib/leaderboard/types";
@@ -26,6 +27,18 @@ export type { LeaderboardData, LeaderboardUser, Period, SortBy } from "@/lib/lea
  */
 const RANKABLE_USER = eq(users.leaderboardHidden, false);
 
+/**
+ * The part of `daily_breakdown.source_breakdown` the leaderboard reads. Every
+ * field is optional because the stored blob has grown over time and rows
+ * written by older CLI versions are still on the board — see db/schema.ts for
+ * the full shape.
+ */
+interface PeriodClientBreakdown {
+  tokens?: number;
+  cost?: number;
+  models?: Record<string, { tokens?: number; cost?: number }>;
+}
+
 interface LeaderboardPeriodRow {
   userId: string;
   username: string;
@@ -33,7 +46,7 @@ interface LeaderboardPeriodRow {
   avatarUrl: string | null;
   tokens: number;
   cost: number;
-  sourceBreakdown: Record<string, { models: Record<string, unknown> }> | null;
+  sourceBreakdown: Record<string, PeriodClientBreakdown> | null;
   /**
    * Carried through so the period path can drop the user from the rankings
    * while still counting them in the period totals. Internal only — it must
@@ -54,7 +67,7 @@ interface PeriodLeaderboardDbRow {
   avatarUrl: string | null;
   tokens: number | string | null;
   cost: number | string | null;
-  sourceBreakdown: Record<string, { models: Record<string, unknown> }> | null;
+  sourceBreakdown: Record<string, PeriodClientBreakdown> | null;
   leaderboardHidden: boolean;
 }
 
@@ -193,6 +206,70 @@ function matchesLeaderboardSearch(
   return false;
 }
 
+/**
+ * Narrows a daily row to the tokens and cost a `client:`/`model:` search
+ * actually asked for, or null when nothing in the row was selected.
+ *
+ * A daily row's own `tokens`/`cost` are the total across every client and
+ * model that shared that day and device, so a filtered board must not sum
+ * them: crediting the whole row to a `client:codex` search hands the user
+ * every other client they happened to run that day. The per-client and
+ * per-model figures inside `sourceBreakdown` are the only ones narrow enough
+ * to add up.
+ *
+ * `client:x model:y` is read as an intersection within one client — a model's
+ * tokens count only where they were spent under a matching client. A union
+ * reading would let `client:codex model:opus` re-credit Codex work that never
+ * touched Opus, which is the same over-count wearing a different hat.
+ */
+function scopeRowToDirectives(
+  row: LeaderboardPeriodRow,
+  parsed: ParsedSearchDirectives
+): { tokens: number; cost: number } | null {
+  if (!row.sourceBreakdown) {
+    return null;
+  }
+
+  let tokens = 0;
+  let cost = 0;
+  let matched = false;
+
+  for (const [clientId, client] of Object.entries(row.sourceBreakdown)) {
+    // Case-insensitive substring, carried over verbatim from the row filter
+    // this replaced: `client:claude` has always matched `claude-code`, and
+    // tightening that to equality here would quietly drop usage from every
+    // saved search built against the old behaviour.
+    const clientMatches =
+      parsed.clients.length === 0 ||
+      parsed.clients.some((candidate) => clientId.toLowerCase().includes(candidate));
+
+    if (!clientMatches) {
+      continue;
+    }
+
+    if (parsed.models.length === 0) {
+      matched = true;
+      tokens += Number(client.tokens) || 0;
+      cost += Number(client.cost) || 0;
+      continue;
+    }
+
+    for (const [modelId, model] of Object.entries(client.models ?? {})) {
+      if (!parsed.models.some((candidate) => modelId.toLowerCase().includes(candidate))) {
+        continue;
+      }
+      matched = true;
+      tokens += Number(model.tokens) || 0;
+      cost += Number(model.cost) || 0;
+    }
+  }
+
+  // Tracked separately from a zero sum: a client that genuinely burned no
+  // tokens still puts its owner on the filtered board and into uniqueUsers,
+  // whereas a row nothing matched must leave no trace at all.
+  return matched ? { tokens, cost } : null;
+}
+
 function buildPeriodLeaderboardData(
   rows: LeaderboardPeriodRow[],
   page: number,
@@ -206,29 +283,9 @@ function buildPeriodLeaderboardData(
 
   let filteredRows = rows;
   if (hasDirectives(parsed)) {
-    filteredRows = rows.filter((row) => {
-      if (!row.sourceBreakdown) return false;
-
-      const clientKeys = Object.keys(row.sourceBreakdown).map((k) => k.toLowerCase());
-      const modelKeys = Object.values(row.sourceBreakdown).flatMap((client) =>
-        client.models ? Object.keys(client.models).map((m) => m.toLowerCase()) : []
-      );
-
-      if (parsed.clients.length > 0) {
-        const hasMatchingClient = parsed.clients.some((c) =>
-          clientKeys.some((k) => k.includes(c))
-        );
-        if (!hasMatchingClient) return false;
-      }
-
-      if (parsed.models.length > 0) {
-        const hasMatchingModel = parsed.models.some((m) =>
-          modelKeys.some((k) => k.includes(m))
-        );
-        if (!hasMatchingModel) return false;
-      }
-
-      return true;
+    filteredRows = rows.flatMap((row) => {
+      const scoped = scopeRowToDirectives(row, parsed);
+      return scoped ? [{ ...row, tokens: scoped.tokens, cost: scoped.cost }] : [];
     });
   }
 


### PR DESCRIPTION
## The bug

`client:`/`model:` searches on the **period** leaderboard (week / month / last-month / custom) filtered whole daily **rows**, then aggregated `row.tokens` and `row.cost` — the row's total across *every* client and model that shared that day and device.

So searching `client:codex` credited the user with all the Claude Code, Cursor and Amp work they happened to do on the same day. The `model:` case was worse: a row survived if *any* client anywhere in it ran the model, and then contributed all of its other models **and** all of its other clients too.

This is not cosmetic — the over-count reorders the board. A user with 300 Codex tokens on a day they also spent 700 in Claude Code outranked a user with 400 pure Codex tokens under a `client:codex` search. There is a regression test for exactly that.

## The fix

The row-level filter is replaced by `scopeRowToDirectives`, which reads the per-client and per-model figures out of `sourceBreakdown` and sums only the selected slice — cost handled the same way as tokens, not left on the row total. A row that matched nothing is dropped entirely, so it leaves no mark on the totals or on `uniqueUsers`.

### Decisions

- **`client:x model:y` means intersection within a single client.** A model's tokens count only where they were spent under a matching client. The union reading would let `client:codex model:opus` re-credit Codex work that never touched Opus — the same over-count in a new costume. Documented in the function's doc comment.
- **Client matching stays a case-insensitive substring test.** `client:claude` has always matched `claude-code`; tightening it to equality here would silently drop usage from any search built against the old behaviour. Carried over verbatim, with a test pinning it.
- **The unfiltered path is untouched.** It never consults `sourceBreakdown` and keeps summing row totals, which is the correct answer when nothing is filtered — and survives rows whose breakdown JSON is absent. Two tests assert it is unchanged.
- **The deliberate double aggregation is intact.** Hidden users still count toward period totals while being excluded from the ranking; a test covers that under an active directive.

## Tests

Eight new cases in `__tests__/lib/getLeaderboard.test.ts`. All eight fail against the unfixed source, including:

```
× counts only the filtered client's share of a row shared with other clients
× ranks on the filtered share, so a heavy unrelated client cannot buy a position
  AssertionError: expected [ 'dana', 'frank' ] to deeply equal [ 'frank', 'dana' ]
× still counts a hidden user's filtered share in the period totals
  AssertionError: expected { totalTokens: 2000, …(2) } to match object { totalTokens: 600, uniqueUsers: 2 }
```

Full suite and typecheck green:

```
 Test Files  77 passed (77)
      Tests  747 passed (747)

$ tsc --noEmit
```

`bun run lint`: 0 errors (16 pre-existing warnings, none in the touched files).

## Known, deliberately not fixed here

- `src/lib/groups/getGroupLeaderboard.ts:146-193` has the **identical** defect, copy-pasted. Same filter, same `existing.totalTokens += row.tokens`. Wants the same treatment in its own PR.
- The **all-time** path filters per user via `sources_used` / `models_used` and sums whole `submissions.totalTokens`, so it over-counts too — and can't be fixed the same way, because those columns are bare arrays with no per-element token attribution. Scoping it needs a join down to `daily_breakdown.source_breakdown`.
- All-time `stats` stays site-wide even under an active directive, which is now inconsistent with the period path, where `stats` reflects the filter.
- `LeaderboardClient.tsx:1180` labels `stats.uniqueUsers` "Ranked users", but `uniqueUsers` deliberately *includes* hidden (unranked) users on both paths. `pagination.totalUsers` is the real rankable count.
- `buildPeriodUserRank` ignores search directives entirely, so a user's own period rank is always computed unfiltered.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes period leaderboard filtering so `client:` and `model:` searches sum only the selected client's/model's tokens and cost from `sourceBreakdown`. Prevents overcounting that previously misordered rankings and inflated stats.

- **Bug Fixes**
  - Replaced row-level filtering with a per-row scoping function (`scopeRowToDirectives`) that sums only matching clients/models and drops non-matching rows.
  - Read `client:x model:y` as an intersection within a single client; keep client matching as case-insensitive substring.
  - Left unfiltered and plain-text searches unchanged (sum row totals); hidden users still count toward totals but not ranks.
  - Added regression tests to verify correct totals, costs, ordering, and unique user counts.

<sup>Written for commit 9680c2b33a4c58f45dce303604321ae3678b32f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

