### PR TITLE
ci(test): run the suite on windows-latest (advisory) and fix the $HOME redirect

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -76,13 +76,25 @@ jobs:
   # Windows is a first-class target - `build-native.yml` ships
   # x86_64/aarch64-pc-windows-msvc artifacts - but until #997 nothing ever
   # *executed* a test there, so Windows-only defects reached users unseen.
-  # The matrix is a hard gate, not `continue-on-error`: an advisory job that
-  # nobody is required to read reproduces the exact failure mode this is
-  # meant to close, and the suite is green on windows-latest as of this
-  # change, so there is nothing to grandfather.
+  #
+  # The windows leg is advisory (`continue-on-error`) and Ubuntu stays a hard
+  # gate. That split is deliberate and temporary. Running the suite for the
+  # first time found 33 pre-existing failures that no one has ever seen,
+  # because cargo used to stop at the first failing binary and nine of the ten
+  # never ran at all. They are not one bug: they span at least six unrelated
+  # root causes, and two of those groups (the crush registry scan returning
+  # nothing, cc-mirror attributing the wrong provider) look like real Windows
+  # defects rather than test artefacts. Blocking every PR on them would mean
+  # either reverting this job or landing a 30-plus-fix change nobody can
+  # review, so the signal goes in first and the failures get fixed against a
+  # visible baseline. See #1014 for the enumerated groups.
+  #
+  # This must not become permanent: an advisory job nobody reads is how #997
+  # happened. Flip `continue-on-error` off as soon as #1014 closes.
   coverage:
     name: Code Coverage
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     strategy:
       # Both platforms must report. Cancelling the Windows leg the moment
       # Ubuntu fails (or vice versa) would hide whether a failure is

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -73,9 +73,24 @@ jobs:
       - name: Run Clippy (strict)
         run: cargo clippy --locked --workspace --all-features -- -D warnings
 
+  # Windows is a first-class target - `build-native.yml` ships
+  # x86_64/aarch64-pc-windows-msvc artifacts - but until #997 nothing ever
+  # *executed* a test there, so Windows-only defects reached users unseen.
+  # The matrix is a hard gate, not `continue-on-error`: an advisory job that
+  # nobody is required to read reproduces the exact failure mode this is
+  # meant to close, and the suite is green on windows-latest as of this
+  # change, so there is nothing to grandfather.
   coverage:
     name: Code Coverage
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Both platforms must report. Cancelling the Windows leg the moment
+      # Ubuntu fails (or vice versa) would hide whether a failure is
+      # cross-platform or platform-specific - the single most useful bit of
+      # information when triaging.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     permissions:
       contents: write
@@ -99,15 +114,20 @@ jobs:
           restore-keys: |
             coverage-${{ runner.os }}-cargo-
 
+      # `--no-fail-fast` because cargo otherwise stops at the first test
+      # binary that fails and never runs the rest. That is precisely how #997
+      # went unnoticed for so long: twelve failures in `tokscale-cli` meant
+      # the other nine binaries produced no result at all, so a contributor
+      # could not tell their own breakage from the pre-existing set.
       - name: Run tests
-        run: cargo test --workspace --all-features
+        run: cargo test --workspace --all-features --no-fail-fast
 
       - name: Install cargo-tarpaulin
-        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: taiki-e/install-action@cargo-tarpaulin
 
       - name: Generate coverage report
-        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           cargo tarpaulin \
             --workspace \
@@ -119,7 +139,7 @@ jobs:
             --verbose
 
       - name: Extract coverage percentage
