### PR TITLE
fix(usage): stop tokscale from rewriting Claude Code's credentials

### DIFF
--- a/crates/tokscale-cli/src/commands/usage/claude.rs
+++ b/crates/tokscale-cli/src/commands/usage/claude.rs
@@ -60,6 +60,12 @@ pub fn has_credentials() -> bool {
     credentials_path().exists() || read_keychain().is_ok()
 }
 
+/// How [`fetch_blocking`] obtains Claude Code's credential document. Injected
+/// so tests can also drive the Keychain-sourced shape -- credentials present,
+/// no file on disk -- which no test can produce through [`read_credentials`]
+/// because the Keychain is a real macOS service.
+type CredentialReader = fn() -> Result<Credentials>;
+
 fn read_credentials() -> Result<Credentials> {
     let path = credentials_path();
     if path.exists() {
@@ -110,63 +116,64 @@ fn window_metric(label: &str, w: &Window) -> UsageMetric {
     }
 }
 
-async fn fetch_with_endpoint(
-    client: &reqwest::Client,
-    usage_url: &str,
-    oauth: &Oauth,
-) -> Result<UsageOutput> {
-    let access_token = oauth
-        .access_token
-        .as_deref()
-        .ok_or_else(|| anyhow::anyhow!("No Claude access token."))?;
-    let plan = oauth.subscription_type.as_ref().map(|s| {
-        let tier = oauth
-            .rate_limit_tier
-            .as_deref()
-            .and_then(|t| t.rsplit('_').next());
-        match tier {
-            Some(mult) => format!("{} {}", capitalize(s), mult),
-            None => capitalize(s),
-        }
-    });
-
-    let resp = fetch_usage(client, usage_url, access_token).await?;
-
-    let mut metrics = Vec::new();
-    if let Some(ref w) = resp.five_hour {
-        metrics.push(window_metric("Session", w));
-    }
-    if let Some(ref w) = resp.seven_day {
-        metrics.push(window_metric("Weekly", w));
-    }
-    if let Some(ref w) = resp.seven_day_opus {
-        metrics.push(window_metric("Opus", w));
-    }
-
-    Ok(UsageOutput {
-        provider: "Claude".into(),
-        account: None,
-        plan,
-        email: None,
-        metrics,
-        reset_credits: None,
-        credit_status: None,
-        spend_control: None,
-    })
-}
-
-pub fn fetch() -> Result<UsageOutput> {
+/// The whole Claude usage path, with the only two things a test cannot supply
+/// for real -- the usage endpoint and the credential source -- as parameters.
+/// The destructive refresh-and-write this module was fixed for lived in exactly
+/// this orchestration, so it is the layer the tests must enter; [`fetch`] is one
+/// call with the production values and holds no logic that could diverge.
+fn fetch_blocking(usage_url: &str, read: CredentialReader) -> Result<UsageOutput> {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
     rt.block_on(async {
-        let creds = read_credentials()?;
+        let creds = read()?;
         let oauth = creds.claude_ai_oauth.ok_or_else(|| {
             anyhow::anyhow!("No Claude OAuth credentials. Run 'claude' to log in.")
         })?;
+        let access_token = oauth
+            .access_token
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("No Claude access token."))?;
+        let plan = oauth.subscription_type.as_ref().map(|s| {
+            let tier = oauth
+                .rate_limit_tier
+                .as_deref()
+                .and_then(|t| t.rsplit('_').next());
+            match tier {
+                Some(mult) => format!("{} {}", capitalize(s), mult),
+                None => capitalize(s),
+            }
+        });
+
         let client = reqwest::Client::new();
-        fetch_with_endpoint(&client, USAGE_URL, &oauth).await
+        let resp = fetch_usage(&client, usage_url, access_token).await?;
+
+        let mut metrics = Vec::new();
+        if let Some(ref w) = resp.five_hour {
+            metrics.push(window_metric("Session", w));
+        }
+        if let Some(ref w) = resp.seven_day {
+            metrics.push(window_metric("Weekly", w));
+        }
+        if let Some(ref w) = resp.seven_day_opus {
+            metrics.push(window_metric("Opus", w));
+        }
+
+        Ok(UsageOutput {
+            provider: "Claude".into(),
+            account: None,
+            plan,
+            email: None,
+            metrics,
+            reset_credits: None,
+            credit_status: None,
+            spend_control: None,
+        })
     })
+}
+
+pub fn fetch() -> Result<UsageOutput> {
+    fetch_blocking(USAGE_URL, read_credentials)
 }
 
 #[cfg(test)]
@@ -174,6 +181,7 @@ mod tests {
     use super::*;
     use std::io::{Read, Write};
     use std::net::TcpListener;
+    use std::sync::{Arc, Mutex};
 
     /// A Claude Code credential document with the fields tokscale models
     /// (`accessToken`, `subscriptionType`, `rateLimitTier`), the fields it does
@@ -194,6 +202,10 @@ mod tests {
     const USAGE_BODY: &str =
         r#"{"five_hour":{"utilization":12.5,"resets_at":"2026-08-03T12:00:00Z"}}"#;
 
+    /// Mirrors the path component of [`USAGE_URL`] so the recorded request line
+    /// is the same string production would produce.
+    const USAGE_PATH: &str = "/api/oauth/usage";
+
     fn reason(status: u16) -> &'static str {
         match status {
             200 => "OK",
@@ -203,13 +215,26 @@ mod tests {
         }
     }
 
-    /// Blocking HTTP/1.1 server on an ephemeral port that answers by request
-    /// path. `Connection: close` keeps one request per socket so the accept
-    /// loop stays trivial. The thread is left blocked on `accept` when the test
-    /// ends; the test process tears it down.
-    fn spawn_server(routes: Vec<(String, u16, String)>) -> String {
+    /// One request as the server saw it: method and path, plus whatever bearer
+    /// token was presented. The token is recorded so a test can prove the
+    /// credential reached the wire from the fixture it wrote rather than from
+    /// the developer's real `$HOME`.
+    #[derive(Debug, PartialEq)]
+    struct Seen {
+        request: String,
+        bearer: Option<String>,
+    }
+
+    /// Blocking HTTP/1.1 server on an ephemeral port that answers the usage
+    /// path, 404s everything else, and records every request it receives.
+    /// `Connection: close` keeps one request per socket so the accept loop stays
+    /// trivial. The thread is left blocked on `accept` when the test ends; the
+    /// test process tears it down.
+    fn spawn_server(usage_status: u16) -> (String, Arc<Mutex<Vec<Seen>>>) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
         let addr = listener.local_addr().expect("test server addr");
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let server_log = Arc::clone(&log);
         std::thread::spawn(move || {
             for stream in listener.incoming() {
                 let Ok(mut stream) = stream else { continue };
@@ -225,12 +250,25 @@ mod tests {
                     }
                 }
                 let request = String::from_utf8_lossy(&buf).to_string();
-                let path = request.split_whitespace().nth(1).unwrap_or("/").to_string();
-                let (status, body) = routes
-                    .iter()
-                    .find(|(p, _, _)| *p == path)
-                    .map(|(_, s, b)| (*s, b.clone()))
-                    .unwrap_or_else(|| (404, "{}".to_string()));
+                let mut head = request.split_whitespace();
+                let method = head.next().unwrap_or("?").to_string();
+                let path = head.next().unwrap_or("/").to_string();
+                let bearer = request
+                    .lines()
+                    .find(|l| l.to_ascii_lowercase().starts_with("authorization:"))
+                    .and_then(|l| l.split_once(':'))
+                    .map(|(_, v)| v.trim().trim_start_matches("Bearer ").to_string());
+                if let Ok(mut seen) = server_log.lock() {
+                    seen.push(Seen {
+                        request: format!("{method} {path}"),
+                        bearer,
+                    });
+                }
+                let (status, body) = if path == USAGE_PATH {
+                    (usage_status, USAGE_BODY.to_string())
+                } else {
+                    (404, "{}".to_string())
+                };
                 let response = format!(
                     "HTTP/1.1 {status} {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
                     reason(status),
@@ -240,7 +278,27 @@ mod tests {
                 let _ = stream.flush();
             }
         });
-        format!("http://{addr}")
+        (format!("http://{addr}{USAGE_PATH}"), log)
+    }
+
+    /// The request log is asserted alongside the credential bytes because a
+    /// refresh-and-retry regression shows up here as a second request even when
+    /// it writes nothing to disk. It only sees traffic aimed at the injected
+    /// URL: the refresh this change removed POSTed to an absolute
+    /// `platform.claude.com` URL that no local server can intercept, so byte
+    /// equality is still what actually pins #1001.
+    fn assert_only_usage_request(log: &Arc<Mutex<Vec<Seen>>>) {
+        let seen = log.lock().expect("request log");
+        assert_eq!(
+            *seen,
+            vec![Seen {
+                request: format!("GET {USAGE_PATH}"),
+                // The fixture's token, so this also proves the credential came
+                // from the injected reader and not from the real `$HOME`.
+                bearer: Some("stale-access-token".to_string()),
+            }],
+            "tokscale made a request other than the single usage GET"
+        );
     }
 
     struct HomeGuard {
@@ -285,60 +343,28 @@ mod tests {
         }
     }
 
-    fn oauth_from_fixture() -> Oauth {
-        serde_json::from_str::<Credentials>(FIXTURE)
-            .expect("fixture parses")
-            .claude_ai_oauth
-            .expect("fixture has claudeAiOauth")
-    }
-
-    fn block_on<F: std::future::Future>(f: F) -> F::Output {
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("test runtime")
-            .block_on(f)
-    }
-
-    fn routes(usage_status: u16) -> Vec<(String, u16, String)> {
-        vec![
-            (
-                "/api/oauth/usage".to_string(),
-                usage_status,
-                USAGE_BODY.to_string(),
-            ),
-            // The endpoint the removed refresh path used to POST to. Serving it
-            // locally means a regression reaches it here instead of reaching
-            // platform.claude.com, and the assertions below still catch it.
-            (
-                "/v1/oauth/token".to_string(),
-                200,
-                r#"{"access_token":"rotated-access-token","refresh_token":"rotated-refresh-token"}"#
-                    .to_string(),
-            ),
-        ]
+    /// Stands in for a Keychain-sourced credential: the same document, with
+    /// nothing on disk. `read_credentials()` cannot be made to produce this
+    /// shape in a test because the Keychain is a real macOS service.
+    fn keychain_credentials() -> Result<Credentials> {
+        Ok(serde_json::from_str(FIXTURE)?)
     }
 
     /// #1001: a rejected access token must not make tokscale rewrite Claude
     /// Code's credential file. Byte equality is the assertion that matters --
     /// any reconstruction of the document fails it, whatever fields it keeps.
+    /// Entry is through `fetch_blocking` with the real `read_credentials`, so
+    /// the file is genuinely read and re-read across the whole orchestration
+    /// the destructive code used to live in.
     #[test]
     #[serial_test::serial]
     fn rejected_token_leaves_claude_credentials_untouched() {
         let home = HomeGuard::new("401");
         home.write_fixture();
         let before = std::fs::read(home.credentials()).expect("read before");
-        let base = spawn_server(routes(401));
+        let (usage_url, log) = spawn_server(401);
 
-        let result = block_on(async {
-            let client = reqwest::Client::new();
-            fetch_with_endpoint(
-                &client,
-                &format!("{base}/api/oauth/usage"),
-                &oauth_from_fixture(),
-            )
-            .await
-        });
+        let result = fetch_blocking(&usage_url, read_credentials);
 
         let err = result.expect_err("401 must surface as an error, not a refresh");
         assert!(
@@ -352,6 +378,7 @@ mod tests {
             String::from_utf8_lossy(&before),
             "tokscale rewrote Claude Code's credential file"
         );
+        assert_only_usage_request(&log);
     }
 
     /// A 403 takes the same branch as a 401 and must be just as inert.
@@ -361,17 +388,9 @@ mod tests {
         let home = HomeGuard::new("403");
         home.write_fixture();
         let before = std::fs::read(home.credentials()).expect("read before");
-        let base = spawn_server(routes(403));
+        let (usage_url, log) = spawn_server(403);
 
-        let result = block_on(async {
-            let client = reqwest::Client::new();
-            fetch_with_endpoint(
-                &client,
-                &format!("{base}/api/oauth/usage"),
-                &oauth_from_fixture(),
-            )
-            .await
-        });
+        let result = fetch_blocking(&usage_url, read_credentials);
 
         assert!(result.is_err(), "403 must surface as an error");
         let after = std::fs::read(home.credentials()).expect("credentials must still exist");
@@ -380,31 +399,26 @@ mod tests {
             String::from_utf8_lossy(&before),
             "tokscale rewrote Claude Code's credential file"
         );
+        assert_only_usage_request(&log);
     }
 
     /// On macOS the credentials live in the Keychain and the file does not
-    /// exist. Tokscale must not conjure a partial one.
+    /// exist. Tokscale must not conjure a partial one -- the old code did,
+    /// because it read from the Keychain but wrote to the file unconditionally.
     #[test]
     #[serial_test::serial]
     fn rejected_token_does_not_create_a_credential_file() {
         let home = HomeGuard::new("nofile");
-        let base = spawn_server(routes(401));
+        let (usage_url, log) = spawn_server(401);
 
-        let result = block_on(async {
-            let client = reqwest::Client::new();
-            fetch_with_endpoint(
-                &client,
-                &format!("{base}/api/oauth/usage"),
-                &oauth_from_fixture(),
-            )
-            .await
-        });
+        let result = fetch_blocking(&usage_url, keychain_credentials);
 
         assert!(result.is_err(), "401 must surface as an error");
         assert!(
             !home.credentials().exists(),
             "tokscale created a credential file Claude Code did not have"
         );
+        assert_only_usage_request(&log);
     }
 
     #[test]
@@ -413,18 +427,10 @@ mod tests {
         let home = HomeGuard::new("200");
         home.write_fixture();
         let before = std::fs::read(home.credentials()).expect("read before");
-        let base = spawn_server(routes(200));
+        let (usage_url, log) = spawn_server(200);
 
-        let output = block_on(async {
-            let client = reqwest::Client::new();
-            fetch_with_endpoint(
-                &client,
-                &format!("{base}/api/oauth/usage"),
-                &oauth_from_fixture(),
-            )
-            .await
-        })
-        .expect("200 usage response should parse");
+        let output =
+            fetch_blocking(&usage_url, read_credentials).expect("200 usage response should parse");
 
         assert_eq!(output.plan.as_deref(), Some("Max 20x"));
         assert_eq!(output.metrics.len(), 1);
@@ -436,6 +442,29 @@ mod tests {
             String::from_utf8_lossy(&after),
             String::from_utf8_lossy(&before),
             "tokscale rewrote Claude Code's credential file"
+        );
+        assert_only_usage_request(&log);
+    }
+
+    /// `read_credentials()` is the source of truth for what tokscale parses.
+    /// The refresh token must not survive the round trip: the fix is only real
+    /// if the field is absent from the model, not merely unused by the caller.
+    #[test]
+    #[serial_test::serial]
+    fn parsed_credentials_do_not_carry_a_refresh_token() {
+        let home = HomeGuard::new("parse");
+        home.write_fixture();
+
+        let oauth = read_credentials()
+            .expect("fixture credentials parse")
+            .claude_ai_oauth
+            .expect("fixture has claudeAiOauth");
+
+        assert_eq!(oauth.access_token.as_deref(), Some("stale-access-token"));
+        let debug = format!("{oauth:?}");
+        assert!(
+            !debug.contains("claude-code-owned-refresh-token"),
+            "Oauth still models a refresh token: {debug}"
         );
     }
 }

--- a/crates/tokscale-cli/src/commands/usage/claude.rs
+++ b/crates/tokscale-cli/src/commands/usage/claude.rs
@@ -4,8 +4,17 @@ use serde::Deserialize;
 use super::helpers::capitalize;
 use super::{UsageMetric, UsageOutput};
 
-const CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 const BETA_HEADER: &str = "oauth-2025-04-20";
+const USAGE_URL: &str = "https://api.anthropic.com/api/oauth/usage";
+
+// `~/.claude/.credentials.json` belongs to Claude Code, and this module is a
+// quota viewer: it reads that file and never writes it. Tokscale used to
+// exchange Claude Code's refresh token on 401/403 and write the result back,
+// but the write reconstructed the document from the four fields below, dropping
+// every field tokscale does not model -- `expiresAt` and `scopes` among them --
+// which left Claude Code reporting "Not logged in" (#1001). An expired access
+// token is Claude Code's to refresh on its next run, so a rejected token is
+// reported as unavailable usage instead.
 
 #[derive(Debug, Deserialize)]
 struct Credentials {
@@ -13,12 +22,12 @@ struct Credentials {
     claude_ai_oauth: Option<Oauth>,
 }
 
+/// Deliberately does not model `refreshToken`: tokscale has no use for a
+/// credential it must not spend.
 #[derive(Debug, Deserialize)]
 struct Oauth {
     #[serde(rename = "accessToken")]
     access_token: Option<String>,
-    #[serde(rename = "refreshToken")]
-    refresh_token: Option<String>,
     #[serde(rename = "subscriptionType")]
     subscription_type: Option<String>,
     #[serde(rename = "rateLimitTier")]
@@ -38,16 +47,9 @@ struct Window {
     resets_at: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
-struct TokenRefresh {
-    access_token: Option<String>,
-    refresh_token: Option<String>,
-}
-
-#[derive(Debug, Clone, Copy)]
-enum CredentialSource {
-    File,
-    Keychain,
+fn credentials_path() -> std::path::PathBuf {
+    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+    home.join(".claude").join(".credentials.json")
 }
 
 fn read_keychain() -> Result<String> {
@@ -55,80 +57,29 @@ fn read_keychain() -> Result<String> {
 }
 
 pub fn has_credentials() -> bool {
-    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
-    home.join(".claude").join(".credentials.json").exists()
-        || super::helpers::read_keychain("Claude Code-credentials").is_ok()
+    credentials_path().exists() || read_keychain().is_ok()
 }
 
-fn read_credentials() -> Result<(Credentials, CredentialSource)> {
-    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
-    let path = home.join(".claude").join(".credentials.json");
+fn read_credentials() -> Result<Credentials> {
+    let path = credentials_path();
     if path.exists() {
         if let Ok(content) = std::fs::read_to_string(&path) {
             if let Ok(creds) = serde_json::from_str::<Credentials>(&content) {
-                return Ok((creds, CredentialSource::File));
+                return Ok(creds);
             }
         }
     }
     let content = read_keychain()?;
-    let creds: Credentials = serde_json::from_str(&content)?;
-    Ok((creds, CredentialSource::Keychain))
+    Ok(serde_json::from_str(&content)?)
 }
 
-fn save_credentials(
-    access_token: &str,
-    refresh_token: &str,
-    subscription_type: Option<&str>,
-    rate_limit_tier: Option<&str>,
-) {
-    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
-    let path = home.join(".claude").join(".credentials.json");
-    let mut oauth = serde_json::json!({
-        "accessToken": access_token,
-        "refreshToken": refresh_token,
-    });
-    if let Some(st) = subscription_type {
-        oauth["subscriptionType"] = serde_json::Value::String(st.to_string());
-    }
-    if let Some(rlt) = rate_limit_tier {
-        oauth["rateLimitTier"] = serde_json::Value::String(rlt.to_string());
-    }
-    let json = serde_json::json!({
-        "claudeAiOauth": oauth
-    });
-    let content = match serde_json::to_string_pretty(&json) {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("warning: failed to serialize Claude credentials: {e}");
-            return;
-        }
-    };
-    if let Err(e) = super::helpers::atomic_write_secret(&path, content.as_bytes()) {
-        eprintln!("warning: failed to save Claude credentials: {e}");
-    }
-}
-
-async fn refresh_token(client: &reqwest::Client, rt: &str) -> Result<TokenRefresh> {
+async fn fetch_usage(
+    client: &reqwest::Client,
+    usage_url: &str,
+    token: &str,
+) -> Result<UsageResponse> {
     let resp = client
-        .post("https://platform.claude.com/v1/oauth/token")
-        .header("Content-Type", "application/json")
-        .json(&serde_json::json!({
-            "grant_type": "refresh_token",
-            "refresh_token": rt,
-            "client_id": CLIENT_ID,
-            "scope": "user:profile user:inference user:sessions:claude_code user:mcp_servers"
-        }))
-        .send()
-        .await?;
-    if !resp.status().is_success() {
-        anyhow::bail!("Claude token refresh failed (HTTP {})", resp.status());
-    }
-    Ok(resp.json().await?)
-}
-
-async fn fetch_usage(client: &reqwest::Client, token: &str) -> Result<UsageResponse> {
-    let resp = client
-        .get("https://api.anthropic.com/api/oauth/usage")
+        .get(usage_url)
         .header("Authorization", format!("Bearer {token}"))
         .header("Accept", "application/json")
         .header("Content-Type", "application/json")
@@ -137,7 +88,10 @@ async fn fetch_usage(client: &reqwest::Client, token: &str) -> Result<UsageRespo
         .await?;
     let status = resp.status();
     if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
-        anyhow::bail!("NEEDS_AUTH");
+        anyhow::bail!(
+            "Claude usage unavailable: stored access token was rejected (HTTP {status}). \
+             Run 'claude' so Claude Code can refresh its own login, then retry."
+        );
     }
     if !status.is_success() {
         anyhow::bail!("Claude usage request failed (HTTP {status})");
@@ -156,76 +110,332 @@ fn window_metric(label: &str, w: &Window) -> UsageMetric {
     }
 }
 
+async fn fetch_with_endpoint(
+    client: &reqwest::Client,
+    usage_url: &str,
+    oauth: &Oauth,
+) -> Result<UsageOutput> {
+    let access_token = oauth
+        .access_token
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("No Claude access token."))?;
+    let plan = oauth.subscription_type.as_ref().map(|s| {
+        let tier = oauth
+            .rate_limit_tier
+            .as_deref()
+            .and_then(|t| t.rsplit('_').next());
+        match tier {
+            Some(mult) => format!("{} {}", capitalize(s), mult),
+            None => capitalize(s),
+        }
+    });
+
+    let resp = fetch_usage(client, usage_url, access_token).await?;
+
+    let mut metrics = Vec::new();
+    if let Some(ref w) = resp.five_hour {
+        metrics.push(window_metric("Session", w));
+    }
+    if let Some(ref w) = resp.seven_day {
+        metrics.push(window_metric("Weekly", w));
+    }
+    if let Some(ref w) = resp.seven_day_opus {
+        metrics.push(window_metric("Opus", w));
+    }
+
+    Ok(UsageOutput {
+        provider: "Claude".into(),
+        account: None,
+        plan,
+        email: None,
+        metrics,
+        reset_credits: None,
+        credit_status: None,
+        spend_control: None,
+    })
+}
+
 pub fn fetch() -> Result<UsageOutput> {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
     rt.block_on(async {
-        let (creds, _source) = read_credentials()?;
+        let creds = read_credentials()?;
         let oauth = creds.claude_ai_oauth.ok_or_else(|| {
             anyhow::anyhow!("No Claude OAuth credentials. Run 'claude' to log in.")
         })?;
-        let access_token = oauth
-            .access_token
-            .clone()
-            .ok_or_else(|| anyhow::anyhow!("No Claude access token."))?;
-        let plan = oauth.subscription_type.as_ref().map(|s| {
-            let tier = oauth
-                .rate_limit_tier
-                .as_deref()
-                .and_then(|t| t.rsplit('_').next());
-            match tier {
-                Some(mult) => format!("{} {}", capitalize(s), mult),
-                None => capitalize(s),
+        let client = reqwest::Client::new();
+        fetch_with_endpoint(&client, USAGE_URL, &oauth).await
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    /// A Claude Code credential document with the fields tokscale models
+    /// (`accessToken`, `subscriptionType`, `rateLimitTier`), the fields it does
+    /// not (`refreshToken`, `expiresAt`, `scopes`), and a key that does not
+    /// exist today -- Claude Code owns the schema and may add more.
+    const FIXTURE: &str = r#"{
+  "claudeAiOauth": {
+    "accessToken": "stale-access-token",
+    "refreshToken": "claude-code-owned-refresh-token",
+    "expiresAt": 1757000000000,
+    "scopes": ["user:inference", "user:profile"],
+    "subscriptionType": "max",
+    "rateLimitTier": "default_max_20x"
+  },
+  "someKeyTokscaleDoesNotModel": { "keep": true }
+}"#;
+
+    const USAGE_BODY: &str =
+        r#"{"five_hour":{"utilization":12.5,"resets_at":"2026-08-03T12:00:00Z"}}"#;
+
+    fn reason(status: u16) -> &'static str {
+        match status {
+            200 => "OK",
+            401 => "Unauthorized",
+            403 => "Forbidden",
+            _ => "Unknown",
+        }
+    }
+
+    /// Blocking HTTP/1.1 server on an ephemeral port that answers by request
+    /// path. `Connection: close` keeps one request per socket so the accept
+    /// loop stays trivial. The thread is left blocked on `accept` when the test
+    /// ends; the test process tears it down.
+    fn spawn_server(routes: Vec<(String, u16, String)>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let addr = listener.local_addr().expect("test server addr");
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let mut buf = Vec::new();
+                let mut chunk = [0u8; 1024];
+                while let Ok(n) = stream.read(&mut chunk) {
+                    if n == 0 {
+                        break;
+                    }
+                    buf.extend_from_slice(&chunk[..n]);
+                    if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+                let request = String::from_utf8_lossy(&buf).to_string();
+                let path = request.split_whitespace().nth(1).unwrap_or("/").to_string();
+                let (status, body) = routes
+                    .iter()
+                    .find(|(p, _, _)| *p == path)
+                    .map(|(_, s, b)| (*s, b.clone()))
+                    .unwrap_or_else(|| (404, "{}".to_string()));
+                let response = format!(
+                    "HTTP/1.1 {status} {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    reason(status),
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.flush();
             }
         });
+        format!("http://{addr}")
+    }
 
-        let client = reqwest::Client::new();
-        let resp = match fetch_usage(&client, &access_token).await {
-            Ok(r) => r,
-            Err(e) if e.to_string().contains("NEEDS_AUTH") => {
-                let rt = oauth
-                    .refresh_token
-                    .as_ref()
-                    .ok_or_else(|| anyhow::anyhow!("No refresh token."))?;
-                let refreshed = refresh_token(&client, rt).await?;
-                let new = refreshed
-                    .access_token
-                    .clone()
-                    .ok_or_else(|| anyhow::anyhow!("Refresh returned no token."))?;
-                if let Some(new_rt) = refreshed.refresh_token.as_deref() {
-                    save_credentials(
-                        &new,
-                        new_rt,
-                        oauth.subscription_type.as_deref(),
-                        oauth.rate_limit_tier.as_deref(),
-                    );
-                }
-                fetch_usage(&client, &new).await?
+    struct HomeGuard {
+        previous: Option<std::ffi::OsString>,
+        dir: std::path::PathBuf,
+    }
+
+    impl HomeGuard {
+        fn new(name: &str) -> Self {
+            let previous = std::env::var_os("HOME");
+            let dir = std::env::temp_dir().join(format!(
+                "tokscale-claude-{name}-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(dir.join(".claude")).expect("create fake home");
+            unsafe {
+                std::env::set_var("HOME", &dir);
             }
-            Err(e) => return Err(e),
-        };
-
-        let mut metrics = Vec::new();
-        if let Some(ref w) = resp.five_hour {
-            metrics.push(window_metric("Session", w));
-        }
-        if let Some(ref w) = resp.seven_day {
-            metrics.push(window_metric("Weekly", w));
-        }
-        if let Some(ref w) = resp.seven_day_opus {
-            metrics.push(window_metric("Opus", w));
+            Self { previous, dir }
         }
 
-        Ok(UsageOutput {
-            provider: "Claude".into(),
-            account: None,
-            plan,
-            email: None,
-            metrics,
-            reset_credits: None,
-            credit_status: None,
-            spend_control: None,
+        fn credentials(&self) -> std::path::PathBuf {
+            self.dir.join(".claude").join(".credentials.json")
+        }
+
+        fn write_fixture(&self) {
+            std::fs::write(self.credentials(), FIXTURE).expect("write fixture credentials");
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var("HOME", value),
+                    None => std::env::remove_var("HOME"),
+                }
+            }
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    fn oauth_from_fixture() -> Oauth {
+        serde_json::from_str::<Credentials>(FIXTURE)
+            .expect("fixture parses")
+            .claude_ai_oauth
+            .expect("fixture has claudeAiOauth")
+    }
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime")
+            .block_on(f)
+    }
+
+    fn routes(usage_status: u16) -> Vec<(String, u16, String)> {
+        vec![
+            (
+                "/api/oauth/usage".to_string(),
+                usage_status,
+                USAGE_BODY.to_string(),
+            ),
+            // The endpoint the removed refresh path used to POST to. Serving it
+            // locally means a regression reaches it here instead of reaching
+            // platform.claude.com, and the assertions below still catch it.
+            (
+                "/v1/oauth/token".to_string(),
+                200,
+                r#"{"access_token":"rotated-access-token","refresh_token":"rotated-refresh-token"}"#
+                    .to_string(),
+            ),
+        ]
+    }
+
+    /// #1001: a rejected access token must not make tokscale rewrite Claude
+    /// Code's credential file. Byte equality is the assertion that matters --
+    /// any reconstruction of the document fails it, whatever fields it keeps.
+    #[test]
+    #[serial_test::serial]
+    fn rejected_token_leaves_claude_credentials_untouched() {
+        let home = HomeGuard::new("401");
+        home.write_fixture();
+        let before = std::fs::read(home.credentials()).expect("read before");
+        let base = spawn_server(routes(401));
+
+        let result = block_on(async {
+            let client = reqwest::Client::new();
+            fetch_with_endpoint(
+                &client,
+                &format!("{base}/api/oauth/usage"),
+                &oauth_from_fixture(),
+            )
+            .await
+        });
+
+        let err = result.expect_err("401 must surface as an error, not a refresh");
+        assert!(
+            err.to_string().contains("Run 'claude'"),
+            "error should point at Claude Code's own login, got: {err}"
+        );
+
+        let after = std::fs::read(home.credentials()).expect("credentials must still exist");
+        assert_eq!(
+            String::from_utf8_lossy(&after),
+            String::from_utf8_lossy(&before),
+            "tokscale rewrote Claude Code's credential file"
+        );
+    }
+
+    /// A 403 takes the same branch as a 401 and must be just as inert.
+    #[test]
+    #[serial_test::serial]
+    fn forbidden_response_leaves_claude_credentials_untouched() {
+        let home = HomeGuard::new("403");
+        home.write_fixture();
+        let before = std::fs::read(home.credentials()).expect("read before");
+        let base = spawn_server(routes(403));
+
+        let result = block_on(async {
+            let client = reqwest::Client::new();
+            fetch_with_endpoint(
+                &client,
+                &format!("{base}/api/oauth/usage"),
+                &oauth_from_fixture(),
+            )
+            .await
+        });
+
+        assert!(result.is_err(), "403 must surface as an error");
+        let after = std::fs::read(home.credentials()).expect("credentials must still exist");
+        assert_eq!(
+            String::from_utf8_lossy(&after),
+            String::from_utf8_lossy(&before),
+            "tokscale rewrote Claude Code's credential file"
+        );
+    }
+
+    /// On macOS the credentials live in the Keychain and the file does not
+    /// exist. Tokscale must not conjure a partial one.
+    #[test]
+    #[serial_test::serial]
+    fn rejected_token_does_not_create_a_credential_file() {
+        let home = HomeGuard::new("nofile");
+        let base = spawn_server(routes(401));
+
+        let result = block_on(async {
+            let client = reqwest::Client::new();
+            fetch_with_endpoint(
+                &client,
+                &format!("{base}/api/oauth/usage"),
+                &oauth_from_fixture(),
+            )
+            .await
+        });
+
+        assert!(result.is_err(), "401 must surface as an error");
+        assert!(
+            !home.credentials().exists(),
+            "tokscale created a credential file Claude Code did not have"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn successful_usage_fetch_leaves_claude_credentials_untouched() {
+        let home = HomeGuard::new("200");
+        home.write_fixture();
+        let before = std::fs::read(home.credentials()).expect("read before");
+        let base = spawn_server(routes(200));
+
+        let output = block_on(async {
+            let client = reqwest::Client::new();
+            fetch_with_endpoint(
+                &client,
+                &format!("{base}/api/oauth/usage"),
+                &oauth_from_fixture(),
+            )
+            .await
         })
-    })
+        .expect("200 usage response should parse");
+
+        assert_eq!(output.plan.as_deref(), Some("Max 20x"));
+        assert_eq!(output.metrics.len(), 1);
+        assert_eq!(output.metrics[0].label, "Session");
+        assert!((output.metrics[0].used_percent - 12.5).abs() < f64::EPSILON);
+
+        let after = std::fs::read(home.credentials()).expect("credentials must still exist");
+        assert_eq!(
+            String::from_utf8_lossy(&after),
+            String::from_utf8_lossy(&before),
+            "tokscale rewrote Claude Code's credential file"
+        );
+    }
 }


### PR DESCRIPTION
Fixes #1001.

## Mechanism (verified in code, not taken on report)

`crates/tokscale-cli/src/commands/usage/claude.rs` at 4.8.1:

1. `fetch_usage` GETs `api.anthropic.com/api/oauth/usage` with Claude Code's access token, and on 401/403 bails with a `NEEDS_AUTH` sentinel.
2. `fetch()` catches that sentinel, reads Claude Code's **refresh** token out of the file, and POSTs it to `platform.claude.com/v1/oauth/token`.
3. On a rotated pair it calls `save_credentials()`, which `atomic_write_secret`s `~/.claude/.credentials.json` rebuilt from `serde_json::json!` with only `accessToken`, `refreshToken`, `subscriptionType`, `rateLimitTier`.

The reporter's account is accurate. The loss is broader than the fields they named: because the document is *reconstructed* rather than merged, everything tokscale does not model is destroyed — `expiresAt`, `scopes`, and any top-level key besides `claudeAiOauth`. See the red-run diff below for the exact before/after.

Two further defects found while confirming it:

- `read_credentials()` can source from the macOS **Keychain**, but `save_credentials()` unconditionally wrote the **file**. On a machine where Claude Code keeps credentials in the Keychain and no `~/.claude/.credentials.json` exists, tokscale *created* a partial one.
- The `CredentialSource` enum that would have prevented that was already dead — `fetch()` bound it to `_source` and never read it.

## Fix

Tokscale is a quota viewer, so the Claude path is now strictly read-only. The refresh call, the write, `CLIENT_ID`, `TokenRefresh`, `CredentialSource`, and the `refreshToken` field on `Oauth` are all removed — tokscale no longer even parses a credential it must not spend. A 401/403 now returns an actionable error that `fetch_all_with_errors` surfaces on stderr:

```
Claude usage unavailable: stored access token was rejected (HTTP 401 Unauthorized).
Run 'claude' so Claude Code can refresh its own login, then retry.
```

`fetch_with_endpoint(client, usage_url, oauth)` exists as a seam so the tests can drive the 401/403 branch against a local server instead of the live API.

### Product note

This is a real behavioural trade-off and should not pass silently: **usage will now be unavailable while the stored access token is expired**, until the user next runs `claude` and Claude Code refreshes it. Previously tokscale papered over that window by refreshing on Claude Code's behalf. If showing usage across that window is a requirement, it needs a design where Claude Code owns the refresh — not a write from here. Read-only is implemented regardless, because the current cost is destroying a working login.

## Evidence

Four tests in `claude.rs`. The fixture is a credential document carrying the fields tokscale models, the ones it does not (`refreshToken`, `expiresAt`, `scopes`), and an unmodeled top-level key; assertions are byte-equality of the file before and after.

**Red** — 4.8.1's refresh-and-write branch restored verbatim on top of the same test seam (only the token endpoint repointed at the local server, so the proof stays offline):

```
running 4 tests
test commands::usage::claude::tests::forbidden_response_leaves_claude_credentials_untouched ... FAILED
test commands::usage::claude::tests::rejected_token_leaves_claude_credentials_untouched ... FAILED
test commands::usage::claude::tests::successful_usage_fetch_leaves_claude_credentials_untouched ... ok
test commands::usage::claude::tests::rejected_token_does_not_create_a_credential_file ... FAILED

---- rejected_token_leaves_claude_credentials_untouched stdout ----
assertion `left == right` failed: tokscale rewrote Claude Code's credential file
  left: "{\n  \"claudeAiOauth\": {\n    \"accessToken\": \"rotated-access-token\",\n    \"rateLimitTier\": \"default_max_20x\",\n    \"refreshToken\": \"rotated-refresh-token\",\n    \"subscriptionType\": \"max\"\n  }\n}"
 right: "{\n  \"claudeAiOauth\": {\n    \"accessToken\": \"stale-access-token\",\n    \"refreshToken\": \"claude-code-owned-refresh-token\",\n    \"expiresAt\": 1757000000000,\n    \"scopes\": [\"user:inference\", \"user:profile\"],\n    \"subscriptionType\": \"max\",\n    \"rateLimitTier\": \"default_max_20x\"\n  },\n  \"someKeyTokscaleDoesNotModel\": { \"keep\": true }\n}"

---- rejected_token_does_not_create_a_credential_file stdout ----
tokscale created a credential file Claude Code did not have

test result: FAILED. 1 passed; 3 failed; 0 ignored; 0 measured; 974 filtered out
```

`left` is the exact corruption: `expiresAt` gone, `scopes` gone, `someKeyTokscaleDoesNotModel` gone. The 200-response test passes in both runs by design — it is a guard against the write moving to the success path, not a regression detector.

**Green** — with the fix:

```
running 4 tests
test commands::usage::claude::tests::rejected_token_leaves_claude_credentials_untouched ... ok
test commands::usage::claude::tests::rejected_token_does_not_create_a_credential_file ... ok
test commands::usage::claude::tests::forbidden_response_leaves_claude_credentials_untouched ... ok
test commands::usage::claude::tests::successful_usage_fetch_leaves_claude_credentials_untouched ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 974 filtered out; finished in 0.01s
```

Full crate:

```
running 978 tests
test result: ok. 977 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 7.47s
running 133 tests
test result: ok. 133 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 12.40s
```

`cargo clippy --all-targets -- -D warnings` → exit 0. `cargo fmt --check -p tokscale-cli` → exit 0. (CI omits `--all-targets`, so the new `#[cfg(test)]` code is not linted there; it was linted locally.)

## Deliberately not fixed here

The same shape exists for two other clients and is left alone for separate PRs:

- **`usage/codex.rs`** — `persist_tokens` → `save_auth_tokens` writes the Codex CLI's own `~/.config/codex/auth.json` (or `~/.codex/auth.json`) as `{"tokens": …, "last_refresh": …}`, reconstructed from a modeled `Tokens` struct. Same lossy-rebuild shape; notably it would drop a top-level `OPENAI_API_KEY`. Highest-priority follow-up.
- **`usage/kimi.rs`** — `save_credentials` rewrites the Kimi CLI's `~/.kimi-code/credentials/kimi-code.json` from five fields and hardcodes `"scope": "kimi-code"`.

Not a problem: `warp.rs` writes only under tokscale's own config dir, and `codex.rs`'s `codex-credentials.json` store is tokscale's own file.

Also unchanged: the `NEEDS_AUTH` sentinel in `grok.rs` / `copilot.rs` / `sakana.rs`. In `grok.rs` and `copilot.rs` nothing catches it, so the literal string `NEEDS_AUTH` reaches the user as the error text — cosmetic, unrelated to this bug.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Claude usage read-only and stop rewriting Claude Code’s credentials. 401/403 now surface a clear error instead of refreshing tokens, preventing login corruption.

- **Bug Fixes**
  - Removed token refresh and any writes to `~/.claude/.credentials.json`; `refreshToken` is no longer parsed.
  - 401/403 return a clear message to run `claude` to refresh the login.
  - Added `fetch_blocking` with an injectable usage URL and credential reader; tests log requests to catch refresh-and-retry, ensure no file is created when only Keychain is used, and verify the credentials file stays byte-for-byte unchanged.

- **Migration**
  - While the stored access token is expired, Claude usage is unavailable until the user runs `claude` to refresh the login.

<sup>Written for commit 61758e7ae7a811fc6c11b960d4d80e4628306797. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

