### PR TITLE
fix(groups): sum only the filtered client's tokens on group period boards

### DIFF
--- a/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
@@ -355,3 +355,280 @@ describe("group leaderboard data", () => {
     );
   });
 });
+
+describe("group period leaderboard directive scoping", () => {
+  // One device, one day, two clients. The row total (1000/10) is the sum of
+  // both, which is exactly what a filtered search must not credit.
+  const mixedClientDay = {
+    userId: "user-dana",
+    username: "dana",
+    displayName: "Dana",
+    avatarUrl: null,
+    role: "member",
+    tokens: 1000,
+    cost: 10,
+    sourceBreakdown: {
+      codex: {
+        tokens: 300,
+        cost: 3,
+        models: {
+          "gpt-5-codex": { tokens: 200, cost: 2 },
+          "gpt-5-mini": { tokens: 100, cost: 1 },
+        },
+      },
+      "claude-code": {
+        tokens: 700,
+        cost: 7,
+        models: {
+          "claude-opus-4": { tokens: 700, cost: 7 },
+        },
+      },
+    },
+  };
+
+  function useWeekOf(rows: Array<Record<string, unknown>>) {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-07T18:45:00Z"));
+    mockState.setPeriodRows(rows);
+  }
+
+  it("counts only the filtered client's share of a row shared with other clients", async () => {
+    useWeekOf([mixedClientDay]);
+
+    const leaderboard = await getGroupLeaderboardData(
+      "group-1",
+      "week",
+      1,
+      50,
+      "tokens",
+      "client:codex"
+    );
+
+    // 300/3, not the row's 1000/10: claude-code ran on the same day and
+    // device but was not asked for.
+    expect(leaderboard.users[0]).toMatchObject({
+      username: "dana",
+      role: "member",
+      totalTokens: 300,
+      totalCost: 3,
+    });
+    expect(leaderboard.stats).toMatchObject({
+      totalTokens: 300,
+      totalCost: 3,
+      activeUsers: 1,
+    });
+  });
+
+  it("counts only the filtered model's share, not every client in the row", async () => {
+    useWeekOf([mixedClientDay]);
+
+    const leaderboard = await getGroupLeaderboardData(
+      "group-1",
+      "week",
+      1,
+      50,
+      "tokens",
+      "model:claude-opus-4"
+    );
+
+    expect(leaderboard.users[0]).toMatchObject({
+      username: "dana",
+      totalTokens: 700,
+      totalCost: 7,
+    });
+    expect(leaderboard.stats).toMatchObject({ totalTokens: 700, totalCost: 7 });
+  });
+
+  it("sums a model directive across every client that ran the model", async () => {
+    useWeekOf([
+      {
+        ...mixedClientDay,
+        sourceBreakdown: {
+          codex: {
+            tokens: 300,
+            cost: 3,
+            models: { "gpt-5-codex": { tokens: 300, cost: 3 } },
+          },
+          crush: {
+            tokens: 700,
+            cost: 7,
+            models: { "gpt-5-codex": { tokens: 500, cost: 5 }, "gpt-4o": { tokens: 200, cost: 2 } },
+          },
+        },
+      },
+    ]);
+
+    const leaderboard = await getGroupLeaderboardData(
+      "group-1",
+      "week",
+      1,
+      50,
+      "tokens",
+      "model:gpt-5-codex"
+    );
+
+    expect(leaderboard.users[0]).toMatchObject({ totalTokens: 800, totalCost: 8 });
+  });
+
+  it("reads client:x model:y as an intersection inside one client", async () => {
+    useWeekOf([mixedClientDay]);
+
+    // claude-opus-4 exists in the row, but under claude-code, not codex. The
+    // union reading would have credited dana all 300 of her Codex tokens for
+    // Opus work she never did there.
+    const leaderboard = await getGroupLeaderboardData(
+      "group-1",
+      "week",
+      1,
+      50,
+      "tokens",
+      "client:codex model:claude-opus-4"
+    );
+
+    expect(leaderboard.users).toHaveLength(0);
+    expect(leaderboard.stats).toMatchObject({
+      totalTokens: 0,
+      totalCost: 0,
+      activeUsers: 0,
+    });
+  });
+
+  it("keeps client matching on case-insensitive substrings", async () => {
+    useWeekOf([mixedClientDay]);
+
+    // `claude` is not a client id — it is a prefix of `claude-code`, and has
+    // matched it since the directive shipped.
+    const leaderboard = await getGroupLeaderboardData(
+      "group-1",
+      "week",
+      1,
+      50,
+      "tokens",
+      "client:CLAUDE"
+    );
+
+    expect(leaderboard.users[0]).toMatchObject({ totalTokens: 700, totalCost: 7 });
+  });
+
+  it("drops rows with no source breakdown when a directive is active", async () => {
+    useWeekOf([
+      mixedClientDay,
+      {
+        userId: "user-erin",
+        username: "erin",
+        displayName: "Erin",
+        avatarUrl: null,
+        role: "member",
+        tokens: 5000,
+        cost: 50,
+        sourceBreakdown: null,
+      },
+    ]);
+
+    const leaderboard = await getGroupLeaderboardData(
+      "group-1",
+      "week",
+      1,
+      50,
+      "tokens",
+      "client:codex"
+    );
+
+    expect(leaderboard.users.map((user) => user.username)).toEqual(["dana"]);
+    expect(leaderboard.stats.totalTokens).toBe(300);
+  });
+
+  it("ranks on the filtered share, so a heavy unrelated client cannot buy a position", async () => {
+    useWeekOf([
+      mixedClientDay,
+      {
+        userId: "user-frank",
+        username: "frank",
+        displayName: "Frank",
+        avatarUrl: null,
+        role: "owner",
+        tokens: 400,
+        cost: 4,
+        sourceBreakdown: {
+          codex: {
+            tokens: 400,
+            cost: 4,
+            models: { "gpt-5-codex": { tokens: 400, cost: 4 } },
+          },
+        },
+      },
+    ]);
+
+    const leaderboard = await getGroupLeaderboardData(
+      "group-1",
+      "week",
+      1,
+      50,
+      "tokens",
+      "client:codex"
+    );
+
+    // dana's 1000-token row outweighs frank's 400 only because 700 of it is
+    // claude-code. On Codex alone frank is ahead.
+    expect(leaderboard.users.map((user) => user.username)).toEqual(["frank", "dana"]);
+    expect(leaderboard.users.map((user) => user.totalTokens)).toEqual([400, 300]);
+  });
+
+  it("scopes every daily row a member contributes, not just the first", async () => {
+    useWeekOf([
+      mixedClientDay,
+      {
+        ...mixedClientDay,
+        sourceBreakdown: {
+          codex: {
+            tokens: 50,
+            cost: 0.5,
+            models: { "gpt-5-codex": { tokens: 50, cost: 0.5 } },
+          },
+        },
+        tokens: 50,
+        cost: 0.5,
+      },
+    ]);
+
+    const leaderboard = await getGroupLeaderboardData(
+      "group-1",
+      "week",
+      1,
+      50,
+      "tokens",
+      "client:codex"
+    );
+
+    // Both of dana's days fold into one entry, each already narrowed to Codex.
+    expect(leaderboard.users).toHaveLength(1);
+    expect(leaderboard.users[0]).toMatchObject({ totalTokens: 350, totalCost: 3.5 });
+  });
+
+  it("leaves the unfiltered path on the row totals", async () => {
+    useWeekOf([mixedClientDay]);
+
+    const leaderboard = await getGroupLeaderboardData("group-1", "week", 1, 50, "tokens");
+
+    // No directive, so sourceBreakdown is never consulted and the whole row
+    // counts, exactly as before.
+    expect(leaderboard.users[0]).toMatchObject({
+      username: "dana",
+      totalTokens: 1000,
+      totalCost: 10,
+    });
+    expect(leaderboard.stats).toMatchObject({
+      totalTokens: 1000,
+      totalCost: 10,
+      activeUsers: 1,
+    });
+  });
+
+  it("leaves a plain text search on the row totals", async () => {
+    useWeekOf([mixedClientDay]);
+
+    const leaderboard = await getGroupLeaderboardData("group-1", "week", 1, 50, "tokens", "dana");
+
+    expect(leaderboard.users[0]).toMatchObject({ totalTokens: 1000, totalCost: 10 });
+  });
+});

