### PR TITLE
feat(submit): record unguarded daily totals in a shadow table (#960)

### DIFF
--- a/docs/ratchet-inflation-recovery.md
+++ b/docs/ratchet-inflation-recovery.md
@@ -6,7 +6,10 @@ totals, and the monotonic guard that causes it exists to prevent a real
 production data loss. This document proposes a correction that heals the
 inflation without weakening that protection.
 
-> **Status: none of Phases 1–6 is implemented.** Accept, reject, or amend.
+> **Status:** Phases 1, 1.5 and 3 are implemented. Phase 4a (shadow table write)
+> lands with `daily_breakdown_reported` — additive, nothing reads it. Phases 2,
+> 4b, 5 and 6 remain gated. Accept, reject, or amend.
+>
 > Several *adjacent* defects this document catalogued have since been fixed and
 > are marked inline — see "Already fixed" below.
 
@@ -620,6 +623,7 @@ review what it is about to do.
 
 ### 4a — Record what the CLI actually reported (additive, safe)
 
+**Implemented** (`daily_breakdown_reported`, migration `0025_bouncy_vertigo`).
 Submit additionally writes each payload's **unguarded** per-`(device, date,
 client)` values to a shadow table:
 

--- a/docs/ratchet-inflation-recovery.md
+++ b/docs/ratchet-inflation-recovery.md
@@ -6,9 +6,10 @@ totals, and the monotonic guard that causes it exists to prevent a real
 production data loss. This document proposes a correction that heals the
 inflation without weakening that protection.
 
-> **Status:** Phases 1, 1.5 and 3 are implemented. Phase 4a (shadow table write)
-> lands with `daily_breakdown_reported` — additive, nothing reads it. Phases 2,
-> 4b, 5 and 6 remain gated. Accept, reject, or amend.
+> **Status:** Phases 1, 1.5 and 3 are implemented. Phase 4a
+> (`daily_breakdown_reported`) is an additive, inert per-cell observation table;
+> nothing reads it. It is not sufficient for Phase 4b. Phases 2, 4b, 5 and 6
+> remain gated. Accept, reject, or amend.
 >
 > Several *adjacent* defects this document catalogued have since been fixed and
 > are marked inline — see "Already fixed" below.
@@ -320,9 +321,9 @@ value served is unchanged. In exchange:
   the recorded deltas agree within tolerance, for a stated share of users, over
   a stated window. "Coverage exists" is a much weaker claim than "the numbers
   match".
-- **The zero-out failure is observed rather than reasoned about.** A user whose
-  high-water sum is 0 or partial shows up as an enormous recorded delta long
-  before any read depends on it.
+- **Missing observations remain ambiguous.** The current per-cell LWW table
+  records only explicit reports; it cannot prove a missing cell was zeroed or
+  outside a partial scan.
 
 ### The table cannot be seeded from `daily_breakdown` — the warm-up is forced
 
@@ -346,8 +347,9 @@ read as `0`.
 - **Can be retired:** the `SUM(daily)` derivation *for submission totals*, once
   Phase 2 is stable and the deltas have stayed flat.
 - **Cannot be retired:** `daily_breakdown` itself. The heatmap and per-day views
-  read it, Phase 4 repairs it, and the high-water table holds bucket totals with
-  no day-level detail to replace it with.
+  read it; a future Phase 4 may repair it after authoritative snapshot support,
+  and the high-water table holds bucket totals with no day-level detail to
+  replace it with.
 
 Dual mode ends by retiring a *derivation*, not a table.
 
@@ -621,11 +623,11 @@ review what it is about to do.
 
 **Split it in two instead.**
 
-### 4a — Record what the CLI actually reported (additive, safe)
+### 4a — Record explicit cell observations (additive, safe)
 
 **Implemented** (`daily_breakdown_reported`, migration `0025_bouncy_vertigo`).
 Submit additionally writes each payload's **unguarded** per-`(device, date,
-client)` values to a shadow table:
+client)` values to an inert observation table:
 
 ```
 daily_breakdown_reported(submitted_device_id, date, client, tokens, cost,
@@ -633,34 +635,31 @@ daily_breakdown_reported(submitted_device_id, date, client, tokens, cost,
 PRIMARY KEY (submitted_device_id, date, client)
 ```
 
-Last-write-wins, no `GREATEST`, no merge, no fold normalisation — it records what
-the most recent scan said, which is the one thing the system currently throws
-away. This is a pure insert alongside the existing write, inside the same
-transaction. It cannot regress anything, because nothing reads it.
+Last-write-wins, no `GREATEST`, no merge, no fold normalisation — each write
+records the latest explicit value for that one cell, which is the one thing the
+system currently throws away. This is a pure upsert alongside the existing
+write, inside the same transaction. It cannot regress anything, because nothing
+reads it.
 
 Sized at roughly one extra `daily_breakdown`, and bounded the same way: one row
 per device per day per client, overwritten rather than accumulated.
 
-### 4b — Reconcile offline
+**It is not a whole-scan snapshot.** A later payload only upserts cells it
+contains; it does not delete or tombstone previous cells. Thus an omitted cell
+means neither zero nor absence, even when `meta.dateRange` contains that date.
+Do not infer deletes from that range. A recovery that needs absence must first
+ship a client-declared authoritative coverage contract and record snapshot
+generations or explicit tombstones under that contract.
 
-A separate, resumable job — not a request handler — compares shadow against
-stored and applies the repair per `(device, client)` when both hold:
+### 4b — Reconcile offline (not yet designed by 4a)
 
-1. **Bucket coverage** — the shadow's dates span the bucket being repaired.
-   Without it a `--since` scan's smaller total is not comparable to the stored
-   high-water for that bucket.
-2. **Invariant clears** — the shadow's token total for `C` in that bucket is at
-   least the stored high-water.
-
-**Both gates are evaluated per bucket**, and a bucket failing either is skipped
-while its neighbours proceed. Checking per bucket, like checking per client,
-keeps one shrunken period from blocking every other period's repair.
-
-An earlier draft scoped gate 1 to the whole `(device, client)` date range, which
-silently contradicted row 6c below: a device that deleted its sessions and then
-kept working fails a range-wide check outright, even though its later buckets
-are perfectly comparable. The two gates were at different granularities and the
-text never said what a coarse-gate failure did. Per-bucket for both resolves it.
+The current table alone cannot support reconciliation: it has no authoritative
+claim about omitted cells. A separate, resumable job remains the right shape,
+but it must not be implemented until a client declares exactly which cells its
+scan authoritatively covers and the server stores generations or explicit
+tombstones for those snapshots. Only then can a worker distinguish an emptied
+day from a partial scan or an out-of-scope date. `meta.dateRange` is not that
+contract and must never drive server-side deletes.
 
 ### Why this is materially safer
 
@@ -673,9 +672,9 @@ text never said what a coarse-gate failure did. Per-bucket for both resolves it.
 - **The diff is reviewable before it is applied.** `shadow ⊖ stored` is the census
   at row granularity — strictly better than the bucket ratio in Phase 1, and it
   can be read, sampled, and sanity-checked by a human before a single row changes.
-- **The zero-out becomes trivial.** A day present in stored and absent from a
-  shadow whose range covers it is unambiguously an emptied day. No inferring
-  absence from an in-flight payload.
+- **No absence conclusion is introduced.** This table is useful evidence about
+  explicit values, but without coverage and generation metadata it cannot
+  safely zero, delete, or otherwise rewrite an omitted cell.
 - **Idempotent, resumable, abortable.** Re-running converges; stopping halfway
   leaves consistent state; a bad batch stops the job instead of failing a user's
   submit.
@@ -700,41 +699,40 @@ complete"* — for alias folds:
 Same structure, different axis: fold is client-keys-within-a-day, re-split is
 days-within-a-client.
 
-### Zero, do not delete
+### No zero or delete path exists today
 
-The route has **no delete path for `daily_breakdown`**, and adding one is the
-largest source of risk here. It is also unnecessary: remove `C`'s entry from
-`source_breakdown` and let `recalculateDayTotals` (`helpers.ts:68`) recompute. A
-day that lands at zero keeps a zero row. `activeDays` already guards with
-`COUNT(DISTINCT CASE WHEN tokens > 0 …)` (`:785`), so a zero row does not inflate
-it; other consumers must be checked before shipping.
+The route has **no delete path for `daily_breakdown`**, and Phase 4a must not add
+one. In particular, do not infer a delete or zero from `meta.dateRange`: it is
+not authoritative coverage. A future recovery design may choose zero rows or
+deletes only after its client coverage and snapshot-generation/tombstone
+contract establishes that a cell is absent.
 
-### The zero-out itself is mandatory
+### A future zero-out requires authoritative snapshots
 
 **Rewriting the day that gained while the day that lost keeps its old value
 reproduces the double count exactly** — a heal without the zero-out repairs
 nothing.
 
-This is where the split earns its keep. In the submit path the signal was
-ambiguous: the per-day loop visits only days present in the payload (`:632`), and
-`aggregate_by_date` emits only days with activity, so an emptied day and a day
-outside the scan's scope are indistinguishable at request time. Against the
-shadow table the question is decidable — a day present in stored, absent from
-shadow, and inside a shadow range that covers it, is unambiguously emptied.
+The current per-cell table intentionally does not make this decision. In the
+submit path the per-day loop visits only days present in the payload (`:632`),
+and `aggregate_by_date` emits only days with activity, so an emptied day and a
+day outside the scan's scope are indistinguishable. The same remains true in an
+LWW table that retains old cells when later payloads omit them. A future design
+needs client-declared authoritative coverage plus snapshot generations or
+tombstones before it can identify an emptied cell safely.
 
-### Assert, then commit
+### Future recovery validation
 
