### PR TITLE
ci: route checks by changed targets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,7 @@ target/
 # Test and dev files
 **/*.test.ts
 **/*.spec.ts
+**/__tests__/
 **/coverage/
 **/.nyc_output/
 

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -12,11 +12,9 @@ on:
   pull_request:
     paths:
       - ".github/workflows/build-native.yml"
-      - ".github/workflows/publish-cli.yml"
       - "crates/**"
       - "packages/cli/package.json"
       - "packages/cli-*/package.json"
-      - "scripts/check-release-workflow-safety.py"
       - "Cargo.toml"
       - "Cargo.lock"
 
@@ -125,9 +123,6 @@ jobs:
         with:
           name: ${{ inputs.bumped-manifests }}
           path: .
-
-      - name: Check release workflow safety
-        run: python3 scripts/check-release-workflow-safety.py
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -3,40 +3,34 @@ name: Frontend CI
 on:
   workflow_dispatch:
   push:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "packages/frontend/**"
+      - "!packages/frontend/**/*.md"
       - "crates/tokscale-core/src/clients.rs"
       - ".github/assets/**"
+      - ".npmrc"
       - "package.json"
       - "bun.lock"
-      - "Dockerfile"
-      - "Dockerfile.tui"
-      - "Makefile"
-      - "README.md"
-      - "docker-compose.yml"
-      - "docker-compose.external-db.yml"
-      - "docker-entrypoint.sh"
       - ".github/workflows/frontend_ci.yml"
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "packages/frontend/**"
+      - "!packages/frontend/**/*.md"
       - "crates/tokscale-core/src/clients.rs"
       - ".github/assets/**"
+      - ".npmrc"
       - "package.json"
       - "bun.lock"
-      - "Dockerfile"
-      - "Dockerfile.tui"
-      - "Makefile"
-      - "README.md"
-      - "docker-compose.yml"
-      - "docker-compose.external-db.yml"
-      - "docker-entrypoint.sh"
       - ".github/workflows/frontend_ci.yml"
 
 permissions:
   contents: read
+
+concurrency:
+  group: frontend-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   BUN_VERSION: 1.3.10
@@ -62,74 +56,3 @@ jobs:
 
       - name: Run frontend type check
         run: bun run --cwd packages/frontend typecheck
-
-  migration-replay:
-    name: Frontend Migration Replay
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: tokscale_ci
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres -d tokscale_ci"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 12
-    env:
-      DATABASE_URL: postgres://postgres:postgres@localhost:5432/tokscale_ci
-      NODE_ENV: test
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Install workspace dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Replay frontend database migrations
-        run: bun run --cwd packages/frontend test:migrations
-
-  container-build:
-    name: Container Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-
-      - name: Build and smoke-test self-hosted frontend image
-        run: |
-          set -euo pipefail
-          trap 'docker compose logs --no-color || true; docker compose down -v || true' EXIT
-          docker build --tag tokscale:latest .
-          APP_URL=http://runtime.example docker compose up -d
-          for attempt in {1..30}; do
-            if curl --fail --silent --show-error http://localhost:3333/ >/dev/null; then
-              docker compose restart app
-              for restart_attempt in {1..30}; do
-                if curl --fail --silent --show-error http://localhost:3333/ >/dev/null; then
-                  bash scripts/test-self-host-runtime.sh http://localhost:3333 http://runtime.example
-                  APP_URL=https://runtime.example DATABASE_URL=postgresql://example.invalid/tokscale docker compose -f docker-compose.external-db.yml config -q
-                  exit 0
-                fi
-                sleep 2
-              done
-              exit 1
-            fi
-            sleep 2
-          done
-          exit 1
-
-      - name: Verify TUI default mount safety
-        run: bash scripts/test-tui-mounts.sh
-
-      - name: Build TUI image
-        run: docker build --file Dockerfile.tui --tag tokscale-tui:self-host-smoke .

--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths:
+    paths: &frontend_paths
       - "packages/frontend/**"
       - "!packages/frontend/**/*.md"
       - "crates/tokscale-core/src/clients.rs"
@@ -15,15 +15,7 @@ on:
       - ".github/workflows/frontend_ci.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "packages/frontend/**"
-      - "!packages/frontend/**/*.md"
-      - "crates/tokscale-core/src/clients.rs"
-      - ".github/assets/**"
-      - ".npmrc"
-      - "package.json"
-      - "bun.lock"
-      - ".github/workflows/frontend_ci.yml"
+    paths: *frontend_paths
 
 permissions:
   contents: read

--- a/.github/workflows/frontend_container_ci.yml
+++ b/.github/workflows/frontend_container_ci.yml
@@ -1,0 +1,80 @@
+name: Frontend Container CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".dockerignore"
+      - "Dockerfile"
+      - ".npmrc"
+      - "package.json"
+      - "bun.lock"
+      - "packages/*/package.json"
+      - "packages/frontend/**"
+      - "!packages/frontend/**/*.md"
+      - "!packages/frontend/**/*.test.ts"
+      - "!packages/frontend/**/*.spec.ts"
+      - "!packages/frontend/__tests__/**"
+      - "docker-compose.yml"
+      - "docker-compose.external-db.yml"
+      - "docker-entrypoint.sh"
+      - "scripts/test-self-host-runtime.sh"
+      - ".github/workflows/frontend_container_ci.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".dockerignore"
+      - "Dockerfile"
+      - ".npmrc"
+      - "package.json"
+      - "bun.lock"
+      - "packages/*/package.json"
+      - "packages/frontend/**"
+      - "!packages/frontend/**/*.md"
+      - "!packages/frontend/**/*.test.ts"
+      - "!packages/frontend/**/*.spec.ts"
+      - "!packages/frontend/__tests__/**"
+      - "docker-compose.yml"
+      - "docker-compose.external-db.yml"
+      - "docker-entrypoint.sh"
+      - "scripts/test-self-host-runtime.sh"
+      - ".github/workflows/frontend_container_ci.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: frontend-container-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  frontend-container:
+    name: Frontend Container
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Build and smoke-test self-hosted frontend image
+        run: |
+          set -euo pipefail
+          trap 'docker compose logs --no-color || true; docker compose down -v || true' EXIT
+          docker build --tag tokscale:latest .
+          APP_URL=http://runtime.example docker compose up -d
+          for _ in {1..30}; do
+            if curl --fail --silent --show-error http://localhost:3333/ >/dev/null; then
+              docker compose restart app
+              for _ in {1..30}; do
+                if curl --fail --silent --show-error http://localhost:3333/ >/dev/null; then
+                  bash scripts/test-self-host-runtime.sh http://localhost:3333 http://runtime.example
+                  APP_URL=https://runtime.example DATABASE_URL=postgresql://example.invalid/tokscale docker compose -f docker-compose.external-db.yml config -q
+                  exit 0
+                fi
+                sleep 2
+              done
+              exit 1
+            fi
+            sleep 2
+          done
+          exit 1

--- a/.github/workflows/frontend_container_ci.yml
+++ b/.github/workflows/frontend_container_ci.yml
@@ -4,9 +4,10 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths:
+    paths: &frontend_container_paths
       - ".dockerignore"
       - "Dockerfile"
+      - "Makefile"
       - "package.json"
       - "bun.lock"
       - "packages/*/package.json"
@@ -22,22 +23,7 @@ on:
       - ".github/workflows/frontend_container_ci.yml"
   pull_request:
     branches: [main]
-    paths:
-      - ".dockerignore"
-      - "Dockerfile"
-      - "package.json"
-      - "bun.lock"
-      - "packages/*/package.json"
-      - "packages/frontend/**"
-      - "!packages/frontend/**/*.md"
-      - "!packages/frontend/**/*.test.ts"
-      - "!packages/frontend/**/*.spec.ts"
-      - "!packages/frontend/__tests__/**"
-      - "docker-compose.yml"
-      - "docker-compose.external-db.yml"
-      - "docker-entrypoint.sh"
-      - "scripts/test-self-host-runtime.sh"
-      - ".github/workflows/frontend_container_ci.yml"
+    paths: *frontend_container_paths
 
 permissions:
   contents: read
@@ -57,9 +43,9 @@ jobs:
       - name: Build and smoke-test self-hosted frontend image
         run: |
           set -euo pipefail
