### PR TITLE
fix(profile): stop the day aggregator from mutating stored breakdown rows

### DIFF
--- a/packages/frontend/__tests__/api/usersProfile.test.ts
+++ b/packages/frontend/__tests__/api/usersProfile.test.ts
@@ -539,6 +539,136 @@ describe("GET /api/users/[username]", () => {
     ]);
   });
 
+  it("merges client model breakdowns without mutating the stored daily rows", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-12T12:00:00.000Z"));
+
+    mockState.pushSelectResult([
+      {
+        id: "user-1",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        totalTokens: 35,
+        totalCost: 2.25,
+        inputTokens: 30,
+        outputTokens: 5,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        reasoningTokens: 0,
+        submissionCount: 1,
+        earliestDate: "2026-04-30",
+        latestDate: "2026-05-01",
+        sessionCount: 0,
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        sourcesUsed: ["codex", "kilo"],
+        modelsUsed: ["gpt-5.5", "k-1"],
+        updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+        cliVersion: "2.0.0",
+        schemaVersion: 2,
+      },
+    ]);
+
+    const model = (
+      tokens: number,
+      cost: number,
+      input: number,
+      output: number,
+    ) => ({
+      tokens,
+      cost,
+      input,
+      output,
+      cacheRead: 0,
+      cacheWrite: 0,
+      reasoning: 0,
+      messages: 1,
+    });
+    // Two shapes that both make the aggregator adopt a stored `models` map and
+    // then merge a second breakdown into it: same-date rows from two devices,
+    // and a single row whose `kilocode` key folds onto `kilo`.
+    const dailyRows = [
+      {
+        date: "2026-04-30",
+        timestampMs: 100,
+        tokens: 10,
+        cost: "1.0000",
+        inputTokens: 10,
+        outputTokens: 0,
+        sourceBreakdown: {
+          codex: {
+            ...model(10, 1, 10, 0),
+            models: { "gpt-5.5": model(10, 1, 10, 0) },
+          },
+        },
+      },
+      {
+        date: "2026-04-30",
+        timestampMs: 200,
+        tokens: 15,
+        cost: "0.7500",
+        inputTokens: 10,
+        outputTokens: 5,
+        sourceBreakdown: {
+          codex: {
+            ...model(15, 0.75, 10, 5),
+            models: { "gpt-5.5": model(15, 0.75, 10, 5) },
+          },
+        },
+      },
+      {
+        date: "2026-05-01",
+        timestampMs: 300,
+        tokens: 10,
+        cost: "0.5000",
+        inputTokens: 10,
+        outputTokens: 0,
+        sourceBreakdown: {
+          kilocode: {
+            ...model(4, 0.2, 4, 0),
+            models: { "k-1": model(4, 0.2, 4, 0) },
+          },
+          kilo: {
+            ...model(6, 0.3, 6, 0),
+            models: { "k-1": model(6, 0.3, 6, 0) },
+          },
+        },
+      },
+    ];
+    const storedRows = structuredClone(dailyRows);
+    mockState.pushSelectResult(dailyRows);
+    mockState.pushExecuteResult([{ rank: 1 }]);
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/users/alice"),
+      { params: Promise.resolve({ username: "alice" }) },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.contributions[0].clients[0].models).toEqual({
+      "gpt-5.5": expect.objectContaining({ tokens: 25, cost: 1.75 }),
+    });
+    expect(body.contributions[1].clients[0].client).toBe("kilo");
+    expect(body.contributions[1].clients[0].models).toEqual({
+      "k-1": expect.objectContaining({ tokens: 10, cost: 0.5 }),
+    });
+
+    // The rows are query results, not scratch space. Accumulating into one in
+    // place leaves the row reporting a merged total it never carried, which is
+    // only harmless while nothing reads it twice — an invariant no caller of
+    // this loop states or is obliged to keep.
+    expect(dailyRows).toEqual(storedRows);
+  });
+
   it("clamps leap-day rolling ranges to the prior year's last valid day", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-02-29T12:00:00.000Z"));

--- a/packages/frontend/src/lib/publicProfileData.ts
+++ b/packages/frontend/src/lib/publicProfileData.ts
@@ -300,6 +300,26 @@ export async function getPublicProfileResponse(
       modelId?: string;
     };
 
+    /**
+     * Every merge below accumulates in place, so whatever an accumulator holds
+     * it will eventually rewrite. `breakdown.models` belongs to a `dailyData`
+     * row, so adopting it by reference makes the accumulator and the row the
+     * same object and the next row's merge silently rewrites the row that
+     * seeded it. Copy the map and its entries at the boundary so the
+     * accumulator only ever mutates memory it owns.
+     */
+    const cloneClientModels = (
+      models: Record<string, ModelData> | undefined,
+    ) => {
+      if (!models) return undefined;
+
+      const copy: Record<string, ModelData> = {};
+      for (const [modelId, model] of Object.entries(models)) {
+        copy[modelId] = { ...model };
+      }
+      return copy;
+    };
+
     const mergeClientModel = (
       client: ClientBreakdown,
       modelId: string,
@@ -405,7 +425,7 @@ export async function getPublicProfileResponse(
                 cacheWrite: breakdown.cacheWrite || 0,
                 reasoning: breakdown.reasoning || 0,
                 messages: breakdown.messages || 0,
-                models: breakdown.models,
+                models: cloneClientModels(breakdown.models),
                 modelId: breakdown.modelId,
               };
             }
@@ -468,7 +488,7 @@ export async function getPublicProfileResponse(
                 cacheWrite: breakdown.cacheWrite || 0,
                 reasoning: breakdown.reasoning || 0,
                 messages: breakdown.messages || 0,
-                models: breakdown.models,
+                models: cloneClientModels(breakdown.models),
                 modelId: breakdown.modelId,
               };
             }