-        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         id: coverage
         run: |
           COVERAGE=$(cat ./coverage/tarpaulin-report.json | jq -r '
@@ -149,11 +169,11 @@ jobs:
           fi
 
       - name: Create badges directory
-        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: mkdir -p .github/badges
 
       - name: Generate coverage badge
-        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: emibcn/badge-action@v2.0.4
         with:
           label: 'coverage'
@@ -162,7 +182,7 @@ jobs:
           path: .github/badges/coverage.svg
 
       - name: Commit coverage badge
-        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
@@ -177,7 +197,7 @@ jobs:
 
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v6
-        if: "!cancelled() && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')"
+        if: "!cancelled() && matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')"
         with:
           name: coverage-report
           path: ./coverage/

--- a/crates/tokscale-cli/src/antigravity.rs
+++ b/crates/tokscale-cli/src/antigravity.rs
@@ -20,7 +20,7 @@ static HTTPS_RPC_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 static HTTPS_RPC_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 
 fn home_dir() -> Result<PathBuf> {
-    dirs::home_dir().context("Could not determine home directory")
+    crate::paths::home_dir().context("Could not determine home directory")
 }
 
 fn antigravity_data_roots() -> Result<Vec<PathBuf>> {

--- a/crates/tokscale-cli/src/auth.rs
+++ b/crates/tokscale-cli/src/auth.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 const API_TOKEN_ENV_VAR: &str = "TOKSCALE_API_TOKEN";
 
 fn home_dir() -> Result<PathBuf> {
-    dirs::home_dir().context("Could not determine home directory")
+    crate::paths::home_dir().context("Could not determine home directory")
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/tokscale-cli/src/commands/autosubmit.rs
+++ b/crates/tokscale-cli/src/commands/autosubmit.rs
@@ -963,7 +963,7 @@ fn render_scheduler_spec(
 }
 
 fn render_launchd_spec(exe: &Path, settings: &AutosubmitSettings) -> Result<SchedulerSpec> {
-    let home = dirs::home_dir().context("Could not determine home directory")?;
+    let home = crate::paths::home_dir().context("Could not determine home directory")?;
     render_launchd_spec_for_home(exe, settings, &home)
 }
 
@@ -1066,7 +1066,7 @@ fn systemd_user_dir() -> Result<PathBuf> {
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
         .or_else(dirs::config_dir)
-        .or_else(|| dirs::home_dir().map(|home| home.join(".config")));
+        .or_else(|| crate::paths::home_dir().map(|home| home.join(".config")));
     Ok(config_dir
         .context("Could not determine XDG config directory")?
         .join("systemd")

--- a/crates/tokscale-cli/src/commands/autosubmit.rs
+++ b/crates/tokscale-cli/src/commands/autosubmit.rs
@@ -1967,13 +1967,30 @@ mod tests {
             SchedulerKind::WindowsTaskScheduler,
         ] {
             let spec = render_scheduler_spec(scheduler, &managed, &settings).unwrap();
-            // `Debug` escapes each `\` as `\\`, so a Windows path compared
-            // against the unescaped `to_string_lossy` never matches. Escape
-            // the needle the same way instead of rendering the spec with
-            // `Display`, which `SchedulerSpec` does not implement.
+            // Two escaping layers stack here, and #1007 only accounted for
+            // one, so this still failed on Windows.
+            //
+            // Layer 1 is the renderer: `systemd_escape_path` doubles every
+            // `\` (and turns spaces into `\x20`) *before* the value reaches
+            // the unit file, while every other renderer stores the path
+            // verbatim. Layer 2 is `Debug`, which doubles whatever it finds.
+            // A Windows path therefore appears as `\\\\` in the systemd spec
+            // and `\\` in the other three; a needle escaped once matches
+            // three of the four and silently fails the fourth.
+            //
+            // Deriving the needle through the renderer's own escaper keeps
+            // the two in step rather than restating its rules here.
+            let stored = match scheduler {
+                SchedulerKind::Systemd => systemd_escape_path(&managed),
+                _ => managed.to_string_lossy().into_owned(),
+            };
             let rendered = format!("{spec:?}");
-            let needle = managed.to_string_lossy().replace('\\', "\\\\");
-            assert!(rendered.contains(&needle));
+            let needle = stored.replace('\\', "\\\\");
+            assert!(
+                rendered.contains(&needle),
+                "{scheduler:?} spec does not reference the managed executable\n\
+                 needle: {needle}\nrendered: {rendered}"
+            );
             let absent = process_executable.to_string_lossy().replace('\\', "\\\\");
             assert!(!rendered.contains(&absent));
         }

--- a/crates/tokscale-cli/src/commands/report.rs
+++ b/crates/tokscale-cli/src/commands/report.rs
@@ -1394,10 +1394,16 @@ impl SessionPathIndex {
 /// the id from the in-file `sessionId`/`session_id` field, so they are keyed by
 /// the parsed id (with the stem kept as a fallback alias).
 fn build_session_path_index(opts: &ReportOptions) -> SessionPathIndex {
+    // Same contract as `tokscale_core::get_home_dir_string`: only
+    // `paths::home_dir` may read `$HOME`, so a Git Bash `HOME=/home/user` on
+    // Windows cannot send this scan to `C:\home\user`. `unwrap_or_default()`
+    // is retained as the last resort because indexing is best-effort, but it
+    // is now only reachable when no home resolves at all rather than whenever
+    // `HOME` was exported blank.
     let home_dir = opts
         .home_dir
         .clone()
-        .or_else(|| std::env::var("HOME").ok())
+        .or_else(|| tokscale_core::paths::home_dir().map(|p| p.to_string_lossy().into_owned()))
         .unwrap_or_default();
     let use_env_roots = opts.home_dir.is_none();
 

--- a/crates/tokscale-cli/src/commands/usage/amp.rs
+++ b/crates/tokscale-cli/src/commands/usage/amp.rs
@@ -22,7 +22,7 @@ struct ApiResult {
 }
 
 fn read_credentials() -> Result<String> {
-    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+    let home = crate::paths::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
     let path = home
         .join(".local")
         .join("share")
@@ -131,7 +131,7 @@ fn detect_plan(metrics: &[UsageMetric]) -> Option<String> {
 }
 
 pub fn has_credentials() -> bool {
-    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+    let home = crate::paths::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
     home.join(".local")
         .join("share")
         .join("amp")

--- a/crates/tokscale-cli/src/commands/usage/claude.rs
+++ b/crates/tokscale-cli/src/commands/usage/claude.rs
@@ -48,7 +48,7 @@ struct Window {
 }
 
 fn credentials_path() -> std::path::PathBuf {
-    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+    let home = crate::paths::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
     home.join(".claude").join(".credentials.json")
 }
 

--- a/crates/tokscale-cli/src/commands/usage/codex.rs
+++ b/crates/tokscale-cli/src/commands/usage/codex.rs
@@ -359,7 +359,7 @@ impl CodexAccountStore {
 }
 
 fn current_auth_paths() -> Vec<PathBuf> {
-    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    let home = crate::paths::home_dir().unwrap_or_else(|| PathBuf::from("."));
     let mut paths = Vec::new();
 
     if let Ok(codex_home) = std::env::var("CODEX_HOME") {

--- a/crates/tokscale-cli/src/commands/usage/copilot.rs
+++ b/crates/tokscale-cli/src/commands/usage/copilot.rs
@@ -52,10 +52,12 @@ fn gh_config_dir() -> std::path::PathBuf {
     if cfg!(windows) {
         return std::env::var_os("APPDATA")
             .map(std::path::PathBuf::from)
-            .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from(".")))
+            .unwrap_or_else(|| {
+                crate::paths::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."))
+            })
             .join("GitHub CLI");
     }
-    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+    let home = crate::paths::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
     home.join(".config").join("gh")
 }
 

--- a/crates/tokscale-cli/src/commands/usage/grok.rs
+++ b/crates/tokscale-cli/src/commands/usage/grok.rs
@@ -31,7 +31,7 @@ enum ProtoValue<'a> {
 fn grok_home() -> std::path::PathBuf {
     std::env::var_os("GROK_HOME")
         .map(std::path::PathBuf::from)
-        .or_else(|| dirs::home_dir().map(|home| home.join(".grok")))
+        .or_else(|| crate::paths::home_dir().map(|home| home.join(".grok")))
         .unwrap_or_else(|| std::path::PathBuf::from(".grok"))
 }
 

--- a/crates/tokscale-cli/src/commands/usage/kimi.rs
+++ b/crates/tokscale-cli/src/commands/usage/kimi.rs
@@ -71,14 +71,14 @@ fn credentials_paths() -> Vec<std::path::PathBuf> {
         .filter(|home| !home.trim().is_empty())
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|| {
-            dirs::home_dir()
+            crate::paths::home_dir()
                 .map(|h| h.join(".kimi-code"))
                 .unwrap_or_else(|| std::path::PathBuf::from("."))
         });
     paths.push(kimi_code_home.join("credentials").join("kimi-code.json"));
 
     // 2) kimi-cli
-    if let Some(home) = dirs::home_dir() {
+    if let Some(home) = crate::paths::home_dir() {
         paths.push(
             home.join(".kimi")
                 .join("credentials")
@@ -376,7 +376,7 @@ mod tests {
         // The blank-equals-unset assertion below needs no such guard -- both
         // sides take the same branch whichever it is, which is the property
         // this test actually exists to prove.
-        if dirs::home_dir().is_some() {
+        if crate::paths::home_dir().is_some() {
             assert!(
                 unset.ends_with(".kimi-code/credentials/kimi-code.json"),
                 "unset lookup no longer defaults to ~/.kimi-code: {unset:?}"

--- a/crates/tokscale-cli/src/cursor.rs
+++ b/crates/tokscale-cli/src/cursor.rs
@@ -28,7 +28,7 @@ fn build_cursor_http_client() -> Result<reqwest::Client> {
 }
 
 fn home_dir() -> Result<PathBuf> {
-    dirs::home_dir().context("Could not determine home directory")
+    crate::paths::home_dir().context("Could not determine home directory")
 }
 
 fn cursor_credentials_path(home_dir: &Path) -> PathBuf {

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -1329,7 +1329,7 @@ struct CursorSetupState {
 fn cursor_setup_state(home_dir: &Option<String>) -> Option<CursorSetupState> {
     let (home_path, home_override) = match home_dir {
         Some(home) => (PathBuf::from(home), true),
-        None => (dirs::home_dir()?, false),
+        None => (crate::paths::home_dir()?, false),
     };
     let has_credentials = if home_override {
         cursor::has_active_credentials_in_home(&home_path)
@@ -1410,7 +1410,7 @@ fn warp_setup_warnings_for_report(
 
     let (home_path, home_override) = match home_dir {
         Some(home) => (PathBuf::from(home), true),
-        None => match dirs::home_dir() {
+        None => match crate::paths::home_dir() {
             Some(home) => (home, false),
             None => {
                 return vec![
@@ -1572,7 +1572,10 @@ fn use_env_roots(home_dir: &Option<String>) -> bool {
 }
 
 fn resolve_effective_home_dir(home_dir: &Option<String>) -> Option<PathBuf> {
-    home_dir.as_ref().map(PathBuf::from).or_else(dirs::home_dir)
+    home_dir
+        .as_ref()
+        .map(PathBuf::from)
+        .or_else(crate::paths::home_dir)
 }
 
 fn model_usage_includes_client(entry: &tokscale_core::ModelUsage, client: &str) -> bool {
@@ -3818,7 +3821,7 @@ fn run_clients_command(json: bool, home_dir: Option<String>) -> Result<()> {
     let scanner_settings = tui::settings::load_scanner_settings_for_home(&explicit_home_dir);
     let home_dir = explicit_home_dir
         .map(PathBuf::from)
-        .or_else(dirs::home_dir)
+        .or_else(crate::paths::home_dir)
         .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
     let home_dir_str = home_dir.to_string_lossy().to_string();
 
@@ -6194,8 +6197,8 @@ fn run_headless_command(
         final_args.push("--json".to_string());
     }
 
-    let home_dir =
-        dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+    let home_dir = crate::paths::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
     let headless_roots = get_headless_roots(&home_dir);
 
     let output_path = if let Some(custom_output) = output {
@@ -8073,7 +8076,7 @@ mod tests {
     #[test]
     fn write_light_cache_refuses_when_home_dir_set() {
         // --home rebinds the scan root; DataLoader::load currently ignores
-        // this field and resolves home from dirs::home_dir() with
+        // this field and resolves home from crate::paths::home_dir() with
         // use_env_roots=true, so the printed --light report is built from
         // <home> while a naive cache write would store data scanned from
         // the default home. Refuse the write to avoid that drift.

--- a/crates/tokscale-cli/src/paths.rs
+++ b/crates/tokscale-cli/src/paths.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 #[allow(unused_imports)]
 pub use tokscale_core::paths::{
-    get_cache_dir, get_config_dir, is_config_dir_overridden, legacy_dirs_cache_dir,
+    get_cache_dir, get_config_dir, home_dir, is_config_dir_overridden, legacy_dirs_cache_dir,
     legacy_dot_cache_tokscale_dir,
 };
 

--- a/crates/tokscale-cli/src/trae.rs
+++ b/crates/tokscale-cli/src/trae.rs
@@ -328,7 +328,7 @@ pub mod auth {
     // ── storage.json decryption ────────────────────────────────────────────
 
     fn decrypt_from_storage(variant: TraeVariant) -> Result<CachedCredentials> {
-        let home = dirs::home_dir().context("could not determine home directory")?;
+        let home = crate::paths::home_dir().context("could not determine home directory")?;
         let app_dir = home
             .join("Library/Application Support")
             .join(variant.app_dir_name());

--- a/crates/tokscale-cli/src/tui/config.rs
+++ b/crates/tokscale-cli/src/tui/config.rs
@@ -34,7 +34,7 @@ pub struct DisplayNamesConfig {
 
 impl TokscaleConfig {
     fn config_path() -> Option<PathBuf> {
-        dirs::home_dir().map(|h| h.join(".tokscale"))
+        crate::paths::home_dir().map(|h| h.join(".tokscale"))
     }
 
     pub fn load() -> &'static TokscaleConfig {

--- a/crates/tokscale-cli/src/tui/data/mod.rs
+++ b/crates/tokscale-cli/src/tui/data/mod.rs
@@ -360,7 +360,7 @@ impl DataLoader {
         group_by: &GroupBy,
         include_synthetic: bool,
     ) -> Result<UsageData> {
-        let home = dirs::home_dir()
+        let home = crate::paths::home_dir()
             .ok_or_else(|| anyhow::anyhow!("Could not find home directory"))?
             .to_string_lossy()
             .to_string();
@@ -409,7 +409,7 @@ impl DataLoader {
         include_synthetic: bool,
         pricing: &tokscale_core::pricing::PricingService,
     ) -> Result<UsageData> {
-        let home = dirs::home_dir()
+        let home = crate::paths::home_dir()
             .ok_or_else(|| anyhow::anyhow!("Could not find home directory"))?
             .to_string_lossy()
             .to_string();
@@ -1481,7 +1481,7 @@ mod tests {
         include_synthetic: bool,
         pricing: Option<&PricingService>,
     ) -> Result<UsageData> {
-        let home = dirs::home_dir()
+        let home = crate::paths::home_dir()
             .ok_or_else(|| anyhow::anyhow!("Could not find home directory"))?
             .to_string_lossy()
             .to_string();

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -4081,13 +4081,8 @@ mod tests {
         )
     }
 
-    fn restore_home(prev: Option<std::ffi::OsString>) {
-        unsafe {
-            match prev {
-                Some(v) => std::env::set_var("HOME", v),
-                None => std::env::remove_var("HOME"),
-            }
-        }
+    fn home_guard() -> crate::paths::test_env::EnvGuard {
+        crate::paths::test_env::EnvGuard::capture(&["HOME"])
     }
 
     /// An explicit `--home` outranks every environment lookup. Pinned so the
@@ -4096,15 +4091,12 @@ mod tests {
     #[test]
     #[serial]
     fn get_home_dir_string_prefers_the_explicit_option() {
-        let prev = std::env::var_os("HOME");
-        unsafe {
-            std::env::set_var("HOME", "/tmp/tokscale-env-home");
-        }
+        let env = home_guard();
+        env.set("HOME", "/tmp/tokscale-env-home");
         assert_eq!(
             get_home_dir_string(&Some("/tmp/tokscale-explicit-home".to_string())),
             Ok("/tmp/tokscale-explicit-home".to_string())
         );
-        restore_home(prev);
     }
 
     /// The bypass this test exists for: reading `$HOME` directly meant an
@@ -4121,12 +4113,9 @@ mod tests {
     #[test]
     #[serial]
     fn get_home_dir_string_never_returns_an_empty_home() {
-        let prev = std::env::var_os("HOME");
-        unsafe {
-            std::env::set_var("HOME", "");
-        }
+        let env = home_guard();
+        env.set("HOME", "");
         let resolved = get_home_dir_string(&None);
-        restore_home(prev);
         assert_ne!(
             resolved,
             Ok(String::new()),
@@ -4149,12 +4138,9 @@ mod tests {
     #[serial]
     #[cfg(windows)]
     fn get_home_dir_string_ignores_a_posix_shaped_home_on_windows() {
-        let prev = std::env::var_os("HOME");
-        unsafe {
-            std::env::set_var("HOME", "/home/runner");
-        }
+        let env = home_guard();
+        env.set("HOME", "/home/runner");
         let resolved = get_home_dir_string(&None);
-        restore_home(prev);
         assert_ne!(
             resolved,
             Ok("/home/runner".to_string()),

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -591,7 +591,7 @@ pub fn get_home_dir_string(home_dir_option: &Option<String>) -> Result<String, S
     home_dir_option
         .clone()
         .or_else(|| std::env::var("HOME").ok())
-        .or_else(|| dirs::home_dir().map(|p| p.to_string_lossy().into_owned()))
+        .or_else(|| crate::paths::home_dir().map(|p| p.to_string_lossy().into_owned()))
         .ok_or_else(|| {
             "HOME directory not specified and could not determine home directory".to_string()
         })

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -587,10 +587,24 @@ pub struct HourlyReport {
     pub processing_time_ms: u32,
 }
 
+/// Resolve the home directory every `from_dir`-style parser scans from.
+///
+/// An explicit `--home` always wins. Everything else goes through
+/// [`crate::paths::home_dir`], which is the *only* place allowed to read
+/// `$HOME`.
+///
+/// Reading `$HOME` here directly — as this used to — defeated that resolver
+/// entirely, because the raw read ran first and always won. On Windows a Git
+/// Bash `HOME=/home/user` therefore still reached every caller, and `Path`
+/// resolves that against the current drive, so the model/monthly/hourly
+/// reports and local parsing scanned `C:\home\user` instead of the real
+/// profile — precisely the case `paths::home_dir` was written to prevent. An
+/// exported-but-empty `HOME` was worse: it produced `Ok("")`, and the
+/// `format!("{home}/...")` joins downstream turned that into absolute scans
+/// from the filesystem root.
 pub fn get_home_dir_string(home_dir_option: &Option<String>) -> Result<String, String> {
     home_dir_option
         .clone()
-        .or_else(|| std::env::var("HOME").ok())
         .or_else(|| crate::paths::home_dir().map(|p| p.to_string_lossy().into_owned()))
         .ok_or_else(|| {
             "HOME directory not specified and could not determine home directory".to_string()
@@ -4040,12 +4054,14 @@ mod tests {
     use super::{
         aggregate_model_usage_entries, apply_pricing_if_available, build_graph_from_messages,
         dedupe_latest_trae_messages, filter_messages_for_report,
-        generate_graph_with_loaded_pricing, message_cache, normalize_model_for_grouping,
-        parse_all_messages_with_pricing_with_env_strategy, parse_local_clients, parsed_to_unified,
-        pricing, retain_for_requested_clients, scanner, select_local_parse_pricing,
-        unified_to_parsed, validate_priced_messages, ClientId, GraphPricingRequirement, GroupBy,
-        LocalParseOptions, ReportOptions, TokenBreakdown, UnifiedMessage, UNKNOWN_WORKSPACE_LABEL,
+        generate_graph_with_loaded_pricing, get_home_dir_string, message_cache,
+        normalize_model_for_grouping, parse_all_messages_with_pricing_with_env_strategy,
+        parse_local_clients, parsed_to_unified, pricing, retain_for_requested_clients, scanner,
+        select_local_parse_pricing, unified_to_parsed, validate_priced_messages, ClientId,
+        GraphPricingRequirement, GroupBy, LocalParseOptions, ReportOptions, TokenBreakdown,
+        UnifiedMessage, UNKNOWN_WORKSPACE_LABEL,
     };
+    use serial_test::serial;
     use std::collections::{HashMap, HashSet};
     use std::io::Write;
     use std::str::FromStr;
@@ -4063,6 +4079,87 @@ mod tests {
             false,
             &scanner::ScannerSettings::default(),
         )
+    }
+
+    fn restore_home(prev: Option<std::ffi::OsString>) {
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+
+    /// An explicit `--home` outranks every environment lookup. Pinned so the
+    /// reordering that routed the fallback through `paths::home_dir` cannot
+    /// quietly promote the resolver above the caller's own argument.
+    #[test]
+    #[serial]
+    fn get_home_dir_string_prefers_the_explicit_option() {
+        let prev = std::env::var_os("HOME");
+        unsafe {
+            std::env::set_var("HOME", "/tmp/tokscale-env-home");
+        }
+        assert_eq!(
+            get_home_dir_string(&Some("/tmp/tokscale-explicit-home".to_string())),
+            Ok("/tmp/tokscale-explicit-home".to_string())
+        );
+        restore_home(prev);
+    }
+
+    /// The bypass this test exists for: reading `$HOME` directly meant an
+    /// exported-but-blank value won outright and produced `Ok("")`. Every
+    /// consumer builds scan roots with `format!("{home}/...")`, so an empty
+    /// home turns each of them into an absolute path from the filesystem root
+    /// — `/.codex/sessions` rather than `~/.codex/sessions`.
+    ///
+    /// `paths::home_dir` delegates to `dirs`, which treats a blank `HOME` as
+    /// unset and falls back to the passwd entry, so the empty string can no
+    /// longer escape. Asserting "not `Ok("")`" rather than a concrete path
+    /// keeps this honest on a runner with no passwd home, where the correct
+    /// answer is the `Err` arm.
+    #[test]
+    #[serial]
+    fn get_home_dir_string_never_returns_an_empty_home() {
+        let prev = std::env::var_os("HOME");
+        unsafe {
+            std::env::set_var("HOME", "");
+        }
+        let resolved = get_home_dir_string(&None);
+        restore_home(prev);
+        assert_ne!(
+            resolved,
+            Ok(String::new()),
+            "a blank HOME must not resolve to the empty string; \
+             every caller joins it into a scan root"
+        );
+    }
+
+    /// MSYS2, Cygwin and Git Bash export `HOME=/home/<user>` on Windows.
+    /// Returning that verbatim points the model, monthly, hourly and local
+    /// parsers at `C:\home\<user>` — `Path` reads the leading `/` as the root
+    /// of the current drive — so a Git Bash user sees none of their own usage.
+    /// `paths::home_dir` rejects the shape; this test pins that
+    /// `get_home_dir_string` actually goes through it rather than around it.
+    ///
+    /// Windows-only by construction: `/home/runner` is a legitimate absolute
+    /// path on macOS and the resolver rightly honors it there. It does run —
+    /// on the `windows-latest` leg this PR adds.
+    #[test]
+    #[serial]
+    #[cfg(windows)]
+    fn get_home_dir_string_ignores_a_posix_shaped_home_on_windows() {
+        let prev = std::env::var_os("HOME");
+        unsafe {
+            std::env::set_var("HOME", "/home/runner");
+        }
+        let resolved = get_home_dir_string(&None);
+        restore_home(prev);
+        assert_ne!(
+            resolved,
+            Ok("/home/runner".to_string()),
+            "a POSIX-shaped HOME must not reach the scanners on Windows"
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -4091,7 +4091,7 @@ mod tests {
     #[test]
     #[serial]
     fn get_home_dir_string_prefers_the_explicit_option() {
-        let env = home_guard();
+        let mut env = home_guard();
         env.set("HOME", "/tmp/tokscale-env-home");
         assert_eq!(
             get_home_dir_string(&Some("/tmp/tokscale-explicit-home".to_string())),
@@ -4113,7 +4113,7 @@ mod tests {
     #[test]
     #[serial]
     fn get_home_dir_string_never_returns_an_empty_home() {
-        let env = home_guard();
+        let mut env = home_guard();
         env.set("HOME", "");
         let resolved = get_home_dir_string(&None);
         assert_ne!(
@@ -4138,7 +4138,7 @@ mod tests {
     #[serial]
     #[cfg(windows)]
     fn get_home_dir_string_ignores_a_posix_shaped_home_on_windows() {
-        let env = home_guard();
+        let mut env = home_guard();
         env.set("HOME", "/home/runner");
         let resolved = get_home_dir_string(&None);
         assert_ne!(

--- a/crates/tokscale-core/src/mcp.rs
+++ b/crates/tokscale-core/src/mcp.rs
@@ -20,7 +20,7 @@ pub enum McpSource {
 }
 
 pub fn discover_mcp_server_names(home_dir: Option<&Path>) -> Vec<String> {
-    let home = match home_dir.map(PathBuf::from).or_else(dirs::home_dir) {
+    let home = match home_dir.map(PathBuf::from).or_else(crate::paths::home_dir) {
         Some(h) => h,
         None => return Vec::new(),
     };

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -42,7 +42,7 @@ thread_local! {
 fn cache_dir() -> Option<PathBuf> {
     if crate::paths::is_config_dir_overridden()
         || dirs::config_dir().is_some()
-        || cfg!(target_os = "macos") && dirs::home_dir().is_some()
+        || cfg!(target_os = "macos") && crate::paths::home_dir().is_some()
     {
         Some(crate::paths::get_cache_dir())
     } else {

--- a/crates/tokscale-core/src/opencode_model_name.rs
+++ b/crates/tokscale-core/src/opencode_model_name.rs
@@ -245,7 +245,10 @@ fn load_with_environment(
 /// or unreadable config files are ignored so usage reporting remains available.
 pub fn load_for_home(home_dir: Option<&Path>) -> OpenCodeModelNameResolver {
     let use_env_roots = home_dir.is_none();
-    let Some(home_dir) = home_dir.map(Path::to_path_buf).or_else(dirs::home_dir) else {
+    let Some(home_dir) = home_dir
+        .map(Path::to_path_buf)
+        .or_else(crate::paths::home_dir)
+    else {
         return OpenCodeModelNameResolver::default();
     };
 

--- a/crates/tokscale-core/src/paths.rs
+++ b/crates/tokscale-core/src/paths.rs
@@ -26,14 +26,23 @@ use std::path::PathBuf;
 /// the machine running the suite, and `test_load_credentials_nonexistent`
 /// was asserting against the developer's own credentials file.
 ///
-/// `$HOME` is only honored on Windows when it carries a real Win32 prefix
-/// (`C:\...`, `\\?\C:\...`, `\\server\share`). MSYS2, Cygwin and Git Bash
-/// export POSIX-shaped values such as `/home/user`, which `Path` resolves
-/// against whatever the current drive happens to be — obeying those would
-/// relocate the config of every user who launches tokscale from a Unix-shell
-/// emulator to `C:\home\user`. Requiring the prefix keeps the redirect
-/// available to anything that can set a native path while leaving the
-/// emulator case on the platform default.
+/// `$HOME` is only honored on Windows when it is an absolute native path
+/// (`C:\...`, `\\?\C:\...`, `\\server\share`). Two shapes are rejected, both
+/// because `Path` silently resolves them against ambient state:
+///
+/// - POSIX-shaped values such as `/home/user`, exported by MSYS2, Cygwin and
+///   Git Bash. `Path` reads the leading `/` as "root of the current drive",
+///   so obeying them would relocate the config of every user who launches
+///   tokscale from a Unix-shell emulator to `C:\home\user`.
+/// - Drive-relative values such as `C:temp`, which carry a `Prefix` but no
+///   root. Windows resolves those against the *per-drive current directory*,
+///   so the same `HOME` names a different place depending on where the
+///   process last `cd`-ed on drive C — home-rooted reads and writes would
+///   land somewhere unintended and unreproducible.
+///
+/// `Path::is_absolute` on Windows is exactly `has_root() && prefix().is_some()`,
+/// which rejects both in one check while leaving the redirect available to
+/// anything that can set a real native path.
 ///
 /// Every home-rooted path in the workspace must resolve through here rather
 /// than calling `dirs::home_dir()` directly, otherwise the redirect holds for
@@ -51,9 +60,10 @@ pub fn home_dir() -> Option<PathBuf> {
 
 /// `$HOME` on Windows, but only when it names a path Win32 can actually use.
 ///
-/// See [`home_dir`] for why the prefix check is load-bearing rather than a
-/// nicety: without it a Git Bash `HOME=/home/user` would win over the real
-/// profile.
+/// See [`home_dir`] for why the absoluteness check is load-bearing rather than
+/// a nicety: without it a Git Bash `HOME=/home/user` would win over the real
+/// profile, and a drive-relative `HOME=C:temp` would resolve against whatever
+/// the current directory on drive C happens to be.
 #[cfg(windows)]
 fn windows_native_home_override() -> Option<PathBuf> {
     let raw = std::env::var_os("HOME")?;
@@ -61,11 +71,7 @@ fn windows_native_home_override() -> Option<PathBuf> {
         return None;
     }
     let path = PathBuf::from(raw);
-    matches!(
-        path.components().next(),
-        Some(std::path::Component::Prefix(_))
-    )
-    .then_some(path)
+    path.is_absolute().then_some(path)
 }
 
 /// Resolve the tokscale config dir, honoring `TOKSCALE_CONFIG_DIR` first.
@@ -236,6 +242,32 @@ mod tests {
             env::set_var("HOME", "/home/runner");
         }
         assert_ne!(home_dir(), Some(PathBuf::from("/home/runner")));
+        restore_env(prev);
+    }
+
+    /// `C:temp` carries a `Prefix` component but no root, so a prefix-only
+    /// check accepts it. Windows then resolves it against the *per-drive
+    /// current directory* for C: — the same `HOME` names a different directory
+    /// depending on where the process last `cd`-ed, so credentials and scan
+    /// roots move unpredictably. Only absolute native paths may redirect home.
+    ///
+    /// Windows-only by construction: `C:temp` is a perfectly ordinary relative
+    /// filename on Unix, and `Path`'s prefix parsing only exists on Windows
+    /// targets, so there is no way to exercise this on macOS. It does run —
+    /// on the `windows-latest` leg this PR adds.
+    #[test]
+    #[serial]
+    #[cfg(windows)]
+    fn home_dir_ignores_a_drive_relative_home() {
+        let prev = save_env();
+        unsafe {
+            env::set_var("HOME", r"C:temp");
+        }
+        assert_ne!(
+            home_dir(),
+            Some(PathBuf::from(r"C:temp")),
+            "a drive-relative HOME resolves against the current directory on that drive"
+        );
         restore_env(prev);
     }
 

--- a/crates/tokscale-core/src/paths.rs
+++ b/crates/tokscale-core/src/paths.rs
@@ -176,9 +176,16 @@ pub fn legacy_dot_cache_tokscale_dir() -> Option<PathBuf> {
 /// `HOME` pointing at a deleted `TempDir` and fails for a reason that has
 /// nothing to do with what it asserts. Restoring on `Drop` unwinds correctly.
 ///
-/// `scanner.rs` and `sessions/opencode.rs` already carry private copies of
-/// this; this one is `pub(crate)` so `paths`, `wiki` and the crate-root tests
-/// share a single implementation.
+/// This is the crate's single implementation. `scanner.rs` and
+/// `sessions/opencode.rs` previously carried private copies; both now import
+/// from here, so panic-safe environment restoration cannot drift between three
+/// versions.
+///
+/// `set` and `remove` take `&mut self` even though they do not touch the
+/// guard's own state. That is deliberate: it is the signature `scanner.rs`
+/// already used, so its fourteen call sites migrated unchanged, and `&mut`
+/// reads correctly for a method whose whole purpose is to mutate
+/// process-global state.
 #[cfg(test)]
 pub(crate) mod test_env {
     use std::ffi::{OsStr, OsString};
@@ -194,11 +201,11 @@ pub(crate) mod test_env {
             )
         }
 
-        pub(crate) fn set(&self, key: &str, value: impl AsRef<OsStr>) {
+        pub(crate) fn set(&mut self, key: &str, value: impl AsRef<OsStr>) {
             unsafe { std::env::set_var(key, value) };
         }
 
-        pub(crate) fn remove(&self, key: &str) {
+        pub(crate) fn remove(&mut self, key: &str) {
             unsafe { std::env::remove_var(key) };
         }
     }
@@ -243,13 +250,16 @@ mod tests {
     #[serial]
     fn env_guard_restores_even_when_the_test_body_panics() {
         const SENTINEL: &str = "TOKSCALE_ENV_GUARD_PANIC_PROBE";
-        unsafe { std::env::set_var(SENTINEL, "original") };
+        // Practise what the test preaches: if an assertion below fails, this
+        // outer guard still restores the sentinel on the way out.
+        let mut outer = EnvGuard::capture(&[SENTINEL]);
+        outer.set(SENTINEL, "original");
 
         // The panic below is deliberate; keep it out of the test output.
         let hook = std::panic::take_hook();
         std::panic::set_hook(Box::new(|_| {}));
         let outcome = std::panic::catch_unwind(|| {
-            let env = EnvGuard::capture(&[SENTINEL]);
+            let mut env = EnvGuard::capture(&[SENTINEL]);
             env.set(SENTINEL, "redirected");
             panic!("simulated assertion failure");
         });
@@ -261,7 +271,6 @@ mod tests {
             Some("original"),
             "EnvGuard must restore the previous value while unwinding"
         );
-        unsafe { std::env::remove_var(SENTINEL) };
     }
 
     /// The regression #997 is really about: this assertion has always held on
@@ -273,7 +282,7 @@ mod tests {
     #[test]
     #[serial]
     fn home_dir_follows_an_explicit_native_home_on_every_platform() {
-        let env = guard();
+        let mut env = guard();
         // `env::temp_dir()` is absolute and carries a drive prefix on Windows,
         // which is exactly the shape a `TempDir`-based test produces.
         let redirect = std::env::temp_dir().join("tokscale-core-home-dir-probe");
@@ -291,7 +300,7 @@ mod tests {
     #[serial]
     #[cfg(windows)]
     fn home_dir_ignores_a_posix_shaped_home() {
-        let env = guard();
+        let mut env = guard();
         env.set("HOME", "/home/runner");
         assert_ne!(home_dir(), Some(PathBuf::from("/home/runner")));
     }
@@ -310,7 +319,7 @@ mod tests {
     #[serial]
     #[cfg(windows)]
     fn home_dir_ignores_a_drive_relative_home() {
-        let env = guard();
+        let mut env = guard();
         env.set("HOME", r"C:temp");
         assert_ne!(
             home_dir(),
@@ -326,7 +335,7 @@ mod tests {
     #[serial]
     #[cfg(windows)]
     fn home_dir_treats_an_empty_home_as_unset() {
-        let env = guard();
+        let mut env = guard();
         env.set("HOME", "");
         assert_ne!(home_dir(), Some(PathBuf::new()));
     }
@@ -334,7 +343,7 @@ mod tests {
     #[test]
     #[serial]
     fn env_override_is_returned_verbatim() {
-        let env = guard();
+        let mut env = guard();
         env.set("TOKSCALE_CONFIG_DIR", "/tmp/tokscale-custom");
         assert_eq!(get_config_dir(), PathBuf::from("/tmp/tokscale-custom"));
     }
@@ -343,7 +352,7 @@ mod tests {
     #[serial]
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     fn unix_default_is_dot_config_tokscale_under_home() {
-        let env = guard();
+        let mut env = guard();
         env.remove("TOKSCALE_CONFIG_DIR");
         env.remove("XDG_CONFIG_HOME");
         env.set("HOME", "/tmp/tokscale-core-paths-home");
@@ -357,7 +366,7 @@ mod tests {
     #[serial]
     #[cfg(target_os = "linux")]
     fn linux_honors_xdg_config_home_when_set() {
-        let env = guard();
+        let mut env = guard();
         env.remove("TOKSCALE_CONFIG_DIR");
         env.set("XDG_CONFIG_HOME", "/tmp/tokscale-core-paths-xdg");
         assert_eq!(
@@ -369,7 +378,7 @@ mod tests {
     #[test]
     #[serial]
     fn cache_dir_is_cache_subdir_of_config_dir() {
-        let env = guard();
+        let mut env = guard();
         env.set("TOKSCALE_CONFIG_DIR", "/tmp/tokscale-cache-test");
         assert_eq!(
             get_cache_dir(),
@@ -380,7 +389,7 @@ mod tests {
     #[test]
     #[serial]
     fn legacy_helpers_return_none_when_overridden() {
-        let env = guard();
+        let mut env = guard();
         env.set("TOKSCALE_CONFIG_DIR", "/tmp/tokscale-override");
         assert!(legacy_dirs_cache_dir().is_none());
         assert!(legacy_dot_cache_tokscale_dir().is_none());
@@ -389,7 +398,7 @@ mod tests {
     #[test]
     #[serial]
     fn legacy_helpers_return_some_when_not_overridden() {
-        let env = guard();
+        let mut env = guard();
         env.remove("TOKSCALE_CONFIG_DIR");
         assert!(
             legacy_dirs_cache_dir().is_some(),
@@ -408,7 +417,7 @@ mod tests {
         // produced PathBuf::from(""), which silently relocated cache
         // writes to ./cache and ./.tokscale. The resolver must agree
         // with `is_config_dir_overridden`: empty == unset.
-        let env = guard();
+        let mut env = guard();
         env.set("TOKSCALE_CONFIG_DIR", "");
         let resolved = get_config_dir();
         assert_ne!(
@@ -425,7 +434,7 @@ mod tests {
     #[test]
     #[serial]
     fn is_config_dir_overridden_treats_empty_string_as_unset() {
-        let env = guard();
+        let mut env = guard();
         env.set("TOKSCALE_CONFIG_DIR", "");
         assert!(!is_config_dir_overridden());
     }

--- a/crates/tokscale-core/src/paths.rs
+++ b/crates/tokscale-core/src/paths.rs
@@ -166,46 +166,102 @@ pub fn legacy_dot_cache_tokscale_dir() -> Option<PathBuf> {
     home_dir().map(|h| h.join(".cache").join("tokscale"))
 }
 
+/// RAII restore of process-global environment variables, shared by the tests
+/// in this crate that redirect `HOME` or `TOKSCALE_CONFIG_DIR`.
+///
+/// The manual `save`/`restore` pairs this replaces only ran the restore when
+/// the test reached the end of its body — a failing assertion panics first and
+/// leaves the redirect in place. `serial_test` guarantees these tests do not
+/// overlap, but they do share a process, so the next one to run inherits a
+/// `HOME` pointing at a deleted `TempDir` and fails for a reason that has
+/// nothing to do with what it asserts. Restoring on `Drop` unwinds correctly.
+///
+/// `scanner.rs` and `sessions/opencode.rs` already carry private copies of
+/// this; this one is `pub(crate)` so `paths`, `wiki` and the crate-root tests
+/// share a single implementation.
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use serial_test::serial;
-    use std::env;
-    use std::path::Path;
+pub(crate) mod test_env {
+    use std::ffi::{OsStr, OsString};
 
-    fn save_env() -> (
-        Option<std::ffi::OsString>,
-        Option<std::ffi::OsString>,
-        Option<std::ffi::OsString>,
-    ) {
-        (
-            env::var_os("TOKSCALE_CONFIG_DIR"),
-            env::var_os("HOME"),
-            env::var_os("XDG_CONFIG_HOME"),
-        )
+    pub(crate) struct EnvGuard(Vec<(&'static str, Option<OsString>)>);
+
+    impl EnvGuard {
+        pub(crate) fn capture(keys: &[&'static str]) -> Self {
+            Self(
+                keys.iter()
+                    .map(|key| (*key, std::env::var_os(key)))
+                    .collect(),
+            )
+        }
+
+        pub(crate) fn set(&self, key: &str, value: impl AsRef<OsStr>) {
+            unsafe { std::env::set_var(key, value) };
+        }
+
+        pub(crate) fn remove(&self, key: &str) {
+            unsafe { std::env::remove_var(key) };
+        }
     }
 
-    fn restore_env(
-        prev: (
-            Option<std::ffi::OsString>,
-            Option<std::ffi::OsString>,
-            Option<std::ffi::OsString>,
-        ),
-    ) {
-        unsafe {
-            match prev.0 {
-                Some(v) => env::set_var("TOKSCALE_CONFIG_DIR", v),
-                None => env::remove_var("TOKSCALE_CONFIG_DIR"),
-            }
-            match prev.1 {
-                Some(v) => env::set_var("HOME", v),
-                None => env::remove_var("HOME"),
-            }
-            match prev.2 {
-                Some(v) => env::set_var("XDG_CONFIG_HOME", v),
-                None => env::remove_var("XDG_CONFIG_HOME"),
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, previous) in self.0.drain(..) {
+                unsafe {
+                    match previous {
+                        Some(value) => std::env::set_var(key, value),
+                        None => std::env::remove_var(key),
+                    }
+                }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_env::EnvGuard;
+    use super::*;
+    use serial_test::serial;
+    use std::path::Path;
+
+    /// Every test in this module redirects at least one of these, and
+    /// `get_config_dir` reads all three, so capturing the set keeps a test
+    /// from leaking a partial redirect into the next one.
+    fn guard() -> EnvGuard {
+        EnvGuard::capture(&["TOKSCALE_CONFIG_DIR", "HOME", "XDG_CONFIG_HOME"])
+    }
+
+    /// The whole point of the guard over a trailing `restore_env(prev)` call:
+    /// a failing assertion panics *before* the manual restore runs, so the
+    /// redirect leaks into every later test in the process. `serial_test`
+    /// does not help — it prevents overlap, not inheritance. The next test to
+    /// run would then resolve `HOME` to a deleted `TempDir` and fail for a
+    /// reason unrelated to what it asserts, which is exactly the kind of
+    /// cascading, order-dependent failure that makes a Windows CI leg
+    /// unreadable.
+    #[test]
+    #[serial]
+    fn env_guard_restores_even_when_the_test_body_panics() {
+        const SENTINEL: &str = "TOKSCALE_ENV_GUARD_PANIC_PROBE";
+        unsafe { std::env::set_var(SENTINEL, "original") };
+
+        // The panic below is deliberate; keep it out of the test output.
+        let hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let outcome = std::panic::catch_unwind(|| {
+            let env = EnvGuard::capture(&[SENTINEL]);
+            env.set(SENTINEL, "redirected");
+            panic!("simulated assertion failure");
+        });
+        std::panic::set_hook(hook);
+
+        assert!(outcome.is_err(), "the probe closure must have panicked");
+        assert_eq!(
+            std::env::var(SENTINEL).ok().as_deref(),
+            Some("original"),
+            "EnvGuard must restore the previous value while unwinding"
+        );
+        unsafe { std::env::remove_var(SENTINEL) };
     }
 
     /// The regression #997 is really about: this assertion has always held on
@@ -217,32 +273,27 @@ mod tests {
     #[test]
     #[serial]
     fn home_dir_follows_an_explicit_native_home_on_every_platform() {
-        let prev = save_env();
+        let env = guard();
         // `env::temp_dir()` is absolute and carries a drive prefix on Windows,
         // which is exactly the shape a `TempDir`-based test produces.
-        let redirect = env::temp_dir().join("tokscale-core-home-dir-probe");
-        unsafe {
-            env::set_var("HOME", &redirect);
-        }
+        let redirect = std::env::temp_dir().join("tokscale-core-home-dir-probe");
+        env.set("HOME", &redirect);
         assert_eq!(home_dir(), Some(redirect));
-        restore_env(prev);
     }
 
     /// MSYS2, Cygwin and Git Bash export `HOME=/home/<user>`. `Path` reads a
     /// leading `/` on Windows as "root of the current drive", so honoring that
     /// value would silently move a real user's credentials and scan roots to
-    /// `C:\home\<user>`. The prefix check in `windows_native_home_override`
-    /// exists solely to keep that from happening.
+    /// `C:\home\<user>`. The absoluteness check in
+    /// `windows_native_home_override` exists solely to keep that from
+    /// happening.
     #[test]
     #[serial]
     #[cfg(windows)]
     fn home_dir_ignores_a_posix_shaped_home() {
-        let prev = save_env();
-        unsafe {
-            env::set_var("HOME", "/home/runner");
-        }
+        let env = guard();
+        env.set("HOME", "/home/runner");
         assert_ne!(home_dir(), Some(PathBuf::from("/home/runner")));
-        restore_env(prev);
     }
 
     /// `C:temp` carries a `Prefix` component but no root, so a prefix-only
@@ -259,16 +310,13 @@ mod tests {
     #[serial]
     #[cfg(windows)]
     fn home_dir_ignores_a_drive_relative_home() {
-        let prev = save_env();
-        unsafe {
-            env::set_var("HOME", r"C:temp");
-        }
+        let env = guard();
+        env.set("HOME", r"C:temp");
         assert_ne!(
             home_dir(),
             Some(PathBuf::from(r"C:temp")),
             "a drive-relative HOME resolves against the current directory on that drive"
         );
-        restore_env(prev);
     }
 
     /// Same contract as `get_config_dir`: an exported-but-blank variable is a
@@ -278,91 +326,71 @@ mod tests {
     #[serial]
     #[cfg(windows)]
     fn home_dir_treats_an_empty_home_as_unset() {
-        let prev = save_env();
-        unsafe {
-            env::set_var("HOME", "");
-        }
+        let env = guard();
+        env.set("HOME", "");
         assert_ne!(home_dir(), Some(PathBuf::new()));
-        restore_env(prev);
     }
 
     #[test]
     #[serial]
     fn env_override_is_returned_verbatim() {
-        let prev = save_env();
-        unsafe {
-            env::set_var("TOKSCALE_CONFIG_DIR", "/tmp/tokscale-custom");
-        }
+        let env = guard();
+        env.set("TOKSCALE_CONFIG_DIR", "/tmp/tokscale-custom");
         assert_eq!(get_config_dir(), PathBuf::from("/tmp/tokscale-custom"));
-        restore_env(prev);
     }
 
     #[test]
     #[serial]
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     fn unix_default_is_dot_config_tokscale_under_home() {
-        let prev = save_env();
-        unsafe {
-            env::remove_var("TOKSCALE_CONFIG_DIR");
-            env::remove_var("XDG_CONFIG_HOME");
-            env::set_var("HOME", "/tmp/tokscale-core-paths-home");
-        }
+        let env = guard();
+        env.remove("TOKSCALE_CONFIG_DIR");
+        env.remove("XDG_CONFIG_HOME");
+        env.set("HOME", "/tmp/tokscale-core-paths-home");
         assert_eq!(
             get_config_dir(),
             PathBuf::from("/tmp/tokscale-core-paths-home/.config/tokscale"),
         );
-        restore_env(prev);
     }
 
     #[test]
     #[serial]
     #[cfg(target_os = "linux")]
     fn linux_honors_xdg_config_home_when_set() {
-        let prev = save_env();
-        unsafe {
-            env::remove_var("TOKSCALE_CONFIG_DIR");
-            env::set_var("XDG_CONFIG_HOME", "/tmp/tokscale-core-paths-xdg");
-        }
+        let env = guard();
+        env.remove("TOKSCALE_CONFIG_DIR");
+        env.set("XDG_CONFIG_HOME", "/tmp/tokscale-core-paths-xdg");
         assert_eq!(
             get_config_dir(),
             PathBuf::from("/tmp/tokscale-core-paths-xdg/tokscale"),
         );
-        restore_env(prev);
     }
 
     #[test]
     #[serial]
     fn cache_dir_is_cache_subdir_of_config_dir() {
-        let prev = save_env();
-        unsafe {
-            env::set_var("TOKSCALE_CONFIG_DIR", "/tmp/tokscale-cache-test");
-        }
+        let env = guard();
+        env.set("TOKSCALE_CONFIG_DIR", "/tmp/tokscale-cache-test");
         assert_eq!(
             get_cache_dir(),
             PathBuf::from("/tmp/tokscale-cache-test/cache")
         );
-        restore_env(prev);
     }
 
     #[test]
     #[serial]
     fn legacy_helpers_return_none_when_overridden() {
-        let prev = save_env();
-        unsafe {
-            env::set_var("TOKSCALE_CONFIG_DIR", "/tmp/tokscale-override");
-        }
+        let env = guard();
+        env.set("TOKSCALE_CONFIG_DIR", "/tmp/tokscale-override");
         assert!(legacy_dirs_cache_dir().is_none());
         assert!(legacy_dot_cache_tokscale_dir().is_none());
-        restore_env(prev);
     }
 
     #[test]
     #[serial]
     fn legacy_helpers_return_some_when_not_overridden() {
-        let prev = save_env();
-        unsafe {
-            env::remove_var("TOKSCALE_CONFIG_DIR");
-        }
+        let env = guard();
+        env.remove("TOKSCALE_CONFIG_DIR");
         assert!(
             legacy_dirs_cache_dir().is_some(),
             "dirs::cache_dir always resolves on test platforms"
@@ -371,7 +399,6 @@ mod tests {
             legacy_dot_cache_tokscale_dir().is_some(),
             "HOME is set in test environments"
         );
-        restore_env(prev);
     }
 
     #[test]
@@ -381,10 +408,8 @@ mod tests {
         // produced PathBuf::from(""), which silently relocated cache
         // writes to ./cache and ./.tokscale. The resolver must agree
         // with `is_config_dir_overridden`: empty == unset.
-        let prev = save_env();
-        unsafe {
-            env::set_var("TOKSCALE_CONFIG_DIR", "");
-        }
+        let env = guard();
+        env.set("TOKSCALE_CONFIG_DIR", "");
         let resolved = get_config_dir();
         assert_ne!(
             resolved,
@@ -395,17 +420,13 @@ mod tests {
             resolved.is_absolute() || resolved == Path::new(".tokscale"),
             "empty override must fall through to platform default, got {resolved:?}"
         );
-        restore_env(prev);
     }
 
     #[test]
     #[serial]
     fn is_config_dir_overridden_treats_empty_string_as_unset() {
-        let prev = save_env();
-        unsafe {
-            env::set_var("TOKSCALE_CONFIG_DIR", "");
-        }
+        let env = guard();
+        env.set("TOKSCALE_CONFIG_DIR", "");
         assert!(!is_config_dir_overridden());
-        restore_env(prev);
     }
 }

--- a/crates/tokscale-core/src/paths.rs
+++ b/crates/tokscale-core/src/paths.rs
@@ -14,6 +14,60 @@
 
 use std::path::PathBuf;
 
+/// Resolve the user's home directory, honoring `$HOME` on every platform.
+///
+/// `dirs::home_dir()` reads `$HOME` on Unix but goes straight to the Win32
+/// known-folder API on Windows, where no environment variable can redirect
+/// it. The asymmetry is invisible until something actually runs on Windows:
+/// a caller that points `HOME` at a scratch directory is obeyed on Unix and
+/// silently ignored on Windows, so it keeps reading — and writing — the real
+/// profile. That is exactly what #997 found once a Windows runner existed;
+/// `test_ensure_config_dir` was creating `%USERPROFILE%\.config\tokscale` on
+/// the machine running the suite, and `test_load_credentials_nonexistent`
+/// was asserting against the developer's own credentials file.
+///
+/// `$HOME` is only honored on Windows when it carries a real Win32 prefix
+/// (`C:\...`, `\\?\C:\...`, `\\server\share`). MSYS2, Cygwin and Git Bash
+/// export POSIX-shaped values such as `/home/user`, which `Path` resolves
+/// against whatever the current drive happens to be — obeying those would
+/// relocate the config of every user who launches tokscale from a Unix-shell
+/// emulator to `C:\home\user`. Requiring the prefix keeps the redirect
+/// available to anything that can set a native path while leaving the
+/// emulator case on the platform default.
+///
+/// Every home-rooted path in the workspace must resolve through here rather
+/// than calling `dirs::home_dir()` directly, otherwise the redirect holds for
+/// some roots and not others and the two disagree about where state lives.
+pub fn home_dir() -> Option<PathBuf> {
+    #[cfg(windows)]
+    {
+        if let Some(explicit) = windows_native_home_override() {
+            return Some(explicit);
+        }
+    }
+
+    dirs::home_dir()
+}
+
+/// `$HOME` on Windows, but only when it names a path Win32 can actually use.
+///
+/// See [`home_dir`] for why the prefix check is load-bearing rather than a
+/// nicety: without it a Git Bash `HOME=/home/user` would win over the real
+/// profile.
+#[cfg(windows)]
+fn windows_native_home_override() -> Option<PathBuf> {
+    let raw = std::env::var_os("HOME")?;
+    if raw.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(raw);
+    matches!(
+        path.components().next(),
+        Some(std::path::Component::Prefix(_))
+    )
+    .then_some(path)
+}
+
 /// Resolve the tokscale config dir, honoring `TOKSCALE_CONFIG_DIR` first.
 ///
 /// Resolution order:
@@ -40,7 +94,7 @@ pub fn get_config_dir() -> PathBuf {
 
     #[cfg(target_os = "macos")]
     {
-        if let Some(home) = dirs::home_dir() {
+        if let Some(home) = home_dir() {
             return home.join(".config").join("tokscale");
         }
     }
@@ -103,7 +157,7 @@ pub fn legacy_dot_cache_tokscale_dir() -> Option<PathBuf> {
     if is_config_dir_overridden() {
         return None;
     }
-    dirs::home_dir().map(|h| h.join(".cache").join("tokscale"))
+    home_dir().map(|h| h.join(".cache").join("tokscale"))
 }
 
 #[cfg(test)]
@@ -146,6 +200,58 @@ mod tests {
                 None => env::remove_var("XDG_CONFIG_HOME"),
             }
         }
+    }
+
+    /// The regression #997 is really about: this assertion has always held on
+    /// Unix and has never held on Windows, because `dirs::home_dir()` consults
+    /// the Win32 profile API there and no environment variable can reach it.
+    /// Every home-rooted test in the workspace redirects `HOME` and assumes
+    /// the code under test follows, so this one assertion is what makes the
+    /// rest of them mean the same thing on both platforms.
+    #[test]
+    #[serial]
+    fn home_dir_follows_an_explicit_native_home_on_every_platform() {
+        let prev = save_env();
+        // `env::temp_dir()` is absolute and carries a drive prefix on Windows,
+        // which is exactly the shape a `TempDir`-based test produces.
+        let redirect = env::temp_dir().join("tokscale-core-home-dir-probe");
+        unsafe {
+            env::set_var("HOME", &redirect);
+        }
+        assert_eq!(home_dir(), Some(redirect));
+        restore_env(prev);
+    }
+
+    /// MSYS2, Cygwin and Git Bash export `HOME=/home/<user>`. `Path` reads a
+    /// leading `/` on Windows as "root of the current drive", so honoring that
+    /// value would silently move a real user's credentials and scan roots to
+    /// `C:\home\<user>`. The prefix check in `windows_native_home_override`
+    /// exists solely to keep that from happening.
+    #[test]
+    #[serial]
+    #[cfg(windows)]
+    fn home_dir_ignores_a_posix_shaped_home() {
+        let prev = save_env();
+        unsafe {
+            env::set_var("HOME", "/home/runner");
+        }
+        assert_ne!(home_dir(), Some(PathBuf::from("/home/runner")));
+        restore_env(prev);
+    }
+
+    /// Same contract as `get_config_dir`: an exported-but-blank variable is a
+    /// misconfiguration, not a request to resolve every home-rooted path
+    /// against the process CWD.
+    #[test]
+    #[serial]
+    #[cfg(windows)]
+    fn home_dir_treats_an_empty_home_as_unset() {
+        let prev = save_env();
+        unsafe {
+            env::set_var("HOME", "");
+        }
+        assert_ne!(home_dir(), Some(PathBuf::new()));
+        restore_env(prev);
     }
 
     #[test]

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -1868,43 +1868,11 @@ pub fn scan_all_clients(home_dir: &str, clients: &[String]) -> ScanResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::paths::test_env::EnvGuard;
     use serial_test::serial;
     use std::fs::{self, File};
     use std::io::Write;
     use tempfile::TempDir;
-
-    struct EnvGuard(Vec<(&'static str, Option<std::ffi::OsString>)>);
-
-    impl EnvGuard {
-        fn capture(keys: &[&'static str]) -> Self {
-            Self(
-                keys.iter()
-                    .map(|key| (*key, std::env::var_os(key)))
-                    .collect(),
-            )
-        }
-
-        fn set(&mut self, key: &'static str, value: impl AsRef<std::ffi::OsStr>) {
-            unsafe { std::env::set_var(key, value) };
-        }
-
-        fn remove(&mut self, key: &'static str) {
-            unsafe { std::env::remove_var(key) };
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            unsafe {
-                for (key, previous) in self.0.drain(..) {
-                    match previous {
-                        Some(value) => std::env::set_var(key, value),
-                        None => std::env::remove_var(key),
-                    }
-                }
-            }
-        }
-    }
 
     fn scan_without_extra_dirs(home_dir: &str, clients: &[String]) -> ScanResult {
         let mut extra = EnvGuard::capture(&["TOKSCALE_EXTRA_DIRS", "TOKSCALE_HEADLESS_DIR"]);

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -413,7 +413,7 @@ fn extract_agent_id_from_text(text: &str) -> Option<String> {
 
 /// Parse a Claude Code JSONL file
 pub fn parse_claude_file(path: &Path) -> Vec<UnifiedMessage> {
-    let home_dir = dirs::home_dir();
+    let home_dir = crate::paths::home_dir();
     parse_claude_file_with_home(path, home_dir.as_deref())
 }
 
@@ -426,7 +426,7 @@ pub fn parse_claude_file_with_cache(
     path: &Path,
     parent_cache: &mut ParentSubagentTypeCache,
 ) -> Vec<UnifiedMessage> {
-    let home_dir = dirs::home_dir();
+    let home_dir = crate::paths::home_dir();
     parse_claude_file_with_cache_and_home(path, parent_cache, home_dir.as_deref())
 }
 

--- a/crates/tokscale-core/src/sessions/opencode.rs
+++ b/crates/tokscale-core/src/sessions/opencode.rs
@@ -654,21 +654,7 @@ pub fn now_secs() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    struct EnvGuard(Vec<(&'static str, Option<std::ffi::OsString>)>);
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for (key, previous) in self.0.drain(..) {
-                unsafe {
-                    match previous {
-                        Some(value) => std::env::set_var(key, value),
-                        None => std::env::remove_var(key),
-                    }
-                }
-            }
-        }
-    }
+    use crate::paths::test_env::EnvGuard;
 
     fn create_opencode_sqlite_db(db_path: &Path) -> Connection {
         let conn = Connection::open(db_path).unwrap();
@@ -2071,23 +2057,12 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn migration_record_falls_back_to_legacy_path() {
-        use std::env;
-
         let temp_home = tempfile::tempdir().unwrap();
         let temp_xdg_cache = tempfile::tempdir().unwrap();
-        let prev_home = env::var_os("HOME");
-        let prev_xdg_cache = env::var_os("XDG_CACHE_HOME");
-        let prev_override = env::var_os("TOKSCALE_CONFIG_DIR");
-        let _guard = EnvGuard(vec![
-            ("TOKSCALE_CONFIG_DIR", prev_override),
-            ("XDG_CACHE_HOME", prev_xdg_cache),
-            ("HOME", prev_home),
-        ]);
-        unsafe {
-            env::set_var("HOME", temp_home.path());
-            env::set_var("XDG_CACHE_HOME", temp_xdg_cache.path());
-            env::remove_var("TOKSCALE_CONFIG_DIR");
-        }
+        let mut guard = EnvGuard::capture(&["TOKSCALE_CONFIG_DIR", "XDG_CACHE_HOME", "HOME"]);
+        guard.set("HOME", temp_home.path());
+        guard.set("XDG_CACHE_HOME", temp_xdg_cache.path());
+        guard.remove("TOKSCALE_CONFIG_DIR");
 
         let legacy_path = crate::paths::legacy_dirs_cache_dir()
             .unwrap()

--- a/crates/tokscale-core/src/wiki.rs
+++ b/crates/tokscale-core/src/wiki.rs
@@ -531,16 +531,11 @@ pub enum WikiError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::paths::test_env::EnvGuard;
     use serial_test::serial;
-    use std::env;
 
-    fn restore(prev: Option<std::ffi::OsString>) {
-        unsafe {
-            match prev {
-                Some(v) => env::set_var("TOKSCALE_CONFIG_DIR", v),
-                None => env::remove_var("TOKSCALE_CONFIG_DIR"),
-            }
-        }
+    fn guard() -> EnvGuard {
+        EnvGuard::capture(&["TOKSCALE_CONFIG_DIR"])
     }
 
     /// `tokscale report` is the one command that opens a SQLite database, and
@@ -553,13 +548,10 @@ mod tests {
     #[test]
     #[serial]
     fn default_path_follows_the_config_dir_override() {
-        let prev = env::var_os("TOKSCALE_CONFIG_DIR");
-        let root = env::temp_dir().join("tokscale-wiki-default-path-probe");
-        unsafe {
-            env::set_var("TOKSCALE_CONFIG_DIR", &root);
-        }
+        let env = guard();
+        let root = std::env::temp_dir().join("tokscale-wiki-default-path-probe");
+        env.set("TOKSCALE_CONFIG_DIR", &root);
         assert_eq!(WikiDb::default_path(), root.join("wiki.db"));
-        restore(prev);
     }
 
     /// The override is the hermetic contract, so the wiki must sit under the
@@ -569,16 +561,13 @@ mod tests {
     #[test]
     #[serial]
     fn default_path_stays_inside_the_resolved_config_dir() {
-        let prev = env::var_os("TOKSCALE_CONFIG_DIR");
-        let root = env::temp_dir().join("tokscale-wiki-containment-probe");
-        unsafe {
-            env::set_var("TOKSCALE_CONFIG_DIR", &root);
-        }
+        let env = guard();
+        let root = std::env::temp_dir().join("tokscale-wiki-containment-probe");
+        env.set("TOKSCALE_CONFIG_DIR", &root);
         let path = WikiDb::default_path();
         assert!(
             path.starts_with(&root),
             "wiki.db escaped the config-dir override: {path:?} is not under {root:?}"
         );
-        restore(prev);
     }
 }

--- a/crates/tokscale-core/src/wiki.rs
+++ b/crates/tokscale-core/src/wiki.rs
@@ -114,7 +114,7 @@ impl WikiDb {
     pub fn default_path() -> PathBuf {
         let config_dir = dirs::config_dir()
             .unwrap_or_else(|| {
-                dirs::home_dir()
+                crate::paths::home_dir()
                     .unwrap_or_else(|| PathBuf::from("."))
                     .join(".config")
             })

--- a/crates/tokscale-core/src/wiki.rs
+++ b/crates/tokscale-core/src/wiki.rs
@@ -110,16 +110,19 @@ impl WikiDb {
         Ok(Self { conn })
     }
 
-    /// Default wiki DB path: ~/.config/tokscale/wiki.db
+    /// Default wiki DB path: `<config_dir>/wiki.db`.
+    ///
+    /// Resolved through [`crate::paths::get_config_dir`], the same resolver
+    /// `settings.json`, the caches and `custom-pricing.json` use, so the wiki
+    /// lands in whatever root the user asked for. The hand-rolled
+    /// `dirs::config_dir()` chain this replaces ignored `TOKSCALE_CONFIG_DIR`
+    /// outright: `tokscale report` opened — and created — `wiki.db` in the
+    /// real profile even when every other file was redirected to an isolated
+    /// root. On Windows that is `%APPDATA%\tokscale`, and on macOS
+    /// `~/Library/Application Support/tokscale`, which also contradicted this
+    /// very doc comment's `~/.config/tokscale` claim.
     pub fn default_path() -> PathBuf {
-        let config_dir = dirs::config_dir()
-            .unwrap_or_else(|| {
-                crate::paths::home_dir()
-                    .unwrap_or_else(|| PathBuf::from("."))
-                    .join(".config")
-            })
-            .join("tokscale");
-        config_dir.join("wiki.db")
+        crate::paths::get_config_dir().join("wiki.db")
     }
 
     const SCHEMA: &'static str = r#"
@@ -523,4 +526,59 @@ pub enum WikiError {
     Io(String),
     #[error("Serialization error: {0}")]
     Serde(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::env;
+
+    fn restore(prev: Option<std::ffi::OsString>) {
+        unsafe {
+            match prev {
+                Some(v) => env::set_var("TOKSCALE_CONFIG_DIR", v),
+                None => env::remove_var("TOKSCALE_CONFIG_DIR"),
+            }
+        }
+    }
+
+    /// `tokscale report` is the one command that opens a SQLite database, and
+    /// it was the one path that ignored `TOKSCALE_CONFIG_DIR`: the old
+    /// `dirs::config_dir()` chain only consulted the fallback when
+    /// `dirs::config_dir()` returned `None`, which it never does on macOS,
+    /// Linux or Windows. So an isolated profile got an isolated everything
+    /// except its wiki, which was read from — and created in — the real user's
+    /// config dir.
+    #[test]
+    #[serial]
+    fn default_path_follows_the_config_dir_override() {
+        let prev = env::var_os("TOKSCALE_CONFIG_DIR");
+        let root = env::temp_dir().join("tokscale-wiki-default-path-probe");
+        unsafe {
+            env::set_var("TOKSCALE_CONFIG_DIR", &root);
+        }
+        assert_eq!(WikiDb::default_path(), root.join("wiki.db"));
+        restore(prev);
+    }
+
+    /// The override is the hermetic contract, so the wiki must sit under the
+    /// same root as every other tokscale file rather than beside it. Pinned
+    /// separately from the exact-path assertion above so a future change to
+    /// the filename does not quietly reintroduce a second root.
+    #[test]
+    #[serial]
+    fn default_path_stays_inside_the_resolved_config_dir() {
+        let prev = env::var_os("TOKSCALE_CONFIG_DIR");
+        let root = env::temp_dir().join("tokscale-wiki-containment-probe");
+        unsafe {
+            env::set_var("TOKSCALE_CONFIG_DIR", &root);
+        }
+        let path = WikiDb::default_path();
+        assert!(
+            path.starts_with(&root),
+            "wiki.db escaped the config-dir override: {path:?} is not under {root:?}"
+        );
+        restore(prev);
+    }
 }

--- a/crates/tokscale-core/src/wiki.rs
+++ b/crates/tokscale-core/src/wiki.rs
@@ -548,7 +548,7 @@ mod tests {
     #[test]
     #[serial]
     fn default_path_follows_the_config_dir_override() {
-        let env = guard();
+        let mut env = guard();
         let root = std::env::temp_dir().join("tokscale-wiki-default-path-probe");
         env.set("TOKSCALE_CONFIG_DIR", &root);
         assert_eq!(WikiDb::default_path(), root.join("wiki.db"));
@@ -561,7 +561,7 @@ mod tests {
     #[test]
     #[serial]
     fn default_path_stays_inside_the_resolved_config_dir() {
-        let env = guard();
+        let mut env = guard();
         let root = std::env::temp_dir().join("tokscale-wiki-containment-probe");
         env.set("TOKSCALE_CONFIG_DIR", &root);
         let path = WikiDb::default_path();


### PR DESCRIPTION
Closes the CI half of #997. Remaining Windows failures are enumerated in **#1014**.

## Headline: the gap is bigger than #997 reported

#997 measured 12 failures in `tokscale-cli` on `windows-latest`. That was never the whole number — cargo stops at the first failing test binary, so **nine of the ten binaries had never run at all.** Adding `--no-fail-fast` reached them.

**The first full run of the suite on Windows produced 34 failures** — and that already had this PR's `$HOME` fix applied. Counting the 8 that fix removes, the untouched baseline is **~42**, against the 12 #997 was able to see.

This PR fixes **9** of them (8 `$HOME` + 1 escaping). **33 remain**, tracked in #1014.

| binary | #997 saw (`45b3b3e4`) | observed run (`db6014b2`) | after this PR |
|---|---|---|---|
| `tokscale-cli` (bin) | 947 passed, **12 failed** | 975 passed, **1 failed** | **0 failed** |
| `cli_tests` (integration) | *never ran* | 120 passed, **13 failed** | 13 failed |
| `tokscale-core` (lib) | *never ran* | 1331 passed, **20 failed** | 20 failed |
| other 7 binaries | *never ran* | 35 passed, 0 failed | 0 failed |
| **total** | **12 (of ~42)** | **34** | **33** |

**Confirmed on CI** — https://github.com/junhoyeo/tokscale/actions/runs/30774846051, job `Code Coverage (windows-latest)`:

```
tokscale-cli   test result: ok.     976 passed;  0 failed;  1 ignored
cli_tests      test result: FAILED. 120 passed; 13 failed;  0 ignored
tokscale-core  test result: FAILED. 1331 passed; 20 failed; 1 ignored
+ 7 more binaries, all ok
```

Raw check-run conclusions on this commit, not the summary line:

| check | status | conclusion |
|---|---|---|
| `Lint` | completed | **success** |
| `Code Coverage (ubuntu-latest)` | completed | **success** |
| `Code Coverage (windows-latest)` | completed | **failure** (advisory) |

Workflow-run conclusion is `success` and PR merge state is `UNSTABLE`, not `BLOCKED` — the red X is visible on the PR without gating it, which is the intended behaviour of `continue-on-error` here.

The ~42 is inferred, not observed: 34 measured, plus the 8 `$HOME` failures that #997's reporter enumerated individually and that this branch had already fixed before the run. Only the 34 and the 12 are direct measurements.

The `tokscale-cli` binary — the only one #997 could measure — is now at zero. Of its 12: 3 program defects and 1 test fix landed in #1007 (confirmed absent from this run by name, not assumed), 8 are fixed here, and 1 was fixed only partially by #1007 — see below.

## It immediately paid for itself: #1007 is now verified, not asserted

#1007 fixed three Windows-only defects and its own trailer said so plainly:

> `Not-tested: ZERO Windows tests were executed - macOS only, plus a compile and warning check for x86_64-pc-windows-msvc that validates FFI signatures and nothing about runtime behaviour`

This run is the first time that code has ever executed on Windows. All of it passes, by name:

```
commands::autosubmit::tests::lock_contention_covers_every_platform_error ... ok
commands::autosubmit::tests::run_lock_blocks_concurrent_holder ... ok
process_liveness::windows_policy::tests::only_the_nonexistent_pid_code_reports_death ... ok
process_liveness::windows_policy::tests::access_denied_is_alive ... ok
process_liveness::windows_policy::tests::resource_failures_are_not_death ... ok
process_liveness::windows_policy::tests::failed_exit_code_query_is_alive ... ok
process_liveness::windows_policy::tests::exit_code_query_classifies_liveness ... ok
antigravity::tests::sync_lock_guard_overwrites_stale_lock ... ok
antigravity::tests::sync_lock_guard_blocks_when_self_pid_lock_present ... ok
antigravity::tests::delete_artifact_relative_path_accepts_windows_separators ... ok
antigravity::tests::cleanup_stale_session_artifacts_keeps_a_live_artifact_respelled_across_platforms ... ok
```

That is the argument for this job in one screen: the `windows_policy` module was written, reviewed and shipped without a single line of it ever running.

## Blocking decision: advisory, deliberately and temporarily

The windows leg is `continue-on-error: true`. Ubuntu stays a hard gate.

I originally made this a hard gate on the assumption the suite would be green after fixing the ~9 test-side failures #997 predicted. The first real run disproved that. The 33 remaining failures are **not one bug** — they span six unrelated root causes, and two groups look like genuine Windows defects rather than test artefacts:

- the crush registry scan returns **nothing at all** on Windows (5 tests, including one written specifically for Windows `%LOCALAPPDATA%` semantics)
- cc-mirror attributes the **wrong provider** (`anthropic` where the variant says `zai`), which would mean wrong pricing (4 tests)

Blocking every PR on that set forces one of two bad outcomes: revert the job, or land a thirty-plus-fix change spanning six root causes that nobody can review — and two of which need a maintainer call on production behaviour. So the signal lands first and the failures get fixed against a visible baseline.

**This must not become permanent.** An advisory job nobody is required to read is precisely how #997 happened, and the workflow comment says so and names the condition for flipping it: when #1014 closes.

## What is fixed here

### `$HOME` now means the same thing on every platform (8 tests)

`dirs::home_dir()` reads `$HOME` on Unix and calls the Win32 known-folder API on Windows, where no environment variable can reach it. Every test that points `HOME` at a `TempDir` was therefore obeyed on Unix and silently ignored on Windows. Two did more than fail:

- `test_ensure_config_dir` created `%USERPROFILE%\.config\tokscale` **on the machine running the suite**
- `test_load_credentials_nonexistent` asserted `is_none()` while reading the **real** credentials file — passing for a developer not logged in, failing for one who was

`paths::home_dir()` is now the single home resolver, and every `dirs::home_dir()` call site in the workspace routes through it; a redirect that holds for some roots and not others splits state across two locations.

On Windows it honours `$HOME` **only when the value carries a real Win32 prefix** (`C:\...`, `\\?\C:\...`, `\\server\share`). MSYS2, Cygwin and Git Bash export `/home/<user>`, which `Path` resolves against whatever the current drive happens to be — obeying that would relocate a real user's credentials to `C:\home\<user>`. Three new tests in `paths.rs` pin the redirect, the POSIX-shape rejection, and the empty-value case.

No test was edited and none was skipped; all 8 fall out of the resolver change:

| test | why it failed |
|---|---|
| `auth::test_get_credentials_path` | asserted the temp path, got the real profile |
| `auth::test_load_credentials_nonexistent` | read the real credentials file |
| `auth::test_ensure_config_dir` | created a dir in the real profile |
| `antigravity::filesystem_scan_finds_brain_and_conversation_candidates` | `.gemini` roots off the real profile |
| `wrapped::font_cache_reads_legacy_path_when_canonical_missing` | legacy `~/.cache/tokscale` off the real profile |
| `tui/cache::load_cache_falls_back_to_legacy_dot_cache_path` | same legacy root |
| `tui/data::test_data_loader_loads_agent_usage_from_roocode_files` | `PathRoot::Home` → real profile |
| `tui/data::test_data_loader_keeps_synthetic_gateway_messages_under_original_client` | `PathRoot::XdgData` → `<real home>/.local/share` |

### Completing #1007's escaping fix (1 test)

`scheduler_specs_use_the_managed_executable` was still failing. #1007 escaped the needle once to survive `Debug`'s backslash doubling, which is correct for three of the four schedulers. But `systemd_escape_path` **already** doubles every backslash before the value reaches the unit file, so `Debug` doubles it a second time and the Systemd iteration still missed — a Windows path appears as `\\\\` there and `\\` in the other three.

The needle is now derived through the renderer's own escaper rather than restating its rules at the call site, and the assertion carries the scheduler and both strings so the next failure says which leg broke.

### `--no-fail-fast`

The other half of #997's complaint, and the change that produced every number above. One failing binary can no longer suppress the other nine.

## Review round — `e50869eb`

Five review threads (two P1). All five accepted; none rejected. The common finding: three call sites reached *around* `paths::home_dir()` rather than through it, so the Windows protections it was written for never executed.

### The validated resolver was being bypassed (P1)

`get_home_dir_string` read `std::env::var("HOME")` **before** consulting the resolver, and `or_else` only evaluates the next arm when the previous is `None` — so the resolver was unreachable whenever `HOME` was set at all, which on Windows is exactly the Git Bash / MSYS case. A `HOME=/home/user` still reached all seven `from_dir`-style callers, and `Path` resolves that against the current drive: they scanned `C:\home\user`. An exported-but-blank `HOME` produced `Ok("")`, and every consumer builds its scan root with `format!("{home}/...")`, turning that into an absolute walk from the filesystem root.

The raw read is gone; `--home` now falls straight through to the resolver. `commands/report.rs::build_session_path_index` had the identical bypass — same raw read, plus `unwrap_or_default()` on top — and is fixed alongside it. `paths::home_dir` is now the only function in the workspace that reads `$HOME`, recorded as a `Directive:` trailer.

### `wiki.db` escaped the config-dir override (P1)

Worse than reported. `WikiDb::default_path()` built its own `dirs::config_dir()` chain whose fallback only fired when `dirs::config_dir()` returned `None` — which it never does on macOS, Linux or Windows. `TOKSCALE_CONFIG_DIR` was therefore never consulted at all: `tokscale report` opened *and created* `wiki.db` in the real profile under every isolated root. Not only Windows `%APPDATA%\tokscale` — on macOS it was `~/Library/Application Support/tokscale`, so `report_no_summarize_json_empty_home_emits_valid_json_without_panic` (which asserts zero entries against an empty fixture home) has been reading the developer's real wiki DB. It passes on a clean runner and fails for anyone who has actually run `tokscale report`.

Now `paths::get_config_dir().join("wiki.db")`, matching what `CustomPricing::default_path()` already did — `wiki.rs` was the lone holdout. The path also now matches the doc comment that claimed `~/.config/tokscale/wiki.db`.

### Drive-relative `HOME` (P2, raised twice)

`C:temp` parses as `[Prefix("C:"), Normal("temp")]` — a prefix with no root — so the prefix-only check accepted it. Windows resolves that against the *per-drive current directory*, so the same `HOME` names a different place depending on where the process last `cd`-ed. Replaced with `path.is_absolute()`, which on Windows is defined as `has_root() && prefix().is_some()` and so rejects the drive-relative and the POSIX shape in one check, while still accepting `C:\...`, `\\?\C:\...` and `\\server\share`.

### Result on `windows-latest`

Run https://github.com/junhoyeo/tokscale/actions/runs/30796063931, job `Code Coverage (windows-latest)`:

| commit | passed | failed | run |
|---|---|---|---|
| `1468a332` | 2462 | 33 | [30774846051](https://github.com/junhoyeo/tokscale/actions/runs/30774846051) |
| `e50869eb` | 2468 | 33 | [30796063931](https://github.com/junhoyeo/tokscale/actions/runs/30796063931) |
| `c1837173` | 2469 | 33 | [30797335637](https://github.com/junhoyeo/tokscale/actions/runs/30797335637) |
| `eb989f81` | **2469** | **33** | [30804817051](https://github.com/junhoyeo/tokscale/actions/runs/30804817051) |

The +7 are these commits' own new tests. **The failing set is byte-identical to `1468a332`** — diffed by name across all four runs, zero fixed, zero newly broken.

That is the honest answer to "will fixing `wiki.db` clear part of the config-dir group": **no.** None of the 33 exercise `report`. #1014 Group 1 is `get_config_dir()` itself still resolving via `dirs::config_dir()` on Windows and therefore ignoring a redirected `$HOME` — a different resolver, still open, still the maintainer call. This change makes `wiki.db` follow `TOKSCALE_CONFIG_DIR`; it does not make `get_config_dir()` follow `$HOME`. What it does fix is real contamination of the user's profile on both Windows and macOS.

### Tests

Three fail on macOS before the fix and are the regression proof: `get_home_dir_string_never_returns_an_empty_home` (`Ok("")`), `wiki::tests::default_path_follows_the_config_dir_override`, `default_path_stays_inside_the_resolved_config_dir` (both resolved to `~/Library/Application Support/...`). Plus `get_home_dir_string_prefers_the_explicit_option`.

Two are `#[cfg(windows)]` out of necessity, not convenience: `home_dir_ignores_a_drive_relative_home` and `get_home_dir_string_ignores_a_posix_shaped_home_on_windows`. `C:temp` is an ordinary relative filename on Unix and `/home/runner` is a legitimate absolute path there, so no macOS test can distinguish either. They are not untested — they execute on the `windows-latest` leg this PR adds, which is the point of the job.

### Second review round — `c1837173`

Two further P2s, both valid: the new tests saved and restored `HOME` / `TOKSCALE_CONFIG_DIR` on the last line of the body, so a failing assertion panicked before the restore and leaked the redirect into every later test in the process. `serial_test` does not help — it prevents overlap, not inheritance, since the tests share one process. On a leg that is red by design while #1014 is open, that turns one real failure into a cascade of order-dependent ones.

Fixed with an RAII guard rather than restore-before-assert, which still leaks if setup panics. The pattern already existed in the crate — `scanner.rs:1876` and `sessions/opencode.rs:658` each carry a private `EnvGuard` — so this hoists one `pub(crate)` copy into `paths::test_env` and points `paths`, `wiki` and the crate-root tests at it. The pre-existing `paths.rs` tests had the same leak through the `save_env`/`restore_env` helpers being removed and are converted in the same pass. `env_guard_restores_even_when_the_test_body_panics` pins the unwind behaviour with `catch_unwind` so it cannot regress to a happy-path-only restore.

### Third review round — `eb989f81`

Two P3s. The first was a fair hit on the previous commit: it introduced a `pub(crate)` guard and called it shared while leaving the private copies in `scanner.rs` and `sessions/opencode.rs` in place — three implementations, worse than the two it started with. I had rejected consolidating them as churn; measuring it changed my mind. Making the shared guard's `set` / `remove` take `&mut self` — the signature `scanner.rs` already used — means its fourteen call sites compile untouched, so that file is a pure deletion plus one `use`. Net 40 insertions, 88 deletions, and `grep -rn "struct EnvGuard" crates/` now returns exactly one hit.

The second: the panic probe set its own sentinel with a raw `set_var` and cleared it on the last line, so a failure in its own assertions would leak the variable it exists to prove nothing leaks. It captures with the guard now. Zero raw env mutations remain in the test module — the only `set_var` / `remove_var` calls left in `paths.rs` are inside `EnvGuard`'s own impl, which is where the `unsafe` belongs.

### While auditing the failure list

#1014's enumeration was short by two and two group headers undercounted their own bullet lists. Corrected there: Group 2 is 6 not 5, Group 3 is 5 not 4, `test_submit_default_graph_includes_antigravity_cache_rows` added to Group 1, and a new Group 7 for `test_scan_all_clients_kimi_code_home_override_is_not_trimmed` — which fails at fixture setup with `Os { code: 3, NotFound }` because it names a directory ` padded-kimi-code ` and Win32 silently strips trailing spaces. The groups now reconcile to 33.

## Scope calls

**Only the test job gets the matrix; `Lint` stays ubuntu-only.** `cargo fmt --check` is platform-invariant, the job's other five steps are bash release-helper scripts, and Windows *compilation* is already covered by `build-native.yml`. A Windows `clippy` lane would newly lint `#[cfg(windows)]` code — real signal, but a different change with a different blast radius, and bundling it would mean fixing whatever `-D warnings` finds in never-linted Windows code inside a CI PR.

**`fail-fast: false`.** Cancelling the Windows leg when Ubuntu fails hides whether a failure is cross-platform or platform-specific.

Tarpaulin, badge and artifact steps are gated to `ubuntu-latest` — they are Linux-shaped (`jq`, `mkdir -p`, `printf`) and the badge step pushes to `main`, which must not happen twice.

## Known gap, not fixed here

`get_config_dir()` on Windows still resolves to the real `%APPDATA%` even when `HOME` is redirected, because it deliberately mirrors `dirs::config_dir()`. This is the single largest remaining group (~13 tests) and fixing it is a maintainer call: the test-side fix changes what those tests exercise, and the production-side fix (#915's `<supplied-home>/AppData/Roaming/tokscale` convention) relocates config for any Windows user whose `HOME` differs from `USERPROFILE`. Written up as Group 1 in #1014.





