### PR TITLE
feat(clients): add standalone Cline CLI and Kimchi sessions

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -69,6 +69,7 @@
 | <img width="48px" src=".github/assets/client-droid.png" alt="Droid" /> | [Droid (Factory Droid)](https://factory.ai/) | `~/.factory/sessions/` |
 | <img width="48px" src=".github/assets/client-pi.png" alt="Pi" /> | [Pi](https://github.com/badlogic/pi-mono) | `~/.pi/agent/sessions/` and `~/.omp/agent/sessions/` ([Oh My Pi](https://github.com/can1357/oh-my-pi)) |
 | <img width="48px" src=".github/assets/client-senpi.png" alt="Senpi" /> | [Senpi (OmO Native)](https://github.com/code-yeongyu/senpi) | `~/.senpi/agent/sessions/` (`SENPI_CODING_AGENT_DIR` でオーバーライド可能) |
+| <img width="48px" src="https://github.com/getkimchi.png" alt="Kimchi" /> | [Kimchi Coding](https://kimchi.dev/) | `~/.config/kimchi/harness/sessions/`（`KIMCHI_CODING_AGENT_DIR` でオーバーライド可能） |
 | <img width="48px" src=".github/assets/client-kimi.png" alt="Kimi" /> | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) / [Kimi Code](https://github.com/MoonshotAI/kimi-code) | kimi-cli: `~/.kimi/sessions/` kimi-code: `~/.kimi-code/sessions/` (`KIMI_CODE_HOME` でオーバーライド可能) |
 | <img width="48px" src=".github/assets/client-qwen.png" alt="Qwen" /> | [Qwen CLI](https://github.com/QwenLM/qwen-cli) | `~/.qwen/projects/` |
 | <img width="48px" src=".github/assets/client-roocode.png" alt="Roo Code" /> | [Roo Code](https://github.com/RooCodeInc/Roo-Code) | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` (+ server: `~/.vscode-server/data/User/globalStorage/rooveterinaryinc.roo-cline/tasks/`) |
@@ -84,7 +85,7 @@
 | <img width="48px" src="https://github.com/xai-org.png" alt="Grok Build" /> | Grok Build | `$GROK_HOME/sessions/*/*/updates.jsonl`（フォールバック: `~/.grok/sessions/*/*/updates.jsonl`） |
 | <img width="48px" src=".github/assets/client-zed.webp" alt="Zed Agent" /> | [Zed Agent](https://zed.dev/docs/ai/agent-panel) | `~/.local/share/zed/threads/threads.db`（macOS: `~/Library/Application Support/Zed/threads/threads.db`; Windows: `%LOCALAPPDATA%/Zed/threads/threads.db`; ホスティング済み Zed モデル専用、外部 ACP エージェントは対象外） |
 | <img width="48px" src="https://github.com/kirodotdev.png" alt="Kiro" /> | Kiro | `~/.kiro/sessions/cli/*.json`（+ `*.jsonl`）、`~/.local/share/kiro-cli/data.sqlite3`（macOS: `~/Library/Application Support/kiro-cli/data.sqlite3`）、および Kiro IDE の globalStorage スナップショット（`Kiro/User/globalStorage/kiro.kiroagent`; macOS は Application Support、Linux は `~/.config/Kiro`、Windows は `%APPDATA%\Kiro`） |
-| <img width="48px" src="https://github.com/cline.png" alt="Cline" /> | [Cline](https://github.com/cline/cline) | VS Code globalStorage のタスクディレクトリ（Linux: `~/.config/Code/...`; macOS: `~/Library/Application Support/Code/...`; Windows: `%APPDATA%\Code\...`; サーバー: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/`） |
+| <img width="48px" src="https://github.com/cline.png" alt="Cline" /> | [Cline](https://github.com/cline/cline) | VS Code globalStorage のタスクディレクトリ（Linux: `~/.config/Code/...`; macOS: `~/Library/Application Support/Code/...`; Windows: `%APPDATA%\Code\...`; サーバー: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/`）+ Cline CLI セッション（利用可能な最初のルートを次の順序で選択: `$CLINE_SESSION_DATA_DIR`、`$CLINE_DATA_DIR/sessions/`、`$CLINE_DIR/data/sessions/`、フォールバック `~/.cline/data/sessions/`；空白または空白文字のみの環境変数は無視） |
 | <img width="48px" src="https://github.com/user-attachments/assets/7246e920-f3f8-4b6e-847e-030ae04e86c2" alt="Gajae-Code" /> | [gajae-code (gjc)](https://github.com/Yeachan-Heo/gajae-code) | `~/.gjc/agent/sessions/`（`GJC_CODING_AGENT_DIR`、`GJC_CONFIG_DIR`、`PI_CONFIG_DIR` でオーバーライド可能；Linux/macOS では `$XDG_DATA_HOME/gjc/sessions/` も解決） |
 | <img width="48px" src=".github/assets/client-jcode.png" alt="Jcode" /> | [Jcode](https://github.com/1jehuang/jcode) | `~/.jcode/sessions/session_*.json` + `session_*.journal.jsonl` サイドカー（`JCODE_HOME` で上書き可） |
 | <img width="48px" src="https://github.com/XiaomiMiMo.png" alt="MiMo Code" /> | [MiMo Code](https://github.com/XiaomiMiMo/MiMo-Code) | `~/.local/share/mimocode/mimocode.db`（XDG データディレクトリ；SQLite） |
@@ -171,7 +172,7 @@ AI支援開発の時代において、**トークンは新しいエネルギー*
   - 設定可能なカラーテーマのGitHubスタイル貢献グラフ
   - リアルタイムフィルタリングとソート
   - ゼロフリッカーレンダリング
-- **マルチプラットフォームサポート** - OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic全体の使用量追跡
+- **マルチプラットフォームサポート** - OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimchi Coding、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic全体の使用量を追跡
 - **リアルタイム価格** - 1時間ディスクキャッシュ付きでLiteLLMから現在の価格を取得；OpenRouter自動フォールバックと新規モデル向けCursor価格サポート
 - **詳細な内訳** - 入力、出力、キャッシュ読み書き、推論トークン追跡
 - **ネイティブRustコア** - 10倍高速な処理のため、すべての解析と集計をRustで実行
@@ -382,7 +383,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-利用可能な値: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `augment`, `synthetic`。
+利用可能な値: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimchi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `augment`, `synthetic`。
 
 > **破壊的変更 (v4.0.0)**: クライアント単位のブール型フラグ（`--opencode`、`--claude`、`--codex` など）は削除され、現在はエラーになります。代わりに正規の `--client`/`-c` フラグを使用してください — 例: `tokscale --client opencode,claude`。
 
@@ -1319,12 +1320,13 @@ AIコーディングツールはクロスプラットフォームの場所にセ
 | Cursor | API同期 | API同期 | Cursor API から取得したデータを `usage*.csv` としてキャッシュ；デスクトップ自動ログインは `state.vscdb` の認証のみ；ローカルの `~/.cursor` セッションデータは解析しない |
 | Droid | `~/.factory/` | `%USERPROFILE%\.factory\` | すべてのプラットフォームで同じパス |
 | Pi | `~/.pi/` and `~/.omp/` | `%USERPROFILE%\.pi\` and `%USERPROFILE%\.omp\` | すべてのプラットフォームで同じパス（Pi と [Oh My Pi](https://github.com/can1357/oh-my-pi) の両方をサポート） |
+| Kimchi Coding | `~/.config/kimchi/harness/sessions/` | `%USERPROFILE%\.config\kimchi\harness\sessions\` | `KIMCHI_CODING_AGENT_DIR` 環境変数でオーバーライド可能；Pi互換のJSONLセッション |
 | Kimi CLI | `~/.kimi/` | `%USERPROFILE%\.kimi\` | すべてのプラットフォームで同じパス |
 | Kimi Code | `~/.kimi-code/` | `%USERPROFILE%\.kimi-code\` | すべてのプラットフォームで同じパス |
 | Qwen CLI | `~/.qwen/` | `%USERPROFILE%\.qwen\` | すべてのプラットフォームで同じパス |
 | Roo Code | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks\` | VS Code globalStorageタスクログ |
 | Kilo | `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\kilocode.kilo-code\tasks\` | VS Code globalStorageタスクログ |
-| Cline | Linux: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`; macOS: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`; サーバー: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/` | `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\tasks\` | VS Code globalStorageタスクログ |
+| Cline | Linux: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`; macOS: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`; サーバー: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/`; Cline CLI フォールバック: `~/.cline/data/sessions/` | `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\tasks\`; Cline CLI フォールバック: `%USERPROFILE%\.cline\data\sessions\` | VS Code globalStorageタスクログ；Cline CLI は `{SESSION_ID}/{SESSION_ID}.messages.json` を使用し、ルートを `$CLINE_SESSION_DATA_DIR` → `$CLINE_DATA_DIR/sessions/` → `$CLINE_DIR/data/sessions/` → `~/.cline/data/sessions/` の順で選択；空白または空白文字のみの環境変数は無視 |
 | Mux | `~/.mux/sessions/` | `%USERPROFILE%\.mux\sessions\` | 全プラットフォームで同じパス |
 | Codebuff | `~/.config/manicode/projects/` (+ `manicode-dev`、`manicode-staging`) | `%USERPROFILE%\.config\manicode\projects\` | `CODEBUFF_DATA_DIR` 環境変数でオーバーライド |
 | Kilo CLI | `~/.local/share/kilo/` | `%USERPROFILE%\.local\share\kilo\` | OpenCodeと同様に`xdg-basedir`を使用 |
@@ -1676,6 +1678,14 @@ Cline は Roo Code と Kilo がフォークした元となるアップストリ�
 - `ui_messages.json`から`say/api_req_started`イベントのみをカウント
 - `text` JSONから`tokensIn`、`tokensOut`、`cacheReads`、`cacheWrites`、`cost`、`apiProtocol`を解析
 - 利用可能な場合、隣接する`api_conversation_history.json`からモデル/エージェントメタデータを補完
+Cline CLI セッションは、次の優先順位で最初に利用可能なルートを選択して検出されます: `$CLINE_SESSION_DATA_DIR` → `$CLINE_DATA_DIR/sessions/` → `$CLINE_DIR/data/sessions/` → フォールバック `~/.cline/data/sessions/`。空または空白文字のみの環境変数は未設定として扱います。選択したルートでは、セッションを `{SESSION_ID}/{SESSION_ID}.messages.json` から読み取ります。Tokscale は永続化された `metrics` を持つアシスタントメッセージをカウントし、入力/出力/キャッシュトークンとプロバイダが報告したコストを含め、兄弟セッションマニフェストからワークスペースとフォールバックモデルのメタデータを使用します。環境ルートの検出を無効にした場合は、ホームのフォールバックのみを使用します。
+
+### Kimchi Coding
+
+場所:
+- `~/.config/kimchi/harness/sessions/{ENCODED_WORKSPACE}/*.jsonl`（または `$KIMCHI_CODING_AGENT_DIR/sessions/`）
+
+Kimchi は Pi 互換の JSONL セッション形式を使用します。Tokscale は永続化された入力/出力/キャッシュ使用量を持つアシスタントメッセージをカウントし、セッションスキーマが共有されていても Kimchi を Pi とは別のクライアントとして扱います。
 
 ### Mux
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -69,6 +69,7 @@
 | <img width="48px" src=".github/assets/client-droid.png" alt="Droid" /> | [Droid (Factory Droid)](https://factory.ai/) | `~/.factory/sessions/` |
 | <img width="48px" src=".github/assets/client-pi.png" alt="Pi" /> | [Pi](https://github.com/badlogic/pi-mono) | `~/.pi/agent/sessions/` and `~/.omp/agent/sessions/` ([Oh My Pi](https://github.com/can1357/oh-my-pi)) |
 | <img width="48px" src=".github/assets/client-senpi.png" alt="Senpi" /> | [Senpi (OmO Native)](https://github.com/code-yeongyu/senpi) | `~/.senpi/agent/sessions/` (`SENPI_CODING_AGENT_DIR`로 오버라이드 가능) |
+| <img width="48px" src="https://github.com/getkimchi.png" alt="Kimchi" /> | [Kimchi Coding](https://kimchi.dev/) | `~/.config/kimchi/harness/sessions/` (`KIMCHI_CODING_AGENT_DIR`로 오버라이드 가능) |
 | <img width="48px" src=".github/assets/client-kimi.png" alt="Kimi" /> | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) / [Kimi Code](https://github.com/MoonshotAI/kimi-code) | kimi-cli: `~/.kimi/sessions/` kimi-code: `~/.kimi-code/sessions/` (override via `KIMI_CODE_HOME`) |
 | <img width="48px" src=".github/assets/client-qwen.png" alt="Qwen" /> | [Qwen CLI](https://github.com/QwenLM/qwen-cli) | `~/.qwen/projects/` |
 | <img width="48px" src=".github/assets/client-roocode.png" alt="Roo Code" /> | [Roo Code](https://github.com/RooCodeInc/Roo-Code) | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` (+ server: `~/.vscode-server/data/User/globalStorage/rooveterinaryinc.roo-cline/tasks/`) |
@@ -84,7 +85,7 @@
 | <img width="48px" src="https://github.com/xai-org.png" alt="Grok Build" /> | Grok Build | `$GROK_HOME/sessions/*/*/updates.jsonl` (폴백: `~/.grok/sessions/*/*/updates.jsonl`) |
 | <img width="48px" src=".github/assets/client-zed.webp" alt="Zed Agent" /> | [Zed Agent](https://zed.dev/docs/ai/agent-panel) | `~/.local/share/zed/threads/threads.db` (macOS: `~/Library/Application Support/Zed/threads/threads.db`; Windows: `%LOCALAPPDATA%/Zed/threads/threads.db`; 호스팅된 Zed 모델 전용, 외부 ACP 에이전트 제외) |
 | <img width="48px" src="https://github.com/kirodotdev.png" alt="Kiro" /> | Kiro | `~/.kiro/sessions/cli/*.json` (+ `*.jsonl`), `~/.local/share/kiro-cli/data.sqlite3` (macOS: `~/Library/Application Support/kiro-cli/data.sqlite3`), 그리고 Kiro IDE globalStorage 스냅샷 (`Kiro/User/globalStorage/kiro.kiroagent`; macOS Application Support, Linux `~/.config/Kiro`, Windows `%APPDATA%\Kiro`) |
-| <img width="48px" src="https://github.com/cline.png" alt="Cline" /> | [Cline](https://github.com/cline/cline) | VS Code globalStorage tasks (Linux: `~/.config/Code/...`; macOS: `~/Library/Application Support/Code/...`; Windows: `%APPDATA%\Code\...`; server: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/`) |
+| <img width="48px" src="https://github.com/cline.png" alt="Cline" /> | [Cline](https://github.com/cline/cline) | VS Code globalStorage tasks (Linux: `~/.config/Code/...`; macOS: `~/Library/Application Support/Code/...`; Windows: `%APPDATA%\Code\...`; server: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/`) + Cline CLI 세션 (사용 가능한 첫 루트를 다음 순서로 선택: `$CLINE_SESSION_DATA_DIR`, `$CLINE_DATA_DIR/sessions/`, `$CLINE_DIR/data/sessions/`, 폴백 `~/.cline/data/sessions/`; 비어 있거나 공백만 있는 환경 변수는 무시) |
 | <img width="48px" src="https://github.com/user-attachments/assets/7246e920-f3f8-4b6e-847e-030ae04e86c2" alt="Gajae-Code" /> | [gajae-code (gjc)](https://github.com/Yeachan-Heo/gajae-code) | `~/.gjc/agent/sessions/` (`GJC_CODING_AGENT_DIR`, `GJC_CONFIG_DIR`, `PI_CONFIG_DIR`로 오버라이드 가능; Linux/macOS에서는 `$XDG_DATA_HOME/gjc/sessions/`도 확인) |
 | <img width="48px" src=".github/assets/client-jcode.png" alt="Jcode" /> | [Jcode](https://github.com/1jehuang/jcode) | `~/.jcode/sessions/session_*.json` + `session_*.journal.jsonl` 사이드카 (`JCODE_HOME`으로 재정의 가능) |
 | <img width="48px" src="https://github.com/XiaomiMiMo.png" alt="MiMo Code" /> | [MiMo Code](https://github.com/XiaomiMiMo/MiMo-Code) | `~/.local/share/mimocode/mimocode.db` (XDG 데이터 디렉토리; SQLite) |
@@ -169,7 +170,7 @@ AI 지원 개발 시대에 **토큰은 새로운 에너지**입니다. 토큰은
   - 설정 가능한 색상 테마의 GitHub 스타일 기여 그래프
   - 실시간 필터링 및 정렬
   - 깜빡임 없는 렌더링
-- **멀티 플랫폼 지원** - OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic 사용량 통합 추적
+- **멀티 플랫폼 지원** - OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimchi Coding, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic 사용량 통합 추적
 - **실시간 가격 반영** - LiteLLM에서 최신 가격을 가져와(디스크 캐시 1시간) 비용 계산; OpenRouter 자동 폴백 및 신규 모델용 Cursor 가격 지원
 - **상세 분석** - 입력, 출력, 캐시 읽기/쓰기, 추론 토큰까지 추적
 - **네이티브 Rust 코어** - 모든 파싱과 집계를 Rust로 처리해 최대 10배 빠른 성능
@@ -378,7 +379,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-가능한 값: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `augment`, `synthetic`.
+가능한 값: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimchi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `augment`, `synthetic`.
 
 > **Breaking change (v4.0.0):** 클라이언트별 boolean 플래그(`--opencode`, `--claude`, `--codex` 등)는 제거되었으며 이제 오류를 발생시킵니다. 대신 정식 `--client`/`-c` 플래그를 사용하세요 — 예: `tokscale --client opencode,claude`.
 
@@ -1320,12 +1321,13 @@ AI 코딩 도구들은 크로스 플랫폼 위치에 세션 데이터를 저장�
 | Cursor | API 동기화 | API 동기화 | API로 가져와 `usage*.csv`로 캐시; 데스크톱 자동 로그인은 `state.vscdb` 인증만 읽음; 로컬 `~/.cursor` 세션 데이터는 파싱하지 않음 |
 | Droid | `~/.factory/` | `%USERPROFILE%\.factory\` | 모든 플랫폼에서 동일한 경로 |
 | Pi | `~/.pi/` and `~/.omp/` | `%USERPROFILE%\.pi\` and `%USERPROFILE%\.omp\` | 모든 플랫폼에서 동일한 경로 (Pi 및 [Oh My Pi](https://github.com/can1357/oh-my-pi) 모두 지원) |
+| Kimchi Coding | `~/.config/kimchi/harness/sessions/` | `%USERPROFILE%\.config\kimchi\harness\sessions\` | `KIMCHI_CODING_AGENT_DIR` 환경변수로 오버라이드 가능; Pi 호환 JSONL 세션 |
 | Kimi CLI | `~/.kimi/` | `%USERPROFILE%\.kimi\` | 모든 플랫폼에서 동일한 경로 |
 | Kimi Code | `~/.kimi-code/` | `%USERPROFILE%\.kimi-code\` | 모든 플랫폼에서 동일한 경로 |
 | Qwen CLI | `~/.qwen/` | `%USERPROFILE%\.qwen\` | 모든 플랫폼에서 동일한 경로 |
 | Roo Code | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks\` | VS Code globalStorage 작업 로그 |
 | Kilo | `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\kilocode.kilo-code\tasks\` | VS Code globalStorage 작업 로그 |
-| Cline | Linux: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`; macOS: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`; 서버: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/` | `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\tasks\` | VS Code globalStorage 작업 로그 |
+| Cline | Linux: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`; macOS: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`; 서버: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/`; Cline CLI 폴백: `~/.cline/data/sessions/` | `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\tasks\`; Cline CLI 폴백: `%USERPROFILE%\.cline\data\sessions\` | VS Code globalStorage 작업 로그; Cline CLI는 `{SESSION_ID}/{SESSION_ID}.messages.json`을 사용하며 루트는 `$CLINE_SESSION_DATA_DIR` → `$CLINE_DATA_DIR/sessions/` → `$CLINE_DIR/data/sessions/` → `~/.cline/data/sessions/` 순으로 선택; 비어 있거나 공백만 있는 환경 변수는 무시 |
 | Mux | `~/.mux/sessions/` | `%USERPROFILE%\.mux\sessions\` | 모든 플랫폼에서 동일한 경로 |
 | Codebuff | `~/.config/manicode/projects/` (+ `manicode-dev`, `manicode-staging`) | `%USERPROFILE%\.config\manicode\projects\` | `CODEBUFF_DATA_DIR` 환경변수로 오버라이드 |
 | Kilo CLI | `~/.local/share/kilo/` | `%USERPROFILE%\.local\share\kilo\` | OpenCode와 같이 `xdg-basedir` 사용 |
@@ -1715,6 +1717,14 @@ Cline은 Roo Code와 Kilo가 포크한 원본(upstream) 프로젝트로, 동일�
 - `ui_messages.json`에서 `say/api_req_started` 이벤트만 계산
 - `text` JSON에서 `tokensIn`, `tokensOut`, `cacheReads`, `cacheWrites`, `cost`, `apiProtocol` 파싱
 - 사용 가능한 경우 인접한 `api_conversation_history.json`에서 모델/에이전트 메타데이터 보강
+Cline CLI 세션은 다음 우선순위에 따라 사용 가능한 첫 번째 루트를 선택합니다: `$CLINE_SESSION_DATA_DIR` → `$CLINE_DATA_DIR/sessions/` → `$CLINE_DIR/data/sessions/` → 폴백 `~/.cline/data/sessions/`. 비어 있거나 공백만 있는 환경 변수는 설정되지 않은 것으로 처리됩니다. 선택된 루트에서 세션은 `{SESSION_ID}/{SESSION_ID}.messages.json`에서 읽습니다. Tokscale은 영구 `metrics`가 있는 어시스턴트 메시지를 계산하며 입력/출력/캐시 토큰과 프로바이더가 보고한 비용을 포함하고, 형제 세션 매니페스트에서 워크스페이스 및 폴백 모델 메타데이터를 사용합니다. 환경 루트 검색을 비활성화하면 홈 폴백만 사용합니다.
+
+### Kimchi Coding
+
+위치:
+- `~/.config/kimchi/harness/sessions/{ENCODED_WORKSPACE}/*.jsonl` (또는 `$KIMCHI_CODING_AGENT_DIR/sessions/`)
+
+Kimchi는 Pi 호환 JSONL 세션 형식을 사용합니다. Tokscale은 영구 입력/출력/캐시 사용량이 있는 어시스턴트 메시지를 계산하며, 세션 스키마가 공유되더라도 Kimchi를 Pi와 별도의 클라이언트로 유지합니다.
 
 ### Mux
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@
 | <img width="48px" src="https://github.com/xai-org.png" alt="Grok Build" /> | Grok Build | `$GROK_HOME/sessions/*/*/updates.jsonl` (fallback: `~/.grok/sessions/*/*/updates.jsonl`) |
 | <img width="48px" src=".github/assets/client-zed.webp" alt="Zed Agent" /> | [Zed Agent](https://zed.dev/docs/ai/agent-panel) | `~/.local/share/zed/threads/threads.db` (macOS: `~/Library/Application Support/Zed/threads/threads.db`; Windows: `%LOCALAPPDATA%/Zed/threads/threads.db`; hosted Zed models only, not external ACP agents) |
 | <img width="48px" src="https://github.com/kirodotdev.png" alt="Kiro" /> | Kiro | `~/.kiro/sessions/cli/*.json` (+ `*.jsonl`), `~/.local/share/kiro-cli/data.sqlite3` (macOS: `~/Library/Application Support/kiro-cli/data.sqlite3`), and Kiro IDE globalStorage snapshots (`Kiro/User/globalStorage/kiro.kiroagent`; macOS Application Support, Linux `~/.config/Kiro`, Windows `%APPDATA%\Kiro`) |
-| <img width="48px" src="https://github.com/cline.png" alt="Cline" /> | [Cline](https://github.com/cline/cline) | VS Code globalStorage tasks (Linux: `~/.config/Code/...`; macOS: `~/Library/Application Support/Code/...`; Windows: `%APPDATA%\Code\...`; server: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/`) + Cline CLI sessions at `~/.cline/data/sessions/` (or `$CLINE_DATA_DIR/sessions/`) |
+| <img width="48px" src="https://github.com/cline.png" alt="Cline" /> | [Cline](https://github.com/cline/cline) | VS Code globalStorage tasks (Linux: `~/.config/Code/...`; macOS: `~/Library/Application Support/Code/...`; Windows: `%APPDATA%\Code\...`; server: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/`) + Cline CLI sessions (first available root, in order: `$CLINE_SESSION_DATA_DIR`, `$CLINE_DATA_DIR/sessions/`, `$CLINE_DIR/data/sessions/`, fallback `~/.cline/data/sessions/`; blank/whitespace-only environment values are ignored) |
 | <img width="48px" src="https://github.com/user-attachments/assets/7246e920-f3f8-4b6e-847e-030ae04e86c2" alt="Gajae-Code" /> | [gajae-code (gjc)](https://github.com/Yeachan-Heo/gajae-code) | `~/.gjc/agent/sessions/` (override via `GJC_CODING_AGENT_DIR`, `GJC_CONFIG_DIR`, `PI_CONFIG_DIR`; `$XDG_DATA_HOME/gjc/sessions/` on Linux/macOS) |
 | <img width="48px" src=".github/assets/client-jcode.png" alt="Jcode" /> | [Jcode](https://github.com/1jehuang/jcode) | `~/.jcode/sessions/session_*.json` + `session_*.journal.jsonl` sidecars (override via `JCODE_HOME`) |
 | <img width="48px" src="https://github.com/XiaomiMiMo.png" alt="MiMo Code" /> | [MiMo Code](https://github.com/XiaomiMiMo/MiMo-Code) | `~/.local/share/mimocode/mimocode.db` (XDG data dir; SQLite) |
@@ -169,7 +169,7 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
   - GitHub-style contribution graph with configurable color themes
   - Real-time filtering and sorting
   - Zero flicker rendering
-- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, and Synthetic
+- **Multi-platform support** - Track usage across OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimchi Coding, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, and Synthetic
 - **Real-time pricing** - Fetches current pricing from LiteLLM with 1-hour disk cache; automatic OpenRouter fallback and Cursor model pricing for newly released models
 - **Detailed breakdowns** - Input, output, cache read/write, and reasoning token tracking
 - **Native Rust core** - All parsing and aggregation done in Rust for 10x faster processing
@@ -1378,12 +1378,13 @@ AI coding tools store their session data in cross-platform locations. Most tools
 | Cursor | API sync | API sync | Data fetched from Cursor API and cached as `usage*.csv`; desktop auto-login reads auth only from `state.vscdb`; local `~/.cursor` session data is not parsed |
 | Droid | `~/.factory/` | `%USERPROFILE%\.factory\` | Same path on all platforms |
 | Pi | `~/.pi/` and `~/.omp/` | `%USERPROFILE%\.pi\` and `%USERPROFILE%\.omp\` | Same path on all platforms (supports both Pi and [Oh My Pi](https://github.com/can1357/oh-my-pi)) |
+| Kimchi Coding | `~/.config/kimchi/harness/sessions/` | `%USERPROFILE%\.config\kimchi\harness\sessions\` | Configurable via `KIMCHI_CODING_AGENT_DIR` env var; Pi-compatible JSONL sessions |
 | Kimi CLI | `~/.kimi/` | `%USERPROFILE%\.kimi\` | Same path on all platforms |
 | Kimi Code | `~/.kimi-code/` | `%USERPROFILE%\.kimi-code\` | Same path on all platforms |
 | Qwen CLI | `~/.qwen/` | `%USERPROFILE%\.qwen\` | Same path on all platforms |
 | Roo Code | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks\` | VS Code globalStorage task logs |
 | Kilo | `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\kilocode.kilo-code\tasks\` | VS Code globalStorage task logs |
-| Cline | Linux: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`; macOS: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`; server: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/` | `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\tasks\` | VS Code globalStorage task logs |
+| Cline | Linux: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`; macOS: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`; server: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/`; Cline CLI fallback: `~/.cline/data/sessions/` | `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\tasks\`; Cline CLI fallback: `%USERPROFILE%\.cline\data\sessions\` | VS Code globalStorage task logs; Cline CLI selects the first available root in order `$CLINE_SESSION_DATA_DIR` → `$CLINE_DATA_DIR/sessions/` → `$CLINE_DIR/data/sessions/` → `~/.cline/data/sessions/`; blank/whitespace-only environment values are ignored |
 | Mux | `~/.mux/sessions/` | `%USERPROFILE%\.mux\sessions\` | Same path on all platforms |
 | Codebuff | `~/.config/manicode/projects/` (+ `manicode-dev`, `manicode-staging`) | `%USERPROFILE%\.config\manicode\projects\` | Override via `CODEBUFF_DATA_DIR` env var |
 | Kilo CLI | `~/.local/share/kilo/` | `%USERPROFILE%\.local\share\kilo\` | Uses `xdg-basedir` like OpenCode |
@@ -1778,7 +1779,7 @@ Cline is the upstream project that Roo Code and Kilo forked from, so it uses the
 - parse `tokensIn`, `tokensOut`, `cacheReads`, `cacheWrites`, `cost`, and `apiProtocol` from `text` JSON
 - enrich model/agent metadata from sibling `api_conversation_history.json` when available
 
-Cline CLI sessions are also read from `~/.cline/data/sessions/{SESSION_ID}/{SESSION_ID}.messages.json` (or `$CLINE_DATA_DIR/sessions/`). Tokscale counts assistant messages with persisted `metrics`, including input/output/cache tokens and provider-reported cost, and uses the sibling session manifest for workspace and fallback model metadata.
+Cline CLI sessions select the first available root in this order: `$CLINE_SESSION_DATA_DIR` → `$CLINE_DATA_DIR/sessions/` → `$CLINE_DIR/data/sessions/` → fallback `~/.cline/data/sessions/`. Blank or whitespace-only environment values are treated as unset. Within the selected root, sessions are read from `{SESSION_ID}/{SESSION_ID}.messages.json`. Tokscale counts assistant messages with persisted `metrics`, including input/output/cache tokens and provider-reported cost, and uses the sibling session manifest for workspace and fallback model metadata. When environment-root discovery is disabled, only the home fallback is used.
 
 ### Kimchi Coding
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@
 | <img width="48px" src=".github/assets/client-droid.png" alt="Droid" /> | [Droid (Factory Droid)](https://factory.ai/) | `~/.factory/sessions/` |
 | <img width="48px" src=".github/assets/client-pi.png" alt="Pi" /> | [Pi](https://github.com/badlogic/pi-mono) | `~/.pi/agent/sessions/` and `~/.omp/agent/sessions/` ([Oh My Pi](https://github.com/can1357/oh-my-pi)) |
 | <img width="48px" src=".github/assets/client-senpi.png" alt="Senpi" /> | [Senpi (OmO Native)](https://github.com/code-yeongyu/senpi) | `~/.senpi/agent/sessions/` (override via `SENPI_CODING_AGENT_DIR`) |
+| <img width="48px" src="https://github.com/getkimchi.png" alt="Kimchi" /> | [Kimchi Coding](https://kimchi.dev/) | `~/.config/kimchi/harness/sessions/` (override via `KIMCHI_CODING_AGENT_DIR`) |
 | <img width="48px" src=".github/assets/client-kimi.png" alt="Kimi" /> | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) / [Kimi Code](https://github.com/MoonshotAI/kimi-code) | kimi-cli: `~/.kimi/sessions/` kimi-code: `~/.kimi-code/sessions/` (override via `KIMI_CODE_HOME`) |
 | <img width="48px" src=".github/assets/client-qwen.png" alt="Qwen" /> | [Qwen CLI](https://github.com/QwenLM/qwen-cli) | `~/.qwen/projects/` |
 | <img width="48px" src=".github/assets/client-roocode.png" alt="Roo Code" /> | [Roo Code](https://github.com/RooCodeInc/Roo-Code) | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` (+ server: `~/.vscode-server/data/User/globalStorage/rooveterinaryinc.roo-cline/tasks/`) |
@@ -379,7 +380,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-Possible values: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `augment`, `synthetic`.
+Possible values: `opencode`, `claude`, `codex`, `copilot`, `gemini`, `cursor`, `amp`, `codebuff`, `droid`, `openclaw`, `hermes`, `pi`, `kimchi`, `kimi`, `qwen`, `roocode`, `kilocode`, `kilo`, `mux`, `crush`, `goose`, `antigravity`, `antigravity-cli`, `zed`, `kiro`, `trae`, `warp`, `cline`, `gjc`, `grok`, `jcode`, `micode`, `commandcode`, `junie`, `zcode`, `opencodereview`, `codebuddy`, `augment`, `synthetic`.
 
 > **Breaking change (v4.0.0):** The per-client boolean flags (`--opencode`, `--claude`, `--codex`, etc.) have been removed and now error. Use the canonical `--client`/`-c` flag instead — e.g. `tokscale --client opencode,claude`.
 
@@ -1778,6 +1779,13 @@ Cline is the upstream project that Roo Code and Kilo forked from, so it uses the
 - enrich model/agent metadata from sibling `api_conversation_history.json` when available
 
 Cline CLI sessions are also read from `~/.cline/data/sessions/{SESSION_ID}/{SESSION_ID}.messages.json` (or `$CLINE_DIR/data/sessions/`). Tokscale counts assistant messages with persisted `metrics`, including input/output/cache tokens and provider-reported cost, and uses the sibling session manifest for workspace and fallback model metadata.
+
+### Kimchi Coding
+
+Location:
+- `~/.config/kimchi/harness/sessions/{ENCODED_WORKSPACE}/*.jsonl` (or `$KIMCHI_CODING_AGENT_DIR/sessions/`)
+
+Kimchi uses the Pi-compatible JSONL session format. Tokscale counts assistant messages with persisted input/output/cache usage and keeps Kimchi as a separate client from Pi, even though the session schema is shared.
 
 ### Mux
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@
 | <img width="48px" src="https://github.com/xai-org.png" alt="Grok Build" /> | Grok Build | `$GROK_HOME/sessions/*/*/updates.jsonl` (fallback: `~/.grok/sessions/*/*/updates.jsonl`) |
 | <img width="48px" src=".github/assets/client-zed.webp" alt="Zed Agent" /> | [Zed Agent](https://zed.dev/docs/ai/agent-panel) | `~/.local/share/zed/threads/threads.db` (macOS: `~/Library/Application Support/Zed/threads/threads.db`; Windows: `%LOCALAPPDATA%/Zed/threads/threads.db`; hosted Zed models only, not external ACP agents) |
 | <img width="48px" src="https://github.com/kirodotdev.png" alt="Kiro" /> | Kiro | `~/.kiro/sessions/cli/*.json` (+ `*.jsonl`), `~/.local/share/kiro-cli/data.sqlite3` (macOS: `~/Library/Application Support/kiro-cli/data.sqlite3`), and Kiro IDE globalStorage snapshots (`Kiro/User/globalStorage/kiro.kiroagent`; macOS Application Support, Linux `~/.config/Kiro`, Windows `%APPDATA%\Kiro`) |
-| <img width="48px" src="https://github.com/cline.png" alt="Cline" /> | [Cline](https://github.com/cline/cline) | VS Code globalStorage tasks (Linux: `~/.config/Code/...`; macOS: `~/Library/Application Support/Code/...`; Windows: `%APPDATA%\Code\...`; server: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/`) |
+| <img width="48px" src="https://github.com/cline.png" alt="Cline" /> | [Cline](https://github.com/cline/cline) | VS Code globalStorage tasks (Linux: `~/.config/Code/...`; macOS: `~/Library/Application Support/Code/...`; Windows: `%APPDATA%\Code\...`; server: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/`) + Cline CLI sessions at `~/.cline/data/sessions/` (or `$CLINE_DIR/data/sessions/`) |
 | <img width="48px" src="https://github.com/user-attachments/assets/7246e920-f3f8-4b6e-847e-030ae04e86c2" alt="Gajae-Code" /> | [gajae-code (gjc)](https://github.com/Yeachan-Heo/gajae-code) | `~/.gjc/agent/sessions/` (override via `GJC_CODING_AGENT_DIR`, `GJC_CONFIG_DIR`, `PI_CONFIG_DIR`; `$XDG_DATA_HOME/gjc/sessions/` on Linux/macOS) |
 | <img width="48px" src=".github/assets/client-jcode.png" alt="Jcode" /> | [Jcode](https://github.com/1jehuang/jcode) | `~/.jcode/sessions/session_*.json` + `session_*.journal.jsonl` sidecars (override via `JCODE_HOME`) |
 | <img width="48px" src="https://github.com/XiaomiMiMo.png" alt="MiMo Code" /> | [MiMo Code](https://github.com/XiaomiMiMo/MiMo-Code) | `~/.local/share/mimocode/mimocode.db` (XDG data dir; SQLite) |
@@ -1776,6 +1776,8 @@ Cline is the upstream project that Roo Code and Kilo forked from, so it uses the
 - count only `say/api_req_started` events from `ui_messages.json`
 - parse `tokensIn`, `tokensOut`, `cacheReads`, `cacheWrites`, `cost`, and `apiProtocol` from `text` JSON
 - enrich model/agent metadata from sibling `api_conversation_history.json` when available
+
+Cline CLI sessions are also read from `~/.cline/data/sessions/{SESSION_ID}/{SESSION_ID}.messages.json` (or `$CLINE_DIR/data/sessions/`). Tokscale counts assistant messages with persisted `metrics`, including input/output/cache tokens and provider-reported cost, and uses the sibling session manifest for workspace and fallback model metadata.
 
 ### Mux
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@
 | <img width="48px" src="https://github.com/xai-org.png" alt="Grok Build" /> | Grok Build | `$GROK_HOME/sessions/*/*/updates.jsonl` (fallback: `~/.grok/sessions/*/*/updates.jsonl`) |
 | <img width="48px" src=".github/assets/client-zed.webp" alt="Zed Agent" /> | [Zed Agent](https://zed.dev/docs/ai/agent-panel) | `~/.local/share/zed/threads/threads.db` (macOS: `~/Library/Application Support/Zed/threads/threads.db`; Windows: `%LOCALAPPDATA%/Zed/threads/threads.db`; hosted Zed models only, not external ACP agents) |
 | <img width="48px" src="https://github.com/kirodotdev.png" alt="Kiro" /> | Kiro | `~/.kiro/sessions/cli/*.json` (+ `*.jsonl`), `~/.local/share/kiro-cli/data.sqlite3` (macOS: `~/Library/Application Support/kiro-cli/data.sqlite3`), and Kiro IDE globalStorage snapshots (`Kiro/User/globalStorage/kiro.kiroagent`; macOS Application Support, Linux `~/.config/Kiro`, Windows `%APPDATA%\Kiro`) |
-| <img width="48px" src="https://github.com/cline.png" alt="Cline" /> | [Cline](https://github.com/cline/cline) | VS Code globalStorage tasks (Linux: `~/.config/Code/...`; macOS: `~/Library/Application Support/Code/...`; Windows: `%APPDATA%\Code\...`; server: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/`) + Cline CLI sessions at `~/.cline/data/sessions/` (or `$CLINE_DIR/data/sessions/`) |
+| <img width="48px" src="https://github.com/cline.png" alt="Cline" /> | [Cline](https://github.com/cline/cline) | VS Code globalStorage tasks (Linux: `~/.config/Code/...`; macOS: `~/Library/Application Support/Code/...`; Windows: `%APPDATA%\Code\...`; server: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/`) + Cline CLI sessions at `~/.cline/data/sessions/` (or `$CLINE_DATA_DIR/sessions/`) |
 | <img width="48px" src="https://github.com/user-attachments/assets/7246e920-f3f8-4b6e-847e-030ae04e86c2" alt="Gajae-Code" /> | [gajae-code (gjc)](https://github.com/Yeachan-Heo/gajae-code) | `~/.gjc/agent/sessions/` (override via `GJC_CODING_AGENT_DIR`, `GJC_CONFIG_DIR`, `PI_CONFIG_DIR`; `$XDG_DATA_HOME/gjc/sessions/` on Linux/macOS) |
 | <img width="48px" src=".github/assets/client-jcode.png" alt="Jcode" /> | [Jcode](https://github.com/1jehuang/jcode) | `~/.jcode/sessions/session_*.json` + `session_*.journal.jsonl` sidecars (override via `JCODE_HOME`) |
 | <img width="48px" src="https://github.com/XiaomiMiMo.png" alt="MiMo Code" /> | [MiMo Code](https://github.com/XiaomiMiMo/MiMo-Code) | `~/.local/share/mimocode/mimocode.db` (XDG data dir; SQLite) |
@@ -1778,7 +1778,7 @@ Cline is the upstream project that Roo Code and Kilo forked from, so it uses the
 - parse `tokensIn`, `tokensOut`, `cacheReads`, `cacheWrites`, `cost`, and `apiProtocol` from `text` JSON
 - enrich model/agent metadata from sibling `api_conversation_history.json` when available
 
-Cline CLI sessions are also read from `~/.cline/data/sessions/{SESSION_ID}/{SESSION_ID}.messages.json` (or `$CLINE_DIR/data/sessions/`). Tokscale counts assistant messages with persisted `metrics`, including input/output/cache tokens and provider-reported cost, and uses the sibling session manifest for workspace and fallback model metadata.
+Cline CLI sessions are also read from `~/.cline/data/sessions/{SESSION_ID}/{SESSION_ID}.messages.json` (or `$CLINE_DATA_DIR/sessions/`). Tokscale counts assistant messages with persisted `metrics`, including input/output/cache tokens and provider-reported cost, and uses the sibling session manifest for workspace and fallback model metadata.
 
 ### Kimchi Coding
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -70,6 +70,7 @@
 | <img width="48px" src=".github/assets/client-droid.png" alt="Droid" /> | [Droid (Factory Droid)](https://factory.ai/) | `~/.factory/sessions/` |
 | <img width="48px" src=".github/assets/client-pi.png" alt="Pi" /> | [Pi](https://github.com/badlogic/pi-mono) | `~/.pi/agent/sessions/` 和 `~/.omp/agent/sessions/`（[Oh My Pi](https://github.com/can1357/oh-my-pi)） |
 | <img width="48px" src=".github/assets/client-senpi.png" alt="Senpi" /> | [Senpi (OmO Native)](https://github.com/code-yeongyu/senpi) | `~/.senpi/agent/sessions/`（通过 `SENPI_CODING_AGENT_DIR` 覆盖） |
+| <img width="48px" src="https://github.com/getkimchi.png" alt="Kimchi" /> | [Kimchi Coding](https://kimchi.dev/) | `~/.config/kimchi/harness/sessions/`（可通过 `KIMCHI_CODING_AGENT_DIR` 覆盖） |
 | <img width="48px" src=".github/assets/client-kimi.png" alt="Kimi" /> | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) / [Kimi Code](https://github.com/MoonshotAI/kimi-code) | kimi-cli: `~/.kimi/sessions/` kimi-code: `~/.kimi-code/sessions/`（可通过 `KIMI_CODE_HOME` 覆盖） |
 | <img width="48px" src=".github/assets/client-qwen.png" alt="Qwen" /> | [Qwen CLI](https://github.com/QwenLM/qwen-cli) | `~/.qwen/projects/` |
 | <img width="48px" src=".github/assets/client-roocode.png" alt="Roo Code" /> | [Roo Code](https://github.com/RooCodeInc/Roo-Code) | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` (+ server: `~/.vscode-server/data/User/globalStorage/rooveterinaryinc.roo-cline/tasks/`) |
@@ -85,7 +86,7 @@
 | <img width="48px" src="https://github.com/xai-org.png" alt="Grok Build" /> | Grok Build | `$GROK_HOME/sessions/*/*/updates.jsonl`（回退：`~/.grok/sessions/*/*/updates.jsonl`） |
 | <img width="48px" src=".github/assets/client-zed.webp" alt="Zed Agent" /> | [Zed Agent](https://zed.dev/docs/ai/agent-panel) | `~/.local/share/zed/threads/threads.db`（macOS: `~/Library/Application Support/Zed/threads/threads.db`；Windows: `%LOCALAPPDATA%/Zed/threads/threads.db`；仅限托管 Zed 模型，不含外部 ACP 代理） |
 | <img width="48px" src="https://github.com/kirodotdev.png" alt="Kiro" /> | Kiro | `~/.kiro/sessions/cli/*.json`（+ `*.jsonl`）、`~/.local/share/kiro-cli/data.sqlite3`（macOS: `~/Library/Application Support/kiro-cli/data.sqlite3`），以及 Kiro IDE globalStorage 快照（`Kiro/User/globalStorage/kiro.kiroagent`；macOS Application Support、Linux `~/.config/Kiro`、Windows `%APPDATA%\Kiro`） |
-| <img width="48px" src="https://github.com/cline.png" alt="Cline" /> | [Cline](https://github.com/cline/cline) | VS Code globalStorage 任务（Linux: `~/.config/Code/...`；macOS: `~/Library/Application Support/Code/...`；Windows: `%APPDATA%\Code\...`；server: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/`） |
+| <img width="48px" src="https://github.com/cline.png" alt="Cline" /> | [Cline](https://github.com/cline/cline) | VS Code globalStorage 任务（Linux: `~/.config/Code/...`；macOS: `~/Library/Application Support/Code/...`；Windows: `%APPDATA%\Code\...`；server: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/`）+ Cline CLI 会话（按顺序选择第一个可用根目录：`$CLINE_SESSION_DATA_DIR`、`$CLINE_DATA_DIR/sessions/`、`$CLINE_DIR/data/sessions/`、回退 `~/.cline/data/sessions/`；空值或仅包含空白字符的环境变量会被忽略） |
 | <img width="48px" src="https://github.com/user-attachments/assets/7246e920-f3f8-4b6e-847e-030ae04e86c2" alt="Gajae-Code" /> | [gajae-code (gjc)](https://github.com/Yeachan-Heo/gajae-code) | `~/.gjc/agent/sessions/`（可通过 `GJC_CODING_AGENT_DIR`、`GJC_CONFIG_DIR`、`PI_CONFIG_DIR` 覆盖；Linux/macOS 上 `$XDG_DATA_HOME/gjc/sessions/` 亦支持） |
 | <img width="48px" src=".github/assets/client-jcode.png" alt="Jcode" /> | [Jcode](https://github.com/1jehuang/jcode) | `~/.jcode/sessions/session_*.json` + `session_*.journal.jsonl` sidecar（可通过 `JCODE_HOME` 覆盖） |
 | <img width="48px" src="https://github.com/XiaomiMiMo.png" alt="MiMo Code" /> | [MiMo Code](https://github.com/XiaomiMiMo/MiMo-Code) | `~/.local/share/mimocode/mimocode.db`（XDG 数据目录；SQLite） |
@@ -169,7 +170,7 @@
   - 支持可配置颜色主题的 GitHub 风格贡献图
   - 实时筛选和排序
   - 零闪烁渲染
-- **多平台支持** - 跟踪 OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code 和 Synthetic 的使用情况
+- **多平台支持** - 跟踪 OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimchi Coding、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code 和 Synthetic 的使用情况
 - **实时定价** - 从 LiteLLM 获取当前价格，带 1 小时磁盘缓存；OpenRouter 自动回退和新模型的 Cursor 定价支持
 - **详细分解** - 输入、输出、缓存读写和推理 Token 跟踪
 - **原生 Rust 核心** - 所有解析和聚合在 Rust 中完成，处理速度提升 10 倍
@@ -379,7 +380,7 @@ tokscale --client synthetic
 tokscale --client opencode,claude --week --json
 ```
 
-可用值：`opencode`、`claude`、`codex`、`copilot`、`gemini`、`cursor`、`amp`、`codebuff`、`droid`、`openclaw`、`hermes`、`pi`、`kimi`、`qwen`、`roocode`、`kilocode`、`kilo`、`mux`、`crush`、`goose`、`antigravity`、`antigravity-cli`、`zed`、`kiro`、`trae`、`warp`、`cline`、`gjc`、`grok`、`jcode`、`micode`、`commandcode`、`junie`、`zcode`、`opencodereview`、`codebuddy`、`augment`、`synthetic`。
+可用值：`opencode`、`claude`、`codex`、`copilot`、`gemini`、`cursor`、`amp`、`codebuff`、`droid`、`openclaw`、`hermes`、`pi`、`kimchi`、`kimi`、`qwen`、`roocode`、`kilocode`、`kilo`、`mux`、`crush`、`goose`、`antigravity`、`antigravity-cli`、`zed`、`kiro`、`trae`、`warp`、`cline`、`gjc`、`grok`、`jcode`、`micode`、`commandcode`、`junie`、`zcode`、`opencodereview`、`codebuddy`、`augment`、`synthetic`。
 
 > **破坏性变更（v4.0.0）**：单客户端布尔选项（`--opencode`、`--claude`、`--codex` 等）已被移除，现在会直接报错。请改用规范的 `--client`/`-c` 选项——例如 `tokscale --client opencode,claude`。
 
@@ -1318,12 +1319,13 @@ AI 编程工具将会话数据存储在跨平台位置。大多数工具在所�
 | Cursor | API 同步 | API 同步 | 通过 API 获取并缓存为 `usage*.csv`；桌面端自动登录仅读取 `state.vscdb` 认证；不解析本地 `~/.cursor` 会话数据 |
 | Droid | `~/.factory/` | `%USERPROFILE%\.factory\` | 所有平台使用相同路径 |
 | Pi | `~/.pi/` and `~/.omp/` | `%USERPROFILE%\.pi\` and `%USERPROFILE%\.omp\` | 所有平台使用相同路径（支持 Pi 和 [Oh My Pi](https://github.com/can1357/oh-my-pi)） |
+| Kimchi Coding | `~/.config/kimchi/harness/sessions/` | `%USERPROFILE%\.config\kimchi\harness\sessions\` | 可通过 `KIMCHI_CODING_AGENT_DIR` 环境变量覆盖；Pi 兼容的 JSONL 会话 |
 | Kimi CLI | `~/.kimi/` | `%USERPROFILE%\.kimi\` | 所有平台使用相同路径 |
 | Kimi Code | `~/.kimi-code/` | `%USERPROFILE%\.kimi-code\` | 所有平台使用相同路径 |
 | Qwen CLI | `~/.qwen/` | `%USERPROFILE%\.qwen\` | 所有平台使用相同路径 |
 | Roo Code | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks\` | VS Code globalStorage 任务日志 |
 | Kilo | `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks/` | `%USERPROFILE%\.config\Code\User\globalStorage\kilocode.kilo-code\tasks\` | VS Code globalStorage 任务日志 |
-| Cline | Linux: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`；macOS: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`；server: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/` | `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\tasks\` | VS Code globalStorage 任务日志 |
+| Cline | Linux: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`；macOS: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`；server: `~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/`；Cline CLI 回退：`~/.cline/data/sessions/` | `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\tasks\`；Cline CLI 回退：`%USERPROFILE%\.cline\data\sessions\` | VS Code globalStorage 任务日志；Cline CLI 使用 `{SESSION_ID}/{SESSION_ID}.messages.json`，按 `$CLINE_SESSION_DATA_DIR` → `$CLINE_DATA_DIR/sessions/` → `$CLINE_DIR/data/sessions/` → `~/.cline/data/sessions/` 的顺序选择根目录；空值或仅包含空白字符的环境变量会被忽略 |
 | Mux | `~/.mux/sessions/` | `%USERPROFILE%\.mux\sessions\` | 所有平台相同路径 |
 | Codebuff | `~/.config/manicode/projects/`（+ `manicode-dev`、`manicode-staging`） | `%USERPROFILE%\.config\manicode\projects\` | 通过 `CODEBUFF_DATA_DIR` 环境变量覆盖 |
 | Kilo CLI | `~/.local/share/kilo/` | `%USERPROFILE%\.local\share\kilo\` | 与 OpenCode 一样使用 `xdg-basedir` |
@@ -1713,6 +1715,14 @@ Cline 是 Roo Code 和 Kilo 从中 fork 的上游项目，因此使用相同的 
 - 仅计算 `ui_messages.json` 中的 `say/api_req_started` 事件
 - 从 `text` JSON 中解析 `tokensIn`、`tokensOut`、`cacheReads`、`cacheWrites`、`cost` 和 `apiProtocol`
 - 在可用时从相邻的 `api_conversation_history.json` 中丰富模型/代理元数据
+Cline CLI 会话按以下优先级选择第一个可用根目录进行发现：`$CLINE_SESSION_DATA_DIR` → `$CLINE_DATA_DIR/sessions/` → `$CLINE_DIR/data/sessions/` → 回退 `~/.cline/data/sessions/`。空值或仅包含空白字符的环境变量视为未设置。在选定根目录中，会话从 `{SESSION_ID}/{SESSION_ID}.messages.json` 读取。Tokscale 统计带有持久化 `metrics` 的 assistant 消息，包括输入/输出/缓存 Token 和提供商报告的成本，并使用同级会话清单中的工作区和回退模型元数据。禁用环境根目录发现时，仅使用主目录回退路径。
+
+### Kimchi Coding
+
+位置：
+- `~/.config/kimchi/harness/sessions/{ENCODED_WORKSPACE}/*.jsonl`（或 `$KIMCHI_CODING_AGENT_DIR/sessions/`）
+
+Kimchi 使用 Pi 兼容的 JSONL 会话格式。Tokscale 统计带有持久化输入/输出/缓存用量的 assistant 消息，并将 Kimchi 保持为独立于 Pi 的客户端，即使两者共享会话架构。
 
 ### Mux
 

--- a/crates/tokscale-cli/src/commands/wrapped.rs
+++ b/crates/tokscale-cli/src/commands/wrapped.rs
@@ -1471,6 +1471,7 @@ fn client_display_name(client: &str) -> Option<&'static str> {
         "jcode" => Some("Jcode"),
         "junie" => Some("Junie"),
         "augment" => Some("Augment Code"),
+        "kimchi" => Some("Kimchi"),
         "synthetic" => Some("Synthetic"),
         _ => None,
     }
@@ -1515,6 +1516,7 @@ fn client_logo_url(client_name: &str) -> Option<&'static str> {
         "Jcode" => Some("https://raw.githubusercontent.com/junhoyeo/tokscale/main/.github/assets/client-jcode.png"),
         "Junie" => Some("https://github.com/JetBrains.png"),
         "Augment Code" => Some("https://github.com/augmentcode.png"),
+        "Kimchi" => Some("https://github.com/getkimchi.png"),
         "Synthetic" => Some("https://tokscale.ai/assets/logos/synthetic.png"),
         _ => None,
     }

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1075,6 +1075,7 @@ pub enum ClientFilter {
     Senpi,
     #[value(alias = "auggie")]
     Augment,
+    Kimchi,
     Synthetic,
 }
 
@@ -1126,6 +1127,7 @@ impl ClientFilter {
             Self::DevinDesktop => "devin-desktop",
             Self::Senpi => "senpi",
             Self::Augment => "augment",
+            Self::Kimchi => "kimchi",
             Self::Synthetic => "synthetic",
         }
     }
@@ -1180,6 +1182,7 @@ impl ClientFilter {
             Self::DevinDesktop => Some(ClientId::DevinDesktop),
             Self::Senpi => Some(ClientId::Senpi),
             Self::Augment => Some(ClientId::Augment),
+            Self::Kimchi => Some(ClientId::Kimchi),
             Self::Synthetic => None,
         }
     }
@@ -1230,6 +1233,7 @@ impl ClientFilter {
             ClientId::DevinDesktop => Self::DevinDesktop,
             ClientId::Senpi => Self::Senpi,
             ClientId::Augment => Self::Augment,
+            ClientId::Kimchi => Self::Kimchi,
         }
     }
 
@@ -3906,6 +3910,7 @@ fn capitalize_client(client: &str) -> String {
         "devin-desktop" => "Devin Desktop".to_string(),
         "senpi" => "Senpi (OmO Native)".to_string(),
         "augment" => "Augment Code".to_string(),
+        "kimchi" => "Kimchi".to_string(),
         other => other.to_string(),
     }
 }

--- a/crates/tokscale-cli/src/tui/client_ui.rs
+++ b/crates/tokscale-cli/src/tui/client_ui.rs
@@ -176,6 +176,10 @@ pub const CLIENT_UI: [ClientUi; ClientId::COUNT] = [
         display_name: "Augment",
         hotkey: 'A',
     },
+    ClientUi {
+        display_name: "Kimchi",
+        hotkey: 'K',
+    },
 ];
 
 pub fn display_name(client: ClientId) -> &'static str {

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -1613,6 +1613,7 @@ mod tests {
         assert_eq!(clients[38], ClientId::DevinDesktop);
         assert_eq!(clients[39], ClientId::Senpi);
         assert_eq!(clients[40], ClientId::Augment);
+        assert_eq!(clients[41], ClientId::Kimchi);
     }
 
     #[test]
@@ -1720,6 +1721,10 @@ mod tests {
             crate::tui::client_ui::display_name(ClientId::Augment),
             "Augment"
         );
+        assert_eq!(
+            crate::tui::client_ui::display_name(ClientId::Kimchi),
+            "Kimchi"
+        );
     }
 
     #[test]
@@ -1756,6 +1761,7 @@ mod tests {
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::CodeBuddy), 'C');
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::WorkBuddy), 'B');
         assert_eq!(crate::tui::client_ui::hotkey(ClientId::Augment), 'A');
+        assert_eq!(crate::tui::client_ui::hotkey(ClientId::Kimchi), 'K');
     }
 
     #[test]
@@ -1867,6 +1873,10 @@ mod tests {
         assert_eq!(
             crate::tui::client_ui::from_hotkey('A'),
             Some(ClientId::Augment)
+        );
+        assert_eq!(
+            crate::tui::client_ui::from_hotkey('K'),
+            Some(ClientId::Kimchi)
         );
     }
 

--- a/crates/tokscale-core/src/clients.rs
+++ b/crates/tokscale-core/src/clients.rs
@@ -578,6 +578,20 @@ define_clients!(
         headless: false,
         parse_local: true,
         submit_default: true
+    },
+    // Kimchi Coding uses the Pi session format under its own agent directory.
+    // The launcher exposes KIMCHI_CODING_AGENT_DIR for relocated installs.
+    Kimchi = 41 => {
+        id: "kimchi",
+        root: PathRoot::EnvVar {
+            var: "KIMCHI_CODING_AGENT_DIR",
+            fallback_relative: ".config/kimchi/harness",
+        },
+        relative: "sessions",
+        pattern: "*.jsonl",
+        headless: false,
+        parse_local: true,
+        submit_default: true
     }
 );
 
@@ -630,7 +644,7 @@ mod tests {
 
     #[test]
     fn test_client_id_count() {
-        assert_eq!(ClientId::COUNT, 41);
+        assert_eq!(ClientId::COUNT, 42);
     }
 
     #[test]
@@ -655,6 +669,46 @@ mod tests {
         assert!(client.data().parse_local);
         assert!(client.data().submit_default);
         assert!(!client.data().headless);
+    }
+
+    #[test]
+    fn test_kimchi_client_registered_as_local_session_source() {
+        let client = ClientId::from_str("kimchi").expect("kimchi client should be registered");
+        assert_eq!(client.data().relative_path, "sessions");
+        assert_eq!(client.data().pattern, "*.jsonl");
+        assert!(client.data().parse_local);
+        assert!(client.data().submit_default);
+        assert!(!client.data().headless);
+    }
+
+    #[test]
+    fn test_kimchi_defaults_to_home_agent_dir_without_env_override() {
+        let _guard = env_lock().lock().unwrap();
+        let previous = std::env::var("KIMCHI_CODING_AGENT_DIR").ok();
+        unsafe { std::env::remove_var("KIMCHI_CODING_AGENT_DIR") };
+
+        let client = ClientId::from_str("kimchi").expect("kimchi client should be registered");
+        assert_eq!(
+            client.data().resolve_path("/tmp/home"),
+            "/tmp/home/.config/kimchi/harness/sessions"
+        );
+
+        restore_env("KIMCHI_CODING_AGENT_DIR", previous);
+    }
+
+    #[test]
+    fn test_kimchi_honors_agent_dir_env_override() {
+        let _guard = env_lock().lock().unwrap();
+        let previous = std::env::var("KIMCHI_CODING_AGENT_DIR").ok();
+        unsafe { std::env::set_var("KIMCHI_CODING_AGENT_DIR", "/custom/kimchi-agent") };
+
+        let client = ClientId::from_str("kimchi").expect("kimchi client should be registered");
+        assert_eq!(
+            client.data().resolve_path("/tmp/home"),
+            "/custom/kimchi-agent/sessions"
+        );
+
+        restore_env("KIMCHI_CODING_AGENT_DIR", previous);
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1669,6 +1669,26 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         }
     }
 
+    let kimchi_outcomes: Vec<CachedParseOutcome> = scan_result
+        .get(ClientId::Kimchi)
+        .par_iter()
+        .map(|path| {
+            load_or_parse_source(
+                message_cache::CacheIdentity::for_client(ClientId::Kimchi),
+                path,
+                &source_cache,
+                pricing,
+                sessions::kimchi::parse_kimchi_file,
+            )
+        })
+        .collect();
+    for outcome in kimchi_outcomes {
+        all_messages.extend(outcome.messages);
+        if let Some(entry) = outcome.cache_entry {
+            source_cache.insert(entry);
+        }
+    }
+
     let senpi_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::Senpi)
         .par_iter()
@@ -3569,6 +3589,20 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     let pi_count = pi_msgs.len() as i32;
     counts.set(ClientId::Pi, pi_count);
     messages.extend(pi_msgs);
+
+    let kimchi_msgs: Vec<ParsedMessage> = scan_result
+        .get(ClientId::Kimchi)
+        .par_iter()
+        .flat_map(|path| {
+            sessions::kimchi::parse_kimchi_file(path)
+                .into_iter()
+                .map(|msg| unified_to_parsed(&msg))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let kimchi_count = kimchi_msgs.len() as i32;
+    counts.set(ClientId::Kimchi, kimchi_count);
+    messages.extend(kimchi_msgs);
 
     let senpi_msgs: Vec<ParsedMessage> = scan_result
         .get(ClientId::Senpi)

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1984,8 +1984,14 @@ fn parse_all_messages_with_pricing_with_env_strategy(
             )
         })
         .collect();
+    let mut cline_seen: HashSet<String> = HashSet::new();
     for outcome in cline_outcomes {
-        all_messages.extend(outcome.messages);
+        all_messages.extend(
+            outcome
+                .messages
+                .into_iter()
+                .filter(|message| should_keep_deduped_message(&mut cline_seen, message)),
+        );
         if let Some(entry) = outcome.cache_entry {
             source_cache.insert(entry);
         }
@@ -3792,15 +3798,16 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     counts.set(ClientId::KiloCode, kilocode_count);
     messages.extend(kilocode_msgs);
 
-    let cline_msgs: Vec<ParsedMessage> = scan_result
+    let cline_msgs_raw: Vec<UnifiedMessage> = scan_result
         .get(ClientId::Cline)
         .par_iter()
-        .flat_map(|path| {
-            sessions::cline::parse_cline_file(path)
-                .into_iter()
-                .map(|msg| unified_to_parsed(&msg))
-                .collect::<Vec<_>>()
-        })
+        .flat_map(|path| sessions::cline::parse_cline_file(path))
+        .collect();
+    let mut cline_seen: HashSet<String> = HashSet::new();
+    let cline_msgs: Vec<ParsedMessage> = cline_msgs_raw
+        .into_iter()
+        .filter(|message| should_keep_deduped_message(&mut cline_seen, message))
+        .map(|message| unified_to_parsed(&message))
         .collect();
     let cline_count = summed_parsed_message_count(&cline_msgs);
     counts.set(ClientId::Cline, cline_count);
@@ -5930,6 +5937,81 @@ mod tests {
 {"type":"message","id":"kimchi-message","timestamp":"2026-08-01T00:00:01.000Z","message":{"role":"assistant","model":"kimi-k2.6","provider":"kimchi-dev","usage":{"input":100,"output":10,"cacheRead":5,"cacheWrite":2,"totalTokens":117}}}"#,
         )
         .unwrap();
+    }
+    fn write_cline_cli_fixture(path: &std::path::Path, messages: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            path,
+            format!(r#"{{"sessionId":"cline-dedup-session","messages":[{messages}]}}"#),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_cline_cli_deduplicates_duplicate_records_in_cached_and_local_paths() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            let duplicate = r#"{"id":"duplicate","role":"assistant","ts":1785320475705,"modelInfo":{"id":"cline-free/glm-5.2","provider":"cline-pass"},"metrics":{"inputTokens":100,"outputTokens":10}}"#;
+            let distinct_a = r#"{"id":"distinct-a","role":"assistant","ts":1785320476705,"metrics":{"inputTokens":200,"outputTokens":20}}"#;
+            let distinct_b = r#"{"id":"distinct-b","role":"assistant","ts":1785320477705,"metrics":{"inputTokens":300,"outputTokens":30}}"#;
+            write_cline_cli_fixture(
+                &source_home
+                    .path()
+                    .join(".cline/data/sessions/first/first.messages.json"),
+                &format!("{duplicate},{distinct_a}"),
+            );
+            write_cline_cli_fixture(
+                &source_home
+                    .path()
+                    .join(".cline/data/sessions/second/second.messages.json"),
+                &format!("{duplicate},{distinct_b}"),
+            );
+
+            let clients = ["cline".to_string()];
+            let scanner_settings = scanner::ScannerSettings::default();
+            let cached = parse_all_messages_with_pricing_with_env_strategy(
+                source_home.path().to_str().unwrap(),
+                &clients,
+                None,
+                false,
+                &scanner_settings,
+            );
+            let mut cached_inputs = cached
+                .iter()
+                .map(|message| message.tokens.input)
+                .collect::<Vec<_>>();
+            cached_inputs.sort_unstable();
+            assert_eq!(cached_inputs, vec![100, 200, 300]);
+
+            let parsed = parse_local_clients(LocalParseOptions {
+                home_dir: Some(source_home.path().to_str().unwrap().to_string()),
+                use_env_roots: false,
+                clients: Some(clients.to_vec()),
+                since: None,
+                until: None,
+                year: None,
+                scanner_settings,
+            })
+            .unwrap();
+            let mut local_inputs = parsed
+                .messages
+                .iter()
+                .map(|message| message.input)
+                .collect::<Vec<_>>();
+            local_inputs.sort_unstable();
+            assert_eq!(local_inputs, vec![100, 200, 300]);
+            assert_eq!(parsed.counts.get(ClientId::Cline), 3);
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1682,8 +1682,14 @@ fn parse_all_messages_with_pricing_with_env_strategy(
             )
         })
         .collect();
+    let mut kimchi_seen: HashSet<String> = HashSet::new();
     for outcome in kimchi_outcomes {
-        all_messages.extend(outcome.messages);
+        all_messages.extend(
+            outcome
+                .messages
+                .into_iter()
+                .filter(|message| should_keep_deduped_message(&mut kimchi_seen, message)),
+        );
         if let Some(entry) = outcome.cache_entry {
             source_cache.insert(entry);
         }
@@ -1973,7 +1979,7 @@ fn parse_all_messages_with_pricing_with_env_strategy(
                 path,
                 &source_cache,
                 pricing,
-                message_cache::SourceFingerprint::check_roo_path_samples_only,
+                message_cache::SourceFingerprint::check_cline_path_samples_only,
                 sessions::cline::parse_cline_file,
             )
         })
@@ -3590,15 +3596,16 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     counts.set(ClientId::Pi, pi_count);
     messages.extend(pi_msgs);
 
-    let kimchi_msgs: Vec<ParsedMessage> = scan_result
+    let kimchi_msgs_raw: Vec<UnifiedMessage> = scan_result
         .get(ClientId::Kimchi)
         .par_iter()
-        .flat_map(|path| {
-            sessions::kimchi::parse_kimchi_file(path)
-                .into_iter()
-                .map(|msg| unified_to_parsed(&msg))
-                .collect::<Vec<_>>()
-        })
+        .flat_map(|path| sessions::kimchi::parse_kimchi_file(path))
+        .collect();
+    let mut kimchi_seen: HashSet<String> = HashSet::new();
+    let kimchi_msgs: Vec<ParsedMessage> = kimchi_msgs_raw
+        .into_iter()
+        .filter(|message| should_keep_deduped_message(&mut kimchi_seen, message))
+        .map(|message| unified_to_parsed(&message))
         .collect();
     let kimchi_count = kimchi_msgs.len() as i32;
     counts.set(ClientId::Kimchi, kimchi_count);
@@ -5915,6 +5922,16 @@ mod tests {
         .unwrap();
     }
 
+    fn write_kimchi_fixture(path: &std::path::Path) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            path,
+            r#"{"type":"session","id":"kimchi-session","timestamp":"2026-08-01T00:00:00.000Z","cwd":"/tmp/kimchi-project"}
+{"type":"message","id":"kimchi-message","timestamp":"2026-08-01T00:00:01.000Z","message":{"role":"assistant","model":"kimi-k2.6","provider":"kimchi-dev","usage":{"input":100,"output":10,"cacheRead":5,"cacheWrite":2,"totalTokens":117}}}"#,
+        )
+        .unwrap();
+    }
+
     #[test]
     #[serial_test::serial]
     fn test_parse_all_messages_with_pricing_prefers_grok_unified_log() {
@@ -6132,6 +6149,65 @@ mod tests {
             assert_eq!(parsed.messages.iter().map(|m| m.input).sum::<i64>(), 40);
             assert_eq!(parsed.messages.iter().map(|m| m.output).sum::<i64>(), 5);
         }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_kimchi_deduplicates_same_message_across_scan_roots() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        let default_path = source_home
+            .path()
+            .join(".config/kimchi/harness/sessions/workspace/session.jsonl");
+        let extra_path = source_home
+            .path()
+            .join("kimchi-extra/workspace/session.jsonl");
+        write_kimchi_fixture(&default_path);
+        write_kimchi_fixture(&extra_path);
+
+        let mut extra_scan_paths = std::collections::BTreeMap::new();
+        extra_scan_paths.insert(
+            "kimchi".to_string(),
+            vec![source_home.path().join("kimchi-extra")],
+        );
+        let scanner_settings = scanner::ScannerSettings {
+            extra_scan_paths,
+            ..Default::default()
+        };
+
+        let parsed = parse_local_clients(LocalParseOptions {
+            home_dir: Some(source_home.path().to_str().unwrap().to_string()),
+            use_env_roots: false,
+            clients: Some(vec!["kimchi".to_string()]),
+            since: None,
+            until: None,
+            year: None,
+            scanner_settings: scanner_settings.clone(),
+        })
+        .unwrap();
+        assert_eq!(parsed.counts.get(ClientId::Kimchi), 1);
+        assert_eq!(parsed.messages.len(), 1);
+
+        let messages = parse_all_messages_with_pricing_with_env_strategy(
+            source_home.path().to_str().unwrap(),
+            &["kimchi".to_string()],
+            None,
+            false,
+            &scanner_settings,
+        );
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some("kimchi:kimchi-session:kimchi-message")
+        );
 
         match original_home {
             Some(home) => std::env::set_var("HOME", home),

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -5987,6 +5987,19 @@ mod tests {
                 .collect::<Vec<_>>();
             cached_inputs.sort_unstable();
             assert_eq!(cached_inputs, vec![100, 200, 300]);
+            let cached_again = parse_all_messages_with_pricing_with_env_strategy(
+                source_home.path().to_str().unwrap(),
+                &clients,
+                None,
+                false,
+                &scanner_settings,
+            );
+            let mut cached_again_inputs = cached_again
+                .iter()
+                .map(|message| message.tokens.input)
+                .collect::<Vec<_>>();
+            cached_again_inputs.sort_unstable();
+            assert_eq!(cached_again_inputs, vec![100, 200, 300]);
 
             let parsed = parse_local_clients(LocalParseOptions {
                 home_dir: Some(source_home.path().to_str().unwrap().to_string()),

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -905,7 +905,10 @@ fn parser_version(client: ClientId) -> u32 {
         ClientId::Kimi => 4,
         // v1->v2: standalone Cline messages subtract cache buckets from gross
         // input tokens, reject non-finite costs, and preserve zero-cost reports.
-        ClientId::Cline => 2,
+        // v2->v3: content-aware Cline CLI turn-start classification now
+        // recognizes user tool-result records as continuations instead of
+        // beginning a new turn, so cached turns must be reparsed.
+        ClientId::Cline => 3,
         // v1->v2: Kimchi's Pi-compatible messages now carry stable namespaced
         // deduplication keys.
         ClientId::Kimchi => 2,

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -362,6 +362,31 @@ impl SourceFingerprint {
         Self::check_roo_path_with_mode(path, cached, ContentHashMode::SamplesOnly)
     }
 
+    pub(crate) fn check_cline_path_samples_only(
+        path: &Path,
+        cached: Option<&Self>,
+    ) -> Option<FingerprintStatus> {
+        let related_paths = if crate::sessions::cline::is_cline_cli_messages_path(path) {
+            std::iter::once((
+                "manifest.json".to_string(),
+                crate::sessions::cline::cline_cli_manifest_path(path),
+            ))
+            .collect::<Vec<_>>()
+        } else {
+            let history = path
+                .parent()
+                .unwrap_or_else(|| Path::new("."))
+                .join("api_conversation_history.json");
+            vec![("api_conversation_history.json".to_string(), history)]
+        };
+        Self::check_path_with_related_mode(
+            path,
+            related_paths,
+            cached,
+            ContentHashMode::SamplesOnly,
+        )
+    }
+
     fn check_roo_path_with_mode(
         path: &Path,
         cached: Option<&Self>,
@@ -878,6 +903,12 @@ fn parser_version(client: ClientId) -> u32 {
         // kimi-code `time`) now fall back to the file mtime instead of
         // anchoring the message in a pre-epoch bucket.
         ClientId::Kimi => 4,
+        // v1->v2: standalone Cline messages subtract cache buckets from gross
+        // input tokens, reject non-finite costs, and preserve zero-cost reports.
+        ClientId::Cline => 2,
+        // v1->v2: Kimchi's Pi-compatible messages now carry stable namespaced
+        // deduplication keys.
+        ClientId::Kimchi => 2,
         // v1->v2: per-model token attribution now comes from
         // session_model_usage instead of crediting the whole session to
         // sessions.model, and dedup keys are namespaced per (session, model).
@@ -1758,6 +1789,45 @@ mod tests {
             plain_before, plain_after,
             "from_path ignores the history sibling (control)"
         );
+    }
+
+    #[test]
+    fn cline_cli_fingerprint_tracks_manifest_changes() {
+        let dir = TempDir::new().unwrap();
+        let messages = dir.path().join("session.messages.json");
+        let manifest = dir.path().join("session.json");
+        std::fs::write(&messages, br#"{"messages":[]}"#).unwrap();
+
+        let initial = match SourceFingerprint::check_cline_path_samples_only(&messages, None) {
+            Some(FingerprintStatus::Changed(fingerprint)) => fingerprint,
+            other => panic!("expected an initial fingerprint, got {other:?}"),
+        };
+        assert!(initial.related_files.iter().any(|related| {
+            related.suffix == "manifest.json"
+                && related.path.to_path_buf() == manifest
+                && !related.exists
+        }));
+        assert!(matches!(
+            SourceFingerprint::check_cline_path_samples_only(&messages, Some(&initial)),
+            Some(FingerprintStatus::Unchanged)
+        ));
+
+        std::fs::write(&manifest, br#"{"title":"first"}"#).unwrap();
+        assert!(matches!(
+            SourceFingerprint::check_cline_path_samples_only(&messages, Some(&initial)),
+            Some(FingerprintStatus::Changed(_))
+        ));
+
+        let with_manifest =
+            match SourceFingerprint::check_cline_path_samples_only(&messages, Some(&initial)) {
+                Some(FingerprintStatus::Changed(fingerprint)) => fingerprint,
+                other => panic!("expected a refreshed fingerprint, got {other:?}"),
+            };
+        std::fs::write(&manifest, br#"{"title":"second"}"#).unwrap();
+        assert!(matches!(
+            SourceFingerprint::check_cline_path_samples_only(&messages, Some(&with_manifest)),
+            Some(FingerprintStatus::Changed(_))
+        ));
     }
 
     fn restore_env_var(key: &str, value: Option<impl AsRef<std::ffi::OsStr>>) {

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -2522,6 +2522,14 @@ mod tests {
         file.write_all(b"{}").unwrap();
     }
 
+    fn setup_mock_kimchi_dir(base: &std::path::Path) {
+        let kimchi_path = base.join(".config/kimchi/harness/sessions/--test--");
+        fs::create_dir_all(&kimchi_path).unwrap();
+        let mut file =
+            File::create(kimchi_path.join("2026-08-01T00-00-00Z_kimchi_ses_001.jsonl")).unwrap();
+        file.write_all(b"{}").unwrap();
+    }
+
     fn setup_mock_kiro_dir(base: &std::path::Path) {
         let kiro_path = base.join(".kiro/sessions/cli");
         fs::create_dir_all(&kiro_path).unwrap();
@@ -3786,6 +3794,24 @@ mod tests {
         assert_eq!(result.get(ClientId::Pi).len(), 1);
         assert!(result.get(ClientId::OpenCode).is_empty());
         assert!(result.get(ClientId::Claude).is_empty());
+    }
+
+    #[test]
+    fn test_scan_all_clients_kimchi() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_kimchi_dir(home);
+
+        let result = scan_all_clients_with_env_strategy(
+            home.to_str().unwrap(),
+            &["kimchi".to_string()],
+            false,
+        );
+        assert_eq!(result.get(ClientId::Kimchi).len(), 1);
+        assert!(result.get(ClientId::Kimchi)[0]
+            .to_string_lossy()
+            .ends_with(".jsonl"));
+        assert!(result.get(ClientId::Pi).is_empty());
     }
 
     #[test]

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -877,16 +877,29 @@ fn cline_additional_vscode_task_roots(home_dir: &str, use_env_roots: bool) -> Ve
 }
 
 fn cline_cli_session_roots(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
-    let data_dir = if use_env_roots {
-        std::env::var_os("CLINE_DATA_DIR")
+    let home_fallback = || PathBuf::from(home_dir).join(".cline/data/sessions");
+
+    if !use_env_roots {
+        return vec![home_fallback()];
+    }
+
+    let non_blank_env_path = |name: &str| {
+        std::env::var_os(name)
             .filter(|value| !value.to_string_lossy().trim().is_empty())
             .map(PathBuf::from)
-            .unwrap_or_else(|| PathBuf::from(home_dir).join(".cline/data"))
-    } else {
-        PathBuf::from(home_dir).join(".cline/data")
     };
 
-    vec![data_dir.join("sessions")]
+    if let Some(path) = non_blank_env_path("CLINE_SESSION_DATA_DIR") {
+        return vec![path];
+    }
+    if let Some(path) = non_blank_env_path("CLINE_DATA_DIR") {
+        return vec![path.join("sessions")];
+    }
+    if let Some(path) = non_blank_env_path("CLINE_DIR") {
+        return vec![path.join("data/sessions")];
+    }
+
+    vec![home_fallback()]
 }
 
 pub fn devin_desktop_additional_roots(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
@@ -2831,7 +2844,11 @@ mod tests {
     }
 
     fn setup_mock_cline_cli_dir(data_dir: &std::path::Path) {
-        let sessions = data_dir.join("sessions/cli-session");
+        setup_mock_cline_cli_session_root(&data_dir.join("sessions"));
+    }
+
+    fn setup_mock_cline_cli_session_root(sessions_root: &std::path::Path) {
+        let sessions = sessions_root.join("cli-session");
         fs::create_dir_all(&sessions).unwrap();
         File::create(sessions.join("cli-session.messages.json")).unwrap();
     }
@@ -4848,28 +4865,117 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_scan_all_clients_cline_cli_uses_data_dir_override() {
-        let mut env = EnvGuard::capture(&["CLINE_DATA_DIR"]);
+    fn test_scan_all_clients_cline_cli_session_data_dir_takes_precedence() {
+        let mut env = EnvGuard::capture(&["CLINE_SESSION_DATA_DIR", "CLINE_DATA_DIR", "CLINE_DIR"]);
         let dir = TempDir::new().unwrap();
         let home = dir.path().join("home");
+        let session_data_dir = dir.path().join("custom-cline-sessions");
         let data_dir = dir.path().join("custom-cline-data");
+        let cline_dir = dir.path().join("custom-cline");
+
+        setup_mock_cline_cli_session_root(&session_data_dir);
         setup_mock_cline_cli_dir(&data_dir);
+        setup_mock_cline_cli_dir(&cline_dir.join("data"));
+        setup_mock_cline_cli_dir(&home.join(".cline/data"));
+        env.set("CLINE_SESSION_DATA_DIR", &session_data_dir);
         env.set("CLINE_DATA_DIR", &data_dir);
+        env.set("CLINE_DIR", &cline_dir);
 
         let result = scan_all_clients_with_env_strategy(
             home.to_str().unwrap(),
             &["cline".to_string()],
             true,
         );
+        let expected = session_data_dir.join("cli-session/cli-session.messages.json");
 
-        assert_eq!(result.get(ClientId::Cline).len(), 1);
-        assert!(result.get(ClientId::Cline)[0].starts_with(&data_dir));
+        assert_eq!(result.get(ClientId::Cline), &vec![expected]);
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_cline_cli_uses_data_dir_override() {
+        let mut env = EnvGuard::capture(&["CLINE_SESSION_DATA_DIR", "CLINE_DATA_DIR", "CLINE_DIR"]);
+        env.remove("CLINE_SESSION_DATA_DIR");
+        env.remove("CLINE_DIR");
+        let dir = TempDir::new().unwrap();
+        let home = dir.path().join("home");
+        let data_dir = dir.path().join("custom-cline-data");
+        let cline_dir = dir.path().join("custom-cline");
+
+        setup_mock_cline_cli_dir(&data_dir);
+        setup_mock_cline_cli_dir(&cline_dir.join("data"));
+        setup_mock_cline_cli_dir(&home.join(".cline/data"));
+        env.set("CLINE_DATA_DIR", &data_dir);
+        env.set("CLINE_DIR", &cline_dir);
+
+        let result = scan_all_clients_with_env_strategy(
+            home.to_str().unwrap(),
+            &["cline".to_string()],
+            true,
+        );
+        let expected = data_dir.join("sessions/cli-session/cli-session.messages.json");
+
+        assert_eq!(result.get(ClientId::Cline), &vec![expected]);
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_cline_cli_uses_cline_dir_override() {
+        let mut env = EnvGuard::capture(&["CLINE_SESSION_DATA_DIR", "CLINE_DATA_DIR", "CLINE_DIR"]);
+        env.remove("CLINE_SESSION_DATA_DIR");
+        env.remove("CLINE_DATA_DIR");
+        let dir = TempDir::new().unwrap();
+        let home = dir.path().join("home");
+        let cline_dir = dir.path().join("custom-cline");
+
+        setup_mock_cline_cli_dir(&cline_dir.join("data"));
+        setup_mock_cline_cli_dir(&home.join(".cline/data"));
+        env.set("CLINE_DIR", &cline_dir);
+
+        let result = scan_all_clients_with_env_strategy(
+            home.to_str().unwrap(),
+            &["cline".to_string()],
+            true,
+        );
+        let expected = cline_dir.join("data/sessions/cli-session/cli-session.messages.json");
+
+        assert_eq!(result.get(ClientId::Cline), &vec![expected]);
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_cline_cli_ignores_env_roots_when_disabled() {
+        let mut env = EnvGuard::capture(&["CLINE_SESSION_DATA_DIR", "CLINE_DATA_DIR", "CLINE_DIR"]);
+        let dir = TempDir::new().unwrap();
+        let home = dir.path().join("home");
+        let session_data_dir = dir.path().join("custom-cline-sessions");
+        let data_dir = dir.path().join("custom-cline-data");
+        let cline_dir = dir.path().join("custom-cline");
+
+        setup_mock_cline_cli_session_root(&session_data_dir);
+        setup_mock_cline_cli_dir(&data_dir);
+        setup_mock_cline_cli_dir(&cline_dir.join("data"));
+        setup_mock_cline_cli_dir(&home.join(".cline/data"));
+        env.set("CLINE_SESSION_DATA_DIR", &session_data_dir);
+        env.set("CLINE_DATA_DIR", &data_dir);
+        env.set("CLINE_DIR", &cline_dir);
+
+        let result = scan_all_clients_with_env_strategy(
+            home.to_str().unwrap(),
+            &["cline".to_string()],
+            false,
+        );
+        let expected = home.join(".cline/data/sessions/cli-session/cli-session.messages.json");
+
+        assert_eq!(result.get(ClientId::Cline), &vec![expected]);
     }
 
     #[test]
     #[serial]
     fn test_scan_all_clients_cline_cli_whitespace_data_dir_uses_default() {
-        let mut env = EnvGuard::capture(&["CLINE_DATA_DIR"]);
+        let mut env = EnvGuard::capture(&["CLINE_SESSION_DATA_DIR", "CLINE_DATA_DIR", "CLINE_DIR"]);
+        env.remove("CLINE_SESSION_DATA_DIR");
+        env.remove("CLINE_DIR");
         let dir = TempDir::new().unwrap();
         let home = dir.path();
         setup_mock_cline_cli_dir(&home.join(".cline/data"));
@@ -4880,9 +4986,9 @@ mod tests {
             &["cline".to_string()],
             true,
         );
+        let expected = home.join(".cline/data/sessions/cli-session/cli-session.messages.json");
 
-        assert_eq!(result.get(ClientId::Cline).len(), 1);
-        assert!(result.get(ClientId::Cline)[0].starts_with(home));
+        assert_eq!(result.get(ClientId::Cline), &vec![expected]);
     }
 
     #[test]

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -877,16 +877,16 @@ fn cline_additional_vscode_task_roots(home_dir: &str, use_env_roots: bool) -> Ve
 }
 
 fn cline_cli_session_roots(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
-    let cline_dir = if use_env_roots {
-        std::env::var_os("CLINE_DIR")
-            .filter(|value| !value.is_empty())
+    let data_dir = if use_env_roots {
+        std::env::var_os("CLINE_DATA_DIR")
+            .filter(|value| !value.to_string_lossy().trim().is_empty())
             .map(PathBuf::from)
-            .unwrap_or_else(|| PathBuf::from(home_dir).join(".cline"))
+            .unwrap_or_else(|| PathBuf::from(home_dir).join(".cline/data"))
     } else {
-        PathBuf::from(home_dir).join(".cline")
+        PathBuf::from(home_dir).join(".cline/data")
     };
 
-    vec![cline_dir.join("data/sessions")]
+    vec![data_dir.join("sessions")]
 }
 
 pub fn devin_desktop_additional_roots(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
@@ -2830,8 +2830,8 @@ mod tests {
         File::create(server.join("ui_messages.json")).unwrap();
     }
 
-    fn setup_mock_cline_cli_dir(base: &std::path::Path) {
-        let sessions = base.join(".cline/data/sessions/cli-session");
+    fn setup_mock_cline_cli_dir(data_dir: &std::path::Path) {
+        let sessions = data_dir.join("sessions/cli-session");
         fs::create_dir_all(&sessions).unwrap();
         File::create(sessions.join("cli-session.messages.json")).unwrap();
     }
@@ -4832,7 +4832,7 @@ mod tests {
     fn test_scan_all_clients_cline_cli() {
         let dir = TempDir::new().unwrap();
         let home = dir.path();
-        setup_mock_cline_cli_dir(home);
+        setup_mock_cline_cli_dir(&home.join(".cline/data"));
 
         let result = scan_all_clients_with_env_strategy(
             home.to_str().unwrap(),
@@ -4844,6 +4844,45 @@ mod tests {
             .file_name()
             .and_then(|name| name.to_str())
             .is_some_and(|name| name.ends_with(".messages.json")));
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_cline_cli_uses_data_dir_override() {
+        let mut env = EnvGuard::capture(&["CLINE_DATA_DIR"]);
+        let dir = TempDir::new().unwrap();
+        let home = dir.path().join("home");
+        let data_dir = dir.path().join("custom-cline-data");
+        setup_mock_cline_cli_dir(&data_dir);
+        env.set("CLINE_DATA_DIR", &data_dir);
+
+        let result = scan_all_clients_with_env_strategy(
+            home.to_str().unwrap(),
+            &["cline".to_string()],
+            true,
+        );
+
+        assert_eq!(result.get(ClientId::Cline).len(), 1);
+        assert!(result.get(ClientId::Cline)[0].starts_with(&data_dir));
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_all_clients_cline_cli_whitespace_data_dir_uses_default() {
+        let mut env = EnvGuard::capture(&["CLINE_DATA_DIR"]);
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_cline_cli_dir(&home.join(".cline/data"));
+        env.set("CLINE_DATA_DIR", " \t ");
+
+        let result = scan_all_clients_with_env_strategy(
+            home.to_str().unwrap(),
+            &["cline".to_string()],
+            true,
+        );
+
+        assert_eq!(result.get(ClientId::Cline).len(), 1);
+        assert!(result.get(ClientId::Cline)[0].starts_with(home));
     }
 
     #[test]

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -396,6 +396,7 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
                 "unified.jsonl" => file_name == "unified.jsonl",
                 "events.jsonl" => file_name == "events.jsonl",
                 "ui_messages.json" => file_name == "ui_messages.json",
+                "cline-cli-messages" => file_name.ends_with(".messages.json"),
                 "session-usage.json" => file_name == "session-usage.json",
                 "chat-messages.json" => file_name == "chat-messages.json",
                 "workbuddy.db" => file_name == "workbuddy.db",
@@ -873,6 +874,19 @@ fn cline_additional_vscode_task_roots(home_dir: &str, use_env_roots: bool) -> Ve
     );
 
     roots
+}
+
+fn cline_cli_session_roots(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
+    let cline_dir = if use_env_roots {
+        std::env::var_os("CLINE_DIR")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(home_dir).join(".cline"))
+    } else {
+        PathBuf::from(home_dir).join(".cline")
+    };
+
+    vec![cline_dir.join("data/sessions")]
 }
 
 pub fn devin_desktop_additional_roots(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
@@ -1615,6 +1629,16 @@ fn scan_all_clients_with_env_strategy_inner(
         for root in cline_additional_vscode_task_roots(home_dir, use_env_roots) {
             push_unique_scan_task(&mut tasks, &mut seen_scan_roots, ClientId::Cline, root);
         }
+
+        for root in cline_cli_session_roots(home_dir, use_env_roots) {
+            push_unique_scan_task_with_pattern(
+                &mut tasks,
+                &mut seen_scan_roots,
+                ClientId::Cline,
+                root,
+                "cline-cli-messages",
+            );
+        }
     }
 
     if enabled.contains(&ClientId::DevinDesktop) {
@@ -2209,6 +2233,19 @@ mod tests {
     }
 
     #[test]
+    fn test_scan_directory_cline_cli_messages_pattern() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path();
+
+        File::create(path.join("session.messages.json")).unwrap();
+        File::create(path.join("session.json")).unwrap();
+        File::create(path.join("session.messages.jsonl")).unwrap();
+
+        let files = scan_directory(path.to_str().unwrap(), "cline-cli-messages");
+        assert_eq!(files, vec![path.join("session.messages.json")]);
+    }
+
+    #[test]
     fn test_scan_directory_nested() {
         let dir = TempDir::new().unwrap();
         let path = dir.path();
@@ -2783,6 +2820,12 @@ mod tests {
         File::create(macos.join("ui_messages.json")).unwrap();
         File::create(windows.join("ui_messages.json")).unwrap();
         File::create(server.join("ui_messages.json")).unwrap();
+    }
+
+    fn setup_mock_cline_cli_dir(base: &std::path::Path) {
+        let sessions = base.join(".cline/data/sessions/cli-session");
+        fs::create_dir_all(&sessions).unwrap();
+        File::create(sessions.join("cli-session.messages.json")).unwrap();
     }
 
     fn setup_mock_crush_registry(registry_path: &Path, projects_json: &str) {
@@ -4757,6 +4800,24 @@ mod tests {
             .get(ClientId::Cline)
             .iter()
             .all(|p| p.ends_with("ui_messages.json")));
+    }
+
+    #[test]
+    fn test_scan_all_clients_cline_cli() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        setup_mock_cline_cli_dir(home);
+
+        let result = scan_all_clients_with_env_strategy(
+            home.to_str().unwrap(),
+            &["cline".to_string()],
+            false,
+        );
+        assert_eq!(result.get(ClientId::Cline).len(), 1);
+        assert!(result.get(ClientId::Cline)[0]
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.ends_with(".messages.json")));
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/cline.rs
+++ b/crates/tokscale-core/src/sessions/cline.rs
@@ -33,9 +33,26 @@ struct ClineCliMessage {
     id: Option<String>,
     role: Option<String>,
     ts: Option<Value>,
+    content: Option<Vec<Value>>,
     #[serde(rename = "modelInfo")]
     model_info: Option<ClineCliModelInfo>,
     metrics: Option<ClineCliMetrics>,
+}
+
+fn is_human_user_prompt(content: Option<&[Value]>) -> bool {
+    let Some(content) = content else {
+        return false;
+    };
+
+    let mut has_text_block = false;
+    for block in content {
+        match block.get("type").and_then(Value::as_str) {
+            Some("tool_result") => return false,
+            Some("text") => has_text_block = true,
+            _ => {}
+        }
+    }
+    has_text_block
 }
 
 #[derive(Debug, Deserialize)]
@@ -160,7 +177,9 @@ pub fn parse_cline_cli_file(path: &Path) -> Vec<UnifiedMessage> {
 
     for entry in file.messages.unwrap_or_default() {
         if entry.role.as_deref() == Some("user") {
-            pending_turn_start = true;
+            if is_human_user_prompt(entry.content.as_deref()) {
+                pending_turn_start = true;
+            }
             continue;
         }
         if entry.role.as_deref() != Some("assistant") {
@@ -338,7 +357,11 @@ mod tests {
   "sessionId": "cline-cli-session",
   "agent": "lead",
   "messages": [
-    {"role": "user", "ts": 1785320464923},
+    {
+      "role": "user",
+      "ts": 1785320464923,
+      "content": [{"type": "text", "text": "Inspect this project."}]
+    },
     {
       "id": "msg-1",
       "role": "assistant",
@@ -377,6 +400,99 @@ mod tests {
         assert_eq!(messages[0].workspace_label.as_deref(), Some("project"));
         assert_eq!(messages[0].session_title.as_deref(), Some("CLI task"));
         assert!(messages[0].is_turn_start);
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some("cline-cli:cline-cli-session:msg-1")
+        );
+    }
+
+    #[test]
+    fn test_parse_cline_cli_turn_starts_ignore_tool_results() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("turns.messages.json");
+        fs::write(
+            &path,
+            r#"{
+  "sessionId": "turns",
+  "messages": [
+    {
+      "id": "prompt-1",
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "Please inspect the repository."}
+      ]
+    },
+    {
+      "id": "assistant-tool-use",
+      "role": "assistant",
+      "content": [
+        {"type": "text", "text": "I will inspect the repository."},
+        {
+          "type": "tool_use",
+          "id": "tool-1",
+          "name": "read_file",
+          "input": {"path": "README.md"}
+        },
+        {"type": "future_block", "payload": {"priority": "low"}}
+      ],
+      "modelInfo": {"id": "provider/model", "provider": "provider"},
+      "metrics": {
+        "inputTokens": 100,
+        "outputTokens": 20,
+        "cacheReadTokens": 10,
+        "cacheWriteTokens": 5,
+        "cost": 0.02
+      }
+    },
+    {
+      "id": "tool-result",
+      "role": "user",
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "tool-1",
+          "content": [{"type": "text", "text": "README contents"}]
+        }
+      ]
+    },
+    {
+      "id": "assistant-final",
+      "role": "assistant",
+      "content": [
+        {"type": "text", "text": "The repository is ready."}
+      ],
+      "metrics": {
+        "inputTokens": 15,
+        "outputTokens": 6,
+        "cacheReadTokens": 0,
+        "cacheWriteTokens": 0
+      }
+    }
+  ]
+}"#,
+        )
+        .unwrap();
+
+        let messages = parse_cline_cli_file(&path);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some("cline-cli:turns:assistant-tool-use")
+        );
+        assert_eq!(
+            messages[1].dedup_key.as_deref(),
+            Some("cline-cli:turns:assistant-final")
+        );
+        assert!(messages[0].is_turn_start);
+        assert!(!messages[1].is_turn_start);
+        assert_eq!(
+            messages
+                .iter()
+                .filter(|message| message.is_turn_start)
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/cline.rs
+++ b/crates/tokscale-core/src/sessions/cline.rs
@@ -67,13 +67,13 @@ struct ClineCliManifest {
     metadata: Option<Value>,
 }
 
-fn is_cline_cli_messages_path(path: &Path) -> bool {
+pub(crate) fn is_cline_cli_messages_path(path: &Path) -> bool {
     path.file_name()
         .and_then(|name| name.to_str())
         .is_some_and(|name| name.ends_with(".messages.json"))
 }
 
-fn cline_cli_manifest_path(path: &Path) -> PathBuf {
+pub(crate) fn cline_cli_manifest_path(path: &Path) -> PathBuf {
     let stem = path
         .file_stem()
         .and_then(|name| name.to_str())
@@ -108,6 +108,10 @@ fn extract_f64(value: Option<&Value>) -> Option<f64> {
             .or_else(|| value.as_u64().map(|value| value as f64))
             .or_else(|| value.as_str().and_then(|value| value.parse::<f64>().ok()))
     })
+}
+
+fn extract_non_negative_finite_f64(value: Option<&Value>) -> Option<f64> {
+    extract_f64(value).filter(|value| value.is_finite() && *value >= 0.0)
 }
 
 /// Parse Cline CLI's persisted assistant messages from
@@ -175,7 +179,7 @@ pub fn parse_cline_cli_file(path: &Path) -> Vec<UnifiedMessage> {
         let Some(metrics) = entry.metrics else {
             continue;
         };
-        let input = extract_i64(metrics.input_tokens.as_ref())
+        let input_tokens = extract_i64(metrics.input_tokens.as_ref())
             .unwrap_or(0)
             .max(0);
         let output = extract_i64(metrics.output_tokens.as_ref())
@@ -187,9 +191,17 @@ pub fn parse_cline_cli_file(path: &Path) -> Vec<UnifiedMessage> {
         let cache_write = extract_i64(metrics.cache_write_tokens.as_ref())
             .unwrap_or(0)
             .max(0);
-        let cost = extract_f64(metrics.cost.as_ref()).unwrap_or(0.0).max(0.0);
+        let input = input_tokens
+            .saturating_sub(cache_read)
+            .saturating_sub(cache_write);
+        let reported_cost = extract_non_negative_finite_f64(metrics.cost.as_ref());
+        let cost = reported_cost.unwrap_or(0.0);
 
-        if input + output + cache_read + cache_write == 0 && cost == 0.0 {
+        let total_tokens = input
+            .saturating_add(output)
+            .saturating_add(cache_read)
+            .saturating_add(cache_write);
+        if total_tokens == 0 && reported_cost.is_none() {
             continue;
         }
 
@@ -223,7 +235,7 @@ pub fn parse_cline_cli_file(path: &Path) -> Vec<UnifiedMessage> {
         message.is_turn_start = pending_turn_start;
         message.session_title = session_title.clone();
         message.set_workspace(workspace_key.clone(), workspace_label.clone());
-        if cost > 0.0 {
+        if reported_cost.is_some() {
             message.mark_provider_reported_cost();
         }
         messages.push(message);
@@ -353,7 +365,7 @@ mod tests {
         assert_eq!(messages[0].model_id, "cline-free/glm-5.2");
         assert_eq!(messages[0].session_id, "cline-cli-session");
         assert_eq!(messages[0].agent.as_deref(), Some("lead"));
-        assert_eq!(messages[0].tokens.input, 7507);
+        assert_eq!(messages[0].tokens.input, 7457);
         assert_eq!(messages[0].tokens.output, 131);
         assert_eq!(messages[0].tokens.cache_read, 50);
         assert_eq!(messages[0].tokens.cache_write, 0);
@@ -365,5 +377,57 @@ mod tests {
         assert_eq!(messages[0].workspace_label.as_deref(), Some("project"));
         assert_eq!(messages[0].session_title.as_deref(), Some("CLI task"));
         assert!(messages[0].is_turn_start);
+    }
+
+    #[test]
+    fn test_parse_cline_cli_normalizes_cache_tokens_and_preserves_zero_cost() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("session.messages.json");
+        fs::write(
+            &path,
+            r#"{
+  "sessionId": "session-1",
+  "messages": [
+    {
+      "id": "zero-cost",
+      "role": "assistant",
+      "metrics": {
+        "inputTokens": 12,
+        "outputTokens": 0,
+        "cacheReadTokens": 5,
+        "cacheWriteTokens": 2,
+        "cost": 0
+      }
+    },
+    {
+      "id": "invalid-cost",
+      "role": "assistant",
+      "metrics": {
+        "inputTokens": 1,
+        "outputTokens": 2,
+        "cost": "NaN"
+      }
+    }
+  ]
+}"#,
+        )
+        .unwrap();
+
+        let messages = parse_cline_cli_file(&path);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].tokens.input, 5);
+        assert_eq!(messages[0].tokens.cache_read, 5);
+        assert_eq!(messages[0].tokens.cache_write, 2);
+        assert_eq!(messages[0].cost, 0.0);
+        assert_eq!(
+            messages[0].cost_source,
+            crate::sessions::CostSource::ProviderReported
+        );
+        assert_eq!(messages[1].cost, 0.0);
+        assert_eq!(
+            messages[1].cost_source,
+            crate::sessions::CostSource::Unknown
+        );
     }
 }

--- a/crates/tokscale-core/src/sessions/cline.rs
+++ b/crates/tokscale-core/src/sessions/cline.rs
@@ -5,11 +5,233 @@
 //! parser helper.
 
 use super::roocode::parse_roo_kilo_file;
-use super::UnifiedMessage;
-use std::path::Path;
+use super::utils::{extract_i64, file_modified_timestamp_ms, parse_timestamp_value};
+use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
+use crate::TokenBreakdown;
+use serde::Deserialize;
+use serde_json::Value;
+use std::path::{Path, PathBuf};
 
 pub fn parse_cline_file(path: &Path) -> Vec<UnifiedMessage> {
+    if is_cline_cli_messages_path(path) {
+        return parse_cline_cli_file(path);
+    }
+
     parse_roo_kilo_file(path, "cline")
+}
+
+#[derive(Debug, Deserialize)]
+struct ClineCliMessagesFile {
+    #[serde(rename = "sessionId")]
+    session_id: Option<String>,
+    agent: Option<String>,
+    messages: Option<Vec<ClineCliMessage>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClineCliMessage {
+    id: Option<String>,
+    role: Option<String>,
+    ts: Option<Value>,
+    #[serde(rename = "modelInfo")]
+    model_info: Option<ClineCliModelInfo>,
+    metrics: Option<ClineCliMetrics>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClineCliModelInfo {
+    id: Option<String>,
+    provider: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClineCliMetrics {
+    #[serde(rename = "inputTokens")]
+    input_tokens: Option<Value>,
+    #[serde(rename = "outputTokens")]
+    output_tokens: Option<Value>,
+    #[serde(rename = "cacheReadTokens")]
+    cache_read_tokens: Option<Value>,
+    #[serde(rename = "cacheWriteTokens")]
+    cache_write_tokens: Option<Value>,
+    cost: Option<Value>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ClineCliManifest {
+    session_id: Option<String>,
+    provider: Option<String>,
+    model: Option<String>,
+    cwd: Option<String>,
+    workspace_root: Option<String>,
+    metadata: Option<Value>,
+}
+
+fn is_cline_cli_messages_path(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".messages.json"))
+}
+
+fn cline_cli_manifest_path(path: &Path) -> PathBuf {
+    let stem = path
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    let session_stem = stem.strip_suffix(".messages").unwrap_or(stem);
+    path.parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(format!("{session_stem}.json"))
+}
+
+fn read_cline_cli_manifest(path: &Path) -> ClineCliManifest {
+    let manifest_path = cline_cli_manifest_path(path);
+    let Ok(mut bytes) = std::fs::read(manifest_path) else {
+        return ClineCliManifest::default();
+    };
+
+    simd_json::from_slice(&mut bytes).unwrap_or_default()
+}
+
+fn non_empty_string(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn extract_f64(value: Option<&Value>) -> Option<f64> {
+    value.and_then(|value| {
+        value
+            .as_f64()
+            .or_else(|| value.as_i64().map(|value| value as f64))
+            .or_else(|| value.as_u64().map(|value| value as f64))
+            .or_else(|| value.as_str().and_then(|value| value.parse::<f64>().ok()))
+    })
+}
+
+/// Parse Cline CLI's persisted assistant messages from
+/// `~/.cline/data/sessions/<session>/<session>.messages.json`.
+pub fn parse_cline_cli_file(path: &Path) -> Vec<UnifiedMessage> {
+    let Some(data) = super::utils::read_file_or_none(path) else {
+        return Vec::new();
+    };
+
+    let mut bytes = data;
+    let Ok(file) = simd_json::from_slice::<ClineCliMessagesFile>(&mut bytes) else {
+        return Vec::new();
+    };
+    let manifest = read_cline_cli_manifest(path);
+
+    let session_id = file
+        .session_id
+        .or(manifest.session_id)
+        .or_else(|| {
+            path.file_stem()
+                .and_then(|name| name.to_str())
+                .map(|name| name.trim_end_matches(".messages").to_string())
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+    let fallback_timestamp = file_modified_timestamp_ms(path);
+    let workspace_key = manifest
+        .workspace_root
+        .as_deref()
+        .or(manifest.cwd.as_deref())
+        .and_then(normalize_workspace_key);
+    let workspace_label = workspace_key.as_deref().and_then(workspace_label_from_key);
+    let session_title = manifest
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("title"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+
+    let mut current_model =
+        non_empty_string(manifest.model.as_deref()).unwrap_or_else(|| "unknown".to_string());
+    let mut current_provider =
+        non_empty_string(manifest.provider.as_deref()).unwrap_or_else(|| "unknown".to_string());
+    let mut pending_turn_start = false;
+    let mut assistant_index = 0usize;
+    let mut messages = Vec::new();
+
+    for entry in file.messages.unwrap_or_default() {
+        if entry.role.as_deref() == Some("user") {
+            pending_turn_start = true;
+            continue;
+        }
+        if entry.role.as_deref() != Some("assistant") {
+            continue;
+        }
+
+        if let Some(model_info) = entry.model_info.as_ref() {
+            if let Some(model) = non_empty_string(model_info.id.as_deref()) {
+                current_model = model;
+            }
+            if let Some(provider) = non_empty_string(model_info.provider.as_deref()) {
+                current_provider = provider;
+            }
+        }
+
+        let Some(metrics) = entry.metrics else {
+            continue;
+        };
+        let input = extract_i64(metrics.input_tokens.as_ref())
+            .unwrap_or(0)
+            .max(0);
+        let output = extract_i64(metrics.output_tokens.as_ref())
+            .unwrap_or(0)
+            .max(0);
+        let cache_read = extract_i64(metrics.cache_read_tokens.as_ref())
+            .unwrap_or(0)
+            .max(0);
+        let cache_write = extract_i64(metrics.cache_write_tokens.as_ref())
+            .unwrap_or(0)
+            .max(0);
+        let cost = extract_f64(metrics.cost.as_ref()).unwrap_or(0.0).max(0.0);
+
+        if input + output + cache_read + cache_write == 0 && cost == 0.0 {
+            continue;
+        }
+
+        let timestamp = entry
+            .ts
+            .as_ref()
+            .and_then(parse_timestamp_value)
+            .unwrap_or(fallback_timestamp);
+        let dedup_key = entry
+            .id
+            .filter(|id| !id.trim().is_empty())
+            .map(|id| format!("cline-cli:{session_id}:{id}"))
+            .unwrap_or_else(|| format!("cline-cli:{session_id}:{assistant_index}"));
+        let mut message = UnifiedMessage::new_with_agent(
+            "cline",
+            current_model.clone(),
+            current_provider.clone(),
+            session_id.clone(),
+            timestamp,
+            TokenBreakdown {
+                input,
+                output,
+                cache_read,
+                cache_write,
+                reasoning: 0,
+            },
+            cost,
+            file.agent.clone(),
+        );
+        message.dedup_key = Some(dedup_key);
+        message.is_turn_start = pending_turn_start;
+        message.session_title = session_title.clone();
+        message.set_workspace(workspace_key.clone(), workspace_label.clone());
+        if cost > 0.0 {
+            message.mark_provider_reported_cost();
+        }
+        messages.push(message);
+        assistant_index += 1;
+        pending_turn_start = false;
+    }
+
+    messages
 }
 
 #[cfg(test)]
@@ -80,5 +302,68 @@ mod tests {
 
         let messages = parse_cline_file(&task_dir.join("ui_messages.json"));
         assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_parse_cline_cli_messages() {
+        let dir = TempDir::new().unwrap();
+        let session_dir = dir.path().join("sessions").join("cline-cli-session");
+        fs::create_dir_all(&session_dir).unwrap();
+        fs::write(
+            session_dir.join("cline-cli-session.json"),
+            r#"{
+  "session_id": "cline-cli-session",
+  "provider": "cline-pass",
+  "model": "cline-pass/glm-5.2",
+  "workspace_root": "/home/example/project",
+  "metadata": {"title": "CLI task"}
+}"#,
+        )
+        .unwrap();
+        fs::write(
+            session_dir.join("cline-cli-session.messages.json"),
+            r#"{
+  "sessionId": "cline-cli-session",
+  "agent": "lead",
+  "messages": [
+    {"role": "user", "ts": 1785320464923},
+    {
+      "id": "msg-1",
+      "role": "assistant",
+      "ts": 1785320475705,
+      "modelInfo": {"id": "cline-free/glm-5.2", "provider": "cline-pass"},
+      "metrics": {
+        "inputTokens": 7507,
+        "outputTokens": 131,
+        "cacheReadTokens": 50,
+        "cacheWriteTokens": 0,
+        "cost": 0.0110232
+      }
+    },
+    {"role": "assistant", "metrics": {"inputTokens": 0, "outputTokens": 0}}
+  ]
+}"#,
+        )
+        .unwrap();
+
+        let messages = parse_cline_file(&session_dir.join("cline-cli-session.messages.json"));
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, "cline");
+        assert_eq!(messages[0].provider_id, "cline-pass");
+        assert_eq!(messages[0].model_id, "cline-free/glm-5.2");
+        assert_eq!(messages[0].session_id, "cline-cli-session");
+        assert_eq!(messages[0].agent.as_deref(), Some("lead"));
+        assert_eq!(messages[0].tokens.input, 7507);
+        assert_eq!(messages[0].tokens.output, 131);
+        assert_eq!(messages[0].tokens.cache_read, 50);
+        assert_eq!(messages[0].tokens.cache_write, 0);
+        assert_eq!(messages[0].cost, 0.0110232);
+        assert_eq!(
+            messages[0].cost_source,
+            crate::sessions::CostSource::ProviderReported
+        );
+        assert_eq!(messages[0].workspace_label.as_deref(), Some("project"));
+        assert_eq!(messages[0].session_title.as_deref(), Some("CLI task"));
+        assert!(messages[0].is_turn_start);
     }
 }

--- a/crates/tokscale-core/src/sessions/kimchi.rs
+++ b/crates/tokscale-core/src/sessions/kimchi.rs
@@ -4,12 +4,12 @@
 //! agent directory. Reuse the shared Pi parser while stamping messages with
 //! the distinct `kimchi` client id.
 
-use super::pi::parse_pi_format_file;
+use super::pi::parse_pi_format_file_with_dedup;
 use super::UnifiedMessage;
 use std::path::Path;
 
 pub fn parse_kimchi_file(path: &Path) -> Vec<UnifiedMessage> {
-    parse_pi_format_file(path, "kimchi", "kimchi")
+    parse_pi_format_file_with_dedup(path, "kimchi", "kimchi")
 }
 
 #[cfg(test)]
@@ -42,6 +42,10 @@ mod tests {
         assert_eq!(messages[0].tokens.input, 9441);
         assert_eq!(messages[0].tokens.output, 131);
         assert_eq!(messages[0].tokens.cache_read, 50);
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some("kimchi:kimchi_ses_001:msg_001")
+        );
         assert_eq!(
             messages[0].workspace_label.as_deref(),
             Some("kimchi-project")

--- a/crates/tokscale-core/src/sessions/kimchi.rs
+++ b/crates/tokscale-core/src/sessions/kimchi.rs
@@ -1,0 +1,50 @@
+//! Kimchi Coding session parser.
+//!
+//! Kimchi stores sessions in the Pi-compatible JSONL format under its own
+//! agent directory. Reuse the shared Pi parser while stamping messages with
+//! the distinct `kimchi` client id.
+
+use super::pi::parse_pi_format_file;
+use super::UnifiedMessage;
+use std::path::Path;
+
+pub fn parse_kimchi_file(path: &Path) -> Vec<UnifiedMessage> {
+    parse_pi_format_file(path, "kimchi", "kimchi")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_parse_kimchi_pi_format_session() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{"type":"session","id":"kimchi_ses_001","timestamp":"2026-08-01T00:00:00.000Z","cwd":"/tmp/kimchi-project"}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            r#"{{"type":"message","id":"msg_001","timestamp":"2026-08-01T00:00:01.000Z","message":{{"role":"assistant","model":"kimi-k2.6","provider":"kimchi-dev","usage":{{"input":9441,"output":131,"cacheRead":50,"cacheWrite":0,"totalTokens":9622}}}}}}"#
+        )
+        .unwrap();
+
+        let messages = parse_kimchi_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, "kimchi");
+        assert_eq!(messages[0].session_id, "kimchi_ses_001");
+        assert_eq!(messages[0].provider_id, "kimchi-dev");
+        assert_eq!(messages[0].model_id, "kimi-k2.6");
+        assert_eq!(messages[0].tokens.input, 9441);
+        assert_eq!(messages[0].tokens.output, 131);
+        assert_eq!(messages[0].tokens.cache_read, 50);
+        assert_eq!(
+            messages[0].workspace_label.as_deref(),
+            Some("kimchi-project")
+        );
+    }
+}

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -28,6 +28,7 @@ pub mod jcode;
 pub mod junie;
 pub mod kilo;
 pub mod kilocode;
+pub mod kimchi;
 pub mod kimi;
 pub mod kiro;
 pub mod micode;

--- a/crates/tokscale-core/src/sessions/pi.rs
+++ b/crates/tokscale-core/src/sessions/pi.rs
@@ -133,6 +133,26 @@ pub(crate) fn parse_pi_format_file(
     client: &str,
     fallback_provider: &'static str,
 ) -> Vec<UnifiedMessage> {
+    parse_pi_format_file_inner(path, client, fallback_provider, None)
+}
+
+/// Parse a Pi-format session and retain message ids in namespaced dedup keys.
+/// Pi-compatible clients that need cross-file deduplication can opt into this
+/// without changing the historical output of the shared Pi and Senpi parsers.
+pub(crate) fn parse_pi_format_file_with_dedup(
+    path: &Path,
+    client: &str,
+    fallback_provider: &'static str,
+) -> Vec<UnifiedMessage> {
+    parse_pi_format_file_inner(path, client, fallback_provider, Some(client))
+}
+
+fn parse_pi_format_file_inner(
+    path: &Path,
+    client: &str,
+    fallback_provider: &'static str,
+    dedup_namespace: Option<&str>,
+) -> Vec<UnifiedMessage> {
     let file = match std::fs::File::open(path) {
         Ok(f) => f,
         Err(_) => return Vec::new(),
@@ -203,6 +223,7 @@ pub(crate) fn parse_pi_format_file(
             continue;
         }
 
+        let message_id = entry.id;
         let message = match entry.message {
             Some(m) => m,
             None => continue,
@@ -261,6 +282,12 @@ pub(crate) fn parse_pi_format_file(
             0.0,
             agent.clone(),
         );
+        if let Some(namespace) = dedup_namespace {
+            if let Some(message_id) = message_id.as_deref().filter(|id| !id.trim().is_empty()) {
+                let session_id = session_id.as_deref().unwrap_or("unknown");
+                unified.dedup_key = Some(format!("{namespace}:{session_id}:{message_id}"));
+            }
+        }
         unified.set_workspace(workspace_key.clone(), workspace_label.clone());
         messages.push(unified);
     }

--- a/packages/frontend/src/lib/constants.ts
+++ b/packages/frontend/src/lib/constants.ts
@@ -70,6 +70,7 @@ export const SOURCE_DISPLAY_NAMES: Record<ClientType, string> = {
   "devin-desktop": "Devin Desktop",
   senpi: "Senpi (OmO Native)",
   augment: "Augment Code",
+  kimchi: "Kimchi",
 };
 
 // Client logos from GitHub CDN (public repo)
@@ -123,6 +124,7 @@ export const SOURCE_LOGOS: Record<ClientType, string> = {
   "devin-desktop": `${GITHUB_CDN_BASE}/client-devin.jpg`,
   senpi: `${GITHUB_CDN_BASE}/client-senpi.png`,
   augment: "https://github.com/augmentcode.png",
+  kimchi: "https://github.com/getkimchi.png",
 };
 
 export const SOURCE_COLORS: Record<ClientType, string> = {
@@ -169,6 +171,7 @@ export const SOURCE_COLORS: Record<ClientType, string> = {
   "devin-desktop": "#334155",
   senpi: "#2F6F63",
   augment: "#9333EA",
+  kimchi: "#F97316",
 };
 
 // Derived values

--- a/packages/frontend/src/lib/constants.ts
+++ b/packages/frontend/src/lib/constants.ts
@@ -171,7 +171,7 @@ export const SOURCE_COLORS: Record<ClientType, string> = {
   "devin-desktop": "#334155",
   senpi: "#2F6F63",
   augment: "#9333EA",
-  kimchi: "#F97316",
+  kimchi: "#14B8A6",
 };
 
 // Derived values

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -42,6 +42,7 @@ export const SUPPORTED_CLIENT_TYPES = [
   "devin-desktop",
   "senpi",
   "augment",
+  "kimchi",
 ] as const;
 
 export type CcMirrorClientType = `cc-mirror/${string}`;


### PR DESCRIPTION
## Summary

- Add standalone Cline CLI session parsing from `~/.cline/data/sessions/` (or `$CLINE_DIR/data/sessions/`) while preserving the existing VS Code Cline parser.
- Add first-class Kimchi Coding support from Pi-compatible JSONL sessions in `~/.config/kimchi/harness/sessions/` (or `$KIMCHI_CODING_AGENT_DIR/sessions/`).
- Preserve model, provider, workspace, session, input/output/cache token, and cost data; Kimchi remains distinct from Pi despite the shared session format.
- Register both clients across scanning, CLI filters, TUI navigation, wrapped output, frontend metadata, and documentation.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p tokscale-core` — 1,329 passed, 1 ignored
- `cargo test -p tokscale-cli` — 972 unit tests and 133 integration tests passed
- `cargo clippy -p tokscale-core --all-features -- -D warnings`
- Live scan: `cargo run -p tokscale-cli -- --client kimchi --light --no-spinner` successfully read the local Kimchi session store.

The frontend typecheck could not run in this checkout because the `tsc` binary is not installed.