--- a/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
+++ b/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
@@ -7,6 +7,10 @@ import {
   hasDirectives,
   parseSearchDirectives,
 } from "@/lib/leaderboard/searchDirectives";
+import {
+  scopeBreakdownToDirectives,
+  type PeriodSourceBreakdown,
+} from "@/lib/leaderboard/sourceBreakdown";
 
 interface GroupLeaderboardPeriodRow {
   userId: string;
@@ -16,7 +20,7 @@ interface GroupLeaderboardPeriodRow {
   role: string;
   tokens: number;
   cost: number;
-  sourceBreakdown: Record<string, { models: Record<string, unknown> }> | null;
+  sourceBreakdown: PeriodSourceBreakdown | null;
 }
 
 interface GroupLeaderboardDbRow {
@@ -145,29 +149,9 @@ function buildPeriodGroupLeaderboardData(
 
   let filteredRows = rows;
   if (hasDirectives(parsed)) {
-    filteredRows = rows.filter((row) => {
-      if (!row.sourceBreakdown) return false;
-
-      const clientKeys = Object.keys(row.sourceBreakdown).map((k) => k.toLowerCase());
-      const modelKeys = Object.values(row.sourceBreakdown).flatMap((client) =>
-        client.models ? Object.keys(client.models).map((m) => m.toLowerCase()) : []
-      );
-
-      if (parsed.clients.length > 0) {
-        const hasMatchingClient = parsed.clients.some((c) =>
-          clientKeys.some((k) => k.includes(c))
-        );
-        if (!hasMatchingClient) return false;
-      }
-
-      if (parsed.models.length > 0) {
-        const hasMatchingModel = parsed.models.some((m) =>
-          modelKeys.some((k) => k.includes(m))
-        );
-        if (!hasMatchingModel) return false;
-      }
-
-      return true;
+    filteredRows = rows.flatMap((row) => {
+      const scoped = scopeBreakdownToDirectives(row.sourceBreakdown, parsed);
+      return scoped ? [{ ...row, tokens: scoped.tokens, cost: scoped.cost }] : [];
     });
   }
 
@@ -262,7 +246,7 @@ async function fetchPeriodRows(
     role: row.role,
     tokens: Number(row.tokens) || 0,
     cost: Number(row.cost) || 0,
-    sourceBreakdown: (row.sourceBreakdown as Record<string, { models: Record<string, unknown> }>) ?? null,
+    sourceBreakdown: row.sourceBreakdown ?? null,
   }));
 }
 

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -12,8 +12,11 @@ import {
   escapeLikePattern,
   hasDirectives,
   parseSearchDirectives,
-  type ParsedSearchDirectives,
 } from "@/lib/leaderboard/searchDirectives";
+import {
+  scopeBreakdownToDirectives,
+  type PeriodSourceBreakdown,
+} from "@/lib/leaderboard/sourceBreakdown";
 
 export type { LeaderboardData, LeaderboardUser, Period, SortBy } from "@/lib/leaderboard/types";
 
@@ -27,18 +30,6 @@ export type { LeaderboardData, LeaderboardUser, Period, SortBy } from "@/lib/lea
  */
 const RANKABLE_USER = eq(users.leaderboardHidden, false);
 
-/**
- * The part of `daily_breakdown.source_breakdown` the leaderboard reads. Every
- * field is optional because the stored blob has grown over time and rows
- * written by older CLI versions are still on the board — see db/schema.ts for
- * the full shape.
- */
-interface PeriodClientBreakdown {
-  tokens?: number;
-  cost?: number;
-  models?: Record<string, { tokens?: number; cost?: number }>;
-}
-
 interface LeaderboardPeriodRow {
   userId: string;
   username: string;
@@ -46,7 +37,7 @@ interface LeaderboardPeriodRow {
   avatarUrl: string | null;
   tokens: number;
   cost: number;
-  sourceBreakdown: Record<string, PeriodClientBreakdown> | null;
+  sourceBreakdown: PeriodSourceBreakdown | null;
   /**
    * Carried through so the period path can drop the user from the rankings
    * while still counting them in the period totals. Internal only — it must
@@ -67,7 +58,7 @@ interface PeriodLeaderboardDbRow {
   avatarUrl: string | null;
   tokens: number | string | null;
   cost: number | string | null;
-  sourceBreakdown: Record<string, PeriodClientBreakdown> | null;
+  sourceBreakdown: PeriodSourceBreakdown | null;
   leaderboardHidden: boolean;
 }
 
@@ -206,70 +197,6 @@ function matchesLeaderboardSearch(
   return false;
 }
 
-/**
- * Narrows a daily row to the tokens and cost a `client:`/`model:` search
- * actually asked for, or null when nothing in the row was selected.
- *
- * A daily row's own `tokens`/`cost` are the total across every client and
- * model that shared that day and device, so a filtered board must not sum
- * them: crediting the whole row to a `client:codex` search hands the user
- * every other client they happened to run that day. The per-client and
- * per-model figures inside `sourceBreakdown` are the only ones narrow enough
- * to add up.
- *
- * `client:x model:y` is read as an intersection within one client — a model's
- * tokens count only where they were spent under a matching client. A union
- * reading would let `client:codex model:opus` re-credit Codex work that never
- * touched Opus, which is the same over-count wearing a different hat.
- */
-function scopeRowToDirectives(
-  row: LeaderboardPeriodRow,
-  parsed: ParsedSearchDirectives
-): { tokens: number; cost: number } | null {
-  if (!row.sourceBreakdown) {
-    return null;
-  }
-
-  let tokens = 0;
-  let cost = 0;
-  let matched = false;
-
-  for (const [clientId, client] of Object.entries(row.sourceBreakdown)) {
-    // Case-insensitive substring, carried over verbatim from the row filter
-    // this replaced: `client:claude` has always matched `claude-code`, and
-    // tightening that to equality here would quietly drop usage from every
-    // saved search built against the old behaviour.
-    const clientMatches =
-      parsed.clients.length === 0 ||
-      parsed.clients.some((candidate) => clientId.toLowerCase().includes(candidate));
-
-    if (!clientMatches) {
-      continue;
-    }
-
-    if (parsed.models.length === 0) {
-      matched = true;
-      tokens += Number(client.tokens) || 0;
-      cost += Number(client.cost) || 0;
-      continue;
-    }
-
-    for (const [modelId, model] of Object.entries(client.models ?? {})) {
-      if (!parsed.models.some((candidate) => modelId.toLowerCase().includes(candidate))) {
-        continue;
-      }
-      matched = true;
-      tokens += Number(model.tokens) || 0;
-      cost += Number(model.cost) || 0;
-    }
-  }
-
-  // Tracked separately from a zero sum: a client that genuinely burned no
-  // tokens still puts its owner on the filtered board and into uniqueUsers,
-  // whereas a row nothing matched must leave no trace at all.
-  return matched ? { tokens, cost } : null;
-}
-
 function buildPeriodLeaderboardData(
   rows: LeaderboardPeriodRow[],
   page: number,
@@ -284,7 +211,7 @@ function buildPeriodLeaderboardData(
   let filteredRows = rows;
   if (hasDirectives(parsed)) {
     filteredRows = rows.flatMap((row) => {
-      const scoped = scopeRowToDirectives(row, parsed);
+      const scoped = scopeBreakdownToDirectives(row.sourceBreakdown, parsed);
       return scoped ? [{ ...row, tokens: scoped.tokens, cost: scoped.cost }] : [];
     });
   }

--- a/packages/frontend/src/lib/leaderboard/sourceBreakdown.ts
+++ b/packages/frontend/src/lib/leaderboard/sourceBreakdown.ts
@@ -1,0 +1,84 @@
+import type { ParsedSearchDirectives } from "@/lib/leaderboard/searchDirectives";
+
+/**
+ * The part of `daily_breakdown.source_breakdown` the leaderboards read. Every
+ * field is optional because the stored blob has grown over time and rows
+ * written by older CLI versions are still on the board — see db/schema.ts for
+ * the full shape.
+ */
+export interface PeriodClientBreakdown {
+  tokens?: number;
+  cost?: number;
+  models?: Record<string, { tokens?: number; cost?: number }>;
+}
+
+export type PeriodSourceBreakdown = Record<string, PeriodClientBreakdown>;
+
+/**
+ * Narrows one daily row's breakdown to the tokens and cost a `client:`/`model:`
+ * search actually asked for, or null when nothing in it was selected.
+ *
+ * A daily row's own `tokens`/`cost` are the total across every client and
+ * model that shared that day and device, so a filtered board must not sum
+ * them: crediting the whole row to a `client:codex` search hands the user
+ * every other client they happened to run that day. The per-client and
+ * per-model figures inside `sourceBreakdown` are the only ones narrow enough
+ * to add up.
+ *
+ * `client:x model:y` is read as an intersection within one client — a model's
+ * tokens count only where they were spent under a matching client. A union
+ * reading would let `client:codex model:opus` re-credit Codex work that never
+ * touched Opus, which is the same over-count wearing a different hat.
+ *
+ * Takes the breakdown rather than a row because the global and group period
+ * boards carry different row shapes (a group row also has `role`) over the
+ * same JSON. The duplicate that this replaced is how the group board inherited
+ * the over-count in the first place.
+ */
+export function scopeBreakdownToDirectives(
+  sourceBreakdown: PeriodSourceBreakdown | null,
+  parsed: ParsedSearchDirectives
+): { tokens: number; cost: number } | null {
+  if (!sourceBreakdown) {
+    return null;
+  }
+
+  let tokens = 0;
+  let cost = 0;
+  let matched = false;
+
+  for (const [clientId, client] of Object.entries(sourceBreakdown)) {
+    // Case-insensitive substring, carried over verbatim from the row filter
+    // this replaced: `client:claude` has always matched `claude-code`, and
+    // tightening that to equality here would quietly drop usage from every
+    // saved search built against the old behaviour.
+    const clientMatches =
+      parsed.clients.length === 0 ||
+      parsed.clients.some((candidate) => clientId.toLowerCase().includes(candidate));
+
+    if (!clientMatches) {
+      continue;
+    }
+
+    if (parsed.models.length === 0) {
+      matched = true;
+      tokens += Number(client.tokens) || 0;
+      cost += Number(client.cost) || 0;
+      continue;
+    }
+
+    for (const [modelId, model] of Object.entries(client.models ?? {})) {
+      if (!parsed.models.some((candidate) => modelId.toLowerCase().includes(candidate))) {
+        continue;
+      }
+      matched = true;
+      tokens += Number(model.tokens) || 0;
+      cost += Number(model.cost) || 0;
+    }
+  }
+
+  // Tracked separately from a zero sum: a client that genuinely burned no
+  // tokens still puts its owner on the filtered board and into the user
+  // counts, whereas a row nothing matched must leave no trace at all.
+  return matched ? { tokens, cost } : null;
+}


### PR DESCRIPTION
> **Stacked on #988.** Base branch is `fix/leaderboard-period-client-filter-overcount`, not `main` — the diff below is only this change. Retarget to `main` once #988 lands.

## The bug

`getGroupLeaderboard.ts` held a byte-identical copy of the row-level directive filter that #988 removed from `getLeaderboard.ts`, followed by the same `existing.totalTokens += row.tokens` aggregation.

A `client:`/`model:` search on a **group** board therefore credits each member with their whole daily row — every client and model that shared that day and device. Group boards are over-counting in production right now, and the over-count reorders them: a member with 300 Codex tokens on a day they also spent 700 in Claude Code outranks a member with 400 pure Codex tokens under `client:codex`.

## The fix: extracted, not copied

A copy-pasted defect is what let the group board inherit this bug in the first place, so landing a third copy was not an option. #988's `scopeRowToDirectives` moves to `src/lib/leaderboard/sourceBreakdown.ts` as `scopeBreakdownToDirectives`, and both boards import it.

It takes the `sourceBreakdown` blob rather than a row. The two boards carry different row shapes over the same JSON (a group row also has `role`), and the function reads nothing but the breakdown — generalising to the narrowest thing it actually touches is what stops a fourth call site from copying it again.

The user board's half is a pure relocation. **#988's tests pass unedited.**

Semantics are carried over exactly: case-insensitive substring matching, `client:x model:y` as an intersection within one client, a row matching nothing dropped entirely, cost scoped the same way as tokens.

## Hidden users on group boards

Checked, and reported rather than changed: **the group path has no equivalent of the user board's deliberate double aggregation, and it does not need one.** `leaderboardHidden` *is* applied on group boards — in SQL, in the `WHERE` of both `fetchPeriodRows` and `fetchAllTimeRows`.

The consequence is a real semantic difference from the site-wide board, left as-is:

- **Site-wide period board:** hidden users are dropped from the rankings but still counted in `stats.totalTokens` / `uniqueUsers`. Hiding withdraws you from the competition, it does not erase your usage.
- **Group board:** hidden members never reach the aggregation at all, so they contribute to neither the ranking nor the group's `totalTokens` / `totalCost` / `activeUsers`. `totalMembers` still counts them (it is a plain `COUNT(*)` on `group_members` with no join to `users`), so a group with a hidden member reports `totalMembers` above `activeUsers`.

## Tests

Ten new cases in `__tests__/lib/getGroupLeaderboard.test.ts`, mirroring #988's. **Eight fail before the fix and pass after**; the two that pass throughout are the unfiltered-path guards, which is the point of including them.

Before — `Tests 8 failed | 7 passed (15)`:

```
× counts only the filtered client's share of a row shared with other clients
× counts only the filtered model's share, not every client in the row
× sums a model directive across every client that ran the model
× reads client:x model:y as an intersection inside one client
× keeps client matching on case-insensitive substrings
× drops rows with no source breakdown when a directive is active
× ranks on the filtered share, so a heavy unrelated client cannot buy a position
× scopes every daily row a member contributes, not just the first
✓ leaves the unfiltered path on the row totals
✓ leaves a plain text search on the row totals
```

Sample failure — the whole row credited to a one-client search:

```
AssertionError: expected { …(7) } to match object { totalTokens: 300, totalCost: 3 }
- Expected      + Received
-   "totalCost": 3,      +   "totalCost": 10,
-   "totalTokens": 300,  +   "totalTokens": 1000,
```

...and the reordering:

```
AssertionError: expected [ 'dana', 'frank' ] to deeply equal [ 'frank', 'dana' ]
```

After — `Tests 15 passed (15)`.

## Verification

| Check | Result |
| --- | --- |
| `bun run test` (full frontend suite) | `Test Files 77 passed (77)` / `Tests 757 passed (757)` |
| `bun run typecheck` | clean, exit 0 |
| `bun run lint` | exit 0 — 0 errors, 16 pre-existing warnings, none in touched files |
| `__tests__/lib/getLeaderboard.test.ts` (#988's, unmodified) | `Tests 20 passed (20)` |

## Not fixed here (reported only)

- **Group all-time path** filters directives at submission granularity against `sourcesUsed`/`modelsUsed` and sums whole submissions — the same class of over-count at a coarser grain. It mirrors the user all-time path that #988 deliberately left alone, so it is untouched.
- **`matchesSearch` in the group path matches `username` only**, while the site-wide `matchesLeaderboardSearch` also matches `displayName`. A group text search for a member's display name finds nothing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes over-counting on group period leaderboards when using `client:`/`model:` filters by summing only the matching tokens/cost from `sourceBreakdown`. Rankings now reflect only the filtered share and match the global board’s behavior.

- **Bug Fixes**
  - Group period boards now aggregate only the filtered client/model share from `sourceBreakdown`; non-matching rows are skipped.
  - Unfiltered and plain-text searches still sum row totals; handling of hidden members on group boards is unchanged.

- **Refactors**
  - Extracted directive scoping into `src/lib/leaderboard/sourceBreakdown.ts` as `scopeBreakdownToDirectives` with `PeriodSourceBreakdown` typing; used by both group and global period boards.

<sup>Written for commit e8164bbe2412920fc61dfb9052097c91d15f9f92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

