### PR TITLE
fix(pricing): centralize degraded source fallback

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -5442,7 +5442,7 @@ fn run_submit_command(
     use colored::Colorize;
     use std::io::IsTerminal;
     use tokio::runtime::Runtime;
-    use tokscale_core::{generate_graph, GroupBy, ReportOptions};
+    use tokscale_core::{generate_submission_graph, GroupBy, ReportOptions};
 
     let auth_token = match auth::resolve_api_token() {
         Some(token) => token,
@@ -5510,7 +5510,7 @@ fn run_submit_command(
     let rt = Runtime::new()?;
     let mut graph_result = rt
         .block_on(async {
-            generate_graph(ReportOptions {
+            generate_submission_graph(ReportOptions {
                 home_dir: None,
                 use_env_roots: true,
                 clients,

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -3521,6 +3521,24 @@ fn test_root_with_group_by() {
 fn test_submit_offline_without_pricing_cache_fails() {
     let tmp = create_temp_fixture_dir_without_pricing_cache();
     write_fake_credentials(tmp.path());
+    let unpriced_dir = tmp
+        .path()
+        .join(".local/share/opencode/storage/message/unpriced");
+    fs::create_dir_all(&unpriced_dir).unwrap();
+    fs::write(
+        unpriced_dir.join("unpriced.json"),
+        r#"{
+            "id": "unpriced",
+            "sessionID": "unpriced",
+            "role": "assistant",
+            "modelID": "genuinely-unpriced-model",
+            "providerID": "unknown-provider",
+            "cost": 0,
+            "tokens": { "input": 1, "output": 0, "reasoning": 0, "cache": { "read": 0, "write": 0 } },
+            "time": { "created": 1736510400000.0 }
+        }"#,
+    )
+    .unwrap();
 
     let output = offline_cmd_with_home(tmp.path())
         .args(["submit", "--client", "opencode", "--dry-run"])
@@ -3529,7 +3547,7 @@ fn test_submit_offline_without_pricing_cache_fails() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         !output.status.success(),
-        "submit should fail when pricing is unavailable; stdout: {}",
+        "submit should fail for genuinely unpriced token usage; stdout: {}",
         String::from_utf8_lossy(&output.stdout)
     );
     // Verify failure is from pricing fetch, not from auth or argument errors

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -2682,6 +2682,7 @@ pub async fn get_hourly_report(options: ReportOptions) -> Result<HourlyReport, S
 async fn generate_graph_with_loaded_pricing(
     options: ReportOptions,
     pricing: Option<&pricing::PricingService>,
+    require_pricing: bool,
 ) -> Result<GraphResult, String> {
     let start = Instant::now();
 
@@ -2705,6 +2706,10 @@ async fn generate_graph_with_loaded_pricing(
     );
 
     let filtered = filter_messages_for_report(all_messages, &options);
+
+    if require_pricing {
+        validate_priced_messages(&filtered, pricing)?;
+    }
 
     let intervals = sessionize::sessionize(&filtered, sessionize::DEFAULT_IDLE_GAP_MS);
     let time_metrics =
@@ -2767,12 +2772,58 @@ pub async fn get_time_metrics_report(options: ReportOptions) -> Result<TimeMetri
 
 pub async fn generate_graph(options: ReportOptions) -> Result<GraphResult, String> {
     let pricing = pricing::PricingService::get_or_init().await?;
-    generate_graph_with_loaded_pricing(options, Some(&pricing)).await
+    generate_graph_with_loaded_pricing(options, Some(&pricing), true).await
 }
 
 pub async fn generate_local_graph_report(options: ReportOptions) -> Result<GraphResult, String> {
     let pricing = load_pricing_for_local_parse().await;
-    generate_graph_with_loaded_pricing(options, pricing.as_deref()).await
+    generate_graph_with_loaded_pricing(options, pricing.as_deref(), false).await
+}
+
+fn validate_priced_messages(
+    messages: &[UnifiedMessage],
+    pricing: Option<&pricing::PricingService>,
+) -> Result<(), String> {
+    let Some(pricing) = pricing else {
+        return Err("pricing data is unavailable for submission".to_string());
+    };
+
+    let unpriced: Vec<String> = messages
+        .iter()
+        .filter(|message| {
+            let tokens = &message.tokens;
+            let token_bearing = tokens.input > 0
+                || tokens.output > 0
+                || tokens.cache_read > 0
+                || tokens.cache_write > 0
+                || tokens.reasoning > 0;
+            token_bearing
+                && !message.has_authoritative_cost()
+                && pricing
+                    .lookup_with_source_and_provider(
+                        &message.model_id,
+                        None,
+                        Some(&message.provider_id),
+                    )
+                    .is_none()
+        })
+        .map(|message| {
+            if message.provider_id.is_empty() {
+                message.model_id.clone()
+            } else {
+                format!("{}/{}", message.provider_id, message.model_id)
+            }
+        })
+        .collect();
+
+    if unpriced.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "pricing is unavailable for submitted token usage: {}",
+            unpriced.join(", ")
+        ))
+    }
 }
 
 fn filter_messages_for_report(
@@ -3826,8 +3877,8 @@ mod tests {
         filter_messages_for_report, generate_graph_with_loaded_pricing, message_cache,
         normalize_model_for_grouping, parse_all_messages_with_pricing_with_env_strategy,
         parse_local_clients, parsed_to_unified, pricing, retain_for_requested_clients, scanner,
-        select_local_parse_pricing, unified_to_parsed, ClientId, GroupBy, LocalParseOptions,
-        ReportOptions, TokenBreakdown, UnifiedMessage, UNKNOWN_WORKSPACE_LABEL,
+        select_local_parse_pricing, unified_to_parsed, validate_priced_messages, ClientId, GroupBy,
+        LocalParseOptions, ReportOptions, TokenBreakdown, UnifiedMessage, UNKNOWN_WORKSPACE_LABEL,
     };
     use std::collections::{HashMap, HashSet};
     use std::io::Write;
@@ -6821,6 +6872,100 @@ mod tests {
     }
 
     #[test]
+    fn strict_pricing_validation_accepts_covered_and_provider_reported_usage() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "covered-model".to_string(),
+            pricing::ModelPricing {
+                input_cost_per_token: Some(0.0),
+                output_cost_per_token: Some(0.0),
+                ..Default::default()
+            },
+        );
+        let pricing = pricing::PricingService::new(litellm, HashMap::new());
+        let covered = UnifiedMessage::new(
+            "synthetic",
+            "covered-model",
+            "openai",
+            "covered",
+            1_733_011_200_000,
+            TokenBreakdown {
+                input: 1,
+                ..Default::default()
+            },
+            0.0,
+        );
+        let mut reported = UnifiedMessage::new(
+            "synthetic",
+            "unlisted-model",
+            "provider",
+            "reported",
+            1_733_011_200_000,
+            TokenBreakdown {
+                output: 1,
+                ..Default::default()
+            },
+            0.0,
+        );
+        reported.mark_provider_reported_cost();
+
+        assert!(validate_priced_messages(&[covered, reported], Some(&pricing)).is_ok());
+    }
+
+    #[test]
+    fn strict_pricing_validation_rejects_unpriced_token_usage() {
+        let message = UnifiedMessage::new(
+            "synthetic",
+            "unlisted-model",
+            "provider",
+            "unpriced",
+            1_733_011_200_000,
+            TokenBreakdown {
+                input: 1,
+                ..Default::default()
+            },
+            0.0,
+        );
+        let pricing = pricing::PricingService::new(HashMap::new(), HashMap::new());
+
+        let error = validate_priced_messages(&[message], Some(&pricing)).unwrap_err();
+        assert!(error.contains("provider/unlisted-model"));
+    }
+
+    #[test]
+    fn strict_pricing_validation_ignores_filtered_out_unpriced_usage() {
+        let mut old = UnifiedMessage::new(
+            "synthetic",
+            "unlisted-model",
+            "provider",
+            "old",
+            1_733_011_200_000,
+            TokenBreakdown {
+                input: 1,
+                ..Default::default()
+            },
+            0.0,
+        );
+        old.date = "2020-01-01".to_string();
+        let filtered = filter_messages_for_report(
+            vec![old],
+            &ReportOptions {
+                since: Some("2021-01-01".to_string()),
+                ..Default::default()
+            },
+        );
+
+        assert!(validate_priced_messages(
+            &filtered,
+            Some(&pricing::PricingService::new(
+                HashMap::new(),
+                HashMap::new()
+            ))
+        )
+        .is_ok());
+    }
+
+    #[test]
     fn test_apply_pricing_if_available_overrides_cost_when_pricing_exists() {
         let mut litellm = HashMap::new();
         litellm.insert(
@@ -8411,6 +8556,7 @@ mod tests {
                     scanner_settings: scanner::ScannerSettings::default(),
                 },
                 None,
+                false,
             ))
             .unwrap();
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1120,7 +1120,9 @@ fn parse_all_messages_with_pricing_with_env_strategy(
             }
             if let Some(key) = message.dedup_key.as_ref() {
                 if let Some(index) = micode_indices.get(key).copied() {
-                    if message.has_authoritative_cost() {
+                    if message.has_authoritative_cost()
+                        && !all_messages[index].has_authoritative_cost()
+                    {
                         all_messages[index].cost = message.cost;
                         all_messages[index].mark_provider_reported_cost();
                     }

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1095,7 +1095,7 @@ fn parse_all_messages_with_pricing_with_env_strategy(
     }
 
     // Parse MiMo Code: SQLite database(s)
-    let mut micode_seen: HashSet<String> = HashSet::new();
+    let mut micode_indices: HashMap<String, usize> = HashMap::new();
 
     for db_path in &scan_result.micode_dbs {
         // Pass `None` so the loader does not reprice: MiMo Code carries an
@@ -1114,22 +1114,22 @@ fn parse_all_messages_with_pricing_with_env_strategy(
             sessions::micode::parse_micode_sqlite,
         );
 
-        all_messages.extend(
-            messages
-                .into_iter()
-                .map(|mut message| {
-                    if message.cost <= 0.0 {
-                        apply_pricing_if_available(&mut message, pricing);
+        for mut message in messages {
+            if !message.has_authoritative_cost() {
+                apply_pricing_if_available(&mut message, pricing);
+            }
+            if let Some(key) = message.dedup_key.as_ref() {
+                if let Some(index) = micode_indices.get(key).copied() {
+                    if message.has_authoritative_cost() {
+                        all_messages[index].cost = message.cost;
+                        all_messages[index].mark_provider_reported_cost();
                     }
-                    message
-                })
-                .filter(|message| {
-                    message
-                        .dedup_key
-                        .as_ref()
-                        .is_none_or(|key| micode_seen.insert(key.clone()))
-                }),
-        );
+                    continue;
+                }
+                micode_indices.insert(key.clone(), all_messages.len());
+            }
+            all_messages.push(message);
+        }
 
         if let Some(entry) = cache_entry {
             source_cache.insert(entry);
@@ -5080,6 +5080,74 @@ mod tests {
                 "authoritative cost must survive the cache hit, got {}",
                 second[0].cost
             );
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_micode_cross_database_dedup_prefers_explicit_zero_cost() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            let micode_dir = source_home.path().join(".local/share/mimocode");
+            std::fs::create_dir_all(&micode_dir).unwrap();
+            let without_cost = r#"{
+                "id": "shared-message",
+                "role": "assistant",
+                "modelID": "unknown-model",
+                "providerID": "mimo",
+                "tokens": { "input": 10, "output": 5 },
+                "time": { "created": 1700000000000.0 }
+            }"#;
+            let with_zero_cost = r#"{
+                "id": "shared-message",
+                "role": "assistant",
+                "modelID": "unknown-model",
+                "providerID": "mimo",
+                "cost": 0,
+                "tokens": { "input": 10, "output": 5 },
+                "time": { "created": 1700000000000.0 }
+            }"#;
+            for (name, data) in [
+                ("mimocode-alpha.db", without_cost),
+                ("mimocode-beta.db", with_zero_cost),
+            ] {
+                let db_path = micode_dir.join(name);
+                let conn = rusqlite::Connection::open(db_path).unwrap();
+                conn.execute_batch(
+                    "CREATE TABLE message (
+                        id TEXT PRIMARY KEY,
+                        session_id TEXT NOT NULL,
+                        data TEXT NOT NULL
+                    );",
+                )
+                .unwrap();
+                conn.execute(
+                    "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+                    rusqlite::params![name, "session", data],
+                )
+                .unwrap();
+            }
+
+            let pricing = pricing::PricingService::new(HashMap::new(), HashMap::new());
+            let messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["micode".to_string()],
+                Some(&pricing),
+            );
+
+            assert_eq!(messages.len(), 1);
+            assert_eq!(messages[0].cost, 0.0);
+            assert!(messages[0].has_authoritative_cost());
+            assert!(validate_priced_messages(&messages, Some(&pricing)).is_ok());
         }
 
         match original_home {

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -2799,13 +2799,11 @@ fn validate_priced_messages(
                 || tokens.reasoning > 0;
             token_bearing
                 && !message.has_authoritative_cost()
-                && pricing
-                    .lookup_with_source_and_provider(
-                        &message.model_id,
-                        None,
-                        Some(&message.provider_id),
-                    )
-                    .is_none()
+                && !pricing.covers_usage_with_provider(
+                    &message.model_id,
+                    Some(&message.provider_id),
+                    &message.tokens,
+                )
         })
         .map(|message| {
             if message.provider_id.is_empty() {
@@ -6982,6 +6980,83 @@ mod tests {
             ))
         )
         .is_ok());
+    }
+
+    #[test]
+    fn strict_pricing_validation_requires_each_populated_bucket_to_have_a_base_rate() {
+        let mut custom = HashMap::new();
+        custom.insert(
+            "input-only".to_string(),
+            pricing::ModelPricing {
+                input_cost_per_token: Some(0.0),
+                ..Default::default()
+            },
+        );
+        custom.insert(
+            "output-only".to_string(),
+            pricing::ModelPricing {
+                output_cost_per_token: Some(1e-6),
+                ..Default::default()
+            },
+        );
+        custom.insert(
+            "tier-only".to_string(),
+            pricing::ModelPricing {
+                input_cost_per_token_above_272k_tokens: Some(1e-6),
+                ..Default::default()
+            },
+        );
+        let pricing = pricing::PricingService::new_with_custom(
+            pricing::custom::CustomPricing::from_models(custom),
+            HashMap::new(),
+            HashMap::new(),
+        );
+        let usage = |model, input, output, reasoning, cache_read, cache_write| {
+            UnifiedMessage::new(
+                "synthetic",
+                model,
+                "provider",
+                model,
+                1_733_011_200_000,
+                TokenBreakdown {
+                    input,
+                    output,
+                    reasoning,
+                    cache_read,
+                    cache_write,
+                },
+                0.0,
+            )
+        };
+
+        assert!(
+            validate_priced_messages(&[usage("input-only", 1, 0, 0, 0, 0)], Some(&pricing)).is_ok()
+        );
+        assert!(
+            validate_priced_messages(&[usage("input-only", 0, 1, 0, 0, 0)], Some(&pricing))
+                .is_err()
+        );
+        assert!(
+            validate_priced_messages(&[usage("output-only", 0, 1, 1, 0, 0)], Some(&pricing))
+                .is_ok()
+        );
+        assert!(
+            validate_priced_messages(&[usage("output-only", 1, 0, 0, 0, 0)], Some(&pricing))
+                .is_err()
+        );
+        assert!(
+            validate_priced_messages(&[usage("output-only", 0, 0, 0, 1, 0)], Some(&pricing))
+                .is_err()
+        );
+        assert!(
+            validate_priced_messages(&[usage("output-only", 0, 0, 0, 0, 1)], Some(&pricing))
+                .is_err()
+        );
+        assert!(validate_priced_messages(
+            &[usage("tier-only", 300_000, 0, 0, 0, 0)],
+            Some(&pricing)
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -2679,10 +2679,16 @@ pub async fn get_hourly_report(options: ReportOptions) -> Result<HourlyReport, S
     })
 }
 
+#[derive(Clone, Copy)]
+enum GraphPricingRequirement {
+    Lenient,
+    Submission,
+}
+
 async fn generate_graph_with_loaded_pricing(
     options: ReportOptions,
     pricing: Option<&pricing::PricingService>,
-    require_pricing: bool,
+    pricing_requirement: GraphPricingRequirement,
 ) -> Result<GraphResult, String> {
     let start = Instant::now();
 
@@ -2707,7 +2713,16 @@ async fn generate_graph_with_loaded_pricing(
 
     let filtered = filter_messages_for_report(all_messages, &options);
 
-    if require_pricing {
+    build_graph_from_messages(filtered, pricing, pricing_requirement, start)
+}
+
+fn build_graph_from_messages(
+    filtered: Vec<UnifiedMessage>,
+    pricing: Option<&pricing::PricingService>,
+    pricing_requirement: GraphPricingRequirement,
+    start: Instant,
+) -> Result<GraphResult, String> {
+    if matches!(pricing_requirement, GraphPricingRequirement::Submission) {
         validate_priced_messages(&filtered, pricing)?;
     }
 
@@ -2772,12 +2787,24 @@ pub async fn get_time_metrics_report(options: ReportOptions) -> Result<TimeMetri
 
 pub async fn generate_graph(options: ReportOptions) -> Result<GraphResult, String> {
     let pricing = pricing::PricingService::get_or_init().await?;
-    generate_graph_with_loaded_pricing(options, Some(&pricing), true).await
+    generate_graph_with_loaded_pricing(options, Some(&pricing), GraphPricingRequirement::Lenient)
+        .await
+}
+
+pub async fn generate_submission_graph(options: ReportOptions) -> Result<GraphResult, String> {
+    let pricing = pricing::PricingService::get_or_init().await?;
+    generate_graph_with_loaded_pricing(options, Some(&pricing), GraphPricingRequirement::Submission)
+        .await
 }
 
 pub async fn generate_local_graph_report(options: ReportOptions) -> Result<GraphResult, String> {
     let pricing = load_pricing_for_local_parse().await;
-    generate_graph_with_loaded_pricing(options, pricing.as_deref(), false).await
+    generate_graph_with_loaded_pricing(
+        options,
+        pricing.as_deref(),
+        GraphPricingRequirement::Lenient,
+    )
+    .await
 }
 
 fn validate_priced_messages(
@@ -3871,11 +3898,12 @@ pub fn parsed_to_unified(msg: &ParsedMessage, cost: f64) -> UnifiedMessage {
 #[cfg(test)]
 mod tests {
     use super::{
-        aggregate_model_usage_entries, apply_pricing_if_available, dedupe_latest_trae_messages,
-        filter_messages_for_report, generate_graph_with_loaded_pricing, message_cache,
-        normalize_model_for_grouping, parse_all_messages_with_pricing_with_env_strategy,
-        parse_local_clients, parsed_to_unified, pricing, retain_for_requested_clients, scanner,
-        select_local_parse_pricing, unified_to_parsed, validate_priced_messages, ClientId, GroupBy,
+        aggregate_model_usage_entries, apply_pricing_if_available, build_graph_from_messages,
+        dedupe_latest_trae_messages, filter_messages_for_report,
+        generate_graph_with_loaded_pricing, message_cache, normalize_model_for_grouping,
+        parse_all_messages_with_pricing_with_env_strategy, parse_local_clients, parsed_to_unified,
+        pricing, retain_for_requested_clients, scanner, select_local_parse_pricing,
+        unified_to_parsed, validate_priced_messages, ClientId, GraphPricingRequirement, GroupBy,
         LocalParseOptions, ReportOptions, TokenBreakdown, UnifiedMessage, UNKNOWN_WORKSPACE_LABEL,
     };
     use std::collections::{HashMap, HashSet};
@@ -6931,6 +6959,41 @@ mod tests {
     }
 
     #[test]
+    fn graph_pricing_policy_is_strict_only_for_submission() {
+        let message = UnifiedMessage::new(
+            "opencode",
+            "genuinely-unpriced-model",
+            "unknown-provider",
+            "unpriced",
+            1_736_510_400_000,
+            TokenBreakdown {
+                input: 1,
+                ..Default::default()
+            },
+            0.0,
+        );
+        let pricing = pricing::PricingService::new(HashMap::new(), HashMap::new());
+
+        let report = build_graph_from_messages(
+            vec![message.clone()],
+            Some(&pricing),
+            GraphPricingRequirement::Lenient,
+            std::time::Instant::now(),
+        )
+        .expect("reporting graphs should retain unpriced usage");
+        let submission_error = build_graph_from_messages(
+            vec![message],
+            Some(&pricing),
+            GraphPricingRequirement::Submission,
+            std::time::Instant::now(),
+        )
+        .expect_err("submission graphs should reject unpriced usage");
+
+        assert_eq!(report.summary.total_tokens, 1);
+        assert!(submission_error.contains("unknown-provider/genuinely-unpriced-model"));
+    }
+
+    #[test]
     fn strict_pricing_validation_accepts_bundled_pricing() {
         let pricing = pricing::PricingService::new(HashMap::new(), HashMap::new());
         let message = UnifiedMessage::new(
@@ -8650,7 +8713,7 @@ mod tests {
                     scanner_settings: scanner::ScannerSettings::default(),
                 },
                 None,
-                false,
+                GraphPricingRequirement::Lenient,
             ))
             .unwrap();
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -6933,6 +6933,25 @@ mod tests {
     }
 
     #[test]
+    fn strict_pricing_validation_accepts_bundled_pricing() {
+        let pricing = pricing::PricingService::new(HashMap::new(), HashMap::new());
+        let message = UnifiedMessage::new(
+            "cursor",
+            "composer-2.5",
+            "cursor",
+            "bundled",
+            1_733_011_200_000,
+            TokenBreakdown {
+                input: 1,
+                ..Default::default()
+            },
+            0.0,
+        );
+
+        assert!(validate_priced_messages(&[message], Some(&pricing)).is_ok());
+    }
+
+    #[test]
     fn strict_pricing_validation_ignores_filtered_out_unpriced_usage() {
         let mut old = UnifiedMessage::new(
             "synthetic",

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -874,6 +874,10 @@ fn parser_version(client: ClientId) -> u32 {
         // session_model_usage instead of crediting the whole session to
         // sessions.model, and dedup keys are namespaced per (session, model).
         ClientId::Hermes => 2,
+        // v1 retained MiMo's embedded `cost` value but did not preserve its
+        // provider-reported provenance. Reparse cached rows so strict submit
+        // validation does not reject valid unknown-model MiMo usage offline.
+        ClientId::MiMoCode => 2,
         _ => 1,
     }
 }
@@ -2113,6 +2117,11 @@ mod tests {
     #[test]
     fn test_hermes_parser_version_invalidates_v1_entries() {
         assert_eq!(parser_version(ClientId::Hermes), 2);
+    }
+
+    #[test]
+    fn test_micode_parser_version_invalidates_rows_without_cost_provenance() {
+        assert_eq!(parser_version(ClientId::MiMoCode), 2);
     }
 
     #[test]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -834,8 +834,10 @@ fn parser_version(client: ClientId) -> u32 {
         ClientId::Claude => 2,
         // Junie's usage-event timestamp is now back-calculated to the call
         // start (timestampMs - usage.time) instead of the recorded
-        // (end-anchored) timestampMs. Follow-up to #890.
-        ClientId::Junie => 2,
+        // (end-anchored) timestampMs. Follow-up to #890. v2->v3: preserve
+        // provider-reported cost provenance, including explicit zeroes, so
+        // strict submission does not reject valid cached unknown-model usage.
+        ClientId::Junie => 3,
         // zcode's model_usage timestamp now prefers `started_at` over
         // `completed_at`. Follow-up to #890. v2->v3: rows with a NULL
         // `started_at` now back-calculate `completed_at - duration_ms`
@@ -877,7 +879,9 @@ fn parser_version(client: ClientId) -> u32 {
         // v1 retained MiMo's embedded `cost` value but did not preserve its
         // provider-reported provenance. Reparse cached rows so strict submit
         // validation does not reject valid unknown-model MiMo usage offline.
-        ClientId::MiMoCode => 2,
+        // v2->v3: duplicate merging now upgrades the retained row when a later
+        // copy carries an explicit cost, including zero.
+        ClientId::MiMoCode => 3,
         _ => 1,
     }
 }
@@ -2101,7 +2105,7 @@ mod tests {
         // end-anchored when the prompt timestamp was missing. Both bump
         // again here so those stale (start-anchored-but-still-wrong) v2/v1
         // cache entries are also invalidated.
-        assert_eq!(parser_version(ClientId::Junie), 2);
+        assert_eq!(parser_version(ClientId::Junie), 3);
         assert_eq!(parser_version(ClientId::Jcode), 7);
         assert_eq!(parser_version(ClientId::DevinCli), 3);
         assert_eq!(parser_version(ClientId::Zcode), 3);
@@ -2121,7 +2125,12 @@ mod tests {
 
     #[test]
     fn test_micode_parser_version_invalidates_rows_without_cost_provenance() {
-        assert_eq!(parser_version(ClientId::MiMoCode), 2);
+        assert_eq!(parser_version(ClientId::MiMoCode), 3);
+    }
+
+    #[test]
+    fn test_junie_parser_version_invalidates_rows_without_cost_provenance() {
+        assert_eq!(parser_version(ClientId::Junie), 3);
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/fetch.rs
+++ b/crates/tokscale-core/src/pricing/fetch.rs
@@ -1,0 +1,41 @@
+use reqwest::{Client, Response, StatusCode};
+use std::time::Duration;
+
+const MAX_RETRIES: u32 = 3;
+const INITIAL_BACKOFF_MS: u64 = 200;
+
+pub(crate) fn pricing_client() -> Result<Client, String> {
+    Client::builder()
+        .timeout(Duration::from_secs(30))
+        .connect_timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|error| error.to_string())
+}
+
+pub(crate) async fn get_with_retry(
+    client: &Client,
+    url: &str,
+    source: &str,
+) -> Result<Response, String> {
+    let mut last_error = None;
+
+    for attempt in 0..MAX_RETRIES {
+        match client.get(url).send().await {
+            Ok(response) if response.status().is_success() => return Ok(response),
+            Ok(response) => {
+                let status = response.status();
+                if !status.is_server_error() && status != StatusCode::TOO_MANY_REQUESTS {
+                    return Err(format!("{source} HTTP {status}"));
+                }
+                last_error = Some(format!("{source} HTTP {status}"));
+            }
+            Err(error) => last_error = Some(format!("{source} network error: {error}")),
+        }
+
+        if attempt < MAX_RETRIES - 1 {
+            tokio::time::sleep(Duration::from_millis(INITIAL_BACKOFF_MS * (1 << attempt))).await;
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| format!("{source} fetch ended without a response")))
+}

--- a/crates/tokscale-core/src/pricing/litellm.rs
+++ b/crates/tokscale-core/src/pricing/litellm.rs
@@ -25,6 +25,42 @@ pub struct ModelPricing {
     pub cache_read_input_token_cost_above_272k_tokens: Option<f64>,
 }
 
+impl ModelPricing {
+    /// Whether this row can price every populated token bucket under
+    /// `compute_cost`'s current base-rate fallback semantics. Explicit zeroes
+    /// are valid prices; a missing base rate is not covered by a later tier.
+    pub(crate) fn covers_usage(&self, usage: &crate::TokenBreakdown) -> bool {
+        let valid_rate =
+            |rate: Option<f64>| rate.is_some_and(|rate| rate.is_finite() && rate >= 0.0);
+        (usage.input <= 0 || valid_rate(self.input_cost_per_token))
+            && (usage.output <= 0 && usage.reasoning <= 0 || valid_rate(self.output_cost_per_token))
+            && (usage.cache_read <= 0 || valid_rate(self.cache_read_input_token_cost))
+            && (usage.cache_write <= 0 || valid_rate(self.cache_creation_input_token_cost))
+    }
+
+    pub(crate) fn has_any_usable_rate(&self) -> bool {
+        [
+            self.input_cost_per_token,
+            self.input_cost_per_token_above_128k_tokens,
+            self.input_cost_per_token_above_200k_tokens,
+            self.input_cost_per_token_above_256k_tokens,
+            self.input_cost_per_token_above_272k_tokens,
+            self.output_cost_per_token,
+            self.output_cost_per_token_above_128k_tokens,
+            self.output_cost_per_token_above_200k_tokens,
+            self.output_cost_per_token_above_256k_tokens,
+            self.output_cost_per_token_above_272k_tokens,
+            self.cache_creation_input_token_cost,
+            self.cache_creation_input_token_cost_above_200k_tokens,
+            self.cache_read_input_token_cost,
+            self.cache_read_input_token_cost_above_200k_tokens,
+            self.cache_read_input_token_cost_above_272k_tokens,
+        ]
+        .into_iter()
+        .any(|rate| rate.is_some_and(|rate| rate.is_finite() && rate >= 0.0))
+    }
+}
+
 pub type PricingDataset = HashMap<String, ModelPricing>;
 
 pub fn load_cached() -> Option<PricingDataset> {
@@ -52,7 +88,7 @@ async fn fetch_inner(url: &str, use_cache: bool) -> Result<PricingDataset, Strin
         .json::<PricingDataset>()
         .await
         .map_err(|error| describe_error(&error))?;
-    if data.is_empty() {
+    if !data.values().any(ModelPricing::has_any_usable_rate) {
         return Err("LiteLLM returned no usable pricing rows".to_string());
     }
     if let Err(e) = cache::save_cache(CACHE_FILENAME, &data) {

--- a/crates/tokscale-core/src/pricing/litellm.rs
+++ b/crates/tokscale-core/src/pricing/litellm.rs
@@ -1,4 +1,4 @@
-use super::cache;
+use super::{cache, describe_error};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -88,7 +88,10 @@ pub async fn fetch() -> Result<PricingDataset, reqwest::Error> {
                         return Ok(data);
                     }
                     Err(e) => {
-                        eprintln!("[tokscale] LiteLLM JSON parse failed: {}", e);
+                        eprintln!(
+                            "[tokscale] LiteLLM JSON parse failed: {}",
+                            describe_error(&e)
+                        );
                         return Err(e);
                     }
                 }
@@ -98,7 +101,7 @@ pub async fn fetch() -> Result<PricingDataset, reqwest::Error> {
                     "[tokscale] LiteLLM network error (attempt {}/{}): {}",
                     attempt + 1,
                     MAX_RETRIES,
-                    e
+                    describe_error(&e)
                 );
                 last_error = Some(e);
                 if attempt < MAX_RETRIES - 1 {
@@ -117,6 +120,64 @@ pub async fn fetch() -> Result<PricingDataset, reqwest::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    /// Serve one 200 response whose body is well-formed JSON that does not fit
+    /// `PricingDataset` (a string where an f64 is expected) — the shape an
+    /// upstream LiteLLM schema change would take.
+    fn malformed_pricing_server() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+
+        thread::spawn(move || {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            let mut buffer = [0; 1024];
+            let _ = stream.read(&mut buffer);
+            let body = r#"{"some-model":{"input_cost_per_token":"not-a-number"}}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes());
+        });
+
+        url
+    }
+
+    // Pins the mechanism behind #1002: reqwest's Display collapses ANY body
+    // decode failure to one opaque sentence, so the reported message proves
+    // only that a response arrived and could not be deserialized — it says
+    // nothing about TLS, and cannot mean "no connection was made".
+    #[tokio::test]
+    async fn reqwest_display_hides_the_decode_cause_that_describe_error_recovers() {
+        let url = malformed_pricing_server();
+        let error = reqwest::Client::new()
+            .get(&url)
+            .send()
+            .await
+            .expect("the request itself succeeds")
+            .json::<PricingDataset>()
+            .await
+            .expect_err("the body must fail to deserialize");
+
+        assert_eq!(
+            error.to_string(),
+            "error decoding response body",
+            "this is verbatim what issue #1002 reported"
+        );
+
+        let described = describe_error(&error);
+        assert!(
+            described.contains("expected f64"),
+            "describe_error must surface the serde cause, got: {}",
+            described
+        );
+    }
 
     #[test]
     fn test_deserialize_model_pricing_with_above_200k_fields() {

--- a/crates/tokscale-core/src/pricing/litellm.rs
+++ b/crates/tokscale-core/src/pricing/litellm.rs
@@ -1,12 +1,10 @@
-use super::{cache, describe_error};
+use super::{cache, describe_error, fetch};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 const CACHE_FILENAME: &str = "pricing-litellm.json";
 const PRICING_URL: &str =
     "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
-const MAX_RETRIES: u32 = 3;
-const INITIAL_BACKOFF_MS: u64 = 200;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ModelPricing {
@@ -37,104 +35,34 @@ pub fn load_cached_any_age() -> Option<PricingDataset> {
     cache::load_cache_any_age(CACHE_FILENAME)
 }
 
-pub async fn fetch() -> Result<PricingDataset, reqwest::Error> {
+pub async fn fetch() -> Result<PricingDataset, String> {
     fetch_inner(PRICING_URL, true).await
 }
 
-async fn fetch_inner(url: &str, use_cache: bool) -> Result<PricingDataset, reqwest::Error> {
+async fn fetch_inner(url: &str, use_cache: bool) -> Result<PricingDataset, String> {
     if use_cache {
         if let Some(cached) = load_cached() {
             return Ok(cached);
         }
     }
 
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .connect_timeout(std::time::Duration::from_secs(10))
-        .build()?;
-
-    let mut last_error: Option<reqwest::Error> = None;
-
-    for attempt in 0..MAX_RETRIES {
-        match client.get(url).send().await {
-            Ok(response) => {
-                let status = response.status();
-
-                if status.is_server_error() || status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-                    eprintln!(
-                        "[tokscale] LiteLLM HTTP {} (attempt {}/{})",
-                        status,
-                        attempt + 1,
-                        MAX_RETRIES
-                    );
-                    // A retryable status never populated `last_error`, so exhausting
-                    // the retries on 5xx/429 — the likeliest raw.githubusercontent.com
-                    // failure — fell through to the tail below and panicked instead of
-                    // returning Err. That aborted the process before the caller's
-                    // degradation policy could run. models_dev::fetch_inner already
-                    // converts the final attempt into an error; do the same here.
-                    if attempt == MAX_RETRIES - 1 {
-                        return Err(response.error_for_status().unwrap_err());
-                    }
-                    let _ = response.bytes().await;
-                    tokio::time::sleep(std::time::Duration::from_millis(
-                        INITIAL_BACKOFF_MS * (1 << attempt),
-                    ))
-                    .await;
-                    continue;
-                }
-
-                if !status.is_success() {
-                    eprintln!("[tokscale] LiteLLM HTTP {}", status);
-                    return Err(response.error_for_status().unwrap_err());
-                }
-
-                match response.json::<PricingDataset>().await {
-                    Ok(data) => {
-                        if let Err(e) = cache::save_cache(CACHE_FILENAME, &data) {
-                            eprintln!(
-                                "[tokscale] Warning: Failed to cache LiteLLM pricing at {}: {}",
-                                cache::get_cache_path(CACHE_FILENAME).display(),
-                                e
-                            );
-                        }
-                        return Ok(data);
-                    }
-                    Err(e) => {
-                        eprintln!(
-                            "[tokscale] LiteLLM JSON parse failed: {}",
-                            describe_error(&e)
-                        );
-                        return Err(e);
-                    }
-                }
-            }
-            Err(e) => {
-                eprintln!(
-                    "[tokscale] LiteLLM network error (attempt {}/{}): {}",
-                    attempt + 1,
-                    MAX_RETRIES,
-                    describe_error(&e)
-                );
-                last_error = Some(e);
-                if attempt < MAX_RETRIES - 1 {
-                    tokio::time::sleep(std::time::Duration::from_millis(
-                        INITIAL_BACKOFF_MS * (1 << attempt),
-                    ))
-                    .await;
-                }
-            }
-        }
+    let client = fetch::pricing_client()?;
+    let response = fetch::get_with_retry(&client, url, "LiteLLM").await?;
+    let data = response
+        .json::<PricingDataset>()
+        .await
+        .map_err(|error| describe_error(&error))?;
+    if data.is_empty() {
+        return Err("LiteLLM returned no usable pricing rows".to_string());
     }
-
-    match last_error {
-        Some(e) => Err(e),
-        // Unreachable: the loop only falls through here after a transport error,
-        // which always records `last_error`. Kept as a non-panicking floor
-        // (matching models_dev::fetch_inner) because the previous `expect` here
-        // was reachable and did abort the process.
-        None => Ok(HashMap::new()),
+    if let Err(e) = cache::save_cache(CACHE_FILENAME, &data) {
+        eprintln!(
+            "[tokscale] Warning: Failed to cache LiteLLM pricing at {}: {}",
+            cache::get_cache_path(CACHE_FILENAME).display(),
+            e
+        );
     }
+    Ok(data)
 }
 
 #[cfg(test)]
@@ -176,7 +104,7 @@ mod tests {
         let url = format!("http://{}", listener.local_addr().unwrap());
 
         thread::spawn(move || {
-            for _ in 0..MAX_RETRIES {
+            for _ in 0..3 {
                 let Ok((mut stream, _)) = listener.accept() else {
                     return;
                 };

--- a/crates/tokscale-core/src/pricing/litellm.rs
+++ b/crates/tokscale-core/src/pricing/litellm.rs
@@ -38,23 +38,12 @@ impl ModelPricing {
             && (usage.cache_write <= 0 || valid_rate(self.cache_creation_input_token_cost))
     }
 
-    pub(crate) fn has_any_usable_rate(&self) -> bool {
+    pub(crate) fn has_any_usable_base_rate(&self) -> bool {
         [
             self.input_cost_per_token,
-            self.input_cost_per_token_above_128k_tokens,
-            self.input_cost_per_token_above_200k_tokens,
-            self.input_cost_per_token_above_256k_tokens,
-            self.input_cost_per_token_above_272k_tokens,
             self.output_cost_per_token,
-            self.output_cost_per_token_above_128k_tokens,
-            self.output_cost_per_token_above_200k_tokens,
-            self.output_cost_per_token_above_256k_tokens,
-            self.output_cost_per_token_above_272k_tokens,
             self.cache_creation_input_token_cost,
-            self.cache_creation_input_token_cost_above_200k_tokens,
             self.cache_read_input_token_cost,
-            self.cache_read_input_token_cost_above_200k_tokens,
-            self.cache_read_input_token_cost_above_272k_tokens,
         ]
         .into_iter()
         .any(|rate| rate.is_some_and(|rate| rate.is_finite() && rate >= 0.0))
@@ -84,11 +73,12 @@ async fn fetch_inner(url: &str, use_cache: bool) -> Result<PricingDataset, Strin
 
     let client = fetch::pricing_client()?;
     let response = fetch::get_with_retry(&client, url, "LiteLLM").await?;
-    let data = response
+    let mut data = response
         .json::<PricingDataset>()
         .await
         .map_err(|error| describe_error(&error))?;
-    if !data.values().any(ModelPricing::has_any_usable_rate) {
+    data.retain(|_, pricing| pricing.has_any_usable_base_rate());
+    if data.is_empty() {
         return Err("LiteLLM returned no usable pricing rows".to_string());
     }
     if let Err(e) = cache::save_cache(CACHE_FILENAME, &data) {
@@ -111,7 +101,7 @@ mod tests {
     /// Serve one 200 response whose body is well-formed JSON that does not fit
     /// `PricingDataset` (a string where an f64 is expected) — the shape an
     /// upstream LiteLLM schema change would take.
-    fn malformed_pricing_server() -> String {
+    fn pricing_server(body: &'static str) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let url = format!("http://{}", listener.local_addr().unwrap());
 
@@ -121,7 +111,6 @@ mod tests {
             };
             let mut buffer = [0; 1024];
             let _ = stream.read(&mut buffer);
-            let body = r#"{"some-model":{"input_cost_per_token":"not-a-number"}}"#;
             let response = format!(
                 "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
                 body.len(),
@@ -131,6 +120,10 @@ mod tests {
         });
 
         url
+    }
+
+    fn malformed_pricing_server() -> String {
+        pricing_server(r#"{"some-model":{"input_cost_per_token":"not-a-number"}}"#)
     }
 
     /// Serve `MAX_RETRIES` responses with a retryable status, so every attempt
@@ -187,6 +180,35 @@ mod tests {
         let result = fetch_inner(&url, false).await;
 
         assert!(result.is_err(), "429 is retried the same way 5xx is");
+    }
+
+    #[tokio::test]
+    async fn tier_only_rows_are_not_cached_as_usable_pricing() {
+        let url =
+            pricing_server(r#"{"tier-only":{"input_cost_per_token_above_272k_tokens":0.00001}}"#);
+
+        let error = fetch_inner(&url, false)
+            .await
+            .expect_err("a tier rate without a base rate cannot price all tokens");
+
+        assert!(error.contains("no usable pricing rows"));
+    }
+
+    #[tokio::test]
+    async fn tier_only_rows_are_removed_from_an_otherwise_usable_response() {
+        let url = pricing_server(
+            r#"{
+                "tier-only":{"input_cost_per_token_above_272k_tokens":0.00001},
+                "usable":{"input_cost_per_token":0.000005}
+            }"#,
+        );
+
+        let data = fetch_inner(&url, false)
+            .await
+            .expect("the response contains one usable base-priced row");
+
+        assert!(!data.contains_key("tier-only"));
+        assert!(data.contains_key("usable"));
     }
 
     // Pins the mechanism behind #1002: reqwest's Display collapses ANY body

--- a/crates/tokscale-core/src/pricing/litellm.rs
+++ b/crates/tokscale-core/src/pricing/litellm.rs
@@ -38,8 +38,14 @@ pub fn load_cached_any_age() -> Option<PricingDataset> {
 }
 
 pub async fn fetch() -> Result<PricingDataset, reqwest::Error> {
-    if let Some(cached) = load_cached() {
-        return Ok(cached);
+    fetch_inner(PRICING_URL, true).await
+}
+
+async fn fetch_inner(url: &str, use_cache: bool) -> Result<PricingDataset, reqwest::Error> {
+    if use_cache {
+        if let Some(cached) = load_cached() {
+            return Ok(cached);
+        }
     }
 
     let client = reqwest::Client::builder()
@@ -50,7 +56,7 @@ pub async fn fetch() -> Result<PricingDataset, reqwest::Error> {
     let mut last_error: Option<reqwest::Error> = None;
 
     for attempt in 0..MAX_RETRIES {
-        match client.get(PRICING_URL).send().await {
+        match client.get(url).send().await {
             Ok(response) => {
                 let status = response.status();
 
@@ -61,13 +67,20 @@ pub async fn fetch() -> Result<PricingDataset, reqwest::Error> {
                         attempt + 1,
                         MAX_RETRIES
                     );
-                    let _ = response.bytes().await;
-                    if attempt < MAX_RETRIES - 1 {
-                        tokio::time::sleep(std::time::Duration::from_millis(
-                            INITIAL_BACKOFF_MS * (1 << attempt),
-                        ))
-                        .await;
+                    // A retryable status never populated `last_error`, so exhausting
+                    // the retries on 5xx/429 — the likeliest raw.githubusercontent.com
+                    // failure — fell through to the tail below and panicked instead of
+                    // returning Err. That aborted the process before the caller's
+                    // degradation policy could run. models_dev::fetch_inner already
+                    // converts the final attempt into an error; do the same here.
+                    if attempt == MAX_RETRIES - 1 {
+                        return Err(response.error_for_status().unwrap_err());
                     }
+                    let _ = response.bytes().await;
+                    tokio::time::sleep(std::time::Duration::from_millis(
+                        INITIAL_BACKOFF_MS * (1 << attempt),
+                    ))
+                    .await;
                     continue;
                 }
 
@@ -114,7 +127,14 @@ pub async fn fetch() -> Result<PricingDataset, reqwest::Error> {
         }
     }
 
-    Err(last_error.expect("should have error after retries"))
+    match last_error {
+        Some(e) => Err(e),
+        // Unreachable: the loop only falls through here after a transport error,
+        // which always records `last_error`. Kept as a non-panicking floor
+        // (matching models_dev::fetch_inner) because the previous `expect` here
+        // was reachable and did abort the process.
+        None => Ok(HashMap::new()),
+    }
 }
 
 #[cfg(test)]
@@ -149,14 +169,75 @@ mod tests {
         url
     }
 
+    /// Serve `MAX_RETRIES` responses with a retryable status, so every attempt
+    /// is consumed. Mirrors `models_dev::tests::retryable_status_server`.
+    fn retryable_status_server(status_line: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+
+        thread::spawn(move || {
+            for _ in 0..MAX_RETRIES {
+                let Ok((mut stream, _)) = listener.accept() else {
+                    return;
+                };
+                let mut buffer = [0; 1024];
+                let _ = stream.read(&mut buffer);
+                let response =
+                    format!("{status_line}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+
+        url
+    }
+
+    /// A client that cannot outlive a wedged listener thread: without this the
+    /// tests below block forever instead of failing if `accept` never fires.
+    fn bounded_client() -> reqwest::Client {
+        reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+            .unwrap()
+    }
+
+    // Regression: retryable statuses never recorded `last_error`, so exhausting
+    // the retries on 5xx/429 panicked out of `fetch` instead of returning Err.
+    // That defeated the caller's whole "no single source may be fatal" contract,
+    // because a panic never reaches the caller at all.
+    #[tokio::test]
+    async fn retryable_statuses_return_an_error_rather_than_panicking() {
+        let url = retryable_status_server("HTTP/1.1 503 Service Unavailable");
+
+        let result = fetch_inner(&url, false).await;
+
+        assert!(
+            result.is_err(),
+            "exhausted retries on 503 must surface as Err so the caller can degrade"
+        );
+    }
+
+    #[tokio::test]
+    async fn rate_limit_status_returns_an_error_rather_than_panicking() {
+        let url = retryable_status_server("HTTP/1.1 429 Too Many Requests");
+
+        let result = fetch_inner(&url, false).await;
+
+        assert!(result.is_err(), "429 is retried the same way 5xx is");
+    }
+
     // Pins the mechanism behind #1002: reqwest's Display collapses ANY body
     // decode failure to one opaque sentence, so the reported message proves
     // only that a response arrived and could not be deserialized — it says
     // nothing about TLS, and cannot mean "no connection was made".
+    //
+    // Asserted as "Display omits what describe_error recovers" rather than
+    // against reqwest's and serde_json's exact wording: the wording is upstream
+    // prose that a dependency bump may reword, and pinning it would redden this
+    // test without any tokscale defect.
     #[tokio::test]
     async fn reqwest_display_hides_the_decode_cause_that_describe_error_recovers() {
         let url = malformed_pricing_server();
-        let error = reqwest::Client::new()
+        let error = bounded_client()
             .get(&url)
             .send()
             .await
@@ -165,16 +246,24 @@ mod tests {
             .await
             .expect_err("the body must fail to deserialize");
 
-        assert_eq!(
-            error.to_string(),
-            "error decoding response body",
-            "this is verbatim what issue #1002 reported"
+        // Anchored on the offending value, which this fixture owns, rather than
+        // on reqwest's or serde_json's phrasing, which it does not.
+        let displayed = error.to_string();
+        assert!(
+            !displayed.contains("not-a-number"),
+            "Display must say nothing about the payload — that is the bug: {}",
+            displayed
         );
 
         let described = describe_error(&error);
         assert!(
-            described.contains("expected f64"),
-            "describe_error must surface the serde cause, got: {}",
+            described.starts_with(&displayed) && described.len() > displayed.len(),
+            "describe_error must extend Display with the source chain, got: {}",
+            described
+        );
+        assert!(
+            described.contains("not-a-number"),
+            "describe_error must surface the serde cause naming the bad value, got: {}",
             described
         );
     }

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -24,6 +24,26 @@ static PRICING_SERVICE: OnceCell<Arc<PricingService>> = OnceCell::const_new();
 /// and should be excluded from pay-per-token cost estimation.
 const EXCLUDED_LITELLM_PREFIXES: &[&str] = &["github_copilot/"];
 
+// @keep: explains why we do not just print the error.
+/// Flatten an error and its `source()` chain into one line.
+///
+/// `reqwest::Error`'s `Display` is deliberately terse: a body-decode failure
+/// renders as the bare string "error decoding response body", and the
+/// `serde_json` cause that names the offending field and byte offset hangs off
+/// `source()`, which `{}` never walks. Issue #1002 was reported with exactly
+/// that message, which is why it was impossible to tell a transport failure
+/// from an upstream schema change and the reporter guessed at TLS. Printing the
+/// chain makes the next such report actionable.
+pub(crate) fn describe_error(error: &(dyn std::error::Error + 'static)) -> String {
+    let mut parts = vec![error.to_string()];
+    let mut source = error.source();
+    while let Some(inner) = source {
+        parts.push(inner.to_string());
+        source = inner.source();
+    }
+    parts.join(": ")
+}
+
 pub struct PricingService {
     custom: CustomPricing,
     lookup: PricingLookup,
@@ -178,21 +198,54 @@ impl PricingService {
             models_dev::fetch()
         );
 
-        let (litellm_data, litellm_error) = match litellm_result {
-            Ok(data) => (Self::filter_litellm_data(data), None),
-            Err(error) => {
+        Self::combine_fetched_sources(
+            litellm_result.map_err(|e| describe_error(&e)),
+            openrouter_data,
+            models_dev_result.map_err(|e| describe_error(&e)),
+            litellm::load_cached_any_age,
+        )
+    }
+
+    // @keep: the asymmetry this removes was load-bearing and non-obvious.
+    /// Assemble a service from whatever the three upstream sources returned.
+    ///
+    /// No single source may be fatal. LiteLLM is the largest dataset, but it is
+    /// not the only one, and propagating its fetch error made every command
+    /// that prices tokens — `submit` included — dead in the water whenever
+    /// raw.githubusercontent.com was unreachable or served something we could
+    /// not decode (#1002). openrouter already degraded (it returns no error at
+    /// all) and models.dev already degraded to an empty map; LiteLLM was the
+    /// lone hard-error, so a single unreachable host took the whole command
+    /// down. A failing source now degrades to its own stale cache, then to
+    /// nothing, and the surviving sources still price what they cover.
+    ///
+    /// The deliberate exception: if *every* source ends up empty we still
+    /// error. Continuing there would price every model at $0.00 and `submit`
+    /// would upload those zeros as though they were real costs, which is a
+    /// worse failure than refusing to run.
+    fn combine_fetched_sources(
+        litellm_result: Result<HashMap<String, ModelPricing>, String>,
+        openrouter_data: HashMap<String, ModelPricing>,
+        models_dev_result: Result<HashMap<String, ModelPricing>, String>,
+        litellm_cached: impl FnOnce() -> Option<HashMap<String, ModelPricing>>,
+    ) -> Result<Self, String> {
+        let litellm_data = match litellm_result {
+            Ok(data) => data,
+            Err(e) => {
+                let cached = litellm_cached();
                 eprintln!(
-                    "[tokscale] Warning: LiteLLM pricing unavailable ({}), using other sources",
-                    error
+                    "[tokscale] Warning: LiteLLM pricing fetch failed ({}); {}",
+                    e,
+                    if cached.is_some() {
+                        "falling back to the cached copy"
+                    } else {
+                        "continuing with the remaining pricing sources"
+                    }
                 );
-                (
-                    litellm::load_cached_any_age()
-                        .map(Self::filter_litellm_data)
-                        .unwrap_or_default(),
-                    Some(error.to_string()),
-                )
+                cached.unwrap_or_default()
             }
         };
+        let litellm_data = Self::filter_litellm_data(litellm_data);
         let models_dev_data = match models_dev_result {
             Ok(data) => data,
             Err(e) => {
@@ -202,8 +255,9 @@ impl PricingService {
         };
 
         if litellm_data.is_empty() && openrouter_data.is_empty() && models_dev_data.is_empty() {
-            return Err(litellm_error
-                .unwrap_or_else(|| "No dynamic pricing source returned usable data".to_string()));
+            return Err(
+                "all pricing sources failed and no cached pricing data is available".to_string(),
+            );
         }
 
         Ok(Self::new_with_custom_and_models_dev(
@@ -376,6 +430,102 @@ mod tests {
             openrouter,
             models_dev,
         )
+    }
+
+    /// Run `body` with the config dir pinned to a throwaway directory.
+    ///
+    /// `combine_fetched_sources` reads user custom pricing from the default
+    /// path; without this the developer's own ~/.config/tokscale could satisfy
+    /// or skew the assertions below.
+    fn with_sandboxed_config_dir<T>(body: impl FnOnce() -> T) -> T {
+        let temp = tempfile::TempDir::new().unwrap();
+        let previous = std::env::var_os("TOKSCALE_CONFIG_DIR");
+        unsafe { std::env::set_var("TOKSCALE_CONFIG_DIR", temp.path()) };
+        let result = body();
+        unsafe {
+            match previous {
+                Some(value) => std::env::set_var("TOKSCALE_CONFIG_DIR", value),
+                None => std::env::remove_var("TOKSCALE_CONFIG_DIR"),
+            }
+        }
+        result
+    }
+
+    // Regression: #1002. A LiteLLM fetch failure used to propagate out of
+    // fetch_inner, so `tokscale submit` died with "error decoding response
+    // body" even though models.dev and openrouter were both reachable and
+    // carried usable pricing.
+    #[test]
+    #[serial_test::serial]
+    fn litellm_fetch_failure_is_not_fatal_when_another_source_has_data() {
+        let mut models_dev = HashMap::new();
+        models_dev.insert("test-model-alpha".to_string(), model_pricing(1e-6, 2e-6));
+
+        let service = with_sandboxed_config_dir(|| {
+            PricingService::combine_fetched_sources(
+                Err("error decoding response body".to_string()),
+                HashMap::new(),
+                Ok(models_dev),
+                // Fresh install, as in the report: nothing cached yet.
+                || None,
+            )
+        })
+        .expect("a LiteLLM failure must not be fatal while another source has pricing");
+
+        let cost = service.calculate_cost("test-model-alpha", 1_000_000, 0, 0, 0, 0);
+        assert!(
+            (cost - 1.0).abs() < 1e-9,
+            "models.dev pricing should still resolve after LiteLLM fails, got {}",
+            cost
+        );
+    }
+
+    // Regression: #1002. The reporter's workaround was hand-populating the
+    // cache file. A cached copy older than the 1h TTL must be preferred over
+    // dropping LiteLLM entirely, so that workaround keeps working unattended.
+    #[test]
+    #[serial_test::serial]
+    fn litellm_fetch_failure_falls_back_to_stale_cache() {
+        let mut cached = HashMap::new();
+        cached.insert("test-model-beta".to_string(), model_pricing(3e-6, 4e-6));
+
+        let service = with_sandboxed_config_dir(|| {
+            PricingService::combine_fetched_sources(
+                Err("error decoding response body".to_string()),
+                HashMap::new(),
+                Ok(HashMap::new()),
+                || Some(cached),
+            )
+        })
+        .expect("a stale LiteLLM cache must keep the service usable");
+
+        let cost = service.calculate_cost("test-model-beta", 1_000_000, 0, 0, 0, 0);
+        assert!(
+            (cost - 3.0).abs() < 1e-9,
+            "stale LiteLLM cache should price the model, got {}",
+            cost
+        );
+    }
+
+    // The deliberate exception to "never fatal": with every source empty we
+    // must NOT hand back a service that silently prices everything at $0.00,
+    // because `submit` would upload those zeros as real costs.
+    #[test]
+    #[serial_test::serial]
+    fn all_sources_empty_still_errors() {
+        let result = with_sandboxed_config_dir(|| {
+            PricingService::combine_fetched_sources(
+                Err("error decoding response body".to_string()),
+                HashMap::new(),
+                Err("models.dev unreachable".to_string()),
+                || None,
+            )
+        });
+
+        assert!(
+            result.is_err(),
+            "a total pricing blackout must stay fatal rather than price everything at $0"
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -93,10 +93,12 @@ impl PricingService {
     ) -> HashMap<String, ModelPricing> {
         data.retain(|key, _| {
             let lower = key.to_lowercase();
-            !EXCLUDED_LITELLM_PREFIXES
+            let included_provider = !EXCLUDED_LITELLM_PREFIXES
                 .iter()
-                .any(|prefix| lower.starts_with(prefix))
+                .any(|prefix| lower.starts_with(prefix));
+            included_provider
         });
+        data.retain(|_, pricing| pricing.has_any_usable_base_rate());
         data
     }
 
@@ -729,13 +731,27 @@ mod tests {
                 ..Default::default()
             },
         );
-        data.insert("openai/gpt-5.2".into(), ModelPricing::default());
+        data.insert(
+            "openai/gpt-5.2".into(),
+            ModelPricing {
+                output_cost_per_token: Some(0.000014),
+                ..Default::default()
+            },
+        );
+        data.insert(
+            "tier-only".into(),
+            ModelPricing {
+                input_cost_per_token_above_272k_tokens: Some(0.00001),
+                ..Default::default()
+            },
+        );
 
         let filtered = PricingService::filter_litellm_data(data);
         assert!(!filtered.contains_key("github_copilot/gpt-5.3-codex"));
         assert!(!filtered.contains_key("github_copilot/gpt-4o"));
         assert!(filtered.contains_key("gpt-5.2"));
         assert!(filtered.contains_key("openai/gpt-5.2"));
+        assert!(!filtered.contains_key("tier-only"));
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -1,6 +1,7 @@
 pub mod aliases;
 pub mod cache;
 pub mod custom;
+mod fetch;
 pub mod litellm;
 pub mod lookup;
 pub mod models_dev;
@@ -199,11 +200,13 @@ impl PricingService {
         );
 
         Self::combine_fetched_sources(
-            litellm_result.map_err(|e| describe_error(&e)),
+            litellm_result,
             openrouter_data,
-            models_dev_result.map_err(|e| describe_error(&e)),
+            models_dev_result,
             litellm::load_cached_any_age,
+            openrouter::load_cached_any_age,
             models_dev::load_cached_any_age,
+            CustomPricing::load_from_default_path(),
         )
     }
 
@@ -253,21 +256,17 @@ impl PricingService {
     /// lone hard-error, so a single unreachable host took the whole command
     /// down. LiteLLM and models.dev now each degrade to their own stale cache
     /// and then to nothing, and the surviving sources still price what they
-    /// cover. openrouter has no stale-cache step here because it never reports
-    /// a failure to begin with: `fetch_all_mapped` swallows per-model errors
-    /// and returns whatever it collected, so there is no error for this
-    /// function to see.
-    ///
-    /// The deliberate exception: if *every* source ends up empty we still
-    /// error. Continuing there would price every model at $0.00 and `submit`
-    /// would upload those zeros as though they were real costs, which is a
-    /// worse failure than refusing to run.
+    /// cover. Submission safety is checked against the actual filtered messages
+    /// later, rather than treating an empty dynamic dataset as a construction
+    /// failure: custom and bundled pricing remain useful during an outage.
     fn combine_fetched_sources(
         litellm_result: Result<HashMap<String, ModelPricing>, String>,
-        openrouter_data: HashMap<String, ModelPricing>,
+        openrouter_result: Result<HashMap<String, ModelPricing>, String>,
         models_dev_result: Result<HashMap<String, ModelPricing>, String>,
         litellm_cached: impl FnOnce() -> Option<HashMap<String, ModelPricing>>,
+        openrouter_cached: impl FnOnce() -> Option<HashMap<String, ModelPricing>>,
         models_dev_cached: impl FnOnce() -> Option<HashMap<String, ModelPricing>>,
+        custom: CustomPricing,
     ) -> Result<Self, String> {
         let mut failures = Vec::new();
 
@@ -283,23 +282,15 @@ impl PricingService {
             models_dev_cached,
             &mut failures,
         );
-
-        if litellm_data.is_empty() && openrouter_data.is_empty() && models_dev_data.is_empty() {
-            // Callers surface this string to the user and to bug reports, so it
-            // has to carry the per-source causes rather than just the verdict.
-            let causes = if failures.is_empty() {
-                "every source returned an empty dataset".to_string()
-            } else {
-                failures.join("; ")
-            };
-            return Err(format!(
-                "all pricing sources failed and no cached pricing data is available ({})",
-                causes
-            ));
-        }
+        let openrouter_data = Self::degrade_source(
+            "OpenRouter",
+            openrouter_result,
+            openrouter_cached,
+            &mut failures,
+        );
 
         Ok(Self::new_with_custom_and_models_dev(
-            CustomPricing::load_from_default_path(),
+            custom,
             litellm_data,
             openrouter_data,
             models_dev_data,
@@ -470,70 +461,25 @@ mod tests {
         )
     }
 
-    /// Restore `TOKSCALE_CONFIG_DIR` on the way out, including on unwind.
-    ///
-    /// Restoring after the call instead is not equivalent: a failed assertion
-    /// unwinds past the restore and leaves the variable pointing at a TempDir
-    /// that has already been deleted, so one red test silently corrupts every
-    /// later config-reading test in the same process. Mirrors the guard in
-    /// tokscale-cli's autosubmit tests, which cannot be imported across crates.
-    struct EnvVarGuard {
-        key: &'static str,
-        previous: Option<std::ffi::OsString>,
-    }
-
-    impl EnvVarGuard {
-        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-            let previous = std::env::var_os(key);
-            unsafe { std::env::set_var(key, value) };
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            unsafe {
-                match self.previous.take() {
-                    Some(value) => std::env::set_var(self.key, value),
-                    None => std::env::remove_var(self.key),
-                }
-            }
-        }
-    }
-
-    /// Run `body` with the config dir pinned to a throwaway directory.
-    ///
-    /// `combine_fetched_sources` reads user custom pricing from the default
-    /// path; without this the developer's own ~/.config/tokscale could satisfy
-    /// or skew the assertions below.
-    fn with_sandboxed_config_dir<T>(body: impl FnOnce() -> T) -> T {
-        let temp = tempfile::TempDir::new().unwrap();
-        // Dropped after the guard, so the directory outlives every read of the
-        // variable that points at it.
-        let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
-        body()
-    }
-
     // Regression: #1002. A LiteLLM fetch failure used to propagate out of
     // fetch_inner, so `tokscale submit` died with "error decoding response
     // body" even though models.dev and openrouter were both reachable and
     // carried usable pricing.
     #[test]
-    #[serial_test::serial]
     fn litellm_fetch_failure_is_not_fatal_when_another_source_has_data() {
         let mut models_dev = HashMap::new();
         models_dev.insert("test-model-alpha".to_string(), model_pricing(1e-6, 2e-6));
 
-        let service = with_sandboxed_config_dir(|| {
-            PricingService::combine_fetched_sources(
-                Err("error decoding response body".to_string()),
-                HashMap::new(),
-                Ok(models_dev),
-                // Fresh install, as in the report: nothing cached yet.
-                || None,
-                || None,
-            )
-        })
+        let service = PricingService::combine_fetched_sources(
+            Err("error decoding response body".to_string()),
+            Err("OpenRouter unavailable".to_string()),
+            Ok(models_dev),
+            // Fresh install, as in the report: nothing cached yet.
+            || None,
+            || None,
+            || None,
+            CustomPricing::default(),
+        )
         .expect("a LiteLLM failure must not be fatal while another source has pricing");
 
         let cost = service.calculate_cost("test-model-alpha", 1_000_000, 0, 0, 0, 0);
@@ -548,20 +494,19 @@ mod tests {
     // cache file. A cached copy older than the 1h TTL must be preferred over
     // dropping LiteLLM entirely, so that workaround keeps working unattended.
     #[test]
-    #[serial_test::serial]
     fn litellm_fetch_failure_falls_back_to_stale_cache() {
         let mut cached = HashMap::new();
         cached.insert("test-model-beta".to_string(), model_pricing(3e-6, 4e-6));
 
-        let service = with_sandboxed_config_dir(|| {
-            PricingService::combine_fetched_sources(
-                Err("error decoding response body".to_string()),
-                HashMap::new(),
-                Ok(HashMap::new()),
-                || Some(cached),
-                || None,
-            )
-        })
+        let service = PricingService::combine_fetched_sources(
+            Err("error decoding response body".to_string()),
+            Err("OpenRouter unavailable".to_string()),
+            Ok(HashMap::new()),
+            || Some(cached),
+            || None,
+            || None,
+            CustomPricing::default(),
+        )
         .expect("a stale LiteLLM cache must keep the service usable");
 
         let cost = service.calculate_cost("test-model-beta", 1_000_000, 0, 0, 0, 0);
@@ -576,20 +521,19 @@ mod tests {
     // dropped straight to an empty map even though it keeps a cache of its own,
     // so a models.dev outage discarded pricing that was sitting on disk.
     #[test]
-    #[serial_test::serial]
     fn models_dev_fetch_failure_falls_back_to_stale_cache() {
         let mut cached = HashMap::new();
         cached.insert("test-model-gamma".to_string(), model_pricing(5e-6, 6e-6));
 
-        let service = with_sandboxed_config_dir(|| {
-            PricingService::combine_fetched_sources(
-                Ok(HashMap::new()),
-                HashMap::new(),
-                Err("models.dev unreachable".to_string()),
-                || None,
-                || Some(cached),
-            )
-        })
+        let service = PricingService::combine_fetched_sources(
+            Ok(HashMap::new()),
+            Err("OpenRouter unavailable".to_string()),
+            Err("models.dev unreachable".to_string()),
+            || None,
+            || None,
+            || Some(cached),
+            CustomPricing::default(),
+        )
         .expect("a stale models.dev cache must keep the service usable");
 
         let cost = service.calculate_cost("test-model-gamma", 1_000_000, 0, 0, 0, 0);
@@ -600,39 +544,42 @@ mod tests {
         );
     }
 
-    // The deliberate exception to "never fatal": with every source empty we
-    // must NOT hand back a service that silently prices everything at $0.00,
-    // because `submit` would upload those zeros as real costs.
-    //
-    // The message is asserted, not just the variant: this is the only place a
-    // user or a bug report learns *why* pricing is unavailable, and an earlier
-    // revision of this function threw the per-source causes away.
     #[test]
-    #[serial_test::serial]
-    fn all_sources_empty_errors_and_names_every_cause() {
-        let result = with_sandboxed_config_dir(|| {
-            PricingService::combine_fetched_sources(
-                Err("error decoding response body: expected f64".to_string()),
-                HashMap::new(),
-                Err("models.dev unreachable".to_string()),
-                || None,
-                || None,
-            )
-        });
+    fn custom_pricing_keeps_service_available_during_dynamic_outage() {
+        let mut custom = HashMap::new();
+        custom.insert("custom-only".to_string(), model_pricing(3e-6, 4e-6));
+        let service = PricingService::combine_fetched_sources(
+            Err("error decoding response body: expected f64".to_string()),
+            Err("OpenRouter unreachable".to_string()),
+            Err("models.dev unreachable".to_string()),
+            || None,
+            || None,
+            || None,
+            CustomPricing::from_models(custom),
+        )
+        .expect("custom pricing should remain usable during an upstream outage");
+        assert!(service.lookup_with_source("custom-only", None).is_some());
+    }
 
-        let error = result
-            .err()
-            .expect("a total pricing blackout must stay fatal rather than price everything at $0");
-        assert!(
-            error.contains("error decoding response body: expected f64"),
-            "the LiteLLM cause must survive into the terminal error, got: {}",
-            error
-        );
-        assert!(
-            error.contains("models.dev unreachable"),
-            "the models.dev cause must survive into the terminal error, got: {}",
-            error
-        );
+    #[test]
+    fn openrouter_fetch_failure_falls_back_to_stale_cache() {
+        let mut cached = HashMap::new();
+        cached.insert("openrouter-only".to_string(), model_pricing(7e-6, 8e-6));
+
+        let service = PricingService::combine_fetched_sources(
+            Err("LiteLLM unavailable".to_string()),
+            Err("OpenRouter unavailable".to_string()),
+            Err("models.dev unavailable".to_string()),
+            || None,
+            || Some(cached),
+            || None,
+            CustomPricing::default(),
+        )
+        .expect("a stale OpenRouter cache must keep the service usable");
+
+        assert!(service
+            .lookup_with_source("openrouter-only", None)
+            .is_some());
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -389,6 +389,18 @@ impl PricingService {
             .calculate_cost_with_provider(model_id, provider_id, usage)
     }
 
+    pub fn covers_usage_with_provider(
+        &self,
+        model_id: &str,
+        provider_id: Option<&str>,
+        usage: &TokenBreakdown,
+    ) -> bool {
+        let Some(result) = self.lookup_with_source_and_provider(model_id, None, provider_id) else {
+            return false;
+        };
+        result.pricing.covers_usage(usage)
+    }
+
     fn lookup_custom(&self, model_id: &str) -> Option<LookupResult> {
         self.custom
             .lookup_with_key(model_id)

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -203,7 +203,42 @@ impl PricingService {
             openrouter_data,
             models_dev_result.map_err(|e| describe_error(&e)),
             litellm::load_cached_any_age,
+            models_dev::load_cached_any_age,
         )
+    }
+
+    // @keep: the eprintln wording is chosen to be actionable; the failure is
+    // also retained because an all-empty result has to name its causes.
+    /// Degrade one failed source to its own stale cache, else to nothing.
+    ///
+    /// Recording the cause in `failures` is what keeps the terminal error
+    /// diagnosable: without it a total blackout reports only that everything
+    /// failed, which is exactly the uninformative message that made #1002 hard
+    /// to triage in the first place.
+    fn degrade_source(
+        label: &str,
+        result: Result<HashMap<String, ModelPricing>, String>,
+        cached: impl FnOnce() -> Option<HashMap<String, ModelPricing>>,
+        failures: &mut Vec<String>,
+    ) -> HashMap<String, ModelPricing> {
+        match result {
+            Ok(data) => data,
+            Err(error) => {
+                let cached = cached();
+                eprintln!(
+                    "[tokscale] Warning: {} pricing fetch failed ({}); {}",
+                    label,
+                    error,
+                    if cached.is_some() {
+                        "falling back to the cached copy"
+                    } else {
+                        "continuing with the remaining pricing sources"
+                    }
+                );
+                failures.push(format!("{}: {}", label, error));
+                cached.unwrap_or_default()
+            }
+        }
     }
 
     // @keep: the asymmetry this removes was load-bearing and non-obvious.
@@ -216,8 +251,12 @@ impl PricingService {
     /// not decode (#1002). openrouter already degraded (it returns no error at
     /// all) and models.dev already degraded to an empty map; LiteLLM was the
     /// lone hard-error, so a single unreachable host took the whole command
-    /// down. A failing source now degrades to its own stale cache, then to
-    /// nothing, and the surviving sources still price what they cover.
+    /// down. LiteLLM and models.dev now each degrade to their own stale cache
+    /// and then to nothing, and the surviving sources still price what they
+    /// cover. openrouter has no stale-cache step here because it never reports
+    /// a failure to begin with: `fetch_all_mapped` swallows per-model errors
+    /// and returns whatever it collected, so there is no error for this
+    /// function to see.
     ///
     /// The deliberate exception: if *every* source ends up empty we still
     /// error. Continuing there would price every model at $0.00 and `submit`
@@ -228,36 +267,35 @@ impl PricingService {
         openrouter_data: HashMap<String, ModelPricing>,
         models_dev_result: Result<HashMap<String, ModelPricing>, String>,
         litellm_cached: impl FnOnce() -> Option<HashMap<String, ModelPricing>>,
+        models_dev_cached: impl FnOnce() -> Option<HashMap<String, ModelPricing>>,
     ) -> Result<Self, String> {
-        let litellm_data = match litellm_result {
-            Ok(data) => data,
-            Err(e) => {
-                let cached = litellm_cached();
-                eprintln!(
-                    "[tokscale] Warning: LiteLLM pricing fetch failed ({}); {}",
-                    e,
-                    if cached.is_some() {
-                        "falling back to the cached copy"
-                    } else {
-                        "continuing with the remaining pricing sources"
-                    }
-                );
-                cached.unwrap_or_default()
-            }
-        };
-        let litellm_data = Self::filter_litellm_data(litellm_data);
-        let models_dev_data = match models_dev_result {
-            Ok(data) => data,
-            Err(e) => {
-                eprintln!("[tokscale] models.dev fetch failed: {}", e);
-                HashMap::new()
-            }
-        };
+        let mut failures = Vec::new();
+
+        let litellm_data = Self::filter_litellm_data(Self::degrade_source(
+            "LiteLLM",
+            litellm_result,
+            litellm_cached,
+            &mut failures,
+        ));
+        let models_dev_data = Self::degrade_source(
+            "models.dev",
+            models_dev_result,
+            models_dev_cached,
+            &mut failures,
+        );
 
         if litellm_data.is_empty() && openrouter_data.is_empty() && models_dev_data.is_empty() {
-            return Err(
-                "all pricing sources failed and no cached pricing data is available".to_string(),
-            );
+            // Callers surface this string to the user and to bug reports, so it
+            // has to carry the per-source causes rather than just the verdict.
+            let causes = if failures.is_empty() {
+                "every source returned an empty dataset".to_string()
+            } else {
+                failures.join("; ")
+            };
+            return Err(format!(
+                "all pricing sources failed and no cached pricing data is available ({})",
+                causes
+            ));
         }
 
         Ok(Self::new_with_custom_and_models_dev(
@@ -432,6 +470,37 @@ mod tests {
         )
     }
 
+    /// Restore `TOKSCALE_CONFIG_DIR` on the way out, including on unwind.
+    ///
+    /// Restoring after the call instead is not equivalent: a failed assertion
+    /// unwinds past the restore and leaves the variable pointing at a TempDir
+    /// that has already been deleted, so one red test silently corrupts every
+    /// later config-reading test in the same process. Mirrors the guard in
+    /// tokscale-cli's autosubmit tests, which cannot be imported across crates.
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe { std::env::set_var(key, value) };
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match self.previous.take() {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
     /// Run `body` with the config dir pinned to a throwaway directory.
     ///
     /// `combine_fetched_sources` reads user custom pricing from the default
@@ -439,16 +508,10 @@ mod tests {
     /// or skew the assertions below.
     fn with_sandboxed_config_dir<T>(body: impl FnOnce() -> T) -> T {
         let temp = tempfile::TempDir::new().unwrap();
-        let previous = std::env::var_os("TOKSCALE_CONFIG_DIR");
-        unsafe { std::env::set_var("TOKSCALE_CONFIG_DIR", temp.path()) };
-        let result = body();
-        unsafe {
-            match previous {
-                Some(value) => std::env::set_var("TOKSCALE_CONFIG_DIR", value),
-                None => std::env::remove_var("TOKSCALE_CONFIG_DIR"),
-            }
-        }
-        result
+        // Dropped after the guard, so the directory outlives every read of the
+        // variable that points at it.
+        let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+        body()
     }
 
     // Regression: #1002. A LiteLLM fetch failure used to propagate out of
@@ -467,6 +530,7 @@ mod tests {
                 HashMap::new(),
                 Ok(models_dev),
                 // Fresh install, as in the report: nothing cached yet.
+                || None,
                 || None,
             )
         })
@@ -495,6 +559,7 @@ mod tests {
                 HashMap::new(),
                 Ok(HashMap::new()),
                 || Some(cached),
+                || None,
             )
         })
         .expect("a stale LiteLLM cache must keep the service usable");
@@ -507,24 +572,66 @@ mod tests {
         );
     }
 
+    // Regression: models.dev is a degradable source too. Its errors used to be
+    // dropped straight to an empty map even though it keeps a cache of its own,
+    // so a models.dev outage discarded pricing that was sitting on disk.
+    #[test]
+    #[serial_test::serial]
+    fn models_dev_fetch_failure_falls_back_to_stale_cache() {
+        let mut cached = HashMap::new();
+        cached.insert("test-model-gamma".to_string(), model_pricing(5e-6, 6e-6));
+
+        let service = with_sandboxed_config_dir(|| {
+            PricingService::combine_fetched_sources(
+                Ok(HashMap::new()),
+                HashMap::new(),
+                Err("models.dev unreachable".to_string()),
+                || None,
+                || Some(cached),
+            )
+        })
+        .expect("a stale models.dev cache must keep the service usable");
+
+        let cost = service.calculate_cost("test-model-gamma", 1_000_000, 0, 0, 0, 0);
+        assert!(
+            (cost - 5.0).abs() < 1e-9,
+            "stale models.dev cache should price the model, got {}",
+            cost
+        );
+    }
+
     // The deliberate exception to "never fatal": with every source empty we
     // must NOT hand back a service that silently prices everything at $0.00,
     // because `submit` would upload those zeros as real costs.
+    //
+    // The message is asserted, not just the variant: this is the only place a
+    // user or a bug report learns *why* pricing is unavailable, and an earlier
+    // revision of this function threw the per-source causes away.
     #[test]
     #[serial_test::serial]
-    fn all_sources_empty_still_errors() {
+    fn all_sources_empty_errors_and_names_every_cause() {
         let result = with_sandboxed_config_dir(|| {
             PricingService::combine_fetched_sources(
-                Err("error decoding response body".to_string()),
+                Err("error decoding response body: expected f64".to_string()),
                 HashMap::new(),
                 Err("models.dev unreachable".to_string()),
+                || None,
                 || None,
             )
         });
 
+        let error = result
+            .err()
+            .expect("a total pricing blackout must stay fatal rather than price everything at $0");
         assert!(
-            result.is_err(),
-            "a total pricing blackout must stay fatal rather than price everything at $0"
+            error.contains("error decoding response body: expected f64"),
+            "the LiteLLM cause must survive into the terminal error, got: {}",
+            error
+        );
+        assert!(
+            error.contains("models.dev unreachable"),
+            "the models.dev cause must survive into the terminal error, got: {}",
+            error
         );
     }
 

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -210,19 +210,11 @@ impl PricingService {
         )
     }
 
-    // @keep: the eprintln wording is chosen to be actionable; the failure is
-    // also retained because an all-empty result has to name its causes.
     /// Degrade one failed source to its own stale cache, else to nothing.
-    ///
-    /// Recording the cause in `failures` is what keeps the terminal error
-    /// diagnosable: without it a total blackout reports only that everything
-    /// failed, which is exactly the uninformative message that made #1002 hard
-    /// to triage in the first place.
     fn degrade_source(
         label: &str,
         result: Result<HashMap<String, ModelPricing>, String>,
         cached: impl FnOnce() -> Option<HashMap<String, ModelPricing>>,
-        failures: &mut Vec<String>,
     ) -> HashMap<String, ModelPricing> {
         match result {
             Ok(data) => data,
@@ -238,7 +230,6 @@ impl PricingService {
                         "continuing with the remaining pricing sources"
                     }
                 );
-                failures.push(format!("{}: {}", label, error));
                 cached.unwrap_or_default()
             }
         }
@@ -251,14 +242,12 @@ impl PricingService {
     /// not the only one, and propagating its fetch error made every command
     /// that prices tokens — `submit` included — dead in the water whenever
     /// raw.githubusercontent.com was unreachable or served something we could
-    /// not decode (#1002). openrouter already degraded (it returns no error at
-    /// all) and models.dev already degraded to an empty map; LiteLLM was the
-    /// lone hard-error, so a single unreachable host took the whole command
-    /// down. LiteLLM and models.dev now each degrade to their own stale cache
-    /// and then to nothing, and the surviving sources still price what they
-    /// cover. Submission safety is checked against the actual filtered messages
-    /// later, rather than treating an empty dynamic dataset as a construction
-    /// failure: custom and bundled pricing remain useful during an outage.
+    /// not decode (#1002). Every dynamic source now preserves fetch failure as
+    /// an error here, degrades to its own stale cache, and finally to nothing;
+    /// the surviving sources still price what they cover. Submission safety is
+    /// checked against the actual filtered messages later, rather than treating
+    /// an empty dynamic dataset as a construction failure: custom and bundled
+    /// pricing remain useful during an outage.
     fn combine_fetched_sources(
         litellm_result: Result<HashMap<String, ModelPricing>, String>,
         openrouter_result: Result<HashMap<String, ModelPricing>, String>,
@@ -268,26 +257,15 @@ impl PricingService {
         models_dev_cached: impl FnOnce() -> Option<HashMap<String, ModelPricing>>,
         custom: CustomPricing,
     ) -> Result<Self, String> {
-        let mut failures = Vec::new();
-
         let litellm_data = Self::filter_litellm_data(Self::degrade_source(
             "LiteLLM",
             litellm_result,
             litellm_cached,
-            &mut failures,
         ));
-        let models_dev_data = Self::degrade_source(
-            "models.dev",
-            models_dev_result,
-            models_dev_cached,
-            &mut failures,
-        );
-        let openrouter_data = Self::degrade_source(
-            "OpenRouter",
-            openrouter_result,
-            openrouter_cached,
-            &mut failures,
-        );
+        let models_dev_data =
+            Self::degrade_source("models.dev", models_dev_result, models_dev_cached);
+        let openrouter_data =
+            Self::degrade_source("OpenRouter", openrouter_result, openrouter_cached);
 
         Ok(Self::new_with_custom_and_models_dev(
             custom,

--- a/crates/tokscale-core/src/pricing/models_dev.rs
+++ b/crates/tokscale-core/src/pricing/models_dev.rs
@@ -1,12 +1,10 @@
-use super::cache;
 use super::litellm::ModelPricing;
+use super::{cache, fetch};
 use serde::Deserialize;
 use std::collections::HashMap;
 
 const CACHE_FILENAME: &str = "pricing-models-dev.json";
 const MODELS_DEV_URL: &str = "https://models.dev/api.json";
-const MAX_RETRIES: u32 = 3;
-const INITIAL_BACKOFF_MS: u64 = 200;
 const PER_MILLION: f64 = 1_000_000.0;
 
 #[derive(Deserialize)]
@@ -44,92 +42,33 @@ pub(crate) fn parse_dataset(content: &str) -> Result<PricingDataset, serde_json:
     Ok(map_providers(providers))
 }
 
-pub async fn fetch() -> Result<PricingDataset, reqwest::Error> {
+pub async fn fetch() -> Result<PricingDataset, String> {
     fetch_inner(MODELS_DEV_URL, true).await
 }
 
-async fn fetch_inner(url: &str, use_cache: bool) -> Result<PricingDataset, reqwest::Error> {
+async fn fetch_inner(url: &str, use_cache: bool) -> Result<PricingDataset, String> {
     if use_cache {
         if let Some(cached) = load_cached() {
             return Ok(cached);
         }
     }
 
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .connect_timeout(std::time::Duration::from_secs(10))
-        .build()?;
-
-    let mut last_error: Option<reqwest::Error> = None;
-
-    for attempt in 0..MAX_RETRIES {
-        match client.get(url).send().await {
-            Ok(response) => {
-                let status = response.status();
-
-                if status.is_server_error() || status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-                    eprintln!(
-                        "[tokscale] models.dev HTTP {} (attempt {}/{})",
-                        status,
-                        attempt + 1,
-                        MAX_RETRIES
-                    );
-                    if attempt == MAX_RETRIES - 1 {
-                        return Err(response.error_for_status().unwrap_err());
-                    }
-                    let _ = response.bytes().await;
-                    tokio::time::sleep(std::time::Duration::from_millis(
-                        INITIAL_BACKOFF_MS * (1 << attempt),
-                    ))
-                    .await;
-                    continue;
-                }
-
-                if !status.is_success() {
-                    eprintln!("[tokscale] models.dev HTTP {}", status);
-                    return Err(response.error_for_status().unwrap_err());
-                }
-
-                let content = response.text().await?;
-                match parse_dataset(&content) {
-                    Ok(data) => {
-                        if let Err(e) = cache::save_cache(CACHE_FILENAME, &data) {
-                            eprintln!(
-                                "[tokscale] Warning: Failed to cache models.dev pricing at {}: {}",
-                                cache::get_cache_path(CACHE_FILENAME).display(),
-                                e
-                            );
-                        }
-                        return Ok(data);
-                    }
-                    Err(e) => {
-                        eprintln!("[tokscale] models.dev JSON parse failed: {}", e);
-                        return Ok(HashMap::new());
-                    }
-                }
-            }
-            Err(e) => {
-                eprintln!(
-                    "[tokscale] models.dev network error (attempt {}/{}): {}",
-                    attempt + 1,
-                    MAX_RETRIES,
-                    e
-                );
-                last_error = Some(e);
-                if attempt < MAX_RETRIES - 1 {
-                    tokio::time::sleep(std::time::Duration::from_millis(
-                        INITIAL_BACKOFF_MS * (1 << attempt),
-                    ))
-                    .await;
-                }
-            }
-        }
+    let client = fetch::pricing_client()?;
+    let response = fetch::get_with_retry(&client, url, "models.dev").await?;
+    let content = response.text().await.map_err(|error| error.to_string())?;
+    let data = parse_dataset(&content)
+        .map_err(|error| format!("models.dev JSON parse failed: {error}"))?;
+    if data.is_empty() {
+        return Err("models.dev returned no usable pricing rows".to_string());
     }
-
-    match last_error {
-        Some(e) => Err(e),
-        None => Ok(HashMap::new()),
+    if let Err(e) = cache::save_cache(CACHE_FILENAME, &data) {
+        eprintln!(
+            "[tokscale] Warning: Failed to cache models.dev pricing at {}: {}",
+            cache::get_cache_path(CACHE_FILENAME).display(),
+            e
+        );
     }
+    Ok(data)
 }
 
 fn map_providers(providers: HashMap<String, Provider>) -> PricingDataset {
@@ -181,7 +120,7 @@ mod tests {
         let url = format!("http://{}", listener.local_addr().unwrap());
 
         thread::spawn(move || {
-            for _ in 0..MAX_RETRIES {
+            for _ in 0..3 {
                 let Ok((mut stream, _)) = listener.accept() else {
                     return;
                 };
@@ -196,6 +135,27 @@ mod tests {
         url
     }
 
+    fn response_server(body: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+
+        thread::spawn(move || {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            let mut buffer = [0; 1024];
+            let _ = stream.read(&mut buffer);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes());
+        });
+
+        url
+    }
+
     #[tokio::test]
     async fn fetch_returns_error_after_retryable_http_statuses() {
         let url = retryable_status_server("HTTP/1.1 503 Service Unavailable");
@@ -203,5 +163,16 @@ mod tests {
         let result = fetch_inner(&url, false).await;
 
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn malformed_and_empty_datasets_are_fetch_errors() {
+        let malformed = fetch_inner(&response_server("not json"), false).await;
+        assert!(malformed
+            .unwrap_err()
+            .contains("models.dev JSON parse failed"));
+
+        let empty = fetch_inner(&response_server("{}"), false).await;
+        assert!(empty.unwrap_err().contains("no usable pricing rows"));
     }
 }

--- a/crates/tokscale-core/src/pricing/openrouter.rs
+++ b/crates/tokscale-core/src/pricing/openrouter.rs
@@ -1,5 +1,5 @@
-use super::cache;
 use super::litellm::ModelPricing;
+use super::{cache, describe_error, fetch};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -7,8 +7,6 @@ use tokio::sync::Semaphore;
 
 const CACHE_FILENAME: &str = "pricing-openrouter.json";
 const MODELS_URL: &str = "https://openrouter.ai/api/v1/models";
-const MAX_RETRIES: u32 = 3;
-const INITIAL_BACKOFF_MS: u64 = 200;
 const MAX_CONCURRENT_REQUESTS: usize = 10;
 
 /// Structs for `/api/v1/models` endpoint (list all models).
@@ -177,99 +175,49 @@ async fn fetch_author_pricing(
 }
 
 /// Fetch all models and get author pricing for each
-pub async fn fetch_all_models() -> HashMap<String, ModelPricing> {
-    if let Some(cached) = load_cached() {
-        return cached;
+pub async fn fetch_all_models() -> Result<HashMap<String, ModelPricing>, String> {
+    fetch_all_models_from_url(MODELS_URL, true).await
+}
+
+async fn fetch_all_models_from_url(
+    models_url: &str,
+    use_cache: bool,
+) -> Result<HashMap<String, ModelPricing>, String> {
+    if use_cache {
+        if let Some(cached) = load_cached() {
+            return Ok(cached);
+        }
     }
 
-    let client = Arc::new(
-        reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(30))
-            .connect_timeout(std::time::Duration::from_secs(10))
-            .build()
-            .unwrap_or_default(),
-    );
-
-    let mut last_error: Option<String> = None;
-
-    let models_with_fallback: Vec<(String, Option<ModelPricing>)> = 'retry: {
-        for attempt in 0..MAX_RETRIES {
-            let response = match client
-                .get(MODELS_URL)
-                .header("Content-Type", "application/json")
-                .send()
-                .await
-            {
-                Ok(r) => r,
-                Err(e) => {
-                    last_error = Some(format!("network error: {}", e));
-                    if attempt < MAX_RETRIES - 1 {
-                        tokio::time::sleep(std::time::Duration::from_millis(
-                            INITIAL_BACKOFF_MS * (1 << attempt),
-                        ))
-                        .await;
-                    }
-                    continue;
-                }
-            };
-
-            let status = response.status();
-            if status.is_server_error() || status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-                last_error = Some(format!("HTTP {}", status));
-                let _ = response.bytes().await;
-                if attempt < MAX_RETRIES - 1 {
-                    tokio::time::sleep(std::time::Duration::from_millis(
-                        INITIAL_BACKOFF_MS * (1 << attempt),
-                    ))
-                    .await;
-                }
-                continue;
-            }
-
-            if !status.is_success() {
-                eprintln!("[tokscale] OpenRouter models API returned {}", status);
-                break 'retry Vec::new();
-            }
-
-            let data: ModelsListResponse = match response.json().await {
-                Ok(d) => d,
-                Err(e) => {
-                    eprintln!("[tokscale] OpenRouter models JSON parse failed: {}", e);
-                    break 'retry Vec::new();
-                }
-            };
-
-            break 'retry data
-                .data
-                .into_iter()
-                .map(|m| {
-                    let fallback = m.pricing.and_then(|p| {
-                        let input = parse_price(&p.prompt)?;
-                        let output = parse_price(&p.completion)?;
-                        Some(ModelPricing {
-                            input_cost_per_token: Some(input),
-                            output_cost_per_token: Some(output),
-                            cache_read_input_token_cost: None,
-                            cache_creation_input_token_cost: None,
-                            ..Default::default()
-                        })
-                    });
-                    (m.id, fallback)
+    let client = Arc::new(fetch::pricing_client()?);
+    let response = fetch::get_with_retry(&client, models_url, "OpenRouter").await?;
+    let data: ModelsListResponse = response.json().await.map_err(|error| {
+        format!(
+            "OpenRouter models JSON parse failed: {}",
+            describe_error(&error)
+        )
+    })?;
+    let models_with_fallback: Vec<(String, Option<ModelPricing>)> = data
+        .data
+        .into_iter()
+        .map(|m| {
+            let fallback = m.pricing.and_then(|p| {
+                let input = parse_price(&p.prompt)?;
+                let output = parse_price(&p.completion)?;
+                Some(ModelPricing {
+                    input_cost_per_token: Some(input),
+                    output_cost_per_token: Some(output),
+                    cache_read_input_token_cost: None,
+                    cache_creation_input_token_cost: None,
+                    ..Default::default()
                 })
-                .collect();
-        }
-
-        if let Some(err) = &last_error {
-            eprintln!(
-                "[tokscale] OpenRouter fetch failed after {} retries: {}",
-                MAX_RETRIES, err
-            );
-        }
-        Vec::new()
-    };
+            });
+            (m.id, fallback)
+        })
+        .collect();
 
     if models_with_fallback.is_empty() {
-        return HashMap::new();
+        return Err("OpenRouter returned no models".to_string());
     }
 
     let models_with_authors: Vec<(String, Option<ModelPricing>)> = models_with_fallback
@@ -312,9 +260,56 @@ pub async fn fetch_all_models() -> HashMap<String, ModelPricing> {
         }
     }
 
-    result
+    if result.is_empty() {
+        return Err("OpenRouter returned no usable pricing rows".to_string());
+    }
+
+    Ok(result)
 }
 
-pub async fn fetch_all_mapped() -> HashMap<String, ModelPricing> {
+pub async fn fetch_all_mapped() -> Result<HashMap<String, ModelPricing>, String> {
     fetch_all_models().await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    fn response_server(status: &'static str, body: &'static str, requests: usize) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        thread::spawn(move || {
+            for _ in 0..requests {
+                let Ok((mut stream, _)) = listener.accept() else {
+                    return;
+                };
+                let mut buffer = [0; 1024];
+                let _ = stream.read(&mut buffer);
+                let response = format!(
+                    "{status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+        url
+    }
+
+    #[tokio::test]
+    async fn list_status_and_decode_failures_remain_explicit() {
+        let status = response_server("HTTP/1.1 503 Service Unavailable", "", 3);
+        assert!(fetch_all_models_from_url(&status, false)
+            .await
+            .unwrap_err()
+            .contains("HTTP 503"));
+
+        let malformed = response_server("HTTP/1.1 200 OK", "not json", 1);
+        assert!(fetch_all_models_from_url(&malformed, false)
+            .await
+            .unwrap_err()
+            .contains("JSON parse failed"));
+    }
 }

--- a/crates/tokscale-core/src/sessions/junie.rs
+++ b/crates/tokscale-core/src/sessions/junie.rs
@@ -99,9 +99,9 @@ pub fn parse_junie_file(path: &Path) -> Vec<UnifiedMessage> {
                 .to_string();
             let provider_id = provider_from_usage(usage, &model_id);
             let tokens = tokens_from_usage(usage);
-            let cost = float_field(usage, "cost")
-                .filter(|cost| cost.is_finite() && *cost >= 0.0)
-                .unwrap_or(0.0);
+            let reported_cost =
+                float_field(usage, "cost").filter(|cost| cost.is_finite() && *cost >= 0.0);
+            let cost = reported_cost.unwrap_or(0.0);
             if tokens.total() == 0 && cost == 0.0 {
                 continue;
             }
@@ -150,6 +150,9 @@ pub fn parse_junie_file(path: &Path) -> Vec<UnifiedMessage> {
             );
             message.dedup_key = Some(dedup_key);
             message.duration_ms = duration_ms;
+            if reported_cost.is_some() {
+                message.mark_provider_reported_cost();
+            }
             if pending_turn_start && !turn_start_assigned {
                 message.is_turn_start = true;
                 turn_start_assigned = true;
@@ -344,6 +347,18 @@ mod tests {
         assert_ne!(
             messages[0].dedup_key, messages[1].dedup_key,
             "distinct usage rows must receive distinct dedup keys"
+        );
+    }
+
+    #[test]
+    fn field_present_cost_is_provider_reported_even_when_zero() {
+        let content = r#"{"timestampMs":1750000000000,"event":{"agentEvent":{"kind":"LlmResponseMetadataEvent","modelUsage":[{"model":"unknown-model","inputTokens":1,"outputTokens":0,"cost":0}]}}}"#;
+        let messages = parse_events(content);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].cost, 0.0);
+        assert_eq!(
+            messages[0].cost_source,
+            super::super::CostSource::ProviderReported
         );
     }
 

--- a/crates/tokscale-core/src/sessions/micode.rs
+++ b/crates/tokscale-core/src/sessions/micode.rs
@@ -314,6 +314,9 @@ pub fn parse_micode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
 
         if let Some(index) = fingerprint_indices.get(&fingerprint).copied() {
             let dedup_state = &mut dedup_states[index];
+            if unified.has_authoritative_cost() {
+                messages[index].mark_provider_reported_cost();
+            }
             if message_id.is_some() && !dedup_state.has_embedded_message_id {
                 dedup_state.has_embedded_message_id = true;
                 messages[index].dedup_key = unified.dedup_key;
@@ -639,6 +642,48 @@ mod tests {
         assert_eq!(messages.len(), 2);
         assert_eq!(messages[0].tokens.input, 1000);
         assert_eq!(messages[1].tokens.input, 1300);
+    }
+
+    #[test]
+    fn duplicate_explicit_zero_cost_upgrades_retained_provenance() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_micode.db");
+        let conn = create_micode_sqlite_db(&db_path);
+        let without_cost = r#"{
+            "role": "assistant",
+            "modelID": "unknown-model",
+            "providerID": "mimo",
+            "tokens": { "input": 10, "output": 5 },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+        let with_zero_cost = r#"{
+            "role": "assistant",
+            "modelID": "unknown-model",
+            "providerID": "mimo",
+            "cost": 0,
+            "tokens": { "input": 10, "output": 5 },
+            "time": { "created": 1700000000000.0 }
+        }"#;
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["row_a", "session_a", without_cost],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["row_b", "session_b", with_zero_cost],
+        )
+        .unwrap();
+        drop(conn);
+
+        let messages = parse_micode_sqlite(&db_path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].cost, 0.0);
+        assert_eq!(
+            messages[0].cost_source,
+            super::super::CostSource::ProviderReported
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/micode.rs
+++ b/crates/tokscale-core/src/sessions/micode.rs
@@ -255,7 +255,8 @@ pub fn parse_micode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
         let cache = tokens.cache.unwrap_or_default();
         let cache_read = cache.read.max(0);
         let cache_write = cache.write.max(0);
-        let cost = msg.cost.unwrap_or(0.0).max(0.0);
+        let reported_cost = msg.cost.filter(|cost| cost.is_finite() && *cost >= 0.0);
+        let cost = reported_cost.unwrap_or(0.0);
         // Normalize epoch values to milliseconds up front so the timestamp, the
         // dedup fingerprint, and the duration all agree even when MiMo writes
         // seconds instead of milliseconds.
@@ -302,6 +303,9 @@ pub fn parse_micode_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
             agent,
         );
         unified.duration_ms = micode_duration_ms(&msg.time);
+        if reported_cost.is_some() {
+            unified.mark_provider_reported_cost();
+        }
         unified.dedup_key = Some(dedup_key);
         let workspace_root = row_workspace_root
             .as_deref()
@@ -386,6 +390,10 @@ mod tests {
         assert_eq!(messages[0].tokens.cache_read, 200);
         assert_eq!(messages[0].tokens.cache_write, 50);
         assert!((messages[0].cost - 0.05).abs() < 1e-9);
+        assert_eq!(
+            messages[0].cost_source,
+            super::super::CostSource::ProviderReported
+        );
         assert_eq!(messages[0].duration_ms, Some(1234));
     }
 


### PR DESCRIPTION
Follow-up to #1003 by @shunkakinoki and the original #1002 report.

## What changed

- Centralize retryable pricing fetch transport for LiteLLM, models.dev, and OpenRouter; retryable failures return errors instead of panicking.
- Preserve malformed, empty, and unusable source outcomes so each failed source can fall back to its own stale cache.
- Keep custom, Cursor, and Sakana pricing available during dynamic-source outages.
- Validate strict submission against the filtered token-bearing messages instead of a global dataset-nonempty proxy. Provider-reported costs and explicit zero-priced rows are valid; every populated estimated-cost bucket must have a usable base rate.
- Scope strict pricing validation to the submit-only graph entrypoint so reporting paths such as `wrapped` remain lenient for unpriced local usage.
- Reject LiteLLM rows that have only threshold-tier rates, including when they come from a pre-existing cache, so reports cannot silently estimate their base-tier usage at zero.
- Preserve MiMo and Junie embedded-cost provenance, including explicit zero, and invalidate legacy MiMo message-cache entries that lack that provenance.
- Preserve provider-reported provenance when MiMo duplicates merge and invalidate both MiMo and Junie caches affected by the provenance changes.
- Merge MiMo duplicates across channel databases so an authoritative copy upgrades a retained estimated copy without replacing an already authoritative first copy.
- Remove process-global config mutation from pricing combiner tests by injecting custom pricing.

## Validation

- `cargo test -p tokscale-core --lib` — 1343 passed, 1 ignored
- `cargo test -p tokscale-core graph_pricing_policy_is_strict_only_for_submission`
- `cargo test -p tokscale-core strict_pricing_validation` — 5 passed
- `cargo test -p tokscale-cli --test cli_tests test_submit_offline_without_pricing_cache_fails`
- `cargo test -p tokscale-cli commands::wrapped::tests` — 145 passed
- `cargo check -p tokscale-core --all-targets`
- `cargo check -p tokscale-cli --all-targets`
- `cargo clippy -p tokscale-core --all-targets -- -D warnings`
- `cargo clippy -p tokscale-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

Independent re-review at `e7a7d53f`: code reviewer `APPROVE`; architecture `CLEAR`.
