### PR TITLE
fix(grok): parse unified token usage

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1357,16 +1357,18 @@ fn parse_all_messages_with_pricing_with_env_strategy(
                 &source_cache,
                 pricing,
                 message_cache::SourceFingerprint::check_grok_path_samples_only,
-                sessions::grok::parse_grok_updates_file,
+                sessions::grok::parse_grok_file,
             )
         })
         .collect();
+    let mut grok_messages = Vec::new();
     for outcome in grok_outcomes {
-        all_messages.extend(outcome.messages);
+        grok_messages.extend(outcome.messages);
         if let Some(entry) = outcome.cache_entry {
             source_cache.insert(entry);
         }
     }
+    all_messages.extend(sessions::grok::prefer_unified_log_messages(grok_messages));
 
     let jcode_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::Jcode)
@@ -3652,15 +3654,14 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     counts.set(ClientId::WorkBuddy, workbuddy_count);
     messages.extend(workbuddy_msgs);
 
-    let grok_msgs: Vec<ParsedMessage> = scan_result
+    let grok_messages: Vec<UnifiedMessage> = scan_result
         .get(ClientId::Grok)
         .par_iter()
-        .flat_map(|path| {
-            sessions::grok::parse_grok_updates_file(path)
-                .into_iter()
-                .map(|msg| unified_to_parsed(&msg))
-                .collect::<Vec<_>>()
-        })
+        .flat_map(|path| sessions::grok::parse_grok_file(path))
+        .collect();
+    let grok_msgs: Vec<ParsedMessage> = sessions::grok::prefer_unified_log_messages(grok_messages)
+        .into_iter()
+        .map(|msg| unified_to_parsed(&msg))
         .collect();
     let grok_count = summed_parsed_message_count(&grok_msgs);
     counts.set(ClientId::Grok, grok_count);
@@ -5024,6 +5025,53 @@ mod tests {
 {"timestamp": 1770983450.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 8, "output": 1, "input_cache_read": 0, "input_cache_creation": 0}}}}"#,
         )
         .unwrap();
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parse_all_messages_with_pricing_prefers_grok_unified_log() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            let session_dir = source_home
+                .path()
+                .join(".grok/sessions/%2Ftmp%2Fproject/session-1");
+            std::fs::create_dir_all(&session_dir).unwrap();
+            std::fs::write(
+                session_dir.join("updates.jsonl"),
+                r#"{"method":"session/update","params":{"sessionId":"session-1","_meta":{"totalTokens":999,"agentTimestampMs":1700000000000}}}"#,
+            )
+            .unwrap();
+
+            let logs_dir = source_home.path().join(".grok/logs");
+            std::fs::create_dir_all(&logs_dir).unwrap();
+            std::fs::write(
+                logs_dir.join("unified.jsonl"),
+                r#"{"ts":"2023-11-14T22:13:20Z","pid":7,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":100,"cached_prompt_tokens":60,"completion_tokens":25,"reasoning_tokens":5}}"#,
+            )
+            .unwrap();
+
+            let messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["grok".to_string()],
+                None,
+            );
+
+            assert_eq!(messages.len(), 1);
+            assert_eq!(messages[0].tokens.input, 40);
+            assert_eq!(messages[0].tokens.cache_read, 60);
+            assert_eq!(messages[0].tokens.output, 20);
+            assert_eq!(messages[0].tokens.reasoning, 5);
+            assert_eq!(messages[0].tokens.total(), 125);
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
     }
 
     #[test]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -874,6 +874,9 @@ fn parser_version(client: ClientId) -> u32 {
         // session_model_usage instead of crediting the whole session to
         // sessions.model, and dedup keys are namespaced per (session, model).
         ClientId::Hermes => 2,
+        // v2 added per-turn usage records. v3 adds the canonical unified log,
+        // non-overlapping output/cache/reasoning buckets, and session metadata.
+        ClientId::Grok => 3,
         _ => 1,
     }
 }

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -372,6 +372,7 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
                 "sessions.json" => file_name == "sessions.json",
                 "wire.jsonl" => file_name == "wire.jsonl",
                 "updates.jsonl" => file_name == "updates.jsonl",
+                "unified.jsonl" => file_name == "unified.jsonl",
                 "events.jsonl" => file_name == "events.jsonl",
                 "ui_messages.json" => file_name == "ui_messages.json",
                 "session-usage.json" => file_name == "session-usage.json",
