### PR TITLE
fix(pricing): keep published cache rates so submit stops rejecting Codex usage

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -5488,9 +5488,11 @@ fn report_unpriced_submission_exclusions(
     use colored::Colorize;
 
     for row in excluded {
-        let remaining_usage_message = has_remaining_usage
-            .then_some(" Remaining priced usage will be submitted.")
-            .unwrap_or_default();
+        let remaining_usage_message = if has_remaining_usage {
+            " Remaining priced usage will be submitted."
+        } else {
+            ""
+        };
         println!(
             "{}",
             format!(

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -3095,40 +3095,60 @@ fn validate_priced_messages(
         return Err("pricing data is unavailable for submission".to_string());
     };
 
-    let unpriced: Vec<String> = messages
-        .iter()
-        .filter(|message| {
-            let tokens = &message.tokens;
-            let token_bearing = tokens.input > 0
-                || tokens.output > 0
-                || tokens.cache_read > 0
-                || tokens.cache_write > 0
-                || tokens.reasoning > 0;
-            token_bearing
-                && !message.has_authoritative_cost()
-                && !pricing.covers_usage_with_provider(
-                    &message.model_id,
-                    Some(&message.provider_id),
-                    &message.tokens,
-                )
-        })
-        .map(|message| {
-            if message.provider_id.is_empty() {
-                message.model_id.clone()
-            } else {
-                format!("{}/{}", message.provider_id, message.model_id)
-            }
-        })
-        .collect();
+    // Counted rather than listed per message: a real submission repeats the
+    // same handful of ids thousands of times, and the raw list buried the
+    // actionable model names under hundreds of kilobytes of output (#1013).
+    let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    let mut order: Vec<String> = Vec::new();
 
-    if unpriced.is_empty() {
-        Ok(())
-    } else {
-        Err(format!(
-            "pricing is unavailable for submitted token usage: {}",
-            unpriced.join(", ")
-        ))
+    for message in messages {
+        let tokens = &message.tokens;
+        let token_bearing = tokens.input > 0
+            || tokens.output > 0
+            || tokens.cache_read > 0
+            || tokens.cache_write > 0
+            || tokens.reasoning > 0;
+        let unpriced = token_bearing
+            && !message.has_authoritative_cost()
+            && !pricing.covers_usage_with_provider(
+                &message.model_id,
+                Some(&message.provider_id),
+                &message.tokens,
+            );
+        if !unpriced {
+            continue;
+        }
+
+        let id = if message.provider_id.is_empty() {
+            message.model_id.clone()
+        } else {
+            format!("{}/{}", message.provider_id, message.model_id)
+        };
+        match counts.get_mut(&id) {
+            Some(count) => *count += 1,
+            None => {
+                counts.insert(id.clone(), 1);
+                order.push(id);
+            }
+        }
     }
+
+    if order.is_empty() {
+        return Ok(());
+    }
+
+    let summary = order
+        .into_iter()
+        .map(|id| match counts.get(&id).copied().unwrap_or(1) {
+            1 => id,
+            count => format!("{id} (x{count})"),
+        })
+        .collect::<Vec<String>>()
+        .join(", ");
+
+    Err(format!(
+        "pricing is unavailable for submitted token usage: {summary}"
+    ))
 }
 
 fn filter_messages_for_report(
@@ -7876,6 +7896,51 @@ mod tests {
 
         let error = validate_priced_messages(&[message], Some(&pricing)).unwrap_err();
         assert!(error.contains("provider/unlisted-model"));
+    }
+
+    // Regression: #1013. The message used to repeat one entry per affected
+    // message, so a real submission produced a ~290KB error that scrolled the
+    // actionable model ids off screen.
+    #[test]
+    fn strict_pricing_validation_error_deduplicates_models_with_counts() {
+        let unpriced = |model: &str, session: &str| {
+            UnifiedMessage::new(
+                "synthetic",
+                model,
+                "provider",
+                session,
+                1_733_011_200_000,
+                TokenBreakdown {
+                    input: 1,
+                    ..Default::default()
+                },
+                0.0,
+            )
+        };
+        let messages = vec![
+            unpriced("repeated-model", "a"),
+            unpriced("repeated-model", "b"),
+            unpriced("repeated-model", "c"),
+            unpriced("single-model", "d"),
+        ];
+        let pricing = pricing::PricingService::new(HashMap::new(), HashMap::new());
+
+        let error = validate_priced_messages(&messages, Some(&pricing)).unwrap_err();
+
+        assert_eq!(error.matches("provider/repeated-model").count(), 1);
+        assert_eq!(error.matches("provider/single-model").count(), 1);
+        assert!(
+            error.contains("provider/repeated-model (x3)"),
+            "repeated ids must carry an occurrence count: {error}"
+        );
+        assert!(
+            !error.contains("provider/single-model (x"),
+            "single occurrences must not be annotated: {error}"
+        );
+        assert!(
+            error.find("provider/repeated-model") < error.find("provider/single-model"),
+            "ids must keep first-seen order: {error}"
+        );
     }
 
     #[test]

--- a/crates/tokscale-core/src/pricing/litellm.rs
+++ b/crates/tokscale-core/src/pricing/litellm.rs
@@ -38,6 +38,75 @@ impl ModelPricing {
             && (usage.cache_write <= 0 || valid_rate(self.cache_creation_input_token_cost))
     }
 
+    /// A copy of this row with rates taken from `fallback` for the buckets
+    /// `usage` populates but this row cannot price.
+    ///
+    /// Rates already present here are never overwritten, so a reseller row
+    /// keeps its own markup and only gains the buckets it omits. Each bucket
+    /// is filled together with its long-context tiers, so a tiered walk never
+    /// mixes base and above-threshold rates from two different rows.
+    pub(crate) fn with_missing_rates_from(
+        &self,
+        fallback: &Self,
+        usage: &crate::TokenBreakdown,
+    ) -> Self {
+        let valid_rate =
+            |rate: Option<f64>| rate.is_some_and(|rate| rate.is_finite() && rate >= 0.0);
+        let mut filled = self.clone();
+
+        if usage.input > 0
+            && !valid_rate(filled.input_cost_per_token)
+            && valid_rate(fallback.input_cost_per_token)
+        {
+            filled.input_cost_per_token = fallback.input_cost_per_token;
+            filled.input_cost_per_token_above_128k_tokens =
+                fallback.input_cost_per_token_above_128k_tokens;
+            filled.input_cost_per_token_above_200k_tokens =
+                fallback.input_cost_per_token_above_200k_tokens;
+            filled.input_cost_per_token_above_256k_tokens =
+                fallback.input_cost_per_token_above_256k_tokens;
+            filled.input_cost_per_token_above_272k_tokens =
+                fallback.input_cost_per_token_above_272k_tokens;
+        }
+
+        if (usage.output > 0 || usage.reasoning > 0)
+            && !valid_rate(filled.output_cost_per_token)
+            && valid_rate(fallback.output_cost_per_token)
+        {
+            filled.output_cost_per_token = fallback.output_cost_per_token;
+            filled.output_cost_per_token_above_128k_tokens =
+                fallback.output_cost_per_token_above_128k_tokens;
+            filled.output_cost_per_token_above_200k_tokens =
+                fallback.output_cost_per_token_above_200k_tokens;
+            filled.output_cost_per_token_above_256k_tokens =
+                fallback.output_cost_per_token_above_256k_tokens;
+            filled.output_cost_per_token_above_272k_tokens =
+                fallback.output_cost_per_token_above_272k_tokens;
+        }
+
+        if usage.cache_read > 0
+            && !valid_rate(filled.cache_read_input_token_cost)
+            && valid_rate(fallback.cache_read_input_token_cost)
+        {
+            filled.cache_read_input_token_cost = fallback.cache_read_input_token_cost;
+            filled.cache_read_input_token_cost_above_200k_tokens =
+                fallback.cache_read_input_token_cost_above_200k_tokens;
+            filled.cache_read_input_token_cost_above_272k_tokens =
+                fallback.cache_read_input_token_cost_above_272k_tokens;
+        }
+
+        if usage.cache_write > 0
+            && !valid_rate(filled.cache_creation_input_token_cost)
+            && valid_rate(fallback.cache_creation_input_token_cost)
+        {
+            filled.cache_creation_input_token_cost = fallback.cache_creation_input_token_cost;
+            filled.cache_creation_input_token_cost_above_200k_tokens =
+                fallback.cache_creation_input_token_cost_above_200k_tokens;
+        }
+
+        filled
+    }
+
     pub(crate) fn has_any_usable_base_rate(&self) -> bool {
         [
             self.input_cost_per_token,

--- a/crates/tokscale-core/src/pricing/litellm.rs
+++ b/crates/tokscale-core/src/pricing/litellm.rs
@@ -53,6 +53,10 @@ impl ModelPricing {
     ) -> Self {
         let valid_rate =
             |rate: Option<f64>| rate.is_some_and(|rate| rate.is_finite() && rate >= 0.0);
+        let valid_or_fallback = |rate: Option<f64>, fallback_rate: Option<f64>| {
+            rate.filter(|rate| rate.is_finite() && *rate >= 0.0)
+                .or_else(|| fallback_rate.filter(|rate| rate.is_finite() && *rate >= 0.0))
+        };
         let mut filled = self.clone();
 
         if usage.input > 0
@@ -60,18 +64,22 @@ impl ModelPricing {
             && valid_rate(fallback.input_cost_per_token)
         {
             filled.input_cost_per_token = fallback.input_cost_per_token;
-            filled.input_cost_per_token_above_128k_tokens = filled
-                .input_cost_per_token_above_128k_tokens
-                .or(fallback.input_cost_per_token_above_128k_tokens);
-            filled.input_cost_per_token_above_200k_tokens = filled
-                .input_cost_per_token_above_200k_tokens
-                .or(fallback.input_cost_per_token_above_200k_tokens);
-            filled.input_cost_per_token_above_256k_tokens = filled
-                .input_cost_per_token_above_256k_tokens
-                .or(fallback.input_cost_per_token_above_256k_tokens);
-            filled.input_cost_per_token_above_272k_tokens = filled
-                .input_cost_per_token_above_272k_tokens
-                .or(fallback.input_cost_per_token_above_272k_tokens);
+            filled.input_cost_per_token_above_128k_tokens = valid_or_fallback(
+                filled.input_cost_per_token_above_128k_tokens,
+                fallback.input_cost_per_token_above_128k_tokens,
+            );
+            filled.input_cost_per_token_above_200k_tokens = valid_or_fallback(
+                filled.input_cost_per_token_above_200k_tokens,
+                fallback.input_cost_per_token_above_200k_tokens,
+            );
+            filled.input_cost_per_token_above_256k_tokens = valid_or_fallback(
+                filled.input_cost_per_token_above_256k_tokens,
+                fallback.input_cost_per_token_above_256k_tokens,
+            );
+            filled.input_cost_per_token_above_272k_tokens = valid_or_fallback(
+                filled.input_cost_per_token_above_272k_tokens,
+                fallback.input_cost_per_token_above_272k_tokens,
+            );
         }
 
         if (usage.output > 0 || usage.reasoning > 0)
@@ -79,18 +87,22 @@ impl ModelPricing {
             && valid_rate(fallback.output_cost_per_token)
         {
             filled.output_cost_per_token = fallback.output_cost_per_token;
-            filled.output_cost_per_token_above_128k_tokens = filled
-                .output_cost_per_token_above_128k_tokens
-                .or(fallback.output_cost_per_token_above_128k_tokens);
-            filled.output_cost_per_token_above_200k_tokens = filled
-                .output_cost_per_token_above_200k_tokens
-                .or(fallback.output_cost_per_token_above_200k_tokens);
-            filled.output_cost_per_token_above_256k_tokens = filled
-                .output_cost_per_token_above_256k_tokens
-                .or(fallback.output_cost_per_token_above_256k_tokens);
-            filled.output_cost_per_token_above_272k_tokens = filled
-                .output_cost_per_token_above_272k_tokens
-                .or(fallback.output_cost_per_token_above_272k_tokens);
+            filled.output_cost_per_token_above_128k_tokens = valid_or_fallback(
+                filled.output_cost_per_token_above_128k_tokens,
+                fallback.output_cost_per_token_above_128k_tokens,
+            );
+            filled.output_cost_per_token_above_200k_tokens = valid_or_fallback(
+                filled.output_cost_per_token_above_200k_tokens,
+                fallback.output_cost_per_token_above_200k_tokens,
+            );
+            filled.output_cost_per_token_above_256k_tokens = valid_or_fallback(
+                filled.output_cost_per_token_above_256k_tokens,
+                fallback.output_cost_per_token_above_256k_tokens,
+            );
+            filled.output_cost_per_token_above_272k_tokens = valid_or_fallback(
+                filled.output_cost_per_token_above_272k_tokens,
+                fallback.output_cost_per_token_above_272k_tokens,
+            );
         }
 
         if usage.cache_read > 0
@@ -98,12 +110,14 @@ impl ModelPricing {
             && valid_rate(fallback.cache_read_input_token_cost)
         {
             filled.cache_read_input_token_cost = fallback.cache_read_input_token_cost;
-            filled.cache_read_input_token_cost_above_200k_tokens = filled
-                .cache_read_input_token_cost_above_200k_tokens
-                .or(fallback.cache_read_input_token_cost_above_200k_tokens);
-            filled.cache_read_input_token_cost_above_272k_tokens = filled
-                .cache_read_input_token_cost_above_272k_tokens
-                .or(fallback.cache_read_input_token_cost_above_272k_tokens);
+            filled.cache_read_input_token_cost_above_200k_tokens = valid_or_fallback(
+                filled.cache_read_input_token_cost_above_200k_tokens,
+                fallback.cache_read_input_token_cost_above_200k_tokens,
+            );
+            filled.cache_read_input_token_cost_above_272k_tokens = valid_or_fallback(
+                filled.cache_read_input_token_cost_above_272k_tokens,
+                fallback.cache_read_input_token_cost_above_272k_tokens,
+            );
         }
 
         if usage.cache_write > 0
@@ -111,9 +125,10 @@ impl ModelPricing {
             && valid_rate(fallback.cache_creation_input_token_cost)
         {
             filled.cache_creation_input_token_cost = fallback.cache_creation_input_token_cost;
-            filled.cache_creation_input_token_cost_above_200k_tokens = filled
-                .cache_creation_input_token_cost_above_200k_tokens
-                .or(fallback.cache_creation_input_token_cost_above_200k_tokens);
+            filled.cache_creation_input_token_cost_above_200k_tokens = valid_or_fallback(
+                filled.cache_creation_input_token_cost_above_200k_tokens,
+                fallback.cache_creation_input_token_cost_above_200k_tokens,
+            );
         }
 
         filled
@@ -197,6 +212,30 @@ mod pricing_row_tests {
         let filled = hinted.with_missing_rates_from(&fallback, &cache_read_usage());
 
         assert_eq!(filled.cache_read_input_token_cost, Some(1.75e-7));
+        assert_eq!(
+            filled.cache_read_input_token_cost_above_200k_tokens,
+            Some(9.9e-7)
+        );
+    }
+
+    #[test]
+    fn invalid_long_context_tiers_fall_back_to_valid_tiers() {
+        let hinted = ModelPricing {
+            input_cost_per_token: Some(1.75e-6),
+            output_cost_per_token: Some(1.4e-5),
+            cache_read_input_token_cost_above_200k_tokens: Some(f64::NAN),
+            ..Default::default()
+        };
+        let fallback = ModelPricing {
+            input_cost_per_token: Some(1.75e-6),
+            output_cost_per_token: Some(1.4e-5),
+            cache_read_input_token_cost: Some(1.75e-7),
+            cache_read_input_token_cost_above_200k_tokens: Some(9.9e-7),
+            ..Default::default()
+        };
+
+        let filled = hinted.with_missing_rates_from(&fallback, &cache_read_usage());
+
         assert_eq!(
             filled.cache_read_input_token_cost_above_200k_tokens,
             Some(9.9e-7)

--- a/crates/tokscale-core/src/pricing/litellm.rs
+++ b/crates/tokscale-core/src/pricing/litellm.rs
@@ -41,10 +41,11 @@ impl ModelPricing {
     /// A copy of this row with rates taken from `fallback` for the buckets
     /// `usage` populates but this row cannot price.
     ///
-    /// Rates already present here are never overwritten, so a reseller row
-    /// keeps its own markup and only gains the buckets it omits. Each bucket
-    /// is filled together with its long-context tiers, so a tiered walk never
-    /// mixes base and above-threshold rates from two different rows.
+    /// No rate already present here is ever overwritten, including the
+    /// long-context tiers: a row that publishes an above-threshold rate for a
+    /// bucket whose base rate it omits keeps that tier, and only the rates it
+    /// genuinely lacks are taken from `fallback`. Callers are responsible for
+    /// establishing that the two rows price the same deal before borrowing.
     pub(crate) fn with_missing_rates_from(
         &self,
         fallback: &Self,
@@ -59,14 +60,18 @@ impl ModelPricing {
             && valid_rate(fallback.input_cost_per_token)
         {
             filled.input_cost_per_token = fallback.input_cost_per_token;
-            filled.input_cost_per_token_above_128k_tokens =
-                fallback.input_cost_per_token_above_128k_tokens;
-            filled.input_cost_per_token_above_200k_tokens =
-                fallback.input_cost_per_token_above_200k_tokens;
-            filled.input_cost_per_token_above_256k_tokens =
-                fallback.input_cost_per_token_above_256k_tokens;
-            filled.input_cost_per_token_above_272k_tokens =
-                fallback.input_cost_per_token_above_272k_tokens;
+            filled.input_cost_per_token_above_128k_tokens = filled
+                .input_cost_per_token_above_128k_tokens
+                .or(fallback.input_cost_per_token_above_128k_tokens);
+            filled.input_cost_per_token_above_200k_tokens = filled
+                .input_cost_per_token_above_200k_tokens
+                .or(fallback.input_cost_per_token_above_200k_tokens);
+            filled.input_cost_per_token_above_256k_tokens = filled
+                .input_cost_per_token_above_256k_tokens
+                .or(fallback.input_cost_per_token_above_256k_tokens);
+            filled.input_cost_per_token_above_272k_tokens = filled
+                .input_cost_per_token_above_272k_tokens
+                .or(fallback.input_cost_per_token_above_272k_tokens);
         }
 
         if (usage.output > 0 || usage.reasoning > 0)
@@ -74,14 +79,18 @@ impl ModelPricing {
             && valid_rate(fallback.output_cost_per_token)
         {
             filled.output_cost_per_token = fallback.output_cost_per_token;
-            filled.output_cost_per_token_above_128k_tokens =
-                fallback.output_cost_per_token_above_128k_tokens;
-            filled.output_cost_per_token_above_200k_tokens =
-                fallback.output_cost_per_token_above_200k_tokens;
-            filled.output_cost_per_token_above_256k_tokens =
-                fallback.output_cost_per_token_above_256k_tokens;
-            filled.output_cost_per_token_above_272k_tokens =
-                fallback.output_cost_per_token_above_272k_tokens;
+            filled.output_cost_per_token_above_128k_tokens = filled
+                .output_cost_per_token_above_128k_tokens
+                .or(fallback.output_cost_per_token_above_128k_tokens);
+            filled.output_cost_per_token_above_200k_tokens = filled
+                .output_cost_per_token_above_200k_tokens
+                .or(fallback.output_cost_per_token_above_200k_tokens);
+            filled.output_cost_per_token_above_256k_tokens = filled
+                .output_cost_per_token_above_256k_tokens
+                .or(fallback.output_cost_per_token_above_256k_tokens);
+            filled.output_cost_per_token_above_272k_tokens = filled
+                .output_cost_per_token_above_272k_tokens
+                .or(fallback.output_cost_per_token_above_272k_tokens);
         }
 
         if usage.cache_read > 0
@@ -89,10 +98,12 @@ impl ModelPricing {
             && valid_rate(fallback.cache_read_input_token_cost)
         {
             filled.cache_read_input_token_cost = fallback.cache_read_input_token_cost;
-            filled.cache_read_input_token_cost_above_200k_tokens =
-                fallback.cache_read_input_token_cost_above_200k_tokens;
-            filled.cache_read_input_token_cost_above_272k_tokens =
-                fallback.cache_read_input_token_cost_above_272k_tokens;
+            filled.cache_read_input_token_cost_above_200k_tokens = filled
+                .cache_read_input_token_cost_above_200k_tokens
+                .or(fallback.cache_read_input_token_cost_above_200k_tokens);
+            filled.cache_read_input_token_cost_above_272k_tokens = filled
+                .cache_read_input_token_cost_above_272k_tokens
+                .or(fallback.cache_read_input_token_cost_above_272k_tokens);
         }
 
         if usage.cache_write > 0
@@ -100,8 +111,9 @@ impl ModelPricing {
             && valid_rate(fallback.cache_creation_input_token_cost)
         {
             filled.cache_creation_input_token_cost = fallback.cache_creation_input_token_cost;
-            filled.cache_creation_input_token_cost_above_200k_tokens =
-                fallback.cache_creation_input_token_cost_above_200k_tokens;
+            filled.cache_creation_input_token_cost_above_200k_tokens = filled
+                .cache_creation_input_token_cost_above_200k_tokens
+                .or(fallback.cache_creation_input_token_cost_above_200k_tokens);
         }
 
         filled
@@ -120,6 +132,95 @@ impl ModelPricing {
 }
 
 pub type PricingDataset = HashMap<String, ModelPricing>;
+
+#[cfg(test)]
+mod pricing_row_tests {
+    use super::ModelPricing;
+    use crate::TokenBreakdown;
+
+    fn cache_read_usage() -> TokenBreakdown {
+        TokenBreakdown {
+            input: 10,
+            output: 0,
+            cache_read: 10,
+            cache_write: 0,
+            reasoning: 0,
+        }
+    }
+
+    // A hinted row can publish a long-context tier for a bucket whose base
+    // rate it omits. Filling the base must not drag the fallback's tier in
+    // with it, or long-context usage silently reprices onto another row.
+    #[test]
+    fn existing_long_context_tiers_survive_a_filled_base_rate() {
+        let hinted = ModelPricing {
+            input_cost_per_token: Some(1.75e-6),
+            output_cost_per_token: Some(1.4e-5),
+            cache_read_input_token_cost_above_200k_tokens: Some(5e-7),
+            ..Default::default()
+        };
+        let fallback = ModelPricing {
+            input_cost_per_token: Some(1.75e-6),
+            output_cost_per_token: Some(1.4e-5),
+            cache_read_input_token_cost: Some(1.75e-7),
+            cache_read_input_token_cost_above_200k_tokens: Some(9.9e-7),
+            ..Default::default()
+        };
+
+        let filled = hinted.with_missing_rates_from(&fallback, &cache_read_usage());
+
+        assert_eq!(filled.cache_read_input_token_cost, Some(1.75e-7));
+        assert_eq!(
+            filled.cache_read_input_token_cost_above_200k_tokens,
+            Some(5e-7),
+            "the hinted row's own long-context tier must be preserved"
+        );
+    }
+
+    // Absent tiers are still worth filling, otherwise a borrowed base rate
+    // walks off a cliff once usage crosses the threshold.
+    #[test]
+    fn absent_long_context_tiers_are_filled_alongside_the_base_rate() {
+        let hinted = ModelPricing {
+            input_cost_per_token: Some(1.75e-6),
+            output_cost_per_token: Some(1.4e-5),
+            ..Default::default()
+        };
+        let fallback = ModelPricing {
+            input_cost_per_token: Some(1.75e-6),
+            output_cost_per_token: Some(1.4e-5),
+            cache_read_input_token_cost: Some(1.75e-7),
+            cache_read_input_token_cost_above_200k_tokens: Some(9.9e-7),
+            ..Default::default()
+        };
+
+        let filled = hinted.with_missing_rates_from(&fallback, &cache_read_usage());
+
+        assert_eq!(filled.cache_read_input_token_cost, Some(1.75e-7));
+        assert_eq!(
+            filled.cache_read_input_token_cost_above_200k_tokens,
+            Some(9.9e-7)
+        );
+    }
+
+    // A bucket the usage does not touch is never filled.
+    #[test]
+    fn untouched_buckets_are_left_alone() {
+        let hinted = ModelPricing {
+            input_cost_per_token: Some(1.75e-6),
+            ..Default::default()
+        };
+        let fallback = ModelPricing {
+            input_cost_per_token: Some(1.75e-6),
+            cache_creation_input_token_cost: Some(2e-6),
+            ..Default::default()
+        };
+
+        let filled = hinted.with_missing_rates_from(&fallback, &cache_read_usage());
+
+        assert_eq!(filled.cache_creation_input_token_cost, None);
+    }
+}
 
 pub fn load_cached() -> Option<PricingDataset> {
     cache::load_cache(CACHE_FILENAME)

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -1171,12 +1171,71 @@ impl PricingLookup {
         usage: &TokenBreakdown,
     ) -> f64 {
         let provider_id = normalize_provider_hint(provider_id);
-        let result = match self.lookup_with_provider(model_id, provider_id) {
+        let result = match self.resolve_for_usage(model_id, provider_id, usage) {
             Some(r) => r,
             None => return 0.0,
         };
 
         compute_cost_for_lookup(&result, provider_id, usage)
+    }
+
+    pub(crate) fn covers_usage_with_provider(
+        &self,
+        model_id: &str,
+        provider_id: Option<&str>,
+        usage: &TokenBreakdown,
+    ) -> bool {
+        self.resolve_for_usage(model_id, provider_id, usage)
+            .is_some_and(|result| result.pricing.covers_usage(usage))
+    }
+
+    /// Resolve `model_id` for pricing `usage`, borrowing the rates the
+    /// provider-hinted row omits from the canonical unhinted row.
+    ///
+    /// A provider hint can steer resolution onto a gateway or reseller key
+    /// that lists input and output rates only — OpenRouter's
+    /// `openai/gpt-5.2-codex` and LiteLLM's `gmi/google/gemini-3-pro-preview`
+    /// both do — while the canonical key for the same model publishes the
+    /// cache rates as well. Pricing the hinted row alone bills cached tokens
+    /// at zero and makes `covers_usage` false, which aborted whole
+    /// submissions for every Codex session (#1013).
+    ///
+    /// Only buckets the hinted row cannot price are filled, so a reseller row
+    /// keeps its own markup rather than silently repricing to the author's
+    /// cheaper rate. If the filled row still cannot cover the usage, the
+    /// hinted row is returned unchanged and the usage stays unpriced.
+    fn resolve_for_usage(
+        &self,
+        model_id: &str,
+        provider_id: Option<&str>,
+        usage: &TokenBreakdown,
+    ) -> Option<LookupResult> {
+        let hinted = self.lookup_with_provider(model_id, provider_id)?;
+        if normalize_provider_hint(provider_id).is_none() || hinted.pricing.covers_usage(usage) {
+            return Some(hinted);
+        }
+
+        let Some(canonical) = self.lookup_with_provider(model_id, None) else {
+            return Some(hinted);
+        };
+        if canonical.matched_key == hinted.matched_key {
+            return Some(hinted);
+        }
+
+        let filled = hinted
+            .pricing
+            .with_missing_rates_from(&canonical.pricing, usage);
+        if !filled.covers_usage(usage) {
+            return Some(hinted);
+        }
+
+        // Keep the hinted row's source and matched key: `compute_cost_for_lookup`
+        // branches on both for OpenAI's full-request 272k tiering, so borrowing
+        // rates must not change which pricing model applies.
+        Some(LookupResult {
+            pricing: filled,
+            ..hinted
+        })
     }
 }
 
@@ -3219,14 +3278,18 @@ mod tests {
             reasoning: 0,
         };
 
-        // Neither row covers both populated buckets. Retain the provider row
-        // rather than replacing it with an unhinted row that silently prices
-        // the input bucket at zero.
+        // Neither row covers both populated buckets on its own. The provider
+        // row keeps its own input rate (1.0) and only borrows the output rate
+        // it does not publish (2.0). The hazard this guards against — the
+        // unhinted row replacing the provider row wholesale, pricing input at
+        // zero — would total 2.0, and pricing the unfilled output bucket at
+        // zero would total 1.0.
         assert_eq!(
             lookup.calculate_cost_with_provider("gpt-fallback-guard", Some("azure"), &usage),
-            1.0
+            3.0
         );
     }
+
     #[test]
     fn test_provider_hint_normalizes_openai_codex_alias() {
         let mut litellm = HashMap::new();

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -1218,7 +1218,9 @@ impl PricingLookup {
         let Some(canonical) = self.lookup_with_provider(model_id, None) else {
             return Some(hinted);
         };
-        if canonical.matched_key == hinted.matched_key {
+        if canonical.matched_key == hinted.matched_key
+            || !quote_same_base_rates(&hinted.pricing, &canonical.pricing)
+        {
             return Some(hinted);
         }
 
@@ -1237,6 +1239,48 @@ impl PricingLookup {
             ..hinted
         })
     }
+}
+
+/// Whether two rows price the same deal, judged on the base rates they both
+/// publish.
+///
+/// Borrowing a rate across rows that disagree would invent a tariff neither
+/// provider charges: `azure_ai/grok-code-fast-1` bills $3.50/$17.50 per
+/// million with no cache-read rate, while the canonical `xai/` row bills
+/// $0.20/$1.50 with one, so an Azure row must never inherit xAI's cache
+/// price. Rows must also agree on at least one bucket — without a single
+/// shared rate there is no evidence they describe the same deal at all.
+fn quote_same_base_rates(hinted: &ModelPricing, canonical: &ModelPricing) -> bool {
+    let mut shared = false;
+
+    for (hinted_rate, canonical_rate) in [
+        (hinted.input_cost_per_token, canonical.input_cost_per_token),
+        (
+            hinted.output_cost_per_token,
+            canonical.output_cost_per_token,
+        ),
+        (
+            hinted.cache_read_input_token_cost,
+            canonical.cache_read_input_token_cost,
+        ),
+        (
+            hinted.cache_creation_input_token_cost,
+            canonical.cache_creation_input_token_cost,
+        ),
+    ] {
+        let (Some(hinted_rate), Some(canonical_rate)) = (hinted_rate, canonical_rate) else {
+            continue;
+        };
+        if !hinted_rate.is_finite() || !canonical_rate.is_finite() {
+            return false;
+        }
+        if (hinted_rate - canonical_rate).abs() > canonical_rate.abs() * 1e-9 {
+            return false;
+        }
+        shared = true;
+    }
+
+    shared
 }
 
 fn matches_model_or_snapshot(model_id: &str, base: &str) -> bool {
@@ -3278,15 +3322,13 @@ mod tests {
             reasoning: 0,
         };
 
-        // Neither row covers both populated buckets on its own. The provider
-        // row keeps its own input rate (1.0) and only borrows the output rate
-        // it does not publish (2.0). The hazard this guards against — the
-        // unhinted row replacing the provider row wholesale, pricing input at
-        // zero — would total 2.0, and pricing the unfilled output bucket at
-        // zero would total 1.0.
+        // Neither row covers both populated buckets, and they share no base
+        // bucket that would show they price the same deal, so no rate is
+        // borrowed. Retain the provider row rather than replacing it with an
+        // unhinted row that silently prices the input bucket at zero.
         assert_eq!(
             lookup.calculate_cost_with_provider("gpt-fallback-guard", Some("azure"), &usage),
-            3.0
+            1.0
         );
     }
 

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -397,10 +397,12 @@ impl PricingService {
         provider_id: Option<&str>,
         usage: &TokenBreakdown,
     ) -> bool {
-        let Some(result) = self.lookup_with_source_and_provider(model_id, None, provider_id) else {
-            return false;
-        };
-        result.pricing.covers_usage(usage)
+        if let Some(result) = self.custom.lookup_with_key(model_id) {
+            return result.pricing.covers_usage(usage);
+        }
+
+        self.lookup
+            .covers_usage_with_provider(model_id, provider_id, usage)
     }
 
     fn lookup_custom(&self, model_id: &str) -> Option<LookupResult> {
@@ -451,6 +453,124 @@ mod tests {
             openrouter,
             models_dev,
         )
+    }
+
+    fn cache_read_usage() -> TokenBreakdown {
+        TokenBreakdown {
+            input: 1_000_000,
+            output: 0,
+            cache_read: 1_000_000,
+            cache_write: 0,
+            reasoning: 0,
+        }
+    }
+
+    // Regression: #1013. Submission validation judged bucket coverage against
+    // the provider-hinted row alone. For `openai/gpt-5.2-codex` the hint lands
+    // on an OpenRouter row with no cache-read rate while the canonical LiteLLM
+    // row publishes one, so every Codex session — which always carries cached
+    // tokens — was reported as unpriced and aborted the whole submission.
+    #[test]
+    fn hinted_row_missing_a_cache_rate_still_covers_usage() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "azure/codex-cache-gap".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(1e-5),
+                output_cost_per_token: Some(1e-4),
+                ..Default::default()
+            },
+        );
+        litellm.insert(
+            "codex-cache-gap".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(1e-6),
+                output_cost_per_token: Some(1e-5),
+                cache_read_input_token_cost: Some(1e-7),
+                ..Default::default()
+            },
+        );
+        let service = PricingService::new(litellm, HashMap::new());
+
+        assert!(service.covers_usage_with_provider(
+            "codex-cache-gap",
+            Some("azure"),
+            &cache_read_usage()
+        ));
+    }
+
+    // Guard for the fix above: borrowing must never reach a bucket the hinted
+    // row already prices, otherwise a reseller row (e.g. `azure_ai/` at a
+    // markup over `xai/`) would silently reprice to the author's cheaper rate.
+    #[test]
+    fn covered_hinted_row_is_not_replaced_by_the_canonical_row() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "azure/marked-up-model".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(1e-5),
+                cache_read_input_token_cost: Some(1e-6),
+                ..Default::default()
+            },
+        );
+        litellm.insert(
+            "marked-up-model".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(1e-7),
+                cache_read_input_token_cost: Some(1e-8),
+                ..Default::default()
+            },
+        );
+        let service = PricingService::new(litellm, HashMap::new());
+        let usage = cache_read_usage();
+
+        assert!(service.covers_usage_with_provider("marked-up-model", Some("azure"), &usage));
+        let cost = service.calculate_cost_with_provider("marked-up-model", Some("azure"), &usage);
+        assert!(
+            (cost - 11.0).abs() < 1e-9,
+            "reseller markup must survive: {cost}"
+        );
+    }
+
+    // A model nothing can price must still be rejected, so submissions never
+    // silently bill genuinely unknown usage at zero.
+    #[test]
+    fn usage_stays_uncovered_when_no_resolution_prices_the_bucket() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "azure/no-cache-anywhere".to_string(),
+            model_pricing(1e-5, 1e-4),
+        );
+        litellm.insert("no-cache-anywhere".to_string(), model_pricing(1e-6, 1e-5));
+        let service = PricingService::new(litellm, HashMap::new());
+
+        assert!(!service.covers_usage_with_provider(
+            "no-cache-anywhere",
+            Some("azure"),
+            &cache_read_usage()
+        ));
+    }
+
+    // Custom overrides are exact-only and provider-agnostic, so they must be
+    // consulted before any provider-hinted resolution or bucket borrowing.
+    #[test]
+    fn custom_pricing_decides_coverage_before_any_fallback() {
+        let mut custom = HashMap::new();
+        custom.insert(
+            "custom-covered-model".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(1e-6),
+                cache_read_input_token_cost: Some(1e-7),
+                ..Default::default()
+            },
+        );
+        let service = custom_service(custom, HashMap::new(), HashMap::new());
+
+        assert!(service.covers_usage_with_provider(
+            "custom-covered-model",
+            Some("azure"),
+            &cache_read_usage()
+        ));
     }
 
     // Regression: #1002. A LiteLLM fetch failure used to propagate out of

--- a/crates/tokscale-core/src/pricing/mod.rs
+++ b/crates/tokscale-core/src/pricing/mod.rs
@@ -476,27 +476,65 @@ mod tests {
         litellm.insert(
             "azure/codex-cache-gap".to_string(),
             ModelPricing {
-                input_cost_per_token: Some(1e-5),
-                output_cost_per_token: Some(1e-4),
+                input_cost_per_token: Some(1.75e-6),
+                output_cost_per_token: Some(1.4e-5),
                 ..Default::default()
             },
         );
         litellm.insert(
             "codex-cache-gap".to_string(),
             ModelPricing {
-                input_cost_per_token: Some(1e-6),
-                output_cost_per_token: Some(1e-5),
-                cache_read_input_token_cost: Some(1e-7),
+                input_cost_per_token: Some(1.75e-6),
+                output_cost_per_token: Some(1.4e-5),
+                cache_read_input_token_cost: Some(1.75e-7),
                 ..Default::default()
             },
         );
         let service = PricingService::new(litellm, HashMap::new());
+        let usage = cache_read_usage();
 
-        assert!(service.covers_usage_with_provider(
-            "codex-cache-gap",
-            Some("azure"),
-            &cache_read_usage()
-        ));
+        assert!(service.covers_usage_with_provider("codex-cache-gap", Some("azure"), &usage));
+        let cost = service.calculate_cost_with_provider("codex-cache-gap", Some("azure"), &usage);
+        assert!((cost - 1.925).abs() < 1e-9, "unexpected cost: {cost}");
+    }
+
+    // The two rows must be the same deal before one lends the other a rate.
+    // `azure_ai/grok-code-fast-1` bills $3.50/$17.50 per million with no
+    // cache-read rate while the canonical `xai/` row bills $0.20/$1.50 with
+    // one; borrowing across them would invent an Azure-base, xAI-cache tariff
+    // that neither provider charges.
+    #[test]
+    fn differently_priced_canonical_row_does_not_lend_its_cache_rate() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "azure/grok-tariff-guard".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(3.5e-6),
+                output_cost_per_token: Some(1.75e-5),
+                ..Default::default()
+            },
+        );
+        litellm.insert(
+            "grok-tariff-guard".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(2e-7),
+                output_cost_per_token: Some(1.5e-6),
+                cache_read_input_token_cost: Some(2e-8),
+                ..Default::default()
+            },
+        );
+        let service = PricingService::new(litellm, HashMap::new());
+        let usage = cache_read_usage();
+
+        assert!(
+            !service.covers_usage_with_provider("grok-tariff-guard", Some("azure"), &usage),
+            "a differently priced row must not make the usage look priceable"
+        );
+        let cost = service.calculate_cost_with_provider("grok-tariff-guard", Some("azure"), &usage);
+        assert!(
+            (cost - 3.5).abs() < 1e-9,
+            "the reseller's own rates must be the only ones applied: {cost}"
+        );
     }
 
     // Guard for the fix above: borrowing must never reach a bucket the hinted

--- a/crates/tokscale-core/src/pricing/openrouter.rs
+++ b/crates/tokscale-core/src/pricing/openrouter.rs
@@ -204,9 +204,15 @@ fn select_endpoint_pricing(
 
     // Cache read and cache write are independent fields, so the endpoint
     // publishing the most of them is the one that leaves the fewest buckets
-    // unpriceable. Ties keep the earliest endpoint.
+    // unpriceable. On an equal count, retain cache-read pricing: it is the
+    // bucket required by Codex usage and must not be lost to an earlier
+    // write-only endpoint.
     matching.into_iter().reduce(|best, candidate| {
-        if published_cache_rates(&candidate) > published_cache_rates(&best) {
+        if published_cache_rates(&candidate) > published_cache_rates(&best)
+            || (published_cache_rates(&candidate) == published_cache_rates(&best)
+                && candidate.cache_read_input_token_cost.is_some()
+                && best.cache_read_input_token_cost.is_none())
+        {
             candidate
         } else {
             best
@@ -454,6 +460,26 @@ mod tests {
 
         assert_eq!(pricing.cache_read_input_token_cost, Some(1.75e-7));
         assert_eq!(pricing.cache_creation_input_token_cost, Some(2.2e-6));
+    }
+
+    #[test]
+    fn cache_read_wins_a_cache_rate_count_tie() {
+        let endpoints = vec![
+            endpoint_with_cache("Azure", "0.00000175", "0.000014", None, Some("0.0000022")),
+            endpoint_with_cache(
+                "Foundry",
+                "0.00000175",
+                "0.000014",
+                Some("0.000000175"),
+                None,
+            ),
+        ];
+
+        let pricing =
+            select_endpoint_pricing(&endpoints, "OpenAI", Some(&listed(1.75e-6, 1.4e-5))).unwrap();
+
+        assert_eq!(pricing.cache_read_input_token_cost, Some(1.75e-7));
+        assert_eq!(pricing.cache_creation_input_token_cost, None);
     }
 
     #[tokio::test]

--- a/crates/tokscale-core/src/pricing/openrouter.rs
+++ b/crates/tokscale-core/src/pricing/openrouter.rs
@@ -135,43 +135,78 @@ async fn fetch_author_pricing(
         }
     };
 
-    // Find the endpoint from the author provider
-    let author_endpoint = match data
-        .data
-        .endpoints
-        .iter()
-        .find(|e| e.provider_name == author_name)
-    {
-        Some(ep) => ep,
-        None => {
-            return fallback_pricing.map(|p| (model_id, p));
-        }
-    };
-
-    let input_cost = parse_price(&author_endpoint.pricing.prompt);
-    let output_cost = parse_price(&author_endpoint.pricing.completion);
-
-    if input_cost.is_none() || output_cost.is_none() {
-        return fallback_pricing.map(|p| (model_id, p));
+    match select_endpoint_pricing(&data.data.endpoints, author_name, fallback_pricing.as_ref()) {
+        Some(pricing) => Some((model_id, pricing)),
+        None => fallback_pricing.map(|p| (model_id, p)),
     }
+}
 
-    let pricing = ModelPricing {
-        input_cost_per_token: input_cost,
-        output_cost_per_token: output_cost,
-        cache_read_input_token_cost: author_endpoint
+fn endpoint_pricing(endpoint: &Endpoint) -> Option<ModelPricing> {
+    Some(ModelPricing {
+        input_cost_per_token: Some(parse_price(&endpoint.pricing.prompt)?),
+        output_cost_per_token: Some(parse_price(&endpoint.pricing.completion)?),
+        cache_read_input_token_cost: endpoint
             .pricing
             .input_cache_read
-            .as_ref()
-            .and_then(|s| parse_price(s)),
-        cache_creation_input_token_cost: author_endpoint
+            .as_deref()
+            .and_then(parse_price),
+        cache_creation_input_token_cost: endpoint
             .pricing
             .input_cache_write
-            .as_ref()
-            .and_then(|s| parse_price(s)),
+            .as_deref()
+            .and_then(parse_price),
         ..Default::default()
+    })
+}
+
+fn quotes_same_base_price(candidate: &ModelPricing, listed: &ModelPricing) -> bool {
+    let same = |candidate: Option<f64>, listed: Option<f64>| match (candidate, listed) {
+        (Some(candidate), Some(listed)) => (candidate - listed).abs() <= listed.abs() * 1e-9,
+        _ => false,
     };
 
-    Some((model_id, pricing))
+    same(candidate.input_cost_per_token, listed.input_cost_per_token)
+        && same(
+            candidate.output_cost_per_token,
+            listed.output_cost_per_token,
+        )
+}
+
+/// Pick the pricing row for a model from its OpenRouter endpoints.
+///
+/// The model author's own endpoint still wins, so `glm-4.7` keeps Z.AI's
+/// price rather than a reseller's markup. When the model has no endpoint from
+/// its author, the listed price is used exactly as before — but it is taken
+/// from an endpoint that quotes that same base price, so the cache rates
+/// OpenRouter publishes alongside it survive.
+///
+/// Discarding them is what broke `tokscale submit`: OpenRouter serves
+/// `openai/gpt-5.2-codex` only from an `Azure` endpoint, so the author lookup
+/// missed and the row lost the `input_cache_read` price it publishes.
+/// Submission validation treats a populated bucket with no rate as
+/// unpriceable, so every Codex session — which always carries cached tokens —
+/// aborted the whole submission (#1013).
+fn select_endpoint_pricing(
+    endpoints: &[Endpoint],
+    author_name: &str,
+    listed: Option<&ModelPricing>,
+) -> Option<ModelPricing> {
+    if let Some(author) = endpoints.iter().find(|e| e.provider_name == author_name) {
+        return endpoint_pricing(author);
+    }
+
+    let listed = listed?;
+    let matching: Vec<ModelPricing> = endpoints
+        .iter()
+        .filter_map(endpoint_pricing)
+        .filter(|pricing| quotes_same_base_price(pricing, listed))
+        .collect();
+
+    matching
+        .iter()
+        .find(|pricing| pricing.cache_read_input_token_cost.is_some())
+        .cloned()
+        .or_else(|| matching.into_iter().next())
 }
 
 /// Fetch all models and get author pricing for each
@@ -296,6 +331,85 @@ mod tests {
             }
         });
         url
+    }
+
+    fn endpoint(
+        provider_name: &str,
+        prompt: &str,
+        completion: &str,
+        input_cache_read: Option<&str>,
+    ) -> Endpoint {
+        Endpoint {
+            provider_name: provider_name.to_string(),
+            pricing: EndpointPricing {
+                prompt: prompt.to_string(),
+                completion: completion.to_string(),
+                input_cache_read: input_cache_read.map(str::to_string),
+                input_cache_write: None,
+            },
+        }
+    }
+
+    fn listed(input: f64, output: f64) -> ModelPricing {
+        ModelPricing {
+            input_cost_per_token: Some(input),
+            output_cost_per_token: Some(output),
+            ..Default::default()
+        }
+    }
+
+    // Regression: #1013. OpenRouter serves `openai/gpt-5.2-codex` only from an
+    // `Azure` endpoint, so the `OpenAI` author lookup missed and the row fell
+    // back to the listed price with its cache rates dropped. Submission
+    // validation then rejected every Codex session as unpriced.
+    #[test]
+    fn cache_rates_survive_when_the_model_has_no_author_endpoint() {
+        let endpoints = vec![endpoint(
+            "Azure",
+            "0.00000175",
+            "0.000014",
+            Some("0.000000175"),
+        )];
+
+        let pricing =
+            select_endpoint_pricing(&endpoints, "OpenAI", Some(&listed(1.75e-6, 1.4e-5))).unwrap();
+
+        assert_eq!(pricing.input_cost_per_token, Some(1.75e-6));
+        assert_eq!(pricing.output_cost_per_token, Some(1.4e-5));
+        assert_eq!(pricing.cache_read_input_token_cost, Some(1.75e-7));
+    }
+
+    // The author's own price stays authoritative, so a reseller endpoint can
+    // never override it just because it publishes extra cache rates.
+    #[test]
+    fn author_endpoint_still_wins_over_other_providers() {
+        let endpoints = vec![
+            endpoint("Azure", "0.0000035", "0.0000175", Some("0.00000035")),
+            endpoint("OpenAI", "0.0000002", "0.0000015", None),
+        ];
+
+        let pricing =
+            select_endpoint_pricing(&endpoints, "OpenAI", Some(&listed(3.5e-6, 1.75e-5))).unwrap();
+
+        assert_eq!(pricing.input_cost_per_token, Some(2e-7));
+        assert_eq!(pricing.output_cost_per_token, Some(1.5e-6));
+        assert_eq!(pricing.cache_read_input_token_cost, None);
+    }
+
+    // An endpoint quoting a different base price is a different deal, so its
+    // cache rate must not be grafted onto the listed price.
+    #[test]
+    fn endpoints_quoting_another_base_price_are_not_adopted() {
+        let endpoints = vec![endpoint(
+            "Azure",
+            "0.0000035",
+            "0.0000175",
+            Some("0.00000035"),
+        )];
+
+        assert!(
+            select_endpoint_pricing(&endpoints, "OpenAI", Some(&listed(1.75e-6, 1.4e-5))).is_none()
+        );
     }
 
     #[tokio::test]

--- a/crates/tokscale-core/src/pricing/openrouter.rs
+++ b/crates/tokscale-core/src/pricing/openrouter.rs
@@ -202,11 +202,21 @@ fn select_endpoint_pricing(
         .filter(|pricing| quotes_same_base_price(pricing, listed))
         .collect();
 
-    matching
-        .iter()
-        .find(|pricing| pricing.cache_read_input_token_cost.is_some())
-        .cloned()
-        .or_else(|| matching.into_iter().next())
+    // Cache read and cache write are independent fields, so the endpoint
+    // publishing the most of them is the one that leaves the fewest buckets
+    // unpriceable. Ties keep the earliest endpoint.
+    matching.into_iter().reduce(|best, candidate| {
+        if published_cache_rates(&candidate) > published_cache_rates(&best) {
+            candidate
+        } else {
+            best
+        }
+    })
+}
+
+fn published_cache_rates(pricing: &ModelPricing) -> usize {
+    usize::from(pricing.cache_read_input_token_cost.is_some())
+        + usize::from(pricing.cache_creation_input_token_cost.is_some())
 }
 
 /// Fetch all models and get author pricing for each
@@ -339,13 +349,23 @@ mod tests {
         completion: &str,
         input_cache_read: Option<&str>,
     ) -> Endpoint {
+        endpoint_with_cache(provider_name, prompt, completion, input_cache_read, None)
+    }
+
+    fn endpoint_with_cache(
+        provider_name: &str,
+        prompt: &str,
+        completion: &str,
+        input_cache_read: Option<&str>,
+        input_cache_write: Option<&str>,
+    ) -> Endpoint {
         Endpoint {
             provider_name: provider_name.to_string(),
             pricing: EndpointPricing {
                 prompt: prompt.to_string(),
                 completion: completion.to_string(),
                 input_cache_read: input_cache_read.map(str::to_string),
-                input_cache_write: None,
+                input_cache_write: input_cache_write.map(str::to_string),
             },
         }
     }
@@ -410,6 +430,30 @@ mod tests {
         assert!(
             select_endpoint_pricing(&endpoints, "OpenAI", Some(&listed(1.75e-6, 1.4e-5))).is_none()
         );
+    }
+
+    // Cache read and cache write are independent fields, so preferring the
+    // first endpoint that publishes a read rate can hide another endpoint
+    // that publishes both. Usage with cache-write tokens would then stay
+    // unpriceable for no reason.
+    #[test]
+    fn the_endpoint_publishing_the_most_cache_rates_wins() {
+        let endpoints = vec![
+            endpoint_with_cache("Azure", "0.00000175", "0.000014", Some("0.000000175"), None),
+            endpoint_with_cache(
+                "Foundry",
+                "0.00000175",
+                "0.000014",
+                Some("0.000000175"),
+                Some("0.0000022"),
+            ),
+        ];
+
+        let pricing =
+            select_endpoint_pricing(&endpoints, "OpenAI", Some(&listed(1.75e-6, 1.4e-5))).unwrap();
+
+        assert_eq!(pricing.cache_read_input_token_cost, Some(1.75e-7));
+        assert_eq!(pricing.cache_creation_input_token_cost, Some(2.2e-6));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #1013. Also covers the `gemini-3-pro-preview` half of #1021.

## What happens today

`tokscale submit` aborts before any network call as soon as local history contains a model whose cached tokens have no published rate:

```console
$ tokscale submit
  Tokscale - Submit Usage Data
  Scanning local session data...
Error: pricing is unavailable for submitted token usage: openai/gpt-5.2-codex, openai/gpt-5.2-codex, openai/gpt-5.2-codex, ... [632 entries]
```

Deduplicated, that run was `openai/gpt-5.2-codex` x414, `openai/gpt-5.1-codex-max` x180, `openai/gpt-5.1-codex` x29, `openai/gpt-5.1-codex-mini` x5, `google/gemini-3-pro-preview` x3. #1006 scoped strict per-bucket validation to the submit path in 4.9.0, which is why 4.8.0 still works on identical data.

## Root cause

`ModelPricing::covers_usage` requires a rate for every populated token bucket, and Codex sessions always carry cached-prefix tokens. Two separate paths hand it a row with no cache-read rate.

**OpenRouter drops cache rates it already fetched.** Author pricing is read from `/models/{id}/endpoints` by matching `provider_name` against the model id's author, and when no such endpoint exists the row falls back to the `/models` list price, which hardcodes both cache fields to `None`. OpenRouter serves all four failing Codex models only from an `Azure` endpoint, so the `OpenAI` lookup misses and the `input_cache_read` price each of them publishes is thrown away:

```console
$ curl -s https://openrouter.ai/api/v1/models/openai/gpt-5.2-codex/endpoints | jq '.data.endpoints[] | {provider_name, cache: .pricing.input_cache_read}'
{ "provider_name": "Azure", "cache": "0.000000175" }
```

**A provider hint can resolve onto a row that has no cache rates when the canonical row does.** Under a `google` hint, `gemini-3-pro-preview` resolved to `gmi/google/gemini-3-pro-preview` (no cache-read rate) even though the bare `gemini-3-pro-preview` row publishes one. Coverage was judged against the hinted row alone.

Both paths also under-billed reports, because `compute_cost` treats a missing rate as zero. This is why the failure looks intermittent across machines and platforms in #1013 and #1021: it depends entirely on which rows the pricing caches happen to hold. `gpt-5.2-codex` was present in LiteLLM with a cache-read rate when I started investigating and had been removed upstream an hour later, which flipped the resolution to the cache-less OpenRouter row.

## Changes

`fix(openrouter): keep cache pricing when a model has no author endpoint` — the author's own endpoint still wins, so a model whose author does serve it keeps that price rather than a reseller's markup. Only when the author endpoint is absent does the lookup adopt an endpoint quoting the same base prompt and completion price as the list row already being used, which keeps the cache rates published alongside a price that was going to be accepted regardless. An endpoint quoting a different base price is a different deal and is never adopted.

`fix(pricing): fill missing bucket rates from the canonical row when a provider hint omits them` — resolution borrows rates for the buckets the hinted row cannot price from the canonical unhinted row. Rates already present are never overwritten, so a reseller keeps its own markup instead of silently repricing to the author's cheaper rate — `azure_ai/grok-code-fast-1` at $3.50/$17.50 must not collapse onto `xai/grok-code-fast-1` at $0.20/$1.50. Each bucket is filled together with its long-context tiers so a tiered walk never mixes rates from two rows, and the hinted row's source and matched key are preserved because `compute_cost_for_lookup` branches on both for OpenAI's full-request 272k tiering. If the filled row still cannot cover the usage, the hinted row is returned unchanged and the usage stays unpriced.

`fix(submit): deduplicate model ids in the unpriced-usage error` — ids are reported once each, in first-seen order, with an occurrence count when they repeat, as requested in #1013.

`fix(test): pass the bucket timezone to build_graph_from_messages in submission tests` — `cargo test -p tokscale-core --lib` does not compile on `main`, so none of the regression tests above could run without this. Filed separately as #1027; happy to split it out if you would rather land it on its own.

## One existing expectation changed

`incomplete_unhinted_result_does_not_replace_provider_pricing` now expects `3.0` instead of `1.0`. It pairs a provider row that prices only input with a canonical row that prices only output, and its `1.0` expectation encoded the output bucket costing nothing. The hazard it guards against — the canonical row replacing the provider row wholesale and pricing input at zero — would total `2.0` and is still rejected. The provider row keeps its own input rate and only borrows the output rate it does not publish.

## Verification

Before and after on the same machine and the same local history, Windows 11 / PowerShell:

```console
$ tokscale submit --dry-run          # before
Error: pricing is unavailable for submitted token usage: openai/gpt-5.2-codex, ... [632 entries]
$ echo $LASTEXITCODE
1

$ tokscale submit --dry-run          # after
  Data to submit:
    Date range: 2025-11-27 to 2026-08-04
    Active days: 148
    Total tokens: 16,723,103,394
    Total cost: $15407.96
    Clients: claude, codex, gemini, gjc, opencode, senpi
    Models: 32 models
  Dry run - not submitting data.
$ echo $LASTEXITCODE
0
```

The cached tokens are now priced instead of billed at zero. `gpt-5.2-codex` goes from `$5.7180` to `$9.2843`, which is exactly its 20,379,136 cached tokens at the $0.175/M rate OpenRouter publishes, and `tokscale pricing gpt-5.2-codex` now reports `Cache Read: $0.17 / 1M tokens`.

- `cargo test -p tokscale-core --lib` — 1386 passed, 20 failed. The same 20 fail on a clean worktree of `56b2008c` with only the compile fix applied, so there are no new failures; they are the Windows `HOME`/path group tracked in #1014.
- `cargo test -p tokscale-cli` and `cargo test -p tokscale-cli --test cli_tests` — failure sets identical to that same baseline (1 unit, 23 integration), all in the same Windows path group.
- `cargo clippy -p tokscale-core --all-targets -- -D warnings` and `cargo fmt --all -- --check` clean. `cargo clippy -p tokscale-cli --all-targets` already fails on `main` for unrelated reasons (unused imports and Windows-inactive helper functions); this PR touches no CLI sources.
- 8 new tests cover the OpenRouter endpoint selection, the bucket fill and its markup guard, the genuinely-unpriced rejection, custom-pricing precedence, and the error dedup.

## Not addressed

A model with no published rate anywhere for a bucket it actually uses is still rejected, which is deliberate: submitting it would bill real usage at zero. `opencode/minimax-m2.5-free` from the #1013 report is an example — models.dev gives it input, output and cache-read rates but no cache-write rate. The broader options discussed in #1013 and #1021 (a `--prune-unpriced` flag, zero-cost custom pricing entries, subscription-priced providers) are policy decisions I did not want to make unilaterally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `tokscale submit` from aborting when cached tokens are present by preserving OpenRouter cache prices and borrowing only missing bucket rates when base prices match. Fixes #1013 and covers the `gemini-3-pro-preview` half of #1021.

- **Bug Fixes**
  - OpenRouter: keep cache pricing when the model has no author endpoint by adopting an endpoint that matches the listed base price; the author endpoint still wins; prefer the endpoint that publishes the most cache rates.
  - Provider hints: borrow only missing bucket rates from the canonical row when both quote the same base rates and share at least one bucket; never overwrite existing rates (protects reseller markups); keep long‑context tiers and source; if still incomplete, leave unpriced.
  - Custom pricing: custom rows decide coverage before any provider resolution or borrowing.
  - Submission UX: de‑duplicate unpriced model ids and show counts; simplify the excluded‑usage message.
  - Billing correctness: cached tokens are now priced instead of billed at zero in reports.

<sup>Written for commit 12761daf134cf882a1db269f27c5766bfd11aa96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

