### PR TITLE
fix(release): allow first-time publish of new platform packages in npm release-state check

### DIFF
--- a/scripts/check-npm-release-state.sh
+++ b/scripts/check-npm-release-state.sh
@@ -76,24 +76,6 @@ npm_view_version_status() {
   return "${status}"
 }
 
-npm_view_required_version() {
-  local __result_var="$1"
-  local spec="$2"
-  local package_label="$3"
-  local status
-  npm_view_version_status "${__result_var}" "${spec}"
-  status=$?
-  if [[ ${status} -eq 0 ]]; then
-    return 0
-  fi
-  if [[ ${status} -eq 1 ]]; then
-    errors+=("${package_label}: package is not visible on npm")
-  else
-    errors+=("${package_label}: npm lookup failed")
-  fi
-  return "${status}"
-}
-
 npm_view_optional_version() {
   local __result_var="$1"
   local spec="$2"
@@ -182,10 +164,31 @@ while IFS=$'\t' read -r path package_name manifest_version; do
     errors+=("${path}: expected version ${NEW_VERSION}, found ${manifest_version}")
   fi
 
-  if ! npm_view_required_version current_version "${package_name}" "${package_name}"; then
+  package_is_primary=false
+  for primary in "${primary_packages[@]}"; do
+    if [[ "${package_name}" == "${primary}" ]]; then
+      package_is_primary=true
+      break
+    fi
+  done
+
+  current_version=""
+  if npm_view_optional_version current_version "${package_name}" "${package_name}"; then
+    echo "${package_name}: npm latest ${current_version}"
+  else
+    lookup_status=$?
+    if [[ ${lookup_status} -ne 1 ]]; then
+      continue
+    fi
+    if [[ "${package_is_primary}" == "true" ]]; then
+      errors+=("${package_name}: package is not visible on npm")
+    else
+      # A platform package that has never been published (e.g. a newly added
+      # target) legitimately 404s here; its first release creates it on npm.
+      echo "${package_name}: not published on npm yet; ${NEW_VERSION} will be its first release"
+    fi
     continue
   fi
-  echo "${package_name}: npm latest ${current_version}"
 
   if npm_view_optional_version target_version "${package_name}@${NEW_VERSION}" "${package_name}@${NEW_VERSION}"; then
     existing_targets=$((existing_targets + 1))
@@ -196,13 +199,11 @@ while IFS=$'\t' read -r path package_name manifest_version; do
     fi
   fi
 
-  for primary in "${primary_packages[@]}"; do
-    if [[ "${package_name}" == "${primary}" && -n "${RELEASE_BASE_VERSION}" && "${RELEASE_RECOVERY}" != "true" ]]; then
-      if semver_gt "${RELEASE_BASE_VERSION}" "${current_version}"; then
-        errors+=("Repository version ${RELEASE_BASE_VERSION} is ahead of npm latest ${current_version} for ${package_name}; set RELEASE_RECOVERY=true and target ${RELEASE_BASE_VERSION} when retrying the failed publish")
-      fi
+  if [[ "${package_is_primary}" == "true" && -n "${RELEASE_BASE_VERSION}" && "${RELEASE_RECOVERY}" != "true" ]]; then
+    if semver_gt "${RELEASE_BASE_VERSION}" "${current_version}"; then
+      errors+=("Repository version ${RELEASE_BASE_VERSION} is ahead of npm latest ${current_version} for ${package_name}; set RELEASE_RECOVERY=true and target ${RELEASE_BASE_VERSION} when retrying the failed publish")
     fi
-  done
+  fi
 done < <(release_packages)
 
 if [[ ${checked} -eq 0 ]]; then

--- a/scripts/test-npm-release-state.sh
+++ b/scripts/test-npm-release-state.sh
@@ -19,6 +19,7 @@ write_release_package_manifests() {
     packages/cli-linux-arm64-musl \
     packages/cli-win32-x64-msvc \
     packages/cli-win32-arm64-msvc \
+    packages/cli-android-arm64 \
     packages/tokscale
 
   cat > packages/cli/package.json <<EOF_MANIFEST
@@ -33,7 +34,8 @@ write_release_package_manifests() {
     "@tokscale/cli-linux-arm64-gnu": "${version}",
     "@tokscale/cli-linux-arm64-musl": "${version}",
     "@tokscale/cli-win32-x64-msvc": "${version}",
-    "@tokscale/cli-win32-arm64-msvc": "${version}"
+    "@tokscale/cli-win32-arm64-msvc": "${version}",
+    "@tokscale/cli-android-arm64": "${version}"
   }
 }
 EOF_MANIFEST
@@ -46,7 +48,8 @@ EOF_MANIFEST
     cli-linux-arm64-gnu \
     cli-linux-arm64-musl \
     cli-win32-x64-msvc \
-    cli-win32-arm64-msvc; do
+    cli-win32-arm64-msvc \
+    cli-android-arm64; do
     cat > "packages/${pkg}/package.json" <<EOF_MANIFEST
 {
   "name": "@tokscale/${pkg}",
@@ -107,6 +110,11 @@ if [[ "${1:-}" == "view" ]]; then
       exit 1
       ;;
     *@3.0.1)
+      echo "npm ERR! code E404" >&2
+      exit 1
+      ;;
+    @tokscale/cli-android-arm64)
+      # Never published: simulates a newly added platform package.
       echo "npm ERR! code E404" >&2
       exit 1
       ;;