-          trap 'docker compose logs --no-color || true; docker compose down -v || true' EXIT
-          docker build --tag tokscale:latest .
-          APP_URL=http://runtime.example docker compose up -d
+          trap 'docker compose logs --no-color || true; make down/volumes || true' EXIT
+          make docker/build
+          APP_URL=http://runtime.example make up
           for _ in {1..30}; do
             if curl --fail --silent --show-error http://localhost:3333/ >/dev/null; then
               docker compose restart app

--- a/.github/workflows/frontend_container_ci.yml
+++ b/.github/workflows/frontend_container_ci.yml
@@ -43,9 +43,9 @@ jobs:
       - name: Build and smoke-test self-hosted frontend image
         run: |
           set -euo pipefail
-          trap 'docker compose logs --no-color || true; make down/volumes || true' EXIT
-          make docker/build
-          APP_URL=http://runtime.example make up
+          trap 'docker compose logs --no-color || true; make COMPOSE="docker compose" down/volumes || true' EXIT
+          make DOCKER=docker docker/build
+          APP_URL=http://runtime.example make COMPOSE="docker compose" up
           for _ in {1..30}; do
             if curl --fail --silent --show-error http://localhost:3333/ >/dev/null; then
               docker compose restart app

--- a/.github/workflows/frontend_container_ci.yml
+++ b/.github/workflows/frontend_container_ci.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - ".dockerignore"
       - "Dockerfile"
-      - ".npmrc"
       - "package.json"
       - "bun.lock"
       - "packages/*/package.json"
@@ -26,7 +25,6 @@ on:
     paths:
       - ".dockerignore"
       - "Dockerfile"
-      - ".npmrc"
       - "package.json"
       - "bun.lock"
       - "packages/*/package.json"

--- a/.github/workflows/frontend_migration_ci.yml
+++ b/.github/workflows/frontend_migration_ci.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths:
+    paths: &frontend_migration_paths
       - "package.json"
       - ".npmrc"
       - "bun.lock"
@@ -15,15 +15,7 @@ on:
       - ".github/workflows/frontend_migration_ci.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "package.json"
-      - ".npmrc"
-      - "bun.lock"
-      - "packages/frontend/package.json"
-      - "packages/frontend/drizzle.config.ts"
-      - "packages/frontend/scripts/check-migrations.ts"
-      - "packages/frontend/src/lib/db/**"
-      - ".github/workflows/frontend_migration_ci.yml"
+    paths: *frontend_migration_paths
 
 permissions:
   contents: read

--- a/.github/workflows/frontend_migration_ci.yml
+++ b/.github/workflows/frontend_migration_ci.yml
@@ -1,0 +1,72 @@
+name: Frontend Migration CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "package.json"
+      - ".npmrc"
+      - "bun.lock"
+      - "packages/frontend/package.json"
+      - "packages/frontend/drizzle.config.ts"
+      - "packages/frontend/scripts/check-migrations.ts"
+      - "packages/frontend/src/lib/db/**"
+      - ".github/workflows/frontend_migration_ci.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "package.json"
+      - ".npmrc"
+      - "bun.lock"
+      - "packages/frontend/package.json"
+      - "packages/frontend/drizzle.config.ts"
+      - "packages/frontend/scripts/check-migrations.ts"
+      - "packages/frontend/src/lib/db/**"
+      - ".github/workflows/frontend_migration_ci.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: frontend-migration-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  BUN_VERSION: 1.3.10
+
+jobs:
+  migration-replay:
+    name: Frontend Migration Replay
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: tokscale_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d tokscale_ci"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/tokscale_ci
+      NODE_ENV: test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install workspace dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Replay frontend database migrations
+        run: bun run --cwd packages/frontend test:migrations

--- a/.github/workflows/launcher_validation.yml
+++ b/.github/workflows/launcher_validation.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths:
+    paths: &launcher_paths
       - "packages/cli/bin.js"
       - "packages/cli/src/**"
       - "packages/cli/tsconfig.json"
@@ -23,23 +23,7 @@ on:
       - "crates/**"
   pull_request:
     branches: [main]
-    paths:
-      - "packages/cli/bin.js"
-      - "packages/cli/src/**"
-      - "packages/cli/tsconfig.json"
-      - "packages/cli/bunfig.toml"
-      - "packages/cli/package.json"
-      - "packages/tokscale/bin.js"
-      - "packages/tokscale/package.json"
-      - "packages/cli-*/package.json"
-      - "scripts/test-package-launchers.sh"
-      - ".github/workflows/launcher_validation.yml"
-      - ".npmrc"
-      - "package.json"
-      - "bun.lock"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "crates/**"
+    paths: *launcher_paths
 
 permissions:
   contents: read

--- a/.github/workflows/launcher_validation.yml
+++ b/.github/workflows/launcher_validation.yml
@@ -3,44 +3,55 @@ name: Launcher Validation
 on:
   workflow_dispatch:
   push:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "packages/cli/bin.js"
       - "packages/cli/src/**"
       - "packages/cli/tsconfig.json"
+      - "packages/cli/bunfig.toml"
       - "packages/cli/package.json"
       - "packages/tokscale/bin.js"
       - "packages/tokscale/package.json"
       - "packages/cli-*/package.json"
       - "scripts/test-package-launchers.sh"
       - ".github/workflows/launcher_validation.yml"
+      - ".npmrc"
       - "package.json"
       - "bun.lock"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "crates/**"
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "packages/cli/bin.js"
       - "packages/cli/src/**"
       - "packages/cli/tsconfig.json"
+      - "packages/cli/bunfig.toml"
       - "packages/cli/package.json"
       - "packages/tokscale/bin.js"
       - "packages/tokscale/package.json"
       - "packages/cli-*/package.json"
       - "scripts/test-package-launchers.sh"
       - ".github/workflows/launcher_validation.yml"
+      - ".npmrc"
       - "package.json"
       - "bun.lock"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "crates/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: launcher-validation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   launcher-smoke:
     name: Launcher Smoke
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -40,6 +40,17 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Require the default branch
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RELEASE_REF_NAME: ${{ github.ref_name }}
+          RELEASE_REF_TYPE: ${{ github.ref_type }}
+        run: |
+          if [[ "$RELEASE_REF_TYPE" != "branch" || "$RELEASE_REF_NAME" != "$DEFAULT_BRANCH" ]]; then
+            echo "Publish must be dispatched from the default branch ($DEFAULT_BRANCH), not $RELEASE_REF_TYPE $RELEASE_REF_NAME." >&2
+            exit 1
+          fi
+
       - name: Check release workflow safety
         run: python3 scripts/check-release-workflow-safety.py
 

--- a/.github/workflows/python_bridge_ci.yml
+++ b/.github/workflows/python_bridge_ci.yml
@@ -1,0 +1,42 @@
+name: Python Bridge CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "scripts/9router_tokscale_bridge_gjc.py"
+      - "scripts/test_9router_tokscale_bridge_gjc.py"
+      - ".github/workflows/python_bridge_ci.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "scripts/9router_tokscale_bridge_gjc.py"
+      - "scripts/test_9router_tokscale_bridge_gjc.py"
+      - ".github/workflows/python_bridge_ci.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: python-bridge-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  bridge-tests:
+    name: Python Bridge Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install test dependency
+        run: python -m pip install pytest
+
+      - name: Run bridge tests
+        run: python -m pytest scripts/test_9router_tokscale_bridge_gjc.py

--- a/.github/workflows/python_bridge_ci.yml
+++ b/.github/workflows/python_bridge_ci.yml
@@ -4,16 +4,13 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths:
+    paths: &python_bridge_paths
       - "scripts/9router_tokscale_bridge_gjc.py"
       - "scripts/test_9router_tokscale_bridge_gjc.py"
       - ".github/workflows/python_bridge_ci.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "scripts/9router_tokscale_bridge_gjc.py"
-      - "scripts/test_9router_tokscale_bridge_gjc.py"
-      - ".github/workflows/python_bridge_ci.yml"
+    paths: *python_bridge_paths
 
 permissions:
   contents: read

--- a/.github/workflows/release_validation.yml
+++ b/.github/workflows/release_validation.yml
@@ -23,6 +23,7 @@ on:
       - "scripts/test-npm-release-state.sh"
       - "scripts/test-prepare-release-provenance.sh"
       - "scripts/test-release-package-artifacts.sh"
