### PR TITLE
fix(cursor): increase HTTP timeout to 15 seconds

### DIFF
--- a/crates/tokscale-cli/src/cursor.rs
+++ b/crates/tokscale-cli/src/cursor.rs
@@ -11,7 +11,7 @@ use std::time::{Duration, SystemTime};
 /// auto-sync (which runs synchronously before local reports and the TUI) while
 /// still tolerating routine API latency. If the network is hung, the report
 /// proceeds against cached data after this timeout instead of stalling forever.
-const CURSOR_HTTP_TIMEOUT: Duration = Duration::from_secs(8);
+const CURSOR_HTTP_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Skip implicit pre-report sync when every expected Cursor account cache file
 /// was modified within this window. Prevents `tokscale models` (and its
@@ -1661,8 +1661,8 @@ mod tests {
         let client = build_cursor_http_client().expect("client builds");
         // reqwest::Client doesn't expose its timeout publicly, but we can at
         // least confirm the const wired into the builder is the documented
-        // 8s value — a future change to the constant must be deliberate.
-        assert_eq!(CURSOR_HTTP_TIMEOUT, std::time::Duration::from_secs(8));
+        // 15s value — a future change to the constant must be deliberate.
+        assert_eq!(CURSOR_HTTP_TIMEOUT, std::time::Duration::from_secs(15));
         // Use the client briefly to ensure it's structurally valid.
         let _ = client.get("https://example.invalid").build();
     }


### PR DESCRIPTION
Seems the request takes **approx 9-10 seconds** for me; not sure if that's due to an old account 🤷 

If this has to be done again, I'd consider a flag/option for the user.

```
tokscale git:(increase-cursor-timeout) ./target/release/tokscale cursor sync
Cursor IDE - Sync
Synced 17832 Cursor usage event(s).
```

closes #1024 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase Cursor HTTP timeout from 8s to 15s to better tolerate slow networks during `tokscale cursor sync`, reducing unnecessary fallbacks to cached data. Updated the test to assert the new 15s constant.

<sup>Written for commit 78fdbec23221e3537040f869ba5f7955458f4cb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

