### PR TITLE
feat(moderation): tell a hidden user they are hidden, and how to appeal

### DIFF
--- a/packages/frontend/__tests__/app/profilePageModeration.test.ts
+++ b/packages/frontend/__tests__/app/profilePageModeration.test.ts
@@ -1,0 +1,113 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadPublicProfileForPage = vi.fn();
+const loadPublicProfileDevicesForPage = vi.fn();
+const getSession = vi.fn();
+const getModerationNotice = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(),
+  permanentRedirect: vi.fn(),
+}));
+
+vi.mock("@/lib/publicProfileData", () => ({ loadPublicProfileForPage }));
+vi.mock("@/lib/publicProfileDevices", () => ({ loadPublicProfileDevicesForPage }));
+vi.mock("@/lib/auth/session", () => ({ getSession }));
+vi.mock("@/lib/moderation/notice", () => ({ getModerationNotice }));
+vi.mock("@/lib/seo/urls", () => ({ profileUrl: vi.fn() }));
+vi.mock("../../src/app/u/[username]/ProfilePageClient", () => ({
+  default: () => null,
+}));
+
+type ModuleExports = typeof import("../../src/app/u/[username]/page");
+
+let ProfilePage: ModuleExports["default"];
+
+const profileData = {
+  user: {
+    id: "profile-owner",
+    username: "owner",
+    displayName: null,
+    avatarUrl: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    rank: null,
+  },
+  stats: {
+    totalTokens: 0,
+    totalCost: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    submissionCount: 0,
+    activeDays: 0,
+    sessionCount: 0,
+  },
+  dateRange: { start: null, end: null },
+  updatedAt: null,
+  clients: [],
+  models: [],
+  contributions: [],
+};
+
+async function renderProfile() {
+  return ProfilePage({
+    params: Promise.resolve({ username: "owner" }),
+    searchParams: Promise.resolve({}),
+  });
+}
+
+beforeAll(async () => {
+  ({ default: ProfilePage } = await import("../../src/app/u/[username]/page"));
+});
+
+beforeEach(() => {
+  loadPublicProfileForPage.mockReset();
+  loadPublicProfileDevicesForPage.mockReset();
+  getSession.mockReset();
+  getModerationNotice.mockReset();
+
+  loadPublicProfileForPage.mockResolvedValue({ kind: "data", data: profileData });
+  loadPublicProfileDevicesForPage.mockResolvedValue([]);
+});
+
+describe("profile moderation notice delivery", () => {
+  it("forwards the notice only to the profile owner", async () => {
+    const notice = {
+      tone: "pending" as const,
+      message: "Your account is currently withheld from the leaderboard pending review.",
+    };
+    getSession.mockResolvedValue({ id: "profile-owner" });
+    getModerationNotice.mockResolvedValue(notice);
+
+    const page = await renderProfile();
+
+    expect(getModerationNotice).toHaveBeenCalledWith("profile-owner");
+    expect(page.props.moderationNotice).toEqual(notice);
+  });
+
+  it("does not look up or forward a notice to anonymous visitors", async () => {
+    getSession.mockResolvedValue(null);
+
+    const page = await renderProfile();
+
+    expect(getModerationNotice).not.toHaveBeenCalled();
+    expect(page.props.moderationNotice).toBeNull();
+  });
+
+  it("does not look up or forward a notice to a different authenticated user", async () => {
+    getSession.mockResolvedValue({ id: "another-user" });
+
+    const page = await renderProfile();
+
+    expect(getModerationNotice).not.toHaveBeenCalled();
+    expect(page.props.moderationNotice).toBeNull();
+  });
+
+  it("preserves a moderation lookup failure for the page error boundary", async () => {
+    getSession.mockResolvedValue({ id: "profile-owner" });
+    getModerationNotice.mockRejectedValue(new Error("database unavailable"));
+
+    await expect(renderProfile()).rejects.toThrow("database unavailable");
+  });
+});

--- a/packages/frontend/__tests__/lib/moderationNotice.test.ts
+++ b/packages/frontend/__tests__/lib/moderationNotice.test.ts
@@ -36,6 +36,7 @@ describe("moderationNoticeFor", () => {
 
       expect(notice.tone).toBe("pending");
       expect(notice.message).not.toMatch(/abus/i);
+      expect(notice.message).toContain("rank badges show N/A");
     }
   });
 