+      - "scripts/test-release-notes.sh"
       - "scripts/test-release-workflow-safety.sh"
       - ".github/workflows/build-native.yml"
       - ".github/workflows/publish-cli.yml"
@@ -57,17 +58,12 @@ jobs:
       - name: Verify release workflow topology
         run: python3 scripts/check-release-workflow-safety.py
 
-      - name: Validate release-only helpers
-        run: |
-          bash -n scripts/test-release-package-artifacts.sh
-          bash -n scripts/post-discord-release.sh
-          bun build scripts/generate-release-notes.ts --target=bun --outfile=/tmp/generate-release-notes.js
-          env -u DISCORD_WEBHOOK_URL bash scripts/post-discord-release.sh 0.0.0-ci
-
       - name: Run release helper tests
         run: |
+          bash -n scripts/test-release-package-artifacts.sh
           bash scripts/test-calculate-release-version.sh
           bash scripts/test-check-version-coherence.sh
           bash scripts/test-npm-release-state.sh
           bash scripts/test-prepare-release-provenance.sh
+          bash scripts/test-release-notes.sh
           bash scripts/test-release-workflow-safety.sh

--- a/.github/workflows/release_validation.yml
+++ b/.github/workflows/release_validation.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths:
+    paths: &release_validation_paths
       - "Cargo.toml"
       - "Cargo.lock"
       - "packages/cli/package.json"
@@ -16,36 +16,20 @@ on:
       - "scripts/check-version-coherence.sh"
       - "scripts/prepare-release-provenance.sh"
       - "scripts/publish-npm-package.sh"
+      - "scripts/generate-release-notes.ts"
+      - "scripts/post-discord-release.sh"
       - "scripts/test-calculate-release-version.sh"
       - "scripts/test-check-version-coherence.sh"
       - "scripts/test-npm-release-state.sh"
       - "scripts/test-prepare-release-provenance.sh"
+      - "scripts/test-release-package-artifacts.sh"
       - "scripts/test-release-workflow-safety.sh"
       - ".github/workflows/build-native.yml"
       - ".github/workflows/publish-cli.yml"
       - ".github/workflows/release_validation.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "packages/cli/package.json"
-      - "packages/tokscale/package.json"
-      - "packages/cli-*/package.json"
-      - "scripts/calculate-release-version.sh"
-      - "scripts/check-npm-release-state.sh"
-      - "scripts/check-release-workflow-safety.py"
-      - "scripts/check-version-coherence.sh"
-      - "scripts/prepare-release-provenance.sh"
-      - "scripts/publish-npm-package.sh"
-      - "scripts/test-calculate-release-version.sh"
-      - "scripts/test-check-version-coherence.sh"
-      - "scripts/test-npm-release-state.sh"
-      - "scripts/test-prepare-release-provenance.sh"
-      - "scripts/test-release-workflow-safety.sh"
-      - ".github/workflows/build-native.yml"
-      - ".github/workflows/publish-cli.yml"
-      - ".github/workflows/release_validation.yml"
+    paths: *release_validation_paths
 
 permissions:
   contents: read
@@ -62,11 +46,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.1.38
+
       - name: Verify version coherence
         run: bash scripts/check-version-coherence.sh
 
       - name: Verify release workflow topology
         run: python3 scripts/check-release-workflow-safety.py
+
+      - name: Validate release-only helpers
+        run: |
+          bash -n scripts/test-release-package-artifacts.sh
+          bash -n scripts/post-discord-release.sh
+          bun build scripts/generate-release-notes.ts --target=bun --outfile=/tmp/generate-release-notes.js
+          env -u DISCORD_WEBHOOK_URL bash scripts/post-discord-release.sh 0.0.0-ci
 
       - name: Run release helper tests
         run: |

--- a/.github/workflows/release_validation.yml
+++ b/.github/workflows/release_validation.yml
@@ -1,0 +1,79 @@
+name: Release Validation
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".npmrc"
+      - "packages/cli/package.json"
+      - "packages/tokscale/package.json"
+      - "packages/cli-*/package.json"
+      - "scripts/calculate-release-version.sh"
+      - "scripts/check-npm-release-state.sh"
+      - "scripts/check-release-workflow-safety.py"
+      - "scripts/check-version-coherence.sh"
+      - "scripts/prepare-release-provenance.sh"
+      - "scripts/publish-npm-package.sh"
+      - "scripts/test-calculate-release-version.sh"
+      - "scripts/test-check-version-coherence.sh"
+      - "scripts/test-npm-release-state.sh"
+      - "scripts/test-prepare-release-provenance.sh"
+      - "scripts/test-release-workflow-safety.sh"
+      - ".github/workflows/build-native.yml"
+      - ".github/workflows/publish-cli.yml"
+      - ".github/workflows/release_validation.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".npmrc"
+      - "packages/cli/package.json"
+      - "packages/tokscale/package.json"
+      - "packages/cli-*/package.json"
+      - "scripts/calculate-release-version.sh"
+      - "scripts/check-npm-release-state.sh"
+      - "scripts/check-release-workflow-safety.py"
+      - "scripts/check-version-coherence.sh"
+      - "scripts/prepare-release-provenance.sh"
+      - "scripts/publish-npm-package.sh"
+      - "scripts/test-calculate-release-version.sh"
+      - "scripts/test-check-version-coherence.sh"
+      - "scripts/test-npm-release-state.sh"
+      - "scripts/test-prepare-release-provenance.sh"
+      - "scripts/test-release-workflow-safety.sh"
+      - ".github/workflows/build-native.yml"
+      - ".github/workflows/publish-cli.yml"
+      - ".github/workflows/release_validation.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-validation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  release-validation:
+    name: Release Scripts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Verify version coherence
+        run: bash scripts/check-version-coherence.sh
+
+      - name: Verify release workflow topology
+        run: python3 scripts/check-release-workflow-safety.py
+
+      - name: Run release helper tests
+        run: |
+          bash scripts/test-calculate-release-version.sh
+          bash scripts/test-check-version-coherence.sh
+          bash scripts/test-npm-release-state.sh
+          bash scripts/test-prepare-release-provenance.sh
+          bash scripts/test-release-workflow-safety.sh

--- a/.github/workflows/release_validation.yml
+++ b/.github/workflows/release_validation.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - "Cargo.toml"
       - "Cargo.lock"
-      - ".npmrc"
       - "packages/cli/package.json"
       - "packages/tokscale/package.json"
       - "packages/cli-*/package.json"
@@ -30,7 +29,6 @@ on:
     paths:
       - "Cargo.toml"
       - "Cargo.lock"
-      - ".npmrc"
       - "packages/cli/package.json"
       - "packages/tokscale/package.json"
       - "packages/cli-*/package.json"

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -3,43 +3,34 @@ name: Test & Coverage
 on:
   workflow_dispatch:
   push:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - 'crates/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
-      - 'packages/cli/package.json'
-      - 'packages/tokscale/package.json'
-      - 'packages/cli-*/package.json'
-      - 'scripts/*.sh'
-      - 'scripts/*.py'
-      - '.github/workflows/build-native.yml'
-      - '.github/workflows/publish-cli.yml'
       - '.github/workflows/test_coverage.yml'
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - 'crates/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
-      - 'packages/cli/package.json'
-      - 'packages/tokscale/package.json'
-      - 'packages/cli-*/package.json'
-      - 'scripts/*.sh'
-      - 'scripts/*.py'
-      - '.github/workflows/build-native.yml'
-      - '.github/workflows/publish-cli.yml'
       - '.github/workflows/test_coverage.yml'
 
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
+concurrency:
+  group: test-coverage-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -47,15 +38,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
-      - name: Verify version coherence
-        run: bash scripts/check-version-coherence.sh
-      - name: Run release helper tests
-        run: |
-          bash scripts/test-calculate-release-version.sh
-          bash scripts/test-check-version-coherence.sh
-          bash scripts/test-npm-release-state.sh
-          bash scripts/test-prepare-release-provenance.sh
-          bash scripts/test-release-workflow-safety.sh
       - name: Cache cargo registry
         uses: actions/cache@v5
         with:
@@ -91,8 +73,8 @@ jobs:
   #
   # This must not become permanent: an advisory job nobody reads is how #997
   # happened. Flip `continue-on-error` off as soon as #1014 closes.
