### PR TITLE
fix(grok): parse unified usage with scoped attribution

### DIFF
--- a/crates/tokscale-core/src/aggregator.rs
+++ b/crates/tokscale-core/src/aggregator.rs
@@ -782,6 +782,7 @@ mod tests {
             dedup_key: None,
             session_title: None,
             is_turn_start: false,
+            model_attribution_conflicted: false,
         }
     }
 
@@ -1397,6 +1398,7 @@ mod tests {
             dedup_key: None,
             session_title: None,
             is_turn_start: false,
+            model_attribution_conflicted: false,
             duration_ms: None,
         }
     }

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -4049,6 +4049,7 @@ pub fn parsed_to_unified(msg: &ParsedMessage, cost: f64) -> UnifiedMessage {
         dedup_key: None,
         session_title: None,
         is_turn_start: false,
+        model_attribution_conflicted: false,
     }
 }
 
@@ -5807,6 +5808,68 @@ mod tests {
             assert_eq!(second.len(), 1);
             assert_eq!(second[0].model_id, "grok-code");
             assert!(second[0].cost > 0.0);
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parse_all_messages_keeps_conflicted_grok_unified_attribution_unpriced() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            let session_dir = source_home
+                .path()
+                .join(".grok/sessions/%2Ftmp%2Fproject/child");
+            std::fs::create_dir_all(&session_dir).unwrap();
+            std::fs::write(
+                session_dir.join("updates.jsonl"),
+                r#"{"method":"session/update","params":{"sessionId":"child","update":{"sessionUpdate":"user_message_chunk","_meta":{"modelId":"grok-code"}},"_meta":{"agentTimestampMs":1700000000000}}}
+{"method":"session/update","params":{"sessionId":"child","update":{"sessionUpdate":"agent_message_chunk"},"_meta":{"totalTokens":999,"agentTimestampMs":1785456003000}}}"#,
+            )
+            .unwrap();
+
+            let logs_dir = source_home.path().join(".grok/logs");
+            std::fs::create_dir_all(&logs_dir).unwrap();
+            std::fs::write(
+                logs_dir.join("unified.jsonl"),
+                r#"{"ts":"2026-07-31T00:00:01Z","pid":19,"msg":"subagent spawn credentials","ctx":{"subagent_id":"child","effective_model":"grok-4.8"}}
+{"ts":"2026-07-31T00:00:02Z","pid":19,"msg":"subagent failed","ctx":{"subagent_id":"child","effective_model":"grok-4.9"}}
+{"ts":"2026-07-31T00:00:03Z","pid":19,"sid":"child","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":100,"cached_prompt_tokens":60,"completion_tokens":25,"reasoning_tokens":5}}"#,
+            )
+            .unwrap();
+
+            let mut litellm = HashMap::new();
+            litellm.insert(
+                "grok-code".to_string(),
+                pricing::ModelPricing {
+                    input_cost_per_token: Some(0.001),
+                    output_cost_per_token: Some(0.002),
+                    ..Default::default()
+                },
+            );
+            let pricing = pricing::PricingService::new(litellm, HashMap::new());
+
+            for _ in 0..2 {
+                let messages = parse_all_messages_with_pricing_with_env_strategy(
+                    source_home.path().to_str().unwrap(),
+                    &["grok".to_string()],
+                    Some(&pricing),
+                    false,
+                    &scanner::ScannerSettings::default(),
+                );
+                assert_eq!(messages.len(), 1);
+                assert_eq!(messages[0].model_id, "grok-unknown");
+                assert!(messages[0].model_attribution_conflicted);
+                assert_eq!(messages[0].cost, 0.0);
+            }
         }
 
         match original_home {

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -5818,31 +5818,21 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn test_parse_all_messages_keeps_conflicted_grok_unified_attribution_unpriced() {
+    fn test_parse_all_messages_keeps_conflicted_grok_scoped_model_change_unpriced_cold_and_warm() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
         let mut env = paths::test_env::EnvGuard::capture(&["HOME"]);
         env.set("HOME", cache_home.path());
 
         {
-            let session_dir = source_home
-                .path()
-                .join(".grok/sessions/%2Ftmp%2Fproject/child");
-            std::fs::create_dir_all(&session_dir).unwrap();
-            std::fs::write(
-                session_dir.join("updates.jsonl"),
-                r#"{"method":"session/update","params":{"sessionId":"child","update":{"sessionUpdate":"user_message_chunk","_meta":{"modelId":"grok-code"}},"_meta":{"agentTimestampMs":1700000000000}}}
-{"method":"session/update","params":{"sessionId":"child","update":{"sessionUpdate":"agent_message_chunk"},"_meta":{"totalTokens":999,"agentTimestampMs":1785456003000}}}"#,
-            )
-            .unwrap();
-
             let logs_dir = source_home.path().join(".grok/logs");
             std::fs::create_dir_all(&logs_dir).unwrap();
             std::fs::write(
                 logs_dir.join("unified.jsonl"),
                 r#"{"ts":"2026-07-31T00:00:01Z","pid":19,"msg":"subagent spawn credentials","ctx":{"subagent_id":"child","effective_model":"grok-4.8"}}
-{"ts":"2026-07-31T00:00:02Z","pid":19,"msg":"subagent failed","ctx":{"subagent_id":"child","effective_model":"grok-4.9"}}
-{"ts":"2026-07-31T00:00:03Z","pid":19,"sid":"child","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":100,"cached_prompt_tokens":60,"completion_tokens":25,"reasoning_tokens":5}}"#,
+{"ts":"2026-07-31T00:00:02Z","pid":19,"sid":"child","msg":"model changed","ctx":{"model":"grok-code"}}
+{"ts":"2026-07-31T00:00:03Z","pid":19,"msg":"subagent failed","ctx":{"subagent_id":"child","effective_model":"grok-4.9"}}
+{"ts":"2026-07-31T00:00:04Z","pid":19,"sid":"child","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":100,"cached_prompt_tokens":60,"completion_tokens":25,"reasoning_tokens":5}}"#,
             )
             .unwrap();
 
@@ -5857,7 +5847,7 @@ mod tests {
             );
             let pricing = pricing::PricingService::new(litellm, HashMap::new());
 
-            for _ in 0..2 {
+            for scan in ["cold", "warm"] {
                 let messages = parse_all_messages_with_pricing_with_env_strategy(
                     source_home.path().to_str().unwrap(),
                     &["grok".to_string()],
@@ -5865,10 +5855,10 @@ mod tests {
                     false,
                     &scanner::ScannerSettings::default(),
                 );
-                assert_eq!(messages.len(), 1);
-                assert_eq!(messages[0].model_id, "grok-unknown");
-                assert!(messages[0].model_attribution_conflicted);
-                assert_eq!(messages[0].cost, 0.0);
+                assert_eq!(messages.len(), 1, "{scan} scan message count");
+                assert_eq!(messages[0].model_id, "grok-unknown", "{scan} scan");
+                assert!(messages[0].model_attribution_conflicted, "{scan} scan");
+                assert_eq!(messages[0].cost, 0.0, "{scan} scan");
             }
         }
     }

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -4060,8 +4060,8 @@ mod tests {
         dedupe_latest_trae_messages, filter_messages_for_report,
         generate_graph_with_loaded_pricing, get_home_dir_string, message_cache,
         normalize_model_for_grouping, parse_all_messages_with_pricing_with_env_strategy,
-        parse_local_clients, parsed_to_unified, pricing, retain_for_requested_clients, scanner,
-        select_local_parse_pricing, unified_to_parsed, validate_priced_messages, ClientId,
+        parse_local_clients, parsed_to_unified, paths, pricing, retain_for_requested_clients,
+        scanner, select_local_parse_pricing, unified_to_parsed, validate_priced_messages, ClientId,
         GraphPricingRequirement, GroupBy, LocalParseOptions, ReportOptions, TokenBreakdown,
         UnifiedMessage, UNKNOWN_WORKSPACE_LABEL,
     };
@@ -5821,8 +5821,8 @@ mod tests {
     fn test_parse_all_messages_keeps_conflicted_grok_unified_attribution_unpriced() {
         let cache_home = tempfile::TempDir::new().unwrap();
         let source_home = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", cache_home.path());
+        let mut env = paths::test_env::EnvGuard::capture(&["HOME"]);
+        env.set("HOME", cache_home.path());
 
         {
             let session_dir = source_home
@@ -5870,11 +5870,6 @@ mod tests {
                 assert!(messages[0].model_attribution_conflicted);
                 assert_eq!(messages[0].cost, 0.0);
             }
-        }
-
-        match original_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
         }
     }
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1502,9 +1502,9 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         .get(ClientId::Grok)
         .par_iter()
         .map(|path| {
-            // Use a Grok-aware fingerprint: parse output depends on the sibling
-            // signals.json rollup, so that file must participate in the cache key
-            // or a late/updated rollup is ignored forever for cached sessions.
+            // Use a Grok-aware fingerprint: legacy output depends on session
+            // sidecars, while unified output reads metadata across the complete
+            // sessions tree; all of those inputs must invalidate cached output.
             load_or_parse_source_with_fingerprint(
                 message_cache::CacheIdentity::for_client(ClientId::Grok),
                 path,
@@ -1522,7 +1522,9 @@ fn parse_all_messages_with_pricing_with_env_strategy(
             source_cache.insert(entry);
         }
     }
-    all_messages.extend(sessions::grok::prefer_unified_log_messages(grok_messages));
+    let mut selected_grok_messages = sessions::grok::prefer_unified_log_messages(grok_messages);
+    apply_pricing_to_messages(&mut selected_grok_messages, pricing);
+    all_messages.extend(selected_grok_messages);
 
     let jcode_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::Jcode)
@@ -5737,6 +5739,74 @@ mod tests {
             assert_eq!(messages[0].tokens.output, 20);
             assert_eq!(messages[0].tokens.reasoning, 5);
             assert_eq!(messages[0].tokens.total(), 125);
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parse_all_messages_reprices_grok_after_legacy_model_attribution() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            let session_dir = source_home
+                .path()
+                .join(".grok/sessions/%2Ftmp%2Fproject/session-1");
+            std::fs::create_dir_all(&session_dir).unwrap();
+            std::fs::write(
+                session_dir.join("updates.jsonl"),
+                r#"{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"user_message_chunk","_meta":{"modelId":"grok-code"}},"_meta":{"agentTimestampMs":1700000000000}}}
+{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"agent_message_chunk"},"_meta":{"totalTokens":999,"agentTimestampMs":1700000000000}}}"#,
+            )
+            .unwrap();
+
+            let logs_dir = source_home.path().join(".grok/logs");
+            std::fs::create_dir_all(&logs_dir).unwrap();
+            std::fs::write(
+                logs_dir.join("unified.jsonl"),
+                r#"{"ts":"2023-11-14T22:13:20Z","pid":7,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":100,"cached_prompt_tokens":60,"completion_tokens":25,"reasoning_tokens":5}}"#,
+            )
+            .unwrap();
+
+            let mut litellm = HashMap::new();
+            litellm.insert(
+                "grok-code".to_string(),
+                pricing::ModelPricing {
+                    input_cost_per_token: Some(0.001),
+                    output_cost_per_token: Some(0.002),
+                    ..Default::default()
+                },
+            );
+            let pricing = pricing::PricingService::new(litellm, HashMap::new());
+
+            let first = parse_all_messages_with_pricing_with_env_strategy(
+                source_home.path().to_str().unwrap(),
+                &["grok".to_string()],
+                Some(&pricing),
+                false,
+                &scanner::ScannerSettings::default(),
+            );
+            assert_eq!(first.len(), 1);
+            assert_eq!(first[0].model_id, "grok-code");
+            assert!(first[0].cost > 0.0);
+
+            let second = parse_all_messages_with_pricing_with_env_strategy(
+                source_home.path().to_str().unwrap(),
+                &["grok".to_string()],
+                Some(&pricing),
+                false,
+                &scanner::ScannerSettings::default(),
+            );
+            assert_eq!(second.len(), 1);
+            assert_eq!(second[0].model_id, "grok-code");
+            assert!(second[0].cost > 0.0);
         }
 
         match original_home {

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1511,16 +1511,18 @@ fn parse_all_messages_with_pricing_with_env_strategy(
                 &source_cache,
                 pricing,
                 message_cache::SourceFingerprint::check_grok_path_samples_only,
-                sessions::grok::parse_grok_updates_file,
+                sessions::grok::parse_grok_file,
             )
         })
         .collect();
+    let mut grok_messages = Vec::new();
     for outcome in grok_outcomes {
-        all_messages.extend(outcome.messages);
+        grok_messages.extend(outcome.messages);
         if let Some(entry) = outcome.cache_entry {
             source_cache.insert(entry);
         }
     }
+    all_messages.extend(sessions::grok::prefer_unified_log_messages(grok_messages));
 
     let jcode_outcomes: Vec<CachedParseOutcome> = scan_result
         .get(ClientId::Jcode)
@@ -3882,15 +3884,14 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     counts.set(ClientId::WorkBuddy, workbuddy_count);
     messages.extend(workbuddy_msgs);
 
-    let grok_msgs: Vec<ParsedMessage> = scan_result
+    let grok_messages: Vec<UnifiedMessage> = scan_result
         .get(ClientId::Grok)
         .par_iter()
-        .flat_map(|path| {
-            sessions::grok::parse_grok_updates_file(path)
-                .into_iter()
-                .map(|msg| unified_to_parsed(&msg))
-                .collect::<Vec<_>>()
-        })
+        .flat_map(|path| sessions::grok::parse_grok_file(path))
+        .collect();
+    let grok_msgs: Vec<ParsedMessage> = sessions::grok::prefer_unified_log_messages(grok_messages)
+        .into_iter()
+        .map(|msg| unified_to_parsed(&msg))
         .collect();
     let grok_count = summed_parsed_message_count(&grok_msgs);
     counts.set(ClientId::Grok, grok_count);
