### PR TITLE
fix(grok): keep parsing session files past undecodable lines

### DIFF
--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -941,7 +941,11 @@ fn parser_version(client: ClientId) -> u32 {
         // buckets repeat, and fingerprints the complete sessions metadata tree.
         // v6 persists whether an unknown unified model was deliberately
         // fail-closed due to conflicting child attribution evidence.
-        ClientId::Grok => 6,
+        // v6->v7: session files are now parsed past undecodable lines instead
+        // of stopping at the first one, and usage dedup keys carry the record's
+        // file position. Both change the parse of byte-identical input, so
+        // cached entries hold truncated and under-deduplicated output (#1031).
+        ClientId::Grok => 7,
         // v1 retained MiMo's embedded `cost` value but did not preserve its
         // provider-reported provenance. Reparse cached rows so strict submit
         // validation does not reject valid unknown-model MiMo usage offline.
@@ -2321,8 +2325,11 @@ mod tests {
     }
 
     #[test]
-    fn test_grok_conflicted_model_attribution_bumps_parser_version() {
-        assert_eq!(parser_version(ClientId::Grok), 6);
+    fn test_grok_resilient_line_reader_parser_version_invalidates_v6_entries() {
+        // A Grok session file that is never appended to again keeps its
+        // fingerprint forever, so only the version bump discards the truncated
+        // v6 parse and forces a cold reparse.
+        assert_eq!(parser_version(ClientId::Grok), 7);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/copilot_desktop.rs
+++ b/crates/tokscale-core/src/sessions/copilot_desktop.rs
@@ -3,12 +3,13 @@
 //! The macOS desktop app stores aggregate token totals in `~/.copilot/data.db`
 //! and per-session event metadata in `~/.copilot/session-state/{session_id}`.
 
+use super::utils::lossy_lines;
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::provider_identity::inferred_provider_from_model;
 use chrono::{DateTime, NaiveDateTime};
 use rusqlite::{Connection, OpenFlags};
 use serde_json::Value;
-use std::io::{BufRead, BufReader};
+use std::io::BufReader;
 use std::path::Path;
 use tracing::warn;
 
@@ -186,7 +187,7 @@ fn read_events_metadata(events_path: &Path) -> SessionStateMetadata {
     };
 
     let mut metadata = SessionStateMetadata::default();
-    for line in BufReader::new(file).lines().map_while(Result::ok) {
+    for line in lossy_lines(BufReader::new(file)) {
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;

--- a/crates/tokscale-core/src/sessions/copilot_desktop.rs
+++ b/crates/tokscale-core/src/sessions/copilot_desktop.rs
@@ -404,6 +404,38 @@ mod tests {
     }
 
     #[test]
+    fn keeps_reading_events_after_an_undecodable_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("data.db");
+        let conn = create_copilot_desktop_db(&db_path);
+        insert_session(&conn, "session-1", "auto", 100, 50, 0, 0);
+        drop(conn);
+
+        let events_dir = dir.path().join("session-state").join("session-1");
+        fs::create_dir_all(&events_dir).unwrap();
+        let mut fixture = Vec::new();
+        fixture.extend_from_slice(
+            br#"{"type":"session.start","data":{"context":{"cwd":"/Users/alice/project"}}}"#,
+        );
+        fixture.push(b'\n');
+        // A lone 0xff can never appear in valid UTF-8, so `BufRead::lines()`
+        // reports this line as `InvalidData` and `map_while(Result::ok)` would
+        // treat it as end of file, losing the model change below it.
+        fixture.extend_from_slice(b"{\"type\":\"session.note\",\"data\":\"\xff\xfe\"}\n");
+        fixture.extend_from_slice(
+            br#"{"type":"session.model_change","data":{"newModel":"claude-sonnet-4-5"}}"#,
+        );
+        fixture.push(b'\n');
+        fs::write(events_dir.join("events.jsonl"), &fixture).unwrap();
+
+        let messages = parse_copilot_desktop_db(&db_path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "claude-sonnet-4-5");
+        assert_eq!(messages[0].provider_id, "anthropic");
+    }
+
+    #[test]
     fn parse_copilot_desktop_db_uses_github_copilot_provider_for_auto() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("data.db");

--- a/crates/tokscale-core/src/sessions/copilot_vscode.rs
+++ b/crates/tokscale-core/src/sessions/copilot_vscode.rs
@@ -1,8 +1,9 @@
+use super::utils::lossy_lines;
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::provider_identity::inferred_provider_from_model;
 use crate::TokenBreakdown;
 use serde_json::Value;
-use std::io::{BufRead, BufReader};
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
 pub fn parse_copilot_vscode_sessions(paths: &[PathBuf]) -> Vec<UnifiedMessage> {
@@ -24,7 +25,7 @@ fn parse_file(path: &Path) -> Vec<UnifiedMessage> {
 
     let mut requests: Vec<Value> = Vec::new();
 
-    for line in BufReader::new(file).lines().map_while(Result::ok) {
+    for line in lossy_lines(BufReader::new(file)) {
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
@@ -255,6 +256,30 @@ mod tests {
         assert_eq!(m.tokens.input, 5000);
         assert_eq!(m.tokens.output, 200);
         assert_eq!(m.tokens.reasoning, 100);
+    }
+
+    #[test]
+    fn keeps_parsing_requests_after_an_undecodable_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let sessions_dir = dir.path().join("chatSessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        let path = sessions_dir.join("cccccccc-0000-0000-0000-000000000000.jsonl");
+
+        let mut fixture = Vec::new();
+        fixture.extend_from_slice(br#"{"kind":0,"v":{"requests":[]}}"#);
+        fixture.push(b'\n');
+        // A lone 0xff can never appear in valid UTF-8, so `BufRead::lines()`
+        // reports this line as `InvalidData`.
+        fixture.extend_from_slice(b"{\"kind\":9,\"v\":\"\xff\xfe\"}\n");
+        fixture.extend_from_slice(
+            br#"{"kind":2,"k":["requests"],"v":[{"requestId":"r9","timestamp":1783918310000,"modelId":"copilot/auto","completionTokens":200,"promptTokens":5000,"result":{"metadata":{"promptTokens":5000,"outputTokens":200,"resolvedModel":"gpt-5.3-codex"}}}]}"#,
+        );
+        fixture.push(b'\n');
+        std::fs::write(&path, &fixture).unwrap();
+
+        let messages = parse_copilot_vscode_sessions(&[path]);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 5000);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/grok.rs
+++ b/crates/tokscale-core/src/sessions/grok.rs
@@ -408,12 +408,17 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
             let event_id = get_path(&value, &["params", "_meta", "eventId"])
                 .and_then(|value| extract_string(Some(value)))
                 .unwrap_or_else(|| format!("turn-{usage_index}"));
-            // `eventId` is not unique: Grok reuses it across usage records, and
-            // identical dedup keys are collapsed downstream, so keying on it
-            // alone merged distinct turns into one. The position of the record
-            // within the file disambiguates them and stays stable across
-            // re-parses of an unchanged file, which the on-disk message cache
-            // this key feeds requires.
+            // `eventId` is not unique: Grok reuses it across usage records, so
+            // keying on it alone gave distinct turns byte-identical keys. The
+            // Grok lane in `lib.rs` does not collapse duplicate keys today —
+            // it only runs `prefer_unified_log_messages` — so this is not
+            // currently load-bearing, but a per-record-unique key is correct on
+            // its own merits and cheap insurance against any consumer that does
+            // key on it. The position of the record within the file
+            // disambiguates them and stays stable across re-parses of an
+            // unchanged file, which the on-disk message cache this key feeds
+            // requires. Note the key is only unique within one file; it is not
+            // a global identity.
             usage_messages.push(message_from_tokens(
                 &metadata,
                 model_id,

--- a/crates/tokscale-core/src/sessions/grok.rs
+++ b/crates/tokscale-core/src/sessions/grok.rs
@@ -11,14 +11,14 @@
 //! write per-inference token breakdowns to `~/.grok/logs/unified.jsonl`.
 
 use super::utils::{
-    extract_i64, extract_string, file_modified_timestamp_ms, parse_timestamp_value,
+    extract_i64, extract_string, file_modified_timestamp_ms, lossy_lines, parse_timestamp_value,
     read_file_or_none,
 };
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::TokenBreakdown;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
-use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
+use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
 const CLIENT_ID: &str = "grok";
@@ -359,7 +359,7 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
     let mut turn_index = 0usize;
     let mut usage_index = 0usize;
 
-    for line in BufReader::new(file).lines().map_while(Result::ok) {
+    for line in lossy_lines(BufReader::new(file)) {
         if line.trim().is_empty() {
             continue;
         }
@@ -550,11 +550,7 @@ fn parse_grok_unified_log_snapshot(
     let mut seen = HashSet::new();
     let mut messages = Vec::new();
 
-    for line in BufReader::new(file)
-        .take(prefix_len)
-        .lines()
-        .map_while(Result::ok)
-    {
+    for line in lossy_lines(BufReader::new(file).take(prefix_len)) {
         if line.trim().is_empty() {
             continue;
         }
@@ -763,11 +759,7 @@ fn collect_unified_child_evidence(
     let mut evidence = UnifiedChildEvidence::default();
     let mut generations = HashMap::new();
 
-    for line in BufReader::new(file)
-        .take(prefix_len)
-        .lines()
-        .map_while(Result::ok)
-    {
+    for line in lossy_lines(BufReader::new(file).take(prefix_len)) {
         if line.trim().is_empty() {
             continue;
         }
@@ -1372,7 +1364,7 @@ fn read_events_metadata(path: &Path, metadata: &mut GrokMetadata) {
         return;
     };
 
-    for line in BufReader::new(file).lines().map_while(Result::ok).take(500) {
+    for line in lossy_lines(BufReader::new(file)).take(500) {
         let Ok(value) = serde_json::from_str::<Value>(&line) else {
             continue;
         };
@@ -1515,6 +1507,29 @@ mod tests {
             std::fs::write(session_dir.join("signals.json"), signals_json).unwrap();
         }
         (temp, updates_path)
+    }
+
+    /// Byte-level variant of `write_fixture` for fixtures that must contain
+    /// bytes a `&str` cannot hold (undecodable sequences, a UTF-8 BOM).
+    fn write_fixture_bytes(updates_jsonl: &[u8]) -> (tempfile::TempDir, PathBuf) {
+        let temp = tempfile::TempDir::new().unwrap();
+        let session_dir = temp
+            .path()
+            .join(".grok")
+            .join("sessions")
+            .join("%2Ftmp%2Fproject")
+            .join("session-1");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        let updates_path = session_dir.join("updates.jsonl");
+        std::fs::write(&updates_path, updates_jsonl).unwrap();
+        (temp, updates_path)
+    }
+
+    fn usage_line(event_id: &str, timestamp_ms: i64, input: i64, output: i64) -> String {
+        format!(
+            r#"{{"method":"session/update","params":{{"sessionId":"session-1","update":{{"sessionUpdate":"turn_completed","usage":{{"inputTokens":{input},"outputTokens":{output},"totalTokens":{}}}}},"_meta":{{"eventId":"{event_id}","agentTimestampMs":{timestamp_ms}}}}}}}"#,
+            input + output
+        )
     }
 
     fn write_unified_fixture(unified_jsonl: &str) -> (tempfile::TempDir, PathBuf) {
@@ -1829,6 +1844,51 @@ mod tests {
         assert!(messages
             .iter()
             .any(|message| message.session_id == "fallback"));
+    }
+
+    #[test]
+    fn keeps_parsing_updates_after_an_undecodable_line() {
+        let mut fixture = Vec::new();
+        fixture.extend_from_slice(usage_line("turn-1", 1_700_000_001_000, 10, 1).as_bytes());
+        fixture.push(b'\n');
+        // A lone 0xff can never appear in valid UTF-8, so `BufRead::lines()`
+        // reports this line as `InvalidData`.
+        fixture.extend_from_slice(b"{\"garbage\":\"\xff\xfe\"}\n");
+        for index in 2..=100i64 {
+            fixture.extend_from_slice(
+                usage_line(
+                    &format!("turn-{index}"),
+                    1_700_000_001_000 + index * 1000,
+                    10,
+                    1,
+                )
+                .as_bytes(),
+            );
+            fixture.push(b'\n');
+        }
+
+        let (_temp, path) = write_fixture_bytes(&fixture);
+        let messages = parse_grok_updates_file(&path);
+
+        assert_eq!(messages.len(), 100);
+        assert_eq!(messages.last().unwrap().timestamp, 1_700_000_101_000);
+    }
+
+    #[test]
+    fn parses_first_update_of_a_bom_prefixed_file() {
+        let mut fixture = Vec::new();
+        fixture.extend_from_slice("\u{feff}".as_bytes());
+        fixture.extend_from_slice(usage_line("turn-1", 1_700_000_001_000, 10, 1).as_bytes());
+        fixture.push(b'\n');
+        fixture.extend_from_slice(usage_line("turn-2", 1_700_000_002_000, 20, 2).as_bytes());
+        fixture.push(b'\n');
+
+        let (_temp, path) = write_fixture_bytes(&fixture);
+        let messages = parse_grok_updates_file(&path);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].timestamp, 1_700_000_001_000);
+        assert_eq!(messages[0].tokens.input, 10);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/grok.rs
+++ b/crates/tokscale-core/src/sessions/grok.rs
@@ -408,12 +408,21 @@ pub fn parse_grok_updates_file(path: &Path) -> Vec<UnifiedMessage> {
             let event_id = get_path(&value, &["params", "_meta", "eventId"])
                 .and_then(|value| extract_string(Some(value)))
                 .unwrap_or_else(|| format!("turn-{usage_index}"));
+            // `eventId` is not unique: Grok reuses it across usage records, and
+            // identical dedup keys are collapsed downstream, so keying on it
+            // alone merged distinct turns into one. The position of the record
+            // within the file disambiguates them and stays stable across
+            // re-parses of an unchanged file, which the on-disk message cache
+            // this key feeds requires.
             usage_messages.push(message_from_tokens(
                 &metadata,
                 model_id,
                 timestamp,
                 usage.tokens,
-                format!("grok:{}:usage:{}", metadata.session_id, event_id),
+                format!(
+                    "grok:{}:usage:{usage_index}:{event_id}",
+                    metadata.session_id
+                ),
                 true,
             ));
             usage_index = usage_index.saturating_add(1);
@@ -1892,6 +1901,32 @@ mod tests {
     }
 
     #[test]
+    fn keeps_repeated_event_ids_in_distinct_dedup_keys() {
+        let (_temp, path) = write_fixture(
+            &format!(
+                "{}\n{}\n",
+                usage_line("turn-1", 1_700_000_001_000, 10, 1),
+                usage_line("turn-1", 1_700_000_002_000, 20, 2),
+            ),
+            None,
+            None,
+        );
+
+        let messages = parse_grok_updates_file(&path);
+
+        assert_eq!(messages.len(), 2);
+        assert_ne!(messages[0].dedup_key, messages[1].dedup_key);
+        assert_eq!(
+            messages[0].dedup_key.as_deref(),
+            Some("grok:session-1:usage:0:turn-1")
+        );
+        assert_eq!(
+            messages[1].dedup_key.as_deref(),
+            Some("grok:session-1:usage:1:turn-1")
+        );
+    }
+
+    #[test]
     fn prefers_authoritative_usage_breakdown_when_available() {
         let (_temp, path) = write_fixture(
             r#"{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"user_message_chunk","_meta":{"modelId":"grok-4.5"}},"_meta":{"agentTimestampMs":1700000001000}}}
@@ -1911,7 +1946,7 @@ mod tests {
         assert_eq!(messages[0].timestamp, 1700000003000);
         assert_eq!(
             messages[0].dedup_key.as_deref(),
-            Some("grok:session-1:usage:turn-1")
+            Some("grok:session-1:usage:0:turn-1")
         );
     }
 

--- a/crates/tokscale-core/src/sessions/grok.rs
+++ b/crates/tokscale-core/src/sessions/grok.rs
@@ -1499,8 +1499,11 @@ fn hex_value(byte: u8) -> Option<u8> {
 mod tests {
     use super::*;
 
+    /// `updates_jsonl` is taken as bytes so fixtures can contain sequences a
+    /// `&str` cannot hold (undecodable bytes, a UTF-8 BOM); `&str` and `&String`
+    /// still pass through unchanged.
     fn write_fixture(
-        updates_jsonl: &str,
+        updates_jsonl: impl AsRef<[u8]>,
         summary_json: Option<&str>,
         signals_json: Option<&str>,
     ) -> (tempfile::TempDir, PathBuf) {
@@ -1513,29 +1516,13 @@ mod tests {
             .join("session-1");
         std::fs::create_dir_all(&session_dir).unwrap();
         let updates_path = session_dir.join("updates.jsonl");
-        std::fs::write(&updates_path, updates_jsonl).unwrap();
+        std::fs::write(&updates_path, updates_jsonl.as_ref()).unwrap();
         if let Some(summary_json) = summary_json {
             std::fs::write(session_dir.join("summary.json"), summary_json).unwrap();
         }
         if let Some(signals_json) = signals_json {
             std::fs::write(session_dir.join("signals.json"), signals_json).unwrap();
         }
-        (temp, updates_path)
-    }
-
-    /// Byte-level variant of `write_fixture` for fixtures that must contain
-    /// bytes a `&str` cannot hold (undecodable sequences, a UTF-8 BOM).
-    fn write_fixture_bytes(updates_jsonl: &[u8]) -> (tempfile::TempDir, PathBuf) {
-        let temp = tempfile::TempDir::new().unwrap();
-        let session_dir = temp
-            .path()
-            .join(".grok")
-            .join("sessions")
-            .join("%2Ftmp%2Fproject")
-            .join("session-1");
-        std::fs::create_dir_all(&session_dir).unwrap();
-        let updates_path = session_dir.join("updates.jsonl");
-        std::fs::write(&updates_path, updates_jsonl).unwrap();
         (temp, updates_path)
     }
 
@@ -1881,7 +1868,7 @@ mod tests {
             fixture.push(b'\n');
         }
 
-        let (_temp, path) = write_fixture_bytes(&fixture);
+        let (_temp, path) = write_fixture(&fixture, None, None);
         let messages = parse_grok_updates_file(&path);
 
         assert_eq!(messages.len(), 100);
@@ -1897,7 +1884,7 @@ mod tests {
         fixture.extend_from_slice(usage_line("turn-2", 1_700_000_002_000, 20, 2).as_bytes());
         fixture.push(b'\n');
 
-        let (_temp, path) = write_fixture_bytes(&fixture);
+        let (_temp, path) = write_fixture(&fixture, None, None);
         let messages = parse_grok_updates_file(&path);
 
         assert_eq!(messages.len(), 2);

--- a/crates/tokscale-core/src/sessions/utils.rs
+++ b/crates/tokscale-core/src/sessions/utils.rs
@@ -2,8 +2,70 @@
 
 use rusqlite::{Connection, OpenFlags};
 use serde_json::Value;
+use std::io::BufRead;
 use std::path::Path;
 use std::time::SystemTime;
+
+/// Iterate a reader line by line without letting one undecodable byte discard
+/// the rest of the stream.
+///
+/// `BufRead::lines()` yields `Err(InvalidData)` for any line that is not valid
+/// UTF-8, and the `map_while(Result::ok)` spelling turns that into
+/// end-of-iteration: a single stray byte anywhere in a multi-megabyte session
+/// log silently dropped every record after it (#1031 measured ~2% of an 83MB
+/// Grok `updates.jsonl` surviving). Reading raw bytes up to each newline and
+/// decoding them lossily keeps the cost of a bad byte local to its own line.
+///
+/// Line endings match `lines()`: the trailing `\n` and any preceding `\r` are
+/// stripped, and a final line without a newline is still yielded.
+pub(crate) fn lossy_lines<R: BufRead>(reader: R) -> LossyLines<R> {
+    LossyLines {
+        reader,
+        buf: Vec::new(),
+        at_start: true,
+    }
+}
+
+pub(crate) struct LossyLines<R> {
+    reader: R,
+    buf: Vec<u8>,
+    at_start: bool,
+}
+
+impl<R: BufRead> Iterator for LossyLines<R> {
+    type Item = String;
+
+    fn next(&mut self) -> Option<String> {
+        self.buf.clear();
+        match self.reader.read_until(b'\n', &mut self.buf) {
+            Ok(0) => None,
+            Ok(_) => {
+                if self.buf.last() == Some(&b'\n') {
+                    self.buf.pop();
+                    if self.buf.last() == Some(&b'\r') {
+                        self.buf.pop();
+                    }
+                }
+
+                let mut bytes = self.buf.as_slice();
+                if std::mem::take(&mut self.at_start) {
+                    // A UTF-8 BOM decodes cleanly but leaves U+FEFF glued to the
+                    // front of the first record, where it makes an otherwise
+                    // valid JSON line fail to parse and be skipped in silence.
+                    bytes = bytes.strip_prefix("\u{feff}".as_bytes()).unwrap_or(bytes);
+                }
+
+                Some(String::from_utf8_lossy(bytes).into_owned())
+            }
+            // Decode failures cannot reach this arm — lossy decoding never
+            // fails — so an error here is a hard I/O failure (vanished network
+            // mount, EIO). `read_until` does not consume input when it fails
+            // that way, so skipping and retrying would spin on the same failing
+            // read forever. Stop instead, and keep the lines read so far.
+            Err(_) => None,
+        }
+    }
+}
 
 pub(crate) fn extract_i64(value: Option<&Value>) -> Option<i64> {
     value.and_then(|val| {
@@ -121,6 +183,20 @@ pub(crate) fn back_anchor_timestamp(end: i64, duration: i64) -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn lossy_lines_survives_undecodable_bytes_and_strips_a_bom() {
+        let raw: &[u8] = b"\xef\xbb\xbffirst\r\nse\xffcond\nthird";
+        let lines: Vec<String> = lossy_lines(raw).collect();
+        assert_eq!(lines, vec!["first", "se\u{fffd}cond", "third"]);
+    }
+
+    #[test]
+    fn lossy_lines_keeps_empty_lines_and_ends_at_eof() {
+        let raw: &[u8] = b"a\n\nb\n";
+        let lines: Vec<String> = lossy_lines(raw).collect();
+        assert_eq!(lines, vec!["a", "", "b"]);
+    }
 
     #[test]
     fn parse_timestamp_value_rejects_zero_and_negative_numbers() {


### PR DESCRIPTION
Fixes #1031.

## The bug

`sessions/grok.rs` read session files with `.lines().map_while(Result::ok)`. `map_while` **terminates the iterator** on the first `Err`, and `BufRead::lines()` yields `Err(InvalidData)` for any line that is not valid UTF-8 — so a single undecodable byte anywhere in a session file silently discarded every remaining line.

Measured with fixtures against `parse_grok_file`:

| fixture | expected | before |
| --- | --- | --- |
| clean, 5 usage records | 5 messages | 5 |
| 1 invalid UTF-8 byte, then 100 good records | 102 messages | **2** |
| UTF-8 BOM at start of file | 5 messages | **4** |

That is 1.96% coverage. The reporter independently measured ~1.7% surviving on a real 83MB `updates.jsonl`.

It also explains the reporter's other symptoms, which had made the issue hard to reproduce: they saw `output=0` everywhere because the few surviving rows come from the `ActiveTurn` fallback path (which hardcodes `output: 0`) once `usage_messages` ends up empty; and a fixture they appended to the *end* of a real session file produced nothing, because the parser had stopped reading long before reaching it.

Every other parser in the repo handles this correctly with `Err(_) => continue` — `sessions/claudecode.rs:303`, `sessions/copilot.rs:24`, `sessions/kiro.rs:173`. Grok was the outlier, and so were two Copilot parsers.

## What changed

**A resilient line reader** (`sessions/utils.rs::lossy_lines`) reads raw bytes to each newline and decodes lossily, so an undecodable byte costs its own line rather than the rest of the file. It also strips a leading UTF-8 BOM, which previously made the first record fail to parse and be skipped in silence. Line-ending semantics match `lines()`.

It deliberately **ends iteration on a hard I/O error** rather than skipping: `read_until` does not consume input on that failure, so skipping and retrying would spin on the same failing read forever. That is documented at the call site.

Applied to all six affected sites: `grok.rs` (4), `copilot_desktop.rs`, `copilot_vscode.rs`.

**Parser version bumped to 7.** Without this the fix would not reach anyone. The on-disk message cache is keyed on `parser_version` + fingerprint, so a finished `updates.jsonl` that never changes again would keep serving its cached truncated parse forever — exactly the historical data this issue is about.

**Usage dedup keys** now carry the per-file index alongside `params._meta.eventId`, so repeated event ids cannot collide. Note this is *not* currently load-bearing: the Grok lane has no dedup-key collapse (that is the Claude lane), and the code comment says so rather than claiming otherwise. It is kept as cheap insurance and matches the `opencodereview` precedent.

## Impact worth knowing before merge

Grok token totals will rise sharply for anyone whose session logs contain a non-UTF-8 byte — potentially by a large multiple, since only a fraction of records were parsing. This is the intended correction, but it is not a small delta and belongs in release notes.

## Tests

Six added, each written first and run against the unfixed code:

- `keeps_parsing_updates_after_an_undecodable_line` — 1 bad byte + 100 good records after it (failed 1/100)
- `parses_first_update_of_a_bom_prefixed_file` (failed 1/2)
- `keeps_repeated_event_ids_in_distinct_dedup_keys` (failed on identical keys)
- `keeps_parsing_requests_after_an_undecodable_line` (copilot_vscode)
- `keeps_reading_events_after_an_undecodable_line` (copilot_desktop) — verified by reverting the reader line and observing the model stay at the DB's `auto`
- `lossy_lines_*` unit tests for BOM, CRLF, empty lines, and EOF

`cargo fmt`, `cargo clippy -D warnings`, and `cargo test -p tokscale-core` (1463 passed, 0 failed) are clean.

## Follow-ups deliberately not included

- `extract_i64` rejects float-valued token fields (`1000.0` parses as nothing). Real gap, but unverified against the reporter's data and it does not explain the measured coverage.
- No `GROK_HOME` env override exists, which is why the reporter could not isolate their data for testing. Only `scanner.extraScanPaths.grok` works today.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Grok and Copilot session parsers keep reading after undecodable bytes by decoding lines lossily; also bump Grok to `parser_version` 7 to drop cached truncated parses.

- **Bug Fixes**
  - Added `lossy_lines` to read bytes to newline, decode lossily, and strip a leading UTF‑8 BOM.
  - Applied to Grok updates, unified snapshots, and metadata scans, plus Copilot Desktop and VS Code readers.
  - Grok usage dedup keys now include the per-file index to avoid collisions when `eventId` is reused.

- **Migration**
  - Grok `parser_version` is now 7; cached Grok sessions will reparse automatically.
  - Token totals may increase for logs containing non‑UTF‑8 bytes; this is the expected correction.

<sup>Written for commit eb5d688220a0f2612a8337787b7edeee31025001. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/junhoyeo/tokscale/pull/1041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