-  coverage:
-    name: Code Coverage
+  tests:
+    name: Tests
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.os == 'windows-latest' }}
     strategy:
@@ -104,8 +86,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
 
-    permissions:
-      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -134,12 +114,37 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --all-features --no-fail-fast
 
+  coverage:
+    name: Coverage Report
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: coverage-${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            coverage-${{ runner.os }}-cargo-
+
       - name: Install cargo-tarpaulin
-        if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: taiki-e/install-action@cargo-tarpaulin
 
       - name: Generate coverage report
-        if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           cargo tarpaulin \
             --workspace \
@@ -151,10 +156,9 @@ jobs:
             --verbose
 
       - name: Extract coverage percentage
-        if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         id: coverage
         run: |
-          COVERAGE=$(cat ./coverage/tarpaulin-report.json | jq -r '
+          COVERAGE=$(jq -r '
             [.files[]] |
             (map(.covered) | add) as $total_covered |
             (map(.coverable) | add) as $total_coverable |
@@ -163,29 +167,27 @@ jobs:
             else
               0
             end
-          ')
-          COVERAGE_INT=$(printf "%.0f" $COVERAGE)
-          echo "percentage=$COVERAGE" >> $GITHUB_OUTPUT
-          echo "percentage_int=$COVERAGE_INT" >> $GITHUB_OUTPUT
+          ' ./coverage/tarpaulin-report.json)
+          COVERAGE_INT=$(printf "%.0f" "$COVERAGE")
+          echo "percentage=$COVERAGE" >> "$GITHUB_OUTPUT"
+          echo "percentage_int=$COVERAGE_INT" >> "$GITHUB_OUTPUT"
           echo "Coverage: $COVERAGE%"
           
           # Determine badge color
-          if [ $COVERAGE_INT -gt 80 ]; then
-            echo "color=green" >> $GITHUB_OUTPUT
-          elif [ $COVERAGE_INT -gt 60 ]; then
-            echo "color=yellow" >> $GITHUB_OUTPUT
-          elif [ $COVERAGE_INT -gt 40 ]; then
-            echo "color=orange" >> $GITHUB_OUTPUT
+          if [ "$COVERAGE_INT" -gt 80 ]; then
+            echo "color=green" >> "$GITHUB_OUTPUT"
+          elif [ "$COVERAGE_INT" -gt 60 ]; then
+            echo "color=yellow" >> "$GITHUB_OUTPUT"
+          elif [ "$COVERAGE_INT" -gt 40 ]; then
+            echo "color=orange" >> "$GITHUB_OUTPUT"
           else
-            echo "color=red" >> $GITHUB_OUTPUT
+            echo "color=red" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create badges directory
-        if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: mkdir -p .github/badges
 
       - name: Generate coverage badge
-        if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: emibcn/badge-action@v2.0.4
         with:
           label: 'coverage'
@@ -194,14 +196,13 @@ jobs:
           path: .github/badges/coverage.svg
 
       - name: Commit coverage badge
-        if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add .github/badges/coverage.svg
           git diff --staged --quiet && exit 0
           git commit -m "ci: update coverage badge [skip ci]"
-          for i in 1 2 3; do
+          for _ in 1 2 3; do
             git push && exit 0
             git pull --rebase -X theirs origin main || exit 1
           done
@@ -209,7 +210,7 @@ jobs:
 
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v6
-        if: "!cancelled() && matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')"
+        if: "!cancelled()"
         with:
           name: coverage-report
           path: ./coverage/

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -116,7 +116,7 @@ jobs:
 
   coverage:
     name: Coverage Report
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -4,18 +4,14 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths:
+    paths: &test_coverage_paths
       - 'crates/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/test_coverage.yml'
   pull_request:
     branches: [main]
-    paths:
-      - 'crates/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - '.github/workflows/test_coverage.yml'
+    paths: *test_coverage_paths
 
 env:
   CARGO_TERM_COLOR: always
@@ -102,9 +98,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: coverage-${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          key: tests-${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            coverage-${{ runner.os }}-cargo-
+            tests-${{ runner.os }}-cargo-
 
       # `--no-fail-fast` because cargo otherwise stops at the first test
       # binary that fails and never runs the rest. That is precisely how #997

--- a/.github/workflows/tui_container_ci.yml
+++ b/.github/workflows/tui_container_ci.yml
@@ -4,9 +4,10 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths:
+    paths: &tui_container_paths
       - ".dockerignore"
       - "Dockerfile.tui"
+      - "Makefile"
       - "Cargo.toml"
       - "Cargo.lock"
       - "crates/**"
@@ -15,15 +16,7 @@ on:
       - ".github/workflows/tui_container_ci.yml"
   pull_request:
     branches: [main]
-    paths:
-      - ".dockerignore"
-      - "Dockerfile.tui"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "crates/**"
-      - "docker-compose.yml"
-      - "scripts/test-tui-mounts.sh"
-      - ".github/workflows/tui_container_ci.yml"
+    paths: *tui_container_paths
 
 permissions:
   contents: read
@@ -44,4 +37,7 @@ jobs:
         run: bash scripts/test-tui-mounts.sh
 
       - name: Build TUI image
-        run: docker build --file Dockerfile.tui --tag tokscale-tui:self-host-smoke .
+        run: make tui/build
+
+      - name: Smoke-test TUI image entrypoint
+        run: docker run --rm tokscale-tui:latest --no-spinner --help

--- a/.github/workflows/tui_container_ci.yml
+++ b/.github/workflows/tui_container_ci.yml
@@ -1,0 +1,47 @@
+name: TUI Container CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".dockerignore"
+      - "Dockerfile.tui"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**"
+      - "docker-compose.yml"
+      - "scripts/test-tui-mounts.sh"
+      - ".github/workflows/tui_container_ci.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".dockerignore"
+      - "Dockerfile.tui"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**"
+      - "docker-compose.yml"
+      - "scripts/test-tui-mounts.sh"
+      - ".github/workflows/tui_container_ci.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tui-container-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  tui-container:
+    name: TUI Container
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Verify TUI default mount safety
+        run: bash scripts/test-tui-mounts.sh
+
+      - name: Build TUI image
+        run: docker build --file Dockerfile.tui --tag tokscale-tui:self-host-smoke .

--- a/.github/workflows/tui_container_ci.yml
+++ b/.github/workflows/tui_container_ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: bash scripts/test-tui-mounts.sh
 
       - name: Build TUI image
-        run: make tui/build
+        run: make DOCKER=docker tui/build
 
       - name: Smoke-test TUI image entrypoint
         run: docker run --rm tokscale-tui:latest --no-spinner --help

--- a/.github/workflows/workflow_lint.yml
+++ b/.github/workflows/workflow_lint.yml
@@ -1,0 +1,30 @@
+name: Workflow Lint
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: workflow-lint-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  actionlint:
+    name: Actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Lint GitHub Actions workflows
+        uses: docker://rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667

--- a/.github/workflows/workflow_lint.yml
+++ b/.github/workflows/workflow_lint.yml
@@ -4,12 +4,11 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths:
+    paths: &workflow_lint_paths
       - ".github/workflows/**"
   pull_request:
     branches: [main]
-    paths:
-      - ".github/workflows/**"
+    paths: *workflow_lint_paths
 
 permissions:
   contents: read
@@ -27,4 +26,5 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Lint GitHub Actions workflows
+        # actionlint 1.7.12; keep the image immutable and review the version when updating this digest.
         uses: docker://rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,7 +197,7 @@ Release version is stored in the Rust workspace and the npm package manifests, a
 
 ### CI-Only Workflow
 
-**`.github/workflows/build-native.yml`** — Runs on PRs touching `crates/tokscale-cli/**`. Builds all 8 native targets to verify compilation. Does not publish.
+**`.github/workflows/build-native.yml`** — Runs on PRs that affect the Rust workspace, CLI platform manifests, or native build workflow. Builds the configured native target matrix to verify compilation. Does not publish.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Prerequisites: a stable Rust toolchain (`rustup` recommended) and [Bun](https://
 
 Run `make help` for the full target list.
 
-CI runs format, Clippy, and Rust tests on Linux, then builds the supported release targets separately. Frontend CI runs Vitest, migration replay, and the type check; it also runs when `crates/tokscale-core/src/clients.rs` or a GitHub CDN asset changes, so cross-registry client checks cannot be skipped by a Rust-only integration PR. A clean local `cargo fmt`, `cargo clippy`, and `cargo test` is the baseline for a reviewable PR.
+CI routes changes to the smallest relevant checks: Rust format, Clippy, and tests; release-script validation; frontend tests and migration replay; package launcher smoke tests; Python bridge tests; and separate self-hosted frontend/TUI container builds. A clean local `cargo fmt`, `cargo clippy`, and `cargo test` is the baseline for a reviewable Rust PR.
 
 ## Repository layout
 

--- a/scripts/check-release-workflow-safety.py
+++ b/scripts/check-release-workflow-safety.py
@@ -78,6 +78,28 @@ def strip_yaml_scalar(value: str) -> str:
     return value
 
 
+def yaml_mapping_entry(line: str, indent: int) -> tuple[str, str] | None:
+    content = strip_yaml_comment(line)
+    match = re.match(
+        rf"\s{{{indent}}}(?:([A-Za-z_][A-Za-z0-9_-]*)|\"([^\"]+)\"|'([^']+)'):\s*(.*)$",
+        content,
+    )
+    if not match:
+        return None
+    key = next(group for group in match.groups()[:3] if group is not None)
+    return key, strip_yaml_scalar(match.group(4))
+
+
+def mapping_scalars(lines: list[str], indent: int) -> dict[str, str]:
+    mappings: dict[str, str] = {}
+    for line in lines:
+        entry = yaml_mapping_entry(line, indent)
+        if entry:
+            key, value = entry
+            mappings[key] = value
+    return mappings
+
+
 def top_level_env(lines: list[str]) -> dict[str, str]:
     env: dict[str, str] = {}
     for index, line in enumerate(lines):
@@ -270,7 +292,8 @@ def step_has_property(step_lines: list[str], property_name: str) -> bool:
         return False
     property_indent = len(match.group(1)) + 2
     return any(
-        re.match(rf"\s{{{property_indent}}}{re.escape(property_name)}:\s*", line)
+        (entry := yaml_mapping_entry(line, property_indent)) is not None
+        and entry[0] == property_name
         for line in uncommented_lines(step_lines[1:])
     )
 
@@ -325,23 +348,27 @@ def main() -> None:
 
     publish_bump = uncommented_lines(job_block(publish_lines, "bump-versions"))
     default_branch_step = named_step_block(publish_bump, "Require the default branch")
-    default_branch_env = (
-        "DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}",
-        "RELEASE_REF_NAME: ${{ github.ref_name }}",
-        "RELEASE_REF_TYPE: ${{ github.ref_type }}",
-    )
+    default_branch_env = {
+        "DEFAULT_BRANCH": "${{ github.event.repository.default_branch }}",
+        "RELEASE_REF_NAME": "${{ github.ref_name }}",
+        "RELEASE_REF_TYPE": "${{ github.ref_type }}",
+    }
     default_branch_env_block = mapping_block(default_branch_step, "env", 8)
+    default_branch_env_values = mapping_scalars(default_branch_env_block, 10)
     default_branch_run = step_run_block(default_branch_step)
     guard = 'if [[ "$RELEASE_REF_TYPE" != "branch" || "$RELEASE_REF_NAME" != "$DEFAULT_BRANCH" ]]; then'
     try:
         guard_index = default_branch_run.index(guard)
-        exit_index = default_branch_run.index("exit 1", guard_index + 1)
-        fi_index = default_branch_run.index("fi", exit_index + 1)
+        fi_index = default_branch_run.index("fi", guard_index + 1)
+        exit_index = default_branch_run.index("exit 1", guard_index + 1, fi_index)
         gate_aborts = guard_index == 0 and guard_index < exit_index < fi_index
     except ValueError:
         gate_aborts = False
     if (
-        not all(block_contains(default_branch_env_block, snippet) for snippet in default_branch_env)
+        not all(
+            default_branch_env_values.get(key) == value
+            for key, value in default_branch_env.items()
+        )
         or step_has_property(default_branch_step, "if")
         or step_has_property(default_branch_step, "continue-on-error")
         or not gate_aborts

--- a/scripts/check-release-workflow-safety.py
+++ b/scripts/check-release-workflow-safety.py
@@ -265,6 +265,16 @@ def main() -> None:
     native_lines = read_lines(BUILD_NATIVE_WORKFLOW)
     errors: list[str] = []
 
+    publish_bump = uncommented_lines(job_block(publish_lines, "bump-versions"))
+    default_branch_gate = (
+        "DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}",
+        "RELEASE_REF_NAME: ${{ github.ref_name }}",
+        "RELEASE_REF_TYPE: ${{ github.ref_type }}",
+        'if [[ "$RELEASE_REF_TYPE" != "branch" || "$RELEASE_REF_NAME" != "$DEFAULT_BRANCH" ]]; then',
+    )
+    if not all(block_contains(publish_bump, snippet) for snippet in default_branch_gate):
+        errors.append("publish workflow must reject non-default branch dispatches")
+
     native_env = top_level_env(native_lines)
     for key in REQUIRED_ENV_KEYS:
         if key not in native_env:

--- a/scripts/check-release-workflow-safety.py
+++ b/scripts/check-release-workflow-safety.py
@@ -217,6 +217,64 @@ def uncommented_lines(lines: list[str]) -> list[str]:
     return [line for line in lines if not line.lstrip().startswith("#")]
 
 
+def named_step_block(job_lines: list[str], step_name: str) -> list[str]:
+    lines = uncommented_lines(job_lines)
+    for index, line in enumerate(lines):
+        match = re.match(r"(\s*)-\s+name:\s*(.+?)\s*$", line)
+        if not match or strip_yaml_scalar(match.group(2)) != step_name:
+            continue
+
+        step_indent = len(match.group(1))
+        end = len(lines)
+        for child_index in range(index + 1, len(lines)):
+            child = strip_yaml_comment(lines[child_index])
+            if not child.strip():
+                continue
+            child_indent = len(child) - len(child.lstrip(" "))
+            if child_indent < step_indent or (
+                child_indent == step_indent and re.match(r"\s*-\s+", child)
+            ):
+                end = child_index
+                break
+        return lines[index:end]
+
+    return []
+
+
+def step_run_block(step_lines: list[str]) -> list[str]:
+    for index, line in enumerate(step_lines):
+        match = re.match(r"(\s*)run:\s*[|>][-+]?\s*$", strip_yaml_comment(line))
+        if not match:
+            continue
+
+        run_indent = len(match.group(1))
+        run_lines: list[str] = []
+        for child in step_lines[index + 1 :]:
+            content = strip_yaml_comment(child)
+            if not content.strip():
+                continue
+            child_indent = len(content) - len(content.lstrip(" "))
+            if child_indent <= run_indent:
+                break
+            run_lines.append(content.strip())
+        return run_lines
+
+    return []
+
+
+def step_has_property(step_lines: list[str], property_name: str) -> bool:
+    if not step_lines:
+        return False
+    match = re.match(r"(\s*)-\s+", step_lines[0])
+    if not match:
+        return False
+    property_indent = len(match.group(1)) + 2
+    return any(
+        re.match(rf"\s{{{property_indent}}}{re.escape(property_name)}:\s*", line)
+        for line in uncommented_lines(step_lines[1:])
+    )
+
+
 def yaml_list_scalars(lines: list[str]) -> set[str]:
     values: set[str] = set()
     for line in lines:
@@ -266,13 +324,28 @@ def main() -> None:
     errors: list[str] = []
 
     publish_bump = uncommented_lines(job_block(publish_lines, "bump-versions"))
-    default_branch_gate = (
+    default_branch_step = named_step_block(publish_bump, "Require the default branch")
+    default_branch_env = (
         "DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}",
         "RELEASE_REF_NAME: ${{ github.ref_name }}",
         "RELEASE_REF_TYPE: ${{ github.ref_type }}",
-        'if [[ "$RELEASE_REF_TYPE" != "branch" || "$RELEASE_REF_NAME" != "$DEFAULT_BRANCH" ]]; then',
     )
-    if not all(block_contains(publish_bump, snippet) for snippet in default_branch_gate):
+    default_branch_env_block = mapping_block(default_branch_step, "env", 8)
+    default_branch_run = step_run_block(default_branch_step)
+    guard = 'if [[ "$RELEASE_REF_TYPE" != "branch" || "$RELEASE_REF_NAME" != "$DEFAULT_BRANCH" ]]; then'
+    try:
+        guard_index = default_branch_run.index(guard)
+        exit_index = default_branch_run.index("exit 1", guard_index + 1)
+        fi_index = default_branch_run.index("fi", exit_index + 1)
+        gate_aborts = guard_index == 0 and guard_index < exit_index < fi_index
+    except ValueError:
+        gate_aborts = False
+    if (
+        not all(block_contains(default_branch_env_block, snippet) for snippet in default_branch_env)
+        or step_has_property(default_branch_step, "if")
+        or step_has_property(default_branch_step, "continue-on-error")
+        or not gate_aborts
+    ):
         errors.append("publish workflow must reject non-default branch dispatches")
 
     native_env = top_level_env(native_lines)

--- a/scripts/check-release-workflow-safety.py
+++ b/scripts/check-release-workflow-safety.py
@@ -78,6 +78,61 @@ def strip_yaml_scalar(value: str) -> str:
     return value
 
 
+def decode_yaml_double_quoted(value: str) -> str:
+    escapes = {
+        "0": "\0",
+        "a": "\a",
+        "b": "\b",
+        "t": "\t",
+        "n": "\n",
+        "v": "\v",
+        "f": "\f",
+        "r": "\r",
+        "e": "\x1b",
+        " ": " ",
+        '"': '"',
+        "/": "/",
+        "\\": "\\",
+        "N": "\x85",
+        "_": "\xa0",
+        "L": "\u2028",
+        "P": "\u2029",
+    }
+    hex_widths = {"x": 2, "u": 4, "U": 8}
+    decoded: list[str] = []
+    index = 0
+    while index < len(value):
+        if value[index] != "\\":
+            decoded.append(value[index])
+            index += 1
+            continue
+
+        index += 1
+        if index >= len(value):
+            raise ValueError("unterminated YAML escape")
+        escape = value[index]
+        if escape in escapes:
+            decoded.append(escapes[escape])
+            index += 1
+            continue
+        if escape not in hex_widths:
+            raise ValueError(f"unsupported YAML escape: \\{escape}")
+
+        width = hex_widths[escape]
+        start = index + 1
+        end = start + width
+        digits = value[start:end]
+        if len(digits) != width or not re.fullmatch(r"[0-9A-Fa-f]+", digits):
+            raise ValueError(f"invalid YAML escape: \\{escape}{digits}")
+        codepoint = int(digits, 16)
+        if codepoint > 0x10FFFF or 0xD800 <= codepoint <= 0xDFFF:
+            raise ValueError(f"invalid YAML codepoint: {codepoint:#x}")
+        decoded.append(chr(codepoint))
+        index = end
+
+    return "".join(decoded)
+
+
 def yaml_mapping_entry(line: str, indent: int) -> tuple[str, str] | None:
     content = strip_yaml_comment(line)
     match = re.match(
@@ -86,7 +141,16 @@ def yaml_mapping_entry(line: str, indent: int) -> tuple[str, str] | None:
     )
     if not match:
         return None
-    key = next(group for group in match.groups()[:3] if group is not None)
+    bare_key, double_quoted_key, single_quoted_key = match.groups()[:3]
+    if double_quoted_key is not None:
+        try:
+            key = decode_yaml_double_quoted(double_quoted_key)
+        except ValueError:
+            return None
+    else:
+        key = bare_key if bare_key is not None else single_quoted_key
+    if key is None:
+        return None
     return key, strip_yaml_scalar(match.group(4))
 
 

--- a/scripts/test-release-notes.sh
+++ b/scripts/test-release-notes.sh
@@ -121,6 +121,10 @@ assert_contains "${notes}" '* @alice made their first contribution in https://gi
 assert_contains "${notes}" '**Full Changelog**: https://github.com/acme/tokscale/compare/v1.2.2...v1.2.3'
 assert_excludes "${notes}" 'chore: bump version'
 
+skip_output="$(env -u DISCORD_WEBHOOK_URL bash scripts/post-discord-release.sh 1.2.3)"
+assert_contains "${skip_output}" 'DISCORD_WEBHOOK_URL not set, skipping Discord notification'
+[ ! -s "${CURL_PAYLOADS}" ] || { echo "Discord skip path unexpectedly posted a payload" >&2; exit 1; }
+
 DISCORD_WEBHOOK_URL="https://discord.invalid/webhook" \
   bash scripts/post-discord-release.sh 1.2.3 >"${TMP_DIR}/discord-output.txt"
 

--- a/scripts/test-release-notes.sh
+++ b/scripts/test-release-notes.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+FAKE_BIN="${TMP_DIR}/bin"
+GH_LOG="${TMP_DIR}/gh.log"
+CURL_PAYLOADS="${TMP_DIR}/curl-payloads.jsonl"
+mkdir -p "${FAKE_BIN}"
+: >"${GH_LOG}"
+: >"${CURL_PAYLOADS}"
+
+cat >"${FAKE_BIN}/git" <<'EOF_GIT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$*" in
+  "describe --tags --abbrev=0 HEAD^")
+    printf '%s\n' 'v1.2.2'
+    ;;
+  "log -1 --format=%cI v1.2.2")
+    printf '%s\n' '2026-07-01T00:00:00+00:00'
+    ;;
+  "log v1.2.2..HEAD --format=%H%x1f%s%x1f%an%x1f%ae --no-merges")
+    printf 'abc123\x1ffix(cli): local subject\x1fAlice\x1falice@example.com\n'
+    printf 'bump456\x1fchore: bump version to 1.2.3\x1fRelease Bot\x1fbot@example.com\n'
+    ;;
+  *)
+    printf 'unexpected git invocation: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
+EOF_GIT
+
+cat >"${FAKE_BIN}/gh" <<'EOF_GH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"${FAKE_GH_LOG:?}"
+case "$*" in
+  "api repos/acme/tokscale/commits/abc123/pulls")
+    printf '%s\n' '[{"number":77,"title":"fix(cli): keep release notifications deterministic","state":"closed","merged_at":"2026-07-02T00:00:00Z","user":{"login":"alice"}}]'
+    ;;
+  "pr list --repo acme/tokscale --state merged --author alice --json number,mergedAt --limit 200")
+    printf '%s\n' '[{"number":77,"mergedAt":"2026-07-02T00:00:00Z"}]'
+    ;;
+  *)
+    printf 'unexpected gh invocation: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
+EOF_GH
+
+cat >"${FAKE_BIN}/curl" <<'EOF_CURL'
+#!/usr/bin/env bash
+set -euo pipefail
+
+payload=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -sf)
+      ;;
+    -H)
+      shift
+      [ "${1:-}" = "Content-Type: application/json" ] || exit 1
+      ;;
+    -d)
+      shift
+      payload="${1:-}"
+      ;;
+    https://discord.invalid/webhook)
+      url="$1"
+      ;;
+    *)
+      printf 'unexpected curl argument: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+[ -n "${payload}" ] || { echo "curl payload is missing" >&2; exit 1; }
+[ "${url}" = "https://discord.invalid/webhook" ] || { echo "curl URL is missing" >&2; exit 1; }
+printf '%s\n' "${payload}" >>"${FAKE_CURL_PAYLOADS:?}"
+EOF_CURL
+
+chmod +x "${FAKE_BIN}/git" "${FAKE_BIN}/gh" "${FAKE_BIN}/curl"
+
+export PATH="${FAKE_BIN}:${PATH}"
+export GITHUB_REPOSITORY="acme/tokscale"
+export FAKE_GH_LOG="${GH_LOG}"
+export FAKE_CURL_PAYLOADS="${CURL_PAYLOADS}"
+
+assert_contains() {
+  local text="$1"
+  local expected="$2"
+  if ! grep -Fq -- "${expected}" <<<"${text}"; then
+    printf 'expected output to contain: %s\n' "${expected}" >&2
+    return 1
+  fi
+}
+
+assert_excludes() {
+  local text="$1"
+  local unexpected="$2"
+  if grep -Fq -- "${unexpected}" <<<"${text}"; then
+    printf 'expected output to exclude: %s\n' "${unexpected}" >&2
+    return 1
+  fi
+}
+
+cd "${ROOT_DIR}"
+notes="$(bun scripts/generate-release-notes.ts 1.2.3)"
+assert_contains "${notes}" '<div align="center">'
+assert_contains "${notes}" '# `tokscale@v1.2.3` is here!'
+assert_contains "${notes}" '* fix(cli): keep release notifications deterministic by @alice in https://github.com/acme/tokscale/pull/77'
+assert_contains "${notes}" '* @alice made their first contribution in https://github.com/acme/tokscale/pull/77'
+assert_contains "${notes}" '**Full Changelog**: https://github.com/acme/tokscale/compare/v1.2.2...v1.2.3'
+assert_excludes "${notes}" 'chore: bump version'
+
+DISCORD_WEBHOOK_URL="https://discord.invalid/webhook" \
+  bash scripts/post-discord-release.sh 1.2.3 >"${TMP_DIR}/discord-output.txt"
+
+jq -s -e 'length == 1' "${CURL_PAYLOADS}" >/dev/null
+content="$(jq -r -s '.[0].content' "${CURL_PAYLOADS}")"
+assert_contains "${content}" '## `tokscale@v1.2.3` is here!'
+assert_contains "${content}" '* fix(cli): keep release notifications deterministic by @alice in https://github.com/acme/tokscale/pull/77'
+assert_contains "${content}" '* @alice made their first contribution in https://github.com/acme/tokscale/pull/77'
+assert_contains "${content}" '**Full Changelog**: https://github.com/acme/tokscale/compare/v1.2.2...v1.2.3'
+assert_excludes "${content}" '<div'
+assert_excludes "${content}" '.github/assets/hero-v2.png'
+if grep -Fxq '# `tokscale@v1.2.3` is here!' <<<"${content}"; then
+  echo "Discord content retained the release-note H1" >&2
+  exit 1
+fi
+
+grep -Fxq 'api repos/acme/tokscale/commits/abc123/pulls' "${GH_LOG}"
+grep -Fxq 'pr list --repo acme/tokscale --state merged --author alice --json number,mergedAt --limit 200' "${GH_LOG}"
+
+echo "release notes and Discord notification tests passed"

