### PR TITLE
test(pricing): cover OrcaRouter reseller semantics

### DIFF
--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -5060,8 +5060,13 @@ mod tests {
     }
 
     #[test]
-    fn orcarouter_litellm_result_uses_progressive_long_context_pricing() {
-        let result = openai_272k_result("orcarouter/gpt-5.5", "LiteLLM");
+    fn orcarouter_hint_keeps_litellm_fallback_on_progressive_long_context_pricing() {
+        // OrcaRouter can fall back to LiteLLM's unscoped OpenAI row when its
+        // provider-specific catalog has no match. The provider hint, not an
+        // invented OrcaRouter LiteLLM key, must keep that fallback on normal
+        // progressive tiers instead of applying direct-OpenAI full-request
+        // 272K semantics.
+        let result = openai_272k_result("gpt-5.5", "LiteLLM");
         let usage = TokenBreakdown {
             input: 200_000,
             output: 10_000,
@@ -5069,14 +5074,24 @@ mod tests {
             ..Default::default()
         };
 
+        assert!(uses_openai_full_request_272k_pricing(
+            &result,
+            Some("openai")
+        ));
         assert!(!uses_openai_full_request_272k_pricing(
             &result,
             Some("orcarouter")
         ));
 
-        let cost = compute_cost_for_lookup(&result, Some("orcarouter"), &usage);
-        let expected = (200_000.0 * 0.000005) + (10_000.0 * 0.000030) + (72_001.0 * 0.0000005);
-        assert!((cost - expected).abs() < 1e-12);
+        let direct_openai_cost = compute_cost_for_lookup(&result, Some("openai"), &usage);
+        let direct_openai_expected =
+            (200_000.0 * 0.000010) + (10_000.0 * 0.000045) + (72_001.0 * 0.000001);
+        assert!((direct_openai_cost - direct_openai_expected).abs() < 1e-12);
+
+        let orcarouter_cost = compute_cost_for_lookup(&result, Some("orcarouter"), &usage);
+        let orcarouter_expected =
+            (200_000.0 * 0.000005) + (10_000.0 * 0.000030) + (72_001.0 * 0.0000005);
+        assert!((orcarouter_cost - orcarouter_expected).abs() < 1e-12);
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -4249,6 +4249,45 @@ mod tests {
         assert_eq!(unhinted.pricing.input_cost_per_token, Some(30e-6));
     }
 
+    /// Regression (#1004 follow-up): a reseller provider hint must select the
+    /// reseller-scoped models.dev row instead of a direct upstream catalog row
+    /// with the same terminal model id.
+    #[test]
+    fn orcarouter_hint_selects_orcarouter_models_dev_row() {
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "openai/gpt-5.5".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(5e-6),
+                output_cost_per_token: Some(30e-6),
+                ..Default::default()
+            },
+        );
+        let mut models_dev = HashMap::new();
+        models_dev.insert(
+            "orcarouter/openai/gpt-5.5".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(8e-6),
+                output_cost_per_token: Some(48e-6),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new_with_models_dev(
+            HashMap::new(),
+            openrouter,
+            HashMap::new(),
+            HashMap::new(),
+            models_dev,
+        );
+
+        let result = lookup
+            .lookup_with_provider("gpt-5.5", Some("orcarouter"))
+            .unwrap();
+        assert_eq!(result.source, "Models.dev");
+        assert_eq!(result.matched_key, "orcarouter/openai/gpt-5.5");
+        assert_eq!(result.pricing.input_cost_per_token, Some(8e-6));
+    }
+
     /// Regression (#707 review, cubic follow-up): the provider-hint pin must
     /// also beat the unscoped OpenRouter MODEL-PART fallback, not just the
     /// separator-normalized passes. When the hinted provider's models.dev key
@@ -5018,6 +5057,26 @@ mod tests {
         ] {
             assert!(!uses_openai_full_request_272k_pricing(&result, provider));
         }
+    }
+
+    #[test]
+    fn orcarouter_litellm_result_uses_progressive_long_context_pricing() {
+        let result = openai_272k_result("orcarouter/gpt-5.5", "LiteLLM");
+        let usage = TokenBreakdown {
+            input: 200_000,
+            output: 10_000,
+            cache_read: 72_001,
+            ..Default::default()
+        };
+
+        assert!(!uses_openai_full_request_272k_pricing(
+            &result,
+            Some("orcarouter")
+        ));
+
+        let cost = compute_cost_for_lookup(&result, Some("orcarouter"), &usage);
+        let expected = (200_000.0 * 0.000005) + (10_000.0 * 0.000030) + (72_001.0 * 0.0000005);
+        assert!((cost - expected).abs() < 1e-12);
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #1004 by @jinhaosong-source.

## What changed

- Add a provider-aware lookup regression proving an OrcaRouter hint selects the nested `orcarouter/openai/...` models.dev row over a direct upstream row.
- Add a long-context cost regression proving OrcaRouter reseller keys use progressive pricing instead of direct-OpenAI full-request 272K semantics.

## Validation

- `cargo test -p tokscale-core pricing::lookup::tests::orcarouter`
- `cargo test -p tokscale-core pricing::lookup::tests --lib`
- `cargo clippy -p tokscale-core --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add regression tests for OrcaRouter reseller pricing behavior in `tokscale-core`.

- Ensures an `orcarouter` provider hint selects the `orcarouter/openai/gpt-5.5` models.dev row over a direct upstream entry.
- Verifies reseller keys use progressive long-context pricing, not OpenAI full-request 272K semantics, including the reachable LiteLLM fallback when the provider catalog has no match.

<sup>Written for commit cdbb8639c950c2a6c11dd6ef58ad2a5983ff526e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

