### PR TITLE
fix(pricing): compose routing-prefix and tier-suffix stripping

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -7957,6 +7957,7 @@ mod tests {
             Some(&pricing),
             GraphPricingRequirement::Submission,
             std::time::Instant::now(),
+            &crate::bucket_tz::BucketTimezone::Local,
         )
         .expect("generic routing label must not block fully priced submission usage");
 
@@ -7997,6 +7998,7 @@ mod tests {
             Some(&pricing),
             GraphPricingRequirement::Submission,
             std::time::Instant::now(),
+            &crate::bucket_tz::BucketTimezone::Local,
         )
         .expect_err("concrete unpriced models must remain a submission error");
 

--- a/crates/tokscale-core/src/pricing/lookup.rs
+++ b/crates/tokscale-core/src/pricing/lookup.rs
@@ -406,6 +406,16 @@ impl PricingLookup {
             if let Some(result) = guarded_lookup(terminal) {
                 return Some(result);
             }
+
+            // The terminal segment can still carry a tier suffix, and the two
+            // transformations have to compose here or they never meet: the
+            // suffix stage below only ever sees the prefixed id, and it splits
+            // on `-`, so it can peel `-xhigh` off `cx/gpt-5.5-xhigh` but is
+            // left with `cx/gpt-5.5`, which is not a dataset key either. Both
+            // halves resolve alone while the combination billed $0 (#846).
+            if let Some(result) = try_strip_unknown_suffix(terminal, guarded_lookup) {
+                return Some(result);
+            }
         }
 
         // 2. Try stripping unknown suffixes (e.g., -thinking, -high, -codex)
@@ -4043,6 +4053,33 @@ mod tests {
             prefixed.pricing.output_cost_per_token,
             direct.pricing.output_cost_per_token
         );
+    }
+
+    /// Regression (#846): an id carrying both a routing prefix and a tier
+    /// suffix resolved to nothing, so real usage billed $0. Each id below
+    /// resolves once one transformation is applied, but the two were never
+    /// applied together: prefix stripping only retried the terminal segment
+    /// as-is, and suffix stripping splits on `-`, so it never shed the `cx/`.
+    #[test]
+    fn test_routing_prefix_and_tier_suffix_strip_together() {
+        let lookup = create_lookup();
+        let expected = lookup.lookup("gpt-5.5").unwrap();
+
+        for id in [
+            "cx/gpt-5.5-xhigh",
+            "cx/gpt-5.5-high",
+            "cx/gpt-5.5-medium",
+            "cx/gpt-5.5-low",
+        ] {
+            let result = lookup
+                .lookup(id)
+                .unwrap_or_else(|| panic!("{id} must resolve"));
+            assert_eq!(result.matched_key, expected.matched_key, "id: {id}");
+            assert_eq!(
+                result.pricing.input_cost_per_token, expected.pricing.input_cost_per_token,
+                "id: {id}"
+            );
+        }
     }
 
     /// Regression (#831): a dataset key that legitimately keeps its own


### PR DESCRIPTION
Fixes #846.

## What happens today

Still reproduces on `main` at `56b2008c`:

```console
$ tokscale pricing "cx/gpt-5.5-xhigh"
  Model not found: cx/gpt-5.5-xhigh

$ tokscale pricing "cx/gpt-5.5"
  Matched key: openai/gpt-5.5      # prefix alone resolves

$ tokscale pricing "gpt-5.5-xhigh"
  Matched key: openai/gpt-5.5      # suffix alone resolves
```

The reporter's OpenCode data records the model as `cx/gpt-5.5-xhigh` through an Omniroute/CodexProxy provider, so all of that usage prices at $0.00 against a $17.30 cross-check.

## Root cause

`lookup_with_source_and_provider` runs prefix stripping and suffix stripping as separate stages that never meet.

The prefix stage takes the terminal path segment and retries it exactly as it stands: `cx/gpt-5.5-xhigh` becomes `gpt-5.5-xhigh`, which is not a dataset key, so the stage gives up and the candidate is discarded. The suffix stage that runs next is handed the original prefixed id, not that candidate, and it splits on `-`, so it can peel `-xhigh` off `cx/gpt-5.5-xhigh` but is then left with `cx/gpt-5.5`, which is not a dataset key either. The prefix stage never sees a suffix-stripped id and the suffix stage never sees a prefix-stripped one, so the combination `gpt-5.5` is never tried.

## The change

The terminal segment produced by prefix stripping is now also offered to `try_strip_unknown_suffix`. That reuses the existing suffix machinery and its guards — the Claude version guards, `MIN_MODEL_NAME_LEN`, and the `MAX_SUFFIX_STRIP_SEGMENTS` cap — rather than adding a new matching rule, and it only runs after the direct lookup on the full id has already failed, so a dataset key that legitimately keeps its prefix still resolves exactly as before.

## Verification

```console
$ tokscale pricing "cx/gpt-5.5-xhigh"
  Matched key: openai/gpt-5.5
  Input:  $5.00 / 1M tokens
  Output: $30.00 / 1M tokens
  Cache Read:  $0.50 / 1M tokens

$ tokscale pricing "cx/gpt-5.4-xhigh"
  Matched key: openai/gpt-5.4
  Input:  $2.50 / 1M tokens
```

`cx/gpt-5.5-xhigh` now resolves to the same key, source and rates as both `cx/gpt-5.5` and `gpt-5.5-xhigh`. The reporter's token counts price to $16.94 at those rates against the $17.30 cross-check in the issue.

- New regression test `test_routing_prefix_and_tier_suffix_strip_together` covers `cx/gpt-5.5-xhigh`, `-high`, `-medium` and `-low`, asserting they match the plain `gpt-5.5` resolution. It fails on `main` with `cx/gpt-5.5-xhigh must resolve`.
- `cargo test -p tokscale-core --lib pricing::lookup` — 179 passed, 0 failed. `test_unknown_prefixed_model_id_strips_to_underlying_model` and `test_known_prefixed_dataset_key_still_resolves_exactly` both stay green, so neither the prefix fallback nor the exact-key precedence changed.
- `cargo test -p tokscale-core --lib` — 1379 passed, 20 failed, all 20 identical to a clean baseline of `56b2008c`; they are the Windows `HOME`/path group tracked in #1014.
- `cargo clippy -p tokscale-core --all-targets -- -D warnings` and `cargo fmt --all -- --check` clean.

## Note on the first commit

`cargo test -p tokscale-core --lib` does not compile on `main`, so the regression test could not run without the two-line fix carried as the first commit here. It is reported separately as #1027 and is also present in #1028; drop it from this branch if either lands first.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pricing lookups where a model id has both a routing prefix and a tier suffix. Now `cx/gpt-5.5-xhigh` resolves to `openai/gpt-5.5` and prices correctly instead of $0.

- **Bug Fixes**
  - After a direct lookup fails, the prefix-stripped terminal segment is also sent through the existing unknown-suffix stripper, so prefix and suffix stripping compose safely and keep exact-key precedence.
  - Added regression test `test_routing_prefix_and_tier_suffix_strip_together` covering `cx/gpt-5.5-{xhigh,high,medium,low}`.
  - Fixed two submission tests by passing `BucketTimezone::Local` to `build_graph_from_messages` so the core test suite compiles.

<sup>Written for commit bbbba53ae7fd74f17411395211aa631400bf61b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