--- a/scripts/test-release-workflow-safety.sh
+++ b/scripts/test-release-workflow-safety.sh
@@ -258,6 +258,56 @@ PY
   grep -q "publish workflow must reject non-default branch dispatches" "${output}"
 }
 
+test_rejects_escaped_conditional_default_branch_gate_step() {
+  local work="${TMP_DIR}/escaped-conditional-default-branch-gate"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/publish-cli.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace(
+    "      - name: Require the default branch\n",
+    '      - name: Require the default branch\n        "\\u0069f": false\n',
+    1,
+)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/escaped-conditional-default-branch-gate-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to reject an escaped conditional default-branch gate" >&2
+    return 1
+  fi
+
+  grep -q "publish workflow must reject non-default branch dispatches" "${output}"
+}
+
+test_rejects_hex_escaped_conditional_default_branch_gate_step() {
+  local work="${TMP_DIR}/hex-escaped-conditional-default-branch-gate"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/publish-cli.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace(
+    "      - name: Require the default branch\n",
+    '      - name: Require the default branch\n        "\\x69f": false\n',
+    1,
+)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/hex-escaped-conditional-default-branch-gate-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to reject a hex-escaped conditional default-branch gate" >&2
+    return 1
+  fi
+
+  grep -q "publish workflow must reject non-default branch dispatches" "${output}"
+}
+
 test_rejects_ignored_default_branch_gate_failure() {
   local work="${TMP_DIR}/ignored-default-branch-gate"
   write_good_workflows "${work}"
@@ -302,6 +352,31 @@ PY
   local output="${TMP_DIR}/quoted-ignored-default-branch-gate-output.txt"
   if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
     echo "Expected workflow safety check to reject a quoted ignored default-branch gate failure" >&2
+    return 1
+  fi
+
+  grep -q "publish workflow must reject non-default branch dispatches" "${output}"
+}
+
+test_rejects_hex_escaped_ignored_default_branch_gate_failure() {
+  local work="${TMP_DIR}/hex-escaped-ignored-default-branch-gate"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/publish-cli.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace(
+    "      - name: Require the default branch\n",
+    '      - name: Require the default branch\n        "continue\\x2don\\x2derror": true\n',
+    1,
+)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/hex-escaped-ignored-default-branch-gate-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to reject a hex-escaped ignored default-branch gate failure" >&2
     return 1
   fi
 
@@ -882,8 +957,11 @@ test_rejects_publish_without_default_branch_gate
 test_rejects_default_branch_gate_without_failure
 test_rejects_conditional_default_branch_gate_step
 test_rejects_quoted_conditional_default_branch_gate_step
+test_rejects_escaped_conditional_default_branch_gate_step
+test_rejects_hex_escaped_conditional_default_branch_gate_step
 test_rejects_ignored_default_branch_gate_failure
 test_rejects_quoted_ignored_default_branch_gate_failure
+test_rejects_hex_escaped_ignored_default_branch_gate_failure
 test_rejects_nested_default_branch_gate_env
 test_rejects_inexact_default_branch_gate_env_value
 test_rejects_default_branch_gate_exit_after_first_fi

--- a/scripts/test-release-workflow-safety.sh
+++ b/scripts/test-release-workflow-safety.sh
@@ -187,6 +187,77 @@ PY
   grep -q "publish workflow must reject non-default branch dispatches" "${output}"
 }
 
