### PR TITLE
fix(provider-identity): recognize bare k2/k3 Kimi model ids

### DIFF
--- a/crates/tokscale-core/src/provider_identity.rs
+++ b/crates/tokscale-core/src/provider_identity.rs
@@ -191,6 +191,15 @@ pub fn inferred_provider_from_model(model: &str) -> Option<&'static str> {
     if contains_delimited(&lower, "kimi") {
         return Some("moonshotai");
     }
+    // Kimi's own coding-plan catalog also serves bare `k2`/`k3`-style ids with
+    // no `kimi` prefix at all (e.g. `k3`, `k3-256k` from the K3 coding-plan
+    // model), so the `kimi` substring check above misses them. No other known
+    // provider uses a bare, delimited `k2`/`k3` model id (checked against the
+    // full litellm/models.dev/openrouter pricing datasets), so this is safe
+    // without the `kimi` prefix.
+    if contains_delimited(&lower, "k2") || contains_delimited(&lower, "k3") {
+        return Some("moonshotai");
+    }
     // MiMo (Xiaomi) — `mimo-v2.5` etc.
     if contains_delimited(&lower, "mimo") {
         return Some("xiaomi");
@@ -316,6 +325,23 @@ mod tests {
         assert_eq!(inferred_provider_from_model("llama-3"), Some("meta"));
         assert_eq!(inferred_provider_from_model("qwen3-coder"), Some("qwen"));
         assert_eq!(inferred_provider_from_model("unknown-model"), None);
+    }
+
+    #[test]
+    fn test_inferred_provider_bare_kimi_k_series_ids() {
+        // Kimi's coding-plan catalog serves these with no `kimi` prefix at all.
+        assert_eq!(inferred_provider_from_model("k3"), Some("moonshotai"));
+        assert_eq!(inferred_provider_from_model("k3-256k"), Some("moonshotai"));
+        assert_eq!(inferred_provider_from_model("K3"), Some("moonshotai"));
+        assert_eq!(inferred_provider_from_model("k2"), Some("moonshotai"));
+        // Already-prefixed forms keep matching via the `kimi` substring check.
+        assert_eq!(
+            inferred_provider_from_model("kimi-k2.5-thinking"),
+            Some("moonshotai")
+        );
+        // A `k2`/`k3` substring that isn't a delimited token must not match.
+        assert_eq!(inferred_provider_from_model("flock3"), None);
+        assert_eq!(inferred_provider_from_model("network2"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `inferred_provider_from_model` only matched a `"kimi"` substring, so Kimi's own coding-plan model ids that ship bare — `k3`, `k3-256k` (no `kimi` prefix at all, confirmed against the live `/coding/v1/models` catalog) — were tagged provider `"unknown"`.
- Surfaced by an [ai-gateway](https://github.com/strokecompany/ai-gateway) change ([PR #23](https://github.com/strokecompany/ai-gateway/pull/23)) that transparently falls back Claude Code to Kimi K3 when Claude is unavailable. Since the gateway honestly reports `model: "k3"` (not a spoofed Claude id), Claude Code writes that verbatim into its own `~/.claude/projects/*.jsonl` transcript — verified directly against a real session. tokscale's pricing *alias* table already resolves `k3` → `kimi-k3` correctly (so cost was right), but the *provider* tag stayed `"unknown"` since `inferred_provider_from_model` never saw it.
- Fix: also match a delimited (word-boundary) `k2`/`k3` token → `moonshotai`. Checked the full litellm/models.dev/openrouter pricing datasets for any other provider using a bare `k2`/`k3` id first — none found, so this doesn't need the `kimi` prefix as a guard.

## Test plan
- [x] `cargo test -p tokscale-core provider_identity` — new test covers `k3`, `k3-256k`, `K3` (case-insensitive), bare `k2`, and confirms already-prefixed `kimi-k2.5-thinking` still matches
- [x] False-positive guard: `flock3` / `network2` (undelimited `k3`/`k2` embedded in a longer word) correctly return `None`
- [x] `cargo test -p tokscale-core --lib` — 1320 passed, 0 failed (no regressions)
- [x] `cargo clippy -p tokscale-core --lib` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix provider inference to recognize Kimi K2/K3 bare IDs (`k3`, `k3-256k`, `k2`) and tag them as `moonshotai`. This corrects "unknown" provider tags when the `kimi` prefix is missing.

- **Bug Fixes**
  - Match delimited `k2`/`k3` tokens (case-insensitive) without requiring `kimi`.
  - Avoid false positives when `k2`/`k3` appear inside other words.
  - Add tests for bare and prefixed forms.

<sup>Written for commit 3372dfb7e69008d7fc7a5df0397417823cb0cfd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

