### PR TITLE
fix(opencodereview): parse the client on the submit path, not just locally

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1629,6 +1629,32 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         .collect();
     all_messages.extend(zcode_messages);
 
+    // opencodereview `llm_response` records carry usage but never a cost, so
+    // every message leaves the parser at 0.0 and pricing is its only cost
+    // source. That makes the generic source cache safe here — unlike Junie
+    // above, there is no authoritative embedded cost for cached_messages()'s
+    // unconditional reprice to overwrite. The parser also dedups within a file
+    // on its own, so no cross-file `should_keep_deduped_message` pass is needed.
+    let opencodereview_outcomes: Vec<CachedParseOutcome> = scan_result
+        .get(ClientId::OpenCodeReview)
+        .par_iter()
+        .map(|path| {
+            load_or_parse_source(
+                message_cache::CacheIdentity::for_client(ClientId::OpenCodeReview),
+                path,
+                &source_cache,
+                pricing,
+                sessions::opencodereview::parse_opencodereview_file,
+            )
+        })
+        .collect();
+    for outcome in opencodereview_outcomes {
+        all_messages.extend(outcome.messages);
+        if let Some(entry) = outcome.cache_entry {
+            source_cache.insert(entry);
+        }
+    }
+
     let kimi_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::Kimi)
         .par_iter()
