### PR TITLE
fix(submit): stop the alias fold from mutating the stored raw breakdown

### DIFF
--- a/packages/frontend/__tests__/api/submitKilocodeFoldRepro.test.ts
+++ b/packages/frontend/__tests__/api/submitKilocodeFoldRepro.test.ts
@@ -530,3 +530,139 @@ describe("POST /api/submit kilocode alias fold vs regression guard", () => {
     expect(warnings.join(" ")).toMatch(/would reduce/i);
   });
 });
+
+// The fold builds its normalized view by copying each client entry, then sums
+// into that copy in place. When the copy was shallow, the nested model objects
+// were still the STORED ones, so folding a day mutated the raw breakdown that
+// the fold-preservation writeback persists moments later -- and every later
+// submit folded the already-folded values into themselves again. Client-level
+// scalars were spread-copied and so stayed correct, which is why this only
+// ever surfaced in per-model views.
+type PersistedBreakdown = Record<
+  string,
+  { tokens: number; models: Record<string, { tokens: number }> }
+>;
+
+describe("POST /api/submit alias fold leaves the stored raw breakdown untouched", () => {
+  /** 40 tokens is below the fold's 100-token largest component, so the guard
+   * preserves the fold and the writeback restores BOTH raw alias keys -- the
+   * path that persists whatever the fold did to the raw model objects. */
+  function mockPartialKiloResubmit() {
+    mockKiloResubmit();
+    mockState.validateSubmission.mockReturnValue({
+      valid: true,
+      errors: [],
+      warnings: [],
+      data: {
+        device: { id: "dev_1", name: "Device one" },
+        meta: {
+          generatedAt: "2026-05-11T00:00:00Z",
+          version: "4.6.0",
+          dateRange: { start: "2026-05-11", end: "2026-05-11" },
+        },
+        summary: { clients: ["kilo"] },
+        years: [],
+        contributions: [
+          {
+            date: "2026-05-11",
+            clients: [
+              {
+                client: "kilo",
+                modelId: "test-model",
+                tokens: { input: 40, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+                cost: 0.4,
+                messages: 2,
+              },
+            ],
+          },
+        ],
+      },
+    });
+  }
+
+  /** One fold-PRESERVING submit (incoming is below the heal floor, so the raw
+   * alias keys are written back verbatim). Returns what was persisted. */
+  async function submitBelowHealFloor(
+    storedBreakdown: Record<string, unknown>
+  ): Promise<PersistedBreakdown> {
+    const existingDay = {
+      id: "day-1",
+      date: "2026-05-11",
+      timestampMs: null,
+      activeTimeMs: null,
+      sourceBreakdown: storedBreakdown,
+    };
+
+    const { executedSqlArgs } = buildTx([
+      [{ id: "submission-existing" }],
+      [existingDay],
+      [AGGREGATES_ROW],
+      [{ sourceBreakdown: existingDay.sourceBreakdown }],
+    ]);
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ meta: {}, contributions: [] }),
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const strings: string[] = [];
+    for (const arg of executedSqlArgs) collectStrings(arg, strings);
+    const breakdownJson = strings.find(
+      (s) => s.includes('"kilocode"') && s.includes('"models"')
+    );
+    expect(breakdownJson).toBeDefined();
+    return JSON.parse(breakdownJson!) as PersistedBreakdown;
+  }
+
+  it("does not compound the raw alias keys' nested model values across repeated submits", async () => {
+    mockPartialKiloResubmit();
+
+    const storedBefore = {
+      kilocode: structuredClone(CLIENT_ENTRY_100),
+      kilo: structuredClone(CLIENT_ENTRY_100),
+    };
+
+    const afterFirst = await submitBelowHealFloor(storedBefore);
+
+    // Each raw key still carries only ITS OWN 100 tokens at the model level.
+    // Pre-fix this was 200: the fold summed kilo's models into the objects
+    // kilocode's entry still pointed at.
+    expect(afterFirst.kilocode.models["test-model"].tokens).toBe(100);
+    expect(afterFirst.kilo.models["test-model"].tokens).toBe(100);
+    // The model total must keep agreeing with the client total it decomposes.
+    expect(afterFirst.kilocode.models["test-model"].tokens).toBe(
+      afterFirst.kilocode.tokens
+    );
+
+    // Feed the persisted row back in, exactly as the next submit would read
+    // it. Pre-fix this second pass produced 300, then 400, without bound.
+    const afterSecond = await submitBelowHealFloor(afterFirst);
+
+    expect(afterSecond.kilocode.models["test-model"].tokens).toBe(100);
+    expect(afterSecond.kilo.models["test-model"].tokens).toBe(100);
+    expect(afterSecond).toEqual(afterFirst);
+  });
+
+  it("leaves the caller's stored breakdown object unmutated by the fold", async () => {
+    mockPartialKiloResubmit();
+
+    const storedBreakdown = {
+      kilocode: structuredClone(CLIENT_ENTRY_100),
+      kilo: structuredClone(CLIENT_ENTRY_100),
+    };
+    const pristine = structuredClone(storedBreakdown);
+
+    await submitBelowHealFloor(storedBreakdown);
+
+    // The row object handed to the route is the parsed source_breakdown JSON;
+    // the merge must treat it as read-only input, not scratch space.
+    expect(storedBreakdown).toEqual(pristine);
+  });
+});

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -54,9 +54,37 @@ function mergeModelBreakdowns(
       existingModel.reasoning = (existingModel.reasoning || 0) + (modelData.reasoning || 0);
       existingModel.messages += modelData.messages || 0;
     } else {
+      // ModelBreakdownData is entirely scalar, so a spread is a full copy --
+      // the merged model never shares state with `incoming`. Adding a nested
+      // field to that interface would silently turn this back into an alias.
       target[modelId] = { ...modelData };
     }
   }
