### PR TITLE
fix(tencent-buddy): don't double-count cached input tokens

### DIFF
--- a/crates/tokscale-core/src/sessions/codebuddy.rs
+++ b/crates/tokscale-core/src/sessions/codebuddy.rs
@@ -29,7 +29,7 @@ mod tests {
         let path = project_dir.join("session-1.jsonl");
         std::fs::write(
             &path,
-            r#"{"id":"assistant-1","timestamp":1780000000100,"type":"message","role":"assistant","status":"completed","sessionId":"session-1","cwd":"/Users/alice/repo","providerData":{"model":"glm-5.2","messageId":"msg-1"},"message":{"usage":{"input_tokens":24486,"output_tokens":3,"cache_read_input_tokens":14720}}}"#,
+            r#"{"id":"assistant-1","timestamp":1780000000100,"type":"message","role":"assistant","status":"completed","sessionId":"session-1","cwd":"/Users/alice/repo","providerData":{"model":"glm-5.2","messageId":"msg-1"},"message":{"usage":{"input_tokens":24486,"output_tokens":3,"total_tokens":24489,"cache_read_input_tokens":14720}}}"#,
         )
         .unwrap();
 
@@ -60,7 +60,7 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].model_id, "minimax-m3-pay");
         assert_eq!(messages[0].provider_id, "minimax");
-        assert_eq!(messages[0].tokens.total(), 12);
+        assert_eq!(messages[0].tokens.total(), 15);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/codebuddy.rs
+++ b/crates/tokscale-core/src/sessions/codebuddy.rs
@@ -38,9 +38,10 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].client, "codebuddy");
         assert_eq!(messages[0].model_id, "glm-5.2");
-        assert_eq!(messages[0].tokens.input, 24486);
+        assert_eq!(messages[0].tokens.input, 9766);
         assert_eq!(messages[0].tokens.output, 3);
         assert_eq!(messages[0].tokens.cache_read, 14720);
+        assert_eq!(messages[0].tokens.total(), 24489);
         assert_eq!(messages[0].workspace_label.as_deref(), Some("repo"));
     }
 
@@ -59,7 +60,7 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].model_id, "minimax-m3-pay");
         assert_eq!(messages[0].provider_id, "minimax");
-        assert_eq!(messages[0].tokens.total(), 15);
+        assert_eq!(messages[0].tokens.total(), 12);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/tencent_buddy.rs
+++ b/crates/tokscale-core/src/sessions/tencent_buddy.rs
@@ -57,6 +57,9 @@ struct BuddyUsage {
     #[serde(rename = "inputTokens")]
     input_tokens_camel: Option<i64>,
     prompt_tokens: Option<i64>,
+    total_tokens: Option<i64>,
+    #[serde(rename = "totalTokens")]
+    total_tokens_camel: Option<i64>,
     #[serde(rename = "output_tokens")]
     output_tokens: Option<i64>,
     #[serde(rename = "outputTokens")]
@@ -94,47 +97,74 @@ impl BuddyUsage {
             self.prompt_cache_hit_tokens,
             self.cached_tokens,
         ]);
+        let output = first_present(&[
+            self.output_tokens,
+            self.output_tokens_camel,
+            self.completion_tokens,
+        ]);
+        let cache_write = first_positive(&[
+            self.cache_creation_input_tokens,
+            self.cache_creation_input_tokens_camel,
+            self.cached_write_tokens,
+            self.prompt_cache_write_tokens,
+        ]);
+        let reasoning = first_present(&[
+            self.completion_thinking_tokens,
+            self.completion_thinking_tokens_camel,
+            self.reasoning_tokens,
+        ]);
         let tokens = TokenBreakdown {
-            input: self.input_exclusive(cache_read),
-            output: first_present(&[
-                self.output_tokens,
-                self.output_tokens_camel,
-                self.completion_tokens,
-            ]),
+            input: self.input_exclusive(cache_read, cache_write, reasoning, output),
+            output,
             cache_read,
-            cache_write: first_positive(&[
-                self.cache_creation_input_tokens,
-                self.cache_creation_input_tokens_camel,
-                self.cached_write_tokens,
-                self.prompt_cache_write_tokens,
-            ]),
-            reasoning: first_present(&[
-                self.completion_thinking_tokens,
-                self.completion_thinking_tokens_camel,
-                self.reasoning_tokens,
-            ]),
+            cache_write,
+            reasoning,
         };
 
         (tokens.total() > 0).then_some(tokens)
     }
 
     /// `cachedMissTokens` / `cacheMissTokens` (extension-log style) already