--- a/packages/frontend/__tests__/lib/moderationNotice.test.ts
+++ b/packages/frontend/__tests__/lib/moderationNotice.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { moderationNoticeFor } from "@/lib/moderation/notice";
+
+const CONTACT = "i@junho.io";
+
+describe("moderationNoticeFor", () => {
+  it("always gives the owner somewhere to appeal", () => {
+    for (const reason of ["Abuse", "Under investigation", "Data issue on our side", null]) {
+      expect(moderationNoticeFor(reason).message).toContain(CONTACT);
+    }
+  });
+
+  it("tells someone hidden for abuse exactly that", () => {
+    const notice = moderationNoticeFor("Abuse");
+
+    expect(notice.tone).toBe("enforcement");
+    expect(notice.message).toContain("abusing");
+  });
+
+  it("never blames the user when the cause is our own data problem", () => {
+    // Hiding someone because of ratchet inflation (#960) and then telling them
+    // they abused the leaderboard is a false accusation they cannot appeal.
+    const notice = moderationNoticeFor("Data issue on our side");
+
+    expect(notice.tone).toBe("our-fault");
+    expect(notice.message).toContain("not anything you did");
+    expect(notice.message).not.toMatch(/abus/i);
+  });
+
+  it("does not accuse anyone when the reason is unknown or missing", () => {
+    // A flag set without an audit row means we do not know what happened, and
+    // "you abused this" is the one message that must never be sent on a guess.
+    for (const reason of [null, "Some reason added later"]) {
+      const notice = moderationNoticeFor(reason);
+
+      expect(notice.tone).toBe("pending");
+      expect(notice.message).not.toMatch(/abus/i);
+    }
+  });
+
+  it("reveals nothing about how the account was identified", () => {
+    // Same rule as the stored reasons: a notice that names the signal is
+    // evasion instructions.
+    for (const reason of ["Abuse", "Under investigation", "Data issue on our side", null]) {
+      const message = moderationNoticeFor(reason).message.toLowerCase();
+
+      for (const leak of ["model name", "duplicate", "median", "daily", "per-token", "slop"]) {
+        expect(message).not.toContain(leak);
+      }
+    }
+  });
+});