+}
+
+// `normalized` is mutated in place below (scalar `+=` on the client entry and
+// mergeModelBreakdowns on its models), while the fold-preservation writeback
+// in POST re-reads the ORIGINAL raw entries afterwards to restore the legacy
+// alias keys. Those two only coexist if the normalized view owns its data
+// outright: a shallow `{ ...data, models: { ...data.models } }` copies the
+// client scalars and the models MAP but leaves the model VALUE objects shared
+// with the stored breakdown, so folding a day mutated the very raw data the
+// writeback then persisted -- and each later submit re-folded the
+// already-folded values, compounding the nested models without bound. Client
+// totals hid it because those are scalars the spread genuinely copied, which
+// is why day totals and the leaderboard stayed correct while per-model views
+// drifted.
+function cloneClientBreakdownForFold(data: ClientBreakdownData): ClientBreakdownData {
+  const models: ClientBreakdownData["models"] = {};
+  for (const [modelId, modelData] of Object.entries(data.models ?? {})) {
+    models[modelId] = { ...modelData };
+  }
+
+  return {
+    ...data,
+    models,
+    ...(data.provenance ? { provenance: { ...data.provenance } } : {}),
+  };
 }
 
 interface NormalizedClientBreakdownAliases {
@@ -91,7 +119,7 @@ function normalizeClientBreakdownAliases(
     );
 
     if (!existing) {
-      normalized[clientName] = { ...data, models: { ...data.models } };
+      normalized[clientName] = cloneClientBreakdownForFold(data);
       continue;
     }
 


### PR DESCRIPTION
## The bug

`normalizeClientBreakdownAliases` in `packages/frontend/src/app/api/submit/route.ts` seeded its normalized view with:

```ts
normalized[clientName] = { ...data, models: { ...data.models } };
```

That copies the client scalars and the models **map**, but every model **value** object inside it is still the object held by the stored `source_breakdown` JSON (`rawExistingBreakdown`). `mergeModelBreakdowns` then sums into those shared objects **in place**, so the fold mutates stored raw data. The fold-preservation writeback restores the raw alias keys from `rawExistingBreakdown` *after* that, persisting the already-inflated values — and every subsequent submit re-folds them into themselves.

Result: for any client with a `LEGACY_CLIENT_ALIASES` entry (kilocode → kilo), the nested `models` map compounds without bound across submits.

Client-level `tokens` escaped the defect because `{ ...data }` copied a scalar. That is exactly why day totals and the leaderboard stayed correct while per-model views drifted.

## The fix

Give the normalized view outright ownership of its data at the point the sharing is created (`cloneClientBreakdownForFold`), instead of making the merge defensive. The raw breakdown is read-only input that the writeback re-reads after the merge, so a private copy at the boundary is the invariant that has to hold — and it also covers the client-level `+=` and the `provenance` object, which today are safe only because they happen to be scalars.

The alternative — making `mergeModelBreakdowns` pure — is recorded in a `Rejected:` trailer: it fixes the models path only and leaves the same aliasing class alive in the sibling scalar block.

The `else` branch `target[modelId] = { ...modelData }` was checked and *is* deep enough: `ModelBreakdownData` is entirely scalar. A comment now records that this holds only while that stays true.

## Test

`packages/frontend/__tests__/api/submitKilocodeFoldRepro.test.ts` gains two regression tests on the fold-preserving path (incoming below the heal floor, so the raw alias keys are written back):

- submits the same aliased payload twice, feeding submit #1's persisted breakdown back in as submit #2's stored row, and asserts the raw keys' nested model values are unchanged (`100`, not `200` then `300`)
- asserts the route never mutates the stored breakdown object it was handed

Verified red before the fix / green after:

```
# without the fix
 Test Files  1 failed (1)
      Tests  2 failed | 4 passed (6)

-  "tokens": 100,     (expected)
+  "tokens": 200,     (received)

# with the fix
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

## Verification

```
$ bun run test
 Test Files  77 passed (77)
      Tests  739 passed (739)

$ bun run typecheck
$ tsc --noEmit
EXIT:0

$ bun run lint
✖ 16 problems (0 errors, 16 warnings)   # all pre-existing, none in touched files
```

## Found but not fixed

`packages/frontend/src/lib/publicProfileData.ts` has the same aliasing shape on the **read** side: the day aggregator adopts the stored map by reference (`models: breakdown.models`, ~:408 and ~:471) and later calls `mergeIncomingClientModels` / `materializeLegacyClientModel`, which mutate it in place. Nothing is written back and `dailyData` is iterated only once, so it is latent rather than an active corruption — but it mutates query-result objects and would become a live double-count the moment those rows are read a second time.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the alias fold in the submit endpoint to stop mutating the stored `source_breakdown`, preventing per‑model totals from compounding across submits for aliased clients (e.g., `kilocode` → `kilo`). The normalized view now owns its data by deep‑copying models.

- **Bug Fixes**
  - Replace shallow seed with `cloneClientBreakdownForFold` in `packages/frontend/src/app/api/submit/route.ts` to deep‑copy `models` (and `provenance`) before merging; keeps the stored raw breakdown read‑only.
  - Document that `ModelBreakdownData` is scalar so `{ ...modelData }` is a full copy.
  - Add regression tests in `packages/frontend/__tests__/api/submitKilocodeFoldRepro.test.ts` to ensure values don’t compound and the input breakdown isn’t mutated.

<sup>Written for commit 3846ef02f8b5b208296e91ac02d4357d355d7d7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