-    /// exclude cached input. The OpenAI-style fields (`input_tokens`,
-    /// `inputTokens`, `prompt_tokens`) include cache-hit tokens, so subtract
-    /// `cache_read` to keep `input + output + cache_*` aligned with provider
-    /// billing instead of counting the cached portion twice.
-    fn input_exclusive(&self, cache_read: i64) -> i64 {
-        let miss_input = first_present(&[self.cached_miss_tokens, self.cache_miss_tokens]);
-        if miss_input > 0 {
+    /// exclude cached input. Other input fields are ambiguous unless a
+    /// reported total proves they include the cache buckets.
+    fn input_exclusive(
+        &self,
+        cache_read: i64,
+        cache_write: i64,
+        reasoning: i64,
+        output: i64,
+    ) -> i64 {
+        if let Some(miss_input) = self
+            .cached_miss_tokens
+            .or(self.cache_miss_tokens)
+            .map(|tokens| tokens.max(0))
+        {
             return miss_input;
         }
-        first_present(&[
+        let input = first_present(&[
             self.input_tokens,
             self.input_tokens_camel,
             self.prompt_tokens,
-        ])
-        .saturating_sub(cache_read)
+        ]);
+        let Some(total) = first_option(&[self.total_tokens, self.total_tokens_camel]) else {
+            return input;
+        };
+
+        let inclusive_total = input.saturating_add(output);
+        let exclusive_total = inclusive_total
+            .saturating_add(cache_read)
+            .saturating_add(cache_write)
+            .saturating_add(reasoning);
+        if cache_read > 0 && total.max(0) == inclusive_total && inclusive_total != exclusive_total {
+            input.saturating_sub(cache_read)
+        } else {
+            input
+        }
     }
+}
+
+fn first_option(values: &[Option<i64>]) -> Option<i64> {
+    values.iter().copied().flatten().next()
 }
 
 fn first_present(values: &[Option<i64>]) -> i64 {
@@ -502,12 +532,12 @@ mod tests {
     }
 
     #[test]
-    fn parse_jsonl_file_reads_function_call_usage() {
+    fn parse_jsonl_file_keeps_ambiguous_raw_usage_input_unchanged() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("session-2.jsonl");
         std::fs::write(
             &path,
-            r#"{"id":"call-1","timestamp":1780000000100,"type":"function_call","sessionId":"session-2","providerData":{"requestModelId":"glm-5.2","messageId":"msg-2","rawUsage":{"prompt_tokens":10,"completion_tokens":2,"prompt_cache_hit_tokens":3,"prompt_cache_write_tokens":4,"completion_thinking_tokens":5}}}"#,
+            r#"{"id":"call-1","timestamp":1780000000100,"type":"function_call","sessionId":"session-2","providerData":{"requestModelId":"glm-5.2","messageId":"msg-2","rawUsage":{"prompt_tokens":3,"completion_tokens":2,"prompt_cache_hit_tokens":4,"prompt_cache_write_tokens":4,"completion_thinking_tokens":5}}}"#,
         )
         .unwrap();
 
@@ -515,12 +545,12 @@ mod tests {
 
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].client, "workbuddy");
-        assert_eq!(messages[0].tokens.input, 7);
+        assert_eq!(messages[0].tokens.input, 3);
         assert_eq!(messages[0].tokens.output, 2);
-        assert_eq!(messages[0].tokens.cache_read, 3);
+        assert_eq!(messages[0].tokens.cache_read, 4);
         assert_eq!(messages[0].tokens.cache_write, 4);
         assert_eq!(messages[0].tokens.reasoning, 5);
-        assert_eq!(messages[0].tokens.total(), 21);
+        assert_eq!(messages[0].tokens.total(), 18);
     }
 
     #[test]
@@ -542,6 +572,46 @@ mod tests {
         assert_eq!(message.tokens.cache_read, 112224);
         // Provider-billed total (114405), not input + cache_read + output (226629).
         assert_eq!(message.tokens.total(), 114405);
+    }
+
+    #[test]
+    fn parse_jsonl_file_keeps_ambiguous_codebuddy_input_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session-ambiguous.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"id":"assistant-1","timestamp":1780000000100,"type":"message","role":"assistant","status":"completed","sessionId":"session-ambiguous","cwd":"/Users/alice/repo","providerData":{"model":"glm-5.2","messageId":"msg-1"},"message":{"usage":{"inputTokens":7,"outputTokens":2,"cacheTokens":10}}}"#,
+        )
+        .unwrap();
+
+        let messages = parse_jsonl_file("codebuddy", "codebuddy", &path);
+
+        assert_eq!(messages.len(), 1);
+        let message = &messages[0];
+        assert_eq!(message.tokens.input, 7);
+        assert_eq!(message.tokens.output, 2);
+        assert_eq!(message.tokens.cache_read, 10);
+        assert_eq!(message.tokens.total(), 19);
+    }
+
+    #[test]
+    fn parse_jsonl_file_keeps_zero_cached_miss_tokens_exclusive() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session-zero-cache-miss.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"id":"assistant-1","timestamp":1780000000100,"type":"message","role":"assistant","status":"completed","sessionId":"session-zero-cache-miss","cwd":"/Users/alice/repo","providerData":{"model":"glm-5.2","messageId":"msg-1"},"message":{"usage":{"inputTokens":100,"outputTokens":5,"cacheTokens":100,"cachedMissTokens":0}}}"#,
+        )
+        .unwrap();
+
+        let messages = parse_jsonl_file("workbuddy", "workbuddy", &path);
+
+        assert_eq!(messages.len(), 1);
+        let message = &messages[0];
+        assert_eq!(message.tokens.input, 0);
+        assert_eq!(message.tokens.output, 5);
+        assert_eq!(message.tokens.cache_read, 100);
+        assert_eq!(message.tokens.total(), 105);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/tencent_buddy.rs
+++ b/crates/tokscale-core/src/sessions/tencent_buddy.rs
@@ -87,26 +87,21 @@ struct BuddyUsage {
 
 impl BuddyUsage {
     fn to_breakdown(&self) -> Option<TokenBreakdown> {
+        let cache_read = first_positive(&[
+            self.cache_read_input_tokens,
+            self.cache_read_input_tokens_camel,
+            self.cache_tokens,
+            self.prompt_cache_hit_tokens,
+            self.cached_tokens,
+        ]);
         let tokens = TokenBreakdown {
-            input: first_present(&[
-                self.cached_miss_tokens,
-                self.cache_miss_tokens,
-                self.input_tokens,
-                self.input_tokens_camel,
-                self.prompt_tokens,
-            ]),
+            input: self.input_exclusive(cache_read),
             output: first_present(&[
                 self.output_tokens,
                 self.output_tokens_camel,
                 self.completion_tokens,
             ]),
-            cache_read: first_positive(&[
-                self.cache_read_input_tokens,
-                self.cache_read_input_tokens_camel,
-                self.cache_tokens,
-                self.prompt_cache_hit_tokens,
-                self.cached_tokens,
-            ]),
+            cache_read,
             cache_write: first_positive(&[
                 self.cache_creation_input_tokens,
                 self.cache_creation_input_tokens_camel,
@@ -121,6 +116,24 @@ impl BuddyUsage {
         };
 
         (tokens.total() > 0).then_some(tokens)
+    }
+
+    /// `cachedMissTokens` / `cacheMissTokens` (extension-log style) already
+    /// exclude cached input. The OpenAI-style fields (`input_tokens`,
+    /// `inputTokens`, `prompt_tokens`) include cache-hit tokens, so subtract
+    /// `cache_read` to keep `input + output + cache_*` aligned with provider
+    /// billing instead of counting the cached portion twice.
+    fn input_exclusive(&self, cache_read: i64) -> i64 {
+        let miss_input = first_present(&[self.cached_miss_tokens, self.cache_miss_tokens]);
+        if miss_input > 0 {
+            return miss_input;
+        }
+        first_present(&[
+            self.input_tokens,
+            self.input_tokens_camel,
+            self.prompt_tokens,
+        ])
+        .saturating_sub(cache_read)
     }
 }
 
@@ -477,9 +490,10 @@ mod tests {
         // identify the model at all.
         assert_eq!(message.provider_id, "zai");
         assert_eq!(message.session_id, "session-1");
-        assert_eq!(message.tokens.input, 24486);
+        assert_eq!(message.tokens.input, 9766);
         assert_eq!(message.tokens.output, 3);
         assert_eq!(message.tokens.cache_read, 14720);
+        assert_eq!(message.tokens.total(), 24489);
         assert_eq!(message.workspace_label.as_deref(), Some("repo"));
         assert_eq!(
             message.dedup_key.as_deref(),
@@ -501,11 +515,33 @@ mod tests {
 
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].client, "workbuddy");
-        assert_eq!(messages[0].tokens.input, 10);
+        assert_eq!(messages[0].tokens.input, 7);
         assert_eq!(messages[0].tokens.output, 2);
         assert_eq!(messages[0].tokens.cache_read, 3);
         assert_eq!(messages[0].tokens.cache_write, 4);
         assert_eq!(messages[0].tokens.reasoning, 5);
+        assert_eq!(messages[0].tokens.total(), 21);
+    }
+
+    #[test]
+    fn parse_jsonl_file_does_not_double_count_inclusive_cache_input() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session-cache.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"id":"assistant-1","timestamp":1780000000100,"type":"message","role":"assistant","status":"completed","sessionId":"session-cache","cwd":"/Users/alice/repo","providerData":{"model":"glm-5.2","messageId":"msg-1"},"message":{"usage":{"input_tokens":113415,"output_tokens":990,"total_tokens":114405,"cache_read_input_tokens":112224}}}"#,
+        )
+        .unwrap();
+
+        let messages = parse_jsonl_file("workbuddy", "workbuddy", &path);
+
+        assert_eq!(messages.len(), 1);
+        let message = &messages[0];
+        assert_eq!(message.tokens.input, 1191);
+        assert_eq!(message.tokens.output, 990);
+        assert_eq!(message.tokens.cache_read, 112224);
+        // Provider-billed total (114405), not input + cache_read + output (226629).
+        assert_eq!(message.tokens.total(), 114405);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/workbuddy.rs
+++ b/crates/tokscale-core/src/sessions/workbuddy.rs
@@ -248,10 +248,9 @@ mod tests {
         let path = dir.path().join("session-1.jsonl");
         std::fs::write(
             &path,
-            // OpenAI-style usage: prompt_tokens (140732) includes the cached
-            // hit (76032); the exclusive input is 64700, matching the
-            // extension-log mirror of the same agent execution.
-            r#"{"id":"call-1","timestamp":1780000000100,"type":"function_call","sessionId":"session-1","cwd":"/Users/alice/admin-panel","providerData":{"requestModelId":"glm-5.2","messageId":"msg-1","rawUsage":{"prompt_tokens":140732,"completion_tokens":635,"prompt_cache_hit_tokens":76032}}}"#,
+            // The reported total proves prompt_tokens includes the cached hit,
+            // so the parser can safely split the cache-exclusive input.
+            r#"{"id":"call-1","timestamp":1780000000100,"type":"function_call","sessionId":"session-1","cwd":"/Users/alice/admin-panel","providerData":{"requestModelId":"glm-5.2","messageId":"msg-1","rawUsage":{"prompt_tokens":140732,"completion_tokens":635,"total_tokens":141367,"prompt_cache_hit_tokens":76032}}}"#,
         )
         .unwrap();
 

--- a/crates/tokscale-core/src/sessions/workbuddy.rs
+++ b/crates/tokscale-core/src/sessions/workbuddy.rs
@@ -248,7 +248,10 @@ mod tests {
         let path = dir.path().join("session-1.jsonl");
         std::fs::write(
             &path,
-            r#"{"id":"call-1","timestamp":1780000000100,"type":"function_call","sessionId":"session-1","cwd":"/Users/alice/admin-panel","providerData":{"requestModelId":"glm-5.2","messageId":"msg-1","rawUsage":{"prompt_tokens":64700,"completion_tokens":635,"prompt_cache_hit_tokens":76032}}}"#,
+            // OpenAI-style usage: prompt_tokens (140732) includes the cached
+            // hit (76032); the exclusive input is 64700, matching the
+            // extension-log mirror of the same agent execution.
+            r#"{"id":"call-1","timestamp":1780000000100,"type":"function_call","sessionId":"session-1","cwd":"/Users/alice/admin-panel","providerData":{"requestModelId":"glm-5.2","messageId":"msg-1","rawUsage":{"prompt_tokens":140732,"completion_tokens":635,"prompt_cache_hit_tokens":76032}}}"#,
         )
         .unwrap();
 


### PR DESCRIPTION
Closes #1022

## Problem

WorkBuddy (and CodeBuddy) JSONL usage records follow OpenAI semantics: `input_tokens` / `prompt_tokens` **already include** cache-hit tokens, and `total_tokens` equals `input + output`. `BuddyUsage::to_breakdown()` mapped them as if they were Anthropic-style (input excludes cache), so aggregators added `cache_read` on top of an input that already contained it.

Example from the issue (`message.usage`):

- `input_tokens: 113415`, `cache_read_input_tokens: 112224`, `output_tokens: 990`, `total_tokens: 114405`
- Before: 113415 + 990 + 112224 = **226629** (roughly 2x billed)
- After: 1191 + 990 + 112224 = **114405** (matches provider `total_tokens`)

## Fix

When no `cachedMissTokens` / `cacheMissTokens` field is present (the extension-log format, where input is already cache-exclusive), subtract `cache_read` from the inclusive input field (`input_tokens`, `inputTokens`, `prompt_tokens`) in `input_exclusive()`:

- `cachedMissTokens` / `cacheMissTokens` present -> input stays as-is (already exclusive)
- otherwise -> `input = max(0, input - cache_read)`

Extension-log parsing and Claude Code parsing are unaffected (their input fields are genuinely cache-excluded).

## Tests

- New regression test with the issue example: `parse_jsonl_file_does_not_double_count_inclusive_cache_input` asserts total 114405, not 226629
- Updated existing fixtures to OpenAI semantics, including the WorkBuddy JSONL fixture that mirrors the extension-log execution (`prompt_tokens` 140732 = 64700 miss + 76032 hit, total still 141367)
- `cargo test -p tokscale-core --lib sessions::` 638 passed
- `cargo test -p tokscale-core --lib` 1355 passed (1 unrelated failure from concurrent local work on #1019)
- `cargo clippy -p tokscale-core --all-features -- -D warnings` clean
- `rustfmt --check` clean on changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes double-counting of cached input tokens in WorkBuddy/CodeBuddy parsing by using provider-reported totals, and preserves explicit zero cache misses so totals match billing.

- **Bug Fixes**
  - Parse `total_tokens`/`totalTokens` and subtract `cache_read` from `input_tokens`/`prompt_tokens` only if `total == input + output`; otherwise keep input unchanged.
  - Treat `cachedMissTokens`/`cacheMissTokens` as authoritative, including `0` (input already exclusive).
  - Updated tests/fixtures in `tencent_buddy`, `workbuddy`, and `codebuddy` to cover inclusive totals, ambiguous cases (leave input as-is), and zero cache misses.

<sup>Written for commit b29a66b0c93dde5df133d113fb022796b4c466d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