--- a/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
+++ b/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
@@ -30,6 +30,7 @@ import {
 import type { DailyContribution } from "@/lib/types";
 import { useSettings } from "@/lib/useSettings";
 import { resolveEffectiveTimeZone } from "@/lib/timezone";
+import type { ModerationNotice } from "@/lib/moderation/notice";
 
 type ProfilePeriod = "all" | "week" | "month";
 
@@ -90,14 +91,58 @@ interface ProfilePageClientProps {
   initialData: ProfileData;
   initialDevices?: ProfileDevice[];
   username: string;
+  /**
+   * Only ever populated when the viewer is the account owner. The server
+   * resolves this outside the cached public payload, so a visitor receives
+   * null and renders nothing — a hide is not announced to anyone else.
+   */
+  moderationNotice?: ModerationNotice | null;
 }
 
 const EARLY_ADOPTERS = ["code-yeongyu", "gtg7784", "qodot"];
+
+/**
+ * Amber for the two cases the account owner may want to contest, neutral blue
+ * when the cause is our own data problem — that one is informational, and
+ * dressing it as a warning would imply they did something wrong.
+ */
+const ModerationNoticeBanner = styled.div<{ $tone: ModerationNotice["tone"] }>`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 20px;
+  padding: 16px 18px;
+  border: 1px solid
+    ${({ $tone }) =>
+      $tone === "our-fault" ? "rgba(47, 143, 255, 0.4)" : "rgba(217, 119, 6, 0.45)"};
+  border-radius: 10px;
+  background: ${({ $tone }) =>
+    $tone === "our-fault" ? "rgba(47, 143, 255, 0.09)" : "rgba(217, 119, 6, 0.09)"};
+
+  strong {
+    color: var(--service-text);
+    font-size: 0.9375rem;
+    font-weight: 600;
+  }
+
+  span {
+    color: var(--service-text-muted);
+    font-size: 0.875rem;
+    line-height: 1.6;
+  }
+`;
+
+const NOTICE_TITLE: Record<ModerationNotice["tone"], string> = {
+  enforcement: "Removed from the leaderboard",
+  pending: "Withheld from the leaderboard",
+  "our-fault": "Temporarily hidden — our issue, not yours",
+};
 
 export default function ProfilePageClient({
   initialData,
   initialDevices,
   username,
+  moderationNotice,
 }: ProfilePageClientProps) {
   const [activeTab, setActiveTab] = useState<ProfileTab>("activity");
   const [contributionView, setContributionView] =
@@ -238,6 +283,13 @@ export default function ProfilePageClient({
 
       <MainContent id="main-content">
         <ContentWrapper>
+          {moderationNotice && (
+            <ModerationNoticeBanner role="status" $tone={moderationNotice.tone}>
+              <strong>{NOTICE_TITLE[moderationNotice.tone]}</strong>
+              <span>{moderationNotice.message}</span>
+            </ModerationNoticeBanner>
+          )}
+
           {showResubmitBanner && (
             <UpdateNotice role="status">
               <strong>Fresh detail is available.</strong> Re-submit with{" "}

--- a/packages/frontend/src/app/u/[username]/page.tsx
+++ b/packages/frontend/src/app/u/[username]/page.tsx
@@ -116,7 +116,7 @@ export default async function ProfilePage({
   const session = await getSession().catch(() => null);
   const moderationNotice =
     session && data.user?.id && session.id === data.user.id
-      ? await getModerationNotice(session.id).catch(() => null)
+      ? await getModerationNotice(session.id)
       : null;
 
   return (

--- a/packages/frontend/src/app/u/[username]/page.tsx
+++ b/packages/frontend/src/app/u/[username]/page.tsx
@@ -4,6 +4,8 @@ import type { ProfileDevice } from '@/components/profile';
 import { loadPublicProfileDevicesForPage } from '@/lib/publicProfileDevices';
 import { loadPublicProfileForPage } from '@/lib/publicProfileData';
 import { profileUrl } from '@/lib/seo/urls';
+import { getSession } from '@/lib/auth/session';
+import { getModerationNotice } from '@/lib/moderation/notice';
 import ProfilePageClient, { type ProfileData } from './ProfilePageClient';
 
 export const revalidate = 60;
@@ -108,5 +110,21 @@ export default async function ProfilePage({
     permanentRedirect(`/u/${data.user.username}${period === "all" ? "" : `?period=${period}`}`);
   }
 
-  return <ProfilePageClient initialData={data} initialDevices={devices} username={username} />;
+  // Fetched outside the cached public payload and only for the account owner:
+  // publicProfileData is unstable_cache'd and served to everyone, so moderation
+  // state must never travel with it. A visitor sees nothing at all.
+  const session = await getSession().catch(() => null);
+  const moderationNotice =
+    session && data.user?.id && session.id === data.user.id
+      ? await getModerationNotice(session.id).catch(() => null)
+      : null;
+
+  return (
+    <ProfilePageClient
+      initialData={data}
+      initialDevices={devices}
+      username={username}
+      moderationNotice={moderationNotice}
+    />
+  );
 }

--- a/packages/frontend/src/lib/moderation/notice.ts
+++ b/packages/frontend/src/lib/moderation/notice.ts
@@ -59,7 +59,7 @@ export function moderationNoticeFor(reason: string | null): ModerationNotice {
     tone: "pending",
     message:
       `Your account is currently withheld from the leaderboard pending review. ` +
-      `Your profile, badges and totals still work. ` +
+      `Your profile and totals still work, but rank badges show N/A while your account is withheld. ` +
       `If you think this is a mistake, email ${CONTACT_EMAIL}`,
   };
 }

--- a/packages/frontend/src/lib/moderation/notice.ts
+++ b/packages/frontend/src/lib/moderation/notice.ts
@@ -1,0 +1,101 @@
+import { and, desc, eq } from "drizzle-orm";
+import { db, moderationActions, users } from "@/lib/db";
+
+/**
+ * The notice a hidden user sees on their own profile.
+ *
+ * Deliberately NOT part of publicProfileData: that response is unstable_cache'd
+ * and served to everyone, so putting moderation state in it would both leak the
+ * decision publicly and pin it in a shared cache entry. This is fetched
+ * separately, uncached, and only after the viewer has been confirmed as the
+ * account owner.
+ */
+export interface ModerationNotice {
+  tone: "enforcement" | "pending" | "our-fault";
+  message: string;
+}
+
+const CONTACT_EMAIL = "i@junho.io";
+
+/**
+ * Maps a stored reason to what the account owner is told.
+ *
+ * Kept pure so the wording is testable without a database, and split by tone
+ * because the reasons are not morally equivalent. "Data issue on our side"
+ * means our own ratchet inflation (#960) removed them — telling that person
+ * they were caught abusing the leaderboard would be a false accusation, and
+ * they have nothing to appeal.
+ *
+ * None of these say how the account was identified. That stays out of anything
+ * user-visible for the same reason the stored reasons are vague.
+ */
+export function moderationNoticeFor(reason: string | null): ModerationNotice {
+  if (reason === "Data issue on our side") {
+    return {
+      tone: "our-fault",
+      message:
+        `Your usage is temporarily hidden from the leaderboard because of a data problem on our side — not anything you did. ` +
+        `Your profile and totals are unaffected, and it will be restored once the underlying issue is corrected. ` +
+        `Questions: ${CONTACT_EMAIL}`,
+    };
+  }
+
+  if (reason === "Abuse") {
+    return {
+      tone: "enforcement",
+      message:
+        `Your account has been removed from the leaderboard for abusing it. ` +
+        `Your profile and totals remain public, but you no longer hold a ranking position. ` +
+        `If you believe this is a mistake, email ${CONTACT_EMAIL}`,
+    };
+  }
+
+  // Everything else, including a missing reason, gets the neutral wording.
+  // Only an explicit "Abuse" accuses anyone: if the flag was set without an
+  // audit row, or under a reason added later, we do not actually know what
+  // happened — and "you abused this" is the one message that is unfair to send
+  // on a guess. This wording is true in every case where someone is hidden.
+  return {
+    tone: "pending",
+    message:
+      `Your account is currently withheld from the leaderboard pending review. ` +
+      `Your profile, badges and totals still work. ` +
+      `If you think this is a mistake, email ${CONTACT_EMAIL}`,
+  };
+}
+
+/**
+ * Returns the notice for `userId`, or null when they are not hidden.
+ *
+ * The caller MUST have already established that the requesting session owns
+ * this account. This performs no authorization of its own.
+ */
+export async function getModerationNotice(
+  userId: string
+): Promise<ModerationNotice | null> {
+  const [row] = await db
+    .select({ leaderboardHidden: users.leaderboardHidden })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  if (!row?.leaderboardHidden) {
+    return null;
+  }
+
+  // The most recent hide explains the current state; earlier entries are
+  // superseded history.
+  const [latest] = await db
+    .select({ reason: moderationActions.reason })
+    .from(moderationActions)
+    .where(
+      and(
+        eq(moderationActions.targetUserId, userId),
+        eq(moderationActions.action, "hide")
+      )
+    )
+    .orderBy(desc(moderationActions.createdAt))
+    .limit(1);
+
+  return moderationNoticeFor(latest?.reason ?? null);
+}


### PR DESCRIPTION
Follow-up to #980 / #984.

## Why

A hidden account currently gets **no notification at all**. The only ways to find out are noticing you have vanished from the leaderboard, or that a rank badge in your README has turned to `N/A` — and then there is nowhere obvious to ask about it.

This adds a banner on the account owner's own profile, with `i@junho.io` to contact.

## Only the owner sees it

`publicProfileData` is `unstable_cache`'d and served to everyone. Putting moderation state in it would both announce the decision publicly and pin it in a shared cache entry.

So the notice is resolved **separately, uncached, and only after the session is confirmed to own the account**. A visitor receives `null` and renders nothing.

## The wording is not the same for every reason

| Stored reason | What the owner is told |
|---|---|
| `Abuse` | Removed for abusing the leaderboard — appeal to `i@junho.io` |
| `Under investigation` | Withheld pending review |
| `Data issue on our side` | **"not anything you did"** — our problem, will be restored |
| missing / unrecognised | Neutral "pending review" |

Someone hidden by our own ratchet inflation (#960) must not be told they abused the leaderboard. That is a false accusation they cannot appeal, and keeping the two apart is the reason the reason list was split in the first place. The banner is also styled neutrally rather than amber in that case, since a warning colour implies fault on its own.

**Only an explicit `Abuse` accuses anyone.** A missing or unrecognised reason falls through to the neutral message: if the flag was set without an audit row, we do not actually know what happened, and that is not something to guess about.

## No notice names a signal

Same rule as the stored reasons — a message explaining *how* the account was identified is evasion instructions. There is a test asserting none of the four messages leaks one.

## Verification

- 765 tests pass, typecheck clean, 0 lint errors, production build succeeds
- New tests cover: every reason offers a contact address, the our-fault case never says "abuse", unknown reasons do not accuse, and no message leaks a detection signal

**Not verified:** the banner rendering end-to-end, which needs both a hidden account and that account's session. Nobody is hidden yet.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a private moderation notice to hidden users on their own profile with clear appeal instructions, without exposing moderation state to others. The notice is fetched outside cached `publicProfileData` after confirming the viewer owns the account, and lookup errors now bubble to the page error boundary.

- **New Features**
  - Owner-only banner on the profile with contact: i@junho.io.
  - Loaded separately from `publicProfileData` (`unstable_cache`) after session check; visitors see nothing.
  - Reason-aware copy and tone:
    - Abuse → enforcement.
    - Our data issue → says "not anything you did" (neutral styling).
    - Unknown/missing → neutral "pending review".
  - Messages avoid revealing detection signals.

- **Bug Fixes**
  - Preserve failures from the owner-only moderation lookup for the page error boundary.

<sup>Written for commit cdda73ce0956e6c33033909edabbf29395bf3ad0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