@@ -197,6 +205,30 @@ test_recovery_requires_base_version() {
     fi
 
     grep -q "Recovery target 3.0.0 requires RELEASE_BASE_VERSION" "${output}"
+  )
+}
+
+test_first_release_of_new_platform_package_is_allowed() {
+  local work="${TMP_DIR}/first-release"
+  mkdir -p "${work}/scripts"
+  cp "${CHECK_SCRIPT}" "${work}/scripts/check-npm-release-state.sh"
+  (
+    cd "${work}"
+    write_release_package_manifests "3.0.1"
+    local fake_npm="${TMP_DIR}/fake-npm-first-release"
+    write_fake_npm "${fake_npm}"
+
+    local output="${TMP_DIR}/first-release-output.txt"
+    FAKE_NPM_LOG="${TMP_DIR}/first-release-npm.log" \
+      FAKE_NPM_PUBLISH_LOG="${TMP_DIR}/first-release-publish.log" \
+      NPM_CMD="${fake_npm}" \
+      NPM_CHECK_AUTH=0 \
+      NEW_VERSION="3.0.1" \
+      RELEASE_BASE_VERSION="2.1.3" \
+      bash scripts/check-npm-release-state.sh >"${output}" 2>&1
+
+    grep -q "@tokscale/cli-android-arm64: not published on npm yet; 3.0.1 will be its first release" "${output}"
+    grep -q "npm release-state OK for 3.0.1" "${output}"
   )
 }
 
@@ -445,6 +477,7 @@ EOF_MANIFEST
 test_refuses_repo_version_ahead_of_npm_without_recovery
 test_recovery_allows_existing_target_versions_for_partial_retry
 test_recovery_requires_base_version
+test_first_release_of_new_platform_package_is_allowed
 test_precheck_fails_on_non_404_npm_lookup_errors
 test_publish_skips_existing_target_version_during_recovery
 test_refuses_to_publish_existing_target_without_recovery


### PR DESCRIPTION
## Problem

The latest publish run ([Commit release provenance](https://github.com/junhoyeo/tokscale/actions/runs/30652672583/job/91234646877)) failed in the npm release-state precheck:

```
npm release-state check failed:
- @tokscale/cli-android-arm64: package is not visible on npm
```

`@tokscale/cli-android-arm64` was added in #948 and has never been published to npm. `scripts/check-npm-release-state.sh` required **every** release package to already be visible on npm, so a newly added platform package could never survive its first release — the precheck 404s on it and aborts before anything gets published.

## Fix

- Treat a 404 (`E404`) lookup for a **non-primary** package as a first-time publish: log `<pkg>: not published on npm yet; <version> will be its first release` and continue.
- Primary packages (`@tokscale/cli`, `tokscale`) must still exist on npm — their absence remains a hard error, and the repo-ahead-of-npm guard still applies to them.
- Non-404 lookup failures (registry errors, auth issues) still fail the check unchanged.
- Removed the now-unused `npm_view_required_version` helper.

## Tests

- Extended `scripts/test-npm-release-state.sh` fixtures with the android-arm64 package and a fake-npm 404 for it, and added `test_first_release_of_new_platform_package_is_allowed`. Full suite passes.
- Verified against the real registry state that failed in CI: the check now logs `@tokscale/cli-android-arm64: not published on npm yet; 4.8.0 will be its first release` instead of erroring (remaining local errors are only the expected version mismatch, since the bump happens in CI's `bump-versions` job).

## Retry

After merging, re-run the **Publish** workflow with the same minor bump — no recovery flags needed, since the failed run never committed the release provenance.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows first-time publish of new platform packages by treating `E404` on non-primary packages during the npm release-state check as a first release, so the publish workflow no longer blocks on newly added targets. Primary packages still must exist on npm.

- **Bug Fixes**
  - Treat registry `E404` for non-primary packages (e.g., `@tokscale/cli-android-arm64`) as first release and continue.
  - Keep strict checks for primary packages (`@tokscale/cli`, `tokscale`) and fail on non-404 lookup errors; repo-ahead-of-npm guard remains for primaries.
  - Removed unused `npm_view_required_version`; added tests and fixtures covering the first-time publish path.

<sup>Written for commit efc371f9712c94f0b3259851bb95ec6547379a53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