@@ -5013,6 +5039,60 @@ mod tests {
             assert_eq!(parsed.messages.len(), 4);
             assert_eq!(parsed.messages.iter().map(|m| m.input).sum::<i64>(), 40);
             assert_eq!(parsed.messages.iter().map(|m| m.output).sum::<i64>(), 5);
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parse_all_messages_with_pricing_includes_opencodereview() {
+        // Regression: opencodereview declares submit_default, and
+        // parse_local_clients has always parsed it, so `tokscale report`
+        // showed the usage. But the submit path
+        // (parse_all_messages_with_pricing_with_env_strategy) had no
+        // opencodereview block at all, so none of that usage was ever
+        // uploaded. Pin the submit path specifically — a green
+        // parse_local_clients test cannot catch this.
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            let session_dir = source_home
+                .path()
+                .join(".opencodereview/sessions/-home-user-project");
+            std::fs::create_dir_all(&session_dir).unwrap();
+            std::fs::write(
+                session_dir.join("session-1.jsonl"),
+                r#"{"type":"session_start","sessionId":"session-1","timestamp":"2026-01-15T10:00:00Z","cwd":"/home/user/project","model":"claude-sonnet-4-20250514"}
+{"type":"llm_response","sessionId":"session-1","timestamp":"2026-01-15T10:00:05Z","model":"claude-sonnet-4-20250514","duration_ms":1500,"usage":{"prompt_tokens":1000,"completion_tokens":200,"cache_read_tokens":500,"cache_write_tokens":100}}
+{"type":"llm_response","sessionId":"session-1","timestamp":"2026-01-15T10:01:00Z","model":"gpt-4o","duration_ms":900,"usage":{"prompt_tokens":300,"completion_tokens":50,"cache_read_tokens":0,"cache_write_tokens":0}}"#,
+            )
+            .unwrap();
+
+            let messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["opencodereview".to_string()],
+                None,
+            );
+
+            assert_eq!(messages.len(), 2);
+            assert!(messages.iter().all(|m| m.client == "opencodereview"));
+            assert_eq!(messages.iter().map(|m| m.tokens.input).sum::<i64>(), 1300);
+            assert_eq!(messages.iter().map(|m| m.tokens.output).sum::<i64>(), 250);
+            assert_eq!(
+                messages.iter().map(|m| m.tokens.cache_read).sum::<i64>(),
+                500
+            );
+            assert_eq!(
+                messages.iter().map(|m| m.tokens.cache_write).sum::<i64>(),
+                100
+            );
         }
 
         match original_home {

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -850,9 +850,13 @@ fn parser_version(client: ClientId) -> u32 {
         // their own `timestamp` now carry a line-number discriminator in the
         // dedup key, so distinct calls sharing a model and token counts no
         // longer collapse into one under the shared file-mtime fallback.
-        // Both bumps are precautionary rather than corrective: opencodereview
-        // is parsed only by parse_local_clients, which does not go through
-        // this cache, so no entry has ever been written under this namespace.
+        // Both bumps were precautionary rather than corrective: until the
+        // submit path learned to parse opencodereview, the only reader was
+        // parse_local_clients, which does not go through this cache, so no
+        // entry was ever written under this namespace. 3 is therefore the
+        // first version to describe real cache entries — it is not carrying
+        // an invalidation debt forward, and a further bump would have had
+        // nothing to invalidate.
         ClientId::OpenCodeReview => 3,
         // Kiro's structured messages.jsonl turns now back-calculate the
         // start anchor from `turn_end - elapsedTime` when the user prompt's


### PR DESCRIPTION
## The bug

`ClientId::OpenCodeReview` declares both `parse_local: true` and `submit_default: true`, and a working parser has existed at `crates/tokscale-core/src/sessions/opencodereview.rs` since the client was added. But `parse_opencodereview_file` was called from exactly one place: `parse_local_clients`.

`parse_local_clients` has three callers — `tokscale report`, `tokscale wrapped`, and `tokscale clients`. None of them is the submit path. The submit path runs through `parse_all_messages_with_pricing_with_env_strategy`, which had no opencodereview block at all.

**Consequence: opencodereview usage showed up in `tokscale report` but had never once reached the server.** Every user of that client has been silently losing 100% of their tokens.

## The fix

Added the missing block to `parse_all_messages_with_pricing_with_env_strategy`, wired the way the submit path wires its peers rather than as a copy of the `parse_local_clients` block — the submit path routes through the source message cache, which `parse_local_clients` does not.

It uses `load_or_parse_source` (the generic cached path, same shape as Qwen). That is safe for this client specifically because opencodereview's `llm_response` records carry usage but never a cost: every message leaves the parser at `0.0` and pricing is its only cost source, so `cached_messages()`'s unconditional reprice has nothing authoritative to overwrite. This is exactly the constraint that keeps Junie and gjc off this path, and it does not apply here.

## parser_version: left at 3, deliberately

`message_cache.rs` set `parser_version(ClientId::OpenCodeReview) => 3` with a comment stating the namespace was unreachable. This change makes that comment false, so it has been rewritten.

The version number itself stays at 3. `parser_version` exists to invalidate stale cache entries, and no entry has ever been written under the `opencodereview` namespace — `CacheIdentity::for_client` derives the namespace from `ClientId::as_str`, so it is exclusive to this client, and this commit adds its first and only writer. Both earlier bumps (1→2, 2→3) were precautionary against a cache that was never reached. Bumping to 4 would invalidate an empty set and add churn for nothing; 3 is simply the first version that will ever describe a real cache entry.

## Test

Added `test_parse_all_messages_with_pricing_includes_opencodereview`, mirroring the house style of the existing kimi submit-path test. It targets the submit path specifically — a green `parse_local_clients` test cannot catch this class of bug, which is why it went unnoticed.

Verified the test actually fails without the fix: with the block neutered it reports `left: 0, right: 2`.

## Verification

- `cargo test -p tokscale-core` — 1308 passed, 0 failed, 1 ignored (plus integration suites: 10 / 4 / 14 / 3 / 4, all passing)
- `cargo clippy --all-targets` — clean. Note CI omits `--all-targets`, so it does not lint `#[cfg(test)]` code; run locally with the flag.
- `cargo build` — clean

## Notes

No frontend change needed — the client registry (`packages/frontend/src/lib/constants.ts`, `types.ts`) was already complete for opencodereview.

Historical usage that predates this fix is not backfilled; only new submissions will carry opencodereview data.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing submit-path parsing for `opencodereview` so usage is uploaded to the server instead of being lost. Routes `opencodereview` through the source message cache on submit for consistent caching and pricing.

- **Bug Fixes**
  - Added `opencodereview` handling in `parse_all_messages_with_pricing_with_env_strategy` via `load_or_parse_source` and `source_cache`.
  - Safe to use the generic cache: `llm_response` records include usage only; costs come from pricing.
  - Kept `parser_version(ClientId::OpenCodeReview)` at 3 and updated the comment; no invalidation needed.
  - Added `test_parse_all_messages_with_pricing_includes_opencodereview`; no frontend change; historical usage is not backfilled.

<sup>Written for commit 1a0a10326470d77ca570960ec471893344adf388. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

