### PR TITLE
fix(windows): stop lock and PID probes silently failing off Unix

### DIFF
--- a/crates/tokscale-cli/src/antigravity.rs
+++ b/crates/tokscale-cli/src/antigravity.rs
@@ -1,3 +1,4 @@
+use crate::process_liveness::pid_is_alive;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -402,7 +403,9 @@ impl SyncLockGuard {
                     // long as their PID is alive, or two processes will
                     // overlap on the manifest and delete each other's
                     // artifacts. Age-based eviction was removed for this
-                    // reason.
+                    // reason. `pid_is_alive` resolves every uncertain probe
+                    // to "alive" so that guarantee survives on platforms
+                    // where liveness is harder to establish.
                     if let Some((existing_pid, _)) = read_sync_lock(&lock_path) {
                         if pid_is_alive(existing_pid) {
                             anyhow::bail!(
@@ -441,28 +444,6 @@ fn read_sync_lock(path: &Path) -> Option<(u32, u64)> {
     let pid = parts.next()?.parse::<u32>().ok()?;
     let timestamp = parts.next()?.parse::<u64>().ok()?;
     Some((pid, timestamp))
-}
-
-fn pid_is_alive(pid: u32) -> bool {
-    if pid == 0 {
-        return false;
-    }
-    #[cfg(unix)]
-    {
-        let result = unsafe { libc_kill(pid as i32, 0) };
-        result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(1)
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = pid;
-        false
-    }
-}
-
-#[cfg(unix)]
-extern "C" {
-    #[link_name = "kill"]
-    fn libc_kill(pid: i32, sig: i32) -> i32;
 }
 
 pub fn load_antigravity_manifest() -> Result<AntigravityManifest> {
@@ -556,8 +537,24 @@ fn delete_artifact_relative_path(relative_path: &str) -> Result<bool> {
     Ok(false)
 }
 
+/// Rewrite `\` to `/` so a stored path parses the same way on every platform.
+///
+/// `to_relative_artifact_path` renders with `Path::to_string_lossy`, so a
+/// manifest written on Windows records `sessions\<id>.jsonl`. Normalising here
+/// also tightens the Unix side: `Path` does not treat `\` as a separator
+/// there, so `..\..\escape.jsonl` would otherwise reach the traversal check
+/// below as one innocuous file name.
+///
+/// Safe against false positives because `sanitize_session_id` strips every
+/// character outside `[A-Za-z0-9._-]`, so a generated artifact name can never
+/// legitimately contain a backslash.
+fn normalize_artifact_path_separators(relative_path: &str) -> String {
+    relative_path.replace('\\', "/")
+}
+
 fn resolve_cache_relative_artifact_path(relative_path: &str) -> Result<PathBuf> {
-    let relative = Path::new(relative_path);
+    let normalized = normalize_artifact_path_separators(relative_path);
+    let relative = Path::new(&normalized);
     if relative.is_absolute() {
         anyhow::bail!("Artifact path must stay within cache root");
     }
@@ -2749,6 +2746,41 @@ mod tests {
 
         let err = delete_artifact_relative_path("manifest.json").unwrap_err();
         assert!(err.to_string().contains("session artifact"));
+    }
+
+    /// A manifest written on Windows stores `sessions\<id>.jsonl`, because
+    /// `to_relative_artifact_path` renders with the native separator. Rejecting
+    /// that form made `cleanup_stale_session_artifacts` — and with it the whole
+    /// `antigravity sync` — fail on every run that had an artifact to retire.
+    #[test]
+    #[serial]
+    fn delete_artifact_relative_path_accepts_windows_separators() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let _env = TestEnvGuard::redirect_to(temp_dir.path());
+
+        let sessions_dir = get_antigravity_sessions_dir().unwrap();
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        let artifact = sessions_dir.join("session-one.jsonl");
+        std::fs::write(&artifact, "{}\n").unwrap();
+
+        assert!(delete_artifact_relative_path("sessions\\session-one.jsonl").unwrap());
+        assert!(!artifact.exists());
+    }
+
+    /// Normalising separators before the component check also closes a hole on
+    /// Unix, where `Path` reads `..\..\outside.jsonl` as a single file name and
+    /// never sees a `ParentDir` component.
+    #[test]
+    #[serial]
+    fn delete_artifact_relative_path_rejects_backslash_traversal() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let _env = TestEnvGuard::redirect_to(temp_dir.path());
+
+        let err = delete_artifact_relative_path("..\\..\\outside.jsonl").unwrap_err();
+        assert!(err.to_string().contains("cache root"));
+
+        let err = delete_artifact_relative_path("sessions\\..\\..\\outside.jsonl").unwrap_err();
+        assert!(err.to_string().contains("cache root"));
     }
 
     #[test]

--- a/crates/tokscale-cli/src/antigravity.rs
+++ b/crates/tokscale-cli/src/antigravity.rs
@@ -403,9 +403,16 @@ impl SyncLockGuard {
                     // long as their PID is alive, or two processes will
                     // overlap on the manifest and delete each other's
                     // artifacts. Age-based eviction was removed for this
-                    // reason. `pid_is_alive` resolves every uncertain probe
-                    // to "alive" so that guarantee survives on platforms
-                    // where liveness is harder to establish.
+                    // reason, and `pid_is_alive` resolves every uncertain
+                    // probe to "alive" so no platform quietly opts out of it.
+                    //
+                    // That is a bias, not a guarantee. The read-decide-unlink
+                    // below is not atomic, so two contenders can still both
+                    // find the same dead owner and both proceed; PID reuse can
+                    // also make a stranger's process look like the owner.
+                    // Closing those needs an OS-held exclusive lock (as
+                    // `autosubmit::try_acquire_run_lock` uses), not a tighter
+                    // liveness probe.
                     if let Some((existing_pid, _)) = read_sync_lock(&lock_path) {
                         if pid_is_alive(existing_pid) {
                             anyhow::bail!(
@@ -545,9 +552,13 @@ fn delete_artifact_relative_path(relative_path: &str) -> Result<bool> {
 /// there, so `..\..\escape.jsonl` would otherwise reach the traversal check
 /// below as one innocuous file name.
 ///
-/// Safe against false positives because `sanitize_session_id` strips every
-/// character outside `[A-Za-z0-9._-]`, so a generated artifact name can never
-/// legitimately contain a backslash.
+/// Safe against false positives because `sanitize_session_id` replaces every
+/// character outside `[A-Za-z0-9._-]` with `-`, so a generated artifact name
+/// can never legitimately contain a backslash.
+///
+/// `stale_relative_paths` keys its comparison through this same function.
+/// Normalising only at deletion made the two disagree about which entries name
+/// the same file, and deletion runs after the manifest has been written.
 fn normalize_artifact_path_separators(relative_path: &str) -> String {
     relative_path.replace('\\', "/")
 }
@@ -2137,16 +2148,24 @@ fn to_safe_i64(value: Option<&Value>) -> i64 {
 }
 
 fn stale_relative_paths(previous: &AntigravityManifest, next: &AntigravityManifest) -> Vec<String> {
-    let next_paths: std::collections::HashSet<&str> = next
+    // Key both sides the way `delete_artifact_relative_path` resolves them.
+    // `to_relative_artifact_path` renders with the native separator, so the
+    // same artifact reads `sessions\<id>.jsonl` in a manifest written on
+    // Windows and `sessions/<id>.jsonl` in one written on Unix. Comparing the
+    // raw strings would retire the old spelling while deletion normalises it
+    // back onto the file the new manifest still points at.
+    let next_paths: std::collections::HashSet<String> = next
         .sessions
         .iter()
-        .map(|session| session.artifact_path.as_str())
+        .map(|session| normalize_artifact_path_separators(&session.artifact_path))
         .collect();
 
     previous
         .sessions
         .iter()
-        .filter(|session| !next_paths.contains(session.artifact_path.as_str()))
+        .filter(|session| {
+            !next_paths.contains(&normalize_artifact_path_separators(&session.artifact_path))
+        })
         .map(|session| session.artifact_path.clone())
         .collect()
 }
@@ -2155,7 +2174,22 @@ fn cleanup_stale_session_artifacts(
     previous: &AntigravityManifest,
     next: &AntigravityManifest,
 ) -> Result<()> {
+    // Second gate, on the resolved path rather than the text. Cleanup runs
+    // after `save_antigravity_manifest`, so a deletion here is unrecoverable
+    // and unannounced: the manifest already advertises the artifact. Any future
+    // spelling that `stale_relative_paths` fails to equate but resolution does
+    // stops here instead of destroying live data.
+    let live: std::collections::HashSet<PathBuf> = next
+        .sessions
+        .iter()
+        .filter_map(|session| resolve_cache_relative_artifact_path(&session.artifact_path).ok())
+        .collect();
+
     for relative_path in stale_relative_paths(previous, next) {
+        let resolved = resolve_cache_relative_artifact_path(&relative_path)?;
+        if live.contains(&resolved) {
+            continue;
+        }
         delete_artifact_relative_path(&relative_path)?;
     }
 
@@ -2687,6 +2721,20 @@ mod tests {
         );
     }
 
+    /// The same artifact is spelled `sessions\<id>.jsonl` in a manifest written
+    /// on Windows and `sessions/<id>.jsonl` in one written on Unix, so a
+    /// textual compare calls the old spelling stale while the new spelling is
+    /// still live. Both sides must be keyed the same way `delete_artifact_relative_path`
+    /// resolves them.
+    #[test]
+    fn stale_relative_paths_ignores_separator_spelling() {
+        let mut previous = sample_manifest();
+        previous.sessions[0].artifact_path = "sessions\\session-1.jsonl".to_string();
+        let next = sample_manifest();
+
+        assert!(stale_relative_paths(&previous, &next).is_empty());
+    }
+
     #[test]
     #[serial]
     fn cleanup_stale_session_artifacts_removes_legacy_files_after_migration() {
@@ -2729,6 +2777,48 @@ mod tests {
         cleanup_stale_session_artifacts(&previous, &next).unwrap();
         assert!(!legacy_path.exists());
         assert!(new_path.exists());
+    }
+
+    /// Cleanup runs *after* `save_antigravity_manifest`, so anything it deletes
+    /// is gone while the manifest still advertises it. A manifest carried from
+    /// Windows spells the entry `sessions\<id>.jsonl` and the re-sync on Unix
+    /// rewrites it to `sessions/<id>.jsonl`; those are the same file, and
+    /// retiring the old spelling would silently destroy the artifact the new
+    /// manifest points at.
+    #[test]
+    #[serial]
+    fn cleanup_stale_session_artifacts_keeps_a_live_artifact_respelled_across_platforms() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let _env = TestEnvGuard::redirect_to(temp_dir.path());
+
+        let sessions_dir = get_antigravity_sessions_dir().unwrap();
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        let artifact = sessions_dir.join("session-one.jsonl");
+        std::fs::write(&artifact, "live\n").unwrap();
+
+        let entry = |artifact_path: &str| ManifestSessionEntry {
+            session_id: "session-one".to_string(),
+            artifact_path: artifact_path.to_string(),
+            last_modified_ms: None,
+            step_count: None,
+            connection_fingerprint: "pid:1:port:1111".to_string(),
+            artifact_hash: None,
+        };
+
+        let previous = AntigravityManifest {
+            sessions: vec![entry("sessions\\session-one.jsonl")],
+            ..AntigravityManifest::default()
+        };
+        let next = AntigravityManifest {
+            sessions: vec![entry("sessions/session-one.jsonl")],
+            ..AntigravityManifest::default()
+        };
+
+        cleanup_stale_session_artifacts(&previous, &next).unwrap();
+        assert!(
+            artifact.exists(),
+            "cleanup deleted an artifact the new manifest still references"
+        );
     }
 
     #[test]

--- a/crates/tokscale-cli/src/commands/autosubmit.rs
+++ b/crates/tokscale-cli/src/commands/autosubmit.rs
@@ -478,6 +478,26 @@ pub fn submit_filters(
     (clients, since, until, year)
 }
 
+/// A contended `LockFileEx` on Windows fails with `ERROR_LOCK_VIOLATION`,
+/// which `std` leaves uncategorised instead of mapping to `WouldBlock`.
+///
+/// Deliberately not behind `cfg(windows)`: the bug this guards against only
+/// reproduces on a platform CI does not run, so keeping the constant
+/// unconditional is what lets the classification be unit-tested at all. No
+/// Unix `flock` failure uses errno 33, so matching it everywhere cannot
+/// disguise a genuine error as contention.
+const WINDOWS_ERROR_LOCK_VIOLATION: i32 = 33;
+
+/// Whether `err` means "another process already holds this lock" rather than a
+/// real I/O failure.
+///
+/// Only `WouldBlock` used to count, so on Windows a second scheduled run hit
+/// the error arm and the caller's `unwrap` panicked — a run that found another
+/// already in progress failed instead of stepping aside.
+fn is_lock_contention(err: &std::io::Error) -> bool {
+    err.kind() == ErrorKind::WouldBlock || err.raw_os_error() == Some(WINDOWS_ERROR_LOCK_VIOLATION)
+}
+
 pub fn try_acquire_run_lock() -> Result<Option<AutosubmitRunLock>> {
     let path = autosubmit_lock_path()?;
     let file = OpenOptions::new()
@@ -489,7 +509,7 @@ pub fn try_acquire_run_lock() -> Result<Option<AutosubmitRunLock>> {
         .with_context(|| format!("Could not open autosubmit lock at {}", path.display()))?;
     match file.try_lock_exclusive() {
         Ok(()) => Ok(Some(AutosubmitRunLock { _file: file })),
-        Err(err) if err.kind() == ErrorKind::WouldBlock => Ok(None),
+        Err(err) if is_lock_contention(&err) => Ok(None),
         Err(err) => Err(err)
             .with_context(|| format!("Could not lock autosubmit state at {}", path.display())),
     }
@@ -1947,9 +1967,15 @@ mod tests {
             SchedulerKind::WindowsTaskScheduler,
         ] {
             let spec = render_scheduler_spec(scheduler, &managed, &settings).unwrap();
+            // `Debug` escapes each `\` as `\\`, so a Windows path compared
+            // against the unescaped `to_string_lossy` never matches. Escape
+            // the needle the same way instead of rendering the spec with
+            // `Display`, which `SchedulerSpec` does not implement.
             let rendered = format!("{spec:?}");
-            assert!(rendered.contains(managed.to_string_lossy().as_ref()));
-            assert!(!rendered.contains(process_executable.to_string_lossy().as_ref()));
+            let needle = managed.to_string_lossy().replace('\\', "\\\\");
+            assert!(rendered.contains(&needle));
+            let absent = process_executable.to_string_lossy().replace('\\', "\\\\");
+            assert!(!rendered.contains(&absent));
         }
     }
 
@@ -2420,6 +2446,35 @@ mod tests {
         assert!(try_acquire_run_lock().unwrap().is_none());
         drop(first);
         assert!(try_acquire_run_lock().unwrap().is_some());
+    }
+
+    /// `run_lock_blocks_concurrent_holder` above only exercises whatever the
+    /// host reports, so it cannot see the Windows classification. These pin the
+    /// error values directly: on Windows a contended lock arrives as
+    /// `ERROR_LOCK_VIOLATION`, which is not `WouldBlock`, and treating it as a
+    /// hard error made a scheduled run fail instead of yielding to the run
+    /// already in progress.
+    #[test]
+    fn lock_contention_covers_every_platform_error() {
+        // Whatever this host reports for a contended lock must classify as
+        // contention — that is the contract `try_acquire_run_lock` relies on.
+        assert!(is_lock_contention(&fs2::lock_contended_error()));
+
+        assert!(is_lock_contention(&std::io::Error::from_raw_os_error(
+            WINDOWS_ERROR_LOCK_VIOLATION
+        )));
+        assert!(is_lock_contention(&std::io::Error::from(
+            ErrorKind::WouldBlock
+        )));
+
+        // A genuine failure must still surface rather than be silently read as
+        // "someone else is running".
+        assert!(!is_lock_contention(&std::io::Error::from(
+            ErrorKind::PermissionDenied
+        )));
+        assert!(!is_lock_contention(&std::io::Error::from(
+            ErrorKind::NotFound
+        )));
     }
     /// The scheduler runs its own copy, so an upgrade that replaces the
     /// installed binary leaves it behind. These pin the detection, because the

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -5,6 +5,7 @@ mod commands;
 mod cursor;
 mod device;
 mod paths;
+mod process_liveness;
 mod trae;
 mod tui;
 mod warp;

--- a/crates/tokscale-cli/src/process_liveness.rs
+++ b/crates/tokscale-cli/src/process_liveness.rs
@@ -6,6 +6,17 @@
 //! delete each other's session artifacts, so every uncertain result here
 //! resolves to "alive" and merely defers a sync.
 //!
+//! Each platform backend answers with a [`Probe`] rather than a bool, and only
+//! `Probe::Absent` — the OS positively reporting an unused PID — releases a
+//! lock. Routing every backend through one verdict is what stops the
+//! fail-alive policy from being re-decided, differently, inside each `cfg`
+//! block.
+//!
+//! The classification is split from the FFI so it can be unit-tested
+//! off-platform. CI runs no Windows job, so a Windows-only `pid_is_alive`
+//! would otherwise ship with its policy never executed; the pure classifiers
+//! below are compiled and asserted on every host that runs the suite.
+//!
 //! The two callers previously carried separate copies of this probe that had
 //! already drifted — Antigravity's comment defended the no-overlap invariant
 //! while Trae's waived it — and both were Unix-only. One module keeps the
@@ -27,35 +38,111 @@ pub fn pid_is_alive(pid: u32) -> bool {
     imp::pid_is_alive(pid)
 }
 
+/// What the OS said about a PID, in the only three categories the lock policy
+/// distinguishes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Probe {
+    /// The OS confirmed something holds this PID.
+    Exists,
+    /// The OS confirmed nothing holds this PID. The sole verdict that evicts a
+    /// lock, so a backend may only return it for a code meaning exactly "no
+    /// such process" — never as a catch-all for "the call failed".
+    Absent,
+    /// The probe failed for a reason that says nothing about the PID: out of
+    /// memory, handle exhaustion, a permission wall, an unrecognised errno.
+    Unknown,
+}
+
+impl Probe {
+    fn is_alive(self) -> bool {
+        !matches!(self, Probe::Absent)
+    }
+}
+
 #[cfg(unix)]
 mod imp {
-    /// `errno` for EPERM, identical across the Unix targets tokscale builds.
+    use super::Probe;
+
+    /// `errno` values for `kill`, identical across the Unix targets tokscale
+    /// builds.
     const EPERM: i32 = 1;
+    const ESRCH: i32 = 3;
 
     extern "C" {
         #[link_name = "kill"]
         fn libc_kill(pid: i32, sig: i32) -> i32;
     }
 
+    /// Classify a `kill(pid, 0)` return value plus `errno`.
+    ///
+    /// Split out from the FFI so the policy is asserted directly rather than
+    /// only through whatever the host happens to report.
+    fn classify_kill(result: i32, raw_os_error: Option<i32>) -> Probe {
+        if result == 0 {
+            return Probe::Exists;
+        }
+        match raw_os_error {
+            // EPERM proves the process exists; it only says we may not signal
+            // it.
+            Some(EPERM) => Probe::Exists,
+            Some(ESRCH) => Probe::Absent,
+            // POSIX defines no other failure for signal 0, so anything else is
+            // the platform behaving in a way this code has not accounted for.
+            // Reading it as death is what would let two syncs overlap.
+            _ => Probe::Unknown,
+        }
+    }
+
     pub(super) fn pid_is_alive(pid: u32) -> bool {
         // Signal 0 runs `kill`'s existence and permission checks without
-        // delivering anything. EPERM still proves the process exists; it only
-        // says we may not signal it.
+        // delivering anything.
         let result = unsafe { libc_kill(pid as i32, 0) };
-        result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(EPERM)
+        classify_kill(result, std::io::Error::last_os_error().raw_os_error()).is_alive()
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn kill_success_is_alive() {
+            assert_eq!(classify_kill(0, None), Probe::Exists);
+        }
+
+        #[test]
+        fn eperm_still_proves_existence() {
+            assert_eq!(classify_kill(-1, Some(EPERM)), Probe::Exists);
+        }
+
+        #[test]
+        fn only_esrch_reports_death() {
+            assert_eq!(classify_kill(-1, Some(ESRCH)), Probe::Absent);
+        }
+
+        /// An errno `kill` is not documented to produce for signal 0 must not
+        /// count as proof of death — that is the permissive direction this
+        /// module never guesses in.
+        #[test]
+        fn unrecognised_errno_is_not_death() {
+            for errno in [4, 12, 22, 24] {
+                let probe = classify_kill(-1, Some(errno));
+                assert_eq!(probe, Probe::Unknown, "errno {errno}");
+                assert!(probe.is_alive(), "errno {errno}");
+            }
+            assert!(classify_kill(-1, None).is_alive());
+        }
     }
 }
 
 #[cfg(windows)]
 mod imp {
+    use super::windows_policy::{classify_exit_code, classify_open_failure};
     use std::ffi::c_void;
 
     /// Narrower than `PROCESS_QUERY_INFORMATION`, so the probe still succeeds
     /// against a process running at a higher integrity level instead of
     /// mistaking "may not inspect" for "does not exist".
     const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
-    const ERROR_ACCESS_DENIED: i32 = 5;
-    const STILL_ACTIVE: u32 = 259;
 
     extern "system" {
         fn OpenProcess(desired_access: u32, inherit_handle: i32, process_id: u32) -> *mut c_void;
@@ -66,11 +153,8 @@ mod imp {
     pub(super) fn pid_is_alive(pid: u32) -> bool {
         let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
         if handle.is_null() {
-            // ERROR_ACCESS_DENIED means the process exists but sits in a
-            // context we may not open — the same distinction the Unix branch
-            // draws for EPERM. An unused PID fails with
-            // ERROR_INVALID_PARAMETER instead, which is a real "dead".
-            return std::io::Error::last_os_error().raw_os_error() == Some(ERROR_ACCESS_DENIED);
+            return classify_open_failure(std::io::Error::last_os_error().raw_os_error())
+                .is_alive();
         }
 
         let mut exit_code: u32 = 0;
@@ -79,24 +163,116 @@ mod imp {
             CloseHandle(handle);
         }
 
-        // A failed query leaves liveness unknown, so report alive rather than
-        // hand the lock to a second sync on a guess. A process that exited
-        // with code 259 is likewise read as alive: STILL_ACTIVE is
-        // indistinguishable from that exit status, and erring toward "alive"
-        // is the direction the lock policy wants.
-        queried == 0 || exit_code == STILL_ACTIVE
+        classify_exit_code(queried != 0, exit_code).is_alive()
+    }
+}
+
+/// Compiled on every host under `cfg(test)` so the suite exercises the Windows
+/// policy even though CI has no Windows job. Nothing here touches the Win32
+/// API, so running it off-platform is meaningful rather than a stub.
+#[cfg(any(windows, test))]
+mod windows_policy {
+    use super::Probe;
+
+    /// What `OpenProcess` reports for a PID no process holds — the only
+    /// failure that proves death.
+    const ERROR_INVALID_PARAMETER: i32 = 87;
+    /// `GetExitCodeProcess` reports this for a running process and,
+    /// indistinguishably, for one that exited with 259.
+    const STILL_ACTIVE: u32 = 259;
+
+    /// Classify a null `OpenProcess` handle from `GetLastError`.
+    ///
+    /// Everything except the nonexistent-PID code is `Unknown`. Recognising
+    /// `ERROR_ACCESS_DENIED` alone — as an earlier revision did — silently
+    /// read handle exhaustion, `ERROR_NOT_ENOUGH_MEMORY` and every unforeseen
+    /// failure as proof of death.
+    pub(super) fn classify_open_failure(raw_os_error: Option<i32>) -> Probe {
+        if raw_os_error == Some(ERROR_INVALID_PARAMETER) {
+            Probe::Absent
+        } else {
+            Probe::Unknown
+        }
+    }
+
+    /// Classify a `GetExitCodeProcess` result on an open handle.
+    ///
+    /// A process that exited with 259 reads as alive: that status is
+    /// indistinguishable from `STILL_ACTIVE`, and erring toward "alive" is the
+    /// direction the lock policy wants.
+    pub(super) fn classify_exit_code(queried: bool, exit_code: u32) -> Probe {
+        if !queried {
+            return Probe::Unknown;
+        }
+        if exit_code == STILL_ACTIVE {
+            return Probe::Exists;
+        }
+        Probe::Absent
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn only_the_nonexistent_pid_code_reports_death() {
+            assert_eq!(
+                classify_open_failure(Some(ERROR_INVALID_PARAMETER)),
+                Probe::Absent
+            );
+        }
+
+        /// `ERROR_ACCESS_DENIED` (5) means the process exists but sits in a
+        /// context we may not open — the same distinction the Unix branch
+        /// draws for `EPERM`.
+        #[test]
+        fn access_denied_is_alive() {
+            assert!(classify_open_failure(Some(5)).is_alive());
+        }
+
+        /// The regression this pins: a resource failure is not evidence of
+        /// death. `ERROR_NOT_ENOUGH_MEMORY` (8), `ERROR_OUTOFMEMORY` (14),
+        /// `ERROR_NO_SYSTEM_RESOURCES` (1450) and anything unmapped must all
+        /// keep the lock held.
+        #[test]
+        fn resource_failures_are_not_death() {
+            for code in [8, 14, 1450, 1816] {
+                let probe = classify_open_failure(Some(code));
+                assert_eq!(probe, Probe::Unknown, "error {code}");
+                assert!(probe.is_alive(), "error {code}");
+            }
+            assert!(classify_open_failure(None).is_alive());
+        }
+
+        #[test]
+        fn exit_code_query_classifies_liveness() {
+            assert_eq!(classify_exit_code(true, STILL_ACTIVE), Probe::Exists);
+            assert_eq!(classify_exit_code(true, 0), Probe::Absent);
+            assert_eq!(classify_exit_code(true, 1), Probe::Absent);
+        }
+
+        /// A failed query leaves liveness unknown, so report alive rather than
+        /// hand the lock to a second sync on a guess.
+        #[test]
+        fn failed_exit_code_query_is_alive() {
+            let probe = classify_exit_code(false, 0);
+            assert_eq!(probe, Probe::Unknown);
+            assert!(probe.is_alive());
+        }
     }
 }
 
 #[cfg(not(any(unix, windows)))]
 mod imp {
+    use super::Probe;
+
     pub(super) fn pid_is_alive(_pid: u32) -> bool {
         // No liveness probe on this platform, so nothing here can prove death.
         // Reporting "alive" blocks a sync until the lock file is removed by
         // hand; reporting "dead" would silently allow the overlapping syncs
         // this module exists to prevent. Unreachable for every target
         // tokscale releases — all of them are Unix or Windows.
-        true
+        Probe::Unknown.is_alive()
     }
 }
 

--- a/crates/tokscale-cli/src/process_liveness.rs
+++ b/crates/tokscale-cli/src/process_liveness.rs
@@ -1,0 +1,142 @@
+//! Cross-platform "is this PID still running" probe.
+//!
+//! The Antigravity and Trae sync locks both record the owning PID and evict a
+//! lock only once that owner is provably dead. A wrong answer in the
+//! permissive direction lets two syncs run against the same manifest and
+//! delete each other's session artifacts, so every uncertain result here
+//! resolves to "alive" and merely defers a sync.
+//!
+//! The two callers previously carried separate copies of this probe that had
+//! already drifted — Antigravity's comment defended the no-overlap invariant
+//! while Trae's waived it — and both were Unix-only. One module keeps the
+//! policy in a single place.
+
+/// Whether `pid` names a process that is currently running.
+///
+/// Returns `true` whenever liveness cannot be established. A false "dead"
+/// answer costs correctness (two syncs overlap and corrupt the manifest); a
+/// false "alive" answer only postpones a sync, which the caller reports and
+/// the next run retries.
+pub fn pid_is_alive(pid: u32) -> bool {
+    // PID 0 is the kernel/idle process on every platform tokscale ships to,
+    // and is also what a truncated or zero-filled lock file parses to, so it
+    // never denotes a live sync.
+    if pid == 0 {
+        return false;
+    }
+    imp::pid_is_alive(pid)
+}
+
+#[cfg(unix)]
+mod imp {
+    /// `errno` for EPERM, identical across the Unix targets tokscale builds.
+    const EPERM: i32 = 1;
+
+    extern "C" {
+        #[link_name = "kill"]
+        fn libc_kill(pid: i32, sig: i32) -> i32;
+    }
+
+    pub(super) fn pid_is_alive(pid: u32) -> bool {
+        // Signal 0 runs `kill`'s existence and permission checks without
+        // delivering anything. EPERM still proves the process exists; it only
+        // says we may not signal it.
+        let result = unsafe { libc_kill(pid as i32, 0) };
+        result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(EPERM)
+    }
+}
+
+#[cfg(windows)]
+mod imp {
+    use std::ffi::c_void;
+
+    /// Narrower than `PROCESS_QUERY_INFORMATION`, so the probe still succeeds
+    /// against a process running at a higher integrity level instead of
+    /// mistaking "may not inspect" for "does not exist".
+    const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
+    const ERROR_ACCESS_DENIED: i32 = 5;
+    const STILL_ACTIVE: u32 = 259;
+
+    extern "system" {
+        fn OpenProcess(desired_access: u32, inherit_handle: i32, process_id: u32) -> *mut c_void;
+        fn GetExitCodeProcess(process: *mut c_void, exit_code: *mut u32) -> i32;
+        fn CloseHandle(object: *mut c_void) -> i32;
+    }
+
+    pub(super) fn pid_is_alive(pid: u32) -> bool {
+        let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+        if handle.is_null() {
+            // ERROR_ACCESS_DENIED means the process exists but sits in a
+            // context we may not open — the same distinction the Unix branch
+            // draws for EPERM. An unused PID fails with
+            // ERROR_INVALID_PARAMETER instead, which is a real "dead".
+            return std::io::Error::last_os_error().raw_os_error() == Some(ERROR_ACCESS_DENIED);
+        }
+
+        let mut exit_code: u32 = 0;
+        let queried = unsafe { GetExitCodeProcess(handle, &mut exit_code) };
+        unsafe {
+            CloseHandle(handle);
+        }
+
+        // A failed query leaves liveness unknown, so report alive rather than
+        // hand the lock to a second sync on a guess. A process that exited
+        // with code 259 is likewise read as alive: STILL_ACTIVE is
+        // indistinguishable from that exit status, and erring toward "alive"
+        // is the direction the lock policy wants.
+        queried == 0 || exit_code == STILL_ACTIVE
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+mod imp {
+    pub(super) fn pid_is_alive(_pid: u32) -> bool {
+        // No liveness probe on this platform, so nothing here can prove death.
+        // Reporting "alive" blocks a sync until the lock file is removed by
+        // hand; reporting "dead" would silently allow the overlapping syncs
+        // this module exists to prevent. Unreachable for every target
+        // tokscale releases — all of them are Unix or Windows.
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    #[test]
+    fn pid_zero_is_never_alive() {
+        assert!(!pid_is_alive(0));
+    }
+
+    /// Runs on Windows too. It was previously `#[cfg(unix)]` in `trae.rs`,
+    /// which is precisely why the always-false Windows stub went unnoticed.
+    #[test]
+    fn current_process_is_alive() {
+        assert!(pid_is_alive(std::process::id()));
+    }
+
+    #[test]
+    fn exited_process_is_not_alive() {
+        #[cfg(windows)]
+        let mut child = Command::new("cmd")
+            .args(["/C", "exit"])
+            .spawn()
+            .expect("spawn a process that exits immediately");
+        #[cfg(unix)]
+        let mut child = Command::new("/bin/sh")
+            .args(["-c", "exit 0"])
+            .spawn()
+            .expect("spawn a process that exits immediately");
+
+        let pid = child.id();
+        child.wait().expect("child exits");
+
+        // `child` is deliberately still in scope: on Windows an open process
+        // handle pins the PID, so it cannot be recycled by an unrelated
+        // process between the wait and the probe.
+        assert!(!pid_is_alive(pid));
+        drop(child);
+    }
+}

--- a/crates/tokscale-cli/src/trae.rs
+++ b/crates/tokscale-cli/src/trae.rs
@@ -930,6 +930,7 @@ pub mod sync {
     //! under the single `trae` client cache.
 
     use super::auth::{self, get_trae_cache_dir, TraeVariant};
+    use crate::process_liveness::pid_is_alive;
     use anyhow::{Context, Result};
     use chrono::Utc;
     use serde::{Deserialize, Serialize};
@@ -1180,37 +1181,6 @@ pub mod sync {
         Some((pid, timestamp))
     }
 
-    fn pid_is_alive(pid: u32) -> bool {
-        if pid == 0 {
-            return false;
-        }
-        #[cfg(unix)]
-        {
-            // `kill(pid, 0)` is a signal-free liveness probe. EPERM (errno
-            // 1) still means the process exists, just that we lack
-            // permission to signal it.
-            let result = unsafe { libc_kill(pid as i32, 0) };
-            result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(1)
-        }
-        #[cfg(not(unix))]
-        {
-            let _ = pid;
-            // No portable PID probe available. Treat the lock as stale so a
-            // crashed previous run doesn't permanently block subsequent
-            // syncs. This matches the policy used by Antigravity sync and
-            // accepts a small concurrent-corruption risk on Windows; that
-            // risk is acceptable because tokscale is a single-user CLI and
-            // overlapping syncs are rare in practice.
-            false
-        }
-    }
-
-    #[cfg(unix)]
-    extern "C" {
-        #[link_name = "kill"]
-        fn libc_kill(pid: i32, sig: i32) -> i32;
-    }
-
     // ── Main sync logic ────────────────────────────────────────────────────
 
     /// Run a single incremental sync for one variant.
@@ -1416,17 +1386,8 @@ pub mod sync {
             assert!(read_sync_lock(&path).is_none());
         }
 
-        #[test]
-        fn test_pid_is_alive_zero_is_dead() {
-            assert!(!pid_is_alive(0));
-        }
-
-        #[test]
-        #[cfg(unix)]
-        fn test_pid_is_alive_current_process_is_alive() {
-            let me = std::process::id();
-            assert!(pid_is_alive(me));
-        }
+        // Liveness probe coverage moved to `crate::process_liveness`, which
+        // now owns the single implementation both sync locks share.
 
         #[test]
         fn test_acquire_recovers_from_stale_lock_with_dead_pid() {


### PR DESCRIPTION
Fixes the three program defects in #997. Windows is a shipped release target (`x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc` in `build-native.yml`), so these affect released binaries — they are just invisible because `test_coverage.yml` is ubuntu-only.

## 1. `try_acquire_run_lock` errored instead of yielding

`commands/autosubmit.rs` accepted only `ErrorKind::WouldBlock` as "someone else holds it". fs2 reports a contended `LockFileEx` as `ERROR_LOCK_VIOLATION` (33), which `std` leaves uncategorised, so the call fell through to the error arm.

The reporter saw this as a test `unwrap` panic, but the production impact is worse than a panicking test: `main.rs:5412` propagates with `?`, so a scheduled autosubmit run that found another run in progress **failed and recorded `last_error`** instead of printing "Autosubmit is already running." and exiting cleanly.

Fix: `is_lock_contention` accepts `WouldBlock` or `ERROR_LOCK_VIOLATION`. The constant is checked unconditionally rather than under `cfg(windows)` — that is the only way the classification is testable on a platform CI actually runs, and no Unix `flock` failure uses errno 33, so it cannot disguise a real error.

## 2. `pid_is_alive` always returned false off Unix

`SyncLockGuard::acquire` holds an existing lock only while its owner is alive, so on Windows every lock looked stale and got taken. The comment at the call site records that age-based eviction was **removed on purpose** so two syncs could not overlap on the manifest and delete each other's artifacts — the stub silently handed that guarantee back.

`trae.rs` carried a **second copy** of the same stub, not mentioned in the issue, and the two had already drifted: Antigravity's comment defends the no-overlap invariant while Trae's explicitly waived it. Both now share `crate::process_liveness`, which probes with `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` + `GetExitCodeProcess` on Windows.

Every uncertain answer resolves to **alive**: a false "dead" corrupts the manifest, a false "alive" only defers a sync. That covers `ERROR_ACCESS_DENIED` (process exists, we may not open it — the same distinction the Unix branch draws for `EPERM`), a failed query, and unknown platforms.

## 3. `resolve_cache_relative_artifact_path` rejected the native separator

**The issue is wrong that this is test-only.** It says "the only caller in the repo is the test, so nothing in production reaches it today". `delete_session_artifact` is indeed `#[cfg(test)]`, but `delete_artifact_relative_path` has a second caller: `cleanup_stale_session_artifacts`, invoked from the main sync path at `antigravity.rs:233`.

And `to_relative_artifact_path` renders with `Path::to_string_lossy`, so on Windows **every** manifest entry is stored as `sessions\<id>.jsonl`. So on Windows any sync with an artifact to retire fails — after `save_antigravity_manifest` has already run, leaving the manifest updated and the artifacts not cleaned up.

Fix: normalise `\` to `/` before validating. This also **tightens** Unix, where `Path` does not treat `\` as a separator and `..\..\escape.jsonl` previously reached the traversal check as a single innocuous file name. Safe against false positives because `sanitize_session_id` strips everything outside `[A-Za-z0-9._-]`, so a generated artifact name can never legitimately contain a backslash.

## Evidence

Each regression test was verified red against the unfixed code by reverting only the source change and keeping the test.

**Artifact path** — with `resolve_cache_relative_artifact_path` reverted to `Path::new(relative_path)`:

```
running 4 tests
test antigravity::tests::delete_artifact_relative_path_rejects_backslash_traversal ... FAILED
test antigravity::tests::delete_artifact_relative_path_rejects_paths_outside_cache_root ... ok
test antigravity::tests::delete_artifact_relative_path_accepts_windows_separators ... FAILED
test antigravity::tests::delete_artifact_relative_path_rejects_symlink_escape ... ok

---- delete_artifact_relative_path_rejects_backslash_traversal stdout ----
assertion failed: err.to_string().contains("cache root")
---- delete_artifact_relative_path_accepts_windows_separators stdout ----
called `Result::unwrap()` on an `Err` value: Artifact path must point to a session artifact

test result: FAILED. 2 passed; 2 failed; 0 ignored; 0 measured; 975 filtered out
```

Restored:

```
running 4 tests
test antigravity::tests::delete_artifact_relative_path_accepts_windows_separators ... ok
test antigravity::tests::delete_artifact_relative_path_rejects_backslash_traversal ... ok
test antigravity::tests::delete_artifact_relative_path_rejects_symlink_escape ... ok
test antigravity::tests::delete_artifact_relative_path_rejects_paths_outside_cache_root ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 975 filtered out
```

**Lock contention** — with `is_lock_contention` reverted to the `WouldBlock`-only predicate:

```
running 1 test
test commands::autosubmit::tests::lock_contention_covers_every_platform_error ... FAILED

---- lock_contention_covers_every_platform_error stdout ----
assertion failed: is_lock_contention(&std::io::Error::from_raw_os_error(WINDOWS_ERROR_LOCK_VIOLATION))

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 978 filtered out
```

Restored:

```
running 1 test
test commands::autosubmit::tests::lock_contention_covers_every_platform_error ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 978 filtered out
```

**Full workspace** (`cargo test --workspace --all-features`, macOS arm64) — all ten binaries green:

```
test result: ok. 977 passed; 0 failed; 2 ignored
test result: ok. 133 passed; 0 failed; 0 ignored
test result: ok. 1320 passed; 0 failed; 1 ignored
test result: ok. 0 passed; 0 failed; 2 ignored
test result: ok. 10 passed; 0 failed; 0 ignored
test result: ok. 4 passed; 0 failed; 0 ignored
test result: ok. 14 passed; 0 failed; 0 ignored
test result: ok. 3 passed; 0 failed; 0 ignored
test result: ok. 4 passed; 0 failed; 0 ignored
test result: ok. 0 passed; 0 failed; 0 ignored
```

`cargo clippy --locked --workspace --all-features --all-targets -- -D warnings` and `cargo fmt --all -- --check` are both clean. Note `--all-targets` is passed here; CI omits it, so `#[cfg(test)]` code is otherwise unlinted.

### What I could not verify

**I was on macOS and ran no Windows test.** The Windows branch of `pid_is_alive` has no runtime coverage from me at all. What I did verify is that it compiles and is warning-clean for the real target, which validates the FFI signatures and cfg gating but nothing about behaviour:

```
$ rustc --target x86_64-pc-windows-msvc --crate-type lib --emit=metadata --edition 2021 -D warnings process_liveness.rs
OK lib
$ rustc --target x86_64-pc-windows-msvc --test --emit=metadata --edition 2021 -D warnings process_liveness.rs
OK tests
```

A full `cargo check --target x86_64-pc-windows-msvc` is not possible here — `zstd-sys` and `rusqlite` need an MSVC toolchain and Windows SDK headers to cross-compile.

`current_process_is_alive` and `exited_process_is_not_alive` now run on Windows too (the former was `#[cfg(unix)]`-gated in `trae.rs`, which is exactly why the always-false stub went unnoticed). They pass on macOS; on Windows they are unexecuted.

## Deliberately not fixed

- **`windows-latest` in the test matrix.** Adding it is the real fix for the class, but it would land red: the eight `home_dir()` redirection failures remain, and fixing those means either teaching `home_dir()` a `TOKSCALE_*` override or gating the tests — the design call the reporter explicitly asked the maintainer to make. I could not have verified a green Windows suite from macOS in any case. Worth a follow-up once that decision is made.
- **The eight `home_dir()` tests** (`auth.rs:713/796/860`, `antigravity.rs`, `commands/wrapped.rs:2171`, `tui/cache.rs:1790`, `tui/data/mod.rs:2707/2770`), including the two with side effects — `test_ensure_config_dir` creating `%USERPROFILE%\.config\tokscale` on the host, and `test_load_credentials_nonexistent` reading real credentials so it passes only for a logged-out developer. Same design call; both deserve fixing but not by guessing at the preferred shape.
- Only one of the nine test defects is fixed here: `scheduler_specs_use_the_managed_executable`, which compared `Debug` output (backslashes doubled) against `to_string_lossy` (not doubled). It was a one-line escape fix on a path already touched by defect 1.

## Scope: #997 is only partially addressed

Refs #997 — **deliberately not `Closes`.** The issue is titled "cargo test does not
complete on Windows" and that headline complaint is still true after this PR. Eight
of its nine test defects (the `dirs::home_dir` redirection cluster) are untouched, so
the suite still aborts on the `tokscale-cli` binary and the other nine binaries still
never run. `windows-latest` is still absent from `test_coverage.yml`, so none of the
three fixes here are exercised by CI on the platform they target. The issue should stay
open until the `home_dir` design call is made.

## Follow-up: #1010

Both PID-file sync lock protocols (`antigravity.rs`, `trae.rs`) do a non-atomic
read-decide-unlink: two contenders can both find the same dead owner and both enter
the critical section, the lock file is visible before the PID is written, and PID reuse
can make a stranger's process look like the owner. That race predates this branch and is
equally present on Unix today, so it is not gated here — but the fix is known: an OS-held
exclusive lock, as `autosubmit::try_acquire_run_lock` already uses. The call-site comment
in `antigravity.rs` now says so explicitly rather than implying the PID probe closes it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows lock contention, PID liveness, and cross-platform artifact path handling to prevent failed autosubmit runs, overlapping syncs, and accidental artifact deletion.

- **Bug Fixes**
  - Treat Windows `ERROR_LOCK_VIOLATION` as lock contention in `try_acquire_run_lock` so autosubmit steps aside instead of failing.
  - Replace Unix-only PID stubs with a shared `pid_is_alive` using `OpenProcess` + `GetExitCodeProcess`; only `ERROR_INVALID_PARAMETER` means “dead”, and all other failures resolve to “alive” to avoid manifest corruption.
  - Normalize `\` to `/` in artifact paths so `sessions\<id>.jsonl` is accepted on Windows and backslash traversal is blocked on Unix.
  - Make cleanup safe across platforms: compare normalized paths in `stale_relative_paths` and refuse to delete any path that resolves to an artifact the new manifest still references.

- **Refactors**
  - Added `process_liveness.rs` and removed duplicated liveness code from `antigravity` and `trae`. Extracted classifiers for unit tests off-Windows. Fixed scheduler spec test to escape Windows paths correctly.

<sup>Written for commit 5f49c01f49d49541e81a4d88c912a067e95c0f46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

