### PR TITLE
fix(cache): keep Claude turns a transcript rewrite dropped

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,6 +914,8 @@ The regenerable CLI/TUI/pricing/Wrapped caches now live under `~/.config/tokscal
 
 It is safe to delete this directory. Tokscale will recreate and repopulate it on demand.
 
+One caveat, for Claude Code only. Claude Code rewrites a session transcript in place when you resume or compact it: the file keeps its name but loses assistant turns it had already written. `source-message-cache-v2/` remembers those turns for as long as the transcript file exists, so they keep counting toward your totals. That is the only place they still exist — the transcript itself no longer has them. Deleting the cache (or letting a Claude parser upgrade rebuild it) rebuilds from the compacted transcripts, so totals for heavily compacted sessions can come back lower. Deleting a transcript still drops its turns either way, which is what makes local disk the source of truth.
+
 ### Environment Variables
 
 Environment variables override config file values. For CI/CD or one-off use:

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -744,7 +744,7 @@ fn parse_all_messages_with_pricing_with_env_strategy(
 
     /// What a changed source file is allowed to do to the history the cache
     /// already holds for it.
-    #[derive(Clone, Copy, PartialEq, Eq)]
+    #[derive(Clone, Copy)]
     enum HistoryRetention {
         /// The live file is the whole truth. Anything it no longer contains
         /// leaves the totals — correct for a source whose file content is a
@@ -752,21 +752,38 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         LiveFileOnly,
         /// Carry forward messages this exact file was previously observed to
         /// contain. For clients that rewrite a transcript in place.
-        RetainObserved,
+        RetainObserved {
+            /// Decides, per dedup key, whether the message may be carried
+            /// forward. A retained copy outlives the bytes that produced it,
+            /// so it has to keep collapsing against a live copy of the same
+            /// message written anywhere else; a key that is only unique
+            /// within one file cannot do that and must be dropped instead.
+            /// The lane owning the key format supplies this.
+            key_is_globally_stable: fn(&str) -> bool,
+        },
     }
 
     /// Merge the messages a previous scan recorded for this exact file back
     /// into a fresh parse of it.
     ///
-    /// The live file stays authoritative for everything it still contains: a
-    /// key present on both sides keeps the freshly parsed message, so a
-    /// corrected re-parse still wins and nothing is frozen at a stale value.
-    /// Only keys the file no longer carries are carried forward.
+    /// Within this entry the live file stays authoritative for everything it
+    /// still contains: a key present on both sides keeps the freshly parsed
+    /// message, so a corrected re-parse still wins and nothing is frozen at a
+    /// stale value. Only keys the file no longer carries are carried forward.
+    /// (Across entries the Claude lane is first-wins on lexical path order, so
+    /// a retained copy in an earlier-sorting file still beats a live copy of
+    /// the same key in a later one.)
     ///
     /// Messages without a dedup key are never retained. The key is what lets a
     /// later scan recognise the message as already-seen; re-emitting an
-    /// unkeyed one would double count it the moment the file regained it.
-    fn retain_observed_messages(parsed: &mut Vec<UnifiedMessage>, cached: &[UnifiedMessage]) {
+    /// unkeyed one would double count it the moment the file regained it. Keys
+    /// that `key_is_globally_stable` rejects are dropped for the same reason:
+    /// they would never collapse against a live copy elsewhere.
+    fn retain_observed_messages(
+        parsed: &mut Vec<UnifiedMessage>,
+        cached: &[UnifiedMessage],
+        key_is_globally_stable: fn(&str) -> bool,
+    ) {
         let mut seen: HashSet<String> = parsed
             .iter()
             .filter_map(|message| message.dedup_key.clone())
@@ -776,6 +793,9 @@ fn parse_all_messages_with_pricing_with_env_strategy(
             let Some(key) = message.dedup_key.as_ref() else {
                 continue;
             };
+            if !key_is_globally_stable(key) {
+                continue;
+            }
             if seen.insert(key.clone()) {
                 parsed.push(message.clone());
             }
@@ -846,9 +866,18 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         // would retire them from history (#994). Only merge when the parse is
         // cacheable: an untrustworthy parse must not be used to synthesise an
         // entry, and the caller invalidates on that path anyway.
-        if history == HistoryRetention::RetainObserved && cacheable {
-            if let Some(cached) = cached {
-                retain_observed_messages(&mut messages, &cached.messages);
+        if let HistoryRetention::RetainObserved {
+            key_is_globally_stable,
+        } = history
+        {
+            if cacheable {
+                if let Some(cached) = cached {
+                    retain_observed_messages(
+                        &mut messages,
+                        &cached.messages,
+                        key_is_globally_stable,
+                    );
+                }
             }
         }
         let cache_entry = if messages.is_empty() || !cacheable {
@@ -904,15 +933,17 @@ fn parse_all_messages_with_pricing_with_env_strategy(
     /// Scoped deliberately rather than made the default. Retention is only
     /// sound where a message carries a dedup key that identifies it by
     /// content across files, because the retained copy has to collapse
-    /// against any live copy of the same message elsewhere. Claude's
-    /// `messageId:requestId` key does that and its lane dedups on it globally;
-    /// sources keyed by file position or by a per-scan ordinal do not, and
-    /// would double count.
+    /// against any live copy of the same message elsewhere. Sources keyed by
+    /// file position or by a per-scan ordinal do not qualify and would double
+    /// count, and neither do some keys inside an otherwise-qualifying lane —
+    /// hence `key_is_globally_stable` rather than a blanket per-client
+    /// promise.
     fn load_or_parse_source_with_fingerprint_retaining_history<F, FingerprintFn>(
         identity: message_cache::CacheIdentity,
         path: &Path,
         source_cache: &message_cache::SourceMessageCache,
         pricing: Option<&pricing::PricingService>,
+        key_is_globally_stable: fn(&str) -> bool,
         fingerprint_from_path: FingerprintFn,
         parse: F,
     ) -> CachedParseOutcome
@@ -928,7 +959,9 @@ fn parse_all_messages_with_pricing_with_env_strategy(
             path,
             source_cache,
             pricing,
-            HistoryRetention::RetainObserved,
+            HistoryRetention::RetainObserved {
+                key_is_globally_stable,
+            },
             fingerprint_from_path,
             |path, _| (parse(path), true),
         )
@@ -1238,11 +1271,18 @@ fn parse_all_messages_with_pricing_with_env_strategy(
             // long as the file itself exists; deleting the transcript still
             // drops them via `prune_missing_files`, which is what makes local
             // disk remain the source of truth.
+            //
+            // Only assistant turns are eligible: their `messageId:requestId`
+            // key comes from the API response, so a retained copy still
+            // collapses against the same turn replayed into a forked
+            // transcript. Tool-result keys embed the transcript's file stem
+            // and would not — see `dedup_key_is_globally_stable`.
             load_or_parse_source_with_fingerprint_retaining_history(
                 message_cache::CacheIdentity::for_client(ClientId::Claude),
                 path,
                 &source_cache,
                 pricing,
+                sessions::claudecode::dedup_key_is_globally_stable,
                 |path, cached| {
                     message_cache::SourceFingerprint::check_claude_code_path_with_home_samples_only(
                         path,
@@ -5211,6 +5251,12 @@ mod tests {
     /// against a live copy of itself somewhere else. Claude Code forks a
     /// session into a new transcript that replays earlier turns, so the same
     /// `messageId:requestId` legitimately appears in two files at once.
+    ///
+    /// The transcripts are named so the retaining file sorts first: the lane
+    /// walks paths in lexical order and keeps the first copy of a key, so this
+    /// is the ordering where a retained copy wins over the live one. Both
+    /// copies come from the same API response, so either winner reports the
+    /// same tokens — what must not happen is both being counted.
     #[test]
     #[serial_test::serial]
     fn test_claude_retained_message_collapses_against_a_forked_transcript() {
@@ -5222,12 +5268,13 @@ mod tests {
         {
             let claude_dir = source_home.path().join(".claude/projects/myproject");
             std::fs::create_dir_all(&claude_dir).unwrap();
-            let original = claude_dir.join("original.jsonl");
+            let original = claude_dir.join("aaa-original.jsonl");
 
             let turn_one = r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50}}}"#;
             let turn_two = r#"{"type":"assistant","timestamp":"2024-12-01T10:05:00.000Z","requestId":"req_002","message":{"id":"msg_002","model":"claude-3-5-sonnet","usage":{"input_tokens":200,"output_tokens":60}}}"#;
+            let turn_three = r#"{"type":"assistant","timestamp":"2024-12-01T10:10:00.000Z","requestId":"req_003","message":{"id":"msg_003","model":"claude-3-5-sonnet","usage":{"input_tokens":300,"output_tokens":70}}}"#;
 
-            std::fs::write(&original, format!("{turn_one}\n{turn_two}\n")).unwrap();
+            std::fs::write(&original, format!("{turn_one}\n{turn_two}\n{turn_three}\n")).unwrap();
             let before = parse_all_messages_with_pricing_with_env_strategy(
                 source_home.path().to_str().unwrap(),
                 &["claude".to_string()],
@@ -5235,12 +5282,14 @@ mod tests {
                 false,
                 &scanner::ScannerSettings::default(),
             );
-            assert_eq!(before.len(), 2);
+            assert_eq!(before.len(), 3);
 
-            // The fork: turn two moves to a new transcript and leaves the old
-            // one. Both files now claim it, and only one may be counted.
+            // The compaction keeps turn one. Turn two is replayed into the
+            // fork, so it exists both retained and live. Turn three exists
+            // only as a retained copy — it is what makes the count here
+            // differ from a run with no retention at all.
             std::fs::write(&original, format!("{turn_one}\n")).unwrap();
-            std::fs::write(claude_dir.join("forked.jsonl"), format!("{turn_two}\n")).unwrap();
+            std::fs::write(claude_dir.join("zzz-fork.jsonl"), format!("{turn_two}\n")).unwrap();
 
             let after = parse_all_messages_with_pricing_with_env_strategy(
                 source_home.path().to_str().unwrap(),
@@ -5251,10 +5300,81 @@ mod tests {
             );
             assert_eq!(
                 after.len(),
-                2,
-                "a retained message must not be counted alongside its live copy"
+                3,
+                "retention must keep turn three and must not double count turn two"
             );
-            assert_eq!(after.iter().map(|m| m.tokens.output).sum::<i64>(), 110);
+            let keys: HashSet<String> = after
+                .iter()
+                .filter_map(|message| message.dedup_key.clone())
+                .collect();
+            assert_eq!(keys.len(), 3, "every surviving message must be distinct");
+            assert_eq!(
+                after.iter().map(|m| m.tokens.output).sum::<i64>(),
+                180,
+                "turn two contributes its 60 once, not twice"
+            );
+            assert_eq!(after.iter().map(|m| m.tokens.input).sum::<i64>(), 600);
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    /// A Claude tool-result key embeds the session id, which is the
+    /// transcript's file stem. A retained tool result therefore could never
+    /// collapse against the same tool result replayed under a fork's filename
+    /// — both would count — so retention has to leave those records behind
+    /// even though it means a compaction still retires their input tokens.
+    #[test]
+    #[serial_test::serial]
+    fn test_claude_path_scoped_tool_result_is_not_retained_across_a_rewrite() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            let claude_dir = source_home.path().join(".claude/projects/myproject");
+            std::fs::create_dir_all(&claude_dir).unwrap();
+            let transcript = claude_dir.join("conversation.jsonl");
+
+            let assistant_turn = r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50}}}"#;
+            let tool_result = r#"{"type":"user","timestamp":"2024-12-01T10:01:00.000Z","message":{"model":"claude-3-5-sonnet","content":[{"type":"tool_result","tool_use_id":"toolu_1","tool_output":{"input_tokens":40,"output":"result"}}]}}"#;
+
+            std::fs::write(&transcript, format!("{assistant_turn}\n{tool_result}\n")).unwrap();
+            let before = parse_all_messages_with_pricing_with_env_strategy(
+                source_home.path().to_str().unwrap(),
+                &["claude".to_string()],
+                None,
+                false,
+                &scanner::ScannerSettings::default(),
+            );
+            assert_eq!(
+                before.len(),
+                2,
+                "cold scan sees the turn and the tool result"
+            );
+            assert_eq!(before.iter().map(|m| m.tokens.input).sum::<i64>(), 140);
+
+            // The rewrite drops both records; only the assistant turn is
+            // re-added, so the tool result is a candidate for retention.
+            std::fs::write(&transcript, format!("{assistant_turn}\n")).unwrap();
+
+            let after = parse_all_messages_with_pricing_with_env_strategy(
+                source_home.path().to_str().unwrap(),
+                &["claude".to_string()],
+                None,
+                false,
+                &scanner::ScannerSettings::default(),
+            );
+            assert_eq!(
+                after.len(),
+                1,
+                "a path-scoped key must not be carried across the rewrite"
+            );
+            assert_eq!(after.iter().map(|m| m.tokens.input).sum::<i64>(), 100);
         }
 
         match original_home {
@@ -5266,6 +5386,11 @@ mod tests {
     /// The retention above must not resurrect a session the user deleted:
     /// `prune_missing_files` drops the entry when the file is gone, which is
     /// the behavior `d9df8c9c` (local session cleanup) depends on.
+    ///
+    /// The transcript is compacted first, and retention is asserted, so the
+    /// deletion runs against an entry that really is holding a turn the live
+    /// file no longer has. Deleting straight after a cold scan would prove
+    /// nothing about retention.
     #[test]
     #[serial_test::serial]
     fn test_claude_deleted_transcript_is_not_resurrected_by_retention() {
@@ -5278,12 +5403,11 @@ mod tests {
             let claude_dir = source_home.path().join(".claude/projects/myproject");
             std::fs::create_dir_all(&claude_dir).unwrap();
             let transcript = claude_dir.join("conversation.jsonl");
-            std::fs::write(
-                &transcript,
-                "{\"type\":\"assistant\",\"timestamp\":\"2024-12-01T10:00:00.000Z\",\"requestId\":\"req_001\",\"message\":{\"id\":\"msg_001\",\"model\":\"claude-3-5-sonnet\",\"usage\":{\"input_tokens\":100,\"output_tokens\":50}}}\n",
-            )
-            .unwrap();
 
+            let turn_one = r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50}}}"#;
+            let turn_two = r#"{"type":"assistant","timestamp":"2024-12-01T10:05:00.000Z","requestId":"req_002","message":{"id":"msg_002","model":"claude-3-5-sonnet","usage":{"input_tokens":200,"output_tokens":60}}}"#;
+
+            std::fs::write(&transcript, format!("{turn_one}\n{turn_two}\n")).unwrap();
             let before = parse_all_messages_with_pricing_with_env_strategy(
                 source_home.path().to_str().unwrap(),
                 &["claude".to_string()],
@@ -5291,7 +5415,21 @@ mod tests {
                 false,
                 &scanner::ScannerSettings::default(),
             );
-            assert_eq!(before.len(), 1);
+            assert_eq!(before.len(), 2);
+
+            std::fs::write(&transcript, format!("{turn_two}\n")).unwrap();
+            let retained = parse_all_messages_with_pricing_with_env_strategy(
+                source_home.path().to_str().unwrap(),
+                &["claude".to_string()],
+                None,
+                false,
+                &scanner::ScannerSettings::default(),
+            );
+            assert_eq!(
+                retained.len(),
+                2,
+                "the entry must actually be holding a retained turn before the delete"
+            );
 
             std::fs::remove_file(&transcript).unwrap();
 
@@ -5304,7 +5442,7 @@ mod tests {
             );
             assert!(
                 after.is_empty(),
-                "a deleted transcript stays deleted; local disk remains the source of truth"
+                "a deleted transcript stays deleted, retained turns and all; local disk remains the source of truth"
             );
         }
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -742,11 +742,52 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         ))
     }
 
+    /// What a changed source file is allowed to do to the history the cache
+    /// already holds for it.
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum HistoryRetention {
+        /// The live file is the whole truth. Anything it no longer contains
+        /// leaves the totals — correct for a source whose file content is a
+        /// faithful record of what the client did.
+        LiveFileOnly,
+        /// Carry forward messages this exact file was previously observed to
+        /// contain. For clients that rewrite a transcript in place.
+        RetainObserved,
+    }
+
+    /// Merge the messages a previous scan recorded for this exact file back
+    /// into a fresh parse of it.
+    ///
+    /// The live file stays authoritative for everything it still contains: a
+    /// key present on both sides keeps the freshly parsed message, so a
+    /// corrected re-parse still wins and nothing is frozen at a stale value.
+    /// Only keys the file no longer carries are carried forward.
+    ///
+    /// Messages without a dedup key are never retained. The key is what lets a
+    /// later scan recognise the message as already-seen; re-emitting an
+    /// unkeyed one would double count it the moment the file regained it.
+    fn retain_observed_messages(parsed: &mut Vec<UnifiedMessage>, cached: &[UnifiedMessage]) {
+        let mut seen: HashSet<String> = parsed
+            .iter()
+            .filter_map(|message| message.dedup_key.clone())
+            .collect();
+
+        for message in cached {
+            let Some(key) = message.dedup_key.as_ref() else {
+                continue;
+            };
+            if seen.insert(key.clone()) {
+                parsed.push(message.clone());
+            }
+        }
+    }
+
     fn load_or_parse_source_with_fingerprint_and_policy<F, FingerprintFn>(
         identity: message_cache::CacheIdentity,
         path: &Path,
         source_cache: &message_cache::SourceMessageCache,
         pricing: Option<&pricing::PricingService>,
+        history: HistoryRetention,
         fingerprint_from_path: FingerprintFn,
         parse: F,
     ) -> CachedParseOutcome
@@ -798,6 +839,18 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         }
 
         let (mut messages, cacheable) = parse(path, Some(&fingerprint));
+        // Reaching here means the file changed under a cache entry we still
+        // hold. For a source that rewrites transcripts in place that is not
+        // only "new content appeared" — it can also be "already-published
+        // messages disappeared", and recomputing purely from the live bytes
+        // would retire them from history (#994). Only merge when the parse is
+        // cacheable: an untrustworthy parse must not be used to synthesise an
+        // entry, and the caller invalidates on that path anyway.
+        if history == HistoryRetention::RetainObserved && cacheable {
+            if let Some(cached) = cached {
+                retain_observed_messages(&mut messages, &cached.messages);
+            }
+        }
         let cache_entry = if messages.is_empty() || !cacheable {
             None
         } else {
@@ -839,6 +892,43 @@ fn parse_all_messages_with_pricing_with_env_strategy(
             path,
             source_cache,
             pricing,
+            HistoryRetention::LiveFileOnly,
+            fingerprint_from_path,
+            |path, _| (parse(path), true),
+        )
+    }
+
+    /// Same as `load_or_parse_source_with_fingerprint`, for clients that
+    /// rewrite an existing transcript instead of only appending to it.
+    ///
+    /// Scoped deliberately rather than made the default. Retention is only
+    /// sound where a message carries a dedup key that identifies it by
+    /// content across files, because the retained copy has to collapse
+    /// against any live copy of the same message elsewhere. Claude's
+    /// `messageId:requestId` key does that and its lane dedups on it globally;
+    /// sources keyed by file position or by a per-scan ordinal do not, and
+    /// would double count.
+    fn load_or_parse_source_with_fingerprint_retaining_history<F, FingerprintFn>(
+        identity: message_cache::CacheIdentity,
+        path: &Path,
+        source_cache: &message_cache::SourceMessageCache,
+        pricing: Option<&pricing::PricingService>,
+        fingerprint_from_path: FingerprintFn,
+        parse: F,
+    ) -> CachedParseOutcome
+    where
+        F: Fn(&Path) -> Vec<UnifiedMessage>,
+        FingerprintFn: Fn(
+            &Path,
+            Option<&message_cache::SourceFingerprint>,
+        ) -> Option<message_cache::FingerprintStatus>,
+    {
+        load_or_parse_source_with_fingerprint_and_policy(
+            identity,
+            path,
+            source_cache,
+            pricing,
+            HistoryRetention::RetainObserved,
             fingerprint_from_path,
             |path, _| (parse(path), true),
         )
@@ -864,6 +954,7 @@ fn parse_all_messages_with_pricing_with_env_strategy(
             path,
             source_cache,
             pricing,
+            HistoryRetention::LiveFileOnly,
             fingerprint_from_path,
             |path, fingerprint| (parse(path, fingerprint), true),
         )
@@ -1141,7 +1232,13 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         .get(ClientId::Claude)
         .par_iter()
         .map(|path| {
-            load_or_parse_source_with_fingerprint(
+            // Claude Code rewrites a transcript in place on resume/compact,
+            // so a file can lose assistant turns it already published. The
+            // retaining loader keeps those turns in the cache entry for as
+            // long as the file itself exists; deleting the transcript still
+            // drops them via `prune_missing_files`, which is what makes local
+            // disk remain the source of truth.
+            load_or_parse_source_with_fingerprint_retaining_history(
                 message_cache::CacheIdentity::for_client(ClientId::Claude),
                 path,
                 &source_cache,
@@ -1283,6 +1380,7 @@ fn parse_all_messages_with_pricing_with_env_strategy(
                 path,
                 &source_cache,
                 pricing,
+                HistoryRetention::LiveFileOnly,
                 message_cache::SourceFingerprint::check_path_samples_only,
                 |path, _| {
                     let parsed = sessions::gemini::parse_gemini_file_with_cache_status(path);
@@ -5002,6 +5100,211 @@ mod tests {
                 (second[0].cost - 0.05).abs() < 1e-9,
                 "authoritative cost must survive the cache hit, got {}",
                 second[0].cost
+            );
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    /// Claude Code rewrites a session transcript in place on resume/compact:
+    /// the file keeps its path and session id but loses already-written
+    /// assistant turns. Because the source cache tracks live file content, a
+    /// rescan after such a rewrite used to drop those turns from history for
+    /// good — and `tokscale submit` feeds the leaderboard from the same
+    /// recompute. See https://github.com/junhoyeo/tokscale/issues/994.
+    #[test]
+    #[serial_test::serial]
+    fn test_claude_in_place_rewrite_preserves_previously_seen_messages() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            let claude_dir = source_home.path().join(".claude/projects/myproject");
+            std::fs::create_dir_all(&claude_dir).unwrap();
+            let transcript = claude_dir.join("conversation.jsonl");
+
+            let turn_one = r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":7,"cache_creation_input_tokens":3}}}"#;
+            let turn_two = r#"{"type":"assistant","timestamp":"2024-12-01T10:05:00.000Z","requestId":"req_002","message":{"id":"msg_002","model":"claude-3-5-sonnet","usage":{"input_tokens":200,"output_tokens":60,"cache_read_input_tokens":11,"cache_creation_input_tokens":5}}}"#;
+            let turn_three = r#"{"type":"assistant","timestamp":"2024-12-01T10:10:00.000Z","requestId":"req_003","message":{"id":"msg_003","model":"claude-3-5-sonnet","usage":{"input_tokens":300,"output_tokens":70,"cache_read_input_tokens":13,"cache_creation_input_tokens":17}}}"#;
+
+            std::fs::write(
+                &transcript,
+                format!("{turn_one}\n{turn_two}\n{turn_three}\n"),
+            )
+            .unwrap();
+
+            let before = parse_all_messages_with_pricing_with_env_strategy(
+                source_home.path().to_str().unwrap(),
+                &["claude".to_string()],
+                None,
+                false,
+                &scanner::ScannerSettings::default(),
+            );
+            assert_eq!(before.len(), 3, "cold scan must see all three turns");
+            let before_output: i64 = before.iter().map(|m| m.tokens.output).sum();
+            let before_cache_read: i64 = before.iter().map(|m| m.tokens.cache_read).sum();
+            let before_cache_write: i64 = before.iter().map(|m| m.tokens.cache_write).sum();
+            assert_eq!(before_output, 180);
+
+            // The rewrite: same path, same session, two assistant turns gone.
+            std::fs::write(&transcript, format!("{turn_three}\n")).unwrap();
+
+            let after = parse_all_messages_with_pricing_with_env_strategy(
+                source_home.path().to_str().unwrap(),
+                &["claude".to_string()],
+                None,
+                false,
+                &scanner::ScannerSettings::default(),
+            );
+
+            assert_eq!(
+                after.len(),
+                3,
+                "an in-place rewrite must not retire messages the cache already observed"
+            );
+            assert_eq!(
+                after.iter().map(|m| m.tokens.output).sum::<i64>(),
+                before_output
+            );
+            assert_eq!(
+                after.iter().map(|m| m.tokens.cache_read).sum::<i64>(),
+                before_cache_read
+            );
+            assert_eq!(
+                after.iter().map(|m| m.tokens.cache_write).sum::<i64>(),
+                before_cache_write
+            );
+
+            // Retention has to survive its own round trip through the cache:
+            // the rewritten entry is what the NEXT scan reads back, so a
+            // union that is computed but not persisted drifts one run later.
+            let third = parse_all_messages_with_pricing_with_env_strategy(
+                source_home.path().to_str().unwrap(),
+                &["claude".to_string()],
+                None,
+                false,
+                &scanner::ScannerSettings::default(),
+            );
+            assert_eq!(
+                third.len(),
+                3,
+                "the retained turns must be written back to the cache, not just returned once"
+            );
+            assert_eq!(
+                third.iter().map(|m| m.tokens.output).sum::<i64>(),
+                before_output
+            );
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    /// Retention is only sound because a retained message still collapses
+    /// against a live copy of itself somewhere else. Claude Code forks a
+    /// session into a new transcript that replays earlier turns, so the same
+    /// `messageId:requestId` legitimately appears in two files at once.
+    #[test]
+    #[serial_test::serial]
+    fn test_claude_retained_message_collapses_against_a_forked_transcript() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            let claude_dir = source_home.path().join(".claude/projects/myproject");
+            std::fs::create_dir_all(&claude_dir).unwrap();
+            let original = claude_dir.join("original.jsonl");
+
+            let turn_one = r#"{"type":"assistant","timestamp":"2024-12-01T10:00:00.000Z","requestId":"req_001","message":{"id":"msg_001","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":50}}}"#;
+            let turn_two = r#"{"type":"assistant","timestamp":"2024-12-01T10:05:00.000Z","requestId":"req_002","message":{"id":"msg_002","model":"claude-3-5-sonnet","usage":{"input_tokens":200,"output_tokens":60}}}"#;
+
+            std::fs::write(&original, format!("{turn_one}\n{turn_two}\n")).unwrap();
+            let before = parse_all_messages_with_pricing_with_env_strategy(
+                source_home.path().to_str().unwrap(),
+                &["claude".to_string()],
+                None,
+                false,
+                &scanner::ScannerSettings::default(),
+            );
+            assert_eq!(before.len(), 2);
+
+            // The fork: turn two moves to a new transcript and leaves the old
+            // one. Both files now claim it, and only one may be counted.
+            std::fs::write(&original, format!("{turn_one}\n")).unwrap();
+            std::fs::write(claude_dir.join("forked.jsonl"), format!("{turn_two}\n")).unwrap();
+
+            let after = parse_all_messages_with_pricing_with_env_strategy(
+                source_home.path().to_str().unwrap(),
+                &["claude".to_string()],
+                None,
+                false,
+                &scanner::ScannerSettings::default(),
+            );
+            assert_eq!(
+                after.len(),
+                2,
+                "a retained message must not be counted alongside its live copy"
+            );
+            assert_eq!(after.iter().map(|m| m.tokens.output).sum::<i64>(), 110);
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    /// The retention above must not resurrect a session the user deleted:
+    /// `prune_missing_files` drops the entry when the file is gone, which is
+    /// the behavior `d9df8c9c` (local session cleanup) depends on.
+    #[test]
+    #[serial_test::serial]
+    fn test_claude_deleted_transcript_is_not_resurrected_by_retention() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            let claude_dir = source_home.path().join(".claude/projects/myproject");
+            std::fs::create_dir_all(&claude_dir).unwrap();
+            let transcript = claude_dir.join("conversation.jsonl");
+            std::fs::write(
+                &transcript,
+                "{\"type\":\"assistant\",\"timestamp\":\"2024-12-01T10:00:00.000Z\",\"requestId\":\"req_001\",\"message\":{\"id\":\"msg_001\",\"model\":\"claude-3-5-sonnet\",\"usage\":{\"input_tokens\":100,\"output_tokens\":50}}}\n",
+            )
+            .unwrap();
+
+            let before = parse_all_messages_with_pricing_with_env_strategy(
+                source_home.path().to_str().unwrap(),
+                &["claude".to_string()],
+                None,
+                false,
+                &scanner::ScannerSettings::default(),
+            );
+            assert_eq!(before.len(), 1);
+
+            std::fs::remove_file(&transcript).unwrap();
+
+            let after = parse_all_messages_with_pricing_with_env_strategy(
+                source_home.path().to_str().unwrap(),
+                &["claude".to_string()],
+                None,
+                false,
+                &scanner::ScannerSettings::default(),
+            );
+            assert!(
+                after.is_empty(),
+                "a deleted transcript stays deleted; local disk remains the source of truth"
             );
         }
 

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -831,6 +831,16 @@ fn parser_version(client: ClientId) -> u32 {
         // Desktop v1 parsed a non-ACP shape and did not track its CLI title
         // lookup; its timestamp handling is unaffected by the #890 follow-up.
         ClientId::DevinDesktop => 2,
+        // WARNING — bumping this discards data that is not recoverable by
+        // re-parsing. Claude Code rewrites a transcript in place on
+        // resume/compact, and since #994 a Claude entry deliberately carries
+        // assistant turns the live file no longer contains (see
+        // `HistoryRetention::RetainObserved`). A bump drops every entry, and
+        // the cold rebuild that follows sees only the compacted file — so it
+        // silently retires those turns from every user's totals and
+        // reintroduces the exact drift #994 reported. Bumping for a real
+        // parser change is still correct; do it knowing the cost, and prefer
+        // a fix that does not need one.
         ClientId::Claude => 2,
         // Junie's usage-event timestamp is now back-calculated to the call
         // start (timestampMs - usage.time) instead of the recorded
@@ -924,6 +934,11 @@ pub(crate) struct CachedSourceEntry {
     parser_version: u32,
     pub path: CachedPath,
     pub fingerprint: SourceFingerprint,
+    /// Not always a pure function of the source file. For a namespace that
+    /// `retained_history_key_filter` covers, this can hold messages the live
+    /// file no longer contains, and re-parsing will not reproduce them — the
+    /// cache is the only copy. That is what makes a parser_version bump for
+    /// those namespaces lossy rather than merely cold.
     pub messages: Vec<UnifiedMessage>,
     pub fallback_timestamp_indices: Vec<usize>,
     pub codex_incremental: Option<CodexIncrementalCache>,
@@ -953,6 +968,62 @@ impl CachedSourceEntry {
         CacheIdentity::current_for_namespace(&self.parser_namespace)
             .is_some_and(|identity| identity.parser_version == self.parser_version)
     }
+
+    /// Carry forward keyed messages an entry already on disk holds for this
+    /// same path and this one does not.
+    ///
+    /// Two processes can scan at once — a running TUI and a `tokscale submit`,
+    /// say. Each loads the entry, parses, and saves back, and the last writer
+    /// replaces the other's entry wholesale. For most namespaces that is
+    /// harmless: the loser's messages come from the same bytes and reappear on
+    /// the next scan. For a namespace that retains history it is not, because
+    /// the messages the loser observed are gone from the live file too, so
+    /// nothing will ever put them back.
+    ///
+    /// Same filter as the parse-time merge: a key that is only unique within
+    /// one file must not outlive the bytes that produced it.
+    fn absorb_retained_history(&mut self, stored: &CachedSourceEntry) {
+        let Some(key_is_globally_stable) = retained_history_key_filter(&self.parser_namespace)
+        else {
+            return;
+        };
+        // A stored entry from a different parser version describes a layout
+        // this one does not agree with; let the wholesale replace stand.
+        if stored.parser_namespace != self.parser_namespace
+            || stored.parser_version != self.parser_version
+        {
+            return;
+        }
+
+        let mut seen: HashSet<String> = self
+            .messages
+            .iter()
+            .filter_map(|message| message.dedup_key.clone())
+            .collect();
+        for message in &stored.messages {
+            let Some(key) = message.dedup_key.as_ref() else {
+                continue;
+            };
+            if !key_is_globally_stable(key) {
+                continue;
+            }
+            if seen.insert(key.clone()) {
+                self.messages.push(message.clone());
+            }
+        }
+    }
+}
+
+/// The dedup-key filter for namespaces whose entries carry history the live
+/// file may no longer contain, or `None` for namespaces that do not retain
+/// history.
+///
+/// Mirrors the `HistoryRetention` choice each lane makes in `lib.rs`. It has to
+/// exist here as well because the save merge is the other place a retained
+/// message can be dropped, and it must honor the same contract.
+fn retained_history_key_filter(namespace: &str) -> Option<fn(&str) -> bool> {
+    (namespace == ClientId::Claude.as_str())
+        .then_some(crate::sessions::claudecode::dedup_key_is_globally_stable)
 }
 
 /// The envelope is deliberately independent from CachedSourceEntry's binary
@@ -1240,7 +1311,15 @@ impl SourceMessageCache {
             if let Some(dirty) = dirty_by_shard.get(&shard_key) {
                 for key in dirty {
                     if let Some(entry) = self.entries.get(key) {
-                        merged_entries.insert(key.clone(), entry.clone());
+                        let mut entry = entry.clone();
+                        // Another process holding the lock before us may have
+                        // stored history for this same path that our in-memory
+                        // entry never saw. Union it in rather than replacing
+                        // wholesale — see `absorb_retained_history`.
+                        if let Some(stored) = merged_entries.remove(key) {
+                            entry.absorb_retained_history(&stored);
+                        }
+                        merged_entries.insert(key.clone(), entry);
                     }
                 }
             }
@@ -3194,6 +3273,188 @@ mod tests {
                 .get(identity, &path)
                 .expect("recreated source cache entry should survive stale delete");
             assert_eq!(entry.messages[0].session_id, "fresh-session");
+        }
+
+        restore_cache_env(prev_env);
+    }
+
+    fn keyed_message(namespace: &str, session_id: &str, dedup_key: &str) -> UnifiedMessage {
+        UnifiedMessage::new_with_dedup(
+            namespace,
+            "claude-3-5-sonnet",
+            "anthropic",
+            session_id,
+            1,
+            TokenBreakdown {
+                input: 1,
+                output: 2,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            0.0,
+            Some(dedup_key.to_string()),
+        )
+    }
+
+    fn entry_with_messages(
+        identity: CacheIdentity,
+        path: &Path,
+        messages: Vec<UnifiedMessage>,
+    ) -> CachedSourceEntry {
+        CachedSourceEntry::new(
+            identity,
+            path,
+            SourceFingerprint::from_path(path).unwrap(),
+            messages,
+            Vec::new(),
+            None,
+        )
+    }
+
+    /// A Claude entry can hold assistant turns the live transcript no longer
+    /// contains (an in-place compaction dropped them). Two processes scanning
+    /// at once therefore hold genuinely different histories for one path, and
+    /// the wholesale last-writer-wins replace would retire the loser's turns
+    /// for good — the live file cannot hand them back.
+    #[test]
+    #[serial_test::serial]
+    fn test_save_if_dirty_unions_retained_history_for_the_same_path() {
+        let temp_home = TempDir::new().unwrap();
+        let prev_env = sandbox_cache_env(temp_home.path());
+
+        {
+            let source_dir = TempDir::new().unwrap();
+            let path = source_dir.path().join("conversation.jsonl");
+            std::fs::write(&path, b"{\"id\":\"live\"}\n").unwrap();
+            let identity = CacheIdentity::for_client(ClientId::Claude);
+            let namespace = ClientId::Claude.as_str();
+
+            // Both processes carry the turn the file still has. Only the first
+            // ever observed the one a compaction later removed.
+            let shared = keyed_message(namespace, "session", "msg_shared:req_shared");
+            let observed_only_by_first =
+                keyed_message(namespace, "session", "msg_dropped:req_dropped");
+
+            let mut observer = SourceMessageCache::load();
+            observer.insert(entry_with_messages(
+                identity,
+                &path,
+                vec![shared.clone(), observed_only_by_first],
+            ));
+            observer.save_if_dirty();
+
+            let mut latecomer = SourceMessageCache::load();
+            latecomer.insert(entry_with_messages(identity, &path, vec![shared]));
+            latecomer.save_if_dirty();
+
+            let loaded = SourceMessageCache::load();
+            let entry = loaded.get(identity, &path).expect("entry should survive");
+            let keys: HashSet<&str> = entry
+                .messages
+                .iter()
+                .filter_map(|message| message.dedup_key.as_deref())
+                .collect();
+            assert!(
+                keys.contains("msg_dropped:req_dropped"),
+                "a concurrent writer must not discard history it never saw, got {keys:?}"
+            );
+            assert_eq!(
+                entry.messages.len(),
+                2,
+                "and must not duplicate the shared turn"
+            );
+        }
+
+        restore_cache_env(prev_env);
+    }
+
+    /// The union is scoped to keys that stay valid wherever the message is
+    /// written. A Claude tool-result key embeds the transcript's file stem, so
+    /// a carried-forward copy could never collapse against the same tool
+    /// result replayed into a forked transcript — both would count.
+    #[test]
+    #[serial_test::serial]
+    fn test_save_if_dirty_does_not_union_path_scoped_keys() {
+        let temp_home = TempDir::new().unwrap();
+        let prev_env = sandbox_cache_env(temp_home.path());
+
+        {
+            let source_dir = TempDir::new().unwrap();
+            let path = source_dir.path().join("conversation.jsonl");
+            std::fs::write(&path, b"{\"id\":\"live\"}\n").unwrap();
+            let identity = CacheIdentity::for_client(ClientId::Claude);
+            let namespace = ClientId::Claude.as_str();
+
+            let shared = keyed_message(namespace, "session", "msg_shared:req_shared");
+            let tool_result = keyed_message(
+                namespace,
+                "session",
+                "claude:tool_result:conversation:tool_result:toolu_1",
+            );
+
+            let mut observer = SourceMessageCache::load();
+            observer.insert(entry_with_messages(
+                identity,
+                &path,
+                vec![shared.clone(), tool_result],
+            ));
+            observer.save_if_dirty();
+
+            let mut latecomer = SourceMessageCache::load();
+            latecomer.insert(entry_with_messages(identity, &path, vec![shared]));
+            latecomer.save_if_dirty();
+
+            let loaded = SourceMessageCache::load();
+            let entry = loaded.get(identity, &path).expect("entry should survive");
+            assert_eq!(
+                entry.messages.len(),
+                1,
+                "path-scoped keys must not outlive the bytes that produced them"
+            );
+        }
+
+        restore_cache_env(prev_env);
+    }
+
+    /// The union exists only for namespaces that retain history. Everywhere
+    /// else the live file is the whole truth, so a stale entry must still be
+    /// replaced outright rather than accumulating.
+    #[test]
+    #[serial_test::serial]
+    fn test_save_if_dirty_still_replaces_entries_for_non_retaining_clients() {
+        let temp_home = TempDir::new().unwrap();
+        let prev_env = sandbox_cache_env(temp_home.path());
+
+        {
+            let source_dir = TempDir::new().unwrap();
+            let path = source_dir.path().join("rollout.jsonl");
+            std::fs::write(&path, b"{\"id\":\"live\"}\n").unwrap();
+            let identity = CacheIdentity::for_client(ClientId::Codex);
+            let namespace = ClientId::Codex.as_str();
+
+            let mut observer = SourceMessageCache::load();
+            observer.insert(entry_with_messages(
+                identity,
+                &path,
+                vec![
+                    keyed_message(namespace, "session", "codex-key-a"),
+                    keyed_message(namespace, "session", "codex-key-b"),
+                ],
+            ));
+            observer.save_if_dirty();
+
+            let mut latecomer = SourceMessageCache::load();
+            latecomer.insert(entry_with_messages(
+                identity,
+                &path,
+                vec![keyed_message(namespace, "session", "codex-key-a")],
+            ));
+            latecomer.save_if_dirty();
+
+            let loaded = SourceMessageCache::load();
+            let entry = loaded.get(identity, &path).expect("entry should survive");
+            assert_eq!(entry.messages.len(), 1);
         }
 
         restore_cache_env(prev_env);

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -923,6 +923,35 @@ struct ClaudeToolResultUsage {
     dedup_key: Option<String>,
 }
 
+/// The segment that marks a dedup key as scoped to one transcript file.
+/// `tool_result_dedup_key` puts the session id — which is the transcript's
+/// file stem — behind it.
+const PATH_SCOPED_KEY_MARKER: &str = ":tool_result:";
+
+/// Whether a dedup key this parser mints identifies its message by content
+/// wherever that message happens to be written.
+///
+/// Assistant keys are `messageId:requestId` (or `message:{id}` when the
+/// transcript recorded no request id). Both come straight out of the API
+/// response, so the same turn replayed into a forked transcript keys
+/// identically and the two copies collapse at the cross-file dedup.
+/// Tool-result keys do not: they embed the session id, so the same tool result
+/// under a new filename is a different key and both copies count.
+///
+/// Only globally stable keys may be carried across an in-place rewrite. A
+/// retained path-scoped copy could never collapse against a live replay of
+/// itself, so retaining one would double count its input tokens.
+pub(crate) fn dedup_key_is_globally_stable(key: &str) -> bool {
+    !key.contains(PATH_SCOPED_KEY_MARKER)
+}
+
+/// A tool_use id is only unique within the conversation that issued it, so the
+/// key is deliberately scoped to the session. See `dedup_key_is_globally_stable`
+/// for what that costs.
+fn tool_result_dedup_key(client_id: &str, session_id: &str, usage_key: &str) -> String {
+    format!("{client_id}{PATH_SCOPED_KEY_MARKER}{session_id}:{usage_key}")
+}
+
 struct ClaudeToolResultContext<'a> {
     entry: &'a ClaudeEntry,
     last_model: Option<&'a str>,
@@ -991,12 +1020,9 @@ fn extract_claude_tool_result_message(
             reasoning: 0,
         },
         0.0,
-        usage.dedup_key.map(|key| {
-            format!(
-                "{}:tool_result:{}:{key}",
-                context.client_id, context.session_id
-            )
-        }),
+        usage
+            .dedup_key
+            .map(|key| tool_result_dedup_key(context.client_id, context.session_id, &key)),
     );
     message.message_count = 0;
     message.agent = context.sidechain_agent;
@@ -2146,6 +2172,24 @@ mod tests {
             Some(expected_dedup_key.as_str())
         );
         assert_eq!(messages[0].message_count, 0);
+    }
+
+    /// History retention across an in-place transcript rewrite is only sound
+    /// for keys that identify a message by content across files. This pins
+    /// which of the parser's own key shapes qualify, so a future key change
+    /// trips here rather than silently making a retained copy double count.
+    #[test]
+    fn test_only_content_derived_dedup_keys_are_globally_stable() {
+        let tool_result =
+            tool_result_dedup_key("claude", "0f1e2d3c-session", "tool_result:toolu_1");
+        assert!(
+            !dedup_key_is_globally_stable(&tool_result),
+            "tool-result keys embed the transcript file stem: {tool_result}"
+        );
+
+        // The two shapes `parse_claude_file` mints for assistant turns.
+        assert!(dedup_key_is_globally_stable("msg_01ABC:req_01XYZ"));
+        assert!(dedup_key_is_globally_stable("message:msg_01ABC"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #994.

## The mechanism, confirmed

The reporter is right about the cause, and the report is unusually precise. I
reproduced it in-tree before changing anything.

Claude Code rewrites a session JSONL in place on resume/compact. The file keeps
its path and its session id, but loses assistant turns it had already written.
The source cache is built to track live file content — the fingerprint reports
`Changed`, and `load_or_parse_source_with_fingerprint_and_policy` re-parses and
replaces the entry — so on the next scan those turns leave every total. `submit`
recomputes from the same parse, so submitted numbers move with them.

Three assistant turns, rewrite the file down to one, rescan:

```
assertion `left == right` failed: an in-place rewrite must not retire messages the cache already observed
  left: 1
 right: 3