-After rewriting `C`, verify `SUM(stored daily for C over the range) == SUM(shadow
-for C over the same range)` inside the batch transaction and roll back on
-mismatch. This turns a silent corruption into a caught error and a preserved
-account — and unlike the in-submit design, a rollback here costs a retry of one
-batch rather than a failed user submission.
+If a future snapshot-based worker rewrites `C`, it must validate its result
+against the authoritative generation inside the batch transaction and roll back
+on mismatch. Comparing the current LWW rows alone is insufficient because they
+cannot establish what an omitted cell means.
 
-### Bound the writes
+### Future write bounds
 
-Touch only rows where stored differs from shadow. A re-split changes a small
-fraction of a long history, and the comparison is now a plain table diff rather
-than something reconstructed per request.
+A future snapshot-based worker should touch only cells that differ from its
+authoritative generation. The current LWW observations alone are not a safe
+comparison set because they do not represent omitted cells.
 
 ### Interactions — what the split neutralises, and what survives it
 
@@ -827,35 +825,37 @@ population is real.
 
 ## Behavior for every user state
 
-P2 fixes ranked totals; P3 removes the cause; P4 fixes day-level rows.
+P2 fixes ranked totals; P3 removes the cause; a future Phase 4 may fix day-level
+rows once authoritative snapshots exist.
 
 | # | User state | P2 | P4 | Outcome |
 |---|---|---|---|---|
 | 1 | Never submitted | n/a | n/a | Plain insert. |
 | 2 | Healthy, stable TZ | correct | no-op | Payload equals stored. |
 | 3 | Healthy, multi-device | correct, additive | per-device | `UNIQUE(submission_id, submitted_device_id, date)` scopes every write. |
-| 4 | **TZ-inflated, sessions intact** | **fixed to within the boundary leak** | **healed** | P3 stops it recurring. |
-| 5 | TZ-inflated, multi-device | fixed | per-device | Each device heals independently. |
+| 4 | **TZ-inflated, sessions intact** | **fixed to within the boundary leak** | gated | P3 stops it recurring. |
+| 5 | TZ-inflated, multi-device | fixed | gated | Requires authoritative snapshots per device. |
 | 6 | **Deleted sessions (`d9df8c9c`)** | high-water held | blocked | Protected exactly as today. |
 | 6b | Sessions moved where the collector does not scan | held | blocked, temporarily | Self-resolves once support lands. |
-| 6c | **Deleted sessions, then kept working** | earlier buckets hold, later buckets grow | later buckets heal | Bucket width bounds how long new work stays invisible. Narrower is better here. |
+| 6c | **Deleted sessions, then kept working** | earlier buckets hold, later buckets grow | gated | Requires authoritative snapshots per bucket. |
 | 7 | Deleted sessions *and* changed TZ | held | blocked | No loss, no healing. Phase 6. |
 | 8 | Retired device | contributes its peak | never runs | Pre-existing, not worsened. |
 | 9 | No high-water yet | falls back to stored | blocked | One-submit warm-up. A missing baseline must not be read as `0`. |
 | 10 | Legacy device-less CLI | max, not sum, across machines | n/a | Pre-#517 behavior, now visible rather than hidden. |
-| 11 | `--client codex` submitter | correct for codex | codex heals | Other clients absent from `submittedClients`, untouched. |
-| 12 | `--since` submitter | correct | blocked | Fails range coverage; heals on the next full scan. |
+| 11 | `--client codex` submitter | correct for codex | gated | Other clients need explicit coverage status. |
+| 12 | `--since` submitter | correct | gated | `meta.dateRange` cannot prove full coverage. |
 | 13 | Backfill user | **additive** via `origin` | excluded | The `origin` key stops import and CLI overwriting each other. |
 | 14 | #961 partial `session_model_usage` | correct | that client blocked | Others still heal. Phase 5. |
 | 15 | Parser regression | held | blocked | Correctly defended. |
 | 16 | Client with an active alias fold | correct | excluded | Fold heal runs first. |
 | 17 | Hidden / moderated user | orthogonal | orthogonal | `leaderboardHidden` affects ranking only. |
-| 18 | Alternating TZ daily | fixed to within the leak | heals each scan | P3 eliminates it at the source. |
+| 18 | Alternating TZ daily | fixed to within the leak | gated | P3 eliminates it at the source. |
 
 ## Known holes
 
 - **Phase 2 bounds inflation, it does not eliminate it.** The boundary leak