+test_rejects_default_branch_gate_without_failure() {
+  local work="${TMP_DIR}/non-failing-default-branch-gate"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/publish-cli.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace("            exit 1\n", "            echo rejected\n", 1)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/non-failing-default-branch-gate-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to reject a non-failing default-branch gate" >&2
+    return 1
+  fi
+
+  grep -q "publish workflow must reject non-default branch dispatches" "${output}"
+}
+
+test_rejects_conditional_default_branch_gate_step() {
+  local work="${TMP_DIR}/conditional-default-branch-gate"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/publish-cli.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace(
+    "      - name: Require the default branch\n",
+    "      - name: Require the default branch\n        if: false\n",
+    1,
+)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/conditional-default-branch-gate-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to reject a conditional default-branch gate" >&2
+    return 1
+  fi
+
+  grep -q "publish workflow must reject non-default branch dispatches" "${output}"
+}
+
+test_rejects_ignored_default_branch_gate_failure() {
+  local work="${TMP_DIR}/ignored-default-branch-gate"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/publish-cli.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace(
+    "      - name: Require the default branch\n",
+    "      - name: Require the default branch\n        continue-on-error: true\n",
+    1,
+)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/ignored-default-branch-gate-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to reject an ignored default-branch gate failure" >&2
+    return 1
+  fi
+
+  grep -q "publish workflow must reject non-default branch dispatches" "${output}"
+}
+
 test_accepts_workflows_without_android_platform() {
   local work="${TMP_DIR}/without-android"
   write_good_workflows "${work}"
@@ -683,6 +754,9 @@ PY
 
 test_accepts_matching_publish_and_native_workflows
 test_rejects_publish_without_default_branch_gate
+test_rejects_default_branch_gate_without_failure
+test_rejects_conditional_default_branch_gate_step
+test_rejects_ignored_default_branch_gate_failure
 test_accepts_workflows_without_android_platform
 test_accepts_yaml_comments_and_manifest_path_quote_styles
 test_reads_workflows_as_utf8_when_locale_is_non_utf8

--- a/scripts/test-release-workflow-safety.sh
+++ b/scripts/test-release-workflow-safety.sh
@@ -233,6 +233,31 @@ PY
   grep -q "publish workflow must reject non-default branch dispatches" "${output}"
 }
 
