### PR TITLE
fix(claude): skip synthetic tool-result attribution

### DIFF
--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -6485,6 +6485,97 @@ mod tests {
         }
     }
 
+    #[test]
+    #[serial_test::serial]
+    fn test_claude_warm_cache_removes_synthetic_placeholder_before_submit_validation() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            let claude_dir = source_home.path().join(".claude/projects/demo");
+            std::fs::create_dir_all(&claude_dir).unwrap();
+            let transcript = claude_dir.join("session.jsonl");
+            std::fs::write(
+                &transcript,
+                r#"{"type":"assistant","timestamp":"2026-06-24T01:00:00.000Z","requestId":"req_live","message":{"id":"live","model":"claude-3-5-sonnet","usage":{"input_tokens":1,"output_tokens":1}}}"#,
+            )
+            .unwrap();
+
+            let identity = message_cache::CacheIdentity::for_client(ClientId::Claude);
+            let fingerprint = message_cache::SourceFingerprint::from_claude_code_path_with_home(
+                &transcript,
+                Some(source_home.path()),
+            )
+            .unwrap();
+            let retained = UnifiedMessage::new_with_dedup(
+                "claude",
+                "claude-3-5-sonnet",
+                "anthropic",
+                "session",
+                1_782_259_200_000,
+                TokenBreakdown {
+                    input: 10,
+                    output: 5,
+                    cache_read: 0,
+                    cache_write: 0,
+                    reasoning: 0,
+                },
+                0.0,
+                Some("old:req_old".to_string()),
+            );
+            let poisoned = UnifiedMessage::new_with_dedup(
+                "claude",
+                "<synthetic>",
+                "unknown",
+                "session",
+                1_782_259_201_000,
+                TokenBreakdown {
+                    input: 100,
+                    output: 0,
+                    cache_read: 0,
+                    cache_write: 0,
+                    reasoning: 0,
+                },
+                0.0,
+                Some("claude:tool_result:session:tool_result:toolu_1".to_string()),
+            );
+            let mut cache = message_cache::SourceMessageCache::default();
+            cache.insert(message_cache::CachedSourceEntry::new(
+                identity,
+                &transcript,
+                fingerprint,
+                vec![retained, poisoned],
+                Vec::new(),
+                None,
+            ));
+            cache.save_if_dirty();
+
+            let messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["claude".to_string()],
+                None,
+            );
+
+            assert_eq!(messages.len(), 1);
+            assert_eq!(messages[0].model_id, "claude-3-5-sonnet");
+            assert_eq!(messages[0].tokens.input, 10);
+
+            let repaired = message_cache::SourceMessageCache::load();
+            let cached = repaired
+                .get(identity, &transcript)
+                .expect("the retained Claude cache entry should remain");
+            assert_eq!(cached.messages.len(), 1);
+            assert_eq!(cached.messages[0].dedup_key.as_deref(), Some("old:req_old"));
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
     #[cfg(unix)]
     #[test]
     #[serial_test::serial]

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -1182,9 +1182,20 @@ impl SourceMessageCache {
                 let path = dir_entry.path();
                 match read_shard(&path, identity) {
                     ShardReadStatus::Loaded(entries) => {
-                        for entry in entries {
+                        for mut entry in entries {
                             let key = CacheKey::from_entry(&entry);
                             if key.shard() == shard_key && entry.identity_is_current() {
+                                if entry.parser_namespace == ClientId::Claude.as_str()
+                                    && crate::sessions::claudecode::remove_synthetic_placeholder_messages(
+                                        &mut entry.messages,
+                                    )
+                                {
+                                    // Do not bump Claude's parser version here: compacted
+                                    // transcripts rely on cached assistant history that a
+                                    // full invalidation cannot recover. Repair only the bad
+                                    // `<synthetic>` rows and persist that narrow migration.
+                                    cache.dirty_keys.insert(key.clone());
+                                }
                                 cache.entries.insert(key, entry);
                             } else {
                                 cache.rewrite_shards.insert(shard_key.clone());
@@ -1207,7 +1218,7 @@ impl SourceMessageCache {
             }
         }
 
-        cache.dirty = !cache.rewrite_shards.is_empty();
+        cache.dirty = !(cache.rewrite_shards.is_empty() && cache.dirty_keys.is_empty());
         cache
     }
 
@@ -1382,6 +1393,11 @@ impl SourceMessageCache {
                         // wholesale — see `absorb_retained_history`.
                         if let Some(stored) = merged_entries.remove(key) {
                             entry.absorb_retained_history(&stored);
+                        }
+                        if entry.parser_namespace == ClientId::Claude.as_str() {
+                            crate::sessions::claudecode::remove_synthetic_placeholder_messages(
+                                &mut entry.messages,
+                            );
                         }
                         merged_entries.insert(key.clone(), entry);
                     }
@@ -3527,6 +3543,122 @@ mod tests {
             Vec::new(),
             None,
         )
+    }
+
+    fn synthetic_placeholder_message(session_id: &str, dedup_key: &str) -> UnifiedMessage {
+        let mut message = keyed_message(ClientId::Claude.as_str(), session_id, dedup_key);
+        message.model_id = " <SYNTHETIC> ".to_string();
+        message.provider_id = "unknown".to_string();
+        message
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_loading_claude_cache_removes_synthetic_placeholder_rows_without_retiring_history() {
+        let temp_home = TempDir::new().unwrap();
+        let prev_env = sandbox_cache_env(temp_home.path());
+
+        {
+            let source_dir = TempDir::new().unwrap();
+            let path = source_dir.path().join("conversation.jsonl");
+            std::fs::write(&path, b"{\"id\":\"live\"}\n").unwrap();
+            let identity = CacheIdentity::for_client(ClientId::Claude);
+            let real_live = keyed_message("claude", "session", "live:req_live");
+            let real_retained = keyed_message("claude", "session", "old:req_old");
+            let synthetic_assistant =
+                synthetic_placeholder_message("session", "synthetic:req_synthetic");
+            let mut synthetic_tool_result = synthetic_placeholder_message(
+                "session",
+                "claude:tool_result:conversation:tool_result:toolu_1",
+            );
+            synthetic_tool_result.tokens.input = 100;
+
+            let mut seed = SourceMessageCache::default();
+            seed.insert(entry_with_messages(
+                identity,
+                &path,
+                vec![
+                    real_live.clone(),
+                    real_retained.clone(),
+                    synthetic_assistant,
+                    synthetic_tool_result,
+                ],
+            ));
+            seed.save_if_dirty();
+
+            let mut repaired = SourceMessageCache::load();
+            let entry = repaired
+                .get(identity, &path)
+                .expect("current Claude cache entry should load");
+            assert_eq!(entry.messages.len(), 2);
+            assert_eq!(
+                entry
+                    .messages
+                    .iter()
+                    .filter_map(|message| message.dedup_key.as_deref())
+                    .collect::<HashSet<_>>(),
+                HashSet::from(["live:req_live", "old:req_old"]),
+                "the targeted migration must retain real live and compacted history"
+            );
+            repaired.save_if_dirty();
+
+            let shard_path = cache_shard_path(identity, &path);
+            assert!(matches!(
+                read_shard(&shard_path, identity),
+                ShardReadStatus::Loaded(entries)
+                    if entries.len() == 1
+                        && entries[0].messages.len() == 2
+                        && entries[0]
+                            .messages
+                            .iter()
+                            .all(|message| message.model_id != " <SYNTHETIC> ")
+            ));
+        }
+
+        restore_cache_env(prev_env);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_claude_cache_save_does_not_restore_synthetic_history_from_another_writer() {
+        let temp_home = TempDir::new().unwrap();
+        let prev_env = sandbox_cache_env(temp_home.path());
+
+        {
+            let source_dir = TempDir::new().unwrap();
+            let path = source_dir.path().join("conversation.jsonl");
+            std::fs::write(&path, b"{\"id\":\"live\"}\n").unwrap();
+            let identity = CacheIdentity::for_client(ClientId::Claude);
+            let real = keyed_message("claude", "session", "live:req_live");
+            let synthetic = synthetic_placeholder_message("session", "synthetic:req_synthetic");
+
+            let mut seed = SourceMessageCache::default();
+            seed.insert(entry_with_messages(
+                identity,
+                &path,
+                vec![real.clone(), synthetic],
+            ));
+            seed.save_if_dirty();
+
+            // Simulate a process that parsed the live source after a compaction
+            // while an old on-disk entry still carries the synthetic notice.
+            // The normal retained-history merge would bring the globally stable
+            // synthetic key back, so sanitation must run after that merge too.
+            let mut fresh_writer = SourceMessageCache::default();
+            fresh_writer.insert(entry_with_messages(identity, &path, vec![real]));
+            fresh_writer.save_if_dirty();
+
+            let shard_path = cache_shard_path(identity, &path);
+            assert!(matches!(
+                read_shard(&shard_path, identity),
+                ShardReadStatus::Loaded(entries)
+                    if entries.len() == 1
+                        && entries[0].messages.len() == 1
+                        && entries[0].messages[0].dedup_key.as_deref() == Some("live:req_live")
+            ));
+        }
+
+        restore_cache_env(prev_env);
     }
 
     /// A Claude entry can hold assistant turns the live transcript no longer

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -503,6 +503,11 @@ pub fn parse_claude_file_with_cache_and_home(
     let mut pending_request_start_timestamp_ms: Option<i64> = None;
     let mut last_model: Option<String> = None;
     let mut last_provider_hint: Option<String> = None;
+    // Claude Code writes local API-error and auth notices as assistant messages
+    // with `<synthetic>` rather than an API model. A following tool result has
+    // no model of its own, so it must not inherit that placeholder and turn a
+    // char estimate into unpriceable usage.
+    let mut suppress_unattributed_tool_results = false;
     // Sidechain detection state (resolved lazily on first parseable entry)
     let mut sidechain_agent: Option<String> = None;
     let mut sidechain_detected = false;
@@ -554,6 +559,7 @@ pub fn parse_claude_file_with_cache_and_home(
                         workspace_key: workspace_key.clone(),
                         workspace_label: workspace_label.clone(),
                         sidechain_agent: sidechain_agent.clone(),
+                        suppress_unattributed: suppress_unattributed_tool_results,
                         allow_char_estimate: !is_bare_transcript,
                     },
                 );
@@ -595,6 +601,14 @@ pub fn parse_claude_file_with_cache_and_home(
                 };
 
                 if let Some(model) = message.model.as_deref() {
+                    if is_claude_synthetic_placeholder_model(model) {
+                        last_model = None;
+                        last_provider_hint = None;
+                        pending_request_start_timestamp_ms = None;
+                        suppress_unattributed_tool_results = true;
+                        continue;
+                    }
+                    suppress_unattributed_tool_results = false;
                     last_model = Some(model.to_string());
                     last_provider_hint = message
                         .provider_id
@@ -963,6 +977,9 @@ struct ClaudeToolResultContext<'a> {
     workspace_key: Option<String>,
     workspace_label: Option<String>,
     sidechain_agent: Option<String>,
+    /// A preceding local Claude Code notice used `<synthetic>` instead of an API
+    /// model. A following tool result with no model cannot be attributed safely.
+    suppress_unattributed: bool,
     /// Whether char-based token estimation may be used as a fallback when no
     /// explicit tool-result token count is present. Bare transcripts (see
     /// `is_bare_transcript`) set this to `false` to avoid double-counting
@@ -978,16 +995,13 @@ fn extract_claude_tool_result_message(
     let value: Value = serde_json::from_str(line).ok()?;
     let usage = extract_claude_tool_result_usage(&value, context.allow_char_estimate)?;
 
-    let raw_model = extract_claude_model(&value)
-        .or_else(|| {
-            context
-                .entry
-                .message
-                .as_ref()
-                .and_then(|message| message.model.clone())
-        })
-        .or_else(|| context.last_model.map(str::to_string))
-        .unwrap_or_else(|| "unknown".to_string());
+    let explicit_model = extract_claude_model(&value).or_else(|| {
+        context
+            .entry
+            .message
+            .as_ref()
+            .and_then(|message| message.model.clone())
+    });
     let provider_hint = extract_claude_provider(&value)
         .or_else(|| {
             context
@@ -996,7 +1010,20 @@ fn extract_claude_tool_result_message(
                 .as_ref()
                 .and_then(|message| message.provider_id.clone())
         })
-        .or_else(|| context.entry.provider_id.clone())
+        .or_else(|| context.entry.provider_id.clone());
+    let raw_model = match explicit_model {
+        Some(model) if is_claude_synthetic_placeholder_model(&model) => return None,
+        Some(model) => model,
+        // A provider alone cannot identify a billable model. Suppress every
+        // model-less result after a local synthetic notice rather than emit
+        // another unpriceable `provider/unknown` estimate.
+        None if context.suppress_unattributed => return None,
+        None => context
+            .last_model
+            .map(str::to_string)
+            .unwrap_or_else(|| "unknown".to_string()),
+    };
+    let provider_hint = provider_hint
         .or_else(|| context.last_provider_hint.map(str::to_string))
         .or_else(|| context.default_provider_hint.map(str::to_string));
 
@@ -1209,6 +1236,22 @@ fn estimate_tokens_from_chars(chars: usize) -> i64 {
     chars.div_ceil(4) as i64
 }
 
+fn is_claude_synthetic_placeholder_model(model: &str) -> bool {
+    model.trim().eq_ignore_ascii_case("<synthetic>")
+}
+
+/// Remove Claude Code's local `<synthetic>` placeholder rows from a cached
+/// transcript. These notices are not API usage and old cache entries can
+/// contain a tool-result char estimate attributed to the placeholder.
+///
+/// This lives with the parser rather than the cache so the sentinel definition
+/// stays consistent between cold parsing and cache migration.
+pub(crate) fn remove_synthetic_placeholder_messages(messages: &mut Vec<UnifiedMessage>) -> bool {
+    let message_count = messages.len();
+    messages.retain(|message| !is_claude_synthetic_placeholder_model(&message.model_id));
+    messages.len() != message_count
+}
+
 fn canonicalize_claude_model(model: &str) -> String {
     pricing::aliases::resolve_alias(model)
         .unwrap_or(model)
@@ -1285,7 +1328,15 @@ fn process_claude_headless_line(
                 default_provider_hint,
             );
 
-            state.model = extract_claude_model(&value);
+            let model = extract_claude_model(&value);
+            if model
+                .as_deref()
+                .is_some_and(is_claude_synthetic_placeholder_model)
+            {
+                *state = ClaudeHeadlessState::default();
+                return completed_message;
+            }
+            state.model = model;
             state.provider_id = extract_claude_provider(&value);
             state.timestamp_ms = extract_claude_timestamp(&value).or(state.timestamp_ms);
             if let Some(usage) = value
@@ -1340,6 +1391,9 @@ fn extract_claude_headless_message(
         .get("usage")
         .or_else(|| value.get("message").and_then(|msg| msg.get("usage")))?;
     let raw_model = extract_claude_model(value)?;
+    if is_claude_synthetic_placeholder_model(&raw_model) {
+        return None;
+    }
     let provider_hint = extract_claude_provider(value);
     let provider_id = claude_provider_id(
         &raw_model,
@@ -1565,6 +1619,10 @@ fn finalize_headless_state(
     default_provider_hint: Option<&str>,
 ) -> Option<UnifiedMessage> {
     let raw_model = state.model.clone()?;
+    if is_claude_synthetic_placeholder_model(&raw_model) {
+        *state = ClaudeHeadlessState::default();
+        return None;
+    }
     let provider_id = claude_provider_id(
         &raw_model,
         state.provider_id.as_deref().or(default_provider_hint),
@@ -2250,6 +2308,42 @@ mod tests {
     }
 
     #[test]
+    fn test_synthetic_notice_does_not_seed_an_unmodelled_tool_result() {
+        let content = r#"{"type":"user","timestamp":"2026-06-24T01:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}
+{"type":"assistant","timestamp":"2026-06-24T01:00:01.000Z","isApiErrorMessage":true,"error":"unknown","message":{"id":"m1","role":"assistant","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0},"content":[{"type":"text","text":"API Error"}]}}
+{"type":"user","timestamp":"2026-06-24T01:00:02.000Z","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"XXXXXXXXXXXXXXXX"}]}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_synthetic_notice_does_not_hide_an_explicitly_modelled_tool_result() {
+        let content = r#"{"type":"assistant","timestamp":"2026-06-24T01:00:01.000Z","message":{"model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0}}}
+{"type":"user","timestamp":"2026-06-24T01:00:02.000Z","message":{"model":"claude-sonnet-4-6","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"XXXXXXXXXXXXXXXX"}]}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "claude-sonnet-4-6");
+        assert_eq!(messages[0].tokens.input, 4);
+    }
+
+    #[test]
+    fn test_synthetic_notice_does_not_emit_a_provider_only_tool_result() {
+        let content = r#"{"type":"assistant","timestamp":"2026-06-24T01:00:01.000Z","message":{"model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0}}}
+{"type":"user","timestamp":"2026-06-24T01:00:02.000Z","provider":"openrouter","message":{"content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"XXXXXXXXXXXXXXXX"}]}}"#;
+
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert!(messages.is_empty());
+    }
+
+    #[test]
     fn test_assistant_usage_with_tool_use_is_not_estimated_from_prompt_text() {
         let content = r#"{"type":"assistant","timestamp":"2026-05-27T10:00:00.000Z","message":{"id":"msg_tool_use","model":"claude-sonnet-4-6","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"file_path":"/tmp/large.txt"}}],"usage":{"input_tokens":100,"output_tokens":50}}}"#;
 
@@ -2284,12 +2378,14 @@ mod tests {
         let file = create_test_file(content);
         let messages = parse_claude_file(file.path());
 
-        assert_eq!(messages.len(), 5);
+        assert_eq!(messages.len(), 4);
         assert_eq!(messages[0].provider_id, "anthropic");
         assert_eq!(messages[1].provider_id, "openai");
         assert_eq!(messages[2].provider_id, "google");
         assert_eq!(messages[3].provider_id, "minimax");
-        assert_eq!(messages[4].provider_id, "unknown");
+        assert!(!messages
+            .iter()
+            .any(|message| message.model_id == "<synthetic>"));
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -1267,6 +1267,10 @@ struct ClaudeHeadlessState {
     cache_read: i64,
     cache_write: i64,
     timestamp_ms: Option<i64>,
+    /// A local Claude Code notice uses `<synthetic>` as its model. Ignore all
+    /// stream deltas until its matching stop event so they cannot leak into the
+    /// next real response.
+    skipping_synthetic_stream: bool,
 }
 
 fn parse_claude_headless_json(
@@ -1320,6 +1324,11 @@ fn process_claude_headless_line(
 
     match event_type {
         "message_start" => {
+            if state.skipping_synthetic_stream {
+                // A new start without a stop means the synthetic stream was
+                // truncated. Its deltas must not survive into the new stream.
+                *state = ClaudeHeadlessState::default();
+            }
             completed_message = finalize_headless_state(
                 state,
                 session_id,
@@ -1334,6 +1343,7 @@ fn process_claude_headless_line(
                 .is_some_and(is_claude_synthetic_placeholder_model)
             {
                 *state = ClaudeHeadlessState::default();
+                state.skipping_synthetic_stream = true;
                 return completed_message;
             }
             state.model = model;
@@ -1348,6 +1358,9 @@ fn process_claude_headless_line(
             }
         }
         "message_delta" => {
+            if state.skipping_synthetic_stream {
+                return None;
+            }
             if let Some(usage) = value
                 .get("usage")
                 .or_else(|| value.get("delta").and_then(|delta| delta.get("usage")))
@@ -1356,6 +1369,10 @@ fn process_claude_headless_line(
             }
         }
         "message_stop" => {
+            if state.skipping_synthetic_stream {
+                *state = ClaudeHeadlessState::default();
+                return None;
+            }
             completed_message = finalize_headless_state(
                 state,
                 session_id,
@@ -2481,6 +2498,41 @@ mod tests {
         assert_eq!(messages[0].provider_id, "google");
         assert_eq!(messages[0].tokens.input, 200);
         assert_eq!(messages[0].tokens.output, 80);
+    }
+
+    #[test]
+    fn test_headless_synthetic_stream_deltas_do_not_leak_into_next_response() {
+        let content = r#"{"type":"message_start","timestamp":"2026-06-24T01:00:00Z","message":{"model":"<synthetic>","usage":{"input_tokens":0}}}
+{"type":"message_delta","usage":{"output_tokens":999,"cache_read_input_tokens":888}}
+{"type":"message_stop"}
+{"type":"message_start","timestamp":"2026-06-24T01:00:02Z","message":{"model":"claude-sonnet-4-6","usage":{"input_tokens":10,"cache_read_input_tokens":2}}}
+{"type":"message_delta","usage":{"output_tokens":3}}
+{"type":"message_stop"}"#;
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "claude-sonnet-4-6");
+        assert_eq!(messages[0].tokens.input, 10);
+        assert_eq!(messages[0].tokens.output, 3);
+        assert_eq!(messages[0].tokens.cache_read, 2);
+    }
+
+    #[test]
+    fn test_truncated_headless_synthetic_stream_does_not_leak_into_next_response() {
+        let content = r#"{"type":"message_start","timestamp":"2026-06-24T01:00:00Z","message":{"model":"<synthetic>","usage":{"input_tokens":0}}}
+{"type":"message_delta","usage":{"output_tokens":999,"cache_read_input_tokens":888}}
+{"type":"message_start","timestamp":"2026-06-24T01:00:02Z","message":{"model":"claude-sonnet-4-6","usage":{"input_tokens":10,"cache_read_input_tokens":2}}}
+{"type":"message_delta","usage":{"output_tokens":3}}
+{"type":"message_stop"}"#;
+        let file = create_test_file(content);
+        let messages = parse_claude_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "claude-sonnet-4-6");
+        assert_eq!(messages[0].tokens.input, 10);
+        assert_eq!(messages[0].tokens.output, 3);
+        assert_eq!(messages[0].tokens.cache_read, 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Treat Claude Code's `<synthetic>` local notices as placeholders rather than billable models.
- Suppress model-less tool-result estimates that follow a synthetic notice, while preserving explicitly modelled results.
- Migrate existing Claude cache entries by removing only synthetic rows, preserving compacted retained assistant history and preventing concurrent cache merges from restoring poisoned rows.

## Validation

- `cargo test -p tokscale-core --lib`
- `cargo clippy -p tokscale-core --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Fixes #1036.

Related: #1011 remains open for the broader Claude tool-result estimate double-counting issue. #1021 and #1035 are separate unpriced-model policy/data cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore Claude Code `<synthetic>` placeholder messages and streams and stop attributing tool‑result estimates to them. Migrate the cache to drop synthetic rows while keeping real assistant history intact.

- **Bug Fixes**
  - Treat `<synthetic>` as a non-billable placeholder; do not emit it in assistant/headless/tool‑result paths, and discard headless `<synthetic>` streams so deltas cannot leak into the next response.
  - Suppress model‑less tool results that follow a synthetic notice; keep tool results with an explicit model.
  - Avoid falling back to `provider/unknown` attribution after a synthetic notice.

- **Migration**
  - Remove `<synthetic>` rows from Claude cache entries on load/save without retiring compacted history.
  - Sanitize after retained‑history merges so concurrent writers do not reintroduce synthetic rows.

<sup>Written for commit 6475a8cc7fe91a1ab61df34c67f1e42669bb7b07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