@@ -5695,6 +5696,53 @@ mod tests {
 {"timestamp": 1770983450.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 8, "output": 1, "input_cache_read": 0, "input_cache_creation": 0}}}}"#,
         )
         .unwrap();
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parse_all_messages_with_pricing_prefers_grok_unified_log() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            let session_dir = source_home
+                .path()
+                .join(".grok/sessions/%2Ftmp%2Fproject/session-1");
+            std::fs::create_dir_all(&session_dir).unwrap();
+            std::fs::write(
+                session_dir.join("updates.jsonl"),
+                r#"{"method":"session/update","params":{"sessionId":"session-1","_meta":{"totalTokens":999,"agentTimestampMs":1700000000000}}}"#,
+            )
+            .unwrap();
+
+            let logs_dir = source_home.path().join(".grok/logs");
+            std::fs::create_dir_all(&logs_dir).unwrap();
+            std::fs::write(
+                logs_dir.join("unified.jsonl"),
+                r#"{"ts":"2023-11-14T22:13:20Z","pid":7,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":100,"cached_prompt_tokens":60,"completion_tokens":25,"reasoning_tokens":5}}"#,
+            )
+            .unwrap();
+
+            let messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["grok".to_string()],
+                None,
+            );
+
+            assert_eq!(messages.len(), 1);
+            assert_eq!(messages[0].tokens.input, 40);
+            assert_eq!(messages[0].tokens.cache_read, 60);
+            assert_eq!(messages[0].tokens.output, 20);
+            assert_eq!(messages[0].tokens.reasoning, 5);
+            assert_eq!(messages[0].tokens.total(), 125);
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
     }
 
     #[test]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -886,7 +886,9 @@ fn parser_version(client: ClientId) -> u32 {
         // session, so the same source can now produce different model IDs.
         // v5 preserves distinct unified events when timestamps and token
         // buckets repeat, and fingerprints the complete sessions metadata tree.
-        ClientId::Grok => 5,
+        // v6 persists whether an unknown unified model was deliberately
+        // fail-closed due to conflicting child attribution evidence.
+        ClientId::Grok => 6,
         // v1 retained MiMo's embedded `cost` value but did not preserve its
         // provider-reported provenance. Reparse cached rows so strict submit
         // validation does not reject valid unknown-model MiMo usage offline.
@@ -2211,8 +2213,8 @@ mod tests {
     }
 
     #[test]