### PR DESCRIPTION
## What this is

A **defensive** fix, not a corrective one. No number the profile endpoint serves today is wrong, and this PR does not change any of them. Please read the "is it live?" section before treating this as a user-facing bug fix.

## The aliasing

`getPublicProfileResponse` builds a per-day, per-client accumulator out of `dailyBreakdown` rows. Both branches that create a client entry copied the scalars into a fresh object but adopted the stored model map by reference:

```ts
models: breakdown.models,   // src/lib/publicProfileData.ts:428 and :491 (post-fix numbering)
```

`breakdown` is a `dailyData` query-result object. Everything downstream of that adoption accumulates in place — `mergeIncomingClientModels` walks the incoming map into `mergeClientModel`, which does `existingModel.tokens += model.tokens` on the accumulator's entries, or adds a new key to the accumulator's map. So the accumulator and the row that seeded it are the same object, and the next merge rewrites the row.

Two shapes reach it:

- **Same-date rows from two devices.** Row 1 seeds `clients.codex.models`; row 2 merges into it, so row 1's stored `gpt-5.5` entry goes 10 tokens -> 25.
- **Alias folding inside one row.** `sourceBreakdown` carrying both `kilocode` and `kilo` normalizes to one client; the first key seeds, the second merges into it, so the row's `kilocode.models["k-1"]` goes 4 -> 10.

Both are in the regression test.

## Is it live? No — and that is the honest framing

I traced the read side before writing anything, because a fix for a bug that does not exist is worse than no fix:

- `dailyData` is iterated exactly once (`src/lib/publicProfileData.ts:389`); it appears nowhere else in the module.
- Within one iteration, the day-level model totals are read from the *current* row (`:436`, `:499`) and the merge only ever writes into an *earlier* row's map. Distinct JSON keys and distinct rows parse to distinct objects, so a row is never both the accumulation target and a later read source.
- Nothing is written back to the database. The module issues four `db.select` calls and one `db.execute` wrapping a read-only `RANK()` CTE — there is no `insert`/`update`/`delete` anywhere in it.
- `unstable_cache` (`:751`) caches the fully serialized `PublicProfilePageResult`, not the query rows, and the aggregation does not run at all on a cache hit. No module-level cache, no React `cache()`, no drizzle query cache.

So: the mutated rows are garbage-collected without ever being read again, and every downstream reader (`scopedContributions`, `periodTotals`, `graphContributions`, `modelUsageMap`) reads the aggregate, which is correct. `modelUsageMap` in particular seeds `{ tokens: 0, cost: 0 }` rather than adopting `day.models[model]`, so it does not extend the aliasing.

The regression test reflects this exactly: its output assertions pass both before and after, and only the "stored rows unchanged" assertion flips.

## Why fix it anyway

The correctness above is a property of the current loop shape, not of any stated contract. It holds only while `dailyData` is single-pass *and* the client merge for a key precedes the day-level read of that same key. Neither is written down, neither is enforced, and adding a second pass for a new stat — an ordinary thing to want here — silently converts it into a double count with no test failing.

The tie-breaker is that the identical class of bug is an active corruption one file over, in the submit route:

```ts
normalized[clientName] = { ...data, models: { ...data.models } };  // submit/route.ts:94
```

That copies the map but leaves the `ModelData` value objects shared, and the in-place `+=` merge below then mutates stored data. This file was strictly worse — it did not copy the map either. Fixing the read side while the same shape is being repaired on the write side keeps the two from diverging again.

## The change

A `cloneClientModels` helper that copies the map and its entries at the adoption boundary, so the accumulator only mutates memory it owns. It returns `undefined` for a missing map, preserving the legacy `modelId` path in `materializeLegacyClientModel` (which keys off `client.models` being nullish or empty) with zero behavioral delta.

## Verification

`bun run test` (packages/frontend) — 77 files, 738 tests, all passing:

```
 Test Files  77 passed (77)
      Tests  738 passed (738)
   Duration  4.43s
```

The new test alone, **before** the fix:

```
 Test Files  1 failed (1)
      Tests  1 failed | 12 skipped (13)

- "cost": 0.2,          + "cost": 0.5,
- "input": 4,           + "input": 10,
- "messages": 1,        + "messages": 2,
- "tokens": 4,          + "tokens": 10,
```

(and the same diff on the `gpt-5.5` entry, 10 -> 25). **After** the fix:

```
 ✓ __tests__/api/usersProfile.test.ts (13 tests) 108ms
```

`bun run typecheck`:

```
$ tsc --noEmit
```

Clean, no output.

`bun run lint`:

```
✖ 16 problems (0 errors, 16 warnings)
```

0 errors. All 16 warnings are pre-existing and in untouched files (`groupTransferOwnership.test.ts`, `submitAuth.test.ts`, `groupInvitesDemotedInviter.test.ts`, `groupsQueries.test.ts`, `GraphControls.tsx`); the count is identical before and after this change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the profile day aggregator from mutating `dailyBreakdown` rows by reference, removing model map aliasing between the accumulator and stored rows. This is a defensive change and does not alter any numbers returned by the API.

- **Bug Fixes**
  - Added `cloneClientModels` to copy `models` maps and entries when creating per-client accumulators in `packages/frontend/src/lib/publicProfileData.ts`.
  - Switched both accumulator creation paths to use the cloned map; preserves legacy `modelId` behavior when `models` is undefined.
  - Added a regression test to ensure aggregation does not mutate the original daily rows.

<sup>Written for commit 5e777b968cff14235ce89694a38554d87b7d4c6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