```

Nothing in parsing is involved, which matches the reporter's finding that every
field lands on the drifted prediction exactly. Per-message accounting, the dedup
key, the per-field max merge and the discovery walk are all untouched here.

## What is actually still exposed on the server

Worth stating, because it changes how urgent this is and it is not what the
issue assumes.

`mergeClientBreakdownsWithRegressionGuard` (`packages/frontend/src/lib/db/helpers.ts:154`)
defends every per-`(day, client)` token decrease, added in `d9df8c9c` after a
user deleted local sessions and lost real history. So for a day that only
*loses* tokens, stored history is already protected and the leaderboard does not
move.

The hole is that the guard compares day totals. A rewrite that drops turns from
day D while D also gains new work nets to an increase, the guard accepts the new
value, and the dropped tokens are silently absent from the new baseline —
permanently. Compaction happens mid-session, so D is usually the active day.
That is the case this fixes, and it is the common one rather than the edge one.

Fixing it in the CLI is also the right layer: the server stops having to see a
decrease at all, rather than growing a second ratchet. That matters because
`docs/ratchet-inflation-recovery.md` is about the ratchet being the *cause* of a
different failure (#960); reducing spurious decreases is complementary to that
document, and this PR does not touch anything it pins.

## The fix

The Claude lane loads through a retaining variant of the same helper. When a
file changes under a cache entry we still hold, messages that entry recorded and
the fresh parse no longer contains are carried forward — into both the returned
messages and the rewritten cache entry.

The live file stays authoritative for everything it still contains: a key
present on both sides keeps the freshly parsed message, so a corrected re-parse
still wins and nothing freezes at a stale value. Only keys the file no longer
carries are carried forward, and only when they have a dedup key.

Two properties make this safe, and both have a test:

- **A retained copy still collapses against a live copy elsewhere.** Claude's
  `messageId:requestId` key is content-derived and its lane dedups on it across
  files, so a forked transcript that replays the same turn counts it once.
- **Deletion still deletes.** `prune_missing_files` drops the entry when the
  file is gone, so local disk remains the source of truth and the `d9df8c9c`
  cleanup scenario is unchanged.

Scoped to Claude on purpose, not made the default: most other lanes key on file
position or a per-scan ordinal, where a retained copy would double count against
its live copy. There is a `Directive:` trailer on the commit saying so.

`parser_version(ClientId::Claude)` is deliberately **not** bumped. The entry
layout is unchanged, and existing warm caches already hold the pre-rewrite
turns — so the fix starts protecting users on their next scan instead of after a
cold rebuild.

## Evidence

The regression test fails against the unfixed code. Reverting only the fix (the
Claude call site back to the non-retaining loader) and re-running:

```
running 3 tests
test tests::test_claude_retained_message_collapses_against_a_forked_transcript ... ok
test tests::test_claude_deleted_transcript_is_not_resurrected_by_retention ... ok
test tests::test_claude_in_place_rewrite_preserves_previously_seen_messages ... FAILED