+test_rejects_quoted_conditional_default_branch_gate_step() {
+  local work="${TMP_DIR}/quoted-conditional-default-branch-gate"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/publish-cli.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace(
+    "      - name: Require the default branch\n",
+    "      - name: Require the default branch\n        \"if\": false\n",
+    1,
+)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/quoted-conditional-default-branch-gate-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to reject a quoted conditional default-branch gate" >&2
+    return 1
+  fi
+
+  grep -q "publish workflow must reject non-default branch dispatches" "${output}"
+}
+
 test_rejects_ignored_default_branch_gate_failure() {
   local work="${TMP_DIR}/ignored-default-branch-gate"
   write_good_workflows "${work}"
@@ -252,6 +277,106 @@ PY
   local output="${TMP_DIR}/ignored-default-branch-gate-output.txt"
   if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
     echo "Expected workflow safety check to reject an ignored default-branch gate failure" >&2
+    return 1
+  fi
+
+  grep -q "publish workflow must reject non-default branch dispatches" "${output}"
+}
+
+test_rejects_quoted_ignored_default_branch_gate_failure() {
+  local work="${TMP_DIR}/quoted-ignored-default-branch-gate"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/publish-cli.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace(
+    "      - name: Require the default branch\n",
+    "      - name: Require the default branch\n        'continue-on-error': true\n",
+    1,
+)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/quoted-ignored-default-branch-gate-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to reject a quoted ignored default-branch gate failure" >&2
+    return 1
+  fi
+
+  grep -q "publish workflow must reject non-default branch dispatches" "${output}"
+}
+
+test_rejects_nested_default_branch_gate_env() {
+  local work="${TMP_DIR}/nested-default-branch-gate-env"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/publish-cli.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace(
+    "        env:\n          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}\n          RELEASE_REF_NAME: ${{ github.ref_name }}\n          RELEASE_REF_TYPE: ${{ github.ref_type }}\n",
+    "        env:\n          NESTED:\n            DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}\n            RELEASE_REF_NAME: ${{ github.ref_name }}\n            RELEASE_REF_TYPE: ${{ github.ref_type }}\n",
+    1,
+)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/nested-default-branch-gate-env-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to reject nested default-branch gate environment values" >&2
+    return 1
+  fi
+
+  grep -q "publish workflow must reject non-default branch dispatches" "${output}"
+}
+
+test_rejects_inexact_default_branch_gate_env_value() {
+  local work="${TMP_DIR}/inexact-default-branch-gate-env"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/publish-cli.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace(
+    "          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}\n",
+    "          DEFAULT_BRANCH: prefix-${{ github.event.repository.default_branch }}\n",
+    1,
+)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/inexact-default-branch-gate-env-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to reject an inexact default-branch environment value" >&2
+    return 1
+  fi
+
+  grep -q "publish workflow must reject non-default branch dispatches" "${output}"
+}
+
+test_rejects_default_branch_gate_exit_after_first_fi() {
+  local work="${TMP_DIR}/late-default-branch-gate-exit"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/publish-cli.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace(
+    "            exit 1\n          fi\n",
+    "            echo rejected\n          fi\n          exit 1\n          fi\n",
+    1,
+)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/late-default-branch-gate-exit-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to require exit 1 before the guard's first fi" >&2
     return 1
   fi
 
@@ -756,7 +881,12 @@ test_accepts_matching_publish_and_native_workflows
 test_rejects_publish_without_default_branch_gate
 test_rejects_default_branch_gate_without_failure
 test_rejects_conditional_default_branch_gate_step
+test_rejects_quoted_conditional_default_branch_gate_step
 test_rejects_ignored_default_branch_gate_failure
+test_rejects_quoted_ignored_default_branch_gate_failure
+test_rejects_nested_default_branch_gate_env
+test_rejects_inexact_default_branch_gate_env_value
+test_rejects_default_branch_gate_exit_after_first_fi
 test_accepts_workflows_without_android_platform
 test_accepts_yaml_comments_and_manifest_path_quote_styles
 test_reads_workflows_as_utf8_when_locale_is_non_utf8

--- a/scripts/test-release-workflow-safety.sh
+++ b/scripts/test-release-workflow-safety.sh
@@ -105,6 +105,17 @@ EOF_YAML
 name: Publish
 
 jobs:
+  bump-versions:
+    steps:
+      - name: Require the default branch
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RELEASE_REF_NAME: ${{ github.ref_name }}
+          RELEASE_REF_TYPE: ${{ github.ref_type }}
+        run: |
+          if [[ "$RELEASE_REF_TYPE" != "branch" || "$RELEASE_REF_NAME" != "$DEFAULT_BRANCH" ]]; then
+            exit 1
+          fi
   build-cli-binary:
     needs: bump-versions
     uses: ./.github/workflows/build-native.yml
@@ -149,6 +160,31 @@ test_accepts_matching_publish_and_native_workflows() {
   )
 
   grep -q "Release workflow safety OK" "${TMP_DIR}/good-output.txt"
+}
+
+test_rejects_publish_without_default_branch_gate() {
+  local work="${TMP_DIR}/missing-default-branch-gate"
+  write_good_workflows "${work}"
+  python3 - "${work}/.github/workflows/publish-cli.yml" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text().replace(
+    "          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}\n",
+    "",
+    1,
+)
+path.write_text(text)
+PY
+
+  local output="${TMP_DIR}/missing-default-branch-gate-output.txt"
+  if (cd "${work}" && python3 "${SCRIPT_UNDER_TEST}" >"${output}" 2>&1); then
+    echo "Expected workflow safety check to reject a missing default-branch gate" >&2
+    return 1
+  fi
+
+  grep -q "publish workflow must reject non-default branch dispatches" "${output}"
 }
 
 test_accepts_workflows_without_android_platform() {
@@ -646,6 +682,7 @@ PY
 }
 
 test_accepts_matching_publish_and_native_workflows