@@ -1158,6 +1159,23 @@ fn scan_all_clients_with_env_strategy_inner(
         let def = client_id.data();
         let path = def.resolve_path_with_env_strategy(home_dir, use_env_roots);
         push_unique_scan_task(&mut tasks, &mut seen_scan_roots, *client_id, path);
+    }
+
+    if enabled.contains(&ClientId::Grok) {
+        let grok_sessions = PathBuf::from(
+            ClientId::Grok
+                .data()
+                .resolve_path_with_env_strategy(home_dir, use_env_roots),
+        );
+        if let Some(grok_home) = grok_sessions.parent() {
+            push_unique_scan_task_with_pattern(
+                &mut tasks,
+                &mut seen_scan_roots,
+                ClientId::Grok,
+                grok_home.join("logs/unified.jsonl"),
+                "unified.jsonl",
+            );
+        }
     }
 
     for (client_id, path) in extra_scan_paths_for(scanner_settings, &enabled_with_devin_lookup) {
@@ -4452,13 +4470,27 @@ mod tests {
         let home = dir.path();
         setup_mock_grok_dir(home);
 
+        let unified_dir = home.join(".grok/logs");
+        fs::create_dir_all(&unified_dir).unwrap();
+        let unified_log = unified_dir.join("unified.jsonl");
+        File::create(&unified_log).unwrap();
+        let nested_dir = unified_dir.join("archive");
+        fs::create_dir_all(&nested_dir).unwrap();
+        let nested_log = nested_dir.join("unified.jsonl");
+        File::create(&nested_log).unwrap();
+
         let result = scan_all_clients_with_env_strategy(
             home.to_str().unwrap(),
             &["grok".to_string()],
             false,
         );
-        assert_eq!(result.get(ClientId::Grok).len(), 1);
-        assert!(result.get(ClientId::Grok)[0].ends_with("updates.jsonl"));
+        let grok_files = result.get(ClientId::Grok);
+        assert_eq!(grok_files.len(), 2);
+        assert!(grok_files
+            .iter()
+            .any(|path| path.ends_with("updates.jsonl")));
+        assert!(grok_files.iter().any(|path| path == &unified_log));
+        assert!(!grok_files.iter().any(|path| path == &nested_log));
         assert!(result.get(ClientId::OpenCode).is_empty());
         assert!(result.get(ClientId::Claude).is_empty());
     }

--- a/crates/tokscale-core/src/sessions/grok.rs
+++ b/crates/tokscale-core/src/sessions/grok.rs
@@ -3,11 +3,12 @@
 //! Grok Build writes JSON-RPC session updates under
 //! `~/.grok/sessions/<urlencoded-workspace>/<session-id>/updates.jsonl`.
 //! Session rollups also land in sibling `signals.json` (including
-//! `totalTokensBeforeCompaction` and `contextTokensUsed`). Current update
-//! logs expose cumulative `totalTokens` counters without a stable
-//! input/output split, so this parser records per-turn positive total-token
-//! deltas as input tokens and reconciles any remaining `signals.json` total
-//! so compacted sessions are not under-counted.
+//! `totalTokensBeforeCompaction` and `contextTokensUsed`). Legacy update logs
+//! expose cumulative `totalTokens` counters without a stable input/output
+//! split, so this parser records per-turn positive total-token deltas as input
+//! tokens and reconciles any remaining `signals.json` total so compacted
+//! sessions are not under-counted. Recent Grok Build releases additionally
+//! write per-inference token breakdowns to `~/.grok/logs/unified.jsonl`.
 
 use super::utils::{
     extract_i64, extract_string, file_modified_timestamp_ms, parse_timestamp_value,
@@ -16,12 +17,14 @@ use super::utils::{
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
 use serde_json::Value;
+use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
 const CLIENT_ID: &str = "grok";
 const PROVIDER_ID: &str = "xai";
 const UNKNOWN_MODEL: &str = "grok-unknown";
+const UNIFIED_LOG_DEDUP_PREFIX: &str = "grok-unified:";
 
 #[derive(Debug, Clone)]
 struct GrokMetadata {
@@ -39,6 +42,119 @@ struct ActiveTurn {
     timestamp: i64,
     model_id: String,
     turn_index: usize,
+}
+
+#[derive(Debug, Clone)]
+struct GrokUsage {
+    tokens: TokenBreakdown,
+}
+
+impl GrokUsage {
+    fn from_update(value: &Value) -> Option<Self> {
+        let usage = get_path(value, &["params", "update", "usage"])?;
+        let raw_input = usage_value(usage, &["inputTokens", "input_tokens", "promptTokens"]);
+        let raw_output = usage_value(
+            usage,
+            &["outputTokens", "output_tokens", "completionTokens"],
+        );
+        let cache_read = usage_value(
+            usage,
+            &[
+                "cachedReadTokens",
+                "cacheReadTokens",
+                "cache_read_input_tokens",
+            ],
+        );
+        let cache_write = usage_value(
+            usage,
+            &[
+                "cachedWriteTokens",
+                "cacheWriteTokens",
+                "cacheCreationTokens",
+                "cache_creation_input_tokens",
+            ],
+        );
+        let reasoning = usage_value(
+            usage,
+            &["reasoningTokens", "thoughtTokens", "thinkingTokens"],
+        );
+        let reported_total = usage
+            .get("totalTokens")
+            .or_else(|| usage.get("total_tokens"))
+            .and_then(|value| extract_i64(Some(value)))
+            .map(|value| value.max(0));
+
+        if raw_input == 0
+            && raw_output == 0
+            && cache_read == 0
+            && cache_write == 0
+            && reasoning == 0
+        {
+            return None;
+        }
+
+        // Grok's `inputTokens` includes the `cachedReadTokens` subset, and its
+        // `outputTokens` includes the `reasoningTokens` subset. The reported
+        // total is input + output, so split those overlaps before handing the
+        // values to TokenBreakdown, whose buckets are additive.
+        let inclusive_total = raw_input.saturating_add(raw_output);
+        let reported_total_is_inclusive = reported_total == Some(inclusive_total);
+
+        Some(Self {
+            tokens: TokenBreakdown {
+                input: if reported_total_is_inclusive {
+                    raw_input.saturating_sub(cache_read)
+                } else {
+                    raw_input
+                },
+                output: if reported_total_is_inclusive {
+                    raw_output.saturating_sub(reasoning)
+                } else {
+                    raw_output
+                },
+                cache_read,
+                cache_write,
+                reasoning,
+            },
+        })
+    }
+}
+
+fn usage_value(value: &Value, keys: &[&str]) -> i64 {
+    keys.iter()
+        .find_map(|key| extract_i64(value.get(*key)))
+        .unwrap_or(0)
+        .max(0)
+}
+
+fn message_from_tokens(
+    metadata: &GrokMetadata,
+    model_id: String,
+    timestamp: i64,
+    tokens: TokenBreakdown,
+    dedup_key: String,
+    is_turn_start: bool,
+) -> UnifiedMessage {
+    let mut message = UnifiedMessage::new_with_dedup(
+        CLIENT_ID,
+        if model_id.trim().is_empty() {
+            UNKNOWN_MODEL.to_string()
+        } else {
+            model_id
+        },
+        PROVIDER_ID,
+        metadata.session_id.clone(),
+        timestamp,
+        tokens,
+        0.0,
+        Some(dedup_key),
+    );
+    message.set_workspace(
+        metadata.workspace_key.clone(),
+        metadata.workspace_label.clone(),
+    );
+    message.is_turn_start = is_turn_start;
+    message
 }
 
 impl ActiveTurn {
@@ -71,11 +187,9 @@ impl ActiveTurn {
             self.model_id
         };
 
-        let mut message = UnifiedMessage::new_with_dedup(
-            CLIENT_ID,
+        Some(message_from_tokens(
+            metadata,
             model_id,
-            PROVIDER_ID,
-            metadata.session_id.clone(),
             self.timestamp,
             TokenBreakdown {
                 input: token_delta,
@@ -84,15 +198,9 @@ impl ActiveTurn {
                 cache_write: 0,
                 reasoning: 0,
             },
-            0.0,
-            Some(format!("grok:{}:{}", metadata.session_id, self.turn_index)),
-        );
-        message.set_workspace(
-            metadata.workspace_key.clone(),
-            metadata.workspace_label.clone(),
-        );
-        message.is_turn_start = true;
-        Some(message)
+            format!("grok:{}:{}", metadata.session_id, self.turn_index),
+            true,
+        ))
     }
 }
 
@@ -107,7 +215,8 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
         Err(_) => return Vec::new(),
     };
 
-    let mut messages = Vec::new();
+    let mut fallback_messages = Vec::new();
+    let mut usage_messages = Vec::new();
     let mut current_model = metadata
         .model_id
         .clone()
@@ -116,6 +225,7 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
     let mut last_total_timestamp = metadata.timestamp;
     let mut active_turn: Option<ActiveTurn> = None;
     let mut turn_index = 0usize;
+    let mut usage_index = 0usize;
 
     for line in BufReader::new(file).lines().map_while(Result::ok) {
         if line.trim().is_empty() {
@@ -139,7 +249,7 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
         if is_user_message_chunk(&value) {
             if let Some(turn) = active_turn.take() {
                 if let Some(message) = turn.into_message(&metadata) {
-                    messages.push(message);
+                    fallback_messages.push(message);
                 }
             }
 
@@ -150,6 +260,31 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
                 turn_index,
             ));
             turn_index = turn_index.saturating_add(1);
+        }
+
+        if let Some(usage) = GrokUsage::from_update(&value) {
+            let model_id = if current_model != UNKNOWN_MODEL {
+                current_model.clone()
+            } else {
+                get_path(&value, &["params", "update", "usage", "modelUsage"])
+                    .and_then(Value::as_object)
+                    .and_then(|models| (models.len() == 1).then(|| models.keys().next().cloned()))
+                    .flatten()
+                    .or_else(|| metadata.model_id.clone())
+                    .unwrap_or_else(|| UNKNOWN_MODEL.to_string())
+            };
+            let event_id = get_path(&value, &["params", "_meta", "eventId"])
+                .and_then(|value| extract_string(Some(value)))
+                .unwrap_or_else(|| format!("turn-{usage_index}"));
+            usage_messages.push(message_from_tokens(
+                &metadata,
+                model_id,
+                timestamp,
+                usage.tokens,
+                format!("grok:{}:usage:{}", metadata.session_id, event_id),
+                true,
+            ));
+            usage_index = usage_index.saturating_add(1);
         }
 
         let Some(total_tokens) = extract_total_tokens(&value) else {
@@ -196,11 +331,11 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
 
     if let Some(turn) = active_turn {
         if let Some(message) = turn.into_message(&metadata) {
-            messages.push(message);
+            fallback_messages.push(message);
         }
     }
 
-    if messages.is_empty() {
+    if fallback_messages.is_empty() && usage_messages.is_empty() {
         if let Some(total_tokens) = last_total.filter(|tokens| *tokens > 0) {
             let aggregate_turn = ActiveTurn {
                 baseline_total: 0,
@@ -210,13 +345,286 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
                 turn_index: 0,
             };
             if let Some(message) = aggregate_turn.into_message(&metadata) {
-                messages.push(message);
+                fallback_messages.push(message);
             }
         }
     }
 
-    append_signals_reconciliation(path, &metadata, &mut messages, &current_model);
+    if usage_messages.is_empty() {
+        append_signals_reconciliation(path, &metadata, &mut fallback_messages, &current_model);
+        return fallback_messages;
+    }
+
+    // A usage record is emitted when a turn completes. Keep only cumulative
+    // counter activity newer than the latest completed turn as a best-effort
+    // representation of a currently running turn; older fallback messages are
+    // the same work already covered by authoritative usage records.
+    let latest_usage_timestamp = usage_messages
+        .iter()
+        .map(|message| message.timestamp)
+        .max()
+        .unwrap_or(0);
+    usage_messages.extend(
+        fallback_messages
+            .into_iter()
+            .filter(|message| message.timestamp > latest_usage_timestamp),
+    );
+    usage_messages
+}
+
+/// Parse Grok Build's append-only unified log. Each
+/// `shell.turn.inference_done` record reports a prompt total that includes
+/// cached prompt tokens and a completion total that includes reasoning tokens.
+/// Store the non-overlapping component buckets so the breakdown remains
+/// additive and the source totals are preserved.
+pub fn parse_grok_unified_log_file(path: &Path) -> Vec<UnifiedMessage> {
+    if path.file_name().and_then(|name| name.to_str()) != Some("unified.jsonl") {
+        return Vec::new();
+    }
+
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(_) => return Vec::new(),
+    };
+
+    let fallback_timestamp = file_modified_timestamp_ms(path);
+    let metadata_by_session = read_unified_session_metadata(path);
+    let mut fallback_model_by_pid = HashMap::new();
+    let mut model_by_pid_and_session = HashMap::new();
+    let mut seen = HashSet::new();
+    let mut messages = Vec::new();
+
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+
+        if let Some((pid, session_id, model_id)) = unified_log_model_change(&value) {
+            if let Some(session_id) = session_id {
+                model_by_pid_and_session.insert((pid, session_id), model_id);
+            } else {
+                fallback_model_by_pid.insert(pid, model_id);
+            }
+            continue;
+        }
+
+        if value.get("msg").and_then(Value::as_str) != Some("shell.turn.inference_done") {
+            continue;
+        }
+
+        let Some(session_id) =
+            extract_string(value.get("sid")).filter(|session_id| !session_id.trim().is_empty())
+        else {
+            continue;
+        };
+        let Some(context) = value.get("ctx") else {
+            continue;
+        };
+        let Some(prompt_tokens) = required_non_negative_i64(context.get("prompt_tokens")) else {
+            continue;
+        };
+        let Some(completion_tokens) = required_non_negative_i64(context.get("completion_tokens"))
+        else {
+            continue;
+        };
+        let Some(cached_prompt_tokens) =
+            optional_non_negative_i64(context.get("cached_prompt_tokens"))
+        else {
+            continue;
+        };
+        let Some(reasoning_tokens) = optional_non_negative_i64(context.get("reasoning_tokens"))
+        else {
+            continue;
+        };
+        if cached_prompt_tokens > prompt_tokens || reasoning_tokens > completion_tokens {
+            continue;
+        }
+
+        let pid = optional_non_negative_i64(value.get("pid")).unwrap_or(0);
+        let loop_index = optional_non_negative_i64(context.get("loop_index")).unwrap_or(0);
+        let timestamp = value
+            .get("ts")
+            .and_then(parse_timestamp_value)
+            .unwrap_or(fallback_timestamp);
+        let dedup_key = format!(
+            "{UNIFIED_LOG_DEDUP_PREFIX}{session_id}:{timestamp}:{pid}:{loop_index}:{prompt_tokens}:{cached_prompt_tokens}:{completion_tokens}:{reasoning_tokens}"
+        );
+        if !seen.insert(dedup_key.clone()) {
+            continue;
+        }
+
+        let metadata = metadata_by_session
+            .get(&session_id)
+            .cloned()
+            .unwrap_or_else(|| fallback_unified_metadata(&session_id, fallback_timestamp));
+        let model_id = model_by_pid_and_session
+            .get(&(pid, session_id.clone()))
+            .cloned()
+            .or_else(|| metadata.model_id.clone())
+            .or_else(|| fallback_model_by_pid.get(&pid).cloned())
+            .unwrap_or_else(|| UNKNOWN_MODEL.to_string());
+        let mut message = message_from_tokens(
+            &metadata,
+            model_id,
+            timestamp,
+            TokenBreakdown {
+                input: prompt_tokens.saturating_sub(cached_prompt_tokens),
+                output: completion_tokens.saturating_sub(reasoning_tokens),
+                cache_read: cached_prompt_tokens,
+                cache_write: 0,
+                reasoning: reasoning_tokens,
+            },
+            dedup_key,
+            loop_index == 1,
+        );
+        message.session_id = session_id;
+        messages.push(message);
+    }
+
     messages
+}
+
+/// Dispatch between Grok's legacy per-session updates and its newer unified
+/// log without accepting unrelated JSONL files under the Grok home directory.
+pub fn parse_grok_file(path: &Path) -> Vec<UnifiedMessage> {
+    match path.file_name().and_then(|name| name.to_str()) {
+        Some("updates.jsonl") => parse_grok_updates_file(path),
+        Some("unified.jsonl") => parse_grok_unified_log_file(path),
+        _ => Vec::new(),
+    }
+}
+
+/// Use the richer unified log for sessions it covers. Legacy updates remain a
+/// fallback for sessions absent from that log, avoiding an additive merge of
+/// two representations of the same activity.
+pub fn prefer_unified_log_messages(messages: Vec<UnifiedMessage>) -> Vec<UnifiedMessage> {
+    let unified_sessions: HashSet<String> = messages
+        .iter()
+        .filter(|message| is_unified_log_message(message))
+        .map(|message| message.session_id.clone())
+        .collect();
+
+    if unified_sessions.is_empty() {
+        return messages;
+    }
+
+    messages
+        .into_iter()
+        .filter(|message| {
+            is_unified_log_message(message) || !unified_sessions.contains(&message.session_id)
+        })
+        .collect()
+}
+
+fn is_unified_log_message(message: &UnifiedMessage) -> bool {
+    message
+        .dedup_key
+        .as_deref()
+        .is_some_and(|key| key.starts_with(UNIFIED_LOG_DEDUP_PREFIX))
+}
+
+fn unified_log_model_change(value: &Value) -> Option<(i64, Option<String>, String)> {
+    let pid = required_non_negative_i64(value.get("pid"))?;
+    let context = value.get("ctx")?;
+    let model_id = match value.get("msg").and_then(Value::as_str)? {
+        "model changed" => extract_string(context.get("model")),
+        "model catalog: notifying clients" => extract_string(context.get("current_model_id")),
+        "backend_search: model switch" => extract_string(context.get("new_model"))
+            .or_else(|| extract_string(context.get("model")))
+            .or_else(|| extract_string(context.get("current_model_id"))),
+        "subagent model resolved" => extract_string(context.get("model_id"))
+            .or_else(|| extract_string(context.get("child_model")))
+            .or_else(|| extract_string(context.get("model"))),
+        _ => None,
+    }?;
+
+    let session_id =
+        extract_string(value.get("sid")).filter(|session_id| !session_id.trim().is_empty());
+    (!model_id.trim().is_empty()).then_some((pid, session_id, model_id))
+}
+
+fn required_non_negative_i64(value: Option<&Value>) -> Option<i64> {
+    extract_i64(value).filter(|value| *value >= 0)
+}
+
+fn optional_non_negative_i64(value: Option<&Value>) -> Option<i64> {
+    match value {
+        Some(value) => required_non_negative_i64(Some(value)),
+        None => Some(0),
+    }
+}
+
+fn fallback_unified_metadata(session_id: &str, timestamp: i64) -> GrokMetadata {
+    GrokMetadata {
+        session_id: session_id.to_string(),
+        model_id: None,
+        timestamp,
+        workspace_key: None,
+        workspace_label: None,
+    }
+}
+
+fn read_unified_session_metadata(path: &Path) -> HashMap<String, GrokMetadata> {
+    let Some(grok_home) = path.parent().and_then(Path::parent) else {
+        return HashMap::new();
+    };
+    let sessions_root = grok_home.join("sessions");
+    let Ok(workspaces) = std::fs::read_dir(sessions_root) else {
+        return HashMap::new();
+    };
+
+    let mut metadata_by_session = HashMap::new();
+    for workspace_entry in workspaces.flatten() {
+        let workspace_dir = workspace_entry.path();
+        if !workspace_dir.is_dir() {
+            continue;
+        }
+
+        let workspace_key = workspace_dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(percent_decode_lossy)
+            .and_then(|decoded| normalize_workspace_key(&decoded));
+        let workspace_label = workspace_key.as_deref().and_then(workspace_label_from_key);
+        let Ok(sessions) = std::fs::read_dir(&workspace_dir) else {
+            continue;
+        };
+
+        for session_entry in sessions.flatten() {
+            let session_dir = session_entry.path();
+            if !session_dir.is_dir() {
+                continue;
+            }
+            let Some(session_id) = session_dir
+                .file_name()
+                .and_then(|name| name.to_str())
+                .filter(|id| !id.trim().is_empty())
+            else {
+                continue;
+            };
+
+            let updates_path = session_dir.join("updates.jsonl");
+            let metadata = if updates_path.is_file() {
+                read_metadata(&updates_path)
+            } else {
+                let mut metadata =
+                    fallback_unified_metadata(session_id, file_modified_timestamp_ms(&session_dir));
+                metadata.workspace_key = workspace_key.clone();
+                metadata.workspace_label = workspace_label.clone();
+                read_summary_metadata(&session_dir.join("summary.json"), &mut metadata);
+                read_events_metadata(&session_dir.join("events.jsonl"), &mut metadata);
+                read_signals_metadata(&session_dir.join("signals.json"), &mut metadata);
+                metadata
+            };
+            metadata_by_session.insert(session_id.to_string(), metadata);
+        }
+    }
+
+    metadata_by_session
 }
 
 fn non_negative_i64(value: Option<&Value>) -> i64 {
@@ -533,6 +941,128 @@ mod tests {
             std::fs::write(session_dir.join("signals.json"), signals_json).unwrap();
         }
         (temp, updates_path)
+    }
+
+    fn write_unified_fixture(unified_jsonl: &str) -> (tempfile::TempDir, PathBuf) {
+        let temp = tempfile::TempDir::new().unwrap();
+        let logs_dir = temp.path().join(".grok/logs");
+        std::fs::create_dir_all(&logs_dir).unwrap();
+        let path = logs_dir.join("unified.jsonl");
+        std::fs::write(&path, unified_jsonl).unwrap();
+        (temp, path)
+    }
+
+    fn test_message(session_id: &str, dedup_key: &str) -> UnifiedMessage {
+        UnifiedMessage::new_with_dedup(
+            CLIENT_ID,
+            "grok-build",
+            PROVIDER_ID,
+            session_id,
+            1_700_000_000_000,
+            TokenBreakdown::default(),
+            0.0,
+            Some(dedup_key.to_string()),
+        )
+    }
+
+    #[test]
+    fn parses_unified_log_token_breakdown_without_double_counting_reasoning() {
+        let (_temp, path) = write_unified_fixture(
+            r#"{"ts":"2023-11-14T22:13:19Z","pid":17,"sid":"session-1","msg":"model changed","ctx":{"model":"grok-composer-2.5-fast"}}
+{"ts":"2023-11-14T22:13:19Z","pid":17,"msg":"model catalog: notifying clients","ctx":{"current_model_id":"grok-4.5"}}
+{"ts":"2023-11-14T22:13:20Z","pid":17,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":100,"cached_prompt_tokens":60,"completion_tokens":25,"reasoning_tokens":5}}
+{"ts":"2023-11-14T22:13:21Z","pid":17,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":2,"prompt_tokens":80,"cached_prompt_tokens":0,"completion_tokens":12,"reasoning_tokens":0}}
+{"ts":"2023-11-14T22:13:20Z","pid":17,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":100,"cached_prompt_tokens":60,"completion_tokens":25,"reasoning_tokens":5}}
+{"ts":"2023-11-14T22:13:22Z","pid":17,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":3,"prompt_tokens":10,"cached_prompt_tokens":11,"completion_tokens":1,"reasoning_tokens":0}}
+{"ts":"2023-11-14T22:13:23Z","pid":17,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":4,"prompt_tokens":10,"cached_prompt_tokens":0,"completion_tokens":1,"reasoning_tokens":2}}"#,
+        );
+
+        let messages = parse_grok_unified_log_file(&path);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].client, CLIENT_ID);
+        assert_eq!(messages[0].model_id, "grok-composer-2.5-fast");
+        assert_eq!(messages[0].session_id, "session-1");
+        assert_eq!(messages[0].tokens.input, 40);
+        assert_eq!(messages[0].tokens.cache_read, 60);
+        assert_eq!(messages[0].tokens.output, 20);
+        assert_eq!(messages[0].tokens.reasoning, 5);
+        assert_eq!(messages[0].tokens.total(), 125);
+        assert!(messages[0].is_turn_start);
+        assert_eq!(messages[1].tokens.input, 80);
+        assert_eq!(messages[1].tokens.output, 12);
+        assert!(!messages[1].is_turn_start);
+    }
+
+    #[test]
+    fn unified_log_preserves_session_workspace_metadata() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let logs_dir = temp.path().join("home/.grok/logs");
+        let session_dir = temp
+            .path()
+            .join("home/.grok/sessions/%2Ftmp%2Fproject/session-1");
+        std::fs::create_dir_all(&logs_dir).unwrap();
+        std::fs::create_dir_all(&session_dir).unwrap();
+        std::fs::write(
+            session_dir.join("summary.json"),
+            r#"{"current_model_id":"grok-4.5","updated_at":"2023-11-14T22:13:20Z"}"#,
+        )
+        .unwrap();
+        let path = logs_dir.join("unified.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"ts":"2023-11-14T22:13:20Z","pid":17,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":10,"cached_prompt_tokens":2,"completion_tokens":4,"reasoning_tokens":1}}"#,
+        )
+        .unwrap();
+
+        let messages = parse_grok_unified_log_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "grok-4.5");
+        assert_eq!(messages[0].workspace_key.as_deref(), Some("/tmp/project"));
+        assert_eq!(messages[0].workspace_label.as_deref(), Some("project"));
+    }
+
+    #[test]
+    fn prefers_unified_log_messages_only_for_covered_sessions() {
+        let covered_legacy = test_message("covered", "grok:covered:0");
+        let uncovered_legacy = test_message("fallback", "grok:fallback:0");
+        let covered_unified = test_message("covered", "grok-unified:covered:1:1:1");
+
+        let messages =
+            prefer_unified_log_messages(vec![covered_legacy, uncovered_legacy, covered_unified]);
+
+        assert_eq!(messages.len(), 2);
+        assert!(messages
+            .iter()
+            .any(|message| { message.session_id == "covered" && is_unified_log_message(message) }));
+        assert!(messages
+            .iter()
+            .any(|message| message.session_id == "fallback"));
+    }
+
+    #[test]
+    fn prefers_authoritative_usage_breakdown_when_available() {
+        let (_temp, path) = write_fixture(
+            r#"{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"user_message_chunk","_meta":{"modelId":"grok-4.5"}},"_meta":{"agentTimestampMs":1700000001000}}}
+{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"agent_message_chunk"},"_meta":{"totalTokens":1200,"agentTimestampMs":1700000002000}}}
+{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"turn_completed","usage":{"inputTokens":1000,"outputTokens":100,"reasoningTokens":20,"cachedReadTokens":400,"totalTokens":1100,"modelUsage":{"grok-4.5-build":{"inputTokens":1000,"outputTokens":100,"reasoningTokens":20,"cachedReadTokens":400,"totalTokens":1100}}}},"_meta":{"eventId":"turn-1","agentTimestampMs":1700000003000}}}"#,
+            None,
+            None,
+        );
+
+        let messages = parse_grok_updates_file(&path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "grok-4.5");
+        assert_eq!(messages[0].tokens.input, 600);
+        assert_eq!(messages[0].tokens.output, 80);
+        assert_eq!(messages[0].tokens.cache_read, 400);
+        assert_eq!(messages[0].tokens.reasoning, 20);
+        assert_eq!(messages[0].timestamp, 1700000003000);
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some("grok:session-1:usage:turn-1")
+        );
     }
 
     #[test]