thread 'tests::test_claude_in_place_rewrite_preserves_previously_seen_messages' panicked at crates/tokscale-core/src/lib.rs:5165:13:
assertion `left == right` failed: an in-place rewrite must not retire messages the cache already observed
  left: 1
 right: 3

test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 1321 filtered out
```

With the fix restored:

```
running 3 tests
test tests::test_claude_deleted_transcript_is_not_resurrected_by_retention ... ok
test tests::test_claude_retained_message_collapses_against_a_forked_transcript ... ok
test tests::test_claude_in_place_rewrite_preserves_previously_seen_messages ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 1321 filtered out
```

The other two pass in both states by design — they are guards on the fix, not
reproductions of the bug, and they would fail against a naive freeze-forever
store.

Full suites:

```
cargo test -p tokscale-core
test result: ok. 1323 passed; 0 failed; 1 ignored
test result: ok. 10 passed; 0 failed
test result: ok. 4 passed; 0 failed
test result: ok. 14 passed; 0 failed
test result: ok. 3 passed; 0 failed
test result: ok. 4 passed; 0 failed

cargo test -p tokscale-cli
test result: ok. 973 passed; 0 failed; 1 ignored
test result: ok. 133 passed; 0 failed

cargo clippy --all-targets -- -D warnings   # clean
```

The third assertion in the main test is deliberate: it scans a *third* time, so
a union that is computed but never persisted would drift one run later instead
of passing.

## What I deliberately did not fix

- **The reporter's suggested shape — an append-only store that never deletes.**
  A store that never deletes resurrects sessions the user deleted, which is the
  exact failure `d9df8c9c` exists for. Retention here is bounded by file
  existence, which is the narrower rule that gets the same result for #994.
- **The other clients.** Only the Claude lane retains. Any other lane needs its
  dedup key checked first.
- **The pre-existing tool-result double count across a session fork.** Those
  keys are `client:tool_result:session:id`, so a fork already counts them twice
  today. This PR neither creates nor heals that.
- **Cross-file ordering.** A retained streaming partial in file A is visited
  before a complete copy in file B, and first-wins keeps the partial. Pre-existing
  cross-file behavior; making live copies globally win needs a two-pass change to
  `CachedParseOutcome` and is not worth it for this.
- **The reporter's second finding — `input` double counting `tool_result`
  content on top of the API-reported `input_tokens`.** Genuinely separate, and
  they say so; it deserves its own issue rather than a rider here.
- **Anything server-side.** No frontend files changed, so no frontend suite was
  run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Claude transcript rewrites from dropping previously counted assistant turns. Retains only globally stable keyed turns on in‑place rewrites and survives concurrent scans so totals stay steady across scans and submits.

- **Bug Fixes**
  - Retention is limited to globally stable keys: assistant `messageId:requestId` kept; path-scoped `tool_result` records excluded to avoid double counts.
  - Added save-time union for same-path entries to prevent last-writer-wins from discarding retained history; live file stays authoritative where keys overlap.
  - Scoped to Claude only; others unchanged. Deleting a transcript still prunes the cache; no resurrection.
  - No parser version bump; warm caches benefit now. README documents the Claude cache caveat for compacted sessions.

<sup>Written for commit 51366b396aa189f6b348fb0590b61a67de66e1d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

