### PR TITLE
feat(submit): populate per-device client/bucket token high-water marks

### DIFF
--- a/packages/frontend/__tests__/api/submitRatchetCensus.test.ts
+++ b/packages/frontend/__tests__/api/submitRatchetCensus.test.ts
@@ -1,0 +1,429 @@
+import { beforeAll, beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+
+// Pins the PLACEMENT contract of the Phase 1 / Phase 1.5 ratchet census
+// (docs/ratchet-inflation-recovery.md, issue #960):
+//
+//   - The high-water write runs AFTER the submit transaction commits, not
+//     inside it. The submit path holds `.for('update')` on the submissions row
+//     for the whole transaction, serializing a user's submits across every
+//     device, so a defect in a write placed there would fail the user's
+//     submission outright. "Nothing reads it" is no protection against that.
+//   - Because the write is a GREATEST upsert it is idempotent, so a failure
+//     after commit costs one deferred measurement — repaired by the next
+//     submit — instead of a rejected submission. It must therefore never
+//     propagate out of the handler.
+//   - Phase 1.5 records a second derivation of the total and serves the
+//     existing one unchanged.
+//   - The write is killable by env flag without reverting a migration.
+const mockState = vi.hoisted(() => {
+  const authenticatePersonalToken = vi.fn();
+  const validateSubmission = vi.fn();
+  const generateSubmissionHash = vi.fn(() => "submission-hash");
+  const revalidateTag = vi.fn();
+  const revalidateUsernamePaths = vi.fn();
+  const revalidateUserGroupLeaderboards = vi.fn();
+  const mergeClientBreakdownsWithRegressionGuard = vi.fn();
+  const recalculateDayTotals = vi.fn();
+  const deriveClientBreakdownProvenance = vi.fn(() => ({
+    schemaVersion: 1,
+    messageCount: 0,
+    modelCount: 1,
+  }));
+  const clientContributionToBreakdownData = vi.fn();
+  const mergeTimestampMs = vi.fn();
+
+  const db = {
+    transaction: vi.fn(),
+    execute: vi.fn(),
+  };
+
+  return {
+    authenticatePersonalToken,
+    validateSubmission,
+    generateSubmissionHash,
+    revalidateTag,
+    revalidateUsernamePaths,
+    revalidateUserGroupLeaderboards,
+    mergeClientBreakdownsWithRegressionGuard,
+    recalculateDayTotals,
+    deriveClientBreakdownProvenance,
+    clientContributionToBreakdownData,
+    mergeTimestampMs,
+    db,
+    reset() {
+      authenticatePersonalToken.mockReset();
+      validateSubmission.mockReset();
+      generateSubmissionHash.mockClear();
+      revalidateTag.mockClear();
+      revalidateUsernamePaths.mockReset();
+      revalidateUserGroupLeaderboards.mockReset();
+      mergeClientBreakdownsWithRegressionGuard.mockReset();
+      recalculateDayTotals.mockReset();
+      deriveClientBreakdownProvenance.mockClear();
+      clientContributionToBreakdownData.mockReset();
+      mergeTimestampMs.mockReset();
+      db.transaction.mockReset();
+      db.execute.mockReset();
+    },
+  };
+});
+
+vi.mock("next/cache", () => ({ revalidateTag: mockState.revalidateTag }));
+
+vi.mock("@/lib/auth/personalTokens", () => ({
+  authenticatePersonalToken: mockState.authenticatePersonalToken,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockState.db,
+  apiTokens: { id: "apiTokens.id" },
+  submissions: {
+    id: "submissions.id",
+    userId: "submissions.userId",
+    totalTokens: "submissions.totalTokens",
+    totalCost: "submissions.totalCost",
+    inputTokens: "submissions.inputTokens",
+    outputTokens: "submissions.outputTokens",
+    cacheCreationTokens: "submissions.cacheCreationTokens",
+    cacheReadTokens: "submissions.cacheReadTokens",
+    reasoningTokens: "submissions.reasoningTokens",
+    dateStart: "submissions.dateStart",
+    dateEnd: "submissions.dateEnd",
+    sourcesUsed: "submissions.sourcesUsed",
+    modelsUsed: "submissions.modelsUsed",
+    cliVersion: "submissions.cliVersion",
+    submissionHash: "submissions.submissionHash",
+    schemaVersion: "submissions.schemaVersion",
+    hasBackfill: "submissions.hasBackfill",
+  },
+  submittedDevices: {
+    id: "submittedDevices.id",
+    userId: "submittedDevices.userId",
+    deviceKey: "submittedDevices.deviceKey",
+    displayName: "submittedDevices.displayName",
+    lastSubmittedAt: "submittedDevices.lastSubmittedAt",
+    updatedAt: "submittedDevices.updatedAt",
+  },
+  dailyBreakdown: {
+    id: "dailyBreakdown.id",
+    submissionId: "dailyBreakdown.submissionId",
+    submittedDeviceId: "dailyBreakdown.submittedDeviceId",
+    date: "dailyBreakdown.date",
+    timestampMs: "dailyBreakdown.timestampMs",
+    activeTimeMs: "dailyBreakdown.activeTimeMs",
+    sourceBreakdown: "dailyBreakdown.sourceBreakdown",
+    tokens: "dailyBreakdown.tokens",
+    cost: "dailyBreakdown.cost",
+    inputTokens: "dailyBreakdown.inputTokens",
+    outputTokens: "dailyBreakdown.outputTokens",
+  },
+}));
+
+vi.mock("@/lib/validation/submission", () => ({
+  validateSubmission: mockState.validateSubmission,
+  generateSubmissionHash: mockState.generateSubmissionHash,
+}));
+
+vi.mock("@/lib/db/helpers", () => ({
+  mergeClientBreakdownsWithRegressionGuard:
+    mockState.mergeClientBreakdownsWithRegressionGuard,
+  recalculateDayTotals: mockState.recalculateDayTotals,
+  deriveClientBreakdownProvenance: mockState.deriveClientBreakdownProvenance,
+  clientContributionToBreakdownData: mockState.clientContributionToBreakdownData,
+  mergeTimestampMs: mockState.mergeTimestampMs,
+}));
+
+vi.mock("@/lib/db/usernameLookup", () => ({
+  normalizeUsernameCacheKey: (username: string) => username.toLowerCase(),
+  revalidateUsernamePaths: mockState.revalidateUsernamePaths,
+}));
+
+vi.mock("@/lib/groups/cache", () => ({
+  revalidateUserGroupLeaderboards: mockState.revalidateUserGroupLeaderboards,
+}));
+
+type ModuleExports = typeof import("../../src/app/api/submit/route");
+
+let POST: ModuleExports["POST"];
+
+beforeAll(async () => {
+  const routeModule = await import("../../src/app/api/submit/route");
+  POST = routeModule.POST;
+});
+
+const flagName = "TOKSCALE_DEVICE_CLIENT_TOTALS_WRITE";
+
+beforeEach(() => {
+  mockState.reset();
+  delete process.env[flagName];
+});
+
+afterEach(() => {
+  delete process.env[flagName];
+  vi.restoreAllMocks();
+});
+
+function makeAwaitableBuilder(result: unknown) {
+  const builder = {
+    from: vi.fn(() => builder),
+    where: vi.fn(() => builder),
+    for: vi.fn(() => builder),
+    limit: vi.fn(() => builder),
+    then: (resolve: (value: unknown) => unknown) => Promise.resolve(resolve(result)),
+  };
+  return builder;
+}
+
+const AGGREGATES_ROW = {
+  totalTokens: 12,
+  totalCost: "0.5000",
+  inputTokens: 7,
+  outputTokens: 5,
+  dateStart: "2026-05-11",
+  dateEnd: "2026-05-11",
+  activeDays: 1,
+  rowCount: 1,
+};
+
+const ALL_DAYS_ROW = {
+  sourceBreakdown: {
+    codex: { cacheRead: 0, cacheWrite: 0, reasoning: 0, models: { "gpt-5.5": { tokens: 12 } } },
+  },
+};
+
+function validSubmissionData(provenance?: { origin: string }) {
+  return {
+    device: { id: "dev_1", name: "Device one" },
+    meta: { version: "4.5.3", dateRange: { start: "2026-05-11", end: "2026-05-11" } },
+    summary: { clients: ["codex"] },
+    contributions: [
+      {
+        date: "2026-05-11",
+        clients: [
+          {
+            client: "codex",
+            modelId: "gpt-5.5",
+            messages: 1,
+            cost: 0.5,
+            tokens: { input: 7, output: 5, cacheRead: 0, cacheWrite: 0, reasoning: 0 },
+          },
+        ],
+      },
+    ],
+    ...(provenance ? { provenance } : {}),
+  };
+}
+
+function primeMocks(provenance?: { origin: string }) {
+  mockState.authenticatePersonalToken.mockResolvedValue({
+    status: "valid",
+    tokenId: "token-1",
+    userId: "11111111-1111-4111-8111-111111111111",
+    username: "alice",
+    displayName: "Alice",
+    avatarUrl: null,
+    expiresAt: null,
+  });
+  mockState.validateSubmission.mockReturnValue({
+    valid: true,
+    data: validSubmissionData(provenance),
+    errors: [],
+    warnings: [],
+  });
+  mockState.clientContributionToBreakdownData.mockReturnValue({
+    tokens: 12,
+    cost: 0.5,
+    input: 7,
+    output: 5,
+    cacheRead: 0,
+    cacheWrite: 0,
+    reasoning: 0,
+    messages: 1,
+  });
+  mockState.recalculateDayTotals.mockReturnValue({
+    tokens: 12,
+    cost: 0.5,
+    inputTokens: 7,
+    outputTokens: 5,
+  });
+  mockState.mergeTimestampMs.mockImplementation((_e: unknown, i: unknown) => i);
+  mockState.mergeClientBreakdownsWithRegressionGuard.mockImplementation(
+    (_existing: unknown, incoming: Record<string, unknown>) => ({
+      merged: incoming,
+      warnings: [],
+      foldPreservedClients: new Set<string>(),
+    })
+  );
+}
+
+interface TxTrace {
+  /** Statements executed INSIDE the submit transaction. */
+  inTransaction: unknown[];
+  /** True once the transaction callback has returned (i.e. commit point). */
+  committed: () => boolean;
+}
+
+function buildMockTx(): TxTrace {
+  const inTransaction: unknown[] = [];
+  let committed = false;
+  const selectResults: unknown[][] = [
+    [], // no existing submission -> insert path
+    [], // no existing device days -> new-day INSERT path
+    [AGGREGATES_ROW],
+    [{ totalActiveTimeMs: 0, sessionCount: 0, longestContinuousMs: 0, maxConcurrentSessions: 0 }],
+    [ALL_DAYS_ROW],
+  ];
+
+  let insertCall = 0;
+  const tx = {
+    update: vi.fn(() => {
+      const builder = {
+        set: vi.fn(() => builder),
+        where: vi.fn(() => Promise.resolve()),
+      };
+      return builder;
+    }),
+    select: vi.fn(() => makeAwaitableBuilder(selectResults.shift() ?? [])),
+    insert: vi.fn(() => {
+      insertCall += 1;
+      if (insertCall === 1) {
+        const builder = {
+          values: vi.fn(() => builder),
+          returning: vi.fn(() => Promise.resolve([{ id: "submission-1" }])),
+        };
+        return builder;
+      }
+      const builder = {
+        values: vi.fn(() => builder),
+        onConflictDoUpdate: vi.fn(() => builder),
+        returning: vi.fn(() =>
+          Promise.resolve([{ id: "22222222-2222-4222-8222-222222222222" }])
+        ),
+      };
+      return builder;
+    }),
+    execute: vi.fn((sqlArg: unknown) => {
+      inTransaction.push(sqlArg);
+      return Promise.resolve();
+    }),
+    transaction: vi.fn(async (cb: (sp: typeof tx) => Promise<unknown>) => cb(tx)),
+  };
+
+  mockState.db.transaction.mockImplementation(
+    async (cb: (transaction: typeof tx) => Promise<unknown>) => {
+      const value = await cb(tx);
+      committed = true;
+      return value;
+    }
+  );
+
+  return { inTransaction, committed: () => committed };
+}
+
+function submitRequest() {
+  return new Request("http://localhost:3000/api/submit", {
+    method: "POST",
+    headers: { Authorization: "Bearer tt_valid", "Content-Type": "application/json" },
+    body: JSON.stringify({ meta: {}, contributions: [] }),
+  });
+}
+
+function renderExecutedSql(calls: unknown[][]): string[] {
+  return calls.map(([arg]) => JSON.stringify(arg));
+}
+
+describe("POST /api/submit ratchet census placement (phase 1 / 1.5)", () => {
+  it("writes the high-water rows AFTER the transaction commits, never inside it", async () => {
+    primeMocks();
+    const trace = buildMockTx();
+    let committedWhenCensusRan: boolean | null = null;
+    mockState.db.execute.mockImplementation(async () => {
+      if (committedWhenCensusRan === null) committedWhenCensusRan = trace.committed();
+      return [{ bucketCount: 1, tokens: 12, cost: "0.5000" }];
+    });
+
+    const response = await POST(submitRequest());
+    expect(response.status).toBe(200);
+
+    // The census upsert reached the db outside the transaction...
+    expect(mockState.db.execute).toHaveBeenCalled();
+    expect(committedWhenCensusRan).toBe(true);
+    const outside = renderExecutedSql(mockState.db.execute.mock.calls);
+    expect(outside.some((s) => s.includes("submitted_device_client_totals"))).toBe(true);
+    // ...and no statement touching the census table ran inside it.
+    const inside = JSON.stringify(trace.inTransaction);
+    expect(inside).not.toContain("submitted_device_client_totals");
+  });
+
+  it("does not fail the submit when the post-commit census write throws", async () => {
+    primeMocks();
+    buildMockTx();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockState.db.execute.mockRejectedValue(new Error("bigint out of range"));
+
+    const response = await POST(submitRequest());
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    // The served metrics are the SUM(daily_breakdown) values, untouched.
+    expect(body.metrics.totalTokens).toBe(12);
+    expect(consoleError).toHaveBeenCalledWith(
+      "Ratchet census write failed (submission unaffected):",
+      expect.any(Error)
+    );
+  });
+
+  it("serves the SUM(daily) total unchanged even when the high-water total disagrees", async () => {
+    primeMocks();
+    buildMockTx();
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    mockState.db.execute.mockResolvedValue([
+      { bucketCount: 1, tokens: 3, cost: "0.1000" },
+    ]);
+
+    const response = await POST(submitRequest());
+    const body = await response.json();
+
+    expect(body.metrics.totalTokens).toBe(12);
+    const censusLog = consoleLog.mock.calls
+      .map((call) => String(call[0]))
+      .find((line) => line.startsWith("ratchet-census "));
+    expect(censusLog).toBeDefined();
+    const record = JSON.parse(censusLog!.slice("ratchet-census ".length));
+    expect(record).toMatchObject({
+      servedTokens: 12,
+      highwaterTokens: 3,
+      tokenDelta: 9,
+      highwaterStatus: "known",
+    });
+  });
+
+  it("records UNKNOWN, not zero, while the user has no buckets yet", async () => {
+    primeMocks();
+    buildMockTx();
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    mockState.db.execute.mockResolvedValue([{ bucketCount: 0, tokens: 0, cost: "0" }]);
+
+    await POST(submitRequest());
+
+    const censusLog = consoleLog.mock.calls
+      .map((call) => String(call[0]))
+      .find((line) => line.startsWith("ratchet-census "));
+    const record = JSON.parse(censusLog!.slice("ratchet-census ".length));
+    expect(record.highwaterStatus).toBe("unknown");
+    expect(record.highwaterTokens).toBeNull();
+    expect(record.tokenDelta).toBeNull();
+  });
+
+  it("is killable by env flag without reverting the migration", async () => {
+    process.env[flagName] = "0";
+    primeMocks();
+    buildMockTx();
+
+    const response = await POST(submitRequest());
+
+    expect(response.status).toBe(200);
+    expect(mockState.db.execute).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/__tests__/api/submitRatchetCensus.test.ts
+++ b/packages/frontend/__tests__/api/submitRatchetCensus.test.ts
@@ -362,6 +362,17 @@ describe("POST /api/submit ratchet census placement (phase 1 / 1.5)", () => {
     expect(inside).not.toContain("submitted_device_client_totals");
   });
 
+  it("registers durable replay work inside the transaction before the daily rows are visible", async () => {
+    primeMocks();
+    const trace = buildMockTx();
+    mockState.db.execute.mockResolvedValue([]);
+
+    const response = await POST(submitRequest());
+
+    expect(response.status).toBe(200);
+    expect(JSON.stringify(trace.inTransaction)).toContain("ratchet_census_work");
+  });
+
   it("does not fail the submit when the post-commit census write throws", async () => {
     primeMocks();
     buildMockTx();

--- a/packages/frontend/__tests__/api/submitRatchetCensus.test.ts
+++ b/packages/frontend/__tests__/api/submitRatchetCensus.test.ts
@@ -93,6 +93,7 @@ vi.mock("@/lib/db", () => ({
     modelsUsed: "submissions.modelsUsed",
     cliVersion: "submissions.cliVersion",
     submissionHash: "submissions.submissionHash",
+    ratchetCensusPending: "submissions.ratchetCensusPending",
     schemaVersion: "submissions.schemaVersion",
     hasBackfill: "submissions.hasBackfill",
   },
@@ -402,6 +403,35 @@ describe("POST /api/submit ratchet census placement (phase 1 / 1.5)", () => {
       highwaterTokens: 3,
       tokenDelta: 9,
       highwaterStatus: "known",
+    });
+  });
+
+  it("defers the A/B comparison when B commits daily rows before its high-water upsert", async () => {
+    primeMocks();
+    buildMockTx();
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    // Deterministic A/B timing: A has finished its upsert and reads the
+    // census after B committed its daily rows plus pending ledger entry, but
+    // before B starts its own deferred upsert. The census must not emit the
+    // apparent 9-token gap as a stable divergence.
+    mockState.db.execute.mockResolvedValue([
+      { snapshotTokens: 12, snapshotCost: "0.5000", censusPending: 2, bucketCount: 1, tokens: 3, cost: "0.1000" },
+    ]);
+
+    const response = await POST(submitRequest());
+    expect(response.status).toBe(200);
+
+    const censusLog = consoleLog.mock.calls
+      .map((call) => String(call[0]))
+      .find((line) => line.startsWith("ratchet-census "));
+    const record = JSON.parse(censusLog!.slice("ratchet-census ".length));
+    expect(record).toMatchObject({
+      racedConcurrentSubmit: true,
+      censusStatus: "pending",
+      highwaterTokens: 3,
+      tokenDelta: null,
+      tokenRatio: null,
     });
   });
 

--- a/packages/frontend/__tests__/api/submitRatchetCensus.test.ts
+++ b/packages/frontend/__tests__/api/submitRatchetCensus.test.ts
@@ -339,7 +339,9 @@ describe("POST /api/submit ratchet census placement (phase 1 / 1.5)", () => {
     let committedWhenCensusRan: boolean | null = null;
     mockState.db.execute.mockImplementation(async () => {
       if (committedWhenCensusRan === null) committedWhenCensusRan = trace.committed();
-      return [{ bucketCount: 1, tokens: 12, cost: "0.5000" }];
+      return [
+        { snapshotTokens: 12, snapshotCost: "0.5000", bucketCount: 1, tokens: 12, cost: "0.5000" },
+      ];
     });
 
     const response = await POST(submitRequest());
@@ -379,7 +381,7 @@ describe("POST /api/submit ratchet census placement (phase 1 / 1.5)", () => {
     buildMockTx();
     const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
     mockState.db.execute.mockResolvedValue([
-      { bucketCount: 1, tokens: 3, cost: "0.1000" },
+      { snapshotTokens: 12, snapshotCost: "0.5000", bucketCount: 1, tokens: 3, cost: "0.1000" },
     ]);
 
     const response = await POST(submitRequest());
@@ -403,7 +405,9 @@ describe("POST /api/submit ratchet census placement (phase 1 / 1.5)", () => {
     primeMocks();
     buildMockTx();
     const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
-    mockState.db.execute.mockResolvedValue([{ bucketCount: 0, tokens: 0, cost: "0" }]);
+    mockState.db.execute.mockResolvedValue([
+      { snapshotTokens: 12, snapshotCost: "0.5000", bucketCount: 0, tokens: 0, cost: "0" },
+    ]);
 
     await POST(submitRequest());
 

--- a/packages/frontend/__tests__/api/submitRatchetCensus.test.ts
+++ b/packages/frontend/__tests__/api/submitRatchetCensus.test.ts
@@ -155,7 +155,11 @@ const flagName = "TOKSCALE_DEVICE_CLIENT_TOTALS_WRITE";
 
 beforeEach(() => {
   mockState.reset();
-  delete process.env[flagName];
+  // The census now defaults OFF so it cannot add latency to `POST /api/submit`
+  // by accident (see the flag's doc comment). These tests exercise the census
+  // itself, so they opt in explicitly rather than depending on the production
+  // default — which is what a test asserting placement should do anyway.
+  process.env[flagName] = "1";
 });
 
 afterEach(() => {

--- a/packages/frontend/__tests__/lib/deviceClientTotals.test.ts
+++ b/packages/frontend/__tests__/lib/deviceClientTotals.test.ts
@@ -1,0 +1,455 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { PgDialect } from "drizzle-orm/pg-core";
+import type { SQL } from "drizzle-orm";
+
+import {
+  DEVICE_CLIENT_TOTALS_BUCKET_WIDTH,
+  DEVICE_CLIENT_TOTALS_WRITE_FLAG,
+  buildDualDerivationRecord,
+  foldContributionsIntoBuckets,
+  interpretHighwaterAggregate,
+  isDeviceClientTotalsWriteEnabled,
+  monthBucketKey,
+  readHighwaterTotal,
+  recordDeviceClientTotals,
+  type DeviceClientTotalsContribution,
+} from "@/lib/db/deviceClientTotals";
+
+// Pins Phase 1 / Phase 1.5 of docs/ratchet-inflation-recovery.md:
+// per-device, per-client, per-bucket token/cost HIGH-WATER marks that nothing
+// reads, written after the submit transaction commits.
+
+const dialect = new PgDialect();
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+}
+
+function capturingExecutor() {
+  const queries: CapturedQuery[] = [];
+  return {
+    queries,
+    execute: async (query: SQL) => {
+      queries.push(dialect.sqlToQuery(query));
+      return [];
+    },
+  };
+}
+
+function day(
+  date: string,
+  clients: Array<{ client: string; modelId?: string; tokens?: number; cost?: number }>
+): DeviceClientTotalsContribution {
+  return {
+    date,
+    clients: clients.map((c) => ({
+      client: c.client,
+      modelId: c.modelId ?? "model-a",
+      messages: 1,
+      cost: c.cost ?? 0,
+      tokens: {
+        input: c.tokens ?? 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        reasoning: 0,
+      },
+    })),
+  };
+}
+
+describe("monthBucketKey", () => {
+  it("folds an ISO date to its month", () => {
+    expect(monthBucketKey("2026-05-11")).toBe("2026-05");
+    expect(monthBucketKey("2026-12-31")).toBe("2026-12");
+  });
+
+  it("refuses to invent a bucket from a malformed date", () => {
+    expect(monthBucketKey("2026-5-11")).toBeNull();
+    expect(monthBucketKey("not-a-date")).toBeNull();
+    expect(monthBucketKey("2026-13-01")).toBeNull();
+    expect(monthBucketKey("")).toBeNull();
+  });
+});
+
+describe("foldContributionsIntoBuckets", () => {
+  it("sums every day of a month into one (client, bucket) row", () => {
+    const buckets = foldContributionsIntoBuckets(
+      [
+        day("2026-05-01", [{ client: "codex", tokens: 10, cost: 1 }]),
+        day("2026-05-31", [{ client: "codex", tokens: 5, cost: 0.5 }]),
+        day("2026-06-01", [{ client: "codex", tokens: 100, cost: 2 }]),
+      ],
+      "cli"
+    );
+
+    expect(buckets).toEqual([
+      {
+        client: "codex",
+        origin: "cli",
+        bucketWidth: "month",
+        bucketKey: "2026-05",
+        tokens: 15,
+        cost: 1.5,
+      },
+      {
+        client: "codex",
+        origin: "cli",
+        bucketWidth: "month",
+        bucketKey: "2026-06",
+        tokens: 100,
+        cost: 2,
+      },
+    ]);
+  });
+
+  it("keeps distinct clients in distinct buckets", () => {
+    const buckets = foldContributionsIntoBuckets(
+      [
+        day("2026-05-01", [
+          { client: "codex", tokens: 10 },
+          { client: "claude-code", tokens: 7 },
+        ]),
+      ],
+      "cli"
+    );
+
+    expect(buckets.map((b) => [b.client, b.tokens])).toEqual([
+      ["codex", 10],
+      ["claude-code", 7],
+    ]);
+  });
+
+  it("writes only the month width, halving the per-submit row count", () => {
+    const buckets = foldContributionsIntoBuckets(
+      [day("2026-05-01", [{ client: "codex", tokens: 1 }])],
+      "cli"
+    );
+    expect(buckets).toHaveLength(1);
+    expect(new Set(buckets.map((b) => b.bucketWidth))).toEqual(
+      new Set([DEVICE_CLIENT_TOTALS_BUCKET_WIDTH])
+    );
+  });
+
+  it("sums every token class, matching the daily-row derivation", () => {
+    const buckets = foldContributionsIntoBuckets(
+      [
+        {
+          date: "2026-05-01",
+          clients: [
+            {
+              client: "codex",
+              modelId: "m",
+              messages: 1,
+              cost: 3,
+              tokens: {
+                input: 1,
+                output: 2,
+                cacheRead: 4,
+                cacheWrite: 8,
+                reasoning: 16,
+              },
+            },
+          ],
+        },
+      ],
+      "cli"
+    );
+    expect(buckets[0].tokens).toBe(31);
+  });
+
+  it("emits ONE row per (client, bucket) even when a day repeats a client", () => {
+    // A day legitimately carries one entry per (client, model). If those did
+    // not fold, a single INSERT would carry two rows with the same primary key
+    // and Postgres would abort it with "ON CONFLICT DO UPDATE command cannot
+    // affect row a second time" — the same hazard the duplicate-dates refine()
+    // on the submission schema exists to prevent.
+    const buckets = foldContributionsIntoBuckets(
+      [
+        day("2026-05-01", [
+          { client: "codex", modelId: "gpt-5.5", tokens: 10, cost: 1 },
+          { client: "codex", modelId: "gpt-5.5-mini", tokens: 3, cost: 0.25 },
+        ]),
+        day("2026-05-02", [{ client: "codex", modelId: "gpt-5.5", tokens: 2, cost: 0.1 }]),
+      ],
+      "cli"
+    );
+
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0]).toMatchObject({ bucketKey: "2026-05", tokens: 15 });
+    expect(buckets[0].cost).toBeCloseTo(1.35, 10);
+
+    const primaryKeys = buckets.map(
+      (b) => `${b.client}|${b.origin}|${b.bucketWidth}|${b.bucketKey}`
+    );
+    expect(new Set(primaryKeys).size).toBe(buckets.length);
+  });
+
+  it("clamps a cost that would not survive the numeric(18,4) cast", () => {
+    // toFixed(4) switches to exponential notation at 1e21, which does not
+    // parse as numeric at all — the statement would error rather than store a
+    // wrong number. Clamping keeps a dishonest payload from costing a real
+    // device its measurement.
+    const buckets = foldContributionsIntoBuckets(
+      [day("2026-05-01", [{ client: "codex", tokens: 1, cost: 1e30 }])],
+      "cli"
+    );
+    expect(buckets[0].cost).toBe(99999999999999);
+    expect(buckets[0].cost.toFixed(4)).toBe("99999999999999.0000");
+  });
+
+  it("drops days whose date could not be bucketed instead of guessing", () => {
+    const buckets = foldContributionsIntoBuckets(
+      [
+        day("2026-05-01", [{ client: "codex", tokens: 10 }]),
+        day("garbage", [{ client: "codex", tokens: 999 }]),
+      ],
+      "cli"
+    );
+    expect(buckets).toEqual([
+      expect.objectContaining({ bucketKey: "2026-05", tokens: 10 }),
+    ]);
+  });
+});
+
+describe("origin separates a backfill from a CLI submit", () => {
+  // getSubmitDevice() falls back to LEGACY_SUBMIT_DEVICE_KEY when a payload
+  // omits `device`, so a `tokscale import` backfill and a legacy CLI submit
+  // land on the SAME submitted_devices row. Keyed without origin, GREATEST
+  // would take the MAX of imported and locally-scanned history instead of
+  // their sum, silently dropping whichever is smaller.
+  it("tags folded rows with the submission origin", () => {
+    const contributions = [day("2026-05-01", [{ client: "codex", tokens: 10 }])];
+    expect(foldContributionsIntoBuckets(contributions, "cli")[0].origin).toBe("cli");
+    expect(foldContributionsIntoBuckets(contributions, "backfill")[0].origin).toBe(
+      "backfill"
+    );
+  });
+
+  it("puts origin in the conflict key, so the two cannot collapse into one row", async () => {
+    const executor = capturingExecutor();
+    await recordDeviceClientTotals({
+      executor,
+      submittedDeviceId: "11111111-1111-4111-8111-111111111111",
+      buckets: foldContributionsIntoBuckets(
+        [day("2026-05-01", [{ client: "codex", tokens: 10 }])],
+        "backfill"
+      ),
+    });
+
+    const [query] = executor.queries;
+    const conflictTarget = query.sql.match(/ON CONFLICT \(([^)]*)\)/)?.[1];
+    expect(conflictTarget?.split(",").map((c) => c.trim())).toEqual([
+      "submitted_device_id",
+      "client",
+      "origin",
+      "bucket_width",
+      "bucket_key",
+    ]);
+    expect(query.params).toContain("backfill");
+  });
+
+  it("matches the primary key the migration actually creates", () => {
+    // A conflict target that does not match a real unique constraint is a
+    // runtime error, so the DDL and the upsert are pinned to each other.
+    const migration = readFileSync(
+      resolve(__dirname, "../../src/lib/db/migrations/0022_uneven_wong.sql"),
+      "utf8"
+    );
+    const pk = migration.match(/PRIMARY KEY\(([^)]*)\)/)?.[1];
+    expect(pk?.split(",").map((c) => c.trim().replace(/"/g, ""))).toEqual([
+      "submitted_device_id",
+      "client",
+      "origin",
+      "bucket_width",
+      "bucket_key",
+    ]);
+  });
+});
+
+describe("recordDeviceClientTotals upsert", () => {
+  it("is monotonic per bucket: a partial resubmit can never lower a stored value", async () => {
+    const executor = capturingExecutor();
+    await recordDeviceClientTotals({
+      executor,
+      submittedDeviceId: "11111111-1111-4111-8111-111111111111",
+      buckets: foldContributionsIntoBuckets(
+        [day("2026-05-01", [{ client: "codex", tokens: 10, cost: 1 }])],
+        "cli"
+      ),
+    });
+
+    const [query] = executor.queries;
+    expect(query.sql).toContain(
+      "tokens_highwater = GREATEST(submitted_device_client_totals.tokens_highwater, EXCLUDED.tokens_highwater)"
+    );
+    expect(query.sql).toContain(
+      "cost_highwater = GREATEST(submitted_device_client_totals.cost_highwater, EXCLUDED.cost_highwater)"
+    );
+    // The conflict arm must not contain a bare assignment from EXCLUDED for
+    // either high-water column — that is precisely the regression.
+    expect(query.sql).not.toMatch(
+      /tokens_highwater\s*=\s*EXCLUDED\.tokens_highwater/
+    );
+    expect(query.sql).not.toMatch(/cost_highwater\s*=\s*EXCLUDED\.cost_highwater/);
+  });
+
+  it("binds the folded totals for the addressed device", async () => {
+    const executor = capturingExecutor();
+    await recordDeviceClientTotals({
+      executor,
+      submittedDeviceId: "22222222-2222-4222-8222-222222222222",
+      buckets: foldContributionsIntoBuckets(
+        [day("2026-05-01", [{ client: "codex", tokens: 12, cost: 0.5 }])],
+        "cli"
+      ),
+      now: new Date("2026-05-11T00:00:00.000Z"),
+    });
+
+    expect(executor.queries).toHaveLength(1);
+    expect(executor.queries[0].params).toEqual([
+      "22222222-2222-4222-8222-222222222222",
+      "codex",
+      "cli",
+      "month",
+      "2026-05",
+      12,
+      "0.5000",
+      "2026-05-11T00:00:00.000Z",
+    ]);
+  });
+
+  it("issues no statement at all when the payload folds to nothing", async () => {
+    const executor = capturingExecutor();
+    const written = await recordDeviceClientTotals({
+      executor,
+      submittedDeviceId: "33333333-3333-4333-8333-333333333333",
+      buckets: [],
+    });
+    expect(written).toBe(0);
+    expect(executor.queries).toHaveLength(0);
+  });
+});
+
+describe("a missing bucket reads as UNKNOWN, never as zero", () => {
+  // The write runs after the submit transaction commits, so the table can lag
+  // the daily rows by one submit; and it can only ever be filled by incoming
+  // payloads, because backfilling it from daily_breakdown would seed it with
+  // the inflated value that GREATEST then keeps forever. Either way an absent
+  // bucket carries no information, and reading it as 0 fabricates a collapse.
+  it("reports unknown when the user has no rows yet", () => {
+    expect(
+      interpretHighwaterAggregate({ bucketCount: 0, tokens: 0, cost: "0" })
+    ).toEqual({ status: "unknown" });
+  });
+
+  it("reports unknown when the aggregate row is absent entirely", () => {
+    expect(interpretHighwaterAggregate(undefined)).toEqual({ status: "unknown" });
+    expect(interpretHighwaterAggregate(null)).toEqual({ status: "unknown" });
+  });
+
+  it("reports a known total once at least one bucket exists", () => {
+    expect(
+      interpretHighwaterAggregate({ bucketCount: 3, tokens: 900, cost: "1.5000" })
+    ).toEqual({ status: "known", tokens: 900, cost: 1.5, bucketCount: 3 });
+  });
+
+  it("distinguishes a genuine zero total from no coverage", () => {
+    expect(
+      interpretHighwaterAggregate({ bucketCount: 2, tokens: 0, cost: "0" })
+    ).toEqual({ status: "known", tokens: 0, cost: 0, bucketCount: 2 });
+  });
+
+  it("propagates unknown through readHighwaterTotal without inventing a zero", async () => {
+    const empty = {
+      execute: async () => [{ bucketCount: 0, tokens: 0, cost: "0" }],
+    };
+    await expect(readHighwaterTotal({ executor: empty, userId: "u" })).resolves.toEqual({
+      status: "unknown",
+    });
+  });
+
+  it("clamps the SUM rather than letting the bigint cast abort the statement", async () => {
+    const executor = capturingExecutor();
+    await readHighwaterTotal({ executor, userId: "11111111-1111-4111-8111-111111111111" });
+    expect(executor.queries[0].sql).toContain(
+      "LEAST(COALESCE(SUM(t.tokens_highwater), 0), 9223372036854775807)::bigint"
+    );
+    expect(executor.queries[0].params).toContain("month");
+  });
+});
+
+describe("buildDualDerivationRecord (Phase 1.5)", () => {
+  it("records both derivations and their delta once coverage exists", () => {
+    const record = buildDualDerivationRecord({
+      userId: "u1",
+      submissionId: "s1",
+      servedTokens: 1200,
+      servedCost: 3,
+      highwater: { status: "known", tokens: 1000, cost: 2.5, bucketCount: 4 },
+    });
+
+    expect(record).toMatchObject({
+      servedTokens: 1200,
+      highwaterTokens: 1000,
+      tokenDelta: 200,
+      tokenRatio: 1.2,
+      bucketCount: 4,
+      highwaterStatus: "known",
+    });
+  });
+
+  it("emits a null delta, not the served total, while coverage is unknown", () => {
+    const record = buildDualDerivationRecord({
+      userId: "u1",
+      submissionId: "s1",
+      servedTokens: 1200,
+      servedCost: 3,
+      highwater: { status: "unknown" },
+    });
+
+    expect(record.highwaterStatus).toBe("unknown");
+    expect(record.highwaterTokens).toBeNull();
+    expect(record.tokenDelta).toBeNull();
+    expect(record.tokenRatio).toBeNull();
+    // The served value is untouched: Phase 1.5 changes nothing that is served.
+    expect(record.servedTokens).toBe(1200);
+  });
+
+  it("does not divide by a zero high-water total", () => {
+    const record = buildDualDerivationRecord({
+      userId: "u1",
+      submissionId: "s1",
+      servedTokens: 500,
+      servedCost: 1,
+      highwater: { status: "known", tokens: 0, cost: 0, bucketCount: 2 },
+    });
+    expect(record.tokenRatio).toBeNull();
+    expect(record.tokenDelta).toBe(500);
+  });
+});
+
+describe("isDeviceClientTotalsWriteEnabled", () => {
+  it("defaults to enabled when the flag is unset", () => {
+    expect(isDeviceClientTotalsWriteEnabled({})).toBe(true);
+  });
+
+  it("is killable without a deploy or a migration revert", () => {
+    for (const value of ["0", "false", "off", "no", "FALSE", " off "]) {
+      expect(
+        isDeviceClientTotalsWriteEnabled({ [DEVICE_CLIENT_TOTALS_WRITE_FLAG]: value })
+      ).toBe(false);
+    }
+  });
+
+  it("stays enabled for any other value", () => {
+    for (const value of ["1", "true", "on", ""]) {
+      expect(
+        isDeviceClientTotalsWriteEnabled({ [DEVICE_CLIENT_TOTALS_WRITE_FLAG]: value })
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/frontend/__tests__/lib/deviceClientTotals.test.ts
+++ b/packages/frontend/__tests__/lib/deviceClientTotals.test.ts
@@ -431,7 +431,14 @@ describe("readDualDerivation reads both sides from ONE snapshot", () => {
   it("still reports unknown coverage while returning a served snapshot", async () => {
     const executor = {
       execute: async () => [
-        { snapshotTokens: 1200, snapshotCost: "3.0000", bucketCount: 0, tokens: 0, cost: "0" },
+        {
+          snapshotTokens: 1200,
+          snapshotCost: "3.0000",
+          censusPending: 1,
+          bucketCount: 0,
+          tokens: 0,
+          cost: "0",
+        },
       ],
     };
     const result = await readDualDerivation({ executor, userId: "u", submissionId: "s" });
@@ -449,6 +456,7 @@ describe("buildDualDerivationRecord (Phase 1.5)", () => {
       servedCost: 3,
       snapshotTokens: 1200,
       snapshotCost: 3,
+      censusPending: 1,
       highwater: { status: "known", tokens: 1000, cost: 2.5, bucketCount: 4 },
     });
 
@@ -476,6 +484,7 @@ describe("buildDualDerivationRecord (Phase 1.5)", () => {
       servedCost: 3,
       snapshotTokens: 1500,
       snapshotCost: 4,
+      censusPending: 1,
       highwater: { status: "known", tokens: 1500, cost: 4, bucketCount: 6 },
     });
 
@@ -498,6 +507,7 @@ describe("buildDualDerivationRecord (Phase 1.5)", () => {
       servedCost: 3,
       snapshotTokens: 1500,
       snapshotCost: 4.25,
+      censusPending: 1,
       highwater: { status: "known", tokens: 1500, cost: 4.25, bucketCount: 6 },
     });
 
@@ -513,6 +523,7 @@ describe("buildDualDerivationRecord (Phase 1.5)", () => {
       servedCost: 3,
       snapshotTokens: 1200,
       snapshotCost: 3,
+      censusPending: 1,
       highwater: { status: "unknown" },
     });
 
@@ -524,6 +535,29 @@ describe("buildDualDerivationRecord (Phase 1.5)", () => {
     expect(record.servedTokens).toBe(1200);
   });
 
+  it("defers an A/B read while B's committed daily rows await their high-water upsert", () => {
+    // Deterministic schedule: A has completed its own high-water upsert and
+    // starts the census after B commits daily_breakdown + its ledger entry,
+    // but before B begins the deferred high-water write. Without the ledger,
+    // this pair would look like a trustworthy +300 divergence with
+    // racedConcurrentSubmit false.
+    const record = buildDualDerivationRecord({
+      userId: "u1",
+      submissionId: "s1",
+      servedTokens: 1200,
+      servedCost: 3,
+      snapshotTokens: 1500,
+      snapshotCost: 4,
+      censusPending: 2,
+      highwater: { status: "known", tokens: 1200, cost: 3, bucketCount: 4 },
+    });
+
+    expect(record.racedConcurrentSubmit).toBe(true);
+    expect(record.censusStatus).toBe("pending");
+    expect(record.tokenDelta).toBeNull();
+    expect(record.tokenRatio).toBeNull();
+  });
+
   it("does not divide by a zero high-water total", () => {
     const record = buildDualDerivationRecord({
       userId: "u1",
@@ -532,6 +566,7 @@ describe("buildDualDerivationRecord (Phase 1.5)", () => {
       servedCost: 1,
       snapshotTokens: 500,
       snapshotCost: 1,
+      censusPending: 1,
       highwater: { status: "known", tokens: 0, cost: 0, bucketCount: 2 },
     });
     expect(record.tokenRatio).toBeNull();

--- a/packages/frontend/__tests__/lib/deviceClientTotals.test.ts
+++ b/packages/frontend/__tests__/lib/deviceClientTotals.test.ts
@@ -15,6 +15,7 @@ import {
   readDualDerivation,
   readHighwaterTotal,
   recordDeviceClientTotals,
+  recoverRatchetCensusWork,
   type DeviceClientTotalsContribution,
 } from "@/lib/db/deviceClientTotals";
 
@@ -33,7 +34,7 @@ function capturingExecutor() {
   const queries: CapturedQuery[] = [];
   return {
     queries,
-    execute: async (query: SQL) => {
+    execute: async (query: SQL): Promise<unknown> => {
       queries.push(dialect.sqlToQuery(query));
       return [];
     },
@@ -352,6 +353,89 @@ describe("recordDeviceClientTotals upsert", () => {
   });
 });
 
+describe("recoverRatchetCensusWork", () => {
+  const recoveredWork = {
+    id: "11111111-1111-4111-8111-111111111111",
+    submittedDeviceId: "22222222-2222-4222-8222-222222222222",
+    buckets: foldContributionsIntoBuckets(
+      [day("2026-05-01", [{ client: "codex", tokens: 12, cost: 0.5 }])],
+      "cli"
+    ),
+  };
+
+  it("replays and removes work left by an interrupted request", async () => {
+    const executor = capturingExecutor();
+    let reads = 0;
+    executor.execute = async (query: SQL) => {
+      const captured = dialect.sqlToQuery(query);
+      executor.queries.push(captured);
+      if (captured.sql.includes("SELECT id, submitted_device_id")) {
+        reads += 1;
+        return reads === 1 ? [recoveredWork] : [];
+      }
+      return [];
+    };
+
+    await expect(
+      recoverRatchetCensusWork({
+        executor,
+        submissionId: "33333333-3333-4333-8333-333333333333",
+      })
+    ).resolves.toBe(1);
+    await expect(
+      recoverRatchetCensusWork({
+        executor,
+        submissionId: "33333333-3333-4333-8333-333333333333",
+      })
+    ).resolves.toBe(0);
+
+    expect(executor.queries.some((q) => q.sql.includes("submitted_device_client_totals"))).toBe(
+      true
+    );
+    expect(executor.queries.some((q) => q.sql.includes("DELETE FROM ratchet_census_work"))).toBe(
+      true
+    );
+  });
+
+  it("is safe for concurrent replayers because the high-water write is idempotent", async () => {
+    const executor = capturingExecutor();
+    executor.execute = async (query: SQL) => {
+      const captured = dialect.sqlToQuery(query);
+      executor.queries.push(captured);
+      return captured.sql.includes("SELECT id, submitted_device_id") ? [recoveredWork] : [];
+    };
+
+    await Promise.all([
+      recoverRatchetCensusWork({ executor, submissionId: "33333333-3333-4333-8333-333333333333" }),
+      recoverRatchetCensusWork({ executor, submissionId: "33333333-3333-4333-8333-333333333333" }),
+    ]);
+
+    expect(
+      executor.queries.filter((q) => q.sql.includes("submitted_device_client_totals"))
+    ).toHaveLength(2);
+    expect(executor.queries.filter((q) => q.sql.includes("DELETE FROM ratchet_census_work"))).toHaveLength(2);
+  });
+
+  it("leaves malformed durable work untouched rather than constructing a write from it", async () => {
+    const executor = capturingExecutor();
+    executor.execute = async (query: SQL) => {
+      const captured = dialect.sqlToQuery(query);
+      executor.queries.push(captured);
+      return captured.sql.includes("SELECT id, submitted_device_id")
+        ? [{ ...recoveredWork, buckets: [{ client: "codex" }] }]
+        : [];
+    };
+
+    await expect(
+      recoverRatchetCensusWork({ executor, submissionId: "33333333-3333-4333-8333-333333333333" })
+    ).resolves.toBe(0);
+    expect(executor.queries.some((q) => q.sql.includes("submitted_device_client_totals"))).toBe(
+      false
+    );
+    expect(executor.queries.some((q) => q.sql.includes("DELETE FROM ratchet_census_work"))).toBe(false);
+  });
+});
+
 describe("a missing bucket reads as UNKNOWN, never as zero", () => {
   // The write runs after the submit transaction commits, so the table can lag
   // the daily rows by one submit; and it can only ever be filled by incoming
@@ -434,7 +518,7 @@ describe("readDualDerivation reads both sides from ONE snapshot", () => {
         {
           snapshotTokens: 1200,
           snapshotCost: "3.0000",
-          censusPending: 1,
+          censusPending: 0,
           bucketCount: 0,
           tokens: 0,
           cost: "0",
@@ -456,7 +540,7 @@ describe("buildDualDerivationRecord (Phase 1.5)", () => {
       servedCost: 3,
       snapshotTokens: 1200,
       snapshotCost: 3,
-      censusPending: 1,
+      censusPending: 0,
       highwater: { status: "known", tokens: 1000, cost: 2.5, bucketCount: 4 },
     });
 
@@ -484,7 +568,7 @@ describe("buildDualDerivationRecord (Phase 1.5)", () => {
       servedCost: 3,
       snapshotTokens: 1500,
       snapshotCost: 4,
-      censusPending: 1,
+      censusPending: 0,
       highwater: { status: "known", tokens: 1500, cost: 4, bucketCount: 6 },
     });
 
@@ -507,7 +591,7 @@ describe("buildDualDerivationRecord (Phase 1.5)", () => {
       servedCost: 3,
       snapshotTokens: 1500,
       snapshotCost: 4.25,
-      censusPending: 1,
+      censusPending: 0,
       highwater: { status: "known", tokens: 1500, cost: 4.25, bucketCount: 6 },
     });
 
@@ -523,7 +607,7 @@ describe("buildDualDerivationRecord (Phase 1.5)", () => {
       servedCost: 3,
       snapshotTokens: 1200,
       snapshotCost: 3,
-      censusPending: 1,
+      censusPending: 0,
       highwater: { status: "unknown" },
     });
 
@@ -548,7 +632,7 @@ describe("buildDualDerivationRecord (Phase 1.5)", () => {
       servedCost: 3,
       snapshotTokens: 1500,
       snapshotCost: 4,
-      censusPending: 2,
+      censusPending: 1,
       highwater: { status: "known", tokens: 1200, cost: 3, bucketCount: 4 },
     });
 
@@ -566,7 +650,7 @@ describe("buildDualDerivationRecord (Phase 1.5)", () => {
       servedCost: 1,
       snapshotTokens: 500,
       snapshotCost: 1,
-      censusPending: 1,
+      censusPending: 0,
       highwater: { status: "known", tokens: 0, cost: 0, bucketCount: 2 },
     });
     expect(record.tokenRatio).toBeNull();

--- a/packages/frontend/__tests__/lib/deviceClientTotals.test.ts
+++ b/packages/frontend/__tests__/lib/deviceClientTotals.test.ts
@@ -74,6 +74,23 @@ describe("monthBucketKey", () => {
     expect(monthBucketKey("2026-13-01")).toBeNull();
     expect(monthBucketKey("")).toBeNull();
   });
+
+  // A day that does not exist is well-formed enough to survive a shape check
+  // and a month range check, and slicing it still yields a real-looking month.
+  // Note `new Date("2026-02-31Z")` does not throw — it rolls over to March — so
+  // bucketing the parsed value would file February usage under March.
+  it("rejects days that do not exist rather than folding them", () => {
+    expect(monthBucketKey("2026-02-31")).toBeNull();
+    expect(monthBucketKey("2026-04-31")).toBeNull();
+    expect(monthBucketKey("2026-06-00")).toBeNull();
+  });
+
+  it("gets leap years right", () => {
+    expect(monthBucketKey("2024-02-29")).toBe("2024-02");
+    expect(monthBucketKey("2025-02-29")).toBeNull();
+    expect(monthBucketKey("2000-02-29")).toBe("2000-02");
+    expect(monthBucketKey("1900-02-29")).toBeNull();
+  });
 });
 
 describe("foldContributionsIntoBuckets", () => {
@@ -468,6 +485,24 @@ describe("buildDualDerivationRecord (Phase 1.5)", () => {
     expect(record.racedConcurrentSubmit).toBe(true);
     // ...and the value actually served is still reported unchanged.
     expect(record.servedTokens).toBe(1200);
+  });
+
+  // A concurrent submit that moved only the cost is still a race. Comparing
+  // tokens alone reported it as `false`, which would let the census treat a
+  // delta computed across two different states as a stable reading.
+  it("records a cost-only concurrent submit as a race", () => {
+    const record = buildDualDerivationRecord({
+      userId: "u1",
+      submissionId: "s1",
+      servedTokens: 1500,
+      servedCost: 3,
+      snapshotTokens: 1500,
+      snapshotCost: 4.25,
+      highwater: { status: "known", tokens: 1500, cost: 4.25, bucketCount: 6 },
+    });
+
+    expect(record.racedConcurrentSubmit).toBe(true);
+    expect(record.servedCost).toBe(3);
   });
 
   it("emits a null delta, not the served total, while coverage is unknown", () => {

--- a/packages/frontend/__tests__/lib/deviceClientTotals.test.ts
+++ b/packages/frontend/__tests__/lib/deviceClientTotals.test.ts
@@ -12,6 +12,7 @@ import {
   interpretHighwaterAggregate,
   isDeviceClientTotalsWriteEnabled,
   monthBucketKey,
+  readDualDerivation,
   readHighwaterTotal,
   recordDeviceClientTotals,
   type DeviceClientTotalsContribution,
@@ -382,6 +383,46 @@ describe("a missing bucket reads as UNKNOWN, never as zero", () => {
   });
 });
 
+describe("readDualDerivation reads both sides from ONE snapshot", () => {
+  // The submit transaction serializes a user's devices only until commit; the
+  // census runs after that, unsynchronized. Two separate reads therefore let
+  // request A pair its own pre-commit served total with a high-water total
+  // that already includes request B — a divergence neither derivation had.
+  it("issues a single statement covering both derivations", async () => {
+    const executor = capturingExecutor();
+    await readDualDerivation({
+      executor,
+      userId: "11111111-1111-4111-8111-111111111111",
+      submissionId: "22222222-2222-4222-8222-222222222222",
+    });
+
+    expect(executor.queries).toHaveLength(1);
+    const [query] = executor.queries;
+    expect(query.sql).toContain("submitted_device_client_totals");
+    expect(query.sql).toContain("daily_breakdown");
+    expect(query.sql).toContain('AS "snapshotTokens"');
+    expect(query.sql).toContain('AS "tokens"');
+  });
+
+  it("clamps the daily-side SUM too, so the census cannot abort on a cast", async () => {
+    const executor = capturingExecutor();
+    await readDualDerivation({ executor, userId: "u", submissionId: "s" });
+    const clamps = executor.queries[0].sql.match(/LEAST\(COALESCE\(SUM\(/g) ?? [];
+    expect(clamps).toHaveLength(2);
+  });
+
+  it("still reports unknown coverage while returning a served snapshot", async () => {
+    const executor = {
+      execute: async () => [
+        { snapshotTokens: 1200, snapshotCost: "3.0000", bucketCount: 0, tokens: 0, cost: "0" },
+      ],
+    };
+    const result = await readDualDerivation({ executor, userId: "u", submissionId: "s" });
+    expect(result.snapshotTokens).toBe(1200);
+    expect(result.highwater).toEqual({ status: "unknown" });
+  });
+});
+
 describe("buildDualDerivationRecord (Phase 1.5)", () => {
   it("records both derivations and their delta once coverage exists", () => {
     const record = buildDualDerivationRecord({
@@ -389,17 +430,44 @@ describe("buildDualDerivationRecord (Phase 1.5)", () => {
       submissionId: "s1",
       servedTokens: 1200,
       servedCost: 3,
+      snapshotTokens: 1200,
+      snapshotCost: 3,
       highwater: { status: "known", tokens: 1000, cost: 2.5, bucketCount: 4 },
     });
 
     expect(record).toMatchObject({
       servedTokens: 1200,
+      snapshotTokens: 1200,
       highwaterTokens: 1000,
       tokenDelta: 200,
       tokenRatio: 1.2,
       bucketCount: 4,
       highwaterStatus: "known",
+      racedConcurrentSubmit: false,
     });
+  });
+
+  it("computes the delta from the SNAPSHOT pair, never the stale served total", () => {
+    // A second device of the same user committed between this request's own
+    // commit and its census read, so SUM(daily) has moved on. Pairing the
+    // stale served total (1200) with the fresh high-water total (1500) would
+    // log a spurious -300; both census operands must come from one snapshot.
+    const record = buildDualDerivationRecord({
+      userId: "u1",
+      submissionId: "s1",
+      servedTokens: 1200,
+      servedCost: 3,
+      snapshotTokens: 1500,
+      snapshotCost: 4,
+      highwater: { status: "known", tokens: 1500, cost: 4, bucketCount: 6 },
+    });
+
+    expect(record.tokenDelta).toBe(0);
+    expect(record.tokenRatio).toBe(1);
+    // The race is recorded rather than hidden...
+    expect(record.racedConcurrentSubmit).toBe(true);
+    // ...and the value actually served is still reported unchanged.
+    expect(record.servedTokens).toBe(1200);
   });
 
   it("emits a null delta, not the served total, while coverage is unknown", () => {
@@ -408,6 +476,8 @@ describe("buildDualDerivationRecord (Phase 1.5)", () => {
       submissionId: "s1",
       servedTokens: 1200,
       servedCost: 3,
+      snapshotTokens: 1200,
+      snapshotCost: 3,
       highwater: { status: "unknown" },
     });
 
@@ -425,6 +495,8 @@ describe("buildDualDerivationRecord (Phase 1.5)", () => {
       submissionId: "s1",
       servedTokens: 500,
       servedCost: 1,
+      snapshotTokens: 500,
+      snapshotCost: 1,
       highwater: { status: "known", tokens: 0, cost: 0, bucketCount: 2 },
     });
     expect(record.tokenRatio).toBeNull();

--- a/packages/frontend/__tests__/lib/deviceClientTotals.test.ts
+++ b/packages/frontend/__tests__/lib/deviceClientTotals.test.ts
@@ -505,23 +505,25 @@ describe("buildDualDerivationRecord (Phase 1.5)", () => {
 });
 
 describe("isDeviceClientTotalsWriteEnabled", () => {
-  it("defaults to enabled when the flag is unset", () => {
-    expect(isDeviceClientTotalsWriteEnabled({})).toBe(true);
+  it("defaults to disabled when the flag is unset", () => {
+    expect(isDeviceClientTotalsWriteEnabled({})).toBe(false);
   });
 
-  it("is killable without a deploy or a migration revert", () => {
-    for (const value of ["0", "false", "off", "no", "FALSE", " off "]) {
-      expect(
-        isDeviceClientTotalsWriteEnabled({ [DEVICE_CLIENT_TOTALS_WRITE_FLAG]: value })
-      ).toBe(false);
-    }
-  });
-
-  it("stays enabled for any other value", () => {
-    for (const value of ["1", "true", "on", ""]) {
+  it("is opt-in without a deploy or a migration revert", () => {
+    for (const value of ["1", "true", "on", "yes", "TRUE", " on "]) {
       expect(
         isDeviceClientTotalsWriteEnabled({ [DEVICE_CLIENT_TOTALS_WRITE_FLAG]: value })
       ).toBe(true);
+    }
+  });
+
+  // Empty string and near-misses stay OFF on purpose: an unset-looking or
+  // mistyped value must not silently turn the write on.
+  it("stays disabled for anything that is not an explicit yes", () => {
+    for (const value of ["0", "false", "off", "no", "", "yep", "enable"]) {
+      expect(
+        isDeviceClientTotalsWriteEnabled({ [DEVICE_CLIENT_TOTALS_WRITE_FLAG]: value })
+      ).toBe(false);
     }
   });
 });

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -21,7 +21,7 @@ import {
   buildDualDerivationRecord,
   foldContributionsIntoBuckets,
   isDeviceClientTotalsWriteEnabled,
-  readHighwaterTotal,
+  readDualDerivation,
   recordDeviceClientTotals,
   DUAL_DERIVATION_LOG_PREFIX,
 } from "@/lib/db/deviceClientTotals";
@@ -259,14 +259,24 @@ async function recordRatchetCensus(params: {
       buckets,
     });
 
-    // Phase 1.5: derive the total the OTHER way and record the pair. The value
-    // already served came from SUM(daily_breakdown.tokens) and is untouched.
-    const highwater = await readHighwaterTotal({ executor: db, userId: params.userId });
+    // Phase 1.5: derive the total the OTHER way and record the pair. Both
+    // derivations are read in ONE statement so they share a snapshot — pairing
+    // this request's in-transaction total with a later high-water read would
+    // report a divergence neither derivation had whenever a second device of
+    // the same user commits in between. The value already SERVED is untouched
+    // either way; it is recorded alongside as evidence of that.
+    const { snapshotTokens, snapshotCost, highwater } = await readDualDerivation({
+      executor: db,
+      userId: params.userId,
+      submissionId: params.submissionId,
+    });
     const record = buildDualDerivationRecord({
       userId: params.userId,
       submissionId: params.submissionId,
       servedTokens: params.servedTokens,
       servedCost: params.servedCost,
+      snapshotTokens,
+      snapshotCost,
       highwater,
     });
     console.log(`${DUAL_DERIVATION_LOG_PREFIX} ${JSON.stringify(record)}`);

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -17,6 +17,14 @@ import {
   mergeTimestampMs,
   type ClientBreakdownData,
 } from "@/lib/db/helpers";
+import {
+  buildDualDerivationRecord,
+  foldContributionsIntoBuckets,
+  isDeviceClientTotalsWriteEnabled,
+  readHighwaterTotal,
+  recordDeviceClientTotals,
+  DUAL_DERIVATION_LOG_PREFIX,
+} from "@/lib/db/deviceClientTotals";
 import { normalizeUsernameCacheKey, revalidateUsernamePaths } from "@/lib/db/usernameLookup";
 import { revalidateUserGroupLeaderboards } from "@/lib/groups/cache";
 import { LEGACY_DEVICE_KEY } from "@/lib/devices/shared";
@@ -210,6 +218,63 @@ function mergeActiveTimeMs(
   if (existing == null) return incoming ?? null;
   if (incoming == null) return existing;
   return Math.max(existing, incoming);
+}
+
+/**
+ * Phase 1 + Phase 1.5 of docs/ratchet-inflation-recovery.md.
+ *
+ * Populates the per-device/client/bucket high-water table and records a
+ * measurement. **This changes no value served to the caller** — it runs after
+ * the response payload has already been computed, and its return value is
+ * discarded.
+ *
+ * Placement is the whole point. The submit path above is one `db.transaction`
+ * holding `.for('update')` on the submissions row, which serializes a user's
+ * submits across every device until commit. A defect in a write placed there
+ * fails the user's submission — "nothing reads it" is no protection. Because
+ * the write is a `GREATEST` upsert it is idempotent, so running it after
+ * commit downgrades any failure from a rejected submission to one deferred
+ * measurement, which the next submit repairs. The cost is that the table can
+ * lag the daily rows by one submit, which is why a missing bucket must read as
+ * UNKNOWN and never as zero.
+ *
+ * Every failure mode is swallowed here on purpose.
+ */
+async function recordRatchetCensus(params: {
+  userId: string;
+  submissionId: string;
+  submittedDeviceId: string;
+  contributions: SubmissionData["contributions"];
+  origin: "cli" | "backfill";
+  servedTokens: number;
+  servedCost: number;
+}): Promise<void> {
+  if (!isDeviceClientTotalsWriteEnabled()) return;
+
+  try {
+    const buckets = foldContributionsIntoBuckets(params.contributions, params.origin);
+    await recordDeviceClientTotals({
+      executor: db,
+      submittedDeviceId: params.submittedDeviceId,
+      buckets,
+    });
+
+    // Phase 1.5: derive the total the OTHER way and record the pair. The value
+    // already served came from SUM(daily_breakdown.tokens) and is untouched.
+    const highwater = await readHighwaterTotal({ executor: db, userId: params.userId });
+    const record = buildDualDerivationRecord({
+      userId: params.userId,
+      submissionId: params.submissionId,
+      servedTokens: params.servedTokens,
+      servedCost: params.servedCost,
+      highwater,
+    });
+    console.log(`${DUAL_DERIVATION_LOG_PREFIX} ${JSON.stringify(record)}`);
+  } catch (e) {
+    // A deferred measurement, not a failed submission. The upsert is
+    // idempotent, so the next submit from this device repairs the gap.
+    console.error("Ratchet census write failed (submission unaffected):", e);
+  }
 }
 
 /**
@@ -915,6 +980,7 @@ export async function POST(request: Request) {
 
       return {
         submissionId,
+        submittedDeviceId: submittedDevice.id,
         isNewSubmission,
         metrics: {
           totalTokens: aggregates.totalTokens,
@@ -927,6 +993,18 @@ export async function POST(request: Request) {
           clients: Array.from(allClients),
         },
       };
+    });
+
+    // Phase 1 / 1.5 census. Deliberately after the transaction commits, and
+    // deliberately unable to affect the response below.
+    await recordRatchetCensus({
+      userId: tokenRecord.userId,
+      submissionId: result.submissionId,
+      submittedDeviceId: result.submittedDeviceId,
+      contributions: data.contributions,
+      origin: isBackfill ? "backfill" : "cli",
+      servedTokens: result.metrics.totalTokens,
+      servedCost: result.metrics.totalCost,
     });
 
     const usernameCacheKey = normalizeUsernameCacheKey(tokenRecord.username);

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -22,7 +22,7 @@ import {
   foldContributionsIntoBuckets,
   isDeviceClientTotalsWriteEnabled,
   readDualDerivation,
-  recordDeviceClientTotals,
+  recoverRatchetCensusWork,
   DUAL_DERIVATION_LOG_PREFIX,
 } from "@/lib/db/deviceClientTotals";
 import { normalizeUsernameCacheKey, revalidateUsernamePaths } from "@/lib/db/usernameLookup";
@@ -243,24 +243,17 @@ function mergeActiveTimeMs(
 async function recordRatchetCensus(params: {
   userId: string;
   submissionId: string;
-  submittedDeviceId: string;
-  contributions: SubmissionData["contributions"];
-  origin: "cli" | "backfill";
   servedTokens: number;
   servedCost: number;
   enabled: boolean;
 }): Promise<void> {
   if (!params.enabled) return;
 
-  let highwaterRecorded = false;
   try {
-    const buckets = foldContributionsIntoBuckets(params.contributions, params.origin);
-    await recordDeviceClientTotals({
+    await recoverRatchetCensusWork({
       executor: db,
-      submittedDeviceId: params.submittedDeviceId,
-      buckets,
+      submissionId: params.submissionId,
     });
-    highwaterRecorded = true;
 
     // Phase 1.5: derive the total the OTHER way and record the pair. Both
     // derivations are read in ONE statement so they share a snapshot — pairing
@@ -285,25 +278,9 @@ async function recordRatchetCensus(params: {
     });
     console.log(`${DUAL_DERIVATION_LOG_PREFIX} ${JSON.stringify(record)}`);
   } catch (e) {
-    // A deferred measurement, not a failed submission. The upsert is
-    // idempotent, so the next submit from this device repairs the gap.
+    // A deferred measurement, not a failed submission. Durable work remains
+    // available for the next enabled submit to replay.
     console.error("Ratchet census write failed (submission unaffected):", e);
-  } finally {
-    // Do not clear the ledger when the upsert failed: later census reads must
-    // remain conservative rather than treating its missing rows as a real
-    // divergence. A successful upsert is enough to complete this entry even
-    // when the diagnostic read/log itself fails.
-    if (highwaterRecorded) {
-      try {
-        await db.execute(sql`
-          UPDATE submissions
-          SET ratchet_census_pending = GREATEST(ratchet_census_pending - 1, 0)
-          WHERE id = ${params.submissionId}::uuid
-        `);
-      } catch (e) {
-        console.error("Ratchet census completion marker failed (submission unaffected):", e);
-      }
-    }
   }
 }
 
@@ -415,6 +392,9 @@ export async function POST(request: Request) {
     // STEP 3: DATABASE OPERATIONS IN TRANSACTION
     // ========================================
     const ratchetCensusEnabled = isDeviceClientTotalsWriteEnabled();
+    const ratchetCensusBuckets = ratchetCensusEnabled
+      ? foldContributionsIntoBuckets(data.contributions, isBackfill ? "backfill" : "cli")
+      : [];
     const result = await db.transaction(async (tx) => {
       await tx
         .update(apiTokens)
@@ -973,11 +953,6 @@ export async function POST(request: Request) {
           // the merged totals still include the imported history.
           ...(isBackfill ? { hasBackfill: true } : {}),
           submitCount: sql`COALESCE(submit_count, 0) + 1`,
-          // Register the post-commit census before its daily rows become
-          // visible. See recordRatchetCensus for the paired completion write.
-          ...(ratchetCensusEnabled
-            ? { ratchetCensusPending: sql`ratchet_census_pending + 1` }
-            : {}),
           schemaVersion: sql`GREATEST(COALESCE(${submissions.schemaVersion}, 0), ${submitDevice.schemaVersion})`,
           // Derived from the per-device high-water marks (see deviceTotals
           // above), floored by whatever is already stored.
@@ -1014,9 +989,22 @@ export async function POST(request: Request) {
         })
         .where(eq(submissions.id, submissionId));
 
+      // Register durable post-commit work before the transaction exposes its
+      // daily rows. If this invocation is interrupted after commit, a later
+      // enabled submit replays this row rather than leaving a stranded counter.
+      if (ratchetCensusEnabled && ratchetCensusBuckets.length > 0) {
+        await tx.execute(sql`
+          INSERT INTO ratchet_census_work (submission_id, submitted_device_id, buckets)
+          VALUES (
+            ${submissionId}::uuid,
+            ${submittedDevice.id}::uuid,
+            ${JSON.stringify(ratchetCensusBuckets)}::jsonb
+          )
+        `);
+      }
+
       return {
         submissionId,
-        submittedDeviceId: submittedDevice.id,
         isNewSubmission,
         metrics: {
           totalTokens: aggregates.totalTokens,
@@ -1036,9 +1024,6 @@ export async function POST(request: Request) {
     await recordRatchetCensus({
       userId: tokenRecord.userId,
       submissionId: result.submissionId,
-      submittedDeviceId: result.submittedDeviceId,
-      contributions: data.contributions,
-      origin: isBackfill ? "backfill" : "cli",
       servedTokens: result.metrics.totalTokens,
       servedCost: result.metrics.totalCost,
       enabled: ratchetCensusEnabled,

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -248,9 +248,11 @@ async function recordRatchetCensus(params: {
   origin: "cli" | "backfill";
   servedTokens: number;
   servedCost: number;
+  enabled: boolean;
 }): Promise<void> {
-  if (!isDeviceClientTotalsWriteEnabled()) return;
+  if (!params.enabled) return;
 
+  let highwaterRecorded = false;
   try {
     const buckets = foldContributionsIntoBuckets(params.contributions, params.origin);
     await recordDeviceClientTotals({
@@ -258,6 +260,7 @@ async function recordRatchetCensus(params: {
       submittedDeviceId: params.submittedDeviceId,
       buckets,
     });
+    highwaterRecorded = true;
 
     // Phase 1.5: derive the total the OTHER way and record the pair. Both
     // derivations are read in ONE statement so they share a snapshot — pairing
@@ -265,7 +268,7 @@ async function recordRatchetCensus(params: {
     // report a divergence neither derivation had whenever a second device of
     // the same user commits in between. The value already SERVED is untouched
     // either way; it is recorded alongside as evidence of that.
-    const { snapshotTokens, snapshotCost, highwater } = await readDualDerivation({
+    const { snapshotTokens, snapshotCost, censusPending, highwater } = await readDualDerivation({
       executor: db,
       userId: params.userId,
       submissionId: params.submissionId,
@@ -277,6 +280,7 @@ async function recordRatchetCensus(params: {
       servedCost: params.servedCost,
       snapshotTokens,
       snapshotCost,
+      censusPending,
       highwater,
     });
     console.log(`${DUAL_DERIVATION_LOG_PREFIX} ${JSON.stringify(record)}`);
@@ -284,6 +288,22 @@ async function recordRatchetCensus(params: {
     // A deferred measurement, not a failed submission. The upsert is
     // idempotent, so the next submit from this device repairs the gap.
     console.error("Ratchet census write failed (submission unaffected):", e);
+  } finally {
+    // Do not clear the ledger when the upsert failed: later census reads must
+    // remain conservative rather than treating its missing rows as a real
+    // divergence. A successful upsert is enough to complete this entry even
+    // when the diagnostic read/log itself fails.
+    if (highwaterRecorded) {
+      try {
+        await db.execute(sql`
+          UPDATE submissions
+          SET ratchet_census_pending = GREATEST(ratchet_census_pending - 1, 0)
+          WHERE id = ${params.submissionId}::uuid
+        `);
+      } catch (e) {
+        console.error("Ratchet census completion marker failed (submission unaffected):", e);
+      }
+    }
   }
 }
 
@@ -394,6 +414,7 @@ export async function POST(request: Request) {
     // ========================================
     // STEP 3: DATABASE OPERATIONS IN TRANSACTION
     // ========================================
+    const ratchetCensusEnabled = isDeviceClientTotalsWriteEnabled();
     const result = await db.transaction(async (tx) => {
       await tx
         .update(apiTokens)
@@ -952,6 +973,11 @@ export async function POST(request: Request) {
           // the merged totals still include the imported history.
           ...(isBackfill ? { hasBackfill: true } : {}),
           submitCount: sql`COALESCE(submit_count, 0) + 1`,
+          // Register the post-commit census before its daily rows become
+          // visible. See recordRatchetCensus for the paired completion write.
+          ...(ratchetCensusEnabled
+            ? { ratchetCensusPending: sql`ratchet_census_pending + 1` }
+            : {}),
           schemaVersion: sql`GREATEST(COALESCE(${submissions.schemaVersion}, 0), ${submitDevice.schemaVersion})`,
           // Derived from the per-device high-water marks (see deviceTotals
           // above), floored by whatever is already stored.
@@ -1015,6 +1041,7 @@ export async function POST(request: Request) {
       origin: isBackfill ? "backfill" : "cli",
       servedTokens: result.metrics.totalTokens,
       servedCost: result.metrics.totalCost,
+      enabled: ratchetCensusEnabled,
     });
 
     const usernameCacheKey = normalizeUsernameCacheKey(tokenRecord.username);

--- a/packages/frontend/src/lib/db/deviceClientTotals.ts
+++ b/packages/frontend/src/lib/db/deviceClientTotals.ts
@@ -259,6 +259,18 @@ export interface HighwaterAggregateRow {
   cost: string;
 }
 
+/**
+ * Both derivations, read in ONE statement so they share a snapshot.
+ *
+ * `snapshotTokens`/`snapshotCost` are `SUM(daily_breakdown)` re-read at census
+ * time — NOT the value served to the caller. See `readDualDerivation` for why
+ * the difference matters.
+ */
+export interface DualDerivationRow extends HighwaterAggregateRow {
+  snapshotTokens: number;
+  snapshotCost: string;
+}
+
 export function interpretHighwaterAggregate(
   row: HighwaterAggregateRow | undefined | null
 ): HighwaterTotalReading {
@@ -322,6 +334,65 @@ export async function readHighwaterTotal(params: {
 }
 
 /**
+ * Read BOTH derivations in a single statement.
+ *
+ * Why this is not just `readHighwaterTotal` plus the value from the response:
+ * the submit transaction takes `.for('update')` on the submissions row, so two
+ * devices belonging to one user serialize only UNTIL COMMIT. The census runs
+ * after that, unsynchronized. So request A can hold a served total captured at
+ * its own commit while request B commits and raises the high-water rows, and
+ * A's later high-water read then sees B's contribution. Pairing those two
+ * numbers reports a divergence that neither derivation actually had — and the
+ * skew goes the wrong way, understating the served side, so it can log a
+ * NEGATIVE delta while both derivations agreed at every commit.
+ *
+ * That noise lands specifically on users submitting from multiple devices,
+ * which is exactly the population the census exists to characterize, so it is
+ * not tolerable in the data meant to gate the Phase 2 cutover.
+ *
+ * A single statement evaluates every subquery in one snapshot, so the two
+ * sides are consistent by construction. The value SERVED to the caller is
+ * still the one computed inside the transaction and is not touched here; it is
+ * recorded alongside so a concurrent submit is visible rather than silent.
+ */
+export async function readDualDerivation(params: {
+  executor: HighwaterQueryExecutor;
+  userId: string;
+  submissionId: string;
+  bucketWidth?: string;
+}): Promise<{ snapshotTokens: number; snapshotCost: number; highwater: HighwaterTotalReading }> {
+  const bucketWidth = params.bucketWidth ?? DEVICE_CLIENT_TOTALS_BUCKET_WIDTH;
+  const result = await params.executor.execute(sql`
+    SELECT
+      (
+        SELECT LEAST(COALESCE(SUM(db.tokens), 0), ${sql.raw(BIGINT_MAX)})::bigint
+        FROM daily_breakdown AS db
+        WHERE db.submission_id = ${params.submissionId}::uuid
+      ) AS "snapshotTokens",
+      (
+        SELECT COALESCE(SUM(CAST(db.cost AS DECIMAL(14,4))), 0)::text
+        FROM daily_breakdown AS db
+        WHERE db.submission_id = ${params.submissionId}::uuid
+      ) AS "snapshotCost",
+      COUNT(*)::int AS "bucketCount",
+      LEAST(COALESCE(SUM(t.tokens_highwater), 0), ${sql.raw(BIGINT_MAX)})::bigint AS "tokens",
+      COALESCE(SUM(t.cost_highwater), 0)::text AS "cost"
+    FROM submitted_device_client_totals AS t
+    JOIN submitted_devices AS d ON d.id = t.submitted_device_id
+    WHERE d.user_id = ${params.userId}::uuid
+      AND t.bucket_width = ${bucketWidth}
+  `);
+
+  const row = firstRow(result) as DualDerivationRow | undefined;
+  const snapshotCost = Number.parseFloat(row?.snapshotCost ?? "0");
+  return {
+    snapshotTokens: Number(row?.snapshotTokens ?? 0),
+    snapshotCost: Number.isFinite(snapshotCost) ? snapshotCost : 0,
+    highwater: interpretHighwaterAggregate(row),
+  };
+}
+
+/**
  * The Phase 1.5 record: the pair of derivations, and the delta between them.
  *
  * The SERVED value is `servedTokens`/`servedCost` — `SUM(daily_breakdown)`,
@@ -331,15 +402,30 @@ export interface DualDerivationRecord {
   userId: string;
   submissionId: string;
   bucketWidth: string;
+  /**
+   * What the HTTP response actually carried, computed inside the transaction.
+   * Recorded as evidence that the served value is unchanged — never used to
+   * compute the delta, because it comes from a different snapshot than the
+   * high-water read (see `readDualDerivation`).
+   */
   servedTokens: number;
   servedCost: number;
+  /** `SUM(daily_breakdown)` from the SAME snapshot as the high-water read. */
+  snapshotTokens: number;
+  snapshotCost: number;
+  /**
+   * True when a concurrent submit for this user landed between this request's
+   * commit and its census read. Not an error — it is why the delta is computed
+   * from `snapshotTokens` rather than `servedTokens`.
+   */
+  racedConcurrentSubmit: boolean;
   highwaterStatus: HighwaterTotalReading["status"];
   highwaterTokens: number | null;
   highwaterCost: number | null;
   bucketCount: number | null;
-  /** servedTokens - highwaterTokens; null while the reading is unknown. */
+  /** snapshotTokens - highwaterTokens; null while the reading is unknown. */
   tokenDelta: number | null;
-  /** servedTokens / highwaterTokens; null while unknown or divide-by-zero. */
+  /** snapshotTokens / highwaterTokens; null while unknown or divide-by-zero. */
   tokenRatio: number | null;
 }
 
@@ -349,6 +435,8 @@ export function buildDualDerivationRecord(params: {
   bucketWidth?: string;
   servedTokens: number;
   servedCost: number;
+  snapshotTokens: number;
+  snapshotCost: number;
   highwater: HighwaterTotalReading;
 }): DualDerivationRecord {
   const { highwater } = params;
@@ -358,6 +446,9 @@ export function buildDualDerivationRecord(params: {
     bucketWidth: params.bucketWidth ?? DEVICE_CLIENT_TOTALS_BUCKET_WIDTH,
     servedTokens: params.servedTokens,
     servedCost: params.servedCost,
+    snapshotTokens: params.snapshotTokens,
+    snapshotCost: params.snapshotCost,
+    racedConcurrentSubmit: params.snapshotTokens !== params.servedTokens,
   };
 
   if (highwater.status === "unknown") {
@@ -378,9 +469,11 @@ export function buildDualDerivationRecord(params: {
     highwaterTokens: highwater.tokens,
     highwaterCost: highwater.cost,
     bucketCount: highwater.bucketCount,
-    tokenDelta: params.servedTokens - highwater.tokens,
+    // Both operands come from one snapshot, so this cannot report a divergence
+    // that neither derivation had.
+    tokenDelta: params.snapshotTokens - highwater.tokens,
     tokenRatio:
-      highwater.tokens > 0 ? params.servedTokens / highwater.tokens : null,
+      highwater.tokens > 0 ? params.snapshotTokens / highwater.tokens : null,
   };
 }
 

--- a/packages/frontend/src/lib/db/deviceClientTotals.ts
+++ b/packages/frontend/src/lib/db/deviceClientTotals.ts
@@ -291,6 +291,7 @@ export interface HighwaterAggregateRow {
 export interface DualDerivationRow extends HighwaterAggregateRow {
   snapshotTokens: number;
   snapshotCost: string;
+  censusPending: number;
 }
 
 export function interpretHighwaterAggregate(
@@ -382,7 +383,12 @@ export async function readDualDerivation(params: {
   userId: string;
   submissionId: string;
   bucketWidth?: string;
-}): Promise<{ snapshotTokens: number; snapshotCost: number; highwater: HighwaterTotalReading }> {
+}): Promise<{
+  snapshotTokens: number;
+  snapshotCost: number;
+  censusPending: number;
+  highwater: HighwaterTotalReading;
+}> {
   const bucketWidth = params.bucketWidth ?? DEVICE_CLIENT_TOTALS_BUCKET_WIDTH;
   const result = await params.executor.execute(sql`
     SELECT
@@ -396,6 +402,11 @@ export async function readDualDerivation(params: {
         FROM daily_breakdown AS db
         WHERE db.submission_id = ${params.submissionId}::uuid
       ) AS "snapshotCost",
+      (
+        SELECT s.ratchet_census_pending
+        FROM submissions AS s
+        WHERE s.id = ${params.submissionId}::uuid
+      )::int AS "censusPending",
       COUNT(*)::int AS "bucketCount",
       LEAST(COALESCE(SUM(t.tokens_highwater), 0), ${sql.raw(BIGINT_MAX)})::bigint AS "tokens",
       COALESCE(SUM(t.cost_highwater), 0)::text AS "cost"
@@ -407,9 +418,11 @@ export async function readDualDerivation(params: {
 
   const row = firstRow(result) as DualDerivationRow | undefined;
   const snapshotCost = Number.parseFloat(row?.snapshotCost ?? "0");
+  const censusPending = Number(row?.censusPending ?? 0);
   return {
     snapshotTokens: Number(row?.snapshotTokens ?? 0),
     snapshotCost: Number.isFinite(snapshotCost) ? snapshotCost : 0,
+    censusPending: Number.isFinite(censusPending) ? Math.max(0, censusPending) : 0,
     highwater: interpretHighwaterAggregate(row),
   };
 }
@@ -435,12 +448,16 @@ export interface DualDerivationRecord {
   /** `SUM(daily_breakdown)` from the SAME snapshot as the high-water read. */
   snapshotTokens: number;
   snapshotCost: number;
+  /** Outstanding deferred high-water writes, including this request's own. */
+  censusPending: number;
   /**
    * True when a concurrent submit for this user landed between this request's
    * commit and its census read. Not an error — it is why the delta is computed
    * from `snapshotTokens` rather than `servedTokens`.
    */
   racedConcurrentSubmit: boolean;
+  /** A pending peer's daily rows may be visible before its high-water upsert. */
+  censusStatus: "stable" | "pending";
   highwaterStatus: HighwaterTotalReading["status"];
   highwaterTokens: number | null;
   highwaterCost: number | null;
@@ -459,9 +476,14 @@ export function buildDualDerivationRecord(params: {
   servedCost: number;
   snapshotTokens: number;
   snapshotCost: number;
+  censusPending: number;
   highwater: HighwaterTotalReading;
 }): DualDerivationRecord {
   const { highwater } = params;
+  // This request increments the ledger in its submit transaction and clears it
+  // only after its high-water upsert. Any additional entry is a committed
+  // submit whose daily rows may be visible while its high-water rows are not.
+  const hasPendingPeer = params.censusPending > 1;
   const base = {
     userId: params.userId,
     submissionId: params.submissionId,
@@ -470,6 +492,7 @@ export function buildDualDerivationRecord(params: {
     servedCost: params.servedCost,
     snapshotTokens: params.snapshotTokens,
     snapshotCost: params.snapshotCost,
+    censusPending: params.censusPending,
     // Costs are compared too, not just tokens. A concurrent submit that moved
     // only the cost — a reprice, or usage whose tokens were already counted —
     // is still a race, and reporting it as `false` would let the census read a
@@ -477,17 +500,19 @@ export function buildDualDerivationRecord(params: {
     // comparison is safe here: both sides come from the same numeric(18,4)
     // column via the same conversion, so equal stored values are equal doubles.
     racedConcurrentSubmit:
+      hasPendingPeer ||
       params.snapshotTokens !== params.servedTokens ||
       params.snapshotCost !== params.servedCost,
+    censusStatus: hasPendingPeer ? "pending" as const : "stable" as const,
   };
 
-  if (highwater.status === "unknown") {
+  if (highwater.status === "unknown" || hasPendingPeer) {
     return {
       ...base,
-      highwaterStatus: "unknown",
-      highwaterTokens: null,
-      highwaterCost: null,
-      bucketCount: null,
+      highwaterStatus: highwater.status,
+      highwaterTokens: highwater.status === "known" ? highwater.tokens : null,
+      highwaterCost: highwater.status === "known" ? highwater.cost : null,
+      bucketCount: highwater.status === "known" ? highwater.bucketCount : null,
       tokenDelta: null,
       tokenRatio: null,
     };

--- a/packages/frontend/src/lib/db/deviceClientTotals.ts
+++ b/packages/frontend/src/lib/db/deviceClientTotals.ts
@@ -27,17 +27,25 @@ import { clientContributionToBreakdownData } from "./helpers";
 export const DEVICE_CLIENT_TOTALS_BUCKET_WIDTH = "month";
 
 /**
- * Kill switch. The migration is effectively irreversible (drizzle stores the
- * content hash of an applied migration), but the WRITE need not inherit that:
- * setting `TOKSCALE_DEVICE_CLIENT_TOTALS_WRITE` to `0`/`false`/`off` disables
- * it in seconds without reverting a migration or shipping a rollback.
+ * Rollout switch, default OFF.
  *
- * Default is ENABLED — the flag exists to switch a misbehaving write off, not
- * to gate it on.
+ * The migration is effectively irreversible — drizzle stores the content hash
+ * of an applied migration — but the WRITE need not inherit that, and this flag
+ * moves it in either direction without a deploy or a migration revert.
+ *
+ * An earlier draft defaulted this ON, on the reasoning that the flag existed to
+ * switch a misbehaving write off rather than to gate it on. Review pushed back
+ * and was right: `recordRatchetCensus` is awaited on `POST /api/submit`, so
+ * defaulting it on makes every submit pay two extra database round-trips from
+ * the moment this deploys — for a value nothing reads and only the log keeps.
+ * The added p50/p95 has not been measured. A census that slows down the thing
+ * it is measuring is not worth having on by accident.
+ *
+ * Opt in with `=1` once that latency is known.
  */
 export const DEVICE_CLIENT_TOTALS_WRITE_FLAG = "TOKSCALE_DEVICE_CLIENT_TOTALS_WRITE";
 
-const DISABLED_FLAG_VALUES = new Set(["0", "false", "off", "no"]);
+const ENABLED_FLAG_VALUES = new Set(["1", "true", "on", "yes"]);
 
 /**
  * PostgreSQL caps a statement at 65,535 bound parameters. Each row binds 7,
@@ -86,8 +94,8 @@ export function isDeviceClientTotalsWriteEnabled(
   env: Record<string, string | undefined> = process.env
 ): boolean {
   const raw = env[DEVICE_CLIENT_TOTALS_WRITE_FLAG];
-  if (raw == null) return true;
-  return !DISABLED_FLAG_VALUES.has(raw.trim().toLowerCase());
+  if (raw == null) return false;
+  return ENABLED_FLAG_VALUES.has(raw.trim().toLowerCase());
 }
 
 /**

--- a/packages/frontend/src/lib/db/deviceClientTotals.ts
+++ b/packages/frontend/src/lib/db/deviceClientTotals.ts
@@ -1,0 +1,386 @@
+/**
+ * Per-device, per-client, per-bucket token/cost high-water marks.
+ *
+ * Phase 1 + Phase 1.5 of `docs/ratchet-inflation-recovery.md`.
+ *
+ * Phase 1 POPULATES `submitted_device_client_totals` and nothing reads it.
+ * Phase 1.5 derives a submission total from it purely so the divergence from
+ * the served `SUM(daily_breakdown.tokens)` can be measured on live traffic.
+ * **No value served to any caller is derived from this module.**
+ *
+ * Everything here is deliberately independent of the submit transaction: the
+ * write is a `GREATEST` upsert and therefore idempotent, so it runs AFTER the
+ * submit commits. A failure there costs one deferred measurement that the next
+ * submit repairs, instead of rejecting the user's submission.
+ */
+
+import { sql, type SQL } from "drizzle-orm";
+import { clientContributionToBreakdownData } from "./helpers";
+
+/**
+ * Only one bucket width is written today. The doc allows `week` alongside
+ * `month`; starting with month alone halves the write volume (measured
+ * 2026-07-31: p50 9 / p95 32 / max 91 rows per full-history submit at month
+ * only, against p50 33 / p95 122 / max 349 at both widths), and Phase 3 makes
+ * the width question far less interesting by permitting daily buckets.
+ */
+export const DEVICE_CLIENT_TOTALS_BUCKET_WIDTH = "month";
+
+/**
+ * Kill switch. The migration is effectively irreversible (drizzle stores the
+ * content hash of an applied migration), but the WRITE need not inherit that:
+ * setting `TOKSCALE_DEVICE_CLIENT_TOTALS_WRITE` to `0`/`false`/`off` disables
+ * it in seconds without reverting a migration or shipping a rollback.
+ *
+ * Default is ENABLED — the flag exists to switch a misbehaving write off, not
+ * to gate it on.
+ */
+export const DEVICE_CLIENT_TOTALS_WRITE_FLAG = "TOKSCALE_DEVICE_CLIENT_TOTALS_WRITE";
+
+const DISABLED_FLAG_VALUES = new Set(["0", "false", "off", "no"]);
+
+/**
+ * PostgreSQL caps a statement at 65,535 bound parameters. Each row binds 7,
+ * so this stays an order of magnitude clear even for the max-cardinality
+ * submit observed in production (91 rows at month width).
+ */
+const UPSERT_CHUNK_SIZE = 1000;
+
+/** int8 max. Mirrors the clamps already applied in the submit route. */
+const BIGINT_MAX = "9223372036854775807";
+
+export type DeviceClientTotalsOrigin = "cli" | "backfill";
+
+export interface DeviceClientBucketTotal {
+  client: string;
+  origin: DeviceClientTotalsOrigin;
+  bucketWidth: string;
+  bucketKey: string;
+  tokens: number;
+  cost: number;
+}
+
+/**
+ * Structural shape of one day of an already-validated payload. Kept structural
+ * rather than importing the Zod-inferred type so this module can be exercised
+ * without constructing a full `SubmissionData`.
+ */
+export interface DeviceClientTotalsContribution {
+  date: string;
+  clients: Array<{
+    client: string;
+    modelId: string;
+    messages: number;
+    cost: number;
+    tokens: {
+      input: number;
+      output: number;
+      cacheRead: number;
+      cacheWrite: number;
+      reasoning?: number;
+    };
+  }>;
+}
+
+export function isDeviceClientTotalsWriteEnabled(
+  env: Record<string, string | undefined> = process.env
+): boolean {
+  const raw = env[DEVICE_CLIENT_TOTALS_WRITE_FLAG];
+  if (raw == null) return true;
+  return !DISABLED_FLAG_VALUES.has(raw.trim().toLowerCase());
+}
+
+/**
+ * `YYYY-MM-DD` -> `YYYY-MM`. Returns null for anything that is not a plain
+ * ISO calendar date, so a malformed date can never invent a bucket. The
+ * validation schema already pins the format; this is the module's own guard so
+ * it holds for callers that bypass it.
+ *
+ * No timezone conversion happens here, deliberately. The stored `date` is
+ * whatever calendar day the CLI attributed the usage to, and re-deriving it
+ * under a different zone is the exact mechanism this table exists to measure
+ * (see Phase 3, which pins the bucket key).
+ */
+export function monthBucketKey(date: string): string | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return null;
+  const month = Number(date.slice(5, 7));
+  if (month < 1 || month > 12) return null;
+  return date.slice(0, 7);
+}
+
+function clampTokens(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  // Values arrive as JS numbers, so precision (not int8 range) is the binding
+  // limit. Clamping at MAX_SAFE_INTEGER keeps the bound parameter exact and
+  // stays far below int8 max.
+  return Math.min(Math.round(value), Number.MAX_SAFE_INTEGER);
+}
+
+/**
+ * numeric(18,4) holds up to 99999999999999.9999. A month bucket sums day costs
+ * that each already fit `daily_breakdown.cost`'s numeric(14,4) (max ~1e10), so
+ * an honest bucket is ~4 orders of magnitude clear of this. The clamp exists
+ * for the dishonest case: `toFixed(4)` switches to exponential notation at
+ * 1e21, which would not parse as numeric at all.
+ */
+const COST_HIGHWATER_MAX = 99999999999999;
+
+function clampCost(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  return Math.min(value, COST_HIGHWATER_MAX);
+}
+
+/**
+ * Fold a payload's daily contributions into (client, origin, bucket) totals.
+ *
+ * Token arithmetic goes through `clientContributionToBreakdownData` — the same
+ * helper the daily rows use — so the two derivations cannot drift apart on
+ * what counts as a token.
+ *
+ * `origin` is applied uniformly from the submission-level provenance tag,
+ * matching how the submit route stamps `origin` into every client entry of a
+ * backfill submission.
+ */
+export function foldContributionsIntoBuckets(
+  contributions: readonly DeviceClientTotalsContribution[],
+  origin: DeviceClientTotalsOrigin,
+  bucketWidth: string = DEVICE_CLIENT_TOTALS_BUCKET_WIDTH
+): DeviceClientBucketTotal[] {
+  const byBucket = new Map<string, DeviceClientBucketTotal>();
+
+  for (const day of contributions) {
+    const bucketKey = monthBucketKey(day.date);
+    if (bucketKey == null) continue;
+
+    for (const contribution of day.clients) {
+      const breakdown = clientContributionToBreakdownData(contribution);
+      // U+0000 cannot occur in a validated client id or a bucket key, so the
+      // composite map key is unambiguous. Written as an escape, not a
+      // literal control character, so the source stays plain text.
+      const mapKey = `${contribution.client}\u0000${bucketKey}`;
+      const existing = byBucket.get(mapKey);
+
+      if (existing) {
+        existing.tokens += breakdown.tokens || 0;
+        existing.cost += breakdown.cost || 0;
+        continue;
+      }
+
+      byBucket.set(mapKey, {
+        client: contribution.client,
+        origin,
+        bucketWidth,
+        bucketKey,
+        tokens: breakdown.tokens || 0,
+        cost: breakdown.cost || 0,
+      });
+    }
+  }
+
+  return Array.from(byBucket.values(), (bucket) => ({
+    ...bucket,
+    tokens: clampTokens(bucket.tokens),
+    cost: clampCost(bucket.cost),
+  }));
+}
+
+export interface DeviceClientTotalsExecutor {
+  execute(query: SQL): Promise<unknown>;
+}
+
+/**
+ * `GREATEST` upsert of the folded buckets for one device.
+ *
+ * Monotonic per bucket: a `--clients`/`--date` filtered submit reports only a
+ * slice of a month and must never lower the stored value. That is also what
+ * makes the write idempotent, and therefore safe to run after commit.
+ *
+ * Returns the number of rows sent (not the number actually raised).
+ */
+export async function recordDeviceClientTotals(params: {
+  executor: DeviceClientTotalsExecutor;
+  submittedDeviceId: string;
+  buckets: readonly DeviceClientBucketTotal[];
+  now?: Date;
+}): Promise<number> {
+  const { executor, submittedDeviceId, buckets } = params;
+  if (buckets.length === 0) return 0;
+
+  const updatedAt = (params.now ?? new Date()).toISOString();
+
+  for (let i = 0; i < buckets.length; i += UPSERT_CHUNK_SIZE) {
+    const chunk = buckets.slice(i, i + UPSERT_CHUNK_SIZE);
+    const valuesClauses = chunk.map(
+      (bucket) =>
+        sql`(${submittedDeviceId}::uuid, ${bucket.client}, ${bucket.origin}, ${bucket.bucketWidth}, ${bucket.bucketKey}, ${bucket.tokens}::bigint, ${bucket.cost.toFixed(4)}::numeric(18,4), ${updatedAt}::timestamptz)`
+    );
+
+    await executor.execute(sql`
+      INSERT INTO submitted_device_client_totals (
+        submitted_device_id, client, origin, bucket_width, bucket_key,
+        tokens_highwater, cost_highwater, updated_at
+      )
+      VALUES ${sql.join(valuesClauses, sql`, `)}
+      ON CONFLICT (submitted_device_id, client, origin, bucket_width, bucket_key) DO UPDATE SET
+        tokens_highwater = GREATEST(submitted_device_client_totals.tokens_highwater, EXCLUDED.tokens_highwater),
+        cost_highwater = GREATEST(submitted_device_client_totals.cost_highwater, EXCLUDED.cost_highwater),
+        updated_at = EXCLUDED.updated_at
+    `);
+  }
+
+  return buckets.length;
+}
+
+/**
+ * A high-water reconstruction of a user's total.
+ *
+ * `unknown` is NOT zero. The write runs after the submit transaction commits,
+ * so the table can lag the daily rows by one submit; and it can only ever be
+ * filled by incoming payloads (backfilling it from `daily_breakdown` would
+ * seed it with the inflated value that `GREATEST` then keeps forever). Both
+ * mean an absent bucket carries no information about usage, and any consumer
+ * that reads it as 0 would report a fabricated collapse.
+ */
+export type HighwaterTotalReading =
+  | { status: "unknown" }
+  | { status: "known"; tokens: number; cost: number; bucketCount: number };
+
+export interface HighwaterAggregateRow {
+  bucketCount: number;
+  tokens: number;
+  cost: string;
+}
+
+export function interpretHighwaterAggregate(
+  row: HighwaterAggregateRow | undefined | null
+): HighwaterTotalReading {
+  if (!row) return { status: "unknown" };
+  const bucketCount = Number(row.bucketCount ?? 0);
+  if (!Number.isFinite(bucketCount) || bucketCount <= 0) {
+    return { status: "unknown" };
+  }
+  const cost = Number.parseFloat(row.cost ?? "0");
+  return {
+    status: "known",
+    tokens: Number(row.tokens ?? 0),
+    cost: Number.isFinite(cost) ? cost : 0,
+    bucketCount,
+  };
+}
+
+export interface HighwaterQueryExecutor {
+  execute(query: SQL): Promise<unknown>;
+}
+
+function firstRow(result: unknown): HighwaterAggregateRow | undefined {
+  if (Array.isArray(result)) return result[0] as HighwaterAggregateRow | undefined;
+  if (result && typeof result === "object" && Array.isArray((result as { rows?: unknown }).rows)) {
+    return (result as { rows: unknown[] }).rows[0] as HighwaterAggregateRow | undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Phase 1.5 read side: sum the high-water marks across every device a user
+ * owns, at the single bucket width Phase 1 writes.
+ *
+ * Summing ACROSS origins is intentional — `cli` and `backfill` history are
+ * additive, which is exactly why `origin` is in the primary key instead of
+ * being collapsed by `GREATEST`.
+ *
+ * `SUM(int8)` widens to numeric, so the cast back to bigint would raise "out
+ * of range" on a pathological total and abort the statement. `LEAST` clamps
+ * instead — the same treatment the submit route applies to its own aggregates.
+ * `SUM(numeric)` needs no clamp; numeric is arbitrary precision.
+ */
+export async function readHighwaterTotal(params: {
+  executor: HighwaterQueryExecutor;
+  userId: string;
+  bucketWidth?: string;
+}): Promise<HighwaterTotalReading> {
+  const bucketWidth = params.bucketWidth ?? DEVICE_CLIENT_TOTALS_BUCKET_WIDTH;
+  const result = await params.executor.execute(sql`
+    SELECT
+      COUNT(*)::int AS "bucketCount",
+      LEAST(COALESCE(SUM(t.tokens_highwater), 0), ${sql.raw(BIGINT_MAX)})::bigint AS "tokens",
+      COALESCE(SUM(t.cost_highwater), 0)::text AS "cost"
+    FROM submitted_device_client_totals AS t
+    JOIN submitted_devices AS d ON d.id = t.submitted_device_id
+    WHERE d.user_id = ${params.userId}::uuid
+      AND t.bucket_width = ${bucketWidth}
+  `);
+
+  return interpretHighwaterAggregate(firstRow(result));
+}
+
+/**
+ * The Phase 1.5 record: the pair of derivations, and the delta between them.
+ *
+ * The SERVED value is `servedTokens`/`servedCost` — `SUM(daily_breakdown)`,
+ * exactly as before. The high-water side is recorded and never returned.
+ */
+export interface DualDerivationRecord {
+  userId: string;
+  submissionId: string;
+  bucketWidth: string;
+  servedTokens: number;
+  servedCost: number;
+  highwaterStatus: HighwaterTotalReading["status"];
+  highwaterTokens: number | null;
+  highwaterCost: number | null;
+  bucketCount: number | null;
+  /** servedTokens - highwaterTokens; null while the reading is unknown. */
+  tokenDelta: number | null;
+  /** servedTokens / highwaterTokens; null while unknown or divide-by-zero. */
+  tokenRatio: number | null;
+}
+
+export function buildDualDerivationRecord(params: {
+  userId: string;
+  submissionId: string;
+  bucketWidth?: string;
+  servedTokens: number;
+  servedCost: number;
+  highwater: HighwaterTotalReading;
+}): DualDerivationRecord {
+  const { highwater } = params;
+  const base = {
+    userId: params.userId,
+    submissionId: params.submissionId,
+    bucketWidth: params.bucketWidth ?? DEVICE_CLIENT_TOTALS_BUCKET_WIDTH,
+    servedTokens: params.servedTokens,
+    servedCost: params.servedCost,
+  };
+
+  if (highwater.status === "unknown") {
+    return {
+      ...base,
+      highwaterStatus: "unknown",
+      highwaterTokens: null,
+      highwaterCost: null,
+      bucketCount: null,
+      tokenDelta: null,
+      tokenRatio: null,
+    };
+  }
+
+  return {
+    ...base,
+    highwaterStatus: "known",
+    highwaterTokens: highwater.tokens,
+    highwaterCost: highwater.cost,
+    bucketCount: highwater.bucketCount,
+    tokenDelta: params.servedTokens - highwater.tokens,
+    tokenRatio:
+      highwater.tokens > 0 ? params.servedTokens / highwater.tokens : null,
+  };
+}
+
+/**
+ * Stable prefix so the pair is greppable in platform logs. The same comparison
+ * is also reconstructable offline at any time from
+ * `submissions.total_tokens` against `SUM(tokens_highwater)`, since both sides
+ * are persisted — the log exists to surface divergence on live traffic without
+ * anyone running a script, not because the data would otherwise be lost.
+ */
+export const DUAL_DERIVATION_LOG_PREFIX = "ratchet-census";

--- a/packages/frontend/src/lib/db/deviceClientTotals.ts
+++ b/packages/frontend/src/lib/db/deviceClientTotals.ts
@@ -240,6 +240,14 @@ export async function recordDeviceClientTotals(params: {
  * seed it with the inflated value that `GREATEST` then keeps forever). Both
  * mean an absent bucket carries no information about usage, and any consumer
  * that reads it as 0 would report a fabricated collapse.
+ *
+ * `known` means "at least one bucket exists" — it does NOT mean coverage is
+ * complete. During the forced warm-up a user can easily have one bucket out of
+ * fifty, which reads as `known` with a total far below the served one. That is
+ * the correct behaviour for a MEASUREMENT (the gap is the signal) but it makes
+ * `status` unsafe as a Phase 2 readiness gate on its own. `bucketCount` is
+ * carried for exactly that reason: the gate belongs on coverage and on the
+ * observed delta, never on `status === "known"`.
  */
 export type HighwaterTotalReading =
   | { status: "unknown" }

--- a/packages/frontend/src/lib/db/deviceClientTotals.ts
+++ b/packages/frontend/src/lib/db/deviceClientTotals.ts
@@ -210,6 +210,27 @@ export interface DeviceClientTotalsExecutor {
   execute(query: SQL): Promise<unknown>;
 }
 
+export interface RatchetCensusWork {
+  id: string;
+  submittedDeviceId: string;
+  buckets: DeviceClientBucketTotal[];
+}
+
+function isDeviceClientBucketTotal(value: unknown): value is DeviceClientBucketTotal {
+  if (!value || typeof value !== "object") return false;
+  const bucket = value as Partial<DeviceClientBucketTotal>;
+  return (
+    typeof bucket.client === "string" &&
+    (bucket.origin === "cli" || bucket.origin === "backfill") &&
+    typeof bucket.bucketWidth === "string" &&
+    typeof bucket.bucketKey === "string" &&
+    typeof bucket.tokens === "number" &&
+    Number.isFinite(bucket.tokens) &&
+    typeof bucket.cost === "number" &&
+    Number.isFinite(bucket.cost)
+  );
+}
+
 /**
  * `GREATEST` upsert of the folded buckets for one device.
  *
@@ -251,6 +272,67 @@ export async function recordDeviceClientTotals(params: {
   }
 
   return buckets.length;
+}
+
+function workRows(result: unknown): RatchetCensusWork[] {
+  const rows = Array.isArray(result)
+    ? result
+    : result && typeof result === "object" && Array.isArray((result as { rows?: unknown }).rows)
+    ? (result as { rows: unknown[] }).rows
+    : [];
+
+  return rows.flatMap((row): RatchetCensusWork[] => {
+    if (!row || typeof row !== "object") return [];
+    const candidate = row as Partial<RatchetCensusWork>;
+    if (
+      typeof candidate.id !== "string" ||
+      typeof candidate.submittedDeviceId !== "string" ||
+      !Array.isArray(candidate.buckets) ||
+      !candidate.buckets.every(isDeviceClientBucketTotal)
+    ) {
+      return [];
+    }
+    return [{
+      id: candidate.id,
+      submittedDeviceId: candidate.submittedDeviceId,
+      buckets: candidate.buckets,
+    }];
+  });
+}
+
+/**
+ * Replay every committed-but-unfinished census write for one submission.
+ *
+ * The work item is inserted with the daily rows in the submit transaction, so
+ * an invocation interrupted after commit leaves durable evidence rather than a
+ * permanently stranded counter. Upserts are idempotent, therefore concurrent
+ * replayers may safely process the same item; only the invocation that deletes
+ * it first completes it.
+ */
+export async function recoverRatchetCensusWork(params: {
+  executor: DeviceClientTotalsExecutor;
+  submissionId: string;
+}): Promise<number> {
+  const result = await params.executor.execute(sql`
+    SELECT id, submitted_device_id AS "submittedDeviceId", buckets
+    FROM ratchet_census_work
+    WHERE submission_id = ${params.submissionId}::uuid
+  `);
+  const work = workRows(result);
+
+  for (const item of work) {
+    await recordDeviceClientTotals({
+      executor: params.executor,
+      submittedDeviceId: item.submittedDeviceId,
+      buckets: item.buckets,
+    });
+    await params.executor.execute(sql`
+      DELETE FROM ratchet_census_work
+      WHERE id = ${item.id}::uuid
+    `);
+  }
+
+  return work.length;
 }
 
 /**
@@ -403,9 +485,9 @@ export async function readDualDerivation(params: {
         WHERE db.submission_id = ${params.submissionId}::uuid
       ) AS "snapshotCost",
       (
-        SELECT s.ratchet_census_pending
-        FROM submissions AS s
-        WHERE s.id = ${params.submissionId}::uuid
+        SELECT COUNT(*)
+        FROM ratchet_census_work AS w
+        WHERE w.submission_id = ${params.submissionId}::uuid
       )::int AS "censusPending",
       COUNT(*)::int AS "bucketCount",
       LEAST(COALESCE(SUM(t.tokens_highwater), 0), ${sql.raw(BIGINT_MAX)})::bigint AS "tokens",
@@ -448,7 +530,7 @@ export interface DualDerivationRecord {
   /** `SUM(daily_breakdown)` from the SAME snapshot as the high-water read. */
   snapshotTokens: number;
   snapshotCost: number;
-  /** Outstanding deferred high-water writes, including this request's own. */
+  /** Outstanding durable deferred high-water writes. */
   censusPending: number;
   /**
    * True when a concurrent submit for this user landed between this request's
@@ -480,10 +562,12 @@ export function buildDualDerivationRecord(params: {
   highwater: HighwaterTotalReading;
 }): DualDerivationRecord {
   const { highwater } = params;
-  // This request increments the ledger in its submit transaction and clears it
-  // only after its high-water upsert. Any additional entry is a committed
-  // submit whose daily rows may be visible while its high-water rows are not.
-  const hasPendingPeer = params.censusPending > 1;
+  // The current invocation replays every work item before reading. Any row
+  // still present in the same snapshot was inserted by a submit that committed
+  // after this invocation's recovery began, so it is a concurrent peer whose
+  // daily rows may be visible while its high-water rows are not. Unlike the
+  // earlier aggregate counter, each item is replayable after interruption.
+  const hasPendingPeer = params.censusPending > 0;
   const base = {
     userId: params.userId,
     submissionId: params.submissionId,

--- a/packages/frontend/src/lib/db/deviceClientTotals.ts
+++ b/packages/frontend/src/lib/db/deviceClientTotals.ts
@@ -111,8 +111,22 @@ export function isDeviceClientTotalsWriteEnabled(
  */
 export function monthBucketKey(date: string): string | null {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return null;
-  const month = Number(date.slice(5, 7));
-  if (month < 1 || month > 12) return null;
+
+  // Round-trip through UTC rather than range-checking the month alone. A date
+  // like `2026-02-31` is not a calendar day, but slicing the month off it still
+  // yields a plausible `2026-02` — so an impossible day would silently land in
+  // a real bucket and skew that month's high-water.
+  //
+  // Note the NaN check is NOT sufficient on its own: `new Date("2026-02-31Z")`
+  // does not fail, it ROLLS OVER to 2026-03-03. Deriving the bucket from the
+  // parsed value would then file February usage under March, which is worse
+  // than the slice it replaced. Comparing the round-trip back to the input is
+  // what actually rejects it, and it gets leap years right for free
+  // (`2024-02-29` passes, `2025-02-29` does not).
+  const parsed = new Date(`${date}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) return null;
+  if (parsed.toISOString().slice(0, 10) !== date) return null;
+
   return date.slice(0, 7);
 }
 
@@ -456,7 +470,15 @@ export function buildDualDerivationRecord(params: {
     servedCost: params.servedCost,
     snapshotTokens: params.snapshotTokens,
     snapshotCost: params.snapshotCost,
-    racedConcurrentSubmit: params.snapshotTokens !== params.servedTokens,
+    // Costs are compared too, not just tokens. A concurrent submit that moved
+    // only the cost — a reprice, or usage whose tokens were already counted —
+    // is still a race, and reporting it as `false` would let the census read a
+    // delta computed across two different states as if it were stable. Exact
+    // comparison is safe here: both sides come from the same numeric(18,4)
+    // column via the same conversion, so equal stored values are equal doubles.
+    racedConcurrentSubmit:
+      params.snapshotTokens !== params.servedTokens ||
+      params.snapshotCost !== params.servedCost,
   };
 
   if (highwater.status === "unknown") {

--- a/packages/frontend/src/lib/db/migrations/0022_uneven_wong.sql
+++ b/packages/frontend/src/lib/db/migrations/0022_uneven_wong.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "submitted_device_client_totals" (
+	"submitted_device_id" uuid NOT NULL,
+	"client" varchar(128) NOT NULL,
+	"origin" varchar(16) NOT NULL,
+	"bucket_width" varchar(8) NOT NULL,
+	"bucket_key" varchar(16) NOT NULL,
+	"tokens_highwater" bigint DEFAULT 0 NOT NULL,
+	"cost_highwater" numeric(18, 4) DEFAULT '0' NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "submitted_device_client_totals_submitted_device_id_client_origin_bucket_width_bucket_key_pk" PRIMARY KEY("submitted_device_id","client","origin","bucket_width","bucket_key")
+);
+--> statement-breakpoint
+ALTER TABLE "submitted_device_client_totals" ADD CONSTRAINT "submitted_device_client_totals_submitted_device_id_submitted_devices_id_fk" FOREIGN KEY ("submitted_device_id") REFERENCES "public"."submitted_devices"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/frontend/src/lib/db/migrations/0023_stormy_iron_lad.sql
+++ b/packages/frontend/src/lib/db/migrations/0023_stormy_iron_lad.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "submissions" ADD COLUMN "ratchet_census_pending" integer DEFAULT 0 NOT NULL;

--- a/packages/frontend/src/lib/db/migrations/0024_parched_dreadnoughts.sql
+++ b/packages/frontend/src/lib/db/migrations/0024_parched_dreadnoughts.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "ratchet_census_work" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"submission_id" uuid NOT NULL,
+	"submitted_device_id" uuid NOT NULL,
+	"buckets" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "ratchet_census_work" ADD CONSTRAINT "ratchet_census_work_submission_id_submissions_id_fk" FOREIGN KEY ("submission_id") REFERENCES "public"."submissions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "ratchet_census_work" ADD CONSTRAINT "ratchet_census_work_submitted_device_id_submitted_devices_id_fk" FOREIGN KEY ("submitted_device_id") REFERENCES "public"."submitted_devices"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_ratchet_census_work_submission_id" ON "ratchet_census_work" USING btree ("submission_id");--> statement-breakpoint
+ALTER TABLE "submissions" DROP COLUMN "ratchet_census_pending";

--- a/packages/frontend/src/lib/db/migrations/meta/0022_snapshot.json
+++ b/packages/frontend/src/lib/db/migrations/meta/0022_snapshot.json
@@ -1,0 +1,1778 @@
+{
+  "id": "29b84e73-5134-4357-98e9-51b60a09c3b6",
+  "prevId": "1ef815ae-b094-4611-821e-7d005744aaba",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_api_tokens_token": {
+          "name": "idx_api_tokens_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_tokens_user_id": {
+          "name": "idx_api_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_unique": {
+          "name": "api_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        },
+        "api_tokens_user_name_unique": {
+          "name": "api_tokens_user_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_breakdown": {
+      "name": "daily_breakdown",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(14, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_breakdown": {
+          "name": "source_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_time_ms": {
+          "name": "active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_daily_breakdown_submission_id": {
+          "name": "idx_daily_breakdown_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_submitted_device_id": {
+          "name": "idx_daily_breakdown_submitted_device_id",
+          "columns": [
+            {
+              "expression": "submitted_device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_date": {
+          "name": "idx_daily_breakdown_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_breakdown_submission_id_submissions_id_fk": {
+          "name": "daily_breakdown_submission_id_submissions_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_breakdown_submitted_device_id_submitted_devices_id_fk": {
+          "name": "daily_breakdown_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_breakdown_submission_device_date_unique": {
+          "name": "daily_breakdown_submission_device_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "submission_id",
+            "submitted_device_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_codes_device_code": {
+          "name": "idx_device_codes_device_code",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_code": {
+          "name": "idx_device_codes_user_code",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_id": {
+          "name": "idx_device_codes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_expires_at": {
+          "name": "idx_device_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_codes_user_id_users_id_fk": {
+          "name": "device_codes_user_id_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_invites": {
+      "name": "group_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_username": {
+          "name": "invited_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_username_normalized": {
+          "name": "invited_username_normalized",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_user_id": {
+          "name": "invited_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_group_invites_group_status": {
+          "name": "idx_group_invites_group_status",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_user_status": {
+          "name": "idx_group_invites_invited_user_status",
+          "columns": [
+            {
+              "expression": "invited_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_username_status": {
+          "name": "idx_group_invites_invited_username_status",
+          "columns": [
+            {
+              "expression": "invited_username_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_expires_at": {
+          "name": "idx_group_invites_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_by": {
+          "name": "idx_group_invites_invited_by",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_invites_group_id_groups_id_fk": {
+          "name": "group_invites_group_id_groups_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_invites_invited_user_id_users_id_fk": {
+          "name": "group_invites_invited_user_id_users_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_invites_invited_by_users_id_fk": {
+          "name": "group_invites_invited_by_users_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_invites_token_hash_unique": {
+          "name": "group_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_members": {
+      "name": "group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_group_members_user_id": {
+          "name": "idx_group_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_members_invited_by": {
+          "name": "idx_group_members_invited_by",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_members_group_id_groups_id_fk": {
+          "name": "group_members_group_id_groups_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_members_user_id_users_id_fk": {
+          "name": "group_members_user_id_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_members_invited_by_users_id_fk": {
+          "name": "group_members_invited_by_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_members_group_user_unique": {
+          "name": "group_members_group_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_created_by": {
+          "name": "idx_groups_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_groups_visibility_updated": {
+          "name": "idx_groups_visibility_updated",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_created_by_users_id_fk": {
+          "name": "groups_created_by_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_slug_unique": {
+          "name": "groups_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moderation_actions": {
+      "name": "moderation_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_username": {
+          "name": "target_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_moderation_actions_target_created": {
+          "name": "idx_moderation_actions_target_created",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_moderation_actions_actor": {
+          "name": "idx_moderation_actions_actor",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moderation_actions_target_user_id_users_id_fk": {
+          "name": "moderation_actions_target_user_id_users_id_fk",
+          "tableFrom": "moderation_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "moderation_actions_actor_user_id_users_id_fk": {
+          "name": "moderation_actions_actor_user_id_users_id_fk",
+          "tableFrom": "moderation_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_token_hash": {
+          "name": "idx_sessions_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sources_used": {
+          "name": "sources_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "models_used": {
+          "name": "models_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_version": {
+          "name": "cli_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_hash": {
+          "name": "submission_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submit_count": {
+          "name": "submit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_backfill": {
+          "name": "has_backfill",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_active_time_ms": {
+          "name": "total_active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longest_continuous_ms": {
+          "name": "longest_continuous_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_sessions": {
+          "name": "max_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_servers": {
+          "name": "mcp_servers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_submissions_created_at": {
+          "name": "idx_submissions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_leaderboard": {
+          "name": "idx_submissions_leaderboard",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_tokens",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_cost",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submissions_user_id_unique": {
+          "name": "submissions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submitted_device_client_totals": {
+      "name": "submitted_device_client_totals",
+      "schema": "",
+      "columns": {
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client": {
+          "name": "client",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_width": {
+          "name": "bucket_width",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_key": {
+          "name": "bucket_key",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens_highwater": {
+          "name": "tokens_highwater",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_highwater": {
+          "name": "cost_highwater",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "submitted_device_client_totals_submitted_device_id_submitted_devices_id_fk": {
+          "name": "submitted_device_client_totals_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "submitted_device_client_totals",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "submitted_device_client_totals_submitted_device_id_client_origin_bucket_width_bucket_key_pk": {
+          "name": "submitted_device_client_totals_submitted_device_id_client_origin_bucket_width_bucket_key_pk",
+          "columns": [
+            "submitted_device_id",
+            "client",
+            "origin",
+            "bucket_width",
+            "bucket_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submitted_devices": {
+      "name": "submitted_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_key": {
+          "name": "device_key",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_active_time_ms": {
+          "name": "total_active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longest_continuous_ms": {
+          "name": "longest_continuous_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_sessions": {
+          "name": "max_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_submitted_devices_user_id": {
+          "name": "idx_submitted_devices_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submitted_devices_user_id_users_id_fk": {
+          "name": "submitted_devices_user_id_users_id_fk",
+          "tableFrom": "submitted_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submitted_devices_user_device_key_unique": {
+          "name": "submitted_devices_user_device_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leaderboard_hidden": {
+          "name": "leaderboard_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_lower_unique": {
+          "name": "users_username_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_github_id": {
+          "name": "idx_users_github_id",
+          "columns": [
+            {
+              "expression": "github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/frontend/src/lib/db/migrations/meta/0023_snapshot.json
+++ b/packages/frontend/src/lib/db/migrations/meta/0023_snapshot.json
@@ -1,0 +1,1785 @@
+{
+  "id": "fd1740b8-39b0-4942-b4ce-405113b6ffbe",
+  "prevId": "29b84e73-5134-4357-98e9-51b60a09c3b6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_api_tokens_token": {
+          "name": "idx_api_tokens_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_tokens_user_id": {
+          "name": "idx_api_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_unique": {
+          "name": "api_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        },
+        "api_tokens_user_name_unique": {
+          "name": "api_tokens_user_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_breakdown": {
+      "name": "daily_breakdown",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(14, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_breakdown": {
+          "name": "source_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_time_ms": {
+          "name": "active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_daily_breakdown_submission_id": {
+          "name": "idx_daily_breakdown_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_submitted_device_id": {
+          "name": "idx_daily_breakdown_submitted_device_id",
+          "columns": [
+            {
+              "expression": "submitted_device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_date": {
+          "name": "idx_daily_breakdown_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_breakdown_submission_id_submissions_id_fk": {
+          "name": "daily_breakdown_submission_id_submissions_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_breakdown_submitted_device_id_submitted_devices_id_fk": {
+          "name": "daily_breakdown_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_breakdown_submission_device_date_unique": {
+          "name": "daily_breakdown_submission_device_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "submission_id",
+            "submitted_device_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_codes_device_code": {
+          "name": "idx_device_codes_device_code",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_code": {
+          "name": "idx_device_codes_user_code",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_id": {
+          "name": "idx_device_codes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_expires_at": {
+          "name": "idx_device_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_codes_user_id_users_id_fk": {
+          "name": "device_codes_user_id_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_invites": {
+      "name": "group_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_username": {
+          "name": "invited_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_username_normalized": {
+          "name": "invited_username_normalized",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_user_id": {
+          "name": "invited_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_group_invites_group_status": {
+          "name": "idx_group_invites_group_status",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_user_status": {
+          "name": "idx_group_invites_invited_user_status",
+          "columns": [
+            {
+              "expression": "invited_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_username_status": {
+          "name": "idx_group_invites_invited_username_status",
+          "columns": [
+            {
+              "expression": "invited_username_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_expires_at": {
+          "name": "idx_group_invites_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_by": {
+          "name": "idx_group_invites_invited_by",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_invites_group_id_groups_id_fk": {
+          "name": "group_invites_group_id_groups_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_invites_invited_user_id_users_id_fk": {
+          "name": "group_invites_invited_user_id_users_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_invites_invited_by_users_id_fk": {
+          "name": "group_invites_invited_by_users_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_invites_token_hash_unique": {
+          "name": "group_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_members": {
+      "name": "group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_group_members_user_id": {
+          "name": "idx_group_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_members_invited_by": {
+          "name": "idx_group_members_invited_by",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_members_group_id_groups_id_fk": {
+          "name": "group_members_group_id_groups_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_members_user_id_users_id_fk": {
+          "name": "group_members_user_id_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_members_invited_by_users_id_fk": {
+          "name": "group_members_invited_by_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_members_group_user_unique": {
+          "name": "group_members_group_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_created_by": {
+          "name": "idx_groups_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_groups_visibility_updated": {
+          "name": "idx_groups_visibility_updated",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_created_by_users_id_fk": {
+          "name": "groups_created_by_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_slug_unique": {
+          "name": "groups_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moderation_actions": {
+      "name": "moderation_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_username": {
+          "name": "target_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_moderation_actions_target_created": {
+          "name": "idx_moderation_actions_target_created",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_moderation_actions_actor": {
+          "name": "idx_moderation_actions_actor",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moderation_actions_target_user_id_users_id_fk": {
+          "name": "moderation_actions_target_user_id_users_id_fk",
+          "tableFrom": "moderation_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "moderation_actions_actor_user_id_users_id_fk": {
+          "name": "moderation_actions_actor_user_id_users_id_fk",
+          "tableFrom": "moderation_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_token_hash": {
+          "name": "idx_sessions_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sources_used": {
+          "name": "sources_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "models_used": {
+          "name": "models_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_version": {
+          "name": "cli_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_hash": {
+          "name": "submission_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submit_count": {
+          "name": "submit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "ratchet_census_pending": {
+          "name": "ratchet_census_pending",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_backfill": {
+          "name": "has_backfill",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_active_time_ms": {
+          "name": "total_active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longest_continuous_ms": {
+          "name": "longest_continuous_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_sessions": {
+          "name": "max_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_servers": {
+          "name": "mcp_servers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_submissions_created_at": {
+          "name": "idx_submissions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_leaderboard": {
+          "name": "idx_submissions_leaderboard",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_tokens",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_cost",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submissions_user_id_unique": {
+          "name": "submissions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submitted_device_client_totals": {
+      "name": "submitted_device_client_totals",
+      "schema": "",
+      "columns": {
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client": {
+          "name": "client",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_width": {
+          "name": "bucket_width",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_key": {
+          "name": "bucket_key",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens_highwater": {
+          "name": "tokens_highwater",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_highwater": {
+          "name": "cost_highwater",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "submitted_device_client_totals_submitted_device_id_submitted_devices_id_fk": {
+          "name": "submitted_device_client_totals_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "submitted_device_client_totals",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "submitted_device_client_totals_submitted_device_id_client_origin_bucket_width_bucket_key_pk": {
+          "name": "submitted_device_client_totals_submitted_device_id_client_origin_bucket_width_bucket_key_pk",
+          "columns": [
+            "submitted_device_id",
+            "client",
+            "origin",
+            "bucket_width",
+            "bucket_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submitted_devices": {
+      "name": "submitted_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_key": {
+          "name": "device_key",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_active_time_ms": {
+          "name": "total_active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longest_continuous_ms": {
+          "name": "longest_continuous_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_sessions": {
+          "name": "max_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_submitted_devices_user_id": {
+          "name": "idx_submitted_devices_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submitted_devices_user_id_users_id_fk": {
+          "name": "submitted_devices_user_id_users_id_fk",
+          "tableFrom": "submitted_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submitted_devices_user_device_key_unique": {
+          "name": "submitted_devices_user_device_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leaderboard_hidden": {
+          "name": "leaderboard_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_lower_unique": {
+          "name": "users_username_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_github_id": {
+          "name": "idx_users_github_id",
+          "columns": [
+            {
+              "expression": "github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/frontend/src/lib/db/migrations/meta/0024_snapshot.json
+++ b/packages/frontend/src/lib/db/migrations/meta/0024_snapshot.json
@@ -1,0 +1,1866 @@
+{
+  "id": "5143df04-f90e-41ac-be9f-7542e5d7c580",
+  "prevId": "fd1740b8-39b0-4942-b4ce-405113b6ffbe",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_api_tokens_token": {
+          "name": "idx_api_tokens_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_tokens_user_id": {
+          "name": "idx_api_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_unique": {
+          "name": "api_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        },
+        "api_tokens_user_name_unique": {
+          "name": "api_tokens_user_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_breakdown": {
+      "name": "daily_breakdown",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(14, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_breakdown": {
+          "name": "source_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_time_ms": {
+          "name": "active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_daily_breakdown_submission_id": {
+          "name": "idx_daily_breakdown_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_submitted_device_id": {
+          "name": "idx_daily_breakdown_submitted_device_id",
+          "columns": [
+            {
+              "expression": "submitted_device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_date": {
+          "name": "idx_daily_breakdown_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_breakdown_submission_id_submissions_id_fk": {
+          "name": "daily_breakdown_submission_id_submissions_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_breakdown_submitted_device_id_submitted_devices_id_fk": {
+          "name": "daily_breakdown_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_breakdown_submission_device_date_unique": {
+          "name": "daily_breakdown_submission_device_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "submission_id",
+            "submitted_device_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_codes_device_code": {
+          "name": "idx_device_codes_device_code",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_code": {
+          "name": "idx_device_codes_user_code",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_id": {
+          "name": "idx_device_codes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_expires_at": {
+          "name": "idx_device_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_codes_user_id_users_id_fk": {
+          "name": "device_codes_user_id_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_invites": {
+      "name": "group_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_username": {
+          "name": "invited_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_username_normalized": {
+          "name": "invited_username_normalized",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_user_id": {
+          "name": "invited_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_group_invites_group_status": {
+          "name": "idx_group_invites_group_status",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_user_status": {
+          "name": "idx_group_invites_invited_user_status",
+          "columns": [
+            {
+              "expression": "invited_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_username_status": {
+          "name": "idx_group_invites_invited_username_status",
+          "columns": [
+            {
+              "expression": "invited_username_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_expires_at": {
+          "name": "idx_group_invites_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_by": {
+          "name": "idx_group_invites_invited_by",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_invites_group_id_groups_id_fk": {
+          "name": "group_invites_group_id_groups_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_invites_invited_user_id_users_id_fk": {
+          "name": "group_invites_invited_user_id_users_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_invites_invited_by_users_id_fk": {
+          "name": "group_invites_invited_by_users_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_invites_token_hash_unique": {
+          "name": "group_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_members": {
+      "name": "group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_group_members_user_id": {
+          "name": "idx_group_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_members_invited_by": {
+          "name": "idx_group_members_invited_by",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_members_group_id_groups_id_fk": {
+          "name": "group_members_group_id_groups_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_members_user_id_users_id_fk": {
+          "name": "group_members_user_id_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_members_invited_by_users_id_fk": {
+          "name": "group_members_invited_by_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_members_group_user_unique": {
+          "name": "group_members_group_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_created_by": {
+          "name": "idx_groups_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_groups_visibility_updated": {
+          "name": "idx_groups_visibility_updated",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_created_by_users_id_fk": {
+          "name": "groups_created_by_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_slug_unique": {
+          "name": "groups_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moderation_actions": {
+      "name": "moderation_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_username": {
+          "name": "target_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_moderation_actions_target_created": {
+          "name": "idx_moderation_actions_target_created",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_moderation_actions_actor": {
+          "name": "idx_moderation_actions_actor",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moderation_actions_target_user_id_users_id_fk": {
+          "name": "moderation_actions_target_user_id_users_id_fk",
+          "tableFrom": "moderation_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "moderation_actions_actor_user_id_users_id_fk": {
+          "name": "moderation_actions_actor_user_id_users_id_fk",
+          "tableFrom": "moderation_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ratchet_census_work": {
+      "name": "ratchet_census_work",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buckets": {
+          "name": "buckets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ratchet_census_work_submission_id": {
+          "name": "idx_ratchet_census_work_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ratchet_census_work_submission_id_submissions_id_fk": {
+          "name": "ratchet_census_work_submission_id_submissions_id_fk",
+          "tableFrom": "ratchet_census_work",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ratchet_census_work_submitted_device_id_submitted_devices_id_fk": {
+          "name": "ratchet_census_work_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "ratchet_census_work",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_token_hash": {
+          "name": "idx_sessions_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sources_used": {
+          "name": "sources_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "models_used": {
+          "name": "models_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_version": {
+          "name": "cli_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_hash": {
+          "name": "submission_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submit_count": {
+          "name": "submit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_backfill": {
+          "name": "has_backfill",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_active_time_ms": {
+          "name": "total_active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longest_continuous_ms": {
+          "name": "longest_continuous_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_sessions": {
+          "name": "max_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_servers": {
+          "name": "mcp_servers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_submissions_created_at": {
+          "name": "idx_submissions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_leaderboard": {
+          "name": "idx_submissions_leaderboard",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_tokens",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_cost",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submissions_user_id_unique": {
+          "name": "submissions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submitted_device_client_totals": {
+      "name": "submitted_device_client_totals",
+      "schema": "",
+      "columns": {
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client": {
+          "name": "client",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_width": {
+          "name": "bucket_width",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_key": {
+          "name": "bucket_key",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens_highwater": {
+          "name": "tokens_highwater",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_highwater": {
+          "name": "cost_highwater",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "submitted_device_client_totals_submitted_device_id_submitted_devices_id_fk": {
+          "name": "submitted_device_client_totals_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "submitted_device_client_totals",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "submitted_device_client_totals_submitted_device_id_client_origin_bucket_width_bucket_key_pk": {
+          "name": "submitted_device_client_totals_submitted_device_id_client_origin_bucket_width_bucket_key_pk",
+          "columns": [
+            "submitted_device_id",
+            "client",
+            "origin",
+            "bucket_width",
+            "bucket_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submitted_devices": {
+      "name": "submitted_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_key": {
+          "name": "device_key",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_active_time_ms": {
+          "name": "total_active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longest_continuous_ms": {
+          "name": "longest_continuous_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_sessions": {
+          "name": "max_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_submitted_devices_user_id": {
+          "name": "idx_submitted_devices_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submitted_devices_user_id_users_id_fk": {
+          "name": "submitted_devices_user_id_users_id_fk",
+          "tableFrom": "submitted_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submitted_devices_user_device_key_unique": {
+          "name": "submitted_devices_user_device_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leaderboard_hidden": {
+          "name": "leaderboard_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_lower_unique": {
+          "name": "users_username_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_github_id": {
+          "name": "idx_users_github_id",
+          "columns": [
+            {
+              "expression": "github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1785783969629,
       "tag": "0023_stormy_iron_lad",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1785785051220,
+      "tag": "0024_parched_dreadnoughts",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1785356630413,
       "tag": "0021_lethal_killraven",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1785715379340,
+      "tag": "0022_uneven_wong",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1785715379340,
       "tag": "0022_uneven_wong",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1785783969629,
+      "tag": "0023_stormy_iron_lad",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -417,6 +417,18 @@ export const dailyBreakdownRelations = relations(dailyBreakdown, ({ one }) => ({
  * take the max of imported and locally-scanned history instead of their sum,
  * silently dropping whichever is smaller.
  *
+ * The flip side of that key, also KNOWN and also left for Phase 2: `origin` is
+ * caller-controlled (`provenance.origin` on the payload), and the two origins
+ * ADD here while `daily_breakdown` MERGES. `mergeClientBreakdownsWithRegression
+ * Guard` REPLACES a client's day entry rather than summing it, so resubmitting
+ * the same history twice — once tagged `backfill`, once untagged — leaves the
+ * daily rows at H but leaves this table with two rows summing to 2H. Additivity
+ * across origins is only correct when the two bodies of history are DISJOINT,
+ * which is the honest case (import old history, scan recent history) but is not
+ * enforced. Phase 2 must not read `SUM(tokens_highwater)` across origins
+ * without accounting for this; Phase 1.5 surfaces it as a served/high-water
+ * ratio near 0.5, the same signature as the adoption case below.
+ *
  * KNOWN, and deliberately not fixed here — Phase 2 inherits it. The submit
  * route's legacy-adoption path re-parents a user's `daily_breakdown` rows from
  * the LEGACY device to their first device-aware device, so those days are

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -13,6 +13,7 @@ import {
   index,
   unique,
   uniqueIndex,
+  primaryKey,
 } from "drizzle-orm/pg-core";
 import { relations } from "drizzle-orm";
 import {
@@ -388,6 +389,103 @@ export const dailyBreakdownRelations = relations(dailyBreakdown, ({ one }) => ({
 }));
 
 // ============================================================================
+// SUBMITTED DEVICE CLIENT TOTALS (ratchet-inflation census, Phase 1)
+// ============================================================================
+/**
+ * Per-device, per-client, per-bucket token/cost HIGH-WATER marks.
+ *
+ * Phase 1 of docs/ratchet-inflation-recovery.md. **Nothing reads this table.**
+ * It exists so the inflation that `SUM(daily_breakdown.tokens)` accumulates can
+ * be measured against a bucket-level high-water reconstruction of the same
+ * history, on live traffic, before any read path is switched over (Phase 2).
+ *
+ * Merge semantics: `GREATEST` on conflict, mirroring the per-device session
+ * metrics on `submitted_devices`. A `--clients`/`--date` filtered submit
+ * reports only a slice of a bucket and must never lower the stored value.
+ *
+ * **This table must never be backfilled from `daily_breakdown`.** Seeding
+ * `tokens_highwater` with `SUM(daily in bucket)` would seed it with the
+ * INFLATED value; a later truthful full scan reports the true, lower total and
+ * `GREATEST(inflated, true)` keeps the inflated one permanently. The table
+ * starts empty and is filled only by incoming payloads — the warm-up is forced
+ * by the merge semantics, not a convenience to optimise away.
+ *
+ * `origin` is part of the primary key and is load-bearing. `getSubmitDevice`
+ * in the submit route falls back to `LEGACY_SUBMIT_DEVICE_KEY` when a payload
+ * omits `device`, so a `tokscale import` backfill and a legacy CLI submit land
+ * on the SAME `submitted_devices` row. Keyed without origin, `GREATEST` would
+ * take the max of imported and locally-scanned history instead of their sum,
+ * silently dropping whichever is smaller.
+ *
+ * KNOWN, and deliberately not fixed here — Phase 2 inherits it. The submit
+ * route's legacy-adoption path re-parents a user's `daily_breakdown` rows from
+ * the LEGACY device to their first device-aware device, so those days are
+ * counted once. This table has no equivalent re-parenting: a user who submits
+ * from a legacy CLI and later from a device-aware one ends up with the same
+ * history recorded under BOTH device ids, so a naive
+ * `SUM(tokens_highwater)` over their devices double-counts it. Phase 1 is
+ * inert so nothing is wrong today, and Phase 1.5 is exactly what surfaces it —
+ * those accounts show a served/high-water ratio near 0.5. Phase 2 must handle
+ * it (adopt the rows the same way, or aggregate per user+client+bucket)
+ * BEFORE it reads from here.
+ *
+ * Column types are chosen deliberately (see the `LEAST(...)` clamps in the
+ * submit route): `tokens_highwater` is bigint because a bucket total is a sum
+ * of day totals, and any aggregate reading it back must clamp before casting.
+ * `cost_highwater` is numeric(18,4) — wider than `daily_breakdown.cost`'s
+ * numeric(14,4), so a month-wide sum of day costs that already fit the
+ * narrower column cannot overflow this one.
+ */
+export const submittedDeviceClientTotals = pgTable(
+  "submitted_device_client_totals",
+  {
+    submittedDeviceId: uuid("submitted_device_id")
+      .notNull()
+      .references(() => submittedDevices.id, { onDelete: "cascade" }),
+    /** Canonical client id (post alias normalization, e.g. "kilo" not "kilocode"). */
+    client: varchar("client", { length: 128 }).notNull(),
+    /** "cli" for locally-scanned usage, "backfill" for `tokscale import`. */
+    origin: varchar("origin", { length: 16 }).notNull(),
+    /** Only "month" is written today; the column keeps Phase 3 open. */
+    bucketWidth: varchar("bucket_width", { length: 8 }).notNull(),
+    /** Stable bucket label: `YYYY-MM` for bucket_width = "month". */
+    bucketKey: varchar("bucket_key", { length: 16 }).notNull(),
+
+    tokensHighwater: bigint("tokens_highwater", { mode: "number" })
+      .notNull()
+      .default(0),
+    costHighwater: decimal("cost_highwater", { precision: 18, scale: 4 })
+      .notNull()
+      .default("0"),
+
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [
+        table.submittedDeviceId,
+        table.client,
+        table.origin,
+        table.bucketWidth,
+        table.bucketKey,
+      ],
+    }),
+  ]
+);
+
+export const submittedDeviceClientTotalsRelations = relations(
+  submittedDeviceClientTotals,
+  ({ one }) => ({
+    submittedDevice: one(submittedDevices, {
+      fields: [submittedDeviceClientTotals.submittedDeviceId],
+      references: [submittedDevices.id],
+    }),
+  })
+);
+
+// ============================================================================
 // GROUPS
 // ============================================================================
 export const groupRoles = ["owner", "admin", "member"] as const;
@@ -601,6 +699,8 @@ export type SubmittedDevice = typeof submittedDevices.$inferSelect;
 export type NewSubmittedDevice = typeof submittedDevices.$inferInsert;
 export type DailyBreakdown = typeof dailyBreakdown.$inferSelect;
 export type NewDailyBreakdown = typeof dailyBreakdown.$inferInsert;
+export type SubmittedDeviceClientTotal = typeof submittedDeviceClientTotals.$inferSelect;
+export type NewSubmittedDeviceClientTotal = typeof submittedDeviceClientTotals.$inferInsert;
 export type Group = typeof groups.$inferSelect;
 export type NewGroup = typeof groups.$inferInsert;
 export type GroupMember = typeof groupMembers.$inferSelect;

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -207,13 +207,6 @@ export const submissions = pgTable(
     cliVersion: varchar("cli_version", { length: 20 }),
     submissionHash: varchar("submission_hash", { length: 64 }),
     submitCount: integer("submit_count").notNull().default(1),
-    /**
-     * Enabled-only Phase 1.5 work ledger. Each committed submit increments
-     * this before its deferred high-water write; that write decrements it only
-     * after succeeding. A census never treats a snapshot with another pending
-     * write as trustworthy.
-     */
-    ratchetCensusPending: integer("ratchet_census_pending").notNull().default(0),
     /** 0=legacy (no timestamps), 1=timestamp-aware CLI */
     schemaVersion: integer("schema_version").notNull().default(0),
     /**
@@ -502,6 +495,42 @@ export const submittedDeviceClientTotalsRelations = relations(
       references: [submittedDevices.id],
     }),
   })
+);
+
+// ============================================================================
+// RATCHET CENSUS WORK (durable post-commit high-water writes)
+// ============================================================================
+/**
+ * One durable deferred high-water write. It is registered in the submit
+ * transaction, then replayed and deleted only after its idempotent upsert
+ * succeeds. This lets a later submit recover work abandoned by an interrupted
+ * request without mistaking that gap for a stable census divergence.
+ */
+export const ratchetCensusWork = pgTable(
+  "ratchet_census_work",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    submissionId: uuid("submission_id")
+      .notNull()
+      .references(() => submissions.id, { onDelete: "cascade" }),
+    submittedDeviceId: uuid("submitted_device_id")
+      .notNull()
+      .references(() => submittedDevices.id, { onDelete: "cascade" }),
+    buckets: jsonb("buckets").$type<
+      Array<{
+        client: string;
+        origin: "cli" | "backfill";
+        bucketWidth: string;
+        bucketKey: string;
+        tokens: number;
+        cost: number;
+      }>
+    >().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [index("idx_ratchet_census_work_submission_id").on(table.submissionId)]
 );
 
 // ============================================================================

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -207,6 +207,13 @@ export const submissions = pgTable(
     cliVersion: varchar("cli_version", { length: 20 }),
     submissionHash: varchar("submission_hash", { length: 64 }),
     submitCount: integer("submit_count").notNull().default(1),
+    /**
+     * Enabled-only Phase 1.5 work ledger. Each committed submit increments
+     * this before its deferred high-water write; that write decrements it only
+     * after succeeding. A census never treats a snapshot with another pending
+     * write as trustworthy.
+     */
+    ratchetCensusPending: integer("ratchet_census_pending").notNull().default(0),
     /** 0=legacy (no timestamps), 1=timestamp-aware CLI */
     schemaVersion: integer("schema_version").notNull().default(0),
     /**


### PR DESCRIPTION
Phase 1 and Phase 1.5 of `docs/ratchet-inflation-recovery.md`. Refs #960.

## What this adds

A per-device, per-client, per-month token/cost **high-water** table, written on every submit, that **nothing reads**.

```
submitted_device_client_totals(
  submitted_device_id, client, origin, bucket_width, bucket_key,
  tokens_highwater, cost_highwater, updated_at)
PRIMARY KEY (submitted_device_id, client, origin, bucket_width, bucket_key)
```

Buckets are folded server-side from the payload's `contributions` on their `date`, so no CLI change is required. Merge semantics are `GREATEST` on conflict, mirroring the per-device session metrics on `submitted_devices` — a `--clients`/`--date` filtered submit reports only a slice of a month and must never lower the stored value.

**Phase 1.5**: on each submission recompute, the total is now derived both ways — `SUM(dailyBreakdown.tokens)` and `SUM(tokens_highwater)` — the existing value is served unchanged, and the pair is recorded so the divergence can be measured on live traffic.

Both derivations are read in a **single statement**, so Postgres evaluates them in one snapshot. This matters: the transaction serializes a user's devices only until commit, and the census runs after that unsynchronized, so pairing this request's in-transaction total with a later high-water read would report a divergence neither derivation had — skewed in the direction that logs a *negative* delta — precisely for multi-device users, the population the census exists to characterize. The value served is still the in-transaction one and is recorded alongside as `servedTokens`, with `racedConcurrentSubmit` set when it differs from the snapshot.

## Merging this deploys the migration to production

`packages/frontend/vercel.json` sets `"buildCommand": "bun run scripts/migrate-prod.ts && next build"`, so **merging this PR applies the migration to prod automatically** on the next production deploy. The migration is `packages/frontend/src/lib/db/migrations/0022_uneven_wong.sql`, generated by `drizzle-kit generate` (nothing hand-written, `_journal.json` untouched by hand). It is DDL only — one `CREATE TABLE` plus one `ADD CONSTRAINT` for the FK. There is no DML in it, by design (see below).

## The constraints this is built around

**The table is never seeded from `daily_breakdown`, and that is not an oversight.** Backfilling `tokens_highwater` from existing daily rows would set it to `SUM(daily in bucket)` — the *inflated* value. A later truthful full scan reports the true, lower bucket total, and `GREATEST(inflated, true)` keeps the inflated one. Permanently. Seeding the table from the data it exists to correct would cement the very inflation it is measuring, with no path back. So the table starts empty and can only be filled by incoming payloads. The warm-up period is forced by the merge semantics, not a convenience to be optimised away.

**The write runs after the submit transaction commits, not inside it.** The submit path is one `db.transaction` holding `.for('update')` on the submissions row, which serializes a user's submits across all their devices until commit. A write placed there inherits both properties: it extends the lock hold, and *a defect in it fails the user's submission entirely*. "Nothing reads it" is no protection against that — this repo has already had a `COALESCE(SUM(x),0)::int` overflow abort a submit transaction, and `tokens_highwater` is exactly the kind of column that invites the same mistake. Because the write is a `GREATEST` upsert it is idempotent, so running it after commit downgrades any failure from a rejected submission to one deferred measurement, which the next submit repairs.

**A missing bucket means UNKNOWN, never zero.** Post-commit placement means the table can lag the daily rows by one submit, and the forced warm-up means most accounts have no coverage at all for a while. The read side returns a discriminated `{ status: "unknown" } | { status: "known", ... }` rather than a number, so a consumer cannot accidentally read absent coverage as a collapse to zero.

**Column types were picked deliberately, given that overflow history.** `tokens_highwater` is `bigint`; `SUM()` widens int8 to numeric, so the Phase 1.5 aggregate clamps with `LEAST(..., 9223372036854775807)` before casting back, exactly as the existing submit aggregates do. `cost_highwater` is `numeric(18,4)` — wider than `daily_breakdown.cost`'s `numeric(14,4)`, so a month-wide sum of day costs that already fit the narrower column cannot overflow this one. The JS-side fold clamps cost too, because `toFixed(4)` switches to exponential notation at 1e21 and would not parse as numeric at all.

**The write is killable in seconds without reverting a migration.** Set `TOKSCALE_DEVICE_CLIENT_TOTALS_WRITE` to `0`/`false`/`off`/`no`. Default is enabled; the flag exists to switch a misbehaving write off, not to gate it on.

**Nothing served changes.** `recordRatchetCensus` returns `void`, runs after the response payload has already been computed inside the transaction, and its result is discarded. The response still carries the `SUM(daily_breakdown)` totals.

## Why `origin` is in the primary key

`getSubmitDevice` falls back to `LEGACY_SUBMIT_DEVICE_KEY` when a payload omits `device`, so a `tokscale import` backfill and a legacy CLI submit land on the **same** `submitted_devices` row. Keyed without `origin`, `GREATEST` would take the **max** of imported and locally-scanned history instead of their sum, silently dropping whichever is smaller. The `ON CONFLICT` target is pinned against the `PRIMARY KEY` the migration actually creates by a test, since a conflict target that does not match a real unique constraint is a runtime error.

## Why one bucket width

Month only, not month + week. Real `(client, bucket)` cardinality measured against production on 2026-07-31:

```
rows per full-history submit — actual distinct (client, bucket) pairs
  both widths      p50   33    p95   122    max   349
  month only       p50    9    p95    32    max    91
  daily_breakdown
  writes today     p50   64    p95   218    max  1257
```

So this writes well under what the submit path already does, and month-only halves it again. (Do not re-derive this by multiplying buckets by clients — that is an upper bound, not a count, and overstates by 6-7x.) Phase 3 makes the width question much less interesting by permitting daily buckets outright.

## What Phase 2 inherits

Flagged in the schema doc comment rather than fixed here, because fixing it is a Phase 2 decision:

The submit route's legacy-adoption path re-parents a user's `daily_breakdown` rows from the LEGACY device to their first device-aware device, so those days are counted once. **This table has no equivalent re-parenting.** A user who submits from a legacy CLI and later from a device-aware one ends up with the same history recorded under *both* device ids, so a naive `SUM(tokens_highwater)` over their devices double-counts it. Phase 1 is inert so nothing is wrong today — and Phase 1.5 is exactly what surfaces it: those accounts show a served/high-water ratio near 0.5. Phase 2 must handle it (adopt the rows the same way, or aggregate per `user+client+bucket`) **before** it reads from here.

Also inherited, by design: the high-water table can only ratchet up. Unlike `daily_breakdown`, which has a regression guard that can heal downward on a truthful resubmit, a bucket that is ever poisoned high stays high. That is inherent to using `GREATEST` as the sensor and is the reason the table must never be seeded.

## How the pair is recorded

A structured line, `ratchet-census {json}`, emitted post-commit with `servedTokens`, `highwaterTokens`, `tokenDelta`, `tokenRatio`, `bucketCount` and `highwaterStatus`. Both sides of the comparison are *also* already persisted (`submissions.total_tokens` against `SUM(tokens_highwater)`), so the same measurement is reconstructable by SQL at any time over any window — the log exists to surface divergence on live traffic without anyone running a script, not because the data would otherwise be lost. That is why no new columns were added to `submissions` for it.

## Tests

`bun run test` — 796 passing, 79 files. Each guarantee was verified to fail without the change by mutating the source and re-running (red-before / green-after captured in the PR thread): `GREATEST` to a plain `EXCLUDED` assignment, `origin` dropped from the conflict key, the unknown-coverage branch removed, the post-commit try/catch removed, the census write moved back inside the transaction, the same-day fold dedup broken, and `tokenDelta` reverted to the stale served operand.

## Verified against a real Postgres 16

The full migration chain was replayed against a throwaway `postgres:16` container (the same thing the `Frontend Migration Replay` CI job does), and the upsert semantics were then executed against it rather than only asserted on the rendered SQL:

```
ok   - a user with no buckets reads as UNKNOWN, not zero
ok   - full submit stored 100 tokens
ok   - partial resubmit did NOT lower the stored value (100, not 40)
ok   - cost did NOT regress either (10.0000, not 4.0000)
ok   - a larger submit DOES raise the high-water mark to 150
ok   - replaying the same write 3x changes nothing (idempotent)
ok   - backfill landed in its OWN row on the same device
ok   - cli(150) + backfill(60) SUM to 210 — not max(150,60)=150
ok   - coverage is now known with 2 buckets
```

The last two are the `origin` argument demonstrated rather than asserted: on a single LEGACY device row, imported and locally-scanned history stay separate and add, instead of `GREATEST` silently discarding the smaller one. The idempotency line is what makes post-commit placement safe.

The Phase 1.5 dual read was verified the same way, including the concurrent-device case that motivated reading both sides in one statement:

```
ok - no high-water rows yet => UNKNOWN, not zero
ok - both derivations now agree at 500
ok - after a concurrent device lands, both sides moved together (800/800)
ok - same-snapshot delta is 0 — the stale pairing would have logged -300
```

Migration replay also emits one `NOTICE` — `identifier "submitted_device_client_totals_submitted_device_id_submitted_devices_id_fk" will be truncated to "..._submitted_de"`. That is Postgres truncating the FK constraint name at 63 bytes. It is harmless here: the `ON CONFLICT` target is a column list, not a constraint name, and no other constraint truncates to the same prefix.

## Not verified

- Concurrent post-commit census writes from two devices of the same user racing each other. Idempotent by construction and idempotency is now demonstrated, and the snapshot skew it used to cause is fixed and covered — but the race is reproduced by sequencing the same writes, not under real contention.
- The Phase 1.5 read adds one aggregate query per submit. It is served by the `submitted_device_client_totals` primary-key btree and `idx_submitted_devices_user_id`, but its latency was not measured against production.
- The census `await`s before the response is returned, so it adds two short queries to submit latency. `after()` from `next/server` would remove that; it was not used because it is harder to test deterministically. Worth revisiting if submit p95 moves.
