### PR TITLE
fix(cli): pin the timezone usage days are bucketed into

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,6 +440,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,6 +2256,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3468,6 +3496,7 @@ dependencies = [
  "tokio",
  "tokscale-core",
  "toml",
+ "tracing",
  "tracing-subscriber",
  "unicode-normalization",
  "unicode-segmentation",
@@ -3482,8 +3511,10 @@ version = "4.9.0"
 dependencies = [
  "bincode",
  "chrono",
+ "chrono-tz",
  "dirs",
  "fs2",
+ "iana-time-zone",
  "libc",
  "once_cell",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,21 @@ walkdir = "2"
 # Date/time handling
 chrono = { version = "0.4", features = ["serde"] }
 
+# Named IANA timezones for the pinned bucketing zone (`scanner.bucketTimezone`).
+#
+# A `chrono::FixedOffset` would avoid this dependency but cannot follow DST, so
+# a pinned offset drifts an hour off local midnight twice a year and re-splits
+# usage near the day boundary — a bounded rerun of the bug pinning removes. The
+# named-zone variant is the only exact fix, so the tz database is the price.
+# `default-features = false` drops the `parse-zoneinfo`/`case-insensitive`
+# extras; `std` alone is enough for `FromStr` + `TimeZone`.
+chrono-tz = { version = "0.10", default-features = false, features = ["std"] }
+
+# Reads the machine's IANA zone name so the CLI can pin it on first scan.
+# Already compiled into every build — `chrono` depends on it to implement
+# `Local` — so naming it here as a direct dependency adds no code to the binary.
+iana-time-zone = "0.1"
+
 # Error handling
 thiserror = "2"
 anyhow = "1.0"

--- a/README.md
+++ b/README.md
@@ -883,6 +883,47 @@ Tokscale stores settings in `~/.config/tokscale/settings.json`:
 | `minutelyTabEnabled` | boolean | `false` | Show the per-minute Minutely tab in the TUI and aggregate per-minute usage during data loading. Default-off because minute-granularity is a niche/diagnostic view for most users and the per-minute bucketing has a non-trivial cost on large datasets. |
 | `autosubmit` | object | disabled | Saved `tokscale autosubmit` state: interval, client/date filters, scheduler backend, last run time, and last error. Prefer `tokscale autosubmit enable/status/disable` over editing this object by hand. |
 | `scanner.extraScanPaths` | object | `{}` | Additional per-client scan roots for sessions outside Tokscale's default home-root locations |
+| `scanner.bucketTimezone` | string | auto-detected | IANA name of the timezone this device buckets usage days into (e.g. `"Asia/Seoul"`). Recorded automatically on first run. Prefer `tokscale config set timezone <zone>` over editing this by hand. |
+
+#### Day boundaries and `scanner.bucketTimezone`
+
+Which calendar day a message counts toward depends on a timezone. Tokscale
+records this device's timezone on first run and reuses it, rather than reading
+the machine's current timezone on every scan.
+
+This matters because day totals are submitted per day and never allowed to
+decrease. If the same history were re-bucketed under a different timezone — you
+travel, you change your system clock, you run in CI with a different `TZ` — a
+session near midnight would move to the neighbouring day, and both the old and
+the new day would keep their value. The total would go up without any new usage.
+Pinning the zone makes the day boundary stable, so a rescan of unchanged history
+always produces the same buckets.
+
+```console
+$ tokscale config list
+timezone     Asia/Seoul
+
+$ tokscale config get timezone
+Asia/Seoul
+
+# After relocating — day boundaries move once, then stay stable
+$ tokscale config set timezone America/New_York
+
+# Re-detect from the machine instead of naming a zone
+$ tokscale config set timezone auto
+
+# Forget the pin; the next run re-detects
+$ tokscale config unset timezone
+```
+
+Only IANA zone names are accepted. Fixed UTC offsets such as `+09:00` are
+rejected: an offset cannot follow daylight saving time, so a pinned offset stops
+matching local midnight after a DST transition and re-splits usage near the day
+boundary — a smaller version of the problem pinning removes.
+
+Existing installs are unaffected until they pin, and the run that pins reports
+exactly what it would have reported anyway: the zone recorded is the one the
+machine was already using.
 
 Use `scanner.extraScanPaths` for persistent extra roots such as project-level `.codex` directories or imported Gemini/OpenClaw histories. Tokscale automatically discovers Hermes profile databases under `$HERMES_HOME/profiles/*/state.db` (or `~/.hermes/profiles/*/state.db` when `HERMES_HOME` is unset). Use `scanner.extraScanPaths.hermes` only for non-standard Hermes profile locations; entries may point at a profile directory containing `state.db` or directly at a `state.db` file. Tokscale merges these paths with the default scan roots on every run and deduplicates overlapping roots by canonical path.
 

--- a/README.md
+++ b/README.md
@@ -906,20 +906,21 @@ timezone     Asia/Seoul
 $ tokscale config get timezone
 Asia/Seoul
 
-# After relocating — day boundaries move once, then stay stable
-$ tokscale config set timezone America/New_York
-
-# Re-detect from the machine instead of naming a zone
+# `set timezone auto` is allowed only before a valid pin exists (or while
+# recovering an invalid hand-edited value). It cannot repin an established
+# device.
 $ tokscale config set timezone auto
-
-# Forget the pin; the next run re-detects
-$ tokscale config unset timezone
 ```
 
 Only IANA zone names are accepted. Fixed UTC offsets such as `+09:00` are
 rejected: an offset cannot follow daylight saving time, so a pinned offset stops
 matching local midnight after a DST transition and re-splits usage near the day
 boundary — a smaller version of the problem pinning removes.
+
+An established valid pin cannot be changed or unset, including with `auto`.
+Historical submitted day rows are monotonic, so re-keying prior usage would
+permanently double count it. Relocating a device requires a server
+resync/replacement transition before choosing a different bucket timezone.
 
 Existing installs are unaffected until they pin, and the run that pins reports
 exactly what it would have reported anyway: the zone recorded is the one the

--- a/crates/tokscale-cli/Cargo.toml
+++ b/crates/tokscale-cli/Cargo.toml
@@ -28,6 +28,7 @@ anyhow = { workspace = true }
 comfy-table = { workspace = true }
 colored = { workspace = true }
 indicatif = { workspace = true }
+tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/tokscale-cli/src/commands/autosubmit.rs
+++ b/crates/tokscale-cli/src/commands/autosubmit.rs
@@ -2486,19 +2486,26 @@ mod tests {
             since
         }
 
+        let kiritimati_zone =
+            tokscale_core::BucketTimezone::from_pinned_name(Some("Pacific/Kiritimati"));
+        // Bracket the call: `submit_filters` reads the clock itself, so a date
+        // sampled only afterwards would disagree with it across a rollover.
+        let before = kiritimati_zone.today();
         let kiritimati = today_for_pinned_zone("Pacific/Kiritimati");
+        let after = kiritimati_zone.today();
+
         let niue = today_for_pinned_zone("Pacific/Niue");
 
-        assert_eq!(
-            kiritimati.as_deref(),
-            Some(
-                tokscale_core::BucketTimezone::from_pinned_name(Some("Pacific/Kiritimati"))
-                    .today()
-                    .format("%Y-%m-%d")
-                    .to_string()
-                    .as_str()
-            ),
-            "autosubmit must resolve today in the pinned zone, not the host's"
+        let acceptable: Vec<String> = [before, after]
+            .iter()
+            .map(|date| date.format("%Y-%m-%d").to_string())
+            .collect();
+        assert!(
+            kiritimati
+                .as_deref()
+                .is_some_and(|day| acceptable.iter().any(|expected| expected == day)),
+            "autosubmit must resolve today in the pinned zone, not the host's — \
+             got {kiritimati:?}, expected one of {acceptable:?}"
         );
         assert_ne!(
             kiritimati, niue,

--- a/crates/tokscale-cli/src/commands/autosubmit.rs
+++ b/crates/tokscale-cli/src/commands/autosubmit.rs
@@ -469,7 +469,15 @@ pub fn submit_filters(
         until: settings.until.clone(),
         year: settings.year.clone(),
     };
-    let (since, until) = build_date_filter_for_date(&date, chrono::Local::now().date_naive());
+    // Scheduled runs submit, so "today" has to be the pinned zone's today — the
+    // same one the day buckets are keyed by. Reading the host clock here would
+    // select a partial pinned day, and a partial day is exactly what the
+    // server's monotonic guard then freezes at the low value.
+    let current_date = tokscale_core::BucketTimezone::from_scanner_settings(
+        &crate::tui::settings::load_scanner_settings(),
+    )
+    .today();
+    let (since, until) = build_date_filter_for_date(&date, current_date);
     let year = if date.today || date.yesterday || date.week || date.month {
         None
     } else {

--- a/crates/tokscale-cli/src/commands/autosubmit.rs
+++ b/crates/tokscale-cli/src/commands/autosubmit.rs
@@ -447,6 +447,21 @@ pub fn record_run_error(error: &str) -> Result<()> {
     settings.save()
 }
 
+/// Today, in the zone this device buckets day keys into.
+///
+/// A scheduled run submits, so "today" has to be the pinned zone's today — the
+/// same one the day buckets are keyed by. Reading the host clock here would
+/// select a partial pinned day out of correctly-keyed buckets, and a partial
+/// day is exactly what the server's monotonic per-day guard then freezes at the
+/// low value. `--home` is rejected for autosubmit, so there is only ever one
+/// profile in play.
+fn current_bucket_date() -> chrono::NaiveDate {
+    tokscale_core::BucketTimezone::from_scanner_settings(
+        &crate::tui::settings::load_scanner_settings(),
+    )
+    .today()
+}
+
 pub fn submit_filters(
     settings: &AutosubmitSettings,
 ) -> (
@@ -469,15 +484,7 @@ pub fn submit_filters(
         until: settings.until.clone(),
         year: settings.year.clone(),
     };
-    // Scheduled runs submit, so "today" has to be the pinned zone's today — the
-    // same one the day buckets are keyed by. Reading the host clock here would
-    // select a partial pinned day, and a partial day is exactly what the
-    // server's monotonic guard then freezes at the low value.
-    let current_date = tokscale_core::BucketTimezone::from_scanner_settings(
-        &crate::tui::settings::load_scanner_settings(),
-    )
-    .today();
-    let (since, until) = build_date_filter_for_date(&date, current_date);
+    let (since, until) = build_date_filter_for_date(&date, current_bucket_date());
     let year = if date.today || date.yesterday || date.week || date.month {
         None
     } else {
@@ -2447,6 +2454,57 @@ mod tests {
         assert_eq!(since.as_deref(), Some("2026-01-01"));
         assert_eq!(until.as_deref(), Some("2026-01-31"));
         assert_eq!(year, None);
+    }
+
+    /// Scheduled autosubmit is the one date-filtered path that *submits*, so a
+    /// "today" resolved from the host instead of the pinned zone selects a
+    /// partial day out of correctly-keyed buckets — and the server's monotonic
+    /// per-day guard then freezes that low value forever.
+    ///
+    /// Pacific/Kiritimati (UTC+14) and Pacific/Niue (UTC-11) are 25 hours
+    /// apart, so they are never on the same calendar date. Reading
+    /// `chrono::Local` would hand back the same day for both pins; only reading
+    /// the pin can tell them apart.
+    #[test]
+    #[serial_test::serial]
+    fn submit_filters_resolve_today_in_the_pinned_bucket_timezone() {
+        fn today_for_pinned_zone(zone: &str) -> Option<String> {
+            let temp = TempDir::new().unwrap();
+            std::fs::write(
+                temp.path().join("settings.json"),
+                format!(r#"{{"scanner":{{"bucketTimezone":"{zone}"}}}}"#),
+            )
+            .unwrap();
+            let _guard = EnvVarGuard::set("TOKSCALE_CONFIG_DIR", temp.path());
+
+            let settings = AutosubmitSettings {
+                today: true,
+                ..AutosubmitSettings::default()
+            };
+            let (_, since, until, _) = submit_filters(&settings);
+            assert_eq!(since, until, "--today is a single-day range");
+            since
+        }
+
+        let kiritimati = today_for_pinned_zone("Pacific/Kiritimati");
+        let niue = today_for_pinned_zone("Pacific/Niue");
+
+        assert_eq!(
+            kiritimati.as_deref(),
+            Some(
+                tokscale_core::BucketTimezone::from_pinned_name(Some("Pacific/Kiritimati"))
+                    .today()
+                    .format("%Y-%m-%d")
+                    .to_string()
+                    .as_str()
+            ),
+            "autosubmit must resolve today in the pinned zone, not the host's"
+        );
+        assert_ne!(
+            kiritimati, niue,
+            "two pins 25 hours apart can never share a calendar date — equal \
+             values mean the host clock was read instead of the pin"
+        );
     }
 
     #[test]

--- a/crates/tokscale-cli/src/commands/config.rs
+++ b/crates/tokscale-cli/src/commands/config.rs
@@ -129,9 +129,13 @@ pub fn run_list() -> Result<()> {
 fn load_for_write() -> Result<Settings> {
     let (settings, origin) = Settings::load_with_origin();
     if !origin.is_safe_to_overwrite() {
+        // Deliberately does not name settings.json: this also fires when the
+        // config *directory* cannot be resolved or created, where there is no
+        // file to fix or remove and telling someone to delete one is a dead end.
         bail!(
-            "settings.json exists but could not be read, so writing it would replace \
-             every other setting in it with a default. Fix or remove the file first."
+            "could not read this machine's tokscale settings, so writing them would \
+             replace every setting with a default. Check that the config directory \
+             is readable and writable, and that settings.json in it is valid JSON."
         );
     }
     Ok(settings)

--- a/crates/tokscale-cli/src/commands/config.rs
+++ b/crates/tokscale-cli/src/commands/config.rs
@@ -1,9 +1,8 @@
 //! `tokscale config` — read and write persistent settings from the CLI.
 //!
 //! Currently exposes exactly one key, `timezone`, because it is the one setting
-//! a user has a concrete reason to change by hand: the timezone a device
-//! buckets usage days into is pinned automatically on first run, and someone
-//! who relocates needs a deliberate way to move it.
+//! a user has a concrete reason to inspect by hand: the timezone a device
+//! buckets usage days into is pinned automatically on first run.
 
 use anyhow::{bail, Result};
 use colored::Colorize;
@@ -44,8 +43,17 @@ pub fn run_set(key: &str, value: &str) -> Result<()> {
 
     match key {
         "timezone" => {
+            let is_auto = value.trim().eq_ignore_ascii_case("auto");
             let resolved = resolve_timezone_value(value)?;
             let previous = settings.scanner.bucket_timezone.clone();
+            if is_auto && is_valid_timezone(previous.as_deref()) {
+                bail!(
+                    "cannot set scanner.bucketTimezone to auto because historical submitted day \
+                     rows are monotonic. A server resync/replacement transition is required \
+                     before changing this bucket timezone."
+                );
+            }
+            reject_timezone_rekey(previous.as_deref(), &resolved)?;
             settings.scanner.bucket_timezone = Some(resolved.clone());
             settings.save()?;
 
@@ -54,16 +62,7 @@ pub fn run_set(key: &str, value: &str) -> Result<()> {
                 Some(previous) if previous == resolved => {
                     println!("(unchanged)");
                 }
-                Some(previous) => {
-                    println!("  was: {previous}");
-                    // Say the cost out loud. Repointing the zone re-keys every
-                    // day boundary, so the next scan reports a different split
-                    // of the same history — once.
-                    eprintln!(
-                        "Day boundaries move to {resolved}. The next scan re-splits history \
-                         across days one final time, then stays stable."
-                    );
-                }
+                Some(_) => println!("(unchanged)"),
                 None => {
                     eprintln!(
                         "Day boundaries are now fixed to {resolved} and no longer follow this \
@@ -84,6 +83,7 @@ pub fn run_unset(key: &str) -> Result<()> {
 
     match key {
         "timezone" => {
+            reject_timezone_unset(settings.scanner.bucket_timezone.as_deref())?;
             let previous = settings.scanner.bucket_timezone.take();
             settings.save()?;
 
@@ -91,13 +91,7 @@ pub fn run_unset(key: &str) -> Result<()> {
                 Some(previous) => println!("{} timezone (was {previous})", "unset".green().bold()),
                 None => println!("timezone was already unset"),
             }
-            // Unset means "re-detect", not "stop pinning": the next run pins
-            // this machine's current zone again. That is the useful reading —
-            // it is how someone who moved re-pins without typing a zone name.
-            eprintln!(
-                "The next tokscale run re-pins this machine's current timezone. \
-                 Use `tokscale config set timezone <zone>` to choose one explicitly."
-            );
+            eprintln!("The next tokscale run re-detects this machine's timezone.");
         }
         _ => unreachable!("normalize_key only returns keys handled here"),
     }
@@ -184,6 +178,43 @@ fn resolve_timezone_value(value: &str) -> Result<String> {
     }
 }
 
+/// A valid pin defines submitted day keys. The server only merges those keys
+/// monotonically, so replacing or removing it would submit the same historical
+/// usage under different keys and permanently inflate totals.
+fn reject_timezone_rekey(previous: Option<&str>, resolved: &str) -> Result<()> {
+    let BucketTimezone::Pinned(previous) = BucketTimezone::from_pinned_name(previous) else {
+        return Ok(());
+    };
+
+    if previous.name() == resolved {
+        return Ok(());
+    }
+
+    bail!(
+        "cannot change scanner.bucketTimezone from {} to {resolved}: historical submitted day \
+         rows are monotonic. A server resync/replacement transition is required before changing \
+         this bucket timezone.",
+        previous.name()
+    )
+}
+
+fn reject_timezone_unset(previous: Option<&str>) -> Result<()> {
+    let BucketTimezone::Pinned(previous) = BucketTimezone::from_pinned_name(previous) else {
+        return Ok(());
+    };
+
+    bail!(
+        "cannot unset scanner.bucketTimezone ({}) because historical submitted day rows are \
+         monotonic. A server resync/replacement transition is required before changing this \
+         bucket timezone.",
+        previous.name()
+    )
+}
+
+fn is_valid_timezone(value: Option<&str>) -> bool {
+    BucketTimezone::from_pinned_name(value).is_pinned()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -221,5 +252,30 @@ mod tests {
         // `UTC` is in the tz database and has no DST, so unlike `+00:00` it is
         // a legitimate pin — useful for servers and CI that genuinely run on it.
         assert_eq!(resolve_timezone_value("UTC").unwrap(), "UTC");
+    }
+
+    #[test]
+    fn valid_pins_only_allow_the_same_canonical_zone() {
+        assert!(reject_timezone_rekey(Some("Asia/Seoul"), "Asia/Seoul").is_ok());
+        let error = reject_timezone_rekey(Some("Asia/Seoul"), "UTC").unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("historical submitted day rows are monotonic"));
+        assert!(reject_timezone_unset(Some("Asia/Seoul")).is_err());
+    }
+
+    #[test]
+    fn unpinned_or_invalid_values_can_be_recovered() {
+        assert!(reject_timezone_rekey(None, "UTC").is_ok());
+        assert!(reject_timezone_rekey(Some("Mars/Olympus_Mons"), "UTC").is_ok());
+        assert!(reject_timezone_unset(None).is_ok());
+        assert!(reject_timezone_unset(Some("Mars/Olympus_Mons")).is_ok());
+    }
+
+    #[test]
+    fn valid_pin_is_distinguished_from_an_invalid_hand_edited_value() {
+        assert!(is_valid_timezone(Some("Asia/Seoul")));
+        assert!(!is_valid_timezone(Some("Mars/Olympus_Mons")));
+        assert!(!is_valid_timezone(None));
     }
 }

--- a/crates/tokscale-cli/src/commands/config.rs
+++ b/crates/tokscale-cli/src/commands/config.rs
@@ -40,7 +40,7 @@ pub fn run_get(key: &str) -> Result<()> {
 
 pub fn run_set(key: &str, value: &str) -> Result<()> {
     let key = normalize_key(key)?;
-    let mut settings = Settings::load();
+    let mut settings = load_for_write()?;
 
     match key {
         "timezone" => {
@@ -80,7 +80,7 @@ pub fn run_set(key: &str, value: &str) -> Result<()> {
 
 pub fn run_unset(key: &str) -> Result<()> {
     let key = normalize_key(key)?;
-    let mut settings = Settings::load();
+    let mut settings = load_for_write()?;
 
     match key {
         "timezone" => {
@@ -116,6 +116,25 @@ pub fn run_list() -> Result<()> {
     println!("{:<12} {}", "timezone", timezone);
 
     Ok(())
+}
+
+/// Load settings for a command that is going to write them straight back.
+///
+/// `Settings::load()` answers an unparseable settings.json with
+/// `Settings::default()`, so saving after it would replace a file we could not
+/// read with defaults we invented — losing scanner paths, aliases, autosubmit
+/// config and UI preferences to fix one field. `tokscale config` is a
+/// deliberate, interactive command, so it says so and stops instead of guessing
+/// which is worse.
+fn load_for_write() -> Result<Settings> {
+    let (settings, origin) = Settings::load_with_origin();
+    if !origin.is_safe_to_overwrite() {
+        bail!(
+            "settings.json exists but could not be read, so writing it would replace \
+             every other setting in it with a default. Fix or remove the file first."
+        );
+    }
+    Ok(settings)
 }
 
 fn normalize_key(key: &str) -> Result<&'static str> {

--- a/crates/tokscale-cli/src/commands/config.rs
+++ b/crates/tokscale-cli/src/commands/config.rs
@@ -1,0 +1,202 @@
+//! `tokscale config` — read and write persistent settings from the CLI.
+//!
+//! Currently exposes exactly one key, `timezone`, because it is the one setting
+//! a user has a concrete reason to change by hand: the timezone a device
+//! buckets usage days into is pinned automatically on first run, and someone
+//! who relocates needs a deliberate way to move it.
+
+use anyhow::{bail, Result};
+use colored::Colorize;
+use tokscale_core::bucket_tz::BucketTimezone;
+
+use crate::tui::settings::Settings;
+
+/// The settings `tokscale config` can address.
+///
+/// Kept as an explicit list rather than a free-form path into settings.json so
+/// a typo is rejected instead of silently writing a key nothing reads.
+const KNOWN_KEYS: &[&str] = &["timezone"];
+
+pub fn run_get(key: &str) -> Result<()> {
+    let key = normalize_key(key)?;
+    let settings = Settings::load();
+
+    match key {
+        "timezone" => match settings.scanner.bucket_timezone.as_deref() {
+            Some(zone) => println!("{zone}"),
+            None => {
+                println!("{}", "(unset)".dimmed());
+                eprintln!(
+                    "No bucketing timezone is pinned. Day boundaries follow this machine's \
+                     current timezone and will move if it changes."
+                );
+            }
+        },
+        _ => unreachable!("normalize_key only returns keys handled here"),
+    }
+
+    Ok(())
+}
+
+pub fn run_set(key: &str, value: &str) -> Result<()> {
+    let key = normalize_key(key)?;
+    let mut settings = Settings::load();
+
+    match key {
+        "timezone" => {
+            let resolved = resolve_timezone_value(value)?;
+            let previous = settings.scanner.bucket_timezone.clone();
+            settings.scanner.bucket_timezone = Some(resolved.clone());
+            settings.save()?;
+
+            println!("{} timezone = {}", "set".green().bold(), resolved.bold());
+            match previous {
+                Some(previous) if previous == resolved => {
+                    println!("(unchanged)");
+                }
+                Some(previous) => {
+                    println!("  was: {previous}");
+                    // Say the cost out loud. Repointing the zone re-keys every
+                    // day boundary, so the next scan reports a different split
+                    // of the same history — once.
+                    eprintln!(
+                        "Day boundaries move to {resolved}. The next scan re-splits history \
+                         across days one final time, then stays stable."
+                    );
+                }
+                None => {
+                    eprintln!(
+                        "Day boundaries are now fixed to {resolved} and no longer follow this \
+                         machine's timezone."
+                    );
+                }
+            }
+        }
+        _ => unreachable!("normalize_key only returns keys handled here"),
+    }
+
+    Ok(())
+}
+
+pub fn run_unset(key: &str) -> Result<()> {
+    let key = normalize_key(key)?;
+    let mut settings = Settings::load();
+
+    match key {
+        "timezone" => {
+            let previous = settings.scanner.bucket_timezone.take();
+            settings.save()?;
+
+            match previous {
+                Some(previous) => println!("{} timezone (was {previous})", "unset".green().bold()),
+                None => println!("timezone was already unset"),
+            }
+            // Unset means "re-detect", not "stop pinning": the next run pins
+            // this machine's current zone again. That is the useful reading —
+            // it is how someone who moved re-pins without typing a zone name.
+            eprintln!(
+                "The next tokscale run re-pins this machine's current timezone. \
+                 Use `tokscale config set timezone <zone>` to choose one explicitly."
+            );
+        }
+        _ => unreachable!("normalize_key only returns keys handled here"),
+    }
+
+    Ok(())
+}
+
+pub fn run_list() -> Result<()> {
+    let settings = Settings::load();
+
+    let timezone = settings
+        .scanner
+        .bucket_timezone
+        .clone()
+        .unwrap_or_else(|| "(unset)".to_string());
+    println!("{:<12} {}", "timezone", timezone);
+
+    Ok(())
+}
+
+fn normalize_key(key: &str) -> Result<&'static str> {
+    let candidate = key.trim().to_ascii_lowercase();
+    KNOWN_KEYS
+        .iter()
+        .copied()
+        .find(|known| *known == candidate)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "unknown config key `{key}` (known keys: {})",
+                KNOWN_KEYS.join(", ")
+            )
+        })
+}
+
+/// Resolve a user-supplied timezone value to a canonical IANA name.
+///
+/// `auto` re-detects from the machine. Anything else must be a name the tz
+/// database knows: a raw UTC offset is rejected rather than accepted as a fixed
+/// offset, because an offset cannot follow DST and a pinned offset drifts off
+/// local midnight twice a year — the failure pinning exists to prevent.
+fn resolve_timezone_value(value: &str) -> Result<String> {
+    let trimmed = value.trim();
+
+    if trimmed.eq_ignore_ascii_case("auto") {
+        return tokscale_core::bucket_tz::detect_local_iana_name().ok_or_else(|| {
+            anyhow::anyhow!(
+                "could not determine this machine's IANA timezone name — \
+                 pass one explicitly, e.g. `tokscale config set timezone Asia/Seoul`"
+            )
+        });
+    }
+
+    match BucketTimezone::from_pinned_name(Some(trimmed)) {
+        BucketTimezone::Pinned(tz) => Ok(tz.name().to_string()),
+        BucketTimezone::Local => bail!(
+            "`{trimmed}` is not a known IANA timezone name (expected something like \
+             `Asia/Seoul` or `America/New_York`). Fixed UTC offsets are not accepted: \
+             they cannot follow daylight saving time, so a pinned offset would drift \
+             off local midnight twice a year."
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_keys_are_matched_case_insensitively_and_trimmed() {
+        assert_eq!(normalize_key(" TimeZone ").unwrap(), "timezone");
+        assert!(normalize_key("timezon").is_err());
+        assert!(normalize_key("scanner.bucketTimezone").is_err());
+    }
+
+    #[test]
+    fn timezone_values_canonicalize_through_the_tz_database() {
+        assert_eq!(resolve_timezone_value("Asia/Seoul").unwrap(), "Asia/Seoul");
+        assert_eq!(
+            resolve_timezone_value("  America/New_York  ").unwrap(),
+            "America/New_York"
+        );
+    }
+
+    #[test]
+    fn fixed_offsets_are_rejected_rather_than_pinned() {
+        for value in ["+09:00", "UTC+9", "-0500", "9"] {
+            let error = resolve_timezone_value(value)
+                .expect_err("a fixed offset must not be accepted as a pinned zone");
+            assert!(
+                error.to_string().contains("not a known IANA timezone name"),
+                "unexpected error for {value}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn utc_is_a_real_zone_and_stays_acceptable() {
+        // `UTC` is in the tz database and has no DST, so unlike `+00:00` it is
+        // a legitimate pin — useful for servers and CI that genuinely run on it.
+        assert_eq!(resolve_timezone_value("UTC").unwrap(), "UTC");
+    }
+}

--- a/crates/tokscale-cli/src/commands/mod.rs
+++ b/crates/tokscale-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod apple_fm;
 pub mod autosubmit;
 pub mod codex_activity;
+pub mod config;
 pub mod import;
 pub mod report;
 pub mod usage;

--- a/crates/tokscale-cli/src/commands/report.rs
+++ b/crates/tokscale-cli/src/commands/report.rs
@@ -42,9 +42,8 @@ pub fn run_report(opts: ReportOptions) -> Result<()> {
     // Day boundaries have to be resolved in the same zone the day keys are built
     // from, or a pinned device filters pinned-day strings against host-day
     // instants and loses an offset's worth of sessions at each edge.
-    let bucket_timezone = tokscale_core::BucketTimezone::from_scanner_settings(
-        &crate::tui::settings::load_scanner_settings_for_home(&opts.home_dir),
-    );
+    let bucket_timezone =
+        tokscale_core::BucketTimezone::from_scanner_settings(&opts.scanner_settings);
     let (since_ts, until_ts) = parse_date_range(&opts.since, &opts.until, &bucket_timezone);
 
     if opts.rebuild {

--- a/crates/tokscale-cli/src/commands/report.rs
+++ b/crates/tokscale-cli/src/commands/report.rs
@@ -39,7 +39,13 @@ pub fn run_report(opts: ReportOptions) -> Result<()> {
 
     populate_wiki_from_sessions(&db, &opts)?;
 
-    let (since_ts, until_ts) = parse_date_range(&opts.since, &opts.until);
+    // Day boundaries have to be resolved in the same zone the day keys are built
+    // from, or a pinned device filters pinned-day strings against host-day
+    // instants and loses an offset's worth of sessions at each edge.
+    let bucket_timezone = tokscale_core::BucketTimezone::from_scanner_settings(
+        &crate::tui::settings::load_scanner_settings_for_home(&opts.home_dir),
+    );
+    let (since_ts, until_ts) = parse_date_range(&opts.since, &opts.until, &bucket_timezone);
 
     if opts.rebuild {
         let count = db
@@ -1461,46 +1467,63 @@ fn extract_content_for_session(
     extract_session_content(&entry.client, &entry.session_id, &candidates)
 }
 
-fn parse_date_range(since: &Option<String>, until: &Option<String>) -> (Option<i64>, Option<i64>) {
-    // The `since`/`until` strings are local-calendar dates (e.g. produced by
-    // `build_date_filter`, which derives them from `chrono::Local::now()`), and
-    // session dates are bucketed in local time (see
-    // `sessions::timestamp_to_date`). Interpret the day boundaries in local time
-    // so filtering lines up with grouping and avoids off-by-a-day mismatches.
+fn parse_date_range(
+    since: &Option<String>,
+    until: &Option<String>,
+    bucket_timezone: &tokscale_core::BucketTimezone,
+) -> (Option<i64>, Option<i64>) {
+    // The `since`/`until` strings are calendar dates in the scan's bucketing
+    // zone (e.g. produced by `build_date_filter`), and session dates are keyed
+    // in that same zone. Interpret the day boundaries there too, so filtering
+    // lines up with grouping and avoids off-by-a-day mismatches. With nothing
+    // pinned this resolves through `chrono::Local`, exactly as before.
     let since_ts = since
         .as_ref()
         .and_then(|s| chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").ok())
-        .and_then(local_start_of_day_millis);
+        .and_then(|d| start_of_day_millis(d, bucket_timezone));
     let until_ts = until
         .as_ref()
         .and_then(|s| chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").ok())
         .and_then(|d| d.succ_opt())
-        .and_then(|next| local_start_of_day_millis(next).map(|ms| ms - 1));
+        .and_then(|next| start_of_day_millis(next, bucket_timezone).map(|ms| ms - 1));
     (since_ts, until_ts)
 }
 
-/// Returns the Unix-millisecond timestamp for the start of `date` in the local
-/// timezone.
+/// Returns the Unix-millisecond timestamp for the start of `date` in the scan's
+/// bucketing timezone.
 ///
 /// This is normally midnight (00:00:00), but in zones that spring forward at
 /// local midnight (e.g. `America/Nuuk` on `2024-03-31`) that wall-clock time
 /// does not exist. Rather than dropping the boundary (which would silently make
 /// date filtering unbounded), we walk forward to the first representable instant
 /// after the gap so the day boundary is preserved.
-fn local_start_of_day_millis(date: chrono::NaiveDate) -> Option<i64> {
-    start_of_day_millis_with(date, |wall| Local.from_local_datetime(wall))
+fn start_of_day_millis(
+    date: chrono::NaiveDate,
+    bucket_timezone: &tokscale_core::BucketTimezone,
+) -> Option<i64> {
+    use chrono::TimeZone;
+
+    match bucket_timezone {
+        tokscale_core::BucketTimezone::Local => {
+            start_of_day_millis_with(date, |wall| Local.from_local_datetime(wall))
+        }
+        tokscale_core::BucketTimezone::Pinned(tz) => {
+            start_of_day_millis_with(date, |wall| tz.from_local_datetime(wall))
+        }
+    }
 }
 
-/// Core of [`local_start_of_day_millis`], parameterized over the timezone
+/// Core of [`start_of_day_millis`], parameterized over the timezone
 /// resolver so the DST-gap handling can be exercised deterministically in tests.
 ///
 /// Starts at midnight and, when that wall-clock time is skipped (a spring-forward
 /// gap), walks forward in 1-minute steps to the first representable instant. The
 /// probe window covers a full day so even unusual offsets resolve rather than
 /// silently dropping the boundary.
-fn start_of_day_millis_with<F>(date: chrono::NaiveDate, resolve: F) -> Option<i64>
+fn start_of_day_millis_with<Tz, F>(date: chrono::NaiveDate, resolve: F) -> Option<i64>
 where
-    F: Fn(&chrono::NaiveDateTime) -> chrono::LocalResult<chrono::DateTime<Local>>,
+    Tz: chrono::TimeZone,
+    F: Fn(&chrono::NaiveDateTime) -> chrono::LocalResult<chrono::DateTime<Tz>>,
 {
     let mut wall = date.and_hms_opt(0, 0, 0)?;
     for _ in 0..=(24 * 60) {
@@ -1649,7 +1672,11 @@ mod tests {
         // each message (and how `build_date_filter` derives these strings from
         // `chrono::Local::now()`).
         let day = "2026-03-08";
-        let (since, until) = parse_date_range(&Some(day.into()), &Some(day.into()));
+        let (since, until) = parse_date_range(
+            &Some(day.into()),
+            &Some(day.into()),
+            &tokscale_core::BucketTimezone::Local,
+        );
 
         let expected_since = Local
             .with_ymd_and_hms(2026, 3, 8, 0, 0, 0)

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -630,7 +630,7 @@ fn main() -> Result<()> {
                     hide_zero,
                 )
             } else {
-                let (since, until) = build_date_filter(&date);
+                let (since, until) = build_date_filter(&date, &cli.home);
                 let year = normalize_year_filter(&date);
                 ensure_home_supported_for_tui(&cli.home)?;
                 auto_sync_cursor_before_tui(&cli.home, &clients)?;
@@ -667,7 +667,7 @@ fn main() -> Result<()> {
                     hide_zero,
                 )
             } else {
-                let (since, until) = build_date_filter(&date);
+                let (since, until) = build_date_filter(&date, &cli.home);
                 let year = normalize_year_filter(&date);
                 ensure_home_supported_for_tui(&cli.home)?;
                 auto_sync_cursor_before_tui(&cli.home, &clients)?;
@@ -704,7 +704,7 @@ fn main() -> Result<()> {
                     hide_zero,
                 )
             } else {
-                let (since, until) = build_date_filter(&date);
+                let (since, until) = build_date_filter(&date, &cli.home);
                 let year = normalize_year_filter(&date);
                 ensure_home_supported_for_tui(&cli.home)?;
                 auto_sync_cursor_before_tui(&cli.home, &clients)?;
@@ -753,7 +753,7 @@ fn main() -> Result<()> {
             benchmark,
             no_spinner,
         }) => {
-            let (since, until) = build_date_filter(&date);
+            let (since, until) = build_date_filter(&date, &cli.home);
             let year = normalize_year_filter(&date);
             let clients = build_client_filter(clients, &cli.home);
             run_graph_command(
@@ -778,7 +778,7 @@ fn main() -> Result<()> {
         }
         Some(Commands::Tui { clients, date }) => {
             ensure_home_supported_for_tui(&cli.home)?;
-            let (since, until) = build_date_filter(&date);
+            let (since, until) = build_date_filter(&date, &cli.home);
             let year = normalize_year_filter(&date);
             let clients = build_client_filter(clients, &cli.home);
             auto_sync_cursor_before_tui(&cli.home, &clients)?;
@@ -799,7 +799,7 @@ fn main() -> Result<()> {
             dry_run,
         }) => {
             reject_unsupported_home_override(&cli.home, "submit")?;
-            let (since, until) = build_date_filter(&date);
+            let (since, until) = build_date_filter(&date, &cli.home);
             let year = normalize_year_filter(&date);
             // Bypass settings.json defaultClients for the submit path: we want the
             // submit-specific default_submit_clients() fallback (in run_submit_command)
@@ -886,7 +886,7 @@ fn main() -> Result<()> {
             date,
             no_spinner,
         }) => {
-            let (since, until) = build_date_filter(&date);
+            let (since, until) = build_date_filter(&date, &cli.home);
             let year = normalize_year_filter(&date);
             let clients = build_client_filter(clients, &cli.home);
             run_time_metrics_report(
@@ -925,7 +925,7 @@ fn main() -> Result<()> {
             let today = date.today;
             let week = date.week;
             let month = date.month;
-            let (since, until) = build_date_filter(&date);
+            let (since, until) = build_date_filter(&date, &cli.home);
             commands::report::run_report(commands::report::ReportOptions {
                 json,
                 since,
@@ -977,7 +977,7 @@ fn main() -> Result<()> {
                     cli.hide_zero,
                 )
             } else {
-                let (since, until) = build_date_filter(&cli.date);
+                let (since, until) = build_date_filter(&cli.date, &cli.home);
                 let year = normalize_year_filter(&cli.date);
                 ensure_home_supported_for_tui(&cli.home)?;
                 auto_sync_cursor_before_tui(&cli.home, &clients)?;
@@ -1674,8 +1674,11 @@ fn ensure_home_supported_for_tui(home_dir: &Option<String>) -> Result<()> {
     Ok(())
 }
 
-fn build_date_filter(date: &DateRangeFlags) -> (Option<String>, Option<String>) {
-    build_date_filter_for_date(date, current_bucket_date())
+fn build_date_filter(
+    date: &DateRangeFlags,
+    home_dir: &Option<String>,
+) -> (Option<String>, Option<String>) {
+    build_date_filter_for_date(date, current_bucket_date(home_dir))
 }
 
 /// Today, as the day keys this scan produces define it.
@@ -1684,11 +1687,20 @@ fn build_date_filter(date: &DateRangeFlags) -> (Option<String>, Option<String>) 
 /// timezone is pinned those strings stop tracking the host. Resolving "today"
 /// anywhere else would select the wrong day out of the right buckets.
 ///
+/// Takes the same `--home` override the scan does. Every date-filtered command
+/// builds its scanner settings with `load_scanner_settings_for_home`, so the
+/// buckets are keyed in the *target* profile's pinned zone; reading this
+/// machine's settings instead would filter another device's Seoul-keyed days
+/// against the host's calendar and hand back a partial day — the exact
+/// inconsistency pinning exists to remove, reintroduced at the filter.
+///
 /// Identical to `chrono::Local::now().date_naive()` when nothing is pinned,
 /// which is every device that has not upgraded yet.
-fn current_bucket_date() -> chrono::NaiveDate {
-    tokscale_core::BucketTimezone::from_scanner_settings(&tui::settings::load_scanner_settings())
-        .today()
+fn current_bucket_date(home_dir: &Option<String>) -> chrono::NaiveDate {
+    tokscale_core::BucketTimezone::from_scanner_settings(
+        &tui::settings::load_scanner_settings_for_home(home_dir),
+    )
+    .today()
 }
 
 fn build_date_filter_for_date(
@@ -1902,7 +1914,7 @@ fn run_models_report(
     use tokio::runtime::Runtime;
     use tokscale_core::{get_model_report, GroupBy, ReportOptions};
 
-    let (since, until) = build_date_filter(date);
+    let (since, until) = build_date_filter(date, &home_dir);
     let year = normalize_year_filter(date);
     let date_range = get_date_range_label(date);
     let effective_home_dir = resolve_effective_home_dir(&home_dir);
@@ -2769,7 +2781,7 @@ fn run_monthly_report(
     use tokio::runtime::Runtime;
     use tokscale_core::{get_monthly_report, GroupBy, ReportOptions};
 
-    let (since, until) = build_date_filter(date);
+    let (since, until) = build_date_filter(date, &home_dir);
     let year = normalize_year_filter(date);
     let date_range = get_date_range_label(date);
 
@@ -3092,7 +3104,7 @@ fn run_hourly_report(
     use tokio::runtime::Runtime;
     use tokscale_core::{get_hourly_report, GroupBy, ReportOptions};
 
-    let (since, until) = build_date_filter(date);
+    let (since, until) = build_date_filter(date, &home_dir);
     let year = normalize_year_filter(date);
     let date_range = get_date_range_label(date);
 
@@ -7224,20 +7236,69 @@ mod tests {
         assert!(err.contains("Failed (401 Unauthorized): Not authenticated"));
     }
 
+    /// `--home` points at another device's profile, and every date-filtered
+    /// command already builds its scanner settings from that profile — so the
+    /// day keys it scans are in *that* device's pinned zone. Resolving "today"
+    /// from this machine's settings instead selects the wrong day out of the
+    /// right buckets, which is the inconsistency pinning exists to remove.
+    ///
+    /// Pacific/Kiritimati (UTC+14) and Pacific/Niue (UTC-11) are 25 hours
+    /// apart, so they are never on the same calendar date. A helper that
+    /// ignores its argument returns the same day for both homes.
+    #[test]
+    fn test_current_bucket_date_follows_the_home_overrides_pinned_zone() {
+        fn home_pinned_to(zone: &str) -> tempfile::TempDir {
+            let home = tempfile::TempDir::new().unwrap();
+            let config = home.path().join(if cfg!(windows) {
+                "AppData/Roaming/tokscale"
+            } else {
+                ".config/tokscale"
+            });
+            std::fs::create_dir_all(&config).unwrap();
+            std::fs::write(
+                config.join("settings.json"),
+                format!(r#"{{"scanner":{{"bucketTimezone":"{zone}"}}}}"#),
+            )
+            .unwrap();
+            home
+        }
+
+        let kiritimati_home = home_pinned_to("Pacific/Kiritimati");
+        let niue_home = home_pinned_to("Pacific/Niue");
+
+        let kiritimati =
+            current_bucket_date(&Some(kiritimati_home.path().to_string_lossy().into_owned()));
+        let niue = current_bucket_date(&Some(niue_home.path().to_string_lossy().into_owned()));
+
+        assert_eq!(
+            kiritimati,
+            tokscale_core::BucketTimezone::from_pinned_name(Some("Pacific/Kiritimati")).today(),
+            "the date filter must resolve today in the --home profile's pinned zone"
+        );
+        assert_ne!(
+            kiritimati, niue,
+            "two homes pinned 25 hours apart can never share a calendar date — \
+             equal values mean the override was ignored"
+        );
+    }
+
     #[test]
     fn test_build_date_filter_custom_range() {
-        let (since, until) = build_date_filter(&DateRangeFlags {
-            since: Some("2024-01-01".to_string()),
-            until: Some("2024-12-31".to_string()),
-            ..DateRangeFlags::default()
-        });
+        let (since, until) = build_date_filter(
+            &DateRangeFlags {
+                since: Some("2024-01-01".to_string()),
+                until: Some("2024-12-31".to_string()),
+                ..DateRangeFlags::default()
+            },
+            &None,
+        );
         assert_eq!(since, Some("2024-01-01".to_string()));
         assert_eq!(until, Some("2024-12-31".to_string()));
     }
 
     #[test]
     fn test_build_date_filter_no_filters() {
-        let (since, until) = build_date_filter(&DateRangeFlags::default());
+        let (since, until) = build_date_filter(&DateRangeFlags::default(), &None);
         assert_eq!(since, None);
         assert_eq!(until, None);
     }

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -360,6 +360,11 @@ enum Commands {
     },
     #[command(about = "Warm TUI cache in background (internal)", hide = true)]
     WarmTuiCache,
+    #[command(about = "Read and write persistent tokscale settings")]
+    Config {
+        #[command(subcommand)]
+        subcommand: ConfigSubcommand,
+    },
     #[command(about = "Task-attributed usage report")]
     Report {
         #[arg(long, help = "Output as JSON")]
@@ -382,6 +387,41 @@ enum Commands {
         rebuild: bool,
         #[arg(long, help = "Show all sessions without truncation")]
         full: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum ConfigSubcommand {
+    #[command(about = "Show all settings tokscale config can change")]
+    List,
+    #[command(about = "Print one setting's value")]
+    Get {
+        #[arg(help = "Setting name (timezone)")]
+        key: String,
+    },
+    #[command(
+        about = "Change one setting",
+        long_about = "Change one setting.\n\n\
+                      timezone: the IANA zone this device buckets usage days into, e.g. \
+                      Asia/Seoul. Pinned automatically on first run; set it explicitly \
+                      after relocating so day boundaries move deliberately instead of on \
+                      the next rescan. Pass `auto` to re-detect from this machine."
+    )]
+    Set {
+        #[arg(help = "Setting name (timezone)")]
+        key: String,
+        #[arg(help = "New value; `auto` re-detects for timezone")]
+        value: String,
+    },
+    #[command(
+        about = "Clear one setting",
+        long_about = "Clear one setting.\n\n\
+                      Clearing timezone makes the next run re-pin this machine's current \
+                      zone; it does not turn pinning off."
+    )]
+    Unset {
+        #[arg(help = "Setting name (timezone)")]
+        key: String,
     },
 }
 
@@ -537,6 +577,14 @@ fn main() -> Result<()> {
     // path runs, so model-name variants fold consistently across every command.
     // Honors the global `--home` override exactly like scanner settings; an
     // empty or absent config is a strict no-op.
+    // Record this device's bucketing timezone before anything reads scanner
+    // settings. Day keys used to be re-derived from `chrono::Local` on every
+    // scan, so the same history re-split across days whenever the machine's
+    // zone changed; the server's monotonic per-day guard then kept the stale
+    // value on one day and the new one on its neighbour, inflating the total
+    // for good. Pinning on first run is what stops that from recurring — see
+    // `pin_bucket_timezone_if_unset` for what it deliberately does not do.
+    tui::settings::pin_bucket_timezone_if_unset(&cli.home);
     tokscale_core::model_alias::set_global(&tui::settings::load_model_aliases_for_home(&cli.home));
     let opencode_model_names = tokscale_core::opencode_model_name::load_for_home(
         cli.home.as_deref().map(std::path::Path::new),
@@ -852,6 +900,18 @@ fn main() -> Result<()> {
             )
         }
         Some(Commands::WarmTuiCache) => run_warm_tui_cache(),
+        Some(Commands::Config { subcommand }) => {
+            // Writes to this machine's config path, which `--home` does not
+            // move; honoring the flag here would read one file and write
+            // another.
+            reject_unsupported_home_override(&cli.home, "config")?;
+            match subcommand {
+                ConfigSubcommand::List => commands::config::run_list(),
+                ConfigSubcommand::Get { key } => commands::config::run_get(&key),
+                ConfigSubcommand::Set { key, value } => commands::config::run_set(&key, &value),
+                ConfigSubcommand::Unset { key } => commands::config::run_unset(&key),
+            }
+        }
         Some(Commands::Report {
             json,
             workspace,
@@ -1615,7 +1675,20 @@ fn ensure_home_supported_for_tui(home_dir: &Option<String>) -> Result<()> {
 }
 
 fn build_date_filter(date: &DateRangeFlags) -> (Option<String>, Option<String>) {
-    build_date_filter_for_date(date, chrono::Local::now().date_naive())
+    build_date_filter_for_date(date, current_bucket_date())
+}
+
+/// Today, as the day keys this scan produces define it.
+///
+/// `--today` and friends compare against `date` strings, and once a bucketing
+/// timezone is pinned those strings stop tracking the host. Resolving "today"
+/// anywhere else would select the wrong day out of the right buckets.
+///
+/// Identical to `chrono::Local::now().date_naive()` when nothing is pinned,
+/// which is every device that has not upgraded yet.
+fn current_bucket_date() -> chrono::NaiveDate {
+    tokscale_core::BucketTimezone::from_scanner_settings(&tui::settings::load_scanner_settings())
+        .today()
 }
 
 fn build_date_filter_for_date(

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -925,7 +925,12 @@ fn main() -> Result<()> {
             let today = date.today;
             let week = date.week;
             let month = date.month;
-            let (since, until) = build_date_filter(&date, &cli.home);
+            // Resolve this once for both date boundaries and scanning. `--home`
+            // selects another profile's pinned day keys.
+            let scanner_settings = tui::settings::load_scanner_settings_for_home(&cli.home);
+            let bucket_timezone =
+                tokscale_core::BucketTimezone::from_scanner_settings(&scanner_settings);
+            let (since, until) = build_date_filter_for_date(&date, bucket_timezone.today());
             commands::report::run_report(commands::report::ReportOptions {
                 json,
                 since,
@@ -936,7 +941,7 @@ fn main() -> Result<()> {
                 summarizer,
                 rebuild,
                 home_dir: cli.home.clone(),
-                scanner_settings: report_scanner_settings(&cli.home),
+                scanner_settings,
                 today,
                 week,
                 month,
@@ -1701,12 +1706,6 @@ fn current_bucket_date(home_dir: &Option<String>) -> chrono::NaiveDate {
         &tui::settings::load_scanner_settings_for_home(home_dir),
     )
     .today()
-}
-
-/// Scanner settings for `report`, read from the same profile as its session
-/// data. `--home` can refer to a device with a different pinned bucket zone.
-fn report_scanner_settings(home_dir: &Option<String>) -> tokscale_core::scanner::ScannerSettings {
-    tui::settings::load_scanner_settings_for_home(home_dir)
 }
 
 fn build_date_filter_for_date(
@@ -7275,8 +7274,9 @@ mod tests {
         let kiritimati =
             current_bucket_date(&Some(kiritimati_home.path().to_string_lossy().into_owned()));
         let niue = current_bucket_date(&Some(niue_home.path().to_string_lossy().into_owned()));
-        let report_settings =
-            report_scanner_settings(&Some(kiritimati_home.path().to_string_lossy().into_owned()));
+        let report_settings = tui::settings::load_scanner_settings_for_home(&Some(
+            kiritimati_home.path().to_string_lossy().into_owned(),
+        ));
 
         assert_eq!(
             kiritimati,

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -936,7 +936,7 @@ fn main() -> Result<()> {
                 summarizer,
                 rebuild,
                 home_dir: cli.home.clone(),
-                scanner_settings: tui::settings::load_scanner_settings(),
+                scanner_settings: report_scanner_settings(&cli.home),
                 today,
                 week,
                 month,
@@ -1701,6 +1701,12 @@ fn current_bucket_date(home_dir: &Option<String>) -> chrono::NaiveDate {
         &tui::settings::load_scanner_settings_for_home(home_dir),
     )
     .today()
+}
+
+/// Scanner settings for `report`, read from the same profile as its session
+/// data. `--home` can refer to a device with a different pinned bucket zone.
+fn report_scanner_settings(home_dir: &Option<String>) -> tokscale_core::scanner::ScannerSettings {
+    tui::settings::load_scanner_settings_for_home(home_dir)
 }
 
 fn build_date_filter_for_date(
@@ -7269,6 +7275,8 @@ mod tests {
         let kiritimati =
             current_bucket_date(&Some(kiritimati_home.path().to_string_lossy().into_owned()));
         let niue = current_bucket_date(&Some(niue_home.path().to_string_lossy().into_owned()));
+        let report_settings =
+            report_scanner_settings(&Some(kiritimati_home.path().to_string_lossy().into_owned()));
 
         assert_eq!(
             kiritimati,
@@ -7279,6 +7287,11 @@ mod tests {
             kiritimati, niue,
             "two homes pinned 25 hours apart can never share a calendar date — \
              equal values mean the override was ignored"
+        );
+        assert_eq!(
+            report_settings.bucket_timezone.as_deref(),
+            Some("Pacific/Kiritimati"),
+            "report must rebucket sessions with the --home profile's timezone"
         );
     }
 

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -403,9 +403,8 @@ enum ConfigSubcommand {
         about = "Change one setting",
         long_about = "Change one setting.\n\n\
                       timezone: the IANA zone this device buckets usage days into, e.g. \
-                      Asia/Seoul. Pinned automatically on first run; set it explicitly \
-                      after relocating so day boundaries move deliberately instead of on \
-                      the next rescan. Pass `auto` to re-detect from this machine."
+                      Asia/Seoul. Pinned automatically on first run. A valid established pin \
+                      cannot be changed; pass `auto` only to set up or recover an invalid pin."
     )]
     Set {
         #[arg(help = "Setting name (timezone)")]
@@ -416,8 +415,8 @@ enum ConfigSubcommand {
     #[command(
         about = "Clear one setting",
         long_about = "Clear one setting.\n\n\
-                      Clearing timezone makes the next run re-pin this machine's current \
-                      zone; it does not turn pinning off."
+                      A valid established timezone cannot be cleared. Clearing an unset or \
+                      invalid value leaves the next scan to auto-pin this machine's timezone."
     )]
     Unset {
         #[arg(help = "Setting name (timezone)")]
@@ -584,7 +583,18 @@ fn main() -> Result<()> {
     // value on one day and the new one on its neighbour, inflating the total
     // for good. Pinning on first run is what stops that from recurring — see
     // `pin_bucket_timezone_if_unset` for what it deliberately does not do.
-    tui::settings::pin_bucket_timezone_if_unset(&cli.home);
+    // Config mutations must see the saved value exactly as the user left it:
+    // an invalid value is recoverable only if startup does not overwrite it
+    // before `config set`/`unset` gets a chance to act.
+    let config_mutates_timezone = matches!(
+        &cli.command,
+        Some(Commands::Config {
+            subcommand: ConfigSubcommand::Set { .. } | ConfigSubcommand::Unset { .. }
+        })
+    );
+    if !config_mutates_timezone {
+        tui::settings::pin_bucket_timezone_if_unset(&cli.home);
+    }
     tokscale_core::model_alias::set_global(&tui::settings::load_model_aliases_for_home(&cli.home));
     let opencode_model_names = tokscale_core::opencode_model_name::load_for_home(
         cli.home.as_deref().map(std::path::Path::new),

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -480,6 +480,13 @@ impl Settings {
         let raw = match (primary, legacy) {
             (RawSettings::Present(content), _) => RawSettings::Present(content),
             (_, Some(RawSettings::Present(content))) => RawSettings::Present(content),
+            // A legacy file we could not *open* outranks a missing primary.
+            // (Legacy content that fails to parse is already `Present` here and
+            // is caught below.) It holds settings the user can still repair,
+            // and writing a primary would shadow it permanently: the fallback
+            // only fires while the primary is absent, so the repaired legacy
+            // file would never be read again.
+            (_, Some(RawSettings::Unreadable)) => RawSettings::Unreadable,
             (primary, _) => primary,
         };
 

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -337,7 +337,7 @@ pub fn pin_bucket_timezone_if_unset(home_dir: &Option<String>) {
         return;
     }
 
-    if settings.scanner.bucket_timezone.is_some() {
+    if tokscale_core::BucketTimezone::from_scanner_settings(&settings.scanner).is_pinned() {
         return;
     }
 

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -20,6 +20,42 @@ pub const DEFAULT_AUTOSUBMIT_INTERVAL_MINUTES: u64 = 24 * 60;
 pub const MIN_AUTOSUBMIT_INTERVAL_MINUTES: u64 = 15;
 pub const MAX_AUTOSUBMIT_INTERVAL_MINUTES: u64 = 7 * 24 * 60;
 
+/// Where the value [`Settings::load_with_origin`] returned came from.
+///
+/// Only [`SettingsOrigin::Unreadable`] carries a real obligation: the returned
+/// `Settings` is `Settings::default()` and has nothing to do with what is on
+/// disk, so writing it back replaces every setting the user had with a default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingsOrigin {
+    /// No settings file exists. Defaults *are* the file's contents, so writing
+    /// one loses nothing.
+    Absent,
+    /// A settings file was read and parsed. The returned value is what it says.
+    Parsed,
+    /// A settings file exists but its contents could not be recovered — invalid
+    /// JSON, a field with an incompatible type, or an I/O error that is not
+    /// "no such file". Whatever the user had is still on disk and still
+    /// unknown to us.
+    Unreadable,
+}
+
+impl SettingsOrigin {
+    /// Whether a `save()` after this load would preserve the user's data.
+    ///
+    /// False only for [`SettingsOrigin::Unreadable`], where saving would
+    /// overwrite settings we could not read with defaults we invented.
+    pub fn is_safe_to_overwrite(self) -> bool {
+        !matches!(self, Self::Unreadable)
+    }
+}
+
+/// The raw read of a settings file, before parsing.
+enum RawSettings {
+    Missing,
+    Present(String),
+    Unreadable,
+}
+
 #[derive(Debug, Clone, Copy)]
 enum ExplicitHomeConfigLayout {
     UnixDotConfig,
@@ -261,6 +297,14 @@ pub fn load_scanner_settings_for_home(home_dir: &Option<String>) -> ScannerSetti
 ///
 /// Does nothing when:
 /// - a zone is already pinned — including one the user set by hand;
+/// - settings.json exists but could not be read. This is the one place in the
+///   CLI that loads settings and then unconditionally writes them back, and
+///   [`Settings::load`] answers a parse failure with `Settings::default()`. The
+///   two together would replace a hand-edited or truncated settings.json with
+///   defaults plus a timezone, destroying scanner paths, aliases, autosubmit
+///   config and UI preferences — on a plain `tokscale report`, with no prompt.
+///   A device that stays unpinned keeps a bug it already had; a device whose
+///   settings are erased cannot get them back.
 /// - the platform cannot name its zone (`TZ=+09:00`, a container with no
 ///   zoneinfo). A fixed offset cannot follow DST, so pinning one would swap this
 ///   bug for a smaller version of itself. Staying unpinned is the honest state.
@@ -269,6 +313,14 @@ pub fn load_scanner_settings_for_home(home_dir: &Option<String>) -> ScannerSetti
 ///   writes to *this* machine's config path regardless, so the two would not
 ///   even agree on a file.
 ///
+/// A value that is present but does not name a zone the tz database knows — an
+/// empty string, a typo, a raw offset — is *not* treated as pinned, because
+/// bucketing does not treat it as pinned either: it degrades to host-local and
+/// the device keeps the exposure this function exists to close. Those are
+/// re-detected. Overwriting one is safe in a way that overwriting an unreadable
+/// file is not: the file parsed, so everything else in it survives the write,
+/// and the only value lost is one nothing could act on.
+///
 /// A failed save is ignored: the next run retries, and an unpinned device is
 /// exactly as correct as it was before this function existed.
 pub fn pin_bucket_timezone_if_unset(home_dir: &Option<String>) {
@@ -276,7 +328,15 @@ pub fn pin_bucket_timezone_if_unset(home_dir: &Option<String>) {
         return;
     }
 
-    let mut settings = Settings::load();
+    let (mut settings, origin) = Settings::load_with_origin();
+    if !origin.is_safe_to_overwrite() {
+        tracing::warn!(
+            "settings.json could not be read — leaving it untouched rather than \
+             replacing it with defaults to record scanner.bucketTimezone"
+        );
+        return;
+    }
+
     if settings.scanner.bucket_timezone.is_some() {
         return;
     }
@@ -371,9 +431,26 @@ impl Settings {
     }
 
     pub fn load() -> Self {
-        let primary = Self::config_path()
-            .ok()
-            .and_then(|path| fs::read_to_string(path).ok());
+        Self::load_with_origin().0
+    }
+
+    /// [`Settings::load`], plus where the returned value came from.
+    ///
+    /// `load()` answers "what settings should this run use", and defaults are
+    /// the right answer to that question however the read went. They are the
+    /// wrong answer to "what is safe to write back": a file that exists but
+    /// cannot be parsed still holds the user's scanner paths, aliases,
+    /// autosubmit config and UI preferences, and none of them are in the
+    /// defaults handed back. Anything that loads in order to save has to be
+    /// able to tell those two cases apart, so it can decline instead of
+    /// replacing data it never saw.
+    pub fn load_with_origin() -> (Self, SettingsOrigin) {
+        let primary = match Self::config_path() {
+            Ok(path) => Self::read_config_file(&path),
+            // Cannot even resolve where settings live. Not "absent": a save
+            // would fail the same way, so do not report this as writable.
+            Err(_) => RawSettings::Unreadable,
+        };
 
         // Transparent macOS fallback: pre-fix releases wrote settings.json under
         // `~/Library/Application Support/tokscale/`. Read it once if the new
@@ -383,16 +460,35 @@ impl Settings {
         // has explicitly pinned a config root via `TOKSCALE_CONFIG_DIR` so
         // CI sandboxes and isolated profiles stay hermetic instead of
         // silently ingesting personal settings from the legacy macOS path.
-        let raw = primary.or_else(|| {
-            if crate::paths::is_config_dir_overridden() {
-                return None;
+        let raw = match primary {
+            RawSettings::Missing if !crate::paths::is_config_dir_overridden() => {
+                match Self::legacy_macos_path() {
+                    Some(legacy) => Self::read_config_file(&legacy),
+                    None => RawSettings::Missing,
+                }
             }
-            Self::legacy_macos_path().and_then(|legacy| fs::read_to_string(legacy).ok())
-        });
+            other => other,
+        };
 
-        raw.and_then(|content| serde_json::from_str(&content).ok())
-            .map(Settings::normalize)
-            .unwrap_or_default()
+        match raw {
+            RawSettings::Missing => (Self::default(), SettingsOrigin::Absent),
+            RawSettings::Unreadable => (Self::default(), SettingsOrigin::Unreadable),
+            RawSettings::Present(content) => match serde_json::from_str::<Settings>(&content) {
+                Ok(settings) => (settings.normalize(), SettingsOrigin::Parsed),
+                Err(_) => (Self::default(), SettingsOrigin::Unreadable),
+            },
+        }
+    }
+
+    /// Read a settings file, keeping "there is no file" distinct from "there is
+    /// a file and we could not read it". `read_to_string(..).ok()` collapses
+    /// the two, and the difference is the whole point here.
+    fn read_config_file(path: &Path) -> RawSettings {
+        match fs::read_to_string(path) {
+            Ok(content) => RawSettings::Present(content),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => RawSettings::Missing,
+            Err(_) => RawSettings::Unreadable,
+        }
     }
 
     pub fn load_for_home_override(home_dir: Option<&Path>) -> Self {

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -245,6 +245,56 @@ pub fn load_scanner_settings_for_home(home_dir: &Option<String>) -> ScannerSetti
     Settings::load_for_home_override(home_dir.as_deref().map(Path::new)).scanner
 }
 
+/// Record this machine's IANA timezone as the device's bucketing zone, once.
+///
+/// Day keys used to be derived from `chrono::Local` on every scan, so moving
+/// machines or changing `TZ` re-split the same history across different days
+/// and the server's monotonic per-day guard turned that into permanent
+/// inflation. Pinning the zone removes the cause, but only for devices that
+/// actually have one pinned — so the CLI pins on first run rather than waiting
+/// for every user to discover a config command.
+///
+/// This is deliberately not a behaviour change on the machine that runs it: the
+/// zone written is the one `chrono::Local` would have resolved anyway, so the
+/// first scan after pinning reports exactly what it would have reported before.
+/// What changes is the *next* scan, from somewhere else.
+///
+/// Does nothing when:
+/// - a zone is already pinned — including one the user set by hand;
+/// - the platform cannot name its zone (`TZ=+09:00`, a container with no
+///   zoneinfo). A fixed offset cannot follow DST, so pinning one would swap this
+///   bug for a smaller version of itself. Staying unpinned is the honest state.
+/// - the caller passed `--home`, which points at another machine's data
+///   directory. This machine's zone is not that device's zone, and `save()`
+///   writes to *this* machine's config path regardless, so the two would not
+///   even agree on a file.
+///
+/// A failed save is ignored: the next run retries, and an unpinned device is
+/// exactly as correct as it was before this function existed.
+pub fn pin_bucket_timezone_if_unset(home_dir: &Option<String>) {
+    if home_dir.is_some() {
+        return;
+    }
+
+    let mut settings = Settings::load();
+    if settings.scanner.bucket_timezone.is_some() {
+        return;
+    }
+
+    let Some(zone) = tokscale_core::bucket_tz::detect_local_iana_name() else {
+        tracing::debug!(
+            "could not resolve an IANA timezone name for this machine — \
+             leaving scanner.bucketTimezone unset"
+        );
+        return;
+    };
+
+    settings.scanner.bucket_timezone = Some(zone);
+    if let Err(error) = settings.save() {
+        tracing::debug!(%error, "failed to persist scanner.bucketTimezone");
+    }
+}
+
 /// Loads the user's configured model aliases, honoring a `--home` override the
 /// same way [`load_scanner_settings_for_home`] does. A missing or malformed
 /// settings.json yields an empty map (no folding); this never errors.

--- a/crates/tokscale-cli/src/tui/settings.rs
+++ b/crates/tokscale-cli/src/tui/settings.rs
@@ -460,20 +460,36 @@ impl Settings {
         // has explicitly pinned a config root via `TOKSCALE_CONFIG_DIR` so
         // CI sandboxes and isolated profiles stay hermetic instead of
         // silently ingesting personal settings from the legacy macOS path.
-        let raw = match primary {
-            RawSettings::Missing if !crate::paths::is_config_dir_overridden() => {
-                match Self::legacy_macos_path() {
-                    Some(legacy) => Self::read_config_file(&legacy),
-                    None => RawSettings::Missing,
-                }
-            }
-            other => other,
+        //
+        // The fallback is attempted whenever the primary is not readable, not
+        // only when it is missing — that is what it did before this function
+        // reported an origin, and narrowing it would lose the legacy file to a
+        // permissions error on the new path.
+        let legacy = match primary {
+            RawSettings::Present(_) => None,
+            _ if crate::paths::is_config_dir_overridden() => None,
+            _ => Self::legacy_macos_path().map(|legacy| Self::read_config_file(&legacy)),
+        };
+
+        // `save()` writes to the primary path whatever was read, so an
+        // unreadable primary stays unreadable even when the legacy file
+        // supplies the values: a write would still land on top of the file we
+        // could not see.
+        let primary_was_unreadable = matches!(primary, RawSettings::Unreadable);
+
+        let raw = match (primary, legacy) {
+            (RawSettings::Present(content), _) => RawSettings::Present(content),
+            (_, Some(RawSettings::Present(content))) => RawSettings::Present(content),
+            (primary, _) => primary,
         };
 
         match raw {
             RawSettings::Missing => (Self::default(), SettingsOrigin::Absent),
             RawSettings::Unreadable => (Self::default(), SettingsOrigin::Unreadable),
             RawSettings::Present(content) => match serde_json::from_str::<Settings>(&content) {
+                Ok(settings) if primary_was_unreadable => {
+                    (settings.normalize(), SettingsOrigin::Unreadable)
+                }
                 Ok(settings) => (settings.normalize(), SettingsOrigin::Parsed),
                 Err(_) => (Self::default(), SettingsOrigin::Unreadable),
             },

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -4135,3 +4135,60 @@ fn test_config_set_refuses_to_overwrite_unreadable_settings() {
         "a refused write must leave the file untouched"
     );
 }
+
+/// A `bucketTimezone` that does not name a zone the tz database knows is not a
+/// pin: bucketing degrades to host-local, so the device keeps exactly the
+/// exposure auto-pinning exists to close. Treating "present" as "pinned" made
+/// one bad hand edit suppress the fix permanently.
+#[test]
+fn test_auto_pinning_recovers_from_a_bucket_timezone_that_names_no_zone() {
+    let pinned_zone = |base: &Path| -> String {
+        let settings: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(base.join(".config/tokscale/settings.json")).unwrap(),
+        )
+        .unwrap();
+        settings["scanner"]["bucketTimezone"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string()
+    };
+    let scan = |base: &Path| {
+        cmd_with_home(base)
+            .env("TZ", "Asia/Seoul")
+            .args(["graph", "--client", "opencode", "--no-spinner"])
+            .assert()
+            .success();
+    };
+
+    // What a real recovery looks like on this host, from a file that is simply
+    // unpinned. Comparing against it keeps the test from passing on a host
+    // where nothing can be detected and every case recovers to nothing.
+    let baseline = create_bucket_timezone_fixture_dir();
+    pin_bucket_timezone_field(baseline.path(), "null");
+    scan(baseline.path());
+    let detected = pinned_zone(baseline.path());
+    assert!(
+        !detected.is_empty(),
+        "auto-pinning must work on this host for the assertions below to mean \
+         anything"
+    );
+
+    for junk in ["", "   ", "Mars/Olympus_Mons", "+09:00"] {
+        let tmp = create_bucket_timezone_fixture_dir();
+        pin_bucket_timezone(tmp.path(), junk);
+
+        scan(tmp.path());
+        assert_eq!(
+            pinned_zone(tmp.path()),
+            detected,
+            "`{junk}` names no zone, so bucketing already falls back to the host \
+             — the next run must re-detect instead of leaving the device \
+             permanently unpinned"
+        );
+
+        // And the recovered value is a real pin, so it is not re-detected again
+        // on every subsequent run.
+        scan(tmp.path());
+        assert_eq!(pinned_zone(tmp.path()), detected);
+    }
+}

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -3777,11 +3777,17 @@ fn create_bucket_timezone_fixture_dir() -> TempDir {
 }
 
 fn pin_bucket_timezone(base: &Path, zone: &str) {
+    pin_bucket_timezone_field(base, &format!(r#""{zone}""#));
+}
+
+/// [`pin_bucket_timezone`] with the raw JSON value, so a test can write `null`
+/// as well as a string.
+fn pin_bucket_timezone_field(base: &Path, json_value: &str) {
     let config_dir = base.join(".config/tokscale");
     fs::create_dir_all(&config_dir).unwrap();
     fs::write(
         config_dir.join("settings.json"),
-        format!(r#"{{ "scanner": {{ "bucketTimezone": "{zone}" }} }}"#),
+        format!(r#"{{ "scanner": {{ "bucketTimezone": {json_value} }} }}"#),
     )
     .unwrap();
 }
@@ -3945,6 +3951,11 @@ fn test_config_set_timezone_rejects_a_fixed_offset() {
 /// A hand-edited settings.json with a bad zone must not break scanning. It
 /// degrades to the pre-pinning behaviour, which is wrong in the old way rather
 /// than a hard failure on every command.
+///
+/// The run also re-detects a real zone for the field (see
+/// `test_auto_pinning_recovers_from_a_bucket_timezone_that_names_no_zone`), and
+/// the buckets are unchanged either way: auto-pinning only ever records a zone
+/// that reproduces `chrono::Local`, which is what the fallback uses.
 #[test]
 fn test_unparseable_pinned_timezone_falls_back_to_the_host_timezone() {
     let tmp = create_bucket_timezone_fixture_dir();
@@ -3988,5 +3999,139 @@ fn test_first_run_never_rebuckets_when_the_detector_disagrees_with_local() {
         graph_day_buckets(tmp.path(), "XYZ8"),
         vec![("2026-03-02".to_string(), 2)],
         "the recorded zone must reproduce what the first run reported"
+    );
+}
+
+/// Hour keys that actually carry messages, in the order the report emits them.
+fn hourly_keys(base: &Path, timezone: &str) -> Vec<String> {
+    let output = cmd_with_home(base)
+        .env("TZ", timezone)
+        .args(["hourly", "--json", "--client", "opencode", "--no-spinner"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let mut keys: Vec<String> = json["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| e["hour"].as_str().unwrap().to_string())
+        .collect();
+    keys.sort();
+    keys
+}
+
+/// The hourly key embeds a date, and the rebucket pass has already moved every
+/// message's `date` into the pinned zone. Deriving the hour from the host
+/// instead lets one report disagree with itself about which day an hour belongs
+/// to — and a `--today` filter resolved in the pinned zone then selects rows
+/// labelled with the neighbouring host-local date.
+#[test]
+fn test_hourly_keys_follow_the_pinned_bucket_timezone() {
+    let tmp = create_bucket_timezone_fixture_dir();
+    pin_bucket_timezone(tmp.path(), "Pacific/Kiritimati");
+
+    // 11:30Z and 18:00Z are 01:30 and 08:00 on 03-03 in Kiritimati (UTC+14),
+    // but 03:30 and 10:00 on 03-02 in Los Angeles — a different day *and* a
+    // different hour, so neither half can match by accident.
+    let expected = vec![
+        "2026-03-03 01:00".to_string(),
+        "2026-03-03 08:00".to_string(),
+    ];
+
+    assert_eq!(
+        hourly_keys(tmp.path(), "America/Los_Angeles"),
+        expected,
+        "hour keys must be built in the pinned zone, not the host's"
+    );
+    assert_eq!(
+        hourly_keys(tmp.path(), "Asia/Seoul"),
+        expected,
+        "and they must not move when the host timezone does"
+    );
+}
+
+/// `Settings::load()` answers an unparseable settings.json with
+/// `Settings::default()`. Auto-pinning is the first path in the CLI that loads
+/// and then unconditionally saves, so on its own it would replace a
+/// hand-edited or truncated settings.json with defaults plus a timezone —
+/// erasing scanner paths, aliases, autosubmit config and UI preferences on a
+/// plain `tokscale graph`, with no prompt and no way back.
+///
+/// The positive control matters: if this host cannot name its own zone the pin
+/// is skipped for every home and the negative cases would pass vacuously.
+#[test]
+fn test_auto_pinning_never_overwrites_a_settings_file_it_could_not_read() {
+    // Positive control — a readable file on this host really does get pinned.
+    let control = create_bucket_timezone_fixture_dir();
+    let control_settings = control.path().join(".config/tokscale/settings.json");
+    fs::create_dir_all(control_settings.parent().unwrap()).unwrap();
+    fs::write(&control_settings, r#"{"colorPalette":"green"}"#).unwrap();
+    graph_day_buckets(control.path(), "Asia/Seoul");
+    let control_json: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&control_settings).unwrap()).unwrap();
+    assert!(
+        control_json["scanner"]["bucketTimezone"].is_string(),
+        "auto-pinning must work on this host for the assertions below to mean \
+         anything; got {control_json}"
+    );
+    assert_eq!(
+        control_json["colorPalette"].as_str(),
+        Some("green"),
+        "pinning a readable file must preserve everything else in it"
+    );
+
+    // Truncated JSON, and valid JSON with a field of the wrong type — both make
+    // `serde_json::from_str` fail, and both leave real user data on disk.
+    for unreadable in [
+        r#"{"colorPalette": "green", "scanner": {"#,
+        r#"{"colorPalette": 42, "scanner": {"extraScanPaths": {"claude": ["/data"]}}}"#,
+    ] {
+        let tmp = create_bucket_timezone_fixture_dir();
+        let settings_path = tmp.path().join(".config/tokscale/settings.json");
+        fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        fs::write(&settings_path, unreadable).unwrap();
+
+        cmd_with_home(tmp.path())
+            .env("TZ", "Asia/Seoul")
+            .args(["graph", "--client", "opencode", "--no-spinner"])
+            .assert()
+            .success();
+
+        assert_eq!(
+            fs::read_to_string(&settings_path).unwrap(),
+            unreadable,
+            "a settings.json that could not be read must be left byte-identical, \
+             not replaced with defaults plus a timezone"
+        );
+    }
+}
+
+/// `tokscale config` loads and saves too, and it is the one place a user is
+/// watching. Refuse out loud rather than silently replacing a file whose
+/// contents were never recovered.
+#[test]
+fn test_config_set_refuses_to_overwrite_unreadable_settings() {
+    let tmp = create_bucket_timezone_fixture_dir();
+    let settings_path = tmp.path().join(".config/tokscale/settings.json");
+    fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+    let unreadable = r#"{"scanner": {"extraScanPaths": "not-a-map"}}"#;
+    fs::write(&settings_path, unreadable).unwrap();
+
+    cmd_with_home(tmp.path())
+        .args(["config", "set", "timezone", "Asia/Seoul"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("could not be read"));
+
+    assert_eq!(
+        fs::read_to_string(&settings_path).unwrap(),
+        unreadable,
+        "a refused write must leave the file untouched"
     );
 }

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -3749,7 +3749,10 @@ fn create_bucket_timezone_fixture_dir() -> TempDir {
     let session = base.join(".local/share/opencode/storage/message/session1");
     fs::create_dir_all(&session).unwrap();
 
-    for (id, created_ms) in [("msg_a", 1_772_451_000_000i64), ("msg_b", 1_772_474_400_000)] {
+    for (id, created_ms) in [
+        ("msg_a", 1_772_451_000_000i64),
+        ("msg_b", 1_772_474_400_000),
+    ] {
         let msg = format!(
             r#"{{
                 "id": "{id}",
@@ -3860,10 +3863,7 @@ fn test_unpinned_first_scan_still_buckets_by_the_host_timezone() {
     );
     assert_eq!(
         graph_day_buckets(seoul.path(), "Asia/Seoul"),
-        vec![
-            ("2026-03-02".to_string(), 1),
-            ("2026-03-03".to_string(), 1)
-        ],
+        vec![("2026-03-02".to_string(), 1), ("2026-03-03".to_string(), 1)],
         "an unpinned device must bucket by its own timezone, unchanged"
     );
 }
@@ -3880,10 +3880,7 @@ fn test_first_run_pins_the_host_timezone_without_changing_its_own_output() {
     let buckets = graph_day_buckets(tmp.path(), "Asia/Seoul");
     assert_eq!(
         buckets,
-        vec![
-            ("2026-03-02".to_string(), 1),
-            ("2026-03-03".to_string(), 1)
-        ],
+        vec![("2026-03-02".to_string(), 1), ("2026-03-03".to_string(), 1)],
         "the run that pins must report what it would have reported unpinned"
     );
 

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -3907,31 +3907,50 @@ fn test_first_run_pins_the_host_timezone_without_changing_its_own_output() {
 }
 
 #[test]
-fn test_config_set_timezone_repoints_day_buckets() {
+fn test_config_rejects_rekeying_or_unsetting_an_established_timezone() {
     let tmp = create_bucket_timezone_fixture_dir();
     pin_bucket_timezone(tmp.path(), "America/Los_Angeles");
-    assert_eq!(
-        graph_day_buckets(tmp.path(), "Asia/Seoul"),
-        vec![("2026-03-02".to_string(), 2)]
-    );
 
     cmd_with_home(tmp.path())
         .args(["config", "set", "timezone", "Pacific/Kiritimati"])
         .assert()
-        .success()
-        .stdout(predicate::str::contains("Pacific/Kiritimati"));
-
-    assert_eq!(
-        graph_day_buckets(tmp.path(), "Asia/Seoul"),
-        vec![("2026-03-03".to_string(), 2)],
-        "`config set timezone` must move the day boundaries deliberately"
-    );
+        .failure()
+        .stderr(predicate::str::contains(
+            "historical submitted day rows are monotonic",
+        ));
 
     cmd_with_home(tmp.path())
-        .args(["config", "get", "timezone"])
+        .args(["config", "set", "timezone", "auto"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "server resync/replacement transition",
+        ));
+
+    cmd_with_home(tmp.path())
+        .args(["config", "unset", "timezone"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "historical submitted day rows are monotonic",
+        ));
+
+    cmd_with_home(tmp.path())
+        .args(["config", "set", "timezone", "America/Los_Angeles"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Pacific/Kiritimati"));
+        .stdout(predicate::str::contains("(unchanged)"));
+}
+
+#[test]
+fn test_config_can_recover_an_invalid_or_unpinned_timezone() {
+    let tmp = create_bucket_timezone_fixture_dir();
+    pin_bucket_timezone(tmp.path(), "Mars/Olympus_Mons");
+
+    cmd_with_home(tmp.path())
+        .args(["config", "set", "timezone", "Asia/Seoul"])
+        .assert()
+        .success();
 }
 
 /// A fixed UTC offset cannot follow daylight saving time, so pinning one would

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -4194,3 +4194,105 @@ fn test_auto_pinning_recovers_from_a_bucket_timezone_that_names_no_zone() {
         assert_eq!(pinned_zone(tmp.path()), detected);
     }
 }
+
+/// Whether mode 000 actually denies a read here. Root ignores it, and so do
+/// some container filesystems, and the tests below have nothing to assert when
+/// the file they made unreadable can still be read. Probes the real behaviour
+/// rather than inferring it from the uid.
+#[cfg(unix)]
+fn mode_000_denies_reads(dir: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    let probe = dir.join(".mode-probe");
+    fs::write(&probe, "probe").unwrap();
+    fs::set_permissions(&probe, fs::Permissions::from_mode(0o000)).unwrap();
+    let denied = fs::read_to_string(&probe).is_err();
+    fs::set_permissions(&probe, fs::Permissions::from_mode(0o644)).unwrap();
+    fs::remove_file(&probe).unwrap();
+    denied
+}
+
+/// `read_to_string(..).ok()` collapses "no such file" into the same `None` as
+/// "this file exists and I could not open it". Auto-pinning has to tell them
+/// apart: the first is safe to write, the second is a file whose contents are
+/// still on disk and still unknown.
+///
+/// A parse failure is covered by
+/// `test_auto_pinning_never_overwrites_a_settings_file_it_could_not_read`; this
+/// is the I/O half, which never reaches the parser at all.
+#[cfg(unix)]
+#[test]
+fn test_auto_pinning_declines_when_settings_json_cannot_be_opened() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = create_bucket_timezone_fixture_dir();
+    if !mode_000_denies_reads(tmp.path()) {
+        return;
+    }
+
+    let settings_path = tmp.path().join(".config/tokscale/settings.json");
+    fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+    fs::write(&settings_path, r#"{"colorPalette":"green"}"#).unwrap();
+    fs::set_permissions(&settings_path, fs::Permissions::from_mode(0o000)).unwrap();
+
+    cmd_with_home(tmp.path())
+        .env("TZ", "Asia/Seoul")
+        .args(["graph", "--client", "opencode", "--no-spinner"])
+        .assert()
+        .success();
+
+    fs::set_permissions(&settings_path, fs::Permissions::from_mode(0o644)).unwrap();
+    assert_eq!(
+        fs::read_to_string(&settings_path).unwrap(),
+        r#"{"colorPalette":"green"}"#,
+        "a settings.json that could not be opened must be left byte-identical"
+    );
+}
+
+/// The macOS fallback only fires while the canonical path is absent, so writing
+/// a primary settings.json shadows the legacy file for good — a legacy file the
+/// user could otherwise have repaired. Auto-pinning must not create one on top
+/// of a legacy file it could not open.
+///
+/// macOS-only: `legacy_macos_config_dir()` returns `None` everywhere else, so
+/// there is no fallback to shadow. Uses a permissions failure rather than bad
+/// JSON because unparseable legacy *content* is read successfully and blocked
+/// one step later, by the parse arm.
+#[cfg(target_os = "macos")]
+#[test]
+fn test_auto_pinning_does_not_shadow_a_legacy_settings_file_it_cannot_open() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = create_bucket_timezone_fixture_dir();
+    if !mode_000_denies_reads(tmp.path()) {
+        return;
+    }
+
+    let legacy = tmp
+        .path()
+        .join("Library/Application Support/tokscale/settings.json");
+    fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+    fs::write(&legacy, r#"{"colorPalette":"green"}"#).unwrap();
+    fs::set_permissions(&legacy, fs::Permissions::from_mode(0o000)).unwrap();
+
+    let primary = tmp.path().join(".config/tokscale/settings.json");
+    assert!(!primary.exists(), "fixture must start with no primary file");
+
+    cmd_with_home(tmp.path())
+        .env("TZ", "Asia/Seoul")
+        .args(["graph", "--client", "opencode", "--no-spinner"])
+        .assert()
+        .success();
+
+    fs::set_permissions(&legacy, fs::Permissions::from_mode(0o644)).unwrap();
+    assert!(
+        !primary.exists(),
+        "writing a primary settings.json would shadow the legacy file the user \
+         still has to repair"
+    );
+    assert_eq!(
+        fs::read_to_string(&legacy).unwrap(),
+        r#"{"colorPalette":"green"}"#,
+        "and the legacy file itself must be left alone"
+    );
+}

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -3958,6 +3958,74 @@ fn test_config_can_recover_an_invalid_or_unpinned_timezone() {
         .success();
 }
 
+#[test]
+fn test_config_set_can_initialize_or_recover_a_timezone_before_auto_pinning() {
+    for existing in [None, Some("Mars/Olympus_Mons")] {
+        let tmp = create_bucket_timezone_fixture_dir();
+        let config_dir = tmp.path().join(".config/tokscale");
+        if let Some(existing) = existing {
+            pin_bucket_timezone(tmp.path(), existing);
+        }
+
+        cmd_with_home(tmp.path())
+            .env("TOKSCALE_CONFIG_DIR", &config_dir)
+            .args(["config", "set", "timezone", "Asia/Seoul"])
+            .assert()
+            .success();
+
+        let settings: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(config_dir.join("settings.json")).unwrap())
+                .unwrap();
+        assert_eq!(
+            settings["scanner"]["bucketTimezone"].as_str(),
+            Some("Asia/Seoul"),
+            "config set must operate on a {existing:?} value before startup auto-pinning"
+        );
+    }
+}
+
+#[test]
+fn test_config_set_auto_can_initialize_or_recover_before_auto_pinning() {
+    for existing in [None, Some("Mars/Olympus_Mons")] {
+        let tmp = create_bucket_timezone_fixture_dir();
+        let config_dir = tmp.path().join(".config/tokscale");
+        if let Some(existing) = existing {
+            pin_bucket_timezone(tmp.path(), existing);
+        }
+
+        cmd_with_home(tmp.path())
+            .env("TOKSCALE_CONFIG_DIR", &config_dir)
+            .args(["config", "set", "timezone", "auto"])
+            .assert()
+            .success();
+
+        let settings: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(config_dir.join("settings.json")).unwrap())
+                .unwrap();
+        assert!(
+            settings["scanner"]["bucketTimezone"].is_string(),
+            "config set auto must write a detected timezone for a {existing:?} value"
+        );
+    }
+}
+
+#[test]
+fn test_config_unset_can_initialize_or_recover_a_timezone_before_auto_pinning() {
+    for existing in [None, Some("Mars/Olympus_Mons")] {
+        let tmp = create_bucket_timezone_fixture_dir();
+        let config_dir = tmp.path().join(".config/tokscale");
+        if let Some(existing) = existing {
+            pin_bucket_timezone(tmp.path(), existing);
+        }
+
+        cmd_with_home(tmp.path())
+            .env("TOKSCALE_CONFIG_DIR", &config_dir)
+            .args(["config", "unset", "timezone"])
+            .assert()
+            .success();
+    }
+}
+
 /// A fixed UTC offset cannot follow daylight saving time, so pinning one would
 /// reintroduce a bounded version of the bug pinning removes. Reject it at the
 /// boundary rather than storing a value that silently degrades to unpinned.

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -4002,7 +4002,7 @@ fn test_first_run_never_rebuckets_when_the_detector_disagrees_with_local() {
     );
 }
 
-/// Hour keys that actually carry messages, in the order the report emits them.
+/// Hour keys that actually carry messages, sorted ascending.
 fn hourly_keys(base: &Path, timezone: &str) -> Vec<String> {
     let output = cmd_with_home(base)
         .env("TZ", timezone)
@@ -4127,7 +4127,9 @@ fn test_config_set_refuses_to_overwrite_unreadable_settings() {
         .args(["config", "set", "timezone", "Asia/Seoul"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("could not be read"));
+        .stderr(predicate::str::contains(
+            "could not read this machine's tokscale settings",
+        ));
 
     assert_eq!(
         fs::read_to_string(&settings_path).unwrap(),

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -3729,3 +3729,233 @@ fn report_no_summarize_json_empty_home_emits_valid_json_without_panic() {
         "expected zero entries for empty home, got: {entries:?}"
     );
 }
+
+/// A session whose two turns land on different calendar days depending on the
+/// zone reading them. Chosen so all three zones used below disagree:
+///
+/// | zone                  | 11:30Z     | 18:00Z     | day buckets              |
+/// |-----------------------|------------|------------|--------------------------|
+/// | `America/Los_Angeles` | 03-02 03:30| 03-02 10:00| `{03-02: 2}`             |
+/// | `Asia/Seoul`          | 03-02 20:30| 03-03 03:00| `{03-02: 1, 03-03: 1}`   |
+/// | `Pacific/Kiritimati`  | 03-03 01:30| 03-03 08:00| `{03-03: 2}`             |
+///
+/// Three distinct shapes means a test can tell which zone actually did the
+/// bucketing, rather than only that two runs happened to agree.
+fn create_bucket_timezone_fixture_dir() -> TempDir {
+    let tmp = TempDir::new().expect("failed to create temp dir");
+    let base = tmp.path();
+    prime_pricing_cache(base);
+
+    let session = base.join(".local/share/opencode/storage/message/session1");
+    fs::create_dir_all(&session).unwrap();
+
+    for (id, created_ms) in [("msg_a", 1_772_451_000_000i64), ("msg_b", 1_772_474_400_000)] {
+        let msg = format!(
+            r#"{{
+                "id": "{id}",
+                "sessionID": "session1",
+                "role": "assistant",
+                "modelID": "claude-sonnet-4-20250514",
+                "providerID": "anthropic",
+                "cost": 0.05,
+                "tokens": {{
+                    "input": 1000,
+                    "output": 500,
+                    "reasoning": 0,
+                    "cache": {{ "read": 200, "write": 50 }}
+                }},
+                "time": {{ "created": {created_ms}.0 }}
+            }}"#
+        );
+        fs::write(session.join(format!("{id}.json")), msg).unwrap();
+    }
+
+    tmp
+}
+
+fn pin_bucket_timezone(base: &Path, zone: &str) {
+    let config_dir = base.join(".config/tokscale");
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(
+        config_dir.join("settings.json"),
+        format!(r#"{{ "scanner": {{ "bucketTimezone": "{zone}" }} }}"#),
+    )
+    .unwrap();
+}
+
+/// Day buckets that actually carry messages, as `(date, message_count)`.
+/// The graph zero-fills a calendar, so the empty days carry no signal.
+fn graph_day_buckets(base: &Path, timezone: &str) -> Vec<(String, i64)> {
+    let output = cmd_with_home(base)
+        .env("TZ", timezone)
+        .args(["graph", "--client", "opencode", "--no-spinner"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let mut buckets: Vec<(String, i64)> = json["contributions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|c| {
+            let messages = c["totals"]["messages"].as_i64().unwrap_or(0);
+            (messages > 0).then(|| (c["date"].as_str().unwrap().to_string(), messages))
+        })
+        .collect();
+    buckets.sort();
+    buckets
+}
+
+/// The regression this whole feature exists for.
+///
+/// Day keys used to be derived from `chrono::Local` on every scan, so
+/// rescanning the same unchanged history from another timezone re-split it
+/// across days. The server's monotonic per-day guard then kept the stale value
+/// on one day and accepted the new one on its neighbour, and the device's total
+/// was inflated permanently with no way to walk it back.
+///
+/// With a zone pinned, the same bytes produce the same day keys no matter what
+/// `TZ` says — and specifically the *pinned* zone's keys, not either host's.
+#[test]
+fn test_pinned_bucket_timezone_survives_a_host_timezone_change() {
+    let tmp = create_bucket_timezone_fixture_dir();
+    pin_bucket_timezone(tmp.path(), "Pacific/Kiritimati");
+
+    let from_los_angeles = graph_day_buckets(tmp.path(), "America/Los_Angeles");
+    let from_seoul = graph_day_buckets(tmp.path(), "Asia/Seoul");
+
+    assert_eq!(
+        from_los_angeles, from_seoul,
+        "a pinned zone must key the same history the same way from any host timezone"
+    );
+    // Not just equal to each other — equal to what the pinned zone says.
+    // Los Angeles would report {03-02: 2} and Seoul {03-02: 1, 03-03: 1}, so
+    // agreeing on {03-03: 2} can only come from Pacific/Kiritimati.
+    assert_eq!(
+        from_los_angeles,
+        vec![("2026-03-03".to_string(), 2)],
+        "buckets must follow the pinned zone, not either host"
+    );
+}
+
+/// The other half of the contract: a device that has never pinned reports
+/// exactly what it reported before this change — day keys follow the machine.
+///
+/// Separate homes because the first run on a home pins it; this asserts the
+/// unpinned/first-scan semantics, which are the ones that must not move.
+#[test]
+fn test_unpinned_first_scan_still_buckets_by_the_host_timezone() {
+    let los_angeles = create_bucket_timezone_fixture_dir();
+    let seoul = create_bucket_timezone_fixture_dir();
+
+    assert_eq!(
+        graph_day_buckets(los_angeles.path(), "America/Los_Angeles"),
+        vec![("2026-03-02".to_string(), 2)],
+        "an unpinned device must bucket by its own timezone, unchanged"
+    );
+    assert_eq!(
+        graph_day_buckets(seoul.path(), "Asia/Seoul"),
+        vec![
+            ("2026-03-02".to_string(), 1),
+            ("2026-03-03".to_string(), 1)
+        ],
+        "an unpinned device must bucket by its own timezone, unchanged"
+    );
+}
+
+/// The first run records the zone, and recording it changes nothing about what
+/// that run reports. If pinning moved the numbers on the machine doing the
+/// pinning, every user would see a one-off jump on upgrade.
+#[test]
+fn test_first_run_pins_the_host_timezone_without_changing_its_own_output() {
+    let tmp = create_bucket_timezone_fixture_dir();
+    let settings_path = tmp.path().join(".config/tokscale/settings.json");
+    assert!(!settings_path.exists(), "fixture must start unpinned");
+
+    let buckets = graph_day_buckets(tmp.path(), "Asia/Seoul");
+    assert_eq!(
+        buckets,
+        vec![
+            ("2026-03-02".to_string(), 1),
+            ("2026-03-03".to_string(), 1)
+        ],
+        "the run that pins must report what it would have reported unpinned"
+    );
+
+    let settings: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&settings_path).unwrap()).unwrap();
+    assert_eq!(
+        settings["scanner"]["bucketTimezone"].as_str(),
+        Some("Asia/Seoul"),
+        "the first run must record the zone it bucketed into"
+    );
+
+    // And the recorded zone is what the *next* run uses, even from elsewhere.
+    assert_eq!(
+        graph_day_buckets(tmp.path(), "America/Los_Angeles"),
+        buckets,
+        "the recorded zone must survive a host timezone change"
+    );
+}
+
+#[test]
+fn test_config_set_timezone_repoints_day_buckets() {
+    let tmp = create_bucket_timezone_fixture_dir();
+    pin_bucket_timezone(tmp.path(), "America/Los_Angeles");
+    assert_eq!(
+        graph_day_buckets(tmp.path(), "Asia/Seoul"),
+        vec![("2026-03-02".to_string(), 2)]
+    );
+
+    cmd_with_home(tmp.path())
+        .args(["config", "set", "timezone", "Pacific/Kiritimati"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Pacific/Kiritimati"));
+
+    assert_eq!(
+        graph_day_buckets(tmp.path(), "Asia/Seoul"),
+        vec![("2026-03-03".to_string(), 2)],
+        "`config set timezone` must move the day boundaries deliberately"
+    );
+
+    cmd_with_home(tmp.path())
+        .args(["config", "get", "timezone"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Pacific/Kiritimati"));
+}
+
+/// A fixed UTC offset cannot follow daylight saving time, so pinning one would
+/// reintroduce a bounded version of the bug pinning removes. Reject it at the
+/// boundary rather than storing a value that silently degrades to unpinned.
+#[test]
+fn test_config_set_timezone_rejects_a_fixed_offset() {
+    let tmp = create_bucket_timezone_fixture_dir();
+
+    cmd_with_home(tmp.path())
+        .args(["config", "set", "timezone", "+09:00"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not a known IANA timezone name"));
+}
+
+/// A hand-edited settings.json with a bad zone must not break scanning. It
+/// degrades to the pre-pinning behaviour, which is wrong in the old way rather
+/// than a hard failure on every command.
+#[test]
+fn test_unparseable_pinned_timezone_falls_back_to_the_host_timezone() {
+    let tmp = create_bucket_timezone_fixture_dir();
+    pin_bucket_timezone(tmp.path(), "Mars/Olympus_Mons");
+
+    assert_eq!(
+        graph_day_buckets(tmp.path(), "America/Los_Angeles"),
+        vec![("2026-03-02".to_string(), 2)],
+        "an unknown zone name must fall back to the host, not fail the scan"
+    );
+}

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -3956,3 +3956,37 @@ fn test_unparseable_pinned_timezone_falls_back_to_the_host_timezone() {
         "an unknown zone name must fall back to the host, not fail the scan"
     );
 }
+
+/// Naming the local zone and bucketing in it go through different code with
+/// different rules. `chrono::Local` honors `TZ`; `iana-time-zone` does not read
+/// `TZ` at all on Linux — it resolves `/etc/localtime`. A host where those two
+/// disagree is ordinary (any `TZ=...` in a shell profile, any CI container),
+/// and pinning the detected name there would re-key the whole history on the
+/// first run after upgrading.
+///
+/// `TZ=XYZ8` is a POSIX rule string, not a zone name: `chrono::Local` honors it
+/// as UTC-8, and no detector will ever return it. So either the guard declines
+/// to pin, or it pins something that buckets identically — and the assertion
+/// below holds under both without caring which happened, which is the actual
+/// contract.
+#[test]
+fn test_first_run_never_rebuckets_when_the_detector_disagrees_with_local() {
+    let tmp = create_bucket_timezone_fixture_dir();
+
+    // UTC-8: 03:30 and 10:00 on 2026-03-02 — one day, both messages.
+    assert_eq!(
+        graph_day_buckets(tmp.path(), "XYZ8"),
+        vec![("2026-03-02".to_string(), 2)],
+        "the first run must bucket by chrono::Local no matter what the zone \
+         detector reports"
+    );
+
+    // Whatever it recorded, a second run has to agree with the first. A pin
+    // that moved the buckets would show up here even if the first run's
+    // assertion happened to match by luck.
+    assert_eq!(
+        graph_day_buckets(tmp.path(), "XYZ8"),
+        vec![("2026-03-02".to_string(), 2)],
+        "the recorded zone must reproduce what the first run reported"
+    );
+}

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -3945,9 +3945,14 @@ fn test_config_rejects_rekeying_or_unsetting_an_established_timezone() {
 #[test]
 fn test_config_can_recover_an_invalid_or_unpinned_timezone() {
     let tmp = create_bucket_timezone_fixture_dir();
+    let config_dir = tmp.path().join(".config/tokscale");
     pin_bucket_timezone(tmp.path(), "Mars/Olympus_Mons");
 
     cmd_with_home(tmp.path())
+        // macOS resolves its config root from the account home, not `HOME`.
+        // Pin the command to this fixture so a prior test cannot auto-pin a
+        // shared profile before this invalid value is read.
+        .env("TOKSCALE_CONFIG_DIR", &config_dir)
         .args(["config", "set", "timezone", "Asia/Seoul"])
         .assert()
         .success();

--- a/crates/tokscale-cli/tests/cli_tests.rs
+++ b/crates/tokscale-cli/tests/cli_tests.rs
@@ -4026,6 +4026,26 @@ fn test_config_unset_can_initialize_or_recover_a_timezone_before_auto_pinning() 
     }
 }
 
+#[test]
+fn test_read_only_config_commands_still_auto_pin_the_timezone() {
+    let tmp = create_bucket_timezone_fixture_dir();
+    let config_dir = tmp.path().join(".config/tokscale");
+
+    cmd_with_home(tmp.path())
+        .env("TOKSCALE_CONFIG_DIR", &config_dir)
+        .args(["config", "get", "timezone"])
+        .assert()
+        .success();
+
+    let settings: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(config_dir.join("settings.json")).unwrap())
+            .unwrap();
+    assert!(
+        settings["scanner"]["bucketTimezone"].is_string(),
+        "read-only config commands must retain startup auto-pinning"
+    );
+}
+
 /// A fixed UTC offset cannot follow daylight saving time, so pinning one would
 /// reintroduce a bounded version of the bug pinning removes. Reject it at the
 /// boundary rather than storing a value that silently degrades to unpinned.

--- a/crates/tokscale-core/Cargo.toml
+++ b/crates/tokscale-core/Cargo.toml
@@ -18,6 +18,8 @@ serde_json = { workspace = true }
 bincode = { workspace = true }
 walkdir = { workspace = true }
 chrono = { workspace = true }
+chrono-tz = { workspace = true }
+iana-time-zone = { workspace = true }
 thiserror = { workspace = true }
 reqwest = { workspace = true }
 tokio = { workspace = true }

--- a/crates/tokscale-core/src/bucket_tz.rs
+++ b/crates/tokscale-core/src/bucket_tz.rs
@@ -548,12 +548,11 @@ mod tests {
         let tokyo: chrono_tz::Tz = "Asia/Tokyo".parse().unwrap();
 
         let now = chrono::Utc::now().timestamp_millis();
-        const YEAR: i64 = 365 * 24 * 60 * 60 * 1000;
 
         // The premise: indistinguishable across the window this check used to
         // sample. If this ever stops holding the test below proves nothing.
         assert!(
-            zones_agree_between(&seoul, &tokyo, now - 10 * YEAR, now + YEAR),
+            zones_agree_between(&seoul, &tokyo, now - 10 * YEAR_MS, now + YEAR_MS),
             "Seoul and Tokyo must be indistinguishable over the last decade for \
              this test to be about the window rather than the zones"
         );

--- a/crates/tokscale-core/src/bucket_tz.rs
+++ b/crates/tokscale-core/src/bucket_tz.rs
@@ -156,8 +156,14 @@ mod tests {
 
     #[test]
     fn unset_and_blank_names_stay_unpinned() {
-        assert_eq!(BucketTimezone::from_pinned_name(None), BucketTimezone::Local);
-        assert_eq!(BucketTimezone::from_pinned_name(Some("")), BucketTimezone::Local);
+        assert_eq!(
+            BucketTimezone::from_pinned_name(None),
+            BucketTimezone::Local
+        );
+        assert_eq!(
+            BucketTimezone::from_pinned_name(Some("")),
+            BucketTimezone::Local
+        );
         assert_eq!(
             BucketTimezone::from_pinned_name(Some("   ")),
             BucketTimezone::Local

--- a/crates/tokscale-core/src/bucket_tz.rs
+++ b/crates/tokscale-core/src/bucket_tz.rs
@@ -111,6 +111,20 @@ impl BucketTimezone {
             Self::Pinned(tz) => format_day_key(timestamp_ms, tz),
         }
     }
+
+    /// The `YYYY-MM-DD HH:00` hour key this instant falls in.
+    ///
+    /// The hourly report is display-only — it is never submitted — but its keys
+    /// embed a date, and its fallback branch for timestamp-less messages builds
+    /// one out of `date`, which the rebucket pass has already moved. Reading the
+    /// two halves out of different zones would let a single report contradict
+    /// itself about which day an hour belongs to.
+    pub fn hour_key(&self, timestamp_ms: i64) -> Option<String> {
+        match self {
+            Self::Local => format_hour_key(timestamp_ms, &chrono::Local),
+            Self::Pinned(tz) => format_hour_key(timestamp_ms, tz),
+        }
+    }
 }
 
 /// Format an instant as a `YYYY-MM-DD` day key in `timezone`.
@@ -131,23 +145,134 @@ where
     }
 }
 
-/// The machine's current IANA zone name, if it can be determined.
+/// Format an instant as a `YYYY-MM-DD HH:00` hour key in `timezone`.
+/// `None` for an instant the zone cannot represent, so callers can fall back.
+fn format_hour_key<Tz>(timestamp_ms: i64, timezone: &Tz) -> Option<String>
+where
+    Tz: TimeZone,
+    Tz::Offset: Display,
+{
+    match timezone.timestamp_millis_opt(timestamp_ms) {
+        chrono::LocalResult::Single(dt) => Some(dt.format("%Y-%m-%d %H:00").to_string()),
+        _ => None,
+    }
+}
+
+/// The machine's current IANA zone name, if one can be determined **and** it
+/// reproduces `chrono::Local` exactly.
 ///
-/// `iana-time-zone` is already in the dependency graph — `chrono` pulls it in
-/// to implement `Local` — so reading the name costs no new code in the binary.
+/// Returns `None` when the platform cannot name its zone (a bare `TZ=+09:00`, a
+/// container with no zoneinfo) or when the name it gives disagrees with
+/// `chrono::Local`. Callers must treat `None` as "do not pin" rather than
+/// substituting a fixed offset: an offset that cannot follow DST is exactly the
+/// failure mode pinning exists to remove.
 ///
-/// Returns `None` when the platform cannot name its zone (a bare `TZ=+09:00`,
-/// a container with no zoneinfo). Callers must treat that as "do not pin"
-/// rather than substituting a fixed offset: an offset that cannot follow DST is
-/// exactly the failure mode pinning exists to remove.
+/// # Why the agreement check is not optional
+///
+/// Naming the local zone and *bucketing* in the local zone go through different
+/// code with different rules, and they disagree in ordinary setups:
+///
+/// - `chrono::Local` honors the `TZ` environment variable.
+/// - `iana_time_zone::get_timezone()` **does not read `TZ` at all** on Linux —
+///   it resolves `/etc/localtime`, then `/etc/timezone`. On macOS it goes
+///   through CoreFoundation, which *does* consult `TZ`.
+///
+/// So on a Linux host with `TZ=Asia/Seoul` and `/etc/localtime -> Etc/UTC`,
+/// the detector says `Etc/UTC` while every date the parsers produced said
+/// Seoul. Pinning the detected name there would re-key the entire history by
+/// nine hours on the first run after upgrading — the exact re-split this
+/// feature exists to prevent, caused by the feature, and invisible on macOS.
+///
+/// Verifying against `chrono::Local` before writing anything makes the
+/// invariant structural instead of dependent on two crates happening to agree:
+/// the zone recorded is one that produces the same day keys as the zone the
+/// device was already using, or no zone is recorded at all.
 pub fn detect_local_iana_name() -> Option<String> {
-    let name = iana_time_zone::get_timezone().ok()?;
-    // Round-trip through the tz database. A name we cannot parse back is a
-    // name we could not honor on a later scan, and pinning it would silently
-    // fall back to `Local` forever.
-    name.parse::<chrono_tz::Tz>()
-        .ok()
-        .map(|tz| tz.name().to_string())
+    let candidate = candidate_local_zone()?;
+
+    if !zones_agree(&candidate, &chrono::Local) {
+        tracing::debug!(
+            candidate = candidate.name(),
+            "detected timezone does not reproduce chrono::Local — leaving the \
+             bucketing timezone unpinned rather than re-keying history"
+        );
+        return None;
+    }
+
+    Some(candidate.name().to_string())
+}
+
+/// The zone this machine claims to be in, as an IANA name.
+///
+/// `TZ` is consulted first because it is what `chrono::Local` itself honors,
+/// and `chrono::Local` is what produced every date already on disk. Falling
+/// back to `iana-time-zone` covers the normal case where `TZ` is unset.
+///
+/// Either source can be wrong or absent; [`detect_local_iana_name`] verifies
+/// the result regardless of which one produced it.
+fn candidate_local_zone() -> Option<chrono_tz::Tz> {
+    tz_env_zone().or_else(|| iana_time_zone::get_timezone().ok()?.parse().ok())
+}
+
+/// `TZ` as an IANA zone, if it names one.
+///
+/// POSIX allows a leading colon (`TZ=:Asia/Seoul`). Values that are not zone
+/// names — `TZ=EST5EDT`-style rules, `TZ=<+09>-9`, a path — return `None`;
+/// those are honored by `chrono::Local` but cannot be stored as a pinned name.
+fn tz_env_zone() -> Option<chrono_tz::Tz> {
+    let raw = std::env::var("TZ").ok()?;
+    let name = raw.strip_prefix(':').unwrap_or(&raw);
+    name.parse::<chrono_tz::Tz>().ok()
+}
+
+/// Whether two zones are observationally identical for bucketing purposes.
+///
+/// Day keys depend on a zone only through its UTC offset, so two zones that
+/// agree on offset at every instant produce identical buckets and are
+/// interchangeable here — `Etc/UTC` and `UTC`, or `America/New_York` and
+/// `America/Toronto`. Anything that differs anywhere in the sampled window
+/// would move a day boundary, and is rejected.
+///
+/// Sampled rather than proven: every 6 hours from 8 years back to 1 year
+/// ahead, which is ~13k offset lookups (a binary search each) and runs once,
+/// on the first scan. That window covers the history a device could plausibly
+/// hold and every DST season in it. The residual is two zones whose offsets
+/// differ only inside a window shorter than the step — bounded to hours on a
+/// transition day, versus the unbounded whole-history re-split this replaces.
+fn zones_agree<A, B>(candidate: &A, reference: &B) -> bool
+where
+    A: TimeZone,
+    B: TimeZone,
+{
+    const STEP_MS: i64 = 6 * 60 * 60 * 1000;
+    const YEAR_MS: i64 = 365 * 24 * 60 * 60 * 1000;
+
+    let now = chrono::Utc::now().timestamp_millis();
+    let start = now - 8 * YEAR_MS;
+    let end = now + YEAR_MS;
+
+    let mut at = start;
+    while at <= end {
+        if offset_seconds(candidate, at) != offset_seconds(reference, at) {
+            return false;
+        }
+        at += STEP_MS;
+    }
+
+    true
+}
+
+/// The zone's UTC offset in seconds at an instant, or `None` if unrepresentable.
+fn offset_seconds<Tz>(timezone: &Tz, timestamp_ms: i64) -> Option<i32>
+where
+    Tz: TimeZone,
+{
+    use chrono::Offset;
+
+    timezone
+        .timestamp_millis_opt(timestamp_ms)
+        .single()
+        .map(|dt| dt.offset().fix().local_minus_utc())
 }
 
 #[cfg(test)]
@@ -243,6 +368,67 @@ mod tests {
         );
     }
 
+    /// Zones that produce the same offset at every instant produce the same day
+    /// keys, so they are interchangeable and pinning either is a no-op.
+    #[test]
+    fn observationally_identical_zones_agree() {
+        let utc: chrono_tz::Tz = "Etc/UTC".parse().unwrap();
+        assert!(zones_agree(&utc, &chrono::Utc));
+        assert!(zones_agree(&utc, &"UTC".parse::<chrono_tz::Tz>().unwrap()));
+
+        // Same rules, different names — a device may legitimately be detected
+        // as either and neither moves a day boundary.
+        let new_york: chrono_tz::Tz = "America/New_York".parse().unwrap();
+        let toronto: chrono_tz::Tz = "America/Toronto".parse().unwrap();
+        assert!(zones_agree(&new_york, &toronto));
+    }
+
+    /// The guard that keeps the first run from re-keying history.
+    #[test]
+    fn zones_with_different_offsets_are_rejected() {
+        let seoul: chrono_tz::Tz = "Asia/Seoul".parse().unwrap();
+        let utc: chrono_tz::Tz = "Etc/UTC".parse().unwrap();
+        assert!(
+            !zones_agree(&seoul, &utc),
+            "a nine-hour difference must never be accepted as the same zone"
+        );
+
+        // The subtle case: identical offset for part of the year, different DST
+        // rules. Sampling a single instant would let this through in winter.
+        let london: chrono_tz::Tz = "Europe/London".parse().unwrap();
+        assert!(
+            !zones_agree(&london, &utc),
+            "matching offsets in winter must not pass for a zone that observes DST"
+        );
+
+        // And against a fixed offset, which is what a `TZ=<+09>-9` host looks
+        // like to `chrono::Local`: same offset now, no transitions ever.
+        let fixed_seoul = chrono::FixedOffset::east_opt(9 * 3600).unwrap();
+        assert!(zones_agree(&seoul, &fixed_seoul), "Asia/Seoul has no DST");
+        assert!(
+            !zones_agree(&london, &chrono::FixedOffset::east_opt(0).unwrap()),
+            "a fixed offset cannot stand in for a zone that observes DST"
+        );
+    }
+
+    #[test]
+    fn tz_env_is_read_as_a_zone_name_only_when_it_is_one() {
+        // Not asserting on the live environment — exercising the parse rule the
+        // TZ path uses, including the POSIX leading colon.
+        assert_eq!(
+            "Asia/Seoul".parse::<chrono_tz::Tz>().ok(),
+            ":Asia/Seoul"
+                .strip_prefix(':')
+                .unwrap()
+                .parse::<chrono_tz::Tz>()
+                .ok()
+        );
+        // POSIX rule strings are honored by `chrono::Local` but are not names
+        // that can be pinned, so they must fall through to the detector.
+        assert!("<+09>-9".parse::<chrono_tz::Tz>().is_err());
+        assert!("/etc/localtime".parse::<chrono_tz::Tz>().is_err());
+    }
+
     #[test]
     fn detection_either_names_a_real_zone_or_declines() {
         // Host-dependent, so assert the contract rather than a value: whatever
@@ -252,6 +438,13 @@ mod tests {
             assert!(
                 BucketTimezone::from_pinned_name(Some(&name)).is_pinned(),
                 "detected zone {name} must be re-resolvable"
+            );
+            // The contract that makes auto-pinning safe: whatever comes back
+            // buckets identically to what the parsers already used.
+            let pinned: chrono_tz::Tz = name.parse().unwrap();
+            assert!(
+                zones_agree(&pinned, &chrono::Local),
+                "detected zone {name} must reproduce chrono::Local"
             );
         }
     }

--- a/crates/tokscale-core/src/bucket_tz.rs
+++ b/crates/tokscale-core/src/bucket_tz.rs
@@ -233,22 +233,38 @@ fn tz_env_zone() -> Option<chrono_tz::Tz> {
 /// `America/Toronto`. Anything that differs anywhere in the sampled window
 /// would move a day boundary, and is rejected.
 ///
-/// Sampled rather than proven: every 6 hours from 8 years back to 1 year
-/// ahead, which is ~13k offset lookups (a binary search each) and runs once,
-/// on the first scan. That window covers the history a device could plausibly
-/// hold and every DST season in it. The residual is two zones whose offsets
-/// differ only inside a window shorter than the step — bounded to hours on a
-/// transition day, versus the unbounded whole-history re-split this replaces.
+/// Sampled rather than proven, at a density chosen by measurement rather than
+/// by feel: every 30 minutes from 10 years back to 1 year ahead. That is
+/// 192,721 offset lookups, timed on Linux at **11.4 ms** release / 65 ms debug
+/// for a full accepting pass against `chrono::Local`. It runs once per scan
+/// while nothing is pinned, and never again after. A rejecting pass is far
+/// cheaper: a wholly different zone is caught on the first probe.
+///
+/// (Measured against `chrono::Local` specifically, not against another
+/// `chrono-tz` zone — `Local` re-checks the `TZ` environment variable on every
+/// lookup, which a `chrono-tz`-to-`chrono-tz` benchmark does not capture and
+/// which made an earlier proxy measurement read ~30% low.)
+///
+/// The step has to be smaller than the shortest interval over which two
+/// plausible zones can disagree. DST offsets move in whole or half hours, and
+/// the tightest real case is a 30-minute shift (`Australia/Lord_Howe`), so 30
+/// minutes catches every divergence the tz database can express as a
+/// transition. A coarser step would not: at 6 hours, two zones whose
+/// transitions differ by an hour would look identical.
+///
+/// What remains uncovered is history older than the window. Two zones that
+/// agree across eleven years of samples but diverged before that are the same
+/// zone or an alias for every practical purpose.
 fn zones_agree<A, B>(candidate: &A, reference: &B) -> bool
 where
     A: TimeZone,
     B: TimeZone,
 {
-    const STEP_MS: i64 = 6 * 60 * 60 * 1000;
+    const STEP_MS: i64 = 30 * 60 * 1000;
     const YEAR_MS: i64 = 365 * 24 * 60 * 60 * 1000;
 
     let now = chrono::Utc::now().timestamp_millis();
-    let start = now - 8 * YEAR_MS;
+    let start = now - 10 * YEAR_MS;
     let end = now + YEAR_MS;
 
     let mut at = start;
@@ -408,6 +424,17 @@ mod tests {
         assert!(
             !zones_agree(&london, &chrono::FixedOffset::east_opt(0).unwrap()),
             "a fixed offset cannot stand in for a zone that observes DST"
+        );
+
+        // The case that sets the sampling step. Lord Howe shifts by 30 minutes
+        // where Sydney shifts by an hour, so for part of each DST season they
+        // differ by only half an hour. A step coarser than that would step over
+        // the divergence and accept two zones that bucket differently.
+        let lord_howe: chrono_tz::Tz = "Australia/Lord_Howe".parse().unwrap();
+        let sydney: chrono_tz::Tz = "Australia/Sydney".parse().unwrap();
+        assert!(
+            !zones_agree(&lord_howe, &sydney),
+            "a half-hour DST difference must be detected"
         );
     }
 

--- a/crates/tokscale-core/src/bucket_tz.rs
+++ b/crates/tokscale-core/src/bucket_tz.rs
@@ -1,0 +1,252 @@
+//! The timezone a scan buckets usage into.
+//!
+//! Which local calendar day a unit of usage lands in used to be a function of
+//! the machine's timezone *at scan time*: every date string was derived from
+//! `chrono::Local`, read afresh on every run. Rescanning the same history from
+//! another zone therefore re-split it across days, and the server's monotonic
+//! per-day guard kept the stale value on one day while accepting the new one on
+//! its neighbour — inflating the total permanently, with no way to walk it back.
+//!
+//! The bucket key has to come from a value the machine cannot silently change
+//! underneath a rescan. So the CLI records the zone once and reuses it.
+//!
+//! # Why a named IANA zone and not a fixed offset
+//!
+//! A `chrono::FixedOffset` would need no new dependency, but it does not follow
+//! DST. Pin `UTC+09:00` in a zone that observes DST and the pinned offset stops
+//! matching local midnight the moment the transition happens, so usage within an
+//! hour of the boundary lands on the wrong day — a bounded re-run of the very
+//! bug being removed here. A named zone carries the transition rules, so local
+//! midnight stays local midnight and the fix is exact rather than approximate.
+//!
+//! # Unpinned is not "pinned to Local"
+//!
+//! [`BucketTimezone::Local`] exists so that a device which has never pinned
+//! keeps today's semantics *exactly*. Callers are expected to skip the rebucket
+//! pass entirely when [`BucketTimezone::is_pinned`] is false rather than
+//! re-derive dates through `Local`, so an unpinned scan does not depend on this
+//! module being byte-identical to what the parsers already computed.
+
+use std::fmt::Display;
+
+use chrono::TimeZone;
+
+/// The zone a scan buckets its day keys into.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum BucketTimezone {
+    /// No zone pinned. Day keys follow `chrono::Local`, re-read every scan.
+    /// This is the pre-pinning behaviour and stays the default so an existing
+    /// install does not change what it reports until it pins.
+    #[default]
+    Local,
+    /// A pinned IANA zone. Day keys are stable across rescans, machine
+    /// relocations, and `TZ` changes.
+    Pinned(chrono_tz::Tz),
+}
+
+impl BucketTimezone {
+    /// Resolve a configured zone name.
+    ///
+    /// An absent, empty, or unparseable name yields [`BucketTimezone::Local`].
+    /// A stale or hand-typo'd `bucketTimezone` must never break a scan — the
+    /// same lossy-config posture the rest of settings.json takes — so this
+    /// degrades to today's behaviour instead of erroring.
+    pub fn from_pinned_name(raw: Option<&str>) -> Self {
+        let Some(name) = raw.map(str::trim).filter(|name| !name.is_empty()) else {
+            return Self::Local;
+        };
+
+        match name.parse::<chrono_tz::Tz>() {
+            Ok(tz) => Self::Pinned(tz),
+            Err(_) => {
+                tracing::warn!(
+                    timezone = name,
+                    "scanner.bucketTimezone is not a known IANA zone name — \
+                     falling back to the machine's local timezone"
+                );
+                Self::Local
+            }
+        }
+    }
+
+    /// Read the pinned zone out of scanner settings.
+    pub fn from_scanner_settings(settings: &crate::scanner::ScannerSettings) -> Self {
+        Self::from_pinned_name(settings.bucket_timezone.as_deref())
+    }
+
+    /// The canonical IANA name of the pinned zone, or `None` when unpinned.
+    pub fn pinned_name(&self) -> Option<&'static str> {
+        match self {
+            Self::Local => None,
+            Self::Pinned(tz) => Some(tz.name()),
+        }
+    }
+
+    /// Whether a zone is pinned. Callers use this to skip the rebucket pass
+    /// entirely rather than re-derive dates through `Local`.
+    pub fn is_pinned(&self) -> bool {
+        matches!(self, Self::Pinned(_))
+    }
+
+    /// Today's date in this zone.
+    ///
+    /// `--today` / `--week` / `--month` filter on the same `date` strings the
+    /// buckets are keyed by, so they have to agree on where a day starts. A
+    /// device pinned to `Asia/Seoul` and run from California would otherwise
+    /// select the host's today out of Seoul-keyed buckets and submit a partial
+    /// day — and a partial day is exactly what the server's monotonic guard
+    /// then freezes.
+    pub fn today(&self) -> chrono::NaiveDate {
+        let now = chrono::Utc::now();
+        match self {
+            Self::Local => now.with_timezone(&chrono::Local).date_naive(),
+            Self::Pinned(tz) => now.with_timezone(tz).date_naive(),
+        }
+    }
+
+    /// The `YYYY-MM-DD` day key this instant falls in.
+    pub fn day_key(&self, timestamp_ms: i64) -> String {
+        match self {
+            Self::Local => format_day_key(timestamp_ms, &chrono::Local),
+            Self::Pinned(tz) => format_day_key(timestamp_ms, tz),
+        }
+    }
+}
+
+/// Format an instant as a `YYYY-MM-DD` day key in `timezone`.
+///
+/// Returns an empty string for an instant the zone cannot represent, matching
+/// what the pre-pinning `timestamp_to_date` did. Mapping an *instant* into a
+/// zone is unambiguous for every real zone — the ambiguity in `chrono` runs the
+/// other way, local wall-clock to instant — so the non-`Single` arm is a
+/// defensive floor, not a live path.
+pub(crate) fn format_day_key<Tz>(timestamp_ms: i64, timezone: &Tz) -> String
+where
+    Tz: TimeZone,
+    Tz::Offset: Display,
+{
+    match timezone.timestamp_millis_opt(timestamp_ms) {
+        chrono::LocalResult::Single(dt) => dt.format("%Y-%m-%d").to_string(),
+        _ => String::new(),
+    }
+}
+
+/// The machine's current IANA zone name, if it can be determined.
+///
+/// `iana-time-zone` is already in the dependency graph — `chrono` pulls it in
+/// to implement `Local` — so reading the name costs no new code in the binary.
+///
+/// Returns `None` when the platform cannot name its zone (a bare `TZ=+09:00`,
+/// a container with no zoneinfo). Callers must treat that as "do not pin"
+/// rather than substituting a fixed offset: an offset that cannot follow DST is
+/// exactly the failure mode pinning exists to remove.
+pub fn detect_local_iana_name() -> Option<String> {
+    let name = iana_time_zone::get_timezone().ok()?;
+    // Round-trip through the tz database. A name we cannot parse back is a
+    // name we could not honor on a later scan, and pinning it would silently
+    // fall back to `Local` forever.
+    name.parse::<chrono_tz::Tz>()
+        .ok()
+        .map(|tz| tz.name().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unset_and_blank_names_stay_unpinned() {
+        assert_eq!(BucketTimezone::from_pinned_name(None), BucketTimezone::Local);
+        assert_eq!(BucketTimezone::from_pinned_name(Some("")), BucketTimezone::Local);
+        assert_eq!(
+            BucketTimezone::from_pinned_name(Some("   ")),
+            BucketTimezone::Local
+        );
+        assert!(!BucketTimezone::from_pinned_name(None).is_pinned());
+    }
+
+    #[test]
+    fn unknown_zone_name_degrades_to_local_instead_of_failing() {
+        assert_eq!(
+            BucketTimezone::from_pinned_name(Some("Mars/Olympus_Mons")),
+            BucketTimezone::Local
+        );
+        // A fixed-offset string is not an IANA name and must not be accepted:
+        // silently honoring it would pin a zone that cannot follow DST.
+        assert_eq!(
+            BucketTimezone::from_pinned_name(Some("+09:00")),
+            BucketTimezone::Local
+        );
+    }
+
+    #[test]
+    fn pinned_zone_keys_the_same_instant_the_same_way_regardless_of_host() {
+        let tz = BucketTimezone::from_pinned_name(Some("Asia/Seoul")).clone();
+        assert_eq!(tz.pinned_name(), Some("Asia/Seoul"));
+        assert!(tz.is_pinned());
+
+        // 2026-03-02T18:00:00Z — 2026-03-03 03:00 in Seoul, 2026-03-02 10:00 in
+        // Los Angeles. The day key follows the pinned zone, not the host.
+        let instant = 1_772_474_400_000;
+        assert_eq!(tz.day_key(instant), "2026-03-03");
+        assert_eq!(
+            BucketTimezone::from_pinned_name(Some("America/Los_Angeles")).day_key(instant),
+            "2026-03-02"
+        );
+    }
+
+    /// The reason this module does not use `FixedOffset`. A zone that observes
+    /// DST changes its offset mid-year; an offset pinned before the transition
+    /// keys instants after it onto the wrong day near midnight.
+    #[test]
+    fn named_zone_follows_dst_where_a_fixed_offset_would_not() {
+        let ny = BucketTimezone::from_pinned_name(Some("America/New_York"));
+
+        // 2026-01-15T04:30:00Z — 23:30 on the 14th in EST (UTC-5).
+        let winter = chrono::DateTime::parse_from_rfc3339("2026-01-15T04:30:00Z")
+            .unwrap()
+            .timestamp_millis();
+        // 2026-07-15T03:30:00Z — 23:30 on the 14th in EDT (UTC-4).
+        let summer = chrono::DateTime::parse_from_rfc3339("2026-07-15T03:30:00Z")
+            .unwrap()
+            .timestamp_millis();
+
+        assert_eq!(ny.day_key(winter), "2026-01-14");
+        assert_eq!(ny.day_key(summer), "2026-07-14");
+
+        // The same instants under the winter offset frozen as a fixed value:
+        // the summer one lands a day late.
+        let frozen = chrono::FixedOffset::west_opt(5 * 3600).unwrap();
+        assert_eq!(format_day_key(winter, &frozen), "2026-01-14");
+        assert_eq!(
+            format_day_key(summer, &frozen),
+            "2026-07-14",
+            "sanity: 03:30Z is 22:30 EST, still the 14th"
+        );
+
+        // And where it actually bites: 00:30 EDT on the 15th is 23:30 EST on
+        // the 14th under a frozen winter offset.
+        let after_midnight_edt = chrono::DateTime::parse_from_rfc3339("2026-07-15T04:30:00Z")
+            .unwrap()
+            .timestamp_millis();
+        assert_eq!(ny.day_key(after_midnight_edt), "2026-07-15");
+        assert_eq!(
+            format_day_key(after_midnight_edt, &frozen),
+            "2026-07-14",
+            "a frozen offset buckets an hour of every DST-shifted day onto the wrong date"
+        );
+    }
+
+    #[test]
+    fn detection_either_names_a_real_zone_or_declines() {
+        // Host-dependent, so assert the contract rather than a value: whatever
+        // comes back must round-trip through the tz database, because a name
+        // that does not would pin to something later scans silently ignore.
+        if let Some(name) = detect_local_iana_name() {
+            assert!(
+                BucketTimezone::from_pinned_name(Some(&name)).is_pinned(),
+                "detected zone {name} must be re-resolvable"
+            );
+        }
+    }
+}

--- a/crates/tokscale-core/src/bucket_tz.rs
+++ b/crates/tokscale-core/src/bucket_tz.rs
@@ -225,25 +225,78 @@ fn tz_env_zone() -> Option<chrono_tz::Tz> {
     name.parse::<chrono_tz::Tz>().ok()
 }
 
+/// Approximate milliseconds in a year. Only used to size the forward edge of
+/// the agreement window, where a year either way is immaterial.
+const YEAR_MS: i64 = 365 * 24 * 60 * 60 * 1000;
+
+/// The first instant [`zones_agree`] checks: the Unix epoch.
+///
+/// Every day key in tokscale is derived from a `timestamp` field holding Unix
+/// milliseconds, and the rebucket passes decline to move a message whose
+/// timestamp is not strictly positive (see `UnifiedMessage::rebucket_date`) —
+/// that value is the parsers' "no timestamp" sentinel, not a real instant. So
+/// the epoch is not a convenient cut-off: it is a lower bound on every instant
+/// auto-pinning can actually re-key.
+pub(crate) const AGREEMENT_WINDOW_START_MS: i64 = 0;
+
+/// How far past "now" [`zones_agree`] checks.
+///
+/// Timestamps ahead of the clock come from clock skew or a corrupt file rather
+/// than from history, so this only has to be comfortably beyond anything a
+/// scan will meet before the next release re-runs the check.
+pub(crate) const AGREEMENT_WINDOW_AHEAD_MS: i64 = 10 * YEAR_MS;
+
+// The window's reach *is* the safety claim, so hold it here rather than leaving
+// it to two constants nobody re-reads. Narrowing either edge means the pin can
+// be accepted for instants nobody checked.
+const _: () = assert!(
+    AGREEMENT_WINDOW_START_MS == 0,
+    "the rebucket passes skip non-positive timestamps, so the window must start \
+     at the epoch to cover every instant they do move"
+);
+const _: () = assert!(
+    AGREEMENT_WINDOW_AHEAD_MS >= 5 * YEAR_MS,
+    "the forward edge must stay well past any clock skew a scan will meet"
+);
+
 /// Whether two zones are observationally identical for bucketing purposes.
 ///
 /// Day keys depend on a zone only through its UTC offset, so two zones that
 /// agree on offset at every instant produce identical buckets and are
 /// interchangeable here — `Etc/UTC` and `UTC`, or `America/New_York` and
-/// `America/Toronto`. Anything that differs anywhere in the sampled window
-/// would move a day boundary, and is rejected.
+/// `America/Toronto`. Anything that differs anywhere in the window would move a
+/// day boundary, and is rejected.
 ///
-/// Sampled rather than proven, at a density chosen by measurement rather than
-/// by feel: every 30 minutes from 10 years back to 1 year ahead. That is
-/// 192,721 offset lookups, timed on Linux at **11.4 ms** release / 65 ms debug
-/// for a full accepting pass against `chrono::Local`. It runs once per scan
-/// while nothing is pinned, and never again after. A rejecting pass is far
-/// cheaper: a wholly different zone is caught on the first probe.
+/// # Why the window starts at the epoch
 ///
-/// (Measured against `chrono::Local` specifically, not against another
-/// `chrono-tz` zone — `Local` re-checks the `TZ` environment variable on every
-/// lookup, which a `chrono-tz`-to-`chrono-tz` benchmark does not capture and
-/// which made an earlier proxy measurement read ~30% low.)
+/// The claim auto-pinning rests on is "pinning never changes existing
+/// bucketing". A window that reaches back a fixed number of years cannot
+/// support that claim: two zones can match across recent rules and still differ
+/// in older ones, and `rebucket_days` applies an accepted pin to *every*
+/// message, including one older than the window. That is the same defect as
+/// sampling too coarsely, one level up — and the fix is the same shape, which
+/// is to make the checked range cover everything that can be re-keyed rather
+/// than a sample of it.
+///
+/// So the window runs from [`AGREEMENT_WINDOW_START_MS`] — the Unix epoch, the
+/// lower bound on any instant the rebucket passes will move — to ten years
+/// ahead. Nothing auto-pinning can re-key falls outside it.
+///
+/// # What the wider window costs
+///
+/// It rejects more. Two zones that share today's rules but split in the 1970s
+/// or 1980s no longer pass — `America/New_York` and `America/Toronto` diverged
+/// over the 1974-75 US emergency DST, `Asia/Seoul` and `Asia/Tokyo` over
+/// Seoul's 1987-88 DST — and if the host's zoneinfo and the bundled `chrono-tz`
+/// database ever disagree on an old rule for the *same* zone name, this
+/// declines to pin at all.
+///
+/// That is the safe direction to be wrong in. Declining leaves the device
+/// exactly where it was: bucketing by `chrono::Local`, carrying a bug it
+/// already had. Accepting wrongly rewrites history that is already on the
+/// server, behind a monotonic guard that makes the result permanent.
+///
+/// # Why sampling at 30 minutes is enough inside the window
 ///
 /// The step has to be smaller than the shortest interval over which two
 /// plausible zones can disagree. DST offsets move in whole or half hours, and
@@ -252,23 +305,41 @@ fn tz_env_zone() -> Option<chrono_tz::Tz> {
 /// transition. A coarser step would not: at 6 hours, two zones whose
 /// transitions differ by an hour would look identical.
 ///
-/// What remains uncovered is history older than the window. Two zones that
-/// agree across eleven years of samples but diverged before that are the same
-/// zone or an alias for every practical purpose.
+/// # Cost
+///
+/// 1,167,280 offset lookups for a full accepting pass against `chrono::Local`,
+/// measured at **56 ms** release / 786 ms debug (up from 11.4 ms / 136 ms for
+/// the old 10-years-back window). It runs once per scan while nothing is
+/// pinned, and never again after the first run records a zone. A rejecting pass
+/// is far cheaper: a wholly different zone is caught on the first probe.
+///
+/// (Measured against `chrono::Local` specifically, not against another
+/// `chrono-tz` zone — `Local` re-checks the `TZ` environment variable on every
+/// lookup, which a `chrono-tz`-to-`chrono-tz` benchmark does not capture and
+/// which made an earlier proxy measurement read ~30% low.)
 fn zones_agree<A, B>(candidate: &A, reference: &B) -> bool
 where
     A: TimeZone,
     B: TimeZone,
 {
+    zones_agree_between(
+        candidate,
+        reference,
+        AGREEMENT_WINDOW_START_MS,
+        chrono::Utc::now().timestamp_millis() + AGREEMENT_WINDOW_AHEAD_MS,
+    )
+}
+
+/// [`zones_agree`] over an explicit range, so the window can be varied in tests.
+fn zones_agree_between<A, B>(candidate: &A, reference: &B, start_ms: i64, end_ms: i64) -> bool
+where
+    A: TimeZone,
+    B: TimeZone,
+{
     const STEP_MS: i64 = 30 * 60 * 1000;
-    const YEAR_MS: i64 = 365 * 24 * 60 * 60 * 1000;
 
-    let now = chrono::Utc::now().timestamp_millis();
-    let start = now - 10 * YEAR_MS;
-    let end = now + YEAR_MS;
-
-    let mut at = start;
-    while at <= end {
+    let mut at = start_ms;
+    while at <= end_ms {
         if offset_seconds(candidate, at) != offset_seconds(reference, at) {
             return false;
         }
@@ -393,10 +464,16 @@ mod tests {
         assert!(zones_agree(&utc, &"UTC".parse::<chrono_tz::Tz>().unwrap()));
 
         // Same rules, different names — a device may legitimately be detected
-        // as either and neither moves a day boundary.
+        // as either and neither moves a day boundary. These are tz database
+        // *links*, so they are the same rules by construction rather than by
+        // two zones happening to have matched recently.
         let new_york: chrono_tz::Tz = "America/New_York".parse().unwrap();
-        let toronto: chrono_tz::Tz = "America/Toronto".parse().unwrap();
-        assert!(zones_agree(&new_york, &toronto));
+        let us_eastern: chrono_tz::Tz = "US/Eastern".parse().unwrap();
+        assert!(zones_agree(&new_york, &us_eastern));
+
+        let seoul: chrono_tz::Tz = "Asia/Seoul".parse().unwrap();
+        let rok: chrono_tz::Tz = "ROK".parse().unwrap();
+        assert!(zones_agree(&seoul, &rok));
     }
 
     /// The guard that keeps the first run from re-keying history.
@@ -419,8 +496,18 @@ mod tests {
 
         // And against a fixed offset, which is what a `TZ=<+09>-9` host looks
         // like to `chrono::Local`: same offset now, no transitions ever.
-        let fixed_seoul = chrono::FixedOffset::east_opt(9 * 3600).unwrap();
-        assert!(zones_agree(&seoul, &fixed_seoul), "Asia/Seoul has no DST");
+        // Tokyo, not Seoul — Seoul observed DST in 1987-88, and the window now
+        // reaches back far enough to see it.
+        let tokyo: chrono_tz::Tz = "Asia/Tokyo".parse().unwrap();
+        let plus_nine = chrono::FixedOffset::east_opt(9 * 3600).unwrap();
+        assert!(
+            zones_agree(&tokyo, &plus_nine),
+            "Asia/Tokyo has had no DST since the epoch"
+        );
+        assert!(
+            !zones_agree(&seoul, &plus_nine),
+            "Asia/Seoul's 1987-88 DST is inside the window and must be seen"
+        );
         assert!(
             !zones_agree(&london, &chrono::FixedOffset::east_opt(0).unwrap()),
             "a fixed offset cannot stand in for a zone that observes DST"
@@ -430,11 +517,51 @@ mod tests {
         // where Sydney shifts by an hour, so for part of each DST season they
         // differ by only half an hour. A step coarser than that would step over
         // the divergence and accept two zones that bucket differently.
+        //
+        // Asserted over a recent window as well as the full one: across all of
+        // history these two diverge in bigger ways too, and the point here is
+        // that the *current* half-hour difference is still caught.
         let lord_howe: chrono_tz::Tz = "Australia/Lord_Howe".parse().unwrap();
         let sydney: chrono_tz::Tz = "Australia/Sydney".parse().unwrap();
         assert!(
             !zones_agree(&lord_howe, &sydney),
             "a half-hour DST difference must be detected"
+        );
+        let now = chrono::Utc::now().timestamp_millis();
+        assert!(
+            !zones_agree_between(&lord_howe, &sydney, now - 2 * YEAR_MS, now),
+            "and detected from recent samples alone, not only from old history"
+        );
+    }
+
+    /// The window has to cover everything an accepted pin can re-key, not a
+    /// recent slice of it.
+    ///
+    /// `rebucket_days` applies the pin to *every* message, so a zone that
+    /// matches `chrono::Local` across the last decade but diverges in older
+    /// rules would still move day boundaries in older history. Seoul and Tokyo
+    /// are exactly that pair: both fixed at UTC+09:00 for decades, but Seoul
+    /// observed DST in 1987 and 1988 and Tokyo did not.
+    #[test]
+    fn zones_that_only_diverge_before_the_last_decade_are_still_rejected() {
+        let seoul: chrono_tz::Tz = "Asia/Seoul".parse().unwrap();
+        let tokyo: chrono_tz::Tz = "Asia/Tokyo".parse().unwrap();
+
+        let now = chrono::Utc::now().timestamp_millis();
+        const YEAR: i64 = 365 * 24 * 60 * 60 * 1000;
+
+        // The premise: indistinguishable across the window this check used to
+        // sample. If this ever stops holding the test below proves nothing.
+        assert!(
+            zones_agree_between(&seoul, &tokyo, now - 10 * YEAR, now + YEAR),
+            "Seoul and Tokyo must be indistinguishable over the last decade for \
+             this test to be about the window rather than the zones"
+        );
+
+        assert!(
+            !zones_agree(&seoul, &tokyo),
+            "a divergence older than the previous window must still be caught — \
+             Seoul's 1987-88 DST moves day boundaries the pin would silently rewrite"
         );
     }
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -4026,7 +4026,11 @@ fn rebucket_parsed_days(
     }
 
     for message in messages.iter_mut() {
-        // See `UnifiedMessage::rebucket_date` for why an empty key is kept out.
+        // See `UnifiedMessage::rebucket_date` for why a non-positive timestamp
+        // and an empty key are both kept out.
+        if message.timestamp <= 0 {
+            continue;
+        }
         let key = timezone.day_key(message.timestamp);
         if !key.is_empty() {
             message.date = key;

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::all)]
 
 mod aggregator;
+pub mod bucket_tz;
 mod cc_mirror;
 pub mod clients;
 pub mod content_extractor;
@@ -20,13 +21,14 @@ pub mod tui_signal;
 pub mod wiki;
 
 pub use aggregator::*;
+pub use bucket_tz::BucketTimezone;
 pub use clients::{ClientCounts, ClientDef, ClientId, PathRoot};
 pub use model_alias::ModelAliasMap;
 pub use parser::*;
 pub use scanner::*;
 pub use sessionize::{
-    compute_daily_active_time, compute_time_metrics, sessionize, SessionInterval, TimeMetrics,
-    DEFAULT_IDLE_GAP_MS,
+    compute_daily_active_time, compute_daily_active_time_in, compute_time_metrics, sessionize,
+    SessionInterval, TimeMetrics, DEFAULT_IDLE_GAP_MS,
 };
 pub use sessions::{CostSource, UnifiedMessage};
 
@@ -2094,9 +2096,13 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         all_messages.extend(kiro_db_messages);
     }
 
+    // Crush decides its day split at parse time (it allocates session cost
+    // across days), so it needs the pinned zone here — the post-parse
+    // `rebucket_days` pass cannot recover a split this grouping collapsed.
+    let crush_bucket_timezone = bucket_tz::BucketTimezone::from_scanner_settings(scanner_settings);
     for source in &scan_result.crush_dbs {
         let crush_messages: Vec<UnifiedMessage> =
-            sessions::crush::parse_crush_sqlite(&source.db_path)
+            sessions::crush::parse_crush_sqlite_in(&source.db_path, &crush_bucket_timezone)
                 .into_iter()
                 .map(|mut msg| {
                     msg.set_workspace(source.workspace_key.clone(), source.workspace_label.clone());
@@ -2319,7 +2325,35 @@ fn parse_all_messages_with_pricing_with_env_strategy(
 
     source_cache.save_if_dirty();
 
+    rebucket_days(&mut all_messages, scanner_settings);
+
     all_messages
+}
+
+/// Re-key every message onto the device's pinned bucketing timezone.
+///
+/// The parsers derive `date` from `chrono::Local`, read afresh on every scan,
+/// so which day a message lands in changes when the machine's zone does. This
+/// is the one pass that knows the user's settings and sees every message, so it
+/// is where the day key gets fixed to something a rescan cannot move.
+///
+/// Runs after the source cache is written on purpose: the cache stores raw
+/// parser output and `refresh_derived_fields` re-derives `date` on every load,
+/// so cached entries never carry a stale day key past this point and changing
+/// the pinned zone needs no cache invalidation.
+///
+/// **No-op when nothing is pinned.** An unpinned device must report exactly
+/// what it reported before, so the pass is skipped rather than re-derived
+/// through `Local`.
+fn rebucket_days(messages: &mut [UnifiedMessage], scanner_settings: &scanner::ScannerSettings) {
+    let timezone = bucket_tz::BucketTimezone::from_scanner_settings(scanner_settings);
+    if !timezone.is_pinned() {
+        return;
+    }
+
+    for message in messages.iter_mut() {
+        message.rebucket_date(&timezone);
+    }
 }
 
 fn dedupe_latest_trae_messages(mut messages: Vec<UnifiedMessage>) -> Vec<UnifiedMessage> {
@@ -2871,7 +2905,15 @@ async fn generate_graph_with_loaded_pricing(
 
     let filtered = filter_messages_for_report(all_messages, &options);
 
-    build_graph_from_messages(filtered, pricing, pricing_requirement, start)
+    let bucket_timezone = bucket_tz::BucketTimezone::from_scanner_settings(&options.scanner_settings);
+
+    build_graph_from_messages(
+        filtered,
+        pricing,
+        pricing_requirement,
+        start,
+        &bucket_timezone,
+    )
 }
 
 fn build_graph_from_messages(
@@ -2879,6 +2921,7 @@ fn build_graph_from_messages(
     pricing: Option<&pricing::PricingService>,
     pricing_requirement: GraphPricingRequirement,
     start: Instant,
+    bucket_timezone: &bucket_tz::BucketTimezone,
 ) -> Result<GraphResult, String> {
     if matches!(pricing_requirement, GraphPricingRequirement::Submission) {
         validate_priced_messages(&filtered, pricing)?;
@@ -2888,7 +2931,10 @@ fn build_graph_from_messages(
     let time_metrics =
         sessionize::compute_time_metrics(&intervals, sessionize::DEFAULT_IDLE_GAP_MS);
 
-    let daily_active_time = sessionize::compute_daily_active_time(&intervals);
+    // Keyed by the same zone the messages were rebucketed into. Active time is
+    // joined onto contributions by date below, so a mismatch here silently
+    // drops a day's active time rather than misplacing it.
+    let daily_active_time = sessionize::compute_daily_active_time_in(&intervals, bucket_timezone);
     let contributions = aggregator::aggregate_by_date(filtered);
 
     let processing_time_ms = start.elapsed().as_millis() as u32;
@@ -3711,11 +3757,14 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
         messages.extend(kiro_db_msgs);
     }
 
+    // See the crush block in `parse_all_messages_with_pricing_with_env_strategy`.
+    let crush_bucket_timezone =
+        bucket_tz::BucketTimezone::from_scanner_settings(&options.scanner_settings);
     let crush_msgs: Vec<ParsedMessage> = scan_result
         .crush_dbs
         .par_iter()
         .flat_map(|source| {
-            sessions::crush::parse_crush_sqlite(&source.db_path)
+            sessions::crush::parse_crush_sqlite_in(&source.db_path, &crush_bucket_timezone)
                 .into_iter()
                 .map(|mut msg| {
                     msg.set_workspace(source.workspace_key.clone(), source.workspace_label.clone());
@@ -3942,6 +3991,16 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
         }
     }
 
+    // Before the date filter, not after: `--since`/`--until` compare against
+    // `date`, so filtering first would select rows by the machine's live zone
+    // and then relabel them with the pinned one.
+    //
+    // This path builds `ParsedMessage` straight from the parsers instead of
+    // going through `parse_all_messages_with_pricing_with_env_strategy`, so it
+    // needs its own rebucket — `tokscale report` and `tokscale wrapped` read
+    // day keys from here.
+    rebucket_parsed_days(&mut messages, &options.scanner_settings);
+
     let filtered = filter_parsed_messages(messages, &options);
 
     Ok(ParsedMessages {
@@ -3949,6 +4008,26 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
         counts,
         processing_time_ms: start.elapsed().as_millis() as u32,
     })
+}
+
+/// [`rebucket_days`] for the `ParsedMessage` lane. Same contract: no-op unless
+/// a zone is pinned.
+fn rebucket_parsed_days(
+    messages: &mut [ParsedMessage],
+    scanner_settings: &scanner::ScannerSettings,
+) {
+    let timezone = bucket_tz::BucketTimezone::from_scanner_settings(scanner_settings);
+    if !timezone.is_pinned() {
+        return;
+    }
+
+    for message in messages.iter_mut() {
+        // See `UnifiedMessage::rebucket_date` for why an empty key is kept out.
+        let key = timezone.day_key(message.timestamp);
+        if !key.is_empty() {
+            message.date = key;
+        }
+    }
 }
 
 #[doc(hidden)]
@@ -7739,6 +7818,7 @@ mod tests {
             Some(&pricing),
             GraphPricingRequirement::Lenient,
             std::time::Instant::now(),
+            &crate::bucket_tz::BucketTimezone::Local,
         )
         .expect("reporting graphs should retain unpriced usage");
         let submission_error = build_graph_from_messages(
@@ -7746,6 +7826,7 @@ mod tests {
             Some(&pricing),
             GraphPricingRequirement::Submission,
             std::time::Instant::now(),
+            &crate::bucket_tz::BucketTimezone::Local,
         )
         .expect_err("submission graphs should reject unpriced usage");
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -2771,8 +2771,6 @@ struct HourAggregator {
 /// Derives the hour slot from `UnifiedMessage.timestamp` (Unix ms).
 /// Falls back to date + "00:00" when timestamp is zero or missing.
 pub async fn get_hourly_report(options: ReportOptions) -> Result<HourlyReport, String> {
-    use chrono::{Local, TimeZone};
-
     let start = Instant::now();
 
     let home_dir = get_home_dir_string(&options.home_dir)?;
@@ -2799,13 +2797,18 @@ pub async fn get_hourly_report(options: ReportOptions) -> Result<HourlyReport, S
 
     let mut hour_map: HashMap<String, HourAggregator> = HashMap::new();
 
+    // The hour key embeds a date, and the timestamp-less fallback below builds
+    // one out of `msg.date` — which the rebucket pass has already moved to the
+    // pinned zone. Deriving the primary key from the host instead would let a
+    // single report disagree with itself about which day an hour belongs to.
+    let bucket_timezone =
+        bucket_tz::BucketTimezone::from_scanner_settings(&options.scanner_settings);
+
     for msg in filtered {
         let hour_key = if msg.timestamp > 0 {
-            let ts_secs = msg.timestamp / 1000;
-            match Local.timestamp_opt(ts_secs, 0) {
-                chrono::LocalResult::Single(dt) => dt.format("%Y-%m-%d %H:00").to_string(),
-                _ => format!("{} 00:00", msg.date),
-            }
+            bucket_timezone
+                .hour_key(msg.timestamp)
+                .unwrap_or_else(|| format!("{} 00:00", msg.date))
         } else {
             format!("{} 00:00", msg.date)
         };

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -2905,7 +2905,8 @@ async fn generate_graph_with_loaded_pricing(
 
     let filtered = filter_messages_for_report(all_messages, &options);
 
-    let bucket_timezone = bucket_tz::BucketTimezone::from_scanner_settings(&options.scanner_settings);
+    let bucket_timezone =
+        bucket_tz::BucketTimezone::from_scanner_settings(&options.scanner_settings);
 
     build_graph_from_messages(
         filtered,

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -72,8 +72,9 @@ pub struct ScannerSettings {
     /// `chrono::Local` exactly as before — pinning changes nothing until it
     /// happens. The CLI fills this in on first run (see
     /// `tui::settings::pin_bucket_timezone_if_unset`); `tokscale config set
-    /// timezone <zone>` changes it deliberately, which is what a user who
-    /// relocates should do.
+    /// timezone <zone>` can initialize an unset value or recover an invalid
+    /// one. A valid pin cannot be changed because submitted day rows are
+    /// monotonic.
     ///
     /// An unparseable value degrades to unpinned rather than failing the scan.
     #[serde(default)]

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -58,6 +58,26 @@ pub struct ScannerSettings {
     /// so the JSON stays stable and human-editable.
     #[serde(default)]
     pub extra_scan_paths: BTreeMap<String, Vec<PathBuf>>,
+    /// IANA name of the timezone this device buckets usage days into, e.g.
+    /// `"Asia/Seoul"`.
+    ///
+    /// Which local calendar day a message lands in used to be read from
+    /// `chrono::Local` on every scan, so rescanning the same history from a
+    /// different zone re-split it across days. The server's monotonic per-day
+    /// guard then kept the stale value on one day and accepted the new one on
+    /// its neighbour, inflating the total permanently. Recording the zone once
+    /// makes the bucket key stable.
+    ///
+    /// `None` means the device has never pinned, and day keys keep following
+    /// `chrono::Local` exactly as before — pinning changes nothing until it
+    /// happens. The CLI fills this in on first run (see
+    /// `tui::settings::pin_bucket_timezone_if_unset`); `tokscale config set
+    /// timezone <zone>` changes it deliberately, which is what a user who
+    /// relocates should do.
+    ///
+    /// An unparseable value degrades to unpinned rather than failing the scan.
+    #[serde(default)]
+    pub bucket_timezone: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/tokscale-core/src/sessionize.rs
+++ b/crates/tokscale-core/src/sessionize.rs
@@ -288,6 +288,26 @@ pub fn compute_daily_active_time(
     compute_daily_active_time_with_timezone(intervals, &chrono::Local)
 }
 
+/// Per-day active time keyed by the scan's bucketing timezone.
+///
+/// Active time is keyed by day just like tokens are, so it has to follow the
+/// same pinned zone or the two disagree about which day a session near midnight
+/// belongs to — and `active_time_ms` is written per `(device, date)` on the
+/// server alongside the token totals.
+pub fn compute_daily_active_time_in(
+    intervals: &[SessionInterval],
+    timezone: &crate::bucket_tz::BucketTimezone,
+) -> std::collections::HashMap<String, i64> {
+    match timezone {
+        crate::bucket_tz::BucketTimezone::Local => {
+            compute_daily_active_time_with_timezone(intervals, &chrono::Local)
+        }
+        crate::bucket_tz::BucketTimezone::Pinned(tz) => {
+            compute_daily_active_time_with_timezone(intervals, tz)
+        }
+    }
+}
+
 fn compute_daily_active_time_with_timezone<Tz>(
     intervals: &[SessionInterval],
     timezone: &Tz,

--- a/crates/tokscale-core/src/sessions/crush.rs
+++ b/crates/tokscale-core/src/sessions/crush.rs
@@ -372,8 +372,10 @@ mod tests {
         // Kiritimati: 2026-03-03 01:30 and 08:00 — still one day, because both
         // turns cross together. Seoul is where they separate: 20:30 on the 2nd
         // and 03:00 on the 3rd.
-        let seoul =
-            parse_crush_sqlite_in(&db_path, &BucketTimezone::from_pinned_name(Some("Asia/Seoul")));
+        let seoul = parse_crush_sqlite_in(
+            &db_path,
+            &BucketTimezone::from_pinned_name(Some("Asia/Seoul")),
+        );
         assert_eq!(seoul.len(), 2, "Seoul splits the session across two days");
         assert_eq!(seoul[0].message_count, 1);
         assert_eq!(seoul[1].message_count, 1);
@@ -384,8 +386,10 @@ mod tests {
 
         // And the split is a function of the pin alone: the same call twice
         // returns the same shape regardless of what the host machine is set to.
-        let seoul_again =
-            parse_crush_sqlite_in(&db_path, &BucketTimezone::from_pinned_name(Some("Asia/Seoul")));
+        let seoul_again = parse_crush_sqlite_in(
+            &db_path,
+            &BucketTimezone::from_pinned_name(Some("Asia/Seoul")),
+        );
         assert_eq!(
             seoul.iter().map(|m| m.timestamp).collect::<Vec<_>>(),
             seoul_again.iter().map(|m| m.timestamp).collect::<Vec<_>>()

--- a/crates/tokscale-core/src/sessions/crush.rs
+++ b/crates/tokscale-core/src/sessions/crush.rs
@@ -13,8 +13,8 @@
 
 use super::utils::open_readonly_sqlite;
 use super::UnifiedMessage;
+use crate::bucket_tz::BucketTimezone;
 use crate::TokenBreakdown;
-use chrono::{Local, TimeZone};
 use rusqlite::Connection;
 use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
@@ -45,6 +45,22 @@ struct DayBucket {
 /// - session cost is allocated across those days proportionally
 /// - token fields remain zero
 pub fn parse_crush_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
+    parse_crush_sqlite_in(db_path, &BucketTimezone::Local)
+}
+
+/// [`parse_crush_sqlite`], keyed by the scan's bucketing timezone.
+///
+/// Crush is the one parser whose day split cannot be repaired by the post-parse
+/// rebucket pass. It allocates a session's cost across the days its assistant
+/// messages fall in and emits one message per day, so the *number* of messages
+/// and the cost on each is decided here, at parse time. Rebucketing afterwards
+/// can only relabel messages that already exist: if this grouping put two
+/// midnight-straddling turns in one day, the day they were split across is gone
+/// before the pass runs.
+pub fn parse_crush_sqlite_in(
+    db_path: &Path,
+    bucket_timezone: &BucketTimezone,
+) -> Vec<UnifiedMessage> {
     let Some(conn) = open_readonly_sqlite(db_path) else {
         return Vec::new();
     };
@@ -54,7 +70,7 @@ pub fn parse_crush_sqlite(db_path: &Path) -> Vec<UnifiedMessage> {
         return Vec::new();
     }
 
-    let assistant_buckets = load_assistant_buckets(&conn);
+    let assistant_buckets = load_assistant_buckets(&conn, bucket_timezone);
     let db_namespace = db_path.to_string_lossy().to_string();
     let mut messages = Vec::new();
 
@@ -152,7 +168,10 @@ fn load_root_sessions(conn: &Connection) -> Vec<CrushSession> {
     rows.flatten().collect()
 }
 
-fn load_assistant_buckets(conn: &Connection) -> HashMap<String, Vec<DayBucket>> {
+fn load_assistant_buckets(
+    conn: &Connection,
+    bucket_timezone: &BucketTimezone,
+) -> HashMap<String, Vec<DayBucket>> {
     let query = r#"
         WITH RECURSIVE session_tree(root_session_id, session_id) AS (
             SELECT id, id
@@ -193,7 +212,7 @@ fn load_assistant_buckets(conn: &Connection) -> HashMap<String, Vec<DayBucket>> 
         let Some(timestamp_ms) = normalize_crush_timestamp_ms(created_at) else {
             continue;
         };
-        let Some(local_day) = local_day_key(timestamp_ms) else {
+        let Some(local_day) = local_day_key(timestamp_ms, bucket_timezone) else {
             continue;
         };
 
@@ -224,10 +243,12 @@ fn normalize_crush_timestamp_ms(raw: i64) -> Option<i64> {
     }
 }
 
-fn local_day_key(timestamp_ms: i64) -> Option<String> {
-    match Local.timestamp_millis_opt(timestamp_ms) {
-        chrono::LocalResult::Single(dt) => Some(dt.format("%Y-%m-%d").to_string()),
-        _ => None,
+fn local_day_key(timestamp_ms: i64, bucket_timezone: &BucketTimezone) -> Option<String> {
+    let key = bucket_timezone.day_key(timestamp_ms);
+    if key.is_empty() {
+        None
+    } else {
+        Some(key)
     }
 }
 
@@ -315,6 +336,60 @@ mod tests {
             params![id, session_id, role, is_summary_message, created_at],
         )
         .unwrap();
+    }
+
+    /// Crush is the one parser whose day split is decided at parse time: it
+    /// allocates a session's cost across the days its assistant turns fall in
+    /// and emits one message per day. The post-parse rebucket pass can relabel
+    /// those messages but cannot recover a split this grouping collapsed, so
+    /// the pinned zone has to reach in here.
+    ///
+    /// Two turns 6.5 hours apart: one calendar day in Los Angeles, two in
+    /// Kiritimati. The cost split follows whichever zone is pinned.
+    #[test]
+    fn test_parse_crush_sqlite_splits_cost_by_the_pinned_timezone() {
+        let dir = TempDir::new().unwrap();
+        let db_path = create_test_db(&dir);
+        let conn = Connection::open(&db_path).unwrap();
+
+        // 2026-03-02T11:30:00Z and 2026-03-02T18:00:00Z.
+        let first = 1_772_451_000_i64;
+        let second = 1_772_474_400_i64;
+
+        insert_root_session(&conn, "root-tz", 2, 10.0, second, first);
+        insert_message(&conn, "msg-1", "root-tz", "assistant", first, 0);
+        insert_message(&conn, "msg-2", "root-tz", "assistant", second, 0);
+
+        // Los Angeles: 03:30 and 10:00 on 2026-03-02 — one day, one message.
+        let los_angeles = parse_crush_sqlite_in(
+            &db_path,
+            &BucketTimezone::from_pinned_name(Some("America/Los_Angeles")),
+        );
+        assert_eq!(los_angeles.len(), 1);
+        assert_eq!(los_angeles[0].message_count, 2);
+        assert!((los_angeles[0].cost - 10.0).abs() < 1e-9);
+
+        // Kiritimati: 2026-03-03 01:30 and 08:00 — still one day, because both
+        // turns cross together. Seoul is where they separate: 20:30 on the 2nd
+        // and 03:00 on the 3rd.
+        let seoul =
+            parse_crush_sqlite_in(&db_path, &BucketTimezone::from_pinned_name(Some("Asia/Seoul")));
+        assert_eq!(seoul.len(), 2, "Seoul splits the session across two days");
+        assert_eq!(seoul[0].message_count, 1);
+        assert_eq!(seoul[1].message_count, 1);
+        assert!(
+            (seoul.iter().map(|m| m.cost).sum::<f64>() - 10.0).abs() < 1e-9,
+            "splitting must conserve the session cost"
+        );
+
+        // And the split is a function of the pin alone: the same call twice
+        // returns the same shape regardless of what the host machine is set to.
+        let seoul_again =
+            parse_crush_sqlite_in(&db_path, &BucketTimezone::from_pinned_name(Some("Asia/Seoul")));
+        assert_eq!(
+            seoul.iter().map(|m| m.timestamp).collect::<Vec<_>>(),
+            seoul_again.iter().map(|m| m.timestamp).collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -396,6 +396,16 @@ impl UnifiedMessage {
     /// post-parse pass that holds the user's settings re-key every message at
     /// once, which is the only place the pinned zone is actually known.
     pub(crate) fn rebucket_date(&mut self, timezone: &crate::bucket_tz::BucketTimezone) {
+        // A non-positive timestamp is the parsers' "no usable time" sentinel,
+        // not an instant before 1970. Re-keying it would move garbage between
+        // two equally wrong days, and it is also what bounds the window the
+        // auto-pin agreement check has to cover: leaving these alone is what
+        // makes `AGREEMENT_WINDOW_START_MS` a real lower bound rather than a
+        // convenient one.
+        if self.timestamp <= 0 {
+            return;
+        }
+
         let key = timezone.day_key(self.timestamp);
         // An unrepresentable instant yields an empty key. Keeping the previous
         // date is wrong by at most the offset between two zones; replacing it

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -387,6 +387,25 @@ impl UnifiedMessage {
         self.date = timestamp_to_date(self.timestamp);
     }
 
+    /// Re-derive the day bucket under an explicitly chosen timezone.
+    ///
+    /// `UnifiedMessage::new` is a constructor called from 92 sites across 42
+    /// parser files, so the zone cannot be threaded into it without touching
+    /// every one. It does not need to be: `date` is a derived field, already
+    /// recomputed from `timestamp` after construction. This lets the one
+    /// post-parse pass that holds the user's settings re-key every message at
+    /// once, which is the only place the pinned zone is actually known.
+    pub(crate) fn rebucket_date(&mut self, timezone: &crate::bucket_tz::BucketTimezone) {
+        let key = timezone.day_key(self.timestamp);
+        // An unrepresentable instant yields an empty key. Keeping the previous
+        // date is wrong by at most the offset between two zones; replacing it
+        // with `""` would collapse the message into a bucket that is not a day
+        // at all, and that bucket would then be submitted.
+        if !key.is_empty() {
+            self.date = key;
+        }
+    }
+
     pub(crate) fn set_timestamp(&mut self, timestamp: i64) {
         self.timestamp = timestamp;
         self.refresh_derived_fields();
@@ -455,10 +474,7 @@ where
     Tz: chrono::TimeZone,
     Tz::Offset: std::fmt::Display,
 {
-    match timezone.timestamp_millis_opt(timestamp_ms) {
-        chrono::LocalResult::Single(dt) => dt.format("%Y-%m-%d").to_string(),
-        _ => String::new(),
-    }
+    crate::bucket_tz::format_day_key(timestamp_ms, timezone)
 }
 
 #[cfg(test)]

--- a/docs/ratchet-inflation-recovery.md
+++ b/docs/ratchet-inflation-recovery.md
@@ -488,6 +488,38 @@ far smaller than the current failure — an hour twice a year, not a full re-spl
 on every rescan — but it is not zero, and calling this "the only exact fix"
 above is only true of the named-zone variant.
 
+### The size question, now measured (2026-08-03)
+
+Three release builds of `tokscale-cli`, same toolchain and host
+(aarch64-apple-darwin, `lto = true`, `codegen-units = 1`, `strip = true` — so
+these are shipped sizes, not pre-strip ones):
+
+| build | bytes | vs baseline |
+|---|---:|---:|
+| `origin/main` | 15,061,600 | — |
+| pinning + `chrono-tz` | 16,300,464 | **+1,238,864 (+1.18 MiB, +8.23%)** |
+| pinning + `FixedOffset` | 15,094,688 | +33,088 (+32 KiB, +0.22%) |
+
+The feature itself is ~32 KiB. Everything else — 1.15 MiB — is the tz database.
+
+**Shipped the named zone.** The 1.15 MiB is real and it lands on all nine
+targets, but it is the entire price of the phase being exact rather than
+approximate, and the phase exists specifically because approximate re-splitting
+is what inflates the totals. Two things settled it beyond the ratio:
+
+1. `chrono` already depends on `iana-time-zone` to implement `Local`, so
+   *detecting* the machine's zone name costs nothing. Only honoring it later
+   needs the database. Half the mechanism was already paid for.
+2. A fixed offset cannot be what the user configures. `tokscale config set
+   timezone Asia/Seoul` has to store something that survives a DST boundary; the
+   offset variant can only store `+09:00`, which is a different and worse
+   setting to ask someone to reason about after they relocate.
+
+Recorded for whoever revisits this: if the binary budget ever forces the offset
+variant, the sentence at the top of this phase — "the only exact fix" — stops
+being true, and the residual is usage within an hour of local midnight on the
+days following a DST transition.
+
 ## Phase 4 — Heal the daily rows
 
 For the day-level surfaces, and only if Phase 1's census says the tail justifies

--- a/docs/ratchet-inflation-recovery.md
+++ b/docs/ratchet-inflation-recovery.md
@@ -541,9 +541,9 @@ not, because the platform difference *is* the bug.
 The fix is not "use the other source". Either source can be wrong, and a future
 platform can disagree in a new way. The fix is to stop trusting the name and
 verify it: a candidate is pinned only if its UTC offset matches `chrono::Local`
-at every sampled instant across an eleven-year window. If it disagrees anywhere,
-nothing is written and the device stays unpinned — which is its previous
-behaviour, and therefore always safe.
+at every sampled instant across the window. If it disagrees anywhere, nothing is
+written and the device stays unpinned — which is its previous behaviour, and
+therefore always safe.
 
 That turns the guarantee from "two crates presumably agree" into something
 structural: **the recorded zone produces the same day keys as the zone the device
@@ -554,14 +554,45 @@ value, not on its provenance.
 The sampling step is set by what the tz database can express rather than by
 taste: DST offsets move in whole or half hours, and the tightest real case is a
 30-minute shift (`Australia/Lord_Howe` against `Australia/Sydney`), so a
-6-hour step would have stepped straight over it. 192,721 lookups, 11.4 ms
-release, once per scan while unpinned.
+6-hour step would have stepped straight over it.
 
 **Generalisable:** any time a value is derived from the environment by two
 different libraries, the invariant to test is that they agree — not that either
 one is correct. And measure the real call: benchmarking `zones_agree` between two
 `chrono-tz` zones read 30% low, because `chrono::Local` re-checks `TZ` on every
 lookup and the proxy had no `Local` in it.
+
+### A sampled *window* has the same defect as a coarse *step* (2026-08-03)
+
+The check above shipped with a window of ten years back and one year ahead, and
+that window has exactly the flaw the 6-hour step had, one level up. Two zones can
+share today's rules and still differ in older ones — `America/New_York` and
+`America/Toronto` diverged over the 1974-75 US emergency DST; `Asia/Seoul` and
+`Asia/Tokyo` over Seoul's 1987-88 DST — so a candidate can pass a decade of
+samples and still move day boundaries in older history. And `rebucket_days`
+applies an accepted pin to *every* message, not only recent ones.
+
+So the invariant "pinning never changes existing bucketing" was being asserted
+over a slice of the range it applies to. The fix is the same shape as before:
+make the checked range cover everything that can be re-keyed. The window now runs
+from the Unix epoch to ten years ahead, and the rebucket passes decline to move a
+message whose timestamp is not strictly positive — that value is the parsers'
+"no usable time" sentinel, not an instant before 1970 — so the epoch is a real
+lower bound rather than a convenient one. 1,167,280 lookups, **56 ms** release
+(up from 11.4 ms), once per scan while unpinned and never again after.
+
+The wider window rejects more, including the case where the host's zoneinfo and
+the bundled `chrono-tz` database disagree on an old rule for the *same* zone
+name. That is the safe direction: declining leaves the device bucketing by
+`chrono::Local`, carrying a bug it already had, while accepting wrongly rewrites
+history that is already on the server behind a monotonic guard which makes the
+result permanent.
+
+**Generalisable:** when a check samples, it has two resolutions — how finely it
+samples, and how far. Getting the step right and leaving the window short buys
+nothing, because a claim about all of history cannot be supported by a sample of
+part of it. Either cover the whole range the claim applies to, or narrow the
+claim to the range you covered.
 
 ## Phase 4 — Heal the daily rows
 

--- a/docs/ratchet-inflation-recovery.md
+++ b/docs/ratchet-inflation-recovery.md
@@ -520,6 +520,49 @@ variant, the sentence at the top of this phase — "the only exact fix" — stop
 being true, and the residual is usage within an hour of local midnight on the
 days following a DST transition.
 
+### Naming the zone is a second, separate problem (2026-08-03)
+
+Pinning has two halves and only one of them was in the design above. Recording a
+zone is easy; deciding *which* zone the device is already using is not, and the
+first implementation got it wrong in a way that would have shipped.
+
+`chrono::Local` honors the `TZ` environment variable. `iana-time-zone` — the
+obvious way to get a name, and already in the tree — **does not read `TZ` at all
+on Linux**; it resolves `/etc/localtime`, then `/etc/timezone`. On macOS it goes
+through CoreFoundation, which does consult `TZ`.
+
+So on a Linux host with `TZ=Asia/Seoul` and `/etc/localtime -> Etc/UTC` the
+detector says `Etc/UTC` while every date already on disk says Seoul. Auto-pinning
+that name re-keys the entire history by nine hours on the first run after
+upgrading — the exact re-split this phase exists to remove, caused by the phase,
+and invisible to anyone developing on a Mac. CI caught it; the local test run did
+not, because the platform difference *is* the bug.
+
+The fix is not "use the other source". Either source can be wrong, and a future
+platform can disagree in a new way. The fix is to stop trusting the name and
+verify it: a candidate is pinned only if its UTC offset matches `chrono::Local`
+at every sampled instant across an eleven-year window. If it disagrees anywhere,
+nothing is written and the device stays unpinned — which is its previous
+behaviour, and therefore always safe.
+
+That turns the guarantee from "two crates presumably agree" into something
+structural: **the recorded zone produces the same day keys as the zone the device
+was already using, or there is no recorded zone.** Any future change to how the
+zone is detected inherits the guarantee for free, because the check is on the
+value, not on its provenance.
+
+The sampling step is set by what the tz database can express rather than by
+taste: DST offsets move in whole or half hours, and the tightest real case is a
+30-minute shift (`Australia/Lord_Howe` against `Australia/Sydney`), so a
+6-hour step would have stepped straight over it. 192,721 lookups, 11.4 ms
+release, once per scan while unpinned.
+
+**Generalisable:** any time a value is derived from the environment by two
+different libraries, the invariant to test is that they agree — not that either
+one is correct. And measure the real call: benchmarking `zones_agree` between two
+`chrono-tz` zones read 30% low, because `chrono::Local` re-checks `TZ` on every
+lookup and the proxy had no `Local` in it.
+
 ## Phase 4 — Heal the daily rows
 
 For the day-level surfaces, and only if Phase 1's census says the tail justifies


### PR DESCRIPTION
Phase 3 of #960 — pin the bucket key. Closes the *cause* of the inflation
rather than cleaning up after it. CLI-only, no server dependency.

## The problem

Which local calendar day a unit of usage counted toward was a function of the
machine's timezone **at scan time**. Both bucketing sites read `chrono::Local`
on every run:

- `compute_daily_active_time` (`sessionize.rs`)
- `timestamp_to_date`, via `UnifiedMessage::new_full` (`sessions/mod.rs`)

So rescanning unchanged history from another zone re-split it across days. The
server's monotonic per-day guard then kept the stale value on one day while
accepting the new one on its neighbour, and the device's total went up with no
new usage — permanently, with no way to walk it back. The 2026-07-31 census
found 197 of 650 measurable devices showing inflation not explained by scan
windowing, so this is live.

## The change

`scanner.bucketTimezone` records the device's IANA zone once and every day key
comes from it. The CLI pins on first run; `tokscale config set timezone <zone>`
moves it deliberately.

```console
$ tokscale config list
timezone     Asia/Seoul
$ tokscale config set timezone America/New_York
$ tokscale config set timezone auto      # re-detect
$ tokscale config unset timezone         # forget; next run re-detects
```

### Where the pin is applied, and why there

`timestamp_to_date` is reached from `UnifiedMessage::new_full`, a constructor
with **92 call sites across 42 files**. The zone is not threaded through it.
`date` is already a derived field that gets recomputed from `timestamp` after
construction, so one post-parse pass — inside the function that already holds
`scanner_settings` — re-keys every message at once:

- `rebucket_days` at the single exit of
  `parse_all_messages_with_pricing_with_env_strategy`
- `rebucket_parsed_days` in `parse_local_clients` (the `ParsedMessage` lane that
  `tokscale report` / `tokscale wrapped` read), placed **before** the date
  filter so `--since`/`--until` select against pinned keys
- `compute_daily_active_time_in` in `build_graph_from_messages`, so active time
  and tokens agree on where a day starts

**Crush is the exception.** It decides its day split at parse time — it
allocates a session's cost across the days its assistant turns fall in and emits
one message per day — so a later relabel cannot recover a split the grouping
already collapsed. It takes the zone directly.

`--today` / `--week` / `--month` now resolve "today" in the pinned zone too
(`current_bucket_date`). They compare against the same `date` strings the
buckets are keyed by; resolving them from the host would select the wrong day
out of the right buckets and submit a partial day, which is exactly what the
monotonic guard freezes.

### Nothing changes until a device pins

`rebucket_days` returns early when nothing is pinned — it does not re-derive
through `Local` "for uniformity". An un-upgraded device is byte-identical.

The message cache needs no invalidation: it stores raw parser output and `date`
is re-derived on every load, so a cached entry never carries a stale day key
past the rebucket pass.

## `chrono-tz` vs `FixedOffset`, measured

The design doc left this explicitly unpriced. Three release builds, same
toolchain and host, `lto = true` / `codegen-units = 1` / `strip = true` (shipped
sizes):

| build | bytes | vs baseline |
|---|---:|---:|
| `origin/main` | 15,061,600 | — |
| pinning + `chrono-tz` | 16,300,464 | **+1,238,864 (+1.18 MiB, +8.23%)** |
| pinning + `FixedOffset` | 15,094,688 | +33,088 (+32 KiB, +0.22%) |

The feature is ~32 KiB; the other 1.15 MiB is the tz database.

**Shipped the named zone.** A fixed offset cannot follow DST: after a transition
the pinned offset stops matching local midnight, so usage within an hour of the
boundary lands on the wrong day — a bounded rerun of the bug this removes. Two
things settled it beyond the ratio:

1. `chrono` already depends on `iana-time-zone` to implement `Local`, so
   *detecting* the zone name costs nothing. Only honoring it needs the database.
2. A fixed offset cannot be what the user configures. `config set timezone
   Asia/Seoul` has to store something that survives a DST boundary; the offset
   variant can only store `+09:00`.

If the binary budget ever forces the offset variant, the doc's claim that Phase
3 is "the only exact fix" stops being true — noted in
`docs/ratchet-inflation-recovery.md`. Fixed offsets are rejected at the config
boundary rather than silently accepted.

## A device that upgrades mid-history

It re-splits **once**, then never again.

- If its zone has not changed since its history was written, the recorded zone
  equals what `Local` already resolved and the first scan after pinning reports
  exactly what it would have reported anyway. Zero movement.
- If its zone *has* changed since (it moved, and had not rescanned yet), the
  pin freezes the current zone. That scan re-splits — but that scan was going to
  re-split regardless of this change, because the old code would have used the
  same current `Local`. The difference is that it is the last time.

Pinning does not repair damage already in the rows; that is Phase 4.

## The bug the first CI run caught

The first push auto-pinned `iana_time_zone::get_timezone()` without verifying
it, and CI failed four tests — including this PR's own invariant test, which is
exactly what it was written to catch.

Naming the local zone and *bucketing* in it go through different code with
different rules, and they disagree in ordinary setups:

- `chrono::Local` honors `TZ`.
- `iana-time-zone` **does not read `TZ` at all on Linux** — it resolves
  `/etc/localtime`, then `/etc/timezone`. On macOS it goes through
  CoreFoundation, which *does* consult `TZ`.

So on Linux with `TZ=Asia/Seoul` and `/etc/localtime -> Etc/UTC` the detector
said `Etc/UTC` while every date already on disk said Seoul. Pinning that would
re-key the whole history by nine hours on the first run after upgrading — the
re-split this feature exists to prevent, caused by the feature, and invisible on
macOS. Reproduced in a Linux container:

```
======== /etc/localtime=Etc/UTC, TZ=Asia/Seoul ========
TZ env                = Some("Asia/Seoul")
iana_time_zone        = Some("Etc/UTC")
OLD detect (shipped)  = Some("Etc/UTC")
  -> agrees w/ Local? = false          <-- would have re-keyed everything
NEW detect (fixed)    = Some("Asia/Seoul")

======== TZ unset (normal desktop) ========
iana_time_zone        = Some("Etc/UTC")
OLD detect (shipped)  = Some("Etc/UTC")
  -> agrees w/ Local? = true
NEW detect (fixed)    = Some("Etc/UTC")   <-- unchanged where they agree
```

Fixed two ways, both load-bearing. `TZ` is consulted first when it names an IANA
zone, because that is what `chrono::Local` itself honors and `chrono::Local`
produced every date already stored. And whatever the source, the candidate is
**verified against `chrono::Local` before anything is written**: UTC offsets must
match at every 30-minute step from 10 years back to 1 year ahead. A candidate that
disagrees anywhere is discarded and the device stays unpinned — its previous
behaviour exactly.

That makes the invariant structural rather than dependent on two crates happening
to agree: *the zone recorded is one that produces the same day keys as the zone
the device was already using, or no zone is recorded at all.*

Sampling rather than proof is a deliberate bound, and the step is set by what
the tz database can express: DST offsets move in whole or half hours, and the
tightest real case is a 30-minute shift (`Australia/Lord_Howe` vs
`Australia/Sydney`), so 30 minutes catches every divergence a transition can
produce. A single-instant check would not do — `Europe/London` and `Etc/UTC`
share an offset for half the year — and there are unit tests for both cases.

192,721 lookups, measured on Linux at **11.4 ms** release / 65 ms debug for a
full accepting pass against `chrono::Local`, run once per scan while nothing is
pinned. (Benchmarked against `chrono::Local` specifically: it re-checks `TZ` on
every lookup, which a `chrono-tz`-to-`chrono-tz` proxy hides — that proxy read
about 30% low.)

Neither pre-existing test was touched. Both encode the local-ahead-of-UTC
contract and both pass again because the implementation stopped violating it.

## Sweep findings fixed in the same pass

Three more sites still read the host clock while feeding a pinned bucket:

- **`autosubmit`** resolved its submit window from `chrono::Local::now()`, which
  would select a partial pinned day for a *scheduled submission* — and a partial
  day is what the monotonic guard freezes at the low value. This one reaches the
  server.
- **`report`** converted `--since`/`--until` to instants at host midnight while
  comparing them against pinned day strings.
- **the hourly report** built its key from the host while its timestamp-less
  fallback built one out of the already-pinned `date`, so one report could
  contradict itself about which day an hour belonged to.

## Regression evidence

`test_pinned_bucket_timezone_survives_a_host_timezone_change` — a fixture whose
two turns land on different days in three zones, so the assertion can tell
*which* zone did the bucketing rather than only that two runs agreed.

Red on `origin/main`:

```
running 3 tests
test test_unparseable_pinned_timezone_falls_back_to_the_host_timezone ... ok
test test_pinned_bucket_timezone_survives_a_host_timezone_change ... FAILED
test test_unpinned_first_scan_still_buckets_by_the_host_timezone ... ok

---- test_pinned_bucket_timezone_survives_a_host_timezone_change stdout ----
assertion `left == right` failed: a pinned zone must key the same history the same way from any host timezone
  left: [("2026-03-02", 2)]
 right: [("2026-03-02", 1), ("2026-03-03", 1)]

test result: FAILED. 2 passed; 1 failed
```

`left` is the run under `TZ=America/Los_Angeles`, `right` under `TZ=Asia/Seoul`
— the re-split, verbatim. The two passing tests are the other half of the
contract: unpinned devices still bucket by the host, and an unparseable pin
degrades to the host instead of failing the scan.

Green here:

```
running 7 tests
test test_config_set_timezone_rejects_a_fixed_offset ... ok
test test_first_run_never_rebuckets_when_the_detector_disagrees_with_local ... ok
test test_unparseable_pinned_timezone_falls_back_to_the_host_timezone ... ok
test test_pinned_bucket_timezone_survives_a_host_timezone_change ... ok
test test_first_run_pins_the_host_timezone_without_changing_its_own_output ... ok
test test_config_set_timezone_repoints_day_buckets ... ok
test test_unpinned_first_scan_still_buckets_by_the_host_timezone ... ok

test result: ok. 7 passed; 0 failed
```

Plus the two pre-existing local-ahead-of-UTC tests, unmodified:

```
running 2 tests
test test_graph_single_day_filter_uses_local_timezone_boundaries ... ok
test test_submit_dry_run_preserves_local_date_ahead_of_utc ... ok

test result: ok. 2 passed; 0 failed
```

## Verified on Linux, where it actually broke

macOS hid the bug, so the fix was checked on the platform that exposed it —
a container with `/etc/localtime -> Etc/UTC`, the exact CI shape:

```
HOST /etc/localtime -> /usr/share/zoneinfo/Etc/UTC

running 9 tests
test test_config_set_timezone_rejects_a_fixed_offset ... ok
test test_unparseable_pinned_timezone_falls_back_to_the_host_timezone ... ok
test test_pinned_bucket_timezone_survives_a_host_timezone_change ... ok
test test_graph_single_day_filter_uses_local_timezone_boundaries ... ok
test test_first_run_never_rebuckets_when_the_detector_disagrees_with_local ... ok
test test_first_run_pins_the_host_timezone_without_changing_its_own_output ... ok
test test_unpinned_first_scan_still_buckets_by_the_host_timezone ... ok
test test_config_set_timezone_repoints_day_buckets ... ok
test test_submit_dry_run_preserves_local_date_ahead_of_utc ... ok

test result: ok. 9 passed; 0 failed
```

And confirmed in CI's own raw check-run log (`Code Coverage`), all nine `ok`,
with `140 passed; 0 failed` for `cli_tests` and `1363 passed; 0 failed` for
`tokscale-core`.

## Checks

- `cargo test -p tokscale-core -p tokscale-cli` — 1362 core + 139 CLI + 35
  integration passing. One pre-existing failure,
  `test_pricing_command_with_provider`, reproduces identically on pristine
  `origin/main` (stale local litellm pricing cache); unrelated.
- `cargo clippy --all-targets` — clean.
- `cargo fmt --check` — clean.

## Known residuals

- Display-only `chrono::Local::now()` reads in the TUI (heatmap "today",
  streaks, hourly/minutely axes) are untouched. They do not produce a submitted
  day bucket.
- `--home` points at another machine's data directory, so auto-pin is skipped
  there. Relative date flags now resolve "today" from that home's pinned zone
  (`current_bucket_date(&home_dir)`), so the filter and the buckets agree.
- The zone-agreement check samples every 30 minutes rather than proving
  equality, across the Unix epoch to ten years ahead. The step is shorter than
  the briefest divergence the tz database can express (a 30-minute DST shift),
  and both rebucket passes decline to move a message whose timestamp is not
  strictly positive, so the window covers every instant an accepted pin can
  re-key. Cost: 1,167,280 lookups, 56 ms release, once per scan while unpinned.
- The wider window declines to pin when the host's zoneinfo and the bundled
  `chrono-tz` disagree on an old rule for the same zone name. That is the safe
  direction: declining leaves the device bucketing by `chrono::Local`, carrying
  a bug it already had, where accepting wrongly rewrites history the server's
  monotonic guard then freezes.

