### PR TITLE
docs(readme): sync localized documentation

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -47,7 +47,7 @@
 |:---:|:---:|
 | <a href="https://tokscale.ai"><img alt="Frontend (3D Contributions Graph)" src=".github/assets/frontend-contributions-graph.png" width="700px" /></a> | <a href="#wrapped-2025"><img alt="Wrapped 2025" src=".github/assets/wrapped-2025-agents.png" width="700px" /></a> |
 
-> **[`bunx tokscale submit`](#ソーシャルプラットフォームコマンド)を実行して、使用量データをリーダーボードに送信し、公開プロフィールを作成しましょう！**
+> **[`bunx tokscale@latest submit`](#ソーシャルプラットフォームコマンド)を実行して、使用量データをリーダーボードに送信し、公開プロフィールを作成しましょう！**
 
 ## 概要
 
@@ -70,6 +70,7 @@
 | <img width="48px" src=".github/assets/client-pi.png" alt="Pi" /> | [Pi](https://github.com/badlogic/pi-mono) | `~/.pi/agent/sessions/` and `~/.omp/agent/sessions/` ([Oh My Pi](https://github.com/can1357/oh-my-pi)) |
 | <img width="48px" src=".github/assets/client-senpi.png" alt="Senpi" /> | [Senpi (OmO Native)](https://github.com/code-yeongyu/senpi) | `~/.senpi/agent/sessions/` (`SENPI_CODING_AGENT_DIR` でオーバーライド可能) |
 | <img width="48px" src="https://github.com/getkimchi.png" alt="Kimchi" /> | [Kimchi Coding](https://kimchi.dev/) | `~/.config/kimchi/harness/sessions/`（`KIMCHI_CODING_AGENT_DIR` でオーバーライド可能） |
+| <img width="48px" src=".github/assets/client-synthetic.png" alt="Reasonix" /> | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | `~/.reasonix/stats/*.jsonl`（`REASONIX_STATE_HOME` または `REASONIX_HOME` でオーバーライド可能） |
 | <img width="48px" src=".github/assets/client-kimi.png" alt="Kimi" /> | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) / [Kimi Code](https://github.com/MoonshotAI/kimi-code) | kimi-cli: `~/.kimi/sessions/` kimi-code: `~/.kimi-code/sessions/` (`KIMI_CODE_HOME` でオーバーライド可能) |
 | <img width="48px" src=".github/assets/client-qwen.png" alt="Qwen" /> | [Qwen CLI](https://github.com/QwenLM/qwen-cli) | `~/.qwen/projects/` |
 | <img width="48px" src=".github/assets/client-roocode.png" alt="Roo Code" /> | [Roo Code](https://github.com/RooCodeInc/Roo-Code) | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` (+ server: `~/.vscode-server/data/User/globalStorage/rooveterinaryinc.roo-cline/tasks/`) |
@@ -153,6 +154,7 @@ AI支援開発の時代において、**トークンは新しいエネルギー*
 - [開発](#開発)
   - [前提条件](#前提条件-1)
   - [実行方法](#実行方法)
+  - [コンテナセットアップ](#コンテナセットアップ)
 - [サポートプラットフォーム](#サポートプラットフォーム)
   - [ネイティブモジュールターゲット](#ネイティブモジュールターゲット)
   - [Windowsサポート](#windowsサポート)
@@ -172,7 +174,7 @@ AI支援開発の時代において、**トークンは新しいエネルギー*
   - 設定可能なカラーテーマのGitHubスタイル貢献グラフ
   - リアルタイムフィルタリングとソート
   - ゼロフリッカーレンダリング
-- **マルチプラットフォームサポート** - OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimchi Coding、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic全体の使用量を追跡
+- **マルチプラットフォームサポート** - OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimchi Coding、Reasonix、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code、Synthetic全体の使用量を追跡
 - **リアルタイム価格** - 1時間ディスクキャッシュ付きでLiteLLMから現在の価格を取得；OpenRouter自動フォールバックと新規モデル向けCursor価格サポート
 - **詳細な内訳** - 入力、出力、キャッシュ読み書き、推論トークン追跡
 - **ネイティブRustコア** - 10倍高速な処理のため、すべての解析と集計をRustで実行
@@ -663,6 +665,10 @@ tokscale trae logout --variant solo
 
 **仕組み**: tokscale はデスクトップクライアントの `iCubeAuthInfo://*` blob（`globalStorage/storage.json`）を復号して JWT を取得するか、`--manual` で貼り付けられた JWT を使用します。その後 `POST /trae/api/v1/pay/query_user_usage_group_by_session` をページングしながら呼び出し、未加工 JSON を保存します。最新の Trae データをレポートに反映したい場合は、レポート実行前に sync を実行してください。
 
+#### アップグレード時の同期ロック復旧
+
+Antigravity と Trae の同期では、ローリングアップグレード中に古い tokscale バイナリと重複しないよう、レガシー互換の `sync.lock` ファイルを使用します。クラッシュまたは強制停止の後、このファイルが残ることがあります。古いバイナリが同じパスを作成または更新している可能性があるため、Tokscale は意図的にファイルを置き換えず、安全側に失敗します。`tokscale antigravity sync` または `tokscale trae sync` のプロセスが動作中でないことを確認し、コマンドが表示した正確な引用付き `sync.lock` パスだけを削除してから再試行してください。同期がまだ実行中の可能性がある間は、ロックを削除しないでください。
+
 > **中国版**: 中国版（`trae.com.cn`）は意図的に未対応です。CN バックエンドはセッション単位の使用量クエリ API を公開していません。上流で公式エンドポイントが提供された場合に追加します。
 
 ### Warp/Oz コマンド
@@ -876,6 +882,30 @@ Tokscaleは設定を`~/.config/tokscale/settings.json`に保存します：
 | `light.writeCache` | boolean | `false` | `true` のとき、`tokscale --light` はレンダリング直後に TUI キャッシュを原子的に上書きします。CLI フラグ `--write-cache` / `--no-write-cache` が実行ごとに優先されます。 |
 | `minutelyTabEnabled` | boolean | `false` | TUI に分単位の Minutely タブを表示し、データ読み込み時に分単位の集計を実行します。分単位の粒度はほとんどのユーザーにとってニッチな診断ビューであり、大規模データセットでは分単位のバケット処理に無視できないコストがかかるため、既定では無効になっています。 |
 | `scanner.extraScanPaths` | object | `{}` | Tokscale のデフォルトのホームルート以外にあるセッション向けの、クライアントごとの追加スキャンルート |
+| `scanner.bucketTimezone` | string | 自動検出 | このデバイスが使用量の日付をバケット化するタイムゾーンの IANA 名（例: `"Asia/Seoul"`）。初回実行時に自動記録されます。手編集ではなく `tokscale config set timezone <zone>` を使用してください。 |
+
+#### 日境界と `scanner.bucketTimezone`
+
+各メッセージをどの暦日に計上するかはタイムゾーンに依存します。Tokscale はスキャンごとにマシンの現在のタイムゾーンを読み取るのではなく、このデバイスのタイムゾーンを初回実行時に記録して再利用します。
+
+これは、日別の合計が日単位で送信され、減らすことを許可されないため重要です。同じ履歴を別のタイムゾーンで再バケット化すると、旅行やシステムクロックの変更、異なる `TZ` の CI 実行などにより、深夜付近のセッションが隣の日へ移動します。古い日と新しい日の両方が値を保持するため、新しい使用量がなくても合計が増加します。タイムゾーンを固定すれば日境界が安定し、変更されていない履歴を再スキャンしても常に同じバケットが生成されます。
+
+```console
+$ tokscale config list
+timezone     Asia/Seoul
+
+$ tokscale config get timezone
+Asia/Seoul
+
+# `set timezone auto` は、有効な固定値がまだない場合（または手編集で無効にした値を復旧する場合）にのみ使用できます。確立済みのデバイスを再固定することはできません。
+$ tokscale config set timezone auto
+```
+
+受け付けるのは IANA タイムゾーン名のみです。`+09:00` のような固定 UTC オフセットは拒否されます。オフセットは夏時間に追従できないため、DST 移行後には固定オフセットがローカルの深夜と一致しなくなり、日境界付近の使用量を再分割します。これは、この固定が防ぐ問題をより小さな形で再現するものです。
+
+確立済みの有効な固定値は、`auto` を含めて変更または解除できません。送信済みの日別履歴行は単調増加であるため、過去の使用量を再キー化すると恒久的に二重計上されます。デバイスを移転するには、別のバケットタイムゾーンを選択する前にサーバーの再同期または置き換えの移行が必要です。
+
+既存のインストールは、タイムゾーンを固定するまで影響を受けません。また、固定する実行では元からマシンが使用していたタイムゾーンが記録されるため、その実行のレポート内容は従来どおりです。
 
 プロジェクトレベルの `.codex` ディレクトリや、インポートした Gemini/OpenClaw 履歴など、恒久的な追加ルートには `scanner.extraScanPaths` を使用してください。Tokscale は `$HERMES_HOME/profiles/*/state.db` 以下の Hermes プロファイルデータベースを自動的に検出します（`HERMES_HOME` が未設定の場合は `~/.hermes/profiles/*/state.db`）。標準外の Hermes プロファイル場所にのみ `scanner.extraScanPaths.hermes` を使用してください。Hermes のエントリは `state.db` を含むプロファイルディレクトリ、または `state.db` ファイルを直接指すことができます。Tokscale はこれらのパスを毎回デフォルトのスキャンルートとマージし、重複するルートを正規パスで重複排除します。
 
@@ -904,6 +934,8 @@ Minutely タブはトークン使用量を分単位で表示し、バースト�
 - `fonts/`、`images/` — Wrapped アセットキャッシュ
 
 このディレクトリは削除しても安全です。必要になれば Tokscale が再作成し、再生成します。
+
+Claude Code に限って注意点があります。Claude Code はセッションを再開またはコンパクト化すると、トランスクリプトを同じファイル名のまま書き換え、すでに書き出していたアシスタントターンを失います。`source-message-cache-v2/` はトランスクリプトファイルが存在する限りそれらのターンを記憶するため、合計には引き続き計上されます。これらのターンが残るのはキャッシュだけであり、トランスクリプト自体にはもう存在しません。キャッシュを削除するか、Claude パーサーのアップグレードによって再構築されると、コンパクト化済みトランスクリプトから再構築されるため、コンパクト化を多用したセッションの合計は低くなることがあります。一方、トランスクリプトを削除すると、どちらの場合でもそのターンは除外されます。これはローカルディスクを信頼できる情報源に保つためです。
 
 ### 環境変数
 
@@ -1136,10 +1168,10 @@ tokscale wrapped --year 2025
 ### 前提条件
 
 ```bash
-# Bun（必須）
+# Bun（JS ツール用に必須）
 bun --version
 
-# Rust（ネイティブモジュール用）
+# Rust（ネイティブ CLI バイナリ用）
 rustc --version
 cargo --version
 ```
@@ -1158,6 +1190,74 @@ cd packages/cli && bun src/index.ts
 # またはレガシーCLIモードを使用
 cd packages/cli && bun src/index.ts --light
 ```
+
+<details>
+
+<summary>セルフホスティングで実行</summary>
+
+### コンテナセットアップ
+
+このリポジトリには、**単一ホストへのデプロイ**用の `Makefile` と Docker/Podman Compose スタックが含まれています。ローカルの Rust または Bun のインストールは不要です。スタックは `docker` より `podman` を優先して自動検出します。
+
+**初回実行** — イメージのビルド中にデータベースへ接続することはありません。Compose が Postgres の正常起動を確認した後、アプリコンテナの開始時にマイグレーションが実行されます。
+
+```bash
+make docker/build   # フロントエンドイメージをビルドしてタグ付け（tokscale:latest）
+make up             # Postgres とフロントエンドを http://localhost:3333 で起動
+```
+
+`make up` はビルド済みの `tokscale:latest` イメージを使用し、Compose の再ビルドは行いません。
+
+**2 回目以降** — イメージはすでにビルド済みなので、サービスを起動するだけです。
+
+```bash
+make up
+```
+
+**TUI** — Web スタックとは独立して動作し、ホストのファイルシステムマウントからセッションデータを直接読み取ります。
+
+```bash
+make tui/build   # 一度だけビルド
+make tui         # 起動
+```
+
+`make tui` は現在のホスト UID と GID でコンテナを実行し、必要な場合にのみ `~/.config/tokscale` と `~/.cache/tokscale` を作成して、この 2 つのディレクトリを読み書き可能でマウントします。セッションデータのマウントは読み取り専用のままなので、コンテナがクライアントディレクトリに root 所有のファイルを作成することはありません。`make tui` ではなく Compose を直接呼び出す場合は、`TOKSCALE_UID=$(id -u)` と `TOKSCALE_GID=$(id -g)` を設定し、この 2 つの書き込み可能ディレクトリを自分で作成してください。
+
+既定の TUI プロファイルは、クライアントデータディレクトリを意図的にバインドしません。root 実行の Docker は、読み取り専用マウントであっても存在しないバインド元を root として作成するためです。自分のマシンにすでに存在するパスだけを明示的に追加してください。例:
+
+```bash
+TOKSCALE_UID=$(id -u) TOKSCALE_GID=$(id -g) \
+  docker compose --profile tui run --rm \
+  -v "$HOME/.claude:/home/tokscale/.claude:ro" tui
+```
+
+利用するクライアントごとに同等の `-v` フラグを追加してください。これにより、既定のコマンドが任意のホストクライアントディレクトリを作成することを防ぎます。
+
+**その他のよく使うターゲット:**
+
+```bash
+make down         # すべてのサービスを停止
+make logs/app     # アプリログを追跡
+make db/migrate   # 保留中のマイグレーションを手動実行
+make help         # すべてのターゲット一覧
+```
+
+**カスタム認証情報** — `make up` の前に 4 つの変数をすべて設定してください。Compose は `POSTGRES_*` 変数から `DATABASE_URL` を自動導出できません。ホスト名 `db` は Compose ネットワーク上のアプリコンテナでのみ有効であり、ホストシェルや Docker ビルド引数では使用しないでください。
+
+```bash
+export POSTGRES_USER=myuser
+export POSTGRES_PASSWORD=mypass
+export POSTGRES_DB=mydb
+export DATABASE_URL=postgresql://myuser:mypass@db:5432/mydb
+```
+
+既定値（`tokscale`/`tokscale`/`tokscale`）はローカル開発専用です。
+
+**公開デプロイ** — この Compose ファイルは両方のポートをループバックにバインドし、TLS を終端するリバースプロキシの背後に置くことを想定しています。`make up` の前に `APP_URL` を公開 HTTPS オリジン（例: `https://tokscale.example.com`）へ設定し、プロキシにもその URL を設定してください。この値は OAuth リダイレクト、CSRF の既定値、正規メタデータ、サイトマップ、robots を実行時に制御します。`DATABASE_SSL=false` は同梱のローカル Postgres サービスでのみ使用してください。マネージドデータベースの場合は、`DATABASE_URL`、`DATABASE_SSL=require`、`APP_URL`、および任意の GitHub OAuth 認証情報を保護された `.env`/シークレットストアに置き、`docker compose -f docker-compose.external-db.yml up -d` を実行してください。このファイルには `db` サービスもローカルデータベース依存もありません。サンプルの既定値では OAuth は意図的に有効化されていません。
+
+再利用可能な 1 つのイメージが実行時の `APP_URL` をページメタデータとソーシャルカードに出力する必要があるため、ルートレイアウトはリクエストごとに動的になります。これは、デプロイごとに正しい公開オリジンを得るためにフルルートの静的/ISR 出力を意図的にトレードオフするものです。データ取得は既存のキャッシュタグと再検証ポリシーを引き続き使用します。
+
+</details>
 
 <details>
 <summary>高度な開発</summary>
@@ -1346,8 +1446,12 @@ AIコーディングツールはクロスプラットフォームの場所にセ
 | OpenCodeReview | `~/.opencodereview/sessions/` | `%USERPROFILE%\.opencodereview\sessions\` | `*.jsonl` セッショントランスクリプトを解析；Alibaba の AI コードレビューツール |
 | CodeBuddy | `~/.codebuddy/projects/` + 拡張機能ログ | `%USERPROFILE%\.codebuddy\projects\` + CodeBuddy / VS Code 拡張機能ログ | CodeBuddy CLI・IDE・VS Code プラグインのトークン使用量を解析 |
 | WorkBuddy | `~/.workbuddy/projects/` + `~/.workbuddy/workbuddy.db` | `%USERPROFILE%\.workbuddy\projects\` + `%USERPROFILE%\.workbuddy\workbuddy.db` | WorkBuddy のトークン使用量を解析し、集約 SQLite データベースをフォールバックとして使用 |
+| Devin CLI | `~/.local/share/devin/cli/sessions.db` | `%USERPROFILE%\.local\share\devin\cli\sessions.db` | 信頼できるローカル SQLite 使用量データベースを読み取る |
+| Devin Desktop | Linux: `~/.config/Devin/User/acp-events/`; macOS: `~/Library/Application Support/Devin/User/acp-events/` | `%APPDATA%\Devin\User\acp-events\` | ACP 使用量イベントを解析し、CLI データベースが存在する場合は一致するセッションタイトルを解決する |
 | Augment Code | `~/.augment/sessions/` | `%USERPROFILE%\.augment\sessions\` | Auggie CLI のセッション JSON スナップショット（`*.json`）を解析。結合キーはトップレベルの `sessionId` |
 | Synthetic | 他ソースから再帰属 | 他ソースから再帰属 | `hf:`モデル + `synthetic`プロバイダを検出 |
+
+> **Devin Desktop のエージェント対応**: ローカル使用量の解析は、NDJSON ストリームで `usage_update` イベントを出力する ACP 接続エージェント（例: Cascade/Windsurf、claude-code、opencode）で機能します。既定の **devin-cloud** エージェントはローカルの `usage_update` を出力しないため、使用量はサーバー側にとどまり、アカウントレベルの API なしには tokscale で追跡できません。
 
 > **注**: Windowsでは`~`は`%USERPROFILE%`に展開されます（例：`C:\Users\ユーザー名`）。これらのツールは`%APPDATA%`のようなWindowsネイティブパスではなく、クロスプラットフォームの一貫性のためにUnixスタイルのパス（`.local/share`など）を意図的に使用しています。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -1238,7 +1238,6 @@ TOKSCALE_UID=$(id -u) TOKSCALE_GID=$(id -g) \
 ```bash
 make down         # すべてのサービスを停止
 make logs/app     # アプリログを追跡
-make db/migrate   # 保留中のマイグレーションを手動実行
 make help         # すべてのターゲット一覧
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1239,7 +1239,6 @@ TOKSCALE_UID=$(id -u) TOKSCALE_GID=$(id -g) \
 ```bash
 make down         # 모든 서비스 중지
 make logs/app     # 앱 로그 추적
-make db/migrate   # 보류 중인 마이그레이션 수동 실행
 make help         # 전체 대상 목록
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -47,7 +47,7 @@
 |:---:|:---:|
 | <a href="https://tokscale.ai"><img alt="Frontend (3D Contributions Graph)" src=".github/assets/frontend-contributions-graph.png" width="700px" /></a> | <a href="#wrapped-2025"><img alt="Wrapped 2025" src=".github/assets/wrapped-2025-agents.png" width="700px" /></a> |
 
-> **[`bunx tokscale submit`](#소셜-플랫폼-명령어)를 실행하여 사용량 데이터를 리더보드에 제출하고 공개 프로필을 만드세요!**
+> **[`bunx tokscale@latest submit`](#소셜-플랫폼-명령어)를 실행하여 사용량 데이터를 리더보드에 제출하고 공개 프로필을 만드세요!**
 
 ## 개요
 
@@ -70,6 +70,7 @@
 | <img width="48px" src=".github/assets/client-pi.png" alt="Pi" /> | [Pi](https://github.com/badlogic/pi-mono) | `~/.pi/agent/sessions/` and `~/.omp/agent/sessions/` ([Oh My Pi](https://github.com/can1357/oh-my-pi)) |
 | <img width="48px" src=".github/assets/client-senpi.png" alt="Senpi" /> | [Senpi (OmO Native)](https://github.com/code-yeongyu/senpi) | `~/.senpi/agent/sessions/` (`SENPI_CODING_AGENT_DIR`로 오버라이드 가능) |
 | <img width="48px" src="https://github.com/getkimchi.png" alt="Kimchi" /> | [Kimchi Coding](https://kimchi.dev/) | `~/.config/kimchi/harness/sessions/` (`KIMCHI_CODING_AGENT_DIR`로 오버라이드 가능) |
+| <img width="48px" src=".github/assets/client-synthetic.png" alt="Reasonix" /> | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | `~/.reasonix/stats/*.jsonl` (`REASONIX_STATE_HOME` 또는 `REASONIX_HOME`으로 오버라이드 가능) |
 | <img width="48px" src=".github/assets/client-kimi.png" alt="Kimi" /> | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) / [Kimi Code](https://github.com/MoonshotAI/kimi-code) | kimi-cli: `~/.kimi/sessions/` kimi-code: `~/.kimi-code/sessions/` (override via `KIMI_CODE_HOME`) |
 | <img width="48px" src=".github/assets/client-qwen.png" alt="Qwen" /> | [Qwen CLI](https://github.com/QwenLM/qwen-cli) | `~/.qwen/projects/` |
 | <img width="48px" src=".github/assets/client-roocode.png" alt="Roo Code" /> | [Roo Code](https://github.com/RooCodeInc/Roo-Code) | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` (+ server: `~/.vscode-server/data/User/globalStorage/rooveterinaryinc.roo-cline/tasks/`) |
@@ -151,8 +152,9 @@ AI 지원 개발 시대에 **토큰은 새로운 에너지**입니다. 토큰은
 - [개발](#개발)
   - [사전 요구사항](#사전-요구사항-1)
   - [실행 방법](#실행-방법)
+  - [컨테이너 설정](#컨테이너-설정)
 - [지원 플랫폼](#지원-플랫폼)
-  - [네이티브 모듈 타겟](#네이티브-모듈-타겟)
+  - [네이티브 모듈 대상](#네이티브-모듈-대상)
   - [Windows 지원](#windows-지원)
 - [세션 데이터 보존](#세션-데이터-보존)
 - [데이터 소스](#데이터-소스)
@@ -170,7 +172,7 @@ AI 지원 개발 시대에 **토큰은 새로운 에너지**입니다. 토큰은
   - 설정 가능한 색상 테마의 GitHub 스타일 기여 그래프
   - 실시간 필터링 및 정렬
   - 깜빡임 없는 렌더링
-- **멀티 플랫폼 지원** - OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimchi Coding, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic 사용량 통합 추적
+- **멀티 플랫폼 지원** - OpenCode, Claude Code, Codex CLI, Copilot CLI, Cursor IDE, Gemini CLI, Amp, Codebuff, Droid, OpenClaw, Hermes Agent, Pi, Kimchi Coding, Reasonix, Kimi CLI, Qwen CLI, Roo Code, Kilo, Mux, Kilo CLI, Crush, Goose, Antigravity, Antigravity CLI, Zed, Kiro, Trae, Warp/Oz, Cline, Gajae-Code, Grok Build, Jcode, MiMo Code, Command Code, Junie, ZCode, OpenCodeReview, CodeBuddy, WorkBuddy, Devin CLI, Devin Desktop, Augment Code, Synthetic 사용량 통합 추적
 - **실시간 가격 반영** - LiteLLM에서 최신 가격을 가져와(디스크 캐시 1시간) 비용 계산; OpenRouter 자동 폴백 및 신규 모델용 Cursor 가격 지원
 - **상세 분석** - 입력, 출력, 캐시 읽기/쓰기, 추론 토큰까지 추적
 - **네이티브 Rust 코어** - 모든 파싱과 집계를 Rust로 처리해 최대 10배 빠른 성능
@@ -658,6 +660,10 @@ tokscale trae logout --variant solo
 
 **동작 방식**: tokscale은 데스크톱 클라이언트의 `iCubeAuthInfo://*` blob(`globalStorage/storage.json`)을 복호화해 JWT를 얻거나, `--manual`로 붙여 넣은 JWT를 사용합니다. 이후 `POST /trae/api/v1/pay/query_user_usage_group_by_session`을 페이지 단위로 호출하고 원본 JSON을 저장합니다. 최신 Trae 데이터를 반영하려면 리포트 실행 전에 sync를 먼저 실행하세요.
 
+#### 업그레이드 중 sync 락 복구
+
+Antigravity와 Trae 동기화는 롤링 업그레이드 중 이전 tokscale 바이너리와 겹치지 않도록 레거시 호환 `sync.lock` 파일을 사용합니다. 크래시나 강제 종료 후에는 이 파일이 남아 있을 수 있습니다. 이전 바이너리가 같은 경로를 생성하거나 갱신 중일 수 있으므로, Tokscale은 이를 교체하지 않고 의도적으로 안전하게 실패합니다. `tokscale antigravity sync` 또는 `tokscale trae sync` 프로세스가 실행 중이 아닌지 확인한 다음, 명령어가 출력한 정확한 따옴표 안의 `sync.lock` 경로를 삭제하고 다시 시도하세요. 동기화가 아직 실행 중일 수 있다면 락을 삭제하지 마세요.
+
 > **가격에 대한 참고**: Trae 비용 수치는 **벤더가 보고한 값**입니다 — tokscale은 토큰 수로부터 tokscale의 가격 엔진을 통해 비용을 재계산하는 대신 Trae 자체 API가 반환한 `dollar_float` 값을 그대로 표시합니다. 따라서 수치는 동일한 사용량에 대해 tokscale이 계산했을 값이 아니라 `trae.ai/account-setting#usage`에서 보이는 값과 일치합니다.
 
 > **중국판**: 중국판(`trae.com.cn`)은 의도적으로 지원하지 않습니다. CN 백엔드는 세션 단위 사용량 조회 API를 공개하지 않습니다. 공식 엔드포인트가 제공되면 지원을 추가할 예정입니다.
@@ -873,6 +879,30 @@ Tokscale은 설정을 `~/.config/tokscale/settings.json`에 저장합니다:
 | `light.writeCache` | boolean | `false` | `true`이면 `tokscale --light`가 렌더링 직후 TUI 캐시를 원자적으로 덮어씁니다. CLI 플래그 `--write-cache` / `--no-write-cache`가 실행별로 우선합니다. |
 | `minutelyTabEnabled` | boolean | `false` | TUI에 분 단위 Minutely 탭을 표시하고 데이터 로딩 중에 분 단위 집계를 수행합니다. 대부분의 사용자에게 분 단위 세분화는 틈새/진단 뷰이며, 대규모 데이터셋에서는 분 단위 버케팅에 무시할 수 없는 비용이 들기 때문에 기본적으로 비활성화되어 있습니다. |
 | `scanner.extraScanPaths` | object | `{}` | Tokscale의 기본 home-root 위치 밖에 있는 세션을 위한 클라이언트별 추가 스캔 루트 |
+| `scanner.bucketTimezone` | string | 자동 감지 | 이 기기가 사용량 날짜를 버킷화하는 시간대의 IANA 이름(예: `"Asia/Seoul"`). 최초 실행 시 자동으로 기록됩니다. 직접 편집하는 대신 `tokscale config set timezone <zone>`을 사용하세요. |
+
+#### 날짜 경계와 `scanner.bucketTimezone`
+
+메시지가 어느 달력 날짜에 집계되는지는 시간대에 따라 달라집니다. Tokscale은 매 스캔마다 현재 시스템 시간대를 읽는 대신, 이 기기의 시간대를 최초 실행 시 기록하고 계속 사용합니다.
+
+일별 합계는 날짜별로 제출되며 절대 감소할 수 없기 때문에 중요합니다. 이동, 시스템 시계 변경, 다른 `TZ`를 사용하는 CI 실행처럼 같은 기록을 다른 시간대에서 다시 버킷화하면 자정 부근의 세션이 인접한 날짜로 이동합니다. 이전 날짜와 새 날짜는 모두 값을 유지하므로 새 사용량이 없어도 합계가 증가합니다. 시간대를 고정하면 날짜 경계가 안정되어, 변경되지 않은 기록을 재스캔해도 항상 동일한 버킷이 생성됩니다.
+
+```console
+$ tokscale config list
+timezone     Asia/Seoul
+
+$ tokscale config get timezone
+Asia/Seoul
+
+# `set timezone auto`는 유효한 고정 값이 아직 없거나, 직접 편집한 잘못된 값을 복구할 때만 허용됩니다. 이미 설정된 기기의 시간대를 다시 고정할 수는 없습니다.
+$ tokscale config set timezone auto
+```
+
+IANA 시간대 이름만 허용됩니다. `+09:00` 같은 고정 UTC 오프셋은 거부됩니다. 오프셋은 일광 절약 시간제를 따를 수 없으므로 DST 전환 후에는 지역 자정과 일치하지 않아 날짜 경계 근처의 사용량이 다시 분할됩니다. 이는 고정으로 방지하려는 문제의 축소판입니다.
+
+유효하게 설정된 시간대는 `auto`를 포함해 변경하거나 해제할 수 없습니다. 과거에 제출된 일별 행은 단조 증가하므로, 이전 사용량의 키를 다시 매기면 영구적인 이중 집계가 발생합니다. 기기를 이전하려면 다른 버킷 시간대를 선택하기 전에 서버 재동기화/교체 전환이 필요합니다.
+
+기존 설치는 시간대를 고정할 때까지 영향을 받지 않습니다. 고정하는 실행은 이미 사용 중인 시간대를 기록하며, 이미 고정된 시간대가 있는 기기를 Tokscale이 자동으로 다시 고정하지 않습니다.
 
 `scanner.extraScanPaths`는 프로젝트 단위 `.codex` 디렉터리나 가져온 Gemini/OpenClaw 히스토리 같은 영구적인 추가 루트에 사용하세요. Tokscale은 `$HERMES_HOME/profiles/*/state.db` 아래의 Hermes 프로필 데이터베이스를 자동으로 발견합니다(`HERMES_HOME`이 없으면 `~/.hermes/profiles/*/state.db`). 비표준 Hermes 프로필 위치에만 `scanner.extraScanPaths.hermes`를 사용하세요. Hermes 항목은 `state.db`를 포함하는 프로필 디렉터리를 가리키거나 `state.db` 파일을 직접 가리킬 수 있습니다. Tokscale은 매 실행마다 이 경로들을 기본 스캔 루트와 병합하고, 겹치는 루트는 정규 경로(canonical path) 기준으로 중복 제거합니다.
 
@@ -903,6 +933,8 @@ Minutely 탭은 토큰 사용량을 분 단위로 표시하며, 버스트 패턴
 - `fonts/`, `images/` — Wrapped 에셋 캐시
 
 이 디렉터리는 삭제해도 안전합니다. 필요할 때 Tokscale이 다시 생성하고 채웁니다.
+
+Claude Code에만 해당하는 주의사항이 있습니다. Claude Code는 세션을 재개하거나 압축할 때 트랜스크립트를 제자리에서 다시 씁니다. 파일 이름은 유지되지만 이전에 기록했던 어시스턴트 턴은 사라집니다. `source-message-cache-v2/`는 트랜스크립트 파일이 존재하는 동안 그 턴을 기억하므로 합계에 계속 반영됩니다. 이 정보는 캐시에만 남으며 트랜스크립트 자체에는 더 이상 존재하지 않습니다. 캐시를 삭제하거나 Claude 파서 업그레이드로 캐시를 다시 만들면 압축된 트랜스크립트에서 재구성되므로, 많이 압축된 세션의 합계는 더 낮아질 수 있습니다. 반대로 트랜스크립트를 삭제하면 어느 경우든 해당 턴은 제거되며, 이것이 로컬 디스크가 소스 오브 트루스인 이유입니다.
 
 ### 환경 변수
 
@@ -1161,6 +1193,74 @@ cd packages/cli && bun src/index.ts --light
 ```
 
 <details>
+
+<summary>셀프 호스팅으로 실행</summary>
+
+### 컨테이너 설정
+
+이 저장소는 **단일 호스트 배포**를 위한 `Makefile`과 Docker/Podman Compose 스택을 제공합니다. 로컬 Rust나 Bun 설치는 필요하지 않으며, 스택은 `docker`보다 `podman`을 자동으로 우선 감지합니다.
+
+**첫 실행** — 이미지 빌드는 데이터베이스에 연결하지 않습니다. Compose가 Postgres의 정상 상태를 확인한 후 앱 컨테이너가 시작될 때 마이그레이션이 실행됩니다.
+
+```bash
+make docker/build   # 프론트엔드 이미지를 빌드하고 태그 지정 (tokscale:latest)
+make up             # Postgres와 프론트엔드를 http://localhost:3333 에서 시작
+```
+
+`make up`은 미리 빌드된 `tokscale:latest` 이미지를 사용하며 Compose 재빌드를 실행하지 않습니다.
+
+**이후 실행** — 이미지가 이미 빌드되어 있으므로 서비스를 시작하기만 하면 됩니다.
+
+```bash
+make up
+```
+
+**TUI** — 웹 스택과 독립적으로 실행되며, 호스트 파일 시스템 마운트에서 세션 데이터를 직접 읽습니다.
+
+```bash
+make tui/build   # 한 번 빌드
+make tui         # 실행
+```
+
+`make tui`는 현재 호스트의 UID와 GID로 컨테이너를 실행하고, 필요한 경우 `~/.config/tokscale`과 `~/.cache/tokscale`만 생성해 읽기/쓰기로 마운트합니다. 세션 데이터 마운트는 읽기 전용으로 유지되므로 컨테이너가 클라이언트 디렉터리에 root 소유 파일을 만들 수 없습니다. `make tui` 대신 Compose를 직접 호출한다면 `TOKSCALE_UID=$(id -u)`와 `TOKSCALE_GID=$(id -g)`를 설정하고, 이 두 쓰기 가능 디렉터리를 직접 만드세요.
+
+기본 TUI 프로필은 의도적으로 클라이언트 데이터 디렉터리를 바인드하지 않습니다. rootful Docker는 읽기 전용 마운트에도 없는 바인드 소스를 root 소유로 만들기 때문입니다. 다음처럼 자신의 컴퓨터에 이미 존재하는 경로만 명시적으로 선택하세요.
+
+```bash
+TOKSCALE_UID=$(id -u) TOKSCALE_GID=$(id -g) \
+  docker compose --profile tui run --rm \
+  -v "$HOME/.claude:/home/tokscale/.claude:ro" tui
+```
+
+사용하는 클라이언트에 맞게 동등한 `-v` 플래그를 추가하세요. 기본 명령어가 임의의 호스트 클라이언트 디렉터리를 생성하지 않도록 합니다.
+
+**그 밖의 자주 쓰는 대상:**
+
+```bash
+make down         # 모든 서비스 중지
+make logs/app     # 앱 로그 추적
+make db/migrate   # 보류 중인 마이그레이션 수동 실행
+make help         # 전체 대상 목록
+```
+
+**사용자 지정 자격 증명** — `make up` 전에 네 변수를 모두 함께 설정하세요. Compose는 `POSTGRES_*` 변수로부터 `DATABASE_URL`을 자동 파생할 수 없습니다. 호스트 이름 `db`는 Compose 네트워크의 앱 컨테이너에서만 유효하므로 호스트 셸이나 Docker 빌드 인수에서 사용하지 마세요.
+
+```bash
+export POSTGRES_USER=myuser
+export POSTGRES_PASSWORD=mypass
+export POSTGRES_DB=mydb
+export DATABASE_URL=postgresql://myuser:mypass@db:5432/mydb
+```
+
+기본값(`tokscale`/`tokscale`/`tokscale`)은 로컬 개발 전용입니다.
+
+**공개 배포** — 이 Compose 파일은 두 포트를 모두 루프백에 바인드하며 TLS를 종료하는 리버스 프록시 뒤에 두는 용도입니다. `make up` 전에 `APP_URL`을 공개 HTTPS origin(예: `https://tokscale.example.com`)으로 설정하고 프록시에도 해당 URL을 구성하세요. 런타임에 OAuth 리디렉션, CSRF 기본값, canonical 메타데이터, sitemap, robots에 사용됩니다. 번들 로컬 Postgres 서비스에만 `DATABASE_SSL=false`를 유지하세요. 관리형 데이터베이스는 `DATABASE_URL`, `DATABASE_SSL=require`, `APP_URL`, 선택적인 GitHub OAuth 자격 증명을 보호된 `.env`/시크릿 저장소에 넣은 후 `docker compose -f docker-compose.external-db.yml up -d`를 실행하세요. 이 파일에는 `db` 서비스나 로컬 데이터베이스 종속성이 없습니다. 샘플 기본값은 의도적으로 OAuth를 활성화하지 않습니다.
+
+재사용 가능한 이미지 하나가 페이지 메타데이터와 소셜 카드에 런타임 `APP_URL`을 출력해야 하므로 루트 레이아웃은 요청 동적입니다. 이는 배포별로 올바른 공개 origin을 제공하는 대신 전체 라우트의 static/ISR 출력을 의도적으로 포기하는 것이며, 데이터 가져오기는 기존 캐시 태그와 재검증 정책을 계속 사용합니다.
+
+</details>
+
+<details>
 <summary>고급 개발</summary>
 
 ### 프로젝트 스크립트
@@ -1347,10 +1447,14 @@ AI 코딩 도구들은 크로스 플랫폼 위치에 세션 데이터를 저장�
 | OpenCodeReview | `~/.opencodereview/sessions/` | `%USERPROFILE%\.opencodereview\sessions\` | `*.jsonl` 세션 트랜스크립트 파싱; Alibaba의 AI 코드 리뷰 도구 |
 | CodeBuddy | `~/.codebuddy/projects/` + 확장 프로그램 로그 | `%USERPROFILE%\.codebuddy\projects\` + CodeBuddy / VS Code 확장 프로그램 로그 | CodeBuddy CLI, IDE, VS Code 플러그인 토큰 사용량 파싱 |
 | WorkBuddy | `~/.workbuddy/projects/` + `~/.workbuddy/workbuddy.db` | `%USERPROFILE%\.workbuddy\projects\` + `%USERPROFILE%\.workbuddy\workbuddy.db` | WorkBuddy 토큰 사용량 파싱, 집계 SQLite 데이터베이스를 폴백으로 사용 |
+| Devin CLI | `~/.local/share/devin/cli/sessions.db` | `%USERPROFILE%\.local\share\devin\cli\sessions.db` | 신뢰할 수 있는 로컬 SQLite 사용량 데이터베이스 읽기 |
+| Devin Desktop | Linux: `~/.config/Devin/User/acp-events/`; macOS: `~/Library/Application Support/Devin/User/acp-events/` | `%APPDATA%\Devin\User\acp-events\` | ACP 사용량 이벤트를 파싱하고, CLI 데이터베이스가 있으면 일치하는 세션 제목을 확인 |
 | Augment Code | `~/.augment/sessions/` | `%USERPROFILE%\.augment\sessions\` | Auggie CLI 세션 JSON 스냅샷(`*.json`) 파싱; 조인 키는 최상위 `sessionId` |
 | Synthetic | 다른 소스에서 재귀속 | 다른 소스에서 재귀속 | `hf:` 모델 접두사 + `synthetic` provider 감지 |
 
 > **참고**: Windows에서 `~`는 `%USERPROFILE%`로 확장됩니다 (예: `C:\Users\사용자이름`). 이러한 도구들은 `%APPDATA%`와 같은 Windows 기본 경로 대신 크로스 플랫폼 일관성을 위해 의도적으로 Unix 스타일 경로(`.local/share` 등)를 사용합니다.
+
+> **Devin Desktop 에이전트 지원**: 로컬 사용량 파싱은 NDJSON 스트림에서 `usage_update` 이벤트를 내보내는 ACP 연결 에이전트(예: Cascade/Windsurf, claude-code, opencode)에서 동작합니다. 기본 **devin-cloud** 에이전트는 로컬 `usage_update` 이벤트를 내보내지 않으므로, 계정 수준 API 없이는 tokscale로 추적할 수 없으며 사용량은 서버에만 남습니다.
 
 #### Windows 전용 설정
 

--- a/README.md
+++ b/README.md
@@ -1270,7 +1270,6 @@ Add equivalent `-v` flags for the clients you use. This keeps the default comman
 ```bash
 make down         # stop all services
 make logs/app     # tail app logs
-make db/migrate   # run pending migrations manually
 make help         # full target list
 ```
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ In the age of AI-assisted development, **tokens are the new energy**. They power
 - [Development](#development)
   - [Prerequisites](#prerequisites-1)
   - [How to Run](#how-to-run)
+  - [Container Setup](#container-setup)
 - [Supported Platforms](#supported-platforms)
   - [Native Module Targets](#native-module-targets)
   - [Windows Support](#windows-support)

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -1240,7 +1240,6 @@ TOKSCALE_UID=$(id -u) TOKSCALE_GID=$(id -g) \
 ```bash
 make down         # 停止所有服务
 make logs/app     # 跟踪应用日志
-make db/migrate   # 手动运行待执行迁移
 make help         # 完整目标列表
 ```
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -48,7 +48,7 @@
 |:---:|:---:|
 | <a href="https://tokscale.ai"><img alt="Frontend (3D Contributions Graph)" src=".github/assets/frontend-contributions-graph.png" width="700px" /></a> | <a href="#wrapped-2025"><img alt="Wrapped 2025" src=".github/assets/wrapped-2025-agents.png" width="700px" /></a> |
 
-> **运行 [`bunx tokscale submit`](#社交平台命令) 将您的使用数据提交到排行榜并创建公开个人资料！**
+> **运行 [`bunx tokscale@latest submit`](#社交平台命令) 将您的使用数据提交到排行榜并创建公开个人资料！**
 
 ## 概述
 
@@ -71,6 +71,7 @@
 | <img width="48px" src=".github/assets/client-pi.png" alt="Pi" /> | [Pi](https://github.com/badlogic/pi-mono) | `~/.pi/agent/sessions/` 和 `~/.omp/agent/sessions/`（[Oh My Pi](https://github.com/can1357/oh-my-pi)） |
 | <img width="48px" src=".github/assets/client-senpi.png" alt="Senpi" /> | [Senpi (OmO Native)](https://github.com/code-yeongyu/senpi) | `~/.senpi/agent/sessions/`（通过 `SENPI_CODING_AGENT_DIR` 覆盖） |
 | <img width="48px" src="https://github.com/getkimchi.png" alt="Kimchi" /> | [Kimchi Coding](https://kimchi.dev/) | `~/.config/kimchi/harness/sessions/`（可通过 `KIMCHI_CODING_AGENT_DIR` 覆盖） |
+| <img width="48px" src=".github/assets/client-synthetic.png" alt="Reasonix" /> | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | `~/.reasonix/stats/*.jsonl`（可通过 `REASONIX_STATE_HOME` 或 `REASONIX_HOME` 覆盖） |
 | <img width="48px" src=".github/assets/client-kimi.png" alt="Kimi" /> | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) / [Kimi Code](https://github.com/MoonshotAI/kimi-code) | kimi-cli: `~/.kimi/sessions/` kimi-code: `~/.kimi-code/sessions/`（可通过 `KIMI_CODE_HOME` 覆盖） |
 | <img width="48px" src=".github/assets/client-qwen.png" alt="Qwen" /> | [Qwen CLI](https://github.com/QwenLM/qwen-cli) | `~/.qwen/projects/` |
 | <img width="48px" src=".github/assets/client-roocode.png" alt="Roo Code" /> | [Roo Code](https://github.com/RooCodeInc/Roo-Code) | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/` (+ server: `~/.vscode-server/data/User/globalStorage/rooveterinaryinc.roo-cline/tasks/`) |
@@ -151,6 +152,7 @@
 - [开发](#开发)
   - [先决条件](#先决条件-1)
   - [运行方法](#运行方法)
+  - [容器设置](#容器设置)
 - [支持的平台](#支持的平台)
   - [原生模块目标](#原生模块目标)
   - [Windows 支持](#windows-支持)
@@ -170,7 +172,7 @@
   - 支持可配置颜色主题的 GitHub 风格贡献图
   - 实时筛选和排序
   - 零闪烁渲染
-- **多平台支持** - 跟踪 OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimchi Coding、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code 和 Synthetic 的使用情况
+- **多平台支持** - 跟踪 OpenCode、Claude Code、Codex CLI、Copilot CLI、Cursor IDE、Gemini CLI、Amp、Codebuff、Droid、OpenClaw、Hermes Agent、Pi、Kimchi Coding、Reasonix、Kimi CLI、Qwen CLI、Roo Code、Kilo、Mux、Kilo CLI、Crush、Goose、Antigravity、Antigravity CLI、Zed、Kiro、Trae、Warp/Oz、Cline、Gajae-Code、Grok Build、Jcode、MiMo Code、Command Code、Junie、ZCode、OpenCodeReview、CodeBuddy、WorkBuddy、Devin CLI、Devin Desktop、Augment Code 和 Synthetic 的使用情况
 - **实时定价** - 从 LiteLLM 获取当前价格，带 1 小时磁盘缓存；OpenRouter 自动回退和新模型的 Cursor 定价支持
 - **详细分解** - 输入、输出、缓存读写和推理 Token 跟踪
 - **原生 Rust 核心** - 所有解析和聚合在 Rust 中完成，处理速度提升 10 倍
@@ -664,6 +666,10 @@ tokscale trae logout --variant solo
 
 **工作原理**：tokscale 会解密桌面客户端的 `iCubeAuthInfo://*` blob（`globalStorage/storage.json`）来恢复 JWT，或接受通过 `--manual` 粘贴的 JWT。随后它分页调用 `POST /trae/api/v1/pay/query_user_usage_group_by_session` 并保存原始 JSON。如果希望报告反映最新的 Trae 数据，请在生成报告前先运行同步。
 
+#### 升级期间的同步锁恢复
+
+Antigravity 和 Trae 同步使用一个与旧版本兼容的 `sync.lock` 文件，以避免滚动升级期间与旧版 tokscale 二进制文件重叠运行。崩溃或强制停止后，该文件可能仍会保留。Tokscale 会刻意采用故障关闭策略，而不是替换它，因为旧版二进制文件可能仍在创建或更新同一路径。确认没有正在运行的 `tokscale antigravity sync` 或 `tokscale trae sync` 进程后，删除命令输出中精确加引号的 `sync.lock` 路径，再重试。如果同步仍可能正在运行，请勿删除该锁。
+
 > **中国区版本**：中国区版本（`trae.com.cn`）目前有意不支持。CN 后端暂未暴露按会话查询使用量的官方 API；如果上游提供正式端点，再加入支持。
 
 ### Warp/Oz 命令
@@ -875,6 +881,31 @@ Tokscale 将设置存储在 `~/.config/tokscale/settings.json`：
 | `light.writeCache` | boolean | `false` | 为 `true` 时，`tokscale --light` 会在渲染完成后以原子方式覆盖 TUI 缓存。CLI 标志 `--write-cache` / `--no-write-cache` 会按次运行覆盖该设置。 |
 | `minutelyTabEnabled` | boolean | `false` | 在 TUI 中显示按分钟的 Minutely 标签，并在数据加载期间执行分钟级聚合。对大多数用户而言，分钟级粒度是较为小众的诊断视图，而在大数据集上分钟分桶有非平凡的代价，因此默认关闭。 |
 | `scanner.extraScanPaths` | object | `{}` | 针对 Tokscale 默认 home 根位置之外的会话，为各客户端额外指定的扫描根目录 |
+| `scanner.bucketTimezone` | string | 自动检测 | 此设备将使用量按天分桶时所用时区的 IANA 名称（例如 `"Asia/Seoul"`）。首次运行时会自动记录。请优先使用 `tokscale config set timezone <zone>`，而非手动编辑。 |
+
+#### 每日边界与 `scanner.bucketTimezone`
+
+一条消息计入哪个日历日取决于时区。Tokscale 会在首次运行时记录此设备的时区并持续复用，而不是在每次扫描时读取机器当前的时区。
+
+这很重要，因为每日总量按天提交，且绝不允许减少。如果同一份历史记录在另一个时区重新分桶——例如旅行、更改系统时钟，或在使用不同 `TZ` 的 CI 中运行——接近午夜的会话会转移到相邻日期，旧日期和新日期都会保留其数值。没有新增使用量时总计也会增加。固定时区可使每日边界保持稳定，因此重新扫描未变更的历史始终产生相同的分桶。
+
+```console
+$ tokscale config list
+timezone     Asia/Seoul
+
+$ tokscale config get timezone
+Asia/Seoul
+
+# 仅在尚未存在有效固定值时（或恢复手动编辑出的无效值时），
+# 才允许使用 `set timezone auto`。它不能重新固定已确立的设备。
+$ tokscale config set timezone auto
+```
+
+只接受 IANA 时区名称。`+09:00` 这样的固定 UTC 偏移量会被拒绝：偏移量无法跟随夏令时，因此在夏令时切换后，固定偏移量会不再匹配当地午夜，并在每日边界附近重新拆分使用量——这正是固定时区要消除的问题，只是规模更小。
+
+一旦建立有效固定值，就不能再更改或取消（包括使用 `auto`）。如果设备确实迁移到新的时区，需要与服务器重新同步，或者使用新的设备身份；Tokscale 不会悄悄重新分配已提交的历史记录。
+
+现有安装在首次建立固定值之前不会受到影响。记录的时区等于该设备当前机器时区，因此首次固定操作不会重新分桶现有历史记录。
 
 使用 `scanner.extraScanPaths` 配置持久化的额外根目录，例如项目级的 `.codex` 目录或导入的 Gemini/OpenClaw 历史。Tokscale 会自动发现 `$HERMES_HOME/profiles/*/state.db` 下的 Hermes 配置文件数据库（未设置 `HERMES_HOME` 时为 `~/.hermes/profiles/*/state.db`）。仅对非标准的 Hermes 配置文件位置使用 `scanner.extraScanPaths.hermes`；Hermes 条目既可以指向包含 `state.db` 的配置文件目录，也可以直接指向 `state.db` 文件。Tokscale 在每次运行时都会将这些路径与默认扫描根目录合并，并按规范路径去重重叠的根目录。
 
@@ -905,6 +936,8 @@ Minutely 标签按分钟显示 Token 使用情况，最适合用于诊断突发�
 - `fonts/`、`images/` —— Wrapped 资源缓存
 
 删除该目录是安全的。Tokscale 会在需要时重新创建并重新生成其中的内容。
+
+仅 Claude Code 有一项注意事项。Claude Code 会在恢复或压缩会话时原地重写会话转录：文件名保留，但先前写入的助手轮次会丢失。`source-message-cache-v2/` 会在转录文件存在期间记住这些轮次，因此它们仍计入总量。这是它们唯一仍然存在的位置——转录本身已不再包含它们。删除缓存（或让 Claude 解析器升级时重建缓存）会从压缩后的转录重新构建，因此大量压缩的会话总量可能会变低。无论如何，删除转录文件仍会丢弃其轮次，这正是本地磁盘成为事实来源的原因。
 
 ### 环境变量
 
@@ -1161,6 +1194,74 @@ cd packages/cli && bun src/index.ts --light
 ```
 
 <details>
+
+<summary>使用自托管运行</summary>
+
+### 容器设置
+
+仓库提供用于**单主机部署**的 `Makefile` 和 Docker/Podman Compose 栈。无需在本地安装 Rust 或 Bun。该栈会优先自动检测 `podman`，否则使用 `docker`。
+
+**首次运行**——构建镜像时不会连接数据库。Compose 将 Postgres 标记为健康后，迁移会在应用容器启动时运行：
+
+```bash
+make docker/build   # 构建并标记前端镜像（tokscale:latest）
+make up             # 启动 Postgres 和前端，访问 http://localhost:3333
+```
+
+`make up` 使用预构建的 `tokscale:latest` 镜像——不会触发 Compose 重新构建。
+
+**后续运行**——镜像已构建完成，只需启动服务：
+
+```bash
+make up
+```
+
+**TUI**——独立于 Web 栈运行，直接从主机文件系统挂载中读取会话数据：
+
+```bash
+make tui/build   # 只需构建一次
+make tui         # 启动
+```
+
+`make tui` 使用当前主机的 UID 和 GID 运行容器，仅在需要时创建 `~/.config/tokscale` 和 `~/.cache/tokscale`，并以读写方式挂载这两个目录。会话数据挂载保持只读，因此容器无法在您的客户端目录中创建归 root 所有的文件。如果直接调用 Compose 而非 `make tui`，请设置 `TOKSCALE_UID=$(id -u)` 和 `TOKSCALE_GID=$(id -g)`，并自行创建这两个可写目录。
+
+默认 TUI profile 刻意不绑定客户端数据目录：即使是只读挂载，rootful Docker 也会将缺失的绑定源创建为 root 所有。只应选择机器上已存在的路径，例如：
+
+```bash
+TOKSCALE_UID=$(id -u) TOKSCALE_GID=$(id -g) \
+  docker compose --profile tui run --rm \
+  -v "$HOME/.claude:/home/tokscale/.claude:ro" tui
+```
+
+为您使用的客户端添加等效的 `-v` 标志。这样默认命令不会创建任意主机客户端目录。
+
+**其他常用目标：**
+
+```bash
+make down         # 停止所有服务
+make logs/app     # 跟踪应用日志
+make db/migrate   # 手动运行待执行迁移
+make help         # 完整目标列表
+```
+
+**自定义凭据**——运行 `make up` 前，请同时设置以下四个变量。Compose 无法从 `POSTGRES_*` 变量自动推导 `DATABASE_URL`。主机名 `db` 只对 Compose 网络中的应用容器有效；不要在主机 shell 中或作为 Docker 构建参数使用它：
+
+```bash
+export POSTGRES_USER=myuser
+export POSTGRES_PASSWORD=mypass
+export POSTGRES_DB=mydb
+export DATABASE_URL=postgresql://myuser:mypass@db:5432/mydb
+```
+
+默认值（`tokscale`/`tokscale`/`tokscale`）仅用于本地开发。
+
+**公开部署**——此 Compose 文件将两个端口绑定到回环地址，旨在置于终止 TLS 的反向代理之后。运行 `make up` 前，将 `APP_URL` 设置为公开 HTTPS 源（例如 `https://tokscale.example.com`），并在代理中配置该 URL；它会在运行时驱动 OAuth 重定向、CSRF 默认值、规范元数据、站点地图和 robots。仅对随附的本地 Postgres 服务保持 `DATABASE_SSL=false`。若使用托管数据库，请将 `DATABASE_URL`、`DATABASE_SSL=require`、`APP_URL` 和可选的 GitHub OAuth 凭据放入受保护的 `.env`/密钥存储，然后运行 `docker compose -f docker-compose.external-db.yml up -d`。该文件没有 `db` 服务，也不依赖本地数据库。示例默认值刻意不启用 OAuth。
+
+由于一个可复用镜像必须在页面元数据和社交卡片中输出运行时 `APP_URL`，根布局会按请求动态渲染。这刻意以完整路由的静态/ISR 输出为代价，换取每次部署都正确的公开源；数据获取仍使用现有的缓存标签和重新验证策略。
+
+</details>
+
+<details>
 <summary>高级开发</summary>
 
 ### 项目脚本
@@ -1345,8 +1446,12 @@ AI 编程工具将会话数据存储在跨平台位置。大多数工具在所�
 | OpenCodeReview | `~/.opencodereview/sessions/` | `%USERPROFILE%\.opencodereview\sessions\` | 解析 `*.jsonl` 会话记录；阿里巴巴的 AI 代码审查工具 |
 | CodeBuddy | `~/.codebuddy/projects/` + 扩展日志 | `%USERPROFILE%\.codebuddy\projects\` + CodeBuddy / VS Code 扩展日志 | 解析 CodeBuddy CLI、IDE 和 VS Code 插件的 token 用量 |
 | WorkBuddy | `~/.workbuddy/projects/` + `~/.workbuddy/workbuddy.db` | `%USERPROFILE%\.workbuddy\projects\` + `%USERPROFILE%\.workbuddy\workbuddy.db` | 解析 WorkBuddy token 用量，以聚合 SQLite 数据库作为回退 |
+| Devin CLI | `~/.local/share/devin/cli/sessions.db` | `%USERPROFILE%\.local\share\devin\cli\sessions.db` | 读取权威的本地 SQLite 用量数据库 |
+| Devin Desktop | Linux：`~/.config/Devin/User/acp-events/`；macOS：`~/Library/Application Support/Devin/User/acp-events/` | `%APPDATA%\Devin\User\acp-events\` | 解析 ACP 用量事件；存在 CLI 数据库时会解析匹配的会话标题 |
 | Augment Code | `~/.augment/sessions/` | `%USERPROFILE%\.augment\sessions\` | 解析 Auggie CLI 会话 JSON 快照（`*.json`）；关联键为顶层 `sessionId` |
 | Synthetic | 从其他来源重归属 | 从其他来源重归属 | 检测 `hf:` 模型前缀 + `synthetic` provider |
+
+> **Devin Desktop 代理支持**：本地用量解析适用于会在 NDJSON 流中发出 `usage_update` 事件的 ACP 连接代理（例如 Cascade/Windsurf、claude-code、opencode）。默认的 **devin-cloud** 代理不会发出本地 `usage_update` 事件——其用量仍保留在服务器端，tokscale 无法在没有账号级 API 的情况下跟踪它。
 
 > **注意**：在 Windows 上，`~` 扩展为 `%USERPROFILE%`（例如 `C:\Users\用户名`）。这些工具故意使用 Unix 风格的路径（如 `.local/share`）而不是 Windows 原生路径（如 `%APPDATA%`），以实现跨平台一致性。
 


### PR DESCRIPTION
## Summary

- sync Korean, Japanese, and Simplified Chinese READMEs with current supported clients and submit command
- document Reasonix, Trae sync-lock recovery, stable day-bucket timezones, and Claude compaction cache retention
- add self-hosting and container deployment guidance, plus Devin Desktop support details
- add the missing English Container Setup table-of-contents entry

## Validation

- `git diff --check`
- internal heading-link validation across all four README files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synced Japanese, Korean, and Simplified Chinese READMEs with current clients and `bunx tokscale@latest submit`, plus clearer self‑hosting and data handling guidance. English README adds a “Container Setup” TOC entry and removes the host‑only `make db/migrate` target.

- **Documentation**
  - Added Reasonix and Devin Desktop to supported platforms with paths and notes (Devin Desktop only tracks agents emitting `usage_update`; default `devin-cloud` does not).
  - Added containerized self‑hosting guide (Makefile + Docker/Podman), TUI container usage, credentials, and public deploy notes.
  - Documented Trae/Antigravity `sync.lock` recovery steps.
  - Introduced stable day‑bucket timezones (`scanner.bucketTimezone`) and `tokscale config set timezone` guidance to keep daily totals consistent.
  - Noted Claude Code compaction cache retention behavior; fixed English README TOC link for “Container Setup”; removed `make db/migrate` from targets.

<sup>Written for commit b505d2f2124c767e442c137dfc89396a05df0ca1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