-    fn test_grok_scoped_model_attribution_bumps_parser_version() {
-        assert_eq!(parser_version(ClientId::Grok), 5);
+    fn test_grok_conflicted_model_attribution_bumps_parser_version() {
+        assert_eq!(parser_version(ClientId::Grok), 6);
     }
 
     #[test]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -886,6 +886,11 @@ fn parser_version(client: ClientId) -> u32 {
         // session_model_usage instead of crediting the whole session to
         // sessions.model, and dedup keys are namespaced per (session, model).
         ClientId::Hermes => 2,
+        // v2 added per-turn usage records. v3 adds the canonical unified log,
+        // non-overlapping output/cache/reasoning buckets, and session metadata.
+        // v4 scopes unified model attribution by PID generation and exact child
+        // session, so the same source can now produce different model IDs.
+        ClientId::Grok => 4,
         // v1 retained MiMo's embedded `cost` value but did not preserve its
         // provider-reported provenance. Reparse cached rows so strict submit
         // validation does not reject valid unknown-model MiMo usage offline.
@@ -2200,6 +2205,11 @@ mod tests {
     #[test]
     fn test_hermes_parser_version_invalidates_v1_entries() {
         assert_eq!(parser_version(ClientId::Hermes), 2);
+    }
+
+    #[test]
+    fn test_grok_scoped_model_attribution_bumps_parser_version() {
+        assert_eq!(parser_version(ClientId::Grok), 4);
     }
 
     #[test]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -23,7 +23,9 @@ use std::time::UNIX_EPOCH;
 // 3: UnifiedMessage gained session_title, changing the bincode payload layout.
 // Old shards must read as Stale (silent rebuild), not Invalid (corruption
 // warning), so the format version moves with the struct.
-const CACHE_FORMAT_VERSION: u32 = 3;
+// 4: UnifiedMessage gained model_attribution_conflicted, changing the bincode
+// payload layout. Old shards must be silently rebuilt rather than decoded.
+const CACHE_FORMAT_VERSION: u32 = 4;
 // V2 intentionally starts cold and leaves source-message-cache.bin untouched:
 // the monolith did not record a trustworthy parser owner for migration.
 const CACHE_SHARD_DIRNAME: &str = "source-message-cache-v2";
@@ -3023,6 +3025,38 @@ mod tests {
         assert!(SourceMessageCache::load()
             .get(claude, source.path())
             .is_some());
+
+        restore_cache_env(prev_env);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_prior_cache_format_shard_is_skipped_before_decoding_payload() {
+        let temp_home = TempDir::new().unwrap();
+        let prev_env = sandbox_cache_env(temp_home.path());
+        let codex = CacheIdentity::for_client(ClientId::Codex);
+        let stale_key = CacheShardKey {
+            namespace: codex.namespace.to_string(),
+            index: 0,
+        };
+        let stale_path = shard_path(&cache_shard_dir().unwrap(), &stale_key);
+        ensure_cache_dir(stale_path.parent().unwrap()).unwrap();
+        let stale_envelope = CachedShardEnvelope {
+            format_version: CACHE_FORMAT_VERSION - 1,
+            parser_namespace: codex.namespace.to_string(),
+            parser_version: codex.parser_version,
+            payload: b"prior UnifiedMessage layout".to_vec(),
+        };
+        let mut writer = BufWriter::new(File::create(&stale_path).unwrap());
+        bincode::options()
+            .serialize_into(&mut writer, &stale_envelope)
+            .unwrap();
+        writer.flush().unwrap();
+
+        assert!(matches!(
+            read_shard(&stale_path, codex),
+            ShardReadStatus::Stale
+        ));
 
         restore_cache_env(prev_env);
     }

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -228,15 +228,12 @@ impl SourceFingerprint {
         Self::from_path_with_related(path, related)
     }
 
-    /// Fingerprint for a Grok `updates.jsonl` session and every sibling read by
-    /// its parser for rollup and session metadata.
+    /// Fingerprint for a Grok source and every file or directory read by its
+    /// parser for rollup and session metadata. Unified-log parsing also reads
+    /// metadata across the complete sessions tree.
     #[cfg(test)]
     pub(crate) fn from_grok_path(path: &Path) -> Option<Self> {
-        let parent = path.parent().unwrap_or_else(|| Path::new("."));
-        let related_paths = ["signals.json", "summary.json", "events.jsonl"]
-            .into_iter()
-            .map(|name| (name.to_string(), parent.join(name)));
-        Self::from_path_with_related(path, related_paths)
+        Self::from_path_with_related(path, crate::sessions::grok::grok_related_paths(path))
     }
 
     /// Fingerprint for a Kiro source file. IDE sessions consume a sibling
@@ -438,10 +435,7 @@ impl SourceFingerprint {
         cached: Option<&Self>,
         mode: ContentHashMode,
     ) -> Option<FingerprintStatus> {
-        let parent = path.parent().unwrap_or_else(|| Path::new("."));
-        let related_paths = ["signals.json", "summary.json", "events.jsonl"]
-            .into_iter()
-            .map(|name| (name.to_string(), parent.join(name)));
+        let related_paths = crate::sessions::grok::grok_related_paths(path);
         Self::check_path_with_related_mode(path, related_paths, cached, mode)
     }
 
@@ -890,7 +884,9 @@ fn parser_version(client: ClientId) -> u32 {
         // non-overlapping output/cache/reasoning buckets, and session metadata.
         // v4 scopes unified model attribution by PID generation and exact child
         // session, so the same source can now produce different model IDs.
-        ClientId::Grok => 4,
+        // v5 preserves distinct unified events when timestamps and token
+        // buckets repeat, and fingerprints the complete sessions metadata tree.
+        ClientId::Grok => 5,
         // v1 retained MiMo's embedded `cost` value but did not preserve its
         // provider-reported provenance. Reparse cached rows so strict submit
         // validation does not reject valid unknown-model MiMo usage offline.
@@ -1518,6 +1514,9 @@ fn read_sample_hash(file: &mut File, offset: u64, len: usize) -> Option<FileSamp
 }
 
 fn compute_sample_hashes(path: &Path, size: u64) -> Option<Vec<FileSampleHash>> {
+    if path.metadata().ok()?.is_dir() {
+        return Some(Vec::new());
+    }
     if size == 0 {
         return Some(Vec::new());
     }
@@ -1592,9 +1591,13 @@ fn file_fingerprint_parts(
         .ok()?
         .as_nanos() as u64;
     let sample_hashes = compute_sample_hashes(path, size)?;
-    let content_hash = match mode {
-        ContentHashMode::Full => hash_prefix(path, size)?,
-        ContentHashMode::SamplesOnly => [0_u8; 32],
+    let content_hash = if metadata.is_dir() {
+        [0_u8; 32]
+    } else {
+        match mode {
+            ContentHashMode::Full => hash_prefix(path, size)?,
+            ContentHashMode::SamplesOnly => [0_u8; 32],
+        }
     };
     Some((size, modified_ns, sample_hashes, content_hash))
 }
@@ -2209,7 +2212,7 @@ mod tests {
 
     #[test]
     fn test_grok_scoped_model_attribution_bumps_parser_version() {
-        assert_eq!(parser_version(ClientId::Grok), 4);
+        assert_eq!(parser_version(ClientId::Grok), 5);
     }
 
     #[test]
@@ -2293,6 +2296,43 @@ mod tests {
         std::fs::write(&events_path, b"event-2\n").unwrap();
         let updated_events = SourceFingerprint::from_grok_path(&updates_path).unwrap();
         assert_ne!(with_events, updated_events);
+    }
+
+    #[test]
+    fn test_grok_unified_fingerprint_tracks_session_metadata_tree_changes() {
+        let dir = TempDir::new().unwrap();
+        let logs_dir = dir.path().join(".grok/logs");
+        let session_dir = dir.path().join(".grok/sessions/%2Ftmp%2Fproject/session-1");
+        std::fs::create_dir_all(&logs_dir).unwrap();
+        std::fs::create_dir_all(&session_dir).unwrap();
+        let unified_path = logs_dir.join("unified.jsonl");
+        std::fs::write(
+            &unified_path,
+            br#"{"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"prompt_tokens":1,"completion_tokens":1}}"#,
+        )
+        .unwrap();
+        let summary_path = session_dir.join("summary.json");
+        std::fs::write(&summary_path, br#"{"current_model_id":"grok-4.5"}"#).unwrap();
+
+        let base = SourceFingerprint::from_grok_path(&unified_path).unwrap();
+
+        std::fs::write(&summary_path, br#"{"current_model_id":"grok-4.6"}"#).unwrap();
+        let changed_summary = SourceFingerprint::from_grok_path(&unified_path).unwrap();
+        assert_ne!(base, changed_summary);
+        assert!(matches!(
+            SourceFingerprint::check_grok_path_samples_only(&unified_path, Some(&base)),
+            Some(FingerprintStatus::Changed(_))
+        ));
+
+        let second_session_dir = dir.path().join(".grok/sessions/%2Ftmp%2Fproject/session-2");
+        std::fs::create_dir_all(&second_session_dir).unwrap();
+        std::fs::write(
+            second_session_dir.join("summary.json"),
+            br#"{"current_model_id":"grok-4.7"}"#,
+        )
+        .unwrap();
+        let changed_tree = SourceFingerprint::from_grok_path(&unified_path).unwrap();
+        assert_ne!(changed_summary, changed_tree);
     }
 
     #[test]

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -926,9 +926,7 @@ fn grok_home_from_scan_root(path: &Path) -> PathBuf {
             .unwrap_or(false)
     }) {
         if let Some(grok_home) = sessions_dir.parent() {
-            if !grok_home.as_os_str().is_empty() {
-                return grok_home.to_path_buf();
-            }
+            return grok_home.to_path_buf();
         }
     }
 

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -910,6 +910,51 @@ fn push_unique_scan_task_with_pattern(
     }
 }
 
+/// Derive the Grok home directory from a scanned root path.
+///
+/// The primary resolution (`ClientDef::resolve_path_with_env_strategy`) returns
+/// `<home>/sessions`, so a configured alternate root may point at either the
+/// home itself (`~/.grok`) or its `sessions` subdirectory. A trailing
+/// `sessions` component is treated as the home's child in both cases, keeping
+/// discovery robust to either configuration shape.
+fn grok_home_from_scan_root(path: &Path) -> PathBuf {
+    if path.file_name().and_then(|name| name.to_str()) == Some("sessions") {
+        path.parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| path.to_path_buf())
+    } else {
+        path.to_path_buf()
+    }
+}
+
+/// Register the dual-source scan tasks for one Grok root.
+///
+/// A Grok root contributes both the legacy per-session rollups
+/// (`sessions/**/updates.jsonl`) and the per-inference token breakdowns
+/// (`logs/unified.jsonl`). The original root is always registered for
+/// `updates.jsonl` — `extraScanPaths` rows are recursive roots, so arbitrary
+/// nested layouts must keep matching — and the sibling `<home>/logs/unified.jsonl`
+/// task is derived from the root via [`grok_home_from_scan_root`].
+///
+/// Running every Grok root — the resolved primary home and each
+/// `scanner.extraScanPaths.grok` entry — through this helper keeps alternate
+/// roots on the same dual-source discovery as the primary home.
+fn push_grok_dual_source_scan_tasks(
+    tasks: &mut Vec<(ClientId, String, &'static str)>,
+    seen: &mut HashSet<(ClientId, PathBuf)>,
+    root: &Path,
+) {
+    push_unique_scan_task(tasks, seen, ClientId::Grok, root);
+    let grok_home = grok_home_from_scan_root(root);
+    push_unique_scan_task_with_pattern(
+        tasks,
+        seen,
+        ClientId::Grok,
+        grok_home.join("logs").join("unified.jsonl"),
+        "unified.jsonl",
+    );
+}
+
 fn kiro_global_storage_roots(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
     let mut roots = vec![
         PathBuf::from(format!(
@@ -1152,6 +1197,7 @@ fn scan_all_clients_with_env_strategy_inner(
                 | ClientId::Gjc
                 | ClientId::MiMoCode
                 | ClientId::DevinCli
+                | ClientId::Grok
         ) {
             continue;
         }
@@ -1167,21 +1213,17 @@ fn scan_all_clients_with_env_strategy_inner(
                 .data()
                 .resolve_path_with_env_strategy(home_dir, use_env_roots),
         );
-        if let Some(grok_home) = grok_sessions.parent() {
-            push_unique_scan_task_with_pattern(
-                &mut tasks,
-                &mut seen_scan_roots,
-                ClientId::Grok,
-                grok_home.join("logs/unified.jsonl"),
-                "unified.jsonl",
-            );
-        }
+        // The resolved path is `<home>/sessions`; `push_grok_dual_source_scan_tasks`
+        // keeps it registered for `updates.jsonl` and derives `logs/unified.jsonl`.
+        push_grok_dual_source_scan_tasks(&mut tasks, &mut seen_scan_roots, &grok_sessions);
     }
 
     for (client_id, path) in extra_scan_paths_for(scanner_settings, &enabled_with_devin_lookup) {
         warn_if_escapes_home(Path::new(home_dir), client_id, &path);
         if client_id == ClientId::DevinCli {
             devin_cli_roots.push(path);
+        } else if client_id == ClientId::Grok {
+            push_grok_dual_source_scan_tasks(&mut tasks, &mut seen_scan_roots, &path);
         } else {
             push_unique_scan_task(&mut tasks, &mut seen_scan_roots, client_id, path);
         }
@@ -1279,6 +1321,12 @@ fn scan_all_clients_with_env_strategy_inner(
             warn_if_escapes_home(Path::new(home_dir), client_id, &PathBuf::from(&path));
             if client_id == ClientId::DevinCli {
                 devin_cli_roots.push(PathBuf::from(path));
+            } else if client_id == ClientId::Grok {
+                push_grok_dual_source_scan_tasks(
+                    &mut tasks,
+                    &mut seen_scan_roots,
+                    &PathBuf::from(path),
+                );
             } else {
                 push_unique_scan_task(&mut tasks, &mut seen_scan_roots, client_id, path);
             }
@@ -2485,6 +2533,110 @@ mod tests {
         let mut file = File::create(grok_session.join("updates.jsonl")).unwrap();
         file.write_all(b"{\"method\":\"session/update\"}\n")
             .unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn test_grok_extra_scan_path_discovers_both_sources() {
+        // Regression guard: `scanner.extraScanPaths.grok` roots must receive
+        // the same dual-source discovery as the primary Grok home — legacy
+        // `updates.jsonl` under the configured root AND the sibling
+        // `logs/unified.jsonl` derived from the Grok home. Previously the
+        // unified log was only added for the resolved primary home, so an
+        // alternate root contributed only the registered `updates.jsonl`
+        // pattern and its inference breakdowns were silently missed.
+        let mut env = EnvGuard::capture(&["GROK_HOME"]);
+        env.remove("GROK_HOME");
+
+        let home = TempDir::new().unwrap();
+        let alt_home = TempDir::new().unwrap();
+
+        // Alternate Grok home laid out like a real ~/.grok.
+        let alt_session = alt_home
+            .path()
+            .join("sessions/%2Ftmp%2Fproject/session-alt");
+        fs::create_dir_all(&alt_session).unwrap();
+        File::create(alt_session.join("updates.jsonl")).unwrap();
+        // A nested legacy update NOT under sessions/ — the configured root is
+        // a recursive scan root, so nested updates.jsonl must keep matching
+        // instead of being replaced by a sessions/ subdirectory task.
+        let nested = alt_home.path().join("imports/nested");
+        fs::create_dir_all(&nested).unwrap();
+        File::create(nested.join("updates.jsonl")).unwrap();
+        fs::create_dir_all(alt_home.path().join("logs")).unwrap();
+        File::create(alt_home.path().join("logs/unified.jsonl")).unwrap();
+
+        let settings: ScannerSettings = serde_json::from_value(serde_json::json!({
+            "extraScanPaths": {
+                "grok": [alt_home.path()]
+            }
+        }))
+        .unwrap();
+
+        let result = scan_all_clients_with_scanner_settings(
+            home.path().to_str().unwrap(),
+            &["grok".to_string()],
+            true,
+            &settings,
+        );
+
+        let files = result.get(ClientId::Grok);
+        assert_eq!(
+            files
+                .iter()
+                .filter(|p| p.ends_with("updates.jsonl"))
+                .count(),
+            2,
+            "alternate Grok root must keep recursive updates.jsonl discovery: {files:?}"
+        );
+        assert!(
+            files.iter().any(|p| p.ends_with("unified.jsonl")),
+            "alternate Grok root must contribute logs/unified.jsonl: {files:?}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_grok_extra_scan_path_sessions_shape_discovers_unified_log() {
+        // extraScanPaths.grok may point at the `sessions` subdirectory (the
+        // shape the primary resolution returns) instead of the home itself;
+        // the unified log is derived from the parent home either way.
+        let mut env = EnvGuard::capture(&["GROK_HOME"]);
+        env.remove("GROK_HOME");
+
+        let home = TempDir::new().unwrap();
+        let alt_home = TempDir::new().unwrap();
+
+        let alt_session = alt_home
+            .path()
+            .join("sessions/%2Ftmp%2Fproject/session-alt");
+        fs::create_dir_all(&alt_session).unwrap();
+        File::create(alt_session.join("updates.jsonl")).unwrap();
+        fs::create_dir_all(alt_home.path().join("logs")).unwrap();
+        File::create(alt_home.path().join("logs/unified.jsonl")).unwrap();
+
+        let settings: ScannerSettings = serde_json::from_value(serde_json::json!({
+            "extraScanPaths": {
+                "grok": [alt_home.path().join("sessions")]
+            }
+        }))
+        .unwrap();
+
+        let result = scan_all_clients_with_scanner_settings(
+            home.path().to_str().unwrap(),
+            &["grok".to_string()],
+            true,
+            &settings,
+        );
+
+        let files = result.get(ClientId::Grok);
+        assert_eq!(
+            files.len(),
+            2,
+            "expected updates.jsonl + unified.jsonl: {files:?}"
+        );
+        assert!(files.iter().any(|p| p.ends_with("updates.jsonl")));
+        assert!(files.iter().any(|p| p.ends_with("unified.jsonl")));
     }
 
     fn setup_mock_jcode_dir(base: &std::path::Path) {

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -913,18 +913,26 @@ fn push_unique_scan_task_with_pattern(
 /// Derive the Grok home directory from a scanned root path.
 ///
 /// The primary resolution (`ClientDef::resolve_path_with_env_strategy`) returns
-/// `<home>/sessions`, so a configured alternate root may point at either the
-/// home itself (`~/.grok`) or its `sessions` subdirectory. A trailing
-/// `sessions` component is treated as the home's child in both cases, keeping
-/// discovery robust to either configuration shape.
+/// `<home>/sessions`, so a configured alternate root may point at the home
+/// itself, its `sessions` directory, or any nested workspace/session directory.
+/// The nearest ancestor named `sessions` (case-insensitively) is treated as the
+/// home's child in all of those cases.
 fn grok_home_from_scan_root(path: &Path) -> PathBuf {
-    if path.file_name().and_then(|name| name.to_str()) == Some("sessions") {
-        path.parent()
-            .map(Path::to_path_buf)
-            .unwrap_or_else(|| path.to_path_buf())
-    } else {
-        path.to_path_buf()
+    if let Some(sessions_dir) = path.ancestors().find(|candidate| {
+        candidate
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(|name| name.eq_ignore_ascii_case("sessions"))
+            .unwrap_or(false)
+    }) {
+        if let Some(grok_home) = sessions_dir.parent() {
+            if !grok_home.as_os_str().is_empty() {
+                return grok_home.to_path_buf();
+            }
+        }
     }
+
+    path.to_path_buf()
 }
 
 /// Register the dual-source scan tasks for one Grok root.
@@ -2545,8 +2553,9 @@ mod tests {
         // unified log was only added for the resolved primary home, so an
         // alternate root contributed only the registered `updates.jsonl`
         // pattern and its inference breakdowns were silently missed.
-        let mut env = EnvGuard::capture(&["GROK_HOME"]);
+        let mut env = EnvGuard::capture(&["GROK_HOME", "TOKSCALE_EXTRA_DIRS"]);
         env.remove("GROK_HOME");
+        env.remove("TOKSCALE_EXTRA_DIRS");
 
         let home = TempDir::new().unwrap();
         let alt_home = TempDir::new().unwrap();
@@ -2601,8 +2610,9 @@ mod tests {
         // extraScanPaths.grok may point at the `sessions` subdirectory (the
         // shape the primary resolution returns) instead of the home itself;
         // the unified log is derived from the parent home either way.
-        let mut env = EnvGuard::capture(&["GROK_HOME"]);
+        let mut env = EnvGuard::capture(&["GROK_HOME", "TOKSCALE_EXTRA_DIRS"]);
         env.remove("GROK_HOME");
+        env.remove("TOKSCALE_EXTRA_DIRS");
 
         let home = TempDir::new().unwrap();
         let alt_home = TempDir::new().unwrap();
@@ -2618,6 +2628,50 @@ mod tests {
         let settings: ScannerSettings = serde_json::from_value(serde_json::json!({
             "extraScanPaths": {
                 "grok": [alt_home.path().join("sessions")]
+            }
+        }))
+        .unwrap();
+
+        let result = scan_all_clients_with_scanner_settings(
+            home.path().to_str().unwrap(),
+            &["grok".to_string()],
+            true,
+            &settings,
+        );
+
+        let files = result.get(ClientId::Grok);
+        assert_eq!(
+            files.len(),
+            2,
+            "expected updates.jsonl + unified.jsonl: {files:?}"
+        );
+        assert!(files.iter().any(|p| p.ends_with("updates.jsonl")));
+        assert!(files.iter().any(|p| p.ends_with("unified.jsonl")));
+    }
+
+    #[test]
+    #[serial]
+    fn test_grok_extra_scan_path_nested_session_shape_discovers_unified_log() {
+        // A root below a mixed-case `sessions` directory still belongs to the
+        // surrounding Grok home, so its sibling logs/unified.jsonl is found.
+        let mut env = EnvGuard::capture(&["GROK_HOME", "TOKSCALE_EXTRA_DIRS"]);
+        env.remove("GROK_HOME");
+        env.remove("TOKSCALE_EXTRA_DIRS");
+
+        let home = TempDir::new().unwrap();
+        let alt_home = TempDir::new().unwrap();
+
+        let alt_session = alt_home
+            .path()
+            .join("Sessions/%2Ftmp%2Fproject/session-alt");
+        fs::create_dir_all(&alt_session).unwrap();
+        File::create(alt_session.join("updates.jsonl")).unwrap();
+        fs::create_dir_all(alt_home.path().join("logs")).unwrap();
+        File::create(alt_home.path().join("logs/unified.jsonl")).unwrap();
+
+        let settings: ScannerSettings = serde_json::from_value(serde_json::json!({
+            "extraScanPaths": {
+                "grok": [alt_session]
             }
         }))
         .unwrap();

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -372,6 +372,7 @@ pub fn scan_directory(root: &str, pattern: &str) -> Vec<PathBuf> {
                 "sessions.json" => file_name == "sessions.json",
                 "wire.jsonl" => file_name == "wire.jsonl",
                 "updates.jsonl" => file_name == "updates.jsonl",
+                "unified.jsonl" => file_name == "unified.jsonl",
                 "events.jsonl" => file_name == "events.jsonl",
                 "ui_messages.json" => file_name == "ui_messages.json",
                 "session-usage.json" => file_name == "session-usage.json",
@@ -1158,6 +1159,23 @@ fn scan_all_clients_with_env_strategy_inner(
         let def = client_id.data();
         let path = def.resolve_path_with_env_strategy(home_dir, use_env_roots);
         push_unique_scan_task(&mut tasks, &mut seen_scan_roots, *client_id, path);
+    }
+
+    if enabled.contains(&ClientId::Grok) {
+        let grok_sessions = PathBuf::from(
+            ClientId::Grok
+                .data()
+                .resolve_path_with_env_strategy(home_dir, use_env_roots),
+        );
+        if let Some(grok_home) = grok_sessions.parent() {
+            push_unique_scan_task_with_pattern(
+                &mut tasks,
+                &mut seen_scan_roots,
+                ClientId::Grok,
+                grok_home.join("logs/unified.jsonl"),
+                "unified.jsonl",
+            );
+        }
     }
 
     for (client_id, path) in extra_scan_paths_for(scanner_settings, &enabled_with_devin_lookup) {
@@ -4420,13 +4438,27 @@ mod tests {
         let home = dir.path();
         setup_mock_grok_dir(home);
 
+        let unified_dir = home.join(".grok/logs");
+        fs::create_dir_all(&unified_dir).unwrap();
+        let unified_log = unified_dir.join("unified.jsonl");
+        File::create(&unified_log).unwrap();
+        let nested_dir = unified_dir.join("archive");
+        fs::create_dir_all(&nested_dir).unwrap();
+        let nested_log = nested_dir.join("unified.jsonl");
+        File::create(&nested_log).unwrap();
+
         let result = scan_all_clients_with_env_strategy(
             home.to_str().unwrap(),
             &["grok".to_string()],
             false,
         );
-        assert_eq!(result.get(ClientId::Grok).len(), 1);
-        assert!(result.get(ClientId::Grok)[0].ends_with("updates.jsonl"));
+        let grok_files = result.get(ClientId::Grok);
+        assert_eq!(grok_files.len(), 2);
+        assert!(grok_files
+            .iter()
+            .any(|path| path.ends_with("updates.jsonl")));
+        assert!(grok_files.iter().any(|path| path == &unified_log));
+        assert!(!grok_files.iter().any(|path| path == &nested_log));
         assert!(result.get(ClientId::OpenCode).is_empty());
         assert!(result.get(ClientId::Claude).is_empty());
     }

--- a/crates/tokscale-core/src/sessionize.rs
+++ b/crates/tokscale-core/src/sessionize.rs
@@ -409,6 +409,7 @@ mod tests {
             dedup_key: None,
             session_title: None,
             is_turn_start: false,
+            model_attribution_conflicted: false,
             duration_ms: None,
         }
     }

--- a/crates/tokscale-core/src/sessions/antigravity_cli.rs
+++ b/crates/tokscale-core/src/sessions/antigravity_cli.rs
@@ -223,7 +223,7 @@ fn file_modified_ms(path: &Path) -> i64 {
 /// Convert a `file://` URI to a filesystem path, percent-decoding UTF-8 escapes
 /// (workspace paths on cloud drives can be percent-encoded CJK). After the
 /// scheme the remainder is `authority + path`; the three shapes RFC 8089 (and
-/// Antigravity) produce are handled:
+/// Antigravity) produces are handled:
 /// - `file:///C:/x`        → `C:/x`            (empty authority, Windows drive: drop the leading slash)
 /// - `file:///home/x`      → `/home/x`         (empty authority, POSIX absolute: keep as-is)
 /// - `file://host/share/x` → `//host/share/x`  (non-empty authority → UNC: restore the leading `//`)

--- a/crates/tokscale-core/src/sessions/grok.rs
+++ b/crates/tokscale-core/src/sessions/grok.rs
@@ -29,6 +29,7 @@ const UNIFIED_LOG_DEDUP_PREFIX: &str = "grok-unified:";
 type UnifiedGeneration = u64;
 type UnifiedProcessKey = (i64, UnifiedGeneration);
 type UnifiedProcessSessionKey = (i64, UnifiedGeneration, String);
+type UnifiedSessionTree = Vec<(PathBuf, Vec<PathBuf>)>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct UnifiedChildScope {
@@ -211,7 +212,12 @@ impl GrokUsage {
         // total is input + output, so split those overlaps before handing the
         // values to TokenBreakdown, whose buckets are additive.
         let inclusive_total = raw_input.saturating_add(raw_output);
-        let reported_total_is_inclusive = reported_total == Some(inclusive_total);
+        // The surrounding Grok usage contract treats input/output as inclusive
+        // buckets even when the optional aggregate total is absent. Do not
+        // require the redundant total field before removing the nested cache
+        // and reasoning buckets.
+        let reported_total_is_inclusive =
+            reported_total.is_none() || reported_total == Some(inclusive_total);
 
         Some(Self {
             tokens: TokenBreakdown {
@@ -669,9 +675,7 @@ fn parse_grok_unified_log_snapshot(
             .and_then(parse_timestamp_value)
             .unwrap_or(fallback_timestamp);
         let reasoning = reasoning_tokens.min(completion_tokens);
-        let dedup_key = format!(
-            "{UNIFIED_LOG_DEDUP_PREFIX}{session_id}:{timestamp}:{pid}:{loop_index}:{prompt_tokens}:{cached_prompt_tokens}:{completion_tokens}:{reasoning_tokens}"
-        );
+        let dedup_key = unified_log_dedup_key(&session_id, &value);
         if !seen.insert(dedup_key.clone()) {
             continue;
         }
@@ -801,6 +805,58 @@ pub fn parse_grok_file(path: &Path) -> Vec<UnifiedMessage> {
     }
 }
 
+/// Return the files and directories that can affect metadata attached to a
+/// unified-log message. The unified parser reads every session under the Grok
+/// home, so the root, workspace/session directories, and metadata siblings all
+/// participate in its source fingerprint. Legacy update files only need their
+/// own sibling metadata.
+pub(crate) fn grok_related_paths(path: &Path) -> Vec<(String, PathBuf)> {
+    if path.file_name().and_then(|name| name.to_str()) != Some("unified.jsonl") {
+        let parent = path.parent().unwrap_or_else(|| Path::new("."));
+        return ["signals.json", "summary.json", "events.jsonl"]
+            .into_iter()
+            .map(|name| (name.to_string(), parent.join(name)))
+            .collect();
+    }
+
+    let Some(grok_home) = path.parent().and_then(Path::parent) else {
+        return Vec::new();
+    };
+    let sessions_root = grok_home.join("sessions");
+    let mut related = vec![("sessions-directory".to_string(), sessions_root.clone())];
+
+    let Some((_, workspaces)) = unified_session_tree(path) else {
+        return related;
+    };
+    for (workspace_dir, session_dirs) in workspaces {
+        let workspace_suffix = cache_path_suffix(grok_home, &workspace_dir);
+        related.push((
+            format!("sessions-workspace:{workspace_suffix}"),
+            workspace_dir.clone(),
+        ));
+        for session_dir in session_dirs {
+            let session_suffix = cache_path_suffix(grok_home, &session_dir);
+            related.push((
+                format!("sessions-session:{session_suffix}"),
+                session_dir.clone(),
+            ));
+            for file_name in [
+                "updates.jsonl",
+                "summary.json",
+                "events.jsonl",
+                "signals.json",
+            ] {
+                related.push((
+                    format!("sessions-file:{session_suffix}/{file_name}"),
+                    session_dir.join(file_name),
+                ));
+            }
+        }
+    }
+
+    related
+}
+
 /// Uses the richer, per-inference unified log for sessions it covers. Legacy
 /// updates remain a fallback for sessions absent from that log, avoiding an
 /// additive merge of two representations of the same activity.
@@ -872,12 +928,69 @@ pub fn prefer_unified_log_messages(mut messages: Vec<UnifiedMessage>) -> Vec<Uni
         }
     }
 
-    messages
-        .into_iter()
-        .filter(|message| {
-            is_unified_log_message(message) || !unified_sessions.contains(&message.session_id)
-        })
-        .collect()
+    // A unified row only proves that one legacy activity row is covered when
+    // both representations agree on the session, timestamp, and inclusive
+    // token total. Retain every unmatched legacy row so a partially migrated
+    // session cannot lose its older history.
+    let mut covered_activity = HashMap::new();
+    let mut covered_fallback_timestamps = HashMap::new();
+    for message in messages
+        .iter()
+        .filter(|message| is_unified_log_message(message))
+    {
+        *covered_activity
+            .entry((
+                message.session_id.clone(),
+                message.timestamp,
+                message.tokens.total(),
+            ))
+            .or_insert(0usize) += 1;
+        *covered_fallback_timestamps
+            .entry((message.session_id.clone(), message.timestamp))
+            .or_insert(0usize) += 1;
+    }
+
+    let mut selected = Vec::with_capacity(messages.len());
+    for message in messages {
+        if is_unified_log_message(&message) {
+            selected.push(message);
+            continue;
+        }
+
+        let key = (
+            message.session_id.clone(),
+            message.timestamp,
+            message.tokens.total(),
+        );
+        let covered = covered_activity.get_mut(&key).is_some_and(|count| {
+            if *count == 0 {
+                false
+            } else {
+                *count -= 1;
+                if let Some(timestamp_count) = covered_fallback_timestamps
+                    .get_mut(&(message.session_id.clone(), message.timestamp))
+                {
+                    *timestamp_count = timestamp_count.saturating_sub(1);
+                }
+                true
+            }
+        }) || (is_legacy_fallback_message(&message)
+            && covered_fallback_timestamps
+                .get_mut(&(message.session_id.clone(), message.timestamp))
+                .is_some_and(|count| {
+                    if *count == 0 {
+                        false
+                    } else {
+                        *count -= 1;
+                        true
+                    }
+                }));
+        if !covered {
+            selected.push(message);
+        }
+    }
+
+    selected
 }
 
 fn is_unified_log_message(message: &UnifiedMessage) -> bool {
@@ -885,6 +998,13 @@ fn is_unified_log_message(message: &UnifiedMessage) -> bool {
         .dedup_key
         .as_deref()
         .is_some_and(|key| key.starts_with(UNIFIED_LOG_DEDUP_PREFIX))
+}
+
+fn is_legacy_fallback_message(message: &UnifiedMessage) -> bool {
+    let Some(key) = message.dedup_key.as_deref() else {
+        return false;
+    };
+    key.starts_with("grok:") && !key.contains(":usage:") && !key.ends_with(":signals")
 }
 
 fn unified_log_process_start_pid(value: &Value) -> Option<i64> {
@@ -944,6 +1064,39 @@ fn optional_non_negative_i64(value: Option<&Value>) -> Option<i64> {
     }
 }
 
+fn unified_log_dedup_key(session_id: &str, value: &Value) -> String {
+    let event_id = [
+        &["event_id"][..],
+        &["eventId"][..],
+        &["id"][..],
+        &["uuid"][..],
+        &["ctx", "event_id"][..],
+        &["ctx", "eventId"][..],
+        &["ctx", "id"][..],
+        &["ctx", "uuid"][..],
+    ]
+    .into_iter()
+    .find_map(|path| {
+        get_path(value, path)
+            .and_then(|value| extract_string(Some(value)))
+            .filter(|id| !id.trim().is_empty())
+    });
+
+    let identity = event_id.map_or_else(
+        || {
+            // Without a source event ID, the complete normalized row is the
+            // stable discriminator. Exact duplicate rows still collapse, but
+            // rows that happen to share timestamp and token fields do not.
+            format!(
+                "row:{}",
+                serde_json::to_string(value).unwrap_or_else(|_| String::new())
+            )
+        },
+        |event_id| format!("id:{event_id}"),
+    );
+    format!("{UNIFIED_LOG_DEDUP_PREFIX}{session_id}:{identity}")
+}
+
 fn fallback_unified_metadata(session_id: &str, timestamp: i64) -> GrokMetadata {
     GrokMetadata {
         session_id: session_id.to_string(),
@@ -955,36 +1108,20 @@ fn fallback_unified_metadata(session_id: &str, timestamp: i64) -> GrokMetadata {
 }
 
 fn read_unified_session_metadata(path: &Path) -> HashMap<String, GrokMetadata> {
-    let Some(grok_home) = path.parent().and_then(Path::parent) else {
-        return HashMap::new();
-    };
-    let sessions_root = grok_home.join("sessions");
-    let Ok(workspaces) = std::fs::read_dir(sessions_root) else {
+    let Some((_, workspaces)) = unified_session_tree(path) else {
         return HashMap::new();
     };
 
     let mut metadata_by_session = HashMap::new();
-    for workspace_entry in workspaces.flatten() {
-        let workspace_dir = workspace_entry.path();
-        if !workspace_dir.is_dir() {
-            continue;
-        }
-
+    for (workspace_dir, session_dirs) in workspaces {
         let workspace_key = workspace_dir
             .file_name()
             .and_then(|name| name.to_str())
             .map(percent_decode_lossy)
             .and_then(|decoded| normalize_workspace_key(&decoded));
         let workspace_label = workspace_key.as_deref().and_then(workspace_label_from_key);
-        let Ok(sessions) = std::fs::read_dir(&workspace_dir) else {
-            continue;
-        };
 
-        for session_entry in sessions.flatten() {
-            let session_dir = session_entry.path();
-            if !session_dir.is_dir() {
-                continue;
-            }
+        for session_dir in session_dirs {
             let Some(session_id) = session_dir
                 .file_name()
                 .and_then(|name| name.to_str())
@@ -1011,6 +1148,43 @@ fn read_unified_session_metadata(path: &Path) -> HashMap<String, GrokMetadata> {
     }
 
     metadata_by_session
+}
+
+fn unified_session_tree(path: &Path) -> Option<(PathBuf, UnifiedSessionTree)> {
+    let grok_home = path.parent().and_then(Path::parent)?;
+    let sessions_root = grok_home.join("sessions");
+    let mut workspaces = Vec::new();
+    let Ok(entries) = std::fs::read_dir(&sessions_root) else {
+        return Some((sessions_root, workspaces));
+    };
+
+    for entry in entries.flatten() {
+        let workspace_dir = entry.path();
+        if !workspace_dir.is_dir() {
+            continue;
+        }
+        let mut session_dirs = Vec::new();
+        if let Ok(entries) = std::fs::read_dir(&workspace_dir) {
+            for entry in entries.flatten() {
+                let session_dir = entry.path();
+                if session_dir.is_dir() {
+                    session_dirs.push(session_dir);
+                }
+            }
+        }
+        session_dirs.sort_unstable();
+        workspaces.push((workspace_dir, session_dirs));
+    }
+    workspaces.sort_by(|left, right| left.0.cmp(&right.0));
+
+    Some((sessions_root, workspaces))
+}
+
+fn cache_path_suffix(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
 }
 
 fn non_negative_i64(value: Option<&Value>) -> i64 {
@@ -1395,6 +1569,22 @@ mod tests {
     }
 
     #[test]
+    fn unified_log_keeps_distinct_rows_when_fallback_timestamp_and_tokens_repeat() {
+        let (_temp, path) = write_unified_fixture(
+            r#"{"pid":17,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":100,"completion_tokens":25,"request_id":"first"}}
+{"pid":17,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":100,"completion_tokens":25,"request_id":"second"}}
+{"pid":17,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":100,"completion_tokens":25,"request_id":"first"}}"#,
+        );
+
+        let messages = parse_grok_unified_log_file(&path);
+
+        assert_eq!(messages.len(), 2);
+        assert_ne!(messages[0].dedup_key, messages[1].dedup_key);
+        assert_eq!(messages[0].timestamp, messages[1].timestamp);
+        assert_eq!(messages[0].tokens.total(), messages[1].tokens.total());
+    }
+
+    #[test]
     fn unified_log_preserves_session_workspace_metadata() {
         let temp = tempfile::TempDir::new().unwrap();
         let logs_dir = temp.path().join("home/.grok/logs");
@@ -1561,6 +1751,30 @@ mod tests {
     }
 
     #[test]
+    fn selector_retains_uncovered_legacy_history_for_partially_unified_session() {
+        let mut older_legacy = test_message("covered", "grok:covered:older");
+        older_legacy.timestamp = 1_700_000_000_000;
+        older_legacy.tokens.input = 10;
+
+        let mut covered_legacy = test_message("covered", "grok:covered:covered");
+        covered_legacy.timestamp = 1_700_000_001_000;
+        covered_legacy.tokens.input = 20;
+
+        let mut covered_unified = test_message("covered", "grok-unified:covered:event");
+        covered_unified.timestamp = covered_legacy.timestamp;
+        covered_unified.tokens.input = covered_legacy.tokens.input;
+
+        let messages =
+            prefer_unified_log_messages(vec![older_legacy, covered_legacy, covered_unified]);
+
+        assert_eq!(messages.len(), 2);
+        assert!(messages
+            .iter()
+            .any(|message| message.dedup_key.as_deref() == Some("grok:covered:older")));
+        assert!(messages.iter().any(is_unified_log_message));
+    }
+
+    #[test]
     fn prefers_unified_log_messages_only_for_covered_sessions() {
         let covered_legacy = test_message("covered", "grok:covered:0");
         let uncovered_legacy = test_message("fallback", "grok:fallback:0");
@@ -1600,6 +1814,24 @@ mod tests {
             messages[0].dedup_key.as_deref(),
             Some("grok:session-1:usage:turn-1")
         );
+    }
+
+    #[test]
+    fn parses_inclusive_usage_buckets_without_total_tokens() {
+        let (_temp, path) = write_fixture(
+            r#"{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"turn_completed","usage":{"inputTokens":100,"outputTokens":25,"reasoningTokens":5,"cachedReadTokens":60}} ,"_meta":{"agentTimestampMs":1700000003000}}}"#,
+            None,
+            None,
+        );
+
+        let messages = parse_grok_updates_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 40);
+        assert_eq!(messages[0].tokens.output, 20);
+        assert_eq!(messages[0].tokens.cache_read, 60);
+        assert_eq!(messages[0].tokens.reasoning, 5);
+        assert_eq!(messages[0].tokens.total(), 125);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/grok.rs
+++ b/crates/tokscale-core/src/sessions/grok.rs
@@ -3,11 +3,12 @@
 //! Grok Build writes JSON-RPC session updates under
 //! `~/.grok/sessions/<urlencoded-workspace>/<session-id>/updates.jsonl`.
 //! Session rollups also land in sibling `signals.json` (including
-//! `totalTokensBeforeCompaction` and `contextTokensUsed`). Current update
-//! logs expose cumulative `totalTokens` counters without a stable
-//! input/output split, so this parser records per-turn positive total-token
-//! deltas as input tokens and reconciles any remaining `signals.json` total
-//! so compacted sessions are not under-counted.
+//! `totalTokensBeforeCompaction` and `contextTokensUsed`). Legacy update logs
+//! expose cumulative `totalTokens` counters without a stable input/output
+//! split, so this parser records per-turn positive total-token deltas as input
+//! tokens and reconciles any remaining `signals.json` total so compacted
+//! sessions are not under-counted. Recent Grok Build releases additionally
+//! write per-inference token breakdowns to `~/.grok/logs/unified.jsonl`.
 
 use super::utils::{
     extract_i64, extract_string, file_modified_timestamp_ms, parse_timestamp_value,
@@ -16,12 +17,127 @@ use super::utils::{
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
 use serde_json::Value;
-use std::io::{BufRead, BufReader};
+use std::collections::{HashMap, HashSet};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
 const CLIENT_ID: &str = "grok";
 const PROVIDER_ID: &str = "xai";
 const UNKNOWN_MODEL: &str = "grok-unknown";
+const UNIFIED_LOG_DEDUP_PREFIX: &str = "grok-unified:";
+
+type UnifiedGeneration = u64;
+type UnifiedProcessKey = (i64, UnifiedGeneration);
+type UnifiedProcessSessionKey = (i64, UnifiedGeneration, String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct UnifiedChildScope {
+    pid: i64,
+    generation: UnifiedGeneration,
+    session_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum UnifiedModelEvidence {
+    Unique(String),
+    Conflict,
+}
+
+#[derive(Debug, Default)]
+struct UnifiedChildEvidence {
+    known_scopes: HashSet<UnifiedChildScope>,
+    child_models: HashMap<UnifiedChildScope, UnifiedModelEvidence>,
+    terminal_scopes: HashSet<UnifiedChildScope>,
+    terminal_models: HashMap<UnifiedChildScope, UnifiedModelEvidence>,
+    child_session_ids: HashSet<String>,
+}
+
+fn authoritative_model(value: Option<&Value>) -> Option<String> {
+    extract_string(value).and_then(|model| {
+        let model = model.trim();
+        (!model.is_empty() && model != UNKNOWN_MODEL).then(|| model.to_string())
+    })
+}
+
+fn record_model_evidence(
+    evidence: &mut HashMap<UnifiedChildScope, UnifiedModelEvidence>,
+    scope: &UnifiedChildScope,
+    model: String,
+) {
+    match evidence.entry(scope.clone()) {
+        std::collections::hash_map::Entry::Vacant(entry) => {
+            entry.insert(UnifiedModelEvidence::Unique(model));
+        }
+        std::collections::hash_map::Entry::Occupied(mut entry) => match entry.get() {
+            UnifiedModelEvidence::Unique(existing) if existing == &model => {}
+            UnifiedModelEvidence::Unique(_) | UnifiedModelEvidence::Conflict => {
+                entry.insert(UnifiedModelEvidence::Conflict);
+            }
+        },
+    }
+}
+
+fn current_unified_generation(
+    generations: &mut HashMap<i64, UnifiedGeneration>,
+    pid: i64,
+) -> UnifiedGeneration {
+    *generations.entry(pid).or_insert(0)
+}
+
+fn advance_unified_generation(generations: &mut HashMap<i64, UnifiedGeneration>, pid: i64) {
+    let generation = generations.entry(pid).or_insert(0);
+    *generation = generation.saturating_add(1);
+}
+
+fn unified_subagent_id(value: &Value) -> Option<String> {
+    extract_string(value.get("ctx")?.get("subagent_id")).filter(|id| !id.trim().is_empty())
+}
+
+fn unified_child_scope(
+    value: &Value,
+    generations: &mut HashMap<i64, UnifiedGeneration>,
+) -> Option<UnifiedChildScope> {
+    let pid = required_non_negative_i64(value.get("pid"))?;
+    Some(UnifiedChildScope {
+        pid,
+        generation: current_unified_generation(generations, pid),
+        session_id: unified_subagent_id(value)?,
+    })
+}
+
+fn unified_spawn_model(value: &Value) -> Option<String> {
+    let context = value.get("ctx")?;
+    authoritative_model(context.get("effective_model"))
+        .or_else(|| authoritative_model(context.get("effective_model_raw")))
+}
+
+fn unified_terminal_model(value: &Value) -> Option<String> {
+    authoritative_model(value.get("ctx")?.get("effective_model"))
+}
+
+fn unique_child_model<'a>(
+    evidence: &'a UnifiedChildEvidence,
+    scope: &UnifiedChildScope,
+) -> Option<&'a str> {
+    let UnifiedModelEvidence::Unique(model) = evidence.child_models.get(scope)? else {
+        return None;
+    };
+    Some(model)
+}
+
+fn unique_terminal_model<'a>(
+    evidence: &'a UnifiedChildEvidence,
+    scope: &UnifiedChildScope,
+) -> Option<&'a str> {
+    if !evidence.terminal_scopes.contains(scope) {
+        return None;
+    }
+    let UnifiedModelEvidence::Unique(terminal_model) = evidence.terminal_models.get(scope)? else {
+        return None;
+    };
+    let child_model = unique_child_model(evidence, scope)?;
+    (terminal_model == child_model).then_some(child_model)
+}
 
 #[derive(Debug, Clone)]
 struct GrokMetadata {
@@ -39,6 +155,119 @@ struct ActiveTurn {
     timestamp: i64,
     model_id: String,
     turn_index: usize,
+}
+
+#[derive(Debug, Clone)]
+struct GrokUsage {
+    tokens: TokenBreakdown,
+}
+
+impl GrokUsage {
+    fn from_update(value: &Value) -> Option<Self> {
+        let usage = get_path(value, &["params", "update", "usage"])?;
+        let raw_input = usage_value(usage, &["inputTokens", "input_tokens", "promptTokens"]);
+        let raw_output = usage_value(
+            usage,
+            &["outputTokens", "output_tokens", "completionTokens"],
+        );
+        let cache_read = usage_value(
+            usage,
+            &[
+                "cachedReadTokens",
+                "cacheReadTokens",
+                "cache_read_input_tokens",
+            ],
+        );
+        let cache_write = usage_value(
+            usage,
+            &[
+                "cachedWriteTokens",
+                "cacheWriteTokens",
+                "cacheCreationTokens",
+                "cache_creation_input_tokens",
+            ],
+        );
+        let reasoning = usage_value(
+            usage,
+            &["reasoningTokens", "thoughtTokens", "thinkingTokens"],
+        );
+        let reported_total = usage
+            .get("totalTokens")
+            .or_else(|| usage.get("total_tokens"))
+            .and_then(|value| extract_i64(Some(value)))
+            .map(|value| value.max(0));
+
+        if raw_input == 0
+            && raw_output == 0
+            && cache_read == 0
+            && cache_write == 0
+            && reasoning == 0
+        {
+            return None;
+        }
+
+        // Grok's `inputTokens` includes the `cachedReadTokens` subset, and its
+        // `outputTokens` includes the `reasoningTokens` subset. The reported
+        // total is input + output, so split those overlaps before handing the
+        // values to TokenBreakdown, whose buckets are additive.
+        let inclusive_total = raw_input.saturating_add(raw_output);
+        let reported_total_is_inclusive = reported_total == Some(inclusive_total);
+
+        Some(Self {
+            tokens: TokenBreakdown {
+                input: if reported_total_is_inclusive {
+                    raw_input.saturating_sub(cache_read)
+                } else {
+                    raw_input
+                },
+                output: if reported_total_is_inclusive {
+                    raw_output.saturating_sub(reasoning)
+                } else {
+                    raw_output
+                },
+                cache_read,
+                cache_write,
+                reasoning,
+            },
+        })
+    }
+}
+
+fn usage_value(value: &Value, keys: &[&str]) -> i64 {
+    keys.iter()
+        .find_map(|key| extract_i64(value.get(*key)))
+        .unwrap_or(0)
+        .max(0)
+}
+
+fn message_from_tokens(
+    metadata: &GrokMetadata,
+    model_id: String,
+    timestamp: i64,
+    tokens: TokenBreakdown,
+    dedup_key: String,
+    is_turn_start: bool,
+) -> UnifiedMessage {
+    let mut message = UnifiedMessage::new_with_dedup(
+        CLIENT_ID,
+        if model_id.trim().is_empty() {
+            UNKNOWN_MODEL.to_string()
+        } else {
+            model_id
+        },
+        PROVIDER_ID,
+        metadata.session_id.clone(),
+        timestamp,
+        tokens,
+        0.0,
+        Some(dedup_key),
+    );
+    message.set_workspace(
+        metadata.workspace_key.clone(),
+        metadata.workspace_label.clone(),
+    );
+    message.is_turn_start = is_turn_start;
+    message
 }
 
 impl ActiveTurn {
@@ -71,11 +300,9 @@ impl ActiveTurn {
             self.model_id
         };
 
-        let mut message = UnifiedMessage::new_with_dedup(
-            CLIENT_ID,
+        Some(message_from_tokens(
+            metadata,
             model_id,
-            PROVIDER_ID,
-            metadata.session_id.clone(),
             self.timestamp,
             TokenBreakdown {
                 input: token_delta,
@@ -84,15 +311,9 @@ impl ActiveTurn {
                 cache_write: 0,
                 reasoning: 0,
             },
-            0.0,
-            Some(format!("grok:{}:{}", metadata.session_id, self.turn_index)),
-        );
-        message.set_workspace(
-            metadata.workspace_key.clone(),
-            metadata.workspace_label.clone(),
-        );
-        message.is_turn_start = true;
-        Some(message)
+            format!("grok:{}:{}", metadata.session_id, self.turn_index),
+            true,
+        ))
     }
 }
 
@@ -107,7 +328,8 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
         Err(_) => return Vec::new(),
     };
 
-    let mut messages = Vec::new();
+    let mut fallback_messages = Vec::new();
+    let mut usage_messages = Vec::new();
     let mut current_model = metadata
         .model_id
         .clone()
@@ -116,6 +338,7 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
     let mut last_total_timestamp = metadata.timestamp;
     let mut active_turn: Option<ActiveTurn> = None;
     let mut turn_index = 0usize;
+    let mut usage_index = 0usize;
 
     for line in BufReader::new(file).lines().map_while(Result::ok) {
         if line.trim().is_empty() {
@@ -139,7 +362,7 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
         if is_user_message_chunk(&value) {
             if let Some(turn) = active_turn.take() {
                 if let Some(message) = turn.into_message(&metadata) {
-                    messages.push(message);
+                    fallback_messages.push(message);
                 }
             }
 
@@ -150,6 +373,31 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
                 turn_index,
             ));
             turn_index = turn_index.saturating_add(1);
+        }
+
+        if let Some(usage) = GrokUsage::from_update(&value) {
+            let model_id = if current_model != UNKNOWN_MODEL {
+                current_model.clone()
+            } else {
+                get_path(&value, &["params", "update", "usage", "modelUsage"])
+                    .and_then(Value::as_object)
+                    .and_then(|models| (models.len() == 1).then(|| models.keys().next().cloned()))
+                    .flatten()
+                    .or_else(|| metadata.model_id.clone())
+                    .unwrap_or_else(|| UNKNOWN_MODEL.to_string())
+            };
+            let event_id = get_path(&value, &["params", "_meta", "eventId"])
+                .and_then(|value| extract_string(Some(value)))
+                .unwrap_or_else(|| format!("turn-{usage_index}"));
+            usage_messages.push(message_from_tokens(
+                &metadata,
+                model_id,
+                timestamp,
+                usage.tokens,
+                format!("grok:{}:usage:{}", metadata.session_id, event_id),
+                true,
+            ));
+            usage_index = usage_index.saturating_add(1);
         }
 
         let Some(total_tokens) = extract_total_tokens(&value) else {
@@ -196,11 +444,11 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
 
     if let Some(turn) = active_turn {
         if let Some(message) = turn.into_message(&metadata) {
-            messages.push(message);
+            fallback_messages.push(message);
         }
     }
 
-    if messages.is_empty() {
+    if fallback_messages.is_empty() && usage_messages.is_empty() {
         if let Some(total_tokens) = last_total.filter(|tokens| *tokens > 0) {
             let aggregate_turn = ActiveTurn {
                 baseline_total: 0,
@@ -210,13 +458,559 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
                 turn_index: 0,
             };
             if let Some(message) = aggregate_turn.into_message(&metadata) {
-                messages.push(message);
+                fallback_messages.push(message);
             }
         }
     }
 
-    append_signals_reconciliation(path, &metadata, &mut messages, &current_model);
+    if usage_messages.is_empty() {
+        append_signals_reconciliation(path, &metadata, &mut fallback_messages, &current_model);
+        return fallback_messages;
+    }
+
+    // A usage record is emitted when a turn completes. Keep only cumulative
+    // counter activity newer than the latest completed turn as a best-effort
+    // representation of a currently running turn; older fallback messages are
+    // the same work already covered by authoritative usage records.
+    let latest_usage_timestamp = usage_messages
+        .iter()
+        .map(|message| message.timestamp)
+        .max()
+        .unwrap_or(0);
+    usage_messages.extend(
+        fallback_messages
+            .into_iter()
+            .filter(|message| message.timestamp > latest_usage_timestamp),
+    );
+    usage_messages
+}
+
+/// Parse Grok Build's append-only unified log. Each
+/// `shell.turn.inference_done` record reports a prompt total that includes
+/// cached prompt tokens and a completion total that includes reasoning tokens.
+/// Store the non-overlapping component buckets so the breakdown remains
+/// additive and the source totals are preserved.
+pub fn parse_grok_unified_log_file(path: &Path) -> Vec<UnifiedMessage> {
+    if path.file_name().and_then(|name| name.to_str()) != Some("unified.jsonl") {
+        return Vec::new();
+    }
+
+    let mut file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(_) => return Vec::new(),
+    };
+    let prefix_len = file.metadata().map(|metadata| metadata.len()).unwrap_or(0);
+    parse_grok_unified_log_snapshot(path, &mut file, prefix_len)
+}
+
+#[cfg(test)]
+fn parse_grok_unified_log_file_with_prefix(path: &Path, prefix_len: u64) -> Vec<UnifiedMessage> {
+    let mut file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(_) => return Vec::new(),
+    };
+    parse_grok_unified_log_snapshot(path, &mut file, prefix_len)
+}
+
+fn parse_grok_unified_log_snapshot(
+    path: &Path,
+    file: &mut std::fs::File,
+    prefix_len: u64,
+) -> Vec<UnifiedMessage> {
+    let fallback_timestamp = file_modified_timestamp_ms(path);
+    let evidence = collect_unified_child_evidence(file, prefix_len);
+    if file.seek(SeekFrom::Start(0)).is_err() {
+        return Vec::new();
+    }
+
+    let metadata_by_session = read_unified_session_metadata(path);
+    let mut generations = HashMap::new();
+    let mut fallback_model_by_pid: HashMap<UnifiedProcessKey, String> = HashMap::new();
+    let mut model_by_pid_and_session: HashMap<UnifiedProcessSessionKey, String> = HashMap::new();
+    let mut model_by_session = HashMap::new();
+    let mut seen = HashSet::new();
+    let mut messages = Vec::new();
+
+    for line in BufReader::new(file)
+        .take(prefix_len)
+        .lines()
+        .map_while(Result::ok)
+    {
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+
+        if let Some(pid) = unified_log_process_start_pid(&value) {
+            // The unified log survives process restarts, so an OS-reused PID
+            // must not inherit model authority from the previous process.
+            advance_unified_generation(&mut generations, pid);
+            continue;
+        }
+
+        let message_name = value.get("msg").and_then(Value::as_str);
+        match message_name {
+            Some("subagent read parent config (live)") => {
+                if let Some((pid, model_id)) = unified_log_parent_model(&value) {
+                    let generation = current_unified_generation(&mut generations, pid);
+                    fallback_model_by_pid.insert((pid, generation), model_id);
+                }
+                continue;
+            }
+            Some("subagent model resolved") => {
+                if let Some((pid, model_id)) = unified_log_parent_model(&value) {
+                    let generation = current_unified_generation(&mut generations, pid);
+                    fallback_model_by_pid.insert((pid, generation), model_id);
+                    continue;
+                }
+            }
+            Some("subagent spawn credentials") => {
+                if let Some((pid, model_id)) = unified_log_parent_model(&value) {
+                    let generation = current_unified_generation(&mut generations, pid);
+                    fallback_model_by_pid.insert((pid, generation), model_id);
+                }
+                if let Some(scope) = unified_child_scope(&value, &mut generations) {
+                    if let Some(model_id) = unified_spawn_model(&value) {
+                        if unique_child_model(&evidence, &scope) == Some(model_id.as_str()) {
+                            model_by_pid_and_session
+                                .entry((scope.pid, scope.generation, scope.session_id))
+                                .or_insert(model_id);
+                        }
+                    }
+                }
+                continue;
+            }
+            Some("subagent completed") | Some("subagent failed") => {
+                if let Some(scope) = unified_child_scope(&value, &mut generations) {
+                    if let Some(model_id) = unified_terminal_model(&value) {
+                        if unique_terminal_model(&evidence, &scope) == Some(model_id.as_str()) {
+                            // A terminal record is fallback evidence, never a
+                            // rewrite of a model established by an earlier
+                            // exact event.
+                            model_by_pid_and_session
+                                .entry((scope.pid, scope.generation, scope.session_id))
+                                .or_insert(model_id);
+                        }
+                    }
+                }
+                continue;
+            }
+            _ => {}
+        }
+
+        if let Some((pid, session_id, model_id)) = unified_log_model_change(&value) {
+            match (pid, session_id) {
+                (Some(pid), Some(session_id)) => {
+                    let generation = current_unified_generation(&mut generations, pid);
+                    model_by_pid_and_session.insert((pid, generation, session_id), model_id);
+                }
+                (None, Some(session_id)) => {
+                    model_by_pid_and_session.retain(|key, _| {
+                        key.2 != session_id || evidence.child_session_ids.contains(&key.2)
+                    });
+                    model_by_session.insert(session_id, model_id);
+                }
+                (Some(pid), None) => {
+                    let generation = current_unified_generation(&mut generations, pid);
+                    fallback_model_by_pid.insert((pid, generation), model_id);
+                }
+                (None, None) => {}
+            }
+            continue;
+        }
+
+        if message_name != Some("shell.turn.inference_done") {
+            continue;
+        }
+
+        let Some(session_id) =
+            extract_string(value.get("sid")).filter(|session_id| !session_id.trim().is_empty())
+        else {
+            continue;
+        };
+        let Some(context) = value.get("ctx") else {
+            continue;
+        };
+        let Some(prompt_tokens) = required_non_negative_i64(context.get("prompt_tokens")) else {
+            continue;
+        };
+        let Some(completion_tokens) = required_non_negative_i64(context.get("completion_tokens"))
+        else {
+            continue;
+        };
+        let Some(mut cached_prompt_tokens) =
+            optional_non_negative_i64(context.get("cached_prompt_tokens"))
+        else {
+            continue;
+        };
+        let Some(reasoning_tokens) = optional_non_negative_i64(context.get("reasoning_tokens"))
+        else {
+            continue;
+        };
+        cached_prompt_tokens = cached_prompt_tokens.min(prompt_tokens);
+
+        let loop_index = match context.get("loop_index") {
+            Some(value) => {
+                let Some(loop_index) = required_non_negative_i64(Some(value)) else {
+                    continue;
+                };
+                loop_index
+            }
+            None => 1,
+        };
+        let Some(pid) = optional_non_negative_i64(value.get("pid")) else {
+            continue;
+        };
+        let timestamp = value
+            .get("ts")
+            .and_then(parse_timestamp_value)
+            .unwrap_or(fallback_timestamp);
+        let reasoning = reasoning_tokens.min(completion_tokens);
+        let dedup_key = format!(
+            "{UNIFIED_LOG_DEDUP_PREFIX}{session_id}:{timestamp}:{pid}:{loop_index}:{prompt_tokens}:{cached_prompt_tokens}:{completion_tokens}:{reasoning_tokens}"
+        );
+        if !seen.insert(dedup_key.clone()) {
+            continue;
+        }
+
+        let metadata = metadata_by_session
+            .get(&session_id)
+            .cloned()
+            .unwrap_or_else(|| fallback_unified_metadata(&session_id, fallback_timestamp));
+        let generation = current_unified_generation(&mut generations, pid);
+        let child_scope = value.get("pid").map(|_| UnifiedChildScope {
+            pid,
+            generation,
+            session_id: session_id.clone(),
+        });
+        let known_scope = child_scope
+            .as_ref()
+            .is_some_and(|scope| evidence.known_scopes.contains(scope));
+        let known_child_session = evidence.child_session_ids.contains(&session_id);
+        let exact_model = model_by_pid_and_session
+            .get(&(pid, generation, session_id.clone()))
+            .cloned();
+        let model_id = if let Some(model_id) = exact_model {
+            model_id
+        } else if known_scope {
+            child_scope
+                .as_ref()
+                .and_then(|scope| unique_terminal_model(&evidence, scope))
+                .map(str::to_string)
+                .unwrap_or_else(|| UNKNOWN_MODEL.to_string())
+        } else if known_child_session {
+            UNKNOWN_MODEL.to_string()
+        } else {
+            model_by_session
+                .get(&session_id)
+                .or_else(|| fallback_model_by_pid.get(&(pid, generation)))
+                .cloned()
+                .or_else(|| metadata.model_id.clone())
+                .unwrap_or_else(|| UNKNOWN_MODEL.to_string())
+        };
+        let mut message = message_from_tokens(
+            &metadata,
+            model_id,
+            timestamp,
+            TokenBreakdown {
+                input: prompt_tokens.saturating_sub(cached_prompt_tokens),
+                output: completion_tokens.saturating_sub(reasoning),
+                cache_read: cached_prompt_tokens,
+                cache_write: 0,
+                reasoning,
+            },
+            dedup_key,
+            loop_index == 1,
+        );
+        message.session_id = session_id;
+        message.message_count = i32::from(message.is_turn_start);
+        messages.push(message);
+    }
+
     messages
+}
+
+fn collect_unified_child_evidence(
+    file: &mut std::fs::File,
+    prefix_len: u64,
+) -> UnifiedChildEvidence {
+    let mut evidence = UnifiedChildEvidence::default();
+    let mut generations = HashMap::new();
+
+    for line in BufReader::new(file)
+        .take(prefix_len)
+        .lines()
+        .map_while(Result::ok)
+    {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        if let Some(pid) = unified_log_process_start_pid(&value) {
+            advance_unified_generation(&mut generations, pid);
+            continue;
+        }
+
+        let message_name = value.get("msg").and_then(Value::as_str);
+        let is_spawn = message_name == Some("subagent spawn credentials");
+        let is_terminal = matches!(message_name, Some("subagent completed" | "subagent failed"));
+        if !is_spawn && !is_terminal {
+            continue;
+        }
+        let Some(subagent_id) = unified_subagent_id(&value) else {
+            continue;
+        };
+        evidence.child_session_ids.insert(subagent_id);
+        let Some(scope) = unified_child_scope(&value, &mut generations) else {
+            continue;
+        };
+        evidence.known_scopes.insert(scope.clone());
+        if is_terminal {
+            evidence.terminal_scopes.insert(scope.clone());
+        }
+
+        let model_id = if is_spawn {
+            unified_spawn_model(&value)
+        } else {
+            unified_terminal_model(&value)
+        };
+        let Some(model_id) = model_id else {
+            continue;
+        };
+        record_model_evidence(&mut evidence.child_models, &scope, model_id.clone());
+        if is_terminal {
+            record_model_evidence(&mut evidence.terminal_models, &scope, model_id);
+        }
+    }
+
+    evidence
+}
+
+/// Dispatch between Grok's legacy per-session updates and its newer unified
+/// log without accepting unrelated JSONL files under the Grok home directory.
+pub fn parse_grok_file(path: &Path) -> Vec<UnifiedMessage> {
+    match path.file_name().and_then(|name| name.to_str()) {
+        Some("updates.jsonl") => parse_grok_updates_file(path),
+        Some("unified.jsonl") => parse_grok_unified_log_file(path),
+        _ => Vec::new(),
+    }
+}
+
+/// Uses the richer, per-inference unified log for sessions it covers. Legacy
+/// updates remain a fallback for sessions absent from that log, avoiding an
+/// additive merge of two representations of the same activity.
+pub fn prefer_unified_log_messages(mut messages: Vec<UnifiedMessage>) -> Vec<UnifiedMessage> {
+    let unified_sessions: HashSet<String> = messages
+        .iter()
+        .filter(|message| is_unified_log_message(message))
+        .map(|message| message.session_id.clone())
+        .collect();
+
+    if unified_sessions.is_empty() {
+        return messages;
+    }
+
+    let mut legacy_models = HashMap::new();
+    let mut legacy_workspaces = HashMap::new();
+    for message in messages
+        .iter()
+        .filter(|message| !is_unified_log_message(message))
+    {
+        if message.model_id != UNKNOWN_MODEL {
+            match legacy_models.entry(message.session_id.clone()) {
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(Some(message.model_id.clone()));
+                }
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    if entry.get().as_ref() != Some(&message.model_id) {
+                        entry.insert(None);
+                    }
+                }
+            }
+        }
+
+        let workspace = (
+            message.workspace_key.clone(),
+            message.workspace_label.clone(),
+        );
+        if workspace == (None, None) {
+            continue;
+        }
+
+        match legacy_workspaces.entry(message.session_id.clone()) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(Some(workspace));
+            }
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                if entry.get().as_ref() != Some(&workspace) {
+                    entry.insert(None);
+                }
+            }
+        }
+    }
+
+    for message in messages
+        .iter_mut()
+        .filter(|message| is_unified_log_message(message))
+    {
+        if message.model_id == UNKNOWN_MODEL {
+            if let Some(Some(model_id)) = legacy_models.get(&message.session_id) {
+                message.model_id = model_id.clone();
+            }
+        }
+        if message.workspace_key.is_none() && message.workspace_label.is_none() {
+            if let Some(Some((workspace_key, workspace_label))) =
+                legacy_workspaces.get(&message.session_id)
+            {
+                message.set_workspace(workspace_key.clone(), workspace_label.clone());
+            }
+        }
+    }
+
+    messages
+        .into_iter()
+        .filter(|message| {
+            is_unified_log_message(message) || !unified_sessions.contains(&message.session_id)
+        })
+        .collect()
+}
+
+fn is_unified_log_message(message: &UnifiedMessage) -> bool {
+    message
+        .dedup_key
+        .as_deref()
+        .is_some_and(|key| key.starts_with(UNIFIED_LOG_DEDUP_PREFIX))
+}
+
+fn unified_log_process_start_pid(value: &Value) -> Option<i64> {
+    if value.get("msg").and_then(Value::as_str) != Some("AuthManager::new") {
+        return None;
+    }
+    required_non_negative_i64(value.get("pid"))
+}
+
+fn unified_log_parent_model(value: &Value) -> Option<(i64, String)> {
+    let pid = required_non_negative_i64(value.get("pid"))?;
+    let context = value.get("ctx")?;
+    let model_id = match value.get("msg").and_then(Value::as_str)? {
+        "subagent read parent config (live)" => {
+            authoritative_model(context.get("session_model_id"))
+                .or_else(|| authoritative_model(context.get("parent_model")))
+                .or_else(|| authoritative_model(context.get("global_model_id")))
+        }
+        "subagent model resolved" | "subagent spawn credentials" => {
+            authoritative_model(context.get("parent_model"))
+        }
+        _ => None,
+    }?;
+    Some((pid, model_id))
+}
+
+fn unified_log_model_change(value: &Value) -> Option<(Option<i64>, Option<String>, String)> {
+    let pid = match value.get("pid") {
+        Some(value) => Some(required_non_negative_i64(Some(value))?),
+        None => None,
+    };
+    let context = value.get("ctx")?;
+    let model_id = match value.get("msg").and_then(Value::as_str)? {
+        "model changed" => authoritative_model(context.get("model")),
+        "model catalog: notifying clients" => authoritative_model(context.get("current_model_id")),
+        "backend_search: model switch" => authoritative_model(context.get("new_model"))
+            .or_else(|| authoritative_model(context.get("model")))
+            .or_else(|| authoritative_model(context.get("current_model_id"))),
+        "subagent model resolved" => authoritative_model(context.get("model_id"))
+            .or_else(|| authoritative_model(context.get("model"))),
+        _ => None,
+    }?;
+
+    let session_id =
+        extract_string(value.get("sid")).filter(|session_id| !session_id.trim().is_empty());
+    (pid.is_some() || session_id.is_some()).then_some((pid, session_id, model_id))
+}
+
+fn required_non_negative_i64(value: Option<&Value>) -> Option<i64> {
+    extract_i64(value).filter(|value| *value >= 0)
+}
+
+fn optional_non_negative_i64(value: Option<&Value>) -> Option<i64> {
+    match value {
+        Some(value) => required_non_negative_i64(Some(value)),
+        None => Some(0),
+    }
+}
+
+fn fallback_unified_metadata(session_id: &str, timestamp: i64) -> GrokMetadata {
+    GrokMetadata {
+        session_id: session_id.to_string(),
+        model_id: None,
+        timestamp,
+        workspace_key: None,
+        workspace_label: None,
+    }
+}
+
+fn read_unified_session_metadata(path: &Path) -> HashMap<String, GrokMetadata> {
+    let Some(grok_home) = path.parent().and_then(Path::parent) else {
+        return HashMap::new();
+    };
+    let sessions_root = grok_home.join("sessions");
+    let Ok(workspaces) = std::fs::read_dir(sessions_root) else {
+        return HashMap::new();
+    };
+
+    let mut metadata_by_session = HashMap::new();
+    for workspace_entry in workspaces.flatten() {
+        let workspace_dir = workspace_entry.path();
+        if !workspace_dir.is_dir() {
+            continue;
+        }
+
+        let workspace_key = workspace_dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(percent_decode_lossy)
+            .and_then(|decoded| normalize_workspace_key(&decoded));
+        let workspace_label = workspace_key.as_deref().and_then(workspace_label_from_key);
+        let Ok(sessions) = std::fs::read_dir(&workspace_dir) else {
+            continue;
+        };
+
+        for session_entry in sessions.flatten() {
+            let session_dir = session_entry.path();
+            if !session_dir.is_dir() {
+                continue;
+            }
+            let Some(session_id) = session_dir
+                .file_name()
+                .and_then(|name| name.to_str())
+                .filter(|id| !id.trim().is_empty())
+            else {
+                continue;
+            };
+
+            let updates_path = session_dir.join("updates.jsonl");
+            let metadata = if updates_path.is_file() {
+                read_metadata(&updates_path)
+            } else {
+                let mut metadata =
+                    fallback_unified_metadata(session_id, file_modified_timestamp_ms(&session_dir));
+                metadata.workspace_key = workspace_key.clone();
+                metadata.workspace_label = workspace_label.clone();
+                read_summary_metadata(&session_dir.join("summary.json"), &mut metadata);
+                read_events_metadata(&session_dir.join("events.jsonl"), &mut metadata);
+                read_signals_metadata(&session_dir.join("signals.json"), &mut metadata);
+                metadata
+            };
+            metadata_by_session.insert(session_id.to_string(), metadata);
+        }
+    }
+
+    metadata_by_session
 }
 
 fn non_negative_i64(value: Option<&Value>) -> i64 {
@@ -533,6 +1327,279 @@ mod tests {
             std::fs::write(session_dir.join("signals.json"), signals_json).unwrap();
         }
         (temp, updates_path)
+    }
+
+    fn write_unified_fixture(unified_jsonl: &str) -> (tempfile::TempDir, PathBuf) {
+        let temp = tempfile::TempDir::new().unwrap();
+        let logs_dir = temp.path().join(".grok/logs");
+        std::fs::create_dir_all(&logs_dir).unwrap();
+        let path = logs_dir.join("unified.jsonl");
+        std::fs::write(&path, unified_jsonl).unwrap();
+        (temp, path)
+    }
+
+    fn test_message(session_id: &str, dedup_key: &str) -> UnifiedMessage {
+        UnifiedMessage::new_with_dedup(
+            CLIENT_ID,
+            "grok-build",
+            PROVIDER_ID,
+            session_id,
+            1_700_000_000_000,
+            TokenBreakdown::default(),
+            0.0,
+            Some(dedup_key.to_string()),
+        )
+    }
+
+    #[test]
+    fn parses_unified_log_token_breakdown_without_double_counting_reasoning() {
+        let (_temp, path) = write_unified_fixture(
+            r#"{"ts":"2023-11-14T22:13:19Z","pid":17,"sid":"session-1","msg":"model changed","ctx":{"model":"grok-composer-2.5-fast"}}
+{"ts":"2023-11-14T22:13:19Z","pid":17,"msg":"model catalog: notifying clients","ctx":{"current_model_id":"grok-4.5"}}
+{"ts":"2023-11-14T22:13:20Z","pid":17,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":100,"cached_prompt_tokens":60,"completion_tokens":25,"reasoning_tokens":5}}
+{"ts":"2023-11-14T22:13:21Z","pid":17,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":2,"prompt_tokens":80,"cached_prompt_tokens":0,"completion_tokens":12,"reasoning_tokens":0}}
+{"ts":"2023-11-14T22:13:20Z","pid":17,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":100,"cached_prompt_tokens":60,"completion_tokens":25,"reasoning_tokens":5}}
+{"ts":"2023-11-14T22:13:22Z","pid":17,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":3,"prompt_tokens":10,"cached_prompt_tokens":11,"completion_tokens":1,"reasoning_tokens":0}}
+{"ts":"2023-11-14T22:13:23Z","pid":17,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":4,"prompt_tokens":10,"cached_prompt_tokens":0,"completion_tokens":1,"reasoning_tokens":2}}"#,
+        );
+
+        let messages = parse_grok_unified_log_file(&path);
+
+        assert_eq!(messages.len(), 4);
+        assert_eq!(messages[0].client, CLIENT_ID);
+        assert_eq!(messages[0].model_id, "grok-composer-2.5-fast");
+        assert_eq!(messages[0].session_id, "session-1");
+        assert_eq!(messages[0].tokens.input, 40);
+        assert_eq!(messages[0].tokens.cache_read, 60);
+        assert_eq!(messages[0].tokens.output, 20);
+        assert_eq!(messages[0].tokens.reasoning, 5);
+        assert_eq!(messages[0].tokens.total(), 125);
+        assert_eq!(messages[0].message_count, 1);
+        assert!(messages[0].is_turn_start);
+        assert_eq!(messages[1].tokens.input, 80);
+        assert_eq!(messages[1].tokens.output, 12);
+        assert_eq!(messages[1].message_count, 0);
+        assert!(!messages[1].is_turn_start);
+        assert_eq!(messages[2].tokens.input, 0);
+        assert_eq!(messages[2].tokens.cache_read, 10);
+        assert_eq!(messages[2].tokens.output, 1);
+        assert_eq!(messages[2].tokens.total(), 11);
+        assert_eq!(messages[2].message_count, 0);
+        assert!(!messages[2].is_turn_start);
+        assert_eq!(messages[3].tokens.input, 10);
+        assert_eq!(messages[3].tokens.output, 0);
+        assert_eq!(messages[3].tokens.reasoning, 1);
+        assert_eq!(messages[3].tokens.total(), 11);
+        assert_eq!(messages[3].message_count, 0);
+        assert!(!messages[3].is_turn_start);
+    }
+
+    #[test]
+    fn unified_log_preserves_session_workspace_metadata() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let logs_dir = temp.path().join("home/.grok/logs");
+        let session_dir = temp
+            .path()
+            .join("home/.grok/sessions/%2Ftmp%2Fproject/session-1");
+        std::fs::create_dir_all(&logs_dir).unwrap();
+        std::fs::create_dir_all(&session_dir).unwrap();
+        std::fs::write(
+            session_dir.join("summary.json"),
+            r#"{"current_model_id":"grok-4.5","updated_at":"2023-11-14T22:13:20Z"}"#,
+        )
+        .unwrap();
+        let path = logs_dir.join("unified.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"ts":"2023-11-14T22:13:20Z","pid":17,"sid":"session-1","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":10,"cached_prompt_tokens":2,"completion_tokens":4,"reasoning_tokens":1}}"#,
+        )
+        .unwrap();
+
+        let messages = parse_grok_unified_log_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "grok-4.5");
+        assert_eq!(messages[0].workspace_key.as_deref(), Some("/tmp/project"));
+        assert_eq!(messages[0].workspace_label.as_deref(), Some("project"));
+    }
+
+    #[test]
+    fn unified_log_applies_pidless_session_model_switch() {
+        let (_temp, path) = write_unified_fixture(
+            r#"{"ts":"2023-11-14T22:13:18Z","pid":17,"msg":"model catalog: notifying clients","ctx":{"current_model_id":"grok-4.5"}}
+{"ts":"2023-11-14T22:13:19Z","pid":17,"sid":"session-with-model-event","msg":"model changed","ctx":{"model":"grok-composer-2.5-fast"}}
+{"ts":"2023-11-14T22:13:20Z","pid":17,"sid":"session-with-model-event","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":10,"completion_tokens":1}}
+{"ts":"2023-11-14T22:13:21Z","sid":"session-with-model-event","msg":"model changed","ctx":{"model":"grok-4.1-fast"}}
+{"ts":"2023-11-14T22:13:22Z","pid":17,"sid":"session-with-model-event","msg":"shell.turn.inference_done","ctx":{"loop_index":2,"prompt_tokens":15,"completion_tokens":2}}
+{"ts":"2023-11-14T22:13:23Z","pid":17,"sid":"session-without-model-event","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":20,"completion_tokens":2}}"#,
+        );
+
+        let messages = parse_grok_unified_log_file(&path);
+
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0].model_id, "grok-composer-2.5-fast");
+        assert_eq!(messages[1].model_id, "grok-4.1-fast");
+        assert_eq!(messages[2].model_id, "grok-4.5");
+    }
+
+    #[test]
+    fn unified_log_expires_pid_scoped_models_on_process_restart() {
+        let (_temp, path) = write_unified_fixture(
+            r#"{"ts":"2023-11-14T22:13:17Z","sid":"session-stable","msg":"model changed","ctx":{"model":"grok-session"}}
+{"ts":"2023-11-14T22:13:18Z","pid":17,"msg":"model catalog: notifying clients","ctx":{"current_model_id":"grok-old"}}
+{"ts":"2023-11-14T22:13:19Z","pid":17,"sid":"session-old","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":10,"completion_tokens":1}}
+{"ts":"2023-11-14T22:13:20Z","pid":17,"msg":"AuthManager::new","src":"shell","ctx":{}}
+{"ts":"2023-11-14T22:13:21Z","pid":17,"sid":"session-stable","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":15,"completion_tokens":1}}
+{"ts":"2023-11-14T22:13:22Z","pid":17,"sid":"session-new","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":20,"completion_tokens":2}}
+{"ts":"2023-11-14T22:13:23Z","pid":17,"msg":"model catalog: notifying clients","ctx":{"current_model_id":"grok-new"}}
+{"ts":"2023-11-14T22:13:24Z","pid":17,"sid":"session-new","msg":"shell.turn.inference_done","ctx":{"loop_index":2,"prompt_tokens":30,"completion_tokens":3}}"#,
+        );
+
+        let messages = parse_grok_unified_log_file(&path);
+
+        assert_eq!(messages.len(), 4);
+        assert_eq!(messages[0].model_id, "grok-old");
+        assert_eq!(messages[1].model_id, "grok-session");
+        assert_eq!(messages[2].model_id, UNKNOWN_MODEL);
+        assert_eq!(messages[3].model_id, "grok-new");
+    }
+
+    #[test]
+    fn unified_log_attributes_parent_and_child_models_by_exact_scope() {
+        let (_temp, path) = write_unified_fixture(
+            r#"{"ts":"2026-07-31T00:00:00Z","pid":17,"msg":"subagent read parent config (live)","ctx":{"session_model_id":" grok-4.6 ","parent_model":"grok-4.5","global_model_id":"grok-4.4"}}
+{"ts":"2026-07-31T00:00:01Z","pid":17,"sid":"parent","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":10,"completion_tokens":2}}
+{"ts":"2026-07-31T00:00:02Z","pid":17,"msg":"subagent spawn credentials","ctx":{"subagent_id":"child-a","effective_model":" grok-4.7 ","effective_model_raw":"raw-a","parent_model":"grok-4.6"}}
+{"ts":"2026-07-31T00:00:03Z","pid":17,"sid":"child-a","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":11,"completion_tokens":2}}
+{"ts":"2026-07-31T00:00:04Z","pid":17,"msg":"subagent spawn credentials","ctx":{"subagent_id":"child-b","effective_model":"grok-4.8","parent_model":"grok-4.6"}}
+{"ts":"2026-07-31T00:00:05Z","pid":17,"sid":"child-b","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":12,"completion_tokens":2}}
+{"ts":"2026-07-31T00:00:06Z","sid":"child-a","msg":"model changed","ctx":{"model":"grok-global"}}
+{"ts":"2026-07-31T00:00:07Z","pid":17,"sid":"child-a","msg":"shell.turn.inference_done","ctx":{"loop_index":2,"prompt_tokens":13,"completion_tokens":2}}
+{"ts":"2026-07-31T00:00:08Z","sid":"ordinary","msg":"model changed","ctx":{"model":" grok-ordinary "}}
+{"ts":"2026-07-31T00:00:09Z","pid":17,"sid":"ordinary","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":14,"completion_tokens":2}}"#,
+        );
+
+        let messages = parse_grok_unified_log_file(&path);
+        assert_eq!(
+            messages
+                .iter()
+                .map(|message| message.model_id.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "grok-4.6",
+                "grok-4.7",
+                "grok-4.8",
+                "grok-4.7",
+                "grok-ordinary"
+            ]
+        );
+    }
+
+    #[test]
+    fn unified_log_fails_closed_on_conflicting_child_evidence() {
+        let (_temp, path) = write_unified_fixture(
+            r#"{"ts":"2026-07-31T00:00:00Z","pid":19,"sid":"child","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":10,"completion_tokens":2}}
+{"ts":"2026-07-31T00:00:01Z","pid":19,"msg":"subagent spawn credentials","ctx":{"subagent_id":"child","effective_model":"grok-4.8"}}
+{"ts":"2026-07-31T00:00:02Z","pid":19,"msg":"subagent failed","ctx":{"subagent_id":"child","effective_model":"grok-4.9"}}
+{"ts":"2026-07-31T00:00:03Z","pid":19,"sid":"child","msg":"shell.turn.inference_done","ctx":{"loop_index":2,"prompt_tokens":11,"completion_tokens":2}}
+{"ts":"2026-07-31T00:00:04Z","pid":19,"msg":"subagent completed","ctx":{"subagent_id":"missing","effective_model":null}}
+{"ts":"2026-07-31T00:00:05Z","pid":19,"sid":"missing","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":12,"completion_tokens":2}}"#,
+        );
+
+        let messages = parse_grok_unified_log_file(&path);
+        assert_eq!(messages.len(), 3);
+        assert!(messages
+            .iter()
+            .all(|message| message.model_id == UNKNOWN_MODEL));
+    }
+
+    #[test]
+    fn unified_log_snapshot_ignores_rows_appended_after_scan_start() {
+        use std::io::Write;
+
+        let (_temp, path) = write_unified_fixture(
+            r#"{"ts":"2026-07-31T00:00:00Z","pid":23,"sid":"first","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":10,"completion_tokens":2}}
+"#,
+        );
+        let prefix_len = std::fs::metadata(&path).unwrap().len();
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(
+                br#"{"ts":"2026-07-31T00:00:01Z","pid":23,"sid":"second","msg":"shell.turn.inference_done","ctx":{"loop_index":1,"prompt_tokens":11,"completion_tokens":2}}
+"#,
+            )
+            .unwrap();
+
+        assert_eq!(
+            parse_grok_unified_log_file_with_prefix(&path, prefix_len).len(),
+            1
+        );
+        assert_eq!(parse_grok_unified_log_file(&path).len(), 2);
+    }
+
+    #[test]
+    fn selector_recovers_unified_model_and_workspace_from_consistent_legacy_rows() {
+        let mut legacy = test_message("covered", "grok:covered:0");
+        legacy.model_id = "grok-4.5".to_string();
+        legacy.set_workspace(
+            Some("/tmp/project".to_string()),
+            Some("project".to_string()),
+        );
+        let mut unified = test_message("covered", "grok-unified:covered:1:1:1");
+        unified.model_id = UNKNOWN_MODEL.to_string();
+        unified.workspace_key = None;
+        unified.workspace_label = None;
+
+        let messages = prefer_unified_log_messages(vec![legacy, unified]);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "grok-4.5");
+        assert_eq!(messages[0].workspace_key.as_deref(), Some("/tmp/project"));
+        assert_eq!(messages[0].workspace_label.as_deref(), Some("project"));
+    }
+
+    #[test]
+    fn prefers_unified_log_messages_only_for_covered_sessions() {
+        let covered_legacy = test_message("covered", "grok:covered:0");
+        let uncovered_legacy = test_message("fallback", "grok:fallback:0");
+        let covered_unified = test_message("covered", "grok-unified:covered:1:1:1");
+
+        let messages =
+            prefer_unified_log_messages(vec![covered_legacy, uncovered_legacy, covered_unified]);
+
+        assert_eq!(messages.len(), 2);
+        assert!(messages
+            .iter()
+            .any(|message| { message.session_id == "covered" && is_unified_log_message(message) }));
+        assert!(messages
+            .iter()
+            .any(|message| message.session_id == "fallback"));
+    }
+
+    #[test]
+    fn prefers_authoritative_usage_breakdown_when_available() {
+        let (_temp, path) = write_fixture(
+            r#"{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"user_message_chunk","_meta":{"modelId":"grok-4.5"}},"_meta":{"agentTimestampMs":1700000001000}}}
+{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"agent_message_chunk"},"_meta":{"totalTokens":1200,"agentTimestampMs":1700000002000}}}
+{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"turn_completed","usage":{"inputTokens":1000,"outputTokens":100,"reasoningTokens":20,"cachedReadTokens":400,"totalTokens":1100,"modelUsage":{"grok-4.5-build":{"inputTokens":1000,"outputTokens":100,"reasoningTokens":20,"cachedReadTokens":400,"totalTokens":1100}}}},"_meta":{"eventId":"turn-1","agentTimestampMs":1700000003000}}}"#,
+            None,
+            None,
+        );
+
+        let messages = parse_grok_updates_file(&path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "grok-4.5");
+        assert_eq!(messages[0].tokens.input, 600);
+        assert_eq!(messages[0].tokens.output, 80);
+        assert_eq!(messages[0].tokens.cache_read, 400);
+        assert_eq!(messages[0].tokens.reasoning, 20);
+        assert_eq!(messages[0].timestamp, 1700000003000);
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some("grok:session-1:usage:turn-1")
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/grok.rs
+++ b/crates/tokscale-core/src/sessions/grok.rs
@@ -706,11 +706,16 @@ fn parse_grok_unified_log_snapshot(
         let known_scope = child_scope
             .as_ref()
             .is_some_and(|scope| evidence.known_scopes.contains(scope));
+        let model_attribution_conflicted = child_scope
+            .as_ref()
+            .is_some_and(|scope| has_conflicting_child_evidence(&evidence, scope));
         let known_child_session = evidence.child_session_ids.contains(&session_id);
         let exact_model = model_by_pid_and_session
             .get(&(pid, generation, session_id.clone()))
             .cloned();
-        let model_id = if let Some(model_id) = exact_model {
+        let model_id = if model_attribution_conflicted {
+            UNKNOWN_MODEL.to_string()
+        } else if let Some(model_id) = exact_model {
             model_id
         } else if known_scope {
             child_scope
@@ -742,9 +747,7 @@ fn parse_grok_unified_log_snapshot(
             dedup_key,
             loop_index == 1,
         );
-        message.model_attribution_conflicted = child_scope
-            .as_ref()
-            .is_some_and(|scope| has_conflicting_child_evidence(&evidence, scope));
+        message.model_attribution_conflicted = model_attribution_conflicted;
         message.session_id = session_id;
         message.message_count = i32::from(message.is_turn_start);
         messages.push(message);

--- a/crates/tokscale-core/src/sessions/grok.rs
+++ b/crates/tokscale-core/src/sessions/grok.rs
@@ -967,11 +967,6 @@ pub fn prefer_unified_log_messages(mut messages: Vec<UnifiedMessage>) -> Vec<Uni
                 false
             } else {
                 *count -= 1;
-                if let Some(timestamp_count) = covered_fallback_timestamps
-                    .get_mut(&(message.session_id.clone(), message.timestamp))
-                {
-                    *timestamp_count = timestamp_count.saturating_sub(1);
-                }
                 true
             }
         }) || (is_legacy_fallback_message(&message)
@@ -1772,6 +1767,31 @@ mod tests {
             .iter()
             .any(|message| message.dedup_key.as_deref() == Some("grok:covered:older")));
         assert!(messages.iter().any(is_unified_log_message));
+    }
+
+    #[test]
+    fn selector_is_order_invariant_for_activity_and_fallback_rows() {
+        let legacy_activity = test_message("covered", "grok:covered:usage:turn");
+        let mut legacy_fallback = test_message("covered", "grok:covered:fallback");
+        legacy_fallback.tokens.input = 10;
+        let unified = test_message("covered", "grok-unified:covered:event");
+
+        let first_order = prefer_unified_log_messages(vec![
+            legacy_activity.clone(),
+            legacy_fallback.clone(),
+            unified.clone(),
+        ]);
+        let second_order =
+            prefer_unified_log_messages(vec![legacy_fallback, legacy_activity, unified]);
+
+        assert_eq!(first_order, second_order);
+        assert_eq!(
+            first_order
+                .iter()
+                .map(|message| message.dedup_key.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("grok-unified:covered:event")]
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/grok.rs
+++ b/crates/tokscale-core/src/sessions/grok.rs
@@ -140,6 +140,19 @@ fn unique_terminal_model<'a>(
     (terminal_model == child_model).then_some(child_model)
 }
 
+fn has_conflicting_child_evidence(
+    evidence: &UnifiedChildEvidence,
+    scope: &UnifiedChildScope,
+) -> bool {
+    matches!(
+        evidence.child_models.get(scope),
+        Some(UnifiedModelEvidence::Conflict)
+    ) || matches!(
+        evidence.terminal_models.get(scope),
+        Some(UnifiedModelEvidence::Conflict)
+    )
+}
+
 #[derive(Debug, Clone)]
 struct GrokMetadata {
     session_id: String,
@@ -729,6 +742,9 @@ fn parse_grok_unified_log_snapshot(
             dedup_key,
             loop_index == 1,
         );
+        message.model_attribution_conflicted = child_scope
+            .as_ref()
+            .is_some_and(|scope| has_conflicting_child_evidence(&evidence, scope));
         message.session_id = session_id;
         message.message_count = i32::from(message.is_turn_start);
         messages.push(message);
@@ -914,7 +930,7 @@ pub fn prefer_unified_log_messages(mut messages: Vec<UnifiedMessage>) -> Vec<Uni
         .iter_mut()
         .filter(|message| is_unified_log_message(message))
     {
-        if message.model_id == UNKNOWN_MODEL {
+        if message.model_id == UNKNOWN_MODEL && !message.model_attribution_conflicted {
             if let Some(Some(model_id)) = legacy_models.get(&message.session_id) {
                 message.model_id = model_id.clone();
             }

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -89,6 +89,10 @@ pub struct UnifiedMessage {
     /// Used to count user interaction turns (as opposed to API message count).
     #[serde(default)]
     pub is_turn_start: bool,
+    /// True when the parser observed conflicting authoritative model evidence.
+    /// Such rows must remain unpriced rather than accepting fallback attribution.
+    #[serde(default)]
+    pub model_attribution_conflicted: bool,
 }
 
 const fn default_message_count() -> i32 {
@@ -366,6 +370,7 @@ impl UnifiedMessage {
             dedup_key,
             session_title: None,
             is_turn_start: false,
+            model_attribution_conflicted: false,
         }
     }
 


### PR DESCRIPTION
## Summary

Grok's unified log now carries role-specific lifecycle events for parent and child model selection. This PR scopes that attribution to the PID generation and exact child session, while keeping the unified token breakdown fix for the original issue.

The earlier parser could reuse a model after a process restarted with the same PID, or let a child inference inherit a parent or unrelated session model. Missing, malformed, or conflicting child evidence now stays `grok-unknown` instead of guessing.

## Changes

- Recognize current parent, spawn, completion, failure, and `AuthManager::new` lifecycle records.
- Scope parent model authority to `(pid, process generation)` and child authority to `(pid, process generation, subagent session)`.
- Support pidless session model changes and recover consistent model/workspace metadata from legacy rows without double-counting them.
- Preserve non-overlapping input, output, cache-read, and reasoning buckets; clamp malformed overlap values and keep tool-loop rows at zero user-message count.
- Bump the Grok parser cache identity because the same source can now produce a different model ID.

The attribution rules are adapted from the merged [Nanako0129/tokscale-core#2](https://github.com/Nanako0129/tokscale-core/pull/2) implementation for this repository's parser and cache layout.

## Verification

- `cargo test -p tokscale-core` — 1333 passed, 1 ignored.
- `cargo test -p tokscale-cli` — 972 passed, 1 ignored; 133 integration tests passed.
- `git diff --check` passed.
- A local cold and warm Grok scan returned the same totals: input 15,346,334; output 922,871; cache-read 170,854,784; reasoning 1,344,668.

Refs #849

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes Grok’s unified model attribution by PID generation and exact child session, prefers per‑inference usage from `~/.grok/logs/unified.jsonl` and legacy per‑turn usage rows, and applies pricing after unified selection, addressing #849. Conflicting child evidence stays `grok-unknown` and unpriced; unified coverage and costs are stable across runs.

- **New Features**
  - Parse unified inference events and legacy per‑turn usage; split overlapping buckets (cache read, reasoning), dedupe by event ID or full row, and keep only post‑usage fallback deltas.
  - Prefer unified rows; recover model/workspace from consistent legacy rows; selection is order‑independent and prevents double counting.
  - Discover `logs/unified.jsonl` for the primary Grok home and `scanner.extraScanPaths.grok` roots (home or `sessions` shapes); keep recursive `updates.jsonl` and ignore nested archives.

- **Bug Fixes**
  - Scope model attribution to `(pid, generation)` and `(pid, generation, subagent session)`; persist `model_attribution_conflicted` so conflicted rows stay `grok-unknown` and unpriced.
  - Bump Grok parser cache to v6 and fingerprint the full sessions metadata tree; bump cache shard format to v4; directory-aware fingerprints; parse a stable unified snapshot; reprice after unified selection.

<sup>Written for commit 1e6f74010bcc7f6fb6be41f78d3a6fa3c8ddd8df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