-  survives until Phase 3 pins the key or Phase 4 repairs the rows.
+  survives until Phase 3 pins the key or a future snapshot-authorized Phase 4
+  repairs the rows.
 - **Filtered *all-time* leaderboards still over-count, independently of all of
   this.** The period boards were fixed in `cb65bbbf` (#988) and `e80b44a3`
   (#991); both now sum only the matching slice through

--- a/docs/ratchet-inflation-recovery.md
+++ b/docs/ratchet-inflation-recovery.md
@@ -638,8 +638,9 @@ PRIMARY KEY (submitted_device_id, date, client)
 Last-write-wins, no `GREATEST`, no merge, no fold normalisation — each write
 records the latest explicit value for that one cell, which is the one thing the
 system currently throws away. This is a pure upsert alongside the existing
-write, inside the same transaction. It cannot regress anything, because nothing
-reads it.
+write, inside the same transaction. It cannot change served totals while nothing
+reads it, but it is still a mandatory transactional write and can affect submit
+availability if it fails.
 
 Sized at roughly one extra `daily_breakdown`, and bounded the same way: one row
 per device per day per client, overwritten rather than accumulated.

--- a/docs/ratchet-inflation-recovery.md
+++ b/docs/ratchet-inflation-recovery.md
@@ -321,10 +321,6 @@ value served is unchanged. In exchange:
   the recorded deltas agree within tolerance, for a stated share of users, over
   a stated window. "Coverage exists" is a much weaker claim than "the numbers
   match".
-- **Missing observations remain ambiguous.** The current per-cell LWW table
-  records only explicit reports; it cannot prove a missing cell was zeroed or
-  outside a partial scan.
-
 ### The table cannot be seeded from `daily_breakdown` — the warm-up is forced
 
 This is the part that makes dual mode mandatory rather than merely prudent, and
@@ -891,21 +887,25 @@ rows once authoritative snapshots exist.
 
 The census settled some of this. Revised standing:
 
-**Ship Phase 3 (pin the bucket key).** 197 of 650 measurable devices show
+**Phase 3 is shipped (pin the bucket key).** 197 of 650 measurable devices show
 inflation that scan windowing does not explain, so the mechanism is active and
 still producing new damage every time someone rescans from another zone. Phase 3
 is CLI-only, has no server dependency, and is the sole change that removes the
 cause rather than cleaning up after it. Nothing else here is worth doing first.
 
-**Ship Phase 1 (populate only).** Its justification is now stronger than when it
-was written, not weaker. The active-time census answered incidence but not
+**Phase 1 is shipped (populate only).** Its justification is now stronger than
+when it was written, not weaker. The active-time census answered incidence but not
 magnitude, because `total_active_time_ms` only exists on recent CLIs — the 650
 visible devices hold ~0.17% of site-wide tokens, so the accounts that actually
 matter are invisible to it. Phase 1 writes a per-device **token** high-water on
 every submit, which is the only way to measure that population. It reads
 nothing, so it cannot regress anything.
 
-**Phases 2, 4, 5 and 6 stay gated**, now on Phase 1's token census specifically
+**Phase 4a is shipped as inert telemetry only.** It records explicit per-cell
+observations, not authoritative scan snapshots. It cannot support zero-out or
+recovery until a future protocol supplies coverage plus generations/tombstones.
+
+**Phases 2, 4b, 5 and 6 stay gated**, now on Phase 1's token census specifically
 rather than on "a census" generally. Do not build them against the active-time
 numbers above; those are an incidence signal on an unrepresentative slice, not a
 magnitude estimate.

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -169,6 +169,24 @@ function flattenSqlChunks(node: unknown): unknown[] {
   return [node];
 }
 
+// Phase 4a writes `daily_breakdown_reported` in the same transaction, so raw
+// `tx.execute` call counts include that shadow upsert. Tests that pin the
+// guarded daily_breakdown path filter it out.
+function isDailyBreakdownReportedSql(node: unknown): boolean {
+  return flattenSqlChunks(node).some(
+    (chunk) =>
+      typeof chunk === "string" && chunk.includes("daily_breakdown_reported")
+  );
+}
+
+function dailyBreakdownExecuteArgs(tx: {
+  execute: { mock: { calls: unknown[][] } };
+}): unknown[] {
+  return tx.execute.mock.calls
+    .map((call) => call[0])
+    .filter((arg) => !isDailyBreakdownReportedSql(arg));
+}
+
 describe("POST /api/submit auth path", () => {
   it("rejects invalid API tokens through the shared auth service", async () => {
     mockState.authenticatePersonalToken.mockResolvedValue({ status: "invalid" });
@@ -504,8 +522,8 @@ describe("POST /api/submit auth path", () => {
       deviceKey: "dev_test",
       displayName: "Test device",
     }));
-    expect(tx.execute).toHaveBeenCalledTimes(1);
-    const insertChunks = flattenSqlChunks(tx.execute.mock.calls[0][0]);
+    expect(dailyBreakdownExecuteArgs(tx)).toHaveLength(1);
+    const insertChunks = flattenSqlChunks(dailyBreakdownExecuteArgs(tx)[0]);
     expect(insertChunks).toEqual(
       expect.arrayContaining([
         expect.stringContaining("INSERT INTO daily_breakdown"),
@@ -703,10 +721,10 @@ describe("POST /api/submit auth path", () => {
     expect(tx.insert).toHaveBeenCalledWith(expect.objectContaining({
       id: "submittedDevices.id",
     }));
-    expect(tx.execute).toHaveBeenCalledTimes(1);
+    expect(dailyBreakdownExecuteArgs(tx)).toHaveLength(1);
     // A same-device update keeps ownership implicit in the selected row and
     // must not rewrite submitted_device_id.
-    expect(flattenSqlChunks(tx.execute.mock.calls[0][0])).not.toEqual(
+    expect(flattenSqlChunks(dailyBreakdownExecuteArgs(tx)[0])).not.toEqual(
       expect.arrayContaining(["submitted-device-1"]),
     );
     expect(mockState.mergeClientBreakdownsWithRegressionGuard).toHaveBeenCalledWith(
@@ -886,8 +904,8 @@ describe("POST /api/submit auth path", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(tx.execute).toHaveBeenCalledTimes(2);
-    expect(flattenSqlChunks(tx.execute.mock.calls[1][0])).toEqual(
+    expect(dailyBreakdownExecuteArgs(tx)).toHaveLength(2);
+    expect(flattenSqlChunks(dailyBreakdownExecuteArgs(tx)[1])).toEqual(
       expect.arrayContaining([
         expect.stringContaining("INSERT INTO daily_breakdown"),
         "submitted-device-phone",
@@ -1090,7 +1108,7 @@ describe("POST /api/submit auth path", () => {
 
     expect(response.status).toBe(200);
     expect(dailyInsertValues).toBeUndefined();
-    expect(tx.execute).toHaveBeenCalledTimes(1);
+    expect(dailyBreakdownExecuteArgs(tx)).toHaveLength(1);
     expect(mockState.mergeClientBreakdownsWithRegressionGuard).toHaveBeenCalledWith(
       existingBreakdown,
       {
@@ -1290,8 +1308,8 @@ describe("POST /api/submit auth path", () => {
 
     expect(response.status).toBe(200);
     expect(tx.insert).toHaveBeenCalledTimes(1);
-    expect(tx.execute).toHaveBeenCalledTimes(2);
-    expect(flattenSqlChunks(tx.execute.mock.calls[1][0])).toEqual(
+    expect(dailyBreakdownExecuteArgs(tx)).toHaveLength(2);
+    expect(flattenSqlChunks(dailyBreakdownExecuteArgs(tx)[1])).toEqual(
       expect.arrayContaining([
         expect.stringContaining("INSERT INTO daily_breakdown"),
         "submission-1",
@@ -1355,7 +1373,7 @@ describe("POST /api/submit auth path", () => {
     // The ON CONFLICT arm is unreachable while the per-user submissions row
     // lock holds, but it must not be a silent hole in the monotonic guard if
     // that ever changes (or if duplicate dates straddle an INSERT chunk).
-    expect(flattenSqlChunks(tx.execute.mock.calls[1][0])).toEqual(
+    expect(flattenSqlChunks(dailyBreakdownExecuteArgs(tx)[1])).toEqual(
       expect.arrayContaining([
         expect.stringContaining("GREATEST(daily_breakdown.active_time_ms"),
       ]),
@@ -1547,8 +1565,8 @@ describe("POST /api/submit auth path", () => {
 
     expect(response.status).toBe(200);
     expect(tx.insert).toHaveBeenCalledTimes(1);
-    expect(tx.execute).toHaveBeenCalledTimes(1);
-    const updateChunks = flattenSqlChunks(tx.execute.mock.calls[0][0]);
+    expect(dailyBreakdownExecuteArgs(tx)).toHaveLength(1);
+    const updateChunks = flattenSqlChunks(dailyBreakdownExecuteArgs(tx)[0]);
     expect(updateChunks).toEqual(
       expect.arrayContaining([
         expect.stringContaining("UPDATE daily_breakdown"),
@@ -1760,7 +1778,7 @@ describe("POST /api/submit auth path", () => {
     expect(response.status).toBe(200);
     // 9_000, not the stored 2_000: the monotonic guard preserves the LARGER
     // value, it does not freeze the row at whatever landed first.
-    const updateChunks = flattenSqlChunks(tx.execute.mock.calls[0][0]);
+    const updateChunks = flattenSqlChunks(dailyBreakdownExecuteArgs(tx)[0]);
     expect(updateChunks).toEqual(expect.arrayContaining([9_000]));
     expect(updateChunks).not.toEqual(expect.arrayContaining([2_000]));
 
@@ -1965,7 +1983,7 @@ describe("POST /api/submit auth path", () => {
 
     expect(response.status).toBe(200);
     expect(tx.insert).toHaveBeenCalledTimes(1);
-    expect(tx.execute).toHaveBeenCalledTimes(2);
+    expect(dailyBreakdownExecuteArgs(tx)).toHaveLength(2);
     expect(mockState.mergeClientBreakdownsWithRegressionGuard).toHaveBeenCalledWith(
       legacyBreakdown,
       incomingBreakdownWithProvenance,
@@ -2252,8 +2270,8 @@ describe("POST /api/submit auth path", () => {
 
     expect(response.status).toBe(200);
     expect(tx.insert).toHaveBeenCalledTimes(1);
-    expect(tx.execute).toHaveBeenCalledTimes(2);
-    expect(flattenSqlChunks(tx.execute.mock.calls[1][0])).toEqual(
+    expect(dailyBreakdownExecuteArgs(tx)).toHaveLength(2);
+    expect(flattenSqlChunks(dailyBreakdownExecuteArgs(tx)[1])).toEqual(
       expect.arrayContaining([
         expect.stringContaining("INSERT INTO daily_breakdown"),
         "submission-1",

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -187,6 +187,14 @@ function dailyBreakdownExecuteArgs(tx: {
     .filter((arg) => !isDailyBreakdownReportedSql(arg));
 }
 
+function dailyBreakdownReportedExecuteArgs(tx: {
+  execute: { mock: { calls: unknown[][] } };
+}): unknown[] {
+  return tx.execute.mock.calls
+    .map((call) => call[0])
+    .filter(isDailyBreakdownReportedSql);
+}
+
 describe("POST /api/submit auth path", () => {
   it("rejects invalid API tokens through the shared auth service", async () => {
     mockState.authenticatePersonalToken.mockResolvedValue({ status: "invalid" });
@@ -547,6 +555,15 @@ describe("POST /api/submit auth path", () => {
           /ON CONFLICT \(submission_id, date\)/.test(chunk),
       ),
     ).toBe(false);
+    const reportedQueries = dailyBreakdownReportedExecuteArgs(tx);
+    expect(reportedQueries).toHaveLength(1);
+    expect(flattenSqlChunks(reportedQueries[0])).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("INSERT INTO daily_breakdown_reported"),
+        "submitted-device-1",
+        "2026-04-30",
+      ]),
+    );
     expect(submissionUpdateValues).toEqual(
       expect.objectContaining({
         mcpServers: ["github", "slack"],

--- a/packages/frontend/__tests__/api/submitTimezoneResplitRepro.test.ts
+++ b/packages/frontend/__tests__/api/submitTimezoneResplitRepro.test.ts
@@ -509,9 +509,8 @@ describe("POST /api/submit timezone re-split vs monotonic merge (#960)", () => {
     // Phase 4a records the unguarded observation for the moved day only. The
     // Seoul day is not written by this payload, but that does not establish it
     // as absent: an earlier observation for the cell could remain in the table.
-    // Assert on calendar-date binds only (`YYYY-MM-DD`), not on `reported_at`
-    // ISO timestamps that can collide with the fixture dates when the suite
-    // runs on that UTC day.
+    // Assert the exact calendar-date bind set separately from other string
+    // parameters such as the `reported_at` ISO timestamp.
     const shadowSqls = executedSqlArgs.filter((arg) => {
       const parts: string[] = [];
       collectStrings(arg, parts);

--- a/packages/frontend/__tests__/api/submitTimezoneResplitRepro.test.ts
+++ b/packages/frontend/__tests__/api/submitTimezoneResplitRepro.test.ts
@@ -509,6 +509,9 @@ describe("POST /api/submit timezone re-split vs monotonic merge (#960)", () => {
     // Phase 4a records the unguarded observation for the moved day only. The
     // Seoul day is not written by this payload, but that does not establish it
     // as absent: an earlier observation for the cell could remain in the table.
+    // Assert on calendar-date binds only (`YYYY-MM-DD`), not on `reported_at`
+    // ISO timestamps that can collide with the fixture dates when the suite
+    // runs on that UTC day.
     const shadowSqls = executedSqlArgs.filter((arg) => {
       const parts: string[] = [];
       collectStrings(arg, parts);
@@ -524,10 +527,13 @@ describe("POST /api/submit timezone re-split vs monotonic merge (#960)", () => {
         (s) => typeof s === "string" && s.includes("GREATEST"),
       ),
     ).toBe(false);
-    expect(shadowParts).toContain("2026-03-02");
     expect(shadowParts).toContain("claude");
     expect(shadowParts).toContain(1000);
-    expect(shadowParts).not.toContain("2026-03-03");
+    const calendarDates = shadowParts.filter(
+      (value): value is string =>
+        typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value),
+    );
+    expect(calendarDates).toEqual(["2026-03-02"]);
   });
 
   it("lets the regression guard preserve the client that moved off a day", async () => {

--- a/packages/frontend/__tests__/api/submitTimezoneResplitRepro.test.ts
+++ b/packages/frontend/__tests__/api/submitTimezoneResplitRepro.test.ts
@@ -20,9 +20,11 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 // WITHIN a day, and the emptied day is not part of the payload at all.
 //
 // These tests characterize CURRENT submit behavior (the inflation is real and
-// silent). Phase 4a (`daily_breakdown_reported`) now records the unguarded
-// payload alongside the guarded store so Phase 4b can heal offline — the
-// served `totalTokens` is unchanged. The CLI-side fix in #1016
+// silent). Phase 4a (`daily_breakdown_reported`) now records each explicitly
+// reported unguarded cell alongside the guarded store — the served
+// `totalTokens` is unchanged. It is not a whole-scan snapshot: omitted cells
+// remain unknowable without client-declared coverage plus generations or
+// tombstones. The CLI-side fix in #1016
 // (pinned `scanner.bucketTimezone`) stops new re-splits from pinned devices;
 // the last test asserts the server-side consequence -- a same-day rescan
 // merges flat instead of inflating.
@@ -504,9 +506,9 @@ describe("POST /api/submit timezone re-split vs monotonic merge (#960)", () => {
       false,
     );
 
-    // Phase 4a: the shadow records the unguarded truth (moved day only). The
-    // emptied Seoul day is absent from the payload, so it is absent from the
-    // shadow write too — that absence is what Phase 4b needs to see.
+    // Phase 4a records the unguarded observation for the moved day only. The
+    // Seoul day is not written by this payload, but that does not establish it
+    // as absent: an earlier observation for the cell could remain in the table.
     const shadowSqls = executedSqlArgs.filter((arg) => {
       const parts: string[] = [];
       collectStrings(arg, parts);

--- a/packages/frontend/__tests__/api/submitTimezoneResplitRepro.test.ts
+++ b/packages/frontend/__tests__/api/submitTimezoneResplitRepro.test.ts
@@ -20,8 +20,9 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 // WITHIN a day, and the emptied day is not part of the payload at all.
 //
 // These tests characterize CURRENT submit behavior (the inflation is real and
-// silent). The offline recovery described in docs/ratchet-inflation-recovery.md
-// is intentionally out of this route's scope. The CLI-side fix in #1016
+// silent). Phase 4a (`daily_breakdown_reported`) now records the unguarded
+// payload alongside the guarded store so Phase 4b can heal offline — the
+// served `totalTokens` is unchanged. The CLI-side fix in #1016
 // (pinned `scanner.bucketTimezone`) stops new re-splits from pinned devices;
 // the last test asserts the server-side consequence -- a same-day rescan
 // merges flat instead of inflating.
@@ -173,6 +174,33 @@ function collectStrings(
   for (const value of Object.values(node as Record<string, unknown>)) {
     collectStrings(value, out, seen);
   }
+}
+
+/** Like collectStrings, but also keeps finite numbers (bind params). */
+function collectPrimitives(
+  node: unknown,
+  out: Array<string | number>,
+  seen = new Set<object>(),
+): void {
+  if (typeof node === "string" || (typeof node === "number" && Number.isFinite(node))) {
+    out.push(node);
+    return;
+  }
+  if (!node || typeof node !== "object") return;
+  if (seen.has(node as object)) return;
+  seen.add(node as object);
+  if (Array.isArray(node)) {
+    for (const item of node) collectPrimitives(item, out, seen);
+    return;
+  }
+  for (const value of Object.values(node as Record<string, unknown>)) {
+    collectPrimitives(value, out, seen);
+  }
+}
+
+function isDailyBreakdownInsert(sqlFragment: string): boolean {
+  // Must not match `INSERT INTO daily_breakdown_reported`.
+  return /INSERT INTO daily_breakdown\b(?!_)/.test(sqlFragment);
 }
 
 function storedClientEntry(tokens: number) {
@@ -475,6 +503,29 @@ describe("POST /api/submit timezone re-split vs monotonic merge (#960)", () => {
     expect(strings.some((s) => s.includes("UPDATE daily_breakdown"))).toBe(
       false,
     );
+
+    // Phase 4a: the shadow records the unguarded truth (moved day only). The
+    // emptied Seoul day is absent from the payload, so it is absent from the
+    // shadow write too — that absence is what Phase 4b needs to see.
+    const shadowSqls = executedSqlArgs.filter((arg) => {
+      const parts: string[] = [];
+      collectStrings(arg, parts);
+      return parts.some((s) =>
+        s.includes("INSERT INTO daily_breakdown_reported"),
+      );
+    });
+    expect(shadowSqls).toHaveLength(1);
+    const shadowParts: Array<string | number> = [];
+    collectPrimitives(shadowSqls[0], shadowParts);
+    expect(
+      shadowParts.some(
+        (s) => typeof s === "string" && s.includes("GREATEST"),
+      ),
+    ).toBe(false);
+    expect(shadowParts).toContain("2026-03-02");
+    expect(shadowParts).toContain("claude");
+    expect(shadowParts).toContain(1000);
+    expect(shadowParts).not.toContain("2026-03-03");
   });
 
   it("lets the regression guard preserve the client that moved off a day", async () => {
@@ -576,8 +627,6 @@ describe("POST /api/submit timezone re-split vs monotonic merge (#960)", () => {
     expect(updateJsons).toHaveLength(1);
     const merged = JSON.parse(updateJsons[0]) as { claude: { tokens: number } };
     expect(merged.claude.tokens).toBe(1000);
-    expect(strings.some((s) => s.includes("INSERT INTO daily_breakdown"))).toBe(
-      false,
-    );
+    expect(strings.some((s) => isDailyBreakdownInsert(s))).toBe(false);
   });
 });

--- a/packages/frontend/__tests__/lib/dailyBreakdownReported.test.ts
+++ b/packages/frontend/__tests__/lib/dailyBreakdownReported.test.ts
@@ -293,9 +293,13 @@ describe("recordDailyBreakdownReported upsert", () => {
     expect(executor.queries).toEqual([]);
   });
 
-  it("chunks large payloads under the Postgres bind-parameter cap", async () => {
+  it("chunks inserts so each statement stays under the Postgres bind-parameter cap", async () => {
+    // Postgres caps a statement at 65,535 binds. Each observation row binds 10
+    // params, so 6,554 unchunked rows would overflow. The module chunks at
+    // 1000; this payload forces several insert statements and pins that none
+    // of them approach the hard cap.
     const executor = capturingExecutor();
-    const padded = Array.from({ length: 1001 }, (_, i) => ({
+    const padded = Array.from({ length: 6554 }, (_, i) => ({
       date: "2020-01-01",
       client: `client-${i}`,
       tokens: 1,
@@ -312,12 +316,16 @@ describe("recordDailyBreakdownReported upsert", () => {
       rows: padded,
     });
 
-    expect(executor.queries).toHaveLength(2);
+    expect(executor.queries.length).toBeGreaterThan(1);
     expect(
       executor.queries.every((q) =>
         q.sql.includes("INSERT INTO daily_breakdown_reported")
       )
     ).toBe(true);
+    expect(executor.queries.every((q) => q.params.length <= 65_535)).toBe(true);
+    expect(
+      Math.max(...executor.queries.map((q) => q.params.length))
+    ).toBeLessThanOrEqual(1000 * 10);
   });
 });
 

--- a/packages/frontend/__tests__/lib/dailyBreakdownReported.test.ts
+++ b/packages/frontend/__tests__/lib/dailyBreakdownReported.test.ts
@@ -1,0 +1,372 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { PgDialect } from "drizzle-orm/pg-core";
+import type { SQL } from "drizzle-orm";
+
+import {
+  foldContributionsIntoReportedRows,
+  recordDailyBreakdownReported,
+  type DailyBreakdownReportedContribution,
+} from "@/lib/db/dailyBreakdownReported";
+
+// Pins Phase 4a of docs/ratchet-inflation-recovery.md: an unguarded
+// per-(device, date, client) shadow of what the CLI last reported. Nothing
+// reads the table; the upsert must be last-write-wins (never GREATEST).
+
+const dialect = new PgDialect();
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+}
+
+function capturingExecutor() {
+  const queries: CapturedQuery[] = [];
+  return {
+    queries,
+    execute: async (query: SQL): Promise<unknown> => {
+      queries.push(dialect.sqlToQuery(query));
+      return [];
+    },
+  };
+}
+
+function day(
+  date: string,
+  clients: Array<{
+    client: string;
+    modelId?: string;
+    tokens?: number;
+    cost?: number;
+    input?: number;
+    output?: number;
+  }>,
+  activeTimeMs?: number | null
+): DailyBreakdownReportedContribution {
+  return {
+    date,
+    activeTimeMs,
+    clients: clients.map((c) => ({
+      client: c.client,
+      modelId: c.modelId ?? "model-a",
+      messages: 1,
+      cost: c.cost ?? 0,
+      tokens: {
+        input: c.input ?? c.tokens ?? 0,
+        output: c.output ?? 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        reasoning: 0,
+      },
+    })),
+  };
+}
+
+describe("foldContributionsIntoReportedRows", () => {
+  it("emits one row per (date, client), summing models on the same day", () => {
+    const rows = foldContributionsIntoReportedRows(
+      [
+        day("2026-03-02", [
+          { client: "claude", modelId: "a", tokens: 400, cost: 0.4 },
+          { client: "claude", modelId: "b", tokens: 600, cost: 0.6 },
+          { client: "codex", tokens: 50, cost: 0.05 },
+        ]),
+        day("2026-03-03", [{ client: "claude", tokens: 10, cost: 0.01 }]),
+      ],
+      "cli"
+    );
+
+    expect(rows).toEqual([
+      {
+        date: "2026-03-02",
+        client: "claude",
+        tokens: 1000,
+        cost: 1,
+        input: 1000,
+        output: 0,
+        activeTimeMs: null,
+        origin: "cli",
+      },
+      {
+        date: "2026-03-02",
+        client: "codex",
+        tokens: 50,
+        cost: 0.05,
+        input: 50,
+        output: 0,
+        activeTimeMs: null,
+        origin: "cli",
+      },
+      {
+        date: "2026-03-03",
+        client: "claude",
+        tokens: 10,
+        cost: 0.01,
+        input: 10,
+        output: 0,
+        activeTimeMs: null,
+        origin: "cli",
+      },
+    ]);
+  });
+
+  it("carries day-level activeTimeMs onto every client row for that day", () => {
+    const rows = foldContributionsIntoReportedRows(
+      [
+        day(
+          "2026-03-02",
+          [
+            { client: "claude", tokens: 10 },
+            { client: "codex", tokens: 20 },
+          ],
+          12_000
+        ),
+      ],
+      "cli"
+    );
+
+    expect(rows.map((r) => r.activeTimeMs)).toEqual([12_000, 12_000]);
+  });
+
+  it("stamps a uniform origin from the submission-level tag", () => {
+    const rows = foldContributionsIntoReportedRows(
+      [day("2026-03-02", [{ client: "claude", tokens: 1 }])],
+      "backfill"
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].origin).toBe("backfill");
+  });
+
+  it("skips malformed dates rather than inventing a shadow key", () => {
+    const rows = foldContributionsIntoReportedRows(
+      [
+        day("2026-02-31", [{ client: "claude", tokens: 10 }]),
+        day("not-a-date", [{ client: "claude", tokens: 10 }]),
+        day("2026-03-02", [{ client: "claude", tokens: 7 }]),
+      ],
+      "cli"
+    );
+    expect(rows).toEqual([
+      expect.objectContaining({ date: "2026-03-02", tokens: 7 }),
+    ]);
+  });
+
+  it("returns nothing for an empty payload", () => {
+    expect(foldContributionsIntoReportedRows([], "cli")).toEqual([]);
+  });
+});
+
+describe("recordDailyBreakdownReported upsert", () => {
+  it("is last-write-wins: conflict assigns EXCLUDED, never GREATEST", async () => {
+    const executor = capturingExecutor();
+    await recordDailyBreakdownReported({
+      executor,
+      submittedDeviceId: "11111111-1111-4111-8111-111111111111",
+      rows: foldContributionsIntoReportedRows(
+        [day("2026-03-02", [{ client: "claude", tokens: 1000, cost: 1 }])],
+        "cli"
+      ),
+    });
+
+    const [query] = executor.queries;
+    expect(query.sql).toContain("INSERT INTO daily_breakdown_reported");
+    expect(query.sql).toMatch(/tokens\s*=\s*EXCLUDED\.tokens/);
+    expect(query.sql).toMatch(/cost\s*=\s*EXCLUDED\.cost/);
+    expect(query.sql).toMatch(/input\s*=\s*EXCLUDED\.input/);
+    expect(query.sql).toMatch(/output\s*=\s*EXCLUDED\.output/);
+    expect(query.sql).toMatch(/active_time_ms\s*=\s*EXCLUDED\.active_time_ms/);
+    expect(query.sql).toMatch(/origin\s*=\s*EXCLUDED\.origin/);
+    expect(query.sql).toMatch(/reported_at\s*=\s*EXCLUDED\.reported_at/);
+    // A GREATEST arm would freeze the inflated shadow the same way the
+    // guarded daily merge freezes #960 — the whole point of this table is
+    // that a lower truthful rescan replaces the previous report.
+    expect(query.sql).not.toContain("GREATEST");
+  });
+
+  it("matches the primary key the migration actually creates", async () => {
+    // A conflict target that does not match a real unique constraint is a
+    // runtime error, so the DDL and the upsert are pinned to each other.
+    const migration = readFileSync(
+      resolve(
+        __dirname,
+        "../../src/lib/db/migrations/0025_bouncy_vertigo.sql"
+      ),
+      "utf8"
+    );
+    const pk = migration.match(/PRIMARY KEY\(([^)]*)\)/)?.[1];
+    expect(pk?.split(",").map((c) => c.trim().replace(/"/g, ""))).toEqual([
+      "submitted_device_id",
+      "date",
+      "client",
+    ]);
+
+    const executor = capturingExecutor();
+    await recordDailyBreakdownReported({
+      executor,
+      submittedDeviceId: "11111111-1111-4111-8111-111111111111",
+      rows: foldContributionsIntoReportedRows(
+        [day("2026-03-02", [{ client: "claude", tokens: 1 }])],
+        "cli"
+      ),
+    });
+    const conflictTarget = executor.queries[0].sql.match(
+      /ON CONFLICT \(([^)]*)\)/
+    )?.[1];
+    expect(conflictTarget?.split(",").map((c) => c.trim())).toEqual([
+      "submitted_device_id",
+      "date",
+      "client",
+    ]);
+  });
+
+  it("keeps origin out of the conflict key so a later scan replaces either provenance", async () => {
+    const executor = capturingExecutor();
+    await recordDailyBreakdownReported({
+      executor,
+      submittedDeviceId: "11111111-1111-4111-8111-111111111111",
+      rows: foldContributionsIntoReportedRows(
+        [day("2026-03-02", [{ client: "claude", tokens: 1 }])],
+        "cli"
+      ),
+    });
+
+    const [query] = executor.queries;
+    const conflictTarget = query.sql.match(/ON CONFLICT \(([^)]*)\)/)?.[1];
+    expect(conflictTarget?.split(",").map((c) => c.trim())).toEqual([
+      "submitted_device_id",
+      "date",
+      "client",
+    ]);
+    // Unlike Phase 1's submitted_device_client_totals, a later scan of either
+    // origin replaces the previous report for that (device, date, client).
+    expect(conflictTarget).not.toContain("origin");
+  });
+
+  it("binds the folded unguarded totals for the addressed device", async () => {
+    const executor = capturingExecutor();
+    await recordDailyBreakdownReported({
+      executor,
+      submittedDeviceId: "22222222-2222-4222-8222-222222222222",
+      rows: foldContributionsIntoReportedRows(
+        [
+          day(
+            "2026-03-02",
+            [
+              {
+                client: "claude",
+                tokens: 1000,
+                cost: 1.5,
+                input: 800,
+                output: 200,
+              },
+            ],
+            4500
+          ),
+        ],
+        "cli"
+      ),
+      now: new Date("2026-03-04T00:00:00.000Z"),
+    });
+
+    const [query] = executor.queries;
+    expect(query.params).toContain("22222222-2222-4222-8222-222222222222");
+    expect(query.params).toContain("2026-03-02");
+    expect(query.params).toContain("claude");
+    expect(query.params).toContain(1000);
+    expect(query.params).toContain("1.5000");
+    expect(query.params).toContain(800);
+    expect(query.params).toContain(200);
+    expect(query.params).toContain(4500);
+    expect(query.params).toContain("cli");
+    expect(query.params).toContain("2026-03-04T00:00:00.000Z");
+  });
+
+  it("writes nothing when the folded payload is empty", async () => {
+    const executor = capturingExecutor();
+    const written = await recordDailyBreakdownReported({
+      executor,
+      submittedDeviceId: "11111111-1111-4111-8111-111111111111",
+      rows: [],
+    });
+    expect(written).toBe(0);
+    expect(executor.queries).toEqual([]);
+  });
+
+  it("chunks large payloads under the Postgres bind-parameter cap", async () => {
+    const executor = capturingExecutor();
+    const padded = Array.from({ length: 1001 }, (_, i) => ({
+      date: "2020-01-01",
+      client: `client-${i}`,
+      tokens: 1,
+      cost: 0,
+      input: 1,
+      output: 0,
+      activeTimeMs: null as number | null,
+      origin: "cli" as const,
+    }));
+
+    await recordDailyBreakdownReported({
+      executor,
+      submittedDeviceId: "11111111-1111-4111-8111-111111111111",
+      rows: padded,
+    });
+
+    expect(executor.queries).toHaveLength(2);
+    expect(
+      executor.queries.every((q) =>
+        q.sql.includes("INSERT INTO daily_breakdown_reported")
+      )
+    ).toBe(true);
+  });
+});
+
+describe("#960 divergence the shadow must capture", () => {
+  it("records the moved day and leaves the emptied day absent from the payload fold", () => {
+    // First Seoul scan reported 2026-03-03 = 1000. UTC rescan moves the same
+    // 1000 tokens onto 2026-03-02. The guarded store keeps both days (2000);
+    // the shadow of THIS payload only knows about 03-02.
+    const rows = foldContributionsIntoReportedRows(
+      [day("2026-03-02", [{ client: "claude", tokens: 1000 }])],
+      "cli"
+    );
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        date: "2026-03-02",
+        client: "claude",
+        tokens: 1000,
+      }),
+    ]);
+    expect(rows.some((r) => r.date === "2026-03-03")).toBe(false);
+  });
+
+  it("records the lower incoming total even when the guard would preserve higher", () => {
+    // Guarded merge would keep stored codex=500 on 03-02 while accepting the
+    // move onto 03-03. The shadow must still report the truthful incoming:
+    // claude 500 on 03-02 and codex 500 on 03-03 — no preserved stale codex.
+    const rows = foldContributionsIntoReportedRows(
+      [
+        day("2026-03-02", [{ client: "claude", tokens: 500 }]),
+        day("2026-03-03", [{ client: "codex", tokens: 500 }]),
+      ],
+      "cli"
+    );
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        date: "2026-03-02",
+        client: "claude",
+        tokens: 500,
+      }),
+      expect.objectContaining({
+        date: "2026-03-03",
+        client: "codex",
+        tokens: 500,
+      }),
+    ]);
+    expect(
+      rows.some((r) => r.date === "2026-03-02" && r.client === "codex")
+    ).toBe(false);
+  });
+});

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -852,10 +852,10 @@ export async function POST(request: Request) {
         `);
       }
 
-      // Phase 4a shadow write — same transaction as the daily rows above, so a
-      // crash cannot leave the guarded store without its unguarded counterpart.
-      // Last-write-wins (no GREATEST): a truthful lower rescan must replace the
-      // previous report or Phase 4b cannot see the #960 emptied-day divergence.
+      // Phase 4a observation write — same transaction as the daily rows above,
+      // so an explicitly reported cell cannot commit without its unguarded
+      // counterpart. Last-write-wins (no GREATEST) for that cell only: omitted
+      // cells are not zero or absent, and this is not a whole-scan snapshot.
       if (reportedRows.length > 0) {
         await recordDailyBreakdownReported({
           executor: tx,

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -399,8 +399,8 @@ export async function POST(request: Request) {
     const ratchetCensusBuckets = ratchetCensusEnabled
       ? foldContributionsIntoBuckets(data.contributions, isBackfill ? "backfill" : "cli")
       : [];
-    // Phase 4a: unguarded per-(date, client) snapshot. Folded once up front so
-    // the write sees the same pre-guard totals the merge loop builds into
+    // Phase 4a: unguarded per-(date, client) observations. Folded once up front
+    // so the write sees the same pre-guard totals the merge loop builds into
     // `incomingClientBreakdown`, not the post-guard values that land in
     // `daily_breakdown`. Always on — nothing reads the table.
     const reportedRows = foldContributionsIntoReportedRows(
@@ -853,8 +853,8 @@ export async function POST(request: Request) {
       }
 
       // Phase 4a observation write — same transaction as the daily rows above,
-      // so an explicitly reported cell cannot commit without its unguarded
-      // counterpart. Last-write-wins (no GREATEST) for that cell only: omitted
+      // so an explicitly reported cell cannot commit without its guarded
+      // daily_breakdown counterpart. Last-write-wins (no GREATEST) for that cell only: omitted
       // cells are not zero or absent, and this is not a whole-scan snapshot.
       if (reportedRows.length > 0) {
         await recordDailyBreakdownReported({

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -25,6 +25,10 @@ import {
   recoverRatchetCensusWork,
   DUAL_DERIVATION_LOG_PREFIX,
 } from "@/lib/db/deviceClientTotals";
+import {
+  foldContributionsIntoReportedRows,
+  recordDailyBreakdownReported,
+} from "@/lib/db/dailyBreakdownReported";
 import { normalizeUsernameCacheKey, revalidateUsernamePaths } from "@/lib/db/usernameLookup";
 import { revalidateUserGroupLeaderboards } from "@/lib/groups/cache";
 import { LEGACY_DEVICE_KEY } from "@/lib/devices/shared";
@@ -395,6 +399,14 @@ export async function POST(request: Request) {
     const ratchetCensusBuckets = ratchetCensusEnabled
       ? foldContributionsIntoBuckets(data.contributions, isBackfill ? "backfill" : "cli")
       : [];
+    // Phase 4a: unguarded per-(date, client) snapshot. Folded once up front so
+    // the write sees the same pre-guard totals the merge loop builds into
+    // `incomingClientBreakdown`, not the post-guard values that land in
+    // `daily_breakdown`. Always on — nothing reads the table.
+    const reportedRows = foldContributionsIntoReportedRows(
+      data.contributions,
+      isBackfill ? "backfill" : "cli"
+    );
     const result = await db.transaction(async (tx) => {
       await tx
         .update(apiTokens)
@@ -838,6 +850,18 @@ export async function POST(request: Request) {
             AS batch(id, tokens, cost, input_tokens, output_tokens, timestamp_ms, active_time_ms, source_breakdown)
           WHERE d.id = batch.id
         `);
+      }
+
+      // Phase 4a shadow write — same transaction as the daily rows above, so a
+      // crash cannot leave the guarded store without its unguarded counterpart.
+      // Last-write-wins (no GREATEST): a truthful lower rescan must replace the
+      // previous report or Phase 4b cannot see the #960 emptied-day divergence.
+      if (reportedRows.length > 0) {
+        await recordDailyBreakdownReported({
+          executor: tx,
+          submittedDeviceId: submittedDevice.id,
+          rows: reportedRows,
+        });
       }
 
       // ------------------------------------------

--- a/packages/frontend/src/lib/db/dailyBreakdownReported.ts
+++ b/packages/frontend/src/lib/db/dailyBreakdownReported.ts
@@ -1,0 +1,201 @@
+/**
+ * Unguarded per-(device, date, client) snapshot of what the CLI last reported.
+ *
+ * Phase 4a of `docs/ratchet-inflation-recovery.md`.
+ *
+ * Written inside the submit transaction alongside `daily_breakdown`, but with
+ * opposite merge semantics: last-write-wins, no `GREATEST`, no regression
+ * guard, no alias-fold normalisation. **Nothing reads this table** — Phase 4b
+ * is the only planned consumer, and it runs offline.
+ */
+
+import { sql, type SQL } from "drizzle-orm";
+import { clientContributionToBreakdownData } from "./helpers";
+
+/**
+ * PostgreSQL caps a statement at 65,535 bound parameters. Each row binds 10,
+ * so this stays clear even for a dense multi-client historical backfill.
+ */
+const UPSERT_CHUNK_SIZE = 1000;
+
+export type DailyBreakdownReportedOrigin = "cli" | "backfill";
+
+export interface DailyBreakdownReportedRow {
+  date: string;
+  client: string;
+  tokens: number;
+  cost: number;
+  input: number;
+  output: number;
+  activeTimeMs: number | null;
+  origin: DailyBreakdownReportedOrigin;
+}
+
+/**
+ * Structural shape of one day of an already-validated payload. Kept structural
+ * rather than importing the Zod-inferred type so this module can be exercised
+ * without constructing a full `SubmissionData`.
+ */
+export interface DailyBreakdownReportedContribution {
+  date: string;
+  activeTimeMs?: number | null;
+  clients: Array<{
+    client: string;
+    modelId: string;
+    messages: number;
+    cost: number;
+    tokens: {
+      input: number;
+      output: number;
+      cacheRead: number;
+      cacheWrite: number;
+      reasoning?: number;
+    };
+  }>;
+}
+
+export interface DailyBreakdownReportedExecutor {
+  execute(query: SQL): Promise<unknown>;
+}
+
+function clampTokens(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  // Values arrive as JS numbers, so precision (not int8 range) is the binding
+  // limit. Clamping at MAX_SAFE_INTEGER keeps the bound parameter exact and
+  // stays far below int8 max.
+  return Math.min(Math.round(value), Number.MAX_SAFE_INTEGER);
+}
+
+/**
+ * numeric(14,4) holds up to 9999999999.9999 — matching `daily_breakdown.cost`.
+ * `toFixed(4)` switches to exponential notation at 1e21, which would not parse
+ * as numeric at all, so dishonest values are clamped before formatting.
+ */
+const COST_MAX = 9999999999;
+
+function clampCost(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  return Math.min(value, COST_MAX);
+}
+
+function isIsoCalendarDate(date: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return false;
+  // Round-trip through UTC so impossible days (2026-02-31) are refused rather
+  // than rolled into a neighbouring month the way `Date` parsing would.
+  const parsed = new Date(`${date}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime())) return false;
+  return parsed.toISOString().slice(0, 10) === date;
+}
+
+/**
+ * Fold a payload's daily contributions into one row per (date, client).
+ *
+ * Token arithmetic goes through `clientContributionToBreakdownData` — the same
+ * helper the daily rows use — so the shadow and the guarded store cannot drift
+ * apart on what counts as a token. Multiple models under one client on one day
+ * sum into a single row, matching how the submit route builds
+ * `incomingClientBreakdown` before the regression guard runs.
+ *
+ * `origin` is applied uniformly from the submission-level provenance tag,
+ * matching how the submit route stamps `origin` into every client entry of a
+ * backfill submission.
+ */
+export function foldContributionsIntoReportedRows(
+  contributions: readonly DailyBreakdownReportedContribution[],
+  origin: DailyBreakdownReportedOrigin
+): DailyBreakdownReportedRow[] {
+  const byKey = new Map<string, DailyBreakdownReportedRow>();
+
+  for (const day of contributions) {
+    if (!isIsoCalendarDate(day.date)) continue;
+    const activeTimeMs =
+      day.activeTimeMs == null || !Number.isFinite(day.activeTimeMs)
+        ? null
+        : Math.max(0, Math.round(day.activeTimeMs));
+
+    for (const client_contrib of day.clients) {
+      const modelData = clientContributionToBreakdownData(client_contrib);
+      const key = `${day.date}\0${client_contrib.client}`;
+      const existing = byKey.get(key);
+      if (existing) {
+        existing.tokens += modelData.tokens;
+        existing.cost += modelData.cost;
+        existing.input += modelData.input;
+        existing.output += modelData.output;
+        // Day-level: last non-null active time wins within one payload. A
+        // contribution list should not carry the same date twice, but if it
+        // does the later day's value is what the route would have used when
+        // iterating `data.contributions` in order.
+        if (activeTimeMs != null) existing.activeTimeMs = activeTimeMs;
+      } else {
+        byKey.set(key, {
+          date: day.date,
+          client: client_contrib.client,
+          tokens: modelData.tokens,
+          cost: modelData.cost,
+          input: modelData.input,
+          output: modelData.output,
+          activeTimeMs,
+          origin,
+        });
+      }
+    }
+  }
+
+  return Array.from(byKey.values(), (row) => ({
+    ...row,
+    tokens: clampTokens(row.tokens),
+    cost: clampCost(row.cost),
+    input: clampTokens(row.input),
+    output: clampTokens(row.output),
+  }));
+}
+
+/**
+ * Last-write-wins upsert of the unguarded per-(date, client) report.
+ *
+ * Deliberately NOT monotonic: a truthful lower rescan must replace the stored
+ * shadow so Phase 4b can see the emptied-day / moved-day divergence that the
+ * guarded `daily_breakdown` merge freezes over. That is also why this write
+ * lives inside the submit transaction — it is the counterpart of the daily
+ * write, not a deferred measurement.
+ *
+ * Returns the number of rows sent.
+ */
+export async function recordDailyBreakdownReported(params: {
+  executor: DailyBreakdownReportedExecutor;
+  submittedDeviceId: string;
+  rows: readonly DailyBreakdownReportedRow[];
+  now?: Date;
+}): Promise<number> {
+  const { executor, submittedDeviceId, rows } = params;
+  if (rows.length === 0) return 0;
+
+  const reportedAt = (params.now ?? new Date()).toISOString();
+
+  for (let i = 0; i < rows.length; i += UPSERT_CHUNK_SIZE) {
+    const chunk = rows.slice(i, i + UPSERT_CHUNK_SIZE);
+    const valuesClauses = chunk.map(
+      (row) =>
+        sql`(${submittedDeviceId}::uuid, ${row.date}::date, ${row.client}, ${row.tokens}::bigint, ${row.cost.toFixed(4)}::numeric(14,4), ${row.input}::bigint, ${row.output}::bigint, ${row.activeTimeMs}::bigint, ${row.origin}, ${reportedAt}::timestamptz)`
+    );
+
+    await executor.execute(sql`
+      INSERT INTO daily_breakdown_reported (
+        submitted_device_id, date, client,
+        tokens, cost, input, output, active_time_ms, origin, reported_at
+      )
+      VALUES ${sql.join(valuesClauses, sql`, `)}
+      ON CONFLICT (submitted_device_id, date, client) DO UPDATE SET
+        tokens = EXCLUDED.tokens,
+        cost = EXCLUDED.cost,
+        input = EXCLUDED.input,
+        output = EXCLUDED.output,
+        active_time_ms = EXCLUDED.active_time_ms,
+        origin = EXCLUDED.origin,
+        reported_at = EXCLUDED.reported_at
+    `);
+  }
+
+  return rows.length;
+}

--- a/packages/frontend/src/lib/db/dailyBreakdownReported.ts
+++ b/packages/frontend/src/lib/db/dailyBreakdownReported.ts
@@ -1,12 +1,13 @@
 /**
- * Unguarded per-(device, date, client) snapshot of what the CLI last reported.
+ * Unguarded latest observation for each reported (device, date, client) cell.
  *
  * Phase 4a of `docs/ratchet-inflation-recovery.md`.
  *
  * Written inside the submit transaction alongside `daily_breakdown`, but with
  * opposite merge semantics: last-write-wins, no `GREATEST`, no regression
- * guard, no alias-fold normalisation. **Nothing reads this table** — Phase 4b
- * is the only planned consumer, and it runs offline.
+ * guard, no alias-fold normalisation. **Nothing reads this table.** This is not
+ * a whole-scan snapshot: a later payload that omits a cell leaves its prior
+ * observation intact, so omission never means zero or absence.
  */
 
 import { sql, type SQL } from "drizzle-orm";
@@ -154,11 +155,12 @@ export function foldContributionsIntoReportedRows(
 /**
  * Last-write-wins upsert of the unguarded per-(date, client) report.
  *
- * Deliberately NOT monotonic: a truthful lower rescan must replace the stored
- * shadow so Phase 4b can see the emptied-day / moved-day divergence that the
- * guarded `daily_breakdown` merge freezes over. That is also why this write
- * lives inside the submit transaction — it is the counterpart of the daily
- * write, not a deferred measurement.
+ * Deliberately NOT monotonic: the latest value explicitly reported for this
+ * cell replaces its prior observation. This does not make omitted cells
+ * authoritative; a future recovery design needs client-declared coverage plus
+ * snapshot generations or tombstones before it can reason about absence. The
+ * write lives inside the submit transaction so each observed cell is committed
+ * alongside its guarded `daily_breakdown` counterpart.
  *
  * Returns the number of rows sent.
  */

--- a/packages/frontend/src/lib/db/migrations/0025_bouncy_vertigo.sql
+++ b/packages/frontend/src/lib/db/migrations/0025_bouncy_vertigo.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "daily_breakdown_reported" (
+	"submitted_device_id" uuid NOT NULL,
+	"date" date NOT NULL,
+	"client" varchar(128) NOT NULL,
+	"tokens" bigint NOT NULL,
+	"cost" numeric(14, 4) NOT NULL,
+	"input" bigint NOT NULL,
+	"output" bigint NOT NULL,
+	"active_time_ms" bigint,
+	"origin" varchar(16) NOT NULL,
+	"reported_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "daily_breakdown_reported_submitted_device_id_date_client_pk" PRIMARY KEY("submitted_device_id","date","client")
+);
+--> statement-breakpoint
+ALTER TABLE "daily_breakdown_reported" ADD CONSTRAINT "daily_breakdown_reported_submitted_device_id_submitted_devices_id_fk" FOREIGN KEY ("submitted_device_id") REFERENCES "public"."submitted_devices"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_daily_breakdown_reported_device_date" ON "daily_breakdown_reported" USING btree ("submitted_device_id","date");

--- a/packages/frontend/src/lib/db/migrations/meta/0025_snapshot.json
+++ b/packages/frontend/src/lib/db/migrations/meta/0025_snapshot.json
@@ -1,0 +1,1985 @@
+{
+  "id": "3600bea7-2dc3-45e2-8749-0c6fa3f7ab21",
+  "prevId": "5143df04-f90e-41ac-be9f-7542e5d7c580",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_api_tokens_token": {
+          "name": "idx_api_tokens_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_tokens_user_id": {
+          "name": "idx_api_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_unique": {
+          "name": "api_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        },
+        "api_tokens_user_name_unique": {
+          "name": "api_tokens_user_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_breakdown": {
+      "name": "daily_breakdown",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(14, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_breakdown": {
+          "name": "source_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_time_ms": {
+          "name": "active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_daily_breakdown_submission_id": {
+          "name": "idx_daily_breakdown_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_submitted_device_id": {
+          "name": "idx_daily_breakdown_submitted_device_id",
+          "columns": [
+            {
+              "expression": "submitted_device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_date": {
+          "name": "idx_daily_breakdown_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_breakdown_submission_id_submissions_id_fk": {
+          "name": "daily_breakdown_submission_id_submissions_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_breakdown_submitted_device_id_submitted_devices_id_fk": {
+          "name": "daily_breakdown_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_breakdown_submission_device_date_unique": {
+          "name": "daily_breakdown_submission_device_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "submission_id",
+            "submitted_device_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_breakdown_reported": {
+      "name": "daily_breakdown_reported",
+      "schema": "",
+      "columns": {
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client": {
+          "name": "client",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(14, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_time_ms": {
+          "name": "active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_breakdown_reported_device_date": {
+          "name": "idx_daily_breakdown_reported_device_date",
+          "columns": [
+            {
+              "expression": "submitted_device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_breakdown_reported_submitted_device_id_submitted_devices_id_fk": {
+          "name": "daily_breakdown_reported_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "daily_breakdown_reported",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_breakdown_reported_submitted_device_id_date_client_pk": {
+          "name": "daily_breakdown_reported_submitted_device_id_date_client_pk",
+          "columns": [
+            "submitted_device_id",
+            "date",
+            "client"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_codes_device_code": {
+          "name": "idx_device_codes_device_code",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_code": {
+          "name": "idx_device_codes_user_code",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_id": {
+          "name": "idx_device_codes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_expires_at": {
+          "name": "idx_device_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_codes_user_id_users_id_fk": {
+          "name": "device_codes_user_id_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_invites": {
+      "name": "group_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_username": {
+          "name": "invited_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_username_normalized": {
+          "name": "invited_username_normalized",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_user_id": {
+          "name": "invited_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_group_invites_group_status": {
+          "name": "idx_group_invites_group_status",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_user_status": {
+          "name": "idx_group_invites_invited_user_status",
+          "columns": [
+            {
+              "expression": "invited_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_username_status": {
+          "name": "idx_group_invites_invited_username_status",
+          "columns": [
+            {
+              "expression": "invited_username_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_expires_at": {
+          "name": "idx_group_invites_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_by": {
+          "name": "idx_group_invites_invited_by",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_invites_group_id_groups_id_fk": {
+          "name": "group_invites_group_id_groups_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_invites_invited_user_id_users_id_fk": {
+          "name": "group_invites_invited_user_id_users_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_invites_invited_by_users_id_fk": {
+          "name": "group_invites_invited_by_users_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_invites_token_hash_unique": {
+          "name": "group_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_members": {
+      "name": "group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_group_members_user_id": {
+          "name": "idx_group_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_members_invited_by": {
+          "name": "idx_group_members_invited_by",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_members_group_id_groups_id_fk": {
+          "name": "group_members_group_id_groups_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_members_user_id_users_id_fk": {
+          "name": "group_members_user_id_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_members_invited_by_users_id_fk": {
+          "name": "group_members_invited_by_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_members_group_user_unique": {
+          "name": "group_members_group_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_created_by": {
+          "name": "idx_groups_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_groups_visibility_updated": {
+          "name": "idx_groups_visibility_updated",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_created_by_users_id_fk": {
+          "name": "groups_created_by_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_slug_unique": {
+          "name": "groups_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moderation_actions": {
+      "name": "moderation_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_username": {
+          "name": "target_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_moderation_actions_target_created": {
+          "name": "idx_moderation_actions_target_created",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_moderation_actions_actor": {
+          "name": "idx_moderation_actions_actor",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moderation_actions_target_user_id_users_id_fk": {
+          "name": "moderation_actions_target_user_id_users_id_fk",
+          "tableFrom": "moderation_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "moderation_actions_actor_user_id_users_id_fk": {
+          "name": "moderation_actions_actor_user_id_users_id_fk",
+          "tableFrom": "moderation_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ratchet_census_work": {
+      "name": "ratchet_census_work",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buckets": {
+          "name": "buckets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ratchet_census_work_submission_id": {
+          "name": "idx_ratchet_census_work_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ratchet_census_work_submission_id_submissions_id_fk": {
+          "name": "ratchet_census_work_submission_id_submissions_id_fk",
+          "tableFrom": "ratchet_census_work",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ratchet_census_work_submitted_device_id_submitted_devices_id_fk": {
+          "name": "ratchet_census_work_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "ratchet_census_work",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_token_hash": {
+          "name": "idx_sessions_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sources_used": {
+          "name": "sources_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "models_used": {
+          "name": "models_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_version": {
+          "name": "cli_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_hash": {
+          "name": "submission_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submit_count": {
+          "name": "submit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_backfill": {
+          "name": "has_backfill",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_active_time_ms": {
+          "name": "total_active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longest_continuous_ms": {
+          "name": "longest_continuous_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_sessions": {
+          "name": "max_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_servers": {
+          "name": "mcp_servers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_submissions_created_at": {
+          "name": "idx_submissions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_leaderboard": {
+          "name": "idx_submissions_leaderboard",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_tokens",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_cost",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submissions_user_id_unique": {
+          "name": "submissions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submitted_device_client_totals": {
+      "name": "submitted_device_client_totals",
+      "schema": "",
+      "columns": {
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client": {
+          "name": "client",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_width": {
+          "name": "bucket_width",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_key": {
+          "name": "bucket_key",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens_highwater": {
+          "name": "tokens_highwater",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_highwater": {
+          "name": "cost_highwater",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "submitted_device_client_totals_submitted_device_id_submitted_devices_id_fk": {
+          "name": "submitted_device_client_totals_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "submitted_device_client_totals",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "submitted_device_client_totals_submitted_device_id_client_origin_bucket_width_bucket_key_pk": {
+          "name": "submitted_device_client_totals_submitted_device_id_client_origin_bucket_width_bucket_key_pk",
+          "columns": [
+            "submitted_device_id",
+            "client",
+            "origin",
+            "bucket_width",
+            "bucket_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submitted_devices": {
+      "name": "submitted_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_key": {
+          "name": "device_key",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_active_time_ms": {
+          "name": "total_active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longest_continuous_ms": {
+          "name": "longest_continuous_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_sessions": {
+          "name": "max_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_submitted_devices_user_id": {
+          "name": "idx_submitted_devices_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submitted_devices_user_id_users_id_fk": {
+          "name": "submitted_devices_user_id_users_id_fk",
+          "tableFrom": "submitted_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submitted_devices_user_device_key_unique": {
+          "name": "submitted_devices_user_device_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leaderboard_hidden": {
+          "name": "leaderboard_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_lower_unique": {
+          "name": "users_username_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_github_id": {
+          "name": "idx_users_github_id",
+          "columns": [
+            {
+              "expression": "github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1785785051220,
       "tag": "0024_parched_dreadnoughts",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1785854002944,
+      "tag": "0025_bouncy_vertigo",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -389,6 +389,73 @@ export const dailyBreakdownRelations = relations(dailyBreakdown, ({ one }) => ({
 }));
 
 // ============================================================================
+// DAILY BREAKDOWN REPORTED (ratchet-inflation shadow, Phase 4a)
+// ============================================================================
+/**
+ * Unguarded per-(device, date, client) values from the most recent scan.
+ *
+ * Phase 4a of docs/ratchet-inflation-recovery.md. **Nothing reads this table.**
+ * It records what the CLI actually reported, which the monotonic merge on
+ * `daily_breakdown` throws away. Phase 4b reconciles the two offline.
+ *
+ * Merge semantics: last-write-wins on conflict. No `GREATEST`, no regression
+ * guard, no alias-fold normalisation. A `--since` scan that omits a day does
+ * not touch that day's shadow row — absence is not zero.
+ *
+ * **Never backfill this from `daily_breakdown`.** The stored rows are the
+ * inflated values this table exists to contradict; seeding from them would
+ * leave Phase 4b with nothing to heal.
+ *
+ * `origin` is a plain column, not part of the primary key. Unlike
+ * `submitted_device_client_totals`, a later scan of either origin replaces the
+ * previous report for that (device, date, client) outright — the shadow is a
+ * snapshot of the latest payload, not a high-water across provenance streams.
+ */
+export const dailyBreakdownReported = pgTable(
+  "daily_breakdown_reported",
+  {
+    submittedDeviceId: uuid("submitted_device_id")
+      .notNull()
+      .references(() => submittedDevices.id, { onDelete: "cascade" }),
+    date: date("date").notNull(),
+    /** Canonical client id (post alias normalization, e.g. "kilo" not "kilocode"). */
+    client: varchar("client", { length: 128 }).notNull(),
+
+    tokens: bigint("tokens", { mode: "number" }).notNull(),
+    cost: decimal("cost", { precision: 14, scale: 4 }).notNull(),
+    input: bigint("input", { mode: "number" }).notNull(),
+    output: bigint("output", { mode: "number" }).notNull(),
+    /** Day-level active time, repeated on each client row for that date. */
+    activeTimeMs: bigint("active_time_ms", { mode: "number" }),
+    /** "cli" for locally-scanned usage, "backfill" for `tokscale import`. */
+    origin: varchar("origin", { length: 16 }).notNull(),
+
+    reportedAt: timestamp("reported_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.submittedDeviceId, table.date, table.client],
+    }),
+    index("idx_daily_breakdown_reported_device_date").on(
+      table.submittedDeviceId,
+      table.date
+    ),
+  ]
+);
+
+export const dailyBreakdownReportedRelations = relations(
+  dailyBreakdownReported,
+  ({ one }) => ({
+    submittedDevice: one(submittedDevices, {
+      fields: [dailyBreakdownReported.submittedDeviceId],
+      references: [submittedDevices.id],
+    }),
+  })
+);
+
+// ============================================================================
 // SUBMITTED DEVICE CLIENT TOTALS (ratchet-inflation census, Phase 1)
 // ============================================================================
 /**

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -392,15 +392,18 @@ export const dailyBreakdownRelations = relations(dailyBreakdown, ({ one }) => ({
 // DAILY BREAKDOWN REPORTED (ratchet-inflation shadow, Phase 4a)
 // ============================================================================
 /**
- * Unguarded per-(device, date, client) values from the most recent scan.
+ * Unguarded latest observations for reported (device, date, client) cells.
  *
  * Phase 4a of docs/ratchet-inflation-recovery.md. **Nothing reads this table.**
- * It records what the CLI actually reported, which the monotonic merge on
- * `daily_breakdown` throws away. Phase 4b reconciles the two offline.
+ * It records explicit cell reports that the monotonic merge on
+ * `daily_breakdown` throws away. It is not a whole-scan snapshot and has no
+ * reader or recovery behavior today.
  *
  * Merge semantics: last-write-wins on conflict. No `GREATEST`, no regression
- * guard, no alias-fold normalisation. A `--since` scan that omits a day does
- * not touch that day's shadow row — absence is not zero.
+ * guard, no alias-fold normalisation. A `--since` scan that omits a cell does
+ * not touch that cell's row — absence is not zero. A future recovery workflow
+ * needs client-declared authoritative coverage and snapshot generations or
+ * tombstones before an omitted cell can be treated as absent.
  *
  * **Never backfill this from `daily_breakdown`.** The stored rows are the
  * inflated values this table exists to contradict; seeding from them would
@@ -408,8 +411,8 @@ export const dailyBreakdownRelations = relations(dailyBreakdown, ({ one }) => ({
  *
  * `origin` is a plain column, not part of the primary key. Unlike
  * `submitted_device_client_totals`, a later scan of either origin replaces the
- * previous report for that (device, date, client) outright — the shadow is a
- * snapshot of the latest payload, not a high-water across provenance streams.
+ * previous explicit observation for that (device, date, client) outright — it
+ * is a per-cell LWW table, not a complete payload snapshot or high-water.
  */
 export const dailyBreakdownReported = pgTable(
   "daily_breakdown_reported",


### PR DESCRIPTION
## Summary

- Implements **Phase 4a** of `docs/ratchet-inflation-recovery.md` for [#960](https://github.com/junhoyeo/tokscale/issues/960): add `daily_breakdown_reported` and write each submit's **unguarded** per-`(device, date, client)` totals inside the same transaction as `daily_breakdown`.
- Upsert is **last-write-wins** (assigns `EXCLUDED.*`, never `GREATEST`) for each explicitly reported cell. Omitted cells remain unknown: the table is not a whole-scan snapshot, carries no authoritative coverage, and cannot itself support Phase 4b zero-outs or recovery. That future phase remains gated on client-declared coverage plus generations/tombstones.
- **Nothing reads the table.** Served `totalTokens` / leaderboard / heatmap calculations are unchanged. The new same-transaction write can still affect submission availability if it fails. Migration `0025_bouncy_vertigo` applies on deploy via the existing frontend migrate path.

This does not heal already-inflated rows (Phase 4b, still gated) and does not weaken the monotonic guard. Prevention of new re-splits remains CLI-side (#1016).

## Test plan

- [x] `bun run test -- __tests__/lib/dailyBreakdownReported.test.ts` — fold, LWW upsert, PK↔migration pin, #960 divergence shapes
- [x] `bun run test -- __tests__/api/submitTimezoneResplitRepro.test.ts` — inflation still 2000; shadow records moved day only; no `GREATEST` on shadow SQL
- [x] `bun run test -- __tests__/lib/deviceClientTotals.test.ts __tests__/api/submitRatchetCensus.test.ts` — Phase 1/1.5 placement unchanged
- [x] Migration `0025` applies cleanly in CI's migration replay
- [ ] After merge: verify production gets `daily_breakdown_reported` via Vercel `buildCommand` migrate, and that no read path references it