### PR DESCRIPTION
The Grok parser was only reading the legacy `sessions/*/*/updates.jsonl` files. Those files expose cumulative token totals, so reports could show input while leaving output and cache columns at zero.

Grok also writes per-inference usage to `logs/unified.jsonl`. This change discovers that file, parses its prompt/cache/completion/reasoning fields into non-overlapping token buckets, and uses the session metadata to retain the workspace and model. Legacy session updates remain as a fallback for sessions that are not present in the unified log, so the two sources are not added together for the same session.

I added parser, scanner, cache, and end-to-end regression coverage. I also checked the result against a local Grok installation; output and cache values are now populated.

Verification: `cargo test -p tokscale-core` and the focused Grok CLI tests pass.

Refs #849


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect Grok token reporting by parsing `~/.grok/logs/unified.jsonl` and computing accurate, non-overlapping input/output/cache/reasoning totals. Addresses #849 where output and cache tokens appeared as zero.

- **Bug Fixes**
  - Parse `unified.jsonl` and map `prompt_tokens`, `cached_prompt_tokens`, `completion_tokens`, and `reasoning_tokens` into non-overlapping buckets.
  - Prefer unified log usage per session and fall back to legacy `updates.jsonl`; avoid double counting by keeping only deltas after the latest usage record.
  - Preserve workspace and model via session metadata; handle model changes emitted in the log.
  - Scanner now discovers `logs/unified.jsonl` (top-level only); added `parse_grok_file` and `prefer_unified_log_messages` to dispatch and merge safely.
  - Bump Grok parser cache version to 3 and add focused tests; adjust pricing path to prefer unified usage.

<sup>Written for commit 99387c22b55a6fc52c6b890b11e5bcee6fe50cfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