+test_rejects_publish_without_default_branch_gate
 test_accepts_workflows_without_android_platform
 test_accepts_yaml_comments_and_manifest_path_quote_styles
 test_reads_workflows_as_utf8_when_locale_is_non_utf8


### PR DESCRIPTION
## Summary

- route frontend tests, migration replay, frontend container smoke, and TUI container smoke through independent target-specific workflows
- add dedicated Python bridge, release-helper, and workflow-lint checks
- narrow Rust coverage/native triggers, isolate main-only coverage write permission, and cancel stale PR runs
- reject release publishing from non-default branches and preserve that invariant with regression coverage

## Why

The old Frontend CI grouped unrelated jobs behind one broad path filter. A README-only translation PR therefore ran Vitest, PostgreSQL migration replay, and two Docker builds, with the container work taking roughly 10–14 minutes per run. Other workflows also had the inverse problem: launcher validation omitted Rust sources it compiles, container scripts could change without exercising their smoke tests, and the Python bridge had tests that no workflow ran.

The new split follows the files and commands each target actually consumes. README-only and localized documentation changes now select no expensive workflow.

## Validation

- `actionlint -color`
- pinned Actionlint Docker image used by Workflow Lint
- parsed every workflow with the repository's YAML parser
- representative path-routing matrix (README, frontend tests/runtime/migrations, Dockerfiles, Rust crates, launcher config, Python bridge, release scripts, workflow files)
- `git diff --check`
- `python3 scripts/check-release-workflow-safety.py`
- all release helper test suites
- `python3 -m pytest scripts/test_9router_tokscale_bridge_gjc.py` (62 passed)
- `bash scripts/test-tui-mounts.sh`
- frontend Vitest (84 files, 822 tests)
- frontend TypeScript typecheck

## Operational note

These leaf workflows use path filters. The repository currently has no required checks or rulesets. If branch protection is introduced later, use an always-created aggregate gate rather than requiring path-filtered leaf checks individually.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes CI checks by changed targets to cut wasted runs and strengthens release safety by enforcing default-branch publishing and catching escaped workflow keys. Keeps coverage writes on `main` only.

- **New Features**
  - Target-specific workflows: frontend tests/typecheck, frontend migration replay, frontend container smoke, TUI container smoke, and Python bridge tests; workflow lint via pinned `actionlint`.
  - Release validation: enforces default-branch-only publish, validates topology, decodes quoted/escaped YAML keys, and adds release-notes/Discord tests.

- **Refactors**
  - Aligned path/branch filters with tested targets (drop `develop`); exclude docs/tests where safe; include `.npmrc` and package manifests where needed.
  - Split frontend CI and moved container builds to dedicated Makefile-backed jobs pinned to the Docker engine.
  - Separated Rust tests from coverage; badge writes only on `main`; manual coverage kept on `main`; tightened permissions and canceled stale PR runs via concurrency.
  - Moved release safety check out of `build-native` into Release Validation; `.dockerignore` now ignores `**/__tests__/`.

<sup>Written for commit dddae6b331905c9719d492061d73a8a2fa8af810. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